### PR TITLE
Gutenboarding: create site with translated default blog title

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -11,6 +11,7 @@ import {
 import { dispatch, select } from '@wordpress/data-controls';
 import guessTimezone from '../../../../lib/i18n-utils/guess-timezone';
 import { getLanguage } from 'lib/i18n-utils';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -54,15 +55,14 @@ export function* createSite(
 	}: State = yield select( ONBOARD_STORE, 'getState' );
 
 	const shouldEnableFse = !! selectedDesign?.is_fse;
-
 	const siteUrl = domain?.domain_name || siteTitle || username;
 	const lang_id = ( getLanguage( languageSlug ) as Language )?.value;
-
 	const defaultTheme = shouldEnableFse ? 'seedlet-blocks' : 'twentytwenty';
+	const blogTitle = siteTitle.trim() === '' ? __( 'Site Title' ) : siteTitle;
 
 	const params: CreateSiteParams = {
 		blog_name: siteUrl?.split( '.wordpress' )[ 0 ],
-		blog_title: siteTitle,
+		blog_title: blogTitle,
 		public: visibility,
 		options: {
 			site_vertical: siteVertical?.id,
@@ -73,7 +73,7 @@ export function* createSite(
 			// TODO: determine default vertical should user input match no official vertical
 			site_vertical_slug: siteVertical?.slug || 'football',
 			site_information: {
-				title: siteTitle,
+				title: blogTitle,
 			},
 			lang_id: lang_id,
 			site_creation_flow: 'gutenboarding',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When creating a new site, we're testing if site title is an empty string. 

If `siteTitle` is empty (the user has not entered a site title), we translate the default string of 'Site Title' **according to the Gutenboarding UI language**. 

If we don't do this, the corresponding create blog method in the backend will use the default locale.

**Before**
<img width="1074" alt="Screen Shot 2020-09-21 at 12 07 04 pm" src="https://user-images.githubusercontent.com/6458278/93728701-6141ea80-fc04-11ea-9a8a-61dded492a93.png">


**After**
<img width="1070" alt="Screen Shot 2020-09-21 at 12 09 33 pm" src="https://user-images.githubusercontent.com/6458278/93728707-656e0800-fc04-11ea-9a25-f89c2ea044f0.png">

#### Testing instructions

Create a site via `/new/{a_mag_16_locale}`

Make sure to skip the intent gathering step, i.e., don't specify a site title

The default site title should be a translation of "Site Title"
