### PR TITLE
Block Editor: AsyncLoad EditorMediaModal

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -11,8 +11,8 @@ import { localize, LocalizeProps } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import AsyncLoad from 'components/async-load';
 import MediaStore from 'lib/media/store';
-import EditorMediaModal from 'post-editor/editor-media-modal';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import {
 	getCustomizerUrl,
@@ -699,7 +699,9 @@ class CalypsoifyIframe extends Component<
 						/* eslint-enable jsx-a11y/iframe-has-title */
 					) }
 				</div>
-				<EditorMediaModal
+				<AsyncLoad
+					require="post-editor/editor-media-modal"
+					placeholder={ null }
 					disabledDataSources={ getDisabledDataSources( allowedTypes ) }
 					enabledFilters={ getEnabledFilters( allowedTypes ) }
 					galleryViewEnabled={ isUsingClassicBlock }


### PR DESCRIPTION
The media editor modal is a huge portion of the `gutenberg-editor` bundle. By asynchronously loading it, we're able to shave off nearly **40% of the bundle size - gzipped**! That's very likely to have an effect on (uncached) user-perceived performance of the block editor, and it's an easy win regardless.

#### Changes proposed in this Pull Request

* Block Editor: AsyncLoad `EditorMediaModal`

#### Testing instructions

* Edit a post with the block editor.
* Verify media modal looks and works just the same way.
* Verify the bundle size improvements in the `gutenberg-editor` bundle.
