### PR TITLE
[GBonWPCOM e2e tests i0] Add assertion for blocks in the frontend (published) page for edge/non-edge, add @parallel tag

### DIFF
--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -250,8 +250,12 @@ export async function clearCookiesAndDeleteLocalStorage( driver, siteURL = null 
 	const url = await driver.getCurrentUrl();
 	await driver.manage().deleteAllCookies();
 	if ( url.startsWith( 'data:' ) === false && url !== 'about:blank' ) {
-		return await driver.executeScript( 'window.localStorage.clear();' );
+		return deleteLocalStorage( driver );
 	}
+}
+
+export function deleteLocalStorage( driver ) {
+	return driver.executeScript( 'window.localStorage.clear();' );
 }
 
 export async function ensureNotLoggedIn( driver ) {

--- a/test/e2e/lib/gutenberg/blocks/blog-posts-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/blog-posts-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,9 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class BlogPostsBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Blog Posts';
 	static blockName = 'a8c/blog-posts';
+	static blockFrontendSelector = By.css(
+		'.entry-content .wp-block-newspack-blocks-homepage-articles'
+	);
 }
 
 export { BlogPostsBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/contact-form-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/contact-form-block-component.js
@@ -12,6 +12,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class ContactFormBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Form';
 	static blockName = 'jetpack/contact-form';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-contact-form' );
 
 	async _postInit() {
 		return await driverHelper.clickWhenClickable(

--- a/test/e2e/lib/gutenberg/blocks/contact-info-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/contact-info-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class ContactInfoBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Contact Info';
 	static blockName = 'jetpack/contact-info';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-contact-info' );
 }
 
 export { ContactInfoBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class DynamicSeparatorBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Dynamic HR';
 	static blockName = 'coblocks/dynamic-separator';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-coblocks-dynamic-separator' );
 }
 
 export { DynamicSeparatorBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/gallery-masonry-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/gallery-masonry-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class GalleryMasonryBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Masonry';
 	static blockName = 'coblocks/gallery-masonry';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-coblocks-gallery-masonry' );
 }
 
 export { GalleryMasonryBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class LayoutGridBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Layout Grid';
 	static blockName = 'jetpack/layout-grid';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-layout-grid' );
 }
 
 export { LayoutGridBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/rating-star-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/rating-star-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class RatingStarBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Star Rating';
 	static blockName = 'jetpack/rating-star';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-rating-star' );
 }
 
 export { RatingStarBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class SlideshowBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Slideshow';
 	static blockName = 'jetpack/slideshow';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-slideshow' );
 }
 
 export { SlideshowBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/subscriptions-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/subscriptions-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class SubscriptionsBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Subscription Form';
 	static blockName = 'jetpack/subscriptions';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-subscriptions' );
 }
 
 export { SubscriptionsBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
@@ -11,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class TiledGalleryBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Tiled Gallery';
 	static blockName = 'jetpack/tiled-gallery';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-tiled-gallery' );
 
 	fileInputSelector = By.xpath(
 		`//*[@id="${ this.blockID.slice( 1 ) }"]/div/div/div[3]/div[2]/input`

--- a/test/e2e/lib/gutenberg/blocks/youtube-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/youtube-block-component.js
@@ -1,11 +1,19 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class YoutubeBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'YouTube';
-	static blockName = 'core-embed/youtube';
+	static blockName = 'core/embed';
+	static blockFrontendSelector = By.css(
+		'.entry-content figure.wp-block-embed iframe.youtube-player'
+	);
 }
 
 export { YoutubeBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/youtube-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/youtube-block-component.js
@@ -11,9 +11,6 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class YoutubeBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'YouTube';
 	static blockName = 'core/embed';
-	static blockFrontendSelector = By.css(
-		'.entry-content figure.wp-block-embed iframe.youtube-player'
-	);
 }
 
 export { YoutubeBlockComponent };

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -74,7 +74,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( closePanel ) {
 			try {
 				await this.closePublishedPanel();
-
 			} catch ( e ) {
 				console.log( 'Publish panel already closed' );
 			}
@@ -154,24 +153,26 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return contactFormBlock.insertSubject( subject );
 	}
 
-	toggleMoreToolsAndOptions() {
-		return driverHelper.clickWhenClickable(
+	async toggleMoreToolsAndOptions() {
+		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//button[@aria-label='More tools & options']" )
+			By.xpath( "//button[@aria-label='More tools & options' or @aria-label='Options']" )
 		);
+
+		await this.driver.sleep( 1000 );
 	}
 
 	async switchToCodeView() {
 		await this.toggleMoreToolsAndOptions();
 
-		// Now click to switch to the code editor
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//div[@aria-label='More tools & options']/div[2]/div[2]/button[2]" )
+			By.xpath(
+				"//div[@aria-label='More tools & options' or @aria-label='Options']/div[2]/div[2]/button[2]"
+			)
 		);
 
 		const textAreaSelector = By.css( 'textarea.editor-post-text-editor' );
-
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, textAreaSelector );
 
 		// close the menu
@@ -185,7 +186,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//div[@aria-label='More tools & options']/div[2]/div[2]/button[1]" )
+			By.xpath(
+				"//div[@aria-label='More tools & options' or @aria-label='Options']/div[2]/div[2]/button[1]"
+			)
 		);
 
 		// close the menu
@@ -218,8 +221,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async errorDisplayed() {
-		await this.driver.sleep( 1000 );
-		return await driverHelper.isElementPresent( this.driver, By.css( '.editor-error-boundary' ) );
+		return driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			By.css( '.editor-error-boundary' )
+		);
 	}
 
 	async hasInvalidBlocks() {
@@ -392,7 +397,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	 * You can just import the class of the block(s) you want to add and pass it to this function, which
 	 * also means we don't need to couple the block class with this one.
 	 *
-	 * @param { GutenbergBlockComponent } blockClass A block class that responds to title and name
+	 * @param { typeof GutenbergBlockComponent } blockClass A block class that responds to title and name
 	 */
 	async insertBlock( blockClass ) {
 		const blockID = await this.addBlock( blockClass.blockTitle );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -391,7 +391,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	 * You can just import the class of the block(s) you want to add and pass it to this function, which
 	 * also means we don't need to couple the block class with this one.
 	 *
-	 * @param { typeof GutenbergBlockComponent } blockClass A block class
+	 * @param { Function } blockClass A block class
 	 */
 	async insertBlock( blockClass ) {
 		const blockID = await this.addBlock( blockClass.blockTitle );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -179,9 +179,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		// Close the menu.
 		await this.toggleMoreToolsAndOptions();
 
-		// Set the editor element active.
-		await driverHelper.clickWhenClickable( this.driver, textAreaSelector );
-
 		return textAreaSelector;
 	}
 
@@ -199,9 +196,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		// Close the menu.
 		await this.toggleMoreToolsAndOptions();
-
-		// Set the editor element active.
-		await driverHelper.clickWhenClickable( this.driver, visualEditorSelector );
 	}
 
 	async getBlocksCode() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -172,10 +172,11 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			By.xpath( "//div[@aria-label='Options']//button[text()='Code editor']" )
 		);
 
+		// Wait for the code editor element.
 		const textAreaSelector = By.css( 'textarea.editor-post-text-editor' );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, textAreaSelector );
 
-		// close the menu
+		// Close the menu.
 		await this.toggleMoreToolsAndOptions();
 
 		return textAreaSelector;
@@ -189,7 +190,11 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			By.xpath( "//div[@aria-label='Options']//button[text()='Visual editor']" )
 		);
 
-		// close the menu
+		// Wait for the visual editor element.
+		const visualEditorSelector = By.css( 'div.edit-post-visual-editor' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, visualEditorSelector );
+
+		// Close the menu.
 		await this.toggleMoreToolsAndOptions();
 	}
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -169,7 +169,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//div[@aria-label='Options']/div[2]/div[2]/button[2]" )
+			By.xpath( "//div[@aria-label='Options']/div[2]/div[2]/button[text()='Code editor']" )
 		);
 
 		const textAreaSelector = By.css( 'textarea.editor-post-text-editor' );
@@ -178,7 +178,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		// close the menu
 		await this.toggleMoreToolsAndOptions();
 
-		return this.driver.findElement( textAreaSelector );
+		return textAreaSelector;
 	}
 
 	async switchToBlockEditor() {
@@ -194,17 +194,13 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async getBlocksCode() {
-		await this.switchToCodeView();
-		const blocksCode = await this.driver
-			.findElement( By.id( 'post-content-0' ) )
-			.getAttribute( 'value' );
-
-		return blocksCode;
+		const textAreaSelector = await this.switchToCodeView();
+		return this.driver.findElement( textAreaSelector ).getAttribute( 'value' );
 	}
 
 	async setBlocksCode( blocksCode ) {
-		await this.switchToCodeView();
-		await driverHelper.setWhenSettable( this.driver, By.id( 'post-content-0' ), blocksCode );
+		const textAreaSelector = await this.switchToCodeView();
+		await driverHelper.setWhenSettable( this.driver, textAreaSelector, blocksCode );
 	}
 
 	blockDisplayedInEditor( dataTypeSelectorVal ) {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -153,7 +153,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return contactFormBlock.insertSubject( subject );
 	}
 
-	async toggleMoreToolsAndOptions() {
+	async toggleOptionsMenu() {
 		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.xpath( "//button[@aria-label='Options']" )
@@ -164,8 +164,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await this.driver.sleep( 2000 );
 	}
 
-	async switchToCodeView() {
-		await this.toggleMoreToolsAndOptions();
+	async switchToCodeEditor() {
+		await this.toggleOptionsMenu();
 
 		await driverHelper.clickWhenClickable(
 			this.driver,
@@ -177,12 +177,12 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, textAreaSelector );
 
 		// Close the menu.
-		await this.toggleMoreToolsAndOptions();
+		await this.toggleOptionsMenu();
 
 		return textAreaSelector;
 	}
 
-	async switchToBlockEditor() {
+	async exitCodeEditor() {
 		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.xpath( "//button[text()='Exit code editor']" )
@@ -190,17 +190,17 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async getBlocksCode() {
-		const textAreaSelector = await this.switchToCodeView();
+		const textAreaSelector = await this.switchToCodeEditor();
 		const blocksCode = this.driver.findElement( textAreaSelector ).getAttribute( 'value' );
-		await this.switchToBlockEditor();
+		await this.exitCodeEditor();
 
 		return blocksCode;
 	}
 
 	async setBlocksCode( blocksCode ) {
-		const textAreaSelector = await this.switchToCodeView();
+		const textAreaSelector = await this.switchToCodeEditor();
 		await driverHelper.setWhenSettable( this.driver, textAreaSelector, blocksCode );
-		await this.switchToBlockEditor();
+		await this.exitCodeEditor();
 	}
 
 	blockDisplayedInEditor( dataTypeSelectorVal ) {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -29,7 +29,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		this.prePublishButtonSelector = By.css( '.editor-post-publish-panel__toggle' );
 		this.publishHeaderSelector = By.css( '.editor-post-publish-panel__header' );
 		this.editoriFrameSelector = By.css( '.calypsoify.is-iframe iframe' );
-		this.optionsPopupSelector = By.css( 'div[role="menu"][aria-label="Options"]' );
 	}
 
 	static async Expect( driver, editorType ) {
@@ -157,18 +156,20 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async toggleMoreToolsAndOptions() {
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//button[@aria-label='Options']" )
+			By.xpath( "//button[@aria-label='More tools & options' or @aria-label='Options']" )
 		);
+
+		await this.driver.sleep( 1000 );
 	}
 
 	async switchToCodeView() {
 		await this.toggleMoreToolsAndOptions();
 
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.optionsPopupSelector );
-
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//div[@aria-label='Options']/div[2]/div[2]/button[2]" )
+			By.xpath(
+				"//div[@aria-label='More tools & options' or @aria-label='Options']/div[2]/div[2]/button[2]"
+			)
 		);
 
 		const textAreaSelector = By.css( 'textarea.editor-post-text-editor' );
@@ -182,8 +183,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async switchToBlockEditor() {
 		await this.toggleMoreToolsAndOptions();
-
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.optionsPopupSelector );
 
 		await driverHelper.clickWhenClickable(
 			this.driver,

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -169,7 +169,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//div[@aria-label='Options']/div[2]/div[2]/button[text()='Code editor']" )
+			By.xpath( "//div[@aria-label='Options']//button[text()='Code editor']" )
 		);
 
 		const textAreaSelector = By.css( 'textarea.editor-post-text-editor' );
@@ -186,7 +186,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//div[@aria-label='Options']/div[2]/div[2]/button[1]" )
+			By.xpath( "//div[@aria-label='Options']//button[text()='Visual editor']" )
 		);
 
 		// close the menu
@@ -195,12 +195,16 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async getBlocksCode() {
 		const textAreaSelector = await this.switchToCodeView();
-		return this.driver.findElement( textAreaSelector ).getAttribute( 'value' );
+		const blocksCode = this.driver.findElement( textAreaSelector ).getAttribute( 'value' );
+		await this.switchToBlockEditor();
+
+		return blocksCode;
 	}
 
 	async setBlocksCode( blocksCode ) {
 		const textAreaSelector = await this.switchToCodeView();
 		await driverHelper.setWhenSettable( this.driver, textAreaSelector, blocksCode );
+		await this.switchToBlockEditor();
 	}
 
 	blockDisplayedInEditor( dataTypeSelectorVal ) {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -195,18 +195,18 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await this.toggleMoreToolsAndOptions();
 	}
 
-	async copyBlocksCode() {
-		const codeEditor = await this.switchToCodeView();
-		return this.driver.executeScript(
-			'arguments[0].select(); document.execCommand("copy");',
-			codeEditor
-		);
+	async getBlocksCode() {
+		await this.switchToCodeView();
+		const blocksCode = await this.driver
+			.findElement( By.id( 'post-content-0' ) )
+			.getAttribute( 'value' );
+
+		return blocksCode;
 	}
 
-	async pasteBlocksCode() {
-		const codeEditor = await this.switchToCodeView();
-		// Might not work in a Mac?
-		return codeEditor.sendKeys( Key.CONTROL + 'v' );
+	async setBlocksCode( blocksCode ) {
+		await this.switchToCodeView();
+		await driverHelper.setWhenSettable( this.driver, By.id( 'post-content-0' ), blocksCode );
 	}
 
 	blockDisplayedInEditor( dataTypeSelectorVal ) {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -29,6 +29,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		this.prePublishButtonSelector = By.css( '.editor-post-publish-panel__toggle' );
 		this.publishHeaderSelector = By.css( '.editor-post-publish-panel__header' );
 		this.editoriFrameSelector = By.css( '.calypsoify.is-iframe iframe' );
+		this.optionsPopupSelector = By.css( 'div[role="menu"][aria-label="Options"]' );
 	}
 
 	static async Expect( driver, editorType ) {
@@ -156,20 +157,18 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async toggleMoreToolsAndOptions() {
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//button[@aria-label='More tools & options' or @aria-label='Options']" )
+			By.xpath( "//button[@aria-label='Options']" )
 		);
-
-		await this.driver.sleep( 1000 );
 	}
 
 	async switchToCodeView() {
 		await this.toggleMoreToolsAndOptions();
 
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.optionsPopupSelector );
+
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath(
-				"//div[@aria-label='More tools & options' or @aria-label='Options']/div[2]/div[2]/button[2]"
-			)
+			By.xpath( "//div[@aria-label='Options']/div[2]/div[2]/button[2]" )
 		);
 
 		const textAreaSelector = By.css( 'textarea.editor-post-text-editor' );
@@ -183,6 +182,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async switchToBlockEditor() {
 		await this.toggleMoreToolsAndOptions();
+
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.optionsPopupSelector );
 
 		await driverHelper.clickWhenClickable(
 			this.driver,

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -179,6 +179,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		// Close the menu.
 		await this.toggleMoreToolsAndOptions();
 
+		// Set the editor element active.
+		await driverHelper.clickWhenClickable( this.driver, textAreaSelector );
+
 		return textAreaSelector;
 	}
 
@@ -196,6 +199,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		// Close the menu.
 		await this.toggleMoreToolsAndOptions();
+
+		// Set the editor element active.
+		await driverHelper.clickWhenClickable( this.driver, visualEditorSelector );
 	}
 
 	async getBlocksCode() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -156,10 +156,12 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async toggleMoreToolsAndOptions() {
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//button[@aria-label='More tools & options' or @aria-label='Options']" )
+			By.xpath( "//button[@aria-label='Options']" )
 		);
 
-		await this.driver.sleep( 1000 );
+		// This sleep is needed for the Options menu to be accessible. I've tried `waitTillPresentAndDisplayed`
+		// but it doesn't seem to work consistently, but this is pending improvement as this adds up on total time.
+		await this.driver.sleep( 2000 );
 	}
 
 	async switchToCodeView() {
@@ -167,9 +169,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath(
-				"//div[@aria-label='More tools & options' or @aria-label='Options']/div[2]/div[2]/button[2]"
-			)
+			By.xpath( "//div[@aria-label='Options']/div[2]/div[2]/button[2]" )
 		);
 
 		const textAreaSelector = By.css( 'textarea.editor-post-text-editor' );
@@ -186,9 +186,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath(
-				"//div[@aria-label='More tools & options' or @aria-label='Options']/div[2]/div[2]/button[1]"
-			)
+			By.xpath( "//div[@aria-label='Options']/div[2]/div[2]/button[1]" )
 		);
 
 		// close the menu

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -183,19 +183,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async switchToBlockEditor() {
-		await this.toggleMoreToolsAndOptions();
-
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//div[@aria-label='Options']//button[text()='Visual editor']" )
+			By.xpath( "//button[text()='Exit code editor']" )
 		);
-
-		// Wait for the visual editor element.
-		const visualEditorSelector = By.css( 'div.edit-post-visual-editor' );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, visualEditorSelector );
-
-		// Close the menu.
-		await this.toggleMoreToolsAndOptions();
 	}
 
 	async getBlocksCode() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -397,7 +397,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	 * You can just import the class of the block(s) you want to add and pass it to this function, which
 	 * also means we don't need to couple the block class with this one.
 	 *
-	 * @param { typeof GutenbergBlockComponent } blockClass A block class that responds to title and name
+	 * @param { typeof GutenbergBlockComponent } blockClass A block class
 	 */
 	async insertBlock( blockClass ) {
 		const blockID = await this.addBlock( blockClass.blockTitle );

--- a/test/e2e/lib/media-helper.js
+++ b/test/e2e/lib/media-helper.js
@@ -69,21 +69,18 @@ export function deleteFile( fileDetails ) {
 	return fs.deleteSync( fileDetails.file );
 }
 
+export const screenshotsDir = path.resolve(
+	process.env.TEMP_ASSET_PATH || __dirname + '/..',
+	process.env.SCREENSHOTDIR || 'screenshots'
+);
+
 export function writeScreenshot( data, filenameCallback, metadata ) {
 	const buffer = Buffer.from( data, 'base64' );
 	let filename;
 	let pt = new PassThrough();
 
-	let screenShotBase = __dirname + '/..';
-	if ( process.env.TEMP_ASSET_PATH ) {
-		screenShotBase = process.env.TEMP_ASSET_PATH;
-	}
-
-	const directoryName = screenShotsDir();
-
-	const screenShotDir = path.resolve( screenShotBase, directoryName );
-	if ( ! fs.existsSync( screenShotDir ) ) {
-		fs.mkdirSync( screenShotDir );
+	if ( ! fs.existsSync( screenshotsDir ) ) {
+		fs.mkdirSync( screenshotsDir );
 	}
 
 	if ( typeof filenameCallback === 'function' ) {
@@ -91,7 +88,8 @@ export function writeScreenshot( data, filenameCallback, metadata ) {
 	} else {
 		filename = new Date().getTime().toString();
 	}
-	const screenshotPath = `${ screenShotDir }/${ filename }.png`;
+	const screenshotPath = `${ screenshotsDir }/${ filename }.png`;
+
 	if ( typeof metadata === 'object' ) {
 		for ( const i in metadata ) {
 			pt = pt.pipe( pngitxt.set( i, metadata[ i ] ) );
@@ -116,8 +114,4 @@ export function writeTextLogFile( textContent, prefix, pathOverride ) {
 	fs.writeFileSync( logPath, textContent );
 
 	return logPath;
-}
-
-export function screenShotsDir() {
-	return process.env.SCREENSHOTDIR || 'screenshots';
 }

--- a/test/e2e/lib/mocha-hooks.js
+++ b/test/e2e/lib/mocha-hooks.js
@@ -72,7 +72,6 @@ afterEach( async function () {
 	let filenameCallback;
 
 	if ( this.currentTest.state === 'failed' ) {
-		console.error( this.currentTest.err );
 		const neverSaveScreenshots = config.get( 'neverSaveScreenshots' );
 		if ( neverSaveScreenshots ) {
 			return null;

--- a/test/e2e/lib/mocha-hooks.js
+++ b/test/e2e/lib/mocha-hooks.js
@@ -72,6 +72,7 @@ afterEach( async function () {
 	let filenameCallback;
 
 	if ( this.currentTest.state === 'failed' ) {
+		console.error( this.currentTest.err );
 		const neverSaveScreenshots = config.get( 'neverSaveScreenshots' );
 		if ( neverSaveScreenshots ) {
 			return null;

--- a/test/e2e/lib/mocha-hooks.js
+++ b/test/e2e/lib/mocha-hooks.js
@@ -162,6 +162,11 @@ after( async function () {
 
 // Quit browser
 after( function () {
+	if ( ! global.__BROWSER__ ) {
+		// Early return if there's no browser, i.e. when all specs were skipped.
+		return;
+	}
+
 	this.timeout( afterHookTimeoutMS );
 	const driver = global.__BROWSER__;
 

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -268,10 +268,6 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 					} );
 
 					step( `Insert and configure ${ blockClass.blockName }`, async function () {
-						// For some reason, after the first run, the code editor is shown by
-						// default, this breaks the insertBlock call, so we force-switch to the
-						// editor before the insert.
-						await gEditorComponent.switchToBlockEditor();
 						await insertBlock( blockClass );
 					} );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -48,9 +48,11 @@ let sampleImages;
 
 const blockInits = new Map()
 	.set( TiledGalleryBlockComponent, ( block ) => block.uploadImages( sampleImages ) )
-	.set( ContactFormBlockComponent, () =>
-		gEditorComponent.insertContactForm( 'testing@automattic.com', "Let's work together" )
-	);
+	.set( ContactFormBlockComponent, async ( block ) => {
+		await block.openEditSettings();
+		await block.insertEmail( 'testing@automattic.com' );
+		await block.insertSubject( "Let's work together" );
+	} );
 
 /**
  * Wrapper that provides an uniform API for creating blocks on the page. It uses
@@ -195,9 +197,17 @@ function verifyBlockInPublishedPage( blockClass, siteName ) {
 		await takePublishedScreenshots( siteName );
 	} );
 
-	step( 'Block is displayed in the published page', async function () {
-		await driverHelper.waitTillPresentAndDisplayed( driver, blockClass.blockFrontendSelector );
-	} );
+	/**
+	 * This is a temporary hack for this changeset to skip checking some blocks in the frontend until
+	 * they are properly setup (which is done in subsequent PRs). Some blocks will not appear if not
+	 * properly configured/filled with sample attributes or assets. This guard and comment will
+	 * eventually be removed.
+	 */
+	if ( ! [ YoutubeBlockComponent, SlideshowBlockComponent ].includes( blockClass ) ) {
+		step( 'Block is displayed in the published page', async function () {
+			await driverHelper.waitTillPresentAndDisplayed( driver, blockClass.blockFrontendSelector );
+		} );
+	}
 }
 
 /**

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -277,12 +277,9 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 
 					verifyBlockInEditor( blockClass, siteName );
 
-					step(
-						'Switch to the code editor and copy the code markup for the block',
-						async function () {
-							currentGutenbergBlocksCode = await gEditorComponent.getBlocksCode();
-						}
-					);
+					step( 'Copy the markup for the block', async function () {
+						currentGutenbergBlocksCode = await gEditorComponent.getBlocksCode();
+					} );
 
 					verifyBlockInPublishedPage( blockClass, siteName );
 				} );
@@ -290,9 +287,9 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 					step( `Switches to edge site (${ edgeSiteName })`, async function () {
 						// Re-use the same session created earlier but change the site
 						await loginFlow.loginAndStartNewPost( `${ edgeSiteName }.wordpress.com`, true );
+					} );
 
-						// Loads the same blocks from the non-edge site by pasting the code markup code in the code editor
-						// and then switching to the block editor
+					step( 'Load block via markup copied from non-edge site', async function () {
 						await gEditorComponent.setBlocksCode( currentGutenbergBlocksCode );
 						await gEditorComponent.switchToBlockEditor();
 					} );

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -247,6 +247,8 @@ before( async function () {
 	driver = await driverManager.startBrowser();
 
 	loginFlow = new LoginFlow( driver, 'gutenbergUpgradeUser' );
+	await loginFlow.login();
+
 	sampleImages = times( 5, () => mediaHelper.createFile() );
 } );
 
@@ -277,8 +279,7 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 				const siteURL = `${ siteName }.wordpress.com`;
 
 				describe( `Test the block in the non-edge site (${ siteName })`, function () {
-					step( `Login to ${ siteName }`, async function () {
-						await loginFlow.login( siteURL, true );
+					step( `Start new post on ${ siteName }`, async function () {
 						await startNewPost( siteURL );
 					} );
 
@@ -288,7 +289,7 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 
 					verifyBlockInEditor( blockClass, siteName );
 
-					step( 'Copy the markup for the block', async function () {
+					step( 'Copy the markup of the block', async function () {
 						currentGutenbergBlocksCode = await gEditorComponent.getBlocksCode();
 					} );
 
@@ -298,7 +299,7 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 				describe( `Test the same block in the corresponding edge site (${ edgeSiteName })`, function () {
 					const edgeSiteURL = `${ edgeSiteName }.wordpress.com`;
 
-					step( `Switches to edge site (${ edgeSiteName })`, async function () {
+					step( `Start new post on (${ edgeSiteName })`, async function () {
 						await startNewPost( edgeSiteURL );
 					} );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -13,6 +13,11 @@ import { promises as fs } from 'fs';
  */
 import LoginFlow from '../lib/flows/login-flow.js';
 
+import ReaderPage from '../lib/pages/reader-page';
+
+import SidebarComponent from '../lib/components/sidebar-component.js';
+import NavBarComponent from '../lib/components/nav-bar-component.js';
+
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 
 import * as driverManager from '../lib/driver-manager.js';
@@ -279,10 +284,18 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 
 					verifyBlockInPublishedPage( blockClass, siteName );
 				} );
+
 				describe( `Test the same block in the corresponding edge site (${ edgeSiteName })`, function () {
 					step( `Switches to edge site (${ edgeSiteName })`, async function () {
-						// Re-use the same session created earlier but change the site
-						await loginFlow.loginAndStartNewPost( `${ edgeSiteName }.wordpress.com`, true );
+						await ReaderPage.Visit( driver );
+
+						const navbarComponent = await NavBarComponent.Expect( driver );
+						await navbarComponent.clickCreateNewPost( {
+							siteURL: `${ edgeSiteName }.wordpress.com`,
+						} );
+
+						gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+						await gEditorComponent.initEditor();
 					} );
 
 					step( 'Load block via markup copied from non-edge site', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -96,17 +96,13 @@ async function takeScreenshot( siteName, totalHeight, viewportHeight, scrollCb )
 	for ( let i = 0; i <= totalHeight / viewportHeight; i++ ) {
 		await scrollCb( i );
 
-		await driver.takeScreenshot().then( ( data ) => {
-			return driver
-				.getCurrentUrl()
-				.then( ( url ) =>
-					mediaHelper.writeScreenshot(
-						data,
-						() => join( siteName, `${ siteName }-${ i }-${ now }` ),
-						{ url }
-					)
-				);
-		} );
+		const screenshotData = await driver.takeScreenshot();
+		const url = await driver.getCurrentUrl();
+		await mediaHelper.writeScreenshot(
+			screenshotData,
+			() => join( siteName, `${ siteName }-${ i }-${ now }` ),
+			{ url }
+		);
 	}
 }
 

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -276,7 +276,7 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 					step(
 						'Switch to the code editor and copy the code markup for the block',
 						async function () {
-							currentGutenbergBlocksCode = await gEditorComponent.copyBlocksCode();
+							currentGutenbergBlocksCode = await gEditorComponent.getBlocksCode();
 						}
 					);
 
@@ -289,7 +289,7 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 
 						// Loads the same blocks from the non-edge site by pasting the code markup code in the code editor
 						// and then switching to the block editor
-						await gEditorComponent.pasteBlocksCode( currentGutenbergBlocksCode );
+						await gEditorComponent.setBlocksCode( currentGutenbergBlocksCode );
 						await gEditorComponent.switchToBlockEditor();
 					} );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -164,9 +164,11 @@ function verifyBlockInEditor( blockClass, siteName ) {
 	} );
 	*/
 
+	/* Commented out for now because of ENOMEM erros on CI
 	step( 'Take screenshots of the block in the editor', async function () {
 		await takeEditorScreenshots( siteName );
 	} );
+	*/
 }
 
 async function assertNoErrorInEditor() {
@@ -189,9 +191,11 @@ function verifyBlockInPublishedPage( blockClass, siteName ) {
 		await gEditorComponent.publish( { visit: true } );
 	} );
 
+	/* Commented out for now because of ENOMEM errors on CI
 	step( 'Take screenshots of the published page', async function () {
 		await takePublishedScreenshots( siteName );
 	} );
+	*/
 
 	/**
 	 * This is a temporary hack for this changeset to skip checking some blocks in the frontend until

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -4,9 +4,9 @@
 import assert from 'assert';
 import config from 'config';
 import { times } from 'lodash';
-import { By } from 'selenium-webdriver';
-import { join } from 'path';
-import { promises as fs } from 'fs';
+// import { By } from 'selenium-webdriver';
+// import { join } from 'path';
+// import { promises as fs } from 'fs';
 
 /**
  * Internal dependencies
@@ -59,12 +59,12 @@ const blockInits = new Map()
 	} );
 
 /**
- * Wrapper that provides an uniform API for creating blocks on the page. It uses
- * the `inits` dictionary defined in this module. If an entry is not found for the
- * passed `blockClass`, it fall-backs to just inserting the block on the page.
+ * Wrapper that provides an uniform API for creating blocks on the page. It uses the `inits`
+ * dictionary defined in this module. If an entry is not found for the passed `blockClass`, it
+ * fall-backs to just inserting the block on the page.
  *
- * IMPORTANT: It relies on the `gEditorComponent` having a proper instance of `GutenbergEditorComponent`,
- * so make sure to call it only when this instance is available.
+ * IMPORTANT: It relies on the `gEditorComponent` having a proper instance of
+ * `GutenbergEditorComponent`, so make sure to call it only when this instance is available.
  *
  * @param { typeof GutenbergBlockComponent } blockClass A block class.
  * @returns { Function } the init function to be called.
@@ -76,79 +76,90 @@ async function insertBlock( blockClass ) {
 	return blockInit && blockInit( block );
 }
 
-/**
- * Take screenshot(s) of a given site's page.
- *
- * There's no way I know of to take a full-height screenshot of the page using wedriver. Because of that,
- * we basically scroll down the page in pieces and take screenshot of those areas. In the end we have multiple
- * screenshots that do represent the full page, vertically.
- *
- * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
- * @param { number } totalHeight The total height of the page
- * @param { number } viewportHeight The visible height
- * @param { Function } scrollCb A callback function that will be called to scroll down the page, it should accept an integer that
- * will be used in formula to calculate how much it should scroll.
- */
-async function takeScreenshot( siteName, totalHeight, viewportHeight, scrollCb ) {
-	const now = Date.now() / 1000;
+// Commented out for now because of ENOMEM erros on CI
+// /**
+//  * Take screenshot(s) of a given site's page.
+//  *
+//  * There's no way I know of to take a full-height screenshot of the page using wedriver. Because of
+//  * that, we basically scroll down the page in pieces and take screenshot of those areas. In the end
+//  * we have multiple screenshots that do represent the full page, vertically.
+//  *
+//  * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
+//  * @param { number } totalHeight The total height of the page
+//  * @param { number } viewportHeight The visible height
+//  * @param { Function } scrollCb A callback function that will be called to scroll down the page, it
+//  * should accept an integer that will be used in formula to calculate how much it should scroll.
+//  */
+// async function takeScreenshot( siteName, totalHeight, viewportHeight, scrollCb ) {
+// 	const now = Date.now() / 1000;
 
-	const siteScreenshotsDir = join( mediaHelper.screenshotsDir, siteName );
-	await fs
-		.access( siteScreenshotsDir )
-		.catch( () => fs.mkdir( siteScreenshotsDir, { recursive: true } ) );
+// 	const siteScreenshotsDir = join( mediaHelper.screenshotsDir, siteName );
+// 	await fs
+// 		.access( siteScreenshotsDir )
+// 		.catch( () => fs.mkdir( siteScreenshotsDir, { recursive: true } ) );
 
-	for ( let i = 0; i <= totalHeight / viewportHeight; i++ ) {
-		await scrollCb( i );
+// 	for ( let i = 0; i <= totalHeight / viewportHeight; i++ ) {
+// 		await scrollCb( i );
 
-		const screenshotData = await driver.takeScreenshot();
-		const url = await driver.getCurrentUrl();
-		await mediaHelper.writeScreenshot(
-			screenshotData,
-			() => join( siteName, `${ siteName }-${ i }-${ now }` ),
-			{ url }
-		);
-	}
+// 		const screenshotData = await driver.takeScreenshot();
+// 		const url = await driver.getCurrentUrl();
+// 		await mediaHelper.writeScreenshot(
+// 			screenshotData,
+// 			() => join( siteName, `${ siteName }-${ i }-${ now }` ),
+// 			{ url }
+// 		);
+// 	}
+// }
+
+// Commented out for now because of ENOMEM erros on CI
+// /**
+//  * Take screenshot(s) of the editor. Useful to diagnose glitches that might manifest visually and
+//  * that we still don't verify automatically.
+//  *
+//  * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
+//  */
+// async function takeEditorScreenshots( siteName ) {
+// 	const editorViewport = await driver.findElement(
+// 		By.css( 'div.interface-interface-skeleton__content' )
+// 	);
+
+// 	const editorViewportScrollHeight = await driver.executeScript(
+// 		'return arguments[0].scrollHeight',
+// 		editorViewport
+// 	);
+// 	const editorViewportClientHeight = await driver.executeScript(
+// 		'return arguments[0].clientHeight',
+// 		editorViewport
+// 	);
+
+// 	await takeScreenshot(
+// 		`${ siteName }-editor`,
+// 		editorViewportScrollHeight,
+// 		editorViewportClientHeight,
+// 		( i ) =>
+// 			driver.executeScript(
+// 				`arguments[0].scroll({top: arguments[0].clientHeight*${ i }})`,
+// 				editorViewport
+// 			)
+// 	);
+// }
+
+async function assertNoErrorInEditor() {
+	const errorDisplayed = await gEditorComponent.errorDisplayed();
+	assert.strictEqual( errorDisplayed, false, 'The block errored in the editor!' );
 }
 
-/**
- * Take screenshot(s) of the editor. Useful to diagnose glitches that might manifest visually and that
- * we still don't verify automatically.
- *
- * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
- */
-async function takeEditorScreenshots( siteName ) {
-	const editorViewport = await driver.findElement(
-		By.css( 'div.interface-interface-skeleton__content' )
-	);
-
-	const editorViewportScrollHeight = await driver.executeScript(
-		'return arguments[0].scrollHeight',
-		editorViewport
-	);
-	const editorViewportClientHeight = await driver.executeScript(
-		'return arguments[0].clientHeight',
-		editorViewport
-	);
-
-	await takeScreenshot(
-		`${ siteName }-editor`,
-		editorViewportScrollHeight,
-		editorViewportClientHeight,
-		( i ) =>
-			driver.executeScript(
-				`arguments[0].scroll({top: arguments[0].clientHeight*${ i }})`,
-				editorViewport
-			)
-	);
-}
+// Commented-out for now because of https://github.com/Automattic/jetpack/issues/16514
+// async function assertNoInvalidBlocksInEditor() {
+// 	assert.strictEqual( await gEditorComponent.hasInvalidBlocks(), false, 'The block is invalid!' );
+// }
 
 /**
  * Re-usable collection of steps for verifying blocks in the editor.
  *
  * @param { typeof GutenbergBlockComponent } blockClass A block class.
- * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
  */
-function verifyBlockInEditor( blockClass, siteName ) {
+function verifyBlockInEditor( blockClass ) {
 	step( 'Block is displayed in the editor', async function () {
 		const displayed = await gEditorComponent.blockDisplayedInEditor( blockClass.blockName );
 		assert.strictEqual(
@@ -162,44 +173,31 @@ function verifyBlockInEditor( blockClass, siteName ) {
 		await assertNoErrorInEditor();
 	} );
 
-	/* Commented-out for now because of https://github.com/Automattic/jetpack/issues/16514
-	step( 'Blocks do not invalidate', async function () {
-			await assertNoInvalidBlocksInEditor();
-	} );
-	*/
+	// Commented-out for now because of https://github.com/Automattic/jetpack/issues/16514
+	// step( 'Blocks do not invalidate', async function () {
+	// 		await assertNoInvalidBlocksInEditor();
+	// } );
 
-	/* Commented out for now because of ENOMEM erros on CI
-	step( 'Take screenshots of the block in the editor', async function () {
-		await takeEditorScreenshots( siteName );
-	} );
-	*/
-}
-
-async function assertNoErrorInEditor() {
-	const errorDisplayed = await gEditorComponent.errorDisplayed();
-	assert.strictEqual( errorDisplayed, false, 'The block errored in the editor!' );
-}
-
-async function assertNoInvalidBlocksInEditor() {
-	assert.strictEqual( await gEditorComponent.hasInvalidBlocks(), false, 'The block is invalid!' );
+	// Commented out for now because of ENOMEM erros on CI
+	// step( 'Take screenshots of the block in the editor', async function () {
+	// 	await takeEditorScreenshots( siteName );
+	// } );
 }
 
 /**
  * Re-usable collection of steps for verifying blocks in the frontend/published page.
  *
  * @param { typeof GutenbergBlockComponent } blockClass A block class.
- * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
  */
-function verifyBlockInPublishedPage( blockClass, siteName ) {
+function verifyBlockInPublishedPage( blockClass ) {
 	step( 'Publish page', async function () {
 		await gEditorComponent.publish( { visit: true } );
 	} );
 
-	/* Commented out for now because of ENOMEM errors on CI
-	step( 'Take screenshots of the published page', async function () {
-		await takePublishedScreenshots( siteName );
-	} );
-	*/
+	// Commented out for now because of ENOMEM errors on CI
+	// step( 'Take screenshots of the published page', async function () {
+	// 	await takePublishedScreenshots( siteName );
+	// } );
 
 	/**
 	 * This is a temporary hack for this changeset to skip checking some blocks in the frontend until
@@ -214,23 +212,24 @@ function verifyBlockInPublishedPage( blockClass, siteName ) {
 	}
 }
 
-/**
- * Take screenshot(s) of the published page for given site. Useful to diagnose glitches that might manifest visually and that
- * we still don't verify automatically.
- *
- * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
- */
-async function takePublishedScreenshots( siteName ) {
-	// Give blocks a chance to render and load assets before taking the screenshots
-	await driver.sleep( 2000 );
+// Commented out for now because of ENOMEM erros on CI
+// /**
+//  * Take screenshot(s) of the published page for given site. Useful to diagnose glitches that might
+//  * manifest visually and that we still don't verify automatically.
+//  *
+//  * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
+//  */
+// async function takePublishedScreenshots( siteName ) {
+// 	// Give blocks a chance to render and load assets before taking the screenshots.
+// 	await driver.sleep( 2000 );
 
-	const totalHeight = await driver.executeScript( 'return document.body.offsetHeight' );
-	const windowHeight = await driver.executeScript( 'return window.outerHeight' );
+// 	const totalHeight = await driver.executeScript( 'return document.body.offsetHeight' );
+// 	const windowHeight = await driver.executeScript( 'return window.outerHeight' );
 
-	await takeScreenshot( `${ siteName }-published`, totalHeight, windowHeight, ( i ) =>
-		driver.executeScript( `window.scrollTo(0, window.outerHeight*${ i })` )
-	);
-}
+// 	await takeScreenshot( `${ siteName }-published`, totalHeight, windowHeight, ( i ) =>
+// 		driver.executeScript( `window.scrollTo(0, window.outerHeight*${ i })` )
+// 	);
+// }
 
 before( async function () {
 	this.timeout( startBrowserTimeoutMS );

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -66,7 +66,7 @@ const blockInits = new Map()
  * IMPORTANT: It relies on the `gEditorComponent` having a proper instance of
  * `GutenbergEditorComponent`, so make sure to call it only when this instance is available.
  *
- * @param { typeof GutenbergBlockComponent } blockClass A block class.
+ * @param { Function } blockClass A block class.
  * @returns { Function } the init function to be called.
  */
 async function insertBlock( blockClass ) {
@@ -157,7 +157,7 @@ async function assertNoErrorInEditor() {
 /**
  * Re-usable collection of steps for verifying blocks in the editor.
  *
- * @param { typeof GutenbergBlockComponent } blockClass A block class.
+ * @param { Function } blockClass A block class.
  */
 function verifyBlockInEditor( blockClass ) {
 	step( 'Block is displayed in the editor', async function () {
@@ -187,7 +187,7 @@ function verifyBlockInEditor( blockClass ) {
 /**
  * Re-usable collection of steps for verifying blocks in the frontend/published page.
  *
- * @param { typeof GutenbergBlockComponent } blockClass A block class.
+ * @param { Function } blockClass A block class.
  */
 function verifyBlockInPublishedPage( blockClass ) {
 	step( 'Publish page', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -26,6 +26,7 @@ const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 import {
+	GutenbergBlockComponent,
 	BlogPostsBlockComponent,
 	ContactFormBlockComponent,
 	ContactInfoBlockComponent,
@@ -45,6 +46,178 @@ let gEditorComponent;
 let currentGutenbergBlocksCode;
 let sampleImages;
 
+const blockInits = new Map()
+	.set( TiledGalleryBlockComponent, async ( block ) => {
+		await block.uploadImages( sampleImages );
+	} )
+	.set( ContactFormBlockComponent, async () => {
+		await gEditorComponent.insertContactForm( 'testing@automattic.com', "Let's work together" );
+	} );
+
+/**
+ * Wrapper that provides an uniform API for creating blocks on the page. It uses
+ * the `inits` dictionary defined in this module. If an entry is not found for the
+ * passed `blockClass`, it fall-backs to just inserting the block on the page.
+ *
+ * IMPORTANT: It relies on the `gEditorComponent` having a proper instance of `GutenbergEditorComponent`,
+ * so make sure to call it only when this instance is available.
+ *
+ * @param { typeof GutenbergBlockComponent } blockClass A block class.
+ * @returns { Function } the init function to be called.
+ */
+async function createBlock( blockClass ) {
+	const blockInit = blockInits.get( blockClass );
+	const block = await gEditorComponent.insertBlock( blockClass );
+
+	return blockInit && blockInit( block );
+}
+
+/**
+ * Take screenshot(s) of a given site's page.
+ *
+ * There's no way I know of to take a full-height screenshot of the page using wedriver. Because of that,
+ * we basically scroll down the page in pieces and take screenshot of those areas. In the end we have multiple
+ * screenshots that do represent the full page, vertically.
+ *
+ * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
+ * @param { number } totalHeight The total height of the page
+ * @param { number } viewportHeight The visible height
+ * @param { Function } scrollCb A callback function that will be called to scroll down the page, it should accept an integer that
+ * will be used in formula to calculate how much it should scroll.
+ */
+async function takeScreenshot( siteName, totalHeight, viewportHeight, scrollCb ) {
+	const now = Date.now() / 1000;
+
+	const siteScreenshotsDir = join( mediaHelper.screenshotsDir, siteName );
+	await fs
+		.access( siteScreenshotsDir )
+		.catch( () => fs.mkdir( siteScreenshotsDir, { recursive: true } ) );
+
+	for ( let i = 0; i <= totalHeight / viewportHeight; i++ ) {
+		await scrollCb( i );
+
+		await driver.takeScreenshot().then( ( data ) => {
+			return driver
+				.getCurrentUrl()
+				.then( ( url ) =>
+					mediaHelper.writeScreenshot(
+						data,
+						() => join( siteName, `${ siteName }-${ i }-${ now }` ),
+						{ url }
+					)
+				);
+		} );
+	}
+}
+
+/**
+ * Take screenshot(s) of the editor. Useful to diagnose glitches that might manifest visually and that
+ * we still don't verify automatically.
+ *
+ * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
+ */
+async function takeBlockScreenshots( siteName ) {
+	const editorViewport = await driver.findElement(
+		By.css( 'div.interface-interface-skeleton__content' )
+	);
+
+	const editorViewportScrollHeight = await driver.executeScript(
+		'return arguments[0].scrollHeight',
+		editorViewport
+	);
+	const editorViewportClientHeight = await driver.executeScript(
+		'return arguments[0].clientHeight',
+		editorViewport
+	);
+
+	await takeScreenshot(
+		`${ siteName }-editor`,
+		editorViewportScrollHeight,
+		editorViewportClientHeight,
+		( i ) =>
+			driver.executeScript(
+				`arguments[0].scroll({top: arguments[0].clientHeight*${ i }})`,
+				editorViewport
+			)
+	);
+}
+
+/**
+ * Re-usable collection of steps for verifying blocks in the editor.
+ *
+ * @param { typeof GutenbergBlockComponent } blockClass A block class.
+ * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
+ */
+function verifyBlockInEditor( blockClass, siteName ) {
+	step( 'Block is displayed in the editor', async function () {
+		const displayed = await gEditorComponent.blockDisplayedInEditor( blockClass.blockName );
+		assert.strictEqual(
+			displayed,
+			true,
+			`The block "${ blockClass.blockName }" was not found in the editor`
+		);
+	} );
+
+	step( 'Block does not error in the editor', async function () {
+		await assertNoErrorInEditor();
+	} );
+
+	/* Commented-out for now because of https://github.com/Automattic/jetpack/issues/16514
+	step( 'Blocks do not invalidate', async function () {
+			await assertNoInvalidBlocksInEditor();
+	} );
+	*/
+
+	step( 'Take screenshots of the block in the editor', async function () {
+		await takeBlockScreenshots( siteName );
+	} );
+}
+
+async function assertNoErrorInEditor() {
+	const errorDisplayed = await gEditorComponent.errorDisplayed();
+	assert.strictEqual( errorDisplayed, false, 'The block errored in the editor!' );
+}
+
+async function assertNoInvalidBlocksInEditor() {
+	assert.strictEqual( await gEditorComponent.hasInvalidBlocks(), false, 'The block is invalid!' );
+}
+
+/**
+ * Re-usable collection of steps for verifying blocks in the frontend/published page.
+ *
+ * @param { typeof GutenbergBlockComponent } blockClass A block class.
+ * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
+ */
+function verifyBlockInPublishedPage( blockClass, siteName ) {
+	step( 'Take screenshots of the published page', async function () {
+		await takePublishedScreenshots( siteName );
+	} );
+
+	step( 'Block is displayed in the published page', async function () {
+		await driverHelper.waitTillPresentAndDisplayed( driver, blockClass.blockFrontendSelector );
+	} );
+}
+
+/**
+ * Take screenshot(s) of the published page for given site. Useful to diagnose glitches that might manifest visually and that
+ * we still don't verify automatically.
+ *
+ * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
+ */
+async function takePublishedScreenshots( siteName ) {
+	await gEditorComponent.publish( { visit: true } );
+
+	// Give blocks a chance to render and load assets before taking the screenshots
+	await driver.sleep( 2000 );
+
+	const totalHeight = await driver.executeScript( 'return document.body.offsetHeight' );
+	const windowHeight = await driver.executeScript( 'return window.outerHeight' );
+
+	await takeScreenshot( `${ siteName }-published`, totalHeight, windowHeight, ( i ) =>
+		driver.executeScript( `window.scrollTo(0, window.outerHeight*${ i })` )
+	);
+}
+
 before( async function () {
 	this.timeout( startBrowserTimeoutMS );
 	driver = await driverManager.startBrowser();
@@ -53,232 +226,53 @@ before( async function () {
 	sampleImages = times( 5, () => mediaHelper.createFile() );
 } );
 
-// Should we keep the @parallel tag here for this e2e test?
-describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites across most popular themes (${ screenSize }) @parallel`, function () {
-	this.timeout( mochaTimeOut );
+[
+	BlogPostsBlockComponent,
+	ContactFormBlockComponent,
+	ContactInfoBlockComponent,
+	DynamicSeparatorBlockComponent,
+	GalleryMasonryBlockComponent,
+	LayoutGridBlockComponent,
+	RatingStarBlockComponent,
+	SlideshowBlockComponent,
+	SubscriptionsBlockComponent,
+	TiledGalleryBlockComponent,
+	YoutubeBlockComponent,
+].forEach( ( blockClass ) => {
+	describe( `[${ host }] Test ${ blockClass.blockName } in edge and non-edge sites across most popular themes (${ screenSize }) @parallel`, function () {
+		this.timeout( mochaTimeOut );
 
-	async function takeScreenshot( siteName, totalHeight, viewportHeight, scrollCb ) {
-		const now = Date.now() / 1000;
+		[
+			'e2egbupgradehever',
+			'e2egbupgradeshawburn',
+			'e2egbupgrademorden',
+			'e2egbupgradeexford',
+			'e2egbupgrademayland',
+		].forEach( ( siteName ) => {
+			const edgeSiteName = siteName + 'edge';
+			describe( `Test the block in the non-edge site (${ siteName })`, function () {
+				step( `Login to ${ siteName }`, async function () {
+					await loginFlow.loginAndStartNewPost( `${ siteName }.wordpress.com`, true );
+					gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				} );
 
-		const siteScreenshotsDir = join( mediaHelper.screenshotsDir, siteName );
-		await fs
-			.access( siteScreenshotsDir )
-			.catch( () => fs.mkdir( siteScreenshotsDir, { recursive: true } ) );
+				step( `Insert and configure ${ blockClass.blockName }`, async function () {
+					await createBlock( blockClass );
+				} );
 
-		for ( let i = 0; i <= totalHeight / viewportHeight; i++ ) {
-			await scrollCb( i );
+				verifyBlockInEditor( blockClass, siteName );
 
-			await driver.takeScreenshot().then( ( data ) => {
-				return driver
-					.getCurrentUrl()
-					.then( ( url ) =>
-						mediaHelper.writeScreenshot(
-							data,
-							() => join( siteName, `${ siteName }-${ i }-${ now }` ),
-							{ url }
-						)
-					);
+				step(
+					'Switch to the code editor and copy the code markup for the block',
+					async function () {
+						currentGutenbergBlocksCode = await gEditorComponent.copyBlocksCode();
+					}
+				);
+
+				verifyBlockInPublishedPage( blockClass, siteName );
 			} );
-		}
-	}
-
-	async function assertNoErrorInEditor() {
-		const errorDisplayed = await gEditorComponent.errorDisplayed();
-		assert.strictEqual( errorDisplayed, false, 'There is an error shown on the editor page!' );
-	}
-
-	async function assertNoInvalidBlocksInEditor() {
-		assert.strictEqual(
-			await gEditorComponent.hasInvalidBlocks(),
-			false,
-			'There is at least one invalid block on the editor page!'
-		);
-	}
-
-	async function takeBlockScreenshots( siteName ) {
-		const editorViewport = await driver.findElement(
-			By.css( 'div.interface-interface-skeleton__content' )
-		);
-
-		const editorViewportScrollHeight = await driver.executeScript(
-			'return arguments[0].scrollHeight',
-			editorViewport
-		);
-		const editorViewportClientHeight = await driver.executeScript(
-			'return arguments[0].clientHeight',
-			editorViewport
-		);
-
-		await takeScreenshot(
-			`${ siteName }-editor`,
-			editorViewportScrollHeight,
-			editorViewportClientHeight,
-			( i ) =>
-				driver.executeScript(
-					`arguments[0].scroll({top: arguments[0].clientHeight*${ i }})`,
-					editorViewport
-				)
-		);
-	}
-
-	async function takePublishedScreenshots( siteName ) {
-		await gEditorComponent.publish( { visit: true } );
-
-		// Give blocks a chance to render and load assets before taking the screenshots
-		await driver.sleep( 2000 );
-
-		const totalHeight = await driver.executeScript( 'return document.body.offsetHeight' );
-		const windowHeight = await driver.executeScript( 'return window.outerHeight' );
-
-		await takeScreenshot( `${ siteName }-published`, totalHeight, windowHeight, ( i ) =>
-			driver.executeScript( `window.scrollTo(0, window.outerHeight*${ i })` )
-		);
-	}
-
-	function verifyBlocksInEditor( siteName ) {
-		step( 'Blocks are displayed in the editor', async function () {
-			await Promise.all(
-				[
-					BlogPostsBlockComponent,
-					ContactFormBlockComponent,
-					ContactInfoBlockComponent,
-					DynamicSeparatorBlockComponent,
-					GalleryMasonryBlockComponent,
-					LayoutGridBlockComponent,
-					RatingStarBlockComponent,
-					SlideshowBlockComponent,
-					SubscriptionsBlockComponent,
-					TiledGalleryBlockComponent,
-					YoutubeBlockComponent,
-				].map( async ( blockClass ) => {
-					const displayed = await gEditorComponent.blockDisplayedInEditor( blockClass.blockName );
-					assert.strictEqual(
-						displayed,
-						true,
-						`The block "${ blockClass.blockName }" was not found in the editor`
-					);
-				} )
-			);
-		} );
-
-		step( 'Blocks do not error in the editor', async function () {
-			await assertNoErrorInEditor();
-		} );
-		// Commented-out for now because of https://github.com/Automattic/jetpack/issues/16514
-		/*step( 'Blocks do not invalidate', async function () {
-			await assertNoInvalidBlocksInEditor();
-		} );*/
-
-		step( 'Take screenshots of all the blocks in the editor', async function () {
-			await takeBlockScreenshots( siteName );
-		} );
-	}
-
-	function verifyBlocksInPublishedPage( siteName ) {
-		step( 'Take screenshots of the published page', async function () {
-			await takePublishedScreenshots( siteName );
-		} );
-
-		step( 'Blocks are displayed in the published page', async function () {
-			await Promise.all(
-				[
-					BlogPostsBlockComponent,
-					ContactFormBlockComponent,
-					ContactInfoBlockComponent,
-					DynamicSeparatorBlockComponent,
-					GalleryMasonryBlockComponent,
-					LayoutGridBlockComponent,
-					RatingStarBlockComponent,
-					SubscriptionsBlockComponent,
-					TiledGalleryBlockComponent,
-				].map( ( blockClass ) =>
-					driverHelper.waitTillPresentAndDisplayed( driver, blockClass.blockFrontendSelector )
-				)
-			);
-		} );
-	}
-
-	[
-		'e2egbupgradehever',
-		'e2egbupgradeshawburn',
-		'e2egbupgrademorden',
-		'e2egbupgradeexford',
-		'e2egbupgrademayland',
-	].forEach( ( siteName ) => {
-		describe( `[${ siteName }] Can add most popular blocks to the editor without errors`, function () {
-			step( `Login to ${ siteName }`, async function () {
-				await loginFlow.loginAndStartNewPost( `${ siteName }.wordpress.com`, true );
-				gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			} );
-
-			// There's the potential for simplifying (reducing) the following steps further by encapsulating the configuration
-			// of the block into each block's class. This way, we could just loop through a list of block classes
-			// since the API would be the same.
-
-			step( 'Insert and configure jetpack/tiled-gallery', async function () {
-				const tiledGallery = await gEditorComponent.insertBlock( TiledGalleryBlockComponent );
-				await tiledGallery.uploadImages( sampleImages );
-			} );
-
-			step( 'Insert and configure jetpack/contact-form', async function () {
-				const contactEmail = 'testing@automattic.com';
-				const subject = "Let's work together";
-
-				// I re-used this method since it was already available
-				await gEditorComponent.insertContactForm( contactEmail, subject );
-			} );
-
-			step( 'Insert and configure jetpack/layout-grid', async function () {
-				await gEditorComponent.insertBlock( LayoutGridBlockComponent );
-			} );
-
-			step( 'Insert and configure core-embed/youtube', async function () {
-				await gEditorComponent.insertBlock( YoutubeBlockComponent );
-			} );
-
-			step( 'Insert and configure a8c/blog-posts', async function () {
-				await gEditorComponent.insertBlock( BlogPostsBlockComponent );
-			} );
-
-			step( 'Insert and configure jetpack/subscriptions', async function () {
-				await gEditorComponent.insertBlock( SubscriptionsBlockComponent );
-			} );
-
-			step( 'Insert and configure jetpack/slideshow', async function () {
-				await gEditorComponent.insertBlock( SlideshowBlockComponent );
-			} );
-
-			step( 'Insert and configure jetpack/rating-star', async function () {
-				await gEditorComponent.insertBlock( RatingStarBlockComponent );
-			} );
-
-			step( 'Insert and configure coblocks/dynamic-separator', async function () {
-				await gEditorComponent.insertBlock( DynamicSeparatorBlockComponent );
-			} );
-
-			step( 'Insert and configure coblocks/gallery-masonry', async function () {
-				await gEditorComponent.insertBlock( GalleryMasonryBlockComponent );
-			} );
-
-			step( 'Insert and configure jetpack/contact-info', async function () {
-				await gEditorComponent.insertBlock( ContactInfoBlockComponent );
-			} );
-
-			verifyBlocksInEditor( siteName );
-
-			step(
-				'Switch to the code editor and copy the code markup for all the blocks',
-				async function () {
-					currentGutenbergBlocksCode = await gEditorComponent.copyBlocksCode();
-				}
-			);
-
-			verifyBlocksInPublishedPage( siteName );
-
-			describe( 'Test the same blocks in the corresponding edge site', function () {
-				const edgeSiteName = siteName + 'edge';
-
-				step( 'Switches to edge site', async function () {
+			describe( `Test the same blocks in the corresponding edge site (${ edgeSiteName })`, function () {
+				step( `Switches to edge site (${ edgeSiteName })`, async function () {
 					// Re-use the same session created earlier but change the site
 					await loginFlow.loginAndStartNewPost( `${ edgeSiteName }.wordpress.com`, true );
 
@@ -288,8 +282,8 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 					await gEditorComponent.switchToBlockEditor();
 				} );
 
-				verifyBlocksInEditor( edgeSiteName );
-				verifyBlocksInPublishedPage( siteName );
+				verifyBlockInEditor( blockClass, edgeSiteName );
+				verifyBlockInPublishedPage( blockClass, edgeSiteName );
 			} );
 		} );
 	} );

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -114,7 +114,7 @@ async function takeScreenshot( siteName, totalHeight, viewportHeight, scrollCb )
  *
  * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
  */
-async function takeBlockScreenshots( siteName ) {
+async function takeEditorScreenshots( siteName ) {
 	const editorViewport = await driver.findElement(
 		By.css( 'div.interface-interface-skeleton__content' )
 	);
@@ -167,7 +167,7 @@ function verifyBlockInEditor( blockClass, siteName ) {
 	*/
 
 	step( 'Take screenshots of the block in the editor', async function () {
-		await takeBlockScreenshots( siteName );
+		await takeEditorScreenshots( siteName );
 	} );
 }
 
@@ -187,6 +187,10 @@ async function assertNoInvalidBlocksInEditor() {
  * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
  */
 function verifyBlockInPublishedPage( blockClass, siteName ) {
+	step( 'Publish page', async function () {
+		await gEditorComponent.publish( { visit: true } );
+	} );
+
 	step( 'Take screenshots of the published page', async function () {
 		await takePublishedScreenshots( siteName );
 	} );
@@ -203,8 +207,6 @@ function verifyBlockInPublishedPage( blockClass, siteName ) {
  * @param { string } siteName the name of the WP test site (it will prepended to .wordpress.com)
  */
 async function takePublishedScreenshots( siteName ) {
-	await gEditorComponent.publish( { visit: true } );
-
 	// Give blocks a chance to render and load assets before taking the screenshots
 	await driver.sleep( 2000 );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -238,8 +238,6 @@ before( async function () {
 	YoutubeBlockComponent,
 ].forEach( ( blockClass ) => {
 	describe( `[${ host }] Test ${ blockClass.blockName } in edge and non-edge sites across most popular themes (${ screenSize })`, function () {
-		this.timeout( mochaTimeOut );
-
 		[
 			'e2egbupgradehever',
 			'e2egbupgradeshawburn',

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -290,7 +290,6 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 
 					step( 'Copy the markup for the block', async function () {
 						currentGutenbergBlocksCode = await gEditorComponent.getBlocksCode();
-						await driverManager.deleteLocalStorage( driver );
 					} );
 
 					verifyBlockInPublishedPage( blockClass, siteName );
@@ -305,7 +304,6 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 
 					step( 'Load block via markup copied from non-edge site', async function () {
 						await gEditorComponent.setBlocksCode( currentGutenbergBlocksCode );
-						await gEditorComponent.switchToBlockEditor();
 					} );
 
 					verifyBlockInEditor( blockClass, edgeSiteName );

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -47,12 +47,10 @@ let currentGutenbergBlocksCode;
 let sampleImages;
 
 const blockInits = new Map()
-	.set( TiledGalleryBlockComponent, async ( block ) => {
-		await block.uploadImages( sampleImages );
-	} )
-	.set( ContactFormBlockComponent, async () => {
-		await gEditorComponent.insertContactForm( 'testing@automattic.com', "Let's work together" );
-	} );
+	.set( TiledGalleryBlockComponent, ( block ) => block.uploadImages( sampleImages ) )
+	.set( ContactFormBlockComponent, () =>
+		gEditorComponent.insertContactForm( 'testing@automattic.com', "Let's work together" )
+	);
 
 /**
  * Wrapper that provides an uniform API for creating blocks on the page. It uses

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -15,7 +15,6 @@ import LoginFlow from '../lib/flows/login-flow.js';
 
 import ReaderPage from '../lib/pages/reader-page';
 
-import SidebarComponent from '../lib/components/sidebar-component.js';
 import NavBarComponent from '../lib/components/nav-bar-component.js';
 
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -65,7 +65,7 @@ const blockInits = new Map()
  * @param { typeof GutenbergBlockComponent } blockClass A block class.
  * @returns { Function } the init function to be called.
  */
-async function createBlock( blockClass ) {
+async function insertBlock( blockClass ) {
 	const blockInit = blockInits.get( blockClass );
 	const block = await gEditorComponent.insertBlock( blockClass );
 
@@ -260,6 +260,7 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 		].forEach( ( siteName ) => {
 			describe( `Test the ${ blockClass.blockName } block on ${ siteName } @parallel`, function () {
 				const edgeSiteName = siteName + 'edge';
+
 				describe( `Test the block in the non-edge site (${ siteName })`, function () {
 					step( `Login to ${ siteName }`, async function () {
 						await loginFlow.loginAndStartNewPost( `${ siteName }.wordpress.com`, true );
@@ -267,7 +268,11 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 					} );
 
 					step( `Insert and configure ${ blockClass.blockName }`, async function () {
-						await createBlock( blockClass );
+						// For some reason, after the first run, the code editor is shown by
+						// default, this breaks the insertBlock call, so we force-switch to the
+						// editor before the insert.
+						await gEditorComponent.switchToBlockEditor();
+						await insertBlock( blockClass );
 					} );
 
 					verifyBlockInEditor( blockClass, siteName );
@@ -281,7 +286,7 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 
 					verifyBlockInPublishedPage( blockClass, siteName );
 				} );
-				describe( `Test the same blocks in the corresponding edge site (${ edgeSiteName })`, function () {
+				describe( `Test the same block in the corresponding edge site (${ edgeSiteName })`, function () {
 					step( `Switches to edge site (${ edgeSiteName })`, async function () {
 						// Re-use the same session created earlier but change the site
 						await loginFlow.loginAndStartNewPost( `${ edgeSiteName }.wordpress.com`, true );

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -5,8 +5,8 @@ import assert from 'assert';
 import config from 'config';
 import { times } from 'lodash';
 import { By } from 'selenium-webdriver';
-import { promises as fs } from 'fs';
 import { join } from 'path';
+import { promises as fs } from 'fs';
 
 /**
  * Internal dependencies
@@ -18,6 +18,7 @@ import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-componen
 import * as driverManager from '../lib/driver-manager.js';
 import * as dataHelper from '../lib/data-helper.js';
 import * as mediaHelper from '../lib/media-helper';
+import * as driverHelper from '../lib/driver-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -42,25 +43,27 @@ let driver;
 let loginFlow;
 let gEditorComponent;
 let currentGutenbergBlocksCode;
-let galleryImages;
+let sampleImages;
 
 before( async function () {
 	this.timeout( startBrowserTimeoutMS );
 	driver = await driverManager.startBrowser();
 
 	loginFlow = new LoginFlow( driver, 'gutenbergUpgradeUser' );
-	galleryImages = times( 5, () => mediaHelper.createFile() );
+	sampleImages = times( 5, () => mediaHelper.createFile() );
 } );
 
 // Should we keep the @parallel tag here for this e2e test?
-describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites across most popular themes (${ screenSize })`, function () {
+describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites across most popular themes (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	async function takeScreenshot( siteName, totalHeight, viewportHeight, scrollCb ) {
 		const now = Date.now() / 1000;
 
-		const siteSshotDir = join( mediaHelper.screenShotsDir(), siteName );
-		await fs.access( siteSshotDir ).catch( () => fs.mkdir( siteSshotDir ) );
+		const siteScreenshotsDir = join( mediaHelper.screenshotsDir, siteName );
+		await fs
+			.access( siteScreenshotsDir )
+			.catch( () => fs.mkdir( siteScreenshotsDir, { recursive: true } ) );
 
 		for ( let i = 0; i <= totalHeight / viewportHeight; i++ ) {
 			await scrollCb( i );
@@ -71,7 +74,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 					.then( ( url ) =>
 						mediaHelper.writeScreenshot(
 							data,
-							() => join( siteName, `${ siteName }-${ i }-${ now }.png` ),
+							() => join( siteName, `${ siteName }-${ i }-${ now }` ),
 							{ url }
 						)
 					);
@@ -79,14 +82,9 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 		}
 	}
 
-	async function assertBlockIsDisplayed( blockClass ) {}
-
 	async function assertNoErrorInEditor() {
-		assert.strictEqual(
-			await gEditorComponent.errorDisplayed(),
-			false,
-			'There is an error shown on the editor page!'
-		);
+		const errorDisplayed = await gEditorComponent.errorDisplayed();
+		assert.strictEqual( errorDisplayed, false, 'There is an error shown on the editor page!' );
 	}
 
 	async function assertNoInvalidBlocksInEditor() {
@@ -152,20 +150,20 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 					SubscriptionsBlockComponent,
 					TiledGalleryBlockComponent,
 					YoutubeBlockComponent,
-				].map( async ( blockClass ) =>
+				].map( async ( blockClass ) => {
+					const displayed = await gEditorComponent.blockDisplayedInEditor( blockClass.blockName );
 					assert.strictEqual(
-						await gEditorComponent.blockDisplayedInEditor( blockClass.blockName ),
+						displayed,
 						true,
 						`The block "${ blockClass.blockName }" was not found in the editor`
-					)
-				)
+					);
+				} )
 			);
 		} );
 
 		step( 'Blocks do not error in the editor', async function () {
 			await assertNoErrorInEditor();
 		} );
-
 		// Commented-out for now because of https://github.com/Automattic/jetpack/issues/16514
 		/*step( 'Blocks do not invalidate', async function () {
 			await assertNoInvalidBlocksInEditor();
@@ -176,6 +174,30 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 		} );
 	}
 
+	function verifyBlocksInPublishedPage( siteName ) {
+		step( 'Take screenshots of the published page', async function () {
+			await takePublishedScreenshots( siteName );
+		} );
+
+		step( 'Blocks are displayed in the published page', async function () {
+			await Promise.all(
+				[
+					BlogPostsBlockComponent,
+					ContactFormBlockComponent,
+					ContactInfoBlockComponent,
+					DynamicSeparatorBlockComponent,
+					GalleryMasonryBlockComponent,
+					LayoutGridBlockComponent,
+					RatingStarBlockComponent,
+					SubscriptionsBlockComponent,
+					TiledGalleryBlockComponent,
+				].map( ( blockClass ) =>
+					driverHelper.waitTillPresentAndDisplayed( driver, blockClass.blockFrontendSelector )
+				)
+			);
+		} );
+	}
+
 	[
 		'e2egbupgradehever',
 		'e2egbupgradeshawburn',
@@ -183,7 +205,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 		'e2egbupgradeexford',
 		'e2egbupgrademayland',
 	].forEach( ( siteName ) => {
-		describe( 'Can add most popular blocks to the editor without errors', function () {
+		describe( `[${ siteName }] Can add most popular blocks to the editor without errors`, function () {
 			step( `Login to ${ siteName }`, async function () {
 				await loginFlow.loginAndStartNewPost( `${ siteName }.wordpress.com`, true );
 				gEditorComponent = await GutenbergEditorComponent.Expect( driver );
@@ -195,7 +217,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 
 			step( 'Insert and configure jetpack/tiled-gallery', async function () {
 				const tiledGallery = await gEditorComponent.insertBlock( TiledGalleryBlockComponent );
-				await tiledGallery.uploadImages( galleryImages );
+				await tiledGallery.uploadImages( sampleImages );
 			} );
 
 			step( 'Insert and configure jetpack/contact-form', async function () {
@@ -251,9 +273,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 				}
 			);
 
-			step( 'Take screenshots of the published page', async function () {
-				await takePublishedScreenshots( siteName );
-			} );
+			verifyBlocksInPublishedPage( siteName );
 
 			describe( 'Test the same blocks in the corresponding edge site', function () {
 				const edgeSiteName = siteName + 'edge';
@@ -269,17 +289,12 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 				} );
 
 				verifyBlocksInEditor( edgeSiteName );
-
-				step( 'Take screenshots of the published page', async function () {
-					await takePublishedScreenshots( siteName );
-				} );
+				verifyBlocksInPublishedPage( siteName );
 			} );
 		} );
 	} );
 } );
 
 after( async function () {
-	await Promise.all(
-		galleryImages.map( ( fileDetails ) => mediaHelper.deleteFile( fileDetails ) )
-	);
+	await Promise.all( sampleImages.map( ( fileDetails ) => mediaHelper.deleteFile( fileDetails ) ) );
 } );

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -224,20 +224,21 @@ before( async function () {
 	sampleImages = times( 5, () => mediaHelper.createFile() );
 } );
 
-[
-	BlogPostsBlockComponent,
-	ContactFormBlockComponent,
-	ContactInfoBlockComponent,
-	DynamicSeparatorBlockComponent,
-	GalleryMasonryBlockComponent,
-	LayoutGridBlockComponent,
-	RatingStarBlockComponent,
-	SlideshowBlockComponent,
-	SubscriptionsBlockComponent,
-	TiledGalleryBlockComponent,
-	YoutubeBlockComponent,
-].forEach( ( blockClass ) => {
-	describe( `[${ host }] Test ${ blockClass.blockName } in edge and non-edge sites across most popular themes (${ screenSize })`, function () {
+describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most popular themes (${ screenSize })`, function () {
+	this.timeout( mochaTimeOut );
+	[
+		BlogPostsBlockComponent,
+		ContactFormBlockComponent,
+		ContactInfoBlockComponent,
+		DynamicSeparatorBlockComponent,
+		GalleryMasonryBlockComponent,
+		LayoutGridBlockComponent,
+		RatingStarBlockComponent,
+		SlideshowBlockComponent,
+		SubscriptionsBlockComponent,
+		TiledGalleryBlockComponent,
+		YoutubeBlockComponent,
+	].forEach( ( blockClass ) => {
 		[
 			'e2egbupgradehever',
 			'e2egbupgradeshawburn',
@@ -245,7 +246,7 @@ before( async function () {
 			'e2egbupgradeexford',
 			'e2egbupgrademayland',
 		].forEach( ( siteName ) => {
-			describe( `${ siteName } @parallel`, function () {
+			describe( `Test the ${ blockClass.blockName } block on ${ siteName } @parallel`, function () {
 				const edgeSiteName = siteName + 'edge';
 				describe( `Test the block in the non-edge site (${ siteName })`, function () {
 					step( `Login to ${ siteName }`, async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -247,8 +247,6 @@ before( async function () {
 	driver = await driverManager.startBrowser();
 
 	loginFlow = new LoginFlow( driver, 'gutenbergUpgradeUser' );
-	await loginFlow.login();
-
 	sampleImages = times( 5, () => mediaHelper.createFile() );
 } );
 
@@ -279,7 +277,8 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 				const siteURL = `${ siteName }.wordpress.com`;
 
 				describe( `Test the block in the non-edge site (${ siteName })`, function () {
-					step( `Start new post on ${ siteName }`, async function () {
+					step( `Login to ${ siteName }`, async function () {
+						await loginFlow.login( siteURL, true );
 						await startNewPost( siteURL );
 					} );
 
@@ -289,7 +288,7 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 
 					verifyBlockInEditor( blockClass, siteName );
 
-					step( 'Copy the markup of the block', async function () {
+					step( 'Copy the markup for the block', async function () {
 						currentGutenbergBlocksCode = await gEditorComponent.getBlocksCode();
 					} );
 
@@ -299,7 +298,7 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 				describe( `Test the same block in the corresponding edge site (${ edgeSiteName })`, function () {
 					const edgeSiteURL = `${ edgeSiteName }.wordpress.com`;
 
-					step( `Start new post on (${ edgeSiteName })`, async function () {
+					step( `Switches to edge site (${ edgeSiteName })`, async function () {
 						await startNewPost( edgeSiteURL );
 					} );
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This is a follow up for https://github.com/Automattic/wp-calypso/pull/45048. Tracking issue: https://github.com/Automattic/wp-calypso/issues/45209.

- The `@parallel` tag (one per block/edge+non edge site test)has been added so that the test is picked up by magellan/CI and will run faster (< 6min timeout limit);
- Initial groundwork that checks for the blocks that should be rendered; this means adding a selector to the block classes for the blocks that already render on the frontend.
- Some blocks require additional setup before appear on the frontend and are not included as part of this changeset (see other related PRs).
- Fixes an issue that was preventing screenshots from being created on the CI VM.


This was extracted from the PR here: https://github.com/Automattic/wp-calypso/pull/45284. We decided to split it into several PRs, instead. The amount of files changed is the same (due to the static property being added to the block classes with the frontend selector) but the actual changeset is simpler, as the logic for filling/setting-up each block has been extracted into other PRs.

⚠️ The goal is to review and merge this **first** so that the other related PR's (see below) diffs become simpler and are easier to review and merge after this one ⚠️ 

## Why

The[ initial task](https://github.com/Automattic/wp-calypso/pull/45048) added the framework/PoC for automating our manual testing process. It only configured two blocks, though. The goal of this PR is to lay the groundwork to later fill in all of the popular blocks being tested as part of the upgrade E2E test, and verify them in the published page too (edge/non-edge and across the most popular themes).

## Testing instructions

1. Setup your env to run Calypso E2E tests (search for "Automated end-to-end Testing") in the FG;
1. Run with `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-upgrade-spec.js`*[0]
1. Wait for the tests to finish. It might take a good while since it tests everything for each test site
1. Make sure it didn't err, if it did, it might not be an actual failure, try running that specific step again. If it continues failing, let us know
1. Add the `Needs e2e Testing Gutenberg Edge` to this PR (already added, if necessary, remove and add again);
1. Check this branch's tests in CI: [Desktop](https://circleci.com/workflow-run/376ad2ba-2c34-4883-a731-5619c8fa5d0f), [Mobile](https://circleci.com/workflow-run/1fdee30c-7da0-4398-be7d-f17b6be5ff63).

*[0] _Make sure to cd into `test/e2e` first._

### Related PRs

Review and test the following PRs after this PR has been merged:

* https://github.com/Automattic/wp-calypso/pull/45795
* https://github.com/Automattic/wp-calypso/pull/45796
* https://github.com/Automattic/wp-calypso/pull/45797
*  https://github.com/Automattic/wp-calypso/pull/45798
* https://github.com/Automattic/wp-calypso/pull/45799
