### PR TITLE
Add missing dependencies to calypso-codemods

### DIFF
--- a/packages/calypso-codemods/package.json
+++ b/packages/calypso-codemods/package.json
@@ -21,6 +21,8 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/calypso-codemods#readme",
 	"dependencies": {
+		"@babel/core": "^7.11.1",
+		"@babel/preset-env": "^7.11.0",
 		"5to6-codemod": "^1.8.0",
 		"jscodeshift": "^0.9.0",
 		"lodash": "^4.17.10",


### PR DESCRIPTION
### Background

There are a few undeclared dependencies, found by running `npx @yarnpkg/doctor`:

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/combine-state-utils-imports/basic.js:1:1: Undeclared dependency on state
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/combine-state-utils-imports/basic.js:2:1: Undeclared dependency on state
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/combine-reducer-with-persistence/basic.js:1:1: Undeclared dependency on redux
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/combine-reducer-with-persistence/basic.js:6:1: Undeclared dependency on internal
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/i18n-mixin-to-localize/basic.js:1:1: Undeclared dependency on react
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/remove-create-reducer/create-reducer.js:2:1: Undeclared dependency on state
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/rename-combine-reducers/basic.js:1:1: Undeclared dependency on state
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/sort-imports/incorrect-docblocks.js:4:1: Undeclared dependency on chicken
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/sort-imports/incorrect-docblocks.js:5:1: Undeclared dependency on okapi-me
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/sort-imports/only-imports.js:2:1: Undeclared dependency on chicken
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/sort-imports/only-imports.js:3:1: Undeclared dependency on okapi-me
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/sort-imports/with-body.js:2:1: Undeclared dependency on chicken
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/tests/sort-imports/with-body.js:3:1: Undeclared dependency on okapi-me
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-codemods/package.json:25:18: Unmet transitive peer dependency on @babel/preset-env@^7.1.6, via jscodeshift@^0.9.0
➤ YN0000: └ Completed in 0.76s
```

Most of them are false alarms as they are used in text fixtures. But the last one is valid.

### Changes

Adds missing dependencies to `packages/components`. Version ranges have been copied from `./package.json` or `./client/package.json` (both end up in `./node_modules`, which is the version that calypso-codemods would have used)


#### Testing instructions

Run `cd packages/calypso-codemods && npx @yarnpkg/doctor` and check the warning about `@babel/preset-env` is gone.
