### PR TITLE
[markdown] Fix linting rule 'code-block-style'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,6 @@ module.exports = {
 
 							// Rules we would like to enable eventually. Violations needs to be fixed manually before enabling the rule.
 							[ 'lint-final-definition', false ],
-							[ 'lint-code-block-style', false ],
 							[ 'lint-no-multiple-toplevel-headings', false ],
 							[ 'lint-fenced-code-flag', false ],
 

--- a/client/state/comments/README.md
+++ b/client/state/comments/README.md
@@ -12,8 +12,10 @@ comments = {
 
 ## Types
 
+```text
     CommentTargetId: `${siteId}-${postId}`;
     RequestId: `${siteId}-${postId}-${stringify(query)}`; // query is the query to wpcom replies()
+```
 
 ## Selectors
 

--- a/packages/components/src/dialog/README.md
+++ b/packages/components/src/dialog/README.md
@@ -139,10 +139,10 @@ You can provide custom styling for a dialog by making use of the following prope
 - `baseClassName`: if you specify this, you are responsible for providing all the following classes for the dialog (you
   can `@extend` the base `dialog` SCSS classes if you just want to tweak things a bit):
 
-      - _baseClassName_
-      - _baseClassName___backdrop
-      - _baseClassName___content
-      - _baseClassName___action-buttons
+  - _baseClassName_
+  - \_baseClassName\_\_\_backdrop
+  - \_baseClassName\_\_\_content
+  - \_baseClassName\_\_\_action-buttons
 
 - `additionalClassNames`: if you specify this, these additional class names will be applied to the dialog element
   (not the backdrop)

--- a/packages/components/src/dialog/README.md
+++ b/packages/components/src/dialog/README.md
@@ -139,10 +139,10 @@ You can provide custom styling for a dialog by making use of the following prope
 - `baseClassName`: if you specify this, you are responsible for providing all the following classes for the dialog (you
   can `@extend` the base `dialog` SCSS classes if you just want to tweak things a bit):
 
-  - _baseClassName_
-  - \_baseClassName\_\_\_backdrop
-  - \_baseClassName\_\_\_content
-  - \_baseClassName\_\_\_action-buttons
+  - `_baseClassName_`
+  - `_baseClassName___backdrop`
+  - `_baseClassName___content`
+  - `_baseClassName___action-buttons`
 
 - `additionalClassNames`: if you specify this, these additional class names will be applied to the dialog element
   (not the backdrop)

--- a/packages/material-design-icons/README.md
+++ b/packages/material-design-icons/README.md
@@ -31,6 +31,8 @@ Move the SVG files in the sub-folder matching the category used on material.io.
 
 Rebuild `material-icons.svg` by running:
 
-    yarn workspace @automattic/material-design-icons run build
+```bash
+yarn workspace @automattic/material-design-icons run build
+```
 
 Beware that default style and size for `MaterialIcon` class is `outline` and `24`.

--- a/test/e2e/docs/running-tests.md
+++ b/test/e2e/docs/running-tests.md
@@ -73,29 +73,31 @@ Or you can use the -s option on the run.sh script:
 
 The `run.sh` script takes the following parameters, which can be combined to execute a variety of suites
 
-    -a [workers]  - Number of parallel workers in Magellan (defaults to 3)
-    -R  - Use custom Slack/Spec/XUnit reporter, otherwise just use Spec reporter
-    -p  - Execute the tests in parallel via CircleCI envvars (implies -g -s mobile,desktop)
-    -S [commitHash]   - Run tests against given commit via https://calypso.live
-    -B [branch]  - Run Jetpack tests on given Jetpack branch via https://jurassic.ninja
-    -s  - Screensizes in a comma-separated list (defaults to mobile,desktop)
-    -g  - Execute general tests in the specs/ directory
-    -j  - Execute Jetpack tests in the specs-jetpack-calypso/ directory (desktop and mobile)
-    -W  - Execute WooCommerce tests in the specs-woocommerce/ directory (desktop and mobile)
-    -C  - Execute tests tagged with @canary
-    -J  - Execute Jetpack connect tests tagged with @canary
-    -H [host]  - Specify an alternate host for Jetpack tests
-    -w - Only execute signup tests on Windows/IE11, not compatible with -g flag
-    -z  - Only execute canary tests on Windows/IE11, not compatible with -g flag
-    -y  - Only execute canary tests on Safari 10 on Mac, not compatible with -g flag
-    -l [config]  - Execute the tests via Sauce Labs with the given configuration
-    -c  - Exit with status code 0 regardless of test results
-    -m [browsers]  - Execute the multi-browser visual-diff tests with the given list of browsers via grunt.  Specify browsers in comma-separated list or 'all'
-    -i  - Execute i18n NUX screenshot tests, not compatible with -g flag
-    -I  - Execute tests in specs-i18n/ directory
-    -x  - Execute the tests from the context of xvfb-run
-    -u [baseUrl]  - Override the calypsoBaseURL config
-    -h  - This help listing
+```text
+-a [workers]  - Number of parallel workers in Magellan (defaults to 3)
+-R  - Use custom Slack/Spec/XUnit reporter, otherwise just use Spec reporter
+-p  - Execute the tests in parallel via CircleCI envvars (implies -g -s mobile,desktop)
+-S [commitHash]   - Run tests against given commit via https://calypso.live
+-B [branch]  - Run Jetpack tests on given Jetpack branch via https://jurassic.ninja
+-s  - Screensizes in a comma-separated list (defaults to mobile,desktop)
+-g  - Execute general tests in the specs/ directory
+-j  - Execute Jetpack tests in the specs-jetpack-calypso/ directory (desktop and mobile)
+-W  - Execute WooCommerce tests in the specs-woocommerce/ directory (desktop and mobile)
+-C  - Execute tests tagged with @canary
+-J  - Execute Jetpack connect tests tagged with @canary
+-H [host]  - Specify an alternate host for Jetpack tests
+-w - Only execute signup tests on Windows/IE11, not compatible with -g flag
+-z  - Only execute canary tests on Windows/IE11, not compatible with -g flag
+-y  - Only execute canary tests on Safari 10 on Mac, not compatible with -g flag
+-l [config]  - Execute the tests via Sauce Labs with the given configuration
+-c  - Exit with status code 0 regardless of test results
+-m [browsers]  - Execute the multi-browser visual-diff tests with the given list of browsers via grunt.  Specify browsers in comma-separated list or 'all'
+-i  - Execute i18n NUX screenshot tests, not compatible with -g flag
+-I  - Execute tests in specs-i18n/ directory
+-x  - Execute the tests from the context of xvfb-run
+-u [baseUrl]  - Override the calypsoBaseURL config
+-h  - This help listing
+```
 
 ## To run headlessly
 


### PR DESCRIPTION
### Background

After linting our Markdown files following prettier format, I'd like to introduce content-based rules from `remark`. The plugin we use (`eslint-plugin-md`) recommends [Markdown Style Guide](https://cirosantilli.com/markdown-style-guide/), and it has [a preset](https://www.npmjs.com/package/remark-preset-lint-markdown-style-guide) for it.

Unfortunately this preset doesn't have the capacity of auto-fix the problems. Instead of enabling the preset and having a ton of errors, I'll enable the rules of the preset one by one and fix each error. When all the rules are enabled we can switch the hardcoded list of rules by the preset.

### Changes

Enables rule [code-block-style](https://github.com/remarkjs/remark-lint/tree/main/packages/code-block-style). This rule forces to use ``` to denote a code block instead of extra indentation (https://cirosantilli.com/markdown-style-guide/#code-blocks)

    Good:

    ```
    code
    ```

    Bad:

        code
```

### Testing
Run `./node_modules/.bin/eslint --ext .md .` and check there are no errors
