### PR TITLE
Editing Toolkit: specify node version in github workflow

### DIFF
--- a/.github/workflows/editing-toolkit-plugin.yml
+++ b/.github/workflows/editing-toolkit-plugin.yml
@@ -11,6 +11,10 @@ jobs:
     name: Build plugin
     runs-on: ubuntu-latest
     steps:
+    - name: Set up Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '^12.18.4'
     - name: Checkout code
       uses: actions/checkout@HEAD
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the version of node used in the editing toolkit workflow

Currently, the Editing toolkit CI is failing:

> 2020-09-20T22:19:23.6584403Z error wp-calypso@0.17.0: The engine "node" is incompatible with this module. Expected version "^v12.18.4". Got "12.18.3"

This is because https://github.com/Automattic/wp-calypso/pull/45721 updated the required node version, but we're still using the default 12.18.3 provided by [ubuntu 18.04](https://github.com/actions/virtual-environments/blob/ubuntu18/20200914.1/images/linux/Ubuntu1804-README.md), so we need to pull in a newer version of node in line with our [other workflows](./.github/workflows/icfy-stats.yml). (Aside: there is a ubutu 20-04, but it's got the same node, so totally don't need to do that)
 
#### Testing instructions

As a circle-CI update, we're really just looking for the CI tests to pass.

I rebased https://github.com/Automattic/wp-calypso/pull/45747 on top of this change as a test, and it's gone from failing to passing, which looks good.

A thorough test would look similar:
- push some change to the Editing Toolkit and verify the CI is failing
- rebase onto this branch and force-push
- verify CI success.

OTOH, CI is broken, so breaking it again isn't much of a risk...