### PR TITLE
Email: Add functionality to email comparison page

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -760,6 +760,19 @@ Undocumented.prototype.validateGoogleAppsContactInformation = function (
 };
 
 /**
+ * Retrieves the Titan order provisioning URL for a domain.
+ *
+ * @param domain the domain name
+ * @param fn The callback function
+ */
+Undocumented.prototype.getTitanOrderProvisioningURL = function ( domain, fn ) {
+	return this.wpcom.req.get(
+		{ path: `/domains/${ encodeURIComponent( domain ) }/titan/order-provisioning-url` },
+		fn
+	);
+};
+
+/**
  * Get a list of WordPress.com products
  *
  * @param {Function} fn The callback function

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -135,11 +135,11 @@ class EmailManagement extends React.Component {
 		}
 
 		if ( config.isEnabled( 'email/titan-mvp' ) ) {
-			const chosenDomain = domainList[ 0 ];
+			const selectedDomain = domainList[ 0 ];
 			return (
 				<EmailProvidersComparison
-					domain={ chosenDomain }
-					isGSuiteSupported={ hasGSuiteSupportedDomain( [ chosenDomain ] ) }
+					domain={ selectedDomain }
+					isGSuiteSupported={ hasGSuiteSupportedDomain( [ selectedDomain ] ) }
 				/>
 			);
 		}

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -134,10 +134,17 @@ class EmailManagement extends React.Component {
 			return this.googleAppsUsersCard();
 		}
 
+		if ( config.isEnabled( 'email/titan-mvp' ) ) {
+			const chosenDomain = domainList[ 0 ];
+			return (
+				<EmailProvidersComparison
+					domain={ chosenDomain }
+					isGSuiteSupported={ hasGSuiteSupportedDomain( [ chosenDomain ] ) }
+				/>
+			);
+		}
+
 		if ( hasGSuiteSupportedDomain( domainList ) ) {
-			if ( config.isEnabled( 'email/titan-mvp' ) ) {
-				return <EmailProvidersComparison domainName={ domainList[ 0 ].name } />;
-			}
 			return this.addGSuiteCta();
 		}
 

--- a/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
@@ -29,6 +29,7 @@ class EmailProviderDetails extends React.Component {
 		buttonLabel: PropTypes.string,
 		hasPrimaryButton: PropTypes.bool,
 		className: PropTypes.string,
+		onButtonClick: PropTypes.func,
 	};
 
 	renderFeatures() {
@@ -36,6 +37,13 @@ class EmailProviderDetails extends React.Component {
 			<EmailProviderFeature key={ `feature-${ index }` } title={ feature } />
 		) );
 	}
+
+	onButtonClick = ( e ) => {
+		const { onButtonClick } = this.props;
+		if ( onButtonClick ) {
+			onButtonClick( e );
+		}
+	};
 
 	render() {
 		const {
@@ -54,7 +62,11 @@ class EmailProviderDetails extends React.Component {
 			<PromoCard { ...{ className, title, image, badge } }>
 				<p className="email-provider-details__description">{ description }</p>
 				<PromoCardPrice { ...{ formattedPrice, discount } } />
-				<Button className="email-provider-details__cta" primary={ hasPrimaryButton }>
+				<Button
+					className="email-provider-details__cta"
+					primary={ hasPrimaryButton }
+					onClick={ this.onButtonClick }
+				>
 					{ buttonLabel }
 				</Button>
 				<div>{ this.renderFeatures() }</div>

--- a/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
@@ -28,6 +28,7 @@ class EmailProviderDetails extends React.Component {
 		discount: PropTypes.string,
 		buttonLabel: PropTypes.string,
 		hasPrimaryButton: PropTypes.bool,
+		className: PropTypes.string,
 	};
 
 	renderFeatures() {
@@ -46,10 +47,11 @@ class EmailProviderDetails extends React.Component {
 			discount,
 			buttonLabel,
 			hasPrimaryButton,
+			className,
 		} = this.props;
 
 		return (
-			<PromoCard { ...{ title, image, badge } }>
+			<PromoCard { ...{ className, title, image, badge } }>
 				<p className="email-provider-details__description">{ description }</p>
 				<PromoCardPrice { ...{ formattedPrice, discount } } />
 				<Button className="email-provider-details__cta" primary={ hasPrimaryButton }>

--- a/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
@@ -24,7 +24,7 @@ class EmailProviderDetails extends React.Component {
 		image: PropTypes.object.isRequired,
 		features: PropTypes.arrayOf( PropTypes.string ).isRequired,
 		badge: PropTypes.string,
-		formattedPrice: PropTypes.string,
+		formattedPrice: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
 		discount: PropTypes.string,
 		buttonLabel: PropTypes.string,
 		hasPrimaryButton: PropTypes.bool,

--- a/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
@@ -30,6 +30,7 @@ class EmailProviderDetails extends React.Component {
 		hasPrimaryButton: PropTypes.bool,
 		className: PropTypes.string,
 		onButtonClick: PropTypes.func,
+		isButtonBusy: PropTypes.bool,
 	};
 
 	renderFeatures() {
@@ -56,6 +57,7 @@ class EmailProviderDetails extends React.Component {
 			buttonLabel,
 			hasPrimaryButton,
 			className,
+			isButtonBusy,
 		} = this.props;
 
 		return (
@@ -66,6 +68,7 @@ class EmailProviderDetails extends React.Component {
 					className="email-provider-details__cta"
 					primary={ hasPrimaryButton }
 					onClick={ this.onButtonClick }
+					busy={ isButtonBusy }
 				>
 					{ buttonLabel }
 				</Button>

--- a/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-details/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,18 +34,15 @@ class EmailProviderDetails extends React.Component {
 		isButtonBusy: PropTypes.bool,
 	};
 
+	static defaultProps = {
+		onButtonClick: noop,
+	};
+
 	renderFeatures() {
 		return this.props.features.map( ( feature, index ) => (
 			<EmailProviderFeature key={ `feature-${ index }` } title={ feature } />
 		) );
 	}
-
-	onButtonClick = ( e ) => {
-		const { onButtonClick } = this.props;
-		if ( onButtonClick ) {
-			onButtonClick( e );
-		}
-	};
 
 	render() {
 		const {
@@ -67,7 +65,7 @@ class EmailProviderDetails extends React.Component {
 				<Button
 					className="email-provider-details__cta"
 					primary={ hasPrimaryButton }
-					onClick={ this.onButtonClick }
+					onClick={ this.props.onButtonClick }
 					busy={ isButtonBusy }
 				>
 					{ buttonLabel }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -19,7 +19,7 @@ import { getAnnualPrice } from 'lib/gsuite';
 import { hasDiscount } from 'components/gsuite/gsuite-price';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
-import { emailManagementForwarding } from 'my-sites/email/paths';
+import { emailManagementForwarding, emailManagementNewGSuiteAccount } from 'my-sites/email/paths';
 import emailIllustration from 'assets/images/email-providers/email-illustration.svg';
 import titanLogo from 'assets/images/email-providers/titan.svg';
 import gSuiteLogo from 'assets/images/email-providers/gsuite.svg';
@@ -39,6 +39,11 @@ class EmailProvidersComparison extends React.Component {
 	goToEmailForwarding = () => {
 		const { domain, currentRoute, selectedSiteSlug } = this.props;
 		page( emailManagementForwarding( selectedSiteSlug, domain.name, currentRoute ) );
+	};
+
+	goToAddGSuite = () => {
+		const { domain, currentRoute, selectedSiteSlug } = this.props;
+		page( emailManagementNewGSuiteAccount( selectedSiteSlug, domain.name, 'basic', currentRoute ) );
 	};
 
 	renderHeaderSection() {
@@ -163,6 +168,7 @@ class EmailProvidersComparison extends React.Component {
 						: null
 				}
 				buttonLabel={ translate( 'Add G Suite' ) }
+				onButtonClick={ this.goToAddGSuite }
 			/>
 		);
 	}

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -16,6 +17,9 @@ import { getProductBySlug } from 'state/products-list/selectors';
 import { GSUITE_BASIC_SLUG } from 'lib/gsuite/constants';
 import { getAnnualPrice } from 'lib/gsuite';
 import { hasDiscount } from 'components/gsuite/gsuite-price';
+import getCurrentRoute from 'state/selectors/get-current-route';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { emailManagementForwarding } from 'my-sites/email/paths';
 import emailIllustration from 'assets/images/email-providers/email-illustration.svg';
 import titanLogo from 'assets/images/email-providers/titan.svg';
 import gSuiteLogo from 'assets/images/email-providers/gsuite.svg';
@@ -30,6 +34,11 @@ class EmailProvidersComparison extends React.Component {
 	static propTypes = {
 		domain: PropTypes.object.isRequired,
 		isGSuiteSupported: PropTypes.bool.isRequired,
+	};
+
+	goToEmailForwarding = () => {
+		const { domain, currentRoute, selectedSiteSlug } = this.props;
+		page( emailManagementForwarding( selectedSiteSlug, domain.name, currentRoute ) );
 	};
 
 	renderHeaderSection() {
@@ -65,7 +74,13 @@ class EmailProvidersComparison extends React.Component {
 	}
 
 	renderForwardingDetails( className ) {
-		const { translate } = this.props;
+		const { domain, translate } = this.props;
+
+		const buttonLabel =
+			domain.emailForwardsCount > 0
+				? translate( 'Manage email forwarding' )
+				: translate( 'Add email forwarding' );
+
 		return (
 			<EmailProviderDetails
 				title={ translate( 'Email Forwarding' ) }
@@ -77,7 +92,8 @@ class EmailProvidersComparison extends React.Component {
 					translate( 'No billing' ),
 					translate( 'Receive emails sent to your custom domain' ),
 				] }
-				buttonLabel={ translate( 'Add email forwarding' ) }
+				buttonLabel={ buttonLabel }
+				onButtonClick={ this.goToEmailForwarding }
 				className={ className }
 			/>
 		);
@@ -171,5 +187,7 @@ export default connect( ( state ) => {
 	return {
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		gSuiteProduct: getProductBySlug( state, GSUITE_BASIC_SLUG ),
+		currentRoute: getCurrentRoute( state ),
+		selectedSiteSlug: getSelectedSiteSlug( state ),
 	};
 } )( localize( EmailProvidersComparison ) );

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -64,7 +64,7 @@ class EmailProvidersComparison extends React.Component {
 		);
 	}
 
-	renderForwardingDetails() {
+	renderForwardingDetails( className ) {
 		const { translate } = this.props;
 		return (
 			<EmailProviderDetails
@@ -78,11 +78,12 @@ class EmailProvidersComparison extends React.Component {
 					translate( 'Receive emails sent to your custom domain' ),
 				] }
 				buttonLabel={ translate( 'Add email forwarding' ) }
+				className={ className }
 			/>
 		);
 	}
 
-	renderTitanDetails() {
+	renderTitanDetails( className ) {
 		const { translate } = this.props;
 
 		return (
@@ -107,6 +108,7 @@ class EmailProvidersComparison extends React.Component {
 				} ) }
 				buttonLabel={ translate( 'Add Titan Mail' ) }
 				hasPrimaryButton={ true }
+				className={ className }
 			/>
 		);
 	}
@@ -150,13 +152,15 @@ class EmailProvidersComparison extends React.Component {
 	}
 
 	render() {
+		const { isGSuiteSupported } = this.props;
+		const cardClassName = isGSuiteSupported ? null : 'no-gsuite';
 		return (
 			<>
 				{ this.renderHeaderSection() }
 				<div className="email-providers-comparison__providers">
-					{ this.renderForwardingDetails() }
-					{ this.renderTitanDetails() }
-					{ this.renderGSuiteDetails() }
+					{ this.renderForwardingDetails( cardClassName ) }
+					{ this.renderTitanDetails( cardClassName ) }
+					{ isGSuiteSupported && this.renderGSuiteDetails() }
 				</div>
 			</>
 		);

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -53,6 +53,10 @@ class EmailProvidersComparison extends React.Component {
 	};
 
 	onAddTitanClick = () => {
+		if ( this.state.isFetchingProvisioningURL ) {
+			return;
+		}
+
 		const { domain, translate } = this.props;
 		this.setState( { isFetchingProvisioningURL: true } );
 		this.fetchTitanOrderProvisioningURL( domain.name ).then( ( { error, provisioningURL } ) => {

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -28,11 +28,12 @@ import './style.scss';
 
 class EmailProvidersComparison extends React.Component {
 	static propTypes = {
-		domainName: PropTypes.string.isRequired,
+		domain: PropTypes.object.isRequired,
+		isGSuiteSupported: PropTypes.bool.isRequired,
 	};
 
 	renderHeaderSection() {
-		const { domainName, translate } = this.props;
+		const { domain, translate } = this.props;
 		const image = {
 			path: emailIllustration,
 			align: 'right',
@@ -40,7 +41,7 @@ class EmailProvidersComparison extends React.Component {
 
 		const translateArgs = {
 			args: {
-				domainName: domainName,
+				domainName: domain.name,
 			},
 			comment: '%(domainName)s is the domain name, e.g example.com',
 		};
@@ -63,78 +64,99 @@ class EmailProvidersComparison extends React.Component {
 		);
 	}
 
-	render() {
+	renderForwardingDetails() {
+		const { translate } = this.props;
+		return (
+			<EmailProviderDetails
+				title={ translate( 'Email Forwarding' ) }
+				description={ translate(
+					'Use your custom domain in your email address and forward all your mail to another address.'
+				) }
+				image={ { path: forwardingIcon } }
+				features={ [
+					translate( 'No billing' ),
+					translate( 'Receive emails sent to your custom domain' ),
+				] }
+				buttonLabel={ translate( 'Add email forwarding' ) }
+			/>
+		);
+	}
+
+	renderTitanDetails() {
+		const { translate } = this.props;
+
+		return (
+			<EmailProviderDetails
+				title={ translate( 'Titan Mail' ) }
+				badge={ translate( 'Recommended' ) }
+				description={ translate(
+					'Easy-to-use email with incredibly powerful features. Manage your email and more on any device.'
+				) }
+				image={ { path: titanLogo } }
+				features={ [
+					translate( 'Monthly billing' ),
+					translate( 'Send and receive from your custom domain' ),
+					translate( '10GB storage' ),
+					translate( 'Email, calendars, and contacts' ),
+				] }
+				formattedPrice={ translate( '{{price/}} /user /month', {
+					components: {
+						price: <span>$4</span>,
+					},
+					comment: '{{price/}} is the formatted price, e.g. $20',
+				} ) }
+				buttonLabel={ translate( 'Add Titan Mail' ) }
+				hasPrimaryButton={ true }
+			/>
+		);
+	}
+
+	renderGSuiteDetails() {
 		const { currencyCode, gSuiteProduct, translate } = this.props;
 
+		return (
+			<EmailProviderDetails
+				title={ translate( 'G Suite by Google' ) }
+				description={ translate(
+					"We've partnered with Google to offer you email, storage, docs, calendars, and more."
+				) }
+				image={ { path: gSuiteLogo } }
+				features={ [
+					translate( 'Monthly billing' ),
+					translate( 'Send and receive from your custom domain' ),
+					translate( '30GB storage' ),
+					translate( 'Email, calendars, and contacts' ),
+					translate( 'Video calls, Docs, spreadsheets, and more' ),
+				] }
+				formattedPrice={ translate( '{{price/}} /user /year', {
+					components: {
+						price: <span>{ getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode ) }</span>,
+					},
+					comment: '{{price/}} is the formatted price, e.g. $20',
+				} ) }
+				discount={
+					hasDiscount( gSuiteProduct )
+						? translate( 'First year %(discountedPrice)s', {
+								args: {
+									discountedPrice: getAnnualPrice( gSuiteProduct.sale_cost, currencyCode ),
+								},
+								comment: '%(discountedPrice)s is a formatted price, e.g. $75',
+						  } )
+						: null
+				}
+				buttonLabel={ translate( 'Add G Suite' ) }
+			/>
+		);
+	}
+
+	render() {
 		return (
 			<>
 				{ this.renderHeaderSection() }
 				<div className="email-providers-comparison__providers">
-					<EmailProviderDetails
-						title={ translate( 'Email Forwarding' ) }
-						description={ translate(
-							'Use your custom domain in your email address and forward all your mail to another address.'
-						) }
-						image={ { path: forwardingIcon } }
-						features={ [
-							translate( 'No billing' ),
-							translate( 'Receive emails sent to your custom domain' ),
-						] }
-						buttonLabel={ translate( 'Add email forwarding' ) }
-					/>
-					<EmailProviderDetails
-						title={ translate( 'Titan Mail' ) }
-						badge={ translate( 'Recommended' ) }
-						description={ translate(
-							'Easy-to-use email with incredibly powerful features. Manage your email and more on any device.'
-						) }
-						image={ { path: titanLogo } }
-						features={ [
-							translate( 'Monthly billing' ),
-							translate( 'Send and receive from your custom domain' ),
-							translate( '10GB storage' ),
-							translate( 'Email, calendars, and contacts' ),
-						] }
-						formattedPrice={ translate( '{{price/}} /user /month', {
-							components: {
-								price: <span>$4</span>,
-							},
-							comment: '{{price/}} is the formatted price, e.g. $20',
-						} ) }
-						buttonLabel={ translate( 'Add Titan Mail' ) }
-						hasPrimaryButton={ true }
-					/>
-					<EmailProviderDetails
-						title={ translate( 'G Suite by Google' ) }
-						description={ translate(
-							"We've partnered with Google to offer you email, storage, docs, calendars, and more."
-						) }
-						image={ { path: gSuiteLogo } }
-						features={ [
-							translate( 'Monthly billing' ),
-							translate( 'Send and receive from your custom domain' ),
-							translate( '30GB storage' ),
-							translate( 'Email, calendars, and contacts' ),
-							translate( 'Video calls, Docs, spreadsheets, and more' ),
-						] }
-						formattedPrice={ translate( '{{price/}} /user /year', {
-							components: {
-								price: <span>{ getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode ) }</span>,
-							},
-							comment: '{{price/}} is the formatted price, e.g. $20',
-						} ) }
-						discount={
-							hasDiscount( gSuiteProduct )
-								? translate( 'First year %(discountedPrice)s', {
-										args: {
-											discountedPrice: getAnnualPrice( gSuiteProduct.sale_cost, currencyCode ),
-										},
-										comment: '%(discountedPrice)s is a formatted price, e.g. $75',
-								  } )
-								: null
-						}
-						buttonLabel={ translate( 'Add G Suite' ) }
-					/>
+					{ this.renderForwardingDetails() }
+					{ this.renderTitanDetails() }
+					{ this.renderGSuiteDetails() }
 				</div>
 			</>
 		);

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -122,7 +122,7 @@ class EmailProvidersComparison extends React.Component {
 				) }
 				image={ { path: gSuiteLogo } }
 				features={ [
-					translate( 'Monthly billing' ),
+					translate( 'Annual billing' ),
 					translate( 'Send and receive from your custom domain' ),
 					translate( '30GB storage' ),
 					translate( 'Email, calendars, and contacts' ),

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -8,8 +8,14 @@
 		width: calc( 33% - 0.5em );
 		margin: 8px 0;
 
+		&.no-gsuite {
+			width: calc( 50% - 0.5em );
+		}
+
 		@include breakpoint-deprecated( '<1040px' ) {
-			width: 100%;
+			&, &.no-gsuite {
+				width: 100%;
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the email comparison page by accounting for the possibility of two instead of three columns (i.e. when G Suite is not supported), as well as makes the buttons work.

#### Testing instructions

- Verify for a domain that doesn't support G Suite that we show only email forwarding and Titan (you can force this by passing `false` to `isGSuiteSupported`)
- Verify that the buttons work correctly for all providers (with Titan it should load a link from the backend)
- The label for the email forwarding button should say `Manage email forwarding` when the user has set up forwarding for that domain
