### PR TITLE
[markdown] Fix lint errors in `packages/wpcom-proxy-request`

### DIFF
--- a/packages/wpcom-proxy-request/.eslintrc.js
+++ b/packages/wpcom-proxy-request/.eslintrc.js
@@ -2,4 +2,12 @@ module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 	},
+	overrides: [
+		{
+			files: [ '*.md.js' ],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+			},
+		},
+	],
 };


### PR DESCRIPTION
### Background

We want to lint the code blocks inside Markdown files to follow our coding style.

### Changes

This PR fixes all markdown errors in `packages/wpcom-proxy-request`

### Testing instructions

Run `./node_modules/.bin/eslint --ext .md --ext .md.js --ext .md.javascript --ext .md.jsx packages/wpcom-proxy-request`, there should be no errors