### PR TITLE
Update Offer Reset experiment datestamp

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -182,7 +182,7 @@ export default {
 		],
 	},
 	offerResetFlow: {
-		datestamp: '20200804',
+		datestamp: '20200916',
 		variations: {
 			showOfferResetFlow: 100,
 			control: 0,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the datestamp of the Offer Reset experiment. Users that visited Calyspo since we initially launched this experiment might have the `control` variant stored, which could prevent them from seeing the new plans page now. Resetting the experiment by changing the datestamp will ensure that the `showOfferResetFlow` variant is default for everybody.

Here's the [A/B test documentation](https://github.com/Automattic/wp-calypso/tree/master/client/lib/abtest).

### Testing instructions

- Download the PR locally
- Open your browser console and run `localStorage.setItem('debug', 'calypso:abtests')`
- Hard refresh Calypso
- Make sure that you see `calypso:abtests offerResetFlow_20200916` printed in the console
- Open the ABTESTS menu in the debug menu at the bottom right of the screen, and check that **no** option is selected under `offerResetFlow`
- Finally, make sure that you see the new plans page at `/plans/:site/`

### Screenshots

<img width="635" alt="Screen Shot 2020-09-16 at 12 00 58 PM" src="https://user-images.githubusercontent.com/1620183/93362835-7f7aa580-f814-11ea-80ce-355df664ffeb.png">

<img width="260" alt="Screen Shot 2020-09-16 at 11 49 43 AM" src="https://user-images.githubusercontent.com/1620183/93362523-12671000-f814-11ea-87ba-648a94df965c.png">
