### PR TITLE
Jetpack Connect: fix Atomic reconnection flow

### DIFF
--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -1,4 +1,8 @@
+export const CALYPSO_MY_PLAN_PAGE = '/plans/my-plan/';
+export const CALYPSO_PLANS_PAGE = '/plans/';
+export const CALYPSO_REDIRECTION_PAGE = '/posts/';
 export const IS_DOT_COM_GET_SEARCH = 'isDotComGetSearch';
+export const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 export const JETPACK_MINIMUM_WORDPRESS_VERSION = '4.7';
 export const JPC_PATH_PLANS = '/jetpack/connect/plans';
 export const JPC_PATH_REMOTE_INSTALL = '/jetpack/connect/install';

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -131,7 +131,12 @@ export default function () {
 	}
 
 	if ( shouldShowOfferResetFlow() ) {
-		plansV2( `/jetpack/connect/plans`, siteSelection, controller.offerResetContext );
+		plansV2(
+			`/jetpack/connect/plans`,
+			siteSelection,
+			controller.offerResetRedirects,
+			controller.offerResetContext
+		);
 	} else {
 		page(
 			'/jetpack/connect/plans/:interval(yearly|monthly)?/:site',

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -30,7 +30,13 @@ import { getPlanBySlug } from 'state/plans/selectors';
 import { getProductBySlug } from 'state/products-list/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
-import { JPC_PATH_PLANS } from './constants';
+import {
+	CALYPSO_MY_PLAN_PAGE,
+	CALYPSO_PLANS_PAGE,
+	CALYPSO_REDIRECTION_PAGE,
+	JETPACK_ADMIN_PATH,
+	JPC_PATH_PLANS,
+} from './constants';
 import { bumpStat } from 'lib/analytics/mc';
 import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -39,11 +45,6 @@ import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { persistSignupDestination } from 'signup/utils';
 import { isJetpackProductSlug as getJetpackProductSlug } from 'lib/products-values';
-
-const CALYPSO_PLANS_PAGE = '/plans/';
-const CALYPSO_MY_PLAN_PAGE = '/plans/my-plan/';
-const CALYPSO_REDIRECTION_PAGE = '/posts/';
-const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 
 class Plans extends Component {
 	static propTypes = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* With the introduction of Offer Reset, we didn't account for the Atomic reconnection flow. Because of this, we are sending Atomic site owners to the Jetpack Plans page instead of to wp-admin after they reconnect to Jetpack. This PRs changes that by reintroducing a set of redirections we had in the past, including one that solves this issue.

#### Implementation notes

95% of these changes come directly from here: https://github.com/Automattic/wp-calypso/blob/master/client/jetpack-connect/plans.jsx#L74-L94. Make sure to read that piece of code so you understand what redirections are being introduced here.

#### Testing instructions

Prerequisite: Atomic site (Business or eCommerce plan).

* Run this PR.
* Manually disconnect Jetpack via the CLI (go to `:siteDomain/_cli` and type `jetpack disconnect blog` or use Jetpack Debugger - under the Blog Details section).
* Visit wp-admin and reconnect your site to Jetpack using the **old** flow (Safari works with the old flow).
* Verify that you are redirect to wp-admin and not to the Jetpack Plans page.
* Make sure that the connection flow still works for Jetpack sites. Try the old flow (Safari) and the in-place flow (Chrome or Firefox).

Fixes 1169247016322522-as-1194461636151967

#### Demo
##### Before
![Kapture 2020-09-22 at 11 53 38](https://user-images.githubusercontent.com/3418513/93899900-2a82d780-fccb-11ea-87a2-7b46f94e2c53.gif)

##### After
![Kapture 2020-09-22 at 11 47 10](https://user-images.githubusercontent.com/3418513/93899908-2bb40480-fccb-11ea-8ad1-5e5bbbff2b18.gif)
