### PR TITLE
composite-checkout: Create filter for legally restricted payment methods

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -527,7 +527,8 @@ export function filterAppropriatePaymentMethods( {
 				methodObject.id,
 				allowedPaymentMethods || serverAllowedPaymentMethods
 			);
-		} );
+		} )
+		.filter( ( methodObject ) => ! isPaymentMethodLegallyRestricted( methodObject.id ) );
 }
 
 export function needsDomainDetails( cart ) {
@@ -557,4 +558,12 @@ export function getPostalCode() {
 	const countryCode = select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value ?? '';
 	const postalCode = select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value ?? '';
 	return tryToGuessPostalCodeFormat( postalCode.toUpperCase(), countryCode );
+}
+
+function isPaymentMethodLegallyRestricted( paymentMethodId ) {
+	const restrictedPaymentMethods = [
+		'wechat', // whitehouse.gov/presidential-actions/executive-order-addressing-threat-posed-wechat/
+	];
+
+	return restrictedPaymentMethods.includes( paymentMethodId );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deactivate wechat payment method from calypso. We could also have done this on the backend, but updating the logic in calypso is much more straightforward. :/

#### Testing instructions

* Use code-D45650 to force wechat to be returned by the API
* Enter checkout; verify that wechat is in the array of payment methods returned by the backend (this is in the response of the `me/shopping-cart` endpoint, you should see `"WPCOM_Billing_Stripe_Source_Wechat"` in `.body.allowed_payment_methods`)
* Verify that wechat is _not_ one of the payment method options
* Verify that the other appropriate payment methods are still available


Discussion is here: p2y3YZ-48E-p2
