### PR TITLE
[markdown] Fix lint errors in `packages/eslint-plugin-wpcalypso`

### DIFF
--- a/packages/eslint-plugin-wpcalypso/.eslintrc.js
+++ b/packages/eslint-plugin-wpcalypso/.eslintrc.js
@@ -1,9 +1,22 @@
 module.exports = {
-	parserOptions: {
-		sourceType: 'script',
-	},
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 		'import/no-nodejs-modules': 0,
 	},
+	overrides: [
+		{
+			files: [ '*.md.js', '*.md.jsx' ],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+				'wpcalypso/i18n-mismatched-placeholders': 'off',
+				'wpcalypso/i18n-named-placeholders': 'off',
+				'wpcalypso/i18n-no-collapsible-whitespace': 'off',
+				'wpcalypso/i18n-no-placeholders-only': 'off',
+				'wpcalypso/i18n-no-this-translate': 'off',
+				'wpcalypso/i18n-no-variables': 'off',
+				'wpcalypso/redux-no-bound-selectors': 'off',
+				'wpcalypso/jsx-gridicon-size': 'off',
+			},
+		},
+	],
 };

--- a/packages/eslint-plugin-wpcalypso/docs/rules/jsx-classname-namespace.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/jsx-classname-namespace.md
@@ -10,12 +10,12 @@ The following patterns are considered warnings:
 
 ```jsx
 // client/sample-component/index.js
-export default function() {
+export function myComponent1() {
 	return <div className="sample" />;
 }
 
 // client/another-sample/index.js
-export default function() {
+export function myComponent2() {
 	return (
 		<div className="another-sample">
 			<div className="another-sample-child" />
@@ -28,12 +28,12 @@ The following patterns are not warnings:
 
 ```jsx
 // client/sample-component/index.js
-export default function() {
+export function myComponent1() {
 	return <div className="sample-component" />;
 }
 
 // client/another-sample/index.js
-export default function() {
+export function myComponent2() {
 	return (
 		<div className="another-sample">
 			<div className="another-sample__child" />
@@ -64,9 +64,11 @@ For example, you can allow `index.jsx` and `main.jsx`:
 Examples of **correct** code for this rule with `rootFiles` set to `[ 'foo.js' ]`: (watch the filename)
 
 ```jsx
-/*eslint jsx-classname-namespace: [ "error", { rootFiles: [ 'foo.js' ] } ]*/
+/* rule config:
+	jsx-classname-namespace: [ "error", { rootFiles: [ 'foo.js' ] } ]
+*/
 // client/sample-component/foo.js
-export default function() {
+export default function () {
 	return <div className="sample" />;
 }
 ```
@@ -74,9 +76,11 @@ export default function() {
 Examples of **incorrect** code for this rule with `rootFiles` set to `[ 'foo.js' ]`: (watch the filename)
 
 ```jsx
-/*eslint jsx-classname-namespace: [ "error", { rootFiles: [ 'foo.js' ] } ]*/
+/* rule config:
+	jsx-classname-namespace: [ "error", { rootFiles: [ 'foo.js' ] } ]
+*/
 // client/sample-component/index.js
-export default function() {
+export default function () {
 	return <div className="sample" />;
 }
 ```

--- a/packages/eslint-plugin-wpcalypso/docs/rules/jsx-gridicon-size.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/jsx-gridicon-size.md
@@ -9,11 +9,11 @@ In previous incarnations, this warning could be subdued by adding a `nonStandard
 The following patterns are considered warnings:
 
 ```jsx
-<Gridicon size={ 20 } />
+<Gridicon size={ 20 } />;
 ```
 
 The following patterns are not warnings:
 
 ```jsx
-<Gridicon size={ 18 } />
+<Gridicon size={ 18 } />;
 ```

--- a/packages/eslint-plugin-wpcalypso/docs/rules/no-package-relative-imports.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/no-package-relative-imports.md
@@ -30,10 +30,10 @@ import * as stats from 'reader/stats';
 import { localizeUrl } from 'lib/i18n-utils';
 export { default as ActionCard } from 'components/action-card/docs/example';
 export * from 'components/AppBar';
-const config1 = require('config');
-const config2 = asyncRequire('config');
+const config1 = require( 'config' );
+const config2 = asyncRequire( 'config' );
 
-const component = <AsyncLoad require="config"/>
+const component = <AsyncLoad require="config" />;
 ```
 
 The following patterns are correct
@@ -44,14 +44,14 @@ import * as stats from 'calypso/reader/stats';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 export { default as ActionCard } from 'calypso/components/action-card/docs/example';
 export * from 'calypso/components/AppBar';
-const config1 = require('calypso/config');
-const config2 = asyncRequire('calypso/config');
+const config1 = require( 'calypso/config' );
+const config2 = asyncRequire( 'calypso/config' );
 
-const component = <AsyncLoad require="calypso/config"/>
+const component = <AsyncLoad require="calypso/config" />;
 
-import config from './config';
-import config from '../../../config';
-import config from 'dirA'; //when `dirA` is not a directory or file in ./client/
+import config3 from './config';
+import config4 from '../../../config';
+import config5 from 'dirA'; //when `dirA` is not a directory or file in ./client/
 ```
 
 ## Configuration

--- a/packages/eslint-plugin-wpcalypso/docs/rules/redux-no-bound-selectors.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/redux-no-bound-selectors.md
@@ -29,17 +29,15 @@ const getFavoriteSites = ( state ) =>
 ```
 
 ```js
-class extends Component {
-  setFoo( foo ) {
-    this.setState( { foo }, ( state ) => {
-      this.markDone( state.bar );
-    } );
-  }
+class MyComponent extends Component {
+	setFoo( foo ) {
+		this.setState( { foo }, ( state ) => {
+			this.markDone( state.bar );
+		} );
+	}
 }
 ```
 
 ```js
-export default connect(
-  partialRight( mapState, 'foo' )
-)( MyComponent );
+export default connect( partialRight( mapState, 'foo' ) )( MyComponent );
 ```


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/eslint-plugin-wpcalypso`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/eslint-plugin-wpcalypso`, there should be no errors