### PR TITLE
[GBonWPCOM e2e tests i0] Resize the Dynamic HR in the editor

### DIFF
--- a/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
@@ -12,6 +12,47 @@ class DynamicSeparatorBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Dynamic HR';
 	static blockName = 'coblocks/dynamic-separator';
 	static blockFrontendSelector = By.css( '.entry-content .wp-block-coblocks-dynamic-separator' );
+
+	/**
+	 * Expands the horizontal ruler by the amount of pixels specified. This is useful
+	 * to test the functionality of the Dynamic HR in the editor and later in the
+	 * frontend too.
+	 *
+	 * @param {number} pixels the amount of pixerls to expand the HR ruler by, horizontally.
+	 */
+	async resizeBy( pixels ) {
+		// We need to move focus away from the layout grid, or any subsequent blocks inserted will be part of it
+		const resizeHandleSelector = await this.driver.findElement(
+			By.css(
+				`div[id='${ this.blockID.slice(
+					1
+				) }'] div.components-resizable-box__handle.components-resizable-box__side-handle.components-resizable-box__handle-bottom`
+			)
+		);
+
+		const bbox = await this.driver.executeScript(
+			'return arguments[0].getBoundingClientRect()',
+			resizeHandleSelector
+		);
+
+		const actions = await this.driver.actions( { bridge: true } );
+
+		// The move function only accepts integers and will fail on floats
+		const resizeHandleX = Math.trunc( bbox.x + bbox.width / 2 );
+		const resizeHandleY = Math.trunc( bbox.y + bbox.height / 2 );
+
+		await actions
+			.move( {
+				x: resizeHandleX,
+				y: resizeHandleY,
+			} )
+			.press()
+			.move( {
+				y: resizeHandleY + pixels,
+			} )
+			.release()
+			.perform();
+	}
 }
 
 export { DynamicSeparatorBlockComponent };

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -78,7 +78,8 @@ const blockInits = new Map()
 	)
 	.set( YoutubeBlockComponent, ( block ) =>
 		block.embed( 'https://www.youtube.com/watch?v=FhMO5QnRNvo' )
-	);
+	)
+	.set( DynamicSeparatorBlockComponent, ( block ) => block.resizeBy( 150 ) );
 
 /**
  * Wrapper that provides an uniform API for creating blocks on the page. It uses the `inits`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Resize the Dynamic HR block in the editor to test that resizing works well in the editor and that it renders correctly in the frontend (by manually checking the screenshots).

⚠️ (Preferably) review and test this PR only after https://github.com/Automattic/wp-calypso/pull/45794 has been merged ⚠️ 

#### Testing instructions

1. Setup your env to run Calypso E2E tests (search for "Automated end-to-end Testing") in the FG;
1. Run with `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-upgrade-spec.js`*[0]
1. Wait for the tests to finish. It might take a good while since it tests everything for each test site;
1. Make sure it didn't err, if it did, it might not be an actual failure, try running that specific step again. If it continues failing, let us know.
1. Add the `Needs e2e Testing Gutenberg Edge` to this PR (already added, if necessary, remove and add again);
1. Check this branch's tests in CI: [Desktop](https://circleci.com/workflow-run/376ad2ba-2c34-4883-a731-5619c8fa5d0f), [Mobile](https://circleci.com/workflow-run/1fdee30c-7da0-4398-be7d-f17b6be5ff63).

*[0] _Make sure to cd into `test/e2e` first._


