### PR TITLE
Email: Add tracks event for email forwarding click

### DIFF
--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -44,6 +44,7 @@ import QuerySiteDomains from 'components/data/query-site-domains';
 import { localizeUrl } from 'lib/i18n-utils';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import EmailProvidersComparison from '../email-providers-comparison';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -247,11 +248,12 @@ class EmailManagement extends React.Component {
 	}
 
 	addEmailForwardingCard( domain ) {
-		const { selectedSiteSlug, currentRoute, translate } = this.props;
+		const { selectedSiteSlug, currentRoute, trackEmailForwardingClick, translate } = this.props;
 
 		return (
 			<VerticalNav>
 				<VerticalNavItem
+					onClick={ trackEmailForwardingClick }
 					path={ emailManagementForwarding( selectedSiteSlug, domain, currentRoute ) }
 				>
 					{ translate( 'Email Forwarding' ) }
@@ -271,16 +273,25 @@ class EmailManagement extends React.Component {
 	};
 }
 
-export default connect( ( state ) => {
-	const selectedSiteId = getSelectedSiteId( state );
-	return {
-		currentRoute: getCurrentRoute( state ),
-		canManageSite: canCurrentUser( state, selectedSiteId, 'manage_options' ),
-		domains: getDomainsBySiteId( state, selectedSiteId ),
-		gsuiteUsers: getGSuiteUsers( state, selectedSiteId ),
-		hasGSuiteUsersLoaded: hasLoadedGSuiteUsers( state, selectedSiteId ),
-		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, selectedSiteId ),
-		selectedSiteId,
-		selectedSiteSlug: getSelectedSiteSlug( state ),
-	};
-}, {} )( localize( EmailManagement ) );
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		return {
+			currentRoute: getCurrentRoute( state ),
+			canManageSite: canCurrentUser( state, selectedSiteId, 'manage_options' ),
+			domains: getDomainsBySiteId( state, selectedSiteId ),
+			gsuiteUsers: getGSuiteUsers( state, selectedSiteId ),
+			hasGSuiteUsersLoaded: hasLoadedGSuiteUsers( state, selectedSiteId ),
+			hasSiteDomainsLoaded: hasLoadedSiteDomains( state, selectedSiteId ),
+			selectedSiteId,
+			selectedSiteSlug: getSelectedSiteSlug( state ),
+		};
+	},
+	( dispatch ) => {
+		return {
+			trackEmailForwardingClick: dispatch(
+				recordTracksEvent( 'calypso_email_email_forwarding_click' )
+			),
+		};
+	}
+)( localize( EmailManagement ) );

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -289,9 +289,8 @@ export default connect(
 	},
 	( dispatch ) => {
 		return {
-			trackEmailForwardingClick: dispatch(
-				recordTracksEvent( 'calypso_email_email_forwarding_click' )
-			),
+			trackEmailForwardingClick: () =>
+				dispatch( recordTracksEvent( 'calypso_email_email_forwarding_click' ) ),
 		};
 	}
 )( localize( EmailManagement ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a tracks event which is fired when the "Email Forwarding" button is clicked on the /email page.

#### Testing instructions

* Go to your site domains
* Click "Add" under the Email column for one of your domains
* Click "Email Forwarding" which is below the G Suite upsell
* Verify the tracks event is fired
