### PR TITLE
[markdown] Fix lint errors in `packages/babel-plugin-transform-wpcalypso-async`

### DIFF
--- a/packages/babel-plugin-transform-wpcalypso-async/README.md
+++ b/packages/babel-plugin-transform-wpcalypso-async/README.md
@@ -40,13 +40,17 @@ asyncRequire( 'components/accordion', ( Accordion ) => {
 ```js
 // Before:
 
-<AsyncLoad require="components/accordion" />
+<AsyncLoad require="components/accordion" />;
+```
 
+```js
 // After:
 
-<AsyncLoad require={ function( callback ) {
-	asyncRequire( 'components/accordion', callback );
-} } />
+<AsyncLoad
+	require={ function ( callback ) {
+		asyncRequire( 'components/accordion', callback );
+	} }
+/>;
 ```
 
 ## Options


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/babel-plugin-transform-wpcalypso-async`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/babel-plugin-transform-wpcalypso-async`, there should be no errors