### PR TITLE
[markdown] Fix linting rule 'no-multiple-toplevel-headings'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,6 @@ module.exports = {
 							[ 'lint-no-duplicate-headings', false ],
 
 							// Rules we would like to enable eventually. Violations needs to be fixed manually before enabling the rule.
-							[ 'lint-no-multiple-toplevel-headings', false ],
 							[ 'lint-fenced-code-flag', false ],
 
 							// This special plugin is used to allow the syntax <!--eslint ignore <rule>-->. It has to come last.

--- a/client/blocks/jitm/README.md
+++ b/client/blocks/jitm/README.md
@@ -12,12 +12,12 @@ future. They're used in all types of scenarios:
 - Inform them about theme specific things
 - Much, much, more
 
-# Props
+## Props
 
-## currentSite (number)
+### currentSite (number)
 
 The user's current selected site
 
-## data (object)
+### data (object)
 
 The jitm information from the API

--- a/client/blocks/keyring-connect-button/README.md
+++ b/client/blocks/keyring-connect-button/README.md
@@ -10,19 +10,19 @@ publicize, a new publicize connection is automatically created.
 Once the keyring connection exists, clicking on this button again will execute the `onConnect`
 action immediately.
 
-# Props
+## Props
 
-## serviceId (string)
+### serviceId (string)
 
 The ID of the external service this button will attempt to connect the user to.
 The list of available services is given by the `/meta/external-services` API endpoint
 but most service IDs are currently visible in the [ServiceExamples](../../my-sites/marketing/connections/service-examples.jsx)
 component.
 
-## onClick (Function)
+### onClick (Function)
 
 Function to execute on button click (often needed for analytics purposes).
 
-## onConnect (Function)
+### onConnect (Function)
 
 Function to execute once the keyring connection has been created.

--- a/client/components/credit-card/README.md
+++ b/client/components/credit-card/README.md
@@ -1,8 +1,10 @@
-# CreditCard
+# Credit card
+
+## CreditCard
 
 The `CreditCard` component serves as a container for a selectable credit card list item, and can display a stored credit card (passed as `card` prop) _or_ a placeholder such as a new card form (passed as `children`).
 
-## Usage
+### Usage
 
 Example credit card selection list:
 
@@ -21,7 +23,7 @@ export default ( { cards, selectedId, onSelectCard } ) => {
 };
 ```
 
-## Props
+### Props
 
 | Name        | Type                      | Description                                                  |
 | ----------- | ------------------------- | ------------------------------------------------------------ |
@@ -30,11 +32,11 @@ export default ( { cards, selectedId, onSelectCard } ) => {
 | `onSelect`  | `func`                    | Handler called with event argument upon selecting card item. |
 | `className` | `string`                  | Extra custom class names to pass to element.                 |
 
-# StoredCard
+## StoredCard
 
 The `StoredCard` component is a representation of a single credit card, used internally to render the `card` passed to `CreditCard`, but can also be used independently or as a child of the `CreditCard`.
 
-## Usage
+### Usage
 
 Example usage within `<CreditCard>`:
 
@@ -51,7 +53,7 @@ export default ( cardData, onRemoveCard ) => {
 };
 ```
 
-## Props
+### Props
 
 | Name              | Type     | Description                                                       |
 | ----------------- | -------- | ----------------------------------------------------------------- |

--- a/client/components/email-verification/README.md
+++ b/client/components/email-verification/README.md
@@ -2,12 +2,12 @@
 
 This module exports several utilities for handling new user's email verification flow.
 
-# `page.js` handler
+## `page.js` handler
 
 Check if the handled URL has an `verified=1` query param and shows an "Email confirmed" notice
 when it does.
 
-## Usage
+### Usage
 
 ```js
 import emailVerification from 'components/email-verification';
@@ -15,13 +15,13 @@ import emailVerification from 'components/email-verification';
 page( '*', emailVerification );
 ```
 
-# Email Verification Dialog
+## Email Verification Dialog
 
 Modal dialog you can use to implement parts of UI where a verified email is required. It
 will display a modal explaining what to do with the verification email and offers an option
 to resend the email.
 
-## Usage
+### Usage
 
 ```jsx
 import VerifyEmailDialog from 'components/email-verification/email-verification-dialog';
@@ -36,12 +36,12 @@ function UI( { showDialog, closeDialog } ) {
 }
 ```
 
-# Email Verification Gate Component
+## Email Verification Gate Component
 
 Wrapper around your content that will put a notice on top if user's email is unverified.
 The wrapped content will be disabled: grayed out and won't react to input events.
 
-## Usage
+### Usage
 
 ```jsx
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';

--- a/client/components/external-link/README.md
+++ b/client/components/external-link/README.md
@@ -1,8 +1,10 @@
 # External Link
 
+## ExternalLink
+
 External Link is a React component for rendering an external link.
 
-## Usage
+### Usage
 
 ```jsx
 
@@ -24,7 +26,7 @@ class MyComponent extends React.Component {
 }
 ```
 
-## Props
+### Props
 
 The following props can be passed to the External Link component:
 
@@ -32,17 +34,17 @@ The following props can be passed to the External Link component:
 | -------- | ------- | -------- | ------------------------------------------------------------------------------ |
 | `icon`   | Boolean | no       | Set to true if you want to render a nice external Gridicon at the end of link. |
 
-## Other Props
+### Other Props
 
 Any other props that you pass into the `a` tag will be rendered as expected.
 For example `onClick` and `href`.
 
-# External Link with Tracking
+## External Link with Tracking
 
 External Link with Tracking is a React component for rendering an external link that is connected to the Redux store
 and is capable of recording Tracks events.
 
-## Usage
+### Usage
 
 ```jsx
 
@@ -66,7 +68,7 @@ class MyComponent extends React.Component {
 }
 ```
 
-## Props
+### Props
 
 In addition to the props that the unconnected `<ExternalLink />` component accepts, you
 can pass the following Tracks-related props to the `<ExternalLinkWithTracking />` component:

--- a/client/components/jetpack-header/README.md
+++ b/client/components/jetpack-header/README.md
@@ -4,12 +4,12 @@ The `JetpackHeader` component is intended to be used for co-branding of Jetpack 
 
 In cases where a partner has referred a new site, we'd want to co-brand the flow.
 
-# Props
+## Props
 
-## partnerSlug (string) optional
+### partnerSlug (string) optional
 
 An optional slug for the hosting partner. This will cause a partner-specific logo to be rendered.
 
-## width (number) optional
+### width (number) optional
 
 An optional width for the Jetpack logo or partner logo groups that will override the defaults.

--- a/client/components/localized-moment/README.md
+++ b/client/components/localized-moment/README.md
@@ -2,14 +2,14 @@
 
 This module provides support for using localized moment.js library inside React components.
 
-# `withLocalizedMoment`
+## `withLocalizedMoment`
 
 Is a higher-order component (HOC) that provides two props to the wrapped child:
 
 - `moment` is the moment.js instance that the component can use to parse and format dates
 - `momentLocale` is a string that contains the current locale slug (e.g., `en` or `de`).
 
-## Usage
+### Usage
 
 ```jsx
 import React from 'react';
@@ -29,13 +29,13 @@ The exported component will format the `date` string prop using the current loca
 The component is reactive, i.e., when the locale changes, all wrapped components will be
 automatically rerendered.
 
-# `useLocalizedMoment`
+## `useLocalizedMoment`
 
 Is a React hook that can be used inside stateless functional components. The function returns
 the moment.js instance that can be used to parse and format dates. Its meaning is the same as
 in `withLocalizedMoment`. It's just a different implementation of the same concept.
 
-## Usage
+### Usage
 
 ```jsx
 import React from 'react';
@@ -50,7 +50,7 @@ export default function Label( { date } ) {
 Once again, the exported `Label` component will format the `date` string prop and automatically
 rerender on locale change.
 
-# `MomentProvider`
+## `MomentProvider`
 
 All usages of `withLocalizedMoment` and `useLocalizedMoment` should be inside a React tree
 that has `MomentProvider` mounted on top. The provider provides a context with the current locale
@@ -59,7 +59,7 @@ and all the subcomponents that consume the context will react to changes.
 The `MomentProvider` component takes one prop: `currentLocale`. It is a string with the desired
 locale slug.
 
-## Usage
+### Usage
 
 ```jsx
 import React from 'react';

--- a/client/components/notice/README.md
+++ b/client/components/notice/README.md
@@ -1,8 +1,10 @@
-# Notice (JSX)
+# Notice
+
+## Notice (JSX)
 
 This component is used to display inline notices, rather than Global ones
 
-## Usage
+### Usage
 
 ```js
 import Notice from 'components/notice';
@@ -30,11 +32,11 @@ function MyNotice() {
 | `onDismissClick` | `function` | null    | A function to call when the notice is dismissed.                                      |
 | `children`       | `string`   | null    | You can also pass the content on the notice within children.                          |
 
-# NoticeAction (JSX)
+## NoticeAction (JSX)
 
 This component is used to display an action inside a notice
 
-## Usage
+### Usage
 
 ```js
 import NoticeAction from 'components/notice/notice-action';

--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -3,33 +3,35 @@
 `Popover` is a react component that can be used to show any content in a
 popover.
 
-## Properties
+## `Popover`
 
-### `autoPosition { bool } - default: true`
+### Properties
+
+#### `autoPosition { bool } - default: true`
 
 Defines if the Popover should be automatically positioned under specific
 circumstances. For instance when the window is scrolled, the viewport is
 resized, etc.
 
-### `autoRtl { bool } - default: true`
+#### `autoRtl { bool } - default: true`
 
 Defines if the Popover should automatically be adjusted for right-to-left
 contexts. `autoRtl={ true }` will swap `right` and `left` position props in RTL
 context.
 
-### `className { string } - optional`
+#### `className { string } - optional`
 
 Set a custom className for the main container. Keep in mind that `popover`
 className will be always added to the instance.
 
-### `closeOnEsc { bool } - default: true`
+#### `closeOnEsc { bool } - default: true`
 
-### `context { DOMElement | ref }`
+#### `context { DOMElement | ref }`
 
 The `context` property must be set to a DOMElement or React ref to the element
 the popover should be attached to (point to).
 
-### `customPosition { object }`
+#### `customPosition { object }`
 
 Provide a custom position to render the popover at. The parent component takes all
 responsibility for moving the popover on resize and scroll.
@@ -40,12 +42,12 @@ Example:
 
 You can specify `positionClass` to control which way the popover arrow points.
 
-### `id { string } - optional`
+#### `id { string } - optional`
 
 Use this optional property to set a Popover identifier among all of the Popover
 instances. This property has been thought for development purpose.
 
-### `ignoreContext`
+#### `ignoreContext`
 
 The `ignoreContext` lets you specify a component that you want to be on the
 inside clickOutside context. So a context that you want to ignore. In most
@@ -53,7 +55,7 @@ cases this is not needed but if you want to also have a label
 that can trigger the opening and closing of the Popover then you need to pass
 in the label component as a reference.
 
-### `isVisible { bool } default - false`
+#### `isVisible { bool } default - false`
 
 By controlling the popover's visibility through the `isVisible` property, the
 popover itself is responsible for providing any CSS transitions to
@@ -61,7 +63,7 @@ animate the opening/closing of the popover. This also keeps the parent's code
 clean and readable, with a minimal amount of boilerplate code required to show
 a popover.
 
-### `position { string } - default: 'top'`
+#### `position { string } - default: 'top'`
 
 The `position` property can be one of the following values:
 
@@ -78,23 +80,23 @@ This describes the position of the popover relative to the thing it is pointing
 at. If the arrow is supposed to point at something to the top and left of the
 Popover, the correct value for `position` is `bottom right`.
 
-### `showDelay { number } - default: 0 (false)`
+#### `showDelay { number } - default: 0 (false)`
 
 Adds a delay before to show the popover. Its value is defined in `milliseconds`.
 
-### `onClose { func }`
+#### `onClose { func }`
 
 The popover's `onClose` property must be set, and should modify the parent's
 state such that the popover's `isVisible` property will be false when `render`
 is called.
 
-### `onShow { func } - optional`
+#### `onShow { func } - optional`
 
 This function will be executed when the popover is shown.
 
-## Usage notes
+### Usage notes
 
-### Within modals / dialogs
+#### Within modals / dialogs
 
 When using a popover within a modal applying the class `is-dialog-visible` to the `Popover` component will cause it to gain the correct `z-index` to allow it to display correctly within the modal.
 
@@ -102,45 +104,45 @@ When using a popover within a modal applying the class `is-dialog-visible` to th
 <Popover className="is-dialog-visible" />
 ```
 
-# PopoverMenu
+## `PopoverMenu`
 
 `PopoverMenu` is a component based on `Popover` used to show a menu of actions
 in a popover. It is fully keyboard accessible.
 
-# PopoverMenuItem
+## `PopoverMenuItem`
 
 `PopoverMenuItem` is a component used to represent a single item in a
 `PopoverMenu`.
 
-## Properties
+### Properties
 
-### `href { string } - optional`
+#### `href { string } - optional`
 
 If set, `PopoverMenuItem` will be rendered as a link; otherwise, it will be
 rendered as a button.
 
-### `className { string } - optional`
+#### `className { string } - optional`
 
 Sets a custom className on the button or link.
 
-### `isSelected { bool } - default: false`
+#### `isSelected { bool } - default: false`
 
 Defines whether or not the `PopoverMenuItem` is the currently selected one.
 
-### `icon { string } - optional`
+#### `icon { string } - optional`
 
 If set, a `Gridicon` is rendered, where its `icon` prop is set to this value.
 
-### `focusOnHover { bool } - default: true`
+#### `focusOnHover { bool } - default: true`
 
 Defines whether or not the `PopoverMenuItem` should receive the focus when it
 is hovered over.
 
-### `children { node } - optional`
+#### `children { node } - optional`
 
 The children to render inside of the `PopoverMenuItem`.
 
-## `Popover` Usage
+### `Popover` Usage
 
 ```jsx
 <button
@@ -161,7 +163,7 @@ The children to render inside of the `PopoverMenuItem`.
 </Popover>
 ```
 
-## `PopoverMenu` Usage
+### `PopoverMenu` Usage
 
 ```jsx
 <button

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -1,5 +1,7 @@
 # Product Card
 
+## `ProductCard`
+
 Product Card is a React component for rendering a box with product name, price, short description and additional
 information.
 
@@ -17,7 +19,7 @@ plan).
 
 See p1HpG7-7ET-p2 for more details.
 
-## How to use the `<ProductCard />`
+### How to use the `<ProductCard />`
 
 ```jsx
 import React, { Fragment } from 'react';
@@ -42,7 +44,7 @@ export default class extends React.Component {
 }
 ```
 
-## <a name="how-purchase-prop-works"></a>How `purchase` prop works
+### How `purchase` prop works
 
 The component can be in two visual and functional states:
 
@@ -50,7 +52,7 @@ The component can be in two visual and functional states:
   has purchase options, they will be listed below the description.
 - `purchase` prop is set - the content area will not contain product options (if they exist).
 
-## `<ProductCard />` props
+### `<ProductCard />` props
 
 The following props can be passed to the Product Card component:
 
@@ -69,12 +71,12 @@ The following props can be passed to the Product Card component:
   used also in other use-cases. It can be a string, a node or a React element (e.g. `<Fragment>`)
 - `title`: ( string | element ) Product title. It can be a string or a React element (e.g. `<Fragment>`)
 
-# <a name="product-card-promo-nudge"></a>Product Card Promo Nudge
+## `ProductCardPromoNudge`
 
 Product Card Promo Nudge is a Product Card's sub-component for rendering a promotion nudge. It consists of a badge label
 (a green star sticker to the left) and a promo text. Both props are optional.
 
-## How to use the `<ProductCardPromoNudge />`
+### How to use the `<ProductCardPromoNudge />`
 
 ```jsx
 import React, { Fragment } from 'react';
@@ -103,7 +105,7 @@ export default class extends React.Component {
 }
 ```
 
-## `<ProductCardPromoNudge />` Props
+### `<ProductCardPromoNudge />` Props
 
 The following props can be passed to the Product Card Promo Nudge component:
 
@@ -111,12 +113,12 @@ The following props can be passed to the Product Card Promo Nudge component:
 - `text`: ( string | element | node ) Promo text. Looks best if a `<strong>` element is used inside. It can be a string,
   a node or a React element (e.g. `<Fragment>`)
 
-# <a name="product-card-options"></a>Product Card Options
+## `ProductCardOptions`
 
 Product Card Options is a Product Card's sub-component for rendering purchase options inside the card. It's meant to
 be passed to the Product Card as a child component.
 
-## How to use the `<ProductCardOptions />`
+### How to use the `<ProductCardOptions />`
 
 ```jsx
 import React, { useState } from 'react';
@@ -161,7 +163,7 @@ export default class extends React.Component {
 }
 ```
 
-## `<ProductCardOptions />` Props
+### `<ProductCardOptions />` Props
 
 The following props can be passed to the Product Card Options component:
 
@@ -183,12 +185,12 @@ The following props can be passed to the Product Card Options component:
 - `forceRadiosEvenIfOnlyOneOption`: (bool) Normally if there is only one option the display is simplified, but
   setting this to `true` overrides that and uses the full display with radio buttons
 
-# <a name="product-card-action"></a>Product Card Action
+## `ProductCardAction`
 
 Product Card Action is a Product Card's sub-component for rendering action section. It consists of an intro
 text (optional) and a button.
 
-## How to use the `<ProductCardAction />`
+### How to use the `<ProductCardAction />`
 
 ```jsx
 import React from 'react';
@@ -213,7 +215,7 @@ export default class extends React.Component {
 }
 ```
 
-## `<ProductCardAction />` Props
+### `<ProductCardAction />` Props
 
 The following props can be passed to the Product Card Action component:
 

--- a/client/components/site-offset/README.md
+++ b/client/components/site-offset/README.md
@@ -2,13 +2,13 @@
 
 This module provides support for using applySiteOffset inside React components without including the necessary selectors and query components.
 
-# `withApplySiteOffset`
+## `withApplySiteOffset`
 
 Is a higher-order component (HOC) that provides one prop to the wrapped child:
 
 - `applySiteOffset` is a function that takes any possible moment input and returns either a moment object with the site offset applied or null if enough information has not yet been loaded to apply a site's offset
 
-## Usage
+### Usage
 
 ```jsx
 import React from 'react';
@@ -29,13 +29,13 @@ The exported component will format the `date` string prop using the current site
 The component is reactive, i.e., when the site offset information is loaded all wrapped components will be
 automatically re-rendered.
 
-# `useApplySiteOffset`
+## `useApplySiteOffset`
 
 Is a React hook that can be used inside stateless functional components. The function returns
 the same `applySiteOffset` function. Its meaning is the same as
 in `withApplySiteOffset`. It's just a different implementation of the same concept.
 
-## Usage
+### Usage
 
 ```jsx
 import React from 'react';
@@ -51,7 +51,7 @@ export default function Label( { date } ) {
 Once again, the exported `Label` component will format the `date` string prop and automatically
 rerender on locale change.
 
-# `SiteOffsetProvider`
+## `SiteOffsetProvider`
 
 All usages of `withApplySiteOffset` and `useApplySiteOffset` should be inside a React tree
 that has `SiteOffsetProvider` mounted on top. The provider provides a context with the current locale
@@ -59,7 +59,7 @@ and all the subcomponents that consume the context will react to changes.
 
 The `SiteOffsetProvider` component takes one prop: `site`. It is a string that is either the current site ID or slug. This means that this Provider will need to be used lower in the React Component Tree than normal.
 
-## Usage
+### Usage
 
 ```jsx
 import React from 'react';

--- a/client/components/tile-grid/README.md
+++ b/client/components/tile-grid/README.md
@@ -1,18 +1,20 @@
-# TileGrid (jsx)
+# Tile Grid
+
+## TileGrid (jsx)
 
 Component used to declare an area for displaying Tiles — it's the main wrapper that takes care of tile alignment and positioning.
 
-## Props
+### Props
 
 - `className`: Add your own class to the grid.
 
 ---
 
-# Tile (jsx)
+## Tile (jsx)
 
 Component used to display a clickable tile with an image, call to action, and description.
 
-## Props
+### Props
 
 - `buttonClassName`: Add your own class to the tile button.
 - `buttonLabel`: Text of the button.
@@ -25,7 +27,7 @@ Component used to display a clickable tile with an image, call to action, and de
 
 ---
 
-## How to use
+### How to use
 
 ```js
 import Tile from 'components/tile-grid/tile';

--- a/client/desktop/app-handlers/crash-reporting/README.md
+++ b/client/desktop/app-handlers/crash-reporting/README.md
@@ -2,6 +2,6 @@
 
 Uses the [Electron crash reporter module](https://github.com/atom/electron/blob/HEAD/docs/api/crash-reporter.md) to send crashes to a remote URL.
 
-# Config
+## Config
 
 Requires `crash_reporter` to be set

--- a/client/extensions/woocommerce/components/form-location-select/README.md
+++ b/client/extensions/woocommerce/components/form-location-select/README.md
@@ -1,44 +1,46 @@
-# FormCountrySelectFromApi
+# Form Location select
+
+## FormCountrySelectFromApi
 
 Display a list of the supported countries for a given WooCommerce site.
 
-## Props
+### Props
 
-### `onChange`
+#### `onChange`
 
 Required. Callback fired when the select changes.
 
-### `value`
+#### `value`
 
 Required. The currently-selected country, as ISO3166 alpha-2 country code (e.g. AU, US, etc)
 
-### `siteId`
+#### `siteId`
 
 The source site for the countries list request. Defaults to the currently-selected site.
 
-# FormStateSelectFromApi
+## FormStateSelectFromApi
 
 Display a list of the supported states in a country for a given WooCommerce site. If the country does not have states, the component renders a disabled dropdown, with 'N/A'.
 
-## Props
+### Props
 
-### `onChange`
+#### `onChange`
 
 Required. Callback fired when the select changes.
 
-### `country`
+#### `country`
 
 Required. The already-selected country, as ISO3166 alpha-2 country code (e.g. AU, US, etc). This is used to fetch the correct set of states.
 
-### `value`
+#### `value`
 
 Required. The currently-selected state, as state code (e.g. NY, CT, QC, etc).
 
-### `siteId`
+#### `siteId`
 
 The source site for the countries list request. Defaults to the currently-selected site.
 
-## How to use
+### How to use
 
 ```jsx
 import FormFieldSet from 'components/forms/form-fieldset';

--- a/client/extensions/woocommerce/components/order-status/README.md
+++ b/client/extensions/woocommerce/components/order-status/README.md
@@ -1,10 +1,12 @@
-# OrderStatus
+# Order status
+
+## OrderStatus
 
 OrderStatus is a component that displays a badge with human-friendly text describing the payment and shipping status of an order. Payment and shipping statuses are considered separate for UI, so we can also individually show just payment or just shipping status.
 
 Some statuses don't have a shipping status: `cancelled`, `refunded`, and `failed`.
 
-## Usage
+### Usage
 
 ```jsx
 render: function() {
@@ -16,27 +18,27 @@ render: function() {
 }
 ```
 
-## Props
+### Props
 
-### `status`
+#### `status`
 
 The WooCommerce order status string. See the [WC API docs](https://docs.woocommerce.com/document/managing-orders/) for statuses.
 
-### `showPayment`
+#### `showPayment`
 
 Boolean. Determines whether the payment label should be shown. Defaults to true.
 
-### `showShipping`
+#### `showShipping`
 
 Boolean. Determines whether the shipping label should be shown. Defaults to true.
 
 ---
 
-# OrderStatusSelect
+## OrderStatusSelect
 
 OrderStatusSelect is a component that displays a dropdown of order statuses.
 
-## Usage
+### Usage
 
 ```jsx
 render: function() {
@@ -48,12 +50,12 @@ render: function() {
 }
 ```
 
-## Props
+### Props
 
-### `value`
+#### `value`
 
 The currently selected status. See `woocommerce/lib/order-status/index.js` for a list of available statuses.
 
-### `onChange`
+#### `onChange`
 
 A function run when a new status is selected.

--- a/client/extensions/woocommerce/lib/formatted-variation-name/README.md
+++ b/client/extensions/woocommerce/lib/formatted-variation-name/README.md
@@ -4,7 +4,7 @@ WooCommerce variations do not have a proper 'name' field.
 
 This method will return a formatted variation name based on the attribute options that a variation contains.
 
-# Example (1 Attribute)
+## Example (1 Attribute)
 
 ```javascript
 import formattedVariationName from 'lib/formatted-variation-name';
@@ -26,7 +26,7 @@ return formattedVariationName( variation );
 
 Returns `Red`.
 
-# Example (Multiple Attributes)
+## Example (Multiple Attributes)
 
 ```javascript
 import formattedVariationName from 'lib/formatted-variation-name';
@@ -52,7 +52,7 @@ return formattedVariationName( variation );
 
 Returns `Red - Small`.
 
-# Example (Fallback)
+## Example (Fallback)
 
 ```javascript
 import formattedVariationName from 'lib/formatted-variation-name';

--- a/client/extensions/woocommerce/lib/generate-variations/README.md
+++ b/client/extensions/woocommerce/lib/generate-variations/README.md
@@ -2,7 +2,7 @@
 
 Given a WooCommerce product object, this library will generate new WooCommerce variation objects based on the available product attributes.
 
-# Example
+## Example
 
 ```javascript
 import generateVariations from 'lib/generate-variations';

--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -6,7 +6,7 @@ Turn on debugging in the JavaScript developer console to view details about what
 
 `localStorage.setItem('debug', 'calypso:abtests');`
 
-# Usage
+## Usage
 
 In `active-tests.js`, add your test info to the exported object:
 
@@ -82,7 +82,7 @@ if ( abtest( 'freeTrialButtonWordingForIndia', userCountryCode ) === 'startFreeT
 <Button text={ buttonWording } />
 ```
 
-## Determining whether the user is a participant in an A/B test
+### Determining whether the user is a participant in an A/B test
 
 If you want to determine whether the user is a participant in a specific A/B test, you can import the `abtest` module's `getABTestVariation` method:
 
@@ -97,7 +97,7 @@ const currentVariation = getABTestVariation( 'freeTrialButtonWording' );
 
 This is useful when your A/B test affects multiple pages and you just want to check on one page whether the user is a participant without assigning them to the test.
 
-## Testing A Variation
+### Testing A Variation
 
 If you would like to manually add yourself to a variant group to test it out visually, you can do so by modifying the `localStorage` setting for the test. For the example above, to add yourself to the `beginYourFreeTrial` group you would execute:
 
@@ -110,13 +110,13 @@ localStorage.setItem( 'ABTests', '{"freeTrialButtonWording_20150216":"beginYourF
 
 The key used in the `ABTests` object above is comprised object key name from the test config object ( In our example `freeTrialButtonWording` ), followed by the `datestamp` of the test start date ( `20150216` in the example ).
 
-## Measuring the impact of an A/B test
+### Measuring the impact of an A/B test
 
 When you set up an A/B test, think about what you want to measure its impact on. For example, if you run a test within the NUX flow you might want to measure its impact on how many people successfully sign up for an account. We call this the _conversion event_.
 
 You should make sure that the conversion event is being record in Tracks prior to deploying your A/B test. To create a new event, see the Tracks API section in the [Analytics README](../analytics/README.md).
 
-## Ensuring users don't participate in future tests
+### Ensuring users don't participate in future tests
 
 After a test ends, you'll often want to run a follow up test to test new variations that affect the same thing. To do this, you can keep the `freeTrialButtonWording` name and simply update the datestamp and variations as appropriate.
 
@@ -124,7 +124,7 @@ We've found that if a user has already participated in a test for a specific thi
 
 To account for this, the A/B test module is smart enough to know that if the user has already participated in a test with the same name (ie `freeTrialButtonWording`), then not to count them in the results of the new test.
 
-## Dealing with ineligible users
+### Dealing with ineligible users
 
 By default, users are only included in the test if their locale is set to English (`en`), the current date is on or after the datestamp you set, they have not participated in a test with the same name in the past, and they registered on or after the date that the test started.
 
@@ -132,19 +132,19 @@ In cases where the user is ineligible, the `abtest` function will return the val
 
 No `calypso_abtest_start` Tracks event is triggered for these users so they don't impact the results of the test.
 
-## Updating our end-to-end tests to avoid inconsistencies with A/B tests
+### Updating our end-to-end tests to avoid inconsistencies with A/B tests
 
 Our WordPress.com end-to-end (e2e) tests need to know which A/B test group to use otherwise this can lead to non-deterministic and inconsistent behaviour and test results.
 
-### Updating A/B tests in the e2e tests
+#### Updating A/B tests in the e2e tests
 
 The e2e tests now read directly from `active-tests.js` and will use the default variation for test runs.
 
-### Changing a known A/B test
+#### Changing a known A/B test
 
 If you're making an update to an A/B test - changing the date for example - you should update the e2e tests in the same way as above to reflect the new date.
 
-### Removing a known A/B test
+#### Removing a known A/B test
 
 When your A/B test is complete and removed from `wp-calypso` you should also remove it from the e2e test config. This doesn't have to happen _immediately_ (it doesn't matter to override an A/B test that doesn't exist) but you should do it as soon as possible to keep things neat and tidy.
 

--- a/client/lib/analytics/with-tracking-tool/README.md
+++ b/client/lib/analytics/with-tracking-tool/README.md
@@ -6,7 +6,7 @@ The `withTrackingTool` is called with a `trackingTool` parameter. Currently, onl
 
 The return is a wrapper function that takes your component and loads the specified tracking tool on top of it.
 
-# Usage
+## Usage
 
 When directly wrapping a component:
 

--- a/client/lib/follow-list/README.md
+++ b/client/lib/follow-list/README.md
@@ -1,4 +1,6 @@
-# FollowList
+# Follow List
+
+## FollowList
 
 If you have components that utlize 'Follow' actions for users, the follow-list acts as a central store for all site/follow data. So if a user clicks follow within one component, all other associated follow buttons can be updated by an emitted change event.
 
@@ -7,7 +9,7 @@ import FollowList from 'follow-list';
 const followList = FollowList();
 ```
 
-## add( { site_id: site.ID, is_following: true } )
+### add( { site_id: site.ID, is_following: true } )
 
 If the `site_id` being passed in does not yet exist in the array of `followList` data, a new `FollowListSite` object is created and added to the array. The method returns the instance of the `FollowListSite` so you can use that object to subscribe to change events:
 
@@ -19,28 +21,28 @@ const newFollowListSite = followList.add( { site_id: 1, is_following: false } );
 <Component mixins={ [ observe( 'newFollowListSite' ) ] } />;
 ```
 
-# FollowListSite
+## FollowListSite
 
 Instances of `FollowListSite` are created using the steps outlined above.
 
-## follow()
+### follow()
 
 If the `is_following === false` this method will call the api to start following the site. Once the api operation complets, a change event is fired.
 
-## unfollow()
+### unfollow()
 
 If the `is_following === true` this method will call the api to stop following the site. Once the api operation complets, a change event is fired.
 
-# Module Dependencies
+## Module Dependencies
 
-# External Dependencies
+## External Dependencies
 
 - `EventEmitter` to send `change` events which are subscribed to via the `mixins\data-observe` within your jsx component.
 
-# Internal Dependencies
+## Internal Dependencies
 
 - `wp` for api operations
 
-# Tests
+## Tests
 
 Execute `make` from the root of the directory

--- a/client/lib/format-number-compact/README.md
+++ b/client/lib/format-number-compact/README.md
@@ -2,7 +2,7 @@
 
 Given a language code, this library will take in a number and display it in a compact format.
 
-# Usage
+## Usage
 
 ```javascript
 import formatNumberCompact from 'lib/format-number-compact';

--- a/client/lib/highlight/README.md
+++ b/client/lib/highlight/README.md
@@ -4,7 +4,7 @@ This module searches a given html string and wraps all matching strings with a `
 
 If you give a custom element as a wrapper, it will be cloned every time it is added via `cloneNode()`
 
-# How to use
+## How to use
 
 ```es6
 const html = '<div>hello world</div>';
@@ -22,7 +22,7 @@ Using a custom highlight wrapper:
 ```es6
 const customWrapper = document.createElement('span');
 customWrapper.setAttribute( 'class', 'my-wrapper' );
-	
+
 const customHighlighted = highlight( 'hello', html, customWrapper );
 ```
 

--- a/client/lib/keyboard-shortcuts/README.md
+++ b/client/lib/keyboard-shortcuts/README.md
@@ -2,7 +2,7 @@
 
 This module emits an event when a keyboard shortcut is used, indicating the keyboard shortcut that was triggered. It provides a layer of abstraction between the keys used to trigger shortcuts and the actions that a component should bind to these shortcuts.
 
-# Usage
+## Usage
 
 This module can be used outside of React, but this is a typical use within React:
 
@@ -59,6 +59,6 @@ A full list of keyboard shortcut events is stored in `key-bindings.js`. New keyb
 }
 ```
 
-# Internationalization
+## Internationalization
 
 The key-bindings module (`key-bindings.js`) uses the `i18n` mixin to provide translations of the descriptions for each keyboard shortcut. When the language changes, `KeyBindings` will emit a `language-change` event, after which any component displaying the textual descriptions of the keyboard shortcuts will need to reload the key-bindings and re-render. At this point, the only other module that should be requiring `key-bindings.js` directly is the keyboard shortcuts menu.

--- a/client/my-sites/people/README.md
+++ b/client/my-sites/people/README.md
@@ -6,14 +6,14 @@ viewers, and invites.
 index.js provides all the routes for this section. controller.js decides which component to render, and main.js
 is the main component used for rendering the different lists in this section.
 
-# People List
+## People List
 
 main.js handles rendering of a list of people. The rendered list depends on the chosen filter in PeopleSectionNav. For example,
 the `people/team` route will render a TeamList component.
 
 Every list will be a collection of PeopleListItem components.
 
-# Data
+## Data
 
 Each list fetches it's list items from the API using slightly different methods.
 By default, the data is managed via a data component ( `client/components/data` ).

--- a/client/my-sites/plugins/README.md
+++ b/client/my-sites/plugins/README.md
@@ -14,6 +14,6 @@ The `Plugins` component renders the list of plugins (all the plugins installed o
 
 The `Plugin` component renders the site description and a list of `PluginSite` components sites, one `PluginSite` per site where the plugin is installed, with actions to update and activate/deactivate the plugin on that particular site.
 
-# Plugins Controller
+## Plugins Controller
 
 Right now, `controller.js` works as the controller for all the plugin-related view. In the future, it would be nice to have it a hub to redirect to single more-specific controllers associated to single views.

--- a/client/my-sites/stats/README.md
+++ b/client/my-sites/stats/README.md
@@ -1,4 +1,6 @@
-# Stats Components
+# Stats
+
+## Stats Components
 
 These components handle the `\stats` section of Calypso. The stats section supports a variety of routes:
 
@@ -8,19 +10,19 @@ These components handle the `\stats` section of Calypso. The stats section suppo
 /stats/:time_period/:site_id
 ```
 
-## overview.jsx
+### overview.jsx
 
 This is the default view that is rendered at `\stats`. For users with more than 1 blog, a summary page of stats are shown for each site. Local storage is leveraged to make this experience load faster for the user when navigating between stat periods/sites.
 
-## site.jsx
+### site.jsx
 
 This is the detail view container for a specific sites stats data.
 
-# Stats Controller
+## Stats Controller
 
 `controller.js` breaks the stats controller into its own individual component.
 
-# Site Stats Modules
+## Site Stats Modules
 
 Within this directory we have also prefixed 'sub' components (aka metaboxes) used on the `site.jsx` with `module_`
 
@@ -33,21 +35,21 @@ Within this directory we have also prefixed 'sub' components (aka metaboxes) use
 - `module-tags-categories.jsx`
 - `module-top-posts.jsx`
 
-# Stats Data Components
+## Stats Data Components
 
 Logic that interfaces with the API, or acts as a collection and / or interface into localStorage can be found within the `/client/stats` directory.
 
-# External Modules
+## External Modules
 
 `moment.js` is being used to perform graceful date transforms and calculations of period dates ( end of week/month/year etc )
 `store` is being used to persist metabox visibility state on the `site-stats` page
 `throttle` is being used to - debounce - window resize events for the responsive visualizations.
 
-# Stats List Markup
+## Stats List Markup
 
 We have spent quite a bit of time to create an extensive set of markup for stats lists that provide hooks for default actions, and action menus depending on screen size. Below is some example markup:
 
-## A Generic Stats List Item - No Action
+### A Generic Stats List Item - No Action
 
 ```html
 <li className="module-content-list-item module-content-list-item-normal">
@@ -60,7 +62,7 @@ We have spent quite a bit of time to create an extensive set of markup for stats
 </li>
 ```
 
-### Stats List Item - Link Row Action
+#### Stats List Item - Link Row Action
 
 ```html
 <li className="module-content-list-item module-content-list-item-link">
@@ -73,7 +75,7 @@ We have spent quite a bit of time to create an extensive set of markup for stats
 </li>
 ```
 
-### Stats List Item - With Additional Action Buttons
+#### Stats List Item - With Additional Action Buttons
 
 ```html
 <li className="module-content-list-item module-content-list-item-link">
@@ -90,7 +92,7 @@ We have spent quite a bit of time to create an extensive set of markup for stats
 </li>
 ```
 
-### Kitchen Sink Example - Avatars, icons in Labels, Nested Lists
+#### Kitchen Sink Example - Avatars, icons in Labels, Nested Lists
 
 ```html
 <li className="module-content-list-item module-content-list-item-link module-content-list-item-large module-content-list-item-toggle is-expanded">

--- a/client/reader/README.md
+++ b/client/reader/README.md
@@ -9,18 +9,18 @@ These routes are served by the module:
 - /recommendations (redirects to /read/search)
 - /tag/\*
 
-# Block Rendering Development
+## Block Rendering Development
 
-## Testing
+### Testing
 
-### Follow a site
+#### Follow a site
 
 1. Go to `https://wordpress.com/following/manage`
 2. In the "Search or enter URL to follow..." input box, enter the website where you'll be publishing
    a block
 3. When your site appears in the search results, click the "Follow" button
 
-### Publish a post
+#### Publish a post
 
 1. Go to `https://wordpress.com/home/{your_url}`
 2. Go to "Posts" on the menu to the left
@@ -28,7 +28,7 @@ These routes are served by the module:
 4. Populate your post with some content, and use the block that you're testing
 5. Click on "Publish" to publish your post or "Update" if the post already exists
 
-### Test that your block renders correctly in the Reader
+#### Test that your block renders correctly in the Reader
 
 There's two places where your block may render.
 
@@ -42,9 +42,9 @@ There's two places where your block may render.
    `https://wordpress.com/read/feeds/{site_id}/posts/{post_id}`. Let's call these "Reader Posts". This
    is the second place your block may render.
 
-## Data Flow
+### Data Flow
 
-### Relevant files (and order of data flow)
+#### Relevant files (and order of data flow)
 
 Reader Previews
 
@@ -68,7 +68,7 @@ Reader Posts
 - The last two files render the post data. It seems that the API endpoints simply return text (as a
   `excerpt` property), but also `content` which contains the rich HTML of the block. Those files also have the ability to render HTML.
 
-### API Endpoints Example Requests
+#### API Endpoints Example Requests
 
 Reader Previews
 

--- a/client/reader/site-stream/README.md
+++ b/client/reader/site-stream/README.md
@@ -2,7 +2,7 @@
 
 A post stream that shows posts from a WordPress.com or Jetpack site.
 
-# Props
+## Props
 
 - `siteId`: number, The site ID to show posts for
 

--- a/client/state/active-promotions/README.md
+++ b/client/state/active-promotions/README.md
@@ -2,21 +2,21 @@
 
 A module for managing activePromotions data.
 
-# Actions
+## Actions
 
 Used in combination with the Redux store instance `dispatch` function, actions can be used in manipulating the current global state.
 
-## Action creators
+### Action creators
 
 > Action creators are exactly that—functions that create actions.
 
-### activePromotionsReceiveAction( activePromotions )
+#### activePromotionsReceiveAction( activePromotions )
 
-### activePromotionsRequestSuccessAction()
+#### activePromotionsRequestSuccessAction()
 
-### activePromotionsRequestFailureAction( error )
+#### activePromotionsRequestFailureAction( error )
 
-### requestActivePromotions()
+#### requestActivePromotions()
 
 ```es6
 import {
@@ -40,7 +40,7 @@ wpcom
 	}
 ```
 
-# Reducer
+## Reducer
 
 Data from the aforementioned actions is added to the global state tree, under `activePromotions`, with the following structure:
 

--- a/client/state/plans/README.md
+++ b/client/state/plans/README.md
@@ -2,29 +2,29 @@
 
 A module for managing plans data.
 
-# Actions
+## Actions
 
 Used in combination with the Redux store instance `dispatch` function, actions can be used in manipulating the current global state.
 
-## `fetchWordPressPlans()`
+### `fetchWordPressPlans()`
 
 Fetches plans
 
-# Action creators
+## Action creators
 
 > Action creators are exactly that—functions that create actions.
 
-## plansReceiveAction( plans )
+### plansReceiveAction( plans )
 
-## plansRequestSuccessAction()
+### plansRequestSuccessAction()
 
-## plansRequestFailureAction( error )
+### plansRequestFailureAction( error )
 
-## plansSerializeAction()
+### plansSerializeAction()
 
-## plansDeserializeAction()
+### plansDeserializeAction()
 
-## requestPlans()
+### requestPlans()
 
 ```es6
 import {
@@ -48,7 +48,7 @@ wpcom
 	}
 ```
 
-# Reducer
+## Reducer
 
 Data from the aforementioned actions is added to the global state tree, under `plans`, with the following structure:
 

--- a/client/state/preferences/README.md
+++ b/client/state/preferences/README.md
@@ -3,7 +3,7 @@
 This store holds preferences specific to Calypso.
 They are persisted in `calypso_preferences` key of `/me/settings`.
 
-# Usage
+## Usage
 
 1. Render `QueryPreferences` from `components/data/query-preferences`
 2. Connect your component specifying proper option keys:

--- a/client/state/sites/domains/README.md
+++ b/client/state/sites/domains/README.md
@@ -2,29 +2,29 @@
 
 A module for managing site domains data.
 
-# Actions
+## Actions
 
 Used in combination with the Redux store instance `dispatch` function, actions can be used in manipulating the current global state.
 
-## `fetchSiteDomains( siteId: Number )`
+### `fetchSiteDomains( siteId: Number )`
 
 Fetches domains for the site with the given site ID.
 
-## `refreshSiteDomains( siteID: Number )`
+### `refreshSiteDomains( siteID: Number )`
 
 Clears domains and fetches them for the given site.
 
-# Action creators
+## Action creators
 
 > Action creators are exactly that—functions that create actions.
 
-## domainsReceiveAction( siteId, response )
+### domainsReceiveAction( siteId, response )
 
-## domainsRequestAction( siteId )
+### domainsRequestAction( siteId )
 
-## domainsRequestSuccessAction( siteId )
+### domainsRequestSuccessAction( siteId )
 
-## domainsRequestFailureAction( siteId, error )
+### domainsRequestFailureAction( siteId, error )
 
 ```es6
 import {
@@ -49,7 +49,7 @@ wpcom
 	dispatch( domainsReceiveAction( site,id, response.domains ) );
 ```
 
-# Reducer
+## Reducer
 
 Data from the aforementioned actions is added to the global state tree, under `sites.domains`, with the following structure:
 

--- a/client/state/sites/vouchers/README.md
+++ b/client/state/sites/vouchers/README.md
@@ -2,37 +2,37 @@
 
 A module for managing site vouchers data.
 
-# Actions
+## Actions
 
 Used in combination with the Redux store instance `dispatch` function, actions can be used in manipulating the current global state.
 
-## `requestSiteVouchers( siteId )`
+### `requestSiteVouchers( siteId )`
 
 Fetches vouchers for the site with the given site ID.
 
-## `assignSiteVoucher( siteId, serviceType )`
+### `assignSiteVoucher( siteId, serviceType )`
 
 Assign a `serviceType` voucher to the given site.
 
-# Action creators
+## Action creators
 
 > Action creators are exactly that—functions that create actions.
 
-## `vouchersReceiveAction( siteId, vouchers )`
+### `vouchersReceiveAction( siteId, vouchers )`
 
-## `vouchersRequestAction( siteId )`
+### `vouchersRequestAction( siteId )`
 
-## `vouchersRequestSuccessAction( siteId )`
+### `vouchersRequestSuccessAction( siteId )`
 
-## `vouchersRequestFailureAction( siteId, error )`
+### `vouchersRequestFailureAction( siteId, error )`
 
-## `vouchersAssignReceiveAction( siteId, serviceType, voucher )`
+### `vouchersAssignReceiveAction( siteId, serviceType, voucher )`
 
-## `vouchersAssignRequestAction( siteId, serviceType )`
+### `vouchersAssignRequestAction( siteId, serviceType )`
 
-## `vouchersAssignRequestSuccessAction( siteId, serviceType )`
+### `vouchersAssignRequestSuccessAction( siteId, serviceType )`
 
-## `vouchersAssignRequestFailureAction( siteId, serviceType, error )`
+### `vouchersAssignRequestFailureAction( siteId, serviceType, error )`
 
 ```es6
 import {
@@ -63,7 +63,7 @@ wpcom
 	dispatch( vouchersReceiveAction( site,id, response.vouchers ) );
 ```
 
-# Reducer
+## Reducer
 
 Data from the aforementioned actions is added to the global state tree, under `sites.vouchers`, with the following structure:
 

--- a/client/state/themes/README.md
+++ b/client/state/themes/README.md
@@ -60,17 +60,17 @@ data: {
 
 This means that individual theme information (like theme name, description, screenshot link etc) is stored in the `items` object, while the `queries` object associates serialized queries with the corresponding themes (stored per theme ID in `itemKeys`).
 
-# Jetpack Sites
+## Jetpack Sites
 
 Jetpack sites come with a REST API endpoint that triggers installation of a theme from either WordPress.org, or WordPress.com. To tell Jetpack which of either repository to use, we append a `-wpcom` suffix for WP.com themes. The suffix is then also present in the installed theme's ID (and directory name). There's another reason for that, which is to avoid collisions with existing themes in the WordPress.org repository -- otherwise, the WP.com theme would get overridden with a WP.org one of the same name by the self-hosted site's updater. Instead, downloaded WP.com themes include a little plugin that updates them from WP.com.
 
 To the user, we hide the `-wpcom` suffix as much as possible, e.g a selector like `getActiveTheme()` will remove it from its return value. The reason is that we want the UX to be as seamless as possible: When a user is looking at the Theme Details Sheet for a WP.com theme for their Jetpack site, i.e. wordpress.com/theme/ixiom/example.com, and presses the 'Activate' button, we need the UI to update accordingly, e.g. change the button to 'Customize' after activation. Scenarios like this wouldn't be possible if we were exposing the suffix.
 
-## Automated Transfer
+### Automated Transfer
 
 There's one exception to the `-wpcom` suffix, which is Automated Transfer (AT) sites. While handled through Jetpack, the `-wpcom` suffix is absent from installed themes there, mostly to facilitate transfer of theme options from WordPress.com. The WordPress core updater isn't of any concern there. Instead, AT itself manages WP.com themes to be always up-to-date.
 
-## Filtering of WP.com Themes on Jetpack Sites
+### Filtering of WP.com Themes on Jetpack Sites
 
 Since our UI for Jetpack sites consists of an 'Uploaded Themes' and a 'WordPress.com Themes' list and we don't want to duplicate themes between them, we filter WP.com themes from a given Jetpack site's installed themes. Unfortunately, we cannot wholly treat this as an implementation detail at view level and filter there (after getting themes from Redux state), but have to do this right after receiving a themes list from the endpoint, in our `requestThemes()` action, _before_ storing it in Redux state (via `ThemeQueryManager`).
 

--- a/client/state/user-settings/README.md
+++ b/client/state/user-settings/README.md
@@ -2,7 +2,7 @@
 
 This store holds user settings from `/me/settings`.
 
-# Usage
+## Usage
 
 1. Render `QueryUserSettings` from `components/data/query-user-settings`
 2. Connect your component specifying proper setting names:

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,6 +1,8 @@
-# master
+# Changelog
 
-# 6.3.0
+## master
+
+## 6.3.0
 
 - Add new `postCssOptions` option for the SASS loader, allowing more powerful customization of the
   PostCSS loader, deprecating the less capable `postCssConfig` option
@@ -15,7 +17,7 @@
 - Removed packages to the list of transpiled NPM dependencies:
   - wp-calypso-client
 
-# 6.2.0
+## 6.2.0
 
 - Set `strictExportPresence` in webpack so missing exports error the build.
   See [#43619](https://github.com/Automattic/wp-calypso/pull/43619).
@@ -72,12 +74,12 @@
   - gridicons
   - wp-calypso-client
 
-# 6.1.0
+## 6.1.0
 
 - Upgrade [mini-css-extract-plugin-with-rtl](https://github.com/Automattic/mini-css-extract-plugin-with-rtl) to 0.8.0, use an npm-published version instead of GitHub branch reference
 - Disable Terser's `extractComments` option to prevent Calypso build from adding LICENSE files into the minified output
 
-# 6.0.0
+## 6.0.0
 
 - Breaking Change: Replace `copy-styles` with a generic `copy-assets` script to handle both styles and images.
 - Upgrade to [sass-loader@8](https://github.com/webpack-contrib/sass-loader/releases/tag/v8.0.0)
@@ -85,17 +87,17 @@
 - Add support for transpiling selected NPM dependencies from ESnext to the target's ES version.
 - Add `punycode` to the list of transpiled NPM dependencies.
 
-# 5.1.0
+## 5.1.0
 
 - Add `util.IncrementalProgressPlugin` to show incremental build progress
 - Add support for [optional chaining](https://github.com/tc39/proposal-optional-chaining).
 - Add support for [nullish coalescing](https://github.com/tc39/proposal-nullish-coalescing).
 
-# 5.0.1
+## 5.0.1
 
 - Fix PostCSS config path default.
 
-# 5.0.0
+## 5.0.0
 
 - Remove `@automattic/calypso-color-schemes` dependency
   - See the [example in the README](./README.md#advanced-usage-use-own-postcss-config) for instructions on how to continue to use color definitions from that file in your project.
@@ -107,11 +109,11 @@
 - Remove `preserveCssCustomProperties` option from SASS preset; default to `true`.
 - Add `postCssConfig` options to SASS preset to enable customization of PostCSS options.
 
-# 4.2.1
+## 4.2.1
 
 - Fix a bad file: dependency in the published package.
 
-# 4.2.0
+## 4.2.0
 
 - Update a number of dependencies
   - @babel/core@7.6.4
@@ -132,7 +134,7 @@
 - Support CommonJS/ESM compilation by adding a `modules` option (and `MODULES` env variable) to the `babel/default` preset.
 - Add `jest-enzyme` assertion library to `jest-preset.js`.
 
-# 4.1.0
+## 4.1.0
 
 - Add config options to file-loader.
 - Add `enzyme-to-json` serializer to `jest-preset.js`.
@@ -140,11 +142,11 @@
 - Handle `TypeScript` files in `transpile` command.
 - Use `require.resolve` to resolve babel plugins and presets.
 
-# 4.0.1
+## 4.0.1
 
 - Replace esm import/export with `require`.
 
-# 4.0.0
+## 4.0.0
 
 - Move `jest.config.js` to `jest-preset.js` so it can be used as a jest preset.
 - Add jest babel transform to load calypso-build babel configuration.
@@ -152,7 +154,7 @@
 - Added transform-runtime versioning to babel/default.js
   This will need to be kept up to date while <https://github.com/babel/babel/issues/10261> is unresolved.
 
-# 3.0.0
+## 3.0.0
 
 - Switch to `@wordpress/dependency-extraction-webpack-plugin` from
   `@automattic/wordpress-external-dependencies-plugin` for WordPress webpack externals.
@@ -161,7 +163,7 @@
 - Update Jest setup to properly initialize Enzyme's adapter.
 - Fix typo that prevented the `output-library-target` argument from being passed to Webpack.
 
-# 2.0.0
+## 2.0.0
 
 - Breaking change: Remove babel plugins incompatible with TypeScript. If your bundle continues to
   compile without error, no changes are necessary. These babel plugins were removed:
@@ -193,6 +195,6 @@
 
 - Bugfix: Add ts and tsx extensions to webpack module resolution rules.
 
-# 1.0.0
+## 1.0.0
 
 - Initial release

--- a/packages/data-stores/CHANGELOG.md
+++ b/packages/data-stores/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Next
+# Changelog
+
+## Next
 
 - Initial release with stores:
   - Domain Suggestions
@@ -7,10 +9,10 @@
   - User
   - Site
 
-# 1.0.0-alpha.1
+## 1.0.0-alpha.1
 
 - Move `@wordpress/data` to peer dependency.
 
-# 1.0.0-alpha.0
+## 1.0.0-alpha.0
 
 - Initial prerelease

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -32,7 +32,7 @@ The following attributes can be set in the options object to alter the translati
 - **options.comment** [string] comment that will be shown to the translator for anything that may need to be explained about the translation.
 - **options.context** [string] provides the ability for the translator to provide a different translation for the same text in two locations (_dependent on context_). Usually context should only be used after a string has been discovered to require different translations. If you want to provide help on how to translate (which is highly appreciated!), please use a comment.
 
-## Usage
+### Usage
 
 If you pass a single string into `translate`, it will trigger a simple translation without any context, pluralization, sprintf arguments, or comments. You would call it like this.
 
@@ -341,7 +341,7 @@ export default function Header() {
 }
 ```
 
-# `withRtl` Higher-Order Component
+### `withRtl` Higher-Order Component
 
 The same functionality is also exposed as a HOC that passes an `isRtl` prop to the wrapped component.
 

--- a/packages/photon/History.md
+++ b/packages/photon/History.md
@@ -1,21 +1,23 @@
-# 3.0.0 / TBD
+# History
+
+## 3.0.0 / TBD
 
 - Drop dependency on `url` npm package.
 - Breaking change: support for URL / URLSearchParams APIs is now required.
 
-# 2.1.0 / 2019-06-03
+## 2.1.0 / 2019-06-03
 
 - Move source into [Calypso](https://github.com/Automattic/wp-calypso).
 - Remove browser build from module.
 - Include esm and commonjs in module.
 - Update debug to v4
 
-# 2.0.1 / 2017-11-08
+## 2.0.1 / 2017-11-08
 
 - Update to support Node.js version 7+ due to changes in `url.format` (#6, @DanReyLop)
 - Update dependencies
 
-# 2.0.0 / 2016-02-02
+## 2.0.0 / 2016-02-02
 
 - Add support for the `ssl` parameter to fetch images from https URLs
 - Readme: add Travis-CI badge
@@ -23,34 +25,34 @@
 - package: update "mocha" to v2.4.5
 - Return `null` for external URLs that contain querystrings (Breaking change!)
 
-# 1.0.4 / 2015-01-26
+## 1.0.4 / 2015-01-26
 
 - package: allow any "debug" v2
 - package: update "browserify" to v8.1.1
 - Fix how querystrings are dealt with for photon hosts, protcolless URLs (#3, @blowery)
 
-# 1.0.3 / 2014-12-20
+## 1.0.3 / 2014-12-20
 
 - fixes photonception issue (#2)
 - package: update "browserify" to v6.1.0
 - dist: recompile
 
-# 1.0.2 / 2014-06-13
+## 1.0.2 / 2014-06-13
 
 - Readme: add "Terms of Service" section
 - index: remove "port 80" debug note
 
-# 1.0.1 / 2014-06-11
+## 1.0.1 / 2014-06-11
 
 - package: be loose with the `debug` version
 - package: update "debug" to v1.0.0
 - Readme: use Cloudup image in examples
 
-# 1.0.0 / 2014-06-02
+## 1.0.0 / 2014-06-02
 
 - Major version bump for npm
 
-# 0.0.1 / 2014-06-02
+## 0.0.1 / 2014-06-02
 
 - Readme: add npm install instructions
 - idnex: statically hash the subdomain based on the URL

--- a/packages/wpcom-proxy-request/History.md
+++ b/packages/wpcom-proxy-request/History.md
@@ -1,4 +1,6 @@
-# 6.0.0 / TBD
+# History
+
+## 6.0.0 / TBD
 
 - Breaking: Return Promise (rather than `XMLHttpRequest` instance) if no callback argument is provided.
   - In practice, most people have probably been using the callback rather than the returned `XMLHttpRequest` instance, so this shouldn't be a breaking change for most.
@@ -9,15 +11,15 @@
 - Remove `component-event` dependency, use `addEventListener`/`removeEventListener` directly
 - Replace unmaintained `uid` dependency by well-maintained `uuid`
 
-# 5.0.2 / 2018-10-30
+## 5.0.2 / 2018-10-30
 
 - Fix the Chrome site isolation workaround to not break file uploads on Safari 10
 
-# 5.0.1 / 2018-10-29
+## 5.0.1 / 2018-10-29
 
 - Work around a Chrome site isolation bug when uploading files
 
-# 3.0.0 / 2016-07-27
+## 3.0.0 / 2016-07-27
 
 - examples: add wp-api example
 - client-test-app: add index.html
@@ -38,31 +40,31 @@
 - Add pinghub example
 - Add support for persistent connections
 
-# 2.0.0 / 2016-03-11
+## 2.0.0 / 2016-03-11
 
 - index: opt-in to `supports_error_obj` better Errors
 
-# 1.2.0 / 2016-03-09
+## 1.2.0 / 2016-03-09
 
 - dist: recompile
 - Use `wp-error` module for common Error handling logic
 - add missing LICENSE stuff
 - index: add missing `uninstall()` function
 
-# 1.1.1 / 2016-03-08
+## 1.1.1 / 2016-03-08
 
 - fix TypeError on string body 'error' from rest-proxy
 
-# 1.1.0 / 2016-02-24
+## 1.1.0 / 2016-02-24
 
 - support persistent connections e.g. websockets
 - add example for connecting to Pinghub via websocket
 
-# 1.0.5 / 2015-11-22
+## 1.0.5 / 2015-11-22
 
 - package: update "debug" to v2.2.0
 
-# 1.0.4 / 2015-02-27
+## 1.0.4 / 2015-02-27
 
 - dist: recompile
 - wrapping try/catch on an IIFE.
@@ -70,21 +72,21 @@
 - detecting support for the structured clone algorithm.
 - forcing JSON string for postMessage/onmessage to circumvent IE9 limitations.
 
-# 1.0.3 / 2015-02-09
+## 1.0.3 / 2015-02-09
 
 - index: don't throw in the case that there's no `buffered` Array
 - examples: better me.html example output
 
-# 1.0.2 / 2014-10-21
+## 1.0.2 / 2014-10-21
 
 - Republish since npm messed up v1.0.1
 
-# 1.0.1 / 2014-10-21
+## 1.0.1 / 2014-10-21
 
 - index: bail if no matching XHR instance was found
 - index: use `event` module to listen for XHR events
 
-# 1.0.0 / 2014-10-20
+## 1.0.0 / 2014-10-20
 
 - index: refactor to not use Promise anymore
 - examples: tweak "me.html" example since it no longer returns a Promise
@@ -95,44 +97,44 @@
 - package: update "browserify" to v6.1.0
 - package: remove unused "promise" dependency
 
-# 0.2.5 / 2014-06-26
+## 0.2.5 / 2014-06-26
 
 - dist: recompile
 - index: honor ports on the host page (#3, @rralian)
 
-# 0.2.4 / 2014-06-24
+## 0.2.4 / 2014-06-24
 
 - dist: recompile
 - package: update all dependencies
 
-# 0.2.3 / 2014-06-24
+## 0.2.3 / 2014-06-24
 
 - dist: recompile
 - index: don't bother doing a debug() call for the metaAPI calls
 - index: use %o debug formatter when it makes sense
 - index: implement File -> ArrayBuffer manual conversion for Firefox
 
-# 0.2.2 / 2014-06-10
+## 0.2.2 / 2014-06-10
 
 - dist: recompile
 - examples: add `freshly-pressed.html` example
 - package: be loose with the `debug` version
 
-# 0.2.1 / 2014-06-05
+## 0.2.1 / 2014-06-05
 
 - package: update "debug" to v1.0.0
 
-# 0.2.0 / 2014-05-27
+## 0.2.0 / 2014-05-27
 
 - index: update <iframe> "src" URL
 - examples: fix <script> tag src location
 
-# 0.1.1 / 2014-05-12
+## 0.1.1 / 2014-05-12
 
 - examples: add `upload.html` example
 - index: rename `res` variable to `body`
 - index: bind to iframe "load" event before setting `.src`
 
-# 0.1.0 / 2014-04-22
+## 0.1.0 / 2014-04-22
 
 - initial release

--- a/packages/wpcom.js/History.md
+++ b/packages/wpcom.js/History.md
@@ -1,17 +1,19 @@
-# 6.0.0 / 2020-XX-XX
+# History
+
+## 6.0.0 / 2020-XX-XX
 
 - Remove dependency on `core-js`: the package user needs to provide the needed JS environment
 - Move the published `build/` folder to `dist/` to align with other Calypso packages
 - No longer provide default request handler. This avoids a mandatory dependency on `wpcom-xhr-request`.
 
-# 5.4.2 / 2018-07-23
+## 5.4.2 / 2018-07-23
 
 - upgrade dependency 'debug' to 3.1.0
 - upgrade dependency 'qs' to 6.5.2
 - upgrade dependency 'wpcom-xhr-request' to 1.1.2
 - stop bundling Node.js 'fs' polyfill in browser package
 
-# 5.3.0 / 2016-10-25
+## 5.3.0 / 2016-10-25
 
 - add media-example test app
 - Add `edit()` method and set `1.2` for `get()`
@@ -19,11 +21,11 @@
 - site: eslint corrections
 - eslint: update dependencies and rules
 
-# 5.2.0 / 2016-07-27
+## 5.2.0 / 2016-07-27
 
 - pkg: update xhr to 1.0.0 and proxy to 3.0.0
 
-# 5.1.0 / 2016-07-12
+## 5.1.0 / 2016-07-12
 
 - fix `Request` reference
 - re-export the Classes
@@ -33,7 +35,7 @@
 - remove `test-all` and add `make-watch` rule
 - add CircleCI badge
 
-# 5.0.0 / 2016-07-04
+## 5.0.0 / 2016-07-04
 
 - clean - ES6ify
 - package: update "n8-make" to v1.4.0
@@ -41,435 +43,435 @@
 - package: add "prepublish" script
 - package: update "wpcom-proxy-request" to v2
 
-# 4.9.15 / 2016-06-06
+## 4.9.15 / 2016-06-06
 
 - Fix minor issues
 
-# 4.9.14 / 2016-06-06
+## 4.9.14 / 2016-06-06
 
 - rename `ad-credit-vouchers` to `credit-voucher`
 - Stats: Add statsInsights method for site.
 
-# 4.9.13 / 2016-05-25
+## 4.9.13 / 2016-05-25
 
 - avoid <https://github.com/webpack/webpack/issues/300> issue
 - marketing.survey. First approach
 - SiteAdCreditVouchers: first implementation
 
-# 4.9.12 / 2016-05-02
+## 4.9.12 / 2016-05-02
 
 - plans: add `./plans` methods
 
-# 4.9.11 / 2016-04-26
+## 4.9.11 / 2016-04-26
 
 - re-build dist/
 - Enable support for post types taxonomies endpoint
 
-# 4.9.10 / 2016-04-22
+## 4.9.10 / 2016-04-22
 
 - runtime: export runtime lists
 
-# 4.9.7 / 2016-04-19
+## 4.9.7 / 2016-04-19
 
 - test: add site.wpcomPlugin() tests
 - SiteWPComPlugin: add Class
 - test: add site.wpcomPluginsList() test
 - Site: add wpcomPluginsList() method
 
-# 4.9.6 / 2016-04-18
+## 4.9.6 / 2016-04-18
 
 - SitePlugin: rename methods: updateVersion() and update()
 
-# 4.9.5 / 2016-14-04
+## 4.9.5 / 2016-14-04
 
 - site.taxonomy and site.taxonomy.term implemented
 - site.plugin updates
 - various test cleanup
 
-  # 4.9.4 / 2016-04-04
+# 4.9.4 / 2016-04-04
 
 - add site.post.del back which was removed in 4.9.3
 
-  # 4.9.3 / 2016-03-30
+## 4.9.3 / 2016-03-30
 
-  - site.post.subscriber: implemented
-  - site.post: add post methods in the runtime
-  - runtime-build: refact -> pass pathBuilder function
-  - site.post: ES6ify
-  - site: ES6ify
+- site.post.subscriber: implemented
+- site.post: add post methods in the runtime
+- runtime-build: refact -> pass pathBuilder function
+- site.post: ES6ify
+- site: ES6ify
 
-  # 4.9.2 / 2016-03-27
+## 4.9.2 / 2016-03-27
 
-  - Fix requiring a JSON file
+- Fix requiring a JSON file
 
-  # 4.9.1 / 2016-03-28
+## 4.9.1 / 2016-03-28
 
-  - site.plugin: add basic site plugins structure
-  - site.domain: add basic site domain structure
+- site.plugin: add basic site plugins structure
+- site.domain: add basic site domain structure
 
-  # 4.9.0 / 2016-03-28
+## 4.9.0 / 2016-03-28
 
 - site: add domain methods (see <https://github.com/Automattic/wpcom.js/pull/163>)
 - version bump wpcom-xhr-request (see <https://github.com/Automattic/wpcom-xhr-request/pull/17>)
 
-  # 4.8.6 / 2016-03-23
+## 4.8.6 / 2016-03-23
 
-  - domain.dns: add `/domains/%s/dns` methods
-  - domain.email: add `/domains/%s/email` methods
-  - domain: add `/domains/%s` methods
-  - domains: add `/domains` methods
-  - site.settings: implemented
-  - me: add me.posts() method
-  - process site methods using runtime libs
-  - site: add generic postTypesList method
-  - site: add site.postCounts()
-  - site.wordads: add several methods
+- domain.dns: add `/domains/%s/dns` methods
+- domain.email: add `/domains/%s/email` methods
+- domain: add `/domains/%s` methods
+- domains: add `/domains` methods
+- site.settings: implemented
+- me: add me.posts() method
+- process site methods using runtime libs
+- site: add generic postTypesList method
+- site: add site.postCounts()
+- site.wordads: add several methods
 
-  # 4.8.5 / 2016-2-23
+## 4.8.5 / 2016-2-23
 
 - version bump wpcom-xhr-request
 
-  # 4.8.4 / 2016-2-18
+## 4.8.4 / 2016-2-18
 
 - adds support for special `apiNamespace` param to integrate core WP-API
 
-  # 4.8.3 / 2015-12-10
+## 4.8.3 / 2015-12-10
 
-  - add methods:
-  - - me.billingHistory
-  - - me.connectedAppication
-  - - me.keyringConnection
-  - - me.publicizeConnection
-  - - me.settins.password
-  - - me.towStep
+- add methods:
+- - me.billingHistory
+- - me.connectedAppication
+- - me.keyringConnection
+- - me.publicizeConnection
+- - me.settins.password
+- - me.towStep
 
-  # 4.8.2 / 2015-11-26
+## 4.8.2 / 2015-11-26
 
-  - add babel-runtime so that es6 features requiring a pollyfill work
+- add babel-runtime so that es6 features requiring a pollyfill work
 
-  # 4.8.1 / 2015-11-20
+## 4.8.1 / 2015-11-20
 
-  - add compiled js files to revision system
+- add compiled js files to revision system
 
-  # 4.8.0 / 2015-11-19
+## 4.8.0 / 2015-11-19
 
-  - Use webpack to build final product
+- Use webpack to build final product
 
-  # 4.7.0 / 2015-09-07
+## 4.7.0 / 2015-09-07
 
-  - Return the static Promise.{reject/resolve} objects
-  - Set default Promise return in absence of callback
+- Return the static Promise.{reject/resolve} objects
+- Set default Promise return in absence of callback
 
-  # 4.6.2 / 2015-09-03
+## 4.6.2 / 2015-09-03
 
-  - Add Promise documentation
-  - circle: add config file. set node version
-  - Add Promsie Wrapper
+- Add Promise documentation
+- circle: add config file. set node version
+- Add Promsie Wrapper
 
-  # 4.6.1 / 2015-08-30
+## 4.6.1 / 2015-08-30
 
-  - Add site.pageTemplates() test
-  - Add site.pageTemplates() method
+- Add site.pageTemplates() test
+- Add site.pageTemplates() method
 
-  # 4.6.0 / 2015-08-13
+## 4.6.0 / 2015-08-13
 
-  - batch: remove bracket in url query
-  - send-request: parse and assign query param rightly
-  - example: add cors batch example
+- batch: remove bracket in url query
+- send-request: parse and assign query param rightly
+- example: add cors batch example
 
-  # 4.5.3 / 2015-08-11
+## 4.5.3 / 2015-08-11
 
-  - send-request: always stringify query object
+- send-request: always stringify query object
 
-  # 4.5.2 / 2015-08-11
+## 4.5.2 / 2015-08-11
 
-  - Use PHP style query params for a batch request
+- Use PHP style query params for a batch request
 
-  # 4.5.1 / 2015-07-08
+## 4.5.1 / 2015-07-08
 
-  - pkg: bump "wpcom-xhr-request" to "0.3.2"
-  - send-request: handler proxyOrigin parameter
+- pkg: bump "wpcom-xhr-request" to "0.3.2"
+- send-request: handler proxyOrigin parameter
 
-  # 4.5.0 / 2015-05-06
+## 4.5.0 / 2015-05-06
 
-  - docs: fix references to `wpcom.sites()` -> `wpcom.site()`
-  - site: fix query args for `statsVideo` and `statsPostViews`
+- docs: fix references to `wpcom.sites()` -> `wpcom.site()`
+- site: fix query args for `statsVideo` and `statsPostViews`
 
-  # 4.4.1 / 2015-04-30
+## 4.4.1 / 2015-04-30
 
-  - core: store token if is defined
+- core: store token if is defined
 
-  # 4.4.0 / 2015-04-20
+## 4.4.0 / 2015-04-20
 
-  - test: fix a couple of failing tests and methods
-  - docs: prepare for auto-generated docs and code samples
+- test: fix a couple of failing tests and methods
+- docs: prepare for auto-generated docs and code samples
 
-  # 4.3.0 / 2015-04-15
+## 4.3.0 / 2015-04-15
 
-  - site: add stats endpoints
-  - docs: update OAuth and testing docs
+- site: add stats endpoints
+- docs: update OAuth and testing docs
 
-  # 4.2.1 / 2015-03-31
+## 4.2.1 / 2015-03-31
 
-  - pkg: bump `wpcom-xhr-request` to `0.3.1`
+- pkg: bump `wpcom-xhr-request` to `0.3.1`
 
-  # 4.2.0 / 2015-03-13
+## 4.2.0 / 2015-03-13
 
-  - send-request: check `query` paramter
-  - test: add util req testing file
-  - test: update wpcom.site.tagsList test
-  - test: update wpcom.site.categoriesList test
+- send-request: check `query` paramter
+- test: add util req testing file
+- test: update wpcom.site.tagsList test
+- test: update wpcom.site.categoriesList test
 
-  # 4.1.0 / 2015-02-18
+## 4.1.0 / 2015-02-18
 
-  - test: force apiVersion to 1 for some stats tests
-  - site: fix embed_url param
-  - send-request: default value for `query` is {}
+- test: force apiVersion to 1 for some stats tests
+- site: fix embed_url param
+- send-request: default value for `query` is {}
 
-  # 4.0.0 / 2015-02-09
+## 4.0.0 / 2015-02-09
 
-  - request: update path for send-request module
-  - core: add sendRequest() to suppoert compatibility
-  - test: add users suggest testing file
-  - update to wpcom.req method
-  - test: add site.follow testing file
-  - test: add site embeds testing file
-  - test: add site.shortcodes testing file
-  - send-response: set apiVersion from wpcom property
-  - core: add apiVersion as property. Define `1.1` as default
-  - request: refact -> create Req class
+- request: update path for send-request module
+- core: add sendRequest() to suppoert compatibility
+- test: add users suggest testing file
+- update to wpcom.req method
+- test: add site.follow testing file
+- test: add site embeds testing file
+- test: add site.shortcodes testing file
+- send-response: set apiVersion from wpcom property
+- core: add apiVersion as property. Define `1.1` as default
+- request: refact -> create Req class
 
-  # 3.2.0 / 2015-02-05
+## 3.2.0 / 2015-02-05
 
-  - site: use `list` builder for `embdesList` method
-  - test: site: add embedsList() test
-  - site: use `list` builder for shortcodesList method
-  - test: add site.shortcodesList test
-  - post: propagate `id` and `slug` when post is added
-  - improve tests
+- site: use `list` builder for `embdesList` method
+- test: site: add embedsList() test
+- site: use `list` builder for shortcodesList method
+- test: add site.shortcodesList test
+- post: propagate `id` and `slug` when post is added
+- improve tests
 
-  # 3.1.1 / 2014-12-08
+## 3.1.1 / 2014-12-08
 
-  - site: URIencode id. This allows to use the API wit Jetpack sites installed on subfolders.
+- site: URIencode id. This allows to use the API wit Jetpack sites installed on subfolders.
 
-  # 3.1.0 / 2014-12-04
+## 3.1.0 / 2014-12-04
 
-  - core: request handler parameter in constructor
-
-  # 3.0.0 / 2014-12-02
-
-  - add `requite` util module
-  - update coding
-  - core: Added users suggest endpoint
-  - Merge pull request #71 from Automattic/add/post-restore-endpoint
-  - Allow optional third-index apiVersion for resource list
-  - test: improve media util functions
-  - test: pre-process files in addFiles test
-  - test: update apiVersion tests using getFiles()
-  - test: add test.getFiles() method
-  - examples: better proxy me.html output
-  - test: fix testing data
-  - Get rid of confusion between `index.js` and `wpcom+xhr.js`
+- core: request handler parameter in constructor
+
+## 3.0.0 / 2014-12-02
+
+- add `requite` util module
+- update coding
+- core: Added users suggest endpoint
+- Merge pull request #71 from Automattic/add/post-restore-endpoint
+- Allow optional third-index apiVersion for resource list
+- test: improve media util functions
+- test: pre-process files in addFiles test
+- test: update apiVersion tests using getFiles()
+- test: add test.getFiles() method
+- examples: better proxy me.html output
+- test: fix testing data
+- Get rid of confusion between `index.js` and `wpcom+xhr.js`
 
-  # 2.6.0 / 2014-11-12
+## 2.6.0 / 2014-11-12
 
-  - media: fix bug in checking File on server-side
+- media: fix bug in checking File on server-side
 
-  # 2.5.0 / 2014-11-12
+## 2.5.0 / 2014-11-12
 
-  - media: fix checking File parameter in #addFiles method
+- media: fix checking File parameter in #addFiles method
 
-  # 2.4.0 / 2014-11-03
+## 2.4.0 / 2014-11-03
 
-  - media: fix bug adding media files in client-side
-  - examples: add browser-proxy "upload.html" example
-  - media: add optional [query] parameter.
-  - pkg: update "wpcom-xhr-request" to v0.3.0
-  - add `return` statement to all `sendRequest()` calls
-  - media: support new api features
-  - media: use api version 1.1
+- media: fix bug adding media files in client-side
+- examples: add browser-proxy "upload.html" example
+- media: add optional [query] parameter.
+- pkg: update "wpcom-xhr-request" to v0.3.0
+- add `return` statement to all `sendRequest()` calls
+- media: support new api features
+- media: use api version 1.1
 
-  # 2.3.0 / 2014-10-10
+## 2.3.0 / 2014-10-10
 
-  - test: add batch test
-  - Add batch support
+- test: add batch test
+- Add batch support
 
-  # 2.2.0 / 2014-10-03
+## 2.2.0 / 2014-10-03
 
-  - test: add tag tests
-  - site: add site#tag() method
-  - tag: add tag library
-  - test: fix typeof asserts
-  - test: add category tests
-  - site: add site#category() method
-  - category: add category
-  - test: move up `global` testing value
-  - package: update "debug" to v2.0.0
-  - Add media.update method
+- test: add tag tests
+- site: add site#tag() method
+- tag: add tag library
+- test: fix typeof asserts
+- test: add category tests
+- site: add site#category() method
+- category: add category
+- test: move up `global` testing value
+- package: update "debug" to v2.0.0
+- Add media.update method
 
-  # 2.1.0 / 2014-09-11
+## 2.1.0 / 2014-09-11
 
-  - Add tests for comment likes
-  - add CommentLike module and functions to Comment (mirroring Like for Posts)
-  - landing v1
+- Add tests for comment likes
+- add CommentLike module and functions to Comment (mirroring Like for Posts)
+- landing v1
 
-  # 2.0.4 / 2014-08-05
+## 2.0.4 / 2014-08-05
 
-  - dist: recompile
-  - docs: update Follow doc page
-  - Add `Follow` implementation
-  - update "browserify" to v4.2.1
+- dist: recompile
+- docs: update Follow doc page
+- Add `Follow` implementation
+- update "browserify" to v4.2.1
 
-  # 2.0.3 / 2014-07-15
+## 2.0.3 / 2014-07-15
 
-  - dist: recompile
-  - package: update "browserify" to v4.2.0
-  - package: update "wpcom-xhr-request" to v0.2.5
-  - site: use `%o` formatter for debug() calls
+- dist: recompile
+- package: update "browserify" to v4.2.0
+- package: update "wpcom-xhr-request" to v0.2.5
+- site: use `%o` formatter for debug() calls
 
-  # 2.0.2 / 2014-06-25
+## 2.0.2 / 2014-06-25
 
-  - dist: recompile
-  - examples: add "browser-proxy" example
-  - Makefile: remove `-xhr`
-  - index: inline the `sendRequest()` function
-  - package: update "browserify" to v4.1.11
-  - package: update "wpcom-xhr-request" to v0.2.3
-  - wpcom+xhr: add JSDoc comment
+- dist: recompile
+- examples: add "browser-proxy" example
+- Makefile: remove `-xhr`
+- index: inline the `sendRequest()` function
+- package: update "browserify" to v4.1.11
+- package: update "wpcom-xhr-request" to v0.2.3
+- wpcom+xhr: add JSDoc comment
 
-  # 2.0.1 / 2014-06-10
+## 2.0.1 / 2014-06-10
 
-  - dist: recompile
-  - package: update "wpcom-xhr-request" to v0.2.2
-  - docs: fix typo in function name
-  - docs: fix typo in `post` docs
-  - docs: fix relative links in `WPCOM` main docs
-  - package: be loose with the `debug` version
-  - package: add "license" field
+- dist: recompile
+- package: update "wpcom-xhr-request" to v0.2.2
+- docs: fix typo in function name
+- docs: fix typo in `post` docs
+- docs: fix relative links in `WPCOM` main docs
+- package: be loose with the `debug` version
+- package: add "license" field
 
-  # 2.0.0 / 2014-06-05
+## 2.0.0 / 2014-06-05
 
-  - dist: rebuild
-  - package: update "debug" and "wpcom-xhr-request" dependencies
-  - package: add "keywords" field
-  - test: fix testing data
-  - package: update "description"
-  - add LICENSE file
-  - package, Redme: use lowercase .JS, add "web"
-  - example: add uploading image browser example
-  - delete legacy wpcom-proxy (#39, @guille)
-  - examples: a few tweaks
-  - example: remove token value
+- dist: rebuild
+- package: update "debug" and "wpcom-xhr-request" dependencies
+- package: add "keywords" field
+- test: fix testing data
+- package: update "description"
+- add LICENSE file
+- package, Redme: use lowercase .JS, add "web"
+- example: add uploading image browser example
+- delete legacy wpcom-proxy (#39, @guille)
+- examples: a few tweaks
+- example: remove token value
 
-  # 1.2.3 / 2014-05-20
+## 1.2.3 / 2014-05-20
 
-  - xhr: add wpcom.setToken()
+- xhr: add wpcom.setToken()
 
-  # 1.2.2 / 2014-05-19
+## 1.2.2 / 2014-05-19
 
-  - New methods:
+- New methods:
 
-    - post.comment()
-    - post.comments()
+  - post.comment()
+  - post.comments()
 
-    - comment.get()
-    - comment.update()
-    - comment.replies()
-    - comment.reply()
-    - comment.delete()
+  - comment.get()
+  - comment.update()
+  - comment.replies()
+  - comment.reply()
+  - comment.delete()
 
-  - dist: recompile
-  - add test for all new methods
-  - update documentation
+- dist: recompile
+- add test for all new methods
+- update documentation
 
-  # 1.2.1 / 2014-05-13
+## 1.2.1 / 2014-05-13
 
-  - New methods:
+- New methods:
 
-    - site.addMediaFiles()
-    - site.addMediaUrls()
-    - site.deleteMedia()
-    - site.usersList()
-    - site.likesList()
+  - site.addMediaFiles()
+  - site.addMediaUrls()
+  - site.deleteMedia()
+  - site.usersList()
+  - site.likesList()
 
-    - media.addFiles()
-    - media.addUrls()
-    - media.del()
+  - media.addFiles()
+  - media.addUrls()
+  - media.del()
 
-    - post.reblog()
-    - post.related()
+  - post.reblog()
+  - post.related()
 
-    - like.state()
-    - like.mine()
-    - like.del()
+  - like.state()
+  - like.mine()
+  - like.del()
 
-    - reblog.to()
-    - reblog.state()
+  - reblog.to()
+  - reblog.state()
 
-  - Add and update examples over the browser
-  - Improve and update documentation
+- Add and update examples over the browser
+- Improve and update documentation
 
-  # 1.2.0 / 2014-04-23
+## 1.2.0 / 2014-04-23
 
-  - Remove internal "endpoints" `.json` files, saves ~8kb uncompressed (#19)
-  - package: update "description" field
-  - History: match `git changelog` output
-  - rename `doc` -> `docs` and `example` to `examples`
+- Remove internal "endpoints" `.json` files, saves ~8kb uncompressed (#19)
+- package: update "description" field
+- History: match `git changelog` output
+- rename `doc` -> `docs` and `example` to `examples`
 
-  # 1.1.0 / 2014-04-22
+## 1.1.0 / 2014-04-22
 
-  - site: rename Sites to Site
-  - dist: add the compiled `wpcom-proxy.js` and `wpcom.js` files
-  - Readme: improve
+- site: rename Sites to Site
+- dist: add the compiled `wpcom-proxy.js` and `wpcom.js` files
+- Readme: improve
 
-  # 1.0.0 / 2014-04-22
+## 1.0.0 / 2014-04-22
 
-  - remove `req.js`, move send() fn to WPCOM class
-  - add wpcom+proxy.js and wpcom+xhr.js wrapper class scripts
-  - add browserify standalone build rules
+- remove `req.js`, move send() fn to WPCOM class
+- add wpcom+proxy.js and wpcom+xhr.js wrapper class scripts
+- add browserify standalone build rules
 
-  # 0.3.0 / 2014-04-11
+## 0.3.0 / 2014-04-11
 
-  - rename npm name to `wpcom`
+- rename npm name to `wpcom`
 
-  # 0.2.3 / 2014-04-10
+## 0.2.3 / 2014-04-10
 
-  - add me.sites() method
+- add me.sites() method
 
-  # 0.2.2 / 2014-04-02
+## 0.2.2 / 2014-04-02
 
-  - New methods:
-    - me.connections()
-    - me.groups()
-    - me.likes()
-    - post.edit()
-    - post.del()
-  - improve error handling
-  - improve endpoint files structure
-  - update documentation
+- New methods:
+  - me.connections()
+  - me.groups()
+  - me.likes()
+  - post.edit()
+  - post.del()
+- improve error handling
+- improve endpoint files structure
+- update documentation
 
-  # 0.2.1 / 2014-03-31
+## 0.2.1 / 2014-03-31
 
-  - replace `request` by `superagent`
+- replace `request` by `superagent`
 
-  # 0.2.0 / 2014-03-28
+## 0.2.0 / 2014-03-28
 
-  - pck: bump wp-connect@0.2.0
-  - set token in the constructor
-  - remove .token() method
+- pck: bump wp-connect@0.2.0
+- set token in the constructor
+- remove .token() method
 
-  # 0.1.1 / 2014-03-27
+## 0.1.1 / 2014-03-27
 
-  - core: cretae a Req instance in this.req property
-  - req: refact -> expose a Req constructor
-  - example: add simple exmaple application
+- core: cretae a Req instance in this.req property
+- req: refact -> expose a Req constructor
+- example: add simple exmaple application
 
-  # 0.1.0 / 2014-03-19
+## 0.1.0 / 2014-03-19
 
-  - change the API
-  - doc: update documentation
-  - add tests
+- change the API
+- doc: update documentation
+- add tests
 
-  # 0.0.2 / 2014-02-20
+## 0.0.2 / 2014-02-20
 
-  - first approach
+- first approach

--- a/packages/wpcom.js/docs/promises.md
+++ b/packages/wpcom.js/docs/promises.md
@@ -25,9 +25,9 @@ comment = comment.del.bind( comment );
 wpcom.Promise( comment );
 ```
 
-# Examples
+## Examples
 
-## Approving a comment
+### Approving a comment
 
 ```js
 const comment = wpcom.site( siteId ).comment( commentId );
@@ -37,7 +37,7 @@ wpcom
 	.catch( ( error ) => alert( error ) );
 ```
 
-## Requesting the freshly-pressed list
+### Requesting the freshly-pressed list
 
 ```js
 wpcom
@@ -47,7 +47,7 @@ wpcom
 	.catch( notifyNetworkError );
 ```
 
-## Chaining promises
+### Chaining promises
 
 ```js
 const post = wpcom.site( siteId ).post( postId );


### PR DESCRIPTION
### Background

After linting our Markdown files following prettier format, I'd like to introduce content-based rules from `remark`. The plugin we use (`eslint-plugin-md`) recommends [Markdown Style Guide](https://cirosantilli.com/markdown-style-guide/), and it has [a preset](https://www.npmjs.com/package/remark-preset-lint-markdown-style-guide) for it.

Unfortunately this preset doesn't have the capacity of auto-fix the problems. Instead of enabling the preset and having a ton of errors, I'll enable the rules of the preset one by one and fix each error. When all the rules are enabled we can switch the hardcoded list of rules by the preset.

### Changes

Enables rule [no-multiple-toplevel-headings](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-multiple-toplevel-headings). This rule forbids having more than one H1 tag per document (https://cirosantilli.com/markdown-style-guide/#top-level-header)

```

Bad:

# Foo
# Bar

--- 

Good:

# Foo
## Bar
```

### Testing
Run `./node_modules/.bin/eslint --ext .md .` and check there are no errors
