### PR TITLE
Show Video Hosting item in My Plan checklist for new Jetpack plans

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -25,6 +25,7 @@ import {
 	TYPE_PREMIUM,
 	GROUP_WPCOM,
 	GROUP_JETPACK,
+	JETPACK_RESET_PLANS,
 } from './constants';
 import { PLANS_LIST } from './plans-list';
 
@@ -299,6 +300,10 @@ export function isJetpackPersonalPlan( planSlug ) {
 
 export function isJetpackFreePlan( planSlug ) {
 	return planMatches( planSlug, { type: TYPE_FREE, group: GROUP_JETPACK } );
+}
+
+export function isJetpackOfferResetPlan( planSlug ) {
+	return JETPACK_RESET_PLANS.includes( planSlug );
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request

Video hosting doesn't work properly for new Jetpack plans for now. It will be fixed in the next Jetpack plugin release. In this PR, we show the Video Hosting item in the My Plan checklist for the future Jetpack releases.

### Implementation notes

Current Jetpack plugin version is 8.9.1

### Testing instructions

- Download the PR locally and run Calypso
- Make sure you have 3 self-hosted Jetpack site ready: with a Free plan, Premium plan, and a new plan
- Visit `plans/my-plan/:site/`
- For each of these 3 sites, make sure you only see the Video Hosting item (see capture) with the Premium plan
- Now in `client/my-sites/plans/current-plan/jetpack-checklist/index.tsx`, update the minimum version of Jetpack (`OFFER_RESET_VIDEO_MINIMUM_JETPACK_VERSION`) so that it's below the versions of your 3 sites
- Make sure you see the item in the checklist with the Premium plan and the new plan

### Screenshots

<img width="797" alt="Screen Shot 2020-09-14 at 2 15 22 PM" src="https://user-images.githubusercontent.com/1620183/93385394-389ca800-f834-11ea-9147-4579b8f316cb.png">
