### PR TITLE
Notifications: Adding parsing of heading elements to web notifications

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -384,7 +384,10 @@
 		}
 
 		.unread {
-			background: rgba( var( --color-primary-rgb ), 0.1 ); // rgba is used to meet AA contrast standard
+			background: rgba(
+				var( --color-primary-rgb ),
+				0.1
+			); // rgba is used to meet AA contrast standard
 		}
 
 		.wpnc__traffic_surge .wpnc__note-icon img {
@@ -512,7 +515,6 @@
 		user-select: none;
 	}
 
-	.wpnc__single-view,
 	.error-view {
 		h1 {
 			text-align: center;

--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -94,7 +94,7 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 			}
 			new_container = document.createElement( range_info_type );
 			if ( range_info.hasOwnProperty( 'class' ) ) {
-				new_container.setAttribute( 'class', range_info.class );
+				new_classes.push( range_info.class );
 			}
 			if ( range_info.hasOwnProperty( 'style' ) ) {
 				new_container.setAttribute( 'style', range_info.style );

--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -81,6 +81,12 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 		case 'strong':
 		case 'em':
 		case 'list':
+		case 'h1':
+		case 'h2':
+		case 'h3':
+		case 'h4':
+		case 'h5':
+		case 'h6':
 			switch ( range_info_type ) {
 				case 'list':
 					range_info_type = 'span';

--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -16,6 +16,23 @@
 		min-width: 0;
 	}
 
+	.has-text-align-center {
+		text-align: center;
+	}
+
+	.has-text-align-right {
+		text-align: right;
+	}
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		font-weight: bold;
+	}
+
 	&.wpnt-open {
 		right: 0;
 		transition: all 0.15s cubic-bezier( 0.075, 0.82, 0.165, 1 );
@@ -37,13 +54,13 @@
 	}
 
 	&.wpnc__main .wpnc__single-view {
-			left: inherit;
-			width: 400px;
+		left: inherit;
+		width: 400px;
 
-			@include breakpoint-deprecated( '<800px' ) {
-		    	left: 0;
-				width: auto;
-		  }
+		@include breakpoint-deprecated( '<800px' ) {
+			left: 0;
+			width: auto;
+		}
 	}
 
 	@include breakpoint-deprecated( '<800px' ) {

--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -24,6 +24,10 @@
 		text-align: right;
 	}
 
+	.has-text-align-left {
+		text-align: left;
+	}
+
 	h1,
 	h2,
 	h3,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This pull request, combined with D50168, updates the notifications app to allow heading elements (h1, h2, etc) to be rendered as allowed tags in web notification previews of posts.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D50168-code in your sandbox and make sure the API is sandboxed.
* Apply this change to calypso, navigate to your Calypso dashboard and open a notification for a post with various heading levels in its content. Verify that the headings are styled distinctly from surrounding paragraphs (for now, just in bold text) and reflected in the markup.

Before:
![image](https://user-images.githubusercontent.com/13437011/94465871-2bfa4700-0186-11eb-9d62-4b837f4bb078.png)
![image](https://user-images.githubusercontent.com/13437011/94465921-40d6da80-0186-11eb-90a9-b4ae2974a4bd.png)

After:
![image](https://user-images.githubusercontent.com/13437011/94465663-dd4cad00-0185-11eb-8b07-2b7e78cd9fed.png)
![image](https://user-images.githubusercontent.com/13437011/94465989-577d3180-0186-11eb-96ad-eb8548ec82e4.png)


Fixes #45649
