### PR TITLE
Components: Remove global text field styles

### DIFF
--- a/client/assets/stylesheets/shared/_forms.scss
+++ b/client/assets/stylesheets/shared/_forms.scss
@@ -2,7 +2,6 @@
 // ==========================================================================
 // Global form elements
 // ==========================================================================
-input[type='text'],
 textarea {
 	@extend %form-field;
 }
@@ -11,7 +10,6 @@ textarea {
 	border-radius: 2px;
 }
 
-input[type='text'],
 textarea,
 label {
 	box-sizing: border-box;

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -1,6 +1,6 @@
 @import 'woocommerce/components/text-control/style.scss';
 
-.signup-form .signup-form__input {
+.signup-form .signup-form__input.form-text-input {
 	margin-bottom: 20px;
 	transition: none;
 

--- a/client/blocks/term-tree-selector/search.scss
+++ b/client/blocks/term-tree-selector/search.scss
@@ -7,7 +7,7 @@
 		top: 9px;
 	}
 
-	input[type='search'] {
+	input[type='search'].form-text-input {
 		right: 0;
 		width: 100%;
 		height: 35px;

--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -67,7 +67,7 @@
 	flex: inherit;
 }
 
-input.map-domain-step__external-domain {
+input[type='text'].form-text-input.map-domain-step__external-domain {
 	flex-grow: 1;
 	width: auto;
 }

--- a/client/components/domains/registrant-extra-info/style.scss
+++ b/client/components/domains/registrant-extra-info/style.scss
@@ -11,7 +11,7 @@
 
 // Turn off number spinners
 .registrant-extra-info__form {
-	input[type=number] {
+	input[type=number].form-text-input {
 		-moz-appearance: textfield;
 
 		&::-webkit-inner-spin-button,

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -248,7 +248,7 @@
 	}
 }
 
-input {
+input[type='text'].form-text-input {
 	&.transfer-domain-step__auth-code-input {
 		width: 200px;
 		margin-top: 15px;

--- a/client/components/forms/form-text-input-with-action/style.scss
+++ b/client/components/forms/form-text-input-with-action/style.scss
@@ -74,7 +74,8 @@ input[type='text'].form-text-input-with-action__input {
 	min-width: 0;
 }
 
-input[type='text'].form-text-input-with-action__input:focus {
+input[type='text'].form-text-input-with-action__input:focus,
+input[type='text'].form-text-input-with-action__input:focus:hover {
 	border: none;
 	box-shadow: none;
 }

--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -11,11 +11,11 @@
 		flex-direction: row;
 	}
 
-	input[type='email'],
-	input[type='password'],
-	input[type='url'],
-	input[type='text'],
-	input[type='number'] {
+	input[type='email'].form-text-input,
+	input[type='password'].form-text-input,
+	input[type='url'].form-text-input,
+	input[type='text'].form-text-input,
+	input[type='number'].form-text-input {
 		flex-grow: 1;
 		border-radius: 0;
 
@@ -79,11 +79,11 @@
 		@include no-prefix-wrap();
 	}
 
-	& + input[type='email'],
-	& + input[type='password'],
-	& + input[type='url'],
-	& + input[type='text'],
-	& + input[type='number'] {
+	& + input[type='email'].form-text-input,
+	& + input[type='password'].form-text-input,
+	& + input[type='url'].form-text-input,
+	& + input[type='text'].form-text-input,
+	& + input[type='number'].form-text-input {
 		&:disabled {
 			border-left-color: var( --color-neutral-10 );
 			border-right-width: 1px;

--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -1,5 +1,6 @@
 .form-text-input {
 	@at-root {
+		input[type='text']#{&},
 		input[type='url']#{&},
 		input[type='password']#{&},
 		input[type='email']#{&},

--- a/client/components/gsuite/gsuite-new-user-list/style.scss
+++ b/client/components/gsuite/gsuite-new-user-list/style.scss
@@ -60,18 +60,18 @@
 	flex-direction: column;
 	flex: 1;
 
-	select {
+	select.form-select {
 		width: 100%;
 	}
 
 	@include breakpoint-deprecated( '>800px' ) {
 		flex-direction: row;
 
-		input {
+		input[type='text'].form-text-input {
 			margin: 0;
 		}
 
-		select {
+		select.form-select {
 			border-bottom-left-radius: 0;
 			border-bottom-width: 1px;
 			border-top-left-radius: 0;

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -1,4 +1,4 @@
-.dialog__content .cancel-purchase-form__reason-input {
+.dialog__content input[type='text'].cancel-purchase-form__reason-input.form-text-input {
 	margin: 4px 0 0 24px;
 	width: calc( 100% - 24px );
 }

--- a/client/components/multiple-choice-question/style.scss
+++ b/client/components/multiple-choice-question/style.scss
@@ -3,7 +3,7 @@
 	width: calc( 100% - 24px );
 }
 
-.form-text-input.multiple-choice-question__answer-item-text-input::placeholder {
+input[type='text'].form-text-input.multiple-choice-question__answer-item-text-input::placeholder {
 	color: var( --color-text-inverted );
 	@include breakpoint-deprecated( '>480px' ) {
 		color: var( --color-neutral );

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -97,7 +97,7 @@ hr.post-schedule__hr {
 	margin: 0 -16px;
 }
 
-input[type='text'].post-schedule__clock-time {
+input[type='text'].form-text-input.post-schedule__clock-time {
 	height: 28px;
 	display: inline-block;
 	border: 1px solid var( --color-neutral-0 );

--- a/client/components/suggestion-search/style.scss
+++ b/client/components/suggestion-search/style.scss
@@ -1,6 +1,6 @@
 .suggestion-search {
 	position: relative;
-	input {
+	input.form-text-input {
 		padding-left: 42px;
 	}
 	.gridicon,

--- a/client/components/tinymce/plugins/embed/style.scss
+++ b/client/components/tinymce/plugins/embed/style.scss
@@ -18,7 +18,7 @@
 				font-weight: 600;
 			}
 
-			input[type='text'].embed__url {
+			input[type='text'].form-text-input.embed__url {
 				margin-top: 1em;
 			}
 		}

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -77,7 +77,7 @@
 	margin-right: 10px;
 }
 
-.wpview-type-simple-payments__pay-quantity-input {
+input[type='text'].form-text-input.wpview-type-simple-payments__pay-quantity-input {
 	border: 1px solid var( --color-neutral-20 );
 	padding: 6px 8px;
 	max-width: 42px;

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -34,7 +34,7 @@
 }
 
 // Token input
-input[type='text'].token-field__input {
+input[type='text'].form-text-input.token-field__input {
 	display: inline-block;
 	flex-grow: 1;
 	width: auto;

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -49,7 +49,8 @@ input[type='text'].form-text-input.token-field__input {
 	font-size: $font-body-small;
 	color: var( --color-neutral-70 );
 
-	&:focus {
+	&:focus,
+	&:focus:hover {
 		box-shadow: none;
 	}
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -68,9 +68,13 @@
 	}
 }
 
-.products__form .token-field__input,
+.products__form .token-field__input.form-text-input,
 .products__form .token-field__token-text {
 	font-size: $font-body;
+
+	&:hover {
+		box-shadow: none;
+	}
 }
 
 .products__product-form-details-wrapper {

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -253,7 +253,7 @@
 		padding: 4px 8px;
 	}
 
-	input:disabled {
+	input.form-text-input:disabled {
 		border-color: var( --color-neutral-10 );
 	}
 }

--- a/client/me/profile-links-add-other/style.scss
+++ b/client/me/profile-links-add-other/style.scss
@@ -1,8 +1,8 @@
-input.profile-links-add-other__value {
+input.form-text-input.profile-links-add-other__value {
 	margin: 0 0 10px;
 }
 
-input.profile-links-add-other__title {
+input.form-text-input.profile-links-add-other__title {
 	margin: 0 0 10px;
 }
 

--- a/client/me/purchases/components/loading-placeholder/style.scss
+++ b/client/me/purchases/components/loading-placeholder/style.scss
@@ -1,5 +1,7 @@
 .loading-placeholder {
-	button, input, select {
+	button.form-button,
+	input[type='text'].form-text-input,
+	select.form-select {
 		@include placeholder( --color-neutral-10 );
 		cursor: default;
 		pointer-events: none;

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -187,7 +187,7 @@
 			margin: 15px -15px 0;
 			padding: 15px 15px 0;
 
-			input[type='text'] {
+			input[type='text'].form-text-input {
 				font-size: $font-body-extra-small;
 				margin: 0 4% 0 0;
 				width: 70%;

--- a/client/my-sites/domains/domain-search/site-redirect-step.scss
+++ b/client/my-sites/domains/domain-search/site-redirect-step.scss
@@ -44,7 +44,7 @@
 	}
 }
 
-.form-text-input.site-redirect-step__external-domain {
+input[type='text'].form-text-input.site-redirect-step__external-domain {
 	@include breakpoint-deprecated( '>660px' ) {
 		float: left;
 		width: calc( 100% - 90px );

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -19,7 +19,7 @@
 	padding: 8px;
 }
 
-.post-selector__search input[type='search'] {
+.post-selector__search input[type='search'].form-text-input {
 	right: 0;
 	width: 100%;
 	height: 35px;

--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -84,7 +84,7 @@
 	display: flex;
 	white-space: nowrap;
 
-	.form-text-input {
+	input[type='text'].form-text-input {
 		line-height: 1em;
 		margin-left: 8px;
 	}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -33,7 +33,7 @@
 		text-align: center;
 	}
 
-	input[type='text'] {
+	input[type='text'].form-text-input {
 		-webkit-appearance: none;
 	}
 

--- a/client/post-editor/editor-page-order/style.scss
+++ b/client/post-editor/editor-page-order/style.scss
@@ -10,7 +10,7 @@
 	text-transform: uppercase;
 }
 
-input[type='number'].editor-page-order__input {
+input[type='number'].form-text-input.editor-page-order__input {
 	-moz-appearance: textfield;
 	font-size: $font-body-small;
 	width: 50px;

--- a/client/post-editor/editor-sharing/style.scss
+++ b/client/post-editor/editor-sharing/style.scss
@@ -27,7 +27,7 @@
 	user-select: none;
 }
 
-input[type='text'].editor-sharing__shortlink-field {
+input[type='text'].form-text-input.editor-sharing__shortlink-field {
 	background: var( --color-neutral-0 );
 	color: var( --color-neutral-70 );
 	flex-grow: 1;

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -25,7 +25,7 @@
 		}
 	}
 
-	.form-text-input {
+	input[type='text'].form-text-input {
 		font-size: $font-body-small;
 		margin-top: 8px;
 	}

--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -122,7 +122,7 @@
 	}
 }
 
-input.editor-media-modal-gallery__caption[type='text'] {
+input.editor-media-modal-gallery__caption.form-text-input[type='text'] {
 	font-size: $font-body-extra-small;
 
 	&:focus {

--- a/client/signup/steps/import-url/style.scss
+++ b/client/signup/steps/import-url/style.scss
@@ -13,7 +13,7 @@
 }
 
 // Actual form input for typing the URL
-.import-url__wrapper .import-url__url-input {
+.import-url__wrapper input[type='text'].form-text-input.import-url__url-input {
 	border: none;
 	border-radius: 2px;
 	padding: 10px 14px;

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -67,6 +67,7 @@
 	color: var( --p2-color-text );
 	border-color: var( --p2-color-border );
 
+	&:focus,
 	&:hover {
 		border-color: var( --p2-color-link );
 	}

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -59,7 +59,7 @@
 	margin-bottom: 16px;
 }
 
-.p2-site__form .form-text-input {
+.p2-site__form input[type='text'].form-text-input {
 	padding: 18px 24px;
 	line-height: 1;
 	border-radius: 2px;
@@ -104,7 +104,7 @@
 	}
 }
 
-.p2-site__form .p2-site__site-url.form-text-input {
+.p2-site__form input[type='text'].p2-site__site-url.form-text-input {
 	padding-right: 160px;
 }
 

--- a/client/signup/steps/site-title/style.scss
+++ b/client/signup/steps/site-title/style.scss
@@ -20,7 +20,7 @@
 		display: none;
 	}
 
-	input {
+	input.form-text-input {
 		// Extra padding to account for the button
 		padding: 10px 90px 12px 16px;
 

--- a/client/signup/steps/site/style.scss
+++ b/client/signup/steps/site/style.scss
@@ -1,4 +1,4 @@
-.site_site-url.form-text-input {
+input[type='text'].site_site-url.form-text-input {
 	padding-right: 122px;
 }
 


### PR DESCRIPTION
This PR removes global form `input[type='text']` styles in favor of more specific component-level styling. It involves a lot of changes, simply because text fields are so common throughout Calypso. This means this PR also requires some thorough testing, so I'd really appreciate some help with that 🙇‍♂️. 

#### Changes proposed in this Pull Request

* Remove global form `input[type='text']` styles in favor of more specific component-level styling. See #45259

#### Testing instructions

(bear with me, this is a long list 😅 )

Test the following against production and ensure that they match stylistically and functionally:

* `/devdocs/design/form-fields` test all text fields, including:
	* Any "Form Text Input", including the ones with affixes(prefix/suffix)
	* Any "Form Tel Input" or "Phone" text field
	* Any "Form Currency Input"
	* "Form Password Input"
* `/devdocs/design/suggestion-search` - the text field
* `/devdocs/design/token-fields` - all the fields
* `/devdocs/design/clipboard-button-input` - the text field
* `/devdocs/design/date-range` - the input fields when you click on the date range selector. Note that this PR fixes those visually, and have been broken for a while.
* `/devdocs/design/site-title-control` - both text fields
* `/devdocs/design/search` - both text fields
* `/devdocs/design/formatted-date` - all three text fields
* `/devdocs/design/multiple-choice-question` - the "Something else" text field
* `/devdocs/blocks/post-schedule` - the time fields
* `/devdocs/blocks/post-selector` - the search field
* `/store` - text fields in all of the WooCommerce extension for a WooCommerce store site, including WooCommerce Services installed. Could I get someone from @automattic/hydra to test this? Some additional payment/shipping gateways or packaging plugins might need to be installed to perform a complete testing here.
* `/extensions/wp-super-cache/:site` - install WP Super Cache on a connected self-hosted WP site and go through all settings pages, checking all the text fields.
* `/extensions/zoninator/:site`  - install the Zone Manager (Zoninator) plugin, and edit a zone, then observe the "Zone name" field.
* `/settings/:site` - go through all settings tabs and subpages for a WP.com site and a Jetpack site, and check all text fields.
* `/settings/disconnect-site/:site` where `:site` is a Jetpack site. Observe the "Other:" text field.
* `/settings/delete-site/:site` where `:site` is a WP.com site on a free plan with no upgrades. Click the "Delete site" button and take a look at the text field inside the dialog.
* `/settings/podcasting/:site`  - adding a new / editing a category for the podcasts, the text field for the category name
* `/marketing/sharing-buttons/:site`, take a look at the text field inside the box when you click "Edit label text", and the twitter username field.
* `/marketing/traffic/:site` - observe the settings for: site verification services, google analytics (shown only for Premium and higher plans) and page title structure.
* `/read/list/:username/:list/edit` - editing a Reader list, name and slug fields.
* `/read/list/:username/:list/edit/items` - adding a site feed,  the URL field
* `/read` - adding a new tag - the form gets revealed once you expand the "Tags" menu item in the Reader sidebar.
* `/me/purchases/:site/:purchaseId/payment/add` - adding a credit card, all the text fields. Observe the placeholder while data is loading, too (you might need to refresh the page several times)
* Domains and GSuite - could I ask for someone from @Automattic/cobalt for testing of the following pieces that have text fields:
	* Mapping a domain
	* Registrant extra info forms (also UK and FR specific TLD forms)
	* Domain search filters - Max characters field
	* Domain transfer - including the domain auth code field in the domain pre-check step
	* GSuite new user: `/email/:domain/gsuite/new/basic/:domain`
	* Editing domain contact info
	* Managing DNS records - all types of DNS records
	* Changing site address
	* `/domains/add/site-redirect/:site` where `:site` corresponds to a WP.com domain that is controlled on WP.com. Try also with a .blog subdomain, as that renders a different interface.
	* Editing a custom nameservers row for a domain bought from WP.com where you don't use WP.com's nameservers but use custom ones.
	* Email forwarding
* 2FA form verification field in any of the 2FA auth flows.
* Jetpack Cloud server credentials form: `/settings/:site` where `:site` is a Jetpack site - cc @Automattic/jetpack-voyager for testing that
* `/me/purchases` - canceling a purchase, the text field that appears when you select "Other reason..." for one of the questions.
* `/settings/jetpack/:site` where `:site` is a Jetpack site - all the text fields
* Classic Calypso editor:
	* Inserting and editing a contact form
	* Inserting an embedded URL
	* Inserting and editing a simple payments button
	* Adding / Editing a link in the content from the visual editor
	* Adding / Editing a link in the content from the HTML editor
	* Changing page order
	* Changing page/post slug
	* Adding/editing a password when you set the post as password protected
	* Shortlink field in Sharing section
	* Editing captions of images inside a gallery
	* Editing a media's details in the media modal in the editor
* Jetpack Connect:
	* `/jetpack/connect` - the site URL field
	* Remote credentials - after inputting a URL of a self-hosted site without Jetpack in the above step - the WP user/email and password fields.
	* `http://calypso.localhost:3000/jetpack/connect/instructions?url=SOMEURL` where `SOMEURL` is the URL of a remote site you want to install Jetpack on - the URL fields in each of the example screens
* `/start/user` for a logged-out user - all text fields
* `/log-in` for a logged-out user - all text fields
* `/me/account/close` - the username field in the dialog once you click "Close account" - should be tested with a non-a11n WP.com account.
* `/me` - all text fields, including adding a new URL link to your profile.
* `/me/account` - all text fields
* `/me/security/account-recovery` - the email field
* `/me/security/two-step` - adding a new application password, the application name field; adding a new security key - the key name field
* `/help/contact` - the subject field
* old checkout - checkout a plan or a product somewhere and add ?flags=old-checkout-force to the URL. Try adding a coupon code and take a close look at the coupon code field.
* Editing a comment under `/comments/all/:site`, including the dialogs for adding an image and link.
* `/earn/ads-settings/:site` for a site that has WordAds enabled.
* `/earn/payments/:site` - the product name. You need to connect Stripe first.
* Guided transfer - `/export/guided/bluehost/:site` - you might need to force-enable the `isEligibleForGuidedTransfer` prop - all the text fields there
* SFTP card at  `/hosting-config/:site` - you might need to generate new credentials first.
* Clearing cache - you need to enable it for your user as displayed in p7DVsv-8uo-p2, then visit `/hosting-config/:site` where `:site` is an Atomic site. Click "Clear cache" and observe the text field in the dialog.
* `/migrate/:site` where `:site` is a WP.com or Atomic site.
* `/media/:site` - click the arrow next to the "Add New" button, then click "Add via URL". Observe the URL text field.
* `/people/edit/:site/:username` - editing a user - observe name fields in the form
* `/people/new/:site` - where `:site` is a p2 site. Observe invite link - the URL field.
* Signup - creating a new site, the URL field.
* Signup - go through each step, starting from the `/start/onboarding-with-preview` flow.
* Signup - go through each step, starting from the `/start/rebrand-cities` flow.
* Signup - as a logged-out user, go through each step, starting from the `/start/simple` flow. 
* Signup - go through each step, starting from the `/start/p2` flow (cc @Automattic/lighthouse).
* Signup - start from `/start/import-onboarding` and click "Already have a website? Import your content here.", then observe the site URL field.
* Signup - start from `/start/clone-site` and when you get to the clone destination step, observe the destination site title and site URL fields.
* Signup - start from `/start/main` and observe the first Site Title field.
* `/oauth-login?flags=oauth` - the username and password fields
