### PR TITLE
Enable premium domain purchases on production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,6 +36,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
+		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/production.json
+++ b/config/production.json
@@ -35,6 +35,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
+		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,6 +38,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
+		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This will enable premium domain purchases in production (it's enabling the `domains/premium-domain-purchases` feature flag in the production env.

#### Testing instructions

* Just verify that you can see premium domains on staging. Once it's deployed premium domains should be visible when you're not proxied too
