### PR TITLE
Nav Unification - add scaffolding for admin menu experience from static data

### DIFF
--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -1,0 +1,523 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+const shouldShowLinks = true;
+const shouldShowTestimonials = true;
+const shouldShowPortfolio = true;
+const shouldShowWooCommerce = true;
+const shouldShowApperanceHeaderAndBackground = true;
+const shouldShowAdControl = true;
+const shouldShowAMP = true;
+const showShowThemeOptions = true;
+
+export default function buildFallbackResponse( { siteDomain = '' } = {} ) {
+	const fallbackResponse = [
+		{
+			icon: 'dashicons-home',
+			slug: 'home',
+			title: translate( 'My Home' ),
+			type: 'menu-item',
+			url: `/home/${ siteDomain }`,
+		},
+		{
+			icon: 'dashicons-home',
+			slug: 'stats',
+			title: translate( 'Stats' ),
+			type: 'menu-item',
+			url: `/stats/day/${ siteDomain }`,
+		},
+		{
+			icon: 'dashicons-home',
+			slug: 'purchases',
+			title: translate( 'Purchases' ),
+			type: 'menu-item',
+			url: `/purchases/${ siteDomain }`,
+		},
+		{
+			icon: 'dashicons-admin-post',
+			slug: 'edit-php',
+			title: translate( 'Posts' ),
+			type: 'menu-item',
+			url: `/posts/${ siteDomain }`,
+			children: [
+				{
+					parent: 'edit.php',
+					slug: 'edit-php',
+					title: translate( 'All Posts' ),
+					type: 'submenu-item',
+					url: `/posts/${ siteDomain }`,
+				},
+				{
+					parent: 'edit.php',
+					slug: 'post-new-php',
+					title: translate( 'Add New' ),
+					type: 'submenu-item',
+					url: `/block-editor/post/${ siteDomain }`,
+				},
+				{
+					parent: 'edit.php',
+					slug: 'edit-tags-phptaxonomycategory',
+					title: translate( 'Categories' ),
+					type: 'submenu-item',
+					url: `/settings/taxonomies/category/${ siteDomain }`,
+				},
+				{
+					parent: 'edit.php',
+					slug: 'edit-tags-phptaxonomypost_tag',
+					title: translate( 'Tags' ),
+					type: 'submenu-item',
+					url: `/settings/taxonomies/post_tag/${ siteDomain }`,
+				},
+			],
+		},
+		{
+			icon: 'dashicons-admin-media',
+			slug: 'upload-php',
+			title: translate( 'Media' ),
+			type: 'menu-item',
+			url: `/media/${ siteDomain }`,
+		},
+		...( shouldShowLinks && [
+			{
+				icon: 'dashicons-admin-links',
+				slug: 'link-manager-php',
+				title: translate( 'Links' ),
+				type: 'menu-item',
+				url: `https://${ siteDomain }/wp-admin/link-manager.php`,
+				children: [
+					{
+						parent: 'link-manager.php',
+						slug: 'link-manager-php',
+						title: translate( 'All Links' ),
+						type: 'submenu-item',
+						url: `https://${ siteDomain }/wp-admin/link-manager.php`,
+					},
+					{
+						parent: 'link-manager.php',
+						slug: 'link-add-php',
+						title: translate( 'Add New' ),
+						type: 'submenu-item',
+						url: `https://${ siteDomain }/wp-admin/link-add.php`,
+					},
+					{
+						parent: 'link-manager.php',
+						slug: 'edit-tags-phptaxonomylink_category',
+						title: translate( 'Link Categories' ),
+						type: 'submenu-item',
+						url: `https://${ siteDomain }/wp-admin/edit-tags.php?taxonomy=link_category`,
+					},
+				],
+			},
+		] ),
+		{
+			icon: 'dashicons-admin-page',
+			slug: 'edit-phppost_typepage',
+			title: translate( 'Pages' ),
+			type: 'menu-item',
+			url: `/pages/${ siteDomain }`,
+			children: [
+				{
+					parent: 'edit.php?post_type=page',
+					slug: 'edit-phppost_typepage',
+					title: translate( 'All Pages' ),
+					type: 'submenu-item',
+					url: `/pages/${ siteDomain }`,
+				},
+				{
+					parent: 'edit.php?post_type=page',
+					slug: 'post-new-phppost_typepage',
+					title: translate( 'Add New' ),
+					type: 'submenu-item',
+					url: `/block-editor/page/${ siteDomain }`,
+				},
+			],
+		},
+		...( shouldShowTestimonials && [
+			{
+				icon: 'dashicons-admin-links',
+				slug: 'testimonials',
+				title: translate( 'Testimonials' ),
+				type: 'menu-item',
+				url: `/types/jetpack-testimonial/${ siteDomain }`,
+				children: [
+					{
+						parent: 'testimonials',
+						slug: 'testimonials',
+						title: translate( 'All Testimonials' ),
+						type: 'submenu-item',
+						url: `/types/jetpack-testimonial/${ siteDomain }`,
+					},
+					{
+						parent: 'testimonials',
+						slug: 'testimonials-add',
+						title: translate( 'Add New' ),
+						type: 'submenu-item',
+						url: `/block-editor/edit/jetpack-testimonial/${ siteDomain }`,
+					},
+				],
+			},
+		] ),
+		...( shouldShowPortfolio && [
+			{
+				icon: 'dashicons-admin-links',
+				slug: 'portfolio',
+				title: translate( 'Portfolio' ),
+				type: 'menu-item',
+				url: `/types/jetpack-portfolio/${ siteDomain }`,
+				children: [
+					{
+						parent: 'portfolio',
+						slug: 'portfolio',
+						title: translate( 'All Projects' ),
+						type: 'submenu-item',
+						url: `/types/jetpack-portfolio/${ siteDomain }`,
+					},
+					{
+						parent: 'portfolio',
+						slug: 'portfolio-add',
+						title: translate( 'Add New' ),
+						type: 'submenu-item',
+						url: `/block-editor/edit/jetpack-portfolio/${ siteDomain }`,
+					},
+					{
+						parent: 'portfolio',
+						slug: 'portfolio-types',
+						title: translate( 'Project Types' ),
+						type: 'submenu-item',
+						url: `https://${ siteDomain }/wp-admin/edit-tags.php?taxonomy=jetpack-portfolio-type&post_type=jetpack-portfolio`,
+					},
+					{
+						parent: 'portfolio',
+						slug: 'portfolio-tags',
+						title: translate( 'Project Tags' ),
+						type: 'submenu-item',
+						url: `https://${ siteDomain }/wp-admin/edit-tags.php?taxonomy=jetpack-portfolio-tag&post_type=jetpack-portfolio`,
+					},
+				],
+			},
+		] ),
+		{
+			icon: 'dashicons-admin-comments',
+			slug: 'edit-comments-php',
+			title: translate( 'Comments' ),
+			type: 'menu-item',
+			url: `/comments/all/${ siteDomain }`,
+		},
+		{
+			icon: 'dashicons-feedback',
+			slug: 'feedback',
+			title: translate( 'Feedback' ),
+			type: 'menu-item',
+			url: `https://${ siteDomain }/wp-admin/?page=feedback`,
+			children: [
+				{
+					parent: 'feedback',
+					slug: 'edit-phppost_typefeedback',
+					title: translate( 'Feedback' ),
+					type: 'submenu-item',
+					url: `https://${ siteDomain }/wp-admin/edit.php?post_type=feedback`,
+				},
+				{
+					parent: 'feedback',
+					slug: 'polls',
+					title: translate( 'Polls' ),
+					type: 'submenu-item',
+					url: `https://${ siteDomain }/wp-admin/admin.php?page=polls`,
+				},
+				{
+					parent: 'feedback',
+					slug: 'ratings',
+					title: translate( 'Ratings' ),
+					type: 'submenu-item',
+					url: `https://${ siteDomain }/wp-admin/admin.php?page=ratings`,
+				},
+			],
+		},
+		{
+			type: 'separator',
+		},
+		{
+			icon: 'dashicons-jetpack',
+			slug: 'jetpack',
+			title: translate( 'Jetpack' ),
+			type: 'menu-item',
+			url: `/activity-log/${ siteDomain }`,
+			children: [
+				{
+					parent: 'jetpack',
+					slug: 'jetpack-activity-log',
+					title: translate( 'Activity Log' ),
+					type: 'submenu-item',
+					url: `/activity-log/${ siteDomain }`,
+				},
+				{
+					parent: 'jetpack',
+					slug: 'jetpack-backup',
+					title: translate( 'Backup' ),
+					type: 'submenu-item',
+					url: `/backup/${ siteDomain }`,
+				},
+				{
+					parent: 'jetpack',
+					slug: 'jetpack-scan',
+					title: translate( 'Scan' ),
+					type: 'submenu-item',
+					url: `/scan/${ siteDomain }`,
+				},
+			],
+		},
+		{
+			type: 'separator',
+		},
+		// Add WooCommerce here
+		...( shouldShowWooCommerce && [] ),
+		{
+			type: 'separator',
+		},
+		{
+			icon: 'dashicons-admin-appearance',
+			slug: 'themes-php',
+			title: translate( 'Appearance' ),
+			type: 'menu-item',
+			url: `/themes/${ siteDomain }`,
+			children: [
+				{
+					parent: 'themes.php',
+					slug: 'themes-php',
+					title: translate( 'Themes' ),
+					type: 'submenu-item',
+					url: `/themes/${ siteDomain }`,
+				},
+				{
+					parent: 'themes.php',
+					slug: 'themes-customize',
+					title: translate( 'Customize' ),
+					type: 'submenu-item',
+					url: `/customize/${ siteDomain }`,
+				},
+				...( shouldShowApperanceHeaderAndBackground && [
+					{
+						parent: 'themes.php',
+						slug: 'themes-header',
+						title: translate( 'Header' ),
+						type: 'submenu-item',
+						url: `https://${ siteDomain }/wp-admin/customize.php?return=%2Fwp-admin%2F&autofocus%5Bcontrol%5D=header_image`,
+					},
+					{
+						parent: 'themes.php',
+						slug: 'themes-background',
+						title: translate( 'Background' ),
+						type: 'submenu-item',
+						url: `https://${ siteDomain }/wp-admin/customize.php?return=%2Fwp-admin%2F&autofocus%5Bcontrol%5D=background_image`,
+					},
+				] ),
+				...( showShowThemeOptions && [
+					{
+						parent: 'themes.php',
+						slug: 'themes-options',
+						title: translate( 'Theme Options' ),
+						type: 'submenu-item',
+						url: `https://${ siteDomain }/wp-admin/`,
+					},
+				] ),
+				{
+					parent: 'themes.php',
+					slug: 'themes-widgets',
+					title: translate( 'Widgets' ),
+					type: 'submenu-item',
+					url: `/customize/${ siteDomain }?autofocus[panel]=widgets`,
+				},
+				{
+					parent: 'themes.php',
+					slug: 'themes-menus',
+					title: translate( 'Menus' ),
+					type: 'submenu-item',
+					url: `/customize/${ siteDomain }?autofocus[panel]=nav_menus`,
+				},
+			],
+		},
+		{
+			icon: 'dashicons-admin-plugins',
+			slug: 'plugins',
+			title: translate( 'Plugins' ),
+			type: 'menu-item',
+			url: `https://${ siteDomain }/wp-admin/plugins.php`,
+			children: [
+				{
+					parent: 'plugins.php',
+					slug: 'plugins-installed',
+					title: translate( 'Installed Plugins' ),
+					type: 'menu-item',
+					url: `https://${ siteDomain }/wp-admin/plugins.php`,
+				},
+				{
+					parent: 'plugins.php',
+					slug: 'plugins-add-new',
+					title: translate( 'Add New' ),
+					type: 'menu-item',
+					url: `https://${ siteDomain }/wp-admin/plugin-editor.php`,
+				},
+			],
+		},
+		{
+			icon: 'dashicons-admin-users',
+			slug: 'users-php',
+			title: translate( 'Users' ),
+			type: 'menu-item',
+			url: `/people/team/${ siteDomain }`,
+			children: [
+				{
+					parent: 'users.php',
+					slug: 'users-all-people',
+					title: translate( 'All People' ),
+					type: 'submenu-item',
+					url: `/people/team/${ siteDomain }`,
+				},
+				{
+					parent: 'users.php',
+					slug: 'users-add-new',
+					title: translate( 'Add New' ),
+					type: 'submenu-item',
+					url: `/people/new/${ siteDomain }`,
+				},
+				{
+					parent: 'users.php',
+					slug: 'users-my-profile',
+					title: translate( 'My Profile' ),
+					type: 'submenu-item',
+					url: `/me/`,
+				},
+				{
+					parent: 'users.php',
+					slug: 'users-account-settings',
+					title: translate( 'Account Settings' ),
+					type: 'submenu-item',
+					url: `/me/account`,
+				},
+			],
+		},
+		{
+			icon: 'dashicons-admin-tools',
+			slug: 'tools-php',
+			title: translate( 'Tools' ),
+			type: 'menu-item',
+			url: `/marketing/tools/${ siteDomain }`,
+			children: [
+				{
+					parent: 'tools.php',
+					slug: 'tools-marketing',
+					title: translate( 'Marketing' ),
+					type: 'menu-item',
+					url: `/marketing/tools/${ siteDomain }`,
+				},
+				{
+					parent: 'tools.php',
+					slug: 'tools-earn',
+					title: translate( 'Earn' ),
+					type: 'menu-item',
+					url: `/earn/${ siteDomain }`,
+				},
+				{
+					parent: 'tools.php',
+					slug: 'tools-import',
+					title: translate( 'Import' ),
+					type: 'submenu-item',
+					url: `/import/${ siteDomain }`,
+				},
+				{
+					parent: 'tools.php',
+					slug: 'tools-export',
+					title: translate( 'Export' ),
+					type: 'submenu-item',
+					url: `/export/${ siteDomain }`,
+				},
+			],
+		},
+		{
+			icon: 'dashicons-admin-settings',
+			slug: 'options-general-php',
+			title: translate( 'Settings' ),
+			type: 'menu-item',
+			url: `/settings/general/${ siteDomain }`,
+			children: [
+				{
+					parent: 'options-general.php',
+					slug: 'options-general-php',
+					title: translate( 'General' ),
+					type: 'submenu-item',
+					url: `/settings/general/${ siteDomain }`,
+				},
+				{
+					parent: 'options-general.php',
+					slug: 'options-reading-php',
+					title: translate( 'Reading' ),
+					type: 'submenu-item',
+					url: `https://${ siteDomain }/wp-admin/options-reading.php`,
+				},
+				{
+					parent: 'options-general.php',
+					slug: 'options-domains-php',
+					title: translate( 'Domains' ),
+					type: 'submenu-item',
+					url: `/domains/manage/${ siteDomain }`,
+				},
+				{
+					parent: 'options-general.php',
+					slug: 'options-media-php',
+					title: translate( 'Media' ),
+					type: 'submenu-item',
+					url: `https://${ siteDomain }/wp-admin/options-media.php`,
+				},
+				{
+					parent: 'options-general.php',
+					slug: 'options-sharing-php',
+					title: translate( 'Sharing' ),
+					type: 'submenu-item',
+					url: `https://${ siteDomain }/wp-admin/options-general.php?page=sharing`,
+				},
+				{
+					parent: 'options-general.php',
+					slug: 'options-hosting-configuration-php',
+					title: translate( 'Hosting Configuration' ),
+					type: 'submenu-item',
+					url: `/hosting-config/${ siteDomain }`,
+				},
+				{
+					parent: 'options-general.php',
+					slug: 'options-polls-php',
+					title: translate( 'Polls' ),
+					type: 'submenu-item',
+					url: `https://${ siteDomain }/wp-admin/options-general.php?page=polls&action=options`,
+				},
+				{
+					parent: 'options-general.php',
+					slug: 'options-ratings-php',
+					title: translate( 'Ratings' ),
+					type: 'submenu-item',
+					url: `https://${ siteDomain }/wp-admin/options-general.php?page=ratings&action=options`,
+				},
+				...( shouldShowAdControl && [
+					{
+						parent: 'options-general.php',
+						slug: 'options-ad-control',
+						title: translate( 'Ad Control' ),
+						type: 'submenu-item',
+						url: `https://${ siteDomain }/wp-admin/options-general.php?page=adcontrol`,
+					},
+				] ),
+			],
+		},
+		...( shouldShowAMP && [
+			{
+				slug: 'amp',
+				title: translate( 'AMP' ),
+				type: 'menu-item',
+				url: `https://${ siteDomain }/wp-admin/admin.php?page=amp-options`,
+			},
+		] ),
+	];
+
+	return fallbackResponse;
+}

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -35,7 +35,13 @@ export const MySitesSidebarUnified = ( { path } ) => {
 	const isAllDomainsView = useDomainsViewStatus();
 	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
 
-	if ( isRequestingMenu ) {
+	/**
+	 * If there are no menu items and we are currently requesting some,
+	 * then show a spinner. The check for menuItems is necessary because
+	 * we may choose to render the menu from statically stored JSON data
+	 * and therefore we need to be ready to render.
+	 */
+	if ( ! menuItems && isRequestingMenu ) {
 		return <Spinner className="sidebar-unified__menu-loading" />;
 	}
 

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -3,6 +3,7 @@
  */
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import buildFallbackResponse from './fallback-data.js';
 
 /**
  * Internal dependencies
@@ -10,11 +11,12 @@ import { useSelector, useDispatch } from 'react-redux';
 import { requestAdminMenu } from '../../state/admin-menu/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getAdminMenu } from 'state/admin-menu/selectors';
+import { getSiteDomain } from 'state/sites/selectors';
 
 const useSiteMenuItems = () => {
 	const dispatch = useDispatch();
 	const selectedSiteId = useSelector( getSelectedSiteId );
-
+	const siteDomain = useSelector( ( state ) => getSiteDomain( state, selectedSiteId ) );
 	const menuItems = useSelector( ( state ) => getAdminMenu( state, selectedSiteId ) );
 
 	useEffect( () => {
@@ -23,8 +25,19 @@ const useSiteMenuItems = () => {
 		}
 	}, [ dispatch, selectedSiteId ] );
 
-	// Selector may return `null` so add sensible default
-	return menuItems ?? [];
+	/**
+	 * To ensure that a menu is always available in the UI even
+	 * if the network fails on an uncached request we provide a
+	 * set of static fallback data to render a basic menu. This
+	 * avoids a situation where the user might be left with an
+	 * empty menu.
+	 */
+	return (
+		menuItems ??
+		buildFallbackResponse( {
+			siteDomain,
+		} )
+	);
 };
 
 export default useSiteMenuItems;

--- a/client/state/admin-menu/test/selectors.js
+++ b/client/state/admin-menu/test/selectors.js
@@ -31,7 +31,7 @@ describe( 'selectors', () => {
 			expect( getAdminMenu( state ) ).toEqual( null );
 		} );
 
-		test( 'returns null when requested siteId key is not present', () => {
+		test( 'returns null data  when requested siteId key is not present', () => {
 			const state = {
 				adminMenu: {
 					menus: {

--- a/client/state/admin-menu/test/selectors.js
+++ b/client/state/admin-menu/test/selectors.js
@@ -31,7 +31,7 @@ describe( 'selectors', () => {
 			expect( getAdminMenu( state ) ).toEqual( null );
 		} );
 
-		test( 'returns null data  when requested siteId key is not present', () => {
+		test( 'returns null data when requested siteId key is not present', () => {
 			const state = {
 				adminMenu: {
 					menus: {


### PR DESCRIPTION
The aim of this PR is to ensure that users always see a menu appear immediately in the sidebar without any noticeable delay. To do this, if the menu state is not populated we render a basic menu from a static JSON snapshot. Once the REST API request returns we then hydrate the state and update the UI to use the dynamic data.

This is very much an edge case experience, as once the endpoint data is cached in browser storage users will rarely see the fallback experience. Nonetheless this is an important safe guard to ensure a user never receives an empty menu.

## Changes proposed in this Pull Request

* Update ~`getAdminMenu` selector~ `useSiteMenuItems` hook to return static data from JSON in the event the `getAdminMenu()` selector returns a falsey value due to the state is not yet beingpopulated with menu data from the REST API.
* Add static fallback data to represent the structure in the approved spreadsheet with translations.

## Testing instructions

* Checkout this PR.
* Open `client/state/admin-menu/fallback-data.json` and amend the `title` prop of the first menu item from `Feedback` to `Testing 123` (or similar). Save the file.
* Apply D49005-code
* Apply blog sticker
* Build calypso - `yarn && yarn start`.
* Visit http://calypso.localhost:3000/?flags=nav-unification.
* You should see a two stage render - initially the Nav will render with the first item as `Testing 123` (or whatever you modified it to be in the `.json` file). Then as the REST API request resolves you should see the Nav update to match the data from the API as generated by D49005-code.
* Also check the static fallback nav confirms to the structure shown in the spreadsheet.

Fixes https://github.com/Automattic/wp-calypso/issues/45487

## Screenshots

Notice how the menu changes from `Testing 123` (static fallback data) to `Feedback` (dynamic data from REST API).

![Screen Capture on 2020-09-22 at 14-52-28](https://user-images.githubusercontent.com/444434/93891468-58741600-fce3-11ea-97fc-aad2d0a1f9a2.gif)
