### PR TITLE
Checkout: guard uses of localStorage and JSON.parse

### DIFF
--- a/client/lib/analytics/utils/save-coupon-query-argument.js
+++ b/client/lib/analytics/utils/save-coupon-query-argument.js
@@ -17,8 +17,15 @@ export default function saveCouponQueryArgument() {
 	}
 
 	// Read coupon list from localStorage, create new if it's not there yet, refresh existing.
-	const couponsJson = window.localStorage.getItem( MARKETING_COUPONS_KEY );
-	const coupons = JSON.parse( couponsJson ) || {};
+	let coupons = null;
+	try {
+		const couponsJson = window.localStorage.getItem( MARKETING_COUPONS_KEY );
+		coupons = JSON.parse( couponsJson );
+	} catch ( err ) {}
+	if ( ! coupons ) {
+		coupons = {};
+	}
+
 	const THIRTY_DAYS_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
 	const now = Date.now();
 	debug( 'Found coupons in localStorage: ', coupons );
@@ -33,6 +40,8 @@ export default function saveCouponQueryArgument() {
 	} );
 
 	// Write remembered coupons back to localStorage.
-	debug( 'Storing coupons in localStorage: ', coupons );
-	window.localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
+	try {
+		debug( 'Storing coupons in localStorage: ', coupons );
+		window.localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
+	} catch ( err ) {}
 }

--- a/client/lib/cart/actions.js
+++ b/client/lib/cart/actions.js
@@ -120,8 +120,11 @@ export function removeCoupon() {
 
 export function getRememberedCoupon() {
 	// read coupon list from localStorage, return early if it's not there
-	const couponsJson = window.localStorage.getItem( MARKETING_COUPONS_KEY );
-	const coupons = JSON.parse( couponsJson );
+	let coupons = null;
+	try {
+		const couponsJson = window.localStorage.getItem( MARKETING_COUPONS_KEY );
+		coupons = JSON.parse( couponsJson );
+	} catch ( err ) {}
 	if ( ! coupons ) {
 		debug( 'No coupons found in localStorage: ', coupons );
 		return null;
@@ -157,8 +160,11 @@ export function getRememberedCoupon() {
 	} );
 
 	// write remembered coupons back to localStorage
-	debug( 'Storing coupons in localStorage: ', coupons );
-	window.localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
+	try {
+		debug( 'Storing coupons in localStorage: ', coupons );
+		window.localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
+	} catch ( err ) {}
+
 	if (
 		ALLOWED_COUPON_CODE_LIST.includes(
 			mostRecentCouponCode?.includes( '_' )

--- a/client/lib/cart/actions.js
+++ b/client/lib/cart/actions.js
@@ -161,7 +161,7 @@ export function getRememberedCoupon() {
 	window.localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
 	if (
 		ALLOWED_COUPON_CODE_LIST.includes(
-			-1 !== mostRecentCouponCode.indexOf( '_' )
+			mostRecentCouponCode?.includes( '_' )
 				? mostRecentCouponCode.substring( 0, mostRecentCouponCode.indexOf( '_' ) )
 				: mostRecentCouponCode
 		)

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -307,8 +307,10 @@ export default function CompositeCheckout( {
 			debug( 'just redirecting to', url );
 
 			if ( createUserAndSiteBeforeTransaction ) {
-				window.localStorage.removeItem( 'shoppingCart' );
-				window.localStorage.removeItem( 'siteParams' );
+				try {
+					window.localStorage.removeItem( 'shoppingCart' );
+					window.localStorage.removeItem( 'siteParams' );
+				} catch ( err ) {}
 
 				// We use window.location instead of page.redirect() so that the cookies are detected on fresh page load.
 				// Using page.redirect() will take to the log in page which we don't want.

--- a/client/my-sites/checkout/composite-checkout/hooks/use-redirect-if-cart-empty.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-redirect-if-cart-empty.ts
@@ -18,8 +18,10 @@ export default function useRedirectIfCartEmpty< T >(
 		if ( ! isLoading && items.length === 0 && errors.length === 0 ) {
 			debug( 'cart is empty and not still loading; redirecting...' );
 			if ( createUserAndSiteBeforeTransaction ) {
-				window.localStorage.removeItem( 'shoppingCart' );
-				window.localStorage.removeItem( 'siteParams' );
+				try {
+					window.localStorage.removeItem( 'shoppingCart' );
+					window.localStorage.removeItem( 'siteParams' );
+				} catch ( err ) {}
 
 				// We use window.location instead of page.redirect() so that if the user already has an account and site at
 				// this point, then window.location will reload with the cookies applied and takes to the /plans page.

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-shopping-cart-reducer.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-shopping-cart-reducer.ts
@@ -243,7 +243,7 @@ function removeItemFromLocalStorage( productSlugsInCart: string[] ) {
 	try {
 		window.localStorage.setItem( 'shoppingCart', JSON.stringify( newCartItems ) );
 	} catch ( err ) {
-		throw new Error( 'An unexpected error occured while saving your cart' );
+		return;
 	}
 }
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-shopping-cart-reducer.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-shopping-cart-reducer.ts
@@ -225,9 +225,12 @@ function getInitialShoppingCartState(): ShoppingCartState {
 }
 
 function removeItemFromLocalStorage( productSlugsInCart: string[] ) {
-	const cartItemsFromLocalStorage = JSON.parse(
-		window.localStorage.getItem( 'shoppingCart' ) || '[]'
-	);
+	let cartItemsFromLocalStorage = null;
+	try {
+		cartItemsFromLocalStorage = JSON.parse( window.localStorage.getItem( 'shoppingCart' ) || '[]' );
+	} catch ( err ) {
+		return;
+	}
 
 	if ( ! Array.isArray( cartItemsFromLocalStorage ) ) {
 		return;
@@ -239,7 +242,7 @@ function removeItemFromLocalStorage( productSlugsInCart: string[] ) {
 
 	try {
 		window.localStorage.setItem( 'shoppingCart', JSON.stringify( newCartItems ) );
-	} catch ( e ) {
+	} catch ( err ) {
 		throw new Error( 'An unexpected error occured while saving your cart' );
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -256,7 +256,12 @@ async function createAccountCallback( response ) {
 }
 
 async function createAccount() {
-	const newSiteParams = JSON.parse( window.localStorage.getItem( 'siteParams' ) || '{}' );
+	let newSiteParams = null;
+	try {
+		newSiteParams = JSON.parse( window.localStorage.getItem( 'siteParams' ) || '{}' );
+	} catch ( err ) {
+		newSiteParams = {};
+	}
 
 	const { email } = select( 'wpcom' )?.getContactInfo() ?? {};
 	const siteId = select( 'wpcom' )?.getSiteId();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Calling `JSON.parse()` (for invalid JSON) and trying to access `window.localStorage` (eg: private browsing in Safari, browsers that don't support it, when quota is full, etc.) can both throw fatal errors in various circumstances. In most cases, the use of localStorage is not critical to the functioning of the page. 

This PR wraps those uses in `try/catch` to allow checkout to continue functioning even if localStorage is not available or fails to work.

Not all these changes are in the checkout code explicitly, but they are all connected to checkout in some way.

#### Testing instructions

- Start checkout with forced sympathy mode: `ENABLE_FEATURES=force-sympathy yarn start`
- In your purchase management pages, click to renew an existing subscription.
- Verify checkout loads without any errors.