### PR TITLE
[markdown] Fix lint errors in `packages/viewport-react`

### DIFF
--- a/packages/viewport-react/.eslintrc.js
+++ b/packages/viewport-react/.eslintrc.js
@@ -2,4 +2,12 @@ module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 	},
+	overrides: [
+		{
+			files: [ '*.md.js' ],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+			},
+		},
+	],
 };


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/viewport-react`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/viewport-react`, there should be no errors