### PR TITLE
Update the premium badge popover text

### DIFF
--- a/client/components/domains/premium-badge/index.jsx
+++ b/client/components/domains/premium-badge/index.jsx
@@ -19,7 +19,9 @@ class PremiumBadge extends React.Component {
 			<Badge className="premium-badge">
 				{ translate( 'Premium domain' ) }
 				<InfoPopover iconSize={ 16 }>
-					Premium domain names are short and easy to remember
+					{ translate(
+						'Premium domain names are usually short, easy to remember, contain popular keywords, or some combination of these factors. Premium domain names are not eligible for purchase using the free plan domain credit.'
+					) }
 				</InfoPopover>
 			</Badge>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the premium badge popover text and make it translatable

Here's how it looks:
<img width="545" alt="Screenshot 2020-09-20 at 15 45 09" src="https://user-images.githubusercontent.com/1355045/93711639-7f521100-fb58-11ea-9766-28723ac4a5dd.png">


#### Testing instructions

* Search for a premium domain in the dev/wpcalypso environment and check the premium badge info popover text
