### PR TITLE
chore: make secrets convenience script

### DIFF
--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -46,6 +46,11 @@ source:
 
 	@cd $(CALYPSO_DIR) && yarn run build-desktop:source
 
+secrets:
+	$(info Making app secrets...)
+
+	@cd $(CALYPSO_DIR) && yarn run build-desktop:secrets
+
 # Note: cannot prepend prepend desktop/package.json with full path: cannot be resolved on Windows.
 package: PACKAGE_ELECTRON_VERSION = $(shell cd $(DESKTOP_DIR) && node -e "console.log(require('./package.json').devDependencies.electron)")
 package:

--- a/desktop/bin/build-desktop-secrets.js
+++ b/desktop/bin/build-desktop-secrets.js
@@ -9,7 +9,7 @@ const { execSync } = require( 'child_process' );
 
 const CALYPSO_SECRETS_ENCRYPTION_KEY = process.env.CALYPSO_SECRETS_ENCRYPTION_KEY;
 if ( ! CALYPSO_SECRETS_ENCRYPTION_KEY ) {
-	console.error( 'Failed to make decrypt: CALYPSO_SECRETS_ENCRYPTION_KEY is not set.' );
+	console.error( 'Failed to decrypt: CALYPSO_SECRETS_ENCRYPTION_KEY is not set.' );
 	process.exit( 1 );
 }
 

--- a/desktop/bin/build-desktop-secrets.js
+++ b/desktop/bin/build-desktop-secrets.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console*/
+/* eslint-disable no-process-exit*/
+/* eslint-disable import/no-nodejs-modules*/
+
+const path = require( 'path' );
+const { execSync } = require( 'child_process' );
+
+const CALYPSO_SECRETS_ENCRYPTION_KEY = process.env.CALYPSO_SECRETS_ENCRYPTION_KEY;
+if ( ! CALYPSO_SECRETS_ENCRYPTION_KEY ) {
+	console.error( 'Failed to make decrypt: CALYPSO_SECRETS_ENCRYPTION_KEY is not set.' );
+	process.exit( 1 );
+}
+
+const PROJECT_DIR = path.join( __dirname, '../' );
+const REPO_DIR = path.join( PROJECT_DIR, '../' );
+
+const secrets = [
+	path.resolve( PROJECT_DIR, 'resource/calypso/secrets.json' ),
+	path.resolve( PROJECT_DIR, 'resource/certificates/mac.p12' ),
+	path.resolve( PROJECT_DIR, 'resource/certificates/win.p12' ),
+];
+
+for ( let i = 0; i < secrets.length; i++ ) {
+	const encrypted = secrets[ i ] + '.enc';
+	let decrypted;
+
+	if ( path.basename( secrets[ i ] ) === 'secrets.json' ) {
+		decrypted = path.join( REPO_DIR, 'config', 'secrets.json' );
+	} else {
+		decrypted = secrets[ i ];
+	}
+
+	let decryptFlags;
+	if ( process.platform === 'win32' ) {
+		decryptFlags = '-d';
+	} else {
+		decryptFlags = '-md md5 -d';
+	}
+
+	try {
+		execSync(
+			`openssl aes-256-cbc ${ decryptFlags } -in ${ encrypted } -out ${ decrypted } -k "${ CALYPSO_SECRETS_ENCRYPTION_KEY }"`
+		);
+	} catch ( e ) {
+		console.error( `Failed to decrypt ${ path.basename( encrypted ) }: `, e );
+		process.exit( 1 );
+	}
+}
+
+console.log( 'OK decrypted application secrets' );

--- a/desktop/bin/build-desktop-secrets.js
+++ b/desktop/bin/build-desktop-secrets.js
@@ -13,13 +13,13 @@ if ( ! CALYPSO_SECRETS_ENCRYPTION_KEY ) {
 	process.exit( 1 );
 }
 
-const PROJECT_DIR = path.join( __dirname, '../' );
-const REPO_DIR = path.join( PROJECT_DIR, '../' );
+const PROJECT_DIR = path.resolve( __dirname, '../' );
+const REPO_DIR = path.resolve( PROJECT_DIR, '../' );
 
 const secrets = [
-	path.resolve( PROJECT_DIR, 'resource/calypso/secrets.json' ),
-	path.resolve( PROJECT_DIR, 'resource/certificates/mac.p12' ),
-	path.resolve( PROJECT_DIR, 'resource/certificates/win.p12' ),
+	path.resolve( PROJECT_DIR, 'resource', 'calypso', 'secrets.json' ),
+	path.resolve( PROJECT_DIR, 'resource', 'certificates', 'mac.p12' ),
+	path.resolve( PROJECT_DIR, 'resource', 'certificates', 'win.p12' ),
 ];
 
 for ( let i = 0; i < secrets.length; i++ ) {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"build-desktop": "run-s build-desktop:source build-desktop:install-app-deps build-desktop:app",
 		"build-desktop:source": "run-s build-desktop:config build-desktop:server build-desktop:client build-desktop:static",
 		"build-desktop:config": "node desktop/bin/build-desktop-config.js",
+		"build-desktop:secrets": "node desktop/bin/build-desktop-secrets.js",
 		"build-desktop:server": "BROWSERSLIST_ENV=server CALYPSO_ENV=desktop webpack --config client/webpack.config.desktop.js --display errors-only",
 		"build-desktop:client": "CALYPSO_ENV=desktop DESKTOP_MONOREPO=true yarn run build-client-fallback",
 		"build-desktop:static": "npx --no-install ncp static desktop/public",


### PR DESCRIPTION
### Description

This PR adds some a script to generate application secrets more conveniently when developing/testing locally.

### To Test

1. Export the correct value of `CALYPSO_SECRETS_ENCRYPTION_KEY`
2. Generate application secrets with `yarn run build-desktop:secrets` or `make -f desktop/Makefile secrets` from repo root