### PR TITLE
Fix redirection to back to the Plans page at the end of the flow

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -62,6 +62,7 @@ import {
 	authorize as authorizeAction,
 	retryAuth as retryAuthAction,
 } from 'state/jetpack-connect/actions';
+import { OFFER_RESET_FLOW_TYPES } from 'state/jetpack-connect/constants';
 import {
 	getAuthAttempts,
 	getAuthorizationData,
@@ -616,10 +617,11 @@ export class JetpackAuthorize extends Component {
 			return `/start/pressable-nux?blogid=${ clientId }`;
 		}
 
-		// If the redirect is part of the Jetpack Search purchase flow
-		const isSearch = this.props.selectedPlanSlug === 'jetpack_search';
-
-		if ( isSearch ) {
+		// If the redirect is part of a Jetpack plan or product go to the checkout page
+		const jetpackCheckoutSlugs = OFFER_RESET_FLOW_TYPES.filter( ( productSlug ) =>
+			productSlug.includes( 'jetpack' )
+		);
+		if ( jetpackCheckoutSlugs.includes( this.props.selectedPlanSlug ) ) {
 			return '/checkout/' + urlToSlug( homeUrl ) + '/' + this.props.selectedPlanSlug;
 		}
 

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -24,6 +24,7 @@ import { managePurchase } from 'me/purchases/paths';
 import Main from 'components/main';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import QuerySites from 'components/data/query-sites';
+import QueryProductsList from 'components/data/query-products-list';
 import JetpackFreeCard from 'components/jetpack/card/jetpack-free-card';
 
 /**
@@ -162,6 +163,7 @@ const SelectorPage = ( {
 				</>
 			) }
 
+			<QueryProductsList />
 			<QueryProducts />
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			{ siteId && <QuerySites siteId={ siteId } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix incorrect redirection to the Plans page after the user has logged in. Now users are redirected to the checkout page.
* Fix loading state for prices. 

#### Testing instructions

* Test the whole flow in every possible way you can imagine. Don't forget to test the flow for products such as Jetpack Scan, Jetpack Search, and others.

