### PR TITLE
[markdown] Fix linting rule 'no-emphasis-as-heading'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,8 +29,7 @@ module.exports = {
 							[ 'lint-maximum-heading-length', false ],
 							[ 'lint-no-duplicate-headings', false ],
 
-							// Rules we would like to enable eventually. Violations need to be fixed manually before enabling the rule.
-							[ 'lint-no-emphasis-as-heading', false ],
+							// Rules we would like to enable eventually. Violations needs to be fixed manually before enabling the rule.
 							[ 'lint-final-definition', false ],
 							[ 'lint-code-block-style', false ],
 							[ 'lint-no-multiple-toplevel-headings', false ],

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/README.md
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/README.md
@@ -45,7 +45,7 @@ h1 {
 
 In the above example, the `body`'s font-family will be what the user selected as the base font, or `serif` if `--font-base` is not set. Likewise, the `h1`'s font-family will be what the user selected as the headings font, or `sans-serif` if `--font-headings` is not set.
 
-**Fallback values for CSS Custom Properties**
+### Fallback values for CSS Custom Properties
 
 Note the font-family fallbacks provided for when `--font-base` or `--font-headings` are not set. There are a number of situations where these variables can have the value `unset` or even not being present (which the browsers also consider as being `unset`):
 
@@ -134,7 +134,7 @@ If the `enqueue_experimental_styles` is present and it's `true`, the plugin will
 
 Note that if the theme requests enqueueing the experimental stylesheet, the experimental Global Styles styles will override the theme ones once the plugin is activated. By default, until the user makes a font choice, the _System Font_ will be used.
 
-**_Theme Default_ option**
+## _Theme Default_ option
 
 Themes that use this experimental feature can also add a _Theme Default_ option in the font picker by setting the `enable_theme_default` property to true. Note that when the user selects _Theme Default_ the font to be used is _System Font_. Per se, this isn't very useful, however, themes can also provide fallback fonts for when the font is `unset` (the user selected _Theme Default_ or hasn't made any choice yet):
 

--- a/apps/notifications/src/doc/note-rendering.md
+++ b/apps/notifications/src/doc/note-rendering.md
@@ -40,6 +40,8 @@ After some initial processing, the `NoteBody` component performs a switch statem
 
 Depending on the item's type, a different block component is rendered - `User` for a representation of a user (for instance, in a notification of a user liking a particular post), `Comment` for a comment made on a blog post, `Post` for a blog post (i.e. on a blog the user is following), `ReplyBlock` for a reply to a comment(?).
 
+<!--eslint ignore no-emphasis-as-heading-->
+
 _n.b. - these 'blocks' are separate from the concept of 'blocks' in the Gutenberg block editor; a notification might have multiple blocks (for instance, multiple `User` blocks for multiple likes on a post), or it might have a single `Post` block, which then further renders Gutenberg blocks as part of the post content._
 
 These notification block components will be your entry point for any modifications you need to do to the way a particular notification is rendered to the user.

--- a/client/components/forms/sortable-list/README.md
+++ b/client/components/forms/sortable-list/README.md
@@ -2,11 +2,11 @@
 
 SortableList is a React component to enable device-friendly item rearranging. For non-touch devices, child elements of SortableList can be rearranged by drag-and-drop. On touch devices, the user must tap an item to activate it before rearranging via one of two directional button controls.
 
-_Desktop_
+## Desktop
 
 ![Desktop](https://cldup.com/kcSdY87WOC.gif)
 
-_Touch_
+## Touch
 
 ![Touch](https://cldup.com/G6xOcADYAl.gif)
 

--- a/client/lib/email-followers/README.md
+++ b/client/lib/email-followers/README.md
@@ -2,28 +2,31 @@
 
 A [flux](https://facebook.github.io/flux/docs/overview.html#content) approach for managing a site's email followers in Calypso.
 
-####Public Methods
+## Email Followers Store
 
-**EmailFollowersStore.getFollowers( fetchOptions );**
+### Public Methods
+
+#### EmailFollowersStore.getFollowers( fetchOptions );
 
 Returns an array of all followers that have been fetched for the given fetch options
 
 ---
 
-**EmailFollowersStore.getPaginationData( fetchOptions );**
+#### EmailFollowersStore.getPaginationData( fetchOptions );
 
 This data will help with pagination and infinite scroll.
 
-###Actions
+## Actions
+
 Actions get triggered by views and stores.
 
-####Public methods.
+### Public methods
 
-**EmailFollowersActions.fetchFollowers( fetchOptions );**
+#### EmailFollowersActions.fetchFollowers( fetchOptions );
 
 Fetches followers in batches of 100 starting from the given page, which defaults to 1.
 
-###Example Component Code
+## Example Component Code
 
 ```es6
 /**
@@ -33,7 +36,7 @@ import React from 'react';
 
 /**
  * Internal dependencies
- */ 
+ */
 import EmailFollowersStore from 'lib/followers/wpcom-followers-store';
 import EmailFollowersActions from 'lib/followers/actions';
 
@@ -67,7 +70,7 @@ export default class extends React.Component {
 
 	render() {
 
-	} 
+	}
 } );
 
 ```

--- a/client/lib/followers/README.md
+++ b/client/lib/followers/README.md
@@ -2,28 +2,31 @@
 
 A [flux](https://facebook.github.io/flux/docs/overview.html#content) approach for managing a site's followers in Calypso.
 
-####Public Methods
+## Followers Store
 
-**FollowersStore.getFollowers( fetchOptions );**
+### Public Methods
+
+#### FollowersStore.getFollowers( fetchOptions );
 
 Returns an array of all followers that have been fetched for the given fetch options
 
 ---
 
-**FollowersStore.getPaginationData( fetchOptions );**
+#### FollowersStore.getPaginationData( fetchOptions );
 
 This data will help with pagination and infinite scroll.
 
-###Actions
+## Actions
+
 Actions get triggered by views and stores.
 
-####Public methods.
+### Public methods
 
-**FollowersActions.fetchFollowers( fetchOptions );**
+#### FollowersActions.fetchFollowers( fetchOptions );
 
 Fetches followers in batches of 100 starting from the given page, which defaults to 1.
 
-###Example Component Code
+## Example Component Code
 
 ```es6
 /**
@@ -41,21 +44,21 @@ export default class extends React.Component {
 	static displayName = 'yourComponent';
 
 	state = this.getFollowers();
-	
+
 	fetchOptions: {
 	    siteId: this.props.siteId,
 	    type: 'email'
 	}
-	
+
 	componentDidMount() {
 		FollowersActions.fetchFollowers( this.fetchOptions );
 		FollowersStore.on( 'change', this.refreshFollowers );
 	}
-	
+
 	componentWillUnmount() {
 		FollowersStore.removeListener( 'change', this.refreshFollowers );
-	} 
-	
+	}
+
 	getFollowers = () => {
 		return {
 			followers: FollowersStore.getFollowers( this.props.fetchOptions )
@@ -65,9 +68,9 @@ export default class extends React.Component {
 	refreshFollowers = () => {
 		this.setState( this.getFollowers() );
 	}
-	
+
 	render() {
-		
-	} 
-} 
+
+	}
+}
 ```

--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -2,10 +2,12 @@
 
 Plugins uses a [flux](https://facebook.github.io/flux/docs/overview.html#content) approach to managing plugins data in calypso.
 
-###Plugins Store
+## Plugins Store
+
 The Plugins Store is responsible for keeping each site's plugin list up to date. Initially it loads the data and request it as it gets updated. This store also listens to any actions relevant to keep the data up to date such as the plugin update/activate/deactivate etc.
 
-####The Data
+### The Data
+
 The Data that is stored in the sites plugin store looks like this:
 
 ```js
@@ -39,15 +41,15 @@ The Data that is stored in the sites plugin store looks like this:
 
 The Data is stored in a private variable but can be accessed though the stores public methods.
 
-####Public Methods
+### Public Methods
 
-**PluginsStore.getPlugin( sites, pluginSlug );**
+#### PluginsStore.getPlugin( sites, pluginSlug );
 
 Returns a plugin object that has a sites attribute which stores an array of sites objects that have that particular plugin.
 
 ---
 
-**PluginsStore.getPlugins( sites, pluginFilter );**
+#### PluginsStore.getPlugins( sites, pluginFilter );
 
 Returns an array of plugin object that has a sites attribute which stores an array of sites objects that have that particular plugin.
 
@@ -55,23 +57,23 @@ Note: pluginFilter can be any of the following string: 'none' , 'all', 'active',
 
 ---
 
-**PluginsStore.getSitePlugins( site );**
+#### PluginsStore.getSitePlugins( site );
 
 Returns an array of plugin objects for a particular site.
 
 ---
 
-**PluginsStore.getSitePlugin( site, pluginSlug );**
+#### PluginsStore.getSitePlugin( site, pluginSlug );
 
 Returns a plugin objects for a particular site.
 
 ---
 
-**PluginsStore.getSites( sites, pluginSlug );**
+#### PluginsStore.getSites( sites, pluginSlug );
 
 Returns an array of sites that have a particular plugin.
 
-####Example Component Code:
+### Example Component Code:
 
 ```es6
 /**
@@ -116,58 +118,59 @@ export default class extends React.Component {
 
 ```
 
-###Actions
+## Actions
+
 Actions get triggered by views and stores.
 
-####Public methods.
+### Public methods.
 
 Triggers api call to fetch the site data.
 
-**PluginsActions.fetchSitePlugins( site );**
+#### PluginsActions.fetchSitePlugins( site );
 
 ---
 
 Update a plugin on a site.
 
-**PluginsActions.updatePlugin( site, plugin );**
+#### PluginsActions.updatePlugin( site, plugin );
 
 ---
 
 Toggle a plugin active state on a site.
 
-**PluginsActions.togglePluginActivation( site, plugin );**
+#### PluginsActions.togglePluginActivation( site, plugin );
 
 ---
 
 Activate a plugin on a site.
 
-**PluginsActions.activatePlugin( site, plugin );**
+#### PluginsActions.activatePlugin( site, plugin );
 
 ---
 
 Deactivate a plugin on a site.
 
-**PluginsActions.deactivatePlugin( site, plugin );**
+#### PluginsActions.deactivatePlugin( site, plugin );
 
 ---
 
 Enable AutoUpdates for a plugin on a site.
 
-**PluginsActions.enableAutoUpdatesPlugin( site, plugin );**
+#### PluginsActions.enableAutoUpdatesPlugin( site, plugin );
 
 ---
 
 Disable AutoUpdates for a plugin on a site.
 
-**PluginsActions.disableAutoUpdatesPlugin( site, plugin );**
+#### PluginsActions.disableAutoUpdatesPlugin( site, plugin );
 
 ---
 
 Toggle AutoUpdates for a plugin on a site.
 
-**PluginsActions.togglePluginAutoUpdate( site, plugin );**
+#### PluginsActions.togglePluginAutoUpdate( site, plugin );
 
-####Example Component Code:
+## Example Component Code:
 
 ```jsx
 /**

--- a/client/lib/users/README.md
+++ b/client/lib/users/README.md
@@ -2,29 +2,32 @@
 
 A [flux](https://facebook.github.io/flux/docs/overview.html#content) approach for managing a site's users in Calypso.
 
-###The Data
+## Users store
+
+### The Data
 
 The Data is stored in a private variable but can be accessed though the stores public methods.
 
-####Public Methods
+### Public Methods
 
-**UsersStore.getUsers( options );**
+#### UsersStore.getUsers( options );
 
 Returns an array of users that have been fetched with the given options describing the fetch query.
 
 ---
 
-**UsersStore.getPaginationData( options );**
+#### UsersStore.getPaginationData( options );
 
 Returns an object: ``{ totalUsers: int, fetchingUsers: bool, usersCurrentOffset: int, numUsersFetched: int }`
 This data will help with pagination and infinite scroll.
 
-###Actions
+## Actions
+
 Actions get triggered by views and stores.
 
-####Public methods.
+### Public methods
 
-**UsersActions.fetchUsers( options );**
+#### UsersActions.fetchUsers( options );
 
 `options` is an object that describes any custom query params you want to pass into the `wpcom.js` [usersList method](https://github.com/Automattic/wpcom.js/blob/HEAD/docs/site.md#siteuserslistquery-fn) which passes parameters into the REST API [`/site/$site/users` endpoint](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/users/). The only required attribute is siteId. Current default values include:
 
@@ -35,7 +38,7 @@ Actions get triggered by views and stores.
 }
 ```
 
-###Example Component Code
+## Example Component Code
 
 ```es6
 /**
@@ -51,15 +54,15 @@ import UsersStore from 'lib/users/store';
 export default class extends React.Component {
 	static displayName = 'yourComponent';
 	state = this.getUsers();
-	
+
 	componentDidMount() {
 		UsersStore.on( 'change', this.refreshUsers );
 	}
-	
+
 	componentWillUnmount() {
 		UsersStore.removeListener( 'change', this.refreshUsers );
-	} 
-	
+	}
+
 	getUsers = () => {
 		return {
 			users: UsersStore.fetch( { siteId: this.props.site.ID } )
@@ -67,9 +70,9 @@ export default class extends React.Component {
 	},
 
 	refreshUsers = () => this.setState( this.getUsers() );
-	
+
 	render() {
-		
-	} 
-} 
+
+	}
+}
 ```


### PR DESCRIPTION
### Background

After linting our Markdown files following prettier format, I'd like to introduce content-based rules from `remark`. The plugin we use (`eslint-plugin-md`) recommends [Markdown Style Guide](https://cirosantilli.com/markdown-style-guide/), and it has [a preset](https://www.npmjs.com/package/remark-preset-lint-markdown-style-guide) for it.

Unfortunately this preset doesn't have the capacity of auto-fix the problems. Instead of enabling the preset and having a ton of errors, I'll enable the rules of the preset one by one and fix each error. When all the rules are enabled we can switch the hardcoded list of rules by the preset.

### Changes

Enables rule [no-emphasis-as-heading](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-emphasis-as-heading). This rule forbids to use emphasis elements (bold or italics) to simulate headers (https://cirosantilli.com/markdown-style-guide/#emphasis-vs-headers)

```
Good:

# Foo

Bad:

**Foo**
```

### Testing
Run `./node_modules/.bin/eslint --ext .md .` and check there are no errors
