### PR TITLE
Jetpack Offer Reset: Update Jetpack checklist Backup item to show for recent purchases

### DIFF
--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -12,4 +12,5 @@ export interface Purchase {
 	mostRecentRenewDate?: string;
 	productSlug: string;
 	siteId: number;
+	subscribedDate: string;
 }

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -182,7 +182,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 		const isRewindUnavailable = rewindState === 'unavailable';
 
 		const hasJetpackProductInstallation = isPaidPlan || hasAntiSpam;
-		const hasRecentJetpackBackupPurchase = this.hasRecentJetpackBackupPurchase();
+		const forceShowJetpackBackupTask = isRewindUnavailable && this.hasRecentJetpackBackupPurchase();
 
 		return (
 			<Fragment>
@@ -213,7 +213,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 						onClick={ this.handleTaskStart( { taskId: 'jetpack_protect' } ) }
 					/>
 
-					{ ( ( isPaidPlan && isRewindAvailable ) || hasRecentJetpackBackupPurchase ) && (
+					{ ( ( isPaidPlan && isRewindAvailable ) || forceShowJetpackBackupTask ) && (
 						<Task
 							id="jetpack_rewind"
 							title={ translate( 'Backup and Scan' ) }
@@ -235,7 +235,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 					{ isPaidPlan &&
 						isRewindUnavailable &&
 						productInstallStatus &&
-						! hasRecentJetpackBackupPurchase && (
+						! forceShowJetpackBackupTask && (
 							<Task
 								id="jetpack_vaultpress"
 								title={ translate( "We're automatically turning on VaultPress." ) }

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -4,8 +4,9 @@
 import { isDesktop } from '@automattic/viewport';
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { get, includes } from 'lodash';
+import { get, includes, minBy } from 'lodash';
 import { localize, LocalizeProps } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -32,20 +33,27 @@ import { requestGuidedTour } from 'state/guided-tours/actions';
 import { URL } from 'types';
 import { hasFeature, getSitePlanSlug } from 'state/sites/plans/selectors';
 import getJetpackWpAdminUrl from 'state/selectors/get-jetpack-wp-admin-url';
-import { isBusinessPlan, isPremiumPlan, isJetpackOfferResetPlan } from 'lib/plans';
+import { isBusinessPlan, isPremiumPlan, isJetpackOfferResetPlan, planHasFeature } from 'lib/plans';
 import { FEATURE_VIDEO_UPLOADS_JETPACK_PRO } from 'lib/plans/constants';
-import { isJetpackAntiSpam } from 'lib/products-values';
+import { isJetpackAntiSpam, isJetpackBackupSlug } from 'lib/products-values';
+import { JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { Button, Card } from '@automattic/components';
 import JetpackProductInstall from 'my-sites/plans/current-plan/jetpack-product-install';
 import { getTaskList } from 'lib/checklist';
 import { settingsPath } from 'lib/jetpack/paths';
 import { CHECKLIST_KNOWN_TASKS } from 'state/data-layer/wpcom/checklist/index.js';
+import { getSitePurchases } from 'state/purchases/selectors';
 
 /**
  * Style dependencies
  */
 import './style.scss';
+
+/**
+ * Type dependencies
+ */
+import type { Purchase } from 'lib/purchases/types';
 
 interface Props {
 	hasVideoHosting: boolean;
@@ -57,6 +65,7 @@ interface Props {
 		  }[]
 		| undefined;
 	widgetCustomizerPaneUrl: URL | null;
+	sitePurchases: Purchase[];
 }
 
 class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
@@ -64,6 +73,34 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 		if ( typeof window !== 'undefined' && typeof window.hj === 'function' ) {
 			window.hj( 'trigger', 'plans_myplan_jetpack-checklist' );
 		}
+	}
+
+	hasRecentJetpackBackupPurchase() {
+		const { sitePurchases } = this.props;
+
+		const includesJetpackBackup = ( planOrProductSlug: string ) => {
+			return (
+				isJetpackBackupSlug( planOrProductSlug ) ||
+				JETPACK_BACKUP_PRODUCTS.some( ( backupSlug ) => {
+					return planHasFeature( planOrProductSlug, backupSlug );
+				} )
+			);
+		};
+
+		const purchasesWithJetpackBackup = sitePurchases.filter( ( sitePurchase ) =>
+			includesJetpackBackup( sitePurchase.productSlug )
+		);
+
+		const earliestPurchaseWithJetpackBackup = minBy( purchasesWithJetpackBackup, ( purchase ) =>
+			moment( purchase.subscribedDate )
+		);
+
+		return (
+			!! earliestPurchaseWithJetpackBackup &&
+			moment( earliestPurchaseWithJetpackBackup.subscribedDate ).isAfter(
+				moment().subtract( 5, 'minutes' )
+			)
+		);
 	}
 
 	isComplete( taskId: string ): boolean {
@@ -145,6 +182,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 		const isRewindUnavailable = rewindState === 'unavailable';
 
 		const hasJetpackProductInstallation = isPaidPlan || hasAntiSpam;
+		const hasRecentJetpackBackupPurchase = this.hasRecentJetpackBackupPurchase();
 
 		return (
 			<Fragment>
@@ -175,7 +213,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 						onClick={ this.handleTaskStart( { taskId: 'jetpack_protect' } ) }
 					/>
 
-					{ isPaidPlan && isRewindAvailable && (
+					{ ( ( isPaidPlan && isRewindAvailable ) || hasRecentJetpackBackupPurchase ) && (
 						<Task
 							id="jetpack_rewind"
 							title={ translate( 'Backup and Scan' ) }
@@ -194,18 +232,23 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 						/>
 					) }
 
-					{ isPaidPlan && isRewindUnavailable && productInstallStatus && (
-						<Task
-							id="jetpack_vaultpress"
-							title={ translate( "We're automatically turning on VaultPress." ) }
-							completedTitle={ translate( "We've automatically turned on VaultPress." ) }
-							completedButtonText={ translate( 'View security dashboard' ) }
-							completed={ vaultpressFinished }
-							href="https://dashboard.vaultpress.com"
-							inProgress={ ! vaultpressFinished }
-							onClick={ this.handleTaskStart( { taskId: CHECKLIST_KNOWN_TASKS.JETPACK_BACKUPS } ) }
-						/>
-					) }
+					{ isPaidPlan &&
+						isRewindUnavailable &&
+						productInstallStatus &&
+						! hasRecentJetpackBackupPurchase && (
+							<Task
+								id="jetpack_vaultpress"
+								title={ translate( "We're automatically turning on VaultPress." ) }
+								completedTitle={ translate( "We've automatically turned on VaultPress." ) }
+								completedButtonText={ translate( 'View security dashboard' ) }
+								completed={ vaultpressFinished }
+								href="https://dashboard.vaultpress.com"
+								inProgress={ ! vaultpressFinished }
+								onClick={ this.handleTaskStart( {
+									taskId: CHECKLIST_KNOWN_TASKS.JETPACK_BACKUPS,
+								} ) }
+							/>
+						) }
 
 					{ hasJetpackProductInstallation && productInstallStatus && (
 						<Task
@@ -384,6 +427,7 @@ function mapStateToProps( state ) {
 			siteId &&
 			hasFeature( state, siteId, FEATURE_VIDEO_UPLOADS_JETPACK_PRO ) &&
 			( ! isJetpackOfferResetPlan( planSlug ) || isMinimumVersion ),
+		sitePurchases: getSitePurchases( state, siteId ),
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In cases where a user comes to the Jetpack checklist from the connect flow, it was happening fast enough that the checklist would load before Rewind was available on the site. This was causing the checklist to show the VaultPress checklist task instead of the Jetpack Backup one.

This PR handles this as a special case where if a user has purchased Jetpack Backup within the past 5 minutes and Rewind is unavailable, then the Jetpack Backup task will be shown and the VaultPress task will not be shown.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set up a new Jurassic Ninja site.
2. In the Jetpack plugin code, edit [the plansPromptUrl](https://github.com/Automattic/jetpack/blob/master/class.jetpack-connection-banner.php#L198) to be http://calypso.localhost:3000/jetpack/connect/plans/[SITE_SLUG]/. This will ensure you can test coming from the connect flow.
3. Make sure the Calypso dev environment is running.
3. Go through the connect flow and purchase any plan that includes Jetpack Backup.
4. When you are taken to `/plans/my-plan/[SITE_SLUG]`, verify that the Jetpack Backup task shows instead of the VaultPress one.

Fixes pbtFFM-rl-p2#comment-704