### PR TITLE
[markdown] Fix lint errors in `packages/wpcom.js`

### DIFF
--- a/packages/wpcom.js/History.md
+++ b/packages/wpcom.js/History.md
@@ -88,7 +88,7 @@
 - site.plugin updates
 - various test cleanup
 
-# 4.9.4 / 2016-04-04
+## 4.9.4 / 2016-04-04
 
 - add site.post.del back which was removed in 4.9.3
 

--- a/packages/wpcom.js/README.md
+++ b/packages/wpcom.js/README.md
@@ -19,14 +19,18 @@ yarn add wpcom
 
 ```js
 // Edit a post on a site
-var wpcomXhrRequest = require( 'wpcom-xhr-request' );
-var wpcom = require( 'wpcom' )( '<your-token>', wpcomXhrRequest );
+const wpcomXhrRequest = require( 'wpcom-xhr-request' );
+const wpcom = require( 'wpcom' )( '<your-token>', wpcomXhrRequest );
 
 wpcom
 	.site( 'your-blog.wordpress.com' )
 	.postsList( { number: 8 } )
-		.then( list => { ... } )
-		.catch( error => { ... } );
+	.then( ( list ) => {
+		/*...*/
+	} )
+	.catch( ( error ) => {
+		/*...*/
+	} );
 ```
 
 ### Client-side code (with a build process)
@@ -49,8 +53,12 @@ const wpcom = wpcomFactory( '<your-token>', wpcomXhrRequest );
 wpcom
 	.site( 'your-blog.wordpress.com' )
 	.postsList( { number: 8 } )
-		.then( list => { ... } )
-		.catch( error => { ... } );
+	.then( ( list ) => {
+		/*...*/
+	} )
+	.catch( ( error ) => {
+		/*...*/
+	} );
 ```
 
 ### Authentication
@@ -89,9 +97,15 @@ import wpcomFactory from 'wpcom';
 
 const wpcom = wpcomFactory( '<your-token>', wpcomXhrRequest );
 const blog = wpcom.site( 'your-blog.wordpress.com' );
-blog.post( { slug: 'a-post-slug' } ).update( data )
-	.then( res => { ... } )
-	.catch( err => { ... } );
+blog
+	.post( { slug: 'a-post-slug' } )
+	.update( data )
+	.then( ( res ) => {
+		/*...*/
+	} )
+	.catch( ( err ) => {
+		/*...*/
+	} );
 ```
 
 You can omit the API token for operations that don't require permissions:
@@ -103,9 +117,14 @@ import wpcomFactory from 'wpcom';
 
 const wpcom = wpcomFactory( wpcomXhrRequest );
 const blog = wpcom.site( 'your-blog.wordpress.com' );
-blog.postsList( { number: 8 } )
-	.then( list => { ... } )
-	.catch( error => { ... } );
+blog
+	.postsList( { number: 8 } )
+	.then( ( list ) => {
+		/*...*/
+	} )
+	.catch( ( error ) => {
+		/*...*/
+	} );
 ```
 
 More pre-made examples are in the [`examples/`](./examples/) directory.

--- a/packages/wpcom.js/docs/comment.md
+++ b/packages/wpcom.js/docs/comment.md
@@ -66,10 +66,9 @@ Create a Comment as a reply to another Comment
 
 ```js
 wpcom
-.site('blog.wordpress.com')
-.comment(123)
-.reply('Im sorry, I've edited the previous comment', function(err, data){
-});
+	.site( 'blog.wordpress.com' )
+	.comment( 123 )
+	.reply( "Im sorry, I've edited the previous comment", function ( err, data ) {} );
 ```
 
 ### Comment#del(body, fn)

--- a/packages/wpcom.js/docs/me.md
+++ b/packages/wpcom.js/docs/me.md
@@ -5,9 +5,8 @@
 ## Create a `Me` instance from WPCOM
 
 ```js
-var wpcom = require('wpcom')('<your-token>');
-var me = wpcom.me();
-});
+const wpcom = require( 'wpcom' )( '<your-token>' );
+const me = wpcom.me();
 ```
 
 ## API

--- a/packages/wpcom.js/docs/media.md
+++ b/packages/wpcom.js/docs/media.md
@@ -7,9 +7,8 @@
 Create a `Media` instance from Site
 
 ```js
-var wpcom = require('wpcom')('<your-token>');
-var media = wpcom.site('<site-id>').media('<media-id>');
-});
+const wpcom = require( 'wpcom' )( '<your-token>' );
+const media = wpcom.site( '<site-id>' ).media( '<media-id>' );
 ```
 
 ## API

--- a/packages/wpcom.js/docs/post.md
+++ b/packages/wpcom.js/docs/post.md
@@ -7,11 +7,8 @@
 Create a `Post` instance from Site
 
 ```js
-var wpcom = require('wpcom')('<your-token>');
-var post = wpcom
-           .site('blog.wordpress.com')
-           .post(342);
-});
+const wpcom = require( 'wpcom' )( '<your-token>' );
+const post = wpcom.site( 'blog.wordpress.com' ).post( 342 );
 ```
 
 ## API

--- a/packages/wpcom.js/docs/site.md
+++ b/packages/wpcom.js/docs/site.md
@@ -7,9 +7,8 @@
 Create a `Site` instance from WPCOM
 
 ```js
-var wpcom = require('wpcom')('<your-token>');
-var post = wpcom.site('<site-id>').post('<post-id>');
-});
+const wpcom = require( 'wpcom' )( '<your-token>' );
+const suggestions = wpcom.users().suggest( '<site-id>' );
 ```
 
 ## API
@@ -180,9 +179,9 @@ site.statsFollowers( function ( err, data ) {
 Returns stats for a certain [post](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/post/%24post_id/).
 
 ```js
-site.statsPostViews( <postId>, function(err, data){
+site.statsPostViews( postId, function ( err, data ) {
 	// data post views response
-});
+} );
 ```
 
 ### Site#statsPublicize([query, ]fn)
@@ -210,9 +209,9 @@ site.statsReferrers( function ( err, data ) {
 Marks a certain domain referrer as [spam](https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/stats/referrers/spam/new/).
 
 ```js
-site.statsRefferersSpamNew( <domain>, function(err, response){
+site.statsRefferersSpamNew( domain, function ( err, response ) {
 	// response returned from procedure
-});
+} );
 ```
 
 ### Site#statsRefferersSpamDelete(domain, fn)
@@ -220,9 +219,9 @@ site.statsRefferersSpamNew( <domain>, function(err, response){
 Removes a domain from referrer [spam](https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/stats/referrers/spam/delete/) list.
 
 ```js
-site.statsRefferersSpamDelete( <domain>, function(err, response){
+site.statsRefferersSpamDelete( domain, function ( err, response ) {
 	// response returned from procedure
-});
+} );
 ```
 
 ### Site#statsSearchTerms([query, ]fn)
@@ -280,9 +279,9 @@ site.statsTopAuthors( function ( err, data ) {
 Returns stats about a particular VideoPress [video](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/video/%24post_id/).
 
 ```js
-site.statsVideo( <videoId>, function(err, data){
+site.statsVideo( videoId, function ( err, data ) {
 	// data about the video
-});
+} );
 ```
 
 ### Site#statsVideoPlays([query, ]fn)

--- a/packages/wpcom.js/docs/users.md
+++ b/packages/wpcom.js/docs/users.md
@@ -7,9 +7,8 @@
 Create a `Users` instance from WPCOM
 
 ```js
-var wpcom = require('wpcom')('<your-token>');
-var suggestions = wpcom.users().suggest('<site-id>');
-});
+const wpcom = require( 'wpcom' )( '<your-token>' );
+const suggestions = wpcom.users().suggest( '<site-id>' );
 ```
 
 ## API

--- a/packages/wpcom.js/docs/wpcom.md
+++ b/packages/wpcom.js/docs/wpcom.md
@@ -12,9 +12,8 @@ make admin actions or to access to protected resources.
 Create a `Me` object. More info in [Me doc page](./me.md).
 
 ```js
-var wpcom = require('wpcom')('<your-token>');
-var me = wpcom.me();
-});
+const wpcom = require( 'wpcom' )( '<your-token>' );
+const me = wpcom.me();
 ```
 
 ## WPCOM#site('site-id')


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/wpcom.js`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/wpcom.js`, there should be no errors