### PR TITLE
Image Editor: Use WP components Button instead of Automattic Button

### DIFF
--- a/client/blocks/image-editor/image-editor-buttons.jsx
+++ b/client/blocks/image-editor/image-editor-buttons.jsx
@@ -8,9 +8,13 @@ import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
 import { getImageEditorFileInfo, imageEditorHasChanges } from 'state/editor/image-editor/selectors';
 
 class ImageEditorButtons extends Component {
@@ -41,7 +45,7 @@ class ImageEditorButtons extends Component {
 			<div className="image-editor__buttons">
 				{ onCancel && (
 					<Button
-						className="image-editor__buttons-button"
+						className="image-editor__buttons-button button"
 						onClick={ onCancel }
 						data-e2e-button="cancel"
 					>
@@ -49,7 +53,7 @@ class ImageEditorButtons extends Component {
 					</Button>
 				) }
 				<Button
-					className="image-editor__buttons-button"
+					className="image-editor__buttons-button button"
 					disabled={ ! hasChanges }
 					onClick={ onReset }
 					data-e2e-button="reset"
@@ -57,9 +61,9 @@ class ImageEditorButtons extends Component {
 					{ translate( 'Reset' ) }
 				</Button>
 				<Button
-					className="image-editor__buttons-button"
+					className="image-editor__buttons-button button"
 					disabled={ ! src }
-					primary
+					isPrimary
 					onClick={ onDone }
 					data-e2e-button="done"
 					data-tip-target="image-editor-button-done"

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -10,6 +10,11 @@ import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 
 /**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import PopoverMenu from 'components/popover/menu';
@@ -196,7 +201,7 @@ export class ImageEditorToolbar extends Component {
 				'is-disabled': button && button.disabled,
 			} );
 			return button ? (
-				<button
+				<Button
 					key={ 'image-editor-toolbar-' + button.tool }
 					ref={ button.ref }
 					className={ buttonClasses }
@@ -204,7 +209,7 @@ export class ImageEditorToolbar extends Component {
 				>
 					<Gridicon icon={ button.icon } />
 					<span>{ button.text }</span>
-				</button>
+				</Button>
 			) : null;
 		} );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update image editor toolbar buttons to use the `Button` component
* Update existing usage of `@automattic/components` to use the `Button` from `@wordpress/components`

This PR includes a small "hack" where to achieve a very quick "calypsoification" of the WordPress components `Button` by applying the `button` class to each one. This was only necessary for the primary button.

I'm currently exploring a different approach where we theme the buttons, but it's proving difficult to do that completely without just importing the whole of our component buttons styles. Maybe that's okay to do though? Let me know what you think @tyxla. What's the best way for us to theme the WP components buttons?

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/devdocs/blocks/image-editor` and ensure that all the buttons appear and function the same as in production.

Related to #45259 
