### PR TITLE
Fix warning about duplicate React keys in ThemeMoreButton

### DIFF
--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -81,7 +81,7 @@ class ThemeMoreButton extends Component {
 								const url = option.getUrl( this.props.themeId );
 								return (
 									<PopoverMenuItem
-										key={ option.label }
+										key={ `${ option.label }-geturl` }
 										action={ this.popoverAction( option.action, option.label ) }
 										href={ url }
 										target={ isOutsideCalypso( url ) ? '_blank' : null }
@@ -93,7 +93,7 @@ class ThemeMoreButton extends Component {
 							if ( option.action ) {
 								return (
 									<PopoverMenuItem
-										key={ option.label }
+										key={ `${ option.label }-action` }
 										action={ this.popoverAction( option.action, option.label ) }
 									>
 										{ option.label }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, two different `<PopoverMenuItem />` components have the same `key = { option.label }` inside `<ThemeMoreButton />`
* The `key` values are changed to `${ option.label }-geturl` and `${ option.label }-action` to avoid duplicate keys

#### Testing instructions

* open dev console
* go to `/themes/:siteId` in a development build
* on any Theme card, click on the `⋮` button
* see that there is no React warning about duplicate keys

<img width="1136" alt="Screenshot 2020-09-23 at 09 41 16" src="https://user-images.githubusercontent.com/1083581/93981966-eeaa4980-fd80-11ea-8f28-4895ed9ef00f.png">

