### PR TITLE
Change Editor notes block to use the correct attributes type

### DIFF
--- a/apps/o2-blocks/src/editor-notes/editor.js
+++ b/apps/o2-blocks/src/editor-notes/editor.js
@@ -8,8 +8,8 @@ import './editor.scss';
 
 const attributes = {
 	notes: {
-		type: 'array',
-	},
+		type: 'string'
+	}
 };
 
 const edit = ( { attributes: { notes }, className, isSelected, setAttributes } ) => (
@@ -26,7 +26,7 @@ const edit = ( { attributes: { notes }, className, isSelected, setAttributes } )
 			tagName="p"
 			className={ className }
 			value={ notes }
-			onChange={ ( newNotes ) => setAttributes( { notes: newNotes } ) }
+			onChange={ newNotes => setAttributes( { notes: newNotes } ) }
 		/>
 	</div>
 );
@@ -39,5 +39,5 @@ registerBlockType( 'a8c/editor-notes', {
 	category: 'a8c',
 	attributes,
 	edit,
-	save,
+	save
 } );

--- a/apps/o2-blocks/src/editor-notes/editor.js
+++ b/apps/o2-blocks/src/editor-notes/editor.js
@@ -8,8 +8,8 @@ import './editor.scss';
 
 const attributes = {
 	notes: {
-		type: 'string'
-	}
+		type: 'string',
+	},
 };
 
 const edit = ( { attributes: { notes }, className, isSelected, setAttributes } ) => (
@@ -26,7 +26,7 @@ const edit = ( { attributes: { notes }, className, isSelected, setAttributes } )
 			tagName="p"
 			className={ className }
 			value={ notes }
-			onChange={ newNotes => setAttributes( { notes: newNotes } ) }
+			onChange={ ( newNotes ) => setAttributes( { notes: newNotes } ) }
 		/>
 	</div>
 );
@@ -39,5 +39,5 @@ registerBlockType( 'a8c/editor-notes', {
 	category: 'a8c',
 	attributes,
 	edit,
-	save
+	save,
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Editor notes block used `array` as an attribute type instead of string, `RichText` doesn't accept an array, this caused the attributes to be lost on parse.

#### Testing instructions


* Insert a new editor notes block.
* Write some text.
* Save the page.
* Refresh, the text should still be there.

Fixes #40173
