### PR TITLE
[TeamCity] - Set node default version on the prepare job

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -154,8 +154,9 @@ object RunAllUnitTests : BuildType({
 				export npm_config_cache=${'$'}(yarn cache dir)
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --install
-				nvm use
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
+				nvm install
+				nvm alias default $(cat .nvmrc)
 
 				# Install modules
 				yarn install


### PR DESCRIPTION
### Changes

Update the "Prepare environment" to install node from `.nvmr`. Turns out `nvm.sh --install` installs the version configured as 'default' in nvm, not the version in `.nvmrc`.

The process is now:

- In prepare job:
    - Load `nvm.sh`, do not try to use .nvmrc (in case it points to a version not installed yet)
    - `nvm install` will install _and use_ the version indicated in `.nvmrc`
    - Set the version in `.nvmrc` as the default version for nvm.

- In other jobs (unchanged):
    - Load `nvm.sh`. Will try use the version from .nvmrc, which is already installed.

### Testing instructions

Validate that TeamCity build passes.
