### PR TITLE
[WIP] Updating parsing logic to account for blockquotes and horizontal rules in notifications

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -1,6 +1,12 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 
+/**
+ * Internal dependencies
+ */
 import Gridicon from '../templates/gridicons';
 import noticon2gridicon from '../utils/noticon2gridicon';
 
@@ -12,14 +18,14 @@ import noticon2gridicon from '../utils/noticon2gridicon';
  * @param {Array} new_sub_range Position/applicable ranges array
  * @param {object} range_info The origin range data for this render
  * @param {Array} range_data All range data
- * @param {object} options
- * @returns {DocumentFragment} Computed DOM nodes for all levels at or below passed range
+ * @param {object} options Options for rendering range
+ * @returns {object} Computed DOM nodes for all levels at or below passed range
  */
 function render_range( new_sub_text, new_sub_range, range_info, range_data, options ) {
 	// Its time to build the outer shell of the range we're recursing into.
 	let new_container = null,
-		new_classes = [],
 		type_mappings;
+	const new_classes = [];
 
 	let range_info_type = range_info.type;
 
@@ -67,6 +73,10 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 		// All of the following are simple element types we want to create and then
 		// recurse into for their constituent blocks or texts
 		case 'blockquote':
+		case 'cite':
+		case 'hr':
+		case 'p':
+		case 'div':
 		case 'code':
 		case 'strong':
 		case 'em':
@@ -98,7 +108,7 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 				new_container = document.createElement( 'a' );
 
 				new_container.setAttribute( 'href', range_info.url );
-				if ( range_info_type == 'stat' ) {
+				if ( range_info_type === 'stat' ) {
 					// Stat links should change the whole window/tab
 					new_container.setAttribute( 'target', '_parent' );
 				} else {
@@ -140,8 +150,8 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
  * @param {string} sub_text  Plain-text upon which ranges act
  * @param {Array} sub_ranges Position/applicable ranges array
  * @param {Array} range_data All range data
- * @param {DocumentFragment} container Destination DOM fragment for output
- * @param {object} options
+ * @param {object} container Destination DOM fragment for output
+ * @param {object} options Options for building chunks
  */
 function build_chunks( sub_text, sub_ranges, range_data, container, options ) {
 	let text_start = null,
@@ -159,7 +169,7 @@ function build_chunks( sub_text, sub_ranges, range_data, container, options ) {
 	// We use sub_ranges and not sub_text because we *can* have an empty string with a range
 	// acting upon it. For example an a tag with just an alt-text-less image tag inside of it
 	for ( i = 0; i < sub_ranges.length; i++ ) {
-		if ( sub_ranges[ i ].index.length == 0 ) {
+		if ( sub_ranges[ i ].index.length === 0 ) {
 			// This is a simple text element without applicable ranges
 			if ( text_start == null ) {
 				// This is the beginning of the text element
@@ -292,7 +302,7 @@ function recurse_convert( text, ranges, options ) {
 	// to smallest gives us the proper order for descending recursively.
 	for ( i = 0; i < ranges_copy.length; i++ ) {
 		id = find_largest_range( ranges_copy );
-		if ( ranges[ id ].indices[ 1 ] == 0 && ranges[ id ].indices[ 1 ] == 0 ) {
+		if ( ranges[ id ].indices[ 1 ] === 0 && ranges[ id ].indices[ 1 ] === 0 ) {
 			// Indices covering 0,0 are special cases only. They always go at the very
 			// beginning of the document, are never nested, and are always "empty"
 			// If there are multiple zero-length ranges, they will return in the order

--- a/apps/notifications/src/panel/templates/functions.jsx
+++ b/apps/notifications/src/panel/templates/functions.jsx
@@ -31,8 +31,11 @@ import { html as toHtml } from '../indices-to-html';
  */
 const toBlocks = ( text ) =>
 	text.split( '\n' ).reduce(
-		( { out, inFence, inList }, raw ) => {
+		( { out, inFence, inList }, raw, index, src ) => {
 			if ( ! raw ) {
+				if ( ! src[ index + 1 ] ) {
+					return { out, inFence, inList };
+				}
 				return {
 					out: out + '<br />',
 					inFence,

--- a/apps/notifications/src/panel/templates/functions.jsx
+++ b/apps/notifications/src/panel/templates/functions.jsx
@@ -34,7 +34,7 @@ const toBlocks = ( text ) =>
 		( { out, inFence, inList }, raw ) => {
 			if ( ! raw ) {
 				return {
-					out,
+					out: out + '<br />',
 					inFence,
 					inList,
 				};

--- a/apps/notifications/src/panel/templates/functions.jsx
+++ b/apps/notifications/src/panel/templates/functions.jsx
@@ -1,7 +1,13 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
-
-import { html as toHtml } from '../indices-to-html';
 import { pickBy, get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { html as toHtml } from '../indices-to-html';
 
 /**
  * Adds markup to some common text patterns
@@ -26,6 +32,26 @@ import { pickBy, get } from 'lodash';
 const toBlocks = ( text ) =>
 	text.split( '\n' ).reduce(
 		( { out, inFence, inList }, raw ) => {
+			if ( ! raw ) {
+				return {
+					out,
+					inFence,
+					inList,
+				};
+			}
+
+			const blockquoteRegex = /blockquote(.*)>/i;
+			const containsBlockquoteTag = blockquoteRegex.test( raw );
+
+			// Blockquote start/end tags do not need to be wrapped in div/p
+			if ( containsBlockquoteTag ) {
+				return {
+					out: out + raw,
+					inFence,
+					inList,
+				};
+			}
+
 			// detect code fences
 			// ```js
 			// doFoo()
@@ -138,6 +164,7 @@ export function internalP( html ) {
 		return (
 			<div
 				key={ key }
+				// eslint-disable-next-line react/no-danger
 				dangerouslySetInnerHTML={ {
 					__html: blocks,
 				} }
@@ -150,22 +177,18 @@ export function p( html, className ) {
 	if ( undefined === className ) {
 		className = 'wpnc__paragraph';
 	}
-	return html.split( '\n\n' ).map( ( chunk, i ) => {
-		const key = `block-text-${ i }-${ chunk.length }-${ chunk.slice( 0, 3 ) }-${ chunk.slice(
-			-3
-		) }`;
-		const blocks = toBlocks( chunk );
+	const blocks = toBlocks( html );
 
-		return (
-			<div
-				className={ className }
-				key={ key }
-				dangerouslySetInnerHTML={ {
-					__html: blocks,
-				} }
-			/>
-		);
-	} );
+	const result = (
+		<div
+			className={ className }
+			// eslint-disable-next-line react/no-danger
+			dangerouslySetInnerHTML={ {
+				__html: blocks,
+			} }
+		/>
+	);
+	return result;
 }
 
 export const pSoup = ( items ) => items.map( toHtml ).map( internalP );
@@ -176,8 +199,8 @@ export function getSignature( blocks, note ) {
 	}
 
 	return blocks.map( function ( block ) {
-		var type = 'text';
-		var id = null;
+		let type = 'text';
+		let id = null;
 
 		if ( 'undefined' !== typeof block.type ) {
 			type = block.type;
@@ -187,7 +210,7 @@ export function getSignature( blocks, note ) {
 			if (
 				block.ranges &&
 				block.ranges.length > 1 &&
-				block.ranges[ 1 ].id == note.meta.ids.reply_comment
+				block.ranges[ 1 ].id === note.meta.ids.reply_comment
 			) {
 				type = 'reply';
 				id = block.ranges[ 1 ].id;
@@ -218,16 +241,16 @@ export function getSignature( blocks, note ) {
 }
 
 export function formatString() {
-	var args = [].slice.apply( arguments );
-	var str = args.shift();
+	const args = [].slice.apply( arguments );
+	const str = args.shift();
 
 	return str.replace( /{(\d+)}/g, function ( match, number ) {
-		return typeof args[ number ] != 'undefined' ? args[ number ] : match;
+		return typeof args[ number ] !== 'undefined' ? args[ number ] : match;
 	} );
 }
 
 export function zipWithSignature( blocks, note ) {
-	var signature = getSignature( blocks, note );
+	const signature = getSignature( blocks, note );
 
 	return blocks.map( function ( block, i ) {
 		return {
@@ -237,7 +260,7 @@ export function zipWithSignature( blocks, note ) {
 	} );
 }
 
-export const validURL = /^(?:http(?:s?)\:\/\/|~\/|\/)?(?:\w+:\w+@)?((?:(?:[-\w\d{1-3}]+\.)+(?:com|org|net|gov|mil|biz|info|mobi|name|aero|jobs|edu|co\.uk|ac\.uk|it|fr|tv|museum|asia|local|travel|blog|[a-z]{2}))|((\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)(\.(\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)){3}))(?::[\d]{1,5})?(?:(?:(?:\/(?:[-\w~!$+|.,=]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?:#(?:[-\w~!$ |\/.,*:;=]|%[a-f\d]{2})*)?$/i;
+export const validURL = /^(?:http(?:s?):\/\/|~\/|\/)?(?:\w+:\w+@)?((?:(?:[-\w\d{1-3}]+\.)+(?:com|org|net|gov|mil|biz|info|mobi|name|aero|jobs|edu|co\.uk|ac\.uk|it|fr|tv|museum|asia|local|travel|blog|[a-z]{2}))|((\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)(\.(\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)){3}))(?::[\d]{1,5})?(?:(?:(?:\/(?:[-\w~!$+|.,=]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?:#(?:[-\w~!$ |/.,*:;=]|%[a-f\d]{2})*)?$/i;
 
 export const linkProps = ( note, block ) => {
 	const { site: noteSite, comment, post } = get( note, 'meta.ids', {} );

--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -51,6 +51,15 @@
 			top: 47px;
 		}
 	}
+
+	blockquote {
+		padding: 0 24px 0 32px;
+		margin: 16px 0 32px;
+		border-left: 3px solid var( --color-neutral-0 );
+		color: var( --color-neutral-50 );
+		font-weight: 400;
+		background: transparent;
+	}
 }
 
 #wpnc-panel.wide {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This pull request begins to address the issues in the web-based notification app, specifically the rendering of blockquotes and horizontal rules in a post detail view, by refactoring some of the formatting logic used to wrap segments of a post in `div`/`p` blocks for display.
* PR also includes some changes required to placate ESLint in the touched files.
* **WIP: Need to finalize styling choices, particularly for `cite` tag, but should be functionally testable.**

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D49621-code in your sandbox and make sure the API is sandboxed.
* Apply this change to calypso, navigate to your Calypso dashboard and open a notification for a post with a blockquote and horizontal rule in its contents. Verify that the blockquote and HR are styled distinctly from surrounding paragraphs.

![image](https://user-images.githubusercontent.com/13437011/93397736-d0ec5a00-f83f-11ea-8cb5-91df5aa029f9.png)


Fixes #45649 / #45120
