### PR TITLE
Fix schema validation warning on /theme-filters API response

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { get, isEmpty, isEqual, noop, some } from 'lodash';
+import { get, isEmpty, isEqual, noop } from 'lodash';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import photon from 'photon';
@@ -112,8 +112,8 @@ export class Theme extends Component {
 
 	isBeginnerTheme() {
 		const { theme } = this.props;
-		const skillLevels = get( theme, [ 'taxonomies', 'theme_skill-level' ] );
-		return some( skillLevels, { slug: 'beginner' } );
+		const skillLevel = get( theme, [ 'taxonomies', 'theme_skill-level' ] );
+		return skillLevel && skillLevel.slug === 'beginner';
 	}
 
 	renderPlaceholder() {

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { get, isEmpty, isEqual, noop } from 'lodash';
+import { get, isEmpty, isEqual, noop, some } from 'lodash';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import photon from 'photon';
@@ -112,8 +112,8 @@ export class Theme extends Component {
 
 	isBeginnerTheme() {
 		const { theme } = this.props;
-		const skillLevel = get( theme, [ 'taxonomies', 'theme_skill-level' ] );
-		return skillLevel && skillLevel.slug === 'beginner';
+		const skillLevels = get( theme, [ 'taxonomies', 'theme_skill-level' ] );
+		return some( skillLevels, { slug: 'beginner' } );
 	}
 
 	renderPlaceholder() {

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -92,20 +92,28 @@ export const themeFiltersSchema = {
 	patternProperties: {
 		// Taxonomy ID
 		'^[\\w-]+$': {
-			title: 'Taxonomy',
-			type: 'object',
-			patternProperties: {
-				// Term (i.e. filter) ID
-				'^\\w+$': {
-					title: 'Term',
+			anyOf: [
+				{
+					title: 'Taxonomy',
 					type: 'object',
-					properties: {
-						name: { type: 'string' },
-						description: { type: 'string' },
+					patternProperties: {
+						// Term (i.e. filter) ID
+						'^\\w+$': {
+							title: 'Term',
+							type: 'object',
+							properties: {
+								name: { type: 'string' },
+								description: { type: 'string' },
+							},
+						},
 					},
+					uniqueItems: true,
 				},
-			},
-			uniqueItems: true,
+				// Certain properties (like "skill-levels") can be an empty array
+				{
+					type: 'array',
+				},
+			],
 		},
 	},
 	additionalProperties: false,

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -92,27 +92,19 @@ export const themeFiltersSchema = {
 	patternProperties: {
 		// Taxonomy ID
 		'^[\\w-]+$': {
-			anyOf: [
-				{
-					title: 'Taxonomy',
+			title: 'Taxonomy',
+			type: 'object',
+			patternProperties: {
+				// Term (i.e. filter) ID
+				'^\\w+$': {
+					title: 'Term',
 					type: 'object',
-					patternProperties: {
-						// Term (i.e. filter) ID
-						'^\\w+$': {
-							title: 'Term',
-							type: 'object',
-							properties: {
-								name: { type: 'string' },
-								description: { type: 'string' },
-							},
-						},
+					properties: {
+						name: { type: 'string' },
+						description: { type: 'string' },
 					},
 				},
-				// Certain properties (like "skill-levels") can be an empty array
-				{
-					type: 'array',
-				},
-			],
+			},
 		},
 	},
 	additionalProperties: false,

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -107,7 +107,6 @@ export const themeFiltersSchema = {
 							},
 						},
 					},
-					uniqueItems: true,
 				},
 				// Certain properties (like "skill-levels") can be an empty array
 				{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allowed properties defined in `themeFiltersSchema` to also be arrays
* This removes the schema validation warning that was triggered when calling the /theme-filters API endpoint (in particular, the response contains a `skill-level` key, mapped to an array value)

<img width="1792" alt="Markup 2020-09-23 at 13 52 51" src="https://user-images.githubusercontent.com/1083581/94008996-1eb71400-fda4-11ea-88a9-643b816df5a8.png">


#### Testing instructions

* open dev console
* go to `/themes/:siteId` in a development build
* refresh the page (this warning would only show when rendering the page on the server)
* See that there's no schema validation error regarding the theme filters data (there may be other unrelated warnings)


