### PR TITLE
chore(logging): add logging refinements

### DIFF
--- a/client/desktop/app-handlers/preferences/index.js
+++ b/client/desktop/app-handlers/preferences/index.js
@@ -6,6 +6,7 @@ const { dialog, ipcMain: ipc } = require( 'electron' ); // eslint-disable-line i
 /**
  * Internal dependencies
  */
+const log = require( 'desktop/lib/logger' )( 'preferences' );
 const Settings = require( 'desktop/lib/settings' );
 
 function promptForRestart( title, message ) {
@@ -23,6 +24,7 @@ function promptForRestart( title, message ) {
 
 module.exports = function () {
 	ipc.on( 'preferences-changed', function ( event, { name, value } ) {
+		log.info( `Changed setting '${ name }': `, value );
 		if ( 'proxy-type' === name ) {
 			promptForRestart( 'Proxy changed', 'You have changed the proxy settings.' );
 		} else if ( 'spellcheck-enabled' === name ) {

--- a/client/desktop/app-handlers/preferences/index.js
+++ b/client/desktop/app-handlers/preferences/index.js
@@ -24,7 +24,7 @@ function promptForRestart( title, message ) {
 
 module.exports = function () {
 	ipc.on( 'preferences-changed', function ( event, { name, value } ) {
-		log.info( `Changed setting '${ name }': `, value );
+		log.info( `Changed setting '${ name }': `, value ? value : 'none' );
 		if ( 'proxy-type' === name ) {
 			promptForRestart( 'Proxy changed', 'You have changed the proxy settings.' );
 		} else if ( 'spellcheck-enabled' === name ) {

--- a/client/desktop/lib/desktop-analytics/index.js
+++ b/client/desktop/lib/desktop-analytics/index.js
@@ -30,10 +30,8 @@ export async function bumpStat( group, name ) {
 	const url = `https://pixel.wp.com/g.gif?v=wpcom-no-pv${ uriComponent }&t=${ Math.random() }`;
 
 	const resp = await fetch( url );
-	if ( resp.status === 200 ) {
-		log.info( 'Sent analytics ping' );
-	} else {
-		log.warn( 'Analytics ping failed', resp.status, resp.statusText );
+	if ( resp.status !== 200 ) {
+		log.warn( `Analytics ping failed (${ resp.status }): `, resp.statusText );
 	}
 }
 

--- a/client/desktop/lib/settings/index.js
+++ b/client/desktop/lib/settings/index.js
@@ -39,15 +39,11 @@ Settings.prototype.getSetting = function ( setting ) {
 
 	if ( typeof value === 'undefined' ) {
 		if ( typeof Config.default_settings[ setting ] !== 'undefined' ) {
-			log.info( 'Get default setting for ' + setting + ' = ' + Config.default_settings[ setting ] );
 			return Config.default_settings[ setting ];
 		}
-
-		log.info( 'Get setting with no defaults for ' + setting );
 		return false;
 	}
 
-	log.info( 'Get setting for ' + setting + ' = ' + value );
 	return value;
 };
 
@@ -67,10 +63,7 @@ Settings.prototype.getSettingGroup = function ( existing, group, values ) {
 				existing[ value ] = settingsGroup[ value ];
 				updated[ value ] = settingsGroup[ value ];
 			}
-
-			log.info( `Updated settings for group '${ group }': `, updated );
 		} else {
-			log.info( `Get settings for group '${ group }': `, settingsGroup );
 			return settingsGroup;
 		}
 	}

--- a/client/desktop/lib/settings/settings-file.js
+++ b/client/desktop/lib/settings/settings-file.js
@@ -30,7 +30,7 @@ module.exports = {
 			try {
 				return JSON.parse( fs.readFileSync( settingsFile ) );
 			} catch ( e ) {
-				log.error( 'Failed to read settings file' );
+				log.error( 'Failed to load settings file: ', e );
 			}
 		}
 
@@ -38,7 +38,7 @@ module.exports = {
 		try {
 			createSettingsFile( getSettingsFile() );
 		} catch ( e ) {
-			log.error( 'Failed to create settings file' );
+			log.error( 'Failed to create settings file: ', e );
 		}
 		return {};
 	},
@@ -52,18 +52,15 @@ module.exports = {
 				createSettingsFile( settingsFile );
 			}
 
-			// Read the existing settings
+			// Read existing settings
 			data = fs.readFileSync( settingsFile );
-
-			log.info( `Read settings from '${ settingsFile }': ${ data.toString( 'utf-8' ) }` );
 
 			data = JSON.parse( data );
 			data[ group ] = groupData;
 
-			log.info( `Updating settings: '${ group }': `, groupData );
 			fs.writeFileSync( settingsFile, JSON.stringify( data ) );
 		} catch ( error ) {
-			log.error( 'Failed to read settings file', error );
+			log.error( `Failed to write settings '${ group }' to file:`, error );
 		}
 
 		return data;

--- a/client/desktop/window-handlers/get-logs/index.js
+++ b/client/desktop/window-handlers/get-logs/index.js
@@ -8,6 +8,7 @@ const { app, dialog } = require( 'electron' ); // eslint-disable-line import/no-
  * Internal dependencies
  */
 const state = require( 'desktop/lib/state' );
+const config = require( 'desktop/lib/config' );
 const system = require( 'desktop/lib/system' );
 const { zipContents } = require( 'desktop/lib/archiver' );
 const log = require( 'desktop/lib/logger' )( 'desktop:get-logs' );
@@ -16,6 +17,7 @@ const log = require( 'desktop/lib/logger' )( 'desktop:get-logs' );
  * Module variables
  */
 const logPath = state.getLogPath();
+const settingsPath = path.join( app.getPath( 'appData' ), config.appPathName, 'settings.json' );
 
 const pad = ( n ) => `${ n }`.padStart( 2, '0' );
 
@@ -70,7 +72,7 @@ module.exports = async function ( window ) {
 		const desktop = app.getPath( 'desktop' );
 		const dst = path.join( desktop, `wpdesktop-${ timestamp }.zip` );
 
-		zipContents( [ logPath ], dst, onZipped( dst ) );
+		zipContents( [ logPath, settingsPath ], dst, onZipped( dst ) );
 	} catch ( error ) {
 		log.error( 'Failed to zip logs: ', error );
 		onError( error );


### PR DESCRIPTION
### Description

This PR removes noisy settings logging, and adds the `settings.json` file to the zip archive for inspection. (This information is useful, but unnecessary to log whenever a setting is fetched (which occurs in a number of places).

<p align="center">
<img width="280" alt="Screen Shot 2020-09-18 at 6 30 25 PM" src="https://user-images.githubusercontent.com/8979548/93650626-067a7a00-f9dd-11ea-8ff0-2fe94b4e41d8.png">
</p>

### To Test

- Build and run the app (or run the built executable from this PR)
- Verify that the archive created with the `Get Application Logs` actions also includes `settings.json`