### PR TITLE
Adds a optional base image with build caches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,25 @@
-FROM node:12.18.4 as builder
+ARG use_cache=false
+ARG node_version=12.18.4
+
+###################
+FROM node:${node_version} as builder-cache-false
+
+
+###################
+# This image contains a directory /calypso/.cache which includes caches
+# for yarn, terser, css-loader and babel.
+FROM registry.a8c.com/calypso/base:latest as builder-cache-true
+
+ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
+ENV NPM_CONFIG_CACHE=/calypso/.cache
+
+
+###################
+FROM builder-cache-${use_cache} as builder
 
 ARG commit_sha="(unknown)"
-ARG workers
+ARG workers=4
+ARG node_memory=8192
 ENV CONTAINER 'docker'
 ENV PROGRESS true
 ENV COMMIT_SHA $commit_sha
@@ -10,6 +28,7 @@ ENV WORKERS $workers
 ENV BUILD_TRANSLATION_CHUNKS true
 ENV CHROMEDRIVER_SKIP_DOWNLOAD true
 ENV PUPPETEER_SKIP_DOWNLOAD true
+ENV NODE_OPTIONS --max-old-space-size=$node_memory
 WORKDIR /calypso
 
 # Build a "base" layer
@@ -38,8 +57,9 @@ RUN yarn install --frozen-lockfile
 # change any time any of the Calypso source-code changes.
 RUN yarn run build && rm -fr .cache
 
+
 ###################
-FROM node:12.18.4-alpine as app
+FROM node:${node_version}-alpine as app
 
 ARG commit_sha="(unknown)"
 ENV COMMIT_SHA $commit_sha


### PR DESCRIPTION
### Background

TeamCity produces a docker image with some build caches (webpack, teserer, babel...) saved in `/calypso/.cache`. This image can be used as a base image to speed up webpack compilations.

### Changes

Introduce a build argument for Docker that allows to select a base image.

Note that nobody is using this build argument yet, so as long as the default case (no build argument) still works, this should be fine.

### Testing instructions

(Warning: these commands takes several minutes to complete)

* Run `docker build --pull -t wp-calypso:base .`, it should _not_ use `.../calypso/base:latest` as the base image

* Run `docker build --pull --build-arg use_cache=true -t wp-calypso:cache.`, it should use `.../calypso/base:latest` as the base image. For this to work you need access to the private docker registry. See PCYsg-stw-p2

* Using `https://github.com/wagoodman/dive`, inspect both images (tagged as `wp-calypso:base` and `wp-calypso:cache`. They should have about the same image size.

* Verify calypso.live still works. It does not use the cache yet, but it will show that the default case still works
