### PR TITLE
Checkout: create multi-site incompatible product notice

### DIFF
--- a/client/my-sites/checkout/checkout/prepurchase-notices/multisites-incompatible-cart-product-notice.tsx
+++ b/client/my-sites/checkout/checkout/prepurchase-notices/multisites-incompatible-cart-product-notice.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import { getJetpackProductDisplayName } from 'lib/products-values/get-jetpack-product-display-name';
+import type { Product } from 'lib/products-values/products-list';
+import PrePurchaseNotice from './prepurchase-notice';
+
+type Props = {
+	products: Product[];
+};
+
+const MultisitesIncompatibleCartProductNotice = ( { products }: Props ) => {
+	const translate = useTranslate();
+
+	// Some names might no fit the component definition that `translate` require so
+	// we make sure to make them all components
+	const productNames = products.map( ( product ) => (
+		<>{ getJetpackProductDisplayName( product ) }</>
+	) );
+
+	let content;
+	if ( products.length === 1 ) {
+		content = translate(
+			"We're sorry, {{product/}} is not compatible with multisite WordPress installations at this time.",
+			{
+				components: {
+					product: productNames[ 0 ],
+				},
+				comment: '`product` refers to the name of a product such as Jetpack Backup',
+			}
+		);
+	} else {
+		content = translate(
+			"We're sorry, {{product1/}} and {{product2/}} are not compatible with multisite WordPress installations at this time.",
+			{
+				components: {
+					product1: productNames[ 0 ],
+					product2: productNames[ 1 ],
+				},
+				comment: '`product1` and `product2` refer to the name of products such as Jetpack Backup',
+			}
+		);
+	}
+
+	return <PrePurchaseNotice message={ content } />;
+};
+
+export default MultisitesIncompatibleCartProductNotice;

--- a/client/my-sites/checkout/checkout/prepurchase-notices/prepurchase-notice.tsx
+++ b/client/my-sites/checkout/checkout/prepurchase-notices/prepurchase-notice.tsx
@@ -4,11 +4,22 @@
 import React from 'react';
 
 /**
- * Internal dependencies
+ * Type dependencies
+ */
+import { TranslateResult } from 'i18n-calypso';
+
+/**
+ * Style dependencies
  */
 import './style.scss';
 
-const PrePurchaseNotice = ( { message, linkUrl, linkText } ) => (
+type Props = {
+	message: TranslateResult;
+	linkUrl?: string;
+	linkText?: TranslateResult;
+};
+
+const PrePurchaseNotice = ( { message, linkUrl, linkText }: Props ) => (
 	<div className="prepurchase-notice">
 		<p className="prepurchase-notice__message">{ message }</p>
 		{ linkUrl && linkText && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Jetpack Backup and Jetpack Scan are not compatible with multi-site installations. This PRs makes the checkout display a Notice when this situation occurs. 

#### Implementation note

* This PR won't block a purchase attempt. That is something we are going to manage in the back-end side.

#### Testing instructions

Prerequisite: Jetpack site in a multi-site network.
* Run this PR.
* Attempt to purchase any flavor of either Jetpack Backup or Jetpack Scan.
* Make sure that in the checkout step, a Notice is displayed that explain that the product is not compatible with multi-sites.
* Make sure that when adding two or more incompatible products, the name of each product is visible in the Notice.

Fixes 1169247016322522-as-1195195007721561

#### Demo

**1 incompatible product**
<img width="1056" alt="Checkout1Product" src="https://user-images.githubusercontent.com/3418513/94079695-f8f63300-fdd4-11ea-8356-a4d71c33a42b.png">

**2 incompatible products**
<img width="1055" alt="Checkout2Products" src="https://user-images.githubusercontent.com/3418513/94079737-fb588d00-fdd4-11ea-9bc0-950dce406f80.png">

**3 incompatible products**
<img width="1053" alt="Checkout3Products" src="https://user-images.githubusercontent.com/3418513/94079755-fc89ba00-fdd4-11ea-8419-9e3398581032.png">
