### PR TITLE
Jetpack Cloud: Make non-EN locales of Jetpack Cloud pricing available when logged out

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -55,6 +55,7 @@ import { setStore } from 'state/redux-store';
 import { requestUnseenStatus } from 'state/reader-ui/seen-posts/actions';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import { inJetpackCloudOAuthOverride } from 'lib/jetpack/oauth-override';
+import { getLanguageSlugs } from 'lib/i18n-utils/utils';
 
 const debug = debugFactory( 'calypso' );
 
@@ -129,6 +130,7 @@ const oauthTokenMiddleware = () => {
 
 		if ( isJetpackCloud() && config.isEnabled( 'jetpack/pricing-page' ) ) {
 			loggedOutRoutes.push( '/pricing' );
+			getLanguageSlugs().forEach( ( slug ) => loggedOutRoutes.push( `/${ slug }/pricing` ) );
 		}
 
 		// Forces OAuth users to the /login page if no token is present


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes all the translated versions of the Jetpack Cloud pricing page available to logged out users.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In an incognito window, visit `http://jetpack.cloud.localhost:3000/[LANGUAGE_SLUG]/pricing` for any language slug. Verify that you are taken to the pricing page for the locale if it is translated, and to the EN version if it is not.

Fixes #1169247016322522-as-1194966372177489