### PR TITLE
Experimental: Checkout sidebar overlay.

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -854,6 +854,22 @@ function getCalypsoUrlInfo( calypsoPort ) {
 	);
 }
 
+function handleUpgradePlan( calypsoPort ) {
+	// When the upgrade button is clicked
+	document.addEventListener( 'click', function ( event ) {
+		if ( event.target.matches( '.jetpack-upgrade-plan-banner__wrapper a' ) ) {
+			// stop it from redirecting to the checkout page
+			event.preventDefault();
+
+			// call parent iframe and show checkout in sidebar
+			calypsoPort.postMessage( {
+				action: 'openCheckoutSidebar',
+				payload: {},
+			} );
+		}
+	} );
+}
+
 /**
  * Passes uncaught errors in window.onerror to Calypso for logging.
  *
@@ -1014,6 +1030,8 @@ function initPort( message ) {
 		handleUncaughtErrors( calypsoPort );
 
 		handleEditorLoaded( calypsoPort );
+
+		handleUpgradePlan( calypsoPort );
 	}
 
 	window.removeEventListener( 'message', initPort, false );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -13,6 +13,7 @@ import { localize, LocalizeProps } from 'i18n-calypso';
  */
 import MediaStore from 'lib/media/store';
 import EditorMediaModal from 'post-editor/editor-media-modal';
+import EditorCheckout from 'post-editor/editor-checkout';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import {
 	getCustomizerUrl,
@@ -85,6 +86,7 @@ interface State {
 	currentIFrameUrl: string;
 	isMediaModalVisible: boolean;
 	isPreviewVisible: boolean;
+	isCheckoutSidebarVisible: boolean;
 	multiple?: any;
 	postUrl?: T.URL;
 	previewUrl: T.URL;
@@ -115,6 +117,7 @@ enum EditorActions {
 	GetNavSidebarLabels = 'getNavSidebarLabels',
 	GetCalypsoUrlInfo = 'getCalypsoUrlInfo',
 	TrackPerformance = 'trackPerformance',
+	OpenCheckoutSidebar = 'openCheckoutSidebar',
 }
 
 class CalypsoifyIframe extends Component<
@@ -125,6 +128,7 @@ class CalypsoifyIframe extends Component<
 		isMediaModalVisible: false,
 		isIframeLoaded: false,
 		isPreviewVisible: false,
+		isCheckoutSidebarVisible: false,
 		previewUrl: 'about:blank',
 		currentIFrameUrl: '',
 	};
@@ -147,6 +151,7 @@ class CalypsoifyIframe extends Component<
 		// provides a redirect to wpadmin for web users - this should now be a rare occurance with
 		// a 3rd party cookie auth issue fix in place https://github.com/Automattic/jetpack/pull/16167
 		this.waitForIframeToInit = setInterval( () => {
+			return; // ignore this one. just for debugging.
 			if ( this.props.shouldLoadIframe ) {
 				clearInterval( this.waitForIframeToInit );
 				this.waitForIframeToLoad = setTimeout( () => {
@@ -410,6 +415,10 @@ class CalypsoifyIframe extends Component<
 				} );
 			}
 		}
+
+		if ( EditorActions.OpenCheckoutSidebar === action ) {
+			this.setState( { isCheckoutSidebarVisible: true } );
+		}
 	};
 
 	handlePostStatusChange = ( status: string ) => {
@@ -578,6 +587,10 @@ class CalypsoifyIframe extends Component<
 		this.navigate( customizerUrl, unsavedChanges );
 	};
 
+	closeCheckoutSidebar = () => {
+		this.setState( { isCheckoutSidebarVisible: false } );
+	};
+
 	getTemplateEditorUrl = ( templateId: T.PostId ) => {
 		const { getTemplateEditorUrl, editedPostId } = this.props;
 
@@ -669,6 +682,7 @@ class CalypsoifyIframe extends Component<
 			postUrl,
 			editedPost,
 			currentIFrameUrl,
+			isCheckoutSidebarVisible,
 		} = this.state;
 
 		const isUsingClassicBlock = !! classicBlockEditorId;
@@ -718,6 +732,7 @@ class CalypsoifyIframe extends Component<
 					showEditHeaderLink={ true }
 					showPreview={ isPreviewVisible }
 				/>
+				<EditorCheckout onClose={ this.closeCheckoutSidebar } isOpen={ isCheckoutSidebarVisible } />
 			</Fragment>
 		);
 	}

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -115,6 +115,7 @@ export default function CompositeCheckout( {
 	isLoggedOutCart,
 	isNoSiteCart,
 	infoMessage,
+	isInEditor,
 } ) {
 	const translate = useTranslate();
 	const isJetpackNotAtomic = useSelector(
@@ -236,6 +237,7 @@ export default function CompositeCheckout( {
 		siteId,
 		hideNudge,
 		recordEvent,
+		isInEditor,
 		isLoggedOutCart,
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -255,12 +255,20 @@ export async function payPalProcessor(
 	transactionOptions
 ) {
 	const { createUserAndSiteBeforeTransaction } = transactionOptions;
-	const { protocol, hostname, port, pathname } = parseUrl( window.location.href, true );
+	const defaultDomain = 'https://wordpress.com';
+	const isWindow = typeof window !== 'undefined';
+	const { protocol, hostname, port, pathname } = parseUrl(
+		isWindow ? window.location.href : defaultDomain,
+		true
+	);
+	const originDomain = isWindow ? window.location.origin : defaultDomain;
+	const thankYouUrl = getThankYouUrl();
+	const relativeThankYouUrl = thankYouUrl.replace?.( originDomain, '' );
 	const successUrl = formatUrl( {
 		protocol,
 		hostname,
 		port,
-		pathname: getThankYouUrl(),
+		pathname: relativeThankYouUrl,
 	} );
 	const cancelUrl = formatUrl( {
 		protocol,

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -54,6 +54,7 @@ export function getThankYouPageUrl( {
 	hideNudge,
 	didPurchaseFail,
 	isTransactionResultEmpty,
+	isInEditor,
 } ) {
 	debug( 'starting getThankYouPageUrl' );
 	// If we're given an explicit `redirectTo` query arg, make sure it's either internal
@@ -100,8 +101,12 @@ export function getThankYouPageUrl( {
 		product,
 	} );
 	debug( 'fallbackUrl is', fallbackUrl );
-
 	saveUrlToCookieIfEcomm( saveUrlToCookie, cart, fallbackUrl );
+	if ( ! hasEcommercePlan( cart ) && isInEditor ) {
+		// If the user is making a purchase/upgrading within the editor,
+		// we want to return them back to the editor after the purchase is successful.
+		saveUrlToCookieIfEditor( saveUrlToCookie, window?.location.href );
+	}
 	modifyCookieUrlIfAtomic( getUrlFromCookie, saveUrlToCookie, siteSlug );
 
 	// Fetch the thank-you page url from a cookie if it is set
@@ -340,6 +345,10 @@ function saveUrlToCookieIfEcomm( saveUrlToCookie, cart, destinationUrl ) {
 	}
 }
 
+function saveUrlToCookieIfEditor( saveUrlToCookie, destinationUrl ) {
+	saveUrlToCookie( destinationUrl );
+}
+
 function modifyCookieUrlIfAtomic( getUrlFromCookie, saveUrlToCookie, siteSlug ) {
 	const signupDestination = getUrlFromCookie();
 	if ( ! signupDestination ) {
@@ -367,6 +376,7 @@ export function useGetThankYouUrl( {
 	siteId,
 	hideNudge,
 	recordEvent,
+	isInEditor,
 } ) {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 	const adminUrl = selectedSiteData?.options?.admin_url;
@@ -402,6 +412,7 @@ export function useGetThankYouUrl( {
 			hideNudge,
 			didPurchaseFail,
 			isTransactionResultEmpty,
+			isInEditor,
 		};
 		debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );
 		const url = getThankYouPageUrl( getThankYouPageUrlArguments );

--- a/client/post-editor/editor-checkout/index.jsx
+++ b/client/post-editor/editor-checkout/index.jsx
@@ -59,7 +59,12 @@ class EditorCheckout extends Component {
 					[X] Close Sidebar
 				</button>
 				<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>
-					<CompositeCheckout siteId={ site.ID } siteSlug={ site.slug } getCart={ getCart } />
+					<CompositeCheckout
+						isInEditor={ true }
+						siteId={ site.ID }
+						siteSlug={ site.slug }
+						getCart={ getCart }
+					/>
 				</StripeHookProvider>
 			</div>
 		);

--- a/client/post-editor/editor-checkout/index.jsx
+++ b/client/post-editor/editor-checkout/index.jsx
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import wp from '../../lib/wp';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import CompositeCheckout from '../../my-sites/checkout/composite-checkout/composite-checkout';
+import { getSelectedSite } from 'state/ui/selectors';
+import { fetchStripeConfiguration } from '../../my-sites/checkout/composite-checkout/payment-method-helpers';
+import { StripeHookProvider } from 'lib/stripe';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const wpcom = wp.undocumented();
+
+class EditorCheckout extends Component {
+	static propTypes = {
+		site: PropTypes.object,
+		isOpen: PropTypes.boolean,
+		onClose: PropTypes.func,
+	};
+
+	static defaultProps = {
+		isOpen: false,
+		onClose: () => {},
+	};
+
+	render() {
+		const { site, isOpen, onClose } = this.props;
+
+		const getCart = async () => {
+			const planProduct = {
+				product_id: 1009,
+				product_slug: 'personal-bundle',
+			};
+
+			let cart = await wpcom.getCart( site.slug );
+
+			cart = await wpcom.setCart( site.ID, {
+				...cart,
+				products: [ ...cart.products, planProduct ],
+			} );
+
+			return cart;
+		};
+
+		return (
+			<div className={ classnames( 'editor-checkout', isOpen ? 'is-open' : '' ) }>
+				<button type="button" className="editor-checkout__close-button" onClick={ onClose }>
+					[X] Close Sidebar
+				</button>
+				<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>
+					<CompositeCheckout siteId={ site.ID } siteSlug={ site.slug } getCart={ getCart } />
+				</StripeHookProvider>
+			</div>
+		);
+	}
+}
+
+function fetchStripeConfigurationWpcom( args ) {
+	return fetchStripeConfiguration( args, wpcom );
+}
+
+export default connect( ( state ) => ( {
+	site: getSelectedSite( state ),
+} ) )( EditorCheckout );

--- a/client/post-editor/editor-checkout/style.scss
+++ b/client/post-editor/editor-checkout/style.scss
@@ -1,0 +1,24 @@
+.editor-checkout {
+	position: fixed;
+	top: 0;
+	right: -100%;
+	z-index: 999999;
+	width: 50%;
+	height: 100%;
+	overflow: auto;
+	padding: 30px;
+	border-left: 1px solid black;
+	background: white;
+	transition: all 0.5s ease-in-out;
+
+	&.is-open {
+		right: 0;
+	}
+}
+
+.editor-checkout__close-button {
+	padding: 15px;
+	border: 1px solid #ccc;
+	margin-bottom: 10px;
+	cursor: pointer;
+}


### PR DESCRIPTION
## Changes proposed in this Pull Request

Show checkout sidebar as an overlay on top of the iframed block editor in the parent calypso.

The current implementation intercepts the **Upgrade** button on jetpack paid blocks (which by default will redirect to checkout page) and then slides out the checkout sidebar.

However, clicking the Complete Payment button will still end up redirecting to the payment complete page.

The idea is that plugins within the iframed block editor can trigger the checkout sidebar by simply calling:

```
calypsoPort.postMessage( {
    action: 'openCheckoutSidebar',
    payload: {
        /* maybe you can pass in your cart items here? */
    },
} );
```


## Testing instructions

* Use a free site.
* Sandbox that free site.
* Sandbox also `widgets.wp.com`.
* Run `yarn dev --sync` on `apps/wpcom-block-editor`.
* Open block editor of the free site, e.g.
   `calypso.localhost:3000/block-editor/post/your_sandboxed_free_site.wordpress.com`
* Add **Premium Content** block.
* Click **Upgrade** button
* The checkout overlay should slide out from the right.

## Screenshots

![2020-09-24_13-31-35 (1)](https://user-images.githubusercontent.com/1287077/94140376-71a7ce80-fe6b-11ea-8bde-0c42ca35de69.gif)

