### PR TITLE
Activate a new section only after it renders for the first time

### DIFF
--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -8,6 +8,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { isUserLoggedIn } from 'state/current-user/selectors';
+import { setSection } from 'state/ui/actions';
+import { activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
 
 export function redirectLoggedIn( context, next ) {
 	const userLoggedIn = isUserLoggedIn( context.store.getState() );
@@ -22,6 +24,20 @@ export function redirectLoggedIn( context, next ) {
 
 export function render( context ) {
 	ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
+
+	// Activate the next section after it's been successfully loaded
+	// `nextSectionToActivate` would be set in client/sections-middleware.js
+	// The section "activation" is triggered when the new section is rendered
+	// for the first time — this avoids glitchs were a sections styles would be
+	// loaded before the section would be rendered in the browser.
+	if ( context.nextSectionToActivate ) {
+		context.store.dispatch( setSection( context.nextSectionToActivate ) );
+		context.store.dispatch( activateNextLayoutFocus() );
+
+		// Removing `nextSectionToActivate` makes sure that `setSection` won't
+		// be dispatched until a new section gets activated.
+		delete context.nextSectionToActivate;
+	}
 }
 
 export function hydrate( context ) {

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -33,10 +33,6 @@ export function render( context ) {
 	if ( context.nextSectionToActivate ) {
 		context.store.dispatch( setSection( context.nextSectionToActivate ) );
 		context.store.dispatch( activateNextLayoutFocus() );
-
-		// Removing `nextSectionToActivate` makes sure that `setSection` won't
-		// be dispatched until a new section gets activated.
-		delete context.nextSectionToActivate;
 	}
 }
 

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -25,11 +25,11 @@ export function redirectLoggedIn( context, next ) {
 export function render( context ) {
 	ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
 
-	// Activate the next section after it's been successfully loaded
-	// `nextSectionToActivate` would be set in client/sections-middleware.js
-	// The section "activation" is triggered when the new section is rendered
-	// for the first time — this avoids glitchs were a sections styles would be
-	// loaded before the section would be rendered in the browser.
+	// Activate the next section after it's been successfully loaded.
+	// (`context.nextSectionToActivate` is set in client/sections-middleware.js)
+	// Section activation is triggered when the new section is rendered for the
+	// first time; this avoids glitches caused by the section's styles loading
+	// before the actual section's markup gets rendered..
 	if ( context.nextSectionToActivate ) {
 		context.store.dispatch( setSection( context.nextSectionToActivate ) );
 		context.store.dispatch( activateNextLayoutFocus() );

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -21,7 +21,7 @@ import sections from './sections';
 receiveSections( sections );
 
 async function loadSection( context, sectionDefinition ) {
-	// Do not update the current active section, only change `isLoading` flag
+	// Do not update the current active section, only set `isLoading` flag to true
 	context.store.dispatch( setSection( undefined, { isLoading: true } ) );
 
 	// If the section chunk is not loaded within 400ms, report it to analytics
@@ -35,8 +35,8 @@ async function loadSection( context, sectionDefinition ) {
 		// call the module initialization function (possibly async, registers page.js handlers etc.)
 		await requiredModule.default( controller.clientRouter, addReducerToStore( context.store ) );
 	} finally {
-		// Do not update the current active section, only change `isLoading` flag
-		context.store.dispatch( setSection( undefined, { isLoading: true } ) );
+		// Do not update the current active section, only set `isLoading` flag to false
+		context.store.dispatch( setSection( undefined, { isLoading: false } ) );
 
 		// If the load was faster than the timeout, this will cancel the analytics reporting
 		clearTimeout( loadReportTimeout );

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -27,7 +27,8 @@ function activateSection( sectionDefinition, context ) {
 }
 
 async function loadSection( context, sectionDefinition ) {
-	context.store.dispatch( { type: 'SECTION_SET', isLoading: true } );
+	// Do not update the current active section, only change `isLoading` flag
+	context.store.dispatch( setSection( undefined, { isLoading: true } ) );
 
 	// If the section chunk is not loaded within 400ms, report it to analytics
 	const loadReportTimeout = setTimeout( () => {
@@ -40,7 +41,8 @@ async function loadSection( context, sectionDefinition ) {
 		// call the module initialization function (possibly async, registers page.js handlers etc.)
 		await requiredModule.default( controller.clientRouter, addReducerToStore( context.store ) );
 	} finally {
-		context.store.dispatch( { type: 'SECTION_SET', isLoading: false } );
+		// Do not update the current active section, only change `isLoading` flag
+		context.store.dispatch( setSection( undefined, { isLoading: true } ) );
 
 		// If the load was faster than the timeout, this will cancel the analytics reporting
 		clearTimeout( loadReportTimeout );

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -8,7 +8,6 @@ import page from 'page';
  * Internal dependencies
  */
 import { setSection } from 'state/ui/actions';
-import { activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { bumpStat } from 'state/analytics/actions';
 import * as LoadingError from 'layout/error';
 import * as controller from './controller/index.web';
@@ -20,11 +19,6 @@ import { performanceTrackerStart } from 'lib/performance-tracking';
 
 import sections from './sections';
 receiveSections( sections );
-
-function activateSection( sectionDefinition, context ) {
-	context.store.dispatch( setSection( sectionDefinition ) );
-	context.store.dispatch( activateNextLayoutFocus() );
-}
 
 async function loadSection( context, sectionDefinition ) {
 	// Do not update the current active section, only change `isLoading` flag
@@ -96,8 +90,8 @@ function createPageDefinition( path, sectionDefinition ) {
 				_loadedSections[ sectionDefinition.module ] = true;
 			}
 
-			// activate the section after ensuring it's fully loaded
-			activateSection( sectionDefinition, context );
+			context.nextSectionToActivate = sectionDefinition;
+
 			next();
 		} catch ( error ) {
 			// delete the cache record on failure; next attempt to load will start from scratch


### PR DESCRIPTION
## Description

As described in #45662, navigating to the "Add new site" flow within Calypso causes the UI to enter a visually glitchy state for a few moments during the transition:

<img width="1080" alt="2020-09-15_10-23-16" src="https://user-images.githubusercontent.com/1287077/93179044-ce094080-f73d-11ea-9b36-675a92df4e7a.png">

This is due to the fact that the `is-section-signup` class is added to the document's `<body />` as soon as the signup module has finished loading, while the actual contents of the signup sections are rendered in the dom at a later point (because of a [redirection happening in the signup controller](https://github.com/Automattic/wp-calypso/blob/a1501fea47cbd5e3fccf09b7f39aaf3eaae86d98/client/signup/index.web.js#L26) )

I believe that this could be looked at as a more generic routing problem, where the code for a section is currently loaded and "activated" (for example, by injection styles in the page and changing the `body` class) before the actual section's content is rendered.


## Changes proposed in this Pull Request

The idea for this PR is to **move a new section's "activation" from when a section has finished loading, to when a section has rendered for the first time**.

- moved the code responsible for the section activation from `loadSection()` (in [`clients/sections-middleware.js`](https://github.com/Automattic/wp-calypso/blob/e96e6a5ba1269c32614e4387f71afdf1373ca147/client/sections-middleware.js#L23)) to the `render()` middleware function that every section's controller is supposed to invoke (in [`client/controller/web-util.js`](https://github.com/Automattic/wp-calypso/blob/e96e6a5ba1269c32614e4387f71afdf1373ca147/client/controller/web-util.js#L28-L40))
- [stored the `sectionDefinition` of the section that needs to be activated in `page.js` context](https://github.com/Automattic/wp-calypso/blob/e96e6a5ba1269c32614e4387f71afdf1373ca147/client/sections-middleware.js#L93). This value will then be used (and cleared) by the section activation code in the `render()` middleware function

This approach has the advantage of fixing the issue without changing the shape of the global state, or requiring any changes to the code of other sections. It also doesn't require changes the docs on how to register a new section in Calypso.


## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/home`
* In the left sidebar, click on "Switch sites"
* Click on the "Add new site" button at the bottom of the left Sidebar
* Notice how there is no visual glitch


## Questions

Would these changes impact server-side/isomorphic rendering, as the "section activation" code has been moved to a file that runs only on the client?


Fixes #45662
