### PR TITLE
[markdown] Fix linting rule 'heading-increments'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
 						plugins: [
 							// Plugins from https://www.npmjs.com/package/remark-preset-lint-markdown-style-guide
 							'lint-no-literal-urls',
+							'lint-heading-increment',
 						],
 					},
 				],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
 			},
 		},
 		{
-			// This lints the codeblocks marked as `javascritp`, `js`, `cjs` or `ejs`, all valid aliases
+			// This lints the codeblocks marked as `javascript`, `js`, `cjs` or `ejs`, all valid aliases
 			// See:
 			//  * https://github.com/highlightjs/highlight.js/blob/master/SUPPORTED_LANGUAGES.md)
 			//  * https://www.npmjs.com/package/eslint-plugin-md#modifying-eslint-setup-for-js-code-inside-md-files

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -2,9 +2,9 @@
 
 This project makes use of Open Source components. Below is a list of these components included in this project's source code, and their license information. This project also uses js packages released by NPM, see [package.json](/package.json). Source code and license information for each of these packages is available at <https://npmjs.org>. Many thanks to all of the original authors!
 
-### <https://github.com/thoughtbot/bourbon>
+## <https://github.com/thoughtbot/bourbon>
 
-#### assets/stylesheets/shared/\_functions.scss
+### assets/stylesheets/shared/\_functions.scss
 
 ```text
 The MIT License (MIT)
@@ -18,7 +18,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### <https://github.com/facebook/react>
+## <https://github.com/facebook/react>
 
 ```text
 BSD License
@@ -54,25 +54,25 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
 ```
 
-### <https://github.com/WordPress/WordPress>
+## <https://github.com/WordPress/WordPress>
 
-#### client/components/tinymce/plugins/wpcom
+### client/components/tinymce/plugins/wpcom
 
-#### client/components/tinymce/plugins/wpcom-autoresize
+### client/components/tinymce/plugins/wpcom-autoresize
 
-#### client/components/tinymce/plugins/wpcom-view
+### client/components/tinymce/plugins/wpcom-view
 
-#### client/components/tinymce/plugins/wpeditimage
+### client/components/tinymce/plugins/wpeditimage
 
-#### client/components/tinymce/plugins/wplink
+### client/components/tinymce/plugins/wplink
 
-#### client/components/tinymce/plugins/wptextpattern
+### client/components/tinymce/plugins/wptextpattern
 
-#### client/lib/media/constants.js
+### client/lib/media/constants.js
 
-#### client/post-editor/media-modal/markup.js
+### client/post-editor/media-modal/markup.js
 
-#### client/lib/formatting/index.js
+### client/lib/formatting/index.js
 
 ```text
 WordPress - Web publishing software
@@ -968,9 +968,9 @@ necessary.  Here is a sample; alter the names:
 That's all there is to it!
 ```
 
-### <https://github.com/slevithan/xregexp>
+## <https://github.com/slevithan/xregexp>
 
-#### client/state/embeds/utils.js
+### client/state/embeds/utils.js
 
 ```text
 The MIT License
@@ -996,9 +996,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-### <https://github.com/kvz/phpjs/>
+## <https://github.com/kvz/phpjs/>
 
-#### client/lib/version-compare
+### client/lib/version-compare
 
 ```text
 Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io)
@@ -1023,9 +1023,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-### <https://github.com/Modernizr/Modernizr>
+## <https://github.com/Modernizr/Modernizr>
 
-#### client/lib/touch-detect/index.js
+### client/lib/touch-detect/index.js
 
 ```text
 
@@ -1050,9 +1050,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-### <https://github.com/strongloop/express>
+## <https://github.com/strongloop/express>
 
-#### server/devdocs/bin/generate-devdocs-index
+### server/devdocs/bin/generate-devdocs-index
 
 ```text
 
@@ -1082,9 +1082,9 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### <https://github.com/SalesforceEng/secure-filters>
+## <https://github.com/SalesforceEng/secure-filters>
 
-#### server/sanitize/index.js
+### server/sanitize/index.js
 
 ```text
 
@@ -1102,25 +1102,9 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-### <https://github.com/reactjs/redux/>
+## <https://github.com/reactjs/redux/>
 
-#### client/state
-
-```text
-The MIT License (MIT)
-
-Copyright (c) 2015 Dan Abramov
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-```
-
-### <https://github.com/gaearon/redux-thunk>
-
-#### client/state
+### client/state
 
 ```text
 The MIT License (MIT)
@@ -1134,7 +1118,9 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### <https://github.com/reactjs/react-redux>
+## <https://github.com/gaearon/redux-thunk>
+
+### client/state
 
 ```text
 The MIT License (MIT)
@@ -1148,7 +1134,21 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### <https://github.com/sindresorhus/srcset>
+## <https://github.com/reactjs/react-redux>
+
+```text
+The MIT License (MIT)
+
+Copyright (c) 2015 Dan Abramov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+## <https://github.com/sindresorhus/srcset>
 
 ```text
 The MIT License (MIT)
@@ -1174,7 +1174,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-### <https://github.com/kentor/react-click-outside>
+## <https://github.com/kentor/react-click-outside>
 
 ```
 The MIT License (MIT)
@@ -1200,7 +1200,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-### <https://github.com/guille/ms.js>
+## <https://github.com/guille/ms.js>
 
 ```text
 (The MIT License)
@@ -1225,7 +1225,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### <https://github.com/avoidwork/filesize.js>
+## <https://github.com/avoidwork/filesize.js>
 
 ```text
 Copyright (c) 2015, Jason Mulligan
@@ -1257,7 +1257,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-### <https://github.com/ogt/valid-url>
+## <https://github.com/ogt/valid-url>
 
 ```text
 Copyright (c) 2013 Odysseas Tsatalos and oDesk Corporation
@@ -1284,9 +1284,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 <span id="facebook/node-haste"></span>
 
-### <https://github.com/facebook/node-haste>
+## <https://github.com/facebook/node-haste>
 
-#### server/devdocs/bin/generate-components-usage-counts
+### server/devdocs/bin/generate-components-usage-counts
 
 ```text
 BSD License
@@ -1321,7 +1321,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-### <https://github.com/mafintosh/is-my-json-valid>
+## <https://github.com/mafintosh/is-my-json-valid>
 
 ```
 The MIT License (MIT)
@@ -1347,9 +1347,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-### <https://github.com/d3/d3>
+## <https://github.com/d3/d3>
 
-#### client/extensions/woocommerce/components/sparkline/index.js
+### client/extensions/woocommerce/components/sparkline/index.js
 
 ```text
 Copyright 2010-2017 Mike Bostock
@@ -1383,7 +1383,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 <span id="prism"></span>
 
-### <https://github.com/PrismJS/prism/>
+## <https://github.com/PrismJS/prism/>
 
 ```
 MIT LICENSE
@@ -1409,9 +1409,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-### <https://classic.yarnpkg.com/en/>
+## <https://classic.yarnpkg.com/en/>
 
-#### .yarn/releases
+### .yarn/releases
 
 ```text
 BSD 2-Clause License

--- a/client/README.md
+++ b/client/README.md
@@ -2,7 +2,7 @@
 
 This is the heart of Calypso, the client side application. It's pieced together with webpack from different components — both external and internal. ([List of technologies used.](../docs/guide/tech-behind-calypso.md)) It only requires an HTML shell with a body to work with.
 
-### Main modules
+## Main modules
 
 These are some of the key modules of the application, kept in `client`'s root for clarity:
 
@@ -11,19 +11,19 @@ These are some of the key modules of the application, kept in `client`'s root fo
 - `layout` - handles the main React layout, including the masterbar. Notably, it sets #primary and #secondary used to render the different sections.
 - `sections.js` - defines section groups, paths, and main modules. (Used by webpack to generate separate chunks.)
 
-### Components
+## Components
 
 The `/components` folder holds all the internal React components used to build the Calypso UI across sections. Most of these are rendered in `/devdocs/design` for reference.
 
-### State
+## State
 
 The `/state` folder holds the structure of the application global state and data flows.
 
-### Lib
+## Lib
 
 The `/lib` folder holds internal modules and utilities that power Calypso.
 
-### Core Sections
+## Core Sections
 
 These represent the top section in the masterbar as well as other significant areas of the app. Within these all the controllers for the entire app are expressed. Most React app-components live within their specific section and not in `client/components`.
 

--- a/client/blocks/all-sites/README.md
+++ b/client/blocks/all-sites/README.md
@@ -2,7 +2,7 @@
 
 This component displays the All Sites item. It's used in the Sidebar as the current site selection and in the picker.
 
-#### How to use:
+## How to use:
 
 ```js
 import AllSites from 'blocks/all-sites';
@@ -14,7 +14,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `sites (array)` - An array of `site` objects.
 - `onSelect (func)` - A function to handle the event callback when clicking/tapping on the site.

--- a/client/blocks/app-promo/README.md
+++ b/client/blocks/app-promo/README.md
@@ -2,7 +2,7 @@
 
 This component is used to suggest the desktop app to users.
 
-#### How to use:
+## How to use:
 
 ```js
 import AppPromo from 'components/app-promo'

--- a/client/blocks/author-selector/README.md
+++ b/client/blocks/author-selector/README.md
@@ -10,7 +10,7 @@ This component allows an administrator with sufficient privileges to edit the au
 
 The component will retrieve site users and render the child span as a clickable element to expand the `author-selector` UX. If selecting other authors is not appropriate (i.e., only one available author, Users not loaded, or insufficient permission), it will simply display the span.
 
-### Props
+## Props
 
 - siteId - The siteId for site from which to fetch authors
 - onSelect - Function to call when user is selected, selected `author` passed as parameter

--- a/client/blocks/comment-button/README.md
+++ b/client/blocks/comment-button/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a button with an embedded number indicator.
 
-#### How to use:
+## How to use:
 
 ```js
 import CommentButton from 'blocks/comment-button';
@@ -14,7 +14,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `commentCount`: Number indicating the number of comments to be displayed next to the button.
 - `href`: String URL destination to be used with a `tagName` of `a`. Defaults to `null`.

--- a/client/blocks/conversation-caterpillar/README.md
+++ b/client/blocks/conversation-caterpillar/README.md
@@ -2,7 +2,7 @@
 
 This component is used to show who's involved in a conversation, and how many comments have been made.
 
-#### How to use:
+## How to use:
 
 ```js
 import ConversationCaterpillar from 'blocks/conversation-caterpillar';
@@ -14,11 +14,11 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `blogId`
 - `postId`
 
-#### Footnote
+## Footnote
 
 "On Saturday, he ate through one piece of chocolate cake, one ice-cream cone, one pickle, one slice of Swiss cheese, one slice of salami, one lollipop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon."

--- a/client/blocks/credit-card-form/README.md
+++ b/client/blocks/credit-card-form/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a credit card form.
 
-#### How to use:
+## How to use:
 
 ```js
 import CreditCardForm from 'blocks/credit-card-form';
@@ -19,7 +19,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `createCardToken`: Function to be executed when a valid form is submitted. It is responsible for a credit card token creation which is the part of the flow.
 - `initialValues`: Optional object containing initial values for the form fields. At the moment only `name` is supported.

--- a/client/blocks/dismissible-card/README.md
+++ b/client/blocks/dismissible-card/README.md
@@ -3,7 +3,7 @@
 This is a card component that can be dismissed for a single page load or be hidden
 via user preference.
 
-#### How to use:
+## How to use:
 
 ```js
 import DismissibleCard from 'blocks/dismissible-card';

--- a/client/blocks/domain-to-plan-nudge/README.md
+++ b/client/blocks/domain-to-plan-nudge/README.md
@@ -3,7 +3,7 @@
 This is an upgrade nudge that targets users with a site that has a free plan
 and a paid domain.
 
-#### How to use:
+## How to use:
 
 ```js
 

--- a/client/blocks/follow-button/README.md
+++ b/client/blocks/follow-button/README.md
@@ -4,7 +4,7 @@ This component is used to display a follow/unfollow button.
 It has two parts, the actual button and a container that works with Redux state.
 For most uses, the container is the easiest route.
 
-#### How to use the container:
+## How to use the container:
 
 ```js
 import FollowButtonContainer from 'blocks/follow-button';
@@ -18,11 +18,11 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `siteUrl`: string, a site URL to follow or unfollow
 
-#### How to use the button directly:
+## How to use the button directly:
 
 ```js
 import FollowButton from 'blocks/follow-button/button';
@@ -36,7 +36,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `following`: (default: false) a boolean indicating if the current user is currently following the site URL
 - `disabled`: (default: false) a boolean indicating if the button is currently disabled

--- a/client/blocks/global-notice/README.md
+++ b/client/blocks/global-notice/README.md
@@ -3,7 +3,7 @@
 These components are used to display global notices.
 They allow you to use a component for your notice instead of calling the notices redux actions directly.
 
-#### How to use the container:
+## How to use the container:
 
 ```js
 import { InfoNotice } from 'blocks/global-notice';
@@ -17,6 +17,6 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `text`: The text that will be displayed while the notice is visible

--- a/client/blocks/like-button/README.md
+++ b/client/blocks/like-button/README.md
@@ -4,7 +4,7 @@ This component is used to display a like button.
 It has two parts, the actual button and a container that works with the LikeStore.
 For most usage, the container is the easiest route.
 
-#### How to use the container:
+## How to use the container:
 
 ```js
 import LikeButtonContainer from 'blocks/like-button';
@@ -18,12 +18,12 @@ render: function() {
 }
 ```
 
-#### Props
+## Props
 
 - `siteId`: number, a site ID to fetch likes for
 - `postId`: number, a post ID to fetch likes for
 
-#### How to use the button directly:
+## How to use the button directly:
 
 ```js
 import LikeButton from 'blocks/like-button/button';
@@ -41,7 +41,7 @@ handleLikeToggle: function( newState ) {
 }
 ```
 
-#### Props
+## Props
 
 - `likeCount`: the number of likes.
 - `showZeroCount`: (default: false) show the number of likes even if it's zero.

--- a/client/blocks/nps-survey/README.md
+++ b/client/blocks/nps-survey/README.md
@@ -2,13 +2,13 @@
 
 This block is used to display a Net Promoter Score (NPS) survey to the user.
 
-### Usage
+## Usage
 
 ```javascript
 <NpsSurvey name="some_screen_v1" onClose={ this.handleSurveyClose } />;
 ```
 
-### Props
+## Props
 
 - `name`: The name of the survey, used in reporting to segment by location survey
   was shown and version of survey. Each distinct location and version combo should

--- a/client/blocks/plan-storage/README.md
+++ b/client/blocks/plan-storage/README.md
@@ -3,14 +3,14 @@
 This component is used to display the remaining media storage limits. Using PlanStorage
 will query media storage limits for you.
 
-#### Usage:
+## Usage:
 
 ```javascript
 	<PlanStorage siteId={ this.props.siteId } />
 }
 ```
 
-#### Props
+## Props
 
 - `siteId`: A site ID (required)
 - `className`: A string that adds additional class names to this component.
@@ -18,7 +18,7 @@ will query media storage limits for you.
 You can also use PlanStorageBar directly if you need more control over when
 media storage limits are fetched.
 
-#### Usage:
+## Usage:
 
 ```javascript
 import PlanStorageBar from 'blocks/plan-storage/bar';
@@ -45,7 +45,7 @@ export default connect( ( state, ownProps ) => {
 } )( MyComponent );
 ```
 
-#### Props
+## Props
 
 - `sitePlanName`: A plan name ( Free or Premium ) (required)
 - `mediaStorage`: Media Storage limits for a given site. If this is not provided, the bar will not render.

--- a/client/blocks/signup-form/README.md
+++ b/client/blocks/signup-form/README.md
@@ -2,7 +2,7 @@
 
 This block renders a Signup Form. It magically handles email, username, and password validation.
 
-#### Usage:
+## Usage:
 
 A Signup Form instance expects `save` and `submitForm` properties, `save` is called `onBlur` of each field. `submitForm` is called when the form is submitted.
 Optional:
@@ -27,7 +27,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `submitForm` function - Called when the form is submitted. It will receive the following parameters: `form`, `userData` and `analyticsData`
 - `submitButtonText` string: The text displayed inside the submit button

--- a/client/blocks/site-icon/README.md
+++ b/client/blocks/site-icon/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the icon for a site. It takes a Site object as a prop. The size is set at 120px, used at 60px for retina display. Using one size allows us to only request one image and cache it on the browser. Even if you are displaying it at smaller sizes you should not change the requested image.
 
-#### How to use:
+## How to use:
 
 ```js
 import SiteIcon from 'blocks/site-icon';
@@ -12,7 +12,7 @@ render: function() {
 }
 ```
 
-#### Props
+## Props
 
 - `site`: a Site object. If no site prop is passed the component will render a fallback website icon.
 - `size`: (default: 32) change the requested image size.

--- a/client/blocks/site/README.md
+++ b/client/blocks/site/README.md
@@ -2,7 +2,7 @@
 
 This component displays a Site item using site data retrieved from Redux store. See the documentation for the `siteId` and `site` props for more details about retrieving the site data.
 
-#### How to use:
+## How to use:
 
 ```js
 import Site from 'blocks/site';
@@ -12,7 +12,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `siteId (number)` - A site ID. Required, unless a `site` object prop is provided (see below).
 - `site (object)` - A site object. Required, unless a `siteId` prop is provided. If both are provided, `siteId` takes precedence.

--- a/client/blocks/subscription-length-picker/README.md
+++ b/client/blocks/subscription-length-picker/README.md
@@ -2,11 +2,11 @@
 
 Represents a term that user could pick when choosing his plan (monthly, yearly, biennially)
 
-### `index.jsx`
+## `index.jsx`
 
 Given basic information, this component creates a representation of given term.
 
-#### Props
+### Props
 
 - `checked`: bool - if this option should be checked (selected)
 - `onCheck`: function({value}) => void ( optional ) A callback called when this term is checked (selected)

--- a/client/blocks/support-article-dialog/README.md
+++ b/client/blocks/support-article-dialog/README.md
@@ -4,7 +4,7 @@ The `SupportArticleDialog` component displays a support article right in Calypso
 
 The component is rendered from our main `<Layout />` component and so is available everywhere in Calypso.
 
-#### Basic usage:
+## Basic usage:
 
 To launch a support article call the corresponding redux action, like so:
 
@@ -23,7 +23,7 @@ render: function() {
 You'll notice that two properties were passed in to the `openSupportArticleDialog` action.
 These two properties are then made available to `SupportArticleDialog` via redux, and are explained below.
 
-#### Props
+## Props
 
 - `postId`: (required) An id used to query the support article and get its contents.
 - `postUrl`: A user-friendly url to be used to render an external link to the article, at the bottom of the dialog.

--- a/client/blocks/user-mentions/README.md
+++ b/client/blocks/user-mentions/README.md
@@ -5,7 +5,7 @@ This block provides a higher-order component `withUserMentions()`, which can be 
 It also provides the components `UserMentionsSuggestionList` and `UserMentionsSuggestion`, which are also used in the
 [Editor Mentions TinyMCE plugin](https://github.com/Automattic/wp-calypso/tree/HEAD/client/components/tinymce/plugins/mentions).
 
-#### How to use
+## How to use
 
 ```js
 import withUserMentions from 'blocks/user-mentions';
@@ -19,7 +19,7 @@ export default withUserMentions( ExampleInput );
 
 Note: you'll need to wrap the child component with `React.forwardRef`, and pass along the `onKeyUp` and `onKeyDown` props.
 
-#### Higher order components
+## Higher order components
 
 `addUserMentions` (add.jsx) provides the suggestion popup to the wrapped component. If you don't want suggestions from the API, you can just hand this component a `suggestions` prop. The Devdocs example uses this HOC.
 

--- a/client/boot/README.md
+++ b/client/boot/README.md
@@ -2,7 +2,7 @@
 
 This module is where all the client-side magic starts. The core set of application modules that contain the client-side application routes, any additional application bootstrapping occurs, and the page.js router is started triggering the initial route handler.
 
-### Folder structure
+## Folder structure
 
 ```text
 client/boot/

--- a/client/components/animate/README.md
+++ b/client/components/animate/README.md
@@ -2,7 +2,7 @@
 
 Simple interface to introduce animations to components on initial render. Used as a wrapper.
 
-#### How to use:
+## How to use:
 
 ```jsx
 import Animate from 'components/animate';
@@ -16,6 +16,6 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `type`: (string) a string matching one of the approved transition effects (`appear` or `fade-in`).

--- a/client/components/bulk-select/README.md
+++ b/client/components/bulk-select/README.md
@@ -2,7 +2,7 @@
 
 This component is used to implement a checkbox which you can use to bulk select a list of elements
 
-#### How to use:
+## How to use:
 
 ```jsx
 import BulkSelect from 'components/bulk-select';
@@ -14,7 +14,7 @@ render: function() {
 }
 ```
 
-#### Props
+## Props
 
 - `selectedElements`: (number) The number of elements currently selected
 - `totalElements`: (number) The number of all the elements that can be selected

--- a/client/components/card-heading/README.md
+++ b/client/components/card-heading/README.md
@@ -2,7 +2,7 @@
 
 This component displays a heading for a `<Card>`
 
-#### How to use:
+## How to use:
 
 ```js
 import CardHeading from 'components/card-heading';
@@ -19,7 +19,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `tagName` (`string`) - The element to wrap the text in
 - `size` (`int`) - The font size of the heading

--- a/client/components/credit-card/README.md
+++ b/client/components/credit-card/README.md
@@ -2,7 +2,7 @@
 
 The `CreditCard` component serves as a container for a selectable credit card list item, and can display a stored credit card (passed as `card` prop) _or_ a placeholder such as a new card form (passed as `children`).
 
-### Usage
+## Usage
 
 Example credit card selection list:
 
@@ -21,7 +21,7 @@ export default ( { cards, selectedId, onSelectCard } ) => {
 };
 ```
 
-### Props
+## Props
 
 | Name        | Type                      | Description                                                  |
 | ----------- | ------------------------- | ------------------------------------------------------------ |
@@ -30,11 +30,11 @@ export default ( { cards, selectedId, onSelectCard } ) => {
 | `onSelect`  | `func`                    | Handler called with event argument upon selecting card item. |
 | `className` | `string`                  | Extra custom class names to pass to element.                 |
 
-## StoredCard
+# StoredCard
 
 The `StoredCard` component is a representation of a single credit card, used internally to render the `card` passed to `CreditCard`, but can also be used independently or as a child of the `CreditCard`.
 
-### Usage
+## Usage
 
 Example usage within `<CreditCard>`:
 
@@ -51,7 +51,7 @@ export default ( cardData, onRemoveCard ) => {
 };
 ```
 
-### Props
+## Props
 
 | Name              | Type     | Description                                                       |
 | ----------------- | -------- | ----------------------------------------------------------------- |

--- a/client/components/d3-base/README.md
+++ b/client/components/d3-base/README.md
@@ -2,7 +2,7 @@
 
 Integrate React Lifecyle methods with d3.js charts.
 
-### Base Component Responsibilities
+## Base Component Responsibilities
 
 - Create and manage mounting and unmounting parent `div` and `svg`
 - Handle resize events, resulting re-renders, and event listeners

--- a/client/components/date-picker/README.md
+++ b/client/components/date-picker/README.md
@@ -47,7 +47,7 @@ export default class extends React.Component {
 
 ## DatePicker
 
-#### Props
+### Props
 
 `initialMonth` - **optional** Date object that defines the month of the calendar. Default is `now`.
 

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/README.md
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/README.md
@@ -27,7 +27,7 @@ Usage:
     />
 ```
 
-#### Props
+## Props
 
 `getFieldProps` _{Function}_ _Required_
 
@@ -50,15 +50,3 @@ Default: `false`.
 Overrides the constants check. Informs the component whether the country code is associated with a list of states, and therefore must display the US-style address fields.
 
 Default: `false`.
-
-#### Props
-
-`getFieldProps` _{Function}_
-
-Returns an object of props expected by our form input components: `my-sites/domains/components/form`
-
-`countryCode` _{string}_ _Optional_
-
-The user's country code, for example: 'AU', 'GB', 'IT', 'US' and so on. Mainly used to determine the correct postcode label.
-
-Default: `'US'`.

--- a/client/components/domains/registrant-extra-info/README.md
+++ b/client/components/domains/registrant-extra-info/README.md
@@ -9,14 +9,14 @@ things:
 2. Expose a single onChange event that returns the state of it's fields when any of them change
 3. Accept errors & warnings through props and display them with the appropriate fields
 
-### Validation
+## Validation
 
 The `WithContactDetailsValidation` higher order component helps validate
 tld-specific requirements for these forms by running the appropriate JSON
 schema against the user's contact details and passing any errors on to the form
 for display.
 
-#### Validation Schemas
+### Validation Schemas
 
 Validation schemas come from the api endpoint. We keep a copy locally to simplify testing that we generate like this:
 `curl https://public-api.wordpress.com/rest/v1/domains/validation-schemas/uk | jq --tab '.uk' > client/components/domains/registrant-extra-info/test/uk-schema.json`

--- a/client/components/empty-component/README.md
+++ b/client/components/empty-component/README.md
@@ -2,7 +2,7 @@
 
 Useful for stubbing out components that will not build on the server when rendering server-side.
 
-#### How to use:
+## How to use:
 
 In the webpack server [config file](/webpack.config.node.js):
 

--- a/client/components/empty-content/README.md
+++ b/client/components/empty-content/README.md
@@ -4,7 +4,7 @@ EmptyContent is used when a customer has no data to show. This is an opportunity
 
 ## Usage
 
-#### As a full view component
+### As a full view component
 
 ```jsx
 // import the component
@@ -19,7 +19,7 @@ function show( context, next ) {
 }
 ```
 
-#### As an inline component
+### As an inline component
 
 ```jsx
 import EmptyContent from 'components/empty-content';
@@ -34,7 +34,7 @@ render() {
 }
 ```
 
-### Props
+## Props
 
 | Name                    | Type            | Default                                  | Description                                                                                                                                   |
 | ----------------------- | --------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/client/components/file-picker/README.md
+++ b/client/components/file-picker/README.md
@@ -4,7 +4,7 @@ This component opens a native file picker when its children are clicked on.
 It is a very thin wrapper around
 [`component/file-picker`](https://github.com/component/file-picker)
 
-#### How to use:
+## How to use:
 
 ```js
 import FilePicker from 'components/file-picker';
@@ -18,7 +18,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `multiple`: (bool) Allow selecting multiple files (Defaults to `false`).
 - `directory`: (bool) Allow selecting of a directory (Defaults to `false`).

--- a/client/components/focusable/README.md
+++ b/client/components/focusable/README.md
@@ -1,4 +1,4 @@
-## Focusable
+# Focusable
 
 This component lets you wrap complex content in an accessible, clickable wrapper. `Focusable` should be used in place of putting an `onClick` event on a div. It adds [the "button" ARIA role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role), for screen reader support, and enables keyboard support for keyboard-only accessibility.
 
@@ -11,7 +11,7 @@ This component lets you wrap complex content in an accessible, clickable wrapper
 
 If you want to add an action to a larger element, for example the Language Picker, you can use this component. Be aware that a screen reader will read the entire contents of `Focusable` to the user, so _try_ to keep the contents short and actionable.
 
-#### How to use:
+## How to use:
 
 ```jsx
 import Focusable from 'components/focusable';
@@ -25,7 +25,7 @@ export default function InteractiveItem() {
 }
 ```
 
-#### Props
+## Props
 
 - `onClick`: (func) Function called when the button is clicked, or when focused and enter or space are pressed. Required.
 - `onKeyDown`: (func) Function called when focused and any other keyboard event happens (useful for arrow navigation)

--- a/client/components/formatted-header/README.md
+++ b/client/components/formatted-header/README.md
@@ -4,7 +4,7 @@ This component displays a header and optional sub-header.
 
 When the `compactOnMobile` flag is set, the header renders in a compact way on smaller screen sizes.
 
-#### How to use:
+## How to use:
 
 ```js
 import FormattedHeader from 'components/formatted-header';
@@ -19,7 +19,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `brandFont` (`bool`) - use the WP.com brand font for `headerText`
 - `id` (`string`) - ID for the header (optional)

--- a/client/components/forms/README.md
+++ b/client/components/forms/README.md
@@ -2,7 +2,7 @@
 
 This is a directory of shared form components.
 
-### Settings Form Fields
+## Settings Form Fields
 
 The following form components were created as an effort to minimize duplication between site settings and me settings.
 

--- a/client/components/forms/form-toggle/README.md
+++ b/client/components/forms/form-toggle/README.md
@@ -2,7 +2,7 @@
 
 This component is used to implement toggle switches.
 
-#### How to use:
+## How to use:
 
 ```js
 import FormToggle from 'components/forms/form-toggle';
@@ -28,7 +28,7 @@ export default function MyComponent() {
 }
 ```
 
-#### Props
+## Props
 
 - `checked`: (bool) the current status of the toggle.
 - `toggling`: (bool) whether the toggle is in the middle of being performed.

--- a/client/components/gauge/README.md
+++ b/client/components/gauge/README.md
@@ -2,7 +2,7 @@
 
 This component renders a simple gauge to show a percentage visually.
 
-#### How to use:
+## How to use:
 
 ```js
 import Gauge from 'components/gauge';
@@ -14,11 +14,11 @@ render() {
 }
 ```
 
-#### Required Props
+## Required Props
 
 - `percentage`: a numeric percentage between 0-100.
 
-#### Optional Props
+## Optional Props
 
 The following props may be used to override defaults.
 

--- a/client/components/gravatar-caterpillar/README.md
+++ b/client/components/gravatar-caterpillar/README.md
@@ -4,7 +4,7 @@ This component is used to display a row of [gravatars](https://gravatar.com/) fo
 
 On smaller screens (<660px wide), the component will display half the maximum number of gravatars.
 
-#### How to use:
+## How to use:
 
 ```js
 import GravatarCaterpillar from 'components/gravatar-caterpillar';
@@ -16,7 +16,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `users`: an array of users. Required keys: avatar_url, email
 - `maxGravatarsToDisplay`: maximum number of gravatars to display. Defaults to 10.

--- a/client/components/gravatar/README.md
+++ b/client/components/gravatar/README.md
@@ -6,7 +6,7 @@ If the current user has uploaded a new Gravatar recently on Calypso, and therefo
 
 The images size is set at 96px, used at smaller sizes for retina display. Using one size allows us to only request one image and cache it on the browser. Even if you are displaying it at smaller sizes you should not change the source image.
 
-#### How to use:
+## How to use:
 
 ```js
 import Gravatar from 'components/gravatar';
@@ -18,7 +18,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `user`: a User object. Not passing a user puts the component in "placeholder" mode.
 - `alt`: (default: User's display_name) By default the alt text will be User's name, but this can be overridden.

--- a/client/components/happiness-engineers-tray/README.md
+++ b/client/components/happiness-engineers-tray/README.md
@@ -2,7 +2,7 @@
 
 Renders a row of Happiness Engineers' Gravatars.
 
-#### How to use:
+## How to use:
 
 ```jsx
 import HappinessEngineersTray from 'components/happiness-engineers-tray';

--- a/client/components/header-button/README.md
+++ b/client/components/header-button/README.md
@@ -6,7 +6,7 @@ to elements like a `Search`. It takes an `icon` prop that is an ID of a
 the other properties are passed to the `Button` component that is used to
 implement this one.
 
-#### How to use:
+## How to use:
 
 ```js
 import HeaderButton from 'components/header-button';
@@ -20,7 +20,7 @@ function MyHeader() {
 }
 ```
 
-#### Props
+## Props
 
 - `icon` : (string) ID of a `Gridicon` icon
 - `label` : The text label of the button

--- a/client/components/infinite-scroll/README.md
+++ b/client/components/infinite-scroll/README.md
@@ -4,7 +4,7 @@ An infinite scroll component to power list views.
 
 There is an alternative implementation called [InfiniteList](../infinite-list), which doesn't render invisible items. However, it is more complex to implement, so use it only if your list contains lot of images or other media and you expect that users will scroll a lot.
 
-### How to use
+## How to use
 
 First, require the component with
 
@@ -20,7 +20,7 @@ This component does not add any analytics tracking - that is also responsibility
 
 The method accepts an object as an argument, with one key `triggeredByScroll`. It signals if fetching page is a response to user action, or if the component is trying to automatically fill available space. This is to prevent tracking analytics event for cases where more than one page fits to screen.
 
-### Example implementation
+## Example implementation
 
 ```jsx
 class List extends Component {

--- a/client/components/info-popover/README.md
+++ b/client/components/info-popover/README.md
@@ -2,14 +2,14 @@
 
 `InfoPopover` is a component based on `Popover` used to show a popover as a tooltip to a `Gridicon`.
 
-### `InfoPopover` Properties
+## `InfoPopover` Properties
 
-#### `autoRtl { bool } - default: true`
+### `autoRtl { bool } - default: true`
 
 Defines if the Popover should automatically be adjusted for right-to-left contexts.
 `autoRtl={ true }` will swap `right` and `left` position props in RTL context.
 
-#### `position`
+### `position`
 
 The `position` property can be one of the following values:
 
@@ -22,16 +22,16 @@ The `position` property can be one of the following values:
 - `left`
 - `top left`
 
-#### `className`
+### `className`
 
 The `className` lets you specify the style class that the element should have.
 
-#### `gaEventCategory`
+### `gaEventCategory`
 
 The `gaEventCategory` lets you specify the Google Analyics Category that you want the toggle event to have.
 Also reqires the `popoverName` attribute.
 
-#### `popoverName`
+### `popoverName`
 
 The `popoverName` lets you specify the Google Analyics Event name that you want the toggle event to have.
 Also reqires the `gaEventCategory` attribute.
@@ -44,13 +44,13 @@ import { gaRecordEvent } from 'lib/analytics/ga';
 gaRecordEvent( gaEventCategory, 'InfoPopover: ' + popoverName + 'Opened' );
 ```
 
-#### `ignoreContext`
+### `ignoreContext`
 
 The `ignoreContext` lets you specify a component that you want to be on the inside clickOutside context.
 So a context that you want to ignore. In most cases this is not needed but if you want to also have a label
 that can trigger the opening and closing of the InfoPopover then you need to pass in the label component as a reference.
 
-### Basic `InfoPopover` Usage
+## Basic `InfoPopover` Usage
 
 ```js
 <InfoPopover position="bottom left">This is some informational text</InfoPopover>;

--- a/client/components/input-chrono/README.md
+++ b/client/components/input-chrono/README.md
@@ -16,15 +16,11 @@ export default class extends React.Component {
 
 	render() {
 		return <InputChrono onSet={ this.onSet }/>;
-	} 
+	}
 }
 ```
 
----
-
-## InputChrono
-
-#### Props
+### Props
 
 `value` - **optional** initial input value
 

--- a/client/components/jetpack-colophon/README.md
+++ b/client/components/jetpack-colophon/README.md
@@ -4,7 +4,7 @@ This component is used to display a "Powered by Jetpack" colophon, usually on th
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import JetpackColophon from 'components/jetpack-colophon';

--- a/client/components/jetpack-logo/README.md
+++ b/client/components/jetpack-logo/README.md
@@ -4,7 +4,7 @@ This component is used to display a Jetpack logo
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import JetpackLogo from 'components/jetpack-logo';
@@ -18,7 +18,7 @@ export default function JetpackLogoExample() {
 }
 ```
 
-#### Props
+## Props
 
 - `className` : (string) Custom class name to be added to the SVG element
 - `full` : (bool) Whether or not to show the Jetpack text alongside the icon

--- a/client/components/jetpack-plus-wpcom-logo/README.md
+++ b/client/components/jetpack-plus-wpcom-logo/README.md
@@ -4,7 +4,7 @@ This component is used to display the Jetpack Plus WPCOM logo (a Jetpack logo, a
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import JetpackPlusWpComLogo from 'components/jetpack-plus-wpcom-logo';
@@ -18,7 +18,7 @@ export default function JetpackPlusWpComLogoExample() {
 }
 ```
 
-#### Props
+## Props
 
 - `className` : (string) Custom class name to be added to the SVG element
 - `size` : (number) The height of the SVG. Default is `32`

--- a/client/components/jetpack/card/jetpack-bundle-card/README.md
+++ b/client/components/jetpack/card/jetpack-bundle-card/README.md
@@ -4,7 +4,7 @@ This component is used to display a Jetpack bundle card.
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import JetpackBundleCard from 'components/jetpack/card/jetpack-bundle-card';
@@ -18,6 +18,6 @@ export default function JetpackBundleCardExample() {
 }
 ```
 
-#### Props
+## Props
 
 See `components/jetpack/card/jetpack-product-card`;

--- a/client/components/jetpack/card/jetpack-plan-card/README.md
+++ b/client/components/jetpack/card/jetpack-plan-card/README.md
@@ -4,7 +4,7 @@ This component is used to display a Jetpack plan card.
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import JetpackPlanCard from 'components/jetpack/card/jetpack-plan-card';
@@ -18,6 +18,6 @@ export default function JetpackPlanCardExample() {
 }
 ```
 
-#### Props
+## Props
 
 See props at `components/jetpack/card/jetpack-product-card`;

--- a/client/components/jetpack/card/jetpack-product-card/README.md
+++ b/client/components/jetpack/card/jetpack-product-card/README.md
@@ -4,7 +4,7 @@ This component is used to display a Jetpack product card.
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
@@ -25,7 +25,7 @@ export default function JetpackProductCardExample() {
 }
 ```
 
-#### Props
+## Props
 
 | Name                 | Type         | Default | Description                                                                                |
 | -------------------- | ------------ | ------- | ------------------------------------------------------------------------------------------ |

--- a/client/components/language-picker/README.md
+++ b/client/components/language-picker/README.md
@@ -59,7 +59,7 @@ The `LanguagePicker` is a form component with API similar to a HTML `input` or `
 element - its value is specified in a `value` prop, and it calls an `onChange` handler
 when its value changes.
 
-#### Props
+### Props
 
 `languages` - **required** Array with information about languages, their names, language
 slugs, popularity etc. It's exported by `config` module under the `languages` key.

--- a/client/components/list-end/README.md
+++ b/client/components/list-end/README.md
@@ -4,7 +4,7 @@ This component is used to display a WordPress logo in the centre of a line. It s
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import ListEnd from 'components/list-end';

--- a/client/components/main/README.md
+++ b/client/components/main/README.md
@@ -2,7 +2,7 @@
 
 Component used to declare the main area of any given section —- it's the main wrapper that gets rendered first inside `#primary`.
 
-#### How to use:
+## How to use:
 
 ```jsx
 import Main from 'components/main';
@@ -16,7 +16,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `className`: Add your own CSS class to the wrapper.
 - `wideLayout`: Use wide layout (larger `max-width`) for the section.

--- a/client/components/null-component/README.md
+++ b/client/components/null-component/README.md
@@ -2,7 +2,7 @@
 
 Useful for stubbing out components that will not build on the server when rendering server-side.
 
-#### How to use:
+## How to use:
 
 In the webpack server [config file](/webpack.config.node.js):
 

--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -3,33 +3,33 @@
 `Popover` is a react component that can be used to show any content in a
 popover.
 
-### Properties
+## Properties
 
-#### `autoPosition { bool } - default: true`
+### `autoPosition { bool } - default: true`
 
 Defines if the Popover should be automatically positioned under specific
 circumstances. For instance when the window is scrolled, the viewport is
 resized, etc.
 
-#### `autoRtl { bool } - default: true`
+### `autoRtl { bool } - default: true`
 
 Defines if the Popover should automatically be adjusted for right-to-left
 contexts. `autoRtl={ true }` will swap `right` and `left` position props in RTL
 context.
 
-#### `className { string } - optional`
+### `className { string } - optional`
 
 Set a custom className for the main container. Keep in mind that `popover`
 className will be always added to the instance.
 
-#### `closeOnEsc { bool } - default: true`
+### `closeOnEsc { bool } - default: true`
 
-#### `context { DOMElement | ref }`
+### `context { DOMElement | ref }`
 
 The `context` property must be set to a DOMElement or React ref to the element
 the popover should be attached to (point to).
 
-#### `customPosition { object }`
+### `customPosition { object }`
 
 Provide a custom position to render the popover at. The parent component takes all
 responsibility for moving the popover on resize and scroll.
@@ -40,12 +40,12 @@ Example:
 
 You can specify `positionClass` to control which way the popover arrow points.
 
-#### `id { string } - optional`
+### `id { string } - optional`
 
 Use this optional property to set a Popover identifier among all of the Popover
 instances. This property has been thought for development purpose.
 
-#### `ignoreContext`
+### `ignoreContext`
 
 The `ignoreContext` lets you specify a component that you want to be on the
 inside clickOutside context. So a context that you want to ignore. In most
@@ -53,7 +53,7 @@ cases this is not needed but if you want to also have a label
 that can trigger the opening and closing of the Popover then you need to pass
 in the label component as a reference.
 
-#### `isVisible { bool } default - false`
+### `isVisible { bool } default - false`
 
 By controlling the popover's visibility through the `isVisible` property, the
 popover itself is responsible for providing any CSS transitions to
@@ -61,7 +61,7 @@ animate the opening/closing of the popover. This also keeps the parent's code
 clean and readable, with a minimal amount of boilerplate code required to show
 a popover.
 
-#### `position { string } - default: 'top'`
+### `position { string } - default: 'top'`
 
 The `position` property can be one of the following values:
 
@@ -78,23 +78,23 @@ This describes the position of the popover relative to the thing it is pointing
 at. If the arrow is supposed to point at something to the top and left of the
 Popover, the correct value for `position` is `bottom right`.
 
-#### `showDelay { number } - default: 0 (false)`
+### `showDelay { number } - default: 0 (false)`
 
 Adds a delay before to show the popover. Its value is defined in `milliseconds`.
 
-#### `onClose { func }`
+### `onClose { func }`
 
 The popover's `onClose` property must be set, and should modify the parent's
 state such that the popover's `isVisible` property will be false when `render`
 is called.
 
-#### `onShow { func } - optional`
+### `onShow { func } - optional`
 
 This function will be executed when the popover is shown.
 
-### Usage notes
+## Usage notes
 
-#### Within modals / dialogs
+### Within modals / dialogs
 
 When using a popover within a modal applying the class `is-dialog-visible` to the `Popover` component will cause it to gain the correct `z-index` to allow it to display correctly within the modal.
 
@@ -112,35 +112,35 @@ in a popover. It is fully keyboard accessible.
 `PopoverMenuItem` is a component used to represent a single item in a
 `PopoverMenu`.
 
-### Properties
+## Properties
 
-#### `href { string } - optional`
+### `href { string } - optional`
 
 If set, `PopoverMenuItem` will be rendered as a link; otherwise, it will be
 rendered as a button.
 
-#### `className { string } - optional`
+### `className { string } - optional`
 
 Sets a custom className on the button or link.
 
-#### `isSelected { bool } - default: false`
+### `isSelected { bool } - default: false`
 
 Defines whether or not the `PopoverMenuItem` is the currently selected one.
 
-#### `icon { string } - optional`
+### `icon { string } - optional`
 
 If set, a `Gridicon` is rendered, where its `icon` prop is set to this value.
 
-#### `focusOnHover { bool } - default: true`
+### `focusOnHover { bool } - default: true`
 
 Defines whether or not the `PopoverMenuItem` should receive the focus when it
 is hovered over.
 
-#### `children { node } - optional`
+### `children { node } - optional`
 
 The children to render inside of the `PopoverMenuItem`.
 
-### `Popover` Usage
+## `Popover` Usage
 
 ```jsx
 <button
@@ -161,7 +161,7 @@ The children to render inside of the `PopoverMenuItem`.
 </Popover>
 ```
 
-### `PopoverMenu` Usage
+## `PopoverMenu` Usage
 
 ```jsx
 <button

--- a/client/components/post-schedule/README.md
+++ b/client/components/post-schedule/README.md
@@ -39,7 +39,7 @@ export default class extends React.Component {
 			/>
 		);
 	}
-	
+
 	// ...
 
 }
@@ -49,7 +49,7 @@ export default class extends React.Component {
 
 ## PostSchedule
 
-#### Props
+### Props
 
 `events` - **optional** Array - Events array to print into the calendar.
 

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -17,7 +17,7 @@ plan).
 
 See p1HpG7-7ET-p2 for more details.
 
-### How to use the `<ProductCard />`
+## How to use the `<ProductCard />`
 
 ```jsx
 import React, { Fragment } from 'react';
@@ -42,7 +42,7 @@ export default class extends React.Component {
 }
 ```
 
-### <a name="how-purchase-prop-works"></a>How `purchase` prop works
+## <a name="how-purchase-prop-works"></a>How `purchase` prop works
 
 The component can be in two visual and functional states:
 
@@ -50,7 +50,7 @@ The component can be in two visual and functional states:
   has purchase options, they will be listed below the description.
 - `purchase` prop is set - the content area will not contain product options (if they exist).
 
-### `<ProductCard />` props
+## `<ProductCard />` props
 
 The following props can be passed to the Product Card component:
 
@@ -74,7 +74,7 @@ The following props can be passed to the Product Card component:
 Product Card Promo Nudge is a Product Card's sub-component for rendering a promotion nudge. It consists of a badge label
 (a green star sticker to the left) and a promo text. Both props are optional.
 
-### How to use the `<ProductCardPromoNudge />`
+## How to use the `<ProductCardPromoNudge />`
 
 ```jsx
 import React, { Fragment } from 'react';
@@ -103,7 +103,7 @@ export default class extends React.Component {
 }
 ```
 
-### `<ProductCardPromoNudge />` Props
+## `<ProductCardPromoNudge />` Props
 
 The following props can be passed to the Product Card Promo Nudge component:
 
@@ -116,7 +116,7 @@ The following props can be passed to the Product Card Promo Nudge component:
 Product Card Options is a Product Card's sub-component for rendering purchase options inside the card. It's meant to
 be passed to the Product Card as a child component.
 
-### How to use the `<ProductCardOptions />`
+## How to use the `<ProductCardOptions />`
 
 ```jsx
 import React, { useState } from 'react';
@@ -161,7 +161,7 @@ export default class extends React.Component {
 }
 ```
 
-### `<ProductCardOptions />` Props
+## `<ProductCardOptions />` Props
 
 The following props can be passed to the Product Card Options component:
 
@@ -188,7 +188,7 @@ The following props can be passed to the Product Card Options component:
 Product Card Action is a Product Card's sub-component for rendering action section. It consists of an intro
 text (optional) and a button.
 
-### How to use the `<ProductCardAction />`
+## How to use the `<ProductCardAction />`
 
 ```jsx
 import React from 'react';
@@ -213,7 +213,7 @@ export default class extends React.Component {
 }
 ```
 
-### `<ProductCardAction />` Props
+## `<ProductCardAction />` Props
 
 The following props can be passed to the Product Card Action component:
 

--- a/client/components/product-expiration/README.md
+++ b/client/components/product-expiration/README.md
@@ -4,29 +4,29 @@
 
 At minimum, it requires an expiry date to display when the product will renew.
 
-### Properties
+## Properties
 
-#### `dateFormat { string } - default 'LL'`
+### `dateFormat { string } - default 'LL'`
 
 This controls the formatting of the date format, which is passed to a localized `moment.format`.
 
-#### `expiryDateMoment { moment }`
+### `expiryDateMoment { moment }`
 
 This is the expiration date as a `moment` instance, and is required for display.
 
-#### `renewDateMoment { moment }`
+### `renewDateMoment { moment }`
 
 This is the date on which the product will be auto-renewed, as a `moment` instance, used only when provided.
 
-#### `isRefundable { boolean } - default false`
+### `isRefundable { boolean } - default false`
 
 Controls whether the product is currently in the refund window, which changes the display to the purchase date, if provided.
 
-#### `purchaseDateMoment { moment } - optional`
+### `purchaseDateMoment { moment } - optional`
 
 Optional purchase date, used only when `isRefundable` provided.
 
-### Usage
+## Usage
 
 ```jsx
 const expiryDateMoment = moment( product.expiry );

--- a/client/components/rating/README.md
+++ b/client/components/rating/README.md
@@ -3,7 +3,7 @@
 This component is used to display a set of 5 stars, full colored, empty or half-colored,
 that represents a rating in a scale between 0 and 5.
 
-#### How to use:
+## How to use:
 
 ```js
 import Rating from 'components/rating';
@@ -18,7 +18,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `rating`: Number - A number with the 0-100 rating to render
 

--- a/client/components/section-header/README.md
+++ b/client/components/section-header/README.md
@@ -33,13 +33,13 @@ export default localize( MyHeader );
 
 This is the base component and acts as a wrapper for a section's (a list of cards) title and any action buttons that act upon that list (like Bulk Edit or Add New Item).
 
-#### Props
+### Props
 
 - `className` - _optional_ (string|object) Classes to be added to the rendered component.
 - `label` - _optional_ (string) The text to be displayed in the header.
 - `popoverText` - _optional_ (string) If entered, a support popover will appear to the right with this text.
 
-### General guidelines
+## General guidelines
 
 - Use clear and accurate labels.
 - Use sentence-style capitalization except when referring to an official/branded feature or service name (e.g. Simple Payments).

--- a/client/components/section-nav/README.md
+++ b/client/components/section-nav/README.md
@@ -15,7 +15,7 @@ import NavSegmented from 'components/section-nav/segmented';
 import NavItem from 'components/section-nav/item';
 import Search from 'components/search';
 
-export default class extends React.Component { 
+export default class extends React.Component {
 	// ...
 
 	render() {
@@ -63,7 +63,7 @@ Keep in mind that every `prop` referenced in the example can and _should_ be dyn
 
 The base component is `SectionNav` and acts as the wrapper for various control groups / other elements.
 
-#### Props
+### Props
 
 `selectedText` - **required** (node - anything that can be rendered)
 
@@ -81,7 +81,7 @@ The tabs sub component will render items inline when there is enough horizontal 
 
 ![Nav Tabs Example](https://cldup.com/SG0UuJKr3i.png)
 
-#### Props
+### Props
 
 `selectedText` - **required** (string)
 
@@ -112,7 +112,7 @@ The segmented sub component utilizes [`SegmentedControl`](/client/components/seg
 
 > Note: `SectionNav` relies on flex box techniques for sizing and that `NavSegmented` will not be allowed to overflow available horizontal space.
 
-#### Props
+### Props
 
 `label` - _optional_ (string)
 
@@ -129,7 +129,7 @@ Text displayed above tabs group when:
 
 These are the sub components that make up the children of both `NavTabs` & `NavSegmented`. They represent the options under each control group.
 
-#### Props
+### Props
 
 `path` - _optional_ (string)
 

--- a/client/components/share-button/README.md
+++ b/client/components/share-button/README.md
@@ -4,7 +4,7 @@ ShareButton is a component which allows you to open a popup window to share cont
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import ShareButton from 'components/share-button';
@@ -28,7 +28,7 @@ function MyButton() {
 
 ---
 
-#### Props
+## Props
 
 - `size`: (string) The size of the button
 - `url`: (string) The URL of the content to share

--- a/client/components/sidebar-navigation/README.md
+++ b/client/components/sidebar-navigation/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the mobile sidebar navigation header at the top of content sections. It sets `layout-focus` to `sidebar`.
 
-#### How to use:
+## How to use:
 
 Put the component in your `Main` component, and wrap it around any components you want it to display as its children. It relies on the [`document-head`](/client/state/document-head) Redux subtree, whose fields you can set through the [`DocumentHead`](/client/components/data/document-head) component. It handles detecting the selected site.
 

--- a/client/components/site-selector-modal/README.md
+++ b/client/components/site-selector-modal/README.md
@@ -2,7 +2,7 @@
 
 Site selector modal component: displays a modal for selecting one of a user's sites.
 
-### `index.jsx`
+## `index.jsx`
 
 Renders a modal displaying a `SitesDropdown` element, a `Back` and a call-for-action button,
 plus optionally some custom content.

--- a/client/components/site-title/README.md
+++ b/client/components/site-title/README.md
@@ -2,7 +2,7 @@
 
 Site Title Control component: Form input controls to set a site's title and tagline.
 
-### `index.jsx`
+## `index.jsx`
 
 Renders two `FormTextInput` components to set a site's title and tagline, respectively.
 
@@ -11,7 +11,7 @@ props, respectively, and pass an `onChange` function prop (accepting an object w
 
 For an example of how to use, have a look at [docs/example.jsx](docs/example.jsx).
 
-#### Props
+## Props
 
 - `autoFocusBlogname` - _optional_ (bool) Whether to auto-focus the site title input field (defaults to `false`).
 - `blogname` - _optional_ (string) Site title to be displayed in corresponding input field.

--- a/client/components/sites-dropdown/README.md
+++ b/client/components/sites-dropdown/README.md
@@ -4,7 +4,7 @@ Renders a dropdown component for selecting a site. This is the canonical site pi
 
 It supports searching if you have many sites, handles sites with empty titles, sites with redirects, etc.
 
-#### How to use:
+## How to use:
 
 ```js
 import SitesDropdown from 'components/sites-dropdown';
@@ -16,7 +16,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 (All optional)
 

--- a/client/components/sites-popover/README.md
+++ b/client/components/sites-popover/README.md
@@ -2,6 +2,6 @@
 
 This component wraps the [Site Selector](../site-selector) component in a [Popover](../popover), allowing a user to pick one of his sites from a list that pops up like a context menu e.g. when clicking on a button.
 
-### Props
+## Props
 
 The component accepts props `visible`, `context`, `onClose`, and `position`. All of these props are passed on to Popover (`visible` is mapped to Popover's `isVisible`). For their documentation, please refer to [Popover's README.md](../popover/README.md).

--- a/client/components/sub-masterbar-nav/README.md
+++ b/client/components/sub-masterbar-nav/README.md
@@ -2,13 +2,13 @@
 
 This component displays a navigation header under the masterbar.
 
-### How to use:
+## How to use:
 
-The component should be inserted into a `Main` component.  
-Options should contain a `label` and an `uri`. If the latter matches the `uri` property of the component, it will be marked as selected.  
+The component should be inserted into a `Main` component.
+Options should contain a `label` and an `uri`. If the latter matches the `uri` property of the component, it will be marked as selected.
 In case no option is selected, the `fallback` value will be shown in the dropdown.
 
-`icon` should be a valid gridicon name. The icon will be displayed next to/on top of the label.  
+`icon` should be a valid gridicon name. The icon will be displayed next to/on top of the label.
 If no `icon` is provided, `star` will be used by default.
 
 ```js

--- a/client/components/theme/README.md
+++ b/client/components/theme/README.md
@@ -2,7 +2,7 @@
 
 Theme component: displays a theme screenshot and details.
 
-### `index.jsx`
+## `index.jsx`
 
 Renders a theme by displaying its name, price, and screenshot.
 

--- a/client/components/themes-list/README.md
+++ b/client/components/themes-list/README.md
@@ -2,7 +2,7 @@
 
 Themes list component: displays a list of Theme components.
 
-### `index.jsx`
+## `index.jsx`
 
 Given an array of themes, this component creates a corresponding list of theme components to display
 information about those themes.
@@ -10,7 +10,7 @@ information about those themes.
 Each item in the `themes` array prop must contain theme attributes that can be used by the `Theme` component.
 Other accepted props are two boolean flags and a callback, all of which are related to pagination.
 
-#### Props
+## Props
 
 - `emptyContent`: element ( optional ), element that will be displayed when the list is empty, if null or not provided default EmptyContent will be used.
 

--- a/client/components/tile-grid/README.md
+++ b/client/components/tile-grid/README.md
@@ -2,7 +2,7 @@
 
 Component used to declare an area for displaying Tiles — it's the main wrapper that takes care of tile alignment and positioning.
 
-#### Props
+## Props
 
 - `className`: Add your own class to the grid.
 
@@ -12,7 +12,7 @@ Component used to declare an area for displaying Tiles — it's the main wrapper
 
 Component used to display a clickable tile with an image, call to action, and description.
 
-#### Props
+## Props
 
 - `buttonClassName`: Add your own class to the tile button.
 - `buttonLabel`: Text of the button.
@@ -25,7 +25,7 @@ Component used to display a clickable tile with an image, call to action, and de
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import Tile from 'components/tile-grid/tile';

--- a/client/components/timezone/README.md
+++ b/client/components/timezone/README.md
@@ -9,7 +9,7 @@ import Timezone from 'components/timezone';
 
 export default class extends React.Component {
 	// ...
-	
+
 	onTimezoneSelect = ( zone ) => {
 		console.log( `timezone selected: %s`, zone.value );
 	}
@@ -26,9 +26,7 @@ export default class extends React.Component {
 }
 ```
 
-## Timezone
-
-#### Props
+## Props
 
 `selectedZone` - **optional** String value to define the selected timezone.
 

--- a/client/components/tinymce/plugins/embed/README.md
+++ b/client/components/tinymce/plugins/embed/README.md
@@ -2,7 +2,7 @@
 
 Component used to show an embedded URL in a dialog
 
-#### Props
+## Props
 
 - `embedUrl`: The URL of the content to show
 - `isVisible`: Whether or not the dialog is visible
@@ -11,7 +11,7 @@ Component used to show an embedded URL in a dialog
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import EmbedDialog from 'components/tinymce/plugins/embed';

--- a/client/components/token-field/README.md
+++ b/client/components/token-field/README.md
@@ -6,7 +6,7 @@ Up to one hundred suggestions that match what the user has typed so far will be 
 
 The `value` property is handled in a manner similar to controlled form components. See [Forms](https://facebook.github.io/react/docs/forms.html) in the React Documentation for more information.
 
-### Keyboard Accessibility
+## Keyboard Accessibility
 
 - `left arrow` - if input field is empty, move insertion point before previous token
 - `right arrow` - if input field is empty, move insertion point after next token
@@ -15,7 +15,7 @@ The `value` property is handled in a manner similar to controlled form component
 - `tab` / `enter` - if suggestion selected, insert suggestion as a new token; otherwise, insert value typed into input as new token
 - `comma` - insert value typed into input as new token
 
-### Properties
+## Properties
 
 - `value` - An array of strings or objects to display as tokens in the field. If objects are present in the array, they **must** have a property of `value`. Here is an example object that could be passed in as a value:
 
@@ -65,7 +65,7 @@ The `value` property is handled in a manner similar to controlled form component
 
 - `isExpanded` - If true, the `TokenField` input will always keep the suggestion list expanded.
 
-### Example
+## Example
 
 ```jsx
 class MyComponent extends React.Component {

--- a/client/components/tooltip/README.md
+++ b/client/components/tooltip/README.md
@@ -2,7 +2,7 @@
 
 A `Tooltip` allows you to add contextual and other information where needed. For example, `Tooltip` is used to display extra information, on hover, about icon-only buttons.
 
-### Properties
+## Properties
 
 - `status` - (string) Modifies the style of the `Tooltip`. Can be one of the following: `error`, `warning`, or `success`.
 - `showOnMobile` - (bool) When true, will show `Tooltip` on mobile screens. By default, `Tooltip` is not displayed for mobile devices.

--- a/client/components/translator-invite/README.md
+++ b/client/components/translator-invite/README.md
@@ -8,12 +8,12 @@ This component invites users to translate WordPress.com into a non-default local
 
 If a locale is found, the component fetches the localized name of the language.
 
-#### Usage:
+## Usage:
 
 ```javascript
 <TranslatorInvite path={ path } />;
 ```
 
-#### Props
+## Props
 
 - `path`: {string} (optional) Current path

--- a/client/components/wpcom-colophon/README.md
+++ b/client/components/wpcom-colophon/README.md
@@ -4,7 +4,7 @@ This component is used to display a "In partnership with WordPress.com" colophon
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import WpcomColophon from 'components/wpcom-colophon';

--- a/client/devdocs/docs-example/README.md
+++ b/client/devdocs/docs-example/README.md
@@ -2,7 +2,7 @@
 
 This component is used to implement a skeleton for components examples which are generally showcased in the devdocs.
 
-#### How to use:
+## How to use:
 
 ```es6
 import DocsExample from 'devdocs/design/docs-example';
@@ -20,7 +20,7 @@ render: function() {
 }
 ```
 
-#### Props
+## Props
 
 - `usageStats`: (object) An object containing the usage stats e.g. `{ count: 10 }`.
 - `toggleHandler`: (func) A function to toggle the example state.

--- a/client/extensions/woocommerce/components/d3/base/README.md
+++ b/client/extensions/woocommerce/components/d3/base/README.md
@@ -2,7 +2,7 @@
 
 Integrate React Lifecyle methods with d3.js charts.
 
-### Base Component Responsibilities
+## Base Component Responsibilities
 
 - Create and manage mounting and unmounting parent `div` and `svg`
 - Handle resize events, resulting re-renders, and event listeners

--- a/client/extensions/woocommerce/components/dashboard-widget/README.md
+++ b/client/extensions/woocommerce/components/dashboard-widget/README.md
@@ -2,7 +2,7 @@
 
 This component sets up some basic styling for dashboard widgets. It allows for full-, half-, and third-width widgets in a row, and has responsive styling for smaller screens. There is also support for adding images, and a per-widget settings panel.
 
-#### How to use:
+## How to use:
 
 ```js
 import DashboardWidget from 'woocommerce/components/dashboard-widget';
@@ -19,7 +19,7 @@ render: function() {
 }
 ```
 
-#### Props `<DashboardWidget />`
+## Props `<DashboardWidget />`
 
 - `className`: Additional classes
 - `title`: Widget title, if set displays in an `h2` before the widget children
@@ -30,6 +30,6 @@ render: function() {
 - `onSettingsClose`: Function called when the settings panel is closed
 - `width`: The width of this widget in a row, one of `'half', 'full', 'third', 'two-thirds'`
 
-#### Props `<DashboardWidgetRow />`
+## Props `<DashboardWidgetRow />`
 
 - `className`: Additional classes

--- a/client/extensions/woocommerce/components/product-search/README.md
+++ b/client/extensions/woocommerce/components/product-search/README.md
@@ -2,7 +2,7 @@
 
 This component is used to search through the products on a given site.
 
-#### How to use:
+## How to use:
 
 To select multiple products:
 
@@ -42,7 +42,7 @@ render: function() {
 }
 ```
 
-#### Props
+## Props
 
 - `onChange`: Function called when a result is clicked, with product object as an argument.
 

--- a/client/extensions/woocommerce/components/table/README.md
+++ b/client/extensions/woocommerce/components/table/README.md
@@ -6,7 +6,7 @@ The `compact` prop applies styling for a more compact table. It also allows for 
 
 ![screen shot 2017-06-13 at 11 42 53 am](https://user-images.githubusercontent.com/1922453/27059946-c1ff77f6-502d-11e7-9af5-aaecd09bb335.png)
 
-#### How to use:
+## How to use:
 
 ```js
 import Table from 'woocommerce/components/table';
@@ -38,19 +38,19 @@ render: function() {
 }
 ```
 
-#### Props `<Table/>`
+## Props `<Table/>`
 
 - `header`: A `<TableRow />` element used to define the table's head.
 - `className`: Classes added to top level element.
 - `compact`: Denotes a more compact table.
 
-#### Props `<TableRow/>`
+## Props `<TableRow/>`
 
 - `className`: Classes added to top level element.
 - `isHeader`: Establishes row as being used for table head.
 - `href`: Optional link, if set, the row becomes clickable/focusable.
 
-#### Props `<TableItem/>`
+## Props `<TableItem/>`
 
 - `alignRight`: Apply `text-align: right` on an item.
 - `className`: Classes added to top level element.

--- a/client/extensions/woocommerce/lib/analytics/README.md
+++ b/client/extensions/woocommerce/lib/analytics/README.md
@@ -5,7 +5,7 @@ This library is for adding analytics code to Store on WP.com
 It's designed to consolidate things like verifying we're using the same prefix on
 all track event ids, and perhaps to add some common event properties automatically.
 
-### How to use:
+## How to use:
 
 ```js
 import { recordTrack } from 'woocommerce/lib/analytics';
@@ -16,9 +16,9 @@ recordTrack( 'calypso_woocommerce_event_to_be_tracked', {
 } );
 ```
 
-### Functions
+## Functions
 
-#### `recordTrack( eventName, eventProperties )`
+### `recordTrack( eventName, eventProperties )`
 
 Arguments:
 

--- a/client/layout/masterbar/README.md
+++ b/client/layout/masterbar/README.md
@@ -7,15 +7,15 @@ there.
 These components should not be called directly. They are managed by the main
 layout components.
 
-### masterbar.jsx
+## masterbar.jsx
 
 This is the masterbar skeleton header and styling, used by logged-out.jsx and
 logged-in.jsx respectively, which pass their items as children to this component.
 
-### logged-out.jsx
+## logged-out.jsx
 
 Renders a logged-out masterbar with only a "Wordpress.com" link.
 
-### logged-in.jsx
+## logged-in.jsx
 
 Renders the masterbar with `props.user` data for displaying the user avatar.

--- a/client/lib/catch-js-errors/README.md
+++ b/client/lib/catch-js-errors/README.md
@@ -10,7 +10,7 @@ If enabled, this module captures `window.onerror` calls and sends them to the AP
 
 For hard-to-debug cases, `log` function is being exported to log unusual events.
 
-#### Example
+### Example
 
 ```JavaScript
 import log from 'lib/catch-js-errors/log';
@@ -20,7 +20,7 @@ log( 'This is unexpected', { additionalData: 'data' } );
 
 ```
 
-#### Use cases
+### Use cases
 
 - A piece of code you suspect is dead
 - Function that is triggered by weird parameters
@@ -28,7 +28,7 @@ log( 'This is unexpected', { additionalData: 'data' } );
 
 Generally, whenever you are wondering "what kind of users hit this place?" or you want to gather more data to debug a hard error, you can use the logger to make your life a bit easier.
 
-#### Gotchas
+### Gotchas
 
 Logger is initialized only on non-SSR environment and after initializing redux store. So you want be able to log any redux discrepencies.
 This is actually good, since you dont want to log any action that can flood the endpoint.

--- a/client/lib/data-poller/README.md
+++ b/client/lib/data-poller/README.md
@@ -9,7 +9,7 @@
 
 The module works by initiating polling when the data module has one or more objects listening for a `change` and stopping when there are no longer any `change` events bound. Polling is also paused when the visibility state of the page changes to hidden and resumed when the page is focused, unless the `pauseWhenHidden` option is set to `false`.
 
-# Usage
+## Usage
 
 ### Pollers#add( store, method, [options] )
 
@@ -26,7 +26,7 @@ Add a new poller that fetches updates
 
 - @param {int|object} `poller` - id or instance of the poller to remove
 
-# Example
+## Example
 
 ```js
 import PollerPool from 'lib/data-poller' );

--- a/client/lib/desktop/README.md
+++ b/client/lib/desktop/README.md
@@ -5,7 +5,7 @@ Provides an interface between Calypso and [Electron](https://github.com/atom/ele
 Note this module only runs when the `desktop` feature is enabled. The `ipc` module is defined as an external in Calypso, and so will only
 run inside Electron (where `ipc` is defined).
 
-#### Input Events
+## Input Events
 
 The following events can be sent to Calypso from Electron via IPC:
 
@@ -18,7 +18,7 @@ The following events can be sent to Calypso from Electron via IPC:
 - `cookie-auth-complete` - Forces the notification client to refresh (with new cookie details)
 - `page-help` - Navigate to the help page
 
-#### Output Events
+## Output Events
 
 The following events are sent from Calypso to Electron via IPC:
 

--- a/client/lib/directly/README.md
+++ b/client/lib/directly/README.md
@@ -21,13 +21,13 @@ should be wrapped here rather than called using the `window.DirectlyRTM()` funct
 
 The following functions are provided:
 
-#### `initialize()`
+### `initialize()`
 
 Configures the RTM widget and loads all its third-party assets (about 200KB at the time of
 writing). If the user has recently interacted with the RTM widget, it will open up on
 initialization (an unavoidable part of the library's mount).
 
-#### `askQuestion( questionText, name, email )`
+### `askQuestion( questionText, name, email )`
 
 Asks a question with the given params and opens the "Alerting experts" view. All parameters
 are required strings. This also initializes the RTM widget if it hasn't already been done.

--- a/client/lib/follow-list/README.md
+++ b/client/lib/follow-list/README.md
@@ -7,7 +7,7 @@ import FollowList from 'follow-list';
 const followList = FollowList();
 ```
 
-### add( { site_id: site.ID, is_following: true } )
+## add( { site_id: site.ID, is_following: true } )
 
 If the `site_id` being passed in does not yet exist in the array of `followList` data, a new `FollowListSite` object is created and added to the array. The method returns the instance of the `FollowListSite` so you can use that object to subscribe to change events:
 
@@ -23,11 +23,11 @@ const newFollowListSite = followList.add( { site_id: 1, is_following: false } );
 
 Instances of `FollowListSite` are created using the steps outlined above.
 
-### follow()
+## follow()
 
 If the `is_following === false` this method will call the api to start following the site. Once the api operation complets, a change event is fired.
 
-### unfollow()
+## unfollow()
 
 If the `is_following === true` this method will call the api to stop following the site. Once the api operation complets, a change event is fired.
 

--- a/client/lib/memoize-last/README.md
+++ b/client/lib/memoize-last/README.md
@@ -7,7 +7,7 @@ previous one through a shallow comparison.
 Useful when you don't want to maintain an arbitrarily large cache of previous
 invocations and are happy just remembering the last one.
 
-### Usage:
+## Usage:
 
 ```
 import memoizeLast from 'lib/memoize-last';

--- a/client/lib/mixins/data-observe/README.md
+++ b/client/lib/mixins/data-observe/README.md
@@ -4,7 +4,7 @@
 
 A React mixin that makes it easy to trigger re-rendering of a component when a `prop` emits a `change` event.
 
-### Usage
+## Usage
 
 ```js
 import observe from 'lib/mixins/data-observe';

--- a/client/lib/mobile-app/README.md
+++ b/client/lib/mobile-app/README.md
@@ -2,7 +2,7 @@
 
 This module contains a function to identify whether requests are coming from the WordPress mobile apps.
 
-### Usage
+## Usage
 
 Simple usage:
 

--- a/client/lib/network-connection/README.md
+++ b/client/lib/network-connection/README.md
@@ -22,7 +22,7 @@ Network connection keeps current network connection status. To check it use:
 NetworkConnectionApp.isConnected();
 ```
 
-#### Sending events
+## Sending events
 
 There are to methods that can be used to emit connection status change.
 
@@ -38,7 +38,7 @@ When you want to notify that network connection has been lost use:
 NetworkConnectionApp.emitDisconnected();
 ```
 
-#### Responding to events
+## Responding to events
 
 It is possible to listen for network connection status change. Events will be fired only when connection changes status from connected to disconnected or other way around.
 

--- a/client/lib/oauth-store/README.md
+++ b/client/lib/oauth-store/README.md
@@ -2,7 +2,7 @@
 
 A flux store to provide the data needed for the OAuth login page.
 
-#### Data
+## Data
 
 This module exposes four pieces of data and emits a `change` event when any of them are changed:
 
@@ -11,7 +11,7 @@ This module exposes four pieces of data and emits a `change` event when any of t
 - `errorLevel` - an error code associated with the last request
 - `errorMessage` - a user-visible error message associated with the last request
 
-#### Actions
+## Actions
 
 The action methods include:
 

--- a/client/lib/performance-tracking/README.md
+++ b/client/lib/performance-tracking/README.md
@@ -2,9 +2,9 @@
 
 This lib provides wrappers around `@automattic/browser-data-collector`
 
-### Start
+## Start
 
-#### Generic function
+### Generic function
 
 It provides a function `startPerformanceTracking()` that accepts the name of the page being tracked and a flag for full page loads. It is a simple
 wrapper around the `start` method in `@automattic/browser-data-collector` with an additional check to validate that the performance tracking is
@@ -13,7 +13,7 @@ enabled for this environment (by checking the feature flag `rum-tracking/logstas
 Unless there is a specialized wrapper (eg: middleware `performanceTrackerStart`), using this function is the recommended approach to track performance
 of loading pages in Calypso.
 
-#### Middleware
+### Middleware
 
 It provides a middleware expected to be used with Page router.
 
@@ -26,13 +26,13 @@ page('/my-page/*', performanceTrackerStart('my-page'), /*...*/);
 The id provided to `performanceTrackerStart` must match the id provided by the hook `usePerformanceTrackerStop`, which equals to the name of the section
 loaded. It will also pass the option `{fullPageLoad: true}` to `@automattic/browser-data-collector` if the route hit comes from a full page load.
 
-### Stop
+## Stop
 
-#### Generic function
+### Generic function
 
 The counterpart of the generic start function.
 
-#### Hook
+### Hook
 
 A hook `usePerformanceTrackerStop`. This is custom hook uses `useEffect` to stop a performance tracking.
 
@@ -52,7 +52,7 @@ It will also get the current section name from the Redux store and use it as the
 This is the recommended approach when using function components and rendering that component _always_ means the page is ready and you want to stop the tracking. If the component
 can render different states (eg: loading vs main content), then you should use `<PerformanceTrackerStop/>` as part of the "main" state output.
 
-#### Component
+### Component
 
 A component `PerformanceTrackerStop`. This is a wrapper around the above hook.
 
@@ -73,7 +73,7 @@ function MyComponent( { isLoading } ) {
 
 Using this component is the recommended approach when the parent component can render different states and we only want to stop the performance tracking in one of them.
 
-#### High Order Component
+### High Order Component
 
 A HoC `withPerformanceTrackerStop` that will automatically append `<PerformanceTrackerStop/>` to the wrapped component.
 

--- a/client/lib/plugins/wporg-data/README.md
+++ b/client/lib/plugins/wporg-data/README.md
@@ -1,10 +1,11 @@
 # WPORG Data
 
-### Store
+## Store
 
 The WPorg Store is responsible for storing the state of plugins from .org so that we don't have to fetch them each time.
 
-####The Data
+### The Data
+
 The data that is stored in the store looks like this:
 
 ```js
@@ -37,13 +38,13 @@ The data that is stored in the store looks like this:
 
 The data is stored in a private variable but can be accessed though the stores public methods.
 
-####Public Methods
+### Public Methods
 
-**PluginsStore.get( pluginSlug );**
+#### PluginsStore.get( pluginSlug );
 
-## Returns a plugin object or null
+Returns a plugin object or null
 
-####Example Component Code:
+### Example Component Code:
 
 ```es6
 /**
@@ -87,18 +88,19 @@ export class YourComponent extends Component {
 
 ```
 
-###Actions
+## Actions
+
 Actions update the data stored in WPorg store.
 
-####Public methods.
+### Public methods.
+
+#### PluginsDataActions.fetchPluginData( pluginSlug );
 
 Triggers api call to fetch the plugin data and update the store.
 
-**PluginsDataActions.fetchPluginData( pluginSlug );**
-
 ---
 
-####Example Component Code:
+### Example Component Code:
 
 ```jsx
 /**

--- a/client/lib/route/README.md
+++ b/client/lib/route/README.md
@@ -2,7 +2,7 @@
 
 A few utilities that help when dealing with changing routes.
 
-### normalize
+## normalize
 
 Sometimes you want to enforce a canonical URL to a resource. You can use `normalize`
 as middleware to redirect any pathname ending in `/` to the same path minus the `/`.
@@ -23,16 +23,16 @@ page( '*', normalize );
 If you want a different behavior, or more control over the redirect, `untrailingslashit` and
 `redirect` are provided.
 
-### addQueryArgs
+## addQueryArgs
 
 This module is meant to simplify the work of adding query arguments to a URL.
 
-#### Parameters
+### Parameters
 
 - `args` (object)(Required) – The first parameter is an object of query arguments to be added to the URL.
 - `url` (string)(Required) – The second parameter is the original URL to add `args` to.
 
-#### Example
+### Example
 
 ```es6
 import { addQueryArgs } from 'lib/route';

--- a/client/lib/service-worker/README.md
+++ b/client/lib/service-worker/README.md
@@ -1,6 +1,6 @@
 # Service Worker
 
-#### How to use
+## How to use
 
 ```js
 import { isServiceWorkerSupported, registerServerWorker } from 'lib/service-worker';

--- a/client/lib/store/README.md
+++ b/client/lib/store/README.md
@@ -1,6 +1,6 @@
 # lib/store
 
-#### `createReducerStore`
+## `createReducerStore`
 
 Create a traditional Flux store from a [Redux]-style (`(state, action)`) reducer.
 Optionally takes an `initialState` object. See inline JSDoc for details.

--- a/client/lib/url-search/README.md
+++ b/client/lib/url-search/README.md
@@ -4,7 +4,7 @@
 
 The `url-search` higher-order component takes the approach of only using state to track whether the search field should be open, and otherwise communicating the value of new searches by updating the URL, where the controller can read the value and use it to call whatever data is necessary, and then also pass it back into the Search component as initialValue.
 
-### Usage
+## Usage
 
 To use this higher-order component, take any component that _contains_ the search component, e.g., `/my-sites/posts/posts.jsx` and enhance it with urlSearch.
 

--- a/client/lib/wp/README.md
+++ b/client/lib/wp/README.md
@@ -4,14 +4,14 @@ Offers a shared `WPCOM` API instance to interact with the WordPress.com REST API
 
 Can be configured to use one of the following authentication methods:
 
-### 1 Client-side
+## 1 Client-side
 
 Calls to `wpcom` use the iframe REST proxy via `postMessage`, where authentication is handled via the user's WordPress.com authentication cookies — as opposed to OAuth.
 
-### 2 Server-side, or Client-side with `oauth` feature flag
+## 2 Server-side, or Client-side with `oauth` feature flag
 
 Uses the [`wpcom-xhr-request`](https://github.com/Automattic/wpcom-xhr-request) library to communicate with the API endpoints after OAuth authentication.
 
-### Undocumented Endpoints
+## Undocumented Endpoints
 
 Those API endpoints that are not yet publicly documented need to be defined as part of the `wpcom-undocumented` module. Publicly document your endpoints when their APIs are stable.

--- a/client/me/sidebar-navigation/README.md
+++ b/client/me/sidebar-navigation/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the mobile sidebar navigation header at the top of content sections. It sets `layout-focus` to `sidebar`.
 
-#### How to use:
+## How to use:
 
 Put the component in your `Main` component. It handles detecting the selected site.
 

--- a/client/my-sites/README.md
+++ b/client/my-sites/README.md
@@ -4,7 +4,7 @@ This area handles the views and routing logic for the _My Sites_ section in Caly
 
 This organization approach allows us to encapsulate modules under sensible groupings, giving developers a clearer sense of place. Any UI component can be reused, like we use `my-sites/site` in many places.
 
-### Adding a new section
+## Adding a new section
 
 When creating a new section module it should typically look like this:
 
@@ -21,6 +21,6 @@ All primary routes should be expressed in `index.js` and the handlers for the va
 
 The first component that is rendered for any section in `#primary` should be called `section/main.jsx`. That component should make use of `components/main` for it's wrapper.
 
-### Shared modules
+## Shared modules
 
 If you are creating a shared individual component directly related to the My Sites area of Calypso, the root of `client/my-sites` may be appropiatte for placement — with its own self-documented README.md file of course!

--- a/client/my-sites/current-site/README.md
+++ b/client/my-sites/current-site/README.md
@@ -3,7 +3,7 @@
 This component displays the currently selected site. All information is received from
 Redux state and the component receives no props. It's used in the My Sites Sidebar.
 
-#### How to use:
+## How to use:
 
 ```js
 import CurrentSite from 'my-sites/current-site';

--- a/client/my-sites/customize/README.md
+++ b/client/my-sites/customize/README.md
@@ -2,10 +2,10 @@
 
 This component enables loading, in an iframe, the Legacy Customizer
 
-### customize.jsx
+## customize.jsx
 
 The React view for rendering the iframe
 
-### message.js
+## message.js
 
 Creates a `postMessage` bridge to the iframe'd customization window to allow closing from inside the iframe to navigate back to the `sites` route.

--- a/client/my-sites/jetpack-manage-error-page/README.md
+++ b/client/my-sites/jetpack-manage-error-page/README.md
@@ -10,7 +10,7 @@ the same properties.
 Additionally, this component accepts a `template` property which will render some pre-defined
 templates. Here are acceptable values for `template` along with examples of how to use them.
 
-### updateJetpack
+## updateJetpack
 
 To display a page that will prompt the user to update Jetpack.
 You'll need to declare `site` which is simply the current site object.
@@ -26,11 +26,11 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 />
 ```
 
-### default
+## default
 
 As stated above, this component renders an `emptyContent` component by default. For example:
 
-### Feature Example
+## Feature Example
 
 If you initialize the component with a property `featureExample` containing jsx, it will be added in the bottom of the Jetpack Manage Error Page as an example of what the user could be viewing if there weren't any access errors.
 

--- a/client/my-sites/people/delete-user/README.md
+++ b/client/my-sites/people/delete-user/README.md
@@ -2,7 +2,7 @@
 
 This component renders an interface for deleting a user from a single site installation and removing a user from a multisite installation.
 
-### Props
+## Props
 
 - user - A user object of the user to be deleted
 - currentUser - A user object of the current user

--- a/client/my-sites/people/people-list-section-header/README.md
+++ b/client/my-sites/people/people-list-section-header/README.md
@@ -2,7 +2,7 @@
 
 This component is responsible for displaying the "invite" button the section header above each list of people.
 
-### Properties
+## Properties
 
 - `label` - (string) The text to be displayed as a label for the section header
 - `count` - (number) The amount of people that match the current people query

--- a/client/my-sites/people/role-select/README.md
+++ b/client/my-sites/people/role-select/README.md
@@ -2,7 +2,7 @@
 
 This component listens to changes from the `RolesStore` and displays a select of the roles for a site.
 
-### Props
+## Props
 
 - siteId - (int) siteId for site from which to fetch roles
 - explanation - (string) Optional explanation to be displayed below select in a FormSettingExplanation

--- a/client/my-sites/plan-compare-card/README.md
+++ b/client/my-sites/plan-compare-card/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a current or next plan, highlighting the features you choose.
 
-#### Usage:
+## Usage:
 
 ```javascript
 	<PlanCompareCard
@@ -29,7 +29,7 @@ This component is used to display a current or next plan, highlighting the featu
 }
 ```
 
-#### Props
+## Props
 
 - `title`: The plan name (required)
 - `line`: The plan tagline (required)

--- a/client/my-sites/plans/README.md
+++ b/client/my-sites/plans/README.md
@@ -12,7 +12,7 @@ Supported routes:
 /plans/select/:site/:plan - deprecated, use /checkout/:site/:plan
 ```
 
-### plans.jsx
+## plans.jsx
 
 React component that renders a list of active WordPress.com plans
 

--- a/client/my-sites/plans/current-plan/my-plan-card/README.md
+++ b/client/my-sites/plans/current-plan/my-plan-card/README.md
@@ -7,7 +7,7 @@ It's meant to be used on `plans/my-plan` page to display plans and products that
 
 See p1HpG7-7ET-p2 for more details.
 
-### How to use the `<MyPlanCard />`
+## How to use the `<MyPlanCard />`
 
 ```jsx
 import React from 'react';
@@ -29,7 +29,7 @@ export default class extends React.Component {
 }
 ```
 
-### `<MyPlanCard />` props
+## `<MyPlanCard />` props
 
 The following props can be passed to the My Plan Card component:
 

--- a/client/my-sites/plugins/plugin-action/README.md
+++ b/client/my-sites/plugins/plugin-action/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a plugin action in the form of a toggle or a disconnect Jetpack button.
 
-#### How to use:
+## How to use:
 
 By default, the PluginAction component will attempt to render a FormToggle.
 
@@ -39,7 +39,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `label` : The user friendly label that described the action.
 - `status`: The state of the progress indicator.

--- a/client/my-sites/plugins/plugin-activate-toggle/README.md
+++ b/client/my-sites/plugins/plugin-activate-toggle/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a plugin activation toggle.
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
@@ -20,7 +20,7 @@ render: function() {
 }
 ```
 
-#### Props
+## Props
 
 - `plugin`: a plugin object.
 - `site`: a site object.

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/README.md
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a plugin autupdate toggle.
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginAutoupdateToggle 'my-sites/plugins/plugin-autoupdate-toggle';
@@ -21,7 +21,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `plugin`: a plugin object.
 - `site`: a site object.

--- a/client/my-sites/plugins/plugin-icon/README.md
+++ b/client/my-sites/plugins/plugin-icon/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the icon for a plugin. It takes a plugin image as a prop.
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
@@ -16,7 +16,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `image` (`string`) - an image source.
 - `isPlaceholder` (`bool`) - `true` to display as a placeholder.

--- a/client/my-sites/plugins/plugin-information/README.md
+++ b/client/my-sites/plugins/plugin-information/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a card including information about a plugin.
 
-#### Props
+## Props
 
 - `plugin` : (object) A plugin object.
 - `isPlaceholder`: (boolean) Whether the component is being rendered in placeholder mode.

--- a/client/my-sites/plugins/plugin-install-button/README.md
+++ b/client/my-sites/plugins/plugin-install-button/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a button that launch a install action when clicked.
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginInstallButton 'my-sites/plugins/plugin-install-button';
@@ -17,7 +17,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `plugin`: a plugin object.
 - `selectedSite`: a site object.

--- a/client/my-sites/plugins/plugin-item/README.md
+++ b/client/my-sites/plugins/plugin-item/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a plugin card in a list of plugins.
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
@@ -10,7 +10,7 @@ import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
 render() {
     return (
         <div className="your-plugins-list">
-            <PluginItem 
+            <PluginItem
                 plugin={ plugin }
                 isSelected={ !! this.state.checkedPlugins[ plugin.slug ] }
                 isSelectable={ this.state.bulkManagement }
@@ -22,7 +22,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `plugin`: a plugin object.
 - `sites`: an array of site objects

--- a/client/my-sites/plugins/plugin-meta/README.md
+++ b/client/my-sites/plugins/plugin-meta/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the meta information of a single plugin. Includes the plugin banner, plugin icon, description, author and plugin link.
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginMeta 'my-sites/plugins/plugin-meta';
@@ -16,7 +16,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `plugin` : (object) A plugin object.
 - `siteURL` : (string) The URL of the selected site. Used to determine if this is a single or all sites view.

--- a/client/my-sites/plugins/plugin-ratings/README.md
+++ b/client/my-sites/plugins/plugin-ratings/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the detail of how the ratings of a plugin are divided.
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginRatings from 'my-sites/plugins/plugin-ratings';
@@ -15,7 +15,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `plugin`: A plugin object
 - `barWidth`: Width in pixels for the percentage bars of the component

--- a/client/my-sites/plugins/plugin-remove-button/README.md
+++ b/client/my-sites/plugins/plugin-remove-button/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a button that launch a remove action when clicked.
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
@@ -16,7 +16,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `plugin`: a plugin object.
 - `site`: a site object.

--- a/client/my-sites/plugins/plugin-sections/README.md
+++ b/client/my-sites/plugins/plugin-sections/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the sections for a plugin as returned from the WP.org plugins API. If a plugin does not have any sections, this component will return `null`.
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginSections from 'my-sites/plugins/plugin-sections';
@@ -16,6 +16,6 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `plugin` : (object) A plugin object.

--- a/client/my-sites/plugins/plugin-site-jetpack/README.md
+++ b/client/my-sites/plugins/plugin-site-jetpack/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a single instance of a plugin within a jetpack single site, including all the options & possible actions the user can do with it
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginSiteJetpack from 'my-sites/plugins/plugin-site/plugin-site-jetpack';
@@ -18,7 +18,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `site`: a site object with the site which would be associated to the component.
 - `plugin`: a plugin object.

--- a/client/my-sites/plugins/plugin-site-list/README.md
+++ b/client/my-sites/plugins/plugin-site-list/README.md
@@ -2,7 +2,7 @@
 
 This component is used to represent a list of `Plugin-Site`, with a `Section-Header` serving as a title for the whole bunch.
 
-#### How to use:
+## How to use:
 
 ```jsx
 import PluginSiteList from 'my-sites/plugins/plugin-site-list';
@@ -15,7 +15,7 @@ return <PluginSiteList
 		/>;
 ```
 
-#### Props
+## Props
 
 - `sites`: (array) a site object array with the sites to show in the list
 - `plugin`: a plugin data object.

--- a/client/my-sites/plugins/plugin-site-network/README.md
+++ b/client/my-sites/plugins/plugin-site-network/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a single instance of a plugin within a multisite network, including all the options & possible actions the user can do with it
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginSiteNetwork from 'my-sites/plugins/plugin-site/plugin-site-network';
@@ -19,7 +19,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `site`: a site object with the site which would be associated to the component.
 - `plugin`: a plugin object.

--- a/client/my-sites/plugins/plugin-site-update-indicator/README.md
+++ b/client/my-sites/plugins/plugin-site-update-indicator/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a update indicator which can be turned into a update button
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginSiteUpdateIndicator from 'my-sites/plugins/plugin-site-update-indicator';
@@ -19,7 +19,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `site`: a site object with the site which would be associated to the component.
 - `notices`: a notices object.

--- a/client/my-sites/plugins/plugin-site/README.md
+++ b/client/my-sites/plugins/plugin-site/README.md
@@ -2,7 +2,7 @@
 
 This component is used to represent the state of a single instance of a plugin in a site. Internally, it follows a factory pattern, returning one instance of `plugin-site-network` or `plugin-site-jetpack` depending on the properties of the site received.
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginSite from 'my-sites/plugins/plugin-site/plugin-site';
@@ -17,7 +17,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `site`: a site object with the site which would be associated to the component.
 - `secondarySites`: if `site` is a network site, secondarySites should contain an array with the lists secondary sites of the network.

--- a/client/my-sites/plugins/plugins-browser-item/README.md
+++ b/client/my-sites/plugins/plugins-browser-item/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display small infobox with the data of a plugin.
 
-#### How to use:
+## How to use:
 
 ```js
 import PluginListItem from 'my-sites/plugins-browser-item';
@@ -21,12 +21,12 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `plugin`: a plugin object. It defaults to a empty plugin used as placeholder
 - `site`: a string containing the slug of the selected site
 
-#### Other
+## Other
 
 - `key`: Unique plugin key, this help react render a list better.
 - `isPlaceholder`: Boolean, it marks if the item is a placeholder

--- a/client/my-sites/plugins/plugins-browser-list/README.md
+++ b/client/my-sites/plugins/plugins-browser-list/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a list with the a parametrizable number of plugins of a certain category of the wordpress.org public plugin directory.
 
-#### How to use:
+## How to use:
 
 ```js
 import React from 'react';
@@ -25,7 +25,7 @@ const MyPluginsList = ( { pluginsData, translate } ) => (
 export default localize( MyPluginsList );
 ```
 
-#### Props
+## Props
 
 - `title`: a string
 - `plugins`: a PluginsData object

--- a/client/my-sites/plugins/plugins-browser/README.md
+++ b/client/my-sites/plugins/plugins-browser/README.md
@@ -2,7 +2,7 @@
 
 This component renders the main plugins browser page.
 
-#### How to use:
+## How to use:
 
 ```js
 import BrowserMainView from 'my-sites/plugins/plugins-browser';
@@ -22,7 +22,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `site`: a string containing the slug of the selected site
 - `sites`: a sites-list object

--- a/client/my-sites/plugins/plugins-list/README.md
+++ b/client/my-sites/plugins/plugins-list/README.md
@@ -2,7 +2,7 @@
 
 This component is used to represent a list `PluginItem`s, with a `PluginsListHeader` serving as a title for the whole bunch.
 
-#### How to use:
+## How to use:
 
 ```jsx
 import PluginsList from 'my-sites/plugins/plugins-list';
@@ -15,7 +15,7 @@ return <PluginsList
 		isPlaceholder= { this.showPluginListPlaceholders( true ) } />;
 ```
 
-#### Props
+## Props
 
 - `plugins`: An array of plugins objects.
 - `header`: A string describing the plugin list.

--- a/client/my-sites/sidebar-navigation/README.md
+++ b/client/my-sites/sidebar-navigation/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the mobile sidebar navigation header at the top of content sections. It sets `layout-focus` to `sidebar`.
 
-#### How to use:
+## How to use:
 
 Put the component in your `Main` component. It handles detecting the selected site.
 

--- a/client/my-sites/site-indicator/README.md
+++ b/client/my-sites/site-indicator/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a round badge next to a site with information about updates available, connection issues with Jetpack, whether a site is Jetpack, upgrades expiring soon, etc. It takes `site` object as property.
 
-#### How to use
+## How to use
 
 ```js
 import SiteIndicator from 'my-sites/site-indicator';

--- a/client/my-sites/stats/README.md
+++ b/client/my-sites/stats/README.md
@@ -8,11 +8,11 @@ These components handle the `\stats` section of Calypso. The stats section suppo
 /stats/:time_period/:site_id
 ```
 
-### overview.jsx
+## overview.jsx
 
 This is the default view that is rendered at `\stats`. For users with more than 1 blog, a summary page of stats are shown for each site. Local storage is leveraged to make this experience load faster for the user when navigating between stat periods/sites.
 
-### site.jsx
+## site.jsx
 
 This is the detail view container for a specific sites stats data.
 
@@ -47,7 +47,7 @@ Logic that interfaces with the API, or acts as a collection and / or interface i
 
 We have spent quite a bit of time to create an extensive set of markup for stats lists that provide hooks for default actions, and action menus depending on screen size. Below is some example markup:
 
-### A Generic Stats List Item - No Action
+## A Generic Stats List Item - No Action
 
 ```html
 <li className="module-content-list-item module-content-list-item-normal">

--- a/client/my-sites/stats/geochart/README.md
+++ b/client/my-sites/stats/geochart/README.md
@@ -2,7 +2,7 @@
 
 This component creates the geochart used in the Countries module. It utilizes the [geo chart](https://developers.google.com/chart/interactive/docs/gallery/geochart) provided by Google.
 
-#### How to use:
+## How to use:
 
 ```js
 import GeoChart from 'my-sites/stats/geochart';
@@ -14,6 +14,6 @@ const MyComponent = () => {
 };
 ```
 
-#### Required Props
+## Required Props
 
 - `query`: A query object used as a prop for `QuerySiteStats` component

--- a/client/my-sites/stats/post-performance/README.md
+++ b/client/my-sites/stats/post-performance/README.md
@@ -2,7 +2,7 @@
 
 This component creates an insights card that displays stats about the last post published for a site.
 
-#### How to use:
+## How to use:
 
 ```js
 import PostPerformance from 'my-sites/stats/post-performance';
@@ -14,6 +14,6 @@ render() {
 }
 ```
 
-#### Required Props
+## Required Props
 
 - `site`: A Site Object

--- a/client/my-sites/stats/post-trends/README.md
+++ b/client/my-sites/stats/post-trends/README.md
@@ -2,7 +2,7 @@
 
 This module provides a React component to visualize frequency of posting in a GitHub-like calendar view
 
-#### How to use:
+## How to use:
 
 ```js
 import PostTrends from 'my-sites/stats/post-trends';

--- a/client/my-sites/stats/stats-download-csv/README.md
+++ b/client/my-sites/stats/stats-download-csv/README.md
@@ -2,7 +2,7 @@
 
 The download csv component creates a download link that allows a stats-list to be exported as a csv file. [browser-filesaver](https://github.com/tmpvar/browser-filesaver) performs the HTML5 file saving operations behind the scenes
 
-#### How to use:
+## How to use:
 
 ```js
 import DownloadCsv from 'my-sites/stats/stats-download-csv';
@@ -14,7 +14,7 @@ const MyComponent = () => {
 };
 ```
 
-#### Required Props
+## Required Props
 
 - `period`: The period object is set by the stats controller and contains the type of period, and start/end date range that helps output a pretty file name for the CSV export
 - `path`: The path is the stats summary section being used. Used for the csv file name along with recording the event in analytics.

--- a/client/my-sites/stats/stats-site-overview/README.md
+++ b/client/my-sites/stats/stats-site-overview/README.md
@@ -2,7 +2,7 @@
 
 This component creates Stats Overview which is what renders each site section on www.wordpress.com/stats when a user has more than 1 site.
 
-#### How to use:
+## How to use:
 
 ```js
 import StatsOverview from 'my-sites/stats/overview';
@@ -14,7 +14,7 @@ const MyComponent = () => {
 }
 ```
 
-#### Required Props
+## Required Props
 
 - `site`: A Site Object
 - `path`: String used to build out the various links to the site

--- a/client/my-sites/themes/README.md
+++ b/client/my-sites/themes/README.md
@@ -2,30 +2,30 @@
 
 Displays the Theme Showcase, which resides on `/themes` and handles multi-site, single-site and Jetpack-site views.
 
-### `theme-options.js`
+## `theme-options.js`
 
 Contains definitions for individual Theme options ('Activate', 'Customize' etc).
 
-### `main.jsx`
+## `main.jsx`
 
 The main parent component for the Themes module.
 
-### `thanks-modal.jsx`
+## `thanks-modal.jsx`
 
 The post-activation 'Thanks' dialog.
 
-### `helpers.js`
+## `helpers.js`
 
 Contains helper functions.
 
-### `theme-search-card`
+## `theme-search-card`
 
 The search bar for the Showcase.
 
-### `themes-selection.jsx`
+## `themes-selection.jsx`
 
 A large component that composes the search box, and the displayed list of themes below.
 
-### `themes-site-selector-modal.jsx`
+## `themes-site-selector-modal.jsx`
 
 Displayed in a multisite scenario, when selection of a site is necessary to exert actions upon a theme, e.g. activation.

--- a/client/my-sites/themes/themes-banner/README.md
+++ b/client/my-sites/themes/themes-banner/README.md
@@ -2,7 +2,7 @@
 
 This component is used to implement a banner with image, text, and button.
 
-#### How to use:
+## How to use:
 
 Add the following code into the same directory of this README file. Each banner should be on its own file.
 
@@ -32,7 +32,7 @@ class SmallBusinessBanner extends PureComponent {
 export default localize( SmallBusinessBanner );
 ```
 
-#### Props
+## Props
 
 The following props are used to control the display of the component.
 

--- a/client/notices/README.md
+++ b/client/notices/README.md
@@ -2,7 +2,7 @@
 
 Provides some helper functions to render a notice on the UI. Types of notices are `error`, `success`, `info`, and `warning`.
 
-### How to use?
+## How to use?
 
 Once you require the component you have access to .
 
@@ -20,7 +20,7 @@ Notices are all dismissible by the user. The available methods are:
 - `notices.info()`
 - `notices.warning()`
 
-### Options
+## Options
 
 The first argument is the text to be displayed on the notice. The second argument is an optional object and accepts some properties:
 
@@ -34,7 +34,7 @@ The first argument is the text to be displayed on the notice. The second argumen
 - `showDismiss: false`: (optional) To indicate if dismiss button should be rendered within the overlay.
 - `persistent: true`: (optional) When set to true it won't be removed from the page when navigating to the next page.
 
-#### onClick
+### onClick
 
 The arguments passed to the `onClick` handler are `( event, closeFunction )`, where:
 

--- a/client/post-editor/README.md
+++ b/client/post-editor/README.md
@@ -2,7 +2,7 @@
 
 This section handles the rendering of the Calypso editor and all its individual components. It is responsible for the `/post` and `/page` routes.
 
-### Architecture
+## Architecture
 
 This module uses a
 [Flux](http://facebook.github.io/flux/docs/overview.html)-inspired architecture.

--- a/client/server/bundler/README.md
+++ b/client/server/bundler/README.md
@@ -2,7 +2,7 @@
 
 This module contains the code for generating the JavaScript files that are sent to the browser. The code leverages [webpack](http://webpack.github.io/), [uglifyjs](http://lisperator.net/uglifyjs/), and the sections module at `client/sections.js` that defines the various sections of the application.
 
-### Glossary
+## Glossary
 
 **Code Splitting** - [Code splitting](https://webpack.js.org/guides/code-splitting) is the term that webpack uses to describe the process of splitting the dependency graph for the application into chunks. Assets (JavaScript files) are then created for the chunks and loaded as part of the initial HTML request via `<script />` tags if the chunk is created as a section and asynchronously via `require.ensure` calls.
 
@@ -16,11 +16,11 @@ This module contains the code for generating the JavaScript files that are sent 
 
 **Webpack plugin** - A plugin is a webpack extension that hooks into webpack in order to enhance or change how it does its thing.
 
-### Sections and Webpack
+## Sections and Webpack
 
 The concept of sections is something that is unique to Calypso. It was created to make implementing code splits something that developers typically don’t have to think about and to connect code splits to routes so that all the code needed to render a route is referenced in `<script />` tags that are part of the initial HTML response.
 
-#### Client
+### Client
 
 The sections module `client/sections.js` is transformed via a custom webpack loader `server/bundler/loader.js` into a series of `page.js` route handlers that use `require.ensure` to asynchronously load the JavaScript code needed for the route.
 
@@ -64,11 +64,11 @@ page( /^\/me(\/.*)?$/, function ( context, next ) {
 
 Webpack then turns `require.ensure` into a jsonp function call that loads the script and then executes the callback `onload`. If there is an error loading the chunk, we append `?retry=1` and try refreshing. This should catch any situations where a user has an old version of the application running and for whatever reason the old version of the JavaScript file is no longer available (e.g. due to the static file cache being flushed).
 
-#### Server
+### Server
 
 On the server, the sections module is used to determine which chunk to send to the client for a given request. This makes it possible to include the JavaScript needed to handle the initial request in the HTML response, which means that all the code needed to render has been loaded when the application boots. The same code for generating the regular expressions is used for both the client and the server to make sure that there aren't any discrepancies between the client and server in terms of when a particular chunk is included.
 
-### JavaScript Asset Pipelines
+## JavaScript Asset Pipelines
 
 There are two different modes of operation:
 
@@ -76,11 +76,11 @@ There are two different modes of operation:
 
 2. production - in production mode, the files are written to the public directory by running the `yarn run build` command. The command runs `webpack`, generates a `assets.json` file, and then minifies each file. The `assets.json` file is used in the server to map the chunk name to the current asset.
 
-### Caching
+## Caching
 
 In most of the environments that Calypso is deployed to, the static assets are served and cached by nginx. Each filename includes a hash that is calculated by Webpack, which means that we can cache assets for all the various versions of Calpso that may be in active use. The hash also busts the cache on the client-side.
 
-### Webpack Stats
+## Webpack Stats
 
 Webpack stats can be serialized as JSON for the purposes of analyzing the results of a build. This can be used with tools like [Webpack Analyze](https://webpack.github.io/analyse/) or [Webpack Visualizer](https://chrisbateman.github.io/webpack-visualizer/) to visualize the modules and dependencies comprising a build. To generate a JSON file during a build, use the `preanalyze-bundles` NPM script:
 

--- a/client/state/action-log/README.md
+++ b/client/state/action-log/README.md
@@ -5,12 +5,12 @@
 The Action Log is a Redux store enhancer which records the most recently dispatched Redux action so
 they can be inspected in the development environment for debugging and interactive design.
 
-### Purpose
+## Purpose
 
 Like the [Redux DevTools](https://github.com/zalmoxisus/redux-devtools-extension), the action log
 is useful to track and inspect actions flowing through the store.
 
-### Methods
+## Methods
 
 - `actionLog.start()`
   Enable action recording to history. It is enabled by default.
@@ -35,7 +35,7 @@ is useful to track and inspect actions flowing through the store.
 - `actionLog.unwatch()`
   Disable action watching.
 
-### Query
+## Query
 
 The `actionLog.filter( query )` and `actionLog.watch( query )` accept a `query`. The following types
 are valid queries which are useful for different situations:
@@ -49,7 +49,7 @@ are valid queries which are useful for different situations:
   `actionLog.filter( action => action.siteId === interestingSiteId)` - A predicate function that
   accepts an action and returns `true` if the action matches.
 
-### Examples
+## Examples
 
 The following examples represent commands and code actually run inside the browser console. These
 are not snippets of bundled JavaScript from Calypso.

--- a/client/state/atomic-transfer/README.md
+++ b/client/state/atomic-transfer/README.md
@@ -5,7 +5,7 @@ The information in this state subtree tracks that process and provides the neces
 
 All Atomic transfer information is stored as a single possible transfer per site.
 
-### Actions
+## Actions
 
 |             action              | description                                              |
 | :-----------------------------: | -------------------------------------------------------- |

--- a/client/state/audio/README.md
+++ b/client/state/audio/README.md
@@ -18,7 +18,7 @@ To play a sound when an action is dispatched, add a new handler in `./middleware
 For example, if a sound should be played when an action of type `SOME_ACTION_TYPE` is dispatched, add the
 following:
 
-#### `./middleware.js`
+### `./middleware.js`
 
 ```js
 export const onSomeEvent = ( dispatch, action ) => {

--- a/client/state/help/README.md
+++ b/client/state/help/README.md
@@ -4,6 +4,6 @@ A module for managing help data.
 
 ## Reducers
 
-#### `courses`
+### `courses`
 
 An array of help courses that are available to users.

--- a/client/state/http/README.md
+++ b/client/state/http/README.md
@@ -4,7 +4,7 @@
 
 It follows the same API as `wpcom-http`, the only difference from the user's perspective being the action dispatched.
 
-### Usage
+## Usage
 
 So, let's say you would like to do a `POST` request to <https://api.example.com> when the action `GET_EXAMPLE_DATA` is dispatched, later continuing with `EXAMPLE_DATA_ADD` for the data or `NOTICE_CREATE` for the error. You'll be able to do that with the following code (that could be located under `third-party`):
 

--- a/client/state/lib/README.md
+++ b/client/state/lib/README.md
@@ -7,7 +7,7 @@ redux store data.
 
 When writing a library there are currently three ways around this:
 
-### Update the library interface to pass through data needs
+## Update the library interface to pass through data needs
 
 If we create a new library, or have a library with few usages, we can
 update the function interface to pass through this data. Calling components
@@ -19,7 +19,7 @@ For example a call like:
 Would turn into:
 `library.doSomething( currentSite )`
 
-### Use Redux Middleware to perform the library side-effect
+## Use Redux Middleware to perform the library side-effect
 
 Similarly for a library with few usages, if we don't expect a return value from
 calling a library function this can be abstracted into a dispatched redux action,
@@ -36,7 +36,7 @@ And in this middleware, we can create a handler:
 
 ```jsx
 import library from 'lib/example'
-//... 
+//...
 
 case MY_EXAMPLE_LIBRARY_ACTION:
 	const state = getState();
@@ -44,7 +44,7 @@ case MY_EXAMPLE_LIBRARY_ACTION:
 	library.doSomething( selectedSite );
 ```
 
-### Use Redux Middleware to setSelectedSite
+## Use Redux Middleware to setSelectedSite
 
 For libraries that are too large to port, or have too many usages,
 we can try working around this by setting the selectedSite when
@@ -60,7 +60,7 @@ Then add a handler in this middleware:
 
 ```jsx
 import library from 'lib/example'
-//... 
+//...
 
 //All relevant site update events
 case SELECTED_SITE_SET:

--- a/client/state/plans/README.md
+++ b/client/state/plans/README.md
@@ -6,25 +6,25 @@ A module for managing plans data.
 
 Used in combination with the Redux store instance `dispatch` function, actions can be used in manipulating the current global state.
 
-### `fetchWordPressPlans()`
+## `fetchWordPressPlans()`
 
 Fetches plans
 
-## Action creators
+# Action creators
 
 > Action creators are exactly that—functions that create actions.
 
-### plansReceiveAction( plans )
+## plansReceiveAction( plans )
 
-### plansRequestSuccessAction()
+## plansRequestSuccessAction()
 
-### plansRequestFailureAction( error )
+## plansRequestFailureAction( error )
 
-### plansSerializeAction()
+## plansSerializeAction()
 
-### plansDeserializeAction()
+## plansDeserializeAction()
 
-### requestPlans()
+## requestPlans()
 
 ```es6
 import {

--- a/client/state/post-formats/README.md
+++ b/client/state/post-formats/README.md
@@ -40,7 +40,7 @@ state.postFormats = {
 
 ## Selectors are intended to assist in extracting data from the global state tree for consumption by other modules.
 
-#### `isRequestingPostFormats`
+### `isRequestingPostFormats`
 
 Returns true if post formats are currently fetching for the given site ID.
 
@@ -50,7 +50,7 @@ import { isRequestingPostFormats } from 'state/post-formats/selectors';
 const isRequesting = isRequestingPostFormats( state, 12345678 );
 ```
 
-#### `getPostFormats`
+### `getPostFormats`
 
 Returns an array of all supported site formats for the given site ID.
 

--- a/client/state/push-notifications/README.md
+++ b/client/state/push-notifications/README.md
@@ -17,7 +17,7 @@ A module for managing push notification state & communicating with the service w
 
 - `toggleEnabled`: Turn push notifications on and off
 
-#### How to use
+### How to use
 
 ```js
 import React from 'react';

--- a/client/state/sharing/keyring/README.md
+++ b/client/state/sharing/keyring/README.md
@@ -52,7 +52,7 @@ state.sharing.keyring = {
 
 Selectors are intended to assist in extracting data from the global state tree for consumption by other modules.
 
-#### `getKeyringConnections( state: object )`
+### `getKeyringConnections( state: object )`
 
 Returns an array of keyring connection objects.
 
@@ -62,7 +62,7 @@ import { getKeyringConnections } from 'state/sharing/keyring/selectors';
 const connections = getKeyringConnections( state );
 ```
 
-#### `getKeyringConnectionById( state: object, keyringConnectionId: number )`
+### `getKeyringConnectionById( state: object, keyringConnectionId: number )`
 
 Returns a keyring connection object with a specified ID.
 
@@ -72,7 +72,7 @@ import { getKeyringConnectionById } from 'state/sharing/keyring/selectors';
 const connection = getKeyringConnectionById( state, 23353 );
 ```
 
-#### `getKeyringConnectionsByName( state: object, service: string )`
+### `getKeyringConnectionsByName( state: object, service: string )`
 
 Returns an array of keyring connection objects for a specified service.
 
@@ -82,7 +82,7 @@ import { getKeyringConnectionsByName } from 'state/sharing/keyring/selectors';
 const twitterConnections = getKeyringConnectionsByName( state, 'twitter' );
 ```
 
-#### `getUserConnections( state: object, userId: number )`
+### `getUserConnections( state: object, userId: number )`
 
 Returns an array of keyring connection objects for a specific user.
 
@@ -92,7 +92,7 @@ import { getUserConnections } from 'state/sharing/keyring/selectors';
 const userConnections = getUserConnections( state, 344325 );
 ```
 
-#### `isKeyringConnectionsFetching( state: object )`
+### `isKeyringConnectionsFetching( state: object )`
 
 Returns true if keyring connections are currently being requested.
 

--- a/client/state/sharing/services/README.md
+++ b/client/state/sharing/services/README.md
@@ -51,7 +51,7 @@ state.sharing.services = {
 
 Selectors are intended to assist in extracting data from the global state tree for consumption by other modules.
 
-#### `getKeyringServices( state: object )`
+### `getKeyringServices( state: object )`
 
 Returns an array of keyring services.
 
@@ -61,7 +61,7 @@ import { getKeyringServices } from 'state/sharing/services/selectors';
 const services = getKeyringServices( state );
 ```
 
-#### `getKeyringServicesByType( state: object, type: string )`
+### `getKeyringServicesByType( state: object, type: string )`
 
 Returns an array of keyring services with the specified type.
 
@@ -71,7 +71,7 @@ import { getKeyringServicesByType } from 'state/sharing/services/selectors';
 const publiciseServices = getKeyringServicesByType( state, 'publicize' );
 ```
 
-#### `getEligibleKeyringServices( state: object, siteId: number, type: string )`
+### `getEligibleKeyringServices( state: object, siteId: number, type: string )`
 
 Returns an array of eligible keyring services with the specified type.
 
@@ -92,7 +92,7 @@ const eligibleServices = getEligibleKeyringServices(
 );
 ```
 
-#### `isKeyringServicesFetching( state: object )`
+### `isKeyringServicesFetching( state: object )`
 
 Returns true if keyring services are currently being requested.
 

--- a/client/state/signup/README.md
+++ b/client/state/signup/README.md
@@ -4,7 +4,7 @@ Handles all reducers that are related to the Signup process.
 
 More information about why it is organized in stores and not proper Redux flow can be seen [here](https://github.com/Automattic/wp-calypso/issues/6709)
 
-### SignupDependencyStore - `dependency-store`
+## SignupDependencyStore - `dependency-store`
 
 Holds the reducers that take care of the data passed to `SignupDependencyStore`, which is now saved in Redux, instead of `localStorage`.
 
@@ -13,7 +13,7 @@ It has only two actions, because these are the only actions that actually happen
 - `SIGNUP_DEPENDENCY_STORE_UPDATE` - update store data with new values
 - `SIGNUP_COMPLETE_RESET` - clear out the store
 
-### `optional-dependencies`
+## `optional-dependencies`
 
 Holds optional data that is used between the steps, outside of the defined `dependencies`, which are stored inside `SignupDependencyStore`.
 

--- a/client/state/site-roles/README.md
+++ b/client/state/site-roles/README.md
@@ -49,9 +49,11 @@ state.siteRoles = {
 };
 ```
 
-## Selectors are intended to assist in extracting data from the global state tree for consumption by other modules.
+## Selectors
 
-#### `isRequestingSiteRoles`
+Selectors are intended to assist in extracting data from the global state tree for consumption by other modules.
+
+### `isRequestingSiteRoles`
 
 Returns true if user roles are currently fetching for the given site ID.
 
@@ -61,7 +63,7 @@ import { isRequestingSiteRoles } from 'state/site-roles/selectors';
 const isRequesting = isRequestingSiteRoles( state, 12345678 );
 ```
 
-#### `getSiteRoles`
+### `getSiteRoles`
 
 Returns an array of all supported user roles for the given site ID.
 

--- a/client/state/sites/README.md
+++ b/client/state/sites/README.md
@@ -20,7 +20,7 @@ dispatch( receiveSite( { ID: 2916284, name: 'WordPress.com Example Blog' } ) );
 
 The included reducers add the following keys to the global state tree, under `sites`:
 
-#### `items`
+### `items`
 
 All known sites, indexed by site ID.
 

--- a/client/state/sites/domains/README.md
+++ b/client/state/sites/domains/README.md
@@ -6,25 +6,25 @@ A module for managing site domains data.
 
 Used in combination with the Redux store instance `dispatch` function, actions can be used in manipulating the current global state.
 
-### `fetchSiteDomains( siteId: Number )`
+## `fetchSiteDomains( siteId: Number )`
 
 Fetches domains for the site with the given site ID.
 
-### `refreshSiteDomains( siteID: Number )`
+## `refreshSiteDomains( siteID: Number )`
 
 Clears domains and fetches them for the given site.
 
-## Action creators
+# Action creators
 
 > Action creators are exactly that—functions that create actions.
 
-### domainsReceiveAction( siteId, response )
+## domainsReceiveAction( siteId, response )
 
-### domainsRequestAction( siteId )
+## domainsRequestAction( siteId )
 
-### domainsRequestSuccessAction( siteId )
+## domainsRequestSuccessAction( siteId )
 
-### domainsRequestFailureAction( siteId, error )
+## domainsRequestFailureAction( siteId, error )
 
 ```es6
 import {

--- a/client/state/sites/vouchers/README.md
+++ b/client/state/sites/vouchers/README.md
@@ -6,33 +6,33 @@ A module for managing site vouchers data.
 
 Used in combination with the Redux store instance `dispatch` function, actions can be used in manipulating the current global state.
 
-### `requestSiteVouchers( siteId )`
+## `requestSiteVouchers( siteId )`
 
 Fetches vouchers for the site with the given site ID.
 
-### `assignSiteVoucher( siteId, serviceType )`
+## `assignSiteVoucher( siteId, serviceType )`
 
 Assign a `serviceType` voucher to the given site.
 
-## Action creators
+# Action creators
 
 > Action creators are exactly that—functions that create actions.
 
-### `vouchersReceiveAction( siteId, vouchers )`
+## `vouchersReceiveAction( siteId, vouchers )`
 
-### `vouchersRequestAction( siteId )`
+## `vouchersRequestAction( siteId )`
 
-### `vouchersRequestSuccessAction( siteId )`
+## `vouchersRequestSuccessAction( siteId )`
 
-### `vouchersRequestFailureAction( siteId, error )`
+## `vouchersRequestFailureAction( siteId, error )`
 
-### `vouchersAssignReceiveAction( siteId, serviceType, voucher )`
+## `vouchersAssignReceiveAction( siteId, serviceType, voucher )`
 
-### `vouchersAssignRequestAction( siteId, serviceType )`
+## `vouchersAssignRequestAction( siteId, serviceType )`
 
-### `vouchersAssignRequestSuccessAction( siteId, serviceType )`
+## `vouchersAssignRequestSuccessAction( siteId, serviceType )`
 
-### `vouchersAssignRequestFailureAction( siteId, serviceType, error )`
+## `vouchersAssignRequestFailureAction( siteId, serviceType, error )`
 
 ```es6
 import {
@@ -58,7 +58,7 @@ wpcom
 
 	// dispacth a success action ...
 	dispatch( vouchersRequestSuccessAction( siteId ) );
-	
+
 	// and populate the global tree dispatching a recieve action
 	dispatch( vouchersReceiveAction( site,id, response.vouchers ) );
 ```
@@ -81,7 +81,7 @@ state.sites.vouchers = {
 			]
 		}
 	},
-	
+
 	requesting: [
 		[ siteId ]: {
 			getAll: Boolean,

--- a/client/state/themes/README.md
+++ b/client/state/themes/README.md
@@ -25,12 +25,12 @@ themes: {
 }
 ```
 
-### `activeThemes`
+## `activeThemes`
 
 The `activeThemes` tree contains one entry for each site a user has (no matter if hosted on WordPress.com, or a Jetpack-connected, self-hosted site). Its keys are the numerical `siteId`s, while the values are `themeId` strings.
 Arguably, this duplicates information that is also found in the `sites` subtree (in `sites.items[ siteId ].options.theme_slug`). However, due to the way theme activation works (in particular after a premium theme is purchased), we've found that relying on that state is unreliable for our purposes.
 
-### `queries`
+## `queries`
 
 Most per-theme information is stored in the `queries` tree. It has one subtree per Jetpack site (keyed by its numerical `siteId`), and additionally, one named `wpcom` (for all themes on WordPress.com), and one named `wporg` (for themes found on WordPress.org). These subtrees are populated by querying the corresponding REST API 'themes list/search' endpoints.
 For retired themes, information obtained from the 'active theme' endpoint is stored in the `wpcom` subtree.
@@ -60,17 +60,17 @@ data: {
 
 This means that individual theme information (like theme name, description, screenshot link etc) is stored in the `items` object, while the `queries` object associates serialized queries with the corresponding themes (stored per theme ID in `itemKeys`).
 
-## Jetpack Sites
+# Jetpack Sites
 
 Jetpack sites come with a REST API endpoint that triggers installation of a theme from either WordPress.org, or WordPress.com. To tell Jetpack which of either repository to use, we append a `-wpcom` suffix for WP.com themes. The suffix is then also present in the installed theme's ID (and directory name). There's another reason for that, which is to avoid collisions with existing themes in the WordPress.org repository -- otherwise, the WP.com theme would get overridden with a WP.org one of the same name by the self-hosted site's updater. Instead, downloaded WP.com themes include a little plugin that updates them from WP.com.
 
 To the user, we hide the `-wpcom` suffix as much as possible, e.g a selector like `getActiveTheme()` will remove it from its return value. The reason is that we want the UX to be as seamless as possible: When a user is looking at the Theme Details Sheet for a WP.com theme for their Jetpack site, i.e. wordpress.com/theme/ixiom/example.com, and presses the 'Activate' button, we need the UI to update accordingly, e.g. change the button to 'Customize' after activation. Scenarios like this wouldn't be possible if we were exposing the suffix.
 
-### Automated Transfer
+## Automated Transfer
 
 There's one exception to the `-wpcom` suffix, which is Automated Transfer (AT) sites. While handled through Jetpack, the `-wpcom` suffix is absent from installed themes there, mostly to facilitate transfer of theme options from WordPress.com. The WordPress core updater isn't of any concern there. Instead, AT itself manages WP.com themes to be always up-to-date.
 
-### Filtering of WP.com Themes on Jetpack Sites
+## Filtering of WP.com Themes on Jetpack Sites
 
 Since our UI for Jetpack sites consists of an 'Uploaded Themes' and a 'WordPress.com Themes' list and we don't want to duplicate themes between them, we filter WP.com themes from a given Jetpack site's installed themes. Unfortunately, we cannot wholly treat this as an implementation detail at view level and filter there (after getting themes from Redux state), but have to do this right after receiving a themes list from the endpoint, in our `requestThemes()` action, _before_ storing it in Redux state (via `ThemeQueryManager`).
 

--- a/client/test-helpers/use-nock/README.md
+++ b/client/test-helpers/use-nock/README.md
@@ -1,6 +1,6 @@
 # Use Nock
 
-##### Ensure `nock` unloads properly after tests are finished
+## Ensure `nock` unloads properly after tests are finished
 
 `nock` allows you to intercept and mock network requests through a variety of filters and functions, providing such abilities as setting custom headers, HTTP response codes, and content.
 

--- a/packages/components/src/dialog/README.md
+++ b/packages/components/src/dialog/README.md
@@ -12,7 +12,7 @@ By controlling the dialog's visibility through the `isVisible` property, the dia
 providing any CSS transitions to animate the opening/closing of the dialog. This also keeps the parent's code clean and
 readable, with a minimal amount of boilerplate code required to show a dialog.
 
-### Basic Usage
+## Basic Usage
 
 ```js
 class MyComponent extends React.Component {
@@ -60,7 +60,7 @@ class MyComponent extends React.Component {
 ReactDom.render( <MyComponent />, document.getElementById( 'content' ) );
 ```
 
-### `onClick` handlers for buttons
+## `onClick` handlers for buttons
 
 You can attach `onClick` handlers for dialog buttons. The `onClick` handler will be passed a function that when
 called will close the dialog the dialog button is a member of.
@@ -89,7 +89,7 @@ called will close the dialog the dialog button is a member of.
 	}
 ```
 
-### Custom Buttons
+## Custom Buttons
 
 If you need more than can be provided by passing button props, you can also pass a ReactElement in the place of
 the button spec. The ReactElement cannot close the dialog directly, but you could close the dialog by routing back
@@ -117,7 +117,7 @@ through the Dialog's host.
 
 ```
 
-### Providing custom styling for a dialog
+## Providing custom styling for a dialog
 
 The dialog component renders the following DOM tree (simplified to only show structure and classes):
 

--- a/packages/components/src/progress-bar/README.md
+++ b/packages/components/src/progress-bar/README.md
@@ -5,7 +5,7 @@ and another bar on top of that filled, in a different color,
 with a % of the size of the background.
 Once this component is mounted, it will always progress forward, never backward: if `value` property is first 20 and later 15, the bar will still reflect the last maximum value, 20.
 
-#### How to use:
+## How to use:
 
 ```js
 import { ProgressBar } from '@automattic/components';
@@ -20,7 +20,7 @@ render() {
 }
 ```
 
-#### Props
+## Props
 
 - `value`: a number representing the amount over the total to be represented in the bar (required).
 - `total`: a number representing the value corresponding to the 100% of the bar (optional, default == 100).

--- a/packages/components/src/ribbon/README.md
+++ b/packages/components/src/ribbon/README.md
@@ -7,7 +7,7 @@ place in our hearts.
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import { Card } from '@automattic/components';
@@ -25,6 +25,6 @@ function MyCard() {
 
 ---
 
-#### Props
+## Props
 
 - `color`: (string) The color of the ribbon. Currently only supports green.

--- a/packages/components/src/screen-reader-text/README.md
+++ b/packages/components/src/screen-reader-text/README.md
@@ -6,7 +6,7 @@ This idea was pulled from WordPress core, for more background & technical detail
 
 ---
 
-#### How to use:
+## How to use:
 
 ```js
 import { Button } from '@automattic/components';

--- a/packages/load-script/README.md
+++ b/packages/load-script/README.md
@@ -2,7 +2,7 @@
 
 This utility function allows us to use a standardized method of loading remote scripts and injecting them into the `<head>` of our document to bring external functionality into the app.
 
-### Usage
+## Usage
 
 ```js
 import { loadScript, loadjQueryDependentScript } from '@automattic/load-script';
@@ -36,6 +36,6 @@ loadScript( REMOTE_SCRIPT_URL )
 	} );
 ```
 
-### Error handling
+## Error handling
 
 If using the callback, it should expect a single argument, which will be `null` on success or an object on failure. This error object contains the `src` property, which will contain the src url of the script that failed to load. If using the Promise form, the error object will be passed to the nearest `catch` handler as a rejection.

--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -1,28 +1,28 @@
 # Changelog
 
-#### v1.1.0 (2020-09-10)
+## v1.1.0 (2020-09-10)
 
 - Twitter: Add previewing for attached images, videos, or quoted tweets.
 - Twitter: Add support for previewing entire threads.
 
-#### v1.0.4 (2020-08-24)
+## v1.0.4 (2020-08-24)
 
 - Fixed Twitter styles for viewports < 600px in width
 
-#### v1.0.3 (2020-08-21)
+## v1.0.3 (2020-08-21)
 
 - Refreshed styles of Twitter, Facebook and Google previews to match their latest design.
 
-#### v1.0.2 (2020-08-03)
+## v1.0.2 (2020-08-03)
 
 - Remove `i18n-calypso` dependency by removing search preview header.
 - Strip html tags from descriptions for social previews.
 - Add helper function with enhanced regex for stripping html tags.
 
-#### v1.0.1 (2020-07-23)
+## v1.0.1 (2020-07-23)
 
 - Mark CSS and SCSS files as `sideEffects` to ensure they are not discarded during build processes tree-shaking.
 
-#### v1.0.0 (2020-07-22)
+## v1.0.0 (2020-07-22)
 
 - Initial release after extracting from Calypso.

--- a/packages/viewport-react/README.md
+++ b/packages/viewport-react/README.md
@@ -4,7 +4,7 @@ This package contains React helpers to identify and track changes to the viewpor
 
 For vanilla methods, please check the `@automattic/viewport` package.
 
-### Usage
+## Usage
 
 Using a hook:
 
@@ -32,19 +32,19 @@ class MyComponent extends React.Component {
 export default withMobileBreakpoint( MyComponent );
 ```
 
-### Supported hooks
+## Supported hooks
 
 - `useBreakpoint( breakpoint )`: Returns the current status for a breakpoint, and keeps it updated.
 - `useMobileBreakpoint()`: Returns the current status for the mobile breakpoint, and keeps it updated.
 - `useDesktopBreakpoint()`: Returns the current status for the desktop breakpoint, and keeps it updated.
 
-### Supported higher-order components
+## Supported higher-order components
 
 - `withBreakpoint( breakpoint )( WrappedComponent )`: Returns a wrapped component with the current status for a breakpoint as the `isBreakpointActive` prop.
 - `withMobileBreakpoint( WrappedComponent )`: Returns a wrapped component with the current status for the mobile breakpoint as the `isBreakpointActive` prop.
 - `withDesktopBreakpoint( WrappedComponent )`: Returns a wrapped component with the current status for the desktop breakpoint as the `isBreakpointActive` prop.
 
-### Supported breakpoints
+## Supported breakpoints
 
 - '<480px'
 - '<660px'

--- a/packages/viewport/README.md
+++ b/packages/viewport/README.md
@@ -4,7 +4,7 @@ This package contains functions to identify and track changes to the viewport. T
 
 For React helpers, please check the `@automattic/viewport-react` package.
 
-### Usage
+## Usage
 
 Simple usage:
 
@@ -53,7 +53,7 @@ class MyComponent extends React.Component {
 
 Note: the above usage is more easily accomplished using the hooks and higher-order components in `@automattic/viewport-react`.
 
-### Supported methods
+## Supported methods
 
 - `isWithinBreakpoint( breakpoint )`: Whether the current screen size matches the breakpoint.
 - `isMobile()`: Whether the current screen size matches a mobile breakpoint (equivalent to "<480px"). See note at end of document.
@@ -63,7 +63,7 @@ Note: the above usage is more easily accomplished using the hooks and higher-ord
 - `subscribeIsDesktop( listener )`: Register a listener for size changes that affect the desktop breakpoint (equivalent to ">960px"). Returns the unsubscribe function. See note at end of document.
 - `getWindowInnerWidth()`: Get the inner width for the browser window. **Warning**: This method triggers a layout recalc, potentially resulting in performance issues. Please use a breakpoint instead wherever possible.
 
-### Supported breakpoints
+## Supported breakpoints
 
 - '<480px'
 - '<660px'

--- a/packages/wpcom-proxy-request/Readme.md
+++ b/packages/wpcom-proxy-request/Readme.md
@@ -11,7 +11,7 @@ pointing to a special URL that proxies API requests on the host page's behalf.
 It is intended to be used in the browser (client-side) via a bundler like
 browserify or webpack.
 
-### Installation
+## Installation
 
 Install `wpcom-proxy-request` using `npm`:
 
@@ -19,7 +19,7 @@ Install `wpcom-proxy-request` using `npm`:
 npm install wpcom-proxy-request
 ```
 
-### Example
+## Example
 
 ```js
 // Import wpcom-proxy-request handler
@@ -36,7 +36,7 @@ proxy( { path: '/me' }, function ( err, body, headers ) {
 } );
 ```
 
-### Running tests
+## Running tests
 
 Compile and `watch` client-test application
 
@@ -52,7 +52,7 @@ make run-test-app
 
 Open a tab pointing to `http://calypso.localhost:3001/`
 
-### License
+## License
 
 MIT – Copyright Automattic 2014
 

--- a/packages/wpcom.js/docs/me.md
+++ b/packages/wpcom.js/docs/me.md
@@ -2,7 +2,7 @@
 
 `Me` handler class.
 
-### Create a `Me` instance from WPCOM
+## Create a `Me` instance from WPCOM
 
 ```js
 var wpcom = require('wpcom')('<your-token>');

--- a/packages/wpcom.js/docs/media.md
+++ b/packages/wpcom.js/docs/media.md
@@ -2,7 +2,9 @@
 
 `Media` handler class.
 
-### Create a `Media` instance from Site
+## Example
+
+Create a `Media` instance from Site
 
 ```js
 var wpcom = require('wpcom')('<your-token>');

--- a/packages/wpcom.js/docs/post.md
+++ b/packages/wpcom.js/docs/post.md
@@ -2,7 +2,9 @@
 
 `Post` handler class.
 
-### Create a `Post` instance from Site
+## Example
+
+Create a `Post` instance from Site
 
 ```js
 var wpcom = require('wpcom')('<your-token>');

--- a/packages/wpcom.js/docs/site.md
+++ b/packages/wpcom.js/docs/site.md
@@ -2,7 +2,9 @@
 
 `Site` handler class.
 
-### Create a `Site` instance from WPCOM
+## Example
+
+Create a `Site` instance from WPCOM
 
 ```js
 var wpcom = require('wpcom')('<your-token>');

--- a/packages/wpcom.js/docs/users.md
+++ b/packages/wpcom.js/docs/users.md
@@ -2,7 +2,9 @@
 
 `Users` handler class.
 
-### Create a `Users` instance from WPCOM
+## Example
+
+Create a `Users` instance from WPCOM
 
 ```js
 var wpcom = require('wpcom')('<your-token>');

--- a/packages/wpcom.js/docs/wpcom.md
+++ b/packages/wpcom.js/docs/wpcom.md
@@ -1,13 +1,13 @@
 # WPCOM
 
-### WPCOM('token');
+## WPCOM('token');
 
 Create a new instance of WPCOM. `token` parameter is optional but it's needed to
 make admin actions or to access to protected resources.
 
 **Note**: You can use the [node-wpcom-oauth][] module to get an _access token_.
 
-### WPCOM#me(fn)
+## WPCOM#me(fn)
 
 Create a `Me` object. More info in [Me doc page](./me.md).
 
@@ -17,7 +17,7 @@ var me = wpcom.me();
 });
 ```
 
-### WPCOM#site('site-id')
+## WPCOM#site('site-id')
 
 Create a `Site` object. More info in [Site doc page](./site.md).
 
@@ -26,7 +26,7 @@ const wpcom = require( 'wpcom' )( '<your-token>' );
 const site = wpcom.site();
 ```
 
-### WPCOM#freshlyPressed([params, ]fn)
+## WPCOM#freshlyPressed([params, ]fn)
 
 View Freshly Pressed posts from the WordPress.com homepage.
 

--- a/packages/wpcom.js/docs/wpcom.req.md
+++ b/packages/wpcom.js/docs/wpcom.req.md
@@ -1,6 +1,6 @@
 # WPCOM#Req
 
-### WPCOM.Req.get(params, query, fn)
+## WPCOM.Req.get(params, query, fn)
 
 Make a `GET` request directly to WordPress.com REST-API
 
@@ -11,14 +11,14 @@ wpcom.req.get( '/me/sites', function ( err, data ) {
 } );
 ```
 
-### WPCOM.Req.post(params, query, body, fn)
+## WPCOM.Req.post(params, query, body, fn)
 
 Make a `POST` request directly to WordPress.com REST-API
 
-### WPCOM.Req.put(params, query, body, fn)
+## WPCOM.Req.put(params, query, body, fn)
 
 It's an alias of `WPCOM.Req.Post()`;
 
-### WPCOM.Req.del(params, query, fn)
+## WPCOM.Req.del(params, query, fn)
 
 It's an alias of `WPCOM.Req.Post()` without passing `body` argument;


### PR DESCRIPTION
### Background

After linting our Markdown files following prettier format, I'd like to introduce content-based rules from `remark`. The plugin we use (`eslint-plugin-md`) recommends [Markdown Style Guide](https://cirosantilli.com/markdown-style-guide/), and it has [a preset](https://www.npmjs.com/package/remark-preset-lint-markdown-style-guide) for it.

Unfortunately this preset doesn't have the capacity of auto-fix the problems. Instead of enabling the preset and having a ton of errors, I'll enable the rules of the preset one by one and fix each error. When all the rules are enabled we can switch the hardcoded list of rules by the preset.

### Changes

Enables rule [heading-increment](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-increment). This rule forbids to skip levels when writing headers:

```
Good: 

# Foo
## Bar

Bad:

# Foo
### Bar
```

### Testing
Run `./node_modules/.bin/eslint --ext .md .` and check there are no errors
