### PR TITLE
[markdown] Fix linting rule 'no-literal-urls'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,8 +17,15 @@ module.exports = {
 			files: [ '*.md' ],
 			parser: 'markdown-eslint-parser',
 			rules: {
-				// Disable remark rules for now, as they are not auto-fixable.
-				'md/remark': [ 'off' ],
+				'md/remark': [
+					'error',
+					{
+						plugins: [
+							// Plugins from https://www.npmjs.com/package/remark-preset-lint-markdown-style-guide
+							'lint-no-literal-urls',
+						],
+					},
+				],
 			},
 		},
 		{

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,8 +1,8 @@
 # Credits
 
-This project makes use of Open Source components. Below is a list of these components included in this project's source code, and their license information. This project also uses js packages released by NPM, see [package.json](/package.json). Source code and license information for each of these packages is available at https://npmjs.org. Many thanks to all of the original authors!
+This project makes use of Open Source components. Below is a list of these components included in this project's source code, and their license information. This project also uses js packages released by NPM, see [package.json](/package.json). Source code and license information for each of these packages is available at <https://npmjs.org>. Many thanks to all of the original authors!
 
-### https://github.com/thoughtbot/bourbon
+### <https://github.com/thoughtbot/bourbon>
 
 #### assets/stylesheets/shared/\_functions.scss
 
@@ -18,7 +18,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### https://github.com/facebook/react
+### <https://github.com/facebook/react>
 
 ```text
 BSD License
@@ -54,7 +54,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
 ```
 
-### https://github.com/WordPress/WordPress
+### <https://github.com/WordPress/WordPress>
 
 #### client/components/tinymce/plugins/wpcom
 
@@ -968,7 +968,7 @@ necessary.  Here is a sample; alter the names:
 That's all there is to it!
 ```
 
-### https://github.com/slevithan/xregexp
+### <https://github.com/WordPress/WordPress>
 
 #### client/state/embeds/utils.js
 
@@ -996,7 +996,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-### https://github.com/kvz/phpjs/
+### <https://github.com/kvz/phpjs/>
 
 #### client/lib/version-compare
 
@@ -1023,7 +1023,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-### https://github.com/Modernizr/Modernizr
+### <https://github.com/Modernizr/Modernizr>
 
 #### client/lib/touch-detect/index.js
 
@@ -1050,7 +1050,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-### https://github.com/strongloop/express
+### <https://github.com/strongloop/express>
 
 #### server/devdocs/bin/generate-devdocs-index
 
@@ -1082,7 +1082,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### https://github.com/SalesforceEng/secure-filters
+### <https://github.com/SalesforceEng/secure-filters>
 
 #### server/sanitize/index.js
 
@@ -1102,7 +1102,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-### https://github.com/reactjs/redux/
+### <https://github.com/reactjs/redux/>
 
 #### client/state
 
@@ -1118,7 +1118,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### https://github.com/gaearon/redux-thunk
+### <https://github.com/gaearon/redux-thunk>
 
 #### client/state
 
@@ -1134,7 +1134,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### https://github.com/reactjs/react-redux
+### <https://github.com/reactjs/react-redux>
 
 ```text
 The MIT License (MIT)
@@ -1148,7 +1148,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### https://github.com/sindresorhus/srcset
+### <https://github.com/sindresorhus/srcset>
 
 ```text
 The MIT License (MIT)
@@ -1174,7 +1174,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-### https://github.com/kentor/react-click-outside
+### <https://github.com/kentor/react-click-outside>
 
 ```
 The MIT License (MIT)
@@ -1200,7 +1200,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-### https://github.com/guille/ms.js
+### <https://github.com/guille/ms.js>
 
 ```text
 (The MIT License)
@@ -1225,7 +1225,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### https://github.com/avoidwork/filesize.js
+### <https://github.com/avoidwork/filesize.js>
 
 ```text
 Copyright (c) 2015, Jason Mulligan
@@ -1257,7 +1257,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-### https://github.com/ogt/valid-url
+### <https://github.com/ogt/valid-url>
 
 ```text
 Copyright (c) 2013 Odysseas Tsatalos and oDesk Corporation
@@ -1284,7 +1284,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 <span id="facebook/node-haste"></span>
 
-### https://github.com/facebook/node-haste
+### <https://github.com/facebook/node-haste>
 
 #### server/devdocs/bin/generate-components-usage-counts
 
@@ -1321,7 +1321,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-### https://github.com/mafintosh/is-my-json-valid
+### <https://github.com/mafintosh/is-my-json-valid>
 
 ```
 The MIT License (MIT)
@@ -1347,7 +1347,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-### https://github.com/d3/d3
+### <https://github.com/d3/d3>
 
 #### client/extensions/woocommerce/components/sparkline/index.js
 
@@ -1383,7 +1383,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 <span id="prism"></span>
 
-### https://github.com/PrismJS/prism/
+### <https://github.com/PrismJS/prism/>
 
 ```
 MIT LICENSE
@@ -1409,7 +1409,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-### https://classic.yarnpkg.com/en/
+### <https://classic.yarnpkg.com/en/>
 
 #### .yarn/releases
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -968,7 +968,7 @@ necessary.  Here is a sample; alter the names:
 That's all there is to it!
 ```
 
-### <ttps://github.com/slevithan/xregexp>
+### <https://github.com/slevithan/xregexp>
 
 #### client/state/embeds/utils.js
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -968,7 +968,7 @@ necessary.  Here is a sample; alter the names:
 That's all there is to it!
 ```
 
-### <https://github.com/WordPress/WordPress>
+### <ttps://github.com/slevithan/xregexp>
 
 #### client/state/embeds/utils.js
 

--- a/client/blocks/calendar-popover/README.md
+++ b/client/blocks/calendar-popover/README.md
@@ -58,7 +58,7 @@ The site's UTC offset.
 	<tr><td>Type</td><td>String</td></tr>
 </table>
 
-The site's timezone value, in the format of 'America/Araguaina (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+The site's timezone value, in the format of 'America/Araguaina (see <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>).
 
 #### Props propagated to the `<Popover />`
 

--- a/client/components/image-preloader/README.md
+++ b/client/components/image-preloader/README.md
@@ -2,7 +2,7 @@
 
 Image Preloader is a React component to display a placeholder element until the network request to retrieve the image has completed. This is particularly useful when changing the `src` attribute of an image, which can have a noticeable delay due to how React applies the minimal DOM diff. This is illustrated by the following CodePen, where progressing between images maintains the current image until the next is finished loading:
 
-http://codepen.io/aduth/pen/doqovP?editors=001
+<http://codepen.io/aduth/pen/doqovP?editors=001>
 
 ## Usage
 
@@ -15,7 +15,7 @@ export default class extends React.Component {
 		return (
 			<ImagePreloader
 				placeholder={ <div>Loading...</div> }
-				src="http://lorempixel.com/200/200" 
+				src="http://lorempixel.com/200/200"
 			/>
 		);
 	}

--- a/client/extensions/woocommerce/state/sites/product-categories/README.md
+++ b/client/extensions/woocommerce/state/sites/product-categories/README.md
@@ -7,7 +7,7 @@ This module is used to manage product categories for a site.
 ### `fetchProductCategories( siteId: number, query: object )`
 
 Get the list of product categories from the remote site.
-An optional query can be provided. See https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-product-categories for available fields.
+An optional query can be provided. See <https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-product-categories> for available fields.
 
 ## Reducer
 

--- a/client/extensions/woocommerce/state/sites/reviews/README.md
+++ b/client/extensions/woocommerce/state/sites/reviews/README.md
@@ -6,7 +6,7 @@ This module is used to manage reviews for a site.
 
 ### `fetchReviews( siteId: number, query: object )`
 
-Pull a set of reviews from the remote site, based on a query. See https://github.com/woocommerce/wc-api-dev/pull/48.
+Pull a set of reviews from the remote site, based on a query. See <https://github.com/woocommerce/wc-api-dev/pull/48>.
 
 ### `deleteReview( siteId: number, productId: number, reviewId: number )`
 

--- a/client/extensions/woocommerce/state/sites/settings/stripe-connect-account/README.md
+++ b/client/extensions/woocommerce/state/sites/settings/stripe-connect-account/README.md
@@ -6,7 +6,7 @@ This module works with WooCommerce Services to create Stripe Connect accounts.
 
 ### `createAccount( siteId: number, emailAddress: string, countryCode: string )`
 
-Attempts to create a Stripe Connect account using the deferred flow. See https://github.com/Automattic/woocommerce-services/pull/1137
+Attempts to create a Stripe Connect account using the deferred flow. See <https://github.com/Automattic/woocommerce-services/pull/1137>
 
 ## Reducer
 

--- a/client/extensions/woocommerce/state/ui/reviews/README.md
+++ b/client/extensions/woocommerce/state/ui/reviews/README.md
@@ -6,7 +6,7 @@ This module is used to track the current page, search term, or product being vie
 
 ### `updateCurrentReviewsQuery( siteId: number, query: object)`
 
-Updates the current reviews list query. See https://github.com/woocommerce/wc-api-dev/pull/48.
+Updates the current reviews list query. See <https://github.com/woocommerce/wc-api-dev/pull/48>.
 
 ## Reducer
 

--- a/client/lib/directly/README.md
+++ b/client/lib/directly/README.md
@@ -45,13 +45,13 @@ script to our self-hosted file.
 
 There are two Directly accounts so we can separate development / staging from production for testing.
 
-- **Sandbox (dev/staging)**  
-  Login: https://automattic-sandbox.directly.com  
-  Apply to be an Expert: https://automattic-sandbox.directly.com/apply
+- **Sandbox (dev/staging)**
+  Login: <https://automattic-sandbox.directly.com>
+  Apply to be an Expert: <https://automattic-sandbox.directly.com/apply>
 
-- **Production**  
-  Login: https://automattic.directly.com  
-  Apply to be an Expert: https://automattic.directly.com/apply
+- **Production**
+  Login: <https://automattic.directly.com>
+  Apply to be an Expert: <https://automattic.directly.com/apply>
 
 To test user interactions with the RTM widget you'll want to apply for an Expert account
 (most likely on the Sandbox environment). Once you apply your account will be reviewed
@@ -76,7 +76,7 @@ as an "Official Expert" because user questions are routed more slowly to these a
   over it. There may be mitigation strategies if this becomes undesirable.
 
 - The widget checks if the user is signed in to Directly with a call to their API:
-  https://www.directly.com/chat/checkAuth. If you aren't signed in this request will
+  <https://www.directly.com/chat/checkAuth>. If you aren't signed in this request will
   return `401` and you'll see an error in the browser console. Directly's team has
   verified that this is expected and doesn't have negative side effects.
 

--- a/client/lib/i18n-utils/README.md
+++ b/client/lib/i18n-utils/README.md
@@ -14,7 +14,7 @@ Intended primarily for reviewers, Calypso can be instructed to load waiting
 translations for a specific user from translate.wordpress.com using the
 query parameter `?load-user-translations=username`.
 
-E.g. https://wordpress.com/start/user/es?load-user-translations=exampleusername
+E.g. <https://wordpress.com/start/user/es?load-user-translations=exampleusername>
 
 In addition, `project` (default `wpcom`), `translationSet` (default: `default`)
 and/or `locale` (default current locale) can be used to load specific

--- a/client/lib/paste-to-link/README.md
+++ b/client/lib/paste-to-link/README.md
@@ -5,7 +5,7 @@ Paste-to-Link is a higher-order component (HOC) that adds special paste behaviou
 If the clipboard contains a URL and some text is selected, pasting will wrap the selected text in an
 <a> element with the href set to the URL in the clipboard.
 
-For example, type and highlight "WordPress" with "http://wordpress.com" in your clipboard and then paste.
+For example, type and highlight "WordPress" with "<http://wordpress.com>" in your clipboard and then paste.
 The textarea will then contain:
 
 <a href="http://wordpress.com">WordPress</a>

--- a/client/lib/shortcode/README.md
+++ b/client/lib/shortcode/README.md
@@ -28,13 +28,13 @@ A shortcode object is comprised of the following properties:
 
 The name of the shortcode.
 
-See: https://codex.wordpress.org/Shortcode_API#Names
+See: <https://codex.wordpress.org/Shortcode_API#Names>
 
 ### `type`
 
 The type of shortcode, `closed`, `self-closing`, or `single`.
 
-See: https://codex.wordpress.org/Shortcode_API#Enclosing_vs_self-closing_shortcodes
+See: <https://codex.wordpress.org/Shortcode_API#Enclosing_vs_self-closing_shortcodes>
 
 ### `attrs`
 

--- a/client/lib/touch-detect/README.md
+++ b/client/lib/touch-detect/README.md
@@ -6,6 +6,6 @@ Depending on the use case, this may be appropriate.
 
 Further reading:
 
-https://github.com/Modernizr/Modernizr/blob/HEAD/feature-detects/touchevents.js
-http://www.stucox.com/blog/you-cant-detect-a-touchscreen/
-http://www.html5rocks.com/en/mobile/touchandmouse/
+<https://github.com/Modernizr/Modernizr/blob/HEAD/feature-detects/touchevents.js>
+<http://www.stucox.com/blog/you-cant-detect-a-touchscreen/>
+<http://www.html5rocks.com/en/mobile/touchandmouse/>

--- a/client/lib/translator-jumpstart/README.md
+++ b/client/lib/translator-jumpstart/README.md
@@ -14,5 +14,5 @@ This module contains the necessary code to launch the external [Community Transl
 
 ## Environment specific functionality
 
-- The launcher controls which GlotPress instance and project the Community-Translator communicates with. This will be https://translate.wordpress.com/projects/wpcom/ by default. In a non-production environment however, the project set to will be `test` instead of `wpcom`.
+- The launcher controls which GlotPress instance and project the Community-Translator communicates with. This will be <https://translate.wordpress.com/projects/wpcom/> by default. In a non-production environment however, the project set to will be `test` instead of `wpcom`.
 - Debug output is enabled in the browser with `localStorage.setItem( 'debug', 'calypso:community-translator' )` or `localStorage.setItem( 'debug', 'calypso:i18n,calypso:community-translator' )` if you want to also include the information about the displayed translated strings.

--- a/client/lib/version-compare/README.md
+++ b/client/lib/version-compare/README.md
@@ -1,3 +1,3 @@
 # PHP.js Version Compare
 
-Function borrowed from php.js in order to do version comparisons for themes, plugins, and WordPress core: http://phpjs.org/functions/version_compare/.
+Function borrowed from php.js in order to do version comparisons for themes, plugins, and WordPress core: <http://phpjs.org/functions/version_compare/>.

--- a/client/my-sites/checkout/README.md
+++ b/client/my-sites/checkout/README.md
@@ -8,10 +8,10 @@ This module supports a variety of routes that are described in each submodule.
 
 To start a plan checkout flow, use appropriate URLS:
 
-- https://wordpress.com/checkout/site.wordpress.com/premium
-- https://wordpress.com/checkout/site.wordpress.com/personal
-- https://wordpress.com/checkout/site.wordpress.com/business
-- https://wordpress.com/checkout/site.jetpack.me/premium
-- https://wordpress.com/checkout/site.jetpack.me/professional
+- <https://wordpress.com/checkout/site.wordpress.com/premium>
+- <https://wordpress.com/checkout/site.wordpress.com/personal>
+- <https://wordpress.com/checkout/site.wordpress.com/business>
+- <https://wordpress.com/checkout/site.jetpack.me/premium>
+- <https://wordpress.com/checkout/site.jetpack.me/professional>
 
 Plan routes are sourced from `lib/plans/constants.js`

--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -157,7 +157,7 @@ hello: { // This will be the slug for the flow, i.e.: wordpress.com/start/hello
 }
 ```
 
-7 - open https://calypso.localhost:3000/start/hello in an incognito window. You will be redirected to
+7 - open <https://calypso.localhost:3000/start/hello> in an incognito window. You will be redirected to
 the first step of the flow at `/start/hello/hello-world`, where you should see your new React component.
 
 8 - now we need a way for users to move to the next step of the flow. Let's add a button and a form to the step's `render` method:
@@ -193,4 +193,4 @@ handleSubmit = ( event ) => {
 }
 ```
 
-9 - open https://calypso.localhost:3000/start/hello in an incognito window. On opening you should be redirected to the first step showing your updated React component, and when you click the "Get started" button you should be taken to the next step.
+9 - open <https://calypso.localhost:3000/start/hello> in an incognito window. On opening you should be redirected to the first step showing your updated React component, and when you click the "Get started" button you should be taken to the next step.

--- a/client/state/http/README.md
+++ b/client/state/http/README.md
@@ -6,10 +6,10 @@ It follows the same API as `wpcom-http`, the only difference from the user's per
 
 ### Usage
 
-So, let's say you would like to do a `POST` request to https://api.example.com when the action `GET_EXAMPLE_DATA` is dispatched, later continuing with `EXAMPLE_DATA_ADD` for the data or `NOTICE_CREATE` for the error. You'll be able to do that with the following code (that could be located under `third-party`):
+So, let's say you would like to do a `POST` request to <https://api.example.com> when the action `GET_EXAMPLE_DATA` is dispatched, later continuing with `EXAMPLE_DATA_ADD` for the data or `NOTICE_CREATE` for the error. You'll be able to do that with the following code (that could be located under `third-party`):
 
 ```js
-import { 
+import {
 	GET_EXAMPLE_DATA,
 	EXAMPLE_DATA_ADD,
 	NOTICE_CREATE,

--- a/config/README.md
+++ b/config/README.md
@@ -42,4 +42,4 @@ If you want to temporarily enable/disable some feature flags you can add a `?fla
 - `?flags=-bar` disables feature _bar_.
 - `?flags=foo,-bar` enables feature _foo_ and disables feature _bar_.
 
-E.g. http://calypso.localhost:3000/?flags=manage/plugins/compatibility-warning
+E.g. <http://calypso.localhost:3000/?flags=manage/plugins/compatibility-warning>

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -150,7 +150,7 @@
 - Add jest babel transform to load calypso-build babel configuration.
 - Reorganize jest transforms under `@automattic/calypso-build/jest/transform/`.
 - Added transform-runtime versioning to babel/default.js
-  This will need to be kept up to date while https://github.com/babel/babel/issues/10261 is unresolved.
+  This will need to be kept up to date while <https://github.com/babel/babel/issues/10261> is unresolved.
 
 # 3.0.0
 

--- a/packages/eslint-plugin-wpcalypso/docs/rules/i18n-no-variables.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/i18n-no-variables.md
@@ -4,7 +4,7 @@ Translate strings cannot be variables or functions, but rather must always be st
 
 This limitation applies to the translatable string itself, as well as the plural form and 'context' and 'comment' options if they are present.
 
-More information: https://github.com/Automattic/i18n-calypso/blob/HEAD/README.md#strings-only
+More information: <https://github.com/Automattic/i18n-calypso/blob/HEAD/README.md#strings-only>
 
 ## Rule Details
 

--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ---
 
-- Update Jed dependency to v1.1.1. This is a breaking change, since as of Jed v1.1, the format of Jed translation files has changed. Refer to https://github.com/messageformat/Jed/pull/33 for details.
+- Update Jed dependency to v1.1.1. This is a breaking change, since as of Jed v1.1, the format of Jed translation files has changed. Refer to <https://github.com/messageformat/Jed/pull/33> for details.
 
   2.0.2
 
@@ -40,9 +40,9 @@
 
 ---
 
-- Update parseOptions passed to xgettext to include more modern features https://github.com/Automattic/i18n-calypso/pull/68
-- Switch to hash.js from sha1 for hashing to cut size https://github.com/Automattic/i18n-calypso/pull/67
-- Remove async dependency, as it was unused https://github.com/Automattic/i18n-calypso/pull/66
+- Update parseOptions passed to xgettext to include more modern features <https://github.com/Automattic/i18n-calypso/pull/68>
+- Switch to hash.js from sha1 for hashing to cut size <https://github.com/Automattic/i18n-calypso/pull/67>
+- Remove async dependency, as it was unused <https://github.com/Automattic/i18n-calypso/pull/66>
 
   2.0.0
 

--- a/packages/material-design-icons/README.md
+++ b/packages/material-design-icons/README.md
@@ -1,7 +1,7 @@
 # Material design icons
 
 This package currently only provides Material icon SVGs required by the Calypso
-nav drawer. The official `material-design-icons` package (https://github.com/google/material-design-icons)
+nav drawer. The official `material-design-icons` package (<https://github.com/google/material-design-icons>)
 is generally quite out-dated. It also includes many image formats that are not
 relevant to Calypso.
 
@@ -24,7 +24,7 @@ import { ReactComponent as SvgExample } from './test.svg';
 To add more Material Design icons, you'll have to download individual icons to appropriate directories
 then rebuild and checkin updated `material-icons.svg` file.
 
-Select and download individual icon's SVG file from https://material.io/tools/icons/,
+Select and download individual icon's SVG file from <https://material.io/tools/icons/>,
 minding the style (like `outline`) and size.
 
 Move the SVG files in the sub-folder matching the category used on material.io.

--- a/packages/wpcom.js/History.md
+++ b/packages/wpcom.js/History.md
@@ -52,7 +52,7 @@
 
 # 4.9.13 / 2016-05-25
 
-- avoid https://github.com/webpack/webpack/issues/300 issue
+- avoid <https://github.com/webpack/webpack/issues/300> issue
 - marketing.survey. First approach
 - SiteAdCreditVouchers: first implementation
 
@@ -109,8 +109,8 @@
 
   # 4.9.0 / 2016-03-28
 
-- site: add domain methods (see https://github.com/Automattic/wpcom.js/pull/163)
-- version bump wpcom-xhr-request (see https://github.com/Automattic/wpcom-xhr-request/pull/17)
+- site: add domain methods (see <https://github.com/Automattic/wpcom.js/pull/163>)
+- version bump wpcom-xhr-request (see <https://github.com/Automattic/wpcom-xhr-request/pull/17>)
 
   # 4.8.6 / 2016-03-23
 

--- a/packages/wpcom.js/examples/Readme.md
+++ b/packages/wpcom.js/examples/Readme.md
@@ -8,7 +8,7 @@ It's an express application that gets the blog posts making a server-side reques
 $ make example-server
 ```
 
-Finally open a browser and load the page pointing to http://localhost:3000.
+Finally open a browser and load the page pointing to <http://localhost:3000>.
 
 Keep in mind that this app gets the config data from test/data.json file.
 

--- a/test/e2e/specs-jetpack/README.md
+++ b/test/e2e/specs-jetpack/README.md
@@ -17,7 +17,7 @@ To run them locally:
 - make sure you have decrypted config and dependencies installed e.g. you can run tests locally
 - run `sh specs-jetpack/runner.sh`
 
-It also possible to run these tests in CI. Visit https://circleci.com/gh/Automattic/wp-e2e-tests-jetpack-smoke/ and re-launch latest CI build.
+It also possible to run these tests in CI. Visit <https://circleci.com/gh/Automattic/wp-e2e-tests-jetpack-smoke/> and re-launch latest CI build.
 
-Wrapper repo: https://github.com/Automattic/wp-e2e-tests-jetpack-smoke
+Wrapper repo: <https://github.com/Automattic/wp-e2e-tests-jetpack-smoke>
 Internal ref: p9dueE-lw-p2


### PR DESCRIPTION
### Background

After linting our Markdown files following prettier format, I'd like to introduce content-based rules from `remark`. The plugin we use (`eslint-plugin-md`) recommends [Markdown Style Guide](https://cirosantilli.com/markdown-style-guide/), and it has [a preset](https://www.npmjs.com/package/remark-preset-lint-markdown-style-guide) for it.

Unfortunately this preset doesn't have the capacity of auto-fix the problems. Instead of enabling the preset and having a ton of errors, I'll enable the rules of the preset one by one and fix each error. When all the rules are enabled we can switch the hardcoded list of rules by the preset.

### Changes

Enables rule [no-literal-urls](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls). This rule forbids to have plain URLs and require them to be [automatic links](https://cirosantilli.com/markdown-style-guide/#automatic-links):

```
Good: <http://wordpress.com>
Bad: http://wordpress.com
```

### Testing
Run `./node_modules/.bin/eslint --ext .md .` and check there are no errors
