### PR TITLE
Server build: transpile Calypso polyfills and bundle core-js modules

### DIFF
--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -65,7 +65,7 @@ function getExternals() {
 				// _not_ externalized and can be processed by the fileLoader.
 				fileLoader.test,
 
-				/[^/]?calypso\//,
+				/^calypso\//,
 			],
 		} ),
 		// Some imports should be resolved to runtime `require()` calls, with paths relative

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -19,8 +19,9 @@ const config = require( './server/config' );
 const bundleEnv = config( 'env' );
 const { workerCount } = require( './webpack.common' );
 const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
-const nodeExternals = require( 'webpack-node-externals' );
 const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
+const { shouldTranspileDependency } = require( '@automattic/calypso-build/webpack/util' );
+const nodeExternals = require( 'webpack-node-externals' );
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 
 /**
@@ -54,6 +55,11 @@ function getExternals() {
 				// `@automattic/components` is forced to be webpack-ed because it has SCSS and other
 				// non-JS asset imports that couldn't be processed by Node.js at runtime.
 				'@automattic/components',
+
+				// The polyfills module is transpiled by Babel and only the `core-js` modules that are
+				// needed by current Node.js are included instead of the whole package.
+				'@automattic/calypso-polyfills',
+				/^core-js\//,
 
 				// Ensure that file-loader files imported from packages in node_modules are
 				// _not_ externalized and can be processed by the fileLoader.
@@ -107,6 +113,13 @@ const webpackConfig = {
 				cacheDirectory: path.join( buildDir, '.babel-server-cache' ),
 				cacheIdentifier,
 				exclude: /node_modules\//,
+			} ),
+			TranspileConfig.loader( {
+				workerCount,
+				presets: [ require.resolve( '@automattic/calypso-build/babel/dependencies' ) ],
+				cacheDirectory: path.join( buildDir, '.babel-server-cache' ),
+				cacheIdentifier,
+				include: shouldTranspileDependency,
 			} ),
 			fileLoader,
 			{


### PR DESCRIPTION
The server build currently doesn't transpile or bundle the `@automattic/calypso-polyfills` module. Therefore, the `@babel/preset-env` doesn't get a chance to convert the `core-js/stable` import to a cherry-picked list of `core-js` polyfills that the current Node.js really needs. The whole `core-js` package is included instead.

The Node.js version we use needs only two polyfills: `Math.hypot` and `String.matchAll`.

This PR fixed that by:
- adding the "transpile dependencies" Babel loader from `calypso-build`, which already includes `@automattic/calypso-polyfills` on the list
- forcing bundling of `@automattic/calypso-polyfills` and `core-js` instead of externalizing them.

Spinoff of #45774 where I discovered these packages are unwanted externals.

@scinos I'm also fixing the `^calypso/` regexp here, as a drive-by fix.

**How to test:**
There should be no behavior change. The server bundle shouldn't contain a `require( '@automattic/calypso-polyfills' )` or `require( 'core-js/*' )` call, shouldn't mind if these are not present in `node_modules`, and should bundle the two `core-js` polyfills mentioned above.