### PR TITLE
[markdown] Fix lint errors in `packages/request-external-access`

### DIFF
--- a/packages/request-external-access/README.md
+++ b/packages/request-external-access/README.md
@@ -4,14 +4,14 @@ Utility for requesting authorization of sharing services.
 
 ## Usage
 
-```es6
+```js
 import requestExternalAccess from '@automattic/request-external-access';
 
 requestExternalAccess( serviceURL, ( { keyring_id } ) => {
-  if ( ! keyring_id ) {
-    return;
-  }
+	if ( ! keyring_id ) {
+		return;
+	}
 
-  newKeyringConnection( keyring_id );
+	newKeyringConnection( keyring_id );
 } );
 ```


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/request-external-access`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/request-external-access`, there should be no errors