### PR TITLE
Masterbar: fix reader unread bubble positioning on mobile

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -91,10 +91,9 @@ $autobar-height: 20px;
 	transition: all 150ms ease-in;
 
 	@include breakpoint-deprecated( '<480px' ) {
-		top: 50%;
-		left: 50%;
+		top: calc( 50% - 14px );
+		left: calc( 50% - 14px );
 		margin: 0;
-		transform: translate( -14px, -14px );
 	}
 }
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -73,6 +73,7 @@ $autobar-height: 20px;
 	border: solid 2px var( --color-masterbar-background );
 	border-radius: 50%;
 	display: none;
+	// stylelint-disable-next-line scales/font-size
 	font-size: 8px;
 	height: 8px;
 	letter-spacing: 0;
@@ -88,6 +89,13 @@ $autobar-height: 20px;
 	// Animation
 	animation: bubble-unread-indication 0.5s linear both;
 	transition: all 150ms ease-in;
+
+	@include breakpoint-deprecated( '<480px' ) {
+		top: 50%;
+		left: 50%;
+		margin: 0;
+		transform: translate( -14px, -14px );
+	}
 }
 
 .masterbar__item {
@@ -388,6 +396,7 @@ $autobar-height: 20px;
 		border: solid 2px var( --color-masterbar-background );
 		border-radius: 50%;
 		display: none;
+		// stylelint-disable-next-line scales/font-size
 		font-size: 8px;
 		height: 8px;
 		letter-spacing: 0;
@@ -533,6 +542,7 @@ $autobar-height: 20px;
 	right: 0;
 	bottom: 0;
 	left: 0;
+	// stylelint-disable-next-line scales/radii
 	border-radius: 0 0 3px 3px;
 
 	.count {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR ensures that the reader unread bubble is positioned correctly across mobile viewports.

#### The issue 

Currently in production the reader unread bubble is not positioned correctly across mobile viewports.

|before|after|
|-|-|
|<img width="371" alt="Screenshot 2020-09-17 at 15 49 35" src="https://user-images.githubusercontent.com/1562646/93480109-613ca480-f8fd-11ea-92f7-e954ea277ca7.png">|<img width="377" alt="Screenshot 2020-09-17 at 15 49 20" src="https://user-images.githubusercontent.com/1562646/93480144-6994df80-f8fd-11ea-88b1-ba738e53254f.png">|

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Locally: check out PR, `yarn && yarn start` and visit http://calypso.localhost:3000/
* Calypso.live: visit https://calypso.live/?branch=fix/masterbar-reader-bubble-on-mobile

Compare the masterbar on this branch to the masterbar in production. Ensure that the reader unread bubble is positioned correctly across mobile viewports.