### PR TITLE
Gutenboarding: pre-select domain feature

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -161,6 +161,10 @@ const selectedFeatures: Reducer< FeatureId[], OnboardAction > = (
 		return [ ...state, action.featureId ];
 	}
 
+	if ( action.type === 'SET_DOMAIN' && action.domain && ! action.domain?.is_free ) {
+		return [ ...state, 'domain' ];
+	}
+
 	if ( action.type === 'REMOVE_FEATURE' ) {
 		return state.filter( ( id ) => id !== action.featureId );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Pre-select custom domain feature when choosing a paid domain.
* Update logic to handle selected plan in Gutenboarding so PlansButton is updated when selecting features. Demo: https://cloudup.com/cQapnqXMVYL

#### Testing instructions
* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-preselect-domain-feature).
* Select a paid domain.
* Custom domain feature should be pre-selected when landing on Features step.
* Select and deselect features => Plans button (top-right corner) value should be updated as in [demo](https://cloudup.com/cQapnqXMVYL).

Fixes part of https://github.com/Automattic/wp-calypso/issues/45611
