### PR TITLE
Session dashboard: Do not allow last minute reschedule/cancel 

### DIFF
--- a/client/me/concierge/cancel/index.js
+++ b/client/me/concierge/cancel/index.js
@@ -13,7 +13,7 @@ import HeaderCake from 'components/header-cake';
 import QuerySites from 'components/data/query-sites';
 import QueryConciergeInitial from 'components/data/query-concierge-initial';
 import QueryConciergeAppointmentDetails from 'components/data/query-concierge-appointment-details';
-import { Button } from '@automattic/components';
+import { Button, CompactCard } from '@automattic/components';
 import Main from 'components/main';
 import { localize } from 'i18n-calypso';
 import Confirmation from '../shared/confirmation';
@@ -42,6 +42,35 @@ class ConciergeCancel extends Component {
 		const { appointmentId, scheduleId } = this.props;
 		this.props.cancelConciergeAppointment( scheduleId, appointmentId );
 	};
+
+	renderBtnPlaceholder() {
+		return (
+			<div className="cancel__placeholders">
+				<div className="cancel__placeholder-button-container">
+					<div className="cancel__placeholder-button is-placeholder" />
+					<div className="cancel__placeholder-button is-placeholder" />
+				</div>
+			</div>
+		);
+	}
+
+	renderDisallowed() {
+		const { translate, siteSlug } = this.props;
+		return (
+			<>
+				<HeaderCake backHref={ `/me/concierge/${ siteSlug }/book` }>
+					{ translate( 'Reschedule or cancel' ) }
+				</HeaderCake>
+				<CompactCard>
+					<div>
+						{ translate(
+							'Sorry, you cannot reschedule or cancel less than 60 minutes before the session.'
+						) }
+					</div>
+				</CompactCard>
+			</>
+		);
+	}
 
 	getDisplayComponent = () => {
 		const {
@@ -84,6 +113,12 @@ class ConciergeCancel extends Component {
 				const disabledRescheduling =
 					signupForm.status === CONCIERGE_STATUS_CANCELLING || ! appointmentDetails || ! scheduleId;
 
+				const canChangeAppointment = appointmentDetails?.meta.canChangeAppointment;
+
+				if ( appointmentDetails && ! canChangeAppointment ) {
+					return this.renderDisallowed();
+				}
+
 				return (
 					<div>
 						{ scheduleId && (
@@ -102,23 +137,28 @@ class ConciergeCancel extends Component {
 							) }
 							title={ translate( 'Cancel your session' ) }
 						>
-							<Button
-								className="cancel__reschedule-button"
-								disabled={ disabledRescheduling }
-								href={ `/me/concierge/${ siteSlug }/${ appointmentId }/reschedule` }
-							>
-								{ translate( 'Reschedule session' ) }
-							</Button>
+							{ ! appointmentDetails && this.renderBtnPlaceholder() }
+							{ appointmentDetails && (
+								<>
+									<Button
+										className="cancel__reschedule-button"
+										disabled={ disabledRescheduling }
+										href={ `/me/concierge/${ siteSlug }/${ appointmentId }/reschedule` }
+									>
+										{ translate( 'Reschedule session' ) }
+									</Button>
 
-							<Button
-								className="cancel__confirmation-button"
-								disabled={ disabledCancelling }
-								onClick={ this.cancelAppointment }
-								primary={ true }
-								scary={ true }
-							>
-								{ translate( 'Cancel session' ) }
-							</Button>
+									<Button
+										className="cancel__confirmation-button"
+										disabled={ disabledCancelling }
+										onClick={ this.cancelAppointment }
+										primary={ true }
+										scary={ true }
+									>
+										{ translate( 'Cancel session' ) }
+									</Button>
+								</>
+							) }
 						</Confirmation>
 					</div>
 				);

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -35,6 +35,8 @@ class AppointmentInfo extends Component {
 
 		const conferenceLink = meta.conference_link || '';
 		const guessedTimezone = moment.tz.guess();
+		const secondsUntilSessionBegins = beginTimestamp / 1000 - moment().unix();
+		const isEligibleToReschedule = secondsUntilSessionBegins > 3600;
 
 		return (
 			<>
@@ -88,13 +90,15 @@ class AppointmentInfo extends Component {
 						<FormSettingExplanation>{ meta.message }</FormSettingExplanation>
 					</FormFieldset>
 
-					<FormFieldset>
-						<a href={ `/me/concierge/${ site.slug }/${ id }/cancel` } rel="noopener noreferrer">
-							<FormButton isPrimary={ false } type="button">
-								{ translate( 'Reschedule or cancel' ) }
-							</FormButton>
-						</a>
-					</FormFieldset>
+					{ isEligibleToReschedule && (
+						<FormFieldset>
+							<a href={ `/me/concierge/${ site.slug }/${ id }/cancel` } rel="noopener noreferrer">
+								<FormButton isPrimary={ false } type="button">
+									{ translate( 'Reschedule or cancel' ) }
+								</FormButton>
+							</a>
+						</FormFieldset>
+					) }
 
 					{ scheduleId === 1 ? (
 						<>

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -35,8 +35,7 @@ class AppointmentInfo extends Component {
 
 		const conferenceLink = meta.conference_link || '';
 		const guessedTimezone = moment.tz.guess();
-		const secondsUntilSessionBegins = beginTimestamp / 1000 - moment().unix();
-		const isEligibleToReschedule = secondsUntilSessionBegins > 3600;
+		const isAllowedToChangeAppointment = meta.canChangeAppointment;
 
 		return (
 			<>
@@ -90,7 +89,7 @@ class AppointmentInfo extends Component {
 						<FormSettingExplanation>{ meta.message }</FormSettingExplanation>
 					</FormFieldset>
 
-					{ isEligibleToReschedule && (
+					{ isAllowedToChangeAppointment && (
 						<FormFieldset>
 							<a href={ `/me/concierge/${ site.slug }/${ id }/cancel` } rel="noopener noreferrer">
 								<FormButton isPrimary={ false } type="button">

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -54,6 +54,30 @@
 	margin-right: 10px;
 }
 
+.cancel__placeholders {
+	.is-placeholder {
+        animation: pulse-light 800ms ease-in-out infinite;
+        background: var( --color-neutral-10 );
+	}
+	
+	.cancel__placeholder-button-container {
+		display: flex;
+		justify-content: center;
+	}
+
+	.cancel__placeholder-button {
+		height: 50px;
+		width: 100%;
+		margin-right: 10px;
+	
+		@include breakpoint-deprecated( '>480px' ) {
+			width: 80px;
+			height: 40px;
+		}
+	}
+	
+}
+
 .book__info-step-phone-input {
 	display: block;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If the time left to start the session is less than one hour, then do not display the option to reschedule/cancel a session in the session dashboard.

**With more than one hour left for the session to begin, users can see the Reschedule/Cancel button:**

<img width="723" alt="Screenshot 2020-09-19 at 1 11 22 AM" src="https://user-images.githubusercontent.com/1269602/93638642-46f5ea00-fa15-11ea-9f83-254ed6c7d98e.png">

**With less than one hour to go, the reschedule/cancel button is hidden:**

<img width="724" alt="Screenshot 2020-09-19 at 1 11 43 AM" src="https://user-images.githubusercontent.com/1269602/93638669-537a4280-fa15-11ea-93e2-9f3394683844.png">

#### Testing instructions

Depends on D49790-code.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Schedule a session and verify that the Reschedule/Cancel option in the session dashboard is not displayed if there's less than 1 hour for the session to begin
* If there's less than one hour for the session to begin, try visiting the direct cancel URL and check that you cannot cancel. You should see a notice like this:

<img width="744" alt="Screenshot 2020-09-18 at 7 26 57 PM" src="https://user-images.githubusercontent.com/1269602/93634410-2f673300-fa0e-11ea-9fe2-e7c660fb80f3.png">





