### PR TITLE
Create TeamCity build to build docker images

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -177,6 +177,19 @@ object BuildDockerImage : BuildType({
 			}
 		}
 	}
+
+	features {
+		pullRequests {
+			vcsRootExtId = "${WpCalypso.id}"
+			provider = github {
+				serverUrl = ""
+				authType = token {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+				filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER_OR_COLLABORATOR
+			}
+		}
+	}
 })
 
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -154,6 +154,10 @@ object RunAllUnitTests : BuildType({
 		cleanCheckout = true
 	}
 
+	params {
+		param("env.DOCKER_BUILDKIT", "1")
+	}
+
 	steps {
 		script {
 			name = "Prepare environment"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -149,10 +149,6 @@ object BuildDockerImage : BuildType({
 		cleanCheckout = true
 	}
 
-	params {
-		param("env.DOCKER_BUILDKIT", "1")
-	}
-
 	steps {
 		dockerCommand {
 			name = "Build docker image"
@@ -179,14 +175,15 @@ object BuildDockerImage : BuildType({
 	}
 
 	features {
+		perfmon {
+		}
 		pullRequests {
 			vcsRootExtId = "${WpCalypso.id}"
 			provider = github {
-				serverUrl = ""
 				authType = token {
 					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
 				}
-				filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER_OR_COLLABORATOR
+				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
 			}
 		}
 	}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -8,6 +8,8 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.dockerRegistry
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.DockerCommandStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
 import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.githubConnection
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
@@ -363,6 +365,28 @@ object RunAllUnitTests : BuildType({
 			dockerPull = true
 			dockerImage = "%docker_image%"
 			dockerRunParameters = "-u %env.UID%"
+		}
+		dockerCommand {
+			name = "Build docker image"
+			commandType = build {
+				source = file {
+					path = "Dockerfile"
+				}
+				namesAndTags = """
+					registry.a8c.com/calypso/app:build-%build.number%
+					registry.a8c.com/calypso/app:commit-${WpCalypso.paramRefs.buildVcsNumber}
+				""".trimIndent()
+				commandArgs = "--pull --build-arg use_cache=true"
+			}
+			param("dockerImage.platform", "linux")
+		}
+		dockerCommand {
+			commandType = push {
+				namesAndTags = """
+					registry.a8c.com/calypso/app:build-%build.number%
+					registry.a8c.com/calypso/app:commit-${WpCalypso.paramRefs.buildVcsNumber}
+				""".trimIndent()
+			}
 		}
 	}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV BUILD_TRANSLATION_CHUNKS true
 ENV CHROMEDRIVER_SKIP_DOWNLOAD true
 ENV PUPPETEER_SKIP_DOWNLOAD true
 ENV NODE_OPTIONS --max-old-space-size=$node_memory
+ENV SOURCEMAP=cheap-source-map
 WORKDIR /calypso
 
 # Build a "base" layer

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV BUILD_TRANSLATION_CHUNKS true
 ENV CHROMEDRIVER_SKIP_DOWNLOAD true
 ENV PUPPETEER_SKIP_DOWNLOAD true
 ENV NODE_OPTIONS --max-old-space-size=$node_memory
-ENV SOURCEMAP=cheap-source-map
+ENV SOURCEMAP=source-map
 WORKDIR /calypso
 
 # Build a "base" layer

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ ENV BUILD_TRANSLATION_CHUNKS true
 ENV CHROMEDRIVER_SKIP_DOWNLOAD true
 ENV PUPPETEER_SKIP_DOWNLOAD true
 ENV NODE_OPTIONS --max-old-space-size=$node_memory
-ENV SOURCEMAP=source-map
 WORKDIR /calypso
 
 # Build a "base" layer
@@ -78,5 +77,6 @@ COPY --from=builder --chown=nobody:nobody /calypso/build /calypso/build
 COPY --from=builder --chown=nobody:nobody /calypso/public /calypso/public
 COPY --from=builder --chown=nobody:nobody /calypso/config /calypso/config
 
+USER nobody
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["node", "build/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,5 @@ COPY --from=builder --chown=nobody:nobody /calypso/build /calypso/build
 COPY --from=builder --chown=nobody:nobody /calypso/public /calypso/public
 COPY --from=builder --chown=nobody:nobody /calypso/config /calypso/config
 
-USER nobody
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["node", "build/server.js"]


### PR DESCRIPTION
### Changes proposed in this Pull Request

Creates a new manual build in TeamCity. It will create a docker image using the base image (#45873), tag it as `calypso/app:build-<tc build number>` and `calypso/app:commit-<commit hash>`, and push it to the registry.

In a future PR I'll change `dserve` to pull those images from the registry.

### Testing instructions

* Functionality can't be tested until merged because TeamCity doesn't allow us to create new plans from a branch. As it is a manual build nothing will break, but the plan may require some tweaks once we can test it.

* Check the any TeamCity build for this PR and verify that it doesn't break when trying to apply the build settings (i.e. there are no syntax errors)
