### PR TITLE
Gutenboarding: Fix messed up plans grid on iOS.

### DIFF
--- a/packages/plans-grid/src/plans-accordion-item/style.scss
+++ b/packages/plans-grid/src/plans-accordion-item/style.scss
@@ -7,7 +7,7 @@ $plans-accordion-item-border-radius: 5px;
 $plans-accordion-item-border-color: var( --studio-gray-5 );
 
 .plans-accordion-item {
-	display: inline-flex;
+	display: block;
 	flex-grow: 1;
 	flex-basis: 0;
 	flex-direction: column;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes messy plans grid on iOS.

I think `display: inline-flex` was a remnant from the multi column plans table. `display: block` will work just fine.

![Image from iOS](https://user-images.githubusercontent.com/1287077/93857858-8a718200-fcbb-11ea-8ab6-ddd191da47ad.png)

