### PR TITLE
Components: Use FormTextInput for all type="text" inputs

### DIFF
--- a/client/components/formatted-date/docs/example.js
+++ b/client/components/formatted-date/docs/example.js
@@ -10,6 +10,8 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
 import FormattedDate from '../';
 import { setLocale } from 'state/ui/language/actions';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
@@ -17,11 +19,16 @@ import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 class FormattedDateExample extends PureComponent {
 	static displayName = 'FormattedDateExample';
 
-	state = {
-		currentDate: new Date(),
-		currentDateString: new Date().toISOString(),
-		format: 'lll',
-	};
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			currentDate: new Date(),
+			currentDateString: new Date().toISOString(),
+			currentLocale: props.currentLocale,
+			format: 'lll',
+		};
+	}
 
 	handleDateChange = ( evt ) => {
 		const val = moment( evt.target.value );
@@ -35,8 +42,13 @@ class FormattedDateExample extends PureComponent {
 
 	handleLocaleChange = ( evt ) => {
 		const val = evt.target.value;
+
+		this.setState( {
+			currentLocale: val,
+		} );
+
 		if ( val.length === 2 || val.length === 5 ) {
-			this.props.setLocale( evt.target.value );
+			this.props.setLocale( val );
 		}
 	};
 
@@ -50,36 +62,24 @@ class FormattedDateExample extends PureComponent {
 	render() {
 		return (
 			<div>
-				<label>
+				<FormLabel>
 					Date
 					<br />
-					<input
-						type="text"
-						name="theDate"
+					<FormTextInput
 						onChange={ this.handleDateChange }
-						defaultValue={ this.state.currentDateString }
+						value={ this.state.currentDateString }
 					/>
-				</label>
-				<label>
+				</FormLabel>
+				<FormLabel>
 					locale
 					<br />
-					<input
-						type="text"
-						name="locale"
-						onChange={ this.handleLocaleChange }
-						defaultValue={ this.props.currentLocale }
-					/>
-				</label>
-				<label>
+					<FormTextInput onChange={ this.handleLocaleChange } value={ this.state.currentLocale } />
+				</FormLabel>
+				<FormLabel>
 					format
 					<br />
-					<input
-						type="text"
-						name="format"
-						onChange={ this.handleFormatChange }
-						defaultValue={ this.state.format }
-					/>
-				</label>
+					<FormTextInput onChange={ this.handleFormatChange } value={ this.state.format } />
+				</FormLabel>
 				<FormattedDate date={ this.state.currentDate } format={ this.state.format } />
 			</div>
 		);

--- a/client/components/formatted-date/docs/example.js
+++ b/client/components/formatted-date/docs/example.js
@@ -32,10 +32,13 @@ class FormattedDateExample extends PureComponent {
 
 	handleDateChange = ( evt ) => {
 		const val = moment( evt.target.value );
+		this.setState( {
+			currentDateString: evt.target.value,
+		} );
+
 		if ( val.isValid() ) {
 			this.setState( {
 				currentDate: val.toDate(),
-				currentDateString: evt.target.value,
 			} );
 		}
 	};

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -12,6 +12,7 @@ import 'moment-timezone'; // monkey patches the existing moment.js
 /**
  * Internal dependencies
  */
+import FormTextInput from 'components/forms/form-text-input';
 import SegmentedControl from 'components/segmented-control';
 import InfoPopover from 'components/info-popover';
 import { withLocalizedMoment } from 'components/localized-moment';
@@ -184,26 +185,24 @@ class PostScheduleClock extends Component {
 
 		return (
 			<div className="post-schedule__clock">
-				<input
+				<FormTextInput
 					className="post-schedule__clock-time"
 					name="post-schedule__clock_hour"
-					ref={ this.hourRef }
+					inputRef={ this.hourRef }
 					value={ date.format( is12hour ? 'hh' : 'HH' ) }
 					onChange={ this.setTime }
 					onKeyDown={ this.adjustHour }
-					type="text"
 				/>
 
 				<span className="post-schedule__clock-divisor">:</span>
 
-				<input
+				<FormTextInput
 					className="post-schedule__clock-time"
 					name="post-schedule__clock_minute"
-					ref={ this.minRef }
+					inputRef={ this.minRef }
 					value={ date.format( 'mm' ) }
 					onChange={ this.setTime }
 					onKeyDown={ this.adjustMinute }
-					type="text"
 				/>
 
 				{ is12hour && (

--- a/client/components/post-schedule/docs/example.jsx
+++ b/client/components/post-schedule/docs/example.jsx
@@ -9,6 +9,8 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
 import PostSchedule from 'components/post-schedule';
 import Timezone from 'components/timezone';
 import { Card } from '@automattic/components';
@@ -160,7 +162,7 @@ const PostScheduleExample = localize(
 								</h3>
 
 								<div className="card__block">
-									<label>
+									<FormLabel>
 										state.timezone
 										<div
 											className="state-value"
@@ -168,7 +170,7 @@ const PostScheduleExample = localize(
 										>
 											{ this.state.timezone || 'not defined' }
 										</div>
-									</label>
+									</FormLabel>
 
 									<Timezone selectedZone={ this.state.timezone } onSelect={ this.setTimezone } />
 
@@ -186,15 +188,14 @@ const PostScheduleExample = localize(
 								</div>
 
 								<div className="card__block">
-									<label>
+									<FormLabel>
 										state.gmtOffset
-										<input
+										<FormTextInput
 											className="editable-property"
-											type="text"
 											onChange={ this.setGMTOffset }
 											value={ this.state.gmtOffset }
 										/>
-									</label>
+									</FormLabel>
 
 									<button
 										className="card__property-action"
@@ -206,12 +207,12 @@ const PostScheduleExample = localize(
 								</div>
 
 								<div className="card__block">
-									<label>
+									<FormLabel>
 										state.date
 										<div className="state-value" style={ { fontSize: '11px' } }>
 											{ this.state.date ? this.state.date.format() : 'not defined' }
 										</div>
-									</label>
+									</FormLabel>
 
 									<button
 										className="card__property-action"
@@ -231,29 +232,29 @@ const PostScheduleExample = localize(
 								</h3>
 
 								<div className="card__block">
-									<label>
+									<FormLabel>
 										prop.onDateChange( date )
 										<div className="state-value" style={ { fontSize: '11px' } }>
 											{ this.state.date ? this.state.date.format() : 'not defined' }
 										</div>
-									</label>
+									</FormLabel>
 								</div>
 
 								<div className="card__block">
-									<label>
+									<FormLabel>
 										prop.onMonthChange( date )
 										<div className="state-value" style={ { fontSize: '11px' } }>
 											{ this.state.month ? this.state.month.format() : 'not defined' }
 										</div>
-									</label>
+									</FormLabel>
 								</div>
 							</Card>
 
 							<Card className="card__component-instance">
-								<label>
+								<FormLabel>
 									chronologically:
 									{ this.renderDateReference() }
-								</label>
+								</FormLabel>
 							</Card>
 						</div>
 					</div>

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
@@ -15,11 +15,12 @@ import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSelect from 'calypso/components/forms/form-select';
+import FormTextInput from 'components/forms/form-text-input';
 
 const textField = ( field, index ) => (
 	<PreviewFieldset key={ 'contact-form-field-' + index }>
 		<PreviewLegend { ...field } />
-		<input type="text" />
+		<FormTextInput />
 	</PreviewFieldset>
 );
 

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -89,7 +89,6 @@ class SimplePaymentsView extends Component {
 							<div className="wpview-type-simple-payments__pay-quantity">
 								<FormTextInput
 									className="wpview-type-simple-payments__pay-quantity-input"
-									type="text"
 									value="1"
 									readOnly
 								/>

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -12,6 +12,7 @@ import formatCurrency from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
+import FormTextInput from 'components/forms/form-text-input';
 import { next } from 'lib/shortcode';
 import { deserialize } from 'components/tinymce/plugins/simple-payments/shortcode-utils';
 import getMediaItem from 'state/selectors/get-media-item';
@@ -86,7 +87,7 @@ class SimplePaymentsView extends Component {
 					<div className="wpview-type-simple-payments__pay-part">
 						{ multiple && (
 							<div className="wpview-type-simple-payments__pay-quantity">
-								<input
+								<FormTextInput
 									className="wpview-type-simple-payments__pay-quantity-input"
 									type="text"
 									value="1"

--- a/client/components/token-field/test/__snapshots__/index.jsx.snap
+++ b/client/components/token-field/test/__snapshots__/index.jsx.snap
@@ -52,7 +52,7 @@ exports[`TokenField render should render tokens 1`] = `
       </svg>
     </span>
     <input
-      class="token-field__input"
+      class="form-text-input token-field__input"
       placeholder=""
       size="1"
       type="text"

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -106,7 +106,7 @@ describe( 'TokenField', () => {
 	beforeEach( () => {
 		wrapper = mount( <TokenFieldWrapper /> );
 		tokenFieldNode = wrapper.find( '.token-field' );
-		textInputNode = wrapper.find( '.token-field__input' );
+		textInputNode = wrapper.find( 'input.token-field__input' );
 		textInputNode.simulate( 'focus' );
 	} );
 

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -5,6 +5,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { omit, noop } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import FormTextInput from 'components/forms/form-text-input';
+
 class TokenInput extends React.PureComponent {
 	static propTypes = {
 		disabled: PropTypes.bool,
@@ -36,12 +41,11 @@ class TokenInput extends React.PureComponent {
 			( ( value.length === 0 && placeholder && placeholder.length ) || value.length ) + 1;
 
 		return (
-			<input
+			<FormTextInput
 				className="token-field__input"
 				onChange={ this.onChange }
-				ref={ this.setTextInput }
+				inputRef={ this.setTextInput }
 				size={ size }
-				type="text"
 				{ ...omit( this.props, [ 'hasFocus', 'onChange' ] ) }
 			/>
 		);

--- a/client/lib/form-state/examples/async-initialize.jsx
+++ b/client/lib/form-state/examples/async-initialize.jsx
@@ -9,6 +9,8 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
+import FormTextInput from 'components/forms/form-text-input';
 import FormStateStore from '../';
 import createFormStore from '../store';
 
@@ -47,25 +49,23 @@ class AsyncInitialize extends React.Component {
 		return (
 			<div>
 				<form onSubmit={ this.handleSubmit.bind( this ) }>
-					<input
+					<FormTextInput
 						name="firstName"
-						type="text"
 						placeholder={ i18n.translate( 'First Name' ) }
 						onChange={ this.handleFieldChange.bind( this ) }
 						disabled={ isFieldDisabled( this.state.form, 'firstName' ) }
 					/>
 
-					<input
+					<FormTextInput
 						name="lastName"
-						type="text"
 						placeholder={ i18n.translate( 'Last Name' ) }
 						onChange={ this.handleFieldChange.bind( this ) }
 						disabled={ isFieldDisabled( this.state.form, 'lastName' ) }
 					/>
 
-					<button type="submit" className="button is-primary">
+					<Button type="submit" primary>
 						Submit
-					</button>
+					</Button>
 				</form>
 
 				<pre>{ JSON.stringify( this.state, null, 2 ) }</pre>

--- a/client/lib/form-state/examples/sync-initialize.jsx
+++ b/client/lib/form-state/examples/sync-initialize.jsx
@@ -9,6 +9,8 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
+import FormTextInput from 'components/forms/form-text-input';
 import FormStateStore from '../';
 import createFormStore from '../store';
 
@@ -35,25 +37,23 @@ class SyncInitialize extends React.Component {
 		return (
 			<div>
 				<form onSubmit={ this.handleSubmit.bind( this ) }>
-					<input
+					<FormTextInput
 						name="firstName"
-						type="text"
 						placeholder={ i18n.translate( 'First Name' ) }
 						onChange={ this.handleFieldChange.bind( this ) }
 						disabled={ isFieldDisabled( this.state.form, 'firstName' ) }
 					/>
 
-					<input
+					<FormTextInput
 						name="lastName"
-						type="text"
 						placeholder={ i18n.translate( 'Last Name' ) }
 						onChange={ this.handleFieldChange.bind( this ) }
 						disabled={ isFieldDisabled( this.state.form, 'lastName' ) }
 					/>
 
-					<button type="submit" className="button is-primary">
+					<Button type="submit" primary>
 						Submit
-					</button>
+					</Button>
 				</form>
 
 				<pre>{ JSON.stringify( this.state, null, 2 ) }</pre>

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -14,6 +14,7 @@ import config from 'config';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dialog, Button } from '@automattic/components';
 import Gridicon from 'components/gridicon';
+import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import InlineSupportLink from 'components/inline-support-link';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -156,10 +157,9 @@ class AccountCloseConfirmDialog extends React.Component {
 								}
 							) }
 						</FormLabel>
-						<input
+						<FormTextInput
 							autoCapitalize="off"
 							className="account-close__confirm-dialog-confirm-input"
-							type="text"
 							onChange={ this.handleInputChange }
 							value={ this.state.inputValue }
 							aria-required="true"

--- a/client/my-sites/checkout/cart/cart-coupon.jsx
+++ b/client/my-sites/checkout/cart/cart-coupon.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import FormTextInput from 'components/forms/form-text-input';
 import { Button } from '@automattic/components';
 import { recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
 import { applyCoupon, removeCoupon } from 'lib/cart/actions';
@@ -85,8 +86,7 @@ export class CartCoupon extends React.Component {
 
 		return (
 			<form onSubmit={ this.applyCoupon } className={ 'cart__form' }>
-				<input
-					type="text"
+				<FormTextInput
 					data-e2e-type="coupon-code"
 					disabled={ this.isSubmitting }
 					placeholder={ this.props.translate( 'Enter Coupon Code', { textOnly: true } ) }

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-row.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-row.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import FormTextInput from 'components/forms/form-text-input';
 import FormFieldset from 'components/forms/form-fieldset';
 import { Button } from '@automattic/components';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
@@ -38,8 +39,7 @@ class CustomNameserversRow extends React.PureComponent {
 		return (
 			<div className="name-servers__custom-nameservers-row">
 				<FormFieldset>
-					<input
-						type="text"
+					<FormTextInput
 						placeholder={ this.props.placeholder }
 						onChange={ this.handleChange }
 						onFocus={ this.handleFocus }

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -72,7 +72,7 @@
 		margin-bottom: 0;
 	}
 
-	input[type='text'] {
+	.form-text-input {
 		padding-right: 38px;
 
 		@include breakpoint-deprecated( '<480px' ) {

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -11,6 +11,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import FormTextInput from 'components/forms/form-text-input';
 import FormFieldset from 'components/forms/form-fieldset';
 import { Button } from '@automattic/components';
 import { hasProduct, siteRedirect } from 'lib/cart-values/cart-items';
@@ -55,9 +56,8 @@ class SiteRedirectStep extends React.Component {
 					<DomainProductPrice price={ price } requiresPlan={ false } />
 
 					<FormFieldset>
-						<input
+						<FormTextInput
 							className="site-redirect-step__external-domain"
-							type="text"
 							value={ this.state.searchQuery }
 							placeholder={ translate( 'Enter a domain', { textOnly: true } ) }
 							onChange={ this.setSearchQuery }

--- a/client/my-sites/domains/domain-search/site-redirect-step.scss
+++ b/client/my-sites/domains/domain-search/site-redirect-step.scss
@@ -44,7 +44,7 @@
 	}
 }
 
-input.site-redirect-step__external-domain {
+.form-text-input.site-redirect-step__external-domain {
 	@include breakpoint-deprecated( '>660px' ) {
 		float: left;
 		width: calc( 100% - 90px );

--- a/client/my-sites/hosting/miscellaneous-card/index.js
+++ b/client/my-sites/hosting/miscellaneous-card/index.js
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import { Button, Card, Dialog } from '@automattic/components';
 import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
 import CardHeading from 'components/card-heading';
 import MaterialIcon from 'components/material-icon';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -103,9 +104,8 @@ const MiscellaneousCard = ( {
 						</p>
 					</FormLabel>
 
-					<input
+					<FormTextInput
 						autoCapitalize="off"
-						type="text"
 						onChange={ onReasonChange }
 						value={ reason }
 						aria-required="true"

--- a/client/my-sites/marketing/buttons/label-editor.jsx
+++ b/client/my-sites/marketing/buttons/label-editor.jsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import FormTextInput from 'components/forms/form-text-input';
 import { decodeEntities } from 'lib/formatting';
 
 const closeKeyCodes = [
@@ -82,8 +83,7 @@ class SharingButtonsLabelEditor extends React.Component {
 					<p className="sharing-buttons-preview__panel-instructions">
 						{ this.props.translate( 'Change the text of the sharing buttons label' ) }
 					</p>
-					<input
-						type="text"
+					<FormTextInput
 						value={ decodeEntities( this.props.value ) }
 						onKeyDown={ this.onKeyDown }
 						onChange={ this.onInputChange }

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
 import MultiCheckbox from 'components/forms/multi-checkbox';
 import SupportInfo from 'components/support-info';
 import { getPostTypes } from 'state/post-types/selectors';
@@ -168,9 +169,8 @@ class SharingButtonsOptions extends Component {
 				<legend className="sharing-buttons__fieldset-heading">
 					{ translate( 'Twitter username' ) }
 				</legend>
-				<input
+				<FormTextInput
 					name={ option }
-					type="text"
 					placeholder={ '@' + translate( 'username' ) }
 					value={ this.getSanitizedTwitterUsername( settings[ option ] ) }
 					onChange={ this.handleTwitterViaChange }

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -28,6 +28,7 @@ import { deleteSite } from 'state/sites/actions';
 import { setSelectedSiteId } from 'state/ui/actions';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
 import hasCancelableSitePurchases from 'state/selectors/has-cancelable-site-purchases';
 
 /**
@@ -355,10 +356,9 @@ class DeleteSite extends Component {
 							) }
 						</FormLabel>
 
-						<input
+						<FormTextInput
 							autoCapitalize="off"
 							className="delete-site__confirm-input"
-							type="text"
 							onChange={ this.onConfirmDomainChange }
 							value={ this.state.confirmDomain }
 							aria-required="true"

--- a/packages/components/src/suggestions/README.md
+++ b/packages/components/src/suggestions/README.md
@@ -9,6 +9,7 @@ A suggestion whose `label` property matches the `query` prop will be highlighted
 
 ```jsx
 import React, { useCallback, useMemo, useState } from 'react';
+import FormTextInput from 'components/forms/form-text-input';
 import { Suggestions } from '@automattic/components';
 
 export default function SuggestionsExample() {
@@ -26,8 +27,7 @@ export default function SuggestionsExample() {
 
 	return (
 		<div className="docs__suggestions-container">
-			<input
-				type="text"
+			<FormTextInput
 				value={ query }
 				onChange={ updateInput }
 				autoComplete="off"

--- a/packages/components/src/suggestions/docs/example.jsx
+++ b/packages/components/src/suggestions/docs/example.jsx
@@ -6,6 +6,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 /**
  * Internal dependencies
  */
+import FormTextInput from 'components/forms/form-text-input';
 import Suggestions from '..';
 
 export default function SuggestionsExample() {
@@ -24,8 +25,7 @@ export default function SuggestionsExample() {
 	return (
 		<div className="docs__suggestions-container">
 			<div>
-				<input
-					type="text"
+				<FormTextInput
 					value={ query }
 					onChange={ updateInput }
 					autoComplete="off"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Components: Use `FormTextInput` for all `type="text"` inputs. See #45259.

#### Testing instructions

* Test the following against production and ensure that they match stylistically and functionally:
  * `/devdocs/design/formatted-date` - all the text fields in the example
  * `/devdocs/blocks/post-schedule` - the time fields, all labels in the example and the `state.gmtOffset` field.
  * classic Calypso editor - insert a Contact form with a text field and observe the preview of the text field.
  * `/devdocs/design/token-fields` - all the examples
  * `/devdocs/form-state-examples/async-initialize` - the entire form
  * `/devdocs/form-state-examples/sync-initialize` - the entire form
  * `/me/account/close` - the username field in the dialog once you click "Close account" - should be tested with a non-a11n WP.com account.
  * old checkout - checkout a plan or a product soewhere and add `?flags=old-checkout-force` to the URL. Try adding a coupon code and take a close look at the coupon code field.
  * Editing a custom nameservers row for a domain bought from WP.com where you don't use WP.com's nameservers but use custom ones.
  * `/domains/add/site-redirect/:site` where `:site` corresponds to a WP.com domain that is controlled on WP.com.
  * clearing cache - you need to enable it for your user as displayed in p7DVsv-8uo-p2, then visit `/hosting-config/:site` where `:site` is an atomic site. Click "Clear cache" and observe the text field in the dialog.
  * `/marketing/sharing-buttons/:site` - the text field when you click to edit the share label text, and the twitter username field at the bottom.
  * `/settings/delete-site/:site` where `:site` is a WP.com site on a free plan without any upgrades. Click the "Delete site" button and observe the text field in the dialog.
  * `/devdocs/design/suggestions` - the text field.

#### Notes

* The following instances are consciously ignored:
  * `apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/edit.js` - uses @wordpress/components and not Calypso ones and isn't used in Calypso.
  * `client/my-sites/checkout/composite-checkout/components/wp-contact-form.js` - composite checkout uses its own set of components
* Lint errors are expected and are not being introduced by this PR. I'm consciously not fixing them, to avoid creating an unnecessarily huge PR.
* There could be visual differences in some of the examples, but that's only because we're now using the right components for labels and inputs, vs. the raw elements.
