### PR TITLE
Checkout: only use alt email in gsuite contact form

### DIFF
--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -323,18 +323,7 @@ export class ManagedContactDetailsFormFields extends Component {
 	}
 
 	renderAlternateEmailFieldForGSuite() {
-		let customErrorMessage = this.props.contactDetailsErrors?.alternateEmail;
-		// We also show 'email' field errors because this field will only be shown
-		// if email is invalid (and email will not be shown) so we should show
-		// those errors somewhere. However, only show them if the `alternateEmail`
-		// has not been entered.
-		if (
-			! customErrorMessage &&
-			this.props.contactDetailsErrors?.email &&
-			! this.props.contactDetails?.alternateEmail?.length > 0
-		) {
-			customErrorMessage = this.props.contactDetailsErrors.email;
-		}
+		const customErrorMessage = this.props.contactDetailsErrors?.alternateEmail;
 		return (
 			<div className="contact-details-form-fields__row">
 				<Input

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -478,13 +478,6 @@ function GSuiteFields( {
 } ) {
 	return (
 		<div className="contact-details-form-fields__row g-apps-fieldset">
-			<Input
-				label={ translate( 'Email' ) }
-				{ ...getFieldProps( 'alternate-email', {
-					customErrorMessage: contactDetailsErrors?.alternateEmail,
-				} ) }
-			/>
-
 			<CountrySelect
 				label={ translate( 'Country' ) }
 				countriesList={ countriesList }

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -478,6 +478,13 @@ function GSuiteFields( {
 } ) {
 	return (
 		<div className="contact-details-form-fields__row g-apps-fieldset">
+			<Input
+				label={ translate( 'Email' ) }
+				{ ...getFieldProps( 'alternate-email', {
+					customErrorMessage: contactDetailsErrors?.alternateEmail,
+				} ) }
+			/>
+
 			<CountrySelect
 				label={ translate( 'Country' ) }
 				countriesList={ countriesList }

--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form-summary.js
@@ -101,6 +101,10 @@ function EmailSummary( {
 		return null;
 	}
 
+	if ( isGSuiteInCart && ! areThereDomainProductsInCart ) {
+		return <SummaryLine>{ contactInfo.alternateEmail.value }</SummaryLine>;
+	}
+
 	if ( isGSuiteInCart && contactInfo.alternateEmail.value ) {
 		return <SummaryLine>{ contactInfo.alternateEmail.value }</SummaryLine>;
 	}

--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form-summary.js
@@ -83,6 +83,7 @@ function joinNonEmptyValues( joinString, ...values ) {
 	return values.filter( ( value ) => value?.length > 0 ).join( joinString );
 }
 
+// The point of this component is to make sure we show at most one email address in the summary, and that the one we show is editable.
 function EmailSummary( {
 	isRenewal,
 	contactInfo,
@@ -102,11 +103,9 @@ function EmailSummary( {
 	}
 
 	if ( isGSuiteInCart && ! areThereDomainProductsInCart ) {
-		return <SummaryLine>{ contactInfo.alternateEmail.value }</SummaryLine>;
-	}
-
-	if ( isGSuiteInCart && contactInfo.alternateEmail.value ) {
-		return <SummaryLine>{ contactInfo.alternateEmail.value }</SummaryLine>;
+		return contactInfo.alternateEmail.value ? (
+			<SummaryLine>{ contactInfo.alternateEmail.value }</SummaryLine>
+		) : null;
 	}
 
 	if ( ! contactInfo.email.value ) {

--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form.js
@@ -33,7 +33,6 @@ import {
 	hasGoogleApps,
 	hasDomainRegistration,
 	hasTransferProduct,
-	needsExplicitAlternateEmailForGSuite,
 } from 'lib/cart-values/cart-items';
 import { useCart } from 'my-sites/checkout/composite-checkout/cart-provider';
 import { getTopLevelOfTld } from 'lib/domains';
@@ -269,9 +268,7 @@ function DomainContactDetails( {
 		! hasDomainRegistration( responseCart ) &&
 		! hasTransferProduct( responseCart );
 	const getIsFieldDisabled = () => isDisabled;
-	const needsAlternateEmailForGSuite =
-		needsOnlyGoogleAppsDetails &&
-		needsExplicitAlternateEmailForGSuite( responseCart, contactDetails );
+	const needsAlternateEmailForGSuite = needsOnlyGoogleAppsDetails;
 	const tlds = getAllTopLevelTlds( domainNames );
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/types/backend/domain-contact-validation-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/backend/domain-contact-validation-endpoint.ts
@@ -28,8 +28,7 @@ export type GSuiteContactValidationRequest = {
 	contact_information: {
 		firstName: string;
 		lastName: string;
-		email?: string;
-		alternateEmail?: string;
+		alternateEmail: string;
 		postalCode: string;
 		countryCode: string;
 	};

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -634,9 +634,7 @@ export function prepareGSuiteContactValidationRequest(
 		contact_information: {
 			firstName: details.firstName?.value ?? '',
 			lastName: details.lastName?.value ?? '',
-			...( details.alternateEmail?.value && { alternateEmail: details.alternateEmail?.value } ),
-			...( ! details.alternateEmail?.value &&
-				details.email?.value && { email: details.email?.value } ),
+			alternateEmail: details.alternateEmail?.value ?? '',
 			postalCode: tryToGuessPostalCodeFormat(
 				details.postalCode?.value ?? '',
 				details.countryCode?.value


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When checking out with gsuite in the cart, but _not_ any domain products, (1) only show the alternate email field in the summary contact details and (2) allow the user to update this field.

#### Testing instructions

Note that GSuite can only be tested in the live environment, with a domain that was purchased in the live environment - so you'll need to turn off store sandbox and use a real domain that does not already have gsuite added to test this.

* Enter checkout with a new gsuite subscription in your cart, but no domain products. You can do this on an account with an existing domain through `Manage > Domains` or directly with `/email/$siteurl/manage/$siteurl`.
* Verify that your "alternate email" is displayed in summary view, if it has already been saved for your user. If not (e.g. your test account doesn't already have gsuite on another domain), edit the contact details and add it.
* Try to set your alternate email to the email address being purchased and verify that you see an error message.

Before:

![image](https://user-images.githubusercontent.com/9310939/93523666-fe490e80-f8f8-11ea-8727-4afcde5af970.png)

After (edit view):

![image](https://user-images.githubusercontent.com/9310939/93523722-128d0b80-f8f9-11ea-9a34-210defc51413.png)

After (summary view):

![image](https://user-images.githubusercontent.com/9310939/93523761-1f116400-f8f9-11ea-9be2-745548727e20.png)

Error:

![image](https://user-images.githubusercontent.com/9310939/93523913-5bdd5b00-f8f9-11ea-89a3-2d6358d28279.png)

