### PR TITLE
Editing toolkit: fix broken sass build

### DIFF
--- a/packages/domain-picker/src/info-tooltip/style.scss
+++ b/packages/domain-picker/src/info-tooltip/style.scss
@@ -1,3 +1,5 @@
+@import '~@automattic/onboarding/styles/variables';
+
 .info-tooltip {
     &.components-button.has-icon.has-text svg {
         margin-right: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The editing toolkit build started failing due to #45490. One of the sass files that gets pulled in was missing a definition for the `$font-body-small` variable.

* `<InfoTooltip>` sass imports it's own dependencies

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* `cd apps/editing-toolkit`
* `yarn clean`
* `node bin/npm-run-build.js --build`
* There should be no errors
* Test for no visual regressions in the domain picker

