### PR TITLE
Jetpack Cloud: Pricing - carry over url query params to wpcom connect

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
@@ -12,18 +12,24 @@ import { Button } from '@automattic/components';
 import { JPC_PATH_REMOTE_INSTALL } from 'jetpack-connect/constants';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import getJetpackWpAdminUrl from 'state/selectors/get-jetpack-wp-admin-url';
+import { addQueryArgs } from 'lib/route';
+import { QueryArgs } from 'my-sites/plans-v2/types';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const JetpackFreeCard: FunctionComponent = () => {
+type JetpackFreeProps = {
+	urlQueryArgs: QueryArgs;
+};
+
+const JetpackFreeCard = ( { urlQueryArgs }: JetpackFreeProps ) => {
 	const translate = useTranslate();
 	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
 
 	const startHref = isJetpackCloud()
-		? `https://wordpress.com${ JPC_PATH_REMOTE_INSTALL }`
+		? addQueryArgs( urlQueryArgs, `https://wordpress.com${ JPC_PATH_REMOTE_INSTALL }` )
 		: wpAdminUrl || JPC_PATH_REMOTE_INSTALL;
 
 	return (

--- a/client/components/jetpack/card/jetpack-free-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card/index.tsx
@@ -13,16 +13,16 @@ import { JPC_PATH_REMOTE_INSTALL } from 'jetpack-connect/constants';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import getJetpackWpAdminUrl from 'state/selectors/get-jetpack-wp-admin-url';
 import { addQueryArgs } from 'lib/route';
-import { QueryArgs } from 'my-sites/plans-v2/types';
+
+/**
+ * Type dependencies
+ */
+import type { JetpackFreeProps } from 'my-sites/plans-v2/types';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-type JetpackFreeProps = {
-	urlQueryArgs: QueryArgs;
-};
 
 const JetpackFreeCard = ( { urlQueryArgs }: JetpackFreeProps ) => {
 	const translate = useTranslate();

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -13,11 +13,14 @@ import JetpackComFooter from './jpcom-footer';
 import { setLocale } from 'state/ui/language/actions';
 
 export function jetpackPricingContext( context, next ) {
+	const { querystring } = context;
 	const { locale } = context.params;
 
 	if ( locale ) {
 		context.store.dispatch( setLocale( locale ) );
-		page.redirect( '/pricing' );
+		const pricingUrl = querystring ? `/pricing?${ querystring }` : '/pricing';
+		page.redirect( pricingUrl );
+		//page.redirect( '/pricing' );
 	}
 
 	context.store.dispatch( hideMasterbar() );

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -11,16 +11,15 @@ import { hideMasterbar } from 'state/ui/actions';
 import Header from './header';
 import JetpackComFooter from './jpcom-footer';
 import { setLocale } from 'state/ui/language/actions';
+import { addQueryArgs } from 'lib/route';
 
-export function jetpackPricingContext( context, next ) {
-	const { querystring } = context;
+export function jetpackPricingContext( context: PageJS.Context, next: Function ) {
+	const urlQueryArgs = context.query;
 	const { locale } = context.params;
 
 	if ( locale ) {
 		context.store.dispatch( setLocale( locale ) );
-		const pricingUrl = querystring ? `/pricing?${ querystring }` : '/pricing';
-		page.redirect( pricingUrl );
-		//page.redirect( '/pricing' );
+		page.redirect( addQueryArgs( urlQueryArgs, `/pricing` ) );
 	}
 
 	context.store.dispatch( hideMasterbar() );

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -19,14 +19,11 @@ export function billingHistoryReceipt( receiptId ) {
 	return billingHistory + `/${ receiptId }`;
 }
 
-export function managePurchase( siteName, purchaseId, queryString ) {
+export function managePurchase( siteName, purchaseId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {
 			throw new Error( 'siteName and purchaseId must be provided' );
 		}
-	}
-	if ( queryString ) {
-		return purchasesRoot + `/${ siteName }/${ purchaseId }?${ queryString }`;
 	}
 	return purchasesRoot + `/${ siteName }/${ purchaseId }`;
 }

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -19,11 +19,14 @@ export function billingHistoryReceipt( receiptId ) {
 	return billingHistory + `/${ receiptId }`;
 }
 
-export function managePurchase( siteName, purchaseId ) {
+export function managePurchase( siteName, purchaseId, queryString ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {
 			throw new Error( 'siteName and purchaseId must be provided' );
 		}
+	}
+	if ( queryString ) {
+		return purchasesRoot + `/${ siteName }/${ purchaseId }?${ queryString }`;
 	}
 	return purchasesRoot + `/${ siteName }/${ purchaseId }`;
 }

--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -25,7 +25,6 @@ export const productSelect = ( rootUrl: string ) => ( context: PageJS.Context, n
 	const siteId = getSelectedSiteId( state );
 	const duration =
 		( siteId && ( getCurrentPlanTerm( state, siteId ) as Duration ) ) || TERM_ANNUALLY;
-
 	context.primary = (
 		<SelectorPage
 			defaultDuration={ duration }
@@ -43,7 +42,7 @@ export const productDetails = ( rootUrl: string ) => (
 	next: Function
 ) => {
 	const productType: string = context.params.product;
-	const duration = stringToDuration( context.params.duration );
+	const duration = stringToDuration( context.params.duration ) || TERM_ANNUALLY;
 	context.primary = (
 		<DetailsPage
 			productSlug={ productType }
@@ -58,7 +57,7 @@ export const productDetails = ( rootUrl: string ) => (
 
 export const productUpsell = ( rootUrl: string ) => ( context: PageJS.Context, next: Function ) => {
 	const productSlug: string = context.params.product;
-	const duration = stringToDuration( context.params.duration );
+	const duration = stringToDuration( context.params.duration ) || TERM_ANNUALLY;
 	context.primary = (
 		<UpsellPage
 			productSlug={ productSlug }

--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -17,19 +17,23 @@ import { TERM_ANNUALLY } from 'lib/plans/constants';
 /**
  * Type dependencies
  */
-import type { Duration } from './types';
+import type { Duration, QueryArgs } from './types';
 
 export const productSelect = ( rootUrl: string ) => ( context: PageJS.Context, next: Function ) => {
 	// Get the selected site's current plan term, and set it as default duration
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
-	const duration =
-		( siteId && ( getCurrentPlanTerm( state, siteId ) as Duration ) ) || TERM_ANNUALLY;
+	const duration: Duration =
+		( siteId && ( getCurrentPlanTerm( state, siteId ) as Duration ) ) ||
+		( TERM_ANNUALLY as Duration );
+	const urlQueryArgs: QueryArgs = context.query;
+
 	context.primary = (
 		<SelectorPage
 			defaultDuration={ duration }
 			rootUrl={ rootUrl }
 			siteSlug={ context.params.site || context.query.site }
+			urlQueryArgs={ urlQueryArgs }
 			header={ context.header }
 			footer={ context.footer }
 		/>
@@ -42,13 +46,16 @@ export const productDetails = ( rootUrl: string ) => (
 	next: Function
 ) => {
 	const productType: string = context.params.product;
-	const duration = stringToDuration( context.params.duration ) || TERM_ANNUALLY;
+	const duration: Duration = stringToDuration( context.params.duration ) || TERM_ANNUALLY;
+	const urlQueryArgs: QueryArgs = context.query;
+
 	context.primary = (
 		<DetailsPage
 			productSlug={ productType }
-			duration={ duration as Duration }
-			siteSlug={ context.params.site || context.query.site }
+			duration={ duration }
 			rootUrl={ rootUrl }
+			siteSlug={ context.params.site || context.query.site }
+			urlQueryArgs={ urlQueryArgs }
 			header={ context.header }
 		/>
 	);
@@ -57,13 +64,16 @@ export const productDetails = ( rootUrl: string ) => (
 
 export const productUpsell = ( rootUrl: string ) => ( context: PageJS.Context, next: Function ) => {
 	const productSlug: string = context.params.product;
-	const duration = stringToDuration( context.params.duration ) || TERM_ANNUALLY;
+	const duration: Duration = stringToDuration( context.params.duration ) || TERM_ANNUALLY;
+	const urlQueryArgs: QueryArgs = context.query;
+
 	context.primary = (
 		<UpsellPage
 			productSlug={ productSlug }
-			duration={ duration as Duration }
-			siteSlug={ context.params.site || context.query.site }
+			duration={ duration }
 			rootUrl={ rootUrl }
+			siteSlug={ context.params.site || context.query.site }
+			urlQueryArgs={ urlQueryArgs }
 			header={ context.header }
 		/>
 	);

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -107,7 +107,9 @@ const DetailsPage = ( {
 				duration: newDuration,
 			} )
 		);
-		page( getPathToDetails( rootUrl, newProductSlug as string, newDuration, siteSlug ) );
+		page(
+			getPathToDetails( rootUrl, urlQueryArgs, newProductSlug as string, newDuration, siteSlug )
+		);
 	};
 
 	const { shortName } = product;

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -45,10 +45,11 @@ import type { ProductSlug } from 'lib/products-values/types';
 import './style.scss';
 
 const DetailsPage = ( {
-	duration,
+	rootUrl,
+	urlQueryArgs,
 	siteSlug: siteSlugProp,
 	productSlug,
-	rootUrl,
+	duration,
 	header,
 }: DetailsPageProps ) => {
 	const dispatch = useDispatch();
@@ -66,11 +67,13 @@ const DetailsPage = ( {
 
 	// If the product slug isn't one that has options, proceed to the upsell.
 	if ( ! ( PRODUCTS_WITH_OPTIONS as readonly string[] ).includes( productSlug ) ) {
-		page.redirect( getPathToUpsell( rootUrl, productSlug, duration as Duration, siteSlug ) );
+		page.redirect(
+			getPathToUpsell( rootUrl, urlQueryArgs, productSlug, duration as Duration, siteSlug )
+		);
 		return null;
 	}
 
-	const selectorPageUrl = getPathToSelector( rootUrl, duration, siteSlug );
+	const selectorPageUrl = getPathToSelector( rootUrl, urlQueryArgs, duration, siteSlug );
 
 	// If the product is not valid, send the user to the selector page.
 	const product = slugToSelectorProduct( productSlug );
@@ -82,11 +85,11 @@ const DetailsPage = ( {
 	// Go to a new page for upsells.
 	const selectProduct: PurchaseCallback = ( { productSlug: slug }: SelectorProduct ) => {
 		if ( hasUpsell( slug as ProductSlug ) ) {
-			page( getPathToUpsell( rootUrl, slug, duration as Duration, siteSlug ) );
+			page( getPathToUpsell( rootUrl, urlQueryArgs, slug, duration as Duration, siteSlug ) );
 			return;
 		}
 
-		checkout( siteSlug, slug );
+		checkout( siteSlug, slug, urlQueryArgs );
 	};
 
 	const onDurationChange = ( newDuration: Duration ) => {

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -45,6 +45,7 @@ const SelectorPage = ( {
 	defaultDuration = TERM_ANNUALLY,
 	siteSlug: siteSlugProp,
 	rootUrl,
+	queryString,
 	header,
 	footer,
 }: SelectorPageProps ) => {
@@ -73,12 +74,12 @@ const SelectorPage = ( {
 		}
 
 		if ( purchase && isUpgradeableToYearly ) {
-			checkout( siteSlug, getYearlyPlanByMonthly( product.productSlug ) );
+			checkout( siteSlug, getYearlyPlanByMonthly( product.productSlug ), queryString );
 			return;
 		}
 
 		if ( purchase ) {
-			page( managePurchase( siteSlug, purchase.id ) );
+			page( managePurchase( siteSlug, purchase.id, queryString ) );
 			return;
 		}
 
@@ -90,16 +91,19 @@ const SelectorPage = ( {
 					duration: currentDuration,
 				} )
 			);
-			page( getPathToDetails( rootUrl, product.productSlug, currentDuration, siteSlug ) );
+			page(
+				getPathToDetails( rootUrl, product.productSlug, currentDuration, siteSlug, queryString )
+			);
 			return;
 		}
 
 		if ( hasUpsell( product.productSlug as ProductSlug ) ) {
-			page( getPathToUpsell( rootUrl, product.productSlug, currentDuration, siteSlug ) );
+			page(
+				getPathToUpsell( rootUrl, product.productSlug, currentDuration, siteSlug, queryString )
+			);
 			return;
 		}
-
-		checkout( siteSlug, product.productSlug );
+		checkout( siteSlug, product.productSlug, queryString );
 	};
 
 	const trackProductTypeChange = ( selectedType: ProductType ) => {

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -45,7 +45,7 @@ const SelectorPage = ( {
 	defaultDuration = TERM_ANNUALLY,
 	siteSlug: siteSlugProp,
 	rootUrl,
-	queryString,
+	urlQueryArgs,
 	header,
 	footer,
 }: SelectorPageProps ) => {
@@ -74,12 +74,12 @@ const SelectorPage = ( {
 		}
 
 		if ( purchase && isUpgradeableToYearly ) {
-			checkout( siteSlug, getYearlyPlanByMonthly( product.productSlug ), queryString );
+			checkout( siteSlug, getYearlyPlanByMonthly( product.productSlug ), urlQueryArgs );
 			return;
 		}
 
 		if ( purchase ) {
-			page( managePurchase( siteSlug, purchase.id, queryString ) );
+			page( managePurchase( siteSlug, purchase.id ) );
 			return;
 		}
 
@@ -92,18 +92,18 @@ const SelectorPage = ( {
 				} )
 			);
 			page(
-				getPathToDetails( rootUrl, product.productSlug, currentDuration, siteSlug, queryString )
+				getPathToDetails( rootUrl, urlQueryArgs, product.productSlug, currentDuration, siteSlug )
 			);
 			return;
 		}
 
 		if ( hasUpsell( product.productSlug as ProductSlug ) ) {
 			page(
-				getPathToUpsell( rootUrl, product.productSlug, currentDuration, siteSlug, queryString )
+				getPathToUpsell( rootUrl, urlQueryArgs, product.productSlug, currentDuration, siteSlug )
 			);
 			return;
 		}
-		checkout( siteSlug, product.productSlug, queryString );
+		checkout( siteSlug, product.productSlug, urlQueryArgs );
 	};
 
 	const trackProductTypeChange = ( selectedType: ProductType ) => {
@@ -172,7 +172,7 @@ const SelectorPage = ( {
 			{ showJetpackFreeCard && (
 				<>
 					<div className="selector__divider" />
-					<JetpackFreeCard />
+					<JetpackFreeCard urlQueryArgs={ urlQueryArgs } />
 				</>
 			) }
 

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -20,7 +20,12 @@ export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY;
 export type DurationString = 'annual' | 'monthly';
 export type ProductType = typeof ALL | typeof PERFORMANCE | typeof SECURITY;
 export type ItemType = typeof ITEM_TYPE_PLAN | typeof ITEM_TYPE_BUNDLE | typeof ITEM_TYPE_PRODUCT;
-export type PurchaseCallback = ( arg0: SelectorProduct, arg1?: boolean, arg2?: Purchase ) => void;
+export type PurchaseCallback = (
+	arg0: SelectorProduct,
+	arg1?: boolean,
+	arg2?: Purchase,
+	arg3?: string
+) => void;
 
 interface BasePageProps {
 	rootUrl: string;

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -55,6 +55,10 @@ export interface WithRedirectToSelectorProps extends BasePageProps {
 	duration: Duration;
 }
 
+export interface JetpackFreeProps {
+	urlQueryArgs: QueryArgs;
+}
+
 export type SelectorProductSlug = typeof PRODUCTS_WITH_OPTIONS[ number ];
 
 export type SelectorProductCost = {

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -20,15 +20,16 @@ export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY;
 export type DurationString = 'annual' | 'monthly';
 export type ProductType = typeof ALL | typeof PERFORMANCE | typeof SECURITY;
 export type ItemType = typeof ITEM_TYPE_PLAN | typeof ITEM_TYPE_BUNDLE | typeof ITEM_TYPE_PRODUCT;
-export type PurchaseCallback = (
-	arg0: SelectorProduct,
-	arg1?: boolean,
-	arg2?: Purchase,
-	arg3?: string
-) => void;
+
+export interface QueryArgs {
+	[ key: string ]: string;
+}
+
+export type PurchaseCallback = ( arg0: SelectorProduct, arg1?: boolean, arg2?: Purchase ) => void;
 
 interface BasePageProps {
 	rootUrl: string;
+	urlQueryArgs: QueryArgs;
 	header: ReactNode;
 	footer?: ReactNode;
 }

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -185,10 +185,11 @@ const UpsellComponent = ( {
 };
 
 const UpsellPage = ( {
-	duration,
+	rootUrl,
+	urlQueryArgs,
 	siteSlug: siteSlugProp,
 	productSlug,
-	rootUrl,
+	duration,
 	header,
 }: UpsellPageProps ) => {
 	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
@@ -202,7 +203,9 @@ const UpsellPage = ( {
 	const upsellProductSlug = getProductUpsell( productSlug );
 	const upsellProduct = upsellProductSlug && slugToSelectorProduct( upsellProductSlug );
 
-	const checkoutCb = useCallback( ( slugs ) => checkout( siteSlug, slugs ), [ siteSlug ] );
+	const checkoutCb = useCallback( ( slugs ) => checkout( siteSlug, slugs, urlQueryArgs ), [
+		siteSlug,
+	] );
 
 	const onPurchaseBothProducts = useCallback(
 		() => checkoutCb( [ productSlug, upsellProductSlug ] ),
@@ -214,7 +217,7 @@ const UpsellPage = ( {
 		productSlug,
 	] );
 
-	const selectorPageUrl = getPathToSelector( rootUrl, duration, siteSlug );
+	const selectorPageUrl = getPathToSelector( rootUrl, urlQueryArgs, duration, siteSlug );
 
 	// If the product is not valid send the user to the selector page.
 	if ( ! mainProduct ) {
@@ -233,7 +236,7 @@ const UpsellPage = ( {
 	// page.
 	const productOption = getOptionFromSlug( productSlug );
 	const backUrl = productOption
-		? getPathToDetails( rootUrl, productOption, duration as Duration, siteSlug )
+		? getPathToDetails( rootUrl, urlQueryArgs, productOption, duration as Duration, siteSlug )
 		: selectorPageUrl;
 
 	const onBackButtonClick = () => page( backUrl );

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -514,7 +514,8 @@ export function checkout( siteSlug: string, products: string | string[] ): void 
  */
 export function getPathToSelector( rootUrl: string, duration?: Duration, siteSlug?: string ) {
 	const strDuration = duration ? durationToString( duration ) : null;
-	return [ rootUrl, strDuration, siteSlug ].filter( Boolean ).join( '/' );
+	const path = [ rootUrl, strDuration, siteSlug ].filter( Boolean ).join( '/' );
+	return path;
 }
 
 /**
@@ -535,7 +536,10 @@ export function getPathToDetails(
 	siteSlug?: string
 ) {
 	const strDuration = durationToString( duration );
-	return [ rootUrl, productSlug, strDuration, 'details', siteSlug ].filter( Boolean ).join( '/' );
+	const path = [ rootUrl, productSlug, strDuration, 'details', siteSlug ]
+		.filter( Boolean )
+		.join( '/' );
+	return path;
 }
 
 /**
@@ -556,7 +560,10 @@ export function getPathToUpsell(
 	siteSlug?: string
 ) {
 	const strDuration = durationToString( duration );
-	return [ rootUrl, productSlug, strDuration, 'additions', siteSlug ].filter( Boolean ).join( '/' );
+	const path = [ rootUrl, productSlug, strDuration, 'additions', siteSlug ]
+		.filter( Boolean )
+		.join( '/' );
+	return path;
 }
 
 /**

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -482,6 +482,7 @@ export function getAllOptionsFromSlug( slug: string ): string[] | null {
  *
  * @param {string} siteSlug Selected site
  * @param {string | string[]} products Slugs of the products to add to the cart
+ * @param {string} queryString (optional) Additional query params appended to url (ie. for affiliate tracking)
  */
 export function checkout( siteSlug: string, products: string | string[] ): void {
 	const productsArray = isArray( products ) ? products : [ products ];
@@ -509,6 +510,7 @@ export function checkout( siteSlug: string, products: string | string[] ): void 
  * @param {string} rootUrl Base URL that relates to the current flow (WordPress.com vs Jetpack Connect).
  * @param {Duration} duration Monthly or annual
  * @param {string} siteSlug (optional) The slug of the selected site
+ * @param {string} queryString (optional) Additional query params appended to url (ie. for affiliate tracking)
  *
  * @returns {string} The path to the Selector page
  */
@@ -526,6 +528,7 @@ export function getPathToSelector( rootUrl: string, duration?: Duration, siteSlu
  * @param {string} productSlug Slug of the product
  * @param {Duration} duration Monthly or annual
  * @param {string} siteSlug (optional) The slug of the selected site
+ * @param {string} queryString (optional) Additional query params appended to url (ie. for affiliate tracking)
  *
  * @returns {string} The path to the Details page
  */
@@ -550,6 +553,7 @@ export function getPathToDetails(
  * @param {string} productSlug Slug of the product
  * @param {Duration} duration Monthly or annual
  * @param {string} siteSlug (optional) The slug of the selected site
+ * @param {string} queryString (optional) Additional query params appended to url (ie. for affiliate tracking)
  *
  * @returns {string} The path to the Upsell page
  */

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -55,6 +55,7 @@ import { getJetpackProductCallToAction } from 'lib/products-values/get-jetpack-p
 import { getJetpackProductDescription } from 'lib/products-values/get-jetpack-product-description';
 import { getJetpackProductShortName } from 'lib/products-values/get-jetpack-product-short-name';
 import { MORE_FEATURES_LINK } from 'my-sites/plans-v2/constants';
+import { addQueryArgs } from 'lib/route';
 
 /**
  * Type dependencies
@@ -66,6 +67,7 @@ import type {
 	DurationString,
 	SelectorProductFeaturesItem,
 	SelectorProductFeaturesSection,
+	QueryArgs,
 } from './types';
 import type {
 	JetpackRealtimePlan,
@@ -482,23 +484,27 @@ export function getAllOptionsFromSlug( slug: string ): string[] | null {
  *
  * @param {string} siteSlug Selected site
  * @param {string | string[]} products Slugs of the products to add to the cart
- * @param {string} queryString (optional) Additional query params appended to url (ie. for affiliate tracking)
+ * @param {QueryArgs} urlQueryArgs Additional query params appended to url (ie. for affiliate tracking, or whatever)
  */
-export function checkout( siteSlug: string, products: string | string[] ): void {
+export function checkout(
+	siteSlug: string,
+	products: string | string[],
+	urlQueryArgs: QueryArgs
+): void {
 	const productsArray = isArray( products ) ? products : [ products ];
 
 	// There is not siteSlug, we need to redirect the user to the site selection
 	// step of the flow. Since purchases of multiple products are allowed, we need
 	// to pass all products separated by comma in the URL.
 	const path = siteSlug
-		? `/checkout/${ siteSlug }/${ isJetpackCloud() ? productsArray.join( ',' ) : '' }`
+		? `/checkout/${ siteSlug }`
 		: `/jetpack/connect/${ productsArray.join( ',' ) }`;
 
 	if ( isJetpackCloud() ) {
-		window.location.href = `https://wordpress.com${ path }`;
+		window.location.href = addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` );
 	} else {
 		addItems( productsArray.map( jetpackProductItem ) );
-		page.redirect( path );
+		page.redirect( addQueryArgs( urlQueryArgs, path ) );
 	}
 }
 
@@ -508,16 +514,22 @@ export function checkout( siteSlug: string, products: string | string[] ): void 
  * '/plans/monthly/site-slug', '/plans/site-slug', or just '/plans'.
  *
  * @param {string} rootUrl Base URL that relates to the current flow (WordPress.com vs Jetpack Connect).
+ * @param {QueryArgs} urlQueryArgs URL query params appended to url (ie. for affiliate tracking, or whatever), or {} if none.
  * @param {Duration} duration Monthly or annual
  * @param {string} siteSlug (optional) The slug of the selected site
- * @param {string} queryString (optional) Additional query params appended to url (ie. for affiliate tracking)
  *
  * @returns {string} The path to the Selector page
  */
-export function getPathToSelector( rootUrl: string, duration?: Duration, siteSlug?: string ) {
+export function getPathToSelector(
+	rootUrl: string,
+	urlQueryArgs: QueryArgs,
+	duration?: Duration,
+	siteSlug?: string
+) {
 	const strDuration = duration ? durationToString( duration ) : null;
 	const path = [ rootUrl, strDuration, siteSlug ].filter( Boolean ).join( '/' );
-	return path;
+
+	return addQueryArgs( urlQueryArgs, path );
 }
 
 /**
@@ -525,15 +537,16 @@ export function getPathToSelector( rootUrl: string, duration?: Duration, siteSlu
  * points to the Details page.
  *
  * @param {string} rootUrl Base URL that relates to the current flow (WordPress.com vs Jetpack Connect).
+ * @param {QueryArgs} urlQueryArgs URL query params appended to url (ie. for affiliate tracking, or whatever), or {} if none.
  * @param {string} productSlug Slug of the product
  * @param {Duration} duration Monthly or annual
  * @param {string} siteSlug (optional) The slug of the selected site
- * @param {string} queryString (optional) Additional query params appended to url (ie. for affiliate tracking)
  *
  * @returns {string} The path to the Details page
  */
 export function getPathToDetails(
 	rootUrl: string,
+	urlQueryArgs: QueryArgs,
 	productSlug: string,
 	duration: Duration,
 	siteSlug?: string
@@ -542,7 +555,8 @@ export function getPathToDetails(
 	const path = [ rootUrl, productSlug, strDuration, 'details', siteSlug ]
 		.filter( Boolean )
 		.join( '/' );
-	return path;
+
+	return addQueryArgs( urlQueryArgs, path );
 }
 
 /**
@@ -550,15 +564,16 @@ export function getPathToDetails(
  * points to the Upsell page.
  *
  * @param {string} rootUrl Base URL that relates to the current flow (WordPress.com vs Jetpack Connect).
+ * @param {QueryArgs} urlQueryArgs URL query params appended to url (ie. for affiliate tracking, or whatever), or {} if none.
  * @param {string} productSlug Slug of the product
  * @param {Duration} duration Monthly or annual
  * @param {string} siteSlug (optional) The slug of the selected site
- * @param {string} queryString (optional) Additional query params appended to url (ie. for affiliate tracking)
  *
  * @returns {string} The path to the Upsell page
  */
 export function getPathToUpsell(
 	rootUrl: string,
+	urlQueryArgs: QueryArgs,
 	productSlug: string,
 	duration: Duration,
 	siteSlug?: string
@@ -567,7 +582,8 @@ export function getPathToUpsell(
 	const path = [ rootUrl, productSlug, strDuration, 'additions', siteSlug ]
 		.filter( Boolean )
 		.join( '/' );
-	return path;
+
+	return addQueryArgs( urlQueryArgs, path );
 }
 
 /**

--- a/client/my-sites/plans-v2/with-redirect-to-selector.tsx
+++ b/client/my-sites/plans-v2/with-redirect-to-selector.tsx
@@ -15,7 +15,7 @@ import { WithRedirectToSelectorProps } from './types';
 const withRedirectToSelector = < T extends object >(
 	Component: React.ComponentType< T >
 ): React.FC< T & WithRedirectToSelectorProps > => ( props: WithRedirectToSelectorProps ) => {
-	const { duration, rootUrl } = props;
+	const { duration, rootUrl, urlQueryArgs } = props;
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const previousSiteSlug = useRef< string | null >( null );
 
@@ -26,7 +26,7 @@ const withRedirectToSelector = < T extends object >(
 		}
 
 		if ( siteSlug && previousSiteSlug.current && siteSlug !== previousSiteSlug.current ) {
-			page.redirect( getPathToSelector( rootUrl, duration, siteSlug ) );
+			page.redirect( getPathToSelector( rootUrl, urlQueryArgs, duration, siteSlug ) );
 			return;
 		}
 	}, [ siteSlug ] );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR allows url query parameters to carry over through the plans page product selection flow over to wordpress.com.  This behavior is required for affiliate tracking, such that affiliate traffic starting at `cloud.jetpack.com/pricing?aff=12345&cid=22&sid=33` (notice the affiliate query parameters in the url) will select their plan and have their affiliate cookie set and tracking recorded upon reaching the wordpress.com domain. 

There is a P2 discussion about this here:  p7JFn6-BX-p2#comment-1631

### Testing instructions

1. Go to wordpress.com, open the console, and enter: `localStorage.setItem('debug', 'calypso:analytics:refer');`
    - (This turns on analytics event reporting in the console for wordpress.com, we'll look at the output in a later step)
2. Checkout this PR and run `yarn start-jetpack-cloud`
3. Go to the jetpack cloud pricing page at: http://jetpack.cloud.localhost:3000/pricing/?aff=57686&cid=2&sid=3
    - (Note the query params in the url. Make sure you test with at least the `?aff=` param.)
4. Go through the product selection flow and verify that the url query params carry over on each route change (Here's a detailed example):
     - Select Jetpack Security, and verify that the url query params carry over to the details page. 
     - Then select Jetpack Security Daily (or Real-time), and verify that url query params carry over to wordpress.com.  (see screencast below)

![Screen Capture on 2020-09-24 at 07-44-17](https://user-images.githubusercontent.com/11078128/94161210-4d7fc980-fe3a-11ea-81cf-84e210537545.gif)

5. Once reached the wordpress.com domain, open the console, view the debug output and verify that the Google Analytics affiliate referral tracking has fired.  You should see something like the following in the console:

![Screenshot on 2020-09-24 at 07-55-53](https://user-images.githubusercontent.com/11078128/94162978-29bd8300-fe3c-11ea-8c37-a755f35f3f00.png)

6. Repeat these steps selecting other products such as Backup, Scan, Complete, etc. Verify that any query parameters starting at jetpack.cloud.localhost:3000/pricing/ are being carried over to wordpress.com.

Fixes: 1169247016322522-as-1195115733367185/f