### PR TITLE
Stop test and launch new AA test

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1077,7 +1077,7 @@ export default connect(
 		let displayUsernameInput = true;
 
 		if ( eligibleFlowsForRemoveUsernameTest.includes( ownProps.flowName ) ) {
-			displayUsernameInput = 'control' === abtest( 'removeUsernameInSignup' );
+			abtest( 'usernameAATest' );
 		} else if ( isDisplayUsernamePropSet ) {
 			displayUsernameInput = ownProps.displayUsernameInput;
 		}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -222,9 +222,18 @@ export default {
 		localeTargets: [ 'en' ],
 	},
 	removeUsernameInSignup: {
-		datestamp: '20200914',
+		datestamp: '20210914',
 		variations: {
 			variantRemoveUsername: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: false,
+	},
+	usernameAATest: {
+		datestamp: '20200921',
+		variations: {
+			variant: 50,
 			control: 50,
 		},
 		defaultVariation: 'control',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Stops the remove username test launched in https://github.com/Automattic/wp-calypso/pull/45609
* Launches a new AA test for the username field. Check pbxNRc-rq-p2/#comment-840.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the /start/user and /start/premium and confirm that you are not assigned to the `removeUsernameInSignup` test.
* Verify that in these flows, you are assigned to the `usernameAATest` and that the username field is visible in both control and variant.
