### PR TITLE
Editing Toolkit: Bump to version 2.6.1

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.6
+ * Version: 2.6.1
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.6' );
+define( 'PLUGIN_VERSION', '2.6.1' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.6
+Stable tag: 2.6.1
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.6.1 =
+* Fixed an error in the Premium Content token subscription service that causing some fatal errors if the auth token was missing (https://github.com/Automattic/wp-calypso/pull/45878)
 
 = 2.6 =
 * Correct regressions to the Premium Content block. (https://github.com/Automattic/wp-calypso/pull/45777)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.6.0",
+	"version": "2.6.1",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
 		"@automattic/webpack-inline-constant-exports-plugin": "^0.0.1",
 		"@automattic/wp-babel-makepot": "^1.0.0",
 		"@automattic/wpcom-block-editor": "^1.0.0-alpha.0",
-		"@automattic/wpcom-editing-toolkit": "^2.6.0",
+		"@automattic/wpcom-editing-toolkit": "^2.6.1",
 		"@babel/cli": "^7.10.5",
 		"@babel/core": "^7.11.1",
 		"@babel/register": "^7.10.5",


### PR DESCRIPTION
Bump the Editing Toolkit plugin to version 2.6.1 that includes a fix for a regression in the Premium Content block (https://github.com/Automattic/wp-calypso/pull/45878)