### PR TITLE
Gutenboarding: align domain feature and plan recommendation

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -57,7 +57,6 @@ interface Cart {
 
 export default function useOnSiteCreation() {
 	const { domain } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
-	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
 	const isRedirecting = useSelect( ( select ) => select( ONBOARD_STORE ).getIsRedirecting() );
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
@@ -133,7 +132,6 @@ export default function useOnSiteCreation() {
 		}
 	}, [
 		domain,
-		hasPaidDomain,
 		selectedPlan,
 		isRedirecting,
 		newSite,

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -29,24 +29,15 @@ export function useSelectedPlan() {
 		select( PLANS_STORE ).getPlanBySlug( recommendedPlanSlug )
 	);
 
-	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
-	const hasPaidDesign = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDesign() );
-
-	const defaultPaidPlan = useSelect( ( select ) => select( PLANS_STORE ).getDefaultPaidPlan() );
-
 	const planFromPath = usePlanFromPath();
-
-	// Use recommendedPlan with priority over the plan derived from domain and design selection
-	const defaultPlan =
-		recommendedPlan || ( ( hasPaidDomain || hasPaidDesign ) && defaultPaidPlan ) || undefined;
 
 	/**
 	 * Plan is decided in this order
 	 * 1. selected from PlansGrid (by dispatching setPlan)
 	 * 2. having the plan slug in the URL
-	 * 3. selecting features, a paid domain or design
+	 * 3. selecting paid features
 	 */
-	return selectedPlan || planFromPath || defaultPlan;
+	return selectedPlan || planFromPath || recommendedPlan;
 }
 
 export function useHasPaidPlanFromPath() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Use only selected features (on Features step) when suggesting a plan in top-right corner (Plans button).
* Keep using the Premium plan as popular on Plans step if no feature is selected.
Demo: https://cloudup.com/cVGGDgch0Zb

#### Testing instructions

* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-domain-feature-and-plan-recommendation)
* Pick a paid domain on Domains step => _Personal plan_ should appear in top-right corner instead of _View plans_.
* Deselect _Custom domains_ feature on Features step. _View plans_ should appear in top-right corner if no other feature is selected.

Fixes #45716
