### PR TITLE
Reader: don't try to sync follows when offline

### DIFF
--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { translate } from 'i18n-calypso';
 import { forEach } from 'lodash';
 
 /**
@@ -14,7 +15,9 @@ import {
 import { receiveFollows, syncComplete } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { errorNotice } from 'state/notices/actions';
 import { isValidApiResponse, subscriptionsFromApi } from './utils';
+
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
 const ITEMS_PER_PAGE = 200;
@@ -93,6 +96,9 @@ export const receivePage = ( action, apiResponse ) => ( dispatch ) => {
 
 export function receiveError() {
 	syncingFollows = false;
+	return errorNotice( translate( 'Sorry, we had a problem fetching your Reader subscriptions.' ), {
+		duration: 4000,
+	} );
 }
 
 const syncPage = dispatchRequest( {

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { translate } from 'i18n-calypso';
 import { forEach } from 'lodash';
 
 /**
@@ -15,9 +14,7 @@ import {
 import { receiveFollows, syncComplete } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { errorNotice } from 'state/notices/actions';
 import { isValidApiResponse, subscriptionsFromApi } from './utils';
-
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
 const ITEMS_PER_PAGE = 200;
@@ -96,7 +93,6 @@ export const receivePage = ( action, apiResponse ) => ( dispatch ) => {
 
 export function receiveError() {
 	syncingFollows = false;
-	return errorNotice( translate( 'Sorry, we had a problem fetching your Reader subscriptions.' ) );
 }
 
 const syncPage = dispatchRequest( {

--- a/client/state/selectors/should-sync-reader-follows.js
+++ b/client/state/selectors/should-sync-reader-follows.js
@@ -2,10 +2,15 @@
  * Internal dependencies
  */
 import { getReaderFollowsLastSyncTime } from 'state/reader/follows/selectors';
+import { isOffline } from 'state/application/selectors';
 
 export const MS_BETWEEN_SYNCS = 1000 * 60 * 60; // one hour
 
 export default function shouldSyncReaderFollows( state ) {
+	if ( isOffline( state ) ) {
+		return false;
+	}
+
 	const lastTime = getReaderFollowsLastSyncTime( state );
 	const eligibleTime = lastTime + MS_BETWEEN_SYNCS;
 	return Date.now() > eligibleTime;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We periodically check the user's Reader subscriptions in the background. If we can't fetch a user's subscriptions from the API, we alert the user with an error notice fired off by the data layer saying:

"Sorry, we had a problem fetching your Reader subscriptions."

This can also happens any time Calypso loses a connection and goes offline. It's fairly annoying to dismiss this every time a connection is lost.

This PR prevents the sync from being triggered if Calypso is offline.

<img width="1226" alt="Screen Shot 2020-09-15 at 15 31 13" src="https://user-images.githubusercontent.com/17325/93162771-97491f80-f769-11ea-91ba-af10b0b3287f.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
1. Check out the PR's branch and `yarn start`
2. Navigate to `/read`
3. Disconnect from the internet
4. Wait several minutes, and make sure the error notice doesn't appear




