### PR TITLE
Plans: scroll to the top when moving across pages

### DIFF
--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -3,7 +3,7 @@
  */
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 /**
@@ -52,6 +52,10 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header }: DetailsPagePro
 	const hasUpsell = useHasProductUpsell();
 	const translate = useTranslate();
 	const isLoading = useIsLoading( siteId );
+
+	useEffect( () => {
+		window.scrollTo( 0, 0 );
+	}, [] );
 
 	// If the product slug isn't one that has options, proceed to the upsell.
 	if ( ! ( PRODUCTS_WITH_OPTIONS as readonly string[] ).includes( productSlug ) ) {

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -3,7 +3,7 @@
  */
 import page from 'page';
 import { useTranslate } from 'i18n-calypso';
-import React, { ReactNode, useCallback, useMemo } from 'react';
+import React, { ReactNode, useCallback, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
@@ -86,6 +86,10 @@ const UpsellComponent = ( {
 		() => JETPACK_BACKUP_PRODUCTS.some( ( slug ) => slug === upsellSlug ),
 		[ upsellSlug ]
 	);
+
+	useEffect( () => {
+		window.scrollTo( 0, 0 );
+	}, [] );
 
 	return (
 		<Main className="upsell" wideLayout>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On mobile, if you move across pages, the scroll position doesn't get reset, which makes the experience confusing. This PR adds a reset in both the Details and the Upsell pages.

#### Testing instructions

* Run this PR.
* Configure your browser in mobile mode. We want a screen with a small viewport.
* Visit the Plans page `/plans/:site`.
* Test the flows of the following products (without going to checkout): Jetpack Security, Jetpack Backup, and Jetpack Scan.
* Verify that every time you visit the Details page the scroll is reset to the top of the page.
* Verify that every time you visit the Upsell page the scroll is reset to the top of the page.

Fixes 1169247016322522-as-1193973893888697

#### Demo
##### Before
![Kapture 2020-09-25 at 11 05 49](https://user-images.githubusercontent.com/3418513/94276828-22bb7100-ff1f-11ea-9d32-47d627a31f3a.gif)

##### After
![Kapture 2020-09-25 at 11 02 02](https://user-images.githubusercontent.com/3418513/94276413-9741e000-ff1e-11ea-9657-a958d0a84359.gif)
