### PR TITLE
Add missing dependencies to packages/components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -39,6 +39,10 @@
 		"react": "^16.8",
 		"react-dom": "^16.8"
 	},
+	"devDependencies": {
+		"@storybook/addon-actions": "^5.3.18",
+		"enzyme": "^3.11.0"
+	},
 	"scripts": {
 		"clean": "npx rimraf dist && tsc --build --clean",
 		"prepublish": "yarn run clean",


### PR DESCRIPTION
### Background

There are a few undeclared dependencies, found by running `npx @yarnpkg/doctor`:

```
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/components/src/button/index.stories.jsx:5:1: Undeclared dependency on @storybook/addon-actions
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/components/src/button/docs/example.jsx:5:1: Undeclared dependency on components
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/components/src/button/docs/example.jsx:12:1: Undeclared dependency on devdocs
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/components/src/button/test/index.js:6:1: Undeclared dependency on enzyme
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/components/src/progress-bar/test/index.jsx:8:1: Undeclared dependency on enzyme
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/components/src/card/test/index.js:4:1: Undeclared dependency on enzyme
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/components/src/root-child/test/index.jsx:8:1: Undeclared dependency on enzyme
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/components/src/suggestions/docs/example.jsx:9:1: Undeclared dependency on components
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/components/src/suggestions/test/index.js:5:1: Undeclared dependency on enzyme
```


### Changes

Adds missing dependencies to `packages/components`. Version ranges have been copied from `./package.json`

### Testing instructions

Run `cd packages/components && npx @yarnpkg/doctor` and check most missing dependencies are gone:


```
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/components/src/button/docs/example.jsx:5:1: Undeclared dependency on components
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/components/src/button/docs/example.jsx:12:1: Undeclared dependency on devdocs
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/components/src/suggestions/docs/example.jsx:9:1: Undeclared dependency on components
```

Those will be fixed when we drop package-relative imports