### PR TITLE
[markdown] Fix linting rule 'final-definition'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,8 +30,6 @@ module.exports = {
 							[ 'lint-no-duplicate-headings', false ],
 
 							// Rules we would like to enable eventually. Violations needs to be fixed manually before enabling the rule.
-							[ 'lint-no-emphasis-as-heading', false ],
-							[ 'lint-code-block-style', false ],
 							[ 'lint-no-multiple-toplevel-headings', false ],
 							[ 'lint-fenced-code-flag', false ],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,8 @@ module.exports = {
 							[ 'lint-no-duplicate-headings', false ],
 
 							// Rules we would like to enable eventually. Violations needs to be fixed manually before enabling the rule.
-							[ 'lint-final-definition', false ],
+							[ 'lint-no-emphasis-as-heading', false ],
+							[ 'lint-code-block-style', false ],
 							[ 'lint-no-multiple-toplevel-headings', false ],
 							[ 'lint-fenced-code-flag', false ],
 

--- a/apps/notifications/src/doc/public-api.md
+++ b/apps/notifications/src/doc/public-api.md
@@ -71,8 +71,6 @@ Similar to how `isVisible` indicates a notion of being able to be seen, `isShowi
 
 Used to force a manual refresh of the notes from the server.
 
-[visibility]: https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState
-
 ## Signals from App
 
 ### `iFrameReady` - `onReady() : {}`
@@ -94,3 +92,5 @@ Indicates a request to close the notifications panel.
 ### `widescreen` - `onLayoutChange() : { layout: 'narrow' | 'widescreen' }`
 
 Indicates that the app is toggling from narrow to widescreen layouts. Passes along the boolean `widescreen` to indicate which layout is active.
+
+[visibility]: https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState

--- a/client/extensions/README.md
+++ b/client/extensions/README.md
@@ -6,11 +6,6 @@ If you're a developer that has a plugin with one million or more active installa
 
 Before you get started we encourage you to get familiar with our [development values], [code-reviewing practice][prs], components and [data approach], and the [rest of the docs][docs] we have. Every folder in the project should have a README describing its purpose.
 
-[development values]: https://wpcalypso.wordpress.com/devdocs/docs/guide/0-values.md
-[data approach]: https://wpcalypso.wordpress.com/devdocs/docs/our-approach-to-data.md
-[docs]: https://wpcalypso.wordpress.com/devdocs
-[prs]: https://wpcalypso.wordpress.com/devdocs/docs/CONTRIBUTING.md#pull-requests
-
 ## Defining a new section
 
 Create a new directory within `/client/extensions` with your plugin name. Add a `package.json` file at the root of your directory. Add a `section` field in the same format as those found in `client/sections.js`:
@@ -85,3 +80,8 @@ import myReducer from 'my-extension/state/reducer';
 ## State
 
 Calypso has almost transitioned to a single-state store provided by Redux. The end scenario is that your extension would have access to the entire state tree and would be allowed to add a sub-tree. This is a work in progress and we need to figure out what are the requirements and safeguards we need to put in place.
+
+[development values]: https://wpcalypso.wordpress.com/devdocs/docs/guide/0-values.md
+[data approach]: https://wpcalypso.wordpress.com/devdocs/docs/our-approach-to-data.md
+[docs]: https://wpcalypso.wordpress.com/devdocs
+[prs]: https://wpcalypso.wordpress.com/devdocs/docs/CONTRIBUTING.md#pull-requests

--- a/client/my-sites/jetpack-manage-error-page/README.md
+++ b/client/my-sites/jetpack-manage-error-page/README.md
@@ -5,7 +5,6 @@ and render an appropriate error page before any management tools are rendered.
 
 This component is an extension of the [EmptyContent component][1], and it accepts
 the same properties.
-[1]: https://github.com/Automattic/wp-calypso/tree/HEAD/client/components/empty-content
 
 Additionally, this component accepts a `template` property which will render some pre-defined
 templates. Here are acceptable values for `template` along with examples of how to use them.
@@ -46,3 +45,5 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
     illustration="/calypso/images/illustrations/illustration-jetpack.svg"
 />
 ```
+
+[1]: https://github.com/Automattic/wp-calypso/tree/HEAD/client/components/empty-content


### PR DESCRIPTION
### Background

After linting our Markdown files following prettier format, I'd like to introduce content-based rules from `remark`. The plugin we use (`eslint-plugin-md`) recommends [Markdown Style Guide](https://cirosantilli.com/markdown-style-guide/), and it has [a preset](https://www.npmjs.com/package/remark-preset-lint-markdown-style-guide) for it.

Unfortunately this preset doesn't have the capacity of auto-fix the problems. Instead of enabling the preset and having a ton of errors, I'll enable the rules of the preset one by one and fix each error. When all the rules are enabled we can switch the hardcoded list of rules by the preset.

### Changes

Enables rule [final-definition](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-definition). This rule forces link definitions to be at the end of the file (https://cirosantilli.com/markdown-style-guide/#reference-style-links)

```

Bad:

Paragraph.

[example]: http://example.com "Example Domain"

Another paragraph.

--- 

Good:

Paragraph.

Another paragraph.

[example]: http://example.com "Example Domain"
```

### Testing
Run `./node_modules/.bin/eslint --ext .md .` and check there are no errors
