### PR TITLE
Add new comment highlights

### DIFF
--- a/client/assets/stylesheets/shared/_animation.scss
+++ b/client/assets/stylesheets/shared/_animation.scss
@@ -45,6 +45,13 @@
 	}
 }
 
+// Pulsing background color for loading placeholders
+@keyframes highlight {
+	50% {
+		background-color: var( --color-warning-10 );
+	}
+}
+
 // Another pulsing animation for placeholders
 @keyframes loading-fade {
 	0% {

--- a/client/blocks/comments/index.jsx
+++ b/client/blocks/comments/index.jsx
@@ -15,6 +15,7 @@ import { requestPostComments } from 'state/comments/actions';
 
 class PostComments extends React.Component {
 	static propTypes = {
+		shouldHighlightNew: PropTypes.bool,
 		post: PropTypes.shape( {
 			ID: PropTypes.number.isRequired,
 			site_ID: PropTypes.number.isRequired,
@@ -22,6 +23,7 @@ class PostComments extends React.Component {
 	};
 
 	static defaultProps = {
+		shouldHighlightNew: false,
 		shouldPollForNewComments: false,
 	};
 

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -78,9 +78,11 @@ class PostCommentList extends React.Component {
 		commentsTree: PropTypes.object,
 		requestPostComments: PropTypes.func.isRequired,
 		requestComment: PropTypes.func.isRequired,
+		shouldHighlightNew: PropTypes.bool,
 	};
 
 	static defaultProps = {
+		shouldHighlightNew: false,
 		pageSize: NUMBER_OF_COMMENTS_PER_FETCH,
 		initialSize: NUMBER_OF_COMMENTS_PER_FETCH,
 		showCommentCount: true,
@@ -224,6 +226,7 @@ class PostCommentList extends React.Component {
 				depth={ 0 }
 				maxDepth={ this.props.maxDepth }
 				showNestingReplyArrow={ this.props.showNestingReplyArrow }
+				shouldHighlightNew={ this.props.shouldHighlightNew }
 			/>
 		);
 	};

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -86,7 +86,7 @@ class PostComment extends React.PureComponent {
 
 		// connect()ed props:
 		currentUser: PropTypes.object.isRequired,
-		highlightNew: PropTypes.bool,
+		shouldHighlightNew: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -99,7 +99,7 @@ class PostComment extends React.PureComponent {
 		showNestingReplyArrow: false,
 		showReadMoreInActions: false,
 		hidePingbacksAndTrackbacks: false,
-		highlightNew: false,
+		shouldHighlightNew: false,
 	};
 
 	state = {
@@ -338,7 +338,7 @@ class PostComment extends React.PureComponent {
 			overflowY,
 			showReadMoreInActions,
 			hidePingbacksAndTrackbacks,
-			highlightNew,
+			shouldHighlightNew,
 		} = this.props;
 
 		const comment = get( commentsTree, [ commentId, 'data' ] );
@@ -391,7 +391,7 @@ class PostComment extends React.PureComponent {
 
 		// highlight comments not older than 10s
 		const isHighlighted =
-			highlightNew && new Date().getTime() - new Date( comment.date ).getTime() < 10000;
+			shouldHighlightNew && new Date().getTime() - new Date( comment.date ).getTime() < 10000;
 
 		const postCommentClassnames = classnames( 'comments__comment', {
 			[ 'depth-' + depth ]: depth <= maxDepth && depth <= 3, // only indent up to 3

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -86,6 +86,7 @@ class PostComment extends React.PureComponent {
 
 		// connect()ed props:
 		currentUser: PropTypes.object.isRequired,
+		highlightNew: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -98,6 +99,7 @@ class PostComment extends React.PureComponent {
 		showNestingReplyArrow: false,
 		showReadMoreInActions: false,
 		hidePingbacksAndTrackbacks: false,
+		highlightNew: false,
 	};
 
 	state = {
@@ -336,6 +338,7 @@ class PostComment extends React.PureComponent {
 			overflowY,
 			showReadMoreInActions,
 			hidePingbacksAndTrackbacks,
+			highlightNew,
 		} = this.props;
 
 		const comment = get( commentsTree, [ commentId, 'data' ] );
@@ -386,8 +389,13 @@ class PostComment extends React.PureComponent {
 			commentAuthorName: parentAuthorName,
 		} = this.getAuthorDetails( parentCommentId );
 
+		// highlight comments not older than 10s
+		const isHighlighted =
+			highlightNew && new Date().getTime() - new Date( comment.date ).getTime() < 10000;
+
 		const postCommentClassnames = classnames( 'comments__comment', {
 			[ 'depth-' + depth ]: depth <= maxDepth && depth <= 3, // only indent up to 3
+			'is-highlighted': isHighlighted,
 		} );
 
 		/* eslint-disable wpcalypso/jsx-gridicon-size */

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -247,6 +247,7 @@ class PostComment extends React.PureComponent {
 								activeEditCommentId={ this.props.activeEditCommentId }
 								onUpdateCommentText={ this.props.onUpdateCommentText }
 								onCommentSubmit={ this.props.onCommentSubmit }
+								shouldHighlightNew={ this.props.shouldHighlightNew }
 							/>
 						) ) }
 					</ol>

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -23,6 +23,11 @@
 		background: transparent;
 	}
 
+	&.is-highlighted {
+		animation: highlight 2s ease-in-out;
+		animation-iteration-count: 1;
+	}
+
 	.comments__form {
 		margin-top: 10px;
 	}

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -262,7 +262,7 @@ export class ConversationCommentList extends React.Component {
 								commentText={ this.state.commentText }
 								showReadMoreInActions={ true }
 								displayType={ POST_COMMENT_DISPLAY_TYPES.excerpt }
-								highlightNew={ true }
+								shouldHighlightNew={ true }
 							/>
 						);
 					} ) }

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -262,6 +262,7 @@ export class ConversationCommentList extends React.Component {
 								commentText={ this.state.commentText }
 								showReadMoreInActions={ true }
 								displayType={ POST_COMMENT_DISPLAY_TYPES.excerpt }
+								highlightNew={ true }
 							/>
 						);
 					} ) }

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -262,7 +262,6 @@ export class ConversationCommentList extends React.Component {
 								commentText={ this.state.commentText }
 								showReadMoreInActions={ true }
 								displayType={ POST_COMMENT_DISPLAY_TYPES.excerpt }
-								shouldHighlightNew={ true }
 							/>
 						);
 					} ) }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -535,6 +535,7 @@ export class FullPostView extends React.Component {
 										showConversationFollowButton={ true }
 										followSource={ READER_FULL_POST }
 										shouldPollForNewComments={ config.isEnabled( 'reader/comment-polling' ) }
+										shouldHighlightNew={ true }
 									/>
 								) }
 							</div>


### PR DESCRIPTION
Integrates, finally, #40858. All props @unDemian.

#### Changes proposed in this Pull Request

* Add highlight effect to new realtime comments 

#### Testing instructions

Add a comment to one of your posts on the frontend, it should be highlighted in Calypso Reader full post view (anything other than Conversations AFAIK).
