### PR TITLE
Update discount copy for bundle upsells

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -21,7 +21,7 @@ import PlanIntervalDiscount from 'my-sites/plan-interval-discount';
 import PlanPill from 'components/plans/plan-pill';
 import { TYPE_FREE, GROUP_WPCOM, TERM_ANNUALLY } from 'lib/plans/constants';
 import { PLANS_LIST } from 'lib/plans/plans-list';
-import { getYearlyPlanByMonthly, planMatches, getPlanClass } from 'lib/plans';
+import { getYearlyPlanByMonthly, planMatches, getPlanClass, isFreePlan } from 'lib/plans';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -163,11 +163,14 @@ export class PlanFeaturesHeader extends Component {
 	}
 
 	getPerMonthDescription() {
-		const { discountPrice, rawPrice, translate, planType } = this.props;
+		const { discountPrice, rawPrice, translate, planType, currentSitePlan } = this.props;
 		if ( typeof discountPrice !== 'number' || typeof rawPrice !== 'number' ) {
 			return null;
 		}
 		if ( ! planMatches( planType, { group: GROUP_WPCOM, term: TERM_ANNUALLY } ) ) {
+			return null;
+		}
+		if ( ! isFreePlan( currentSitePlan.productSlug ) ) {
 			return null;
 		}
 		const discountPercent = Math.round( ( 100 * ( rawPrice - discountPrice ) ) / rawPrice );


### PR DESCRIPTION
It was suggested that we keep the old billing timeframe copy for plan upgrades because in that case the discount comes from plan credits and is not a discount.

This change will only display the `Save %d` timeframe to users on a free plan.

#### Testing instructions

1. On an existing site, change the currency to PHP, MXN, or INR
2. When the plan is free, the user should see the Save ... copy
<img width="349" alt="Screenshot 2020-09-24 at 12 53 14" src="https://user-images.githubusercontent.com/82778/94130689-a87ae600-fe65-11ea-8ab0-ffa36a6d15a7.png">
3. Add a Personal plan
4. The copy is now the default discount copy, no "Save %d":
<img width="349" alt="Screenshot 2020-09-24 at 12 51 35" src="https://user-images.githubusercontent.com/82778/94131015-1a532f80-fe66-11ea-964d-d45fed4223c6.png">
5. Change the currency to EUR or USD or another that's not with 1st year discounts. Same copy
<img width="349" alt="Screenshot 2020-09-24 at 12 52 47" src="https://user-images.githubusercontent.com/82778/94131227-56869000-fe66-11ea-8515-32dd1512f17f.png">
6. If the currency is EUR and there's no plan, there should be no discount copy whatsoever.
<img width="349" alt="Screenshot 2020-09-24 at 13 04 29" src="https://user-images.githubusercontent.com/82778/94131376-82097a80-fe66-11ea-860f-4d70f51252d5.png">
