### PR TITLE
Declare extensions in eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,10 @@ module.exports = {
 	],
 	overrides: [
 		{
+			// Nothing to override for these files. This is here so eslint also checks for `.jsx` files by default
+			files: [ '**/*.jsx' ],
+		},
+		{
 			files: [ '*.md' ],
 			parser: 'markdown-eslint-parser',
 			rules: {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
 		"lint": "run-s -s lint:*",
 		"lint:config-defaults": "node bin/validate-config-keys.js",
 		"lint:css": "stylelint \"**/*.scss\" --syntax scss",
-		"lint:js": "yarn run install-if-deps-outdated && eslint --ext .js --ext .jsx --ext .ts --ext .tsx --cache .",
+		"lint:js": "yarn run install-if-deps-outdated && eslint --cache .",
 		"lint:mixedindent": "mixedindentlint --ignore-comments \"client/**/*.scss\" \"assets/**/*.scss\" \"**/*.js\" \"**/*.jsx\" \"**/*.tsx\" \"**/*.tsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\" \"!client/config/index.js\"",
 		"lint:package-json": "npmPkgJsonLint './package.json' './client/package.json' './packages/*/package.json' './apps/*/package.json'",
 		"prestart": "npx check-node-version --package && yarn run install-if-deps-outdated && node bin/welcome.js",


### PR DESCRIPTION
### Background

Since eslint 7.0 it has support to automatically check for lint errors in all files that matches the overrides, no need to specify the extensions as flags when calling `eslint`.

See https://eslint.org/docs/user-guide/migrating-to-7.0.0#additional-lint-targets

### Changes

Delete the list of extensions in the CLI, and add overrides for the missing extensions instead.

### Testing instructions

#### Quick

Run `./node_modules/.bin/eslint client/components/accordion/docs` in master, it should complain that there are no files. Run the same command in this branch, it should not complain now.

For an extra check, edit the file `./client/components/accordion/docs/example.jsx` and introduce a few spaces here and there to break the style guide. Run the above command again and see how eslint finds those problems.

#### Thorough (and slow)

Run `yarn lint:js > out1` in master (it will take a few minutes) and `yarn lint:js > out2` in this branch. Then do a diff between both outputs.

All errors from master (`out1`) should still be in this branch (`out2`) (which will also include Markdown errors). This proves that when we remove the `--ext` flags in the CLI we are not missing any existing error, therefore it is matching (at least) the same extensions than before.
