### PR TITLE
Plans: fix broken Product Type filter

### DIFF
--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -97,13 +97,22 @@ export const PRODUCT_TYPE_OPTIONS = {
  */
 Object.defineProperties( PRODUCT_TYPE_OPTIONS, {
 	[ SECURITY ]: {
-		get: () => translate( 'Security' ),
+		get: () => ( {
+			id: SECURITY,
+			label: translate( 'Security' ),
+		} ),
 	},
 	[ PERFORMANCE ]: {
-		get: () => translate( 'Performance' ),
+		get: () => ( {
+			id: PERFORMANCE,
+			label: translate( 'Performance' ),
+		} ),
 	},
 	[ ALL ]: {
-		get: () => translate( 'All' ),
+		get: () => ( {
+			id: ALL,
+			label: translate( 'All' ),
+		} ),
 	},
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Inadvertently we introduced a bug in #45727 which transformed an object with two properties into a translated string. This PRs fixes that.

#### Testing instructions

* Run this PR.
* Visit `/plans/:site`.
* Make sure that the Product Type filter works as expected (try every option).
* Make sure that there are no errors in the console.

Fixes 1169247016322522-as-1194422915651802.

#### Demo
##### Before
![image](https://user-images.githubusercontent.com/3418513/93493941-d3ec5680-f8e2-11ea-99a4-f2ddb1294180.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/93493976-dea6eb80-f8e2-11ea-8392-a0c886fd1201.png)