### PR TITLE
Activity Log: Remove WordPress.com links from the Jetpack Cloud Activity Log

### DIFF
--- a/client/components/activity-card/activity-description.tsx
+++ b/client/components/activity-card/activity-description.tsx
@@ -7,7 +7,6 @@ import React, { FunctionComponent } from 'react';
  * Internal dependencies
  */
 import FormattedBlock from 'components/notes-formatted-block';
-import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 
 // FUTURE WORK: move this to a shared location
 interface Activity {
@@ -31,16 +30,11 @@ const ActivityDescription: FunctionComponent< Props > = ( {
 } ) => (
 	<>
 		{ activityDescription.map( ( description, index ) => {
-			const { intent, section, type, url } = description;
-
-			const content =
-				isJetpackCloud() && type === 'link' && url?.startsWith( 'https://wordpress.com/' )
-					? { ...description, type: undefined, url: undefined }
-					: description;
+			const { intent, section } = description;
 
 			return (
 				<FormattedBlock
-					content={ content }
+					content={ description }
 					key={ index }
 					meta={ { activity: activityName, intent, section } }
 				/>

--- a/client/components/notes-formatted-block/test/blocks.js
+++ b/client/components/notes-formatted-block/test/blocks.js
@@ -5,85 +5,313 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 /**
+ * Mock dependencies
+ */
+jest.mock( 'lib/jetpack/is-jetpack-cloud' );
+import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
+
+// NOTE: There's a repeating pattern in these tests that links to WordPress.com
+//       aren't rendered in the context of Jetpack Cloud. Best I can tell, this
+//       is to keep people inside the Jetpack Cloud experience, as opposed to
+//       "booting" them back into Calypso.
+
+/**
  * Internal dependencies
  */
 import * as Blocks from '../blocks';
 
+expect.extend( {
+	toBeTextNodeWithValue( received, val ) {
+		const pass = received.type() === undefined && received.debug() === val;
+
+		return pass
+			? {
+					message: () => `expected not to be a text node with value '${ val }'`,
+					pass: true,
+			  }
+			: {
+					message: () => `expected to be a text node with value '${ val }'`,
+					pass: false,
+			  };
+	},
+} );
+
 describe( 'Link block', () => {
-	test( 'relativizes links to wordpress.com', () => {
+	beforeEach( () => jest.resetAllMocks() );
+
+	test( 'on Calypso, relativizes links to WordPress.com', () => {
+		isJetpackCloud.mockImplementation( () => false );
+
 		const pathAbsoluteUrl = '/my/test/link?with=params&more=stuff+plus%20junk';
+		const text = 'my link text';
 		const link = shallow(
-			<Blocks.Link content={ { url: `https://wordpress.com${ pathAbsoluteUrl }` } } />
+			<Blocks.Link
+				content={ { url: `https://wordpress.com${ pathAbsoluteUrl }` } }
+				children={ text }
+			/>
 		);
 
 		expect( link.prop( 'href' ) ).toEqual( pathAbsoluteUrl );
+		expect( link.text() ).toEqual( text );
 	} );
 
-	test( 'renders links to non-WordPress sites as-is', () => {
-		const arbitraryUrl = 'http://iscalypsofastyet.com/p/buildlog?branch=master';
-		const link = shallow( <Blocks.Link content={ { url: arbitraryUrl } } /> );
+	test( 'on Jetpack Cloud, does not render links to WordPress.com', () => {
+		isJetpackCloud.mockImplementation( () => true );
 
-		expect( link.prop( 'href' ) ).toEqual( arbitraryUrl );
+		const text = 'link text';
+		const link = shallow(
+			<Blocks.Link content={ { url: 'https://wordpress.com/my/test/link' } } children={ text } />
+		);
+
+		expect( link ).toBeTextNodeWithValue( text );
 	} );
+
+	test.each( [ false, true ] )(
+		'when isJetpackCloud() === %s, renders links to non-WordPress sites as-is',
+		( val ) => {
+			isJetpackCloud.mockImplementation( () => val );
+
+			const arbitraryUrl = 'http://iscalypsofastyet.com/p/buildlog?test1=test1';
+			const text = 'my link text';
+			const link = shallow( <Blocks.Link content={ { url: arbitraryUrl } } children={ text } /> );
+
+			expect( link.prop( 'href' ) ).toEqual( arbitraryUrl );
+			expect( link.text() ).toEqual( text );
+		}
+	);
 } );
 
 describe( 'Post block', () => {
-	test( 'links to the Trash page if the post is in the trash', () => {
+	beforeEach( () => jest.resetAllMocks() );
+
+	test( 'on Calypso, if the post is in the trash, links to the Trash page', () => {
+		isJetpackCloud.mockImplementation( () => false );
+
 		const content = {
 			siteId: 1,
 			isTrashed: true,
 		};
 
-		const post = shallow( <Blocks.Post content={ content } /> );
+		const text = 'this is a post';
+		const post = shallow( <Blocks.Post content={ content } children={ text } /> );
 
 		expect( post.prop( 'href' ) ).toEqual( `/posts/${ content.siteId }/trash` );
+		expect( post.text() ).toEqual( text );
 	} );
 
-	test( 'links to the post itself if the post is not trashed', () => {
+	test( 'on Jetpack Cloud, if the post is in the trash, shows text but does not link', () => {
+		isJetpackCloud.mockImplementation( () => true );
+
+		const content = {
+			siteId: 1,
+			isTrashed: true,
+		};
+
+		const text = 'this is a post';
+		const post = shallow( <Blocks.Post content={ content } children={ text } /> );
+
+		expect( post ).toBeTextNodeWithValue( text );
+	} );
+
+	test( 'on Calypso, if the post is not trashed, links to the post itself', () => {
+		isJetpackCloud.mockImplementation( () => false );
+
 		const content = {
 			siteId: 1,
 			postId: 10,
 			isTrashed: false,
 		};
 
-		const post = shallow( <Blocks.Post content={ content } /> );
+		const text = 'another post';
+		const post = shallow( <Blocks.Post content={ content } children={ text } /> );
 
 		expect( post.prop( 'href' ) ).toEqual(
 			`/read/blogs/${ content.siteId }/posts/${ content.postId }`
 		);
+		expect( post.text() ).toEqual( text );
+	} );
+
+	test( 'on Jetpack Cloud, if the post is not trashed, shows emphasized text but does not link', () => {
+		isJetpackCloud.mockImplementation( () => true );
+
+		const content = {
+			siteId: 1,
+			postId: 10,
+			isTrashed: false,
+		};
+
+		const text = 'another post';
+		const post = shallow( <Blocks.Post content={ content } children={ text } /> );
+
+		expect( post.type() ).toEqual( 'em' );
+		expect( post.text() ).toEqual( text );
+	} );
+} );
+
+describe( 'Comment block', () => {
+	beforeEach( () => jest.resetAllMocks() );
+	test( 'on Calypso, links to the comment itself', () => {
+		isJetpackCloud.mockImplementation( () => false );
+
+		const content = {
+			siteId: 'site_id',
+			postId: 'post_id',
+			commentId: 'comment_id',
+		};
+
+		const text = 'what a cool comment';
+		const comment = shallow( <Blocks.Comment content={ content } children={ text } /> );
+
+		expect( comment.prop( 'href' ) ).toEqual(
+			`/read/blogs/${ content.siteId }/posts/${ content.postId }#comment-${ content.commentId }`
+		);
+		expect( comment.text() ).toEqual( text );
+	} );
+
+	test( 'on Jetpack Cloud, shows text but does not link', () => {
+		isJetpackCloud.mockImplementation( () => true );
+
+		const content = {
+			siteId: 'site_id',
+			postId: 'post_id',
+			commentId: 'comment_id',
+		};
+
+		const text = 'what a cool comment';
+		const comment = shallow( <Blocks.Comment content={ content } children={ text } /> );
+
+		expect( comment ).toBeTextNodeWithValue( text );
+	} );
+} );
+
+describe( 'Person block', () => {
+	beforeEach( () => jest.resetAllMocks() );
+
+	test( 'on Calypso, links to the corresponding Person page', () => {
+		isJetpackCloud.mockImplementation( () => false );
+
+		const content = {
+			siteId: 'site_id',
+			name: 'Tony Stark',
+		};
+
+		const text = 'what a unique and wonderful person';
+		const person = shallow( <Blocks.Person content={ content } children={ text } meta={ {} } /> );
+
+		expect( person.prop( 'href' ) ).toEqual( `/people/edit/${ content.siteId }/${ content.name }` );
+		expect( person.text() ).toEqual( text );
+	} );
+
+	test( 'on Jetpack Cloud, shows text but does not link', () => {
+		isJetpackCloud.mockImplementation( () => true );
+
+		const content = {
+			siteId: 'site_id',
+			name: 'Tony Stark',
+		};
+
+		const text = 'what a unique and wonderful person';
+		const person = shallow( <Blocks.Person content={ content } children={ text } meta={ {} } /> );
+
+		expect( person.type() ).toEqual( 'strong' );
+		expect( person.text() ).toEqual( text );
+	} );
+} );
+
+describe( 'Plugin block', () => {
+	beforeEach( () => jest.resetAllMocks() );
+
+	test( 'on Calypso, links to the corresponding Plugin page', () => {
+		isJetpackCloud.mockImplementation( () => false );
+
+		const content = {
+			pluginSlug: 'plugin_slug',
+			siteSlug: 'site_slug',
+		};
+
+		const text = 'nifty plugin';
+		const plugin = shallow( <Blocks.Plugin content={ content } children={ text } meta={ {} } /> );
+
+		expect( plugin.prop( 'href' ) ).toEqual(
+			`/plugins/${ content.pluginSlug }/${ content.siteSlug }`
+		);
+		expect( plugin.text() ).toEqual( text );
+	} );
+
+	test( 'on Jetpack Cloud, shows text but does not link', () => {
+		isJetpackCloud.mockImplementation( () => true );
+
+		const content = {
+			pluginSlug: 'plugin_slug',
+			siteSlug: 'site_slug',
+		};
+
+		const text = 'nifty plugin';
+		const plugin = shallow( <Blocks.Plugin content={ content } children={ text } meta={ {} } /> );
+
+		expect( plugin ).toBeTextNodeWithValue( text );
 	} );
 } );
 
 describe( 'Theme block', () => {
-	test( 'uses a relative link if the theme URI points to wordpress.com', () => {
+	beforeEach( () => jest.resetAllMocks() );
+
+	test( 'on Calypso, if the theme URI is WordPress.com, renders the theme link with a relative URL', () => {
+		isJetpackCloud.mockImplementation( () => false );
+
 		const content = {
 			themeUri: 'https://wordpress.com/noneofthispartmatters',
 			themeSlug: 'mythemeslug',
 			siteSlug: 'mysiteslug',
 		};
 
-		const theme = shallow( <Blocks.Theme content={ content } meta={ {} } /> );
+		const text = 'oh neato a theme';
+		const theme = shallow( <Blocks.Theme content={ content } meta={ {} } children={ text } /> );
 
 		expect( theme.prop( 'href' ) ).toEqual( `/theme/${ content.themeSlug }/${ content.siteSlug }` );
+		expect( theme.text() ).toEqual( text );
 	} );
 
-	test( 'opens the original theme URI in a new tab if it does not point to wordpress.com', () => {
+	test( 'on Jetpack Cloud, if the theme URI is WordPress.com, does not render a link', () => {
+		isJetpackCloud.mockImplementation( () => true );
+
 		const content = {
-			themeUri: 'https://mycoolthemesite.example/thebestthemeever',
-			themeSlug: 'best-theme-ever',
-			siteSlug: 'asleep-newt.jurassic.ninja',
+			themeUri: 'https://wordpress.com/noneofthispartmatters',
+			themeSlug: 'mythemeslug',
+			siteSlug: 'mysiteslug',
 		};
 
-		const theme = shallow( <Blocks.Theme content={ content } meta={ {} } /> );
+		const text = 'oh neato a theme';
+		const theme = shallow( <Blocks.Theme content={ content } meta={ {} } children={ text } /> );
 
-		expect( theme.prop( 'href' ) ).toEqual( content.themeUri );
-		expect( theme.prop( 'target' ) ).toEqual( '_blank' );
-		expect( theme.prop( 'rel' ) ).toEqual( 'noopener noreferrer' );
+		expect( theme ).toBeTextNodeWithValue( text );
 	} );
 
-	test( 'does not render a link if no theme URI is present', () => {
-		const theme = shallow( <Blocks.Theme content={ {} } /> );
+	test.each( [ false, true ] )(
+		'when isJetpackCloud() === %s, if the theme URI is not WordPress.com, renders a new-tab link to the original theme URI',
+		( val ) => {
+			isJetpackCloud.mockImplementation( () => val );
 
-		expect( theme.exists( 'a' ) ).toBe( false );
+			const content = {
+				themeUri: 'https://mycoolthemesite.example/thebestthemeever',
+				themeSlug: 'best-theme-ever',
+				siteSlug: 'asleep-newt.jurassic.ninja',
+			};
+
+			const text = 'themes are pretty';
+			const theme = shallow( <Blocks.Theme content={ content } meta={ {} } children={ text } /> );
+
+			expect( theme.prop( 'href' ) ).toEqual( content.themeUri );
+			expect( theme.prop( 'target' ) ).toEqual( '_blank' );
+			expect( theme.prop( 'rel' ) ).toEqual( 'noopener noreferrer' );
+			expect( theme.text() ).toEqual( text );
+		}
+	);
+
+	test( 'if no theme URI is present, renders text but no link', () => {
+		const text = 'oh no, no url';
+		const theme = shallow( <Blocks.Theme content={ {} } children={ text } /> );
+
+		expect( theme ).toBeTextNodeWithValue( text );
 	} );
 } );


### PR DESCRIPTION
Fixes `1164141197617539-as-1192179611031378`.

#### Changes proposed in this Pull Request

* Add conditional logic and test coverage to ensure that Jetpack Cloud doesn't link out to WordPress.com from cards in the Activity Log.

##### Implementation note

As far as I know, the goal here is to not kick people out of Jetpack Cloud and back into WordPress.com when they're browsing their site's Activity Log. If we want to revisit this behavior later, it'll be easy enough to change because of the earlier refactor in #45591.

#### Testing instructions

**IMPORTANT:** This pull request creates divergent behavior between Calypso and Jetpack Cloud. Each of these environments should be tested for correctness before approval.

As a rule, Activity Log entries should behave as follows:
* If you're using Calypso/WordPress.com, all links to WordPress.com should be rendered as relative links (i.e., starting with the path, not the domain).
* If you're using Jetpack Cloud, all links to WordPress.com should be removed, but the text for these links should still remain.
* All links that lead to destinations outside WordPress.com (e.g., third-party themes, including WordPress.org) should be displayed as-is in both environments.

To test in either environment:

* Create or select a site that has Jetpack and a varied history of activities. Specifically, try to select for the following types of activities:
  * Plugin changes
  * Theme changes
  * People changes
  * Post changes
  * Comment changes
* After locating a specific activity from the above list on your site's Activity Log, examine the link markup (or lack thereof) to verify that it's been rendered correctly.

#### Reference screenshots

##### Calypso/WordPress.com

<img width="635" alt="Screen Shot 2020-09-14 at 13 41 02" src="https://user-images.githubusercontent.com/670067/93125084-3ef21f00-f690-11ea-9f18-85c75ff6f6b6.png">
<img width="537" alt="Screen Shot 2020-09-14 at 13 41 11" src="https://user-images.githubusercontent.com/670067/93125087-3f8ab580-f690-11ea-88f8-43eb95b31a85.png">
<img width="663" alt="Screen Shot 2020-09-14 at 13 42 52" src="https://user-images.githubusercontent.com/670067/93125089-3f8ab580-f690-11ea-9d5a-cad34d0ae343.png">

##### Jetpack Cloud

<img width="475" alt="Screen Shot 2020-09-14 at 13 48 51" src="https://user-images.githubusercontent.com/670067/93125669-1a4a7700-f691-11ea-8bab-a3a7e26b7c75.png">
<img width="337" alt="Screen Shot 2020-09-14 at 13 48 43" src="https://user-images.githubusercontent.com/670067/93125686-1e769480-f691-11ea-956f-44c7dc447d4a.png">
<img width="515" alt="Screen Shot 2020-09-14 at 13 49 10" src="https://user-images.githubusercontent.com/670067/93125746-2e8e7400-f691-11ea-846c-56315f2f3ce2.png">