### PR TITLE
Correcting incorrect case on the plans page.

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1010,7 +1010,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_PREMIUM_CONTENT_BLOCK ]: {
 		getSlug: () => constants.FEATURE_PREMIUM_CONTENT_BLOCK,
-		getTitle: () => i18n.translate( 'Subscriber-only Content' ),
+		getTitle: () => i18n.translate( 'Subscriber-only content' ),
 		getDescription: () => i18n.translate( 'Limit content to paying subscribers.' ),
 	},
 


### PR DESCRIPTION
This PR is just a small tweak, changing the line "Subscriber-only Content" to "Subscriber-only content":

Here's a screenshot highlight the line that will change:
<img width="846" alt="Screen Shot 2020-09-17 at 8 35 11 AM" src="https://user-images.githubusercontent.com/35781181/93922209-a25afd00-fcdf-11ea-905a-eeb20d284555.png">


#### Testing instructions

* Checkout this PR and start Calypso
* Navigate to the plans page and confirm that the line of copy has changed.
