### PR TITLE
[markdown] Fix lint errors in `packages/webpack-extensive-lodash-replacement-plugin`

### DIFF
--- a/packages/webpack-extensive-lodash-replacement-plugin/.eslintrc.js
+++ b/packages/webpack-extensive-lodash-replacement-plugin/.eslintrc.js
@@ -3,4 +3,12 @@ module.exports = {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 		'import/no-nodejs-modules': 0,
 	},
+	overrides: [
+		{
+			files: [ '*.md.js' ],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+			},
+		},
+	],
 };

--- a/packages/webpack-extensive-lodash-replacement-plugin/README.md
+++ b/packages/webpack-extensive-lodash-replacement-plugin/README.md
@@ -3,16 +3,16 @@
 Replaces most usage of `lodash` with `lodash-es`:
 
 ```js
-import { map } from 'lodash';
-// becomes
-import { map } from 'lodash-es';
-
+import { uniq } from 'lodash';
 import map from 'lodash/map';
-// becomes
-import map from 'lodash-es/map';
-
 import camelCase from 'lodash.camelcase';
-// becomes
+```
+
+Becomes:
+
+```js
+import { uniq } from 'lodash-es';
+import map from 'lodash-es/map';
 import camelCase from 'lodash-es/camelCase';
 ```
 
@@ -25,16 +25,15 @@ replaced.
 _webpack.config.js_
 
 ```js
-const ExtensiveLodashReplacementPlugin =
-  require( '@automattic/webpack-extensive-lodash-replacement-plugin' );
+const ExtensiveLodashReplacementPlugin = require( '@automattic/webpack-extensive-lodash-replacement-plugin' );
 
 module.exports = {
-  ...,
-  plugins: [
-    new ExtensiveLodashReplacementPlugin( { baseDir: '.' } ),
-    ...
-  ]
+	plugins: [ new ExtensiveLodashReplacementPlugin( { baseDir: '.' } ) ],
 };
 ```
 
 The optional `baseDir` is the base directory for the root project.
+
+```
+
+```


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/webpack-extensive-lodash-replacement-plugin`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/webpack-extensive-lodash-replacement-plugin`, there should be no errors