### PR TITLE
Add/loading state to unified nav

### DIFF
--- a/client/layout/sidebar-unified/style.scss
+++ b/client/layout/sidebar-unified/style.scss
@@ -1,11 +1,21 @@
 .sidebar-unified__switcher {
 	position: absolute;
 	z-index: 1000;
-	background-color: #633;
+	background-color:red;
 	right: 0;
+	bottom: 0;
 	cursor: pointer;
 	text-decoration: underline;
 	font-size: 0.75rem;
+	padding: 5px 10px;
+}
+
+.sidebar-unified__menu-loading {
+	position: absolute;
+	top: 0;
+	right: 0;
+	left: 0;
+	bottom: 0;
 }
 
 .sidebar-unified__sparkline {

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -34,7 +34,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
 
 	if ( isRequestingMenu ) {
-		return <Spinner />;
+		return <Spinner className="sidebar-unified__menu-loading" />;
 	}
 
 	return (

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -11,6 +11,7 @@
  * External dependencies
  */
 import React from 'react';
+import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -20,14 +21,21 @@ import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
 import useSiteMenuItems from './use-site-menu-items';
 import useDomainsViewStatus from './use-domains-view-status';
+import { getIsRequestingAdminMenu } from 'state/admin-menu/selectors';
 import Sidebar from 'layout/sidebar';
 import SidebarSeparator from 'layout/sidebar/separator';
 import 'layout/sidebar-unified/style.scss';
 import 'state/admin-menu/init';
+import Spinner from 'components/spinner';
 
 export const MySitesSidebarUnified = ( { path } ) => {
 	const menuItems = useSiteMenuItems();
 	const isAllDomainsView = useDomainsViewStatus();
+	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
+
+	if ( isRequestingMenu ) {
+		return <Spinner />;
+	}
 
 	return (
 		<Sidebar>

--- a/client/state/admin-menu/reducer.js
+++ b/client/state/admin-menu/reducer.js
@@ -1,11 +1,16 @@
 /**
  * Internal dependencies
  */
-import { withStorageKey, keyedReducer } from 'state/utils';
+import { withStorageKey, keyedReducer, combineReducers } from 'state/utils';
 import 'state/data-layer/wpcom/sites/admin-menu';
-import { ADMIN_MENU_RECEIVE } from 'state/action-types';
+import {
+	ADMIN_MENU_RECEIVE,
+	ADMIN_MENU_REQUEST,
+	ADMIN_MENU_REQUEST_SUCCESS,
+	ADMIN_MENU_REQUEST_FAILURE,
+} from 'state/action-types';
 
-export const adminMenu = ( state = [], action ) => {
+export const menus = ( state = [], action ) => {
 	switch ( action.type ) {
 		case ADMIN_MENU_RECEIVE:
 			return [ ...state, ...action.menu ];
@@ -14,4 +19,26 @@ export const adminMenu = ( state = [], action ) => {
 	}
 };
 
-export default withStorageKey( 'adminMenu', keyedReducer( 'siteId', adminMenu ) );
+export function requesting( state = {}, action ) {
+	switch ( action.type ) {
+		case ADMIN_MENU_REQUEST:
+			return {
+				...state,
+				isRequesting: true,
+			};
+		case ADMIN_MENU_RECEIVE:
+			return {
+				...state,
+				isRequesting: false,
+			};
+	}
+
+	return state;
+}
+
+const reducer = combineReducers( {
+	requesting,
+	menus: keyedReducer( 'siteId', menus ),
+} );
+
+export default withStorageKey( 'adminMenu', reducer );

--- a/client/state/admin-menu/reducer.js
+++ b/client/state/admin-menu/reducer.js
@@ -3,12 +3,7 @@
  */
 import { withStorageKey, keyedReducer, combineReducers } from 'state/utils';
 import 'state/data-layer/wpcom/sites/admin-menu';
-import {
-	ADMIN_MENU_RECEIVE,
-	ADMIN_MENU_REQUEST,
-	ADMIN_MENU_REQUEST_SUCCESS,
-	ADMIN_MENU_REQUEST_FAILURE,
-} from 'state/action-types';
+import { ADMIN_MENU_RECEIVE, ADMIN_MENU_REQUEST } from 'state/action-types';
 
 export const menus = ( state = [], action ) => {
 	switch ( action.type ) {
@@ -19,18 +14,11 @@ export const menus = ( state = [], action ) => {
 	}
 };
 
-export function requesting( state = {}, action ) {
+export function requesting( state = false, action ) {
 	switch ( action.type ) {
 		case ADMIN_MENU_REQUEST:
-			return {
-				...state,
-				isRequesting: true,
-			};
 		case ADMIN_MENU_RECEIVE:
-			return {
-				...state,
-				isRequesting: false,
-			};
+			return action.type === ADMIN_MENU_REQUEST;
 	}
 
 	return state;

--- a/client/state/admin-menu/reducer.js
+++ b/client/state/admin-menu/reducer.js
@@ -5,14 +5,14 @@ import { withStorageKey, keyedReducer, combineReducers } from 'state/utils';
 import 'state/data-layer/wpcom/sites/admin-menu';
 import { ADMIN_MENU_RECEIVE, ADMIN_MENU_REQUEST } from 'state/action-types';
 
-export const menus = ( state = [], action ) => {
+export const menus = keyedReducer( 'siteId', ( state = [], action ) => {
 	switch ( action.type ) {
 		case ADMIN_MENU_RECEIVE:
 			return [ ...state, ...action.menu ];
 		default:
 			return state;
 	}
-};
+} );
 
 export function requesting( state = false, action ) {
 	switch ( action.type ) {
@@ -25,8 +25,8 @@ export function requesting( state = false, action ) {
 }
 
 const reducer = combineReducers( {
+	menus,
 	requesting,
-	menus: keyedReducer( 'siteId', menus ),
 } );
 
 export default withStorageKey( 'adminMenu', reducer );

--- a/client/state/admin-menu/selectors/index.js
+++ b/client/state/admin-menu/selectors/index.js
@@ -20,5 +20,5 @@ export function getIsRequestingAdminMenu( state ) {
 		return null;
 	}
 
-	return state.adminMenu.requesting.isRequesting;
+	return state.adminMenu.requesting;
 }

--- a/client/state/admin-menu/selectors/index.js
+++ b/client/state/admin-menu/selectors/index.js
@@ -4,11 +4,21 @@
 import 'state/admin-menu/init';
 
 export function getAdminMenu( state, siteId ) {
-	const stateSlice = state?.adminMenu;
+	const stateSlice = state?.adminMenu?.menus;
 
 	if ( ! stateSlice || ! siteId ) {
 		return null;
 	}
 
-	return state.adminMenu[ siteId ] || null;
+	return state.adminMenu.menus[ siteId ] || null;
+}
+
+export function getIsRequestingAdminMenu( state ) {
+	const stateSlice = state?.adminMenu?.requesting;
+
+	if ( ! stateSlice ) {
+		return null;
+	}
+
+	return state.adminMenu.requesting.isRequesting;
 }

--- a/client/state/admin-menu/test/reducer.js
+++ b/client/state/admin-menu/test/reducer.js
@@ -13,7 +13,10 @@ import adminReducer from '../reducer';
 describe( 'reducer', () => {
 	describe( 'adminReducer', () => {
 		test( 'returns default state when no arguments provided', () => {
-			const defaultState = deepFreeze( {} );
+			const defaultState = deepFreeze( {
+				menus: {},
+				requesting: {},
+			} );
 			expect( adminReducer( undefined, {} ) ).toEqual( defaultState );
 		} );
 
@@ -23,10 +26,18 @@ describe( 'reducer', () => {
 				siteId: 123456,
 				menu: menuFixture,
 			};
-			const initalState = deepFreeze( {} );
+			const initalState = deepFreeze( {
+				menus: {},
+				requesting: {},
+			} );
 
 			expect( adminReducer( initalState, action ) ).toEqual( {
-				123456: menuFixture,
+				menus: {
+					123456: menuFixture,
+				},
+				requesting: {
+					isRequesting: false,
+				},
 			} );
 		} );
 	} );

--- a/client/state/admin-menu/test/reducer.js
+++ b/client/state/admin-menu/test/reducer.js
@@ -7,17 +7,14 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import menuFixture from './fixture/menu-fixture';
-import { ADMIN_MENU_RECEIVE } from 'state/action-types';
-import adminReducer from '../reducer';
+import { ADMIN_MENU_RECEIVE, ADMIN_MENU_REQUEST } from 'state/action-types';
+import { menus as menusReducer, requesting as requestingReducer } from '../reducer';
 
 describe( 'reducer', () => {
-	describe( 'adminReducer', () => {
+	describe( 'menus reducer', () => {
 		test( 'returns default state when no arguments provided', () => {
-			const defaultState = deepFreeze( {
-				menus: {},
-				requesting: {},
-			} );
-			expect( adminReducer( undefined, {} ) ).toEqual( defaultState );
+			const defaultState = deepFreeze( {} );
+			expect( menusReducer( undefined, {} ) ).toEqual( defaultState );
 		} );
 
 		test( 'adds menu to state keyed by provided siteId', () => {
@@ -26,19 +23,44 @@ describe( 'reducer', () => {
 				siteId: 123456,
 				menu: menuFixture,
 			};
-			const initalState = deepFreeze( {
-				menus: {},
-				requesting: {},
-			} );
+			const initialState = deepFreeze( {} );
 
-			expect( adminReducer( initalState, action ) ).toEqual( {
-				menus: {
-					123456: menuFixture,
-				},
-				requesting: {
-					isRequesting: false,
-				},
+			expect( menusReducer( initialState, action ) ).toEqual( {
+				123456: menuFixture,
 			} );
+		} );
+	} );
+
+	describe( 'requesting reducer', () => {
+		test( 'returns default state when no action provided', () => {
+			expect( requestingReducer( undefined, {} ) ).toBe( false );
+		} );
+
+		test( 'returns true for ADMIN_MENU_REQUEST action', () => {
+			const initialState = deepFreeze( false );
+			expect(
+				requestingReducer( initialState, {
+					type: ADMIN_MENU_REQUEST,
+				} )
+			).toBe( true );
+		} );
+
+		test( 'resets to false for ADMIN_MENU_RECEIVE action', () => {
+			const initialState = deepFreeze( true );
+			expect(
+				requestingReducer( initialState, {
+					type: ADMIN_MENU_RECEIVE,
+				} )
+			).toBe( false );
+		} );
+
+		test.each( [ false, true ] )( 'ignores invalid action types', ( theInitialStateBool ) => {
+			const initialState = deepFreeze( theInitialStateBool );
+			expect(
+				requestingReducer( initialState, {
+					type: 'A_FAKE_ACTION_SHOULD_BE_IGNORED',
+				} )
+			).toBe( theInitialStateBool );
 		} );
 	} );
 } );

--- a/client/state/admin-menu/test/selectors.js
+++ b/client/state/admin-menu/test/selectors.js
@@ -20,7 +20,13 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'returns null when siteId is not provided', () => {
-			const state = {};
+			const state = {
+				adminMenu: {
+					menus: {
+						56789: frozenFixture,
+					},
+				},
+			};
 
 			expect( getAdminMenu( state ) ).toEqual( null );
 		} );
@@ -28,7 +34,9 @@ describe( 'selectors', () => {
 		test( 'returns null when requested siteId key is not present', () => {
 			const state = {
 				adminMenu: {
-					56789: frozenFixture,
+					menus: {
+						56789: frozenFixture,
+					},
 				},
 			};
 
@@ -38,10 +46,12 @@ describe( 'selectors', () => {
 		test( 'returns menu data when siteId is present', () => {
 			const state = {
 				adminMenu: {
-					56789: {},
-					12345: frozenFixture,
-					84649: {},
-					95538: {},
+					menus: {
+						56789: {},
+						12345: frozenFixture,
+						84649: {},
+						95538: {},
+					},
 				},
 			};
 


### PR DESCRIPTION
<img width="1280" alt="Screen Shot 2020-09-22 at 12 03 21" src="https://user-images.githubusercontent.com/444434/93874676-a2e99880-fccb-11ea-93bb-fa9ea2ef3d1a.png">

#### Changes proposed in this Pull Request

* Amend state shape to allow for tracking state of the API request.
* Add temporary loading UI `<Spinner />`.

#### Testing instructions

* Checkout this PR.
* Apply D49005-code
* Apply blog sticker
* Run calypso
* Visit http://calypso.localhost:3000/?flags=nav-unification.
* You should see a loading spinner appear in the sidebar whilst the Nav data is being loaded.
* The Nav should then appear once loading and loading state should disappear.

For debugging purposes you can force this UI state to appear by opening browser dev tools and typing `state.adminMenu.requesting.isRequesting = true`.

Fixes https://github.com/Automattic/wp-calypso/issues/45830
