### PR TITLE
Use resolved path to replace languages-meta instead of the module name

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -376,13 +376,14 @@ const webpackConfig = {
 			: [] ),
 
 		/*
-		 * When not available, replace languages-meta.json with fallback-languages-meta.json.
+		 * When available, replace fallback-languages-meta.json with languages-meta.json
 		 */
 		hasLanguagesMeta &&
 			new webpack.NormalModuleReplacementPlugin(
-				/^languages[/\\]fallback-languages-meta.json$/,
-				'languages/languages-meta.json'
+				new RegExp( path.join( __dirname, 'languages/fallback-languages-meta.json' ) ),
+				'./languages-meta.json'
 			),
+
 		/*
 		 * Replace `lodash` with `lodash-es`
 		 */


### PR DESCRIPTION
### Background

We have a list of supported languages in `client/languages/fallback-languages-meta.json`. However, this list may get out of date, so at build time we download a new list from `https://widgets.wp.com/languages/calypso/languages-meta.json` and use it to replace the fallback list using Webpack config.

This is done by matching the module name `languages/fallback-languages-meta.json` and replacing it with the module `languages/languages-meta.json` if the latter is available (i.e. if it was downloaded correctly)

### Changes proposed in this Pull Request

Use paths instead of module names to do the replacement. This makes it more robust, as it doesn't require the module name to be exact. This will allow to import from `languages/fallback-languages-meta.json`, `calypso/languages/fallback-languages-meta.json`, `../../languages/fallback-languages-meta.json` or any other valid variation.

### Testing instructions

First, checkout the branch and run `yarn start`. Then go to <http://calypso.localhost:3000/me/account> and change your language. You should see the language `Gaelige`. This is using the downloaded list.

Next, delete the downloaded file (`client/languages/languages-meta.json`) and comment out the content of `./bin/download-languages-meta.js` so it doesn't get downloaded again. Start the server again with `yarn start` and change your language. Now you should see the language `Gaeilge` (note the typo). This is using the fallback list.
