### PR TITLE
Write devdocs search index to a JSON file, read it as regular file rather than module

### DIFF
--- a/client/server/devdocs/index.js
+++ b/client/server/devdocs/index.js
@@ -2,10 +2,11 @@
  * External dependencies
  */
 import express from 'express';
+import fs from 'fs';
 import fspath from 'path';
 import marked from 'marked';
 import lunr from 'lunr';
-import { escapeRegExp, find, escape as escapeHTML } from 'lodash';
+import { escapeRegExp, find, escape as escapeHTML, once } from 'lodash';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-json';
@@ -15,10 +16,17 @@ import 'prismjs/components/prism-scss';
  * Internal dependencies
  */
 import config from 'config';
-import searchIndex from 'server/devdocs/search-index';
 import { primeSelectorsCache, selectorsRouter } from './selectors';
 
-const docsIndex = lunr.Index.load( searchIndex.index );
+const loadSearchIndex = once( async () => {
+	const searchIndexPath = fspath.resolve( __dirname, '../../../build/devdocs-search-index.json' );
+	const searchIndex = await fs.promises.readFile( searchIndexPath, 'utf-8' );
+	const { index, documents } = JSON.parse( searchIndex );
+	return {
+		documents,
+		index: lunr.Index.load( index ),
+	};
+} );
 
 /**
  * Constants
@@ -45,15 +53,16 @@ marked.setOptions( {
  * @param {object} query The search query for lunr
  * @returns {Array} The results from the query
  */
-function queryDocs( query ) {
-	return docsIndex.search( query ).map( ( result ) => {
-		const doc = searchIndex.documents[ result.ref ];
-		const snippet = makeSnippet( doc, query );
+async function queryDocs( query ) {
+	const { index, documents } = await loadSearchIndex();
+	const results = index.search( query );
+	return results.map( ( result ) => {
+		const doc = documents[ result.ref ];
 
 		return {
 			path: doc.path,
 			title: doc.title,
-			snippet,
+			snippet: makeSnippet( doc, query ),
 		};
 	} );
 }
@@ -64,9 +73,10 @@ function queryDocs( query ) {
  * @param {Array} filePaths An array of file paths
  * @returns {Array} The results from the docs
  */
-function listDocs( filePaths ) {
+async function listDocs( filePaths ) {
+	const { documents } = await loadSearchIndex();
 	return filePaths.map( ( path ) => {
-		const doc = find( searchIndex.documents, { path } );
+		const doc = find( documents, { path } );
 
 		if ( doc ) {
 			return {
@@ -135,6 +145,19 @@ function defaultSnippet( doc ) {
 	return escapeHTML( content ) + '…';
 }
 
+function normalizeDocPath( path ) {
+	// if the path is a directory, default to README.md in that dir
+	if ( ! path.endsWith( '.md' ) ) {
+		path = fspath.join( path, 'README.md' );
+	}
+
+	// Remove the optional leading `/` to make the path relative, i.e., convert `/client/README.md`
+	// to `client/README.md`. The `path` query arg can use both forms.
+	path = path.replace( /^\//, '' );
+
+	return path;
+}
+
 export default function devdocs() {
 	const app = express();
 
@@ -149,38 +172,45 @@ export default function devdocs() {
 	} );
 
 	// search the documents using a search phrase "q"
-	app.get( '/devdocs/service/search', ( request, response ) => {
-		const query = request.query.q;
+	app.get( '/devdocs/service/search', async ( request, response ) => {
+		const { q: query } = request.query;
 
 		if ( ! query ) {
-			response.status( 400 ).json( {
-				message: 'Missing required "q" parameter',
-			} );
+			response.status( 400 ).json( { message: 'Missing required "q" parameter' } );
 			return;
 		}
 
-		response.json( queryDocs( query ) );
+		try {
+			const result = await queryDocs( query );
+			response.json( result );
+		} catch ( error ) {
+			console.error( error );
+			response.status( 400 ).json( { message: 'Internal server error: no document index' } );
+		}
 	} );
 
 	// return a listing of documents from filenames supplied in the "files" parameter
-	app.get( '/devdocs/service/list', ( request, response ) => {
-		const files = request.query.files;
+	app.get( '/devdocs/service/list', async ( request, response ) => {
+		const { files } = request.query;
 
 		if ( ! files ) {
-			response.status( 400 ).json( {
-				message: 'Missing required "files" parameter',
-			} );
+			response.status( 400 ).json( { message: 'Missing required "files" parameter' } );
 			return;
 		}
 
-		response.json( listDocs( files.split( ',' ) ) );
+		try {
+			const result = await listDocs( files.split( ',' ) );
+			response.json( result );
+		} catch ( error ) {
+			console.error( error );
+			response.status( 400 ).json( { message: 'Internal server error: no document index' } );
+		}
 	} );
 
 	// return the content of a document in the given format (assumes that the document is in
 	// markdown format)
-	app.get( '/devdocs/service/content', ( request, response ) => {
-		let { path } = request.query;
-		const { format = 'html' } = request.query;
+	app.get( '/devdocs/service/content', async ( request, response ) => {
+		const { path, format = 'html' } = request.query;
 
 		if ( ! path ) {
 			response
@@ -189,22 +219,20 @@ export default function devdocs() {
 			return;
 		}
 
-		if ( ! path.endsWith( '.md' ) ) {
-			path = fspath.join( path, 'README.md' );
+		try {
+			const { documents } = await loadSearchIndex();
+			const doc = find( documents, { path: normalizeDocPath( path ) } );
+
+			if ( ! doc ) {
+				response.status( 404 ).send( 'File does not exist' );
+				return;
+			}
+
+			response.send( 'html' === format ? marked( doc.content ) : doc.content );
+		} catch ( error ) {
+			console.error( error );
+			response.status( 400 ).json( { message: 'Internal server error: no document index' } );
 		}
-
-		// Remove the optional leading `/` to make the path relative, i.e., convert `/client/README.md`
-		// to `client/README.md`. The `path` query arg can use both forms.
-		path = path.replace( /^\//, '' );
-
-		const doc = find( searchIndex.documents, { path } );
-
-		if ( ! doc ) {
-			response.status( 404 ).send( 'File does not exist' );
-			return;
-		}
-
-		response.send( 'html' === format ? marked( doc.content ) : doc.content );
 	} );
 
 	// In environments where enabled, prime the selectors search cache whenever

--- a/client/webpack.config.desktop.js
+++ b/client/webpack.config.desktop.js
@@ -78,8 +78,6 @@ module.exports = {
 
 		// These are Calypso server modules we don't need, so let's not bundle them
 		'webpack.config',
-		'server/devdocs/search-index',
-		'calypso/server/devdocs/search-index',
 	],
 	resolve: {
 		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -72,13 +72,6 @@ function getExternals() {
 			'calypso/webpack.config': {
 				commonjs: '../client/webpack.config.js',
 			},
-			// Exclude the devdocs search-index, as it's huge.
-			'server/devdocs/search-index': {
-				commonjs: '../client/server/devdocs/search-index.js',
-			},
-			'calypso/server/devdocs/search-index': {
-				commonjs: '../client/server/devdocs/search-index.js',
-			},
 		},
 	];
 }


### PR DESCRIPTION
Devdocs have a feature where the user can search and view `*.md` files from the Calypso repo. It's implemented by reading all the `*.md` files at build time, and storing the contents and a lunr search index in the `search-index.js` file. This file is the imported by the devdocs code during the server webpack build.

The webpack config for server (and also desktop) contains some workarounds to keep this file external and avoid bundling it into the server bundle.

This PR writes the search index to a JSON file, and reads it at runtime with `fs.readFile`, i.e., treating it as a file, not a JS module. This has two benefits:
- simplifies the webpack config by removing workarounds and exceptions for the index module
- the search index is not loaded at server boot time, but on demand when the first REST requests that uses it arrives. This should improve the server startup time a bit. Also, many environments (production, desktop, ...) don't support Devdocs at all.

**How to test:**
Go to `/devdocs` and verify that it shows the "default document list", i.e., the results we show when there is no search term:

<img width="733" alt="Screenshot 2020-09-21 at 10 00 02" src="https://user-images.githubusercontent.com/664258/93743990-5598f880-fbf1-11ea-8612-577e74c8e9f9.png">

Then try to enter a search term (e.g., "redux") and expect to see matching results.

Then click on any of the documents and expect to see the full content.

These three operations are using the `/devdocs/service/list`, `/devdocs/service/search` and `/devdocs/service/content` server endpoints, respectively, and all of them get their data from the search index JSON file.