### PR TITLE
Jetpack Offer Reset: Fix [Object object] in plan title

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -164,12 +164,17 @@ class CurrentPlan extends Component {
 		} = this.props;
 
 		const currentPlanSlug = selectedSite.plan.product_slug,
-			isLoading = this.isLoading();
+			isLoading = this.isLoading(),
+			planTitle = getPlan( currentPlanSlug ).getTitle();
 
-		const planConstObj = getPlan( currentPlanSlug ),
-			planFeaturesHeader = translate( '%(planName)s plan features', {
-				args: { planName: planConstObj.getTitle() },
-			} );
+		const planFeaturesHeader =
+			typeof planTitle === 'string'
+				? translate( '%(planName)s plan features', {
+						args: { planName: planTitle },
+				  } )
+				: translate( '{{planName/}} plan features', {
+						components: { planName: planTitle },
+				  } );
 
 		const shouldQuerySiteDomains = selectedSiteId && shouldShowDomainWarnings;
 		const showDomainWarnings = hasDomainsLoaded && shouldShowDomainWarnings;

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -163,18 +163,13 @@ class CurrentPlan extends Component {
 			translate,
 		} = this.props;
 
-		const currentPlanSlug = selectedSite.plan.product_slug,
-			isLoading = this.isLoading(),
-			planTitle = getPlan( currentPlanSlug ).getTitle();
+		const currentPlanSlug = selectedSite.plan.product_slug;
+		const isLoading = this.isLoading();
+		const planTitle = getPlan( currentPlanSlug ).getTitle();
 
-		const planFeaturesHeader =
-			typeof planTitle === 'string'
-				? translate( '%(planName)s plan features', {
-						args: { planName: planTitle },
-				  } )
-				: translate( '{{planName/}} plan features', {
-						components: { planName: planTitle },
-				  } );
+		const planFeaturesHeader = translate( '{{planName/}} plan features', {
+			components: { planName: <>{ planTitle }</> },
+		} );
 
 		const shouldQuerySiteDomains = selectedSiteId && shouldShowDomainWarnings;
 		const showDomainWarnings = hasDomainsLoaded && shouldShowDomainWarnings;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes the [Object object] in the plan title, at the bottom of the Plans page in Calypso. (see screenshot).

![Screenshot on 2020-09-15 at 11-40-22](https://user-images.githubusercontent.com/11078128/93251046-86d47d00-f748-11ea-8bb8-1b56a5fb4e22.png)

Additional data:  This only happens with "Security _Daily_" or "Security _Realtime_" plans because of the way the i18n-calypso.translate() function handles the emphasized/italicized words (<em>daily</em> & <em>realtime</em>)

### Testing instructions

1. Select a site that has a Plan of Jetpack Security Daily or Realtime.
2. Go to My Plan tab on the Plans page and make sure you do Not see [Object object] in the plan title at the bottom of the page like shown in the screenshot above.
3. Next select a site with any plan other than Security Daily or Realtime and make sure the plan title at the bottom of the page displays correctly.


Fixes: 1169247016322522-as-1193991362792017/f