### PR TITLE
Update unified nav to expect array data from REST API

### DIFF
--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -15,10 +15,7 @@ const useSiteMenuItems = () => {
 	const dispatch = useDispatch();
 	const selectedSiteId = useSelector( getSelectedSiteId );
 
-	const menuItems = useSelector( ( state ) => {
-		const menu = getAdminMenu( state, selectedSiteId );
-		return menu ? Object.values( menu ) : [];
-	} );
+	const menuItems = useSelector( ( state ) => getAdminMenu( state, selectedSiteId ) );
 
 	useEffect( () => {
 		if ( selectedSiteId !== null ) {
@@ -26,7 +23,8 @@ const useSiteMenuItems = () => {
 		}
 	}, [ dispatch, selectedSiteId ] );
 
-	return menuItems;
+	// Selector may return `null` so add sensible default
+	return menuItems ?? [];
 };
 
 export default useSiteMenuItems;

--- a/client/state/admin-menu/reducer.js
+++ b/client/state/admin-menu/reducer.js
@@ -5,10 +5,10 @@ import { withStorageKey, keyedReducer } from 'state/utils';
 import 'state/data-layer/wpcom/sites/admin-menu';
 import { ADMIN_MENU_RECEIVE } from 'state/action-types';
 
-export const adminMenu = ( state = {}, action ) => {
+export const adminMenu = ( state = [], action ) => {
 	switch ( action.type ) {
 		case ADMIN_MENU_RECEIVE:
-			return { ...state, ...action.menu };
+			return [ ...state, ...action.menu ];
 		default:
 			return state;
 	}

--- a/client/state/admin-menu/test/fixture/menu-fixture.js
+++ b/client/state/admin-menu/test/fixture/menu-fixture.js
@@ -1,76 +1,76 @@
-export default {
-	0: {
+export default [
+	{
 		icon: 'dashicons-feedback',
 		slug: 'feedback',
 		title: 'Feedback',
 		type: 'menu-item',
 		url: 'https://examplewebsite.wordpress.com/wp-admin/admin.php?page=feedback',
-		children: {
-			1: {
+		children: [
+			{
 				parent: 'feedback',
 				slug: 'edit-phppost_typefeedback',
 				title: 'Feedback',
 				type: 'submenu-item',
 				url: 'https://examplewebsite.wordpress.com/wp-admin/edit.php?post_type=feedback',
 			},
-			2: {
+			{
 				parent: 'feedback',
 				slug: 'polls',
 				title: 'Polls',
 				type: 'submenu-item',
 				url: 'http://feedback?page=polls',
 			},
-			3: {
+			{
 				parent: 'feedback',
 				slug: 'ratings',
 				title: 'Ratings',
 				type: 'submenu-item',
 				url: 'http://feedback?page=ratings',
 			},
-		},
+		],
 	},
-	1: {
+	{
 		icon: 'dashicons-dashboard',
 		slug: 'index-php',
 		title: 'Dashboard',
 		type: 'menu-item',
 		url: 'https://examplewebsite.wordpress.com/wp-admin/index.php',
-		children: {
-			0: {
+		children: [
+			{
 				parent: 'index.php',
 				slug: 'index-php',
 				title: 'Home',
 				type: 'submenu-item',
 				url: 'https://examplewebsite.wordpress.com/wp-admin/index.php',
 			},
-			6: {
+			{
 				parent: 'index.php',
 				slug: 'my-comments',
 				title: 'Comments I&#8217;ve Made',
 				type: 'submenu-item',
 				url: 'index.php?page=my-comments',
 			},
-			7: {
+			{
 				parent: 'index.php',
 				slug: 'stats',
 				title: 'Site Stats',
 				type: 'submenu-item',
 				url: 'index.php?page=stats',
 			},
-			8: {
+			{
 				parent: 'index.php',
 				slug: 'my-blogs',
 				title: 'My Blogs',
 				type: 'submenu-item',
 				url: 'index.php?page=my-blogs',
 			},
-			9: {
+			{
 				parent: 'index.php',
 				slug: 'subscriptions',
 				title: 'Blogs I Follow',
 				type: 'submenu-item',
 				url: 'index.php?page=subscriptions',
 			},
-		},
+		],
 	},
-};
+];


### PR DESCRIPTION
With the merge of the REST API endpoint the endpoint now returns data as an array. Thus we need to update the state and component to expect that format.

#### Changes proposed in this Pull Request

* Update reducer state shape to expect array data.
* Update `useSiteMenuItems` hook to default to empty array of data.

#### Testing instructions

* Checkout this PR.
* No need to apply diffs as they are now merged.
* Apply blog sticker.
* Run calypso
* Visit http://calypso.localhost:3000/?flags=nav-unification.
* You should see the Unified Nav loaded as per `master`.
* In the console check the state:

```js
state.adminMenu
```

It should have a shape of:

```js
{
    123456: [
        // array of menu data (NOT an object!)
    ]
}
```

Fixes https://github.com/Automattic/wp-calypso/issues/45868
