### PR TITLE
Plans: change the source query parameter that triggers the banner

### DIFF
--- a/client/my-sites/plans-v2/plans-header.tsx
+++ b/client/my-sites/plans-v2/plans-header.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { translate } from 'i18n-calypso';
 
@@ -53,13 +53,9 @@ const PlansHeader = ( { context }: { context: PageJS.Context } ) => {
 			?.map( ( { productSlug } ) => productSlug )
 			.filter( ( productSlug ) => JETPACK_PRODUCTS_LIST.includes( productSlug ) ) ?? [];
 
-	// When coming from in-connect flow, the url contains 'source=jetpack-plans' query param.
-	const isInConnectFlow = useMemo(
-		() => context.query?.source && context.query.source === 'jetpack-plans',
-		[ siteId ]
-	);
+	// When coming from in-connect flow, the url contains 'source=jetpack-connect-plans' query param.
+	const isInConnectFlow = context.query?.source === 'jetpack-connect-plans';
 
-	// TODO: Maybe make Notice dismissal persistent?
 	const [ showNotice, setShowNotice ] = useState( true );
 
 	// Only show ConnectFlowPlansHeader if coming from in-connect flow and if no products or plans have been purchased.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Now, users coming from the in-place connection flow will be identified by the `source=jetpack-connect-plans` and not by 
`source=jetpack-plans`.

#### Testing instructions

* Run this PR.
* Visit http://calypso.localhost:3000/plans/:site?source=jetpack-connect-plans.
* Verify that a banner that says "Jetpack is now connected. Next select a plan." appears at the top of the page.
* Visit http://calypso.localhost:3000/plans/:site?source=jetpack-plans.
* Verify that there is no banner at the top of the page.

Fixes 1169247016322522-as-1195150225960508

#### Demo

##### `source=jetpack-plans`
![image](https://user-images.githubusercontent.com/3418513/93937834-bc580800-fcfe-11ea-8cc2-cd29c6f49399.png)

##### `source=jetpack-connect-plans`
![image](https://user-images.githubusercontent.com/3418513/93937855-c5e17000-fcfe-11ea-96eb-44362613793d.png)
