### PR TITLE
Jetpack Pricing: Use dynamic getters for translatable constants

### DIFF
--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -65,6 +65,15 @@ export const MORE_FEATURES_LINK = {
 	label: translate( 'See all features' ),
 };
 
+/**
+ * Define properties with translatable strings getters.
+ */
+Object.defineProperties( MORE_FEATURES_LINK, {
+	label: {
+		get: () => translate( 'See all features' ),
+	},
+} );
+
 /*
  * Options displayed in the Product Type filter in the Plans page.
  */
@@ -82,6 +91,21 @@ export const PRODUCT_TYPE_OPTIONS = {
 		label: translate( 'All' ),
 	},
 };
+
+/**
+ * Define properties with translatable strings getters.
+ */
+Object.defineProperties( PRODUCT_TYPE_OPTIONS, {
+	[ SECURITY ]: {
+		get: () => translate( 'Security' ),
+	},
+	[ PERFORMANCE ]: {
+		get: () => translate( 'Performance' ),
+	},
+	[ ALL ]: {
+		get: () => translate( 'All' ),
+	},
+} );
 
 /**
  * Plans and products that have options and can't be purchased themselves.
@@ -148,6 +172,31 @@ export const OPTION_PLAN_SECURITY_MONTHLY: SelectorProduct = {
 	costProductSlug: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 };
 
+/**
+ * Define properties with translatable strings getters.
+ */
+[ OPTION_PLAN_SECURITY, OPTION_PLAN_SECURITY_MONTHLY ].forEach( ( target ) => {
+	Object.defineProperties( target, {
+		displayName: {
+			get: () => translate( 'Jetpack Security' ),
+		},
+		shortName: {
+			get: () =>
+				translate( 'Security', {
+					comment: 'Short name of the Jetpack Security generic plan',
+				} ),
+		},
+		tagline: { get: () => translate( 'Comprehensive WordPress protection' ) },
+		description: {
+			get: () =>
+				translate(
+					'Enjoy the peace of mind of complete site security. ' +
+						'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
+				),
+		},
+	} );
+} );
+
 // Jetpack Backup
 export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
 	productSlug: OPTIONS_JETPACK_BACKUP,
@@ -177,6 +226,7 @@ export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
 		),
 	},
 };
+
 export const OPTION_PRODUCT_BACKUP_MONTHLY: SelectorProduct = {
 	...OPTION_PRODUCT_BACKUP,
 	productSlug: OPTIONS_JETPACK_BACKUP_MONTHLY,
@@ -184,6 +234,28 @@ export const OPTION_PRODUCT_BACKUP_MONTHLY: SelectorProduct = {
 	subtypes: [ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY, PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ],
 	costProductSlug: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 };
+
+/**
+ * Define properties with translatable strings getters.
+ */
+[ OPTION_PRODUCT_BACKUP, OPTION_PRODUCT_BACKUP_MONTHLY ].forEach( ( target ) => {
+	Object.defineProperties( target, {
+		displayName: {
+			get: () => translate( 'Jetpack Backup' ),
+		},
+		shortName: {
+			get: () =>
+				translate( 'Backup', {
+					comment: 'Short name of the Jetpack Backup generic product',
+				} ),
+		},
+		tagline: { get: () => translate( 'Recommended for all sites' ) },
+		description: {
+			get: () => translate( 'Never lose a word, image, page, or time worrying about your site.' ),
+		},
+		buttonLabel: { get: () => translate( 'Get Backup' ) },
+	} );
+} );
 
 // Map slug to objects.
 export const OPTIONS_SLUG_MAP: Record< SelectorProductSlug, SelectorProduct > = {


### PR DESCRIPTION
Pricing constant properties with translatable strings are being defined before the actual translations are loaded. In this case the result of individual `translate` calls will remain the original string and not the translation for the given locale.

#### Changes proposed in this Pull Request

* Define getters for pricing constants properties which use `translate` calls.

**Before:**
![image](https://user-images.githubusercontent.com/2722412/93473704-0015d080-f8ff-11ea-850e-aaf64b620369.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/93473587-dceb2100-f8fe-11ea-8fa5-8df16303a58a.png)


#### Testing instructions

* Boot Calypso with `CALYPSO_ENV=jetpack-cloud-development BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks,wpcom-user-bootstrap yarn start`
* Go to `/es/pricing`  and confirm all strings in the pricing blocks are in Spanish.

Fixes p1600269537067800-slack-C02AED43D
