### PR TITLE
[markdown] Fix lint errors in `packages/react-i18n`

### DIFF
--- a/packages/react-i18n/.eslintrc.js
+++ b/packages/react-i18n/.eslintrc.js
@@ -2,4 +2,12 @@ module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 	},
+	overrides: [
+		{
+			files: [ '*.md.js' ],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+			},
+		},
+	],
 };

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -21,7 +21,13 @@ An `I18nProvider` should be mounted above any localized components:
 ```js
 import { I18nProvider } from '@automattic/react-i18n';
 
-<I18nProvider localeData={ /* Localed data object */ }>
+<I18nProvider
+	localeData={
+		{
+			/* Localed data object */
+		}
+	}
+>
 	<MyLocalizedApp />
 </I18nProvider>;
 ```


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/react-i18n`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/react-i18n`, there should be no errors