### PR TITLE
[markdown] Fix lint errors in `apps/notifications`

### DIFF
--- a/apps/notifications/README.md
+++ b/apps/notifications/README.md
@@ -28,11 +28,11 @@ When running in an iframe communication with the parent frame occurs through a `
 Messages we handle from the notifications iframe have the form:
 
 ```js
-{
-	type: "notesIframeMessage",
-	action: < varies >,
+const obj = {
+	type: 'notesIframeMessage',
+	action: action,
 	//... other properties depending on action ...
-}
+};
 ```
 
 - `togglePanel`: This is a message from the client that the panel open state

--- a/apps/notifications/src/doc/data-model.md
+++ b/apps/notifications/src/doc/data-model.md
@@ -43,9 +43,9 @@ We maintain a "hidden notes" list of note ids which shouldn't be rendered.
 When undoing a _trash_ or _spam_ action we should remove the id from this list.
 
 ```js
-state.notes.hiddenNoteIds = [ id1, id2, id3, … ]
+state.notes.hiddenNoteIds = [ id1, id2, id3 /*...*/ ];
 
-getIsNoteHidden( store.getState(), noteId )
+getIsNoteHidden( store.getState(), noteId );
 ```
 
 The list of hidden ids is maintained in the `state/notes/reducers.js#hiddenNoteIds` reducer.
@@ -77,7 +77,7 @@ See the description for liking and unliking above.
 This works the same way except that the function is different.
 
 ```js
-store.dispatch( actions.notes.approveNote( noteId, isApproved )
+store.dispatch( actions.notes.approveNote( noteId, isApproved ) );
 
-getIsNoteApproved( store.getState(), note )
+getIsNoteApproved( store.getState(), note );
 ```

--- a/apps/notifications/src/doc/note-rendering.md
+++ b/apps/notifications/src/doc/note-rendering.md
@@ -9,29 +9,22 @@ This `detailView` prop further causes the `Note` component to render (among othe
 The notification object returned from the server contains, among other things, a `body` array of one or more `block` objects which contain a type, the text of the notification, and an array of `ranges`:
 
 ```js
-"ranges": [
-	{
-		"url": "https://www.example.com/",
-		"indices": [
-			397,
-			416
-		]
-	},
-	{
-		"type": "match",
-		"indices": [
-			598,
-			616
-		]
-	},
-	{
-		"type": "match",
-		"indices": [
-			682,
-			700
-		]
-	}
-]
+const object = {
+	ranges: [
+		{
+			url: 'https://www.example.com/',
+			indices: [ 397, 416 ],
+		},
+		{
+			type: 'match',
+			indices: [ 598, 616 ],
+		},
+		{
+			type: 'match',
+			indices: [ 682, 700 ],
+		},
+	],
+};
 ```
 
 The indices of these ranges indicate locations in the body's text string where special formatting is needed.


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `apps/notifications`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx apps/notifications`, there should be no errors