### PR TITLE
Clean up the domain management security option feature flag

### DIFF
--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -445,14 +445,6 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	getSecurity() {
 		const { selectedSite, domain, currentRoute, translate } = this.props;
 
-		const shouldRenderDomainSecurity = config.isEnabled(
-			'domains/new-status-design/security-option'
-		);
-
-		if ( ! shouldRenderDomainSecurity ) {
-			return null;
-		}
-
 		const { pointsToWpcom, sslStatus } = domain;
 
 		if ( ! pointsToWpcom || ! sslStatus ) {

--- a/config/development.json
+++ b/config/development.json
@@ -56,7 +56,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
-		"domains/new-status-design/security-option": true,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
 		"external-media": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -34,7 +34,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
-		"domains/new-status-design/security-option": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/production.json
+++ b/config/production.json
@@ -33,7 +33,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
-		"domains/new-status-design/security-option": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -36,7 +36,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
-		"domains/new-status-design/security-option": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -41,7 +41,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
-		"domains/new-status-design/security-option": true,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
 		"external-media": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Clean up the domain management security option feature flag - that's basically it. We're keeping the page and the nav item so no need to keep the feature flag.

#### Testing instructions

* Make sure that you can see the "Security" nav item for registered domain
