### PR TITLE
Try: Create a site-card that can be iframed

### DIFF
--- a/client/my-sites/site-card/index.js
+++ b/client/my-sites/site-card/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+
+import page from 'page';
+
+/**
+ * Internal Dependencies
+ */
+import { navigation, siteSelection } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'controller';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default function () {
+	page( '/site-card/:domain?', siteSelection, navigation, navigation, makeLayout, clientRender ); // 4th arguement should be null (context.primary), but null is not a function
+}

--- a/client/my-sites/site-card/index.js
+++ b/client/my-sites/site-card/index.js
@@ -16,5 +16,5 @@ import { makeLayout, render as clientRender } from 'controller';
 import './style.scss';
 
 export default function () {
-	page( '/site-card/:domain?', siteSelection, navigation, navigation, makeLayout, clientRender ); // 4th arguement should be null (context.primary), but null is not a function
+	page( '/site-card/:domain?', siteSelection, navigation, null, makeLayout, clientRender );
 }

--- a/client/my-sites/site-card/main.jsx
+++ b/client/my-sites/site-card/main.jsx
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+
+export default SidebarNavigation;

--- a/client/my-sites/site-card/style.scss
+++ b/client/my-sites/site-card/style.scss
@@ -1,0 +1,23 @@
+.masterbar,
+.layout__primary,
+.global-notices,
+.inline-help,
+.sidebar__menu-wrapper {
+	display: none;
+}
+
+.layout__content {
+	padding: 0;
+	margin: 0;
+}
+
+.layout__secondary {
+	top: 0;
+	width: 100%;
+}
+
+@media ( max-width: 660px ) {
+	.layout.focus-content .layout__secondary {
+		transform: translateX( 0 );
+	}
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -461,6 +461,12 @@ const sections = [
 			},
 		],
 	},
+	{
+		name: 'site-card',
+		paths: [ '/site-card' ],
+		module: 'calypso/my-sites/site-card',
+		group: 'sites',
+	},
 ];
 
 for ( const extension of require( './extensions' ) ) {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -252,9 +252,13 @@ function setUpLocalLanguageRevisions( req ) {
 }
 
 function setUpLoggedOutRoute( req, res, next ) {
-	// We should change that back to SAMEORIGIN before merging to master
+	let allowedOrigin;
+	if ( req.url.indexOf( 'site-card/' ) !== -1 ) {
+		allowedOrigin = req.url.split( 'site-card/' )[ 1 ];
+	}
+
 	res.set( {
-		'X-Frame-Options': 'allow',
+		'X-Frame-Options': allowedOrigin ? allowedOrigin : 'SAMEORIGIN',
 	} );
 
 	const setupRequests = [];
@@ -270,9 +274,13 @@ function setUpLoggedOutRoute( req, res, next ) {
 
 function setUpLoggedInRoute( req, res, next ) {
 	let redirectUrl, start;
-	// We should change that back to SAMEORIGIN before merging to master
+	let allowedOrigin;
+	if ( req.url.indexOf( 'site-card/' ) !== -1 ) {
+		allowedOrigin = req.url.split( 'site-card/' )[ 1 ];
+	}
+
 	res.set( {
-		'X-Frame-Options': 'allow',
+		'X-Frame-Options': allowedOrigin ? allowedOrigin : 'SAMEORIGIN',
 	} );
 
 	const setupRequests = [];

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -252,8 +252,9 @@ function setUpLocalLanguageRevisions( req ) {
 }
 
 function setUpLoggedOutRoute( req, res, next ) {
+	// We should change that back to SAMEORIGIN before merging to master
 	res.set( {
-		'X-Frame-Options': 'SAMEORIGIN',
+		'X-Frame-Options': 'allow',
 	} );
 
 	const setupRequests = [];
@@ -269,9 +270,9 @@ function setUpLoggedOutRoute( req, res, next ) {
 
 function setUpLoggedInRoute( req, res, next ) {
 	let redirectUrl, start;
-
+	// We should change that back to SAMEORIGIN before merging to master
 	res.set( {
-		'X-Frame-Options': 'SAMEORIGIN',
+		'X-Frame-Options': 'allow',
 	} );
 
 	const setupRequests = [];

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -253,8 +253,8 @@ function setUpLocalLanguageRevisions( req ) {
 
 function setUpLoggedOutRoute( req, res, next ) {
 	let allowedOrigin;
-	if ( req.url.indexOf( 'site-card/' ) !== -1 ) {
-		allowedOrigin = req.url.split( 'site-card/' )[ 1 ];
+	if ( req.path.indexOf( 'site-card/' ) !== -1 ) {
+		allowedOrigin = req.path.split( 'site-card/' )[ 1 ];
 	}
 
 	res.set( {
@@ -275,8 +275,8 @@ function setUpLoggedOutRoute( req, res, next ) {
 function setUpLoggedInRoute( req, res, next ) {
 	let redirectUrl, start;
 	let allowedOrigin;
-	if ( req.url.indexOf( 'site-card/' ) !== -1 ) {
-		allowedOrigin = req.url.split( 'site-card/' )[ 1 ];
+	if ( req.path.indexOf( 'site-card/' ) !== -1 ) {
+		allowedOrigin = req.path.split( 'site-card/' )[ 1 ];
 	}
 
 	res.set( {


### PR DESCRIPTION
Current PR is an attempt to showcase whether we can iframe the `site-switcher`, `site-card`, `nudges` and `notices` within `wp-admin`. It is a very draft - rough prototype so that we can pinpoint feasibility and possible issues.

#### Changes proposed in this Pull Request

* create a page containing only the sidebar and masterbar
* visually hide masterbar, menu items, notices, inline-help

#### Current Issues
- Security - In order for calypso screens to be iframed in inside example.com we need to send a `X-Frame-Options: "example.com"` . Since we may have unlimited domains, I am not sure if / whether we can bypass this. Possible fix 12df840
- Styling - The iframe needs to have variable height (because we may - may not have notices). This can possibly be achieved through JS.
- UX - URLs have to redirect the parent page (`wp-admin`) to calypso (not navigate inside the iframe)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/site-card/YOURDOMAIN (pick a site that has notices, such as "Free domain with a plan"
* You should something like the following
![](https://cln.sh/hugHa5+)
* Fire up YOURDOMAIN/wp-admin and insert `<iframe src="http://calypso.localhost:3000/site-card/YOURDOMAIN" frameborder="0" width="200px" height="183px"></iframe>` in the admin menu bar you should get something like the following (just set the admin bar width to 200px!)
![](https://cln.sh/JSnxFc+)

Resolves #45574 
