### PR TITLE
fix(linux): manual updater

### DIFF
--- a/client/desktop/app-handlers/updater/manual-updater/index.js
+++ b/client/desktop/app-handlers/updater/manual-updater/index.js
@@ -153,7 +153,7 @@ class ManualUpdater extends Updater {
 			return null;
 		}
 		const asset = assets.find( ( file ) => file.name === 'latest.yml' );
-		return asset ? asset.browser_download_url || null : null;
+		return asset ? asset.browser_download_url : null;
 	}
 
 	async getReleaseVersion( url ) {

--- a/client/desktop/app-handlers/updater/manual-updater/index.js
+++ b/client/desktop/app-handlers/updater/manual-updater/index.js
@@ -43,7 +43,11 @@ class ManualUpdater extends Updater {
 	async ping() {
 		try {
 			const url = this.apiUrl;
-			log.info( `Checking for update. Channel: ${ this.beta }, Update URL: ${ url }` );
+			log.info(
+				`Checking for update. Channel: ${
+					this.beta
+				}, Version: ${ app.getVersion() }, Update URL: ${ url }`
+			);
 
 			const releaseResp = await fetch( url, requestOptions );
 
@@ -58,10 +62,10 @@ class ManualUpdater extends Updater {
 
 			// Get latest release and pre-release from sorted releases
 			const latestStableRelease = releases.find(
-				( d ) => this.getConfigUrl( d.assets ) & ! d.prerelease
+				( d ) => ! d.prerelease && this.getConfigUrl( d.assets )
 			);
 			const latestBetaRelease = releases.find(
-				( d ) => this.getConfigUrl( d.assets ) && d.prerelease
+				( d ) => d.prerelease && this.getConfigUrl( d.assets )
 			);
 
 			if ( ! latestStableRelease && ! this.beta ) {
@@ -71,6 +75,9 @@ class ManualUpdater extends Updater {
 
 			let latestStableReleaseVersion;
 			if ( latestStableRelease ) {
+				log.info(
+					`Latest stable release: ${ latestStableRelease.name } (${ latestStableRelease.tag_name })`
+				);
 				const assetUrl = this.getConfigUrl( latestStableRelease.assets );
 				latestStableReleaseVersion = await this.getReleaseVersion( assetUrl );
 			}
@@ -78,6 +85,9 @@ class ManualUpdater extends Updater {
 			let latestReleaseVersion;
 
 			if ( this.beta && latestBetaRelease ) {
+				log.info(
+					`Latest beta release: ${ latestBetaRelease.name } (${ latestBetaRelease.tag_name })`
+				);
 				const assetUrl = this.getConfigUrl( latestBetaRelease.assets );
 				const latestBetaReleaseVersion = await this.getReleaseVersion( assetUrl );
 
@@ -143,7 +153,7 @@ class ManualUpdater extends Updater {
 			return null;
 		}
 		const asset = assets.find( ( file ) => file.name === 'latest.yml' );
-		return asset.browser_download_url || null;
+		return asset ? asset.browser_download_url || null : null;
 	}
 
 	async getReleaseVersion( url ) {


### PR DESCRIPTION
### Description

This PR fixes the Linux manual updater to ensure that it resolves Github releases and redirects to the WordPress Desktop landing page.

### Context

Auto-updating in Linux is not supported by Electron. Instead, the open-source community submits Linux builds to the Snap store. However, as an in-app alternative, the `Manual Updater` pings Github for latest release information and redirects the user to download the `.deb` installer accordingly.

### To Test

Build this branch with a version number less than officially deployed (edit in `desktop/package.json`). Verify that a prompt to update is displayed when the app is booted, and redirects to the WordPress Desktop landing page when clicked.

<p align="center">
<img width="400" alt="linux-manual-updater-prompt" src="https://user-images.githubusercontent.com/8979548/93493329-c7afcb80-f8d9-11ea-99a9-f863eda3a9ae.png">
</br>
<img width="400" alt="linux-manual-updater-redirect" src="https://user-images.githubusercontent.com/8979548/93493326-c7173500-f8d9-11ea-9418-5bebc9303ce2.png">
</p>
