### PR TITLE
Add NS record component and validation to the DNS Editor

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -17,6 +17,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import MxRecord from './mx-record';
+import NsRecord from './ns-record';
 import TxtRecord from './txt-record';
 import SrvRecord from './srv-record';
 import formState from 'calypso/lib/form-state';
@@ -59,6 +60,14 @@ class DnsAddNew extends React.Component {
 				name: '',
 				data: '',
 				aux: 10,
+			},
+		},
+		{
+			component: NsRecord,
+			types: [ 'NS' ],
+			initialFields: {
+				name: '',
+				data: '',
 			},
 		},
 		{

--- a/client/my-sites/domains/domain-management/dns/dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-record.jsx
@@ -49,6 +49,13 @@ class DnsRecord extends React.Component {
 					},
 				} );
 
+			case 'NS':
+				return translate( 'Name servers handles by %(data)s', {
+					args: {
+						data,
+					},
+				} );
+
 			case 'MX':
 				return translate( 'Mail handled by %(data)s with priority %(aux)s', {
 					args: {

--- a/client/my-sites/domains/domain-management/dns/ns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/ns-record.jsx
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+class NsRecord extends React.Component {
+	static propTypes = {
+		fieldValues: PropTypes.object.isRequired,
+		onChange: PropTypes.func.isRequired,
+		selectedDomainName: PropTypes.string.isRequired,
+		show: PropTypes.bool.isRequired,
+	};
+
+	render() {
+		const { fieldValues, isValid, onChange, selectedDomainName, show, translate } = this.props;
+		const classes = classnames( { 'is-hidden': ! show } );
+		const isNameValid = isValid( 'name' );
+		const isDataValid = isValid( 'data' );
+
+		return (
+			<div className={ classes }>
+				<FormFieldset>
+					<FormLabel>{ translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
+					<FormTextInputWithAffixes
+						name="name"
+						placeholder={ translate( 'Enter subdomain (required)', {
+							context: 'Placeholder shown when entering the subdomain part of a new DNS record',
+						} ) }
+						isError={ ! isNameValid }
+						onChange={ onChange }
+						value={ fieldValues.name }
+						suffix={ '.' + selectedDomainName }
+					/>
+					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid Name' ) } isError /> }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>{ translate( 'Handled by', { context: 'NS Dns Record' } ) }</FormLabel>
+					<FormTextInput
+						name="data"
+						isError={ ! isDataValid }
+						onChange={ onChange }
+						value={ fieldValues.data }
+						placeholder={ translate( 'e.g. %(example)s', {
+							args: { example: 'ns.your-provider.com' },
+						} ) }
+					/>
+					{ ! isDataValid && (
+						<FormInputValidation text={ translate( 'Invalid NS Server' ) } isError />
+					) }
+					<FormSettingExplanation>
+						{ translate(
+							'Please use a domain name here (e.g. %(domain)s) - an IP address (e.g. %(ipAddress)s) will {{strong}}not{{/strong}} work.',
+							{
+								args: {
+									domain: 'mail.your-provider.com',
+									ipAddress: '123.45.78.9',
+								},
+								components: {
+									strong: <strong />,
+								},
+								context: "Hint for the 'Handled by' field of a NS record",
+							}
+						) }
+					</FormSettingExplanation>
+				</FormFieldset>
+			</div>
+		);
+	}
+}
+
+export default localize( NsRecord );

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -67,6 +67,7 @@ function isValidData( data, type ) {
 		case 'AAAA':
 			return data.match( /^[a-f0-9:]+$/i );
 		case 'CNAME':
+		case 'NS':
 		case 'MX':
 			return isValidDomain( data );
 		case 'TXT':


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We recently got a request to add external NS records for a subdomain in our name servers. We should be able to do that 

depends on: D50187-code

#### Testing instructions

* Try to add NS records for a subdomain, try removing them. Verify that it all works.
