### PR TITLE
Fix nav unification to load the correct state module init

### DIFF
--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -52,7 +52,6 @@ export const MySitesSidebarUnified = ( { path } ) => {
 		return isUnderDomainManagementAll( currentRoute ) || isUnderEmailManagementAll( currentRoute );
 	} );
 
-	//console.log( { menuItems } );
 	return (
 		<Sidebar>
 			<CurrentSite forceAllSitesView={ isAllDomainsView } />

--- a/client/state/admin-menu/actions/index.js
+++ b/client/state/admin-menu/actions/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import 'state/inline-help/init';
+import 'state/admin-menu/init';
 import 'state/data-layer/wpcom/sites/admin-menu';
 import { ADMIN_MENU_REQUEST, ADMIN_MENU_RECEIVE } from 'state/action-types';
 

--- a/client/state/admin-menu/selectors/index.js
+++ b/client/state/admin-menu/selectors/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import 'state/inline-help/init';
+import 'state/admin-menu/init';
 
 export function getAdminMenu( state, siteId ) {
 	const stateSlice = state?.adminMenu;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes and error with the Nav Unification modularized state which was loading the `inline-help/init` file rather than the `admin-menu/init` file. I have no idea how this happened or how this has ever worked. This PR resolves things to use the correct init.

#### Testing instructions

* Apply D49005-code
* Apply blog sticker
* Run calypso
* Visit http://calypso.localhost:3000/?flags=nav-unification.
* You should see left hand Nav rendered so match API output as generated by D49005-code.

Basically nothing should change. It should be "as is".


