### PR TITLE
docs: add docs

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,46 @@
+# WordPress.com for Desktop
+
+WordPress.com for Desktop is an [Electron](https://github.com/atom/electron) wrapper for [Calypso](https://github.com/Automattic/wp-calypso), the WordPress.com front-end. It works on Mac, Windows, and Linux.
+
+![WordPress.com for Desktop](https://en-blog.files.wordpress.com/2015/12/01-writing-with-dock.png?w=1150)
+
+# Getting Started & Running Locally
+
+1. Clone the Calypso repository locally
+1. Install all root level dependencies with `yarn` or `yarn install --frozen-lockfile`
+1. Create `./config/secrets.json` file and fill it with [secrets](docs/secrets.md)
+1. Build the app with `yarn run build-desktop`
+1. Find the built apps in the `desktop/release`
+
+Need more detailed instructions? [We have them.](docs/install.md)
+
+# Development
+
+Refer to the [development guide](docs/development.md) for help with how the app works and how to change stuff.
+
+# Running The End-To-End Test Suite
+
+1. Set the environment variables `E2EUSERNAME` and `E2EPASSWORD`.
+2. Use `npm run e2e` or `make e2e` to invoke the test suite.
+
+To manually start each platform's _pre-packaged_ executable used for end-to-end testing:
+
+- Mac: Double-click `WordPress.com.app` (extract with [`ditto`](##Extracting-Published-ZIP-Archive-in-MacOS-10.15-(Catalina)))
+- Windows: Double-click WordPress.com.exe in `win-unpacked` directory
+- Linux: `npx electron /path/to/linux-unpacked/resources/app`
+
+# MacOS Notarization
+
+Notes on MacOS notarization can be found [here](docs/notarization.md).
+
+# Building & Packaging a Release
+
+While running the app locally in a development environment is great, you will eventually need to [build a release version](docs/release.md) you can share.
+
+# Troubleshooting
+
+If you have any problems running the app please see the [most common issues](docs/troubleshooting.md).
+
+# License
+
+WordPress.com for Desktop is licensed under [GNU General Public License v2 (or later)](LICENSE.md).

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -6,13 +6,25 @@ WordPress.com for Desktop is an [Electron](https://github.com/atom/electron) wra
 
 # Getting Started & Running Locally
 
+The steps marked _Production*_ can be omitted but should be taken when building the production version of the app.
+
 1. Clone the Calypso repository locally
 1. Install all root level dependencies with `yarn` or `yarn install --frozen-lockfile`
-1. Create `./config/secrets.json` file and fill it with [secrets](docs/secrets.md)
+1. Export the environment variables:
+    - `CHROMEDRIVER_SKIP_DOWNLOAD` (set to `true`)
+    - `DETECT_CHROMEDRIVER_VERSION` (set to `false`)
+    - _Production*_: `CONFIG_ENV` (set to `release`)
+    - _Production*_: `CALYPSO_SECRETS_ENCRYPTION_KEY` (it's a secret!)
+1. _Production*_: `yarn run build-desktop:secrets`
 1. Build the app with `yarn run build-desktop`
 1. Find the built apps in the `desktop/release`
 
-Need more detailed instructions? [We have them.](docs/install.md)
+To disable the auto-updater when testing locally, make sure to export the `DEBUG` environment variable and invoke the Electron binary directly. For example on Mac:
+
+```
+export DEBUG='*'
+./desktop/release/mac/WordPress.com.app/Contents/MacOS/WordPress.com
+```
 
 # Development
 

--- a/desktop/docs/development.md
+++ b/desktop/docs/development.md
@@ -1,0 +1,75 @@
+# Development
+
+At its simplest level, the WordPress.com for Desktop app uses Electron to wrap Calypso inside a native app.
+
+Electron provides all the interfacing between Chrome (the browser that is used inside Electron), and the native platform. This means we can re-use Calypso code while still providing native platform features.
+
+It is important to understand where code runs, and for this the terminology is:
+
+- Main - this is the Electron wrapper. All code for this is contained in `desktop`
+- Renderer - this is the Chrome browser and is where Calypso runs
+
+We use Electron's [IPC](https://github.com/atom/electron/blob/master/docs/api/ipc-main.md) mechanism to send data between the main process and the renderer.
+
+## Starting the app
+
+### How does it work?
+
+It's a fairly complicated process so buckle up. Note that *(main)* and *(renderer)* will be added to show where the code actually runs.
+
+- *(main)* Electron looks at the `main` item in `package.json` - this is the boot file, and refers to `desktop/index.js`
+- *(main)* `desktop/index.js` sets up the environment in `desktop/env.js` - this includes Node paths for Calypso
+- *(main)* Various [app handlers](../../client/desktop/app-handlers/README.md) are loaded from `desktop/app-handlers` - these are bits of code that run before the main window opens
+- *(main)* A Calypso server is started in `desktop/start-app.js` in a forked child_process. The server is customized to serve files from the following directories:
+  - `/` - mapped to the Calypso server
+  - `/calypso` - mapped to `calypso/public`
+  - `/desktop` - mapped to `public_desktop`
+- *(main)* An Electron `BrowserWindow` is opened and loads the 'index' page from the Calypso server
+- *(main)* Once the window has opened the [window handlers](../../client/desktop/window-handlers/README.md) load to provide interaction between Calypso and Electron
+- *(renderer)* Calypso provides the 'index' page from `calypso/server/pages/desktop.pug`, which is a standard Calypso start page plus:
+  - `public_desktop/wordpress-desktop.css` - any CSS specific to the desktop app
+  - `public_desktop/desktop-app.js` - desktop app specific JS and also the Calypso boot code
+  - `calypso/public/build.js` - a prebuilt Calypso
+- *(renderer)* The `desktop-app.js` code runs which sets up various app specific handlers that need to be inside the renderer. It also starts Calypso with `AppBoot()`
+- *(renderer)* The code in `calypso/client/lib/desktop` runs to send and receive IPC messages between the main process and Calypso.
+
+Phew!
+
+## How do I change the main app?
+
+All app code is contained in `desktop`. Any changes you make there require a rebuild and restart of the app.
+
+- [Config](../desktop-config/README.md) - app configuration values
+- [Libraries](../desktop/lib/README.md) - details of the local libraries used
+- [App Handlers](.,/desktop/app-handlers/README.md) - handlers that run before the main window is created
+- [Window Handlers](../desktop/window-handlers/README.md) - handlers that run after the main window is created
+
+## Debugging
+
+Debug from Calypso will appear inside the renderer. To enable, open Chrome dev tools from the View menu and enable debug:
+
+```js
+localStorage.setItem( 'debug', '*' );
+```
+
+## Building and Debugging on Windows
+
+Building Calypso on Windows is not supported, and therefore a virtual Linux environment is required to build the application source. Application binaries, however, should be built natively on Windows prior to packaging the app.
+
+- For convenience, a Docker configuration is included [here](../Dockerfile). The image can be built and ran via the Makefile.
+
+- An alternative to using Docker on Windows is the Windows Subsystem for Linux ("WSL"), which will have to be manually configured.
+
+### Recommended Windows Environment and Tooling
+
+- [MSYS2](https://www.msys2.org/) is recommended to maximize compatibility of the Makefile across platforms. This can be installed explicitly and added to your `PATH`, or implicitly by installing [Git Bash](https://gitforwindows.org/) for Windows.
+
+  - IMPORTANT: Historically, developers expect the "bash" executable to refer to Git/MSYS2 bash. To avoid collisions with Windows Subsystem for Linux ("WSL"), you can rename the WSL bash executable in PowerShell:
+
+  ```
+  takeown /F "$env:SystemRoot\System32\bash.exe"
+  icacls "$env:SystemRoot\System32\bash.exe" /grant administrators:F
+  ren "$env:SystemRoot\System32\bash.exe" wsl-bash.exe
+  ```
+
+- Install the npm package `windows-build-tools` to allow compilation of native node modules.

--- a/desktop/docs/development.md
+++ b/desktop/docs/development.md
@@ -17,19 +17,21 @@ We use Electron's [IPC](https://github.com/atom/electron/blob/master/docs/api/ip
 
 It's a fairly complicated process so buckle up. Note that *(main)* and *(renderer)* will be added to show where the code actually runs.
 
-- *(main)* Electron looks at the `main` item in `package.json` - this is the boot file, and refers to `desktop/index.js`
-- *(main)* `desktop/index.js` sets up the environment in `desktop/env.js` - this includes Node paths for Calypso
-- *(main)* Various [app handlers](../../client/desktop/app-handlers/README.md) are loaded from `desktop/app-handlers` - these are bits of code that run before the main window opens
-- *(main)* A Calypso server is started in `desktop/start-app.js` in a forked child_process. The server is customized to serve files from the following directories:
+For clarity, all file and folder locations are relative to the root of the Calypso monorepo.
+
+- *(main)* Electron looks at the `main` item in `desktop/package.json` - this is the boot file, and refers to `client/desktop/index.js`
+- *(main)* `client/desktop/index.js` sets up the environment in `client/desktop/env.js` - this includes Node paths for Calypso
+- *(main)* Various [app handlers](../../client/desktop/app-handlers/README.md) are loaded from `client/desktop/app-handlers` - these are bits of code that run before the main window opens
+- *(main)* A Calypso server is started drectly from Electron's Node process in `client/desktop/server.js`. The server is customized to serve files from the following directories:
   - `/` - mapped to the Calypso server
   - `/calypso` - mapped to `calypso/public`
   - `/desktop` - mapped to `public_desktop`
 - *(main)* An Electron `BrowserWindow` is opened and loads the 'index' page from the Calypso server
 - *(main)* Once the window has opened the [window handlers](../../client/desktop/window-handlers/README.md) load to provide interaction between Calypso and Electron
 - *(renderer)* Calypso provides the 'index' page from `calypso/server/pages/desktop.pug`, which is a standard Calypso start page plus:
-  - `public_desktop/wordpress-desktop.css` - any CSS specific to the desktop app
-  - `public_desktop/desktop-app.js` - desktop app specific JS and also the Calypso boot code
-  - `calypso/public/build.js` - a prebuilt Calypso
+  - `desktop/public_desktop/wordpress-desktop.css` - any CSS specific to the desktop app
+  - `desktop/public_desktop/desktop-app.js` - desktop app specific JS and also the Calypso boot code
+  - `desktop/calypso/public/build.js` - a prebuilt Calypso
 - *(renderer)* The `desktop-app.js` code runs which sets up various app specific handlers that need to be inside the renderer. It also starts Calypso with `AppBoot()`
 - *(renderer)* The code in `calypso/client/lib/desktop` runs to send and receive IPC messages between the main process and Calypso.
 

--- a/desktop/docs/development.md
+++ b/desktop/docs/development.md
@@ -31,11 +31,11 @@ For clarity, all file and folder locations are relative to the root of the Calyp
 - *(main)* Once the window has opened the [window handlers](../../client/desktop/window-handlers/README.md) load to provide interaction between Calypso and Electron
 - *(renderer)* Calypso's index page is served by a React renderer in `client/document/desktop.jsx`. In addition:
   - `desktop/public_desktop/wordpress-desktop.css` - any CSS specific to the desktop app (mapped to `desktop` directory mentioned above)
-  - `desktop/public_desktop/desktop-app.js` - desktop app specific JS and also the Calypso boot code (mapped to `desktop` directory mentioned above)
+  - `desktop/public_desktop/desktop-app.js` - desktop-specific JS and also the Calypso boot code (mapped to `desktop` directory mentioned above)
   - The Calypso client bundle for the Desktop app is built to `desktop/public`.
     - The built Calypso bundle has multiple webpack entrypoints (like `entry-main.[hash].min.js`).
     - The various Calypso filenames are written to `desktop/build/assets-evergreen.js` at buildtime. The Express.js server loads this `assets-evergreen.js` file to find out which `<script>` and `link rel="stylesheet">` tags to send to the browser.
-- *(renderer)* The `desktop-app.js` code runs which sets up various app specific handlers that need to be inside the renderer. It also starts Calypso with `AppBoot()`
+- *(renderer)* The `desktop-app.js` code runs which sets up various app-specific handlers that need to be inside the renderer. It also starts Calypso with `AppBoot()`
 - *(renderer)* The code in `calypso/client/lib/desktop` runs to send and receive IPC messages between the main process and Calypso.
 
 Phew!

--- a/desktop/docs/development.md
+++ b/desktop/docs/development.md
@@ -19,19 +19,22 @@ It's a fairly complicated process so buckle up. Note that *(main)* and *(rendere
 
 For clarity, all file and folder locations are relative to the root of the Calypso monorepo.
 
-- *(main)* Electron looks at the `main` item in `desktop/package.json` - this is the boot file, and refers to `client/desktop/index.js`
+- *(main)* The `main` entry in `desktop/package.json` refers to `build/desktop.js`, which is the entrypoint of the compiled webpack bundle of the Calypso server running in Electron's main process.
+  - The Calypso server is an Express.js HTTP server that serves files to Electron's Renderer process.
+  - `client/desktop/server/index.js` is where the Calypso server is started by the Electron process. Calypso's `boot` code is contained in the file `client/server/boot/index.js`.
 - *(main)* `client/desktop/index.js` sets up the environment in `client/desktop/env.js` - this includes Node paths for Calypso
 - *(main)* Various [app handlers](../../client/desktop/app-handlers/README.md) are loaded from `client/desktop/app-handlers` - these are bits of code that run before the main window opens
-- *(main)* A Calypso server is started drectly from Electron's Node process in `client/desktop/server.js`. The server is customized to serve files from the following directories:
-  - `/` - mapped to the Calypso server
-  - `/calypso` - mapped to `calypso/public`
-  - `/desktop` - mapped to `public_desktop`
+- *(main)* A Calypso server is started directly from Electron's Node process in `client/desktop/server.js`. The server is customized to serve files from the following directories:
+  - `/calypso` - mapped to `/public`
+  - `/desktop` - mapped to `/public_desktop`
 - *(main)* An Electron `BrowserWindow` is opened and loads the 'index' page from the Calypso server
 - *(main)* Once the window has opened the [window handlers](../../client/desktop/window-handlers/README.md) load to provide interaction between Calypso and Electron
-- *(renderer)* Calypso provides the 'index' page from `calypso/server/pages/desktop.pug`, which is a standard Calypso start page plus:
-  - `desktop/public_desktop/wordpress-desktop.css` - any CSS specific to the desktop app
-  - `desktop/public_desktop/desktop-app.js` - desktop app specific JS and also the Calypso boot code
-  - `desktop/calypso/public/build.js` - a prebuilt Calypso
+- *(renderer)* Calypso's index page is served by a React renderer in `client/document/desktop.jsx`. In addition:
+  - `desktop/public_desktop/wordpress-desktop.css` - any CSS specific to the desktop app (mapped to `desktop` directory mentioned above)
+  - `desktop/public_desktop/desktop-app.js` - desktop app specific JS and also the Calypso boot code (mapped to `desktop` directory mentioned above)
+  - The Calypso client bundle for the Desktop app is built to `desktop/public`.
+    - The built Calypso bundle has multiple webpack entrypoints (like `entry-main.[hash].min.js`).
+    - The various Calypso filenames are written to `desktop/build/assets-evergreen.js` at buildtime. The Express.js server loads this `assets-evergreen.js` file to find out which `<script>` and `link rel="stylesheet">` tags to send to the browser.
 - *(renderer)* The `desktop-app.js` code runs which sets up various app specific handlers that need to be inside the renderer. It also starts Calypso with `AppBoot()`
 - *(renderer)* The code in `calypso/client/lib/desktop` runs to send and receive IPC messages between the main process and Calypso.
 

--- a/desktop/docs/development.md
+++ b/desktop/docs/development.md
@@ -6,7 +6,7 @@ Electron provides all the interfacing between Chrome (the browser that is used i
 
 It is important to understand where code runs, and for this the terminology is:
 
-- Main - this is the Electron wrapper. All code for this is contained in `desktop`
+- Main - this is the Electron wrapper. All code for this is contained in `desktop` and `client/desktop` directories
 - Renderer - this is the Chrome browser and is where Calypso runs
 
 We use Electron's [IPC](https://github.com/atom/electron/blob/master/docs/api/ipc-main.md) mechanism to send data between the main process and the renderer.
@@ -39,12 +39,12 @@ Phew!
 
 ## How do I change the main app?
 
-All app code is contained in `desktop`. Any changes you make there require a rebuild and restart of the app.
+All app code is contained in the `desktop` and `client/desktop` directories. Any changes you make there require a rebuild and restart of the app.
 
 - [Config](../desktop-config/README.md) - app configuration values
-- [Libraries](../desktop/lib/README.md) - details of the local libraries used
-- [App Handlers](.,/desktop/app-handlers/README.md) - handlers that run before the main window is created
-- [Window Handlers](../desktop/window-handlers/README.md) - handlers that run after the main window is created
+- [Libraries](../../client/desktop/lib/README.md) - details of the local libraries used
+- [App Handlers](../../client/desktop/app-handlers/README.md) - handlers that run before the main window is created
+- [Window Handlers](../../client/desktop/window-handlers/README.md) - handlers that run after the main window is created
 
 ## Debugging
 

--- a/desktop/docs/notarization.md
+++ b/desktop/docs/notarization.md
@@ -1,0 +1,21 @@
+# MacOS Notarization
+
+Notes on MacOS notarization can be found [here](docs/notarization.md).
+
+Per the current [Electron docs](https://www.electron.build/configuration/dmg), DMG signing is disabled by default as it will "lead to unwanted errors in combination with notarization requirements." Only the app bundle is zipped and submitted to Apple for notarization.
+
+## Extracting Published ZIP Archive in MacOS 10.15 (Catalina)
+
+There is a [known bug](https://github.com/electron-userland/electron-builder/issues/4299#issuecomment-544683923) in which extracting notarized contents from a zip archive via double-click will lead to an invalid .app bundle that cannot be opened in macOS 10.15. Instead, the bundled app should be extracted via `ditto`:
+
+`ditto -x -k <zip archive> <destination folder>`
+
+## Verification
+
+Notarization status of an application bundle can be verified via the `codesign`, `stapler` and `spctl` utilities:
+
+`codesign --test-requirement="=notarized" --verify --verbose WordPress.com.app`
+
+`xrun stapler validate WordPress.com.app`
+
+`spctl -a -v WordPress.com.app`

--- a/desktop/docs/release.md
+++ b/desktop/docs/release.md
@@ -1,0 +1,77 @@
+# Building a Release
+
+Running the app in your [development environment](development.md) uses the prebuilt Electron binary to run the app directly from the directory.
+
+In order to run outside of the development environment you need to build a release version, which takes Electron, the app, and Calypso, and builds an 'executable' as well as installers appropriate for your platform. (Windows: NSIS installer, macOS: DMG image, Linux: Debian package)
+
+To do this, run the following command:
+
+```bash
+make build
+```
+
+If you do not want to re-compile your code you can split the command into building the source files and packaging.
+
+```bash
+# Creating the JS bundles, CSS files, ...
+make build-source [CONFIG]
+
+# Package the App
+make package [BUILD_PLATFORM]
+```
+
+**Notes:**
+- `make build` will by default only create a distributable package for your current host system.
+- All packages are saved in the `./release` directory.
+- We are using CircleCI for creating release builds. For advanced configuration use cases please check the [`.circleci/config.yml`](../.circleci/config.yml)  
+
+## Customizing the build
+
+### Multiplatform build
+`make build` can build for Windows, macOS and Linux. To do so add the target platform you want to build for by adding the `BUILD_PLATFORM` parameter.
+
+```bash
+make build BUILD_PLATFORM=wml
+```
+
+We are using [electron-builder](https://electron.build)s default values to modify the build target:
+`w` = Windows, `m` = macOS, `l` = Linux
+
+### Desktop Configs
+
+In [`desktop-config`](../desktop-config) you can find various configurations for building the app. The most used configurations are
+`release`, `development` and `test`.
+
+To use a specific configuration, run:
+
+```bash
+make build CONFIG=release
+```
+
+By default, we fall back to `base` if no configuration is specified.
+
+## Platform Requirements
+
+You can build all three platforms on macOS. The macOS app however can't be built on any other platform than macOS as codesigning would not work. 
+For native dependencies such as `node-spellchecker` we are using prebuilt binaries to avoid platform specific re-builds. This allows us to build e.g. the Windows App from macOS as well as Linux.
+
+### Mac
+
+A Mac build requires the app to be signed. This prevents a security warning being issued when you run the app. It is also a requirement of the auto-updater feature.
+
+You can obtain all the appropriate signing certificates from an Apple Developer account.
+
+Note that you need the certificates installed prior to building.
+
+### Windows
+
+You can create the Windows build using OS X, which is much easier since all the tools needed to run Calypso are already in place.
+
+
+### Linux
+
+To build on Linux, you need the following libraries in order to be able to manually re-build native dependencies:
+
+```
+apt install libx11-dev libxext-dev libxss-dev libxkbfile-dev
+```

--- a/desktop/docs/release.md
+++ b/desktop/docs/release.md
@@ -33,7 +33,7 @@ In [`desktop-config`](../desktop-config) you can find various configurations for
 To use a specific configuration, run:
 
 ```bash
-make build CONFIG=release
+make build CONFIG_ENV=...
 ```
 
 By default, we fall back to `base` if no configuration is specified.

--- a/desktop/docs/release.md
+++ b/desktop/docs/release.md
@@ -1,7 +1,5 @@
 # Building a Release
 
-Running the app in your [development environment](development.md) uses the prebuilt Electron binary to run the app directly from the directory.
-
 In order to run outside of the development environment you need to build a release version, which takes Electron, the app, and Calypso, and builds an 'executable' as well as installers appropriate for your platform. (Windows: NSIS installer, macOS: DMG image, Linux: Debian package)
 
 To do this, run the following command:
@@ -10,32 +8,22 @@ To do this, run the following command:
 make build
 ```
 
-If you do not want to re-compile your code you can split the command into building the source files and packaging.
+If you do not want to re-compile your code you can split the command into building the JavaScript source and application packaging.
 
 ```bash
 # Creating the JS bundles, CSS files, ...
-make build-source [CONFIG]
+make source [CONFIG]
 
 # Package the App
-make package [BUILD_PLATFORM]
+make package
 ```
 
 **Notes:**
 - `make build` will by default only create a distributable package for your current host system.
-- All packages are saved in the `./release` directory.
-- We are using CircleCI for creating release builds. For advanced configuration use cases please check the [`.circleci/config.yml`](../.circleci/config.yml)  
+- All packages are saved to the `./release` directory.
+- We are using CircleCI for creating release builds. For advanced configuration use cases please check the [`.circleci/config.yml`](../.circleci/config.yml)
 
 ## Customizing the build
-
-### Multiplatform build
-`make build` can build for Windows, macOS and Linux. To do so add the target platform you want to build for by adding the `BUILD_PLATFORM` parameter.
-
-```bash
-make build BUILD_PLATFORM=wml
-```
-
-We are using [electron-builder](https://electron.build)s default values to modify the build target:
-`w` = Windows, `m` = macOS, `l` = Linux
 
 ### Desktop Configs
 
@@ -52,9 +40,6 @@ By default, we fall back to `base` if no configuration is specified.
 
 ## Platform Requirements
 
-You can build all three platforms on macOS. The macOS app however can't be built on any other platform than macOS as codesigning would not work. 
-For native dependencies such as `node-spellchecker` we are using prebuilt binaries to avoid platform specific re-builds. This allows us to build e.g. the Windows App from macOS as well as Linux.
-
 ### Mac
 
 A Mac build requires the app to be signed. This prevents a security warning being issued when you run the app. It is also a requirement of the auto-updater feature.
@@ -65,13 +50,12 @@ Note that you need the certificates installed prior to building.
 
 ### Windows
 
-You can create the Windows build using OS X, which is much easier since all the tools needed to run Calypso are already in place.
-
+Refer to Windows environment requires in the [development docs](./development.md).
 
 ### Linux
 
 To build on Linux, you need the following libraries in order to be able to manually re-build native dependencies:
 
 ```
-apt install libx11-dev libxext-dev libxss-dev libxkbfile-dev
+apt-get install -y libsecret-1-devdev
 ```

--- a/desktop/docs/secrets.md
+++ b/desktop/docs/secrets.md
@@ -1,0 +1,43 @@
+# Secrets
+
+Some secrets are needed to build the app. You will need to create the files yourself.
+
+## Calypso Secrets
+
+We use an OAuth connection to authenticate logins against the WordPress.com API.
+You can [create an application here](https://developer.wordpress.com/apps/new/).
+
+When creating your application, you'll need to fill in all the fields:
+
+* **Name:** Any name of your choosing.
+* **Description:** A description, e.g. "My wp-desktop testing app".
+* **Website URL:** A URL. For testing the desktop app, you can use the repo URL
+  `https://github.com/Automattic/wp-desktop`.
+* **Redirect URLs:** The form requires a valid URL. Please use:
+	```
+	http://127.0.0.1:41050
+	http://calypso.localhost:3000
+	```
+* **Javascript Origins:**
+	```
+	http://127.0.0.1:41050
+	http://calypso.localhost:3000
+	```
+* Answer the bot challenge correctly.
+* **Type:** Native
+
+When you've filled out the form, click the create button.
+
+In the end, your application details should look similar to:
+![application details](../.github/images/secrets.png)
+
+After your application is created, copy your client id and client secret, and add a
+`calypso/config/secrets.json` file:
+
+```json
+{
+	"desktop_oauth_token_endpoint": "https://public-api.wordpress.com/oauth2/token",
+	"desktop_oauth_client_id": "<YOUR CLIENT ID>",
+	"desktop_oauth_client_secret": "<YOUR CLIENT SECRET>"
+}
+```

--- a/desktop/docs/troubleshooting.md
+++ b/desktop/docs/troubleshooting.md
@@ -1,0 +1,5 @@
+# Troubleshooting
+
+* The WordPress icon will only show in the release version. The dev version will use the Electron icon
+* If you see issue, try deleting `node_modules` and `yarn`
+* Electron is more or less Chrome, you can get developer tools using `CMD+ALT+I`

--- a/desktop/docs/troubleshooting.md
+++ b/desktop/docs/troubleshooting.md
@@ -1,5 +1,5 @@
 # Troubleshooting
 
 * The WordPress icon will only show in the release version. The dev version will use the Electron icon
-* If you see issue, try deleting `node_modules` and `yarn`
-* Electron is more or less Chrome, you can get developer tools using `CMD+ALT+I`
+    * If you see issue, try deleting `node_modules` and `yarn`
+* You can open Electron's Chromium Developer Tools using `CTRL+SHIFT+I`


### PR DESCRIPTION
### Description

Add (and update) desktop docs that weren't part of the initial migration from wp-desktop repo.