### PR TITLE
Styles: Load the @wordpress/components stylesheet

### DIFF
--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -18,3 +18,6 @@
 // Styles for the nav unification prototype (see pbAPfg-O2)
 // TODO: depending on project outcome move or delete styles
 @import './_nav-unification';
+
+// @wordpress/components stylesheet
+@import '~@wordpress/components/build-style/style.css';

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -32,6 +32,7 @@
 	display: block;
 	margin: 0 10px;
 	padding: 8px 34px 8px 50px;
+	height: auto;
 	border-radius: 0;
 	line-height: 1.5;
 	background-color: var( --color-surface );

--- a/client/post-editor/editor-deprecation-dialog/index.jsx
+++ b/client/post-editor/editor-deprecation-dialog/index.jsx
@@ -31,7 +31,6 @@ import { withLocalizedMoment } from 'components/localized-moment';
 /**
  * Style dependencies
  */
-import '@wordpress/components/build-style/style.css';
 import './style.scss';
 
 class EditorDeprecationDialog extends Component {


### PR DESCRIPTION
We've started using `@wordpress/components` for some components here and there in Calypso, but there is a fundamental issue with that: we're not loading any `@wordpress/components` styles yet. The reason is that the styles are decoupled from the package itself, and they're usually loaded through either of the following methods:

* Invoking `wp_enqueue_style()` directly or as a dependency of another enqueued stylesheet - for WP environments.
* Including the built stylesheet file in your app - for JS apps and non WP environments (like Calypso).

So this PR is including the stylesheet directly. This isn't a great solution, because that way we're including the entire stylesheet and don't benefit from tree shaking for those styles. However, improving that may and likely will require architectural changes in the way that the component styles are defined and consumed in the Gutenberg project. And this is a task for another time.

Finally, by including this stylesheet, we have to verify all the instances that use `@wordpress/components` already look well.

#### Changes proposed in this Pull Request

* Styles: Load the `@wordpress/components` stylesheet globally.
* Styles: Remove the `@wordpress/components` stylesheet from `EditorDeprecationDialog` as it'll now be loaded globally above.

#### Testing instructions

* Do a smoke testing around Calypso to verify components are looking unchanged.
* Go to `/read`.
* Enable the `shouldRenderAppPromo` prop inside `ReaderSidebarPromo` that lives at the bottom of the sidebar.
* Verify it looks good, as shown on the "After" screenshot:

Before fixing the button height after loading the `@wordpress/components` stylesheet:
![](https://cldup.com/0xZZE8IAV8.png)

After fixing the button height after loading the `@wordpress/components` stylesheet:
![](https://cldup.com/by5cmnp339.png)

* Go through [these steps](https://github.com/Automattic/wp-calypso/pull/45724#issuecomment-694188388) and verify the "Resend it" link looks good.
* Verify there are no other affected changes that can be seen/reproduced.

#### Notes

~cc @allendav @Automattic/hydra - any idea how we could repro the "Woo DNA" flow so we could test the magic login step? This also appears to be using `@wordpress/components`.~ Thanks to @DanReyLop for the testing instructions.

