### PR TITLE
 [GBonWPCOM e2e tests i0] Setup and fill-in the Contact Info block with sample data

### DIFF
--- a/test/e2e/lib/gutenberg/blocks/contact-info-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/contact-info-block-component.js
@@ -12,6 +12,48 @@ class ContactInfoBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Contact Info';
 	static blockName = 'jetpack/contact-info';
 	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-contact-info' );
+
+	async fillUp( {
+		email,
+		phoneNumber,
+		streetAddress,
+		addressLine2,
+		addressLine3,
+		city,
+		state,
+		zipCode,
+		country,
+		linkToGmaps,
+	} ) {
+		const blockQuery = `div[id='${ this.blockID.slice( 1 ) }']`;
+
+		const selectField = ( name ) => By.css( `${ blockQuery } textarea[aria-label='${ name }']` );
+
+		const emailInputEl = await this.driver.findElement( selectField( 'Email' ) );
+		const phoneNumberInputEl = await this.driver.findElement( selectField( 'Phone number' ) );
+		const streetAddressInputEl = await this.driver.findElement( selectField( 'Street Address' ) );
+		const addressLine2InputEl = await this.driver.findElement( selectField( 'Address Line 2' ) );
+		const addressLine3InputEl = await this.driver.findElement( selectField( 'Address Line 3' ) );
+		const cityInputEl = await this.driver.findElement( selectField( 'City' ) );
+		const stateInputEl = await this.driver.findElement( selectField( 'State/Province/Region' ) );
+		const zipCodeInputEl = await this.driver.findElement( selectField( 'Postal/Zip Code' ) );
+		const countryInputEl = await this.driver.findElement( selectField( 'Country' ) );
+		const linkToGmapsEl = await this.driver.findElement(
+			By.css( `${ blockQuery } span.components-form-toggle` )
+		);
+
+		await emailInputEl.sendKeys( email );
+		await phoneNumberInputEl.sendKeys( phoneNumber );
+		await streetAddressInputEl.sendKeys( streetAddress );
+		await addressLine2InputEl.sendKeys( addressLine2 );
+		await addressLine3InputEl.sendKeys( addressLine3 );
+		await cityInputEl.sendKeys( city );
+		await stateInputEl.sendKeys( state );
+		await zipCodeInputEl.sendKeys( zipCode );
+		await countryInputEl.sendKeys( country );
+
+		if ( linkToGmaps ) await linkToGmapsEl.click();
+	}
 }
 
 export { ContactInfoBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/contact-info-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/contact-info-block-component.js
@@ -6,6 +6,7 @@ import { By } from 'selenium-webdriver';
 /**
  * Internal dependencies
  */
+import * as driverHelper from '../../driver-helper';
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class ContactInfoBlockComponent extends GutenbergBlockComponent {
@@ -25,34 +26,29 @@ class ContactInfoBlockComponent extends GutenbergBlockComponent {
 		country,
 		linkToGmaps,
 	} ) {
-		const blockQuery = `div[id='${ this.blockID.slice( 1 ) }']`;
+		const setInputValue = ( name, value ) =>
+			driverHelper.setWhenSettable(
+				this.driver,
+				By.css( `${ this.blockID } textarea[aria-label='${ name }']` ),
+				value
+			);
 
-		const selectField = ( name ) => By.css( `${ blockQuery } textarea[aria-label='${ name }']` );
+		await setInputValue( 'Email', email );
+		await setInputValue( 'Phone number', phoneNumber );
+		await setInputValue( 'Street Address', streetAddress );
+		await setInputValue( 'Address Line 2', addressLine2 );
+		await setInputValue( 'Address Line 3', addressLine3 );
+		await setInputValue( 'City', city );
+		await setInputValue( 'State/Province/Region', state );
+		await setInputValue( 'Postal/Zip Code', zipCode );
+		await setInputValue( 'Country', country );
 
-		const emailInputEl = await this.driver.findElement( selectField( 'Email' ) );
-		const phoneNumberInputEl = await this.driver.findElement( selectField( 'Phone number' ) );
-		const streetAddressInputEl = await this.driver.findElement( selectField( 'Street Address' ) );
-		const addressLine2InputEl = await this.driver.findElement( selectField( 'Address Line 2' ) );
-		const addressLine3InputEl = await this.driver.findElement( selectField( 'Address Line 3' ) );
-		const cityInputEl = await this.driver.findElement( selectField( 'City' ) );
-		const stateInputEl = await this.driver.findElement( selectField( 'State/Province/Region' ) );
-		const zipCodeInputEl = await this.driver.findElement( selectField( 'Postal/Zip Code' ) );
-		const countryInputEl = await this.driver.findElement( selectField( 'Country' ) );
-		const linkToGmapsEl = await this.driver.findElement(
-			By.css( `${ blockQuery } span.components-form-toggle` )
-		);
-
-		await emailInputEl.sendKeys( email );
-		await phoneNumberInputEl.sendKeys( phoneNumber );
-		await streetAddressInputEl.sendKeys( streetAddress );
-		await addressLine2InputEl.sendKeys( addressLine2 );
-		await addressLine3InputEl.sendKeys( addressLine3 );
-		await cityInputEl.sendKeys( city );
-		await stateInputEl.sendKeys( state );
-		await zipCodeInputEl.sendKeys( zipCode );
-		await countryInputEl.sendKeys( country );
-
-		if ( linkToGmaps ) await linkToGmapsEl.click();
+		if ( linkToGmaps ) {
+			driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( `${ this.blockID } span.components-form-toggle` )
+			);
+		}
 	}
 }
 

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -26,10 +26,12 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 		);
 		await driverHelper.clickWhenClickable( this.driver, columnButtonSelector );
 
-		// Updates the blockId, since the block is replaced by another one upon the selection of the columns.
-		this.blockID = await this.driver
+		const updatedBlockID = await this.driver
 			.findElement( By.css( 'div.block-editor-block-list__block.is-selected' ) )
 			.getAttribute( 'id' );
+
+		// Update the blockID, since the block is replaced by another one upon the selection of the columns.
+		this.blockID = `#${ updatedBlockID }`;
 		this.columns = number;
 	}
 
@@ -46,16 +48,14 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 		}
 
 		const screenSize = driverManager.currentScreenSize();
-		const blockSelector = By.id( this.blockID );
-		const addBlockButtonSelector = By.css(
-			`${ blockSelector.value } button[aria-label="Add block"]`
-		);
+		const addBlockButtonSelector = By.css( `${ this.blockID } button[aria-label="Add block"]` );
 
 		if ( screenSize === 'mobile' ) {
 			const addBlockButtons = await this.driver.findElements( addBlockButtonSelector );
 			const firstEmptyColumnIndex = this.columns - addBlockButtons.length + 1;
+			const blockSelector = By.css( this.blockID );
 			const columnSelector = By.css(
-				`${ blockSelector.value } div[data-type="jetpack/layout-grid-column"]:nth-child(${ firstEmptyColumnIndex })`
+				`${ this.blockID } div[data-type="jetpack/layout-grid-column"]:nth-child(${ firstEmptyColumnIndex })`
 			);
 
 			// On mobiles, we need to click through the layers until the appender is clickable:
@@ -85,7 +85,7 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 		);
 
 		const insertedBlockSelector = By.css(
-			`div[id="${ this.blockID }"] div.wp-block-jetpack-layout-grid .block-editor-block-list__block[aria-label='Block: ${ blockClass.blockTitle }']`
+			`${ this.blockID } div.wp-block-jetpack-layout-grid .block-editor-block-list__block[aria-label='Block: ${ blockClass.blockTitle }']`
 		);
 		const blockId = await this.driver.findElement( insertedBlockSelector ).getAttribute( 'id' );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -61,7 +61,21 @@ const blockInits = new Map()
 		await block.setupColumns( 2 );
 		await block.insertBlock( RatingStarBlockComponent );
 		await block.insertBlock( DynamicSeparatorBlockComponent );
-	} );
+	} )
+	.set( ContactInfoBlockComponent, ( block ) =>
+		block.fillUp( {
+			email: 'awesome@possum.ttt',
+			phoneNumber: '555-234-4323',
+			streetAddress: 'E2E street',
+			addressLine2: 'underground bunker 2',
+			addressLine3: '#1111',
+			city: 'GutenPolis',
+			state: 'Gutenfolia',
+			zipCode: '1337',
+			country: 'United Gutenberg States of Calypsoland',
+			linkToGmaps: true,
+		} )
+	);
 
 /**
  * Wrapper that provides an uniform API for creating blocks on the page. It uses the `inits`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Setup and fill the Contact Info block with sample data to further test it on the editor and to make sure it properly renders on the frontend (to compare against in the screenshots).

✅  ⚠️ (Preferably) review and test this PR only after https://github.com/Automattic/wp-calypso/pull/45794 has been merged ⚠️ 

#### Testing instructions

1. Setup your env to run Calypso E2E tests (search for "Automated end-to-end Testing") in the FG;
1. Run with `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-upgrade-spec.js`*[0]
1. Wait for the tests to finish. It might take a good while since it tests everything for each test site;
1. Make sure it didn't err, if it did, it might not be an actual failure, try running that specific step again. If it continues failing, let us know.
1. Add the `Needs e2e Testing Gutenberg Edge` to this PR (already added, if necessary, remove and add again);
1. Check this branch's tests in CI: [Desktop](https://circleci.com/workflow-run/376ad2ba-2c34-4883-a731-5619c8fa5d0f), [Mobile](https://circleci.com/workflow-run/1fdee30c-7da0-4398-be7d-f17b6be5ff63).

*[0] _Make sure to cd into `test/e2e` first._


