### PR TITLE
Reader: try v2 tag posts endpoint

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -159,6 +159,7 @@
 		"reader/list-management": true,
 		"reader/seen-posts": true,
 		"reader/user-mention-suggestions": true,
+		"reader/v2-tag-streams": true,
 		"recommend-plugins": true,
 		"republicize": true,
 		"rum-tracking/logstash": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -134,6 +134,7 @@
 		"reader/full-errors": true,
 		"reader/seen-posts": true,
 		"reader/user-mention-suggestions": true,
+		"reader/v2-tag-streams": true,
 		"recommend-plugins": true,
 		"republicize": true,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Try using the new v2 `/read/tags/posts` endpoint for tag streams.

Todo: 
- [ ] fix pagination
- [ ] fix polling
- [ ] try popularity sort

#### Testing instructions

Head to a tag stream like https://wpcalypso.wordpress.com/tag/animals.
