### PR TITLE
My Home: Update font size for title and body text on task cards

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -48,12 +48,11 @@
 
 	.task__title {
 		@extend .wp-brand-font;
-		font-size: $font-title-large;
+		font-size: $font-title-medium;
 		line-height: 36px;
 		margin-bottom: 4px;
 
 		@include breakpoint-deprecated( '>800px' ) {
-			font-size: $font-title-large;
 			line-height: 40px;
 		}
 	}
@@ -65,7 +64,6 @@
 		color: var( --color-text );
 
 		@include breakpoint-deprecated( '>800px' ) {
-			font-size: $font-title-small;
 			line-height: 28px;
 			margin-bottom: 32px;
 		}

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -48,7 +48,7 @@
 
 	.task__title {
 		@extend .wp-brand-font;
-		font-size: $font-title-medium;
+		font-size: $font-title-large;
 		line-height: 36px;
 		margin-bottom: 4px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reduce the font size of the body copy on the main card element on My Home.
* We may revisit the card design in a future PR, but this is a quick adjustment to bring the body copy in line so it doesn't appear huge.

**Before**

<img width="1109" alt="Screen Shot 2020-11-03 at 1 26 13 PM" src="https://user-images.githubusercontent.com/2124984/98026433-1dccc580-1dd9-11eb-8d28-121b149ddcdd.png">

<img width="1096" alt="Screen Shot 2020-11-03 at 1 24 52 PM" src="https://user-images.githubusercontent.com/2124984/98026516-3dfc8480-1dd9-11eb-9cf2-055a7544c1fd.png">

**After**

<img width="1105" alt="Screen Shot 2020-11-03 at 1 26 23 PM" src="https://user-images.githubusercontent.com/2124984/98026451-232a1000-1dd9-11eb-9b16-056a24046206.png">

<img width="1096" alt="Screen Shot 2020-11-03 at 1 24 52 PM" src="https://user-images.githubusercontent.com/2124984/98026505-3806a380-1dd9-11eb-8b7a-8885795768ef.png">


#### Testing instructions

* Switch to this PR
* Navigate to `/home` on your test site
* Note the difference in size on the body copy text. Check on a site that has a checklist, as well as a site that has completed the checklist.

Fixes #45084
