### PR TITLE
[markdown] Fix linting rule 'no-heading-punctuation' 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
 							// Plugins from https://www.npmjs.com/package/remark-preset-lint-markdown-style-guide
 							'lint-no-literal-urls',
 							'lint-heading-increment',
+							'lint-no-heading-punctuation',
 						],
 					},
 				],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,9 @@ module.exports = {
 							'lint-no-literal-urls',
 							'lint-heading-increment',
 							'lint-no-heading-punctuation',
+
+							// This special plugin is used to allow the syntax <!--eslint ignore <rule>-->. It has to come last
+							[ 'message-control', { name: 'eslint', source: 'remark-lint' } ],
 						],
 					},
 				],

--- a/apps/editing-toolkit/README.md
+++ b/apps/editing-toolkit/README.md
@@ -85,7 +85,7 @@ yarn build:posts-list-block`
 
 ## Local Development
 
-### Docker:
+### Docker
 
 For a simple Docker experience, use wp-env.
 
@@ -107,7 +107,7 @@ wp-env run cli wp ... # Runs a wp-cli command.
 
 Once the environment running, you can use the dev script (shown above), and the environment will automatically see the updated build. It works by mounting the editing toolkit plugin as a Docker volume.
 
-### Other:
+### Other
 
 Build (or `dev`) and symlink the plugin into a local WordPress install.
 

--- a/client/blocks/all-sites/README.md
+++ b/client/blocks/all-sites/README.md
@@ -2,7 +2,7 @@
 
 This component displays the All Sites item. It's used in the Sidebar as the current site selection and in the picker.
 
-## How to use:
+## How to use
 
 ```js
 import AllSites from 'blocks/all-sites';

--- a/client/blocks/app-promo/README.md
+++ b/client/blocks/app-promo/README.md
@@ -2,7 +2,7 @@
 
 This component is used to suggest the desktop app to users.
 
-## How to use:
+## How to use
 
 ```js
 import AppPromo from 'components/app-promo'

--- a/client/blocks/comment-button/README.md
+++ b/client/blocks/comment-button/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a button with an embedded number indicator.
 
-## How to use:
+## How to use
 
 ```js
 import CommentButton from 'blocks/comment-button';

--- a/client/blocks/conversation-caterpillar/README.md
+++ b/client/blocks/conversation-caterpillar/README.md
@@ -2,7 +2,7 @@
 
 This component is used to show who's involved in a conversation, and how many comments have been made.
 
-## How to use:
+## How to use
 
 ```js
 import ConversationCaterpillar from 'blocks/conversation-caterpillar';

--- a/client/blocks/credit-card-form/README.md
+++ b/client/blocks/credit-card-form/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a credit card form.
 
-## How to use:
+## How to use
 
 ```js
 import CreditCardForm from 'blocks/credit-card-form';

--- a/client/blocks/dismissible-card/README.md
+++ b/client/blocks/dismissible-card/README.md
@@ -3,7 +3,7 @@
 This is a card component that can be dismissed for a single page load or be hidden
 via user preference.
 
-## How to use:
+## How to use
 
 ```js
 import DismissibleCard from 'blocks/dismissible-card';

--- a/client/blocks/domain-to-plan-nudge/README.md
+++ b/client/blocks/domain-to-plan-nudge/README.md
@@ -3,7 +3,7 @@
 This is an upgrade nudge that targets users with a site that has a free plan
 and a paid domain.
 
-## How to use:
+## How to use
 
 ```js
 

--- a/client/blocks/follow-button/README.md
+++ b/client/blocks/follow-button/README.md
@@ -4,7 +4,7 @@ This component is used to display a follow/unfollow button.
 It has two parts, the actual button and a container that works with Redux state.
 For most uses, the container is the easiest route.
 
-## How to use the container:
+## How to use the container
 
 ```js
 import FollowButtonContainer from 'blocks/follow-button';
@@ -22,7 +22,7 @@ render() {
 
 - `siteUrl`: string, a site URL to follow or unfollow
 
-## How to use the button directly:
+## How to use the button directly
 
 ```js
 import FollowButton from 'blocks/follow-button/button';

--- a/client/blocks/global-notice/README.md
+++ b/client/blocks/global-notice/README.md
@@ -3,7 +3,7 @@
 These components are used to display global notices.
 They allow you to use a component for your notice instead of calling the notices redux actions directly.
 
-## How to use the container:
+## How to use the container
 
 ```js
 import { InfoNotice } from 'blocks/global-notice';

--- a/client/blocks/like-button/README.md
+++ b/client/blocks/like-button/README.md
@@ -4,7 +4,7 @@ This component is used to display a like button.
 It has two parts, the actual button and a container that works with the LikeStore.
 For most usage, the container is the easiest route.
 
-## How to use the container:
+## How to use the container
 
 ```js
 import LikeButtonContainer from 'blocks/like-button';
@@ -23,7 +23,7 @@ render: function() {
 - `siteId`: number, a site ID to fetch likes for
 - `postId`: number, a post ID to fetch likes for
 
-## How to use the button directly:
+## How to use the button directly
 
 ```js
 import LikeButton from 'blocks/like-button/button';

--- a/client/blocks/plan-storage/README.md
+++ b/client/blocks/plan-storage/README.md
@@ -3,7 +3,7 @@
 This component is used to display the remaining media storage limits. Using PlanStorage
 will query media storage limits for you.
 
-## Usage:
+## Usage
 
 ```javascript
 	<PlanStorage siteId={ this.props.siteId } />
@@ -18,7 +18,7 @@ will query media storage limits for you.
 You can also use PlanStorageBar directly if you need more control over when
 media storage limits are fetched.
 
-## Usage:
+## Usage
 
 ```javascript
 import PlanStorageBar from 'blocks/plan-storage/bar';

--- a/client/blocks/signup-form/README.md
+++ b/client/blocks/signup-form/README.md
@@ -2,7 +2,7 @@
 
 This block renders a Signup Form. It magically handles email, username, and password validation.
 
-## Usage:
+## Usage
 
 A Signup Form instance expects `save` and `submitForm` properties, `save` is called `onBlur` of each field. `submitForm` is called when the form is submitted.
 Optional:

--- a/client/blocks/site-icon/README.md
+++ b/client/blocks/site-icon/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the icon for a site. It takes a Site object as a prop. The size is set at 120px, used at 60px for retina display. Using one size allows us to only request one image and cache it on the browser. Even if you are displaying it at smaller sizes you should not change the requested image.
 
-## How to use:
+## How to use
 
 ```js
 import SiteIcon from 'blocks/site-icon';

--- a/client/blocks/site/README.md
+++ b/client/blocks/site/README.md
@@ -2,7 +2,7 @@
 
 This component displays a Site item using site data retrieved from Redux store. See the documentation for the `siteId` and `site` props for more details about retrieving the site data.
 
-## How to use:
+## How to use
 
 ```js
 import Site from 'blocks/site';

--- a/client/blocks/support-article-dialog/README.md
+++ b/client/blocks/support-article-dialog/README.md
@@ -4,7 +4,7 @@ The `SupportArticleDialog` component displays a support article right in Calypso
 
 The component is rendered from our main `<Layout />` component and so is available everywhere in Calypso.
 
-## Basic usage:
+## Basic usage
 
 To launch a support article call the corresponding redux action, like so:
 

--- a/client/components/animate/README.md
+++ b/client/components/animate/README.md
@@ -2,7 +2,7 @@
 
 Simple interface to introduce animations to components on initial render. Used as a wrapper.
 
-## How to use:
+## How to use
 
 ```jsx
 import Animate from 'components/animate';

--- a/client/components/bulk-select/README.md
+++ b/client/components/bulk-select/README.md
@@ -2,7 +2,7 @@
 
 This component is used to implement a checkbox which you can use to bulk select a list of elements
 
-## How to use:
+## How to use
 
 ```jsx
 import BulkSelect from 'components/bulk-select';

--- a/client/components/card-heading/README.md
+++ b/client/components/card-heading/README.md
@@ -2,7 +2,7 @@
 
 This component displays a heading for a `<Card>`
 
-## How to use:
+## How to use
 
 ```js
 import CardHeading from 'components/card-heading';

--- a/client/components/empty-component/README.md
+++ b/client/components/empty-component/README.md
@@ -2,7 +2,7 @@
 
 Useful for stubbing out components that will not build on the server when rendering server-side.
 
-## How to use:
+## How to use
 
 In the webpack server [config file](/webpack.config.node.js):
 

--- a/client/components/file-picker/README.md
+++ b/client/components/file-picker/README.md
@@ -4,7 +4,7 @@ This component opens a native file picker when its children are clicked on.
 It is a very thin wrapper around
 [`component/file-picker`](https://github.com/component/file-picker)
 
-## How to use:
+## How to use
 
 ```js
 import FilePicker from 'components/file-picker';

--- a/client/components/focusable/README.md
+++ b/client/components/focusable/README.md
@@ -11,7 +11,7 @@ This component lets you wrap complex content in an accessible, clickable wrapper
 
 If you want to add an action to a larger element, for example the Language Picker, you can use this component. Be aware that a screen reader will read the entire contents of `Focusable` to the user, so _try_ to keep the contents short and actionable.
 
-## How to use:
+## How to use
 
 ```jsx
 import Focusable from 'components/focusable';

--- a/client/components/formatted-header/README.md
+++ b/client/components/formatted-header/README.md
@@ -4,7 +4,7 @@ This component displays a header and optional sub-header.
 
 When the `compactOnMobile` flag is set, the header renders in a compact way on smaller screen sizes.
 
-## How to use:
+## How to use
 
 ```js
 import FormattedHeader from 'components/formatted-header';

--- a/client/components/forms/form-toggle/README.md
+++ b/client/components/forms/form-toggle/README.md
@@ -2,7 +2,7 @@
 
 This component is used to implement toggle switches.
 
-## How to use:
+## How to use
 
 ```js
 import FormToggle from 'components/forms/form-toggle';

--- a/client/components/gauge/README.md
+++ b/client/components/gauge/README.md
@@ -2,7 +2,7 @@
 
 This component renders a simple gauge to show a percentage visually.
 
-## How to use:
+## How to use
 
 ```js
 import Gauge from 'components/gauge';

--- a/client/components/gravatar-caterpillar/README.md
+++ b/client/components/gravatar-caterpillar/README.md
@@ -4,7 +4,7 @@ This component is used to display a row of [gravatars](https://gravatar.com/) fo
 
 On smaller screens (<660px wide), the component will display half the maximum number of gravatars.
 
-## How to use:
+## How to use
 
 ```js
 import GravatarCaterpillar from 'components/gravatar-caterpillar';

--- a/client/components/gravatar/README.md
+++ b/client/components/gravatar/README.md
@@ -6,7 +6,7 @@ If the current user has uploaded a new Gravatar recently on Calypso, and therefo
 
 The images size is set at 96px, used at smaller sizes for retina display. Using one size allows us to only request one image and cache it on the browser. Even if you are displaying it at smaller sizes you should not change the source image.
 
-## How to use:
+## How to use
 
 ```js
 import Gravatar from 'components/gravatar';

--- a/client/components/happiness-engineers-tray/README.md
+++ b/client/components/happiness-engineers-tray/README.md
@@ -2,7 +2,7 @@
 
 Renders a row of Happiness Engineers' Gravatars.
 
-## How to use:
+## How to use
 
 ```jsx
 import HappinessEngineersTray from 'components/happiness-engineers-tray';

--- a/client/components/header-button/README.md
+++ b/client/components/header-button/README.md
@@ -6,7 +6,7 @@ to elements like a `Search`. It takes an `icon` prop that is an ID of a
 the other properties are passed to the `Button` component that is used to
 implement this one.
 
-## How to use:
+## How to use
 
 ```js
 import HeaderButton from 'components/header-button';

--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -4,7 +4,7 @@ This component displays a link and icon. If `props.supportPostId` is supplied, w
 
 The component's `children` prop will be used for the link text; if none is supplied, it will defaut to the text "Learn more". The `showText` property (default `true`) can be set to `false` in order to display no text.
 
-## Example Usage:
+## Example Usage
 
 ```js
 import InlineSupportLink from 'components/inline-support-link';

--- a/client/components/jetpack-colophon/README.md
+++ b/client/components/jetpack-colophon/README.md
@@ -4,7 +4,7 @@ This component is used to display a "Powered by Jetpack" colophon, usually on th
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import JetpackColophon from 'components/jetpack-colophon';

--- a/client/components/jetpack-logo/README.md
+++ b/client/components/jetpack-logo/README.md
@@ -4,7 +4,7 @@ This component is used to display a Jetpack logo
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import JetpackLogo from 'components/jetpack-logo';

--- a/client/components/jetpack-plus-wpcom-logo/README.md
+++ b/client/components/jetpack-plus-wpcom-logo/README.md
@@ -4,7 +4,7 @@ This component is used to display the Jetpack Plus WPCOM logo (a Jetpack logo, a
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import JetpackPlusWpComLogo from 'components/jetpack-plus-wpcom-logo';

--- a/client/components/jetpack/card/jetpack-bundle-card/README.md
+++ b/client/components/jetpack/card/jetpack-bundle-card/README.md
@@ -4,7 +4,7 @@ This component is used to display a Jetpack bundle card.
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import JetpackBundleCard from 'components/jetpack/card/jetpack-bundle-card';

--- a/client/components/jetpack/card/jetpack-plan-card/README.md
+++ b/client/components/jetpack/card/jetpack-plan-card/README.md
@@ -4,7 +4,7 @@ This component is used to display a Jetpack plan card.
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import JetpackPlanCard from 'components/jetpack/card/jetpack-plan-card';

--- a/client/components/jetpack/card/jetpack-product-card/README.md
+++ b/client/components/jetpack/card/jetpack-product-card/README.md
@@ -4,7 +4,7 @@ This component is used to display a Jetpack product card.
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';

--- a/client/components/list-end/README.md
+++ b/client/components/list-end/README.md
@@ -4,7 +4,7 @@ This component is used to display a WordPress logo in the centre of a line. It s
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import ListEnd from 'components/list-end';

--- a/client/components/main/README.md
+++ b/client/components/main/README.md
@@ -2,7 +2,7 @@
 
 Component used to declare the main area of any given section —- it's the main wrapper that gets rendered first inside `#primary`.
 
-## How to use:
+## How to use
 
 ```jsx
 import Main from 'components/main';

--- a/client/components/null-component/README.md
+++ b/client/components/null-component/README.md
@@ -2,7 +2,7 @@
 
 Useful for stubbing out components that will not build on the server when rendering server-side.
 
-## How to use:
+## How to use
 
 In the webpack server [config file](/webpack.config.node.js):
 

--- a/client/components/rating/README.md
+++ b/client/components/rating/README.md
@@ -3,7 +3,7 @@
 This component is used to display a set of 5 stars, full colored, empty or half-colored,
 that represents a rating in a scale between 0 and 5.
 
-## How to use:
+## How to use
 
 ```js
 import Rating from 'components/rating';

--- a/client/components/section-header/README.md
+++ b/client/components/section-header/README.md
@@ -3,7 +3,7 @@
 This component is used to display a header with a label
 and optional actions buttons.
 
-## Example Usage:
+## Example Usage
 
 ```js
 import React from 'react';

--- a/client/components/section-nav/README.md
+++ b/client/components/section-nav/README.md
@@ -73,7 +73,7 @@ Text displayed in the header of the panel when rendered on mobile.
 
 `selectedCount` - **optional** (Number)
 
-## Count displayed in the header of the panel.
+## Count displayed in the header of the panel
 
 ## Nav Tabs
 

--- a/client/components/share-button/README.md
+++ b/client/components/share-button/README.md
@@ -4,7 +4,7 @@ ShareButton is a component which allows you to open a popup window to share cont
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import ShareButton from 'components/share-button';

--- a/client/components/sidebar-navigation/README.md
+++ b/client/components/sidebar-navigation/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the mobile sidebar navigation header at the top of content sections. It sets `layout-focus` to `sidebar`.
 
-## How to use:
+## How to use
 
 Put the component in your `Main` component, and wrap it around any components you want it to display as its children. It relies on the [`document-head`](/client/state/document-head) Redux subtree, whose fields you can set through the [`DocumentHead`](/client/components/data/document-head) component. It handles detecting the selected site.
 

--- a/client/components/sites-dropdown/README.md
+++ b/client/components/sites-dropdown/README.md
@@ -4,7 +4,7 @@ Renders a dropdown component for selecting a site. This is the canonical site pi
 
 It supports searching if you have many sites, handles sites with empty titles, sites with redirects, etc.
 
-## How to use:
+## How to use
 
 ```js
 import SitesDropdown from 'components/sites-dropdown';

--- a/client/components/sub-masterbar-nav/README.md
+++ b/client/components/sub-masterbar-nav/README.md
@@ -2,7 +2,7 @@
 
 This component displays a navigation header under the masterbar.
 
-## How to use:
+## How to use
 
 The component should be inserted into a `Main` component.
 Options should contain a `label` and an `uri`. If the latter matches the `uri` property of the component, it will be marked as selected.

--- a/client/components/support-info/README.md
+++ b/client/components/support-info/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a support info icon. When clicked, it displays a popover with a description, a learn more link, and a privacy info link.
 
-## Example Usage:
+## Example Usage
 
 ```js
 import SupportInfo from 'components/support-info';

--- a/client/components/tile-grid/README.md
+++ b/client/components/tile-grid/README.md
@@ -25,7 +25,7 @@ Component used to display a clickable tile with an image, call to action, and de
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import Tile from 'components/tile-grid/tile';

--- a/client/components/tinymce/plugins/embed/README.md
+++ b/client/components/tinymce/plugins/embed/README.md
@@ -11,7 +11,7 @@ Component used to show an embedded URL in a dialog
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import EmbedDialog from 'components/tinymce/plugins/embed';

--- a/client/components/translator-invite/README.md
+++ b/client/components/translator-invite/README.md
@@ -8,7 +8,7 @@ This component invites users to translate WordPress.com into a non-default local
 
 If a locale is found, the component fetches the localized name of the language.
 
-## Usage:
+## Usage
 
 ```javascript
 <TranslatorInvite path={ path } />;

--- a/client/components/wpcom-colophon/README.md
+++ b/client/components/wpcom-colophon/README.md
@@ -4,7 +4,7 @@ This component is used to display a "In partnership with WordPress.com" colophon
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import WpcomColophon from 'components/wpcom-colophon';

--- a/client/devdocs/docs-example/README.md
+++ b/client/devdocs/docs-example/README.md
@@ -2,7 +2,7 @@
 
 This component is used to implement a skeleton for components examples which are generally showcased in the devdocs.
 
-## How to use:
+## How to use
 
 ```es6
 import DocsExample from 'devdocs/design/docs-example';

--- a/client/extensions/woocommerce/components/dashboard-widget/README.md
+++ b/client/extensions/woocommerce/components/dashboard-widget/README.md
@@ -2,7 +2,7 @@
 
 This component sets up some basic styling for dashboard widgets. It allows for full-, half-, and third-width widgets in a row, and has responsive styling for smaller screens. There is also support for adding images, and a per-widget settings panel.
 
-## How to use:
+## How to use
 
 ```js
 import DashboardWidget from 'woocommerce/components/dashboard-widget';

--- a/client/extensions/woocommerce/components/form-location-select/README.md
+++ b/client/extensions/woocommerce/components/form-location-select/README.md
@@ -38,7 +38,7 @@ Required. The currently-selected state, as state code (e.g. NY, CT, QC, etc).
 
 The source site for the countries list request. Defaults to the currently-selected site.
 
-## How to use:
+## How to use
 
 ```jsx
 import FormFieldSet from 'components/forms/form-fieldset';

--- a/client/extensions/woocommerce/components/product-search/README.md
+++ b/client/extensions/woocommerce/components/product-search/README.md
@@ -2,7 +2,7 @@
 
 This component is used to search through the products on a given site.
 
-## How to use:
+## How to use
 
 To select multiple products:
 

--- a/client/extensions/woocommerce/components/table/README.md
+++ b/client/extensions/woocommerce/components/table/README.md
@@ -6,7 +6,7 @@ The `compact` prop applies styling for a more compact table. It also allows for 
 
 ![screen shot 2017-06-13 at 11 42 53 am](https://user-images.githubusercontent.com/1922453/27059946-c1ff77f6-502d-11e7-9af5-aaecd09bb335.png)
 
-## How to use:
+## How to use
 
 ```js
 import Table from 'woocommerce/components/table';

--- a/client/extensions/woocommerce/lib/analytics/README.md
+++ b/client/extensions/woocommerce/lib/analytics/README.md
@@ -5,7 +5,7 @@ This library is for adding analytics code to Store on WP.com
 It's designed to consolidate things like verifying we're using the same prefix on
 all track event ids, and perhaps to add some common event properties automatically.
 
-## How to use:
+## How to use
 
 ```js
 import { recordTrack } from 'woocommerce/lib/analytics';

--- a/client/extensions/woocommerce/state/sites/promotions/README.md
+++ b/client/extensions/woocommerce/state/sites/promotions/README.md
@@ -43,7 +43,7 @@ const obj = {
 
 The `appliesTo` object for a promotion is a complex object which describes what all the promotion can be applied to. At this point, excluded products or categories are not supported.
 
-#### Example: all products.
+#### Example: all products
 
 ```js
 const obj = {
@@ -53,7 +53,7 @@ const obj = {
 };
 ```
 
-#### Example: specific products.
+#### Example: specific products
 
 ```js
 const obj = {
@@ -63,7 +63,7 @@ const obj = {
 };
 ```
 
-### Example: products by category.
+### Example: products by category
 
 ```js
 const obj = {

--- a/client/layout/guided-tours/docs/TUTORIAL.md
+++ b/client/layout/guided-tours/docs/TUTORIAL.md
@@ -50,7 +50,7 @@ We only want our tour to show for users who have registered in the past 7 days. 
 
 Now we're ready to actually start writing our tour.
 
-### Scaffolding, etc.
+### Scaffolding, etc
 
 First we'll need to create a directory tour, under `tours`. In there, we create two files: `meta.js` and `index.js`.
 `meta.js` contains the metadata for a tour. Here's an empty boilerplate:

--- a/client/layout/guided-tours/docs/TUTORIAL.md
+++ b/client/layout/guided-tours/docs/TUTORIAL.md
@@ -50,7 +50,9 @@ We only want our tour to show for users who have registered in the past 7 days. 
 
 Now we're ready to actually start writing our tour.
 
-### Scaffolding, etc
+<!--eslint ignore no-heading-punctuation-->
+
+### Scaffolding, etc.
 
 First we'll need to create a directory tour, under `tours`. In there, we create two files: `meta.js` and `index.js`.
 `meta.js` contains the metadata for a tour. Here's an empty boilerplate:

--- a/client/layout/guided-tours/docs/examples/README.md
+++ b/client/layout/guided-tours/docs/examples/README.md
@@ -10,6 +10,6 @@ When we archive an unused tour as an example, we aim to move all the selectors o
 
 - `simple-payments-end-of-year-guide.js`: This tour was used as a temporary end-of-year advertisement for the Simple Payments feature. It triggers on a variety of paths but only for premium and business users. The tour guides people through the creation of a page and the insertion of a Simple Payments button.
 
-## Selectors etc.
+## Selectors etc
 
 - `hasSelectedSitePremiumOrBusinessPlan` (in `simple-payments-end-of-year-guide.js`): true if the selected site is on the Premium or Business plan.

--- a/client/layout/guided-tours/docs/examples/README.md
+++ b/client/layout/guided-tours/docs/examples/README.md
@@ -10,6 +10,8 @@ When we archive an unused tour as an example, we aim to move all the selectors o
 
 - `simple-payments-end-of-year-guide.js`: This tour was used as a temporary end-of-year advertisement for the Simple Payments feature. It triggers on a variety of paths but only for premium and business users. The tour guides people through the creation of a page and the insertion of a Simple Payments button.
 
-## Selectors etc
+<!--eslint ignore no-heading-punctuation-->
+
+## Selectors etc.
 
 - `hasSelectedSitePremiumOrBusinessPlan` (in `simple-payments-end-of-year-guide.js`): true if the selected site is on the Premium or Business plan.

--- a/client/lib/memoize-last/README.md
+++ b/client/lib/memoize-last/README.md
@@ -7,7 +7,7 @@ previous one through a shallow comparison.
 Useful when you don't want to maintain an arbitrarily large cache of previous
 invocations and are happy just remembering the last one.
 
-## Usage:
+## Usage
 
 ```
 import memoizeLast from 'lib/memoize-last';

--- a/client/lib/network-connection/README.md
+++ b/client/lib/network-connection/README.md
@@ -2,7 +2,7 @@
 
 `Network connection` provides simple UI for the cases when the user lost connection to the internet or to our servers.
 
-## How to use:
+## How to use
 
 Public API can be used through main file:
 

--- a/client/lib/plugins/wporg-data/README.md
+++ b/client/lib/plugins/wporg-data/README.md
@@ -44,7 +44,7 @@ The data is stored in a private variable but can be accessed though the stores p
 
 Returns a plugin object or null
 
-### Example Component Code:
+### Example Component Code
 
 ```es6
 /**
@@ -92,7 +92,7 @@ export class YourComponent extends Component {
 
 Actions update the data stored in WPorg store.
 
-### Public methods.
+### Public methods
 
 #### PluginsDataActions.fetchPluginData( pluginSlug );
 
@@ -100,7 +100,7 @@ Triggers api call to fetch the plugin data and update the store.
 
 ---
 
-### Example Component Code:
+### Example Component Code
 
 ```jsx
 /**

--- a/client/me/sidebar-navigation/README.md
+++ b/client/me/sidebar-navigation/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the mobile sidebar navigation header at the top of content sections. It sets `layout-focus` to `sidebar`.
 
-## How to use:
+## How to use
 
 Put the component in your `Main` component. It handles detecting the selected site.
 

--- a/client/my-sites/current-site/README.md
+++ b/client/my-sites/current-site/README.md
@@ -3,7 +3,7 @@
 This component displays the currently selected site. All information is received from
 Redux state and the component receives no props. It's used in the My Sites Sidebar.
 
-## How to use:
+## How to use
 
 ```js
 import CurrentSite from 'my-sites/current-site';

--- a/client/my-sites/plan-compare-card/README.md
+++ b/client/my-sites/plan-compare-card/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a current or next plan, highlighting the features you choose.
 
-## Usage:
+## Usage
 
 ```javascript
 	<PlanCompareCard

--- a/client/my-sites/plugins/plugin-action/README.md
+++ b/client/my-sites/plugins/plugin-action/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a plugin action in the form of a toggle or a disconnect Jetpack button.
 
-## How to use:
+## How to use
 
 By default, the PluginAction component will attempt to render a FormToggle.
 

--- a/client/my-sites/plugins/plugin-activate-toggle/README.md
+++ b/client/my-sites/plugins/plugin-activate-toggle/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a plugin activation toggle.
 
-## How to use:
+## How to use
 
 ```js
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';

--- a/client/my-sites/plugins/plugin-automated-transfer/README.md
+++ b/client/my-sites/plugins/plugin-automated-transfer/README.md
@@ -1,6 +1,6 @@
 This component is used to display an install bar for automated transfers.
 
-#### How to use:
+#### How to use
 
 ```js
 import PluginAutomatedTransfer from 'my-sites/plugins/plugin-automated-transfer';

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/README.md
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a plugin autupdate toggle.
 
-## How to use:
+## How to use
 
 ```js
 import PluginAutoupdateToggle 'my-sites/plugins/plugin-autoupdate-toggle';

--- a/client/my-sites/plugins/plugin-icon/README.md
+++ b/client/my-sites/plugins/plugin-icon/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the icon for a plugin. It takes a plugin image as a prop.
 
-## How to use:
+## How to use
 
 ```js
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';

--- a/client/my-sites/plugins/plugin-install-button/README.md
+++ b/client/my-sites/plugins/plugin-install-button/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a button that launch a install action when clicked.
 
-## How to use:
+## How to use
 
 ```js
 import PluginInstallButton 'my-sites/plugins/plugin-install-button';

--- a/client/my-sites/plugins/plugin-item/README.md
+++ b/client/my-sites/plugins/plugin-item/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a plugin card in a list of plugins.
 
-## How to use:
+## How to use
 
 ```js
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';

--- a/client/my-sites/plugins/plugin-meta/README.md
+++ b/client/my-sites/plugins/plugin-meta/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the meta information of a single plugin. Includes the plugin banner, plugin icon, description, author and plugin link.
 
-## How to use:
+## How to use
 
 ```js
 import PluginMeta 'my-sites/plugins/plugin-meta';

--- a/client/my-sites/plugins/plugin-ratings/README.md
+++ b/client/my-sites/plugins/plugin-ratings/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the detail of how the ratings of a plugin are divided.
 
-## How to use:
+## How to use
 
 ```js
 import PluginRatings from 'my-sites/plugins/plugin-ratings';

--- a/client/my-sites/plugins/plugin-remove-button/README.md
+++ b/client/my-sites/plugins/plugin-remove-button/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a button that launch a remove action when clicked.
 
-## How to use:
+## How to use
 
 ```js
 import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';

--- a/client/my-sites/plugins/plugin-sections/README.md
+++ b/client/my-sites/plugins/plugin-sections/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the sections for a plugin as returned from the WP.org plugins API. If a plugin does not have any sections, this component will return `null`.
 
-## How to use:
+## How to use
 
 ```js
 import PluginSections from 'my-sites/plugins/plugin-sections';

--- a/client/my-sites/plugins/plugin-site-jetpack/README.md
+++ b/client/my-sites/plugins/plugin-site-jetpack/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a single instance of a plugin within a jetpack single site, including all the options & possible actions the user can do with it
 
-## How to use:
+## How to use
 
 ```js
 import PluginSiteJetpack from 'my-sites/plugins/plugin-site/plugin-site-jetpack';

--- a/client/my-sites/plugins/plugin-site-list/README.md
+++ b/client/my-sites/plugins/plugin-site-list/README.md
@@ -2,7 +2,7 @@
 
 This component is used to represent a list of `Plugin-Site`, with a `Section-Header` serving as a title for the whole bunch.
 
-## How to use:
+## How to use
 
 ```jsx
 import PluginSiteList from 'my-sites/plugins/plugin-site-list';

--- a/client/my-sites/plugins/plugin-site-network/README.md
+++ b/client/my-sites/plugins/plugin-site-network/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a single instance of a plugin within a multisite network, including all the options & possible actions the user can do with it
 
-## How to use:
+## How to use
 
 ```js
 import PluginSiteNetwork from 'my-sites/plugins/plugin-site/plugin-site-network';

--- a/client/my-sites/plugins/plugin-site-update-indicator/README.md
+++ b/client/my-sites/plugins/plugin-site-update-indicator/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a update indicator which can be turned into a update button
 
-## How to use:
+## How to use
 
 ```js
 import PluginSiteUpdateIndicator from 'my-sites/plugins/plugin-site-update-indicator';

--- a/client/my-sites/plugins/plugin-site/README.md
+++ b/client/my-sites/plugins/plugin-site/README.md
@@ -2,7 +2,7 @@
 
 This component is used to represent the state of a single instance of a plugin in a site. Internally, it follows a factory pattern, returning one instance of `plugin-site-network` or `plugin-site-jetpack` depending on the properties of the site received.
 
-## How to use:
+## How to use
 
 ```js
 import PluginSite from 'my-sites/plugins/plugin-site/plugin-site';

--- a/client/my-sites/plugins/plugins-browser-item/README.md
+++ b/client/my-sites/plugins/plugins-browser-item/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display small infobox with the data of a plugin.
 
-## How to use:
+## How to use
 
 ```js
 import PluginListItem from 'my-sites/plugins-browser-item';

--- a/client/my-sites/plugins/plugins-browser-list/README.md
+++ b/client/my-sites/plugins/plugins-browser-list/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display a list with the a parametrizable number of plugins of a certain category of the wordpress.org public plugin directory.
 
-## How to use:
+## How to use
 
 ```js
 import React from 'react';

--- a/client/my-sites/plugins/plugins-browser/README.md
+++ b/client/my-sites/plugins/plugins-browser/README.md
@@ -2,7 +2,7 @@
 
 This component renders the main plugins browser page.
 
-## How to use:
+## How to use
 
 ```js
 import BrowserMainView from 'my-sites/plugins/plugins-browser';

--- a/client/my-sites/plugins/plugins-list/README.md
+++ b/client/my-sites/plugins/plugins-list/README.md
@@ -2,7 +2,7 @@
 
 This component is used to represent a list `PluginItem`s, with a `PluginsListHeader` serving as a title for the whole bunch.
 
-## How to use:
+## How to use
 
 ```jsx
 import PluginsList from 'my-sites/plugins/plugins-list';

--- a/client/my-sites/sidebar-navigation/README.md
+++ b/client/my-sites/sidebar-navigation/README.md
@@ -2,7 +2,7 @@
 
 This component is used to display the mobile sidebar navigation header at the top of content sections. It sets `layout-focus` to `sidebar`.
 
-## How to use:
+## How to use
 
 Put the component in your `Main` component. It handles detecting the selected site.
 

--- a/client/my-sites/site-settings/redirect-non-jetpack/README.md
+++ b/client/my-sites/site-settings/redirect-non-jetpack/README.md
@@ -18,7 +18,7 @@ Destination site route passed to the HoC. The default redirect fallback is `/set
 `redirectRoute` can be custom created with a `siteSlug` of choice.
 If absent, it uses current `siteSlug` (if loaded).
 
-### How to use:
+### How to use
 
 The following code redirects to the `Plans` site for non-Jetpack and Atomic
 sites:

--- a/client/my-sites/stats/geochart/README.md
+++ b/client/my-sites/stats/geochart/README.md
@@ -2,7 +2,7 @@
 
 This component creates the geochart used in the Countries module. It utilizes the [geo chart](https://developers.google.com/chart/interactive/docs/gallery/geochart) provided by Google.
 
-## How to use:
+## How to use
 
 ```js
 import GeoChart from 'my-sites/stats/geochart';

--- a/client/my-sites/stats/post-performance/README.md
+++ b/client/my-sites/stats/post-performance/README.md
@@ -2,7 +2,7 @@
 
 This component creates an insights card that displays stats about the last post published for a site.
 
-## How to use:
+## How to use
 
 ```js
 import PostPerformance from 'my-sites/stats/post-performance';

--- a/client/my-sites/stats/post-trends/README.md
+++ b/client/my-sites/stats/post-trends/README.md
@@ -2,7 +2,7 @@
 
 This module provides a React component to visualize frequency of posting in a GitHub-like calendar view
 
-## How to use:
+## How to use
 
 ```js
 import PostTrends from 'my-sites/stats/post-trends';

--- a/client/my-sites/stats/stats-download-csv/README.md
+++ b/client/my-sites/stats/stats-download-csv/README.md
@@ -2,7 +2,7 @@
 
 The download csv component creates a download link that allows a stats-list to be exported as a csv file. [browser-filesaver](https://github.com/tmpvar/browser-filesaver) performs the HTML5 file saving operations behind the scenes
 
-## How to use:
+## How to use
 
 ```js
 import DownloadCsv from 'my-sites/stats/stats-download-csv';

--- a/client/my-sites/stats/stats-site-overview/README.md
+++ b/client/my-sites/stats/stats-site-overview/README.md
@@ -2,7 +2,7 @@
 
 This component creates Stats Overview which is what renders each site section on www.wordpress.com/stats when a user has more than 1 site.
 
-## How to use:
+## How to use
 
 ```js
 import StatsOverview from 'my-sites/stats/overview';

--- a/client/my-sites/themes/themes-banner/README.md
+++ b/client/my-sites/themes/themes-banner/README.md
@@ -2,7 +2,7 @@
 
 This component is used to implement a banner with image, text, and button.
 
-## How to use:
+## How to use
 
 Add the following code into the same directory of this README file. Each banner should be on its own file.
 

--- a/client/state/comments/README.md
+++ b/client/state/comments/README.md
@@ -1,6 +1,6 @@
 # Comments
 
-## This store has the following structure:
+## This store has the following structure
 
 ```
 comments = {
@@ -10,7 +10,7 @@ comments = {
 }>;
 ```
 
-## Types:
+## Types
 
     CommentTargetId: `${siteId}-${postId}`;
     RequestId: `${siteId}-${postId}-${stringify(query)}`; // query is the query to wpcom replies()
@@ -36,12 +36,12 @@ getPostCommentsTree - returns a memoized comments tree of the form:
 	}
 ```
 
-### Simple selectors:
+### Simple selectors
 
 getPostCommentItems - gets items of siteId, postId;
 getPostTotalCommentsCount - gets totalCommentsCount of siteId, postId
 
-### Compute selectors:
+### Compute selectors
 
 getPostMostRecentCommentDate - gets the date of most recent comment
 getPostOldestCommentDate - gets the date of the earliest comment

--- a/client/state/notices/README.md
+++ b/client/state/notices/README.md
@@ -31,7 +31,7 @@ this.props.successNotice( 'Settings saved successfully!', {
 } );
 ```
 
-### The available methods are:
+### The available methods are
 
 - `successNotice()`
 - `errorNotice()`

--- a/client/state/post-formats/README.md
+++ b/client/state/post-formats/README.md
@@ -38,7 +38,7 @@ state.postFormats = {
 };
 ```
 
-## Selectors are intended to assist in extracting data from the global state tree for consumption by other modules.
+## Selectors are intended to assist in extracting data from the global state tree for consumption by other modules
 
 ### `isRequestingPostFormats`
 

--- a/client/state/push-notifications/README.md
+++ b/client/state/push-notifications/README.md
@@ -2,9 +2,9 @@
 
 A module for managing push notification state & communicating with the service worker.
 
-## Selected selectors:
+## Selected selectors
 
-### `getStatus` (string):
+### `getStatus` (string)
 
 - `denied`: The user denied the push notification via the browser's UI. Further calls to the `activateSubscription` action will fail. The user must grant permission manually via the browser's UI. We cannot trigger that UI.
 - `subscribed`: The user has opted into push notifications via a call to `subscribe()`.
@@ -13,7 +13,7 @@ A module for managing push notification state & communicating with the service w
 - `unsubscribed`: The user has either not yet given permissions, or has revoked them via a call to `unsubscribe()`
 - `unknown`: The browser may not support push notifications, or the state has not yet been determined
 
-## Selected Action creators:
+## Selected Action creators
 
 - `toggleEnabled`: Turn push notifications on and off
 

--- a/client/test-helpers/use-nock/README.md
+++ b/client/test-helpers/use-nock/README.md
@@ -8,7 +8,7 @@ Because it's possible to allow `nock` interceptions and modifiers to persist bey
 
 `nock` is re-exported as a convenience so you don't have to import both `nock` and this module.
 
-## Format:
+## Format
 
 ```js
 useNock();

--- a/packages/calypso-analytics/README.md
+++ b/packages/calypso-analytics/README.md
@@ -1,4 +1,4 @@
-# Calypso Analytics.
+# Calypso Analytics
 
 Currently this package supports calls to Tracks only.
 

--- a/packages/components/src/progress-bar/README.md
+++ b/packages/components/src/progress-bar/README.md
@@ -5,7 +5,7 @@ and another bar on top of that filled, in a different color,
 with a % of the size of the background.
 Once this component is mounted, it will always progress forward, never backward: if `value` property is first 20 and later 15, the bar will still reflect the last maximum value, 20.
 
-## How to use:
+## How to use
 
 ```js
 import { ProgressBar } from '@automattic/components';

--- a/packages/components/src/ribbon/README.md
+++ b/packages/components/src/ribbon/README.md
@@ -7,7 +7,7 @@ place in our hearts.
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import { Card } from '@automattic/components';

--- a/packages/components/src/screen-reader-text/README.md
+++ b/packages/components/src/screen-reader-text/README.md
@@ -6,7 +6,7 @@ This idea was pulled from WordPress core, for more background & technical detail
 
 ---
 
-## How to use:
+## How to use
 
 ```js
 import { Button } from '@automattic/components';

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -16,7 +16,7 @@ yarn add @automattic/typography
 
 Note that this package contains two sass files and there are use cases for `@import`ing either file.
 
-### Import the `variables.scss` file:
+### Import the `variables.scss` file
 
 `@import '~@automattic/typography/styles/variables';`
 
@@ -28,7 +28,7 @@ Apply font variables as needed:
 }
 ```
 
-### Import the `fonts.sccc` file:
+### Import the `fonts.sccc` file
 
 `@import '~@automattic/typography/styles/fonts';`
 


### PR DESCRIPTION
### Background

After linting our Markdown files following prettier format, I'd like to introduce content-based rules from `remark`. The plugin we use (`eslint-plugin-md`) recommends [Markdown Style Guide](https://cirosantilli.com/markdown-style-guide/), and it has [a preset](https://www.npmjs.com/package/remark-preset-lint-markdown-style-guide) for it.

Unfortunately this preset doesn't have the capacity of auto-fix the problems. Instead of enabling the preset and having a ton of errors, I'll enable the rules of the preset one by one and fix each error. When all the rules are enabled we can switch the hardcoded list of rules by the preset.

### Changes

Enables rule [no-heading-punctuation](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-punctuation). This rule forbids to use `.` or `:` at the end of the titles (https://cirosantilli.com/markdown-style-guide/#punctuation-at-the-end-of-headers)

```
Good:

# Foo
# Bar

Bad:

# Foo:
# Bar.
```

### Testing
Run `./node_modules/.bin/eslint --ext .md .` and check there are no errors
