### PR TITLE
DevDocs: Use URL interface instead of url package

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -1,12 +1,10 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { stringify } from 'qs';
 import { debounce } from 'lodash';
 import page from 'page';
-import url from 'url';
 
 /**
  * Internal dependencies
@@ -137,7 +135,7 @@ const devdocs = {
 	},
 
 	pleaseLogIn: function ( context, next ) {
-		const currentUrl = url.parse( window.location.href );
+		const currentUrl = new URL( window.location.href );
 		const redirectTo = currentUrl.protocol + '//' + currentUrl.host + '/devdocs/welcome';
 		if ( ! getCurrentUserId( context.store.getState() ) ) {
 			context.primary = React.createElement( EmptyContent, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* DevDocs: Use URL interface instead of `url` package

#### Testing instructions

* Checkout this branch.
* Go to `/devdocs/start` as a logged-in user.
* Verify you're still correctly redirected to `/devdocs/welcome`.

#### Context

Discovered while working on #45523.
