### PR TITLE
Change concierge upsell offer with the new 30 minute duration

### DIFF
--- a/client/me/concierge/shared/available-time-card.js
+++ b/client/me/concierge/shared/available-time-card.js
@@ -134,12 +134,14 @@ class CalendarCard extends Component {
 			disabled,
 			isDefaultLocale,
 			times,
-			appointmentTimespan,
 			translate,
-			moment,
+			// Temporarily harcoding durationInMinutes
+			// appointmentTimespan,
+			// moment,
 		} = this.props;
 
-		const durationInMinutes = moment.duration( appointmentTimespan, 'seconds' ).minutes();
+		// Temporarily hardcoded to 30mins.
+		const durationInMinutes = 30; // moment.duration( appointmentTimespan, 'seconds' ).minutes();
 
 		const description = isDefaultLocale
 			? translate( 'Sessions are %(durationInMinutes)d minutes long.', {

--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -89,10 +89,11 @@ class ConciergeBanner extends Component {
 			case CONCIERGE_HAS_AVAILABLE_PURCHASED_SESSION:
 				headerText = translate( 'Our experts are waiting to help you' );
 				mainText = translate(
-					'Schedule your 45-minute 1-1 Quick Start Session with a Happiness Engineer!',
+					'Schedule your %(durationInMinutes)d-minute 1-1 Quick Start Session with a Happiness Engineer!',
 					{
 						comment:
 							'Quick Start Session is a one-on-one video session between the user and our support staff.',
+						args: { durationInMinutes: 30 },
 					}
 				);
 				buttonText = translate( 'Schedule now' );

--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -88,14 +88,10 @@ class ConciergeBanner extends Component {
 
 			case CONCIERGE_HAS_AVAILABLE_PURCHASED_SESSION:
 				headerText = translate( 'Our experts are waiting to help you' );
-				mainText = translate(
-					'Schedule your %(durationInMinutes)d-minute 1-1 Quick Start Session with a Happiness Engineer!',
-					{
-						comment:
-							'Quick Start Session is a one-on-one video session between the user and our support staff.',
-						args: { durationInMinutes: 30 },
-					}
-				);
+				mainText = translate( 'Schedule your 1-1 Quick Start Session with a Happiness Engineer!', {
+					comment:
+						'Quick Start Session is a one-on-one video session between the user and our support staff.',
+				} );
 				buttonText = translate( 'Schedule now' );
 				buttonHref = '/me/concierge';
 				illustrationUrl = conciergeImage;

--- a/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
@@ -95,9 +95,10 @@ export class ConciergeQuickstartSession extends PureComponent {
 						</p>
 						<p>
 							{ translate(
-								"{{em}}Quick Start{{/em}} sessions are 45-minute one-on-one conversations between you and one of our website building experts. They know WordPress inside out and will help you achieve your goals with a smile. That's why we call them Happiness Engineers.",
+								"{{em}}Quick Start{{/em}} sessions are %(durationInMinutes)d-minute one-on-one conversations between you and one of our website building experts. They know WordPress inside out and will help you achieve your goals with a smile. That's why we call them Happiness Engineers.",
 								{
 									components: { em: <em /> },
+									args: { durationInMinutes: 30 },
 								}
 							) }
 						</p>

--- a/client/my-sites/checkout/upsell-nudge/concierge-support-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-support-session/index.jsx
@@ -76,7 +76,10 @@ export class ConciergeSupportSession extends PureComponent {
 						<p>
 							<b>
 								{ translate(
-									'Reserve a 45-minute one-on-one call with a website expert to help you get started on the right foot.'
+									'Reserve a %(durationInMinutes)d-minute one-on-one call with a website expert to help you get started on the right foot.',
+									{
+										args: { durationInMinutes: 30 },
+									}
 								) }
 							</b>
 						</p>
@@ -157,10 +160,11 @@ export class ConciergeSupportSession extends PureComponent {
 
 						<h4 className="concierge-support-session__sub-header">
 							{ translate(
-								'Reserve a 45-minute "Quick Start" appointment, and save %(saveAmount)s if you sign up today.',
+								'Reserve a %(durationInMinutes)d-minute "Quick Start" appointment, and save %(saveAmount)s if you sign up today.',
 								{
 									args: {
 										saveAmount: formatCurrency( savings, currencyCode, { stripZeros: true } ),
+										durationInMinutes: 30,
 									},
 								}
 							) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

More info: pbBQWj-kR#comment-1156-p2
This PR changes the hardcoded copy to match the new 30 minute duration of the Purchased Concierge session.
It uses a hardcode variable as we don't have access to the real duration until after purchasing a session.
There are 4 locations where this has been replaced:

##### /me/concierge booking
<img width="480" src="https://user-images.githubusercontent.com/2749938/94526603-6cb59700-023e-11eb-9e1b-c54bb07d4f1e.png">

##### /me/purchases QS upsell banner
<img width="480" src="https://user-images.githubusercontent.com/2749938/94424349-bd6fb600-0192-11eb-894c-5f72d8733854.png">

##### /checkout/offer-quickstart-session
<img width="480" src="https://user-images.githubusercontent.com/2749938/94424406-d8422a80-0192-11eb-80ca-aa83218bbde7.png">


##### /checkout/offer-support-session
<img width="480"  src="https://user-images.githubusercontent.com/2749938/94424412-da0bee00-0192-11eb-8f41-0d2633d2fbab.png">


#### Testing instructions

##### /me/concierge booking
* Go to /me/concierge
* Select a site with QS session
* Fill in form and submit
* Open any of the days and it should mention that the session has lasts 30mins
<img width="480" src="https://user-images.githubusercontent.com/2749938/94526731-9ff82600-023e-11eb-8625-ce2ff8d4efb8.png">


##### /me/purchases QS upsell banner
* Make sure you have at least 1 QS session (included or purchased) -  this is to make sure the proper banner appears
* Go to /me/purchases
* QS upsell banner should not mention the duration of the QS
<img width="480" src="https://user-images.githubusercontent.com/2749938/94424495-fc9e0700-0192-11eb-9ed8-7433e876f9d3.png">

##### /checkout/offer-quickstart-session
* Make sure you have a site {SITE_NAME} without QS sessions 
* Go to /checkout/offer-quickstart-session?site={SITE_NAME}.wordpress.com
* Content should mention 30 minute session

<img width="480" src="https://user-images.githubusercontent.com/2749938/94424668-438bfc80-0193-11eb-86c3-b2598040f134.png">


##### /checkout/offer-support-session
* Make sure you have a site {SITE_NAME} without QS sessions 
* Go to /checkout/offer-support-session?site={SITE_NAME}.wordpress.com
* Content should mention 30 minute session

<img width="480" src="https://user-images.githubusercontent.com/2749938/94424677-4a1a7400-0193-11eb-977c-d17cb6e8ac23.png">