### PR TITLE
Bump WordPress.com Editing Toolkit plugin to v2.4

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.3
+ * Version: 2.4
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.3' );
+define( 'PLUGIN_VERSION', '2.4' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -43,6 +43,8 @@ This plugin is experimental, so we don't provide any support for it outside of w
 = 2.4 =
 * Remove direct dependency on `swiper` (https://github.com/Automattic/wp-calypso/pull/45492)
 * Fix core patterns incorrectly appearing in block patterns inserter (https://github.com/Automattic/wp-calypso/pull/45499)
+* Fixed typo in "multi-column text with headline" block pattern (https://github.com/Automattic/wp-calypso/pull/45682)
+* Fix Fatal Error from Custom Exceptions (https://github.com/Automattic/wp-calypso/pull/45656)
 
 = 2.3 =
 * Bump NewsPack version to 1.8.0 (https://github.com/Automattic/wp-calypso/pull/45423)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.3
+Stable tag: 2.4
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.4 =
+* Remove direct dependency on `swiper` (https://github.com/Automattic/wp-calypso/pull/45492)
+* Fix core patterns incorrectly appearing in block patterns inserter (https://github.com/Automattic/wp-calypso/pull/45499)
 
 = 2.3 =
 * Bump NewsPack version to 1.8.0 (https://github.com/Automattic/wp-calypso/pull/45423)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
 		"@automattic/webpack-inline-constant-exports-plugin": "^0.0.1",
 		"@automattic/wp-babel-makepot": "^1.0.0",
 		"@automattic/wpcom-block-editor": "^1.0.0-alpha.0",
-		"@automattic/wpcom-editing-toolkit": "^2.3.0",
+		"@automattic/wpcom-editing-toolkit": "^2.4.0",
 		"@babel/cli": "^7.10.5",
 		"@babel/core": "^7.11.1",
 		"@babel/register": "^7.10.5",


### PR DESCRIPTION
#### Changes included in this release

* https://github.com/Automattic/wp-calypso/pull/45492 (added to notes)
* https://github.com/Automattic/wp-calypso/pull/45499 (added to notes)
* https://github.com/Automattic/wp-calypso/pull/45571
* https://github.com/Automattic/wp-calypso/pull/45604
* https://github.com/Automattic/wp-calypso/pull/45651
* https://github.com/Automattic/wp-calypso/pull/45634
* https://github.com/Automattic/wp-calypso/pull/45682 (added to notes)
* https://github.com/Automattic/wp-calypso/pull/45656 (added to notes)

#### Testing instructions

* Apply generated diff to sandbox
* Test changes listed in release notes are present
* Install build on an atomic site
* Test that editor works on atomic with and without gutenberg plugin enabled