### PR TITLE
Add missing dependencies for composite-checkout

### DIFF
--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -39,6 +39,7 @@
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
 		"@emotion/core": "^10.0.27",
 		"@emotion/styled": "^10.0.27",
+		"@wordpress/data": "^4.22.3",
 		"@wordpress/i18n": "^3.14.0",
 		"debug": "^4.1.1",
 		"emotion-theming": "^10.0.27",
@@ -46,10 +47,6 @@
 		"react-dom": "^16.12.0",
 		"react-stripe-elements": "^4.0.2",
 		"react": "^16.12.0"
-	},
-	"peerDependencies": {
-		"@wordpress/data": "^4.22",
-		"react": "^16.8"
 	},
 	"devDependencies": {
 		"@automattic/calypso-polyfills": "^1.0.0",

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -37,19 +37,26 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/composite-checkout#readme",
 	"dependencies": {
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
-		"@babel/runtime": "^7.11.1",
 		"@emotion/core": "^10.0.27",
 		"@emotion/styled": "^10.0.27",
 		"@wordpress/i18n": "^3.14.0",
-		"cache-loader": "^4.1.0",
 		"debug": "^4.1.1",
 		"emotion-theming": "^10.0.27",
 		"prop-types": "^15.7.2",
-		"react-stripe-elements": "^4.0.2"
+		"react-dom": "^16.12.0",
+		"react-stripe-elements": "^4.0.2",
+		"react": "^16.12.0"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^4.22",
 		"react": "^16.8"
+	},
+	"devDependencies": {
+		"@automattic/calypso-polyfills": "^1.0.0",
+		"@testing-library/jest-dom": "^5.9.0",
+		"@testing-library/react": "^10.0.5",
+		"cache-loader": "^4.1.0",
+		"webpack": "^4.44.1"
 	},
 	"private": true
 }


### PR DESCRIPTION
### Background

There are a few undeclared dependencies, found by running `npx @yarnpkg/doctor`:

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/package.json
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepare") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepublish") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/webpack.config.demo.js:2:17: Undeclared dependency on webpack
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/demo/index.js:2:1: Undeclared dependency on @automattic/calypso-polyfills
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/demo/index.js:9:1: Undeclared dependency on react-dom
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/test/checkout-provider.js:5:1: Undeclared dependency on @testing-library/react
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/test/checkout-provider.js:6:1: Undeclared dependency on @testing-library/jest-dom
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/test/checkout.js:5:1: Undeclared dependency on @testing-library/react
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/test/checkout.js:13:1: Undeclared dependency on @testing-library/jest-dom
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/test/line-items.js:5:1: Undeclared dependency on @testing-library/react
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/test/line-items.js:6:1: Undeclared dependency on @testing-library/jest-dom
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/src/components/order-review-line-items.tsx:11:1: Undeclared dependency on src
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/src/components/radio-button.tsx:10:1: Undeclared dependency on src
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/package.json:44:19: Unmet transitive peer dependency on webpack@^4.0.0, via cache-loader@^4.1.0
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/composite-checkout/package.json:48:28: Unmet transitive peer dependency on react-dom@^15.5.4 || ^16.0.0-0, via react-stripe-elements@^4.0.2
➤ YN0000: └ Completed in 6.19s
```


### Changes

* Adds missing dependencies to `packages/composite-checkout`. Version ranges have been copied from `./package.json` or `./client/package.json` (both end up in `./node_modules`, which is the version that composite-checkout would have used)

* Move some dependencies from `dependencies` to `devDependencies`

* Merge `peerDependencies` into `dependencies`, as they are required for building the package and it is not a plugin for any of those libraries.

### Testing instructions

* Run `cd packages/composite-checkout && npx @yarnpkg/doctor` and check the warning about missing dependencies are gone:

    ```
    ➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/composite-checkout/package.json
    ➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepare") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
    ➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepublish") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
    ➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/composite-checkout/src/components/order-review-line-items.tsx:11:1: Undeclared dependency on src
    ➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/composite-checkout/src/components/radio-button.tsx:10:1: Undeclared dependency on src
    ➤ YN0000: └ Completed in 5.4s
    ```

* Run `cd packages/composite-checkout && yarn prepare` in this branch and master, and compare that the result are the same (`diff -bur wp-calypso-branch/packages/composite-checkout/dist wp-calypso-master/packages/composite-checkout/dist`)

* Verify the demo site (`yarn composite-checkout-demo`) still works.

