### PR TITLE
[markdown] Fix lint errors in `packages/data-stores`

### DIFF
--- a/packages/data-stores/.eslintrc.js
+++ b/packages/data-stores/.eslintrc.js
@@ -9,6 +9,12 @@ module.exports = {
 	},
 	overrides: [
 		{
+			files: [ '*.md.jsx', '*.md.js' ],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+			},
+		},
+		{
 			files: [ '**/test/**/*' ],
 			rules: {
 				'import/no-extraneous-dependencies': [


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/data-stores`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/data-stores`, there should be no errors