### PR TITLE
Premium Content: Fix Fatal Error from Custom Exceptions

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/subscription-service/class-jwt.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/subscription-service/class-jwt.php
@@ -28,9 +28,15 @@ use \DateTime;
  */
 
 // define extra exceptions used
-class SignatureInvalidException extends \UnexpectedValueException { }
-class ExpiredException extends \UnexpectedValueException { }
-class BeforeValidException extends \UnexpectedValueException { }
+if ( ! class_exists( 'SignatureInvalidException' ) ) {
+	class SignatureInvalidException extends \UnexpectedValueException { }
+}
+if ( ! class_exists( 'ExpiredException' ) ) {
+	class ExpiredException extends \UnexpectedValueException { }
+}
+if ( ! class_exists( 'BeforeValidException' ) ) {
+	class BeforeValidException extends \UnexpectedValueException { }
+}
 
 class JWT {
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/subscription-service/class-jwt.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/subscription-service/class-jwt.php
@@ -26,6 +26,12 @@ use \DateTime;
  * @license  http://opensource.org/licenses/BSD-3-Clause 3-clause BSD
  * @link     https://github.com/firebase/php-jwt
  */
+
+// define extra exceptions used
+class SignatureInvalidException extends \UnexpectedValueException { }
+class ExpiredException extends \UnexpectedValueException { }
+class BeforeValidException extends \UnexpectedValueException { }
+
 class JWT {
 
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Premium Content seems to be missing custom exceptions resulting in fatal errors experienced in Calypso. See this thread: p1599397148031300-slack-C4N88L95W. I synced up with @obenland about steps to reproduce, and we were unable to come up with a way to reproduce these fatal errors -- but we know it's happening per p1599397148031300-slack-C4N88L95W
* What we know is that in our code editors, there is a warning message whenever you hover over these exceptions used. Resolving these warning messages is considered a reasonable fix to this since the type is defined and hopefully prevents the fatal error, since we're not able to reproduce the fatal error messages another way
* A caveat here that could be encountered is if another plugin defines these exceptions, and they clash

#### Testing instructions

* These errors could not be reproduced, however, there are errors listed in the code editor for certain exceptions
* In your code editor (if you're running VSCode, make sure you install PHP Intelephense, if you have another code editor, use the equivalent) hover over the uses for `SignatureInvalidException`, `ExpiredException`, and `BeforeValidException` in `apps/editing-toolkit/editing-toolkit-plugin/premium-content/subscription-service/class-jwt.php`. You should no longer see an `Undefined type` error for any of them.

#### Screenshots
Before | After
--- | ---
<img width="893" alt="Screen Shot 2020-09-14 at 6 37 59 PM" src="https://user-images.githubusercontent.com/66652282/93145717-103d6e00-f6bb-11ea-8acc-f1ffdf74fecc.png"> | <img width="861" alt="Screen Shot 2020-09-14 at 6 38 09 PM" src="https://user-images.githubusercontent.com/66652282/93145732-17647c00-f6bb-11ea-8b5f-ceec9fad955a.png">


Fixes #45417 
