### PR TITLE
Gutenboarding: enable patterns toolkit in all environments

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -80,7 +80,7 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 						font_headings: selectedFonts.headings,
 						font_base: selectedFonts.base,
 					} ),
-					use_patterns: isEnabled( 'gutenboarding/use-patterns' ),
+					use_patterns: true,
 				} );
 				if ( isEnabled( 'gutenboarding/style-preview-verticals' ) ) {
 					url = addQueryArgs( url, {

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -85,7 +85,7 @@ export function* createSite(
 				font_base: selectedFonts.base,
 				font_headings: selectedFonts.headings,
 			} ),
-			use_patterns: isEnabled( 'gutenboarding/use-patterns' ),
+			use_patterns: true,
 			selected_features: selectedFeatures,
 			...( isEnabled( 'gutenboarding/public-coming-soon' ) &&
 				visibility === Site.Visibility.PublicNotIndexed && {

--- a/config/development.json
+++ b/config/development.json
@@ -69,7 +69,6 @@
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch": true,
-		"gutenboarding/use-patterns": true,
 		"gutenboarding/show-vertical-input": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -43,7 +43,6 @@
 		"google-my-business": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch": true,
-		"gutenboarding/use-patterns": false,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -56,7 +56,6 @@
 		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch": true,
-		"gutenboarding/use-patterns": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This commit removes the use patterns toolkit feature flag and sets the default value of the API query parameter to `true`. 

In short, we're turning on the patterns toolkit for Gutenboarding in all environments. 

This enables translations of starter designs.

<img width="969" alt="Screen Shot 2020-09-24 at 5 05 06 pm" src="https://user-images.githubusercontent.com/6458278/94111990-205a0800-fe88-11ea-94f6-70feca139d53.png">

Sweet.

#### Testing instructions

Translations are available for our mag 16 languages: ` 'es', 'pt-br', 'de', 'fr', 'he', 'ja', 'it', 'nl', 'ru', 'tr', 'id', 'zh-cn', 'zh-tw', 'ko', 'ar', 'sv'`

Test at:

`/new/{locale_slug}`

Check the previews for all designs in your locale. Create a site and check that the post and page content is translated.
