### PR TITLE
Spike: using i18nized packages in WP plugins

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
@@ -33,6 +33,8 @@ function enqueue_script_and_style() {
 		true
 	);
 
+	wp_set_script_translations( 'a8c-fse-editor-site-launch-script', 'full-site-editing' );
+
 	wp_enqueue_style(
 		'a8c-fse-editor-site-launch-style',
 		plugins_url( 'dist/editor-site-launch.css', __FILE__ ),

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -146,6 +146,7 @@
 		"@types/wordpress__plugins": "^2.3.6",
 		"@babel/preset-typescript": "^7.10.4",
 		"@wordpress/eslint-plugin": "^7.1.0",
-		"babel-jest": "^26.3.0"
+		"babel-jest": "^26.3.0",
+		"webpack": "^4.44.1"
 	}
 }

--- a/apps/editing-toolkit/webpack.config.js
+++ b/apps/editing-toolkit/webpack.config.js
@@ -10,6 +10,7 @@ const _ = require( 'lodash' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );
+const webpack = require( 'webpack' );
 
 const FSE_MODULE_PREFIX = 'a8c-fse';
 
@@ -90,6 +91,9 @@ function getWebpackConfig( env = {}, argv = {} ) {
 						}
 					}
 				},
+			} ),
+			new webpack.DefinePlugin( {
+				'process.env.TEXT_DOMAIN': '"full-site-editing"',
 			} ),
 		],
 		watch: isDevelopment,

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -284,6 +284,7 @@ const webpackConfig = {
 			'process.env.FORCE_REDUCED_MOTION': JSON.stringify(
 				!! process.env.FORCE_REDUCED_MOTION || false
 			),
+			'process.env.TEXT_DOMAIN': 'undefined',
 			global: 'window',
 		} ),
 		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -7,7 +7,8 @@ import { times } from 'lodash';
 import { Button, TextControl } from '@wordpress/components';
 import { Icon, search } from '@wordpress/icons';
 import { getNewRailcarId, recordTrainTracksRender } from '@automattic/calypso-analytics';
-import { useI18n } from '@automattic/react-i18n';
+import { __ } from '@wordpress/i18n';
+
 import type { DomainSuggestions } from '@automattic/data-stores';
 /**
  * Internal dependencies
@@ -103,7 +104,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	existingSubdomain,
 	segregateFreeAndPaid = false,
 } ) => {
-	const { __ } = useI18n();
 	const label = __( 'Search for a domain' );
 
 	const [ isExpanded, setIsExpanded ] = useState( false );
@@ -120,7 +120,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		domainSearch.trim(),
 		quantityExpanded,
 		domainCategory,
-		useI18n().i18nLocale
+		'en'
 	) as DomainSuggestion[] | undefined;
 
 	const domainSuggestions = allDomainSuggestions?.slice(
@@ -204,7 +204,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					<div className="domain-picker__suggestion-sections">
 						<>
 							{ segregateFreeAndPaid && (
-								<p className="domain-picker__suggestion-group-label">{ __( 'Keep sub-domain' ) }</p>
+								<p className="domain-picker__suggestion-group-label">
+									{ __( 'Keep sub-domain', process.env.TEXT_DOMAIN ) }
+								</p>
 							) }
 							<ItemGrouper groupItems={ segregateFreeAndPaid }>
 								{ existingSubdomain && (


### PR DESCRIPTION
### The constraints

1. A WP plugins can only contain a single text-domain. I don't know the reasoning, but I know it's very hard to change this limitation. It's a core limitation that is very established and well-documented.

2. JavaScript packages don't know their prospective text-domain, thus can't hardcode it. Technically, a package can hardcode a single text-domain, but that makes it usable in a single plugin (eg full-site-editing), but that would defy the purpose of making it a package — reusability.

3. Text domains must be hardcoded in the compiled files. They can't be variables.

### Suggested solution

Given that our translation bots only scan the compiled files in `dist/build`, we can use Webpack `DefinePlugin` to transpile an environment variable into a hardcoded text-domain. 

We can establish a rule to always use `process.env.TEXT_DOMAIN` if you want to use i18n in your package. We can also create an eslint rule that checks packages for rule violations.

### Downside

This solution makes packages require Webpack to be used. And requires Webpack to have the following config:

```js
new webpack.DefinePlugin( {
	'process.env.TEXT_DOMAIN': '"full-site-editing"', // full-site-editing is an example
} ),
```

If this config is missing, the package will be unusable. This limitation is fine within Calypso and our own plugins, but if some other project needed to use one of this i18nized packages, it'll probably be a bit confusing DevX.