### PR TITLE
Nav Unification: responsive

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,7 +3,7 @@
 	"rules": {
 		"scales/font-weight": [[ 400, 600, 700, "normal", "bold", "inherit" ]],
 		"scales/font-size": [[ 0.75, 0.875, 1, 1.25, 1.5, 2, 2.25, 3, 3.375 ], { unit: "rem" }],
-		"scales/radii": [[ 2, 5 ], { unit: "px" }],
+		"scales/radii": [[ 2 ], { unit: "px" }],
 
 		"color-hex-case": "lower",
 		"color-no-invalid-hex": true,

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,7 +3,7 @@
 	"rules": {
 		"scales/font-weight": [[ 400, 600, 700, "normal", "bold", "inherit" ]],
 		"scales/font-size": [[ 0.75, 0.875, 1, 1.25, 1.5, 2, 2.25, 3, 3.375 ], { unit: "rem" }],
-		"scales/radii": [[ 2 ], { unit: "px" }],
+		"scales/radii": [[ 2, 5 ], { unit: "px" }],
 
 		"color-hex-case": "lower",
 		"color-no-invalid-hex": true,

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -47,7 +47,7 @@
 
 	// client/layout/masterbar/style.scss
 	.masterbar__item-bubble {
-		top: 2px;
+		top: calc( 50% - 14px );
 		left: -7px;
 	}
 
@@ -169,14 +169,6 @@
 		}
 
 		// client/layout/masterbar/style.scss
-		.masterbar__item-bubble {
-			top: 50%;
-			left: 50%;
-			margin: 0;
-			transform: translate( -39px, -14px );
-		}
-
-		// client/layout/masterbar/style.scss
 		.masterbar__item-me {
 			// fix for profile picture currently hidden in production
 			.masterbar__item-content {
@@ -198,7 +190,7 @@
 	// client/layout/masterbar/style.scss
 	@include breakpoint-deprecated( '<480px' ) {
 		.masterbar__item-bubble {
-			transform: translate( -14px, -14px );
+			left: calc( 50% - 14px );
 		}
 	}
 }

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -6,7 +6,7 @@
  * This file contains all relevant styles for the nav unification prototype (see pbAPfg-O2).
  * Using a single place to store these styles will allow us to easily (re)move them later.
  * Depending on the outcome they'll either be deleted or moved to the relevant places.
- * 
+ *
  * IMPORTANT: When adding to this file please also add the source file in a comment.
  */
 
@@ -136,8 +136,18 @@
 	// breakpoint used in wp-admin
 	@media only screen and ( max-width: 782px ) {
 		// client/layout/style.scss
+		&.layout.focus-content .layout__secondary {
+			transform: translateX( -100% );
+			padding: 71px 24px 24px;
+		}
+
 		.layout__secondary {
 			top: $nav-unification-masterbar-height-mobile;
+		}
+
+		.layout.focus-sites:not( .is-section-post-editor ) .layout__primary .main,
+		.layout.focus-sidebar:not( .is-section-post-editor ) .layout__primary .main {
+			transform: translateX( 100% );
 		}
 
 		// client/layout/masterbar/style.scss

--- a/client/assets/stylesheets/shared/_variables.scss
+++ b/client/assets/stylesheets/shared/_variables.scss
@@ -2,8 +2,8 @@
 // Layout
 // =======================
 
-// Sidebar size limits
 :root {
+	// Sidebar size limits
 	--sidebar-width-max: 272px;
 	--sidebar-width-min: 228px;
 }

--- a/client/components/mobile-back-to-sidebar/index.jsx
+++ b/client/components/mobile-back-to-sidebar/index.jsx
@@ -9,6 +9,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal Dependencies
  */
+import config from 'config';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 
 /**
@@ -17,6 +18,10 @@ import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import './style.scss';
 
 function MobileBackToSidebar( { children, toggleSidebar } ) {
+	if ( config.isEnabled( 'nav-unification' ) ) {
+		return null;
+	}
+
 	return (
 		<button className="mobile-back-to-sidebar" onClick={ toggleSidebar }>
 			<Gridicon icon="chevron-left" className="mobile-back-to-sidebar__icon" />

--- a/client/components/sidebar-navigation/index.jsx
+++ b/client/components/sidebar-navigation/index.jsx
@@ -12,6 +12,7 @@ import Gridicon from 'components/gridicon';
  */
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import TranslatableString from 'components/translatable/proptype';
+import config from 'config';
 
 /**
  * Style dependencies
@@ -19,6 +20,10 @@ import TranslatableString from 'components/translatable/proptype';
 import './style.scss';
 
 function SidebarNavigation( { sectionTitle, children, toggleSidebar } ) {
+	if ( config.isEnabled( 'nav-unification' ) ) {
+		return null;
+	}
+
 	return (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<header className="current-section">

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -136,7 +136,12 @@ class MasterbarLoggedIn extends React.Component {
 			homeUrl = isCustomerHomeEnabled
 				? `/home/${ siteSlug }`
 				: getStatsPathForTab( 'day', siteSlug ),
-			mySitesUrl = domainOnlySite ? domainManagementList( siteSlug ) : homeUrl;
+			// eslint-disable-next-line no-nested-ternary
+			mySitesUrl = config.isEnabled( 'nav-unification' )
+				? ''
+				: domainOnlySite
+				? domainManagementList( siteSlug )
+				: homeUrl;
 
 		return (
 			<Item

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -26,6 +26,7 @@ import isNotificationsOpen from 'state/selectors/is-notifications-open';
 import isSiteMigrationInProgress from 'state/selectors/is-site-migration-in-progress';
 import isSiteMigrationActiveRoute from 'state/selectors/is-site-migration-active-route';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
+import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
@@ -45,6 +46,7 @@ class MasterbarLoggedIn extends React.Component {
 		domainOnlySite: PropTypes.bool,
 		section: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		setNextLayoutFocus: PropTypes.func.isRequired,
+		currentLayoutFocus: PropTypes.string,
 		siteSlug: PropTypes.string,
 		hasMoreThanOneSite: PropTypes.bool,
 		isCheckout: PropTypes.bool,
@@ -53,7 +55,14 @@ class MasterbarLoggedIn extends React.Component {
 
 	clickMySites = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_my_sites_clicked' );
-		this.props.setNextLayoutFocus( 'sidebar' );
+		if ( ! config.isEnabled( 'nav-unification' ) ) {
+			this.props.setNextLayoutFocus( 'sidebar' );
+		} else if ( 'sites' !== this.props.section || 'sidebar' === this.props.currentLayoutFocus ) {
+			// when sites is not focused or sidebar is open, focus to sites content. Else, open sites sidebar.
+			this.props.setNextLayoutFocus( 'content' );
+		} else {
+			this.props.setNextLayoutFocus( 'sidebar' );
+		}
 
 		/**
 		 * Site Migration: Reset a failed migration when clicking on My Sites
@@ -93,7 +102,14 @@ class MasterbarLoggedIn extends React.Component {
 
 	clickReader = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_reader_clicked' );
-		this.props.setNextLayoutFocus( 'content' );
+		if ( ! config.isEnabled( 'nav-unification' ) ) {
+			this.props.setNextLayoutFocus( 'content' );
+		} else if ( 'reader' !== this.props.section || 'sidebar' === this.props.currentLayoutFocus ) {
+			// when reader is not focused or sidebar is open, focus to reader content. Else, open reader sidebar.
+			this.props.setNextLayoutFocus( 'content' );
+		} else {
+			this.props.setNextLayoutFocus( 'sidebar' );
+		}
 	};
 
 	clickMe = () => {
@@ -132,17 +148,16 @@ class MasterbarLoggedIn extends React.Component {
 				siteSlug,
 				translate,
 				isCustomerHomeEnabled,
+				section,
 			} = this.props,
 			homeUrl = isCustomerHomeEnabled
 				? `/home/${ siteSlug }`
-				: getStatsPathForTab( 'day', siteSlug ),
-			// eslint-disable-next-line no-nested-ternary
-			mySitesUrl = config.isEnabled( 'nav-unification' )
-				? ''
-				: domainOnlySite
-				? domainManagementList( siteSlug )
-				: homeUrl;
+				: getStatsPathForTab( 'day', siteSlug );
 
+		let mySitesUrl = domainOnlySite ? domainManagementList( siteSlug ) : homeUrl;
+		if ( config.isEnabled( 'nav-unification' ) && 'reader' !== section ) {
+			mySitesUrl = '';
+		}
 		return (
 			<Item
 				url={ mySitesUrl }
@@ -191,7 +206,7 @@ class MasterbarLoggedIn extends React.Component {
 				<Item
 					tipTarget="reader"
 					className="masterbar__reader"
-					url="/read"
+					url={ config.isEnabled( 'nav-unification' ) ? '/read?flags=nav-unification' : '/read' }
 					icon="reader"
 					onClick={ this.clickReader }
 					isActive={ this.isActive( 'reader' ) }
@@ -269,6 +284,7 @@ export default connect(
 			currentSelectedSiteId,
 			previousPath: getPreviousPath( state ),
 			isJetpackNotAtomic: isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ),
+			currentLayoutFocus: getCurrentLayoutFocus( state ),
 		};
 	},
 	{ setNextLayoutFocus, recordTracksEvent, updateSiteMigrationMeta }

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -20,8 +20,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarCustomIcon from 'layout/sidebar/custom-icon';
 import StatsSparkline from 'blocks/stats-sparkline';
-import addQueryArgs from 'lib/url/add-query-args';
-import config from 'config';
 
 const onNav = () => null;
 
@@ -38,9 +36,6 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) =>
 	if ( isStats && selectedSiteId ) {
 		children = <StatsSparkline className="sidebar-unified__sparkline" siteId={ selectedSiteId } />;
 	}
-	url = config.isEnabled( 'nav-unification' )
-		? addQueryArgs( { flags: 'nav-unification' }, url )
-		: url;
 
 	return (
 		<SidebarItem

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -20,6 +20,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarCustomIcon from 'layout/sidebar/custom-icon';
 import StatsSparkline from 'blocks/stats-sparkline';
+import addQueryArgs from 'lib/url/add-query-args';
+import config from 'config';
 
 const onNav = () => null;
 
@@ -36,6 +38,9 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) =>
 	if ( isStats && selectedSiteId ) {
 		children = <StatsSparkline className="sidebar-unified__sparkline" siteId={ selectedSiteId } />;
 	}
+	url = config.isEnabled( 'nav-unification' )
+		? addQueryArgs( { flags: 'nav-unification' }, url )
+		: url;
 
 	return (
 		<SidebarItem
@@ -44,6 +49,7 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) =>
 			onNavigate={ onNav }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
+			forceInternalLink
 		>
 			{ children }
 		</SidebarItem>

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -9,7 +9,8 @@
 
 	--color-sidebar-background: #23282d;
 	--color-sidebar-background-rgb: 35, 40, 45;
-	--color-sidebar-menu-hover-background: #191e23;
+	--color-sidebar-menu-hover-background: #32373c;
+	--color-sidebar-menu-hover-background-rgb: rgb( #32373c );
 	--color-sidebar-menu-hover: var ( --color-sidebar-text );
 	--color-sidebar-menu-selected-background: #006fad;
 	--color-sidebar-border: var( --color-surface-backdrop );
@@ -126,6 +127,20 @@ $font-size: rem( 14px );
 	.current-site .all-sites,
 	.current-site__switch-sites {
 		border-color: #333333;
+	}
+
+	//client/components/site-selector/style.scss
+	.site-selector .site.is-highlighted {
+		background-color: var ( --color-sidebar-menu-hover-background );
+	}
+
+	.site-selector .site.is-highlighted .site__domain,
+	.site-selector .site.is-highlighted .site__title {
+		color: var( --color-sidebar-text );
+	}
+
+	.site__badge {
+		background: var( --color-sidebar-text );
 	}
 }
 

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -120,11 +120,6 @@ $font-size: rem( 14px );
 		.sidebar__menu-icon {
 			color: var( --color-sidebar-gridicon-fill );
 		}
-
-		.selected .sidebar__menu-link,
-		.selected .sidebar__menu-link:hover {
-			background-color: var( --color-sidebar-menu-selected-background );
-		}
 	}
 
 	//client/my-sites/current-site/style.scss

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -108,7 +108,8 @@ $font-size: rem( 14px );
 				font-weight: 400;
 				color: #b4b9be;
 
-				&:hover {
+				&:hover,
+				&:focus {
 					background-color: transparent;
 					color: white;
 					font-weight: 600;

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -175,7 +175,7 @@ $font-size: rem( 14px );
 
 			.sidebar__expandable-title,
 			.sidebar__menu-link-text {
-				padding: 12px 0;
+				padding: 13px 0;
 			}
 
 			.sidebar__expandable-content {

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -132,6 +132,10 @@ $font-size: rem( 14px );
 @media screen and ( max-width: 782px ) {
 	// client/layout/sidebar/style.scss
 	.is-nav-unification {
+		&.focus-content .layout__content {
+			padding: 71px 24px 24px;
+		}
+
 		.sidebar {
 			.sidebar__separator {
 				margin: 0 0 11px;
@@ -161,8 +165,13 @@ $font-size: rem( 14px );
 
 			.sidebar__expandable-content {
 				.sidebar__menu-link {
-					padding: 5px 16px;
+					font-size: 1rem;
+					padding: 7px 16px 7px 48px;
 				}
+			}
+
+			.sidebar__menu.is-toggle-open .sidebar__heading::after {
+				display: none;
 			}
 		}
 	}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -13,7 +13,7 @@
 	--color-sidebar-menu-hover-background-rgb: rgb( #32373c );
 	--color-sidebar-menu-hover: var ( --color-sidebar-text );
 	--color-sidebar-menu-selected-background: #006fad;
-	--color-sidebar-border: var( --color-surface-backdrop );
+	--color-sidebar-border: #333333;
 	--color-sidebar-text: #eee;
 	--color-sidebar-text-alternative: #a2aab2;
 	--color-sidebar-gridicon-fill: #a2aab2;
@@ -124,13 +124,6 @@ $font-size: rem( 14px );
 		.sidebar__menu-icon {
 			color: var( --color-sidebar-gridicon-fill );
 		}
-	}
-
-	//client/my-sites/current-site/style.scss
-	.current-site .site,
-	.current-site .all-sites,
-	.current-site__switch-sites {
-		border-color: #333333;
 	}
 
 	//client/components/site-selector/style.scss

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -87,6 +87,10 @@ $font-size: rem( 14px );
 				top: 50%;
 				margin-top: -8px;
 			}
+
+			.sidebar__menu-icon {
+				color: #fff;
+			}
 		}
 
 		.sidebar__expandable-content {
@@ -104,6 +108,7 @@ $font-size: rem( 14px );
 				&:hover {
 					background-color: transparent;
 					color: white;
+					font-weight: 600;
 				}
 			}
 
@@ -164,13 +169,13 @@ $font-size: rem( 14px );
 
 			.sidebar__menu.is-togglable {
 				.sidebar__heading {
-					padding: 0 0 0 16px;
+					padding: 0 0 0 12px;
 					font-size: 1rem;
 				}
 			}
 
 			.sidebar__menu-icon {
-				margin-right: 13px;
+				margin-right: 10px;
 			}
 
 			.sidebar__expandable-title,
@@ -181,7 +186,7 @@ $font-size: rem( 14px );
 			.sidebar__expandable-content {
 				.sidebar__menu-link {
 					font-size: 1rem;
-					padding: 7px 16px 7px 48px;
+					padding: 7px 16px 7px 42px;
 				}
 			}
 

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -27,6 +27,7 @@ $font-size: rem( 14px );
 	// client/layout/sidebar/style.scss
 	.sidebar {
 		background-color: var( --color-sidebar-background );
+		padding-bottom: 12px;
 
 		.sidebar__separator {
 			margin: 0 0 11px;
@@ -158,7 +159,7 @@ $font-size: rem( 14px );
 
 			.sidebar__heading,
 			.sidebar__menu-link {
-				padding: 0 0 0 16px;
+				padding: 0 0 0 12px;
 				font-size: 1rem;
 			}
 

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -43,7 +43,8 @@ $font-size: rem( 14px );
 			color: var( --color-sidebar-text );
 			align-items: center;
 
-			&:hover {
+			&:hover,
+			&:focus {
 				background-color: var( --color-sidebar-menu-hover-background );
 				color: var( --color-sidebar-menu-hover );
 			}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -65,7 +65,8 @@ $font-size: rem( 14px );
 				padding: 0 0 0 8px;
 				font-weight: 400;
 
-				&:hover {
+				&:hover,
+				&:focus {
 					background-color: var( --color-sidebar-menu-hover-background );
 					color: var( --color-sidebar-menu-hover );
 				}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -131,29 +131,39 @@ $font-size: rem( 14px );
 
 @media screen and ( max-width: 782px ) {
 	// client/layout/sidebar/style.scss
-	hr,
-	.sidebar__separator {
-		margin: 0 0 11px;
-	}
+	.is-nav-unification {
+		.sidebar {
+			.sidebar__separator {
+				margin: 0 0 11px;
+			}
 
-	.sidebar__heading,
-	.sidebar__menu-link {
-		padding: 0 0 0 16px;
-	}
+			.sidebar__heading,
+			.sidebar__menu-link {
+				padding: 0 0 0 16px;
+				font-size: 1rem;
+			}
 
-	.sidebar__menu.is-togglable {
-		.sidebar__heading {
-			padding: 0 0 0 16px;
+			.sidebar__menu.is-togglable {
+				.sidebar__heading {
+					padding: 0 0 0 16px;
+					font-size: 1rem;
+				}
+			}
+
+			.sidebar__menu-icon {
+				margin-right: 13px;
+			}
+
+			.sidebar__expandable-title,
+			.sidebar__menu-link-text {
+				padding: 12px 0;
+			}
+
+			.sidebar__expandable-content {
+				.sidebar__menu-link {
+					padding: 5px 16px;
+				}
+			}
 		}
-	}
-
-	.sidebar__expandable-content {
-		.sidebar__menu-link {
-			padding: 5px 16px;
-		}
-	}
-
-	.sidebar__menu-icon {
-		margin-right: 13px;
 	}
 }

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -9,10 +9,13 @@
 
 	--color-sidebar-background: #23282d;
 	--color-sidebar-background-rgb: 35, 40, 45;
+	--color-sidebar-menu-hover-background: #191e23;
+	--color-sidebar-menu-hover: var ( --color-sidebar-text );
+	--color-sidebar-menu-selected-background: #006fad;
 	--color-sidebar-border: var( --color-surface-backdrop );
 	--color-sidebar-text: #eee;
-	--color-sidebar-gridicon-fill: #a0a5aa;
 	--color-sidebar-text-alternative: #a2aab2;
+	--color-sidebar-gridicon-fill: #a2aab2;
 }
 
 // Local Vars
@@ -34,14 +37,13 @@ $font-size: rem( 14px );
 			font-size: $font-size;
 			font-weight: 400;
 			line-height: 1.3;
-			padding: 0;
+			padding: 0 0 0 8px;
 			color: var( --color-sidebar-text );
 			align-items: center;
-			padding-left: 8px;
 
 			&:hover {
-				background-color: #191e23;
-				color: #00b9eb;
+				background-color: var( --color-sidebar-menu-hover-background );
+				color: var( --color-sidebar-menu-hover );
 			}
 		}
 
@@ -56,15 +58,14 @@ $font-size: rem( 14px );
 			width: 20px;
 			height: 20px;
 		}
-
 		.sidebar__menu.is-togglable {
 			.sidebar__heading {
 				padding: 0 0 0 8px;
 				font-weight: 400;
 
 				&:hover {
-					background-color: #191e23;
-					color: #00b9eb;
+					background-color: var( --color-sidebar-menu-hover-background );
+					color: var( --color-sidebar-menu-hover );
 				}
 			}
 		}
@@ -113,12 +114,46 @@ $font-size: rem( 14px );
 		.sidebar__menu-icon {
 			color: var( --color-sidebar-gridicon-fill );
 		}
+
+		.selected .sidebar__menu-link,
+		.selected .sidebar__menu-link:hover {
+			background-color: var( --color-sidebar-menu-selected-background );
+		}
 	}
 
 	//client/my-sites/current-site/style.scss
 	.current-site .site,
 	.current-site .all-sites,
 	.current-site__switch-sites {
-		border-color: transparent;
+		border-color: #333333;
+	}
+}
+
+@media screen and ( max-width: 782px ) {
+	// client/layout/sidebar/style.scss
+	hr,
+	.sidebar__separator {
+		margin: 0 0 11px;
+	}
+
+	.sidebar__heading,
+	.sidebar__menu-link {
+		padding: 0 0 0 16px;
+	}
+
+	.sidebar__menu.is-togglable {
+		.sidebar__heading {
+			padding: 0 0 0 16px;
+		}
+	}
+
+	.sidebar__expandable-content {
+		.sidebar__menu-link {
+			padding: 5px 16px;
+		}
+	}
+
+	.sidebar__menu-icon {
+		margin-right: 13px;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- [x] in calypso remove the white stripe containing the hamburger menu and site name
- [x] in calypso adjust the WP logo so that it toggles the menu without redirecting to home
- [x] check that spacing, padding, margin, font-size are in par with the designs
- [x] check that menus have the correct width
- [x] for breakpoints where the sidebar is not visible we have two sections (My Sites, Reader) that display different content in the sidebar: 
* When a section is not active, clicking that section icon shows the section. Actually switches sections.
* When a section is active, clicking that section icon opens the sidebar and subsequent click closes the sidebar while the sidebar shows corresponding content depending on that section. Actually switches sidebar visibility.
- [ ] `Collapse Menu` button of wp-admin with sidebar showing only icons. Continue on https://github.com/Automattic/wp-calypso/issues/45962
- [x] In wp-admin remove the hamburger menu, move the functionality to WP logo
- [x] In wp-admin make the sidebar full width when open and remove the arrow

D50265-code has to be reviewed too

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply sticker to your sandbox `wp blog-stickers add --sticker=nav-unification --who=<username> --blog_id=<blog_id>`
* Apply D50265-code
* UI should be like https://www.figma.com/file/9cy0DIowQkPAu0rodb9jsL/WP-Admin-for-Dotcom?node-id=343%3A986&viewport=-14159%2C2498%2C2.3297765254974365
* Check that clicking reader and back to my sites behaves as it should

**Calypso**
* Run calyspo and load your sandboxed site
* Add `?flags=nav-unification` to the url

**Wp-admin**
* Go to your sandboxed site /wp-admin

Fixes #45674