### PR TITLE
Extensions: Hide outline for focused text control

### DIFF
--- a/client/extensions/woocommerce/components/text-control/style.scss
+++ b/client/extensions/woocommerce/components/text-control/style.scss
@@ -61,6 +61,7 @@
 	input[type='text']:focus, input[type='email']:focus, input[type='password']:focus {
 		box-shadow: none;
 		border: 0;
+		outline: 0;
 	}
 
 	&.active {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Extensions: Hide outline for focused text control

#### Testing instructions

* Visit `/log-in?from=woocommerce-onboarding` as a logged out user.
* Input a username.
* Focus the password field.
* Verify you don't see an inner blue outline in the field.

Before this PR:
![](https://cldup.com/nLHoP1ALcK.png)

After this PR:
![](https://cldup.com/bmjJVDNkod.png)

(ignore the lastpass helper at the right side)

#### Context
This is a follow-up to #45431.