### PR TITLE
Nav Unification: Adds dash-icons

### DIFF
--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -1,7 +1,9 @@
 /**
  * SidebarCustomIcon -
- *   Renders an <img> tag with props supplied, but adds
- *   className="sidebar__menu-icon" to the supplied className.
+ *   Renders an <img> tag with props supplied if icon is a data image
+ *   or a dashicon in other case. If icon is not supplied or undefined
+ *   returns a blank SVG
+ *   Adds className="sidebar__menu-icon" to the supplied className.
  *
  *   Purpose: To display a custom icon in the sidebar when using a
  *   source other than grid icons or material icons.
@@ -10,12 +12,35 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-const SidebarCustomIcon = ( props ) => {
-	const { alt, className, ...rest } = props;
-	return (
-		<img alt={ alt || '' } className={ 'sidebar__menu-icon ' + ( className || '' ) } { ...rest } />
-	);
+
+const blankSvg =
+	"data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E";
+const blankSvgStyle = { height: '20px', width: '20px' };
+
+const SidebarCustomIcon = ( { alt, className, icon, ...rest } ) => {
+	if ( ! icon ) {
+		return (
+			<img
+				alt={ alt || '' }
+				className={ 'sidebar__menu-icon ' + ( className || '' ) }
+				src={ blankSvg }
+				style={ blankSvgStyle }
+				{ ...rest }
+			/>
+		);
+	}
+	if ( icon.indexOf( 'data:image' ) === 0 ) {
+		return (
+			<img
+				alt={ alt || '' }
+				className={ 'sidebar__menu-icon ' + ( className || '' ) }
+				src={ icon }
+				{ ...rest }
+			/>
+		);
+	}
+
+	return <span className={ 'sidebar__menu-icon dashicons-before ' + icon } { ...rest }></span>;
 };
 export default SidebarCustomIcon;

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -43,7 +43,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 					return <MySitesSidebarUnifiedMenu key={ item.slug } path={ path } { ...item } />;
 				}
 
-				return <MySitesSidebarUnifiedItem isTopLevel key={ item.slug } path={ path } { ...item } />;
+				return <MySitesSidebarUnifiedItem key={ item.slug } path={ path } { ...item } />;
 			} ) }
 		</Sidebar>
 	);

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -24,19 +24,9 @@ const onNav = () => null;
 
 // selected={ itemLinkMatches( [ '/domains', '/email' ], path ) }
 
-const blankSvg =
-	"data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E";
-const blankSvgStyle = { height: '24px', width: '24px' };
-
-export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug, isTopLevel } ) => {
+export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selected = path === url;
-	let customIcon = null;
-	if ( icon && typeof icon === 'string' && icon.match( /data:image/ ) ) {
-		customIcon = <SidebarCustomIcon src={ icon } />;
-	} else if ( isTopLevel ) {
-		customIcon = <SidebarCustomIcon crc={ blankSvg } style={ blankSvgStyle } />;
-	}
 
 	let children = null;
 
@@ -52,7 +42,7 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug, isTop
 			link={ url }
 			onNavigate={ onNav }
 			selected={ selected }
-			customIcon={ customIcon }
+			customIcon={ <SidebarCustomIcon icon={ icon } /> }
 		>
 			{ children }
 		</SidebarItem>
@@ -60,7 +50,6 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug, isTop
 };
 
 MySitesSidebarUnifiedItem.propTypes = {
-	isTopLevel: PropTypes.bool,
 	path: PropTypes.string,
 	title: PropTypes.string,
 	icon: PropTypes.string,

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -19,19 +19,21 @@ import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
 import { toggleMySitesSidebarSection as toggleSection } from 'state/my-sites/sidebar/actions';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import MySitesSidebarUnifiedItem from './item';
+import SidebarCustomIcon from 'layout/sidebar/custom-icon';
 
 export const MySitesSidebarUnifiedMenu = ( { slug, title, icon, children, path } ) => {
 	const reduxDispatch = useDispatch();
 	const sectionId = 'SIDEBAR_SECTION_' + slug;
 	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
+
 	return (
 		<ExpandableSidebarMenu
 			onClick={ () => reduxDispatch( toggleSection( sectionId ) ) }
 			expanded={ isExpanded }
 			title={ title }
-			materialIcon={ icon }
+			customIcon={ <SidebarCustomIcon icon={ icon } /> }
 		>
-			{ Object.values( children ).map( ( item ) => (
+			{ children.map( ( item ) => (
 				<MySitesSidebarUnifiedItem key={ item.slug } path={ path } { ...item } />
 			) ) }
 		</ExpandableSidebarMenu>

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -1,4 +1,5 @@
 // The following changes should be merged in their respective files before nav unification goes to production
+@import url( '//s1.wp.com/wp-includes/css/dashicons.css?v=20150727' );
 
 // Override Global Vars
 .is-nav-unification {
@@ -10,7 +11,7 @@
 	--color-sidebar-background-rgb: 35, 40, 45;
 	--color-sidebar-border: var( --color-surface-backdrop );
 	--color-sidebar-text: #eee;
-	--color-sidebar-gridicon-fill: var( --color-sidebar-text );
+	--color-sidebar-gridicon-fill: #a0a5aa;
 	--color-sidebar-text-alternative: #a2aab2;
 }
 
@@ -107,6 +108,10 @@ $font-size: rem( 14px );
 			.sidebar__menu-link-text {
 				padding: 0;
 			}
+		}
+
+		.sidebar__menu-icon {
+			color: var( --color-sidebar-gridicon-fill );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds dashicons import for nav unification

It seems that they are not in the critical path
![](https://cln.sh/68nHj5+)

### Known Issues
- There might be some inconsistencies with `wp-admin` in spacing. They will be handled in a follow up PR
- Feedback icon is served as html `<img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSJub25lIiBkPSJNMTMgNy41aDV2MmgtNXptMCA3aDV2MmgtNXpNMTkgM0g1Yy0xLjEgMC0yIC45LTIgMnYxNGMwIDEuMS45IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjVjMC0xLjEtLjktMi0yLTJ6bTAgMTZINVY1aDE0djE0ek0xMSA2SDZ2NWg1VjZ6bS0xIDRIN1Y3aDN2M3ptMSAzSDZ2NWg1di01em0tMSA0SDd2LTNoM3YzeiIvPjwvc3ZnPg==" alt="" />` we will fix it server side

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run calyspo 
* Add ?flags=nav-unification to the url

Before | After
-------|------
![](https://cln.sh/I6CGeP+) | ![](https://cln.sh/tq7zs1+)

Fixes #45844
