### PR TITLE
Write server logs to a file

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -134,6 +134,7 @@
 		"is-my-json-valid": "^2.20.0",
 		"jest-emotion": "^10.0.27",
 		"jest-fetch-mock": "^2.1.2",
+		"jest-mock-process": "^1.4.0",
 		"jquery": "^1.12.3",
 		"js-yaml": "^3.14.0",
 		"keymaster": "^1.6.2",

--- a/client/server/lib/logger/index.js
+++ b/client/server/lib/logger/index.js
@@ -13,15 +13,12 @@ const createLogger = () => {
 				stream: process.stdout,
 				level: 'info',
 			},
-			{
-				stream: process.stderr,
-				level: 'error',
-			},
 		],
 	} );
 	if ( process.env.CALYPSO_LOGFILE ) {
 		logger.addStream( {
 			path: process.env.CALYPSO_LOGFILE,
+			level: 'info',
 		} );
 	}
 };

--- a/client/server/lib/logger/index.js
+++ b/client/server/lib/logger/index.js
@@ -6,7 +6,24 @@ import bunyan from 'bunyan';
 let logger;
 
 const createLogger = () => {
-	logger = bunyan.createLogger( { name: 'calypso' } );
+	logger = bunyan.createLogger( {
+		name: 'calypso',
+		streams: [
+			{
+				stream: process.stdout,
+				level: 'info',
+			},
+			{
+				stream: process.stderr,
+				level: 'error',
+			},
+		],
+	} );
+	if ( process.env.CALYPSO_LOGFILE ) {
+		logger.addStream( {
+			path: process.env.CALYPSO_LOGFILE,
+		} );
+	}
 };
 
 export const getLogger = () => {

--- a/client/server/lib/logger/test/index.js
+++ b/client/server/lib/logger/test/index.js
@@ -1,17 +1,15 @@
 /**
  * External dependencies
  */
-import { mockProcessStdout, mockProcessStderr } from 'jest-mock-process';
+import { mockProcessStdout } from 'jest-mock-process';
 import mockFs from 'mock-fs';
 import fs from 'fs';
 
 let mockStdout;
-let mockStderr;
 let getLogger;
 
 beforeEach( () => {
 	( { getLogger } = require( '../index' ) );
-	mockStderr = mockProcessStderr();
 	mockStdout = mockProcessStdout();
 	mockFs( {
 		'/tmp': {},
@@ -21,7 +19,6 @@ beforeEach( () => {
 afterEach( () => {
 	jest.resetModules();
 	mockStdout.mockRestore();
-	mockStderr.mockRestore();
 	delete process.env.CALYPSO_LOGFILE;
 	mockFs.restore();
 } );
@@ -50,23 +47,6 @@ it( 'Logs info and above levels to stdout', () => {
 	expect( loggedMessages ).toEqual( [
 		expect.objectContaining( { msg: 'info', level: 30 } ),
 		expect.objectContaining( { msg: 'warn', level: 40 } ),
-		expect.objectContaining( { msg: 'error', level: 50 } ),
-		expect.objectContaining( { msg: 'fatal', level: 60 } ),
-	] );
-} );
-
-it( 'Logs error and above levels to stderr', () => {
-	const logger = getLogger();
-
-	logger.trace( 'trace' ); // not logged
-	logger.debug( 'debug' ); // not logged
-	logger.info( 'info' ); // not logged
-	logger.warn( 'warn' ); // not logged
-	logger.error( 'error' );
-	logger.fatal( 'fatal' );
-
-	const loggedMessages = mockStderr.mock.calls.map( ( args ) => JSON.parse( args[ 0 ] ) );
-	expect( loggedMessages ).toEqual( [
 		expect.objectContaining( { msg: 'error', level: 50 } ),
 		expect.objectContaining( { msg: 'fatal', level: 60 } ),
 	] );

--- a/client/server/lib/logger/test/index.js
+++ b/client/server/lib/logger/test/index.js
@@ -1,38 +1,98 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { getLogger } from '../index';
-import bunyan from 'bunyan';
+import { mockProcessStdout, mockProcessStderr } from 'jest-mock-process';
+import mockFs from 'mock-fs';
+import fs from 'fs';
 
-/**
- * Mocks `bunyan` so every instance returned by `createLogger` logs to a buffer instead
- * of process.stdout. We can retrieve that buffer with `bunyan.getOutputBuffer()` and make
- * assertions on it.
- */
-jest.mock( 'bunyan', () => {
-	const realBunyan = jest.requireActual( 'bunyan' );
-	const buffer = new realBunyan.RingBuffer( { limit: 100 } );
+let mockStdout;
+let mockStderr;
+let getLogger;
 
-	return {
-		createLogger: jest.fn( ( options ) => {
-			return realBunyan.createLogger( {
-				...options,
-				streams: [ { type: 'raw', stream: buffer } ],
-			} );
-		} ),
-		getOutputBuffer: () => buffer,
-	};
+beforeEach( () => {
+	( { getLogger } = require( '../index' ) );
+	mockStderr = mockProcessStderr();
+	mockStdout = mockProcessStdout();
+	mockFs( {
+		'/tmp': {},
+	} );
+} );
+
+afterEach( () => {
+	jest.resetModules();
+	mockStdout.mockRestore();
+	mockStderr.mockRestore();
+	delete process.env.CALYPSO_LOGFILE;
+	mockFs.restore();
 } );
 
 it( "Returns a logger with the name 'calypso'", () => {
-	const buffer = bunyan.getOutputBuffer();
+	const logger = getLogger();
 
-	getLogger().info( 'message' );
+	logger.info( 'message' );
 
-	expect( buffer.records ).toHaveLength( 1 );
-	expect( buffer.records ).toEqual(
-		expect.arrayContaining( [ expect.objectContaining( { name: 'calypso' } ) ] )
-	);
+	expect( mockStdout ).toHaveBeenCalledTimes( 1 );
+	const loggedMessage = mockStdout.mock.calls[ 0 ][ 0 ];
+	expect( JSON.parse( loggedMessage ) ).toEqual( expect.objectContaining( { name: 'calypso' } ) );
+} );
+
+it( 'Logs info and above levels to stdout', () => {
+	const logger = getLogger();
+
+	logger.trace( 'trace' ); // not logged
+	logger.debug( 'debug' ); // not logged
+	logger.info( 'info' );
+	logger.warn( 'warn' );
+	logger.error( 'error' );
+	logger.fatal( 'fatal' );
+
+	const loggedMessages = mockStdout.mock.calls.map( ( args ) => JSON.parse( args[ 0 ] ) );
+	expect( loggedMessages ).toEqual( [
+		expect.objectContaining( { msg: 'info', level: 30 } ),
+		expect.objectContaining( { msg: 'warn', level: 40 } ),
+		expect.objectContaining( { msg: 'error', level: 50 } ),
+		expect.objectContaining( { msg: 'fatal', level: 60 } ),
+	] );
+} );
+
+it( 'Logs error and above levels to stderr', () => {
+	const logger = getLogger();
+
+	logger.trace( 'trace' ); // not logged
+	logger.debug( 'debug' ); // not logged
+	logger.info( 'info' ); // not logged
+	logger.warn( 'warn' ); // not logged
+	logger.error( 'error' );
+	logger.fatal( 'fatal' );
+
+	const loggedMessages = mockStderr.mock.calls.map( ( args ) => JSON.parse( args[ 0 ] ) );
+	expect( loggedMessages ).toEqual( [
+		expect.objectContaining( { msg: 'error', level: 50 } ),
+		expect.objectContaining( { msg: 'fatal', level: 60 } ),
+	] );
+} );
+
+it( 'Logs info and above levels to the filesystem when the env variable is present', async () => {
+	process.env.CALYPSO_LOGFILE = '/tmp/calypso.log';
+	const logger = getLogger();
+
+	logger.trace( 'trace' ); // not logged
+	logger.debug( 'debug' ); // not logged
+	logger.info( 'info' );
+	logger.warn( 'warn' );
+	logger.error( 'error' );
+	logger.fatal( 'fatal' );
+
+	const logLines = ( await fs.promises.readFile( '/tmp/calypso.log', 'utf8' ) )
+		.split( '\n' )
+		.filter( ( line ) => line.length > 0 )
+		.map( JSON.parse );
+	expect( logLines ).toEqual( [
+		expect.objectContaining( { msg: 'info', level: 30 } ),
+		expect.objectContaining( { msg: 'warn', level: 40 } ),
+		expect.objectContaining( { msg: 'error', level: 50 } ),
+		expect.objectContaining( { msg: 'fatal', level: 60 } ),
+	] );
 } );
 
 it( 'Reuses the same logger', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16746,6 +16746,11 @@ jest-message-util@^26.3.0:
     slash "^3.0.0"
     stack-utils "^2.0.2"
 
+jest-mock-process@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jest-mock-process/-/jest-mock-process-1.4.0.tgz#7031384115a2d678ee54761356cfcfdc2a34e493"
+  integrity sha512-3LM1TyEaRKRjh/x9rZPmuy28r7q8cgNkHYcrPWtxXT3ZzPPS+bKNs2ysb8BJPVB41X5yM1sMtatvE5z2XJ0S/w==
+
 jest-mock@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.9.0.tgz#c22835541ee379b908673ad51087a2185c13f1c6"


### PR DESCRIPTION
### Background

We want to store server logs in a file. See pMz3w-c0R-p2

More info about bunyan streams: https://github.com/trentm/node-bunyan#streams-introduction

### Changes

* Refactor logger tests to be more robust when several streams are used
* Add a new logger stream to a file when the env var is present

### Testing instructions

Run `yarn build-server` to build the server. Then run `CALYPSO_LOGFILE=/tmp/calypso.log node build/server.js`.
You should see the logs in the console *and* in `/tmp/calypso.log`.
