### PR TITLE
Block Patterns: Track pattern insertion events

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -5,7 +5,7 @@
 import { use, select } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
 import { applyFilters } from '@wordpress/hooks';
-import { castArray, noop } from 'lodash';
+import { castArray, noop, isPlainObject } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -114,12 +114,21 @@ const getBlocksTracker = ( eventName ) => ( blockIds ) => {
  * Track block insertion.
  *
  * @param {object|Array} blocks block instance object or an array of such objects
+ * @param {Array} args additional insertBlocks data e.g. metadata containing pattern name.
  * @returns {void}
  */
-const trackBlockInsertion = ( blocks ) => {
+const trackBlockInsertion = ( blocks, ...args ) => {
+	const patternName =
+		4 === args.length && isPlainObject( args[ 3 ] ) ? args[ 3 ].patternName : undefined;
+
+	if ( patternName ) {
+		tracksRecordEvent( 'wpcom_pattern_inserted', { pattern_name: patternName } );
+	}
+
 	trackBlocksHandler( blocks, 'wpcom_block_inserted', ( { name } ) => ( {
 		block_name: name,
 		blocks_replaced: false,
+		pattern_name: patternName,
 	} ) );
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* With the new metadata additions given to the insertBlocks and replaceBlocks actions, we can determine when a block pattern is being inserted and record a Track event for this.

68-gh-view-design

#### Testing instructions

* Checkout this PR
* Build `wpcom-block-editor`
* Sync the built files to your sandbox's widget directory
* Also sync a build of Gutenberg `add/pattern-meta-to-replace-blocks` branch to the folder on your sandbox of the version the site is running, eg. `wp-content/plugins/gutenberg-core/9.0.0`
* Ensure you have `widgets.wp.com` sandboxed
* Visit a sandboxed site's block editor:
`https://YOUR-SANDBOX-DOMAIN/wp-admin/post.php?post=YOUR-POST-ID&action=edit`
* Open dev tools console and turn on tracking debugging via localStorage value:
`localStorage.setItem( 'debug', 'wpcom-block-editor:*' );`
* Reload the editor page
* Now add a block pattern to the page.
* In the console, you should see two events tracked `wpcom_pattern_inserted` & `wpcom_block_inserted`
<img width="1049" alt="Screen Shot 2020-09-17 at 6 56 45 pm" src="https://user-images.githubusercontent.com/60436221/93449054-9f46c200-f917-11ea-8171-98de55f02c8d.png">
* Now add an empty paragraph block to the post and click within it to leave the cursor inside the block.
* Now add another block pattern
* In the console, you should see the `replaceBlocks` action was triggered and another `wpcom_pattern_inserted` event.
<img width="970" alt="Screen Shot 2020-09-18 at 1 24 36 pm" src="https://user-images.githubusercontent.com/60436221/93552384-b5a25b80-f9b3-11ea-9776-20b8ce9faa83.png">

* After a couple of minutes the new `wpcom_pattern_inserted` event should also appear within the Tracks Live View
