### PR TITLE
Backup: Make activity card 'Actions' button visible again for Backup Real-time

### DIFF
--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -90,8 +90,16 @@
 	.button {
 		color: var( --color-neutral-70 );
 
+		&.is-borderless {
+			color: var( --color-text-subtle );
+		}
+
 		&.is-primary {
 			color: var( --color-text-inverted );
+		}
+
+		&.is-primary.is-borderless {
+			color: var( --color-accent );
 		}
 
 		&[disabled] {


### PR DESCRIPTION
Fixes `1164141197617539-as-1195587518788493`.

#### Changes proposed in this Pull Request

* Add style rules to make the Actions pop-out/button visible for rewindable activities on sites that have Backup Real-time.

##### Implementation notes

These styling changes are scoped specifically to Calypso via the `.wordpressdotcom` class, so in theory, there's no way anything in Jetpack Could would be affected. They're also scoped to the `.backup__page` class, so no other pages should be affected, either.

#### Testing instructions

**Prerequisite:** To test this PR, you must be able to view the Backup page for a site that has Backup Real-time and a history of rewindable activities.

* Start Calypso in your testing environment and select a site that has Backup Real-time.
* Navigate to the Backup page and find a day that has rewindable activities.
* For all rewindable activities, verify that the 'Actions' button is visible and functional in the bottom right of the activity card.
* Verify that all other buttons on the Backup page appear as normal.

#### Screenshots

##### Before

<img width="729" alt="Screen Shot 2020-09-24 at 08 34 38" src="https://user-images.githubusercontent.com/670067/94152608-65a71700-fe41-11ea-98f2-605780fd5b5a.png">

##### After

<img width="735" alt="Screen Shot 2020-09-24 at 08 34 22" src="https://user-images.githubusercontent.com/670067/94152626-6a6bcb00-fe41-11ea-8f26-62e8187b21ce.png">