### PR TITLE
[markdown] Fix lint errors in `packages/webpack-inline-constant-exports-plugin`

### DIFF
--- a/packages/webpack-inline-constant-exports-plugin/.eslintrc.js
+++ b/packages/webpack-inline-constant-exports-plugin/.eslintrc.js
@@ -3,4 +3,12 @@ module.exports = {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 		'import/no-nodejs-modules': 0,
 	},
+	overrides: [
+		{
+			files: [ '*.md.js' ],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+			},
+		},
+	],
 };

--- a/packages/webpack-inline-constant-exports-plugin/README.md
+++ b/packages/webpack-inline-constant-exports-plugin/README.md
@@ -38,11 +38,7 @@ _webpack.config.js_
 const InlineConstantExportsPlugin = require( '@automattic/webpack-inline-constant-exports-plugin' );
 
 module.exports = {
-  ...,
-  plugins: [
-    new InlineConstantExportsPlugin( [ /\/constants.js/ ] ),
-    ...
-  ]
+	plugins: [ new InlineConstantExportsPlugin( [ /\/constants.js/ ] ) ],
 };
 ```
 


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/webpack-inline-constant-exports-plugin`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/webpack-inline-constant-exports-plugin`, there should be no errors