### PR TITLE
Enable 'import/no-extraneous-dependencies' in apps/o2-blocks

### DIFF
--- a/apps/o2-blocks/.eslintrc.js
+++ b/apps/o2-blocks/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
 	rules: {
-		'import/no-extraneous-dependencies': 0,
+		'import/no-extraneous-dependencies': 'error',
 		'react/react-in-jsx-scope': 0,
 		'wpcalypso/jsx-classname-namespace': 0,
 	},

--- a/apps/o2-blocks/package.json
+++ b/apps/o2-blocks/package.json
@@ -32,6 +32,7 @@
 		"@wordpress/element": "^2.16.0",
 		"@wordpress/hooks": "^2.9.0",
 		"@wordpress/i18n": "^3.14.0",
+		"@wordpress/primitives": "^1.7.0",
 		"classnames": "^2.2.6",
 		"lodash": "^4.17.15",
 		"moment": "^2.26.0",


### PR DESCRIPTION
### Changes

* Enable rule `import/no-extraneous-dependencies` for `apps/o2-blocks`
* Add missing dependency on `@wordpress/primitives`

### Testing instructions

#### Eslint rules
Running eslint in `apps/editing-toolkit` and comparing the results with master shows no new errors were introduced:

```
$ ./node_modules/.bin/eslint apps/o2-blocks

# In master
✖ 4 problems (4 errors, 0 warnings)

# In this branch
✖ 4 problems (4 errors, 0 warnings)
```

#### Dependencies

Validate these are true for master and this branch:
  * `apps/o2-blocks/node_modules/@wordpress/primitives` does not exist
  * `apps/node_modules/@wordpress/primitives` does not exist
  * `cat node_modules/@wordpress/primitives/package.json | grep version` is "1.7.0"
