### PR TITLE
Desktop manual check for updates

### DIFF
--- a/client/desktop/app-handlers/updater/index.js
+++ b/client/desktop/app-handlers/updater/index.js
@@ -53,7 +53,7 @@ function getUpdater() {
 	return updater;
 }
 
-// Syntax: intermediary module const is REQUIRED
-// to support both unnamed (default) and named exports.
+// !! Syntax: assignment via intermediary module const is
+// necessary to support both unnamed (default) and named exports !!
 const main = ( module.exports = init );
 main.getUpdater = getUpdater;

--- a/client/desktop/app-handlers/updater/index.js
+++ b/client/desktop/app-handlers/updater/index.js
@@ -15,19 +15,19 @@ const log = require( 'desktop/lib/logger' )( 'desktop:updater' );
 
 let updater = false;
 
-module.exports = function () {
+function init() {
 	log.info( 'Updater config: ', Config.updater );
 	if ( Config.updater ) {
 		app.on( 'will-finish-launching', function () {
 			const beta = settings.getSetting( 'release-channel' ) === 'beta';
 			log.info( `Update channel: '${ settings.getSetting( 'release-channel' ) }'` );
 			if ( platform.isOSX() || platform.isWindows() || process.env.APPIMAGE ) {
-				log.info( 'Auto Update' );
+				log.info( 'Initializing auto updater...' );
 				updater = new AutoUpdater( {
 					beta,
 				} );
 			} else {
-				log.info( 'Manual Update' );
+				log.info( 'Initializing manual updater...' );
 				updater = new ManualUpdater( {
 					downloadUrl: Config.updater.downloadUrl,
 					apiUrl: Config.updater.apiUrl,
@@ -47,4 +47,13 @@ module.exports = function () {
 	} else {
 		log.info( 'Skipping Update – no configuration' );
 	}
-};
+}
+
+function getUpdater() {
+	return updater;
+}
+
+// Syntax: intermediary module const is REQUIRED
+// to support both unnamed (default) and named exports.
+const main = ( module.exports = init );
+main.getUpdater = getUpdater;

--- a/client/desktop/lib/menu/app-menu.js
+++ b/client/desktop/lib/menu/app-menu.js
@@ -142,7 +142,7 @@ function checkForUpdates() {
 	log.info( `User clicked 'Check For Updates'` );
 	const updater = getUpdater();
 	if ( updater ) {
-		updater.ping();
+		updater.ping( true );
 	} else {
 		log.error( 'Updater not set' );
 	}

--- a/client/desktop/lib/menu/app-menu.js
+++ b/client/desktop/lib/menu/app-menu.js
@@ -13,6 +13,8 @@ const WindowManager = require( 'desktop/lib/window-manager' );
 const platform = require( 'desktop/lib/platform' );
 const AppQuit = require( 'desktop/lib/app-quit' );
 const debugMenu = require( './debug-menu' );
+const { getUpdater } = require( 'desktop/app-handlers/updater' );
+const log = require( 'desktop/lib/logger' )( 'desktop:menu' );
 
 /**
  * Module variables
@@ -120,9 +122,28 @@ module.exports = function ( app, mainWindow ) {
 			},
 			{
 				type: 'separator',
+			},
+			{
+				label: 'Check For Updates',
+				click: function () {
+					checkForUpdates();
+				},
+			},
+			{
+				type: 'separator',
 			}
 		);
 	}
 
 	return menuItems;
 };
+
+function checkForUpdates() {
+	log.info( `User clicked 'Check For Updates'` );
+	const updater = getUpdater();
+	if ( updater ) {
+		updater.ping();
+	} else {
+		log.error( 'Updater not set' );
+	}
+}

--- a/client/desktop/lib/updater/index.js
+++ b/client/desktop/lib/updater/index.js
@@ -75,6 +75,17 @@ class Updater extends EventEmitter {
 		}
 	}
 
+	notifyNotAvailable() {
+		const mainWindow = BrowserWindow.getFocusedWindow();
+
+		const notAvailableDialogOptions = {
+			buttons: [ 'OK' ],
+			message: 'There are currently no updates available.',
+		};
+
+		dialog.showMessageBox( mainWindow, notAvailableDialogOptions );
+	}
+
 	setVersion( version ) {
 		this._version = version;
 	}


### PR DESCRIPTION
### Description

This PR adds a manual "Check for Updates" menu item. If an update is available, this feature will follow the established updater flow for each platform (download and install on Mac, Windows; and navigate to WordPress Desktop homepage for Linux). If an update is not available, an "Update not available" dialog is displayed to the user.

<p align="center">
<img width="300" alt="check-for-updates-menu" src="https://user-images.githubusercontent.com/8979548/93634647-f05dc100-f9be-11ea-9747-c5e81755d93b.png">
<br>
<img width="300" alt="check-for-updates-update-available" src="https://user-images.githubusercontent.com/8979548/93634645-efc52a80-f9be-11ea-96ad-a325c3efe19e.png">
<br>
<img width="300" alt="check-for-updates-no-update" src="https://user-images.githubusercontent.com/8979548/93634646-f05dc100-f9be-11ea-9439-54b7c52a407f.png">
</p>

### To Test

Build and run this branch and amend the version number in `desktop/package.json` to verify behavior for update available/not available. (When testing locally, don't forget to set `CONFIG_ENV === release`.),