### PR TITLE
Hide in-connect-flow notice and header if any plans or products owned

### DIFF
--- a/client/my-sites/plans-v2/plans-header.tsx
+++ b/client/my-sites/plans-v2/plans-header.tsx
@@ -42,7 +42,6 @@ const ConnectFlowPlansHeader = () => (
 );
 
 const PlansHeader = ( { context }: { context: PageJS.Context } ) => {
-	//const state = context.store.getState();
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	// Site plan
 	const currentPlan =
@@ -59,6 +58,7 @@ const PlansHeader = ( { context }: { context: PageJS.Context } ) => {
 		[ siteId ]
 	);
 
+	// TODO: Maybe make Notice dismissal persistent?
 	const [ showNotice, setShowNotice ] = useState( true );
 
 	// Only show ConnectFlowPlansHeader if coming from in-connect flow and if no products or plans have been purchased.

--- a/client/my-sites/plans-v2/plans-header.tsx
+++ b/client/my-sites/plans-v2/plans-header.tsx
@@ -15,6 +15,7 @@ import Notice from 'components/notice';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getSitePlan from 'state/sites/selectors/get-site-plan';
 import getSiteProducts from 'state/sites/selectors/get-site-products';
+import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
 
 const StandardPlansHeader = () => (
@@ -62,7 +63,7 @@ const PlansHeader = ( { context }: { context: PageJS.Context } ) => {
 	const [ showNotice, setShowNotice ] = useState( true );
 
 	// Only show ConnectFlowPlansHeader if coming from in-connect flow and if no products or plans have been purchased.
-	return isInConnectFlow && currentPlan === 'jetpack_free' && ! purchasedProducts.length ? (
+	return isInConnectFlow && currentPlan === PLAN_JETPACK_FREE && ! purchasedProducts.length ? (
 		<>
 			{ showNotice && (
 				<Notice status="is-success" onDismissClick={ () => setShowNotice( false ) }>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR makes it so that the special notice and header on the Plans page is only displayed when coming from wp-admin and only if the user has not purchased any plans or products. (See screenshot)

![Markup 2020-09-16 at 11 43 52](https://user-images.githubusercontent.com/11078128/93379019-14c86a80-f812-11ea-9ab4-3456507eda5c.png)



### Testing instructions

1. Create a new JN site and activate Jetpack by either clicking "Setup Jetpack" button in the Dashboard, or by clicking "Jetpack" in the side menu.
2. Choose "Jetpack Free", or don't select any plan at all, either way.
3. Go back to to wp-admin, select "Jetpack" in the side menu to get to the Jetpack Dashboard and then select "Plans".
4. You will be directed to the Jetpack Plans page (in Calypso). Since no plans or products have been purchased (and you're coming from wp-admin) you should see the special notice and header at the top of the page.
5. Visit the Plans page in other scenarios where a plan or product has been purchased and/or not coming from wp-admin and verify that you are not seeing the special notice and header.


Fixes: 1169247016322522-as-1194161784057873/f