### PR TITLE
[GBonWPCOM e2e tests i0] Setup and fill-in the Youtube core embed block with a sample video

### DIFF
--- a/test/e2e/lib/gutenberg/blocks/youtube-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/youtube-block-component.js
@@ -11,6 +11,23 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class YoutubeBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'YouTube';
 	static blockName = 'core/embed';
+	static blockFrontendSelector = By.css(
+		'.entry-content figure.wp-block-embed iframe.youtube-player'
+	);
+
+	async embed( videoURL ) {
+		const blockDivSelector = `div[id='${ this.blockID.slice( 1 ) }']`;
+
+		const embedInput = await this.driver.findElement(
+			By.css( `${ blockDivSelector } input[type='url']` )
+		);
+		const embedButton = await this.driver.findElement(
+			By.css( `${ blockDivSelector } button[type='submit']` )
+		);
+
+		await embedInput.sendKeys( videoURL );
+		await embedButton.click();
+	}
 }
 
 export { YoutubeBlockComponent };

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -75,6 +75,9 @@ const blockInits = new Map()
 			country: 'United Gutenberg States of Calypsoland',
 			linkToGmaps: true,
 		} )
+	)
+	.set( YoutubeBlockComponent, ( block ) =>
+		block.embed( 'https://www.youtube.com/watch?v=FhMO5QnRNvo' )
 	);
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Setup the Youtube core embed block variation with a sample video to test this functionality in the editor and check for its presence in the frontend.

⚠️ (Preferably) review and test this PR only after https://github.com/Automattic/wp-calypso/pull/45794 has been merged ⚠️ 

#### Testing instructions

1. Setup your env to run Calypso E2E tests (search for "Automated end-to-end Testing") in the FG;
1. Run with `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-upgrade-spec.js`*[0]
1. Wait for the tests to finish. It might take a good while since it tests everything for each test site;
1. Make sure it didn't err, if it did, it might not be an actual failure, try running that specific step again. If it continues failing, let us know.
1. Add the `Needs e2e Testing Gutenberg Edge` to this PR (already added, if necessary, remove and add again);
1. Check this branch's tests in CI: [Desktop](https://circleci.com/workflow-run/376ad2ba-2c34-4883-a731-5619c8fa5d0f), [Mobile](https://circleci.com/workflow-run/1fdee30c-7da0-4398-be7d-f17b6be5ff63).

*[0] _Make sure to cd into `test/e2e` first._


