### PR TITLE
Remove faqs from plan select details page and upsell page.

### DIFF
--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -45,7 +45,6 @@ export const productDetails = ( rootUrl: string ) => (
 			duration={ duration }
 			rootUrl={ rootUrl }
 			header={ context.header }
-			footer={ context.footer }
 		/>
 	);
 	next();
@@ -60,7 +59,6 @@ export const productUpsell = ( rootUrl: string ) => ( context: PageJS.Context, n
 			duration={ duration }
 			rootUrl={ rootUrl }
 			header={ context.header }
-			footer={ context.footer }
 		/>
 	);
 	next();

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -40,7 +40,7 @@ import type { Duration, DetailsPageProps, PurchaseCallback, SelectorProduct } fr
 
 import './style.scss';
 
-const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: DetailsPageProps ) => {
+const DetailsPage = ( { duration, productSlug, rootUrl, header }: DetailsPageProps ) => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
@@ -89,7 +89,7 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 			<QueryProducts />
 			{ header }
 			<HeaderCake onClick={ backButton }>
-				{ isBundle ? translate( 'Bundle Options' ) : translate( 'Product Options' ) }
+				{ isBundle ? translate( 'Plan Options' ) : translate( 'Product Options' ) }
 			</HeaderCake>
 			<FormattedHeader
 				headerText={
@@ -130,7 +130,6 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 					} )
 				) }
 			</div>
-			{ footer }
 		</Main>
 	);
 };

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -25,7 +25,7 @@ export type PurchaseCallback = ( arg0: SelectorProduct, arg1?: boolean, arg2?: P
 interface BasePageProps {
 	rootUrl: string;
 	header: ReactNode;
-	footer: ReactNode;
+	footer?: ReactNode;
 }
 
 export interface SelectorPageProps extends BasePageProps {

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -177,7 +177,7 @@ const UpsellComponent = ( {
 	);
 };
 
-const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellPageProps ) => {
+const UpsellPage = ( { duration, productSlug, rootUrl, header }: UpsellPageProps ) => {
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const isLoading = useIsLoading( siteId );
@@ -238,7 +238,6 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 				onBackButtonClick={ onBackButtonClick }
 				isLoading={ isLoading }
 			/>
-			{ footer }
 		</>
 	);
 };


### PR DESCRIPTION
Fixes: 1169247016322522-as-1193933927242258/f

### Changes proposed in this Pull Request

1. On the Jetpack Plans selection page, change "Bundle Options" text to "Plan Options".
2. On the Jetpack Plans selection pages and upsell pages, remove FAQ section at the bottom.
(See Screenshot)

![Markup 2020-09-15 at 16 42 44](https://user-images.githubusercontent.com/11078128/93276045-6372f780-f773-11ea-8d3a-e5f43c60dfad.png)


### Testing instructions

- Go to http://calypso.localhost:3000/jetpack/connect/store
- Select a Plan that has options. (At this time, the only _Plan_ that offers daily and real-time options is Jetpack Security.)
- Verify that it no longer says "Bundle Options", and now it says: "Plan Options" (see image)

![Markup 2020-09-15 at 16 54 32](https://user-images.githubusercontent.com/11078128/93276392-396e0500-f774-11ea-8408-d6e35afd6a44.png)

- Next, verify that the FAQ's are no longer showing on Plan or Product select pages (select daily or real-time options), and also on product upsell pages. For example, these pages:

http://calypso.localhost:3000/jetpack/connect/store/jetpack_security_monthly/monthly/details
http://calypso.localhost:3000/jetpack/connect/store/jetpack_backup/annual/details
Upsell pages:
http://calypso.localhost:3000/jetpack/connect/store/jetpack_backup_daily/annual/additions

Product select pages (select daily or real-time options)
![Markup 2020-09-15 at 17 09 06](https://user-images.githubusercontent.com/11078128/93277169-7dfaa000-f776-11ea-9af1-94f468a2e578.png)

Upsell pages
![Markup 2020-09-15 at 17 10 39](https://user-images.githubusercontent.com/11078128/93277194-97035100-f776-11ea-92d4-bc7bf40de63a.png)
