### PR TITLE
Masterbar: show profile picture on mobile

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -73,6 +73,7 @@ $autobar-height: 20px;
 	border: solid 2px var( --color-masterbar-background );
 	border-radius: 50%;
 	display: none;
+	// stylelint-disable-next-line scales/font-size
 	font-size: 8px;
 	height: 8px;
 	letter-spacing: 0;
@@ -344,8 +345,9 @@ $autobar-height: 20px;
 .masterbar__item-me {
 	.gravatar {
 		position: absolute;
-		left: 16px;
-		top: 12px;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
 		width: 18px;
 		height: 18px;
 
@@ -353,6 +355,7 @@ $autobar-height: 20px;
 	}
 
 	.gridicon + .masterbar__item-content {
+		display: block;
 		padding: 0;
 	}
 
@@ -388,6 +391,7 @@ $autobar-height: 20px;
 		border: solid 2px var( --color-masterbar-background );
 		border-radius: 50%;
 		display: none;
+		// stylelint-disable-next-line scales/font-size
 		font-size: 8px;
 		height: 8px;
 		letter-spacing: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR ensures that the profile picture in the masterbar is showing on mobile viewports.
* This PR also ensures that the profile picture in the masterbar is also always perfectly positioned across viewports.

|before|after|
|-|-|
|<img width="376" alt="Screenshot 2020-09-17 at 15 34 04" src="https://user-images.githubusercontent.com/1562646/93477411-436e4000-f8fb-11ea-91ab-3767f07ddca9.png">|<img width="377" alt="Screenshot 2020-09-17 at 15 33 35" src="https://user-images.githubusercontent.com/1562646/93477419-4701c700-f8fb-11ea-9eb1-f43ffec9a853.png">|

#### The issue 

Currently in production the profile picture is not showing in the masterbar on mobile viewports.

This is caused by `.masterbar__item-content` being set to `display:none` on viewports <480px. This makes sense for all other instances of `.masterbar__item-content` because it includes text that shouldn't show on small viewports. For the profile menu item, `.masterbar__item-content` also includes the profile picture though and it's thus hidden.

In addition, after showing the profile picture, it turned out that it is misaligned to varying degrees in mobile viewports.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Locally: check out PR, `yarn && yarn start` and visit http://calypso.localhost:3000/
* Calypso.live: visit https://calypso.live/?branch=fix/masterbar-show-profile-picture-on-mobile

Compare the masterbar on this branch to the masterbar in production. Ensure that the profile picture shows on mobile viewports and sits in the center of the button on all viewports.
