### PR TITLE
 [GBonWPCOM e2e tests i0] Setup and fill-in the Slidehow and Gallery Masonry block with sample images 

### DIFF
--- a/test/e2e/lib/gutenberg/blocks/gallery-masonry-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/gallery-masonry-block-component.js
@@ -12,6 +12,23 @@ class GalleryMasonryBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Masonry';
 	static blockName = 'coblocks/gallery-masonry';
 	static blockFrontendSelector = By.css( '.entry-content .wp-block-coblocks-gallery-masonry' );
+
+	/**
+	 * Uploads images to the gallery.
+	 *
+	 * NOTE/TODO This is common to a few gallery-like blocks. DRY it using a mixin or common base class.
+	 *
+	 * @param {{imageName: string, fileName: string, file: string}} filesDetails a list of fileDetails
+	 */
+	async uploadImages( filesDetails ) {
+		const fileInputSelector = By.css( `div[id="${ this.blockID.slice( 1 ) }"] input[type=file]` );
+
+		const fileInput = this.driver.findElement( fileInputSelector );
+
+		const files = filesDetails.map( ( f ) => f.file ).join( '\n ' );
+
+		fileInput.sendKeys( files );
+	}
 }
 
 export { GalleryMasonryBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
@@ -12,6 +12,21 @@ class SlideshowBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Slideshow';
 	static blockName = 'jetpack/slideshow';
 	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-slideshow' );
+
+	/**
+	 * Uploads images to the slideshow.
+	 *
+	 * @param {{imageName: string, fileName: string, file: string}} filesDetails a list of fileDetails
+	 */
+	async uploadImages( filesDetails ) {
+		const fileInputSelector = By.css( `div[id="${ this.blockID.slice( 1 ) }"] input[type=file]` );
+
+		const fileInput = this.driver.findElement( fileInputSelector );
+
+		const files = filesDetails.map( ( f ) => f.file ).join( '\n ' );
+
+		fileInput.sendKeys( files );
+	}
 }
 
 export { SlideshowBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
@@ -13,12 +13,17 @@ class TiledGalleryBlockComponent extends GutenbergBlockComponent {
 	static blockName = 'jetpack/tiled-gallery';
 	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-tiled-gallery' );
 
-	fileInputSelector = By.xpath(
-		`//*[@id="${ this.blockID.slice( 1 ) }"]/div/div/div[3]/div[2]/input`
-	);
-
+	/**
+	 * Uploads images to the gallery.
+	 *
+	 * @param {{imageName: string, fileName: string, file: string}} filesDetails a list of fileDetails
+	 */
 	async uploadImages( filesDetails ) {
-		const fileInput = this.driver.findElement( this.fileInputSelector );
+		const fileInputSelector = By.xpath(
+			`//*[@id="${ this.blockID.slice( 1 ) }"]/div/div/div[3]/div[2]/input`
+		);
+
+		const fileInput = this.driver.findElement( fileInputSelector );
 
 		const files = filesDetails.map( ( f ) => f.file ).join( '\n ' );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -79,7 +79,9 @@ const blockInits = new Map()
 	.set( YoutubeBlockComponent, ( block ) =>
 		block.embed( 'https://www.youtube.com/watch?v=FhMO5QnRNvo' )
 	)
-	.set( DynamicSeparatorBlockComponent, ( block ) => block.resizeBy( 150 ) );
+	.set( DynamicSeparatorBlockComponent, ( block ) => block.resizeBy( 150 ) )
+	.set( SlideshowBlockComponent, ( block ) => block.uploadImages( sampleImages ) )
+	.set( GalleryMasonryBlockComponent, ( block ) => block.uploadImages( sampleImages ) );
 
 /**
  * Wrapper that provides an uniform API for creating blocks on the page. It uses the `inits`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Setup and fill the Slideshow and Gallery Masonry blocks with some sample images. I chose to group them together here because the API is the same. 

⚠️ (Preferably) review and test this PR only after https://github.com/Automattic/wp-calypso/pull/45794 has been merged ⚠️ 

#### Testing instructions

1. Setup your env to run Calypso E2E tests (search for "Automated end-to-end Testing") in the FG;
1. Run with `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-upgrade-spec.js`*[0]
1. Wait for the tests to finish. It might take a good while since it tests everything for each test site;
1. Make sure it didn't err, if it did, it might not be an actual failure, try running that specific step again. If it continues failing, let us know.
1. Add the `Needs e2e Testing Gutenberg Edge` to this PR (already added, if necessary, remove and add again);
1. Check this branch's tests in CI: [Desktop](https://circleci.com/workflow-run/376ad2ba-2c34-4883-a731-5619c8fa5d0f), [Mobile](https://circleci.com/workflow-run/1fdee30c-7da0-4398-be7d-f17b6be5ff63).

*[0] _Make sure to cd into `test/e2e` first._


