### PR TITLE
Gutenboarding: remove free plan override

### DIFF
--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -22,7 +22,6 @@ export function useSelectedPlan() {
 	const selectedPlan = useSelect( ( select ) => select( ONBOARD_STORE ).getPlan() );
 
 	const recommendedPlan = useRecommendedPlan();
-	const isPlanFree = useSelect( ( select ) => select( PLANS_STORE ).isPlanFree );
 
 	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
 	const hasPaidDesign = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDesign() );
@@ -34,11 +33,6 @@ export function useSelectedPlan() {
 	// Use recommendedPlan with priority over the plan derived from domain and design selection
 	const defaultPlan =
 		recommendedPlan || ( ( hasPaidDomain || hasPaidDesign ) && defaultPaidPlan ) || undefined;
-
-	// If the selected plan is free and the user selection determines a paid plan, return the paid plan
-	if ( isPlanFree( selectedPlan?.storeSlug ) && defaultPlan ) {
-		return defaultPlan;
-	}
 
 	/**
 	 * Plan is decided in this order


### PR DESCRIPTION
* After https://github.com/Automattic/wp-calypso/pull/45693 Free plan couldn't be selected after the user selected some features on `/new/features` step.

#### Changes proposed in this Pull Request
* Removed the overriding of explicitly selected _Free plan_ when paid features are selected.

#### Testing instructions (main fix)
* Go to [/new](https://calypso.live/new?branch=fix/gutenboarding-free-site-creation).
* On `/new/features` step select some features.
* You'll notice a plan is recommended, but select the _Free plan_.
* After site creation you should land in editor (no checkout).

#### Testing instructions (side change: free plan override removal)
1. Go to https://wordpress.com/new/design?fresh.
2. Open the Plans modal (using the top-right _View plans_ button) and select _Free plan_.
3. Advance to `/new/features` and select some features => Plans buttons value will change.
4. Go to [/new/design](https://calypso.live/new/design?branch=fix/gutenboarding-free-site-creation).
5. When repeating steps 2 and 3 you'll notice Plans button value remains _Free plan_.