### PR TITLE
[markdown] Fix lint errors in `packages/calypso-polyfills`

### DIFF
--- a/packages/calypso-polyfills/.eslintrc.js
+++ b/packages/calypso-polyfills/.eslintrc.js
@@ -2,4 +2,12 @@ module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 	},
+	overrides: [
+		{
+			files: [ '*.md.js' ],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+			},
+		},
+	],
 };

--- a/packages/calypso-polyfills/README.md
+++ b/packages/calypso-polyfills/README.md
@@ -19,12 +19,12 @@ require( '@automattic/calypso-polyfills' );
 In a browser, a similar naked import will include the polyfills (defaulting to the `fallback` set):
 
 ```js
-	import from '@automattic/calypso-polyfills';
+import '@automattic/calypso-polyfills';
 ```
 
 If you want to explicitly include the `evergreen` or `fallback` polyfills, you can append to the import path:
 
 ```js
-  import from '@automattic/calypso-polyfills/browser-evergreen';
-  import from '@automattic/calypso-polyfills/browser-fallback';
+import '@automattic/calypso-polyfills/browser-evergreen';
+import '@automattic/calypso-polyfills/browser-fallback';
 ```


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/calypso-polyfills`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/calypso-polyfills`, there should be no errors