### PR TITLE
[markdown] Enable `plugin:md/prettier` preset and disable rules we haven't fixed yet

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,12 +21,22 @@ module.exports = {
 					'error',
 					{
 						plugins: [
-							// Plugins from https://www.npmjs.com/package/remark-preset-lint-markdown-style-guide
-							'lint-no-literal-urls',
-							'lint-heading-increment',
-							'lint-no-heading-punctuation',
+							// This is the original ruleset from `plugin:md/prettier`.
+							// We need to include it again because eslint doesn't compose overrides
+							...require( 'eslint-plugin-md' ).configs.prettier.rules[ 'md/remark' ][ 1 ].plugins,
 
-							// This special plugin is used to allow the syntax <!--eslint ignore <rule>-->. It has to come last
+							// Disabled because they don't make a lot of sense or they are buggy
+							[ 'lint-maximum-heading-length', false ],
+							[ 'lint-no-duplicate-headings', false ],
+
+							// Rules we would like to enable eventually. Violations needs to be fixed manually before enabling the rule.
+							[ 'lint-no-emphasis-as-heading', false ],
+							[ 'lint-final-definition', false ],
+							[ 'lint-code-block-style', false ],
+							[ 'lint-no-multiple-toplevel-headings', false ],
+							[ 'lint-fenced-code-flag', false ],
+
+							// This special plugin is used to allow the syntax <!--eslint ignore <rule>-->. It has to come last.
 							[ 'message-control', { name: 'eslint', source: 'remark-lint' } ],
 						],
 					},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
 							[ 'lint-maximum-heading-length', false ],
 							[ 'lint-no-duplicate-headings', false ],
 
-							// Rules we would like to enable eventually. Violations needs to be fixed manually before enabling the rule.
+							// Rules we would like to enable eventually. Violations need to be fixed manually before enabling the rule.
 							[ 'lint-no-emphasis-as-heading', false ],
 							[ 'lint-final-definition', false ],
 							[ 'lint-code-block-style', false ],

--- a/apps/notifications/src/doc/note-rendering.md
+++ b/apps/notifications/src/doc/note-rendering.md
@@ -56,7 +56,7 @@ The result of this function (a string enhanced with HTML tag information) is the
 
 Local development of Calypso logic for rendering notifications can take place making use of the Calypso dev server, as any changes made to `src/apps/notifications` will be reflected in the Calypso local development environment automatically.
 
-However, as notifications can also be viewed in an iframe on non-Calypso sites using the masterbar (see https://github.com/Automattic/wp-calypso/edit/master/apps/notifications/README.md), any changes to the notifications sub-application should also be tested on a sandboxed WP.com site. To do this, run the following commands:
+However, as notifications can also be viewed in an iframe on non-Calypso sites using the masterbar (see <https://github.com/Automattic/wp-calypso/edit/master/apps/notifications/README.md>), any changes to the notifications sub-application should also be tested on a sandboxed WP.com site. To do this, run the following commands:
 
 ```bash
 # Builds files and places them in `apps/notifications/dist`
@@ -70,7 +70,7 @@ Then copy the built `dist` folder to your sandbox environment to test updated re
 
 You can also use a syncing utility included as a `package.json` script in the notifications app to push changes to your sandbox site automatically.
 
-To prepare your sandbox for this purpose, follow the prerequisite setup instructions for adding an SSH alias for your sandbox described in PCYsg-ly5-p2 "Editing Toolkit plugin and your WP.com sandbox" (the process is exactly the same as that used for the FSE plugin). 
+To prepare your sandbox for this purpose, follow the prerequisite setup instructions for adding an SSH alias for your sandbox described in PCYsg-ly5-p2 "Editing Toolkit plugin and your WP.com sandbox" (the process is exactly the same as that used for the FSE plugin).
 
 Then, after making a change in the notification app, make sure you are `cd`'d into `/apps/notifications/` and run the command
 
@@ -92,7 +92,7 @@ To test notification rendering of Gutenberg posts, the easiest way is to follow 
 
 ![follow button](https://cdn-std.droplr.net/files/acc_1037067/sEftC1)
 
-Then navigate to https://wordpress.com/following/manage and enable "Notify me of new posts" for the blog in question:
+Then navigate to <https://wordpress.com/following/manage> and enable "Notify me of new posts" for the blog in question:
 
 ![enable notifications](https://user-images.githubusercontent.com/1233880/92739752-81101d80-f37d-11ea-955f-640b3e5f9092.png).
 

--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -55,7 +55,7 @@ Note: pluginFilter can be any of the following string: 'none' , 'all', 'active',
 
 ---
 
-** PluginsStore.getSitePlugins( site ); **
+**PluginsStore.getSitePlugins( site );**
 
 Returns an array of plugin objects for a particular site.
 
@@ -97,7 +97,7 @@ export default class extends React.Component {
 		PluginsStore.removeListener( 'change', this.refreshSitesAndPlugins );
 	}
 
-	getPlugins = () => { 
+	getPlugins = () => {
 		let sites = this.props.sites.getSelectedOrAllWithPlugins();
 
 		return {
@@ -111,7 +111,7 @@ export default class extends React.Component {
 
 	render() {
 
-	} 
+	}
 } );
 
 ```
@@ -191,7 +191,7 @@ export default class extends React.Component {
 		return (
 			<button onClick={ this.updatePlugin } >Update { this.props.plugin.name }</button>
 		)
-	} 
+	}
 } );
 
 ```

--- a/client/my-sites/plugins/plugin-automated-transfer/README.md
+++ b/client/my-sites/plugins/plugin-automated-transfer/README.md
@@ -16,6 +16,6 @@ render: function() {
 }
 ```
 
-#### Props:
+#### Props
 
 - `plugin`: a plugin object.

--- a/client/my-sites/site-settings/redirect-non-jetpack/README.md
+++ b/client/my-sites/site-settings/redirect-non-jetpack/README.md
@@ -38,7 +38,7 @@ For default behavior call `redirectNonJetpack()` with no parameters.
 Optionally, we can invoke the same behavior inside the component
 to be wrapped using the HoC. Namely, we can use the redirection action inside the component we pass to the HoC (see below).
 
-### Exemplary use:
+### Exemplary use
 
 ```js
 render() {

--- a/client/reader/README.md
+++ b/client/reader/README.md
@@ -1,17 +1,15 @@
-Reader
-======
+# Reader
 
-The Reader module handles the view and routing logic for the *Reader* section of Calypso.
+The Reader module handles the view and routing logic for the _Reader_ section of Calypso.
 
 These routes are served by the module:
 
 - /activities/likes
-- /read/*
+- /read/\*
 - /recommendations (redirects to /read/search)
-- /tag/*
+- /tag/\*
 
-Block Rendering Development
-======
+# Block Rendering Development
 
 ## Testing
 
@@ -19,7 +17,7 @@ Block Rendering Development
 
 1. Go to `https://wordpress.com/following/manage`
 2. In the "Search or enter URL to follow..." input box, enter the website where you'll be publishing
-a block
+   a block
 3. When your site appears in the search results, click the "Follow" button
 
 ### Publish a post
@@ -37,18 +35,19 @@ There's two places where your block may render.
 1. Go to `https://wordpress.com/home/{your_url}`
 2. Click on "Reader"
 3. Check the two tabs -- "All" and the site that you followed -- to ensure that they have rendered
-your block correctly. These are at located at the URLs `https://wordpress.com/read` and
-`https://wordpress.com/read/feeds/{site_id}` respectively. Let's call these "Reader Previews". This
-is the first place your block may render.
+   your block correctly. These are at located at the URLs `https://wordpress.com/read` and
+   `https://wordpress.com/read/feeds/{site_id}` respectively. Let's call these "Reader Previews". This
+   is the first place your block may render.
 4. Click into the post and ensure that the block is rendered correctly. This is located at
-`https://wordpress.com/read/feeds/{site_id}/posts/{post_id}`. Let's call these "Reader Posts". This
-is the second place your block may render.
+   `https://wordpress.com/read/feeds/{site_id}/posts/{post_id}`. Let's call these "Reader Posts". This
+   is the second place your block may render.
 
 ## Data Flow
 
 ### Relevant files (and order of data flow)
 
 Reader Previews
+
 1. `client/reader/index.js`
 2. `client/reader/controller.js`
 3. `client/reader/following/main.jsx`
@@ -67,19 +66,19 @@ Reader Posts
 5. `client/components/post-excerpt/index.jsx`
 
 - The last two files render the post data. It seems that the API endpoints simply return text (as a
-`excerpt` property), but also `content` which contains the rich HTML of the block. Those files also have the ability to render HTML.
+  `excerpt` property), but also `content` which contains the rich HTML of the block. Those files also have the ability to render HTML.
 
 ### API Endpoints Example Requests
 
 Reader Previews
 
 - All
-`https://public-api.wordpress.com/rest/v1.2/read/following?http_envelope=1&orderBy=date&meta=post%2Cdiscover_original_post&before=2020-08-11T15%3A00%3A00%2B00%3A00&number=7&content_width=675`
+  `https://public-api.wordpress.com/rest/v1.2/read/following?http_envelope=1&orderBy=date&meta=post%2Cdiscover_original_post&before=2020-08-11T15%3A00%3A00%2B00%3A00&number=7&content_width=675`
 
 - Specific Site
-`https://public-api.wordpress.com/rest/v1.2/read/feed/108654568/posts?http_envelope=1&orderBy=date&meta=post%2Cdiscover_original_post&number=7&content_width=675`
+  `https://public-api.wordpress.com/rest/v1.2/read/feed/108654568/posts?http_envelope=1&orderBy=date&meta=post%2Cdiscover_original_post&number=7&content_width=675`
 
 Reader Posts
 
 - Specific Post
-`https://public-api.wordpress.com/rest/v1.2/read/feed/108654568/posts/2904184411?http_envelope=1&content_width=656`
+  `https://public-api.wordpress.com/rest/v1.2/read/feed/108654568/posts/2904184411?http_envelope=1&content_width=656`

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -21,7 +21,7 @@ export default function RockOnButton() {
 
 | Name         | Type     | Default | Description                                                                        |
 | ------------ | -------- | ------- | ---------------------------------------------------------------------------------- |
-| `plain`    | `bool`   | false   | Renders a button with no user-agent styles                                                   |
+| `plain`      | `bool`   | false   | Renders a button with no user-agent styles                                         |
 | `compact`    | `bool`   | false   | Decreases the size of the button                                                   |
 | `primary`    | `bool`   | false   | Provides extra visual weight and identifies the primary action in a set of buttons |
 | `borderless` | `bool`   | false   | Renders a button without borders                                                   |


### PR DESCRIPTION
### Background

After linting our Markdown files following prettier format, I'd like to introduce content-based rules from `remark`. The plugin we use (`eslint-plugin-md`) recommends [Markdown Style Guide](https://cirosantilli.com/markdown-style-guide/), and it has [a preset](https://www.npmjs.com/package/remark-preset-lint-markdown-style-guide) for it.

### Changes

This PR enables the preset and then disables the rules we haven't fixed yet.

### Testing instructions

Checkout the branch and run `./node_modules/.bin/eslint --ext .md .`. There should be no errors.
