### PR TITLE
[markdown] Fix lint errors in `packages/calypso-color-schemes`

### DIFF
--- a/packages/calypso-color-schemes/.eslintrc.js
+++ b/packages/calypso-color-schemes/.eslintrc.js
@@ -2,4 +2,12 @@ module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 	},
+	overrides: [
+		{
+			files: [ '*.md.jsx', '*.md.js' ],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+			},
+		},
+	],
 };

--- a/packages/calypso-color-schemes/README.md
+++ b/packages/calypso-color-schemes/README.md
@@ -30,7 +30,7 @@ And this will give you the CSS.
 Sometimes, `calypso-color-schemes` properties are consumed in JavaScript. To avoid parsing CSS syntax on your own, or to help `postcss-custom-properties` use them without parsing the CSS (much faster), use the JS output as follows:
 
 ```js
-import { customProperties } import '@automattic/calypso-color-schemes/js' // mind the js suffix
+import { customProperties } from '@automattic/calypso-color-schemes/js'; // mind the js suffix
 ```
 
 Or with `postcss-custom-properties`, and `postcss.config.js` can look like this:


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/calypso-color-schemes`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/calypso-color-schemes`, there should be no errors