### PR TITLE
Components: Remove unnecessary type prop from text field components

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -345,7 +345,6 @@ export class SiteAddressChanger extends Component {
 						<FormTextInputWithAffixes
 							id="site-address-changer__text-input"
 							className="site-address-changer__input"
-							type="text"
 							value={ domainFieldValue }
 							suffix={ this.renderDomainSuffix() }
 							onChange={ this.onFieldChange }

--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -45,7 +45,6 @@ function ClipboardButtonInput( { value = '', className, disabled, hideHttp, disp
 				{ ...rest }
 				disabled={ disabled }
 				value={ hideHttp ? withoutHttp( value ) : value }
-				type="text"
 				selectOnFocus
 				readOnly
 			/>

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -111,7 +111,6 @@ class MapDomainStep extends React.Component {
 					<div className="map-domain-step__add-domain" role="group">
 						<FormTextInput
 							className="map-domain-step__external-domain"
-							type="text"
 							value={ this.state.searchQuery }
 							placeholder={ translate( 'example.com' ) }
 							onBlur={ this.save }

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -377,7 +377,6 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 					<FormTextInput
 						id="sirenSiret"
 						value={ sirenSiret }
-						type="text"
 						inputMode="numeric"
 						pattern="[0-9]*"
 						placeholder={ translate( 'ex. 123 456 789 or 123 456 789 01234', {
@@ -399,7 +398,6 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 					<FormTextInput
 						id="trademarkNumber"
 						value={ trademarkNumber }
-						type="text"
 						inputMode="numeric"
 						pattern="[0-9]*"
 						autoCapitalize="off"

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -255,7 +255,6 @@ class TransferDomainStep extends React.Component {
 						<FormTextInput
 							// eslint-disable-next-line jsx-a11y/no-autofocus
 							autoFocus={ true }
-							type="text"
 							value={ searchQuery }
 							placeholder={ translate( 'example.com' ) }
 							onBlur={ this.save }

--- a/client/components/happychat/composer.jsx
+++ b/client/components/happychat/composer.jsx
@@ -85,7 +85,6 @@ export const Composer = createReactClass( {
 						aria-label="Enter your support request"
 						ref={ this.setScrollbleedTarget }
 						onFocus={ onFocus }
-						type="text"
 						placeholder={ translate( 'Type a message…' ) }
 						onChange={ this.onChange }
 						onKeyDown={ this.onKeyDown }

--- a/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
@@ -121,7 +121,6 @@ class OrderFeeDialog extends Component {
 				<FormTextInput
 					id="new_fee_name"
 					name="new_fee_name"
-					type="text"
 					value={ this.state.name }
 					onChange={ this.handleChange }
 				/>

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -157,7 +157,6 @@ class RequestLoginEmailForm extends React.Component {
 							disabled={ isFetching || emailRequested }
 							value={ usernameOrEmail }
 							name="usernameOrEmail"
-							type="text"
 							ref={ this.saveUsernameOrEmailRef }
 							onChange={ this.onUsernameOrEmailFieldChange }
 						/>

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -143,7 +143,6 @@ class SiteRedirect extends React.Component {
 									onChange={ this.handleChange }
 									onFocus={ this.handleFocus }
 									prefix="http://"
-									type="text"
 									value={ this.state.redirectUrl }
 									id="site-redirect__input"
 								/>

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new.jsx
@@ -180,7 +180,6 @@ class EmailForwardingAddNew extends React.Component {
 						onFocus={ this.mailboxFieldFocus }
 						isError={ ! isValidMailbox }
 						placeholder={ exampleEmailText }
-						type="text"
 						suffix={ '@' + selectedDomainName }
 						value={ mailbox }
 					/>
@@ -201,7 +200,6 @@ class EmailForwardingAddNew extends React.Component {
 						onFocus={ this.destinationFieldFocus }
 						isError={ ! isValidDestination }
 						placeholder={ translate( 'Your Existing Email Address' ) }
-						type="text"
 						value={ destination }
 					/>
 					{ ! isValidDestination && (

--- a/client/my-sites/site-settings/comment-display-settings/index.jsx
+++ b/client/my-sites/site-settings/comment-display-settings/index.jsx
@@ -56,7 +56,6 @@ class CommentDisplaySettings extends Component {
 					</FormLabel>
 					<FormTextInput
 						name="highlander_comment_form_prompt"
-						type="text"
 						id="highlander_comment_form_prompt"
 						value={ fields.highlander_comment_form_prompt || '' }
 						onChange={ onChangeField( 'highlander_comment_form_prompt' ) }

--- a/client/my-sites/site-settings/date-time-format/date-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/date-format-option.jsx
@@ -53,7 +53,6 @@ export const DateFormatOption = ( {
 							disabled={ disabled }
 							name="date_format_custom"
 							onChange={ setCustomDateFormat }
-							type="text"
 							value={ dateFormat || '' }
 						/>
 						<FormSettingExplanation>

--- a/client/my-sites/site-settings/date-time-format/time-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/time-format-option.jsx
@@ -55,7 +55,6 @@ export const TimeFormatOption = ( {
 							disabled={ disabled }
 							name="time_format_custom"
 							onChange={ setCustomTimeFormat }
-							type="text"
 							value={ timeFormat || '' }
 						/>
 						<FormSettingExplanation>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -103,7 +103,6 @@ export class SiteSettingsFormGeneral extends Component {
 							name="blogname"
 							id="blogname"
 							data-tip-target="site-title-input"
-							type="text"
 							value={ fields.blogname || '' }
 							onChange={ onChangeField( 'blogname' ) }
 							disabled={ isRequestingSettings }
@@ -115,7 +114,6 @@ export class SiteSettingsFormGeneral extends Component {
 						<FormLabel htmlFor="blogdescription">{ translate( 'Site tagline' ) }</FormLabel>
 						<FormInput
 							name="blogdescription"
-							type="text"
 							id="blogdescription"
 							data-tip-target="site-tagline-input"
 							value={ fields.blogdescription || '' }
@@ -200,7 +198,6 @@ export class SiteSettingsFormGeneral extends Component {
 				<div className="site-settings__blogaddress-settings">
 					<FormInput
 						name="blogaddress"
-						type="text"
 						id="blogaddress"
 						value={ site.domain }
 						disabled="disabled"

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -135,7 +135,6 @@ class PodcastingDetails extends Component {
 				<FormComponent
 					id={ key }
 					name={ key }
-					type="text"
 					value={ decodeEntities( fields[ key ] ) || '' }
 					onChange={ onChangeField( key ) }
 					disabled={ isRequestingSettings || ! isPodcastingEnabled }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -440,7 +440,6 @@ export class SeoForm extends React.Component {
 									</FormLabel>
 									<CountedTextarea
 										name="advanced_seo_front_page_description"
-										type="text"
 										id="advanced_seo_front_page_description"
 										value={ frontPageMetaDescription || '' }
 										disabled={ isSeoDisabled }

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -365,7 +365,6 @@ class SiteVerification extends Component {
 							<FormInput
 								prefix={ translate( 'Google' ) }
 								name="verification_code_google"
-								type="text"
 								value={ googleCode }
 								id="verification_code_google"
 								spellCheck="false"
@@ -380,7 +379,6 @@ class SiteVerification extends Component {
 							<FormInput
 								prefix={ translate( 'Bing' ) }
 								name="verification_code_bing"
-								type="text"
 								value={ bingCode }
 								id="verification_code_bing"
 								spellCheck="false"
@@ -395,7 +393,6 @@ class SiteVerification extends Component {
 							<FormInput
 								prefix={ translate( 'Pinterest' ) }
 								name="verification_code_pinterest"
-								type="text"
 								value={ pinterestCode }
 								id="verification_code_pinterest"
 								spellCheck="false"
@@ -410,7 +407,6 @@ class SiteVerification extends Component {
 							<FormInput
 								prefix={ translate( 'Yandex' ) }
 								name="verification_code_yandex"
-								type="text"
 								value={ yandexCode }
 								id="verification_code_yandex"
 								spellCheck="false"

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -382,7 +382,6 @@ class P2Site extends React.Component {
 						autoCapitalize={ 'off' }
 						className="p2-site__site-title"
 						disabled={ fieldDisabled }
-						type="text"
 						name="site-title"
 						value={ formState.getFieldValue( this.state.form, 'siteTitle' ) }
 						isError={ formState.isFieldInvalid( this.state.form, 'siteTitle' ) }
@@ -403,7 +402,6 @@ class P2Site extends React.Component {
 						autoCapitalize={ 'off' }
 						className="p2-site__site-url"
 						disabled={ fieldDisabled }
-						type="text"
 						name="site"
 						value={ formState.getFieldValue( this.state.form, 'site' ) }
 						isError={ formState.isFieldInvalid( this.state.form, 'site' ) }

--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -176,7 +176,6 @@ export class PasswordlessStep extends Component {
 					<FormTextInput
 						autoCapitalize={ 'off' }
 						className="passwordless__code"
-						type="text"
 						name="code"
 						onChange={ this.handleFieldChange }
 						disabled={ this.state.submitting }

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -250,7 +250,6 @@ class Site extends React.Component {
 					autoCapitalize={ 'off' }
 					className="site__site-url"
 					disabled={ fieldDisabled }
-					type="text"
 					name="site"
 					value={ formState.getFieldValue( this.state.form, 'site' ) }
 					isError={ formState.isFieldInvalid( this.state.form, 'site' ) }


### PR DESCRIPTION
There are plenty of locations where we specifically add `type="text"` to components, where that's already specified inside the component, so specifying it is just unnecessary overhead. Furthermore, there are a couple of instances where we pass the `type` prop to textarea fields. This PR takes care of all those instances.

This is part of #45259 and the first step towards removing global text field styles.

#### Changes proposed in this Pull Request

* Components: Remove unnecessary type prop from text field components

#### Testing instructions

* Go through each changed case and verify that the `type` attribute is indeed not necessary because it's already being specified further down the component tree.

#### Notes

Note, lint errors are expected and unrelated.