### PR TITLE
[markdown] Fix lint errors in `packages/material-design-icons`

### DIFF
--- a/packages/material-design-icons/README.md
+++ b/packages/material-design-icons/README.md
@@ -16,7 +16,7 @@ We use svgr to load SVG files and convert them to React components.
 ```jsx
 import { ReactComponent as SvgExample } from './test.svg';
 
-<SvgExample />
+<SvgExample />;
 ```
 
 ## Adding icons


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/material-design-icons`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/material-design-icons`, there should be no errors