### PR TITLE
[GBonWPCOM e2e tests i0] Setup and fill-in the Layout Grid block with some sample inner blocks

### DIFF
--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -7,11 +7,94 @@ import { By } from 'selenium-webdriver';
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
+import * as driverHelper from '../../driver-helper';
 
 class LayoutGridBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Layout Grid';
 	static blockName = 'jetpack/layout-grid';
 	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-layout-grid' );
+
+	/**
+	 * Setups the number of columns for the layout grid block.
+	 *
+	 * This needs to be called before you call @see {@link insertBlock}.
+	 *
+	 * @param {number} no number of columns, 1 to 4 (based on the default buttons in the block).
+	 */
+	async setupColumns( no ) {
+		const columnButtonSelector = By.css( `${ this.blockID } button[aria-label="${ no } columns"]` );
+		await driverHelper.clickWhenClickable( this.driver, columnButtonSelector );
+
+		// Updates the blockId, since the block is replaced by another one upon the selection of the columns.
+		this.blockID = await this.driver
+			.findElement( By.css( 'div.block-editor-block-list__block.is-selected' ) )
+			.getAttribute( 'id' );
+	}
+
+	/**
+	 * Inserts a block in the last available grid for the layout grid.
+	 *
+	 * You must call @see {@link setupColumns} before inserting an inner block using this method.
+	 *
+	 * This will add to each column in sequence, from left to right.
+	 *
+	 * @param { typeof GutenbergBlockComponent } blockClass A block class that responds to blockTitle and blockName
+	 * @returns { GutenbergBlockComponent } instance of the added block
+	 **/
+	async insertBlock( blockClass ) {
+		const addColumnButtonsSelector = By.css(
+			`div[id="${ this.blockID }"] div.wp-block-jetpack-layout-grid button[aria-label="Add block"]`
+		);
+		const buttons = await this.driver.findElements( addColumnButtonsSelector );
+
+		await buttons[ 0 ].click();
+
+		const inserterSearchInputSelector = By.css( 'input.block-editor-inserter__search-input' );
+
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( 'div.block-editor-inserter__quick-inserter.has-search.has-expand' ),
+			3000
+		);
+
+		await driverHelper.setWhenSettable(
+			this.driver,
+			inserterSearchInputSelector,
+			blockClass.blockTitle
+		);
+
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( `button.editor-block-list-item-${ blockClass.blockName.replace( '/', '-' ) }` )
+		);
+
+		const insertedBlockSelector = By.css(
+			`div[id="${ this.blockID }"] div.wp-block-jetpack-layout-grid .block-editor-block-list__block[aria-label='Block: ${ blockClass.blockTitle }']`
+		);
+		const blockId = await this.driver.findElement( insertedBlockSelector ).getAttribute( 'id' );
+
+		// We need to move focus away from the layout grid, or any subsequent blocks inserted will be part of it
+		const blockAppenderWrapperSelector = await this.driver.findElement(
+			By.css( '.interface-interface-skeleton__content' )
+		);
+
+		const blockAppenderWrapperBox = await this.driver.executeScript(
+			'return arguments[0].getBoundingClientRect()',
+			blockAppenderWrapperSelector
+		);
+
+		const actions = await this.driver.actions( { bridge: true } );
+
+		await actions
+			.move( {
+				x: Math.trunc( blockAppenderWrapperBox.x + blockAppenderWrapperBox.width / 2 ),
+				y: Math.trunc( blockAppenderWrapperBox.bottom - 50 ),
+			} )
+			.click()
+			.perform();
+
+		return blockClass.Expect( this.driver, blockId );
+	}
 }
 
 export { LayoutGridBlockComponent };

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -56,6 +56,11 @@ const blockInits = new Map()
 		await block.openEditSettings();
 		await block.insertEmail( 'testing@automattic.com' );
 		await block.insertSubject( "Let's work together" );
+	} )
+	.set( LayoutGridBlockComponent, async ( block ) => {
+		await block.setupColumns( 2 );
+		await block.insertBlock( RatingStarBlockComponent );
+		await block.insertBlock( DynamicSeparatorBlockComponent );
 	} );
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Setup the number of columns to 2 and fill in those two columns with inner blocks (Star Rating and Dynamic HR respectively). 

⚠️ (Preferably) review and test this PR only after https://github.com/Automattic/wp-calypso/pull/45794 has been merged ⚠️ 

#### Testing instructions

1. Setup your env to run Calypso E2E tests (search for "Automated end-to-end Testing") in the FG;
1. Run with `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-upgrade-spec.js`*[0]
1. Wait for the tests to finish. It might take a good while since it tests everything for each test site;
1. Make sure it didn't err, if it did, it might not be an actual failure, try running that specific step again. If it continues failing, let us know.
1. Add the `Needs e2e Testing Gutenberg Edge` to this PR (already added, if necessary, remove and add again);
1. Check this branch's tests in CI: [Desktop](https://circleci.com/workflow-run/376ad2ba-2c34-4883-a731-5619c8fa5d0f), [Mobile](https://circleci.com/workflow-run/1fdee30c-7da0-4398-be7d-f17b6be5ff63).

*[0] _Make sure to cd into `test/e2e` first._


