### PR TITLE
Make Jetpack Search first item in product column in Plans page

### DIFF
--- a/client/my-sites/plans-v2/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans-v2/use-get-plans-grid-products.ts
@@ -40,6 +40,13 @@ const useSelectorPageProducts = ( siteId: number | null ) => {
 	// Directly and indirectly owned products
 	const ownedProducts = [ ...purchasedProducts, ...includedInPlanProducts ];
 
+	// If Jetpack Search is directly or indirectly owned, continue, otherwise make it available.
+	if (
+		! ownedProducts.some( ( ownedProduct ) => JETPACK_SEARCH_PRODUCTS.includes( ownedProduct ) )
+	) {
+		availableProducts = [ ...availableProducts, ...JETPACK_SEARCH_PRODUCTS ];
+	}
+
 	// If Jetpack Backup is directly or indirectly owned, continue, otherwise make it available by displaying
 	// the option cards.
 	if (
@@ -64,13 +71,6 @@ const useSelectorPageProducts = ( siteId: number | null ) => {
 		! ownedProducts.some( ( ownedProduct ) => JETPACK_ANTI_SPAM_PRODUCTS.includes( ownedProduct ) )
 	) {
 		availableProducts = [ ...availableProducts, ...JETPACK_ANTI_SPAM_PRODUCTS ];
-	}
-
-	// If Jetpack Search is directly or indirectly owned, continue, otherwise make it available.
-	if (
-		! ownedProducts.some( ( ownedProduct ) => JETPACK_SEARCH_PRODUCTS.includes( ownedProduct ) )
-	) {
-		availableProducts = [ ...availableProducts, ...JETPACK_SEARCH_PRODUCTS ];
 	}
 
 	return {


### PR DESCRIPTION
### Changes proposed in this Pull Request

Title sums it up.

Fixes 1169247016322522-as-1194011618084897

### Testing instructions

- Make sure the offer reset flow is enabled (should be by default)
- Visit the _Plans_ page and select the _All_ type
- Check that _Search_ appears first in the product column

### Screenshots

<img width="705" alt="Screen Shot 2020-09-15 at 3 06 08 PM" src="https://user-images.githubusercontent.com/1620183/93253820-6b2b9f80-f765-11ea-93e5-5dc9ea359df5.png">
