### PR TITLE
fix: remove pinghub origin header

### DIFF
--- a/client/desktop/app-handlers/web-requests/README.md
+++ b/client/desktop/app-handlers/web-requests/README.md
@@ -1,0 +1,3 @@
+# Web Requests
+
+Modifies requests made by the client to ensure compatibility with the WordPress.com API.

--- a/client/desktop/app-handlers/web-requests/index.js
+++ b/client/desktop/app-handlers/web-requests/index.js
@@ -1,0 +1,12 @@
+const { session } = require( 'electron' );
+
+const filter = {
+	urls: [ 'https://public-api.wordpress.com/pinghub/wpcom/me/newest-note-data' ],
+};
+
+module.exports = function () {
+	session.defaultSession.webRequest.onBeforeSendHeaders( filter, ( details, callback ) => {
+		delete details.requestHeaders.Origin;
+		callback( { cancel: false, requestHeaders: details.requestHeaders } );
+	} );
+};

--- a/client/desktop/app-handlers/web-requests/index.js
+++ b/client/desktop/app-handlers/web-requests/index.js
@@ -1,12 +1,14 @@
-const { session } = require( 'electron' );
+const { app, session } = require( 'electron' );
 
 const filter = {
 	urls: [ 'https://public-api.wordpress.com/pinghub/wpcom/me/newest-note-data' ],
 };
 
 module.exports = function () {
-	session.defaultSession.webRequest.onBeforeSendHeaders( filter, ( details, callback ) => {
-		delete details.requestHeaders.Origin;
-		callback( { cancel: false, requestHeaders: details.requestHeaders } );
+	app.on( 'ready', () => {
+		session.defaultSession.webRequest.onBeforeSendHeaders( filter, ( details, callback ) => {
+			delete details.requestHeaders.Origin;
+			callback( { cancel: false, requestHeaders: details.requestHeaders } );
+		} );
 	} );
 };

--- a/client/desktop/app-handlers/web-requests/index.js
+++ b/client/desktop/app-handlers/web-requests/index.js
@@ -1,7 +1,7 @@
 const { app, session } = require( 'electron' );
 
 const filter = {
-	urls: [ 'https://public-api.wordpress.com/pinghub/wpcom/me/newest-note-data' ],
+	urls: [ 'wss://public-api.wordpress.com/pinghub/wpcom/me/newest-note-data*' ],
 };
 
 module.exports = function () {

--- a/client/desktop/app.js
+++ b/client/desktop/app.js
@@ -8,6 +8,7 @@ module.exports = function ( finished_cb ) {
 	log.info( 'Starting app handlers' );
 
 	// Stuff that can run before the main window
+	require( './app-handlers/web-requests' )();
 	require( './app-handlers/logging' )();
 	require( './app-handlers/crash-reporting' )();
 	require( './app-handlers/updater' )();


### PR DESCRIPTION
### Description

Remove the `Origin` header for compatibility with server-side [Pinghub authentication checks](https://github.com/Automattic/pinghub/blob/625d8a6528847961521f99774af2ceae4bc39523/handlers.go#L40).

Ref: Electron [API docs](https://www.electronjs.org/docs/api/web-request)

_Potential blocker_: Turns out we may want to scrap this approach as it looks like there might be issues getting this API to work with websocket requests ([link](https://www.electronjs.org/docs/api/web-request)) - will need to test and see. If this isn't viable, a server-side patch may be necessary.

### To-Do

- [ ] Needs testing!