### PR TITLE
Plans: FAQ update link to contact support

### DIFF
--- a/client/my-sites/plans-features-main/jetpack-faq.jsx
+++ b/client/my-sites/plans-features-main/jetpack-faq.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -10,17 +9,11 @@ import { localize } from 'i18n-calypso';
  */
 import FAQ from 'components/faq';
 import FAQItem from 'components/faq/faq-item';
-import HappychatButton from 'components/happychat/button';
-import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
-import { isEnabled } from 'config';
 
-const JetpackFAQ = ( { isChatAvailable, translate } ) => {
-	const helpLink =
-		isEnabled( 'jetpack/happychat' ) && isChatAvailable ? (
-			<HappychatButton className="plans-features-main__happychat-button" />
-		) : (
-			<a href="https://jetpack.com/contact-support/" target="_blank" rel="noopener noreferrer" />
-		);
+const JetpackFAQ = ( { translate } ) => {
+	const helpLink = (
+		<a href="https://jetpack.com/contact-support/" target="_blank" rel="noopener noreferrer" />
+	);
 
 	return (
 		<FAQ>
@@ -74,6 +67,4 @@ const JetpackFAQ = ( { isChatAvailable, translate } ) => {
 	);
 };
 
-export default connect( ( state ) => ( {
-	isChatAvailable: isHappychatAvailable( state ),
-} ) )( localize( JetpackFAQ ) );
+export default localize( JetpackFAQ );

--- a/client/my-sites/plans-features-main/jetpack-faq.jsx
+++ b/client/my-sites/plans-features-main/jetpack-faq.jsx
@@ -11,8 +11,17 @@ import FAQ from 'components/faq';
 import FAQItem from 'components/faq/faq-item';
 
 const JetpackFAQ = ( { translate } ) => {
+	// We want to allow Jetpack Free users to contact support, even when it isn't not available
+	// for them, because it could push them into purchasing a product. To make this possible, we
+	// add two query parameters that let's show the support form to Jetpack Free users:
+	// 1. rel=support is what shows the contact form
+	// 2. hpi=1 stands for has purchase intent
 	const helpLink = (
-		<a href="https://jetpack.com/contact-support/" target="_blank" rel="noopener noreferrer" />
+		<a
+			href="https://jetpack.com/contact-support/?rel=support&hpi=1"
+			target="_blank"
+			rel="noopener noreferrer"
+		/>
 	);
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the link to contact support with a link specially created for Jetpack Free users.
* Remove Happychat alternative since it's no longer supported.

#### Testing instructions

* Run this PR.
* Visit `jetpack/connect/store` and go to the FAQ section (at the bottom of the page).
* Make sure the contact link points to `https://jetpack.com/contact-support/?rel=support&hpi=1`.

Fixes 1169247016322522-as-1193677921810235

#### Demo

![image](https://user-images.githubusercontent.com/3418513/93128230-8cc55200-f6a5-11ea-89f0-78d6446b63e6.png)
