### PR TITLE
Offer Reset: Show Plan Features on My Plans page for Jetpack Security and Complete.

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -317,7 +317,28 @@ export class ProductPurchaseFeaturesList extends Component {
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isPlaceholder={ isPlaceholder }
 					showLiveChatButton
-					liveChatButtonEventName={ 'calypso_livechat_my_plan_jetpack_professsional' }
+					liveChatButtonEventName={ 'calypso_livechat_my_plan_jetpack_security' }
+				/>
+			</Fragment>
+		);
+	}
+
+	getJetpackCompleteFeatures() {
+		const { isAutomatedTransfer, isPlaceholder, selectedSite } = this.props;
+		return (
+			<Fragment>
+				<SiteActivity />
+				<MonetizeSite selectedSite={ selectedSite } />
+				<MobileApps onClick={ this.handleMobileAppsClick } />
+				<JetpackPublicize selectedSite={ selectedSite } />
+				<SellOnlinePaypal isJetpack />
+				<GoogleAnalyticsStats selectedSite={ selectedSite } />
+				<FindNewTheme selectedSite={ selectedSite } />
+				<HappinessSupportCard
+					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
+					isPlaceholder={ isPlaceholder }
+					showLiveChatButton
+					liveChatButtonEventName={ 'calypso_livechat_my_plan_jetpack_complete' }
 				/>
 			</Fragment>
 		);
@@ -346,7 +367,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				[ TYPE_FREE ]: () => this.getJetpackFreeFeatures(),
 				[ TYPE_SECURITY_DAILY ]: () => this.getJetpackSecurityFeatures(),
 				[ TYPE_SECURITY_REALTIME ]: () => this.getJetpackSecurityFeatures(),
-				[ TYPE_ALL ]: () => this.getJetpackSecurityFeatures(),
+				[ TYPE_ALL ]: () => this.getJetpackCompleteFeatures(),
 			},
 		};
 

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -21,6 +21,9 @@ import {
 	PLAN_BUSINESS_2_YEARS,
 	PLAN_BUSINESS_ONBOARDING_EXPIRE,
 	PLAN_BUSINESS_2Y_ONBOARDING_EXPIRE,
+	TYPE_SECURITY_DAILY,
+	TYPE_SECURITY_REALTIME,
+	TYPE_ALL,
 } from 'lib/plans/constants';
 import { PLANS_LIST } from 'lib/plans/plans-list';
 import FindNewTheme from './find-new-theme';
@@ -299,6 +302,27 @@ export class ProductPurchaseFeaturesList extends Component {
 		);
 	}
 
+	getJetpackSecurityFeatures() {
+		const { isAutomatedTransfer, isPlaceholder, selectedSite } = this.props;
+		return (
+			<Fragment>
+				<SiteActivity />
+				<MonetizeSite selectedSite={ selectedSite } />
+				<MobileApps onClick={ this.handleMobileAppsClick } />
+				<JetpackPublicize selectedSite={ selectedSite } />
+				<SellOnlinePaypal isJetpack />
+				<GoogleAnalyticsStats selectedSite={ selectedSite } />
+				<FindNewTheme selectedSite={ selectedSite } />
+				<HappinessSupportCard
+					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
+					isPlaceholder={ isPlaceholder }
+					showLiveChatButton
+					liveChatButtonEventName={ 'calypso_livechat_my_plan_jetpack_professsional' }
+				/>
+			</Fragment>
+		);
+	}
+
 	getFeatures() {
 		const { plan, isPlaceholder } = this.props;
 
@@ -320,6 +344,9 @@ export class ProductPurchaseFeaturesList extends Component {
 				[ TYPE_PREMIUM ]: () => this.getJetpackPremiumFeatures(),
 				[ TYPE_PERSONAL ]: () => this.getJetpackPersonalFeatures(),
 				[ TYPE_FREE ]: () => this.getJetpackFreeFeatures(),
+				[ TYPE_SECURITY_DAILY ]: () => this.getJetpackSecurityFeatures(),
+				[ TYPE_SECURITY_REALTIME ]: () => this.getJetpackSecurityFeatures(),
+				[ TYPE_ALL ]: () => this.getJetpackSecurityFeatures(),
 			},
 		};
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Fixes: 1169247016322522-as-1194230427737465/f

This PR displays the Plan Features for Jetpack Security and Jetpack Complete plans.

Currently there are no "Plan Features" showing at the bottom of the "My Plan" page for the new Offer Reset plans (Jetpack Security and Jetpack Complete). Only the title is showing. Plan features should display under the title.  See screenshot below.

![Markup 2020-09-17 at 16 20 17](https://user-images.githubusercontent.com/11078128/93538115-27ba6800-f902-11ea-9805-18f1144a792d.png)

### Implementation notes:

Per the [plans comparison page](https://jetpack.com/features/comparison/), JetPack Security and Jetpack Complete offer the same overall features, except that Complete offers CRM on an 'Enterprise' level, so therefore in this PR, the features displayed for Jetpack Security and Complete will be the same.

Also, this PR only displays the feature components that are currently available within Calypso (and that are offered with the plan, of course), but ideally in the near future, I think we may want to create some additional feature components, and modify existing ones to match the features that are displayed in the "My Plans" section within the Plugin (wp-admin), like for example see this screenshot:

![Markup 2020-09-18 at 10 48 10](https://user-images.githubusercontent.com/11078128/93629071-82080700-f99c-11ea-8802-8680006ce149.png)


### Testing instructions

- Run this PR`
- Go to the 'Plans" section, in "My Plan" tab, with a site that has plan:
  - Jetpack Security Daily
  - Jetpack Security Realtime
  - Jetpack Complete
- Verify that all 8 features are showing at the bottom of the page (See screenshot):

![Markup 2020-09-18 at 11 02 49](https://user-images.githubusercontent.com/11078128/93630253-89c8ab00-f99e-11ea-9fb1-3b505fa0b123.png)
