### PR TITLE
Gutenboarding: update store feature and track Features step

### DIFF
--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -93,9 +93,17 @@ type TracksPlanSelectEventProperties = {
 	selected_plan: string | undefined;
 };
 
+type TracksFeaturesSelectEventProperties = {
+	/**
+	 * The selected features
+	 */
+	has_selected_features: boolean | undefined;
+};
+
 export type TracksEventProperties =
 	| TracksAcquireIntentEventProperties
 	| TracksStyleSelectEventProperties
 	| TracksDesignSelectEventProperties
 	| TracksDomainSelectEventProperties
-	| TracksPlanSelectEventProperties;
+	| TracksPlanSelectEventProperties
+	| TracksFeaturesSelectEventProperties;

--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -88,7 +88,7 @@ type TracksDomainSelectEventProperties = {
 
 type TracksPlanSelectEventProperties = {
 	/**
-	 * The selected level domain name
+	 * The selected plan slug
 	 */
 	selected_plan: string | undefined;
 };

--- a/client/landing/gutenboarding/onboarding-block/features/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/features/index.tsx
@@ -23,6 +23,7 @@ import classnames from 'classnames';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { WPCOM_FEATURES_STORE } from '../../stores/wpcom-features';
 import useStepNavigation from '../../hooks/use-step-navigation';
+import { useTrackStep } from '../../hooks/use-track-step';
 
 /**
  * Style dependencies
@@ -49,6 +50,16 @@ const FeaturesStep: React.FunctionComponent = () => {
 			addFeature( featureId );
 		}
 	};
+
+	// Keep a copy of the selected domain locally so it's available when the component is unmounting
+	const hasSelectedFeaturesRef = React.useRef< boolean >();
+	React.useEffect( () => {
+		hasSelectedFeaturesRef.current = hasSelectedFeatures;
+	}, [ hasSelectedFeatures ] );
+
+	useTrackStep( 'Features', () => ( {
+		has_selected_features: hasSelectedFeaturesRef.current,
+	} ) );
 
 	return (
 		<div className="gutenboarding-page features">

--- a/packages/data-stores/src/wpcom-features/features-data.tsx
+++ b/packages/data-stores/src/wpcom-features/features-data.tsx
@@ -7,7 +7,7 @@ import type { FeatureId, Feature } from './types';
 /**
  * Internal dependencies
  */
-const { PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS } = Plans;
+const { PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE } = Plans;
 
 export const featuresList: Record< FeatureId, Feature > = {
 	domain: {
@@ -22,9 +22,9 @@ export const featuresList: Record< FeatureId, Feature > = {
 		id: 'store',
 		name: translate( 'Store' ) as string,
 		description: translate(
-			'Sell products, digital subscriptions, and receive payments.'
+			'Sell unlimited products or services with a powerful, flexible online store.'
 		) as string,
-		minSupportedPlan: PLAN_PREMIUM,
+		minSupportedPlan: PLAN_ECOMMERCE,
 	},
 	seo: {
 		id: 'seo',


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Update copy for "Store" feature to better reflect what customers will get.
* Recommend eCommerce plan when "Store" feature is selected.
* Fire tracks events when landing and advancing from Features step.
  * `calypso_newsite_step_enter` event called with props `{flow: "gutenboarding", step: "Features"}`
  * `calypso_newsite_step_leave` event called with props `{flow: "gutenboarding", step: "Features", has_selected_features: true}`


#### Testing instructions (copy and mechanics change)
* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-features-store)
* Advance to /features step and check the copy for Store feature. Then select it and advance
* On Plans step, the recommended plan should be _eCommerce plan_

#### Testing instructions (analytics change)
* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-features-store)
* Open console and execute `localStorage.setItem('debug', 'calypso:analytics');`
* Refresh, then advance to Features step. `calypso_newsite_step_enter` with `step: "Features"` prop.
* When leaving Features step (by pressing back, next or opening a modal), `calypso_newsite_step_leave` event should fire with correct props. `has_selected_features` prop should reflect the last state of features selection.

#### Screenshot
<img width="900" alt="Screenshot 2020-09-18 at 16 20 55" src="https://user-images.githubusercontent.com/14192054/93602231-083b4200-f9cb-11ea-8050-d7a69187b09b.png">


Fixes part of #45748 
