### PR TITLE
Nav Unification: DRY up and extract reusable code

### DIFF
--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -40,13 +40,11 @@ export const MySitesSidebarUnified = ( { path } ) => {
 		}
 	}, [ reduxDispatch, selectedSiteId ] );
 
-	// Extract this?
 	const menuItems = useSelector( ( state ) => {
 		const menu = getAdminMenu( state, getSelectedSiteId( state ) );
 		return menu ? Object.values( menu ) : [];
 	} );
 
-	// Extract this?
 	const isAllDomainsView = useSelector( ( state ) => {
 		const currentRoute = getCurrentRoute( state );
 		return isUnderDomainManagementAll( currentRoute ) || isUnderEmailManagementAll( currentRoute );
@@ -56,11 +54,11 @@ export const MySitesSidebarUnified = ( { path } ) => {
 		<Sidebar>
 			<CurrentSite forceAllSitesView={ isAllDomainsView } />
 			{ menuItems.map( ( item, i ) => {
-				if ( 'type' in item && item.type === 'separator' ) {
+				if ( 'separator' === item?.type ) {
 					return <SidebarSeparator key={ i } />;
 				}
 
-				if ( item.children && Object.keys( item.children ).length ) {
+				if ( item?.children && Object.keys( item.children ).length ) {
 					return <MySitesSidebarUnifiedMenu key={ item.slug } path={ path } { ...item } />;
 				}
 

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -25,6 +25,7 @@ import { requestAdminMenu } from '../../state/admin-menu/actions';
 import CurrentSite from 'my-sites/current-site';
 import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
+import useSiteMenuItems from './use-site-menu-items';
 import Sidebar from 'layout/sidebar';
 import SidebarSeparator from 'layout/sidebar/separator';
 
@@ -32,18 +33,7 @@ import 'layout/sidebar-unified/style.scss';
 import 'state/admin-menu/init';
 
 export const MySitesSidebarUnified = ( { path } ) => {
-	const reduxDispatch = useDispatch();
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	useEffect( () => {
-		if ( selectedSiteId !== null ) {
-			reduxDispatch( requestAdminMenu( selectedSiteId ) );
-		}
-	}, [ reduxDispatch, selectedSiteId ] );
-
-	const menuItems = useSelector( ( state ) => {
-		const menu = getAdminMenu( state, getSelectedSiteId( state ) );
-		return menu ? Object.values( menu ) : [];
-	} );
+	const menuItems = useSiteMenuItems();
 
 	const isAllDomainsView = useSelector( ( state ) => {
 		const currentRoute = getCurrentRoute( state );

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -43,7 +43,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	// Extract this?
 	const menuItems = useSelector( ( state ) => {
 		const menu = getAdminMenu( state, getSelectedSiteId( state ) );
-		return menu != null ? Object.values( menu ) : [];
+		return menu ? Object.values( menu ) : [];
 	} );
 
 	// Extract this?

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -10,35 +10,25 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React from 'react';
+import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import { getCurrentRoute } from 'state/selectors/get-current-route';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getAdminMenu } from 'state/admin-menu/selectors';
-import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
-import { isUnderEmailManagementAll } from 'my-sites/email/paths';
-import { requestAdminMenu } from '../../state/admin-menu/actions';
 import CurrentSite from 'my-sites/current-site';
 import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
 import useSiteMenuItems from './use-site-menu-items';
 import Sidebar from 'layout/sidebar';
 import SidebarSeparator from 'layout/sidebar/separator';
-
+import { getIsAllDomainsView } from 'state/admin-menu/selectors';
 import 'layout/sidebar-unified/style.scss';
 import 'state/admin-menu/init';
 
 export const MySitesSidebarUnified = ( { path } ) => {
+	const isAllDomainsView = useSelector( getIsAllDomainsView );
 	const menuItems = useSiteMenuItems();
-
-	const isAllDomainsView = useSelector( ( state ) => {
-		const currentRoute = getCurrentRoute( state );
-		return isUnderDomainManagementAll( currentRoute ) || isUnderEmailManagementAll( currentRoute );
-	} );
 
 	return (
 		<Sidebar>

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -20,15 +20,15 @@ import CurrentSite from 'my-sites/current-site';
 import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
 import useSiteMenuItems from './use-site-menu-items';
+import useDomainsViewStatus from './use-domains-view-status';
 import Sidebar from 'layout/sidebar';
 import SidebarSeparator from 'layout/sidebar/separator';
-import { getIsAllDomainsView } from 'state/admin-menu/selectors';
 import 'layout/sidebar-unified/style.scss';
 import 'state/admin-menu/init';
 
 export const MySitesSidebarUnified = ( { path } ) => {
-	const isAllDomainsView = useSelector( getIsAllDomainsView );
 	const menuItems = useSiteMenuItems();
+	const isAllDomainsView = useDomainsViewStatus();
 
 	return (
 		<Sidebar>

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -11,7 +11,6 @@
  * External dependencies
  */
 import React from 'react';
-import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -52,7 +52,6 @@ export const MySitesSidebarUnified = ( { path } ) => {
 		return isUnderDomainManagementAll( currentRoute ) || isUnderEmailManagementAll( currentRoute );
 	} );
 
-	//console.log( { menuItems } );
 	return (
 		<Sidebar>
 			<CurrentSite forceAllSitesView={ isAllDomainsView } />
@@ -60,12 +59,12 @@ export const MySitesSidebarUnified = ( { path } ) => {
 				if ( 'type' in item && item.type === 'separator' ) {
 					return <SidebarSeparator key={ i } />;
 				}
-				if ( ! ( 'children' in item ) || item.children.length === 0 ) {
-					return (
-						<MySitesSidebarUnifiedItem isTopLevel key={ item.slug } path={ path } { ...item } />
-					);
+
+				if ( item.children && Object.keys( item.children ).length ) {
+					return <MySitesSidebarUnifiedMenu key={ item.slug } path={ path } { ...item } />;
 				}
-				return <MySitesSidebarUnifiedMenu key={ item.slug } path={ path } { ...item } />;
+
+				return <MySitesSidebarUnifiedItem isTopLevel key={ item.slug } path={ path } { ...item } />;
 			} ) }
 		</Sidebar>
 	);

--- a/client/my-sites/sidebar-unified/use-domains-view-status.js
+++ b/client/my-sites/sidebar-unified/use-domains-view-status.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentRoute } from 'state/selectors/get-current-route';
+import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
+import { isUnderEmailManagementAll } from 'my-sites/email/paths';
+
+const useDomainsViewStatus = () =>
+	useSelector( ( state ) => {
+		const currentRoute = getCurrentRoute( state );
+		return isUnderDomainManagementAll( currentRoute ) || isUnderEmailManagementAll( currentRoute );
+	} );
+
+export default useDomainsViewStatus;

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -11,7 +11,7 @@ import { requestAdminMenu } from '../../state/admin-menu/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getAdminMenu } from 'state/admin-menu/selectors';
 
-function useSiteMenuItems() {
+const useSiteMenuItems = () => {
 	const dispatch = useDispatch();
 	const selectedSiteId = useSelector( getSelectedSiteId );
 
@@ -27,6 +27,6 @@ function useSiteMenuItems() {
 	}, [ dispatch, selectedSiteId ] );
 
 	return menuItems;
-}
+};
 
 export default useSiteMenuItems;

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestAdminMenu } from '../../state/admin-menu/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getAdminMenu } from 'state/admin-menu/selectors';
+
+function useSiteMenuItems() {
+	const dispatch = useDispatch();
+	const selectedSiteId = useSelector( getSelectedSiteId );
+
+	const menuItems = useSelector( ( state ) => {
+		const menu = getAdminMenu( state, selectedSiteId );
+		return menu ? Object.values( menu ) : [];
+	} );
+
+	useEffect( () => {
+		if ( selectedSiteId !== null ) {
+			dispatch( requestAdminMenu( selectedSiteId ) );
+		}
+	}, [ dispatch, selectedSiteId ] );
+
+	return menuItems;
+}
+
+export default useSiteMenuItems;

--- a/client/state/admin-menu/selectors/index.js
+++ b/client/state/admin-menu/selectors/index.js
@@ -3,10 +3,6 @@
  */
 import 'state/inline-help/init';
 
-import { getCurrentRoute } from 'state/selectors/get-current-route';
-import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
-import { isUnderEmailManagementAll } from 'my-sites/email/paths';
-
 export function getAdminMenu( state, siteId ) {
 	const stateSlice = state?.adminMenu;
 
@@ -15,9 +11,4 @@ export function getAdminMenu( state, siteId ) {
 	}
 
 	return state.adminMenu[ siteId ] || null;
-}
-
-export function getIsAllDomainsView( state ) {
-	const currentRoute = getCurrentRoute( state );
-	return isUnderDomainManagementAll( currentRoute ) || isUnderEmailManagementAll( currentRoute );
 }

--- a/client/state/admin-menu/selectors/index.js
+++ b/client/state/admin-menu/selectors/index.js
@@ -3,6 +3,10 @@
  */
 import 'state/inline-help/init';
 
+import { getCurrentRoute } from 'state/selectors/get-current-route';
+import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
+import { isUnderEmailManagementAll } from 'my-sites/email/paths';
+
 export function getAdminMenu( state, siteId ) {
 	const stateSlice = state?.adminMenu;
 
@@ -11,4 +15,9 @@ export function getAdminMenu( state, siteId ) {
 	}
 
 	return state.adminMenu[ siteId ] || null;
+}
+
+export function getIsAllDomainsView( state ) {
+	const currentRoute = getCurrentRoute( state );
+	return isUnderDomainManagementAll( currentRoute ) || isUnderEmailManagementAll( currentRoute );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove left over debugging.
* Modernize tests for presence of menu item props.
* Extract menu items fetch to Hook.
* Extract selector for all domains.

## Testing instructions

The key is checking that the UI output on `master` and this branch as the same.

#### On Master

* Apply D49005-code
* Apply blog sticker
* Run calypso
* Visit http://calypso.localhost:3000/?flags=nav-unification.
* You should see left hand Nav rendered so match API output as generated by D49005-code.

#### This PR

* Checkout this PR.
* Apply D49005-code
* Apply blog sticker
* Run calypso
* Visit http://calypso.localhost:3000/?flags=nav-unification.
* You should see left hand Nav rendered so match API output as generated by D49005-code. 
* There should be no change!

