### PR TITLE
[markdown] Fix lint errors in `packages/calypso-build`

### DIFF
--- a/packages/calypso-build/.eslintrc.js
+++ b/packages/calypso-build/.eslintrc.js
@@ -5,4 +5,12 @@ module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 	},
+	overrides: [
+		{
+			files: [ '*.md.jsx', '*.md.js' ],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+			},
+		},
+	],
 };

--- a/packages/calypso-build/jest/transform/README.md
+++ b/packages/calypso-build/jest/transform/README.md
@@ -15,7 +15,7 @@ This helper can be used to transform all those imports to a module that returns
 the asset file's basename as a string:
 
 ```js
-const conig = {
+const config = {
 	transform: {
 		'\\.(gif|jpg|jpeg|png|svg|scss|sass|css)$': require.resolve(
 			'@automattic/calypso-build/jest/transform/asset.js'
@@ -29,7 +29,7 @@ const conig = {
 A babel transform for Jest so it can correctly process JSX, TypeScript, etc.
 
 ```js
-const conig = {
+const config = {
 	transform: {
 		'\\.[jt]sx?$': require.resolve( '@automattic/calypso-build/jest/transform/babel.js' ),
 	},

--- a/packages/calypso-build/jest/transform/README.md
+++ b/packages/calypso-build/jest/transform/README.md
@@ -15,13 +15,13 @@ This helper can be used to transform all those imports to a module that returns
 the asset file's basename as a string:
 
 ```js
-{
+const conig = {
 	transform: {
 		'\\.(gif|jpg|jpeg|png|svg|scss|sass|css)$': require.resolve(
 			'@automattic/calypso-build/jest/transform/asset.js'
-		)
+		),
 	},
-}
+};
 ```
 
 ## Babel
@@ -29,11 +29,9 @@ the asset file's basename as a string:
 A babel transform for Jest so it can correctly process JSX, TypeScript, etc.
 
 ```js
-{
+const conig = {
 	transform: {
-		'\\.[jt]sx?$': require.resolve(
-			'@automattic/calypso-build/jest/transform/babel.js'
-		)
+		'\\.[jt]sx?$': require.resolve( '@automattic/calypso-build/jest/transform/babel.js' ),
 	},
-}
+};
 ```


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/calypso-build`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/calypso-build`, there should be no errors