### PR TITLE
Add pinghub handler to wpcom-xhr-wrapper

### DIFF
--- a/client/lib/wpcom-xhr-wrapper/index.js
+++ b/client/lib/wpcom-xhr-wrapper/index.js
@@ -7,6 +7,7 @@ import debugModule from 'debug';
  * Internal dependencies
  */
 import userUtils from 'lib/user/utils';
+import handlePinghubMessage from './pinghub';
 
 /**
  * Module variables
@@ -16,6 +17,10 @@ const debug = debugModule( 'calypso:wpcom-xhr-wrapper' );
 export default async function ( params, callback ) {
 	const xhr = ( await import( /* webpackChunkName: "wpcom-xhr-request" */ 'wpcom-xhr-request' ) )
 		.default;
+
+	if ( params.path && params.path.startsWith( '/pinghub/' ) ) {
+		return handlePinghubMessage( params, callback );
+	}
 
 	return xhr( params, function ( error, response, headers ) {
 		if ( error && error.name === 'InvalidTokenError' ) {

--- a/client/lib/wpcom-xhr-wrapper/pinghub.js
+++ b/client/lib/wpcom-xhr-wrapper/pinghub.js
@@ -1,0 +1,71 @@
+const pinghubConnections = {};
+
+function pinghubConnect( { path }, callback ) {
+	if ( pinghubConnections[ path ] ) {
+		callback( { body: { type: 'error', text: 'already subscribed' }, code: 444 } );
+		return;
+	}
+
+	const ws = new window.WebSocket( 'wss://public-api.wordpress.com' + path );
+	pinghubConnections[ path ] = ws;
+
+	ws.onopen = function () {
+		callback( { body: { type: 'open' }, code: 207 } );
+	};
+
+	ws.onclose = function () {
+		delete pinghubConnections[ path ];
+		callback( { body: { type: 'close' }, code: 200 } );
+	};
+
+	ws.onerror = function () {
+		delete pinghubConnections[ path ];
+		callback( { body: { type: 'error' }, code: 500 } );
+	};
+
+	ws.onmessage = function ( e ) {
+		callback( { body: { type: 'message', data: e.data }, code: 207 } );
+	};
+}
+
+function pinghubDisconnect( { path }, callback ) {
+	const ws = pinghubConnections[ path ];
+	if ( ! ws ) {
+		callback( { body: { type: 'error', data: 'not connected' }, code: 200 } );
+		return;
+	}
+
+	ws.close();
+	delete pinghubConnections[ path ];
+	callback( { body: { type: 'disconnect' }, code: 200 } );
+}
+
+function pinghubSend( { path, message }, callback ) {
+	const ws = pinghubConnections[ path ];
+	if ( ! ws ) {
+		callback( { body: { type: 'error' }, code: 404 } );
+		return;
+	}
+
+	try {
+		ws.send( message );
+		callback( { body: { type: 'sent' }, code: 201 } );
+	} catch ( e ) {
+		callback( { body: { type: 'error' }, code: 600 } );
+	}
+}
+
+export default function handlePinghubMessage( params, callback ) {
+	switch ( params.action ) {
+		case 'connect':
+			pinghubConnect( params, callback );
+			break;
+		case 'disconnect':
+			pinghubDisconnect( params, callback );
+			break;
+
+		case 'send':
+			pinghubSend( params, callback );
+			break;
+	}
+}


### PR DESCRIPTION
Add pinghub support for WebSocket connections to `wpcom-xhr-wrapper`, the `wpcom` handler used by Desktop app. The Desktop app uses OAuth and doesn't use the REST proxy iframe.

The pinghub handler intercepts requests to `/pinghub/*` paths and instead of making HTTP requests (XHR or fetch), handles them specially with WebSockets. In the web version of Calypso, this is done by the REST proxy provider loaded in the iframe.

This code doesn't fully work yet, it's just a proof of concept that shows what needs to be done to make Pinghub WebSockets work in Desktop app.