### PR TITLE
Fix: avoid nesting arrays of link objects in documentHead redux state

### DIFF
--- a/client/document/domains-landing.jsx
+++ b/client/document/domains-landing.jsx
@@ -34,9 +34,7 @@ function DomainsLanding( {
 					<meta { ...props } key={ index } />
 				) ) }
 				{ head.links.map( ( props, index ) => (
-					<>
-						<link { ...props } key={ index } />
-					</>
+					<link { ...props } key={ index } />
 				) ) }
 				{ chunkCssLinks( entrypoint, isRTL ) }
 			</Head>

--- a/client/document/domains-landing.jsx
+++ b/client/document/domains-landing.jsx
@@ -34,7 +34,9 @@ function DomainsLanding( {
 					<meta { ...props } key={ index } />
 				) ) }
 				{ head.links.map( ( props, index ) => (
-					<link { ...props } key={ index } />
+					<>
+						<link { ...props } key={ index } />
+					</>
 				) ) }
 				{ chunkCssLinks( entrypoint, isRTL ) }
 			</Head>

--- a/client/state/document-head/actions.js
+++ b/client/state/document-head/actions.js
@@ -41,7 +41,7 @@ export function setDocumentHeadUnreadCount( count ) {
  * Returns an action object used in signalling that the specified link object
  * should be included in the set of document head links.
  *
- * @param  {object} link Link object
+ * @param  {object|Array<object>} link Link object (or array of link objects)
  * @returns {object}      Action object
  */
 export function setDocumentHeadLink( link ) {

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniqWith, isEqual } from 'lodash';
+import { uniqWith, isEqual, isArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -53,8 +53,16 @@ export const meta = withSchemaValidation( metaSchema, ( state = DEFAULT_META_STA
 export const link = withSchemaValidation( linkSchema, ( state = [], action ) => {
 	switch ( action.type ) {
 		case DOCUMENT_HEAD_LINK_SET:
-			// Prevent duplicate objects
-			return uniqWith( [ ...state, action.link ], isEqual );
+			if ( ! action.link ) {
+				return state;
+			}
+
+			// Append action.link to the state array and prevent duplicate objects.
+			// Works with action.link being a single link object or an array of link objects.
+			return uniqWith(
+				[ ...state, ...( isArray( action.link ) ? action.link : [ action.link ] ) ],
+				isEqual
+			);
 	}
 
 	return state;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update document head `link` reducer to accept either a link object, or an array of link objects
* This change also avoids nesting arrays of links into the the global redux state, and avoids a warning being displayed in the browser's console when in development mode

#### Testing instructions

* open dev console
* go to `/themes/:siteId` in a development build
* refresh the page (this warning would only show when rendering the page on the server)
* See that there are no schema State validation errors regarding the document head links (there may be other unrelated warnings)
* Also, open Redux devtool and observe that the `documentHead.links` property in the global state object doesn't have nested arrays as children (but has objects instead)


#### Before

<img width="1792" alt="Markup 2020-09-23 at 16 01 29" src="https://user-images.githubusercontent.com/1083581/94023084-18319800-fdb6-11ea-84af-824134e39729.png">


#### After

<img width="1792" alt="Markup 2020-09-23 at 16 10 08" src="https://user-images.githubusercontent.com/1083581/94024088-48c60180-fdb7-11ea-910c-2ff4e47098c1.png">

