### PR TITLE
Earn: Remove Reference to "Digital Goods" with PayPal

### DIFF
--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -27,7 +27,7 @@ export default localize( ( { isJetpack, translate } ) => {
 			<PurchaseDetail
 				buttonText={ translate( 'Collect PayPal payments' ) }
 				description={ translate(
-					'Add a button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations.'
+					'Add a button to any post or page to collect PayPal payments for physical products, services, or donations.'
 				) }
 				href={ supportDocLink }
 				icon={ <img alt="" src={ paymentsImage } /> }

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -141,7 +141,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		const body = (
 			<>
 				{ translate(
-					'Accept credit card payments via PayPal for physical products, digital goods, services, donations, or support of your creative work.'
+					'Accept credit card payments via PayPal for physical products, services, donations, or support of your creative work.'
 				) }
 				{ ! hasSimplePayments && <em>{ getPlanNames() }</em> }
 			</>
@@ -189,7 +189,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			"Manage your customers and subscribers, or your current subscription options and review the total revenue that you've made from payments."
 		);
 		const noConnectionBody = translate(
-			'Accept one-time and recurring credit card payments for digital goods, physical products, services, memberships, subscriptions, and donations. {{em}}Available with any paid plan{{/em}}.',
+			'Accept one-time and recurring credit card payments for physical products, services, memberships, subscriptions, and donations. {{em}}Available with any paid plan{{/em}}.',
 			{
 				components: {
 					em: <em />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The reasoning behind this change is expressed in the original issue, along with approval of the copy, but this effectively just removes reference to "digital goods" 

#### Testing instructions

Verify this touches the copy on the Earn page, along with the "My Plan" page.

<img width="598" alt="Screenshot 2020-09-16 at 17 14 54" src="https://user-images.githubusercontent.com/43215253/93364195-2c1e4c80-f840-11ea-931a-f547e21fc874.png">

cc @gwwar 

Fixes #45646
