### PR TITLE
Coming soon: add coming soon page selector

### DIFF
--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -9,6 +9,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { isComingSoonPage, isFrontPage, isPostsPage } from 'state/pages/selectors';
 import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -102,7 +103,9 @@ export default connect( ( state, props ) => {
 	const themeId = PostMetadata.homepageTemplate( props.page );
 
 	return {
-		isComingSoon: isComingSoonPage( state, props.page.site_ID, props.page.ID ),
+		isComingSoon:
+			isComingSoonPage( state, props.page.site_ID, props.page.ID ) &&
+			!! config.isEnabled( 'editing-toolkit/coming-soon' ),
 		isFront: isFrontPage( state, props.page.site_ID, props.page.ID ),
 		isPosts: isPostsPage( state, props.page.site_ID, props.page.ID ),
 		theme: themeId && getTheme( state, 'wpcom', themeId ),

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -9,7 +9,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
-import { isFrontPage, isPostsPage } from 'state/pages/selectors';
+import { isComingSoonPage, isFrontPage, isPostsPage } from 'state/pages/selectors';
 import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
 import canCurrentUser from 'state/selectors/can-current-user';
 import getEditorUrl from 'state/selectors/get-editor-url';
@@ -42,6 +42,7 @@ function PageCardInfo( {
 	page,
 	showTimestamp,
 	showPublishedStatus,
+	isComingSoon,
 	isFront,
 	isPosts,
 	siteUrl,
@@ -65,6 +66,12 @@ function PageCardInfo( {
 						gridiconSize={ ICON_SIZE }
 						includeBasicStatus={ true }
 					/>
+				) }
+				{ isComingSoon && (
+					<span className="page-card-info__badge">
+						<Gridicon icon="time" size={ ICON_SIZE } className="page-card-info__badge-icon" />
+						<span className="page-card-info__badge-text">{ translate( 'Coming Soon' ) }</span>
+					</span>
 				) }
 				{ isFront && (
 					<span className="page-card-info__badge">
@@ -95,6 +102,7 @@ export default connect( ( state, props ) => {
 	const themeId = PostMetadata.homepageTemplate( props.page );
 
 	return {
+		isComingSoon: isComingSoonPage( state, props.page.site_ID, props.page.ID ),
 		isFront: isFrontPage( state, props.page.site_ID, props.page.ID ),
 		isPosts: isPostsPage( state, props.page.site_ID, props.page.ID ),
 		theme: themeId && getTheme( state, 'wpcom', themeId ),

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -105,7 +105,7 @@ export default connect( ( state, props ) => {
 	return {
 		isComingSoon:
 			isComingSoonPage( state, props.page.site_ID, props.page.ID ) &&
-			!! config.isEnabled( 'editing-toolkit/coming-soon' ),
+			!! config.isEnabled( 'coming-soon-v2' ),
 		isFront: isFrontPage( state, props.page.site_ID, props.page.ID ),
 		isPosts: isPostsPage( state, props.page.site_ID, props.page.ID ),
 		theme: themeId && getTheme( state, 'wpcom', themeId ),

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -33,6 +33,7 @@ import {
 	hasStaticFrontPage,
 	isJetpackSite,
 	isSitePreviewable,
+	isCurrentPlanPaid,
 } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isComingSoonPage, isFrontPage, isPostsPage } from 'state/pages/selectors';
@@ -359,9 +360,10 @@ class Page extends Component {
 	};
 
 	getComingSoonPageItem() {
-		const { canManageOptions, translate } = this.props;
+		const { canManageOptions, isFreePlan, translate } = this.props;
 
 		if (
+			isFreePlan ||
 			! config.isEnabled( 'coming-soon-v2' ) ||
 			! canManageOptions ||
 			'publish' !== this.props.page.status ||
@@ -803,6 +805,7 @@ const mapState = ( state, props ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const isPreviewable =
 		false !== isSitePreviewable( state, pageSiteId ) && site && site.ID === selectedSiteId;
+	const isFreePlan = ! isCurrentPlanPaid( state, selectedSiteId );
 
 	return {
 		hasStaticFrontPage: hasStaticFrontPage( state, pageSiteId ),
@@ -823,6 +826,7 @@ const mapState = ( state, props ) => {
 		duplicateUrl: getEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID, 'page' ),
 		isFullSiteEditing: isSiteUsingFullSiteEditing( state, pageSiteId ),
 		canManageOptions: canCurrentUser( state, pageSiteId, 'manage_options' ),
+		isFreePlan,
 	};
 };
 

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -362,7 +362,7 @@ class Page extends Component {
 		const { canManageOptions, translate } = this.props;
 
 		if (
-			! config.isEnabled( 'editing-toolkit/coming-soon' ) ||
+			! config.isEnabled( 'coming-soon-v2' ) ||
 			! canManageOptions ||
 			'publish' !== this.props.page.status ||
 			this.props.isFrontPage ||

--- a/client/state/data-layer/wpcom/sites/homepage/index.js
+++ b/client/state/data-layer/wpcom/sites/homepage/index.js
@@ -13,6 +13,16 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { updateSiteFrontPage } from 'state/sites/actions';
 
+const getIsPageOnFront = ( show_on_front ) => {
+	if ( 'page' === show_on_front ) {
+		return true;
+	}
+	if ( 'posts' === show_on_front ) {
+		return false;
+	}
+	return undefined;
+};
+
 const updateSiteFrontPageRequest = ( action ) =>
 	http(
 		{
@@ -20,9 +30,13 @@ const updateSiteFrontPageRequest = ( action ) =>
 			method: 'POST',
 			apiVersion: '1.1',
 			body: {
-				is_page_on_front: 'page' === get( action.frontPageOptions, 'show_on_front' ),
+				is_page_on_front: getIsPageOnFront( get( action.frontPageOptions, 'show_on_front' ) ),
 				page_on_front_id: get( action.frontPageOptions, 'page_on_front' ),
 				page_for_posts_id: get( action.frontPageOptions, 'page_for_posts' ),
+				wpcom_public_coming_soon_page_id: get(
+					action.frontPageOptions,
+					'wpcom_public_coming_soon_page_id'
+				),
 			},
 		},
 		action

--- a/client/state/pages/selectors.js
+++ b/client/state/pages/selectors.js
@@ -5,7 +5,11 @@
 /**
  * Internal dependencies
  */
-import { getSiteFrontPage, getSitePostsPage } from 'state/sites/selectors';
+import { getComingSoonPageId, getSiteFrontPage, getSitePostsPage } from 'state/sites/selectors';
+
+export function isComingSoonPage( state, siteId, pageId ) {
+	return pageId === getComingSoonPageId( state, siteId );
+}
 
 export function isFrontPage( state, siteId, pageId ) {
 	return pageId === getSiteFrontPage( state, siteId );

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -54,6 +54,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'permalink_structure',
 	'page_on_front',
 	'page_for_posts',
+	'wpcom_public_coming_soon_page_id',
 	'podcasting_archive',
 	'podcasting_category_id',
 	'publicize_permanently_disabled',

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -133,7 +133,7 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 			let nextSite = site;
 
 			return reduce(
-				[ 'blog_public', 'wpcom_public_coming_soon', 'site_icon' ],
+				[ 'blog_public', 'wpcom_public_coming_soon', 'wpcom_coming_soon', 'site_icon' ],
 				( memo, key ) => {
 					// A site settings update may or may not include the icon or blog_public property.
 					// If not, we should simply return state unchanged.
@@ -155,8 +155,11 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 							};
 							break;
 						}
+						case 'wpcom_coming_soon':
 						case 'wpcom_public_coming_soon': {
-							const isComingSoon = parseInt( settings.wpcom_public_coming_soon, 10 ) === 1;
+							const isComingSoon =
+								parseInt( settings.wpcom_public_coming_soon, 10 ) === 1 ||
+								parseInt( settings.wpcom_coming_soon, 10 ) === 1;
 
 							if ( site.is_coming_soon === isComingSoon ) {
 								return memo;

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -133,7 +133,7 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 			let nextSite = site;
 
 			return reduce(
-				[ 'blog_public', 'wpcom_coming_soon', 'site_icon' ],
+				[ 'blog_public', 'wpcom_public_coming_soon', 'site_icon' ],
 				( memo, key ) => {
 					// A site settings update may or may not include the icon or blog_public property.
 					// If not, we should simply return state unchanged.
@@ -155,8 +155,8 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 							};
 							break;
 						}
-						case 'wpcom_coming_soon': {
-							const isComingSoon = parseInt( settings.wpcom_coming_soon, 10 ) === 1;
+						case 'wpcom_public_coming_soon': {
+							const isComingSoon = parseInt( settings.wpcom_public_coming_soon, 10 ) === 1;
 
 							if ( site.is_coming_soon === isComingSoon ) {
 								return memo;

--- a/client/state/sites/selectors/get-coming-soon-page-id.js
+++ b/client/state/sites/selectors/get-coming-soon-page-id.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { getSiteOption } from 'state/sites/selectors';
+
+/**
+ * Returns the ID of the coming soon page, or 0 if not set.
+ *
+ * @param {object} state Global state tree
+ * @param {object} siteId Site ID
+ * @returns {number} ID of the static page set as the coming soon page, or 0 if not set
+ */
+export default function getComingSoonPageId( state, siteId ) {
+	return getSiteOption( state, siteId, 'wpcom_public_coming_soon_page_id' );
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -8,6 +8,7 @@ export { default as canCurrentUserUseStore } from './can-current-user-use-store'
 export { default as canJetpackSiteAutoUpdateCore } from './can-jetpack-site-auto-update-core';
 export { default as canJetpackSiteAutoUpdateFiles } from './can-jetpack-site-auto-update-files';
 export { default as canJetpackSiteUpdateFiles } from './can-jetpack-site-update-files';
+export { default as getComingSoonPageId } from './get-coming-soon-page-id';
 export { default as getCustomizerUrl } from './get-customizer-url';
 export { default as getJetpackComputedAttributes } from './get-jetpack-computed-attributes';
 export { default as getJetpackSiteUpdateFilesDisabledReasons } from './get-jetpack-site-update-files-disabled-reasons';
@@ -41,6 +42,7 @@ export { default as hasJetpackSiteJetpackThemes } from './has-jetpack-site-jetpa
 export { default as hasSiteProduct } from './has-site-product';
 export { default as hasJetpackSiteJetpackThemesExtendedFeatures } from './has-jetpack-site-jetpack-themes-extended-features';
 export { default as hasStaticFrontPage } from './has-static-front-page';
+export { default as isComingSoonModeActive } from './is-coming-soon-mode-active';
 export { default as isCurrentPlanPaid } from './is-current-plan-paid';
 export { default as isCurrentSitePlan } from './is-current-site-plan';
 export { default as isJetpackMinimumVersion } from './is-jetpack-minimum-version';

--- a/client/state/sites/selectors/is-coming-soon-mode-active.js
+++ b/client/state/sites/selectors/is-coming-soon-mode-active.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { getSiteOption } from 'state/sites/selectors';
+
+/**
+ * Returns the ID of the coming soon page, or 0 if not set.
+ *
+ * @param {object} state Global state tree
+ * @param {object} siteId Site ID
+ * @returns {number} ID of the static page set as the coming soon page, or 0 if not set
+ */
+export default function isComingSoonModeActive( state, siteId ) {
+	return parseInt( getSiteOption( state, siteId, 'wpcom_public_coming_soon' ), 10 ) === 1;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR splits out the page selector functionality in https://github.com/Automattic/wp-calypso/pull/45606.

We're adding a coming soon page selector to the ellipsis menu for **sites with a paid plan**. 

We're also showing a coming soon badge to indicate that a page has been selected as coming soon.

#### Testing instructions

Make sure your test site as a paid upgrade, e.g., a personal plan.

Ensure that the new coming soon mode is activated on your test site, e.g., 

```
wp option --url=your_site add wpcom_public_coming_soon 1
```

Go to http://calypso.localhost:3000/pages/{your_site}?flags=coming-soon-v2

Assign a site to be your coming soon page

<img width="435" alt="Screen Shot 2020-09-24 at 3 02 40 pm" src="https://user-images.githubusercontent.com/6458278/94103816-d61d5a80-fe78-11ea-9f05-d58d10c12619.png">

Check that we're firing the coming soon page set toggle tracks event `calypso_coming_soon_set_page`:

<img width="315" alt="Screen Shot 2020-09-30 at 11 44 16 am" src="https://user-images.githubusercontent.com/6458278/94634087-76103380-0312-11eb-8531-c7f827935f2e.png">

Check that the badge is assigned

<img width="492" alt="Screen Shot 2020-09-24 at 3 13 56 pm" src="https://user-images.githubusercontent.com/6458278/94103837-e03f5900-fe78-11ea-901f-2e45a48e70fe.png">


Also make sure the network request to `public-api.wordpress.com/rest/v1.1/sites/{site_id}/homepage` is fired with the correct page ID:

<img width="388" alt="Screen Shot 2020-09-24 at 3 04 27 pm" src="https://user-images.githubusercontent.com/6458278/94103863-f0efcf00-fe78-11ea-964e-39cb10cece46.png">

Refresh the page to check that the page id has been saved. Also run:

```
wp option --url=your_site get wpcom_public_coming_soon_page_id
```

Now switch off the feature flag (Go to http://calypso.localhost:3000/pages/{your_site}) and make sure the coming soon ellipsis menu and page badge are not visible.

Repeat the above steps with a free site. You shouldn't see the coming soon options at all in the ellipsis menu.

Fixes: https://github.com/Automattic/wp-calypso/issues/45022
