### PR TITLE
Make sure new customers don't see old plans upsells

### DIFF
--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -400,6 +400,7 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 	} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
+		constants.FEATURE_WORDADS_INSTANT,
 		constants.FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 		constants.FEATURE_JETPACK_BACKUP_DAILY,
 		constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
@@ -448,6 +449,7 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 	} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
+		constants.FEATURE_WORDADS_INSTANT,
 		constants.FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 		constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 		constants.FEATURE_JETPACK_BACKUP_REALTIME,
@@ -507,6 +509,7 @@ const getPlanJetpackCompleteDetails = () => ( {
 	} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
+		constants.FEATURE_WORDADS_INSTANT,
 		constants.FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 		constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 		constants.FEATURE_JETPACK_BACKUP_REALTIME,

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -447,6 +447,7 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 	} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
+		constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 		constants.FEATURE_JETPACK_BACKUP_REALTIME,
 		constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
 		constants.FEATURE_JETPACK_SCAN_DAILY,
@@ -504,6 +505,7 @@ const getPlanJetpackCompleteDetails = () => ( {
 	} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
+		constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 		constants.FEATURE_JETPACK_BACKUP_REALTIME,
 		constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
 		constants.FEATURE_JETPACK_SCAN_DAILY,

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -400,6 +400,7 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 	} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
+		constants.FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 		constants.FEATURE_JETPACK_BACKUP_DAILY,
 		constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
 		constants.FEATURE_JETPACK_SCAN_DAILY,
@@ -447,6 +448,7 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 	} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
+		constants.FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 		constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 		constants.FEATURE_JETPACK_BACKUP_REALTIME,
 		constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
@@ -505,6 +507,7 @@ const getPlanJetpackCompleteDetails = () => ( {
 	} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
+		constants.FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 		constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 		constants.FEATURE_JETPACK_BACKUP_REALTIME,
 		constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 import {
 	isWordadsInstantActivationEligible,
 	isWordadsInstantActivationEligibleButNotOwner,
@@ -228,6 +229,10 @@ class AdsWrapper extends Component {
 	}
 
 	renderjetpackUpsell() {
+		if ( shouldShowOfferResetFlow() ) {
+			return null;
+		}
+
 		const { siteSlug, translate } = this.props;
 		const bannerURL = `/checkout/${ siteSlug }/premium`;
 		return (

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -31,6 +31,7 @@ import {
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import { CtaButton } from 'components/promo-section/promo-card/cta';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 import { localizeUrl } from 'lib/i18n-utils';
 
 /**
@@ -99,11 +100,16 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		} );
 	};
 
-	const getPlanNames = () =>
+	const getPlanNames = () => {
+		const jetpackText = shouldShowOfferResetFlow()
+			? ''
+			: ' ' + translate( 'Available only with a Premium or Professional plan.' );
+
 		// Space isn't included in the translatable string to prevent it being easily missed.
-		isNonAtomicJetpack
-			? ' ' + translate( 'Available only with a Premium or Professional plan.' )
+		return isNonAtomicJetpack
+			? jetpackText
 			: ' ' + translate( 'Available only with a Premium, Business, or eCommerce plan.' );
+	};
 
 	/**
 	 * Return the content to display in the Simple Payments card based on the current plan.

--- a/client/my-sites/marketing/tools/google-my-business-feature.tsx
+++ b/client/my-sites/marketing/tools/google-my-business-feature.tsx
@@ -23,6 +23,7 @@ import MarketingToolsFeatureButtonWithPlanGate from './feature-button-with-plan-
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import QueryKeyringServices from 'components/data/query-keyring-services';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
 /**
@@ -68,6 +69,10 @@ const MarketingToolsGoogleMyBusinessFeature: FunctionComponent< Props > = ( {
 	};
 
 	const translate = useTranslate();
+
+	if ( shouldShowOfferResetFlow() ) {
+		return null;
+	}
 
 	return (
 		<Fragment>

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -27,6 +27,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 import { FEATURE_GOOGLE_ANALYTICS, TYPE_PREMIUM, TERM_ANNUALLY } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
@@ -118,6 +119,22 @@ export class GoogleAnalyticsForm extends Component {
 			  )
 			: translate( 'Connect your site to Google Analytics in seconds with the Premium plan' );
 
+		const nudge = shouldShowOfferResetFlow() ? null : (
+			<UpsellNudge
+				description={ translate(
+					"Add your unique tracking ID to monitor your site's performance in Google Analytics."
+				) }
+				event={ 'google_analytics_settings' }
+				feature={ FEATURE_GOOGLE_ANALYTICS }
+				plan={ findFirstSimilarPlanKey( site.plan.product_slug, {
+					type: TYPE_PREMIUM,
+					...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
+				} ) }
+				showIcon={ true }
+				title={ nudgeTitle }
+			/>
+		);
+
 		return (
 			<form id="analytics" onSubmit={ handleSubmitForm }>
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
@@ -131,19 +148,7 @@ export class GoogleAnalyticsForm extends Component {
 				/>
 
 				{ showUpgradeNudge && site && site.plan ? (
-					<UpsellNudge
-						description={ translate(
-							"Add your unique tracking ID to monitor your site's performance in Google Analytics."
-						) }
-						event={ 'google_analytics_settings' }
-						feature={ FEATURE_GOOGLE_ANALYTICS }
-						plan={ findFirstSimilarPlanKey( site.plan.product_slug, {
-							type: TYPE_PREMIUM,
-							...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
-						} ) }
-						showIcon={ true }
-						title={ nudgeTitle }
-					/>
+					nudge
 				) : (
 					<Card className="analytics-settings site-settings__analytics-settings">
 						{ siteIsJetpack && (

--- a/client/my-sites/site-settings/jetpack-ads.jsx
+++ b/client/my-sites/site-settings/jetpack-ads.jsx
@@ -20,6 +20,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import SupportInfo from 'components/support-info';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -50,6 +51,10 @@ class JetpackAds extends Component {
 	}
 
 	renderUpgradeBanner() {
+		if ( shouldShowOfferResetFlow() ) {
+			return null;
+		}
+
 		const { translate } = this.props;
 
 		return (

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -16,6 +16,7 @@ import filesize from 'filesize';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import SupportInfo from 'components/support-info';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 import {
 	PLAN_JETPACK_PREMIUM,
 	FEATURE_VIDEO_UPLOADS,
@@ -127,6 +128,7 @@ class MediaSettingsPerformance extends Component {
 		const { isVideoPressAvailable, translate } = this.props;
 
 		return (
+			! shouldShowOfferResetFlow() &&
 			! isVideoPressAvailable && (
 				<UpsellNudge
 					description={ translate(

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -35,6 +35,7 @@ import isSiteComingSoon from 'state/selectors/is-site-coming-soon';
 import { toApi as seoTitleToApi } from 'components/seo/meta-title-editor/mappings';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestSite } from 'state/sites/actions';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 import {
 	isBusiness,
 	isEnterprise,
@@ -50,6 +51,7 @@ import {
 	TYPE_BUSINESS,
 	TYPE_PREMIUM,
 	TERM_ANNUALLY,
+	JETPACK_RESET_PLANS,
 } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
@@ -365,7 +367,8 @@ export class SeoForm extends React.Component {
 
 				{ ! this.props.hasSeoPreviewFeature &&
 					! this.props.hasAdvancedSEOFeature &&
-					selectedSite.plan && (
+					selectedSite.plan &&
+					! shouldShowOfferResetFlow() && (
 						<UpsellNudge
 							description={ translate(
 								'Get tools to optimize your site for improved performance in search engine results.'
@@ -483,7 +486,10 @@ export class SeoForm extends React.Component {
 const mapStateToProps = ( state ) => {
 	const selectedSite = getSelectedSite( state );
 	// SEO Tools are available with Business plan on WordPress.com, and with Premium plan on Jetpack sites
-	const isAdvancedSeoEligible = selectedSite.plan && hasSupportingPlan( selectedSite.plan );
+	const isAdvancedSeoEligible =
+		selectedSite.plan &&
+		( hasSupportingPlan( selectedSite.plan ) ||
+			JETPACK_RESET_PLANS.includes( selectedSite.plan.product_slug ) );
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
 

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -24,7 +24,13 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackSettingsSaveFailure from 'state/selectors/is-jetpack-settings-save-failure';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import { hasFeature } from 'state/sites/plans/selectors';
-import { FEATURE_SPAM_AKISMET_PLUS, PLAN_JETPACK_PERSONAL } from 'lib/plans/constants';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
+import {
+	FEATURE_SPAM_AKISMET_PLUS,
+	FEATURE_JETPACK_ANTI_SPAM,
+	FEATURE_JETPACK_ANTI_SPAM_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
+} from 'lib/plans/constants';
 
 const SpamFilteringSettings = ( {
 	currentAkismetKey,
@@ -32,6 +38,7 @@ const SpamFilteringSettings = ( {
 	fields,
 	hasAkismetFeature,
 	hasAkismetKeyError,
+	hasAntiSpam,
 	isRequestingSettings,
 	isSavingSettings,
 	onChangeField,
@@ -52,7 +59,12 @@ const SpamFilteringSettings = ( {
 		className,
 		header = null;
 
-	if ( ! inTransition && ! hasAkismetFeature && ! isValidKey ) {
+	if (
+		! shouldShowOfferResetFlow() &&
+		! inTransition &&
+		! ( hasAkismetFeature || hasAntiSpam ) &&
+		! isValidKey
+	) {
 		return (
 			<UpsellNudge
 				description={ translate( 'Automatically remove spam from comments and contact forms.' ) }
@@ -146,9 +158,13 @@ export default connect( ( state, { dirtyFields, fields } ) => {
 		isJetpackSettingsSaveFailure( state, selectedSiteId, fields ) &&
 		includes( dirtyFields, 'wordpress_api_key' );
 	const hasAkismetFeature = hasFeature( state, selectedSiteId, FEATURE_SPAM_AKISMET_PLUS );
+	const hasAntiSpam =
+		hasFeature( state, selectedSiteId, FEATURE_JETPACK_ANTI_SPAM ) ||
+		hasFeature( state, selectedSiteId, FEATURE_JETPACK_ANTI_SPAM_MONTHLY );
 
 	return {
 		hasAkismetFeature,
 		hasAkismetKeyError,
+		hasAntiSpam,
 	};
 } )( localize( SpamFilteringSettings ) );

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -16,6 +16,7 @@ import FormattedHeader from 'components/formatted-header';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import AutoLoadingHomepageModal from 'my-sites/themes/auto-loading-homepage-modal';
 import config from 'config';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 import { isPartnerPurchase } from 'lib/purchases';
 import JetpackReferrerMessage from './jetpack-referrer-message';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
@@ -96,20 +97,24 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 				align="left"
 			/>
 			<CurrentTheme siteId={ siteId } />
-			{ ! requestingSitePlans && currentPlan && ! hasUnlimitedPremiumThemes && ! isPartnerPlan && (
-				<UpsellNudge
-					forceDisplay
-					plan={ PLAN_JETPACK_BUSINESS }
-					title={ translate( 'Access all our premium themes with our Professional plan!' ) }
-					description={ translate(
-						'In addition to our collection of premium themes, ' +
-							'get Elasticsearch-powered site search, real-time offsite backups, ' +
-							'and security scanning.'
-					) }
-					event="themes_plans_free_personal_premium"
-					showIcon={ true }
-				/>
-			) }
+			{ ! shouldShowOfferResetFlow() &&
+				! requestingSitePlans &&
+				currentPlan &&
+				! hasUnlimitedPremiumThemes &&
+				! isPartnerPlan && (
+					<UpsellNudge
+						forceDisplay
+						plan={ PLAN_JETPACK_BUSINESS }
+						title={ translate( 'Access all our premium themes with our Professional plan!' ) }
+						description={ translate(
+							'In addition to our collection of premium themes, ' +
+								'get Elasticsearch-powered site search, real-time offsite backups, ' +
+								'and security scanning.'
+						) }
+						event="themes_plans_free_personal_premium"
+						showIcon={ true }
+					/>
+				) }
 			<ThemeShowcase
 				{ ...props }
 				siteId={ siteId }

--- a/client/state/themes/selectors/get-jetpack-upgrade-url-if-premium-theme.js
+++ b/client/state/themes/selectors/get-jetpack-upgrade-url-if-premium-theme.js
@@ -2,7 +2,10 @@
  * Internal dependencies
  */
 import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
-import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_JETPACK_SECURITY_DAILY } from 'lib/plans/constants';
+import {
+	FEATURE_UNLIMITED_PREMIUM_THEMES,
+	PLAN_JETPACK_SECURITY_REALTIME,
+} from 'lib/plans/constants';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { isThemePremium } from 'state/themes/selectors/is-theme-premium';
@@ -24,7 +27,7 @@ export function getJetpackUpgradeUrlIfPremiumTheme( state, themeId, siteId ) {
 		! hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES )
 	) {
 		return `/checkout/${ getSiteSlug( state, siteId ) }/${
-			shouldShowOfferResetFlow() ? PLAN_JETPACK_SECURITY_DAILY : 'professional'
+			shouldShowOfferResetFlow() ? PLAN_JETPACK_SECURITY_REALTIME : 'professional'
 		}`;
 	}
 	return null;

--- a/client/state/themes/selectors/get-jetpack-upgrade-url-if-premium-theme.js
+++ b/client/state/themes/selectors/get-jetpack-upgrade-url-if-premium-theme.js
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
+import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_JETPACK_SECURITY_DAILY } from 'lib/plans/constants';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { isThemePremium } from 'state/themes/selectors/is-theme-premium';
@@ -22,7 +23,9 @@ export function getJetpackUpgradeUrlIfPremiumTheme( state, themeId, siteId ) {
 		isThemePremium( state, themeId ) &&
 		! hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES )
 	) {
-		return `/checkout/${ getSiteSlug( state, siteId ) }/professional`;
+		return `/checkout/${ getSiteSlug( state, siteId ) }/${
+			shouldShowOfferResetFlow() ? PLAN_JETPACK_SECURITY_DAILY : 'professional'
+		}`;
 	}
 	return null;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

In this PR, we make sure that when the offer reset flow is enabled, customers don't see legacy Jetpack plans upsells in Calypso.

Fixes 1169247016322522-as-1193712760461723

_Note: it's quite urgent to remove old plans mentions, so this PR just does that. I'll follow up with what we want to replace them with eventually_

### Testing instructions

Select a self-hosted site with Jetpack Free

#### Premium themes
- Go to `/themes/:site/`
- With the offer reset flow disabled, make sure you see the plan upsell (see capture below)
- With the OR flow enabled, make sure it's not there anymore
- Go to `/themes/premium/:site/`
- Click the "three dot menu" on a theme and "Upgrade to activate"
- Verify you are taken to checkout with a Real-time security plan

#### Site settings

- Visit `/settings/performance/:site/`
- Check the _Media_ section
- Check that you see an upsell with the OR disabled, and that you don't see it when enabled
- Visit `/settings/security/:site/`
- Check the _Anti-spam_ section
- Check that you see an upsell with the OR disabled, and that you don't see it when enabled

#### Earn

- Visit `/earn/:site/`
- Check that you seen the mentions of the legacy plans in the _Collect PayPal payments_ and _Earn ad revenue_ sections when OR is disabled, but not when enabled
- Visit `/earn/ads-earnings/:site/`
- Check that you don't see any upsell when OR is enabled

#### Marketing

- Visit `/marketing/traffic/:site/`
- Check the _Ads_ section, _Search engine optimization_, and _Google Analytics_ sections
- For each section, check that you see an upsell with the OR disabled, and that you don't see it when enabled
- Visit `/marketing/tools/:site/`
- Check that the card `Let your customers find you on Google` is visible when OR is disabled, but not when enabled

### Screenshots

#### Premium themes
![screenshot](https://user-images.githubusercontent.com/1620183/93219591-85e81f00-f739-11ea-8195-3a015d32851e.png)

#### Site settings

**Performance**
![screenshot](https://user-images.githubusercontent.com/1620183/93223061-a74b0a00-f73d-11ea-98c8-210c9feb1978.png)

**Security**
![screenshot](https://user-images.githubusercontent.com/1620183/93227241-2a6e5f00-f742-11ea-94e7-ddf45c5524a4.png)

#### Earn

![screenshot](https://user-images.githubusercontent.com/1620183/93237440-1df00380-f74e-11ea-9916-51dd87cd6e45.png)
![screenshot](https://user-images.githubusercontent.com/1620183/93238845-f9952680-f74f-11ea-81ee-d56c7ccd41bf.png)



#### Marketing

![screenshot](https://user-images.githubusercontent.com/1620183/93228737-d3698980-f743-11ea-9d67-bd1c921abfcc.png)
![screenshot (1)](https://user-images.githubusercontent.com/1620183/93228748-d6fd1080-f743-11ea-9570-2897817b72e6.png)
![screenshot](https://user-images.githubusercontent.com/1620183/93236229-8f2eb700-f74c-11ea-98f7-ae4dd8cd862c.png)
