### PR TITLE
Adds missing dependencies to data-stores

### DIFF
--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -45,7 +45,7 @@
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^4",
-		"react": "^16.12.0"
+		"react": "^16.8"
 	},
 	"devDependencies": {
 		"jest-fetch-mock": "^2.1.2",

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -48,10 +48,8 @@
 		"react": "^16.12.0"
 	},
 	"devDependencies": {
-		"@testing-library/react": "^10.0.5",
 		"jest-fetch-mock": "^2.1.2",
 		"nock": "^12.0.3",
-		"react": "^16.12.0",
-		"react-dom": "^16.12.0"
+		"wait-for-expect": "^3.0.2"
 	}
 }

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -44,6 +44,14 @@
 		"wpcom-proxy-request": "^6.0.0"
 	},
 	"peerDependencies": {
-		"@wordpress/data": "^4"
+		"@wordpress/data": "^4",
+		"react": "^16.12.0"
+	},
+	"devDependencies": {
+		"@testing-library/react": "^10.0.5",
+		"jest-fetch-mock": "^2.1.2",
+		"nock": "^12.0.3",
+		"react": "^16.12.0",
+		"react-dom": "^16.12.0"
 	}
 }

--- a/packages/data-stores/src/auth/test/flows.ts
+++ b/packages/data-stores/src/auth/test/flows.ts
@@ -14,7 +14,7 @@ import { parse } from 'qs';
 import wpcomRequest from 'wpcom-proxy-request';
 import 'jest-fetch-mock';
 import nock from 'nock';
-import { waitFor } from '@testing-library/react';
+import waitForExpect from 'wait-for-expect';
 
 /**
  * Internal dependencies
@@ -237,11 +237,11 @@ describe( 'password login flow', () => {
 		// Don't await the promise, it doesn't resolve until login flow is complete
 		submitPassword( 'passw0rd' );
 
-		await waitFor( () => expect( getLoginFlowState() ).toBe( 'WAITING_FOR_2FA_APP' ) );
+		await waitForExpect( () => expect( getLoginFlowState() ).toBe( 'WAITING_FOR_2FA_APP' ) );
 
 		userHandledPushNotification = true;
 
-		await waitFor( () => expect( getLoginFlowState() ).toBe( 'LOGGED_IN' ) );
+		await waitForExpect( () => expect( getLoginFlowState() ).toBe( 'LOGGED_IN' ) );
 	} );
 } );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28585,6 +28585,11 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
+wait-for-expect@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
+
 wait-on@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-3.3.0.tgz#9940981d047a72a9544a97b8b5fca45b2170a082"


### PR DESCRIPTION
### Background

There are a few undeclared dependencies, found by running `npx @yarnpkg/doctor`:

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/data-stores/package.json
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepare") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepublish") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/data-stores/src/auth/test/flows.ts:15:1: Undeclared dependency on jest-fetch-mock-
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/data-stores/src/auth/test/flows.ts:16:1: Undeclared dependency on nock
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/data-stores/src/auth/test/flows.ts:17:1: Undeclared dependency on @testing-library/react
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/data-stores/package.json:39:19: Unmet transitive peer dependency on react@^16.8, via i18n-calypso@^5.0.0
➤ YN0000: └ Completed in 0.44s
```

### Changes

* Adds missing dependencies to `@testing-library/react`, `jest-fetch-mock` and `nock`. Version ranges have been copied from `./package.json`.
* Adds `react` and `react-dom` as devDependencies (they are peerDependencies of `@testing-library/react`). Version ranges have been copied from `./package.json` as well.
* Add missing `peerDependency` to `react`, required by `i18n-calypso`.

The reasoning for declaring react twice is:
- React is required to _develop_ this package, namely to run tests. As such, it must be a `devDependency`.
- React is required to be present when this package is imported, because `i18n-calypso` says so. But we don't want bring in our own copy, so we declare it as a `peerDependency`.

But to be honest, I'm not 100% sure of my reasoning. Please let me know if you think we should do something different.

### Testing instructions

Run `cd packages/data-stores && npx @yarnpkg/doctor` and check the warnings about missing dependencies are gone