### PR TITLE
Add lighthouse team workflow

### DIFF
--- a/.github/workflows/lighthouse-review-requested.yml
+++ b/.github/workflows/lighthouse-review-requested.yml
@@ -1,0 +1,38 @@
+name: Lighthouse Review Requested
+
+on:
+  pull_request:
+    types: [review_requested]
+
+jobs:
+  add_review_label:
+    runs-on: ubuntu-latest
+    name: Add P2 labels and project
+    steps:
+      - name: Add label "Needs Review"
+        if: ${{ contains(github.event.pull_request.requested_teams.*.name, 'Lighthouse') }}
+        run: |
+          curl --request POST \
+          --url 'https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels' \
+          --header 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'Accept: application/vnd.github.v3+json' \
+          --data-raw '{"labels":["[Status] Needs Review"]}'
+
+      - name: Add author as assignee
+        if: ${{ contains(github.event.pull_request.requested_teams.*.name, 'Lighthouse') }}
+        run: |
+          curl --request PATCH \
+          --url 'https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}' \
+          --header 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'Accept: application/vnd.github.v3+json' \
+          --data-raw '{"assignees": [ "${{ github.event.pull_request.user.login }}" ]}'
+
+      - name: Add to P2 project board
+        if: ${{ contains(github.event.pull_request.requested_teams.*.name, 'Lighthouse') }}
+        run: |
+          curl --request POST \
+            --url 'https://api.github.com/projects/columns/8374542/cards' \
+            --header 'Accept: application/vnd.github.inertia-preview+json' \
+            --header 'Authorization: token ${{ secrets.AUTOMATTIC_FINANCE }}' \
+            --header 'Content-Type: application/json; charset=utf-8' \
+            --data-raw '{"content_type": "PullRequest", "content_id": ${{ github.event.pull_request.id }}}'


### PR DESCRIPTION
## Overview
Github actions for PR, whenever Lighthouse team is requested as a reviewer it will automatically

- Add "Needs Review" label
- Add the PR to our "Productize P2" board under "Needs Review" column
- Assign the author to the PR

## Testing
- Remove "Needs Review" label
- Remove PR from Project
- Unassign PR
- Remove "Lighthouse" from Reviewers and add it back