### PR TITLE
Block Editor: Wait for only the current site to load

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -18,7 +18,6 @@ import {
 	getCustomizerUrl,
 	getSiteOption,
 	getSiteAdminUrl,
-	isRequestingSites,
 	isRequestingSite,
 	isJetpackSite,
 	getSite,
@@ -44,6 +43,7 @@ import { editPost, trashPost } from 'state/posts/actions';
 import { getEditorPostId } from 'state/editor/selectors';
 import { protectForm, ProtectedFormProps } from 'lib/protect-form';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QuerySites from 'components/data/query-sites';
 import config from 'config';
 import EditorDocumentHead from 'post-editor/editor-document-head';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
@@ -657,7 +657,7 @@ class CalypsoifyIframe extends Component<
 	};
 
 	render() {
-		const { iframeUrl, shouldLoadIframe } = this.props;
+		const { iframeUrl, siteId, shouldLoadIframe } = this.props;
 		const {
 			classicBlockEditorId,
 			isMediaModalVisible,
@@ -675,6 +675,7 @@ class CalypsoifyIframe extends Component<
 
 		return (
 			<Fragment>
+				<QuerySites siteId={ siteId } />
 				<PageViewTracker
 					path={ this.getStatsPath() }
 					title={ this.getStatsTitle() }
@@ -776,7 +777,7 @@ const mapStateToProps = (
 	const iframeUrl = addQueryArgs( queryArgs, siteAdminUrl );
 
 	// Prevents the iframe from loading using a cached frame nonce.
-	const shouldLoadIframe = ! isRequestingSites( state ) && ! isRequestingSite( state, siteId );
+	const shouldLoadIframe = ! isRequestingSite( state, siteId );
 
 	const { url: closeUrl, label: closeLabel } = getEditorCloseConfig(
 		state,


### PR DESCRIPTION
When loading a post with the Block Editor in Calypso, it's usually taking me on average **24 seconds** to get the block editor to fully load. There are multiple factors that make the editor load so slow, but this PR is exploring one of them. 

After investigating, I found a low-hanging fruit: we're waiting for **all sites to load** (`/me/sites`) before initiating the request to the Calypsoify iframe, and that's particularly slow for users with many sites. However, we don't need all of the sites; we only need the current one to get the editor running. As a user with 400+ sites in my account, this is obviously taking a while. This will likely happen to many other a12s that have a lot of sites.

When I changed the logic to wait for **only the current site to load** before initiating the request to the iframe, the time to fully get the block editor to load got down to **12 seconds** - a **50% improvement** for my account!

#### Changes proposed in this Pull Request

* Block Editor: Wait for only the current site to load before initializing the Calypsoify iframe

#### Testing instructions

* Test against the primary Calypso branch with a user with a ton of sites, and verify it's indeed loading faster.
* Verify block editor still works well in Calypso.