### PR TITLE
Block Editor: Preload together with Post Editor section

### DIFF
--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -15,7 +15,7 @@ import { connect } from 'react-redux';
  */
 import AsyncLoad from 'components/async-load';
 import { translate } from 'i18n-calypso';
-import { preload } from 'sections-helper';
+import { preloadEditor } from 'sections-preloaders';
 import { Button } from '@automattic/components';
 import { markPostSeen } from 'state/reader/posts/actions';
 import { recordGaEvent, recordAction, recordTrackForPost } from 'reader/stats';
@@ -41,10 +41,6 @@ function getPingbackAttributes( post ) {
 		title,
 		url: post.URL,
 	};
-}
-
-function preloadEditor() {
-	preload( 'post-editor' );
 }
 
 export class DailyPostButton extends React.Component {

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -29,17 +29,13 @@ import PostActionsEllipsisMenuEdit from 'my-sites/post-type-list/post-actions-el
 import PostActionsEllipsisMenuTrash from 'my-sites/post-type-list/post-actions-ellipsis-menu/trash';
 import PostTypeSiteInfo from 'my-sites/post-type-list/post-type-site-info';
 import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
-import { preload } from 'sections-helper';
+import { preloadEditor } from 'sections-preloaders';
 import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-function preloadEditor() {
-	preload( 'post-editor' );
-}
 
 class PostItem extends React.Component {
 	clickHandler = ( clickTarget ) => () => {

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -18,7 +18,7 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'components/gridicon';
 import SocialLogo from 'components/social-logo';
 import * as stats from 'reader/stats';
-import { preload } from 'sections-helper';
+import { preloadEditor } from 'sections-preloaders';
 import SiteSelector from 'components/site-selector';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import { Button } from '@automattic/components';
@@ -27,10 +27,6 @@ import { Button } from '@automattic/components';
  * Style dependencies
  */
 import './style.scss';
-
-function preloadEditor() {
-	preload( 'post-editor' );
-}
 
 /**
  * Local variables

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
 import AsyncLoad from 'components/async-load';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import MasterbarItem from './item';
-import { preload } from 'sections-helper';
+import { preloadEditor } from 'sections-preloaders';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
 import MasterbarDrafts from './drafts';
@@ -57,8 +57,6 @@ class MasterbarItemNew extends React.Component {
 			event.preventDefault();
 		}
 	};
-
-	preloadPostEditor = () => preload( 'post-editor' );
 
 	getPopoverPosition() {
 		return isMobile() ? 'bottom' : 'bottom left';
@@ -104,7 +102,7 @@ class MasterbarItemNew extends React.Component {
 					isActive={ this.props.isActive }
 					tooltip={ this.props.tooltip }
 					className={ classes }
-					preloadSection={ this.preloadPostEditor }
+					preloadSection={ preloadEditor }
 				>
 					{ this.props.children }
 				</MasterbarItem>

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -14,7 +14,7 @@ import { flowRight, isEqual, size, without } from 'lodash';
 import ListEnd from 'components/list-end';
 import QueryPosts from 'components/data/query-posts';
 import Page from './page';
-import { preload } from 'sections-helper';
+import { preloadEditor } from 'sections-preloaders';
 import InfiniteScroll from 'components/infinite-scroll';
 import EmptyContent from 'components/empty-content';
 import NoResults from 'my-sites/no-results';
@@ -33,10 +33,6 @@ import SectionHeader from 'components/section-header';
 import { Button } from '@automattic/components';
 import { withLocalizedMoment } from 'components/localized-moment';
 import config from 'config';
-
-function preloadEditor() {
-	preload( 'post-editor' );
-}
 
 export default class PageList extends Component {
 	static propTypes = {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -27,7 +27,7 @@ import MenuSeparator from 'components/popover/menu-separator';
 import PageCardInfo from '../page-card-info';
 import InfoPopover from 'components/info-popover';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
-import { preload } from 'sections-helper';
+import { preloadEditor } from 'sections-preloaders';
 import {
 	getSite,
 	hasStaticFrontPage,
@@ -51,10 +51,6 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import config from 'config';
 
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
-
-function preloadEditor() {
-	preload( 'post-editor' );
-}
 
 function sleep( ms ) {
 	return new Promise( ( r ) => setTimeout( r, ms ) );

--- a/client/my-sites/post-type-list/empty-content.jsx
+++ b/client/my-sites/post-type-list/empty-content.jsx
@@ -15,11 +15,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import getEditorUrl from 'state/selectors/get-editor-url';
 import QueryPostTypes from 'components/data/query-post-types';
 import EmptyContent from 'components/empty-content';
-import { preload } from 'sections-helper';
-
-function preloadEditor() {
-	preload( 'post-editor' );
-}
+import { preloadEditor } from 'sections-preloaders';
 
 function PostTypeListEmptyContent( {
 	siteId,

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -15,11 +15,7 @@ import { bumpStatGenerator } from './utils';
 import { getPost } from 'state/posts/selectors';
 import { canCurrentUserEditPost } from 'state/posts/selectors/can-current-user-edit-post';
 import getEditorUrl from 'state/selectors/get-editor-url';
-import { preload } from 'sections-helper';
-
-function preloadEditor() {
-	preload( 'post-editor' );
-}
+import { preloadEditor } from 'sections-preloaders';
 
 function PostActionsEllipsisMenuEdit( { translate, canEdit, status, editUrl, bumpStat } ) {
 	if ( 'trash' === status || ! canEdit ) {

--- a/client/sections-preloaders.js
+++ b/client/sections-preloaders.js
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { preload } from './sections-helper';
+
+export function preloadEditor() {
+	preload( 'gutenberg-editor' );
+	preload( 'post-editor' );
+}

--- a/client/sections-preloaders.js
+++ b/client/sections-preloaders.js
@@ -5,5 +5,4 @@ import { preload } from './sections-helper';
 
 export function preloadEditor() {
 	preload( 'gutenberg-editor' );
-	preload( 'post-editor' );
 }


### PR DESCRIPTION
Currently, at multiple places, when the user intends to click on a link to open the post editor, we preload the post editor section. That helps with perceived performance, because the section starts loading immediately, and when the user navigates to the post editor, it loads faster because it had already loaded.

However, for many of the users, we use the block editor, and this introduces a couple of problems:
* We're still preloading the post editor section, which is totally unnecessary for those users because it never gets used.
* We're not preloading the block editor section, so we're missing out on an opportunity to improve the loading speed.

This PR introduces a common preloader helper that preloads both sections, and updates all the locations that were previously preloading the post editor to preload both sections. That resolves both of the abovementioned problems.

Ideally, we would know which section to preload and would preload only that section, but at this point, I expect the positive impact of preloading both sections to be higher than the negative one.

#### Changes proposed in this Pull Request

* Block Editor: Preload together with Post Editor section

#### Testing instructions

* Checkout this branch.
* Go to `/posts/:site`
* Open your network tab
* Roll over a post
* Verify the `gutenberg-editor` section chunk gets preloaded.
