### PR TITLE
Update stylelint config to include border radius

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,7 +2,8 @@
 	"plugins": ["@signal-noise/stylelint-scales"],
 	"rules": {
 		"scales/font-weight": [[ 400, 600, 700, "normal", "bold", "inherit" ]],
-		"scales/font-size": [[ 0.75, 0.875, 1, 1.25, 1.5, 2, 2.25, 3, 3.375 ], { unit: "rem" } ],
+		"scales/font-size": [[ 0.75, 0.875, 1, 1.25, 1.5, 2, 2.25, 3, 3.375 ], { unit: "rem" }],
+		"scales/radii": [[ 2 ], { unit: "px" }],
 
 		"color-hex-case": "lower",
 		"color-no-invalid-hex": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set a standard for border radii widths to 2px in the stylelint scales rules to better match Gutenberg styles.

#### Testing instructions

* Switch to this branch and run `yarn` to make sure it builds
* Edit any `style.scss` file in Calypso and add an invalid `border-radius` (ie. `border-radius: 4px` or `border-radius: 2em`) to any element. Save, and try to add and commit your changes.
* The linter should throw an error like this, preventing you from committing:

<img width="532" alt="Screen Shot 2020-09-16 at 2 54 10 PM" src="https://user-images.githubusercontent.com/2124984/93385620-7bf71680-f834-11ea-9618-9241f74a3e74.png">

* Fix the value to `border-radius: 2px` and try to commit again. The linter should pass and allow you to add a commit message.

See #44883 