### PR TITLE
Limit premium domain purchases that exceed the price limit

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -154,6 +154,11 @@ class DomainRegistrationSuggestion extends React.Component {
 
 		if ( premiumDomain?.pending ) {
 			buttonStyles = { ...buttonStyles, disabled: true };
+		} else if ( premiumDomain?.is_price_limit_exceeded ) {
+			buttonStyles = { ...buttonStyles, disabled: true };
+			buttonContent = translate( 'Limited', {
+				context: 'Premium domain is not available for registration',
+			} );
 		} else if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
 			buttonStyles = { ...buttonStyles, disabled: true };
 			buttonContent = translate( 'Unavailable', {

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -156,7 +156,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			buttonStyles = { ...buttonStyles, disabled: true };
 		} else if ( premiumDomain?.is_price_limit_exceeded ) {
 			buttonStyles = { ...buttonStyles, disabled: true };
-			buttonContent = translate( 'Limited', {
+			buttonContent = translate( 'Restricted', {
 				context: 'Premium domain is not available for registration',
 			} );
 		} else if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
@@ -229,6 +229,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			isFeatured,
 			showHstsNotice,
 			productSaleCost,
+			premiumDomain,
 			suggestion: { domain_name: domain, is_premium: isPremium },
 			translate,
 			isReskinned,
@@ -259,7 +260,9 @@ class DomainRegistrationSuggestion extends React.Component {
 		return (
 			<div className={ titleWrapperClassName }>
 				<h3 className="domain-registration-suggestion__title">{ title }</h3>
-				{ isPremium && <PremiumBadge /> }
+				{ isPremium && (
+					<PremiumBadge restrictedPremium={ premiumDomain?.is_price_limit_exceeded } />
+				) }
 				{ productSaleCost && paidDomain && <Badge>{ saleBadgeText }</Badge> }
 				{ showHstsNotice && (
 					<InfoPopover

--- a/client/components/domains/premium-badge/index.jsx
+++ b/client/components/domains/premium-badge/index.jsx
@@ -20,7 +20,7 @@ class PremiumBadge extends React.Component {
 			return {
 				text: translate( 'Restricted premium' ),
 				description: translate(
-					"This premium domain tier is currently not available at WordPress.com. Please contact our support if you're interested."
+					"This premium domain is currently not available at WordPress.com. Please contact support if you're interested in this domain."
 				),
 			};
 		}

--- a/client/components/domains/premium-badge/index.jsx
+++ b/client/components/domains/premium-badge/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -13,16 +14,34 @@ import InfoPopover from 'components/info-popover';
 import './style.scss';
 
 class PremiumBadge extends React.Component {
-	render() {
+	getPopoverText( restrictedPremium ) {
 		const { translate } = this.props;
+		if ( restrictedPremium ) {
+			return {
+				text: translate( 'Restricted premium' ),
+				description: translate(
+					"This premium domain tier is currently not available at WordPress.com. Please contact our support if you're interested."
+				),
+			};
+		}
+		return {
+			text: translate( 'Premium domain' ),
+			description: translate(
+				'Premium domain names are usually short, easy to remember, contain popular keywords, or some combination of these factors. Premium domain names are not eligible for purchase using the free plan domain credit.'
+			),
+		};
+	}
+
+	render() {
+		const { restrictedPremium } = this.props;
+		const { text, description } = this.getPopoverText( restrictedPremium );
+		const badgeClassNames = classNames( 'premium-badge', {
+			'restricted-premium': restrictedPremium,
+		} );
 		return (
-			<Badge className="premium-badge">
-				{ translate( 'Premium domain' ) }
-				<InfoPopover iconSize={ 16 }>
-					{ translate(
-						'Premium domain names are usually short, easy to remember, contain popular keywords, or some combination of these factors. Premium domain names are not eligible for purchase using the free plan domain credit.'
-					) }
-				</InfoPopover>
+			<Badge className={ badgeClassNames }>
+				{ text }
+				<InfoPopover iconSize={ 16 }>{ description }</InfoPopover>
 			</Badge>
 		);
 	}

--- a/client/components/domains/premium-badge/style.scss
+++ b/client/components/domains/premium-badge/style.scss
@@ -14,5 +14,11 @@ div.premium-badge {
 
 	&.restricted-premium {
 		background-color: var( --color-warning-30 );
+		color: var( --color-text );
+		.info-popover {
+			.gridicon {
+				color: var( --color-text );
+			}
+		}
 	}
 }

--- a/client/components/domains/premium-badge/style.scss
+++ b/client/components/domains/premium-badge/style.scss
@@ -11,4 +11,8 @@ div.premium-badge {
 			color: var( --color-text-inverted );
 		}
 	}
+
+	&.restricted-premium {
+		background-color: var( --color-warning-30 );
+	}
 }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -777,6 +777,7 @@ class RegisterDomainStep extends React.Component {
 					pending: false,
 					is_premium: result.is_premium,
 					cost: result.cost,
+					is_price_limit_exceeded: result?.is_price_limit_exceeded,
 				} );
 			} );
 		} );
@@ -1226,6 +1227,11 @@ class RegisterDomainStep extends React.Component {
 
 		// disable adding a domain to the cart while the premium price is still fetching
 		if ( premiumDomains?.[ domain ]?.pending ) {
+			return;
+		}
+
+		// also don't allow premium domain purchases over certain price point
+		if ( premiumDomains?.[ domain ]?.is_price_limit_exceeded ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We need to limit certain premium domain price points, so we'll get an extra property in the domain pricing API response. We should also not allow premium domains over that price point to be added to the cart.

Here's how it looks:

**when loading the price:**
<img width="545" alt="Screenshot 2020-09-22 at 13 36 33" src="https://user-images.githubusercontent.com/1355045/93872709-37a6c300-fcd9-11ea-9ee8-1578e982ac3c.png">

**when the price is loaded and it's above the price limit:**
<img width="532" alt="Screenshot 2020-09-23 at 10 21 19" src="https://user-images.githubusercontent.com/3376401/93986399-9a09cd00-fd86-11ea-878c-3e984ef5fba6.png">

**what you see if you click on the info badge:**
<img width="533" alt="Screenshot 2020-09-23 at 10 22 31" src="https://user-images.githubusercontent.com/3376401/93986501-b7d73200-fd86-11ea-8442-68ddfa97c71a.png">

see: p99Zz8-1qh-p2

#### Testing instructions

* in the dev or wpcalypso env search for a premium domain that costs above 6000 (search for image.blog for example). Make sure that once the price is loaded the badge changes to "Restricted premium". Verify that the info popover text also changes.