### PR TITLE
Gutenboarding: Launch flow mobile layout.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/actions.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/actions.ts
@@ -10,6 +10,14 @@ import { dispatch, select } from '@wordpress/data-controls';
 import { SITE_ID, SITE_STORE, PLANS_STORE } from './constants';
 import type { LaunchStepType } from './types';
 
+export const setSidebarFullscreen = () => ( {
+	type: 'SET_SIDEBAR_FULLSCREEN' as const,
+} );
+
+export const unsetSidebarFullscreen = () => ( {
+	type: 'UNSET_SIDEBAR_FULLSCREEN' as const,
+} );
+
 export const setStep = ( step: LaunchStepType ) => ( {
 	type: 'SET_STEP' as const,
 	step,

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/actions.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/actions.ts
@@ -10,51 +10,62 @@ import { dispatch, select } from '@wordpress/data-controls';
 import { SITE_ID, SITE_STORE, PLANS_STORE } from './constants';
 import type { LaunchStepType } from './types';
 
-export const setSidebarFullscreen = () => ( {
-	type: 'SET_SIDEBAR_FULLSCREEN' as const,
-} );
+export const setSidebarFullscreen = () =>
+	( {
+		type: 'SET_SIDEBAR_FULLSCREEN',
+	} as const );
 
-export const unsetSidebarFullscreen = () => ( {
-	type: 'UNSET_SIDEBAR_FULLSCREEN' as const,
-} );
+export const unsetSidebarFullscreen = () =>
+	( {
+		type: 'UNSET_SIDEBAR_FULLSCREEN',
+	} as const );
 
-export const setStep = ( step: LaunchStepType ) => ( {
-	type: 'SET_STEP' as const,
-	step,
-} );
+export const setStep = ( step: LaunchStepType ) =>
+	( {
+		type: 'SET_STEP',
+		step,
+	} as const );
 
-export const setDomain = ( domain: DomainSuggestions.DomainSuggestion ) => ( {
-	type: 'SET_DOMAIN' as const,
-	domain,
-} );
+export const setDomain = ( domain: DomainSuggestions.DomainSuggestion ) =>
+	( {
+		type: 'SET_DOMAIN',
+		domain,
+	} as const );
 
-export const unsetDomain = () => ( {
-	type: 'UNSET_DOMAIN' as const,
-} );
+export const unsetDomain = () =>
+	( {
+		type: 'UNSET_DOMAIN',
+	} as const );
 
-export const confirmDomainSelection = () => ( {
-	type: 'CONFIRM_DOMAIN_SELECTION' as const,
-} );
+export const confirmDomainSelection = () =>
+	( {
+		type: 'CONFIRM_DOMAIN_SELECTION',
+	} as const );
 
-export const setDomainSearch = ( domainSearch: string ) => ( {
-	type: 'SET_DOMAIN_SEARCH' as const,
-	domainSearch,
-} );
+export const setDomainSearch = ( domainSearch: string ) =>
+	( {
+		type: 'SET_DOMAIN_SEARCH',
+		domainSearch,
+	} as const );
 
-export const setPlan = ( plan: Plans.Plan ) => ( {
-	type: 'SET_PLAN' as const,
-	plan,
-} );
+export const setPlan = ( plan: Plans.Plan ) =>
+	( {
+		type: 'SET_PLAN',
+		plan,
+	} as const );
 
-export const unsetPlan = () => ( {
-	type: 'UNSET_PLAN' as const,
-} );
+export const unsetPlan = () =>
+	( {
+		type: 'UNSET_PLAN',
+	} as const );
 
+/* eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types */
 export function* updatePlan( planSlug: Plans.PlanSlug ) {
 	const plan: Plans.Plan = yield select( PLANS_STORE, 'getPlanBySlug', planSlug );
 	yield setPlan( plan );
 }
 
+/* eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types */
 export function* launchSite() {
 	try {
 		const success = yield dispatch( SITE_STORE, 'launchSite', SITE_ID );
@@ -64,17 +75,20 @@ export function* launchSite() {
 	}
 }
 
-export const openSidebar = () => ( {
-	type: 'OPEN_SIDEBAR' as const,
-} );
+export const openSidebar = () =>
+	( {
+		type: 'OPEN_SIDEBAR',
+	} as const );
 
-export const closeSidebar = () => ( {
-	type: 'CLOSE_SIDEBAR' as const,
-} );
+export const closeSidebar = () =>
+	( {
+		type: 'CLOSE_SIDEBAR',
+	} as const );
 
-export const enableExperimental = () => ( {
-	type: 'ENABLE_EXPERIMENTAL' as const,
-} );
+export const enableExperimental = () =>
+	( {
+		type: 'ENABLE_EXPERIMENTAL',
+	} as const );
 
 export type LaunchAction = ReturnType<
 	| typeof unsetDomain

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/data.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/data.ts
@@ -1,11 +1,11 @@
-export const LaunchStep = {
+export const LaunchStep: Record< string, string > = {
 	Name: 'name',
 	Domain: 'domain',
 	Plan: 'plan',
 	Final: 'final',
 };
 
-export const LaunchSequence = [
+export const LaunchSequence: Array< string > = [
 	LaunchStep.Name,
 	LaunchStep.Domain,
 	LaunchStep.Plan,

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/reducer.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/reducer.ts
@@ -67,6 +67,16 @@ const isSidebarOpen: Reducer< boolean, LaunchAction > = ( state = false, action 
 	return state;
 };
 
+const isSidebarFullscreen: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
+	if ( action.type === 'SET_SIDEBAR_FULLSCREEN' ) {
+		return true;
+	}
+	if ( action.type === 'UNSET_SIDEBAR_FULLSCREEN' ) {
+		return false;
+	}
+	return state;
+};
+
 const isExperimental: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
 	if ( action.type === 'ENABLE_EXPERIMENTAL' ) {
 		return true;
@@ -82,6 +92,7 @@ const reducer = combineReducers( {
 	domainSearch,
 	plan,
 	isSidebarOpen,
+	isSidebarFullscreen,
 	isExperimental,
 } );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -50,7 +50,7 @@ function updateEditor() {
 		}
 		clearInterval( awaitSettingsBar );
 
-		const isMobile = window.innerWidth < 768;
+		const isMobile = window.innerWidth < 782;
 		const isNewLaunch = window?.calypsoifyGutenberg?.isNewLaunch;
 		const isNewLaunchMobile = window?.calypsoifyGutenberg?.isNewLaunchMobile;
 		const isExperimental = window?.calypsoifyGutenberg?.isExperimental;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -50,13 +50,18 @@ function updateEditor() {
 		}
 		clearInterval( awaitSettingsBar );
 
+		const isMobile = window.innerWidth < 768;
 		const isNewLaunch = window?.calypsoifyGutenberg?.isNewLaunch;
+		const isNewLaunchMobile = window?.calypsoifyGutenberg?.isNewLaunchMobile;
 		const isExperimental = window?.calypsoifyGutenberg?.isExperimental;
 
 		// Assert reason: We have an early return above with optional and falsy values. This should be a string.
 		const launchHref = window?.calypsoifyGutenberg?.frankenflowUrl as string;
 
-		const launchLabel = __( 'Complete setup', 'full-site-editing' );
+		// On mobile there is not enough space to display "Complete setup" label.
+		const launchLabel = isMobile
+			? __( 'Launch', 'full-site-editing' )
+			: __( 'Complete setup', 'full-site-editing' );
 
 		const saveAndNavigate = async () => {
 			await dispatch( 'core/editor' ).savePost();
@@ -68,7 +73,7 @@ function updateEditor() {
 			// Disable href navigation
 			e.preventDefault();
 
-			const shouldOpenNewFlow = isNewLaunch;
+			const shouldOpenNewFlow = isNewLaunch && ( ! isMobile || ( isMobile && isNewLaunchMobile ) );
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click', {
 				is_new_flow: shouldOpenNewFlow,

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
 import { addAction } from '@wordpress/hooks';
-import { dispatch } from '@wordpress/data';
+import { dispatch, subscribe, select } from '@wordpress/data';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import 'a8c-fse-common-data-stores';
 
@@ -50,17 +50,13 @@ function updateEditor() {
 		}
 		clearInterval( awaitSettingsBar );
 
-		const isMobile = window.innerWidth < 768;
 		const isNewLaunch = window?.calypsoifyGutenberg?.isNewLaunch;
 		const isExperimental = window?.calypsoifyGutenberg?.isExperimental;
 
 		// Assert reason: We have an early return above with optional and falsy values. This should be a string.
 		const launchHref = window?.calypsoifyGutenberg?.frankenflowUrl as string;
 
-		// On mobile there is not enough space to display "Complete setup" label.
-		const launchLabel = isMobile
-			? __( 'Launch', 'full-site-editing' )
-			: __( 'Complete setup', 'full-site-editing' );
+		const launchLabel = __( 'Complete setup', 'full-site-editing' );
 
 		const saveAndNavigate = async () => {
 			await dispatch( 'core/editor' ).savePost();
@@ -72,7 +68,7 @@ function updateEditor() {
 			// Disable href navigation
 			e.preventDefault();
 
-			const shouldOpenNewFlow = isNewLaunch && ! isMobile;
+			const shouldOpenNewFlow = isNewLaunch;
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click', {
 				is_new_flow: shouldOpenNewFlow,

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
 import { addAction } from '@wordpress/hooks';
-import { dispatch, subscribe, select } from '@wordpress/data';
+import { dispatch } from '@wordpress/data';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import 'a8c-fse-common-data-stores';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
 
@@ -17,10 +18,17 @@ const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > 
 registerPlugin( 'a8c-editor-site-launch', {
 	render: function LaunchSidebar() {
 		const { isSidebarOpen } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
-		const { closeSidebar } = useDispatch( LAUNCH_STORE );
+		const { closeSidebar, setSidebarFullscreen, unsetSidebarFullscreen } = useDispatch(
+			LAUNCH_STORE
+		);
 
 		// handle redirects to checkout / my home after launch
 		useOnLaunch();
+
+		React.useEffect( () => {
+			// @automattic/viewport doesn't have a breakpoint for medium (782px)
+			window.innerWidth < 782 ? setSidebarFullscreen() : unsetSidebarFullscreen();
+		}, [ isSidebarOpen, setSidebarFullscreen, unsetSidebarFullscreen ] );
 
 		if ( ! isSidebarOpen ) {
 			return null;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
@@ -13,6 +13,7 @@ import { useOnLaunch } from './hooks';
 import { LAUNCH_STORE } from './stores';
 
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	originalRegisterPlugin( name, settings as any );
 
 registerPlugin( 'a8c-editor-site-launch', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/index.tsx
@@ -10,10 +10,15 @@ import { __ } from '@wordpress/i18n';
  */
 import { LAUNCH_STORE } from '../stores';
 import LaunchMenuItem from './item';
+import type { LaunchStepType } from '../../../common/data-stores/launch/types';
 
 import './styles.scss';
 
-const LaunchMenu = () => {
+interface Props {
+	onMenuItemClick: ( step: LaunchStepType ) => void;
+}
+
+const LaunchMenu: React.FunctionComponent< Props > = ( { onMenuItemClick } ) => {
 	const { step: currentStep } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 	const LaunchStep = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchStep() );
 	const LaunchSequence = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchSequence() );
@@ -29,16 +34,22 @@ const LaunchMenu = () => {
 
 	const { setStep } = useDispatch( LAUNCH_STORE );
 
+	const handleClick = ( step ) => {
+		setStep( step );
+		onMenuItemClick( step );
+	};
+
 	return (
 		<div className="nux-launch-menu">
 			<h4>{ __( 'Site Launch Steps', 'full-site-editing' ) }</h4>
 			<div className="nux-launch-menu__item-group">
 				{ LaunchSequence.map( ( step ) => (
 					<LaunchMenuItem
+						key={ step }
 						title={ LaunchStepMenuItemTitles[ step ] }
 						isCompleted={ isStepCompleted( step ) }
 						isCurrent={ step === currentStep }
-						onClick={ () => setStep( step ) }
+						onClick={ () => handleClick( step ) }
 						isDisabled={ step === LaunchStep.Final && ! isFlowStarted }
 					/>
 				) ) }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/styles.scss
@@ -37,12 +37,15 @@
 		left: -1px;
 	}
 
-	&.is-current {
-		background: var( --studio-blue-0 );
-		color: initial;
-
-		svg {
+	// This is only highlighted when sidebar is not fullscreen
+	@include break-medium {
+		&.is-current {
+			background: var( --studio-blue-0 );
 			color: initial;
+
+			svg {
+				color: initial;
+			}
 		}
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/styles.scss
@@ -3,7 +3,7 @@
 .nux-launch-menu {
 	h4 {
 		text-transform: uppercase;
-		margin: 50px 0 20px;
+		margin-bottom: 16px;
 	}
 }
 
@@ -18,7 +18,7 @@
 	width: 100%;
 	text-align: left;
 	text-decoration: none;
-	padding: 20px 14px;
+	padding: 16px 14px;
 
 	&:hover {
 		color: initial;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/index.tsx
@@ -15,6 +15,7 @@ import classnames from 'classnames';
 import { LAUNCH_STORE } from '../stores';
 import Launch from '../launch';
 import LaunchSidebar from '../launch-sidebar';
+import LaunchProgress from '../launch-progress';
 import { useSite } from '../hooks';
 
 import './styles.scss';
@@ -23,8 +24,24 @@ interface Props {
 	onClose: () => void;
 }
 
+const CloseButton = ( { onClick } ) => {
+	return (
+		<Button
+			isLink
+			className="nux-launch-modal__close-button"
+			onClick={ onClick }
+			aria-label={ __( 'Close dialog', 'full-site-editing' ) }
+			disabled={ ! onClick }
+		>
+			<Icon icon={ close } size={ 24 } />
+		</Button>
+	);
+};
+
 const LaunchModal: React.FunctionComponent< Props > = ( { onClose } ) => {
-	const { step: currentStep } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+	const { step: currentStep, isSidebarFullscreen } = useSelect( ( select ) =>
+		select( LAUNCH_STORE ).getState()
+	);
 	const { launchSite } = useDispatch( LAUNCH_STORE );
 
 	const [ isLaunching, setIsLaunching ] = React.useState( false );
@@ -43,7 +60,11 @@ const LaunchModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 	return (
 		<Modal
 			open={ true }
-			className={ classnames( 'nux-launch-modal', `step-${ currentStep }` ) }
+			className={ classnames(
+				'nux-launch-modal',
+				`step-${ currentStep }`,
+				isSidebarFullscreen ? 'is-sidebar-fullscreen' : ''
+			) }
 			overlayClassName="nux-launch-modal-overlay"
 			bodyOpenClassName="has-nux-launch-modal"
 			onRequestClose={ onClose }
@@ -59,6 +80,8 @@ const LaunchModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 						<div className="nux-launch-modal-header__wp-logo">
 							<Icon icon={ wordpress } size={ 36 } />
 						</div>
+						<LaunchProgress />
+						<CloseButton onClick={ onClose } />
 					</div>
 					<div className="nux-launch-modal-body">
 						<EntityProvider kind="root" type="site">
@@ -66,15 +89,7 @@ const LaunchModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 						</EntityProvider>
 					</div>
 					<div className="nux-launch-modal-aside">
-						<Button
-							isLink
-							className="nux-launch-modal__close-button"
-							onClick={ onClose }
-							aria-label={ __( 'Close dialog', 'full-site-editing' ) }
-							disabled={ ! onClose }
-						>
-							<Icon icon={ close } size={ 24 } />
-						</Button>
+						<CloseButton onClick={ onClose } />
 						<LaunchSidebar />
 					</div>
 				</>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/index.tsx
@@ -24,20 +24,6 @@ interface Props {
 	onClose: () => void;
 }
 
-const CloseButton = ( { onClick } ) => {
-	return (
-		<Button
-			isLink
-			className="nux-launch-modal__close-button"
-			onClick={ onClick }
-			aria-label={ __( 'Close dialog', 'full-site-editing' ) }
-			disabled={ ! onClick }
-		>
-			<Icon icon={ close } size={ 24 } />
-		</Button>
-	);
-};
-
 const LaunchModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 	const { step: currentStep, isSidebarFullscreen } = useSelect( ( select ) =>
 		select( LAUNCH_STORE ).getState()
@@ -88,9 +74,19 @@ const LaunchModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 						</EntityProvider>
 					</div>
 					<div className="nux-launch-modal-aside">
-						<CloseButton onClick={ onClose } />
 						<LaunchSidebar />
 					</div>
+					<Button
+						isLink
+						className="nux-launch-modal__close-button"
+						onClick={ onClose }
+						aria-label={ __( 'Close dialog', 'full-site-editing' ) }
+						disabled={ ! onClose }
+					>
+						<span>
+							<Icon icon={ close } size={ 24 } />
+						</span>
+					</Button>
 				</>
 			) }
 		</Modal>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/index.tsx
@@ -76,14 +76,13 @@ const LaunchModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 				</div>
 			) : (
 				<>
-					<div className="nux-launch-modal-header">
-						<div className="nux-launch-modal-header__wp-logo">
-							<Icon icon={ wordpress } size={ 36 } />
-						</div>
-						<LaunchProgress />
-						<CloseButton onClick={ onClose } />
-					</div>
 					<div className="nux-launch-modal-body">
+						<div className="nux-launch-modal-header">
+							<div className="nux-launch-modal-header__wp-logo">
+								<Icon icon={ wordpress } size={ 36 } />
+							</div>
+							<LaunchProgress />
+						</div>
 						<EntityProvider kind="root" type="site">
 							<Launch onSubmit={ handleLaunch } />
 						</EntityProvider>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
@@ -23,48 +23,36 @@ body.has-nux-launch-modal {
 		position: fixed;
 		top: 0;
 		left: 0;
-		display: block;
+		display: flex;
 		background: var( --studio-white );
 		width: 100%;
 		height: 100%;
 		padding: 0;
-		overflow-y: scroll;
-		overflow-x: auto;
+		overflow: auto;
 	}
 }
 
 .nux-launch-modal-header {
+	@include onboarding-block-edge2edge;
 	display: flex;
 	position: sticky;
 	top: 0;
-	left: 0;
-	z-index: z-index( '.components-modal__header' );
-	width: 100%;
 	height: $onboarding-header-height;
-	background: var( --studio-white );
 	border-bottom: 1px solid $gray-200;
+	background: var( --studio-white );
+	z-index: z-index( '.components-modal__header' );
 
+	// On desktop, do not show bottom border.
 	@include break-medium {
-		height: 0;
-		margin-right: $sidebar-width;
-		background: transparent;
+		position: relative;
 		border-bottom: none;
-		overflow: visible;
 	}
 
 	.nux-launch-progress {
-		display: flex;
-		align-items: center;
 		height: $onboarding-header-height;
 
 		@include break-medium {
 			display: none;
-		}
-	}
-
-	@media ( max-width: $break-medium ) {
-		.is-sidebar-fullscreen & {
-			opacity: 0; // Using visibility: hidden or display: none closes modal
 		}
 	}
 }
@@ -78,12 +66,15 @@ body.has-nux-launch-modal {
 }
 
 .nux-launch-modal-body {
-	padding-bottom: $onboarding-footer-height;
 	position: relative;
+	flex-grow: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	@include onboarding-block-margin;
 
-	@include break-medium {
-		padding-top: $header-height;
-		margin-right: $sidebar-width;
+	.nux-launch-step__body {
+		flex-grow: 1;
 	}
 
 	@media ( max-width: $break-medium ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
@@ -121,17 +121,40 @@ body.has-nux-launch-modal {
 }
 
 .nux-launch-modal__close-button.components-button.is-link {
-	position: absolute;
+	// This keeps the button on the top right corner even when scrolled down
+	position: sticky;
 	top: 0;
-	right: 0;
-	z-index: z-index( '.components-modal__header' ) + 2;
-	width: 60px;
-	height: 60px;
-	justify-content: center;
-	color: var( --studio-gray-50 );
+	z-index: z-index( '.components-modal__header' ) + 3;
 
+	// Give it no dimension so it doesn't take any flex space
+	// but overflow it so the close button is visible
+	width: 0;
+	height: 0;
+	overflow: visible;
+
+	// Anchor the inline content to the top right (instead of middle).
+	display: flex;
+	align-items: flex-start;
+
+	// Close button icon color
+	color: var( --studio-gray-50 );
 	&:hover {
 		color: var( --studio-gray-40 );
+	}
+
+	> span {
+		// Push the icon back out from the right side
+		position: relative;
+		right: $onboarding-header-height;
+
+		// Use padding to create width
+		// (18px left padding + 24px icon width + 18px right padding = 60px width)
+		padding: 0 #{( $onboarding-header-height - 24px ) / 2};
+		height: $onboarding-header-height;
+
+		// Vertically align icon
+		display: flex;
+		align-items: center;
 	}
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
@@ -28,6 +28,9 @@ body.has-nux-launch-modal {
 		width: 100%;
 		height: 100%;
 		padding: 0;
+		// Using overflow-y: scroll for consistent viewport width has an unintended
+		// consequence where if the content height is shorter than the viewport height
+		// the modal header overlaps the scrollbar on Chrome.
 		overflow: auto;
 	}
 }
@@ -35,8 +38,13 @@ body.has-nux-launch-modal {
 .nux-launch-modal-header {
 	@include onboarding-block-edge2edge;
 	display: flex;
-	position: sticky;
+
+	// Modal header uses position: fixed instead of position: sticky because:
+	// - no scrollbar overlap issue. close button is another sticky element outside of header.
+	// - using position: sticky causes the header to pushed out in plans step when scrolling down.
+	position: fixed;
 	top: 0;
+	width: 100%;
 	height: $onboarding-header-height;
 	border-bottom: 1px solid $gray-200;
 	background: var( --studio-white );
@@ -83,6 +91,14 @@ body.has-nux-launch-modal {
 		// from disappearing when clicked, causing the modal to blur
 		// itself out and abruptly closes the modal.
 		overflow: hidden;
+	}
+
+	// To accomodate fixed .nux-launch-modal-header
+	padding-top: $onboarding-header-height;
+
+	@include break-medium {
+		// Modal header is not sticky on desktop.
+		padding-top: 0;
 	}
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
@@ -77,43 +77,46 @@ body.has-nux-launch-modal {
 		flex-grow: 1;
 	}
 
-	@media ( max-width: $break-medium ) {
-		.is-sidebar-fullscreen & {
-			opacity: 0; // Using visibility: hidden or display: none closes modal
-		}
+	.is-sidebar-fullscreen & {
+		// Instead of display: none, this clips the modal body when
+		// fullscreen sidebar is showing, this is to prevents "Go Back" button
+		// from disappearing when clicked, causing the modal to blur
+		// itself out and abruptly closes the modal.
+		overflow: hidden;
 	}
 }
 
 .nux-launch-modal-aside {
-	position: fixed;
+	// Instead of display: none, the sidebar hides off-screen
+	// on mobile view, this is to prevents "Get Started" button
+	// from disappearing when clicked, causing the modal to blur
+	// itself out and abruptly closes the modal.
+	position: absolute;
 	top: 0;
-	right: 18px;
-	width: $sidebar-width;
-	max-width: $sidebar-width;
-	max-width: $sidebar-width;
-	min-height: 100vh;
-	border-left: 1px solid var( --studio-gray-5 );
-	padding-top: $header-height;
-	padding-bottom: $onboarding-footer-height;
+	left: -200%;
+	width: 100%;
+	height: 100%;
 	background: var( --studio-white );
-	z-index: z-index( '.components-modal__header' ) + 1;
-	display: none;
-
-	@include break-medium {
-		display: block;
-	}
+	z-index: z-index( '.components-modal__header' ) + 2;
 
 	@media ( max-width: $break-medium ) {
+		// This brings the sidebar that is hiding offscreen into view.
 		.is-sidebar-fullscreen & {
-			position: absolute;
-			top: 0;
 			left: 0;
-			width: 100%;
-			height: 100%;
-			max-width: none;
-			border: none;
-			display: block;
 		}
+	}
+
+	@include break-medium {
+		// Use sticky or relative positioning because fixed or absolute
+		// positioning causes the vertical scrollbar from the parent element
+		// to overlap the content on the sidebar.
+		position: sticky;
+		top: 0;
+		left: auto;
+		width: $sidebar-width;
+		min-width: $sidebar-width;
+		max-width: $sidebar-width;
+		border-left: 1px solid var( --studio-gray-5 );
 	}
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/styles.scss
@@ -1,7 +1,10 @@
 @import '~@wordpress/base-styles/mixins';
 @import '~@wordpress/base-styles/variables';
+@import '~@wordpress/base-styles/breakpoints';
 @import '~@wordpress/base-styles/z-index';
 @import '~@automattic/typography/styles/variables';
+@import '~@automattic/onboarding/styles/variables';
+@import '~@automattic/onboarding/styles/mixins';
 
 body.has-nux-launch-modal {
 	overflow: hidden;
@@ -31,13 +34,39 @@ body.has-nux-launch-modal {
 }
 
 .nux-launch-modal-header {
-	position: fixed;
+	display: flex;
+	position: sticky;
 	top: 0;
 	left: 0;
 	z-index: z-index( '.components-modal__header' );
 	width: 100%;
-	height: 0;
-	overflow: visible;
+	height: $onboarding-header-height;
+	background: var( --studio-white );
+	border-bottom: 1px solid $gray-200;
+
+	@include break-medium {
+		height: 0;
+		margin-right: $sidebar-width;
+		background: transparent;
+		border-bottom: none;
+		overflow: visible;
+	}
+
+	.nux-launch-progress {
+		display: flex;
+		align-items: center;
+		height: $onboarding-header-height;
+
+		@include break-medium {
+			display: none;
+		}
+	}
+
+	@media ( max-width: $break-medium ) {
+		.is-sidebar-fullscreen & {
+			opacity: 0; // Using visibility: hidden or display: none closes modal
+		}
+	}
 }
 
 .nux-launch-modal-header__wp-logo {
@@ -49,9 +78,19 @@ body.has-nux-launch-modal {
 }
 
 .nux-launch-modal-body {
-	padding-top: $header-height;
-	margin-right: $sidebar-width;
+	padding-bottom: $onboarding-footer-height;
 	position: relative;
+
+	@include break-medium {
+		padding-top: $header-height;
+		margin-right: $sidebar-width;
+	}
+
+	@media ( max-width: $break-medium ) {
+		.is-sidebar-fullscreen & {
+			opacity: 0; // Using visibility: hidden or display: none closes modal
+		}
+	}
 }
 
 .nux-launch-modal-aside {
@@ -64,8 +103,27 @@ body.has-nux-launch-modal {
 	min-height: 100vh;
 	border-left: 1px solid var( --studio-gray-5 );
 	padding-top: $header-height;
+	padding-bottom: $onboarding-footer-height;
 	background: var( --studio-white );
 	z-index: z-index( '.components-modal__header' ) + 1;
+	display: none;
+
+	@include break-medium {
+		display: block;
+	}
+
+	@media ( max-width: $break-medium ) {
+		.is-sidebar-fullscreen & {
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			max-width: none;
+			border: none;
+			display: block;
+		}
+	}
 }
 
 .nux-launch-modal__close-button.components-button.is-link {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-progress/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-progress/index.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useSelect } from '@wordpress/data';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
+
+/**
+ * Internal dependencies
+ */
+import { LAUNCH_STORE } from '../stores';
+
+import './styles.scss';
+
+const LaunchProgress: React.FunctionComponent = () => {
+	const { __ } = useI18n();
+
+	const { step: currentStep } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+
+	const LaunchSequence = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchSequence() );
+
+	const current = LaunchSequence.indexOf( currentStep ) + 1;
+	const total = LaunchSequence.length;
+
+	/* translators: current progress in launch flow, eg: "2 of 4" */
+	const summary = sprintf( __( '%1$d of %2$d', 'full-site-editing' ), current, total );
+
+	return <div className="nux-launch-progress">{ summary }</div>;
+};
+
+export default LaunchProgress;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-progress/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-progress/styles.scss
@@ -1,3 +1,5 @@
 .nux-launch-progress {
+	display: flex;
+	align-items: center;
 	font-weight: 600;
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-progress/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-progress/styles.scss
@@ -1,0 +1,3 @@
+.nux-launch-progress {
+	font-weight: 600;
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/index.tsx
@@ -3,25 +3,49 @@
  */
 import * as React from 'react';
 import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { ActionButtons, NextButton } from '@automattic/onboarding';
 
 /**
  * Internal dependencies
  */
 import LaunchMenu from '../launch-menu';
+import { LAUNCH_STORE } from '../stores';
 
 import './styles.scss';
 
-const LaunchSidebar = () => (
-	<div className="nux-launch-sidebar">
-		<h2>{ __( "You're almost there!", 'full-site-editing' ) }</h2>
-		<h3>
-			{ __(
-				'Complete the following steps to launch your site. Your site will remain private until you Launch.',
-				'full-site-editing'
-			) }
-		</h3>
-		<LaunchMenu />
-	</div>
-);
+const LaunchSidebar = () => {
+	const { setStep, unsetSidebarFullscreen } = useDispatch( LAUNCH_STORE );
+
+	const LaunchSequence = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchSequence() );
+
+	const handleStart = () => {
+		// TODO: Fix modal closing itself.
+		setStep( LaunchSequence[ 0 ] );
+		unsetSidebarFullscreen();
+	};
+
+	const handleMenuItemClick = () => {
+		unsetSidebarFullscreen();
+	};
+
+	return (
+		<div className="nux-launch-sidebar">
+			<h2>{ __( "You're almost there!", 'full-site-editing' ) }</h2>
+			<h3>
+				{ __(
+					'Complete the following steps to launch your site. Your site will remain private until you Launch.',
+					'full-site-editing'
+				) }
+			</h3>
+			<LaunchMenu onMenuItemClick={ handleMenuItemClick } />
+			<ActionButtons stickyBreakpoint="medium">
+				<NextButton onClick={ handleStart }>
+					{ __( 'Get Started', 'full-site-editing' ) }
+				</NextButton>
+			</ActionButtons>
+		</div>
+	);
+};
 
 export default LaunchSidebar;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { ActionButtons, NextButton } from '@automattic/onboarding';
+import { Title, SubTitle, ActionButtons, NextButton } from '@automattic/onboarding';
 
 /**
  * Internal dependencies
@@ -20,7 +20,6 @@ const LaunchSidebar = () => {
 	const LaunchSequence = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchSequence() );
 
 	const handleStart = () => {
-		// TODO: Fix modal closing itself.
 		setStep( LaunchSequence[ 0 ] );
 		unsetSidebarFullscreen();
 	};
@@ -31,19 +30,25 @@ const LaunchSidebar = () => {
 
 	return (
 		<div className="nux-launch-sidebar">
-			<h2>{ __( "You're almost there!", 'full-site-editing' ) }</h2>
-			<h3>
-				{ __(
-					'Complete the following steps to launch your site. Your site will remain private until you Launch.',
-					'full-site-editing'
-				) }
-			</h3>
-			<LaunchMenu onMenuItemClick={ handleMenuItemClick } />
-			<ActionButtons stickyBreakpoint="medium">
-				<NextButton onClick={ handleStart }>
-					{ __( 'Get Started', 'full-site-editing' ) }
-				</NextButton>
-			</ActionButtons>
+			<div className="nux-launch-sidebar__header">
+				<Title>{ __( "You're almost there!", 'full-site-editing' ) }</Title>
+				<SubTitle>
+					{ __(
+						'Complete the following steps to launch your site. Your site will remain private until you Launch.',
+						'full-site-editing'
+					) }
+				</SubTitle>
+			</div>
+			<div className="nux-launch-sidebar__body">
+				<LaunchMenu onMenuItemClick={ handleMenuItemClick } />
+			</div>
+			<div className="nux-launch-sidebar__footer">
+				<ActionButtons sticky={ true }>
+					<NextButton onClick={ handleStart }>
+						{ __( 'Get Started', 'full-site-editing' ) }
+					</NextButton>
+				</ActionButtons>
+			</div>
 		</div>
 	);
 };

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/index.tsx
@@ -14,7 +14,7 @@ import { LAUNCH_STORE } from '../stores';
 
 import './styles.scss';
 
-const LaunchSidebar = () => {
+const LaunchSidebar: React.FunctionComponent = () => {
 	const { setStep, unsetSidebarFullscreen } = useDispatch( LAUNCH_STORE );
 
 	const LaunchSequence = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchSequence() );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/styles.scss
@@ -14,7 +14,6 @@
 		height: auto;
 		margin: 0 24px;
 		padding-top: 0;
-		overflow: hidden;
 
 		// On mobile & tablet, inherit onboarding title & subtitle styling.
 		// On desktop, use designated title & subtitle styling.

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/styles.scss
@@ -15,4 +15,18 @@
 		line-height: 1.5;
 		color: var( --studio-gray-60 );
 	}
+
+	.action-buttons {
+		justify-content: flex-end;
+	}
+
+	// When fullscreen, inherit onboarding styling.
+	.is-sidebar-fullscreen & {
+		padding: 0;
+		@include onboarding-block-margin;
+
+		h2 {
+			@include onboarding-heading-title;
+		}
+	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/styles.scss
@@ -1,32 +1,59 @@
+@import '~@wordpress/base-styles/breakpoints';
 @import '~@automattic/onboarding/styles/mixins';
 
 .nux-launch-sidebar {
-	padding: 0 24px;
+	@include onboarding-block-margin;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	background: var( --studio-white );
+	padding-top: $onboarding-header-height;
 
-	h2 {
-		@include onboarding-font-recoleta;
-		font-size: $font-title-medium;
-	}
+	@include break-medium {
+		display: block;
+		height: auto;
+		margin: 0 24px;
+		padding-top: 0;
+		overflow: hidden;
 
-	h3 {
-		font-family: $default-font;
-		font-weight: normal;
-		font-size: $font-body-small;
-		line-height: 1.5;
-		color: var( --studio-gray-60 );
+		// On mobile & tablet, inherit onboarding title & subtitle styling.
+		// On desktop, use designated title & subtitle styling.
+		h1.onboarding-title {
+			font-size: $font-title-medium;
+		}
+
+		h2.onboarding-subtitle {
+			font-family: $default-font;
+			font-weight: normal;
+			font-size: $font-body-small;
+			line-height: 1.5;
+			color: var( --studio-gray-60 );
+		}
 	}
+}
+
+.nux-launch-sidebar__header {
+	@include onboarding-heading-padding;
+}
+
+.nux-launch-sidebar__body {
+	flex-grow: 1;
+	@include onboarding-body-margin;
+}
+
+.nux-launch-sidebar__footer {
+	// On mobile & tablet, show sidebar footer, sticky at bottom.
+	@include onboarding-block-edge2edge;
+	position: sticky;
+	bottom: 0;
 
 	.action-buttons {
+		position: relative;
 		justify-content: flex-end;
 	}
 
-	// When fullscreen, inherit onboarding styling.
-	.is-sidebar-fullscreen & {
-		padding: 0;
-		@include onboarding-block-margin;
-
-		h2 {
-			@include onboarding-heading-title;
-		}
+	// On desktop, hide sidebar footer.
+	@include break-medium {
+		display: none;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import * as React from 'react';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -10,13 +9,12 @@ import classnames from 'classnames';
 import './styles.scss';
 
 export interface Props {
-	className?: string;
 	onPrevStep?: () => void;
 	onNextStep?: () => void;
 }
 
-const LaunchStep: React.FunctionComponent< Props > = ( { className, children } ) => {
-	return <div className={ classnames( 'nux-launch-step', className ) }>{ children }</div>;
+const LaunchStep: React.FunctionComponent< Props > = ( { children } ) => {
+	return <>{ children }</>;
 };
 
 export default LaunchStep;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/styles.scss
@@ -3,27 +3,25 @@
 @import '~@automattic/typography/styles/fonts';
 @import '~@automattic/onboarding/styles/mixins';
 
-.nux-launch-step {
-	@include onboarding-block-margin;
-	background: var( --studio-white );
+.nux-launch-step__header {
+	@include onboarding-heading-padding;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 
-	// Only show back button when sticky
-	.action-buttons__back {
-		display: inline-flex;
+	// On mobile, show header action buttons.
+	// On desktop, hide header action buttons.
+	.action-buttons {
+		display: none;
 
 		@include break-medium {
-			display: none;
+			display: block;
 		}
 	}
 }
 
-.nux-launch-step__header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	@include onboarding-heading-padding;
+.nux-launch-step__body {
+	@include onboarding-body-margin;
 }
 
-.nux-launch-step__heading {
-	flex-grow: 1;
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/styles.scss
@@ -1,9 +1,20 @@
+@import '~@wordpress/base-styles/variables';
+@import '~@wordpress/base-styles/breakpoints';
 @import '~@automattic/typography/styles/fonts';
 @import '~@automattic/onboarding/styles/mixins';
 
 .nux-launch-step {
 	@include onboarding-block-margin;
 	background: var( --studio-white );
+
+	// Only show back button when sticky
+	.action-buttons__back {
+		display: inline-flex;
+
+		@include break-medium {
+			display: none;
+		}
+	}
 }
 
 .nux-launch-step__header {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/styles.scss
@@ -24,4 +24,18 @@
 	@include onboarding-body-margin;
 }
 
+.nux-launch-step__footer {
+	// On mobile & tablet, show step footer, sticky at bottom.
+	@include onboarding-block-edge2edge;
+	position: sticky;
+	bottom: 0;
+
+	.action-buttons {
+		position: relative;
+	}
+
+	// On desktop, hide step footer.
+	@include break-medium {
+		display: none;
+	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -6,7 +6,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import DomainPicker from '@automattic/domain-picker';
 import type { DomainSuggestions } from '@automattic/data-stores';
-import { Title, SubTitle, ActionButtons, NextButton } from '@automattic/onboarding';
+import { Title, SubTitle, ActionButtons, BackButton, NextButton } from '@automattic/onboarding';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 
 /**
@@ -18,7 +18,7 @@ import { useSite, useDomainSearch } from '../../hooks';
 import { FLOW_ID } from '../../constants';
 import './styles.scss';
 
-const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) => {
+const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
 	const { plan, domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 	const { currentDomainName } = useSite();
 	const domainSearch = useDomainSearch();
@@ -34,6 +34,10 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } 
 	const handleNext = () => {
 		confirmDomainSelection();
 		onNextStep?.();
+	};
+
+	const handlePrev = () => {
+		onPrevStep?.();
 	};
 
 	const handleDomainSelect = ( suggestion: DomainSuggestions.DomainSuggestion ) => {
@@ -65,7 +69,8 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } 
 						{ __( 'Free for the first year with any paid plan.', 'full-site-editing' ) }
 					</SubTitle>
 				</div>
-				<ActionButtons>
+				<ActionButtons stickyBreakpoint="medium">
+					<BackButton onClick={ handlePrev } />
 					<NextButton onClick={ handleNext } disabled={ ! domainSearch } />
 				</ActionButtons>
 			</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -69,8 +69,7 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 						{ __( 'Free for the first year with any paid plan.', 'full-site-editing' ) }
 					</SubTitle>
 				</div>
-				<ActionButtons stickyBreakpoint="medium">
-					<BackButton onClick={ handlePrev } />
+				<ActionButtons sticky={ false }>
 					<NextButton onClick={ handleNext } disabled={ ! domainSearch } />
 				</ActionButtons>
 			</div>
@@ -87,6 +86,12 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 					analyticsUiAlgo="editor_domain_modal"
 					segregateFreeAndPaid
 				/>
+			</div>
+			<div className="nux-launch-step__footer">
+				<ActionButtons sticky={ true }>
+					<BackButton onClick={ handlePrev } />
+					<NextButton onClick={ handleNext } disabled={ ! domainSearch } />
+				</ActionButtons>
 			</div>
 		</LaunchStepContainer>
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -61,7 +61,7 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 	};
 
 	return (
-		<LaunchStepContainer className="nux-launch-domain-step">
+		<LaunchStepContainer>
 			<div className="nux-launch-step__header">
 				<div>
 					<Title>{ __( 'Choose a domain', 'full-site-editing' ) }</Title>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/styles.scss
@@ -1,9 +1,5 @@
 @import '~@automattic/onboarding/styles/variables';
 
-.nux-launch-domain-step {
-	padding-bottom: $onboarding-footer-height + 28px;
-}
-
 .domain-picker__suggestion-item {
 	input[type='radio'].domain-picker__suggestion-radio-button {
 		// Specific for WP-Admin environment.

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -10,7 +10,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Button, Tip } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import { useEntityProp } from '@wordpress/core-data';
-import { Title, SubTitle } from '@automattic/onboarding';
+import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
 import {
 	CheckoutStepBody,
 	checkoutTheme,
@@ -33,7 +33,7 @@ import './styles.scss';
 
 const TickIcon = <Icon icon={ check } size={ 17 } />;
 
-const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) => {
+const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, onPrevStep } ) => {
 	const domain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
 	const plan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
 	const planPrices = useSelect( ( select ) => select( PLANS_STORE ).getPrices() );
@@ -127,6 +127,10 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } )
 		</div>
 	);
 
+	const handlePrev = () => {
+		onPrevStep?.();
+	};
+
 	return (
 		<LaunchStepContainer>
 			<div className="nux-launch-step__header">
@@ -206,6 +210,11 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } )
 						</CheckoutStepAreaWrapper>
 					</MainContentWrapper>
 				</ThemeProvider>
+			</div>
+			<div className="nux-launch-step__footer">
+				<ActionButtons sticky={ true }>
+					<BackButton onClick={ handlePrev } />
+				</ActionButtons>
 			</div>
 		</LaunchStepContainer>
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -128,7 +128,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } )
 	);
 
 	return (
-		<LaunchStepContainer className="nux-launch-final-step">
+		<LaunchStepContainer>
 			<div className="nux-launch-step__header">
 				<div>
 					<Title>{ __( 'Launch your site', 'full-site-editing' ) }</Title>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { __ } from '@wordpress/i18n';
 import { TextControl, Tip } from '@wordpress/components';
-import { Title, SubTitle, ActionButtons, NextButton } from '@automattic/onboarding';
+import { Title, SubTitle, ActionButtons, BackButton, NextButton } from '@automattic/onboarding';
 
 /**
  * Internal dependencies
@@ -13,12 +13,16 @@ import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step
 import { useTitle } from '../../hooks';
 import './styles.scss';
 
-const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) => {
+const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
 	const { title, updateTitle, saveTitle } = useTitle();
 
 	const handleNext = () => {
 		saveTitle();
 		onNextStep?.();
+	};
+
+	const handlePrev = () => {
+		onPrevStep?.();
 	};
 
 	const handleBlur = () => saveTitle();
@@ -30,7 +34,8 @@ const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) 
 					<Title>{ __( 'Name your site', 'full-site-editing' ) }</Title>
 					<SubTitle>{ __( 'Pick a name for your site.', 'full-site-editing' ) }</SubTitle>
 				</div>
-				<ActionButtons>
+				<ActionButtons stickyBreakpoint="medium">
+					<BackButton onClick={ handlePrev } />
 					<NextButton onClick={ handleNext } disabled={ ! title?.trim() } />
 				</ActionButtons>
 			</div>
@@ -48,11 +53,11 @@ const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) 
 						autoCorrect="off"
 						data-hj-whitelist
 					/>
-					<p className="nux-launch-step__input-hint">
+					<div className="nux-launch-step__input-hint">
 						<Tip size={ 18 } />
 						{ /* translators: The "it" here refers to the site title. */ }
 						<span>{ __( "Don't worry, you can change it later.", 'full-site-editing' ) }</span>
-					</p>
+					</div>
 				</form>
 			</div>
 		</LaunchStepContainer>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
@@ -34,8 +34,7 @@ const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 					<Title>{ __( 'Name your site', 'full-site-editing' ) }</Title>
 					<SubTitle>{ __( 'Pick a name for your site.', 'full-site-editing' ) }</SubTitle>
 				</div>
-				<ActionButtons stickyBreakpoint="medium">
-					<BackButton onClick={ handlePrev } />
+				<ActionButtons sticky={ false }>
 					<NextButton onClick={ handleNext } disabled={ ! title?.trim() } />
 				</ActionButtons>
 			</div>
@@ -59,6 +58,12 @@ const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 						<span>{ __( "Don't worry, you can change it later.", 'full-site-editing' ) }</span>
 					</div>
 				</form>
+			</div>
+			<div className="nux-launch-step__footer">
+				<ActionButtons sticky={ true }>
+					<BackButton onClick={ handlePrev } />
+					<NextButton onClick={ handleNext } disabled={ ! title?.trim() } />
+				</ActionButtons>
 			</div>
 		</LaunchStepContainer>
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
@@ -28,7 +28,7 @@ const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 	const handleBlur = () => saveTitle();
 
 	return (
-		<LaunchStepContainer className="nux-launch-name-step">
+		<LaunchStepContainer>
 			<div className="nux-launch-step__header">
 				<div>
 					<Title>{ __( 'Name your site', 'full-site-editing' ) }</Title>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -14,6 +14,7 @@ import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboardi
 import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
 import { LAUNCH_STORE } from '../../stores';
 import { useSite } from '../../hooks';
+import './styles.scss';
 
 const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
 	const domain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -6,7 +6,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Plans } from '@automattic/data-stores';
 import PlansGrid from '@automattic/plans-grid';
-import { Title, SubTitle } from '@automattic/onboarding';
+import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step
 import { LAUNCH_STORE } from '../../stores';
 import { useSite } from '../../hooks';
 
-const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) => {
+const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
 	const domain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
 	const LaunchStep = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchStep() );
 	const { isExperimental } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
@@ -29,6 +29,10 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) 
 	const handleSelect = ( planSlug: Plans.PlanSlug ) => {
 		updatePlan( planSlug );
 		onNextStep?.();
+	};
+
+	const handlePrev = () => {
+		onPrevStep?.();
 	};
 
 	const handlePickDomain = () => {
@@ -47,6 +51,9 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) 
 						) }
 					</SubTitle>
 				</div>
+				<ActionButtons stickyBreakpoint="medium">
+					<BackButton onClick={ handlePrev } />
+				</ActionButtons>
 			</div>
 			<div className="nux-launch-step__body">
 				<PlansGrid

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -40,7 +40,7 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 	};
 
 	return (
-		<LaunchStepContainer className="nux-launch-plan-step">
+		<LaunchStepContainer>
 			<div className="nux-launch-step__header">
 				<div>
 					<Title>{ __( 'Select a plan', 'full-site-editing' ) }</Title>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -51,9 +51,6 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 						) }
 					</SubTitle>
 				</div>
-				<ActionButtons stickyBreakpoint="medium">
-					<BackButton onClick={ handlePrev } />
-				</ActionButtons>
 			</div>
 			<div className="nux-launch-step__body">
 				<PlansGrid
@@ -73,6 +70,11 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 					isExperimental={ isExperimental }
 					selectedFeatures={ selectedFeatures }
 				/>
+			</div>
+			<div className="nux-launch-step__footer">
+				<ActionButtons sticky={ true }>
+					<BackButton onClick={ handlePrev } />
+				</ActionButtons>
 			</div>
 		</LaunchStepContainer>
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
@@ -1,0 +1,8 @@
+@import '~@automattic/onboarding/styles/mixins';
+
+.nux-launch-modal.step-plan {
+	.plans-grid__details-container {
+		position: relative;
+		@include onboarding-block-edge2edge-container;
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
@@ -1,6 +1,12 @@
 @import '~@automattic/onboarding/styles/mixins';
 
 .nux-launch-modal.step-plan {
+	// Remove extraneous whitespace after plans details.
+	.nux-launch-step__body,
+	.plans-grid {
+		margin-bottom: 0;
+	}
+
 	.plans-grid__details-container {
 		position: relative;
 		@include onboarding-block-edge2edge-container;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch/index.tsx
@@ -27,7 +27,7 @@ const Launch: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		select( LAUNCH_STORE ).getFirstIncompleteStep()
 	);
 
-	const { setStep } = useDispatch( LAUNCH_STORE );
+	const { setStep, setSidebarFullscreen, unsetSidebarFullscreen } = useDispatch( LAUNCH_STORE );
 
 	const LaunchStepComponents = {
 		[ LaunchStep.Name ]: NameStep,
@@ -42,6 +42,7 @@ const Launch: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		let prevSequence = currentSequence - 1;
 		if ( prevSequence < 0 ) {
 			prevSequence = 0;
+			setSidebarFullscreen();
 		}
 		setStep( LaunchSequence[ prevSequence ] );
 	};
@@ -52,6 +53,7 @@ const Launch: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		if ( nextSequence > maxSequence ) {
 			onSubmit?.();
 		}
+		unsetSidebarFullscreen();
 		setStep( LaunchSequence[ nextSequence ] );
 	};
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch/index.tsx
@@ -65,11 +65,7 @@ const Launch: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		}
 	}, [] );
 
-	return (
-		<div className="nux-launch">
-			<CurrentLaunchStep onPrevStep={ handlePrevStep } onNextStep={ handleNextStep } />
-		</div>
-	);
+	return <CurrentLaunchStep onPrevStep={ handlePrevStep } onNextStep={ handleNextStep } />;
 };
 
 export default Launch;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch/index.tsx
@@ -63,6 +63,7 @@ const Launch: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		if ( firstIncompleteStep && firstIncompleteStep !== LaunchStep.Name ) {
 			setStep( firstIncompleteStep );
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	return <CurrentLaunchStep onPrevStep={ handlePrevStep } onNextStep={ handleNextStep } />;

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/stripe-nudge.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/stripe-nudge.js
@@ -64,8 +64,6 @@ export default compose( [
 		 * Complicated to define the valid type with JSDoc
 		 *
 		 * @param dispatch
-		 * @param root0
-		 * @param root0.stripeConnectUrl
 		 */
 		// @ts-ignore
 		( dispatch, { stripeConnectUrl } ) => ( {

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/stripe-nudge.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/stripe-nudge.js
@@ -64,6 +64,8 @@ export default compose( [
 		 * Complicated to define the valid type with JSDoc
 		 *
 		 * @param dispatch
+		 * @param root0
+		 * @param root0.stripeConnectUrl
 		 */
 		// @ts-ignore
 		( dispatch, { stripeConnectUrl } ) => ( {

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -72,10 +72,9 @@ const copyStylesToIframe = ( srcDocument, targetiFrameDocument ) => {
  * @param {object} props.className CSS class to apply to component
  * @param {string} props.bodyClassName CSS class to apply to the iframe's `<body>` tag
  * @param {number} props.viewportWidth pixel width of the viewable size of the preview
- * @param {Array} props.blocks array of Gutenberg Block objects
+ * @param {Array}  props.blocks array of Gutenberg Block objects
  * @param {object} props.settings block Editor settings object
  * @param {Function} props.setTimeout safe version of window.setTimeout via `withSafeTimeout`
- * @param props.title
  */
 const BlockFramePreview = ( {
 	className = 'block-iframe-preview',

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -72,9 +72,10 @@ const copyStylesToIframe = ( srcDocument, targetiFrameDocument ) => {
  * @param {object} props.className CSS class to apply to component
  * @param {string} props.bodyClassName CSS class to apply to the iframe's `<body>` tag
  * @param {number} props.viewportWidth pixel width of the viewable size of the preview
- * @param {Array}  props.blocks array of Gutenberg Block objects
+ * @param {Array} props.blocks array of Gutenberg Block objects
  * @param {object} props.settings block Editor settings object
  * @param {Function} props.setTimeout safe version of window.setTimeout via `withSafeTimeout`
+ * @param props.title
  */
 const BlockFramePreview = ( {
 	className = 'block-iframe-preview',

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -92,6 +92,7 @@
 		"@automattic/format-currency": "^1.0.0-alpha.0",
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/plans-grid": "^1.0.0-alpha.0",
+		"@automattic/react-i18n": "^1.0.0-alpha.0",
 		"@automattic/typography": "^1.0.0",
 		"@babel/core": "^7.11.1",
 		"@testing-library/jest-dom": "^5.9.0",

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -754,10 +754,17 @@ function getGutenboardingStatus( calypsoPort ) {
 		[ port2 ]
 	);
 	port1.onmessage = ( { data } ) => {
-		const { isGutenboarding, frankenflowUrl, isNewLaunch, isExperimental } = data;
+		const {
+			isGutenboarding,
+			frankenflowUrl,
+			isNewLaunch,
+			isNewLaunchMobile,
+			isExperimental,
+		} = data;
 		calypsoifyGutenberg.isGutenboarding = isGutenboarding;
 		calypsoifyGutenberg.frankenflowUrl = frankenflowUrl;
 		calypsoifyGutenberg.isNewLaunch = isNewLaunch;
+		calypsoifyGutenberg.isNewLaunchMobile = isNewLaunchMobile;
 		calypsoifyGutenberg.isExperimental = isExperimental;
 		// Hook necessary if message recieved after editor has loaded.
 		window.wp.hooks.doAction( 'setGutenboardingStatus', isGutenboarding );

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -764,6 +764,18 @@ function getGutenboardingStatus( calypsoPort ) {
 	};
 }
 
+function handleLaunchModal( calypsoPort ) {
+	subscribe( () => {
+		const { isSidebarOpen } = select( 'automattic/launch' ).getState();
+
+		// Hide inline help when launch modal is open
+		calypsoPort.postMessage( {
+			action: 'toggleInlineHelp',
+			payload: { hidden: isSidebarOpen },
+		} );
+	} );
+}
+
 /**
  * Hooks the nav sidebar to change some of its button labels and behaviour.
  *
@@ -1034,6 +1046,8 @@ function initPort( message ) {
 		getCloseButtonUrl( calypsoPort );
 
 		getGutenboardingStatus( calypsoPort );
+
+		handleLaunchModal( calypsoPort );
 
 		getNavSidebarLabels( calypsoPort );
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -368,12 +368,14 @@ class CalypsoifyIframe extends Component<
 				this.props.siteCreationFlow === 'gutenboarding' && this.props.isSiteUnlaunched;
 			const frankenflowUrl = `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteSlug }&source=editor`;
 			const isNewLaunch = config.isEnabled( 'gutenboarding/new-launch' );
+			const isNewLaunchMobile = config.isEnabled( 'gutenboarding/new-launch-mobile' );
 			const isExperimental = config.isEnabled( 'gutenboarding/feature-picker' );
 
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
 				frankenflowUrl,
 				isNewLaunch,
+				isNewLaunchMobile,
 				isExperimental,
 			} );
 		}

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -114,6 +114,7 @@ enum EditorActions {
 	GetCloseButtonUrl = 'getCloseButtonUrl',
 	LogError = 'logError',
 	GetGutenboardingStatus = 'getGutenboardingStatus',
+	ToggleInlineHelp = 'toggleInlineHelp',
 	GetNavSidebarLabels = 'getNavSidebarLabels',
 	GetCalypsoUrlInfo = 'getCalypsoUrlInfo',
 	TrackPerformance = 'trackPerformance',
@@ -375,6 +376,12 @@ class CalypsoifyIframe extends Component<
 				isNewLaunch,
 				isExperimental,
 			} );
+		}
+
+		if ( EditorActions.ToggleInlineHelp === action ) {
+			const inlineHelp = window.top.document.querySelector( '#wpcom > .layout > .inline-help' );
+			const { hidden } = payload;
+			inlineHelp.hidden = hidden;
 		}
 
 		if ( EditorActions.GetNavSidebarLabels === action ) {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -11,9 +11,9 @@ import { localize, LocalizeProps } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import AsyncLoad from 'components/async-load';
-import MediaStore from 'lib/media/store';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import AsyncLoad from 'calypso/components/async-load';
+import MediaStore from 'calypso/lib/media/store';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
 	getCustomizerUrl,
 	getSiteOption,
@@ -21,40 +21,46 @@ import {
 	isRequestingSite,
 	isJetpackSite,
 	getSite,
-} from 'state/sites/selectors';
-import { addQueryArgs } from 'lib/route';
+} from 'calypso/state/sites/selectors';
+import { addQueryArgs } from 'calypso/lib/route';
 import { getEnabledFilters, getDisabledDataSources, mediaCalypsoToGutenberg } from './media-utils';
-import { replaceHistory, navigate } from 'state/ui/actions';
-import { clearLastNonEditorRoute, setRoute } from 'state/route/actions';
-import { updateSiteFrontPage } from 'state/sites/actions';
-import getCurrentRoute from 'state/selectors/get-current-route';
-import getPostTypeTrashUrl from 'state/selectors/get-post-type-trash-url';
-import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
-import { getSelectedEditor } from 'state/selectors/get-selected-editor';
-import getEditorCloseConfig from 'state/selectors/get-editor-close-config';
-import wpcom from 'lib/wp';
-import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
-import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
-import { setEditorIframeLoaded, startEditingPost } from 'state/editor/actions';
-import { notifyDesktopViewPostClicked, notifyDesktopCannotOpenEditor } from 'state/desktop/actions';
+import { replaceHistory, navigate } from 'calypso/state/ui/actions';
+import { clearLastNonEditorRoute, setRoute } from 'calypso/state/route/actions';
+import { updateSiteFrontPage } from 'calypso/state/sites/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getPostTypeTrashUrl from 'calypso/state/selectors/get-post-type-trash-url';
+import getGutenbergEditorUrl from 'calypso/state/selectors/get-gutenberg-editor-url';
+import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
+import getEditorCloseConfig from 'calypso/state/selectors/get-editor-close-config';
+import wpcom from 'calypso/lib/wp';
+import EditorRevisionsDialog from 'calypso/post-editor/editor-revisions/dialog';
+import { openPostRevisionsDialog } from 'calypso/state/posts/revisions/actions';
+import { setEditorIframeLoaded, startEditingPost } from 'calypso/state/editor/actions';
+import {
+	notifyDesktopViewPostClicked,
+	notifyDesktopCannotOpenEditor,
+} from 'calypso/state/desktop/actions';
 import { Placeholder } from './placeholder';
-import WebPreview from 'components/web-preview';
-import { editPost, trashPost } from 'state/posts/actions';
-import { getEditorPostId } from 'state/editor/selectors';
-import { protectForm, ProtectedFormProps } from 'lib/protect-form';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import config from 'config';
-import EditorDocumentHead from 'post-editor/editor-document-head';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
-import { withStopPerformanceTrackingProp, PerformanceTrackProps } from 'lib/performance-tracking';
-import { REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE } from 'state/desktop/window-events';
-import { setMediaLibrarySelectedItems } from 'state/media/actions';
-import { fetchMediaItem, getMediaItem } from 'state/media/thunks';
+import WebPreview from 'calypso/components/web-preview';
+import { editPost, trashPost } from 'calypso/state/posts/actions';
+import { getEditorPostId } from 'calypso/state/editor/selectors';
+import { protectForm, ProtectedFormProps } from 'calypso/lib/protect-form';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import config from 'calypso/config';
+import EditorDocumentHead from 'calypso/post-editor/editor-document-head';
+import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
+import {
+	withStopPerformanceTrackingProp,
+	PerformanceTrackProps,
+} from 'calypso/lib/performance-tracking';
+import { REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE } from 'calypso/state/desktop/window-events';
+import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
+import { fetchMediaItem, getMediaItem } from 'calypso/state/media/thunks';
 import Iframe from './iframe';
 /**
  * Types
  */
-import * as T from 'types';
+import * as T from 'calypso/types';
 
 /**
  * Style dependencies
@@ -730,7 +736,7 @@ class CalypsoifyIframe extends Component<
 					) }
 				</div>
 				<AsyncLoad
-					require="post-editor/editor-media-modal"
+					require="calypso/post-editor/editor-media-modal"
 					placeholder={ null }
 					disabledDataSources={ getDisabledDataSources( allowedTypes ) }
 					enabledFilters={ getEnabledFilters( allowedTypes ) }
@@ -744,7 +750,7 @@ class CalypsoifyIframe extends Component<
 				/>
 				{ isCheckoutOverlayEnabled && isCheckoutModalVisible && (
 					<AsyncLoad
-						require="blocks/editor-checkout-modal"
+						require="calypso/blocks/editor-checkout-modal"
 						onClose={ this.closeCheckoutModal }
 						isOpen={ isCheckoutModalVisible }
 						cartData={ cartData }

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -93,7 +93,7 @@ interface State {
 	multiple?: any;
 	postUrl?: T.URL;
 	previewUrl: T.URL;
-	cartData?: object;
+	cartData?: any;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -599,6 +599,7 @@ class CalypsoifyIframe extends Component<
 
 	closePreviewModal = () => this.setState( { isPreviewVisible: false } );
 
+	/* eslint-disable @typescript-eslint/ban-types */
 	openCustomizer = ( autofocus: object, unsavedChanges: boolean ) => {
 		let { customizerUrl } = this.props;
 		if ( autofocus ) {

--- a/client/landing/gutenboarding/components/titles.scss
+++ b/client/landing/gutenboarding/components/titles.scss
@@ -2,16 +2,7 @@
 @import '../mixins';
 
 .gutenboarding-title {
-	@include onboarding-heading-text-mobile;
-	color: var( --mainColor );
-
-	@include break-mobile {
-		@include onboarding-heading-text-tablet;
-	}
-
-	@include break-xlarge {
-		@include onboarding-heading-text;
-	}
+	@include onboarding-heading-title;
 }
 
 .gutenboarding-subtitle {

--- a/config/development.json
+++ b/config/development.json
@@ -66,6 +66,7 @@
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch": true,
+		"gutenboarding/new-launch-mobile": false,
 		"gutenboarding/show-vertical-input": false,
 		"help": true,
 		"help/courses": true,

--- a/packages/onboarding/src/action-buttons/index.tsx
+++ b/packages/onboarding/src/action-buttons/index.tsx
@@ -11,21 +11,27 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import './style.scss';
 
-// TODO: I would rather if this is sticky: true/false/null. When null, it sticks when breakpoint is small.
 interface ActionButtonsProps {
 	className?: string;
-	stickyBreakpoint?: string;
+	sticky?: boolean | null;
 }
 
 const ActionButtons: React.FunctionComponent< ActionButtonsProps > = ( {
 	className,
 	children,
-	stickyBreakpoint = 'small',
-} ) => (
-	<div className={ classnames( 'action-buttons', className, `stick-${ stickyBreakpoint }` ) }>
-		{ children }
-	</div>
-);
+	sticky = null,
+} ) => {
+	// if null, auto-stick (stick when small).
+	// if true, always stick.
+	// if false, never stick.
+	let stickyClass = '';
+	if ( sticky === true ) stickyClass = 'is-sticky';
+	if ( sticky === false ) stickyClass = 'no-sticky';
+
+	return (
+		<div className={ classnames( 'action-buttons', className, stickyClass ) }>{ children }</div>
+	);
+};
 
 export default ActionButtons;
 

--- a/packages/onboarding/src/action-buttons/index.tsx
+++ b/packages/onboarding/src/action-buttons/index.tsx
@@ -11,14 +11,21 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import './style.scss';
 
+// TODO: I would rather if this is sticky: true/false/null. When null, it sticks when breakpoint is small.
 interface ActionButtonsProps {
 	className?: string;
+	stickyBreakpoint?: string;
 }
 
 const ActionButtons: React.FunctionComponent< ActionButtonsProps > = ( {
 	className,
 	children,
-} ) => <div className={ classnames( 'action-buttons', className ) }>{ children }</div>;
+	stickyBreakpoint = 'small',
+} ) => (
+	<div className={ classnames( 'action-buttons', className, `stick-${ stickyBreakpoint }` ) }>
+		{ children }
+	</div>
+);
 
 export default ActionButtons;
 

--- a/packages/onboarding/src/action-buttons/style.scss
+++ b/packages/onboarding/src/action-buttons/style.scss
@@ -16,7 +16,9 @@
 	align-items: center;
 	z-index: onboarding-z-index( '.onboarding__footer' );
 
-	@include break-small {
+	// TODO: This introduces duplication (and only limited to small & medium). Determine breakpoint via JS and use a class to toggle sticky mode.
+
+	@mixin not-sticky {
 		padding: 0;
 		margin-left: 20px;
 		position: static;
@@ -28,6 +30,18 @@
 			&:first-child {
 				margin-left: 0;
 			}
+		}
+	}
+
+	&.stick-small {
+		@include break-small {
+			@include not-sticky;
+		}
+	}
+
+	&.stick-medium {
+		@include break-medium {
+			@include not-sticky;
 		}
 	}
 }

--- a/packages/onboarding/src/action-buttons/style.scss
+++ b/packages/onboarding/src/action-buttons/style.scss
@@ -16,9 +16,7 @@
 	align-items: center;
 	z-index: onboarding-z-index( '.onboarding__footer' );
 
-	// TODO: This introduces duplication (and only limited to small & medium). Determine breakpoint via JS and use a class to toggle sticky mode.
-
-	@mixin not-sticky {
+	@mixin unstick {
 		padding: 0;
 		margin-left: 20px;
 		position: static;
@@ -33,16 +31,14 @@
 		}
 	}
 
-	&.stick-small {
+	&:not( .is-sticky ) {
 		@include break-small {
-			@include not-sticky;
+			@include unstick;
 		}
 	}
 
-	&.stick-medium {
-		@include break-medium {
-			@include not-sticky;
-		}
+	&.no-sticky {
+		@include unstick;
 	}
 }
 

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -63,14 +63,17 @@
 }
 
 @mixin onboarding-block-margin {
-	margin: 0 $onboarding-block-margin-mobile;
+	margin-left: $onboarding-block-margin-mobile;
+	margin-right: $onboarding-block-margin-mobile;
 
 	@include break-small {
-		margin: 0 $onboarding-block-margin-small;
+		margin-left: $onboarding-block-margin-small;
+		margin-right: $onboarding-block-margin-small;
 	}
 
 	@include break-medium {
-		margin: 0 $onboarding-block-margin-medium;
+		margin-left: $onboarding-block-margin-medium;
+		margin-right: $onboarding-block-margin-medium;
 	}
 }
 

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -120,21 +120,32 @@
 	background: var( --studio-white );
 }
 
-@mixin onboarding-block-edge2edge-container {
-	width: calc( 100% + #{$onboarding-block-margin-mobile * 2} );
+@mixin onboarding-block-edge2edge {
 	margin-left: #{$onboarding-block-margin-mobile * -1};
 	margin-right: #{$onboarding-block-margin-mobile * -1};
 
 	@include break-small {
-		width: calc( 100% + #{$onboarding-block-margin-small * 2} );
 		margin-left: #{$onboarding-block-margin-small * -1};
 		margin-right: #{$onboarding-block-margin-small * -1};
 	}
 
 	@include break-medium {
-		width: calc( 100% + #{$onboarding-block-margin-medium * 2} );
 		margin-left: #{$onboarding-block-margin-medium * -1};
 		margin-right: #{$onboarding-block-margin-medium * -1};
+	}
+}
+
+@mixin onboarding-block-edge2edge-container {
+	@include onboarding-block-edge2edge;
+
+	width: calc( 100% + #{$onboarding-block-margin-mobile * 2} );
+
+	@include break-small {
+		width: calc( 100% + #{$onboarding-block-margin-small * 2} );
+	}
+
+	@include break-medium {
+		width: calc( 100% + #{$onboarding-block-margin-medium * 2} );
 	}
 }
 

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -88,6 +88,16 @@
 		margin: $onboarding-heading-margin-medium;
 	}
 }
+
+@mixin onboarding-body-margin {
+	margin: $onboarding-body-margin-mobile;
+
+	@include break-small {
+		margin: $onboarding-body-margin-small;
+	}
+
+	@include break-medium {
+		margin: $onboarding-body-margin-medium;
 	}
 }
 

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -9,23 +9,40 @@
 
 @mixin onboarding-heading-text {
 	@include onboarding-font-recoleta;
+	/* stylelint-disable-line */
 	font-size: 42px;
 	line-height: 57px;
 }
 
 @mixin onboarding-heading-text-tablet {
 	@include onboarding-font-recoleta;
+	/* stylelint-disable-line */
 	font-size: 36px;
 	line-height: 40px;
 }
 
 @mixin onboarding-heading-text-mobile {
 	@include onboarding-font-recoleta;
+	/* stylelint-disable-line */
 	font-size: 32px;
 	line-height: 40px;
 }
 
+@mixin onboarding-heading-title {
+	@include onboarding-heading-text-mobile;
+	color: var( --mainColor );
+
+	@include break-mobile {
+		@include onboarding-heading-text-tablet;
+	}
+
+	@include break-xlarge {
+		@include onboarding-heading-text;
+	}
+}
+
 @mixin onboarding-large-text {
+	/* stylelint-disable-line */
 	font-size: 16px;
 	line-height: 24px;
 }

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -78,10 +78,16 @@
 }
 
 @mixin onboarding-heading-padding {
-	margin: $onboarding-heading-padding-mobile;
+	margin: $onboarding-heading-margin-mobile;
 
-	@include break-mobile {
-		margin: $onboarding-heading-padding-desktop;
+	@include break-small {
+		margin: $onboarding-heading-margin-small;
+	}
+
+	@include break-medium {
+		margin: $onboarding-heading-margin-medium;
+	}
+}
 	}
 }
 

--- a/packages/onboarding/styles/variables.scss
+++ b/packages/onboarding/styles/variables.scss
@@ -13,3 +13,8 @@ $onboarding-block-margin-medium: 96px;
 $onboarding-heading-margin-mobile: 48px 0 ( 48px * 0.8 );
 $onboarding-heading-margin-small: 64px 0 ( 64px * 0.8 );
 $onboarding-heading-margin-medium: 80px 0 ( 80px * 0.8 );
+
+// Body margins increment by 16px
+$onboarding-body-margin-mobile: 0 0 48px 0;
+$onboarding-body-margin-small: 0 0 64px 0;
+$onboarding-body-margin-medium: 0 0 80px 0;

--- a/packages/onboarding/styles/variables.scss
+++ b/packages/onboarding/styles/variables.scss
@@ -5,6 +5,8 @@ $onboarding-header-height: $header-height;
 $onboarding-footer-height: $header-height;
 $onboarding-heading-padding-desktop: 64px 0 80px;
 $onboarding-heading-padding-mobile: 44px 0 50px;
-$onboarding-block-margin-mobile: 20px;
-$onboarding-block-margin-small: 44px;
-$onboarding-block-margin-medium: 88px;
+
+// Block margins increment by 2x
+$onboarding-block-margin-mobile: 24px;
+$onboarding-block-margin-small: 48px;
+$onboarding-block-margin-medium: 96px;

--- a/packages/onboarding/styles/variables.scss
+++ b/packages/onboarding/styles/variables.scss
@@ -3,10 +3,13 @@
 // Reusable style variables
 $onboarding-header-height: $header-height;
 $onboarding-footer-height: $header-height;
-$onboarding-heading-padding-desktop: 64px 0 80px;
-$onboarding-heading-padding-mobile: 44px 0 50px;
 
 // Block margins increment by 2x
 $onboarding-block-margin-mobile: 24px;
 $onboarding-block-margin-small: 48px;
 $onboarding-block-margin-medium: 96px;
+
+// Heading margins increment by 16px
+$onboarding-heading-margin-mobile: 48px 0 ( 48px * 0.8 );
+$onboarding-heading-margin-small: 64px 0 ( 64px * 0.8 );
+$onboarding-heading-margin-medium: 80px 0 ( 80px * 0.8 );


### PR DESCRIPTION
## Changes proposed in this Pull Request

**Visual changes:**
- **Show launch sidebar as fullscreen on mobile. **
  The sidebar is always shown first before continuing to the next uncompleted step on mobile.
- **Added sticky footer for all launch steps.**
 This includes **Go Back** button on all launch steps.
- **Added `<LaunchProgress>` component. **
  This shows the (1 of 4, 2 of 4, ...) text on the header. 
- **Hide inline help button (blue round question mark button on the bottom right corner) when launch modal is open. **
  This was blocking the buttons on the sticky footer.

**Technical changes:**
- **Added `sticky=true|false|null` prop on `<ActionButtons>` component. **
  This forces action buttons to be sticky all the time, not sticky all the time or automatically sticky on small viewport.
- **Added `onMenuItemClick` event on `<LaunchMenu>` component.**
  The fullscreen sidebar hides itself when a launch menu is clicked on.
- **Added `isSidebarFullscreen` reducer and `(set|unset)SidebarFullscreen` actions.**
- **Reduce nested divs where possible.**
   To fix all sticky header/footer + scrollbar quirks, nested divs were removed where possible to help make this easier to work with.
- **SASS changes:**
  - Added mixins `onboarding-heading-title`, `onboarding-body-margin` & `onboarding-block-edge2edge`.
  - Proporionate scaling for `$onboarding-(block|heading|body)-margin-(mobile|small|medium)`.

**Fixes:**
- Fix nested `<p>` tag warning when name step is rendered.

**Design Deviations:**
- On mobile view, a 1px bottom border is added to the sticky header. This creates a clearer separation between header and body.
- On desktop view, the header (where the wordpress logo is) is no longer sticky. This is to simplify handling of overflowing content / scrollbar.

## Testing instructions

**How to build:**
* On root folder, run `yarn start`.
* On `apps/full-site-editing`, run `yarn dev --sync`.
* On `apps/wpcom-block-editor`, run `yarn dev --sync`.

**How to test:**
* Point `widgets.wp.com` to your sandbox.
* Create an unlaunched test site using Gutenboarding (`/new`)
* Test on local calypso with the flag appended to the end of the url `?flags=gutenboarding/new-launch-mobile` flag, e.g. `calypso.localhost:3000/block-editor/page/UNLAUNCHED_SITE_HERE.wordpress.com/home?flags=gutenboarding/new-launch-mobile`

**What to test:**
* When `gutenboarding/new-launch-mobile` flag is enabled, it should show the launch flow in mobile.
* Test all **Go back** and **Continue** buttons on sticky footer.
* Test launch flow mobile view in various viewport width & height.
  - Check if launch progress (1 of 4, 2 of 4, ...) is showing correctly.
  - Ensure inline help badge (blue round question mark button on the bottom right corner) is hidden when launch flow is 
opened.
  - Ensure there are no weird scrollbar quirks by testing on long content like plans step and short content like name step.
     - Also test on Firefox as Firefox scrollbar & clipping behaves differently.
  - Test on Safari iOS!
* Test launch flow desktop view to ensure there's no regression.
* Test onboarding flow `/new` both mobile & desktop to ensure there's no regression.

## Screenshots
![2020-09-22_10-57-41 (1)](https://user-images.githubusercontent.com/1287077/93862708-bd6b4400-fcc2-11ea-91c3-39919629f4b4.gif)

Fixes https://github.com/Automattic/wp-calypso/issues/44692
