### PR TITLE
Add/duration toggle to product subtypes view

### DIFF
--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -139,6 +139,8 @@ export const PRODUCTS_WITH_OPTIONS = [
 // Jetpack Security
 export const OPTION_PLAN_SECURITY: SelectorProduct = {
 	productSlug: OPTIONS_JETPACK_SECURITY,
+	annualOptionSlug: OPTIONS_JETPACK_SECURITY,
+	monthlyOptionSlug: OPTIONS_JETPACK_SECURITY_MONTHLY,
 	term: TERM_ANNUALLY,
 	type: ITEM_TYPE_BUNDLE,
 	subtypes: [ PLAN_JETPACK_SECURITY_DAILY, PLAN_JETPACK_SECURITY_REALTIME ],
@@ -209,6 +211,8 @@ export const OPTION_PLAN_SECURITY_MONTHLY: SelectorProduct = {
 // Jetpack Backup
 export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
 	productSlug: OPTIONS_JETPACK_BACKUP,
+	annualOptionSlug: OPTIONS_JETPACK_BACKUP,
+	monthlyOptionSlug: OPTIONS_JETPACK_BACKUP_MONTHLY,
 	term: TERM_ANNUALLY,
 	type: ITEM_TYPE_PRODUCT,
 	subtypes: [ PRODUCT_JETPACK_BACKUP_DAILY, PRODUCT_JETPACK_BACKUP_REALTIME ],

--- a/client/my-sites/plans-v2/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar/index.tsx
@@ -28,16 +28,20 @@ import type { Duration, ProductType } from '../types';
 import './style.scss';
 
 interface Props {
-	duration: Duration;
-	productType: ProductType;
-	onDurationChange: Function;
-	onProductTypeChange: Function;
+	showDurations?: boolean;
+	showProductTypes?: boolean;
+	duration?: Duration;
+	productType?: ProductType;
+	onDurationChange?: Function;
+	onProductTypeChange?: Function;
 }
 
 const CALYPSO_MASTERBAR_HEIGHT = 47;
 const CLOUD_MASTERBAR_HEIGHT = 94;
 
 const PlansFilterBar = ( {
+	showDurations,
+	showProductTypes,
 	duration,
 	productType,
 	onDurationChange,
@@ -57,32 +61,36 @@ const PlansFilterBar = ( {
 
 	return (
 		<div ref={ barRef } className={ classNames( 'plans-filter-bar', { sticky: hasCrossed } ) }>
-			<SelectDropdown selectedText={ PRODUCT_TYPE_OPTIONS[ productType ].label }>
-				{ Object.values( PRODUCT_TYPE_OPTIONS ).map( ( option ) => (
-					<SelectDropdown.Item
-						key={ option.id }
-						selected={ productType === option.id }
-						onClick={ () => onProductTypeChange( option.id ) }
+			{ showProductTypes && (
+				<SelectDropdown selectedText={ productType && PRODUCT_TYPE_OPTIONS[ productType ].label }>
+					{ Object.values( PRODUCT_TYPE_OPTIONS ).map( ( option ) => (
+						<SelectDropdown.Item
+							key={ option.id }
+							selected={ productType === option.id }
+							onClick={ () => onProductTypeChange?.( option.id ) }
+						>
+							{ option.label }
+						</SelectDropdown.Item>
+					) ) }
+				</SelectDropdown>
+			) }
+			{ showDurations && (
+				<SegmentedControl primary={ true }>
+					<SegmentedControl.Item
+						onClick={ () => onDurationChange?.( TERM_MONTHLY ) }
+						selected={ duration === TERM_MONTHLY }
 					>
-						{ option.label }
-					</SelectDropdown.Item>
-				) ) }
-			</SelectDropdown>
-			<SegmentedControl primary={ true }>
-				<SegmentedControl.Item
-					onClick={ () => onDurationChange( TERM_MONTHLY ) }
-					selected={ duration === TERM_MONTHLY }
-				>
-					{ translate( 'Monthly' ) }
-				</SegmentedControl.Item>
+						{ translate( 'Monthly' ) }
+					</SegmentedControl.Item>
 
-				<SegmentedControl.Item
-					onClick={ () => onDurationChange( TERM_ANNUALLY ) }
-					selected={ duration === TERM_ANNUALLY }
-				>
-					{ translate( 'Yearly' ) }
-				</SegmentedControl.Item>
-			</SegmentedControl>
+					<SegmentedControl.Item
+						onClick={ () => onDurationChange?.( TERM_ANNUALLY ) }
+						selected={ duration === TERM_ANNUALLY }
+					>
+						{ translate( 'Yearly' ) }
+					</SegmentedControl.Item>
+				</SegmentedControl>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -6,7 +6,7 @@
 	$border-radius: 2px;
 
 	display: flex;
-	justify-content: space-between;
+	justify-content: space-evenly;
 	align-items: center;
 	background: var( --color-surface );
 	padding: 16px 0;

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -136,6 +136,8 @@ const SelectorPage = ( {
 		<Main className="selector__main" wideLayout>
 			{ header }
 			<PlansFilterBar
+				showDurations
+				showProductTypes
 				onProductTypeChange={ trackProductTypeChange }
 				productType={ productType }
 				onDurationChange={ trackDurationChange }

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -81,6 +81,8 @@ export type SelectorProductFeatures = {
 
 export interface SelectorProduct extends SelectorProductCost {
 	productSlug: string;
+	annualOptionSlug?: string;
+	monthlyOptionSlug?: string;
 	iconSlug: string;
 	type: ItemType;
 	costProductSlug?: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a toggle to the page for products that have more than one sub-type, so that people can compare costs more easily for monthly vs. annual billing.
* Add two properties to `PlanFilterBar` to control which controls are shown: `showDurations` and `showProductTypes`. They both default to false for now.
* Change the flex alignment for `PlanFilterBar` from `space-between` to `space-evenly` on mobile layouts, so that the visible toggles appear center-aligned.

##### Implementation notes

* I added two new fields to the `SelectorProduct` type to facilitate the changes in this PR: `annualOptionSlug` and `monthlyOptionSlug`. I wasn't able to find any existing way to convert between different billing terms for the same product, and this was the simplest option I found to implement. I'm not super fond of it, so I encourage any attempts to iterate on it.
* The selected duration currently does not persist when moving "backward" from the Details page to the main Plans page.
* This pull request creates a new Tracks event, `calypso_product_duration_change`.

#### Testing instructions

##### For changes in this pull request

* From your testing envionment, navigate to the Plans page, either as:
  * an unauthenticated user (e.g., on Jetpack Cloud's pricing page); or,
  * as an authenticated user, selecting a site that does not already have Jetpack Complete, Jetpack Security, or Jetpack Backup.
* Select a product or bundle that has sub-types/variants (i.e., Jetpack Security or Jetpack Backup).
* Verify that you see the duration toggle above the product options, but below the page header.
* Verify that the page loads with the duration you selected on the previous page.
* Verify that you're able to change the duration, and that the prices change accordingly.
* Verify that when you change the value of the duration toggle on the Details page, a Tracks event fires. The outgoing network request should have the following parameters:
  * name (`_en`): `calypso_product_duration_change`
  * `site_id`: your current site ID, if applicable (not present if no site is selected)
  * `product_slug`: the selected product slug, appropriate to the selected duration (e.g., `jetpack_security_monthly` is Security's slug when the duration is Monthly)
  * `duration`: the selected duration (i.e., either `TERM_ANNUALLY` or `TERM_MONTHLY`)

##### To test for regressions

* Verify that the Plans page otherwise works as it does in production:
  * Selecting a product that does not have sub-types should send you immediately to checkout.
  * Duration and product type controls should work as normal on the main Plans page.
  * Selecting an external product (e.g., Jetpack CRM) should send you immediately to its pricing page.
  * On both mobile and desktop layouts, `PlanFilterBar` controls should center-align themselves.

#### Screenshots

![Kapture 2020-09-21 at 10 28 52](https://user-images.githubusercontent.com/670067/93786742-46b44500-fbf5-11ea-9ca5-d2f8ba051e85.gif)
