### PR TITLE
Fix warning about a missing prop that isn't technically required

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -46,7 +46,7 @@ class AutoLoadingHomepageModal extends Component {
 		siteId: PropTypes.number,
 		isVisible: PropTypes.bool,
 		onClose: PropTypes.func,
-		installingThemeId: PropTypes.string.isRequired,
+		installingThemeId: PropTypes.string,
 	};
 
 	closeModalHandler = ( activate = false ) => () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the `.isRequired` annotation from the `AutoLoadingHomepageModal`'s `installingThemeId` prop

The `installingThemeId` prop isn't actually required because `<AutoLoadingHomepageModal>` is designed to be mounted and hidden as soon as you navigate to the themes page; before any install process starts.

The `getPreActivateThemeId` selector which provides the value for this prop returns `undefined` when there's no theme install in progress. So even the store considers `undefined` a valid value for this prop.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open dev console
* go to `/themes/:siteId` in a development build
* see that there is no React warning about a missing `installingThemeId` prop in the `AutoLoadingHomepageModal` component
