### PR TITLE
Server build: import source-map-support instead of using BannerPlugin

### DIFF
--- a/client/server/index.js
+++ b/client/server/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 /* eslint-disable import/no-nodejs-modules */
 
+import 'source-map-support/register';
 import '@automattic/calypso-polyfills';
 
 /**

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -150,12 +150,6 @@ const webpackConfig = {
 					chunkGroups: true,
 				},
 			} ),
-		// Require source-map-support at the top, so we get source maps for the bundle
-		new webpack.BannerPlugin( {
-			banner: 'require( "source-map-support" ).install();',
-			raw: true,
-			entryOnly: false,
-		} ),
 		new webpack.ExternalsPlugin( 'commonjs', getExternals() ),
 		new webpack.DefinePlugin( {
 			BUILD_TIMESTAMP: JSON.stringify( new Date().toISOString() ),


### PR DESCRIPTION
The server bundle does `require( 'source-map-support' )` as the very first thing to do, patching the `Error.prepareStackTrace` method and the unhandled exception handler, to use source maps when logging errors with stack traces.

Until now, it did that using `BannerPlugin`, but that has two shortcomings:
- the import is not visible to webpack and it can't process it. That breaks the bundling in #45570, and even if we end up not using the bundling, it prevents us from tracking all the externals in a webpack plugin.
- the `entryOnly: false` option was wrong, doing the initialization at the start of every dynamic chunk. We need to do that only once.

**How to test:**
Put some random `throw new Error()` or `console.trace()` in the server code and run the server.

Verify that the source map support reports source-mapped call stacks like this:
```
Error: sorry
    at setup (/Users/jsnajdr/src/wp-calypso/build/webpack:/client/server/boot/index.js:28:8)
    at Module../client/server/index.js (/Users/jsnajdr/src/wp-calypso/build/webpack:/client/server/index.js:22:17)
    at __webpack_require__ (/Users/jsnajdr/src/wp-calypso/build/webpack:/webpack/bootstrap:25:1)
    at /Users/jsnajdr/src/wp-calypso/build/webpack:/webpack/bootstrap:116:1
    at Object.<anonymous> (/Users/jsnajdr/src/wp-calypso/build/server.js:120:10)
    at Module._compile (internal/modules/cjs/loader.js:1138:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Module.load (internal/modules/cjs/loader.js:986:32)
    at Function.Module._load (internal/modules/cjs/loader.js:879:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
```

and compare to the same error with `source-map-support` removed, where all source locations are in the `server.js` bundle:
```
Error: sorry
    at setup (/Users/jsnajdr/src/wp-calypso/build/server.js:84313:9)
    at Module../client/server/index.js (/Users/jsnajdr/src/wp-calypso/build/server.js:85078:66)
    at __webpack_require__ (/Users/jsnajdr/src/wp-calypso/build/server.js:26:30)
    at /Users/jsnajdr/src/wp-calypso/build/server.js:117:18
    at Object.<anonymous> (/Users/jsnajdr/src/wp-calypso/build/server.js:120:10)
    at Module._compile (internal/modules/cjs/loader.js:1138:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Module.load (internal/modules/cjs/loader.js:986:32)
    at Function.Module._load (internal/modules/cjs/loader.js:879:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
```