### PR TITLE
[markdown] Fix lint errors in `packages/components`

### DIFF
--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '*.stories.jsx' ],
+			files: [ '*.md.jsx', '*.md.js', '*.stories.jsx' ],
 			rules: {
 				'import/no-extraneous-dependencies': 'off',
 			},

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -21,10 +21,11 @@ import { Button } from '@automattic/components';
 
 const CallToAction = () => (
 	<>
-		<Button primary onClick={() => alert('Thank you for taking action!')}>Take action now!</Button>
+		<Button primary onClick={ () => alert( 'Thank you for taking action!' ) }>
+			Take action now!
+		</Button>
 	</>
 );
-
 ```
 
 ## Development Workflow

--- a/packages/components/src/card/README.md
+++ b/packages/components/src/card/README.md
@@ -7,21 +7,20 @@ Cards are used as containers to group similar information and tasks together to 
 ## Usage
 
 ```jsx
-import { Card } from '@automattic/components';
-import { CompactCard } from '@automattic/components';
+import { Card, CompactCard } from '@automattic/components';
 
-render: function() {
-  return (
-    <div className="your-stuff">
-      <Card>
-        <span>Your stuff in a Card</span>
-      </Card>
+function render() {
+	return (
+		<div className="your-stuff">
+			<Card>
+				<span>Your stuff in a Card</span>
+			</Card>
 
-      <CompactCard>
-        <span>Your stuff in a CompactCard</span>
-      </CompactCard>
-    </div>
-  );
+			<CompactCard>
+				<span>Your stuff in a CompactCard</span>
+			</CompactCard>
+		</div>
+	);
 }
 ```
 

--- a/packages/components/src/dialog/README.md
+++ b/packages/components/src/dialog/README.md
@@ -66,27 +66,27 @@ You can attach `onClick` handlers for dialog buttons. The `onClick` handler will
 called will close the dialog the dialog button is a member of.
 
 ```js
-	render() {
-		const { translate } = this.props;
+function render() {
+	const { translate } = this.props;
 
-		buttons = [
-			{ action: 'more-options', label: translate( 'More Options…' ), onClick: this.onMoreOptions },
-			{ action: 'cancel', label: translate( 'Cancel' ) },
-			{ action: 'save', label: translate( 'Save' ), isPrimary: true }
-		];
+	buttons = [
+		{ action: 'more-options', label: translate( 'More Options…' ), onClick: this.onMoreOptions },
+		{ action: 'cancel', label: translate( 'Cancel' ) },
+		{ action: 'save', label: translate( 'Save' ), isPrimary: true },
+	];
 
-		return (
-			<Dialog isVisible={ this.state.showDialog } buttons={ buttons } onClose={ this.onCloseDialog }>
-				<h1>{ translate( 'Dialog Title' ) }</h1>
-				<p>{ translate( 'Dialog content' ) }</p>
-			</Dialog>
-		);
-	}
+	return (
+		<Dialog isVisible={ this.state.showDialog } buttons={ buttons } onClose={ this.onCloseDialog }>
+			<h1>{ translate( 'Dialog Title' ) }</h1>
+			<p>{ translate( 'Dialog content' ) }</p>
+		</Dialog>
+	);
+}
 
-	onMoreOptions = ( closeDialog ) => {
-		// call the passed in `closeDialog` function to close the dialog the dialog button is
-		// a member of
-	}
+onMoreOptions = ( closeDialog ) => {
+	// call the passed in `closeDialog` function to close the dialog the dialog button is
+	// a member of
+};
 ```
 
 ## Custom Buttons
@@ -96,25 +96,22 @@ the button spec. The ReactElement cannot close the dialog directly, but you coul
 through the Dialog's host.
 
 ```js
-	render() {
-		const { translate } = this.props;
+function render() {
+	const { translate } = this.props;
 
-		const buttons = [
-			<MyCustomButton onAction={ this.onCustomButtonAction } />
-		];
+	const buttons = [ <MyCustomButton onAction={ this.onCustomButtonAction } /> ];
 
-		return (
-			<Dialog isVisible={ this.state.showDialog } buttons={ buttons } onClose={ this.onCloseDialog }>
-				<h1>{ translate( 'Dialog Title' ) }</h1>
-				<p>{ translate( 'Dialog content' ) }</p>
-			</Dialog>
-		);
-	},
+	return (
+		<Dialog isVisible={ this.state.showDialog } buttons={ buttons } onClose={ this.onCloseDialog }>
+			<h1>{ translate( 'Dialog Title' ) }</h1>
+			<p>{ translate( 'Dialog content' ) }</p>
+		</Dialog>
+	);
+}
 
-	onCustomButtonAction = () => {
-		this.setState( { showDialog: false } );
-	}
-
+function onCustomButtonAction() {
+	this.setState( { showDialog: false } );
+}
 ```
 
 ## Providing custom styling for a dialog
@@ -148,19 +145,19 @@ You can provide custom styling for a dialog by making use of the following prope
   (not the backdrop)
 
 ```js
-	render {
-		const { translate } = this.props;
+function render() {
+	const { translate } = this.props;
 
-		return (
-			<Dialog
-				baseClassName="custom-dialog"
-				additionalClassNames="critical error"
-				isVisible={ this.state.showDialog }
-				onClose={ this.onCloseDialog }
-			>
-				<h1>{ translate( 'Dialog Title' ) }</h1>
-				<p>{ translate( 'Dialog content' ) }</p>
-			</Dialog>
-		);
-	}
+	return (
+		<Dialog
+			baseClassName="custom-dialog"
+			additionalClassNames="critical error"
+			isVisible={ this.state.showDialog }
+			onClose={ this.onCloseDialog }
+		>
+			<h1>{ translate( 'Dialog Title' ) }</h1>
+			<p>{ translate( 'Dialog content' ) }</p>
+		</Dialog>
+	);
+}
 ```

--- a/packages/components/src/progress-bar/README.md
+++ b/packages/components/src/progress-bar/README.md
@@ -10,13 +10,8 @@ Once this component is mounted, it will always progress forward, never backward:
 ```js
 import { ProgressBar } from '@automattic/components';
 
-render() {
-	return <ProgressBar
-		value={ amount }
-		total={ total }
-		color={ color }
-		title={ title }
-	/>;
+function render() {
+	return <ProgressBar value={ amount } total={ total } color={ color } title={ title } />;
 }
 ```
 

--- a/packages/components/src/ribbon/README.md
+++ b/packages/components/src/ribbon/README.md
@@ -10,8 +10,7 @@ place in our hearts.
 ## How to use
 
 ```js
-import { Card } from '@automattic/components';
-import { Ribbon } from '@automattic/components';
+import { Card, Ribbon } from '@automattic/components';
 
 function MyCard() {
 	return (

--- a/packages/components/src/screen-reader-text/README.md
+++ b/packages/components/src/screen-reader-text/README.md
@@ -9,9 +9,8 @@ This idea was pulled from WordPress core, for more background & technical detail
 ## How to use
 
 ```js
-import { Button } from '@automattic/components';
+import { Button, ScreenReaderText } from '@automattic/components';
 import Gridicon from 'components/gridicons';
-import { ScreenReaderText } from '@automattic/components';
 
 function ScreenReaderTextExample() {
 	return (

--- a/packages/components/src/suggestions/README.md
+++ b/packages/components/src/suggestions/README.md
@@ -14,13 +14,13 @@ import { Suggestions } from '@automattic/components';
 
 export default function SuggestionsExample() {
 	const [ query, setQuery ] = useState( '' );
-	const updateInput = useCallback( e => setQuery( e.target.value ), [ setQuery ] );
+	const updateInput = useCallback( ( e ) => setQuery( e.target.value ), [ setQuery ] );
 
 	const suggestions = useMemo( () => {
 		if ( ! query ) {
 			return [];
 		}
-		const allSuggestions = [ 'Foo', 'Bar', 'Baz' ].map( s => ( { label: s, value: s } ) );
+		const allSuggestions = [ 'Foo', 'Bar', 'Baz' ].map( ( s ) => ( { label: s, value: s } ) );
 		const r = new RegExp( query, 'i' );
 		return allSuggestions.filter( ( { label } ) => r.test( label ) );
 	}, [ query ] );


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/components`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/components`, there should be no errors