### PR TITLE
Premium Content: Decode token only if present

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/subscription-service/class-token-subscription-service.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/subscription-service/class-token-subscription-service.php
@@ -66,11 +66,11 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 		if ( empty( $token ) ) {
 			// no token, no access.
 			$is_valid_token = false;
-		}
-
-		$payload = $this->decode_token( $token );
-		if ( empty( $payload ) ) {
-			$is_valid_token = false;
+		} else {
+			$payload = $this->decode_token( $token );
+			if ( empty( $payload ) ) {
+				$is_valid_token = false;
+			}
 		}
 
 		if ( $is_valid_token ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We shouldn't decode a token if, well, we don't have a token to decode. Otherwise that will result in fatal errors as reported in p1600868752006200-slack-C0Q664T29.

This PR adds a guard so `decode_token` is only executed if the given token is not empty, which hopefully will stop the fatal errors from happening.

#### Testing instructions

I have not been able to replicate the fatal errors in my sandbox, so not sure how can we test this, but I'm quite confident that this will stop the fatals.