### PR TITLE
Clean up the old domain management navigation component

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -31,7 +31,6 @@ import {
 } from 'state/purchases/selectors';
 import ExpiringCreditCard from '../card/notices/expiring-credit-card';
 import ExpiringSoon from '../card/notices/expiring-soon';
-import DomainManagementNavigation from '../navigation';
 import DomainManagementNavigationEnhanced from '../navigation/enhanced';
 import { DomainExpiryOrRenewal, WrapDomainStatusButtons } from './helpers';
 import { hasPendingGSuiteUsers } from 'lib/gsuite';
@@ -217,9 +216,6 @@ class MappedDomainType extends React.Component {
 		} );
 
 		const newStatusDesignAutoRenew = config.isEnabled( 'domains/new-status-design/auto-renew' );
-		const newDomainManagementNavigation = config.isEnabled(
-			'domains/new-status-design/new-options'
-		);
 
 		return (
 			<div className="domain-types__container">
@@ -260,21 +256,12 @@ class MappedDomainType extends React.Component {
 					) }
 					{ newStatusDesignAutoRenew && domain.currentUserCanManage && this.renderAutoRenew() }
 				</Card>
-				{ newDomainManagementNavigation ? (
-					<DomainManagementNavigationEnhanced
-						domain={ domain }
-						selectedSite={ this.props.selectedSite }
-						purchase={ mappingPurchase }
-						isLoadingPurchase={ isLoadingPurchase }
-					/>
-				) : (
-					<DomainManagementNavigation
-						domain={ domain }
-						selectedSite={ this.props.selectedSite }
-						purchase={ mappingPurchase }
-						isLoadingPurchase={ isLoadingPurchase }
-					/>
-				) }
+				<DomainManagementNavigationEnhanced
+					domain={ domain }
+					selectedSite={ this.props.selectedSite }
+					purchase={ mappingPurchase }
+					isLoadingPurchase={ isLoadingPurchase }
+				/>
 			</div>
 		);
 	}

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -37,7 +37,6 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import { shouldRenderExpiringCreditCard } from 'lib/purchases';
 import ExpiringCreditCard from '../card/notices/expiring-credit-card';
 import ExpiringSoon from '../card/notices/expiring-soon';
-import DomainManagementNavigation from '../navigation';
 import DomainManagementNavigationEnhanced from '../navigation/enhanced';
 import { DomainExpiryOrRenewal, WrapDomainStatusButtons } from './helpers';
 import OutboundTransferConfirmation from '../../components/outbound-transfer-confirmation';
@@ -305,9 +304,6 @@ class RegisteredDomainType extends React.Component {
 		} );
 
 		const newStatusDesignAutoRenew = config.isEnabled( 'domains/new-status-design/auto-renew' );
-		const newDomainManagementNavigation = config.isEnabled(
-			'domains/new-status-design/new-options'
-		);
 
 		return (
 			<div className="domain-types__container">
@@ -361,21 +357,12 @@ class RegisteredDomainType extends React.Component {
 					) }
 					{ newStatusDesignAutoRenew && domain.currentUserCanManage && this.renderAutoRenew() }
 				</Card>
-				{ newDomainManagementNavigation ? (
-					<DomainManagementNavigationEnhanced
-						domain={ domain }
-						selectedSite={ this.props.selectedSite }
-						purchase={ purchase }
-						isLoadingPurchase={ isLoadingPurchase }
-					/>
-				) : (
-					<DomainManagementNavigation
-						domain={ domain }
-						selectedSite={ this.props.selectedSite }
-						purchase={ purchase }
-						isLoadingPurchase={ isLoadingPurchase }
-					/>
-				) }
+				<DomainManagementNavigationEnhanced
+					domain={ domain }
+					selectedSite={ this.props.selectedSite }
+					purchase={ purchase }
+					isLoadingPurchase={ isLoadingPurchase }
+				/>
 			</div>
 		);
 	}

--- a/client/my-sites/domains/domain-management/edit/domain-types/wpcom-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/wpcom-domain-type.jsx
@@ -7,9 +7,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import DomainStatus from '../card/domain-status';
-import DomainManagementNavigation from '../navigation';
 import DomainManagementNavigationEnhanced from '../navigation/enhanced';
 
 class WpcomDomainType extends React.Component {
@@ -20,10 +18,6 @@ class WpcomDomainType extends React.Component {
 			selectedSite,
 		} = this.props;
 
-		const newDomainManagementNavigation = config.isEnabled(
-			'domains/new-status-design/new-options'
-		);
-
 		return (
 			<div className="domain-types__container">
 				<DomainStatus
@@ -32,11 +26,7 @@ class WpcomDomainType extends React.Component {
 					statusClass="status-success"
 					icon="check_circle"
 				/>
-				{ newDomainManagementNavigation ? (
-					<DomainManagementNavigationEnhanced domain={ domain } selectedSite={ selectedSite } />
-				) : (
-					<DomainManagementNavigation domain={ domain } selectedSite={ selectedSite } />
-				) }
+				<DomainManagementNavigationEnhanced domain={ domain } selectedSite={ selectedSite } />
 			</div>
 		);
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -56,7 +56,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
-		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -34,7 +34,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
-		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,

--- a/config/production.json
+++ b/config/production.json
@@ -33,7 +33,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
-		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -36,7 +36,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
-		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -41,7 +41,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
-		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Clean up the old domain management navigation component and feature flag. We're going to use only the new enhanced navigation so no need to keep the old code around.

#### Testing instructions

* Open mapped/registered or wpcom domain and verify that you see the new enhanced domain management nav
