### PR TITLE
Premium Content: Display subscriber view to logged in users who have subscribed

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
@@ -24,7 +24,13 @@ const alignmentHooksSetting = {
 	isEmbedButton: true,
 };
 
-function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
+function ButtonsEdit( {
+	context,
+	jetpackButton,
+	subscribeButton,
+	setSubscribeButtonText,
+	setSubscribeButtonPlan,
+} ) {
 	const planId = context ? context[ 'premium-content/planId' ] : null;
 
 	const template = [
@@ -68,6 +74,14 @@ function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 		);
 	}, [ subscribeButton ] );
 
+	// Updates the subscribe button text.
+	useEffect( () => {
+		if ( ! jetpackButton ) {
+			return;
+		}
+		setSubscribeButtonText( __( 'Subscribe', 'full-site-editing' ) );
+	}, [ jetpackButton, setSubscribeButtonText ] );
+
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Block.div className="wp-block-buttons">
@@ -83,13 +97,21 @@ function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 }
 
 export default compose( [
-	withSelect( ( select, props ) => ( {
+	withSelect( ( select, props ) => {
 		// Only first block is assumed to be a subscribe button (users can add additional Recurring Payments blocks for
 		// other plans).
-		subscribeButton: select( 'core/block-editor' )
+		const subscribeButton = select( 'core/block-editor' )
 			.getBlock( props.clientId )
-			.innerBlocks.find( ( block ) => block.name === 'jetpack/recurring-payments' ),
-	} ) ),
+			.innerBlocks.find( ( block ) => block.name === 'jetpack/recurring-payments' );
+
+		const jetpackButton = select( 'core/block-editor' )
+			.getBlock( subscribeButton.clientId )
+			.innerBlocks.find( ( block ) => block.name === 'jetpack/button' );
+		return {
+			subscribeButton,
+			jetpackButton,
+		};
+	} ),
 	withDispatch( ( dispatch, props ) => ( {
 		/**
 		 * Updates the plan on the Recurring Payments block acting as a subscribe button.
@@ -99,6 +121,16 @@ export default compose( [
 		setSubscribeButtonPlan( planId ) {
 			dispatch( 'core/block-editor' ).updateBlockAttributes( props.subscribeButton.clientId, {
 				planId,
+			} );
+		},
+		/**
+		 * Updates the button text on the Recurring Payments block acting as a subscribe button.
+		 *
+		 * @param text {string} Button text.
+		 */
+		setSubscribeButtonText( text ) {
+			dispatch( 'core/block-editor' ).updateBlockAttributes( props.jetpackButton.clientId, {
+				text,
 			} );
 		},
 	} ) ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/index.js
@@ -31,7 +31,7 @@ const settings = {
 	keywords: [ __( 'link', 'full-site-editing' ) ],
 	edit,
 	save,
-	context: [ 'premium-content/planId' ],
+	usesContext: [ 'premium-content/planId' ],
 };
 
 export { name, category, settings };

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
@@ -70,7 +70,6 @@ const defaultString = null;
  * @property { boolean } isSelected
  * @property { string } className
  * @property { string } clientId
- * @property { string } containerClientId
  * @property { Attributes } attributes
  * @property { (attributes: object<Attributes>) => void } setAttributes
  * @property { ?object } noticeUI
@@ -275,7 +274,10 @@ function Edit( props ) {
 				onError( props, result.message );
 			}
 		);
-		props.selectBlock();
+
+		// Execution delayed with setTimeout to ensure it runs after any block auto-selection performed by inner blocks
+		// (such as the Recurring Payments block)
+		setTimeout( () => props.selectBlock(), 1000 );
 	}, [] );
 
 	if ( apiState === API_STATE_LOADING ) {
@@ -458,14 +460,10 @@ function getConnectUrl( props, connectURL ) {
 }
 
 export default compose( [
-	withSelect( ( select, ownProps ) => {
+	withSelect( ( select ) => {
 		const { getCurrentPostId } = select( 'core/editor' );
 		return {
 			postId: getCurrentPostId(),
-			// @ts-ignore difficult to type via JSDoc
-			containerClientId: select( 'core/block-editor' ).getBlockHierarchyRootClientId(
-				ownProps.clientId
-			),
 		};
 	} ),
 	withNotices,
@@ -474,7 +472,7 @@ export default compose( [
 		return {
 			selectBlock() {
 				// @ts-ignore difficult to type via JSDoc
-				blockEditor.selectBlock( ownProps.containerClientId );
+				blockEditor.selectBlock( ownProps.clientId );
 			},
 		};
 	} ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/edit.js
@@ -3,9 +3,6 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
-import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,75 +11,36 @@ import Context from '../container/context';
 
 /**
  * Block edit function
- *
- * @typedef { import('./').Attributes } Attributes
- * @typedef { object } Props
- * @property { boolean } isSelected
- * @property { string } className
- * @property { string } clientId
- * @property { string } containerClientId
- * @property { Attributes } attributes
- * @property { Function } setAttributes
- * @property { Function } selectContainerBlock
- *
- * @param { Props } props Properties
  */
-function Edit( { selectContainerBlock } ) {
-	useEffect( () => {
-		// Selects the container block on mount.
-		//
-		// Execution delayed with setTimeout to ensure it runs after any block auto-selection performed by inner blocks
-		// (such as the Recurring Payments block). @see https://github.com/Automattic/wp-calypso/issues/43450
-		setTimeout( selectContainerBlock, 0 );
-	}, [] );
+const Edit = () => (
+	<Context.Consumer>
+		{ ( { selectedTab, stripeNudge } ) => (
+			/** @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md#case-the-event-handler-is-only-being-used-to-capture-bubbled-events */
+			// eslint-disable-next-line
+			<div hidden={ selectedTab.id === 'premium' } className={ selectedTab.className }>
+				{ stripeNudge }
+				<InnerBlocks
+					templateLock={ false }
+					template={ [
+						[
+							'core/heading',
+							{ content: __( 'Subscribe to get access', 'full-site-editing' ), level: 3 },
+						],
+						[
+							'core/paragraph',
+							{
+								content: __(
+									'Read more of this content when you subscribe today.',
+									'full-site-editing'
+								),
+							},
+						],
+						[ 'premium-content/buttons' ],
+					] }
+				/>
+			</div>
+		) }
+	</Context.Consumer>
+);
 
-	return (
-		<Context.Consumer>
-			{ ( { selectedTab, stripeNudge } ) => (
-				/** @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md#case-the-event-handler-is-only-being-used-to-capture-bubbled-events */
-				// eslint-disable-next-line
-				<div hidden={ selectedTab.id === 'premium' } className={ selectedTab.className }>
-					{ stripeNudge }
-					<InnerBlocks
-						templateLock={ false }
-						template={ [
-							[
-								'core/heading',
-								{ content: __( 'Subscribe to get access', 'full-site-editing' ), level: 3 },
-							],
-							[
-								'core/paragraph',
-								{
-									content: __(
-										'Read more of this content when you subscribe today.',
-										'full-site-editing'
-									),
-								},
-							],
-							[ 'premium-content/buttons' ],
-						] }
-					/>
-				</div>
-			) }
-		</Context.Consumer>
-	);
-}
-
-export default compose( [
-	withSelect( ( select, props ) => {
-		const { getBlockHierarchyRootClientId } = select( 'core/block-editor' );
-		return {
-			// @ts-ignore difficult to type with JSDoc
-			containerClientId: getBlockHierarchyRootClientId( props.clientId ),
-		};
-	} ),
-	withDispatch( ( dispatch, props ) => {
-		const { selectBlock } = dispatch( 'core/block-editor' );
-		return {
-			selectContainerBlock() {
-				// @ts-ignore difficult to type with JSDoc
-				selectBlock( props.containerClientId );
-			},
-		};
-	} ),
-] )( Edit );
+export default Edit;

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/edit.js
@@ -3,9 +3,8 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { withDispatch, withSelect } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,43 +16,36 @@ import Context from '../container/context';
  *
  * @typedef { object } Props
  * @property { string } clientId
- * @property { string } containerClientId
- * @property { Function } selectBlock
+ * @property { boolean } hasInnerBlocks
  *
  * @param { Props } props Properties
  */
-function Edit( props ) {
-	useEffect( () => {
-		props.selectBlock();
-	}, [] );
-
-	return (
-		<Context.Consumer>
-			{ ( { selectedTab, stripeNudge } ) => (
-				/** @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md#case-the-event-handler-is-only-being-used-to-capture-bubbled-events */
-				// eslint-disable-next-line
-				<div hidden={ selectedTab.id === 'wall' } className={ selectedTab.className }>
-					{ stripeNudge }
-					<InnerBlocks
-						renderAppender={ ! props.hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
-						templateLock={ false }
-						template={ [
-							[
-								'core/paragraph',
-								{
-									placeholder: __(
-										'Insert the piece of content you want your visitors to see after they subscribe.',
-										'full-site-editing'
-									),
-								},
-							],
-						] }
-					/>
-				</div>
-			) }
-		</Context.Consumer>
-	);
-}
+const Edit = ( props ) => (
+	<Context.Consumer>
+		{ ( { selectedTab, stripeNudge } ) => (
+			/** @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md#case-the-event-handler-is-only-being-used-to-capture-bubbled-events */
+			// eslint-disable-next-line
+			<div hidden={ selectedTab.id === 'wall' } className={ selectedTab.className }>
+				{ stripeNudge }
+				<InnerBlocks
+					renderAppender={ ! props.hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
+					templateLock={ false }
+					template={ [
+						[
+							'core/paragraph',
+							{
+								placeholder: __(
+									'Insert the piece of content you want your visitors to see after they subscribe.',
+									'full-site-editing'
+								),
+							},
+						],
+					] }
+				/>
+			</div>
+		) }
+	</Context.Consumer>
+);
 
 export default compose( [
 	withSelect( ( select, props ) => {
@@ -61,19 +53,6 @@ export default compose( [
 			// @ts-ignore difficult to type with JSDoc
 			hasInnerBlocks: !! select( 'core/block-editor' ).getBlocksByClientId( props.clientId )[ 0 ]
 				.innerBlocks.length,
-			// @ts-ignore difficult to type with JSDoc
-			containerClientId: select( 'core/block-editor' ).getBlockHierarchyRootClientId(
-				props.clientId
-			),
-		};
-	} ),
-	withDispatch( ( dispatch, props ) => {
-		const blockEditor = dispatch( 'core/block-editor' );
-		return {
-			selectBlock() {
-				// @ts-ignore difficult to type with JSDoc
-				blockEditor.selectBlock( props.containerClientId );
-			},
 		};
 	} ),
 ] )( Edit );

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
@@ -155,7 +155,6 @@ function register_blocks() {
 		array(
 			'render_callback' => '\A8C\FSE\Earn\PremiumContent\premium_content_render_login_button_block',
 			'style'           => 'premium-content-frontend',
-			$uses             => array( 'premium-content/planId' ),
 		)
 	);
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
@@ -299,19 +299,16 @@ function premium_content_block_subscriber_view_render( $attributes, $content, $b
  *
  * @param array  $attributes Block attributes.
  * @param string $content Block content.
- * @param object $block Block object.
  *
  * @return string Final content to render.
  */
-function premium_content_render_login_button_block( $attributes, $content, $block = null ) {
+function premium_content_render_login_button_block( $attributes, $content ) {
 	if ( ! premium_content_pre_render_checks() ) {
 		return '';
 	}
 
-	$visitor_has_access = premium_content_current_visitor_can_access( $attributes, $block );
-
-	if ( $visitor_has_access ) {
-		// The viewer has access, so they shouldn't see the login button.
+	if ( is_user_logged_in() ) {
+		// The viewer is logged it, so they shouldn't see the login button.
 		return '';
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
@@ -155,6 +155,7 @@ function register_blocks() {
 		array(
 			'render_callback' => '\A8C\FSE\Earn\PremiumContent\premium_content_render_login_button_block',
 			'style'           => 'premium-content-frontend',
+			$uses             => array( 'premium-content/planId' ),
 		)
 	);
 }
@@ -298,16 +299,19 @@ function premium_content_block_subscriber_view_render( $attributes, $content, $b
  *
  * @param array  $attributes Block attributes.
  * @param string $content Block content.
+ * @param object $block Block object.
  *
  * @return string Final content to render.
  */
-function premium_content_render_login_button_block( $attributes, $content ) {
+function premium_content_render_login_button_block( $attributes, $content, $block = null ) {
 	if ( ! premium_content_pre_render_checks() ) {
 		return '';
 	}
 
-	if ( is_user_logged_in() ) {
-		// The viewer is logged it, so they shouldn't see the login button.
+	$visitor_has_access = premium_content_current_visitor_can_access( $attributes, $block );
+
+	if ( $visitor_has_access ) {
+		// The viewer has access, so they shouldn't see the login button.
 		return '';
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/subscription-service/class-token-subscription-service.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/subscription-service/class-token-subscription-service.php
@@ -1,17 +1,25 @@
-<?php declare( strict_types = 1 );
+<?php
 /**
- * @package A8C\FSE\Earn
- *
  * A paywall that exchanges JWT tokens from WordPress.com to allow
  * a current visitor to view content that has been deemed "Premium content".
+ *
+ * @package A8C\FSE\Earn
  */
+
+declare( strict_types = 1 );
+
 namespace A8C\FSE\Earn\PremiumContent\SubscriptionService;
 
 use A8C\FSE\Earn\PremiumContent\JWT;
 
 // phpcs:ignore ImportDetection.Imports.RequireImports.Symbol
-abstract class Token_Subscription_Service implements Subscription_Service {
 
+/**
+ * Class Token_Subscription_Service
+ *
+ * @package A8C\FSE\Earn\PremiumContent\SubscriptionService
+ */
+abstract class Token_Subscription_Service implements Subscription_Service {
 
 	const JWT_AUTH_TOKEN_COOKIE_NAME = 'jp-premium-content-session';
 	const DECODE_EXCEPTION_FEATURE   = 'memberships';
@@ -19,11 +27,13 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	const REST_URL_ORIGIN            = 'https://subscribe.wordpress.com/';
 
 	/**
+	 * Initialize the token subscription service.
+	 *
 	 * @inheritDoc
 	 */
 	public function initialize() {
 		$token = $this->token_from_request();
-		if ( $token !== null ) {
+		if ( null !== $token ) {
 			$this->set_token_cookie( $token );
 		}
 	}
@@ -38,6 +48,8 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	 * still a WIP (see api/auth branch)
 	 *
 	 * @inheritDoc
+	 *
+	 * @param array $valid_plan_ids List of valid plan IDs.
 	 */
 	public function visitor_can_view_content( $valid_plan_ids ) {
 
@@ -49,22 +61,40 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 			$token = $this->token_from_cookie();
 		}
 
+		$is_valid_token = true;
+
 		if ( empty( $token ) ) {
-			// no token, no access
-			return false;
+			// no token, no access.
+			$is_valid_token = false;
 		}
 
 		$payload = $this->decode_token( $token );
 		if ( empty( $payload ) ) {
+			$is_valid_token = false;
+		}
+
+		if ( $is_valid_token ) {
+			$subscriptions = (array) $payload['subscriptions'];
+		} elseif ( is_user_logged_in() ) {
+			// If there is no token, but the user is logged in, get current subscriptions and determine if the user has
+			// a valid subscription to match the plan ID.
+			$subscriptions = apply_filters( 'earn_get_user_subscriptions_for_site_id', array(), wp_get_current_user()->ID, $this->get_site_id() );
+			if ( empty( $subscriptions ) ) {
+				return false;
+			}
+			// format the subscriptions so that they can be validated.
+			$subscriptions = self::abbreviate_subscriptions( $subscriptions );
+		} else {
 			return false;
 		}
 
-		$subscriptions = (array) $payload['subscriptions'];
 		return $this->validate_subscriptions( $valid_plan_ids, $subscriptions );
 	}
 
 	/**
-	 * @param string $token
+	 * Decode the given token.
+	 *
+	 * @param string $token Token to decode.
 	 *
 	 * @return array|false
 	 */
@@ -78,7 +108,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 			$logstash = array(
 				'feature' => self::DECODE_EXCEPTION_FEATURE,
 				'message' => self::DECODE_EXCEPTION_MESSAGE,
-				'extra'   => json_encode( compact( 'exception', 'token' ) ),
+				'extra'   => wp_json_encode( compact( 'exception', 'token' ) ),
 			);
          // phpcs:ignore ImportDetection.Imports.RequireImports.Symbol
 			log2logstash( $logstash );
@@ -87,19 +117,25 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	}
 
 	/**
+	 * Get the key for decoding the auth token.
+	 *
 	 * @return string|false
 	 */
-	abstract function get_key();
+	abstract public function get_key();
 
 	/**
+	 * Get the ID of the current site.
+	 *
 	 * @return int
 	 */
-	abstract function get_site_id();
+	abstract public function get_site_id();
 
 	/**
-	 * @inheritDoc
+	 * Get the URL to access the protected content.
+	 *
+	 * @param string $mode Access mode (either "subscribe" or "login").
 	 */
-	public function access_url( $mode = 'subscribe' ) {
+	public function access_url( $mode = 'subscribe' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 		global $wp;
 		$permalink = get_permalink();
 		if ( empty( $permalink ) ) {
@@ -111,16 +147,21 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	}
 
 	/**
+	 * Get the token stored in the auth cookie.
+	 *
 	 * @return ?string
 	 */
 	private function token_from_cookie() {
 		if ( isset( $_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ] ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			return $_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ];
 		}
 	}
 
 	/**
-	 * @param  string $token
+	 * Store the auth cookie.
+	 *
+	 * @param  string $token Auth token.
 	 * @return void
 	 */
 	private function set_token_cookie( $token ) {
@@ -130,13 +171,17 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	}
 
 	/**
+	 * Get the token if present in the current request.
+	 *
 	 * @return ?string
 	 */
 	private function token_from_request() {
 		$token = null;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['token'] ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 			if ( preg_match( '/^[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+?\.([a-zA-Z0-9\-_]+)?$/', $_GET['token'], $matches ) ) {
-				// token matches a valid JWT token pattern
+				// token matches a valid JWT token pattern.
 				$token = reset( $matches );
 			}
 		}
@@ -146,14 +191,14 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	/**
 	 * Return true if any ID/date pairs are valid. Otherwise false.
 	 *
-	 * @param int[]                          $valid_plan_ids
+	 * @param int[]                          $valid_plan_ids List of valid plan IDs.
 	 * @param array<int, Token_Subscription> $token_subscriptions : ID must exist in the provided <code>$valid_subscriptions</code> parameter.
 	 *                                                            The provided end date needs to be greater than <code>now()</code>.
 	 *
 	 * @return bool
 	 */
 	protected function validate_subscriptions( $valid_plan_ids, $token_subscriptions ) {
-		// Create a list of product_ids to compare against:
+		// Create a list of product_ids to compare against.
 		$product_ids = array();
 		foreach ( $valid_plan_ids as $plan_id ) {
 			$product_id = (int) get_post_meta( $plan_id, 'jetpack_memberships_product_id', true );
@@ -162,10 +207,6 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 			}
 		}
 
-		/**
-		 * @var int $product_id
-		 * @var Token_Subscription $token_subscription
-		 */
 		foreach ( $token_subscriptions as $product_id => $token_subscription ) {
 			if ( in_array( $product_id, $product_ids, true ) ) {
 				$end = is_int( $token_subscription->end_date ) ? $token_subscription->end_date : strtotime( $token_subscription->end_date );
@@ -178,12 +219,38 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	}
 
 	/**
-	 * @param  int    $site_id
-	 * @param  string $redirect_url
-	 * @return string
+	 * Get the URL of the JWT endpoint.
+	 *
+	 * @param  int    $site_id Site ID.
+	 * @param  string $redirect_url URL to redirect after checking the token validity.
+	 * @return string URL of the JWT endpoint.
 	 */
 	private function get_rest_api_token_url( $site_id, $redirect_url ) {
-		return sprintf( '%smemberships/jwt?site_id=%d&redirect_url=%s', self::REST_URL_ORIGIN, $site_id, urlencode( $redirect_url ) );
+		return sprintf( '%smemberships/jwt?site_id=%d&redirect_url=%s', self::REST_URL_ORIGIN, $site_id, rawurlencode( $redirect_url ) );
 	}
 
+	/**
+	 * Report the subscriptions as an ID => [ 'end_date' => ]. mapping
+	 *
+	 * @param array $subscriptions_from_bd List of subscriptions from BD.
+	 *
+	 * @return array<int, array>
+	 */
+	public static function abbreviate_subscriptions( $subscriptions_from_bd ) {
+		$subscriptions = array();
+		foreach ( $subscriptions_from_bd as $subscription ) {
+			// We are picking the expiry date that is the most in the future.
+			if (
+				'active' === $subscription['status'] && (
+					! isset( $subscriptions[ $subscription['product_id'] ] ) ||
+					empty( $subscription['end_date'] ) || // Special condition when subscription has no expiry date - we will default to a year from now for the purposes of the token.
+					strtotime( $subscription['end_date'] ) > strtotime( (string) $subscriptions[ $subscription['product_id'] ]['end_date'] )
+				)
+			) {
+				$subscriptions[ $subscription['product_id'] ]           = new \stdClass();
+				$subscriptions[ $subscription['product_id'] ]->end_date = empty( $subscription['end_date'] ) ? ( time() + 365 * 24 * 3600 ) : $subscription['end_date'];
+			}
+		}
+		return $subscriptions;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the token subscription service of the Premium Content block so the subscriber view is rendered for logged in users who are subscribed to the plan used in the block, even if the token/auth cookie is missing.
* The block has been completely broken since changes from https://github.com/WordPress/gutenberg/pull/24155 and https://github.com/Automattic/jetpack/pull/15915 landed in WP.com. The first dropped support for the `context` property when registering a block in favor of a new `usesContext`, while the latter dropped support for the `submitButtonText` attribute of the `jetpack/recurring-payments` block in favor of the inner `jetpack/button` block's `text` attribute. This PR updates the code so block is usable again:

Before | After
--- | ---
![Sep-21-2020 12-34-17](https://user-images.githubusercontent.com/1233880/93771052-49c32b80-fc1d-11ea-8685-8b1645b615c9.gif) | ![Sep-21-2020 15-15-44](https://user-images.githubusercontent.com/1233880/93771119-5f385580-fc1d-11ea-81d8-409d2d082813.gif)
 
#### Testing instructions
* Modify your `/etc/hosts` file and point the addresses below to your WP.com sandbox IP:
  * `public-api.wordpress.com`.
  * `subscribe.wordpress.com`.
  * The address of a WP.com simple site under a paid plan.
* Add the code below to the `/wp-content/mu-plugins/0-sandbox.php` file of your WP.com sandbox:
```
define( 'USE_STORE_SANDBOX', true );
define( 'USE_BILLING_SANDBOX', true );
define( 'BILLINGDADDY_SANDBOX', rtrim( 'https://' . `hostname` ) );
```
* Checkout this branch and run `cd apps/editing-toolkit && yarn dev --sync`
* Go to https://wordpress.com/block-editor.
* Select the WP.com simple site you sandboxed above.
* Insert a Premium Content block.
* Make sure you can easily change the plan from the block toolbar.
* Publish the post.
* Visit the post in an incognito/private session.
* Subscribe to the Premium Content plan using a secondary account which don't have access to the WP.com simple site you sandboxed above.
* Make sure the protected content is visible.
* Close the incognito/private session and visit wordpress.com/login in an incognito/private session (this is to make sure any auth cookie is gone).
* Log in as the secondary account you used above.
* Visit the post that contains the Premium Content block.
* Make sure the protected content is visible.

Fixes https://github.com/Automattic/wp-calypso/issues/45663
Fixes https://github.com/Automattic/wp-calypso/issues/45498