### PR TITLE
Check domain availabilities for domain suggestions on the UI

### DIFF
--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -13,7 +13,7 @@ const fontTitles: Partial< Record< Font, string > > = {
 	'Playfair Display': 'Playfair',
 };
 
-export const PAID_DOMAINS_TO_SHOW = 5;
+export const domainIsAvailableStatus = [ 'available', 'available_premium' ];
 
 /**
  * The status needed to proceed with a selected domain when performing an availability check

--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -15,12 +15,6 @@ const fontTitles: Partial< Record< Font, string > > = {
 
 export const domainIsAvailableStatus = [ 'available', 'available_premium' ];
 
-/**
- * The status needed to proceed with a selected domain when performing an availability check
- *
- */
-export const DOMAIN_AVAILABLE_STATUS = 'available';
-
 export function getFontTitle( fontFamily: string ): string {
 	return fontTitles[ fontFamily as Font ] ?? fontFamily;
 }

--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -15,6 +15,12 @@ const fontTitles: Partial< Record< Font, string > > = {
 
 export const PAID_DOMAINS_TO_SHOW = 5;
 
+/**
+ * The status needed to proceed with a selected domain when performing an availability check
+ *
+ */
+export const DOMAIN_AVAILABLE_STATUS = 'available';
+
 export function getFontTitle( fontFamily: string ): string {
 	return fontTitles[ fontFamily as Font ] ?? fontFamily;
 }

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -87,18 +87,19 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			if ( domain?.is_free ) {
 				// is this a reliable way to check for .wordpress.com subdomains?
 				handleNext();
-			}
-			try {
-				const availability: DomainAvailability | undefined = await waitForDomainAvailability(
-					domain?.domain_name
-				);
-				if ( domainIsAvailableStatus.includes( availability?.status ) ) {
-					// If the selected domain is available, proceed to next step.
+			} else {
+				try {
+					const availability: DomainAvailability | undefined = await waitForDomainAvailability(
+						domain?.domain_name
+					);
+					if ( domainIsAvailableStatus.includes( availability?.status ) ) {
+						// If the selected domain is available, proceed to next step.
+						handleNext();
+					}
+				} catch {
+					// if there is an error checking the domain availability, do we continue as normal?
 					handleNext();
 				}
-			} catch {
-				// if there is an error checking the domain availability, do we continue as normal?
-				handleNext();
 			}
 		}
 	};

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -24,7 +24,7 @@ import useStepNavigation from '../../hooks/use-step-navigation';
 import { trackEventWithFlow } from '../../lib/analytics';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { DOMAIN_SUGGESTIONS_STORE } from '../../stores/domain-suggestions';
-import { FLOW_ID, DOMAIN_AVAILABLE_STATUS } from '../../constants';
+import { FLOW_ID, domainIsAvailableStatus } from '../../constants';
 import waitForDomainAvailability from './wait-for-domain-availability';
 
 /**
@@ -84,16 +84,20 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	};
 	const handleDomainAvailabilityCheck = async () => {
 		if ( domain ) {
+			if ( domain?.is_free ) {
+				// is this a reliable way to check for .wordpress.com subdomains?
+				handleNext();
+			}
 			try {
 				const availability: DomainAvailability | undefined = await waitForDomainAvailability(
 					domain?.domain_name
 				);
-				if ( availability?.status === DOMAIN_AVAILABLE_STATUS ) {
+				if ( domainIsAvailableStatus.includes( availability?.status ) ) {
 					// If the selected domain is available, proceed to next step.
 					handleNext();
 				}
 			} catch {
-				// if there is an error checking the domain availability, lets continue as normal
+				// if there is an error checking the domain availability, do we continue as normal?
 				handleNext();
 			}
 		}

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -139,7 +139,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				onSetDomainSearch={ setDomainSearch }
 				onDomainSearchBlur={ trackDomainSearchInteraction }
 				currentDomain={ domain?.domain_name }
-				checkingDomainAvailability={ isCheckingDomainAvailability }
+				isCheckingDomainAvailability={ isCheckingDomainAvailability }
 				onDomainSelect={ onDomainSelect }
 				analyticsUiAlgo={ isModal ? 'domain_modal' : 'domain_page' }
 			/>

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -23,7 +23,9 @@ import { useTrackStep } from '../../hooks/use-track-step';
 import useStepNavigation from '../../hooks/use-step-navigation';
 import { trackEventWithFlow } from '../../lib/analytics';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
-import { FLOW_ID } from '../../constants';
+import { DOMAIN_SUGGESTIONS_STORE } from '../../stores/domain-suggestions';
+import { FLOW_ID, DOMAIN_AVAILABLE_STATUS } from '../../constants';
+import waitForDomainAvailability from './wait-for-domain-availability';
 
 /**
  * Style dependencies
@@ -31,6 +33,7 @@ import { FLOW_ID } from '../../constants';
 import './style.scss';
 
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
+type DomainAvailability = DomainSuggestions.DomainAvailability;
 
 interface Props {
 	isModal?: boolean;
@@ -38,7 +41,6 @@ interface Props {
 
 const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	const { __ } = useI18n();
-
 	const history = useHistory();
 	const { goBack, goNext } = useStepNavigation();
 
@@ -46,6 +48,12 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 
 	// using the selector will get the explicit domain search query with site title and vertical as fallbacks
 	const domainSearch = useSelect( ( select ) => select( ONBOARD_STORE ).getDomainSearch() );
+
+	const isCheckingDomainAvailability = useSelect( ( select ): boolean =>
+		select( 'core/data' ).isResolving( DOMAIN_SUGGESTIONS_STORE, 'isAvailable', [
+			domain?.domain_name,
+		] )
+	);
 
 	const { setDomain, setDomainSearch, setHasUsedDomainsStep } = useDispatch( ONBOARD_STORE );
 
@@ -74,6 +82,22 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			goNext();
 		}
 	};
+	const handleDomainAvailabilityCheck = async () => {
+		if ( domain ) {
+			try {
+				const availability: DomainAvailability | undefined = await waitForDomainAvailability(
+					domain?.domain_name
+				);
+				if ( availability?.status === DOMAIN_AVAILABLE_STATUS ) {
+					// If the selected domain is available, proceed to next step.
+					handleNext();
+				}
+			} catch {
+				// if there is an error checking the domain availability, lets continue as normal
+				handleNext();
+			}
+		}
+	};
 
 	const onDomainSelect = ( suggestion: DomainSuggestion | undefined ) => {
 		setDomain( suggestion );
@@ -87,7 +111,14 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			</div>
 			<ActionButtons>
 				<BackButton onClick={ handleBack } />
-				{ domain ? <NextButton onClick={ handleNext } /> : <SkipButton onClick={ handleNext } /> }
+				{ domain ? (
+					<NextButton
+						onClick={ handleDomainAvailabilityCheck }
+						disabled={ isCheckingDomainAvailability }
+					/>
+				) : (
+					<SkipButton onClick={ handleNext } />
+				) }
 			</ActionButtons>
 		</div>
 	);
@@ -108,6 +139,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				onSetDomainSearch={ setDomainSearch }
 				onDomainSearchBlur={ trackDomainSearchInteraction }
 				currentDomain={ domain?.domain_name }
+				checkingDomainAvailability={ isCheckingDomainAvailability }
 				onDomainSelect={ onDomainSelect }
 				analyticsUiAlgo={ isModal ? 'domain_modal' : 'domain_page' }
 			/>

--- a/client/landing/gutenboarding/onboarding-block/domains/wait-for-domain-availability.ts
+++ b/client/landing/gutenboarding/onboarding-block/domains/wait-for-domain-availability.ts
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { subscribe, select } from '@wordpress/data';
+import type { DomainSuggestions } from '@automattic/data-stores';
+
+/**
+ * Internal dependencies
+ */
+import { DOMAIN_SUGGESTIONS_STORE } from '../../stores/domain-suggestions';
+
+type DomainAvailability = DomainSuggestions.DomainAvailability;
+
+export default function waitForDomainAvailability( domain: string ): Promise< DomainAvailability > {
+	let unsubscribe: () => void = () => undefined;
+	return new Promise< DomainAvailability >( ( resolve ) => {
+		unsubscribe = subscribe( () => {
+			const domainAvailability = select( DOMAIN_SUGGESTIONS_STORE ).isAvailable( domain );
+			if ( domainAvailability ) {
+				resolve( domainAvailability );
+			}
+		} );
+
+		const alreadyResolved = select( DOMAIN_SUGGESTIONS_STORE ).isAvailable( domain );
+
+		if ( alreadyResolved ) {
+			resolve( alreadyResolved );
+		}
+	} ).finally( unsubscribe );
+}

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -101,6 +101,10 @@ const createSelectors = ( vendor: string ) => {
 		return state.availability[ domainName ];
 	}
 
+	function getDomainAvailabilities( state: State ) {
+		return state.availability;
+	}
+
 	return {
 		getCategories,
 		getDomainSuggestions,
@@ -108,6 +112,7 @@ const createSelectors = ( vendor: string ) => {
 		isLoadingDomainSuggestions,
 		__internalGetDomainSuggestions,
 		isAvailable,
+		getDomainAvailabilities,
 	};
 };
 

--- a/packages/domain-picker/src/constants.ts
+++ b/packages/domain-picker/src/constants.ts
@@ -13,4 +13,4 @@ export const DOMAIN_SEARCH_DEBOUNCE_INTERVAL = 300;
 
 export const DOMAIN_SUGGESTIONS_STORE = 'automattic/domains/suggestions';
 
-export const DOMAIN_UNAVAILABLE_STATUS = 'unavailable';
+export const domainIsAvailableStatus = [ 'available', 'available_premium' ];

--- a/packages/domain-picker/src/constants.ts
+++ b/packages/domain-picker/src/constants.ts
@@ -12,3 +12,5 @@ export const PAID_DOMAINS_TO_SHOW_EXPANDED = 10;
 export const DOMAIN_SEARCH_DEBOUNCE_INTERVAL = 300;
 
 export const DOMAIN_SUGGESTIONS_STORE = 'automattic/domains/suggestions';
+
+export const DOMAIN_UNAVAILABLE_STATUS = 'unavailable';

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -21,6 +21,7 @@ import {
 	PAID_DOMAINS_TO_SHOW,
 	PAID_DOMAINS_TO_SHOW_EXPANDED,
 	DOMAIN_SUGGESTIONS_STORE,
+	domainIsAvailableStatus,
 } from '../constants';
 import { DomainNameExplanationImage } from '../domain-name-explanation/';
 
@@ -233,10 +234,16 @@ const DomainPicker: FunctionComponent< Props > = ( {
 								{ domainSuggestions?.map( ( suggestion, i ) => {
 									const index = existingSubdomain ? i + 1 : i;
 									const isRecommended = index === 1;
+									const availabilityStatus =
+										domainAvailabilities[ suggestion?.domain_name ]?.status;
+									// should availabilityStatus be falsy then we assume it is available as we have not checked yet.
+									const isAvailable = availabilityStatus
+										? domainIsAvailableStatus?.includes( availabilityStatus )
+										: true;
 									return (
 										<SuggestionItem
 											key={ suggestion.domain_name }
-											availabilityStatus={ domainAvailabilities[ suggestion.domain_name ]?.status }
+											isUnavailable={ ! isAvailable }
 											domain={ suggestion.domain_name }
 											cost={ suggestion.cost }
 											isLoading={

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -65,7 +65,7 @@ export interface Props {
 
 	currentDomain?: string;
 
-	checkingDomainAvailability?: boolean;
+	isCheckingDomainAvailability?: boolean;
 
 	existingSubdomain?: string;
 
@@ -98,7 +98,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	initialDomainSearch = '',
 	onSetDomainSearch,
 	currentDomain,
-	checkingDomainAvailability,
+	isCheckingDomainAvailability,
 	existingSubdomain,
 	segregateFreeAndPaid = false,
 } ) => {
@@ -240,7 +240,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 											domain={ suggestion.domain_name }
 											cost={ suggestion.cost }
 											isLoading={
-												currentDomain === suggestion.domain_name && checkingDomainAvailability
+												currentDomain === suggestion.domain_name && isCheckingDomainAvailability
 											}
 											hstsRequired={ suggestion.hsts_required }
 											isFree={ suggestion.is_free }

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -15,6 +15,7 @@ import type { DomainSuggestions } from '@automattic/data-stores';
 import SuggestionItem from './suggestion-item';
 import SuggestionItemPlaceholder from './suggestion-item-placeholder';
 import { useDomainSuggestions } from '../hooks/use-domain-suggestions';
+import { useDomainAvailabilities } from '../hooks/use-domain-availabilities';
 import DomainCategories from '../domain-categories';
 import {
 	PAID_DOMAINS_TO_SHOW,
@@ -64,6 +65,8 @@ export interface Props {
 
 	currentDomain?: string;
 
+	checkingDomainAvailability?: boolean;
+
 	existingSubdomain?: string;
 
 	/** The flow where the Domain Picker is used. Eg: Gutenboarding */
@@ -95,6 +98,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	initialDomainSearch = '',
 	onSetDomainSearch,
 	currentDomain,
+	checkingDomainAvailability,
 	existingSubdomain,
 	segregateFreeAndPaid = false,
 } ) => {
@@ -122,6 +126,8 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		existingSubdomain ? 1 : 0,
 		isExpanded ? quantityExpanded : quantity
 	);
+
+	const domainAvailabilities = useDomainAvailabilities();
 
 	const onDomainSearchBlurValue = ( event: React.FormEvent< HTMLInputElement > ) => {
 		if ( onDomainSearchBlur ) {
@@ -230,8 +236,12 @@ const DomainPicker: FunctionComponent< Props > = ( {
 									return (
 										<SuggestionItem
 											key={ suggestion.domain_name }
+											availabilityStatus={ domainAvailabilities[ suggestion.domain_name ]?.status }
 											domain={ suggestion.domain_name }
 											cost={ suggestion.cost }
+											isLoading={
+												currentDomain === suggestion.domain_name && checkingDomainAvailability
+											}
 											hstsRequired={ suggestion.hsts_required }
 											isFree={ suggestion.is_free }
 											isRecommended={ isRecommended }

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -108,6 +108,10 @@
 		margin-top: -1px;
 	}
 
+	&.is-unavailable {
+		color: var( --studio-gray-40 );
+	}
+
 	// animate the added domains after you click expand
 	@for $i from 7 through 14 {
 		&:nth-child( #{$i} ) {
@@ -169,6 +173,14 @@
 			border-color: var( --studio-blue-30 );
 			box-shadow: 0 0 0 1px var( --studio-blue-30 );
 		}
+
+		&:disabled {
+			border-color: var( --studio-gray-40 );
+		}
+	}
+
+	.components-spinner {
+		margin: 1px 10px 0 0;
 	}
 }
 
@@ -213,6 +225,10 @@
 		// margin isnt applied if hstsRequired is truthy as InfoTooltip component
 		// provides equal spacing between this and the recommended badge.
 		margin-right: 10px;
+	}
+
+	.domain-picker__suggestion-item.is-unavailable & {
+		color: var( --studio-gray-40 );
 	}
 }
 

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -17,10 +17,9 @@ import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
 import InfoTooltip from '../info-tooltip';
 // TODO: remove when all needed core types are available
 /*#__PURE__*/ import '../types-patch';
-import { DOMAIN_UNAVAILABLE_STATUS } from '../constants';
 
 interface Props {
-	availabilityStatus?: string;
+	isUnavailable?: boolean;
 	domain: string;
 	isLoading?: boolean;
 	cost: string;
@@ -35,7 +34,7 @@ interface Props {
 }
 
 const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
-	availabilityStatus,
+	isUnavailable,
 	domain,
 	isLoading,
 	cost,
@@ -54,7 +53,6 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	const dotPos = domain.indexOf( '.' );
 	const domainName = domain.slice( 0, dotPos );
 	const domainTld = domain.slice( dotPos );
-	const isUnavailable = availabilityStatus === DOMAIN_UNAVAILABLE_STATUS;
 
 	const [ previousDomain, setPreviousDomain ] = useState< string | undefined >();
 	const [ previousRailcarId, setPreviousRailcarId ] = useState< string | undefined >();

--- a/packages/domain-picker/src/hooks/use-domain-availabilities.ts
+++ b/packages/domain-picker/src/hooks/use-domain-availabilities.ts
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { DOMAIN_SUGGESTIONS_STORE } from '../constants';
+
+export function useDomainAvailabilities() {
+	return useSelect( ( select ) => {
+		return select( DOMAIN_SUGGESTIONS_STORE ).getDomainAvailabilities();
+	}, [] );
+}

--- a/packages/domain-picker/test/suggestion-item.tsx
+++ b/packages/domain-picker/test/suggestion-item.tsx
@@ -409,7 +409,7 @@ describe( 'test that suggested items are rendered correctly based on availabilit
 			cost: '€12.00',
 			railcarId: 'id',
 			isRecommended: true,
-			availabilityStatus: 'unavailable',
+			isUnavailable: true,
 		};
 
 		render(
@@ -431,7 +431,7 @@ describe( 'test that suggested items are rendered correctly based on availabilit
 			cost: '€12.00',
 			railcarId: 'id',
 			isRecommended: true,
-			availabilityStatus: 'available',
+			isUnavailable: false,
 		};
 
 		render(

--- a/packages/domain-picker/test/suggestion-item.tsx
+++ b/packages/domain-picker/test/suggestion-item.tsx
@@ -337,4 +337,82 @@ describe( 'check conditional elements render correctly', () => {
 		// use `queryBy` to avoid throwing an error with `getBy`
 		expect( screen.queryByTestId( 'info-tooltip' ) ).toBeFalsy();
 	} );
+
+	it( 'renders recommendation badge if is given prop isRecommended true', async () => {
+		const testRequiredProps = {
+			domain: 'testdomain.com',
+			cost: '€12.00',
+			railcarId: 'id',
+			isRecommended: true,
+		};
+
+		render(
+			<SuggestionItem { ...testRequiredProps } onSelect={ jest.fn() } onRender={ jest.fn() } />
+		);
+
+		expect( screen.getByText( /Recommended/i ) ).toBeTruthy();
+	} );
+
+	it( 'does not render recommendation badge if is given prop isRecommended false', async () => {
+		const testRequiredProps = {
+			domain: 'testdomain.com',
+			cost: '€12.00',
+			railcarId: 'id',
+			isRecommended: false,
+		};
+
+		render(
+			<SuggestionItem { ...testRequiredProps } onSelect={ jest.fn() } onRender={ jest.fn() } />
+		);
+
+		// use `queryBy` to avoid throwing an error with `getBy`
+		expect( screen.queryByText( /Recommended/i ) ).toBeFalsy();
+	} );
+} );
+
+describe( 'test that suggested items are rendered correctly based on availability', () => {
+	it( 'should have the disabled UI state when provided an availabilityStatus of unavailable', () => {
+		const testRequiredProps = {
+			domain: 'testdomain.com',
+			cost: '€12.00',
+			railcarId: 'id',
+			isRecommended: true,
+			availabilityStatus: 'unavailable',
+		};
+
+		render(
+			<SuggestionItem { ...testRequiredProps } onSelect={ jest.fn() } onRender={ jest.fn() } />
+		);
+
+		// we have to test for the domain and the TLD separately because they get split in the component
+		expect( screen.queryByText( /testdomain/i ) ).toBeTruthy();
+		expect( screen.queryAllByText( /.com/i ) ).toBeTruthy();
+
+		expect( screen.queryByText( /Unavailable/i ) ).toBeTruthy();
+		expect( screen.queryByText( /Recommended/i ) ).toBeFalsy();
+		expect( screen.queryByRole( 'radio' ).getAttribute( 'disabled' ) ).not.toBe( null );
+	} );
+
+	it( 'should have the enabled UI state when provided an availabilityStatus that is available', () => {
+		const testRequiredProps = {
+			domain: 'testdomain.com',
+			cost: '€12.00',
+			railcarId: 'id',
+			isRecommended: true,
+			availabilityStatus: 'available',
+		};
+
+		render(
+			<SuggestionItem { ...testRequiredProps } onSelect={ jest.fn() } onRender={ jest.fn() } />
+		);
+
+		// we have to test for the domain and the TLD separately because they get split in the component
+		expect( screen.queryByText( /testdomain/i ) ).toBeTruthy();
+		expect( screen.queryAllByText( /.com/i ) ).toBeTruthy();
+
+		expect( screen.queryByText( /Unavailable/i ) ).toBeFalsy();
+		expect( screen.queryByText( /€12.00/i ) ).toBeTruthy();
+		expect( screen.queryByText( /Recommended/i ) ).toBeTruthy();
+		expect( screen.queryByRole( 'radio' ).getAttribute( 'disabled' ) ).toBe( null );
+	} );
 } );

--- a/packages/domain-picker/test/suggestion-item.tsx
+++ b/packages/domain-picker/test/suggestion-item.tsx
@@ -338,7 +338,7 @@ describe( 'check conditional elements render correctly', () => {
 		expect( screen.queryByTestId( 'info-tooltip' ) ).toBeFalsy();
 	} );
 
-	it( 'renders recommendation badge if is given prop isRecommended true', async () => {
+	it( 'renders recommendation badge if given prop isRecommended true', async () => {
 		const testRequiredProps = {
 			domain: 'testdomain.com',
 			cost: '€12.00',
@@ -351,6 +351,38 @@ describe( 'check conditional elements render correctly', () => {
 		);
 
 		expect( screen.getByText( /Recommended/i ) ).toBeTruthy();
+	} );
+
+	it( 'renders the cost if given prop of cost with a value', async () => {
+		const testRequiredProps = {
+			domain: 'testdomain.com',
+			cost: '€12.00',
+			railcarId: 'id',
+			isRecommended: true,
+		};
+
+		render(
+			<SuggestionItem { ...testRequiredProps } onSelect={ jest.fn() } onRender={ jest.fn() } />
+		);
+
+		expect( screen.queryByText( /€12.00/i ) ).toBeTruthy();
+	} );
+
+	it( 'renders the cost as free if given prop of isFree even though it has a cost prop', async () => {
+		const testRequiredProps = {
+			domain: 'testdomain.com',
+			cost: '€12.00',
+			railcarId: 'id',
+			isFree: true,
+			isRecommended: true,
+		};
+
+		render(
+			<SuggestionItem { ...testRequiredProps } onSelect={ jest.fn() } onRender={ jest.fn() } />
+		);
+
+		expect( screen.queryByText( /€12.00/i ) ).toBeFalsy();
+		expect( screen.queryByText( /Free/i ) ).toBeTruthy();
 	} );
 
 	it( 'does not render recommendation badge if is given prop isRecommended false', async () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Using the `.isAvailable` store selector created here https://github.com/Automattic/wp-calypso/issues/41220 to check for domain availability on the UI when on the domain suggestions step of Gutenboarding.

#### Testing instructions

**Available domain testing steps:**
* Go to [/new](https://hash-368cdb6a2ee41916c2f6a2dda24552149e61b319.calypso.live/new)
* Enter a site name you know will generate domains that are available (e.g. "This Domain Should Be Avaialble")
* Select one of the suggested domains when it takes you to `/new/domains`
* Loading spinner should appear and button should be in a disabled state, once the request resolves it should take you to the next step without any issues
* _Optional_ Now follow process through to the end to create a site.

Demo: https://cloudup.com/iNp-8K4y_5r

**Unavailable domain testing steps**
* Go to [/new](https://hash-368cdb6a2ee41916c2f6a2dda24552149e61b319.calypso.live/new)
* Enter a site name you know will generate domains that are unavailable (e.g. "Demo")
* Select `demo.cloud` from the suggested domains list if its there. This should be unavailable.
* Loading spinner should appear and button should be in a disabled state, once the request resolves it should NOT take you to the next step but instead replace the price with "Unavailable" and disable the suggested domain from being selected again.
* Now select any of the other available domains (or `.wordpress.com` free domain) to continue
* _Optional_ Now follow process through to the end to create a site.

Demo: https://cloudup.com/iurerR3_aY2

**Other testing steps to consider**
* When selecting an unavailable domain, and then reselecting an available domain to take you to the next step. Clicking "Go back" to return to the domains step should still have that unavailable domain listed in a disabled state.
* When selecting an available domain, when you get taken to the next step be sure to "Go back" to ensure your domain is still selected.
* When selecting a `.wordpress.com` free domain, no availability check is performed as it will always return `restricted_domain` in the response so we assume this is readily available (Demo: https://cloudup.com/iDya28ZS3Mr)

Fixes https://github.com/Automattic/wp-calypso/issues/41220
