### PR TITLE
[markdown] Fix lint errors in `packages/popup-monitor`

### DIFF
--- a/packages/popup-monitor/README.md
+++ b/packages/popup-monitor/README.md
@@ -7,13 +7,13 @@ Popup Monitor is a small utility to facilitate the monitoring of a popup window 
 A Popup Monitor instance offers an `open` function which accepts an identical set of arguments as the standard `window.open` browser offering. When the window is closed, a `close` event is emitted to the instance with the name of the closed window.
 
 ```js
-import PopupMonitor '@automattic/popup-monitor';
+import PopupMonitor from '@automattic/popup-monitor';
 
 const popupMonitor = new PopupMonitor();
 
 popupMonitor.open( 'https://wordpress.com/', 'my-popup' );
 
-popupMonitor.on( 'close', function( name ) {
+popupMonitor.on( 'close', function ( name ) {
 	if ( 'my-popup' === name ) {
 		console.log( 'Window closed!' );
 	}


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/popup-monitor`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/popup-monitor`, there should be no errors