### PR TITLE
[markdown] Fix lint errors in `packages/media-library`

### DIFF
--- a/packages/media-library/.eslintrc.js
+++ b/packages/media-library/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '*.stories.jsx' ],
+			files: [ '*.stories.jsx', '*.md.jsx' ],
 			rules: {
 				'import/no-extraneous-dependencies': 'off',
 			},


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/media-library`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/media-library`, there should be no errors