### PR TITLE
Business plan bump: Show offer for PayPal and other redirect payments

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -49,8 +49,6 @@ export default function getThankYouPageUrl( {
 	saveUrlToCookie = persistSignupDestination,
 	isEligibleForSignupDestinationResult,
 	hideNudge,
-	didPurchaseFail,
-	isTransactionResultEmpty,
 	isInEditor,
 }: {
 	siteSlug: string | undefined;
@@ -67,8 +65,6 @@ export default function getThankYouPageUrl( {
 	saveUrlToCookie?: SaveUrlToCookie;
 	isEligibleForSignupDestinationResult: boolean;
 	hideNudge: boolean;
-	didPurchaseFail: boolean;
-	isTransactionResultEmpty: boolean;
 	isInEditor?: boolean;
 } ): string {
 	debug( 'starting getThankYouPageUrl' );
@@ -171,8 +167,6 @@ export default function getThankYouPageUrl( {
 		cart,
 		siteSlug,
 		hideNudge,
-		didPurchaseFail,
-		isTransactionResultEmpty,
 	} );
 	if ( redirectPathForConciergeUpsell ) {
 		debug( 'redirect for concierge exists, so returning', redirectPathForConciergeUpsell );
@@ -277,20 +271,16 @@ function maybeShowPlanBumpOffer( {
 	cart,
 	siteSlug,
 	orderId,
-	didPurchaseFail,
-	isTransactionResultEmpty,
 }: {
 	pendingOrReceiptId: string;
 	orderId: number | undefined;
 	cart: ResponseCart | undefined;
 	siteSlug: string | undefined;
-	didPurchaseFail: boolean;
-	isTransactionResultEmpty: boolean;
 } ): string | undefined {
 	if ( orderId ) {
 		return;
 	}
-	if ( hasPremiumPlan( cart ) && ! isTransactionResultEmpty && ! didPurchaseFail ) {
+	if ( hasPremiumPlan( cart ) ) {
 		return `/checkout/${ siteSlug }/offer-plan-upgrade/business/${ pendingOrReceiptId }`;
 	}
 	return;
@@ -302,16 +292,12 @@ function getRedirectUrlForConciergeNudge( {
 	cart,
 	siteSlug,
 	hideNudge,
-	didPurchaseFail,
-	isTransactionResultEmpty,
 }: {
 	pendingOrReceiptId: string;
 	orderId: number | undefined;
 	cart: ResponseCart | undefined;
 	siteSlug: string | undefined;
 	hideNudge: boolean;
-	didPurchaseFail: boolean;
-	isTransactionResultEmpty: boolean;
 } ): string | undefined {
 	if ( hideNudge ) {
 		return;
@@ -337,8 +323,6 @@ function getRedirectUrlForConciergeNudge( {
 			cart,
 			orderId,
 			siteSlug,
-			didPurchaseFail,
-			isTransactionResultEmpty,
 		} );
 		if ( upgradePath ) {
 			return upgradePath;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -171,6 +171,8 @@ export default function getThankYouPageUrl( {
 		cart,
 		siteSlug,
 		hideNudge,
+		didPurchaseFail,
+		isTransactionResultEmpty,
 	} );
 	if ( redirectPathForConciergeUpsell ) {
 		debug( 'redirect for concierge exists, so returning', redirectPathForConciergeUpsell );
@@ -335,6 +337,8 @@ function getRedirectUrlForConciergeNudge( {
 			cart,
 			orderId,
 			siteSlug,
+			didPurchaseFail,
+			isTransactionResultEmpty,
 		} );
 		if ( upgradePath ) {
 			return upgradePath;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -171,8 +171,6 @@ export default function getThankYouPageUrl( {
 		cart,
 		siteSlug,
 		hideNudge,
-		didPurchaseFail,
-		isTransactionResultEmpty,
 	} );
 	if ( redirectPathForConciergeUpsell ) {
 		debug( 'redirect for concierge exists, so returning', redirectPathForConciergeUpsell );
@@ -337,8 +335,6 @@ function getRedirectUrlForConciergeNudge( {
 			cart,
 			orderId,
 			siteSlug,
-			didPurchaseFail,
-			isTransactionResultEmpty,
 		} );
 		if ( upgradePath ) {
 			return upgradePath;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.ts
@@ -5,7 +5,6 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { defaultRegistry } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
-import { isEmpty } from 'lodash';
 import type { ResponseCart } from '@automattic/shopping-cart';
 
 /**
@@ -49,10 +48,8 @@ export default function useGetThankYouUrl( {
 	const getThankYouUrl = useCallback( () => {
 		const transactionResult: TransactionResponse = select( 'wpcom' ).getTransactionResult();
 		debug( 'for getThankYouUrl, transactionResult is', transactionResult );
-		const didPurchaseFail = Object.keys( transactionResult.failed_purchases ?? {} ).length > 0;
 		const receiptId = transactionResult.receipt_id;
 		const orderId = transactionResult.order_id;
-		const isTransactionResultEmpty = isEmpty( transactionResult );
 
 		if ( siteSlug === 'no-user' || ! siteSlug ) {
 			// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -72,8 +69,6 @@ export default function useGetThankYouUrl( {
 			productAliasFromUrl,
 			isEligibleForSignupDestinationResult,
 			hideNudge,
-			didPurchaseFail,
-			isTransactionResultEmpty,
 			isInEditor,
 		};
 		debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -105,6 +105,25 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/offer-quickstart-session/:receiptId/foo.bar' );
 	} );
 
+	// Note: This just verifies the existing behavior; this URL is invalid unless
+	// placed after a `redirectTo` query string; see the redirect payment
+	// processor
+	it( 'redirects to the business plan bump offer page with a placeholder receipt id when a site but no orderId is set and the cart contains the premium plan', () => {
+		const cart = {
+			products: [
+				{
+					product_slug: 'value_bundle',
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+		} );
+		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/business/:receiptId' );
+	} );
+
 	it( 'redirects to the thank-you page with a placeholder receiptId with a site when the cart is not empty but there is no receipt id', () => {
 		const cart = { products: [ { id: 'something' } ] };
 		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', cart } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As mentioned in https://github.com/Automattic/wp-calypso/pull/44590#discussion_r487009202, the business plan bump offer will not be seen by Premium plan customers if they paid with redirect payments like PayPal or Giropay. This PR fixes the issue.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a premium plan during signup and purchase the plan with PayPal. Verify that after payment is successful, you are shown the business plan bump offer.
