### PR TITLE
Jetpack connect: support new plans title and description

### DIFF
--- a/client/jetpack-connect/main-header.jsx
+++ b/client/jetpack-connect/main-header.jsx
@@ -80,16 +80,6 @@ class JetpackConnectMainHeader extends Component {
 			};
 		}
 
-		if ( type === 'jetpack_search' ) {
-			return {
-				title: translate( 'Get Jetpack Search' ),
-				subtitle: translate(
-					'Incredibly powerful and customizable, Jetpack Search helps your visitors ' +
-						'instantly find the right content – right when they need it.'
-				),
-			};
-		}
-
 		if ( shouldShowOfferResetFlow() ) {
 			if ( JETPACK_RESET_PLANS.includes( type ) ) {
 				const plan = getPlan( type );
@@ -98,7 +88,7 @@ class JetpackConnectMainHeader extends Component {
 					return {
 						title: translate( 'Get {{name/}}', {
 							components: {
-								name: plan.getTitle(),
+								name: <>{ plan.getTitle() }</>,
 							},
 							comment: '{{name/}} is the name of a plan',
 						} ),
@@ -114,7 +104,7 @@ class JetpackConnectMainHeader extends Component {
 					return {
 						title: translate( 'Get {{name/}}', {
 							components: {
-								name: getJetpackProductShortName( product ),
+								name: <>{ getJetpackProductShortName( product ) }</>,
 							},
 							comment: '{{name/}} is the name of a plan',
 						} ),
@@ -122,6 +112,14 @@ class JetpackConnectMainHeader extends Component {
 					};
 				}
 			}
+		} else if ( type === 'jetpack_search' ) {
+			return {
+				title: translate( 'Get Jetpack Search' ),
+				subtitle: translate(
+					'Incredibly powerful and customizable, Jetpack Search helps your visitors ' +
+						'instantly find the right content – right when they need it.'
+				),
+			};
 		}
 
 		return {

--- a/client/jetpack-connect/main-header.jsx
+++ b/client/jetpack-connect/main-header.jsx
@@ -10,6 +10,12 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import FormattedHeader from 'components/formatted-header';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
+import { getPlan } from 'lib/plans';
+import { JETPACK_RESET_PLANS } from 'lib/plans/constants';
+import { getJetpackProductShortName, getJetpackProductDescription } from 'lib/products-values';
+import { PRODUCTS_LIST } from 'lib/products-values/products-list';
+import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
 import { FLOW_TYPES } from 'state/jetpack-connect/constants';
 import { retrievePlan } from './persistence-utils';
 
@@ -82,6 +88,40 @@ class JetpackConnectMainHeader extends Component {
 						'instantly find the right content – right when they need it.'
 				),
 			};
+		}
+
+		if ( shouldShowOfferResetFlow() ) {
+			if ( JETPACK_RESET_PLANS.includes( type ) ) {
+				const plan = getPlan( type );
+
+				if ( plan ) {
+					return {
+						title: translate( 'Get {{name/}}', {
+							components: {
+								name: plan.getTitle(),
+							},
+							comment: '{{name/}} is the name of a plan',
+						} ),
+						subtitle: plan.getDescription(),
+					};
+				}
+			}
+
+			if ( JETPACK_PRODUCTS_LIST.includes( type ) ) {
+				const product = PRODUCTS_LIST[ type ];
+
+				if ( product ) {
+					return {
+						title: translate( 'Get {{name/}}', {
+							components: {
+								name: getJetpackProductShortName( product ),
+							},
+							comment: '{{name/}} is the name of a plan',
+						} ),
+						subtitle: getJetpackProductDescription( product ),
+					};
+				}
+			}
 		}
 
 		return {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR makes sure that the Jetpack connect page copy supports new plans and products.

### Testing instructions

Make sure the offer reset flow is enabled.

- Visit `/jetpack/connect/jetpack_complete`
- Check that the title and description represent _Jetpack Complete_
- Visit `/jetpack/connect/jetpack_anti_spam`
- Check that the title and description represent _Jetpack Anti-spam_
- Visit `/jetpack/connect/jetpack_search`
- Check that the title and description represent _Jetpack Search_

### Screenshots

**Complete**
<img width="458" alt="Screen Shot 2020-09-15 at 5 13 35 PM" src="https://user-images.githubusercontent.com/1620183/93265669-f5303400-f776-11ea-8093-579bb7b91c58.png">

**Anti-spam**
<img width="452" alt="Screen Shot 2020-09-15 at 5 13 46 PM" src="https://user-images.githubusercontent.com/1620183/93265678-f7928e00-f776-11ea-824c-10dd2cdf26e8.png">

**Search**
<img width="474" alt="Screen Shot 2020-09-15 at 5 19 23 PM" src="https://user-images.githubusercontent.com/1620183/93266174-b0f16380-f777-11ea-92f8-437a32412569.png">

