### PR TITLE
Consider the site slug passed to the pricing page URL in Jetpack cloud

### DIFF
--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -12,8 +12,12 @@ import UpsellPage from './upsell';
 import { stringToDuration } from './utils';
 import getCurrentPlanTerm from 'state/selectors/get-current-plan-term';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { Duration } from 'my-sites/plans-v2/types';
 import { TERM_ANNUALLY } from 'lib/plans/constants';
+
+/**
+ * Type dependencies
+ */
+import type { Duration } from './types';
 
 export const productSelect = ( rootUrl: string ) => ( context: PageJS.Context, next: Function ) => {
 	// Get the selected site's current plan term, and set it as default duration
@@ -26,6 +30,7 @@ export const productSelect = ( rootUrl: string ) => ( context: PageJS.Context, n
 		<SelectorPage
 			defaultDuration={ duration }
 			rootUrl={ rootUrl }
+			siteSlug={ context.params.site || context.query.site }
 			header={ context.header }
 			footer={ context.footer }
 		/>
@@ -42,7 +47,8 @@ export const productDetails = ( rootUrl: string ) => (
 	context.primary = (
 		<DetailsPage
 			productSlug={ productType }
-			duration={ duration }
+			duration={ duration as Duration }
+			siteSlug={ context.params.site || context.query.site }
 			rootUrl={ rootUrl }
 			header={ context.header }
 		/>
@@ -56,7 +62,8 @@ export const productUpsell = ( rootUrl: string ) => ( context: PageJS.Context, n
 	context.primary = (
 		<UpsellPage
 			productSlug={ productSlug }
-			duration={ duration }
+			duration={ duration as Duration }
+			siteSlug={ context.params.site || context.query.site }
 			rootUrl={ rootUrl }
 			header={ context.header }
 		/>

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -44,10 +44,17 @@ import type { ProductSlug } from 'lib/products-values/types';
 
 import './style.scss';
 
-const DetailsPage = ( { duration, productSlug, rootUrl, header }: DetailsPageProps ) => {
+const DetailsPage = ( {
+	duration,
+	siteSlug: siteSlugProp,
+	productSlug,
+	rootUrl,
+	header,
+}: DetailsPageProps ) => {
 	const dispatch = useDispatch();
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const siteSlug = siteSlugProp || siteSlugState;
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
 	const hasUpsell = useHasProductUpsell();
 	const translate = useTranslate();

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -43,6 +43,7 @@ import './style.scss';
 
 const SelectorPage = ( {
 	defaultDuration = TERM_ANNUALLY,
+	siteSlug: siteSlugProp,
 	rootUrl,
 	header,
 	footer,
@@ -50,7 +51,8 @@ const SelectorPage = ( {
 	const dispatch = useDispatch();
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const siteSlug = siteSlugProp || siteSlugState;
 	const hasUpsell = useHasProductUpsell();
 	const [ productType, setProductType ] = useState< ProductType >( SECURITY );
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -30,16 +30,19 @@ interface BasePageProps {
 
 export interface SelectorPageProps extends BasePageProps {
 	defaultDuration?: Duration;
+	siteSlug?: string;
 }
 
 export interface DetailsPageProps extends BasePageProps {
 	duration?: Duration;
 	productSlug: string;
+	siteSlug?: string;
 }
 
 export interface UpsellPageProps extends BasePageProps {
 	duration?: Duration;
 	productSlug: string;
+	siteSlug?: string;
 }
 
 export interface WithRedirectToSelectorProps extends BasePageProps {

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -180,8 +180,15 @@ const UpsellComponent = ( {
 	);
 };
 
-const UpsellPage = ( { duration, productSlug, rootUrl, header }: UpsellPageProps ) => {
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+const UpsellPage = ( {
+	duration,
+	siteSlug: siteSlugProp,
+	productSlug,
+	rootUrl,
+	header,
+}: UpsellPageProps ) => {
+	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const siteSlug = siteSlugProp || siteSlugState;
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const isLoading = useIsLoading( siteId );
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -490,7 +490,7 @@ export function checkout( siteSlug: string, products: string | string[] ): void 
 	// step of the flow. Since purchases of multiple products are allowed, we need
 	// to pass all products separated by comma in the URL.
 	const path = siteSlug
-		? `/checkout/${ siteSlug }`
+		? `/checkout/${ siteSlug }/${ isJetpackCloud() ? productsArray.join( ',' ) : '' }`
 		: `/jetpack/connect/${ productsArray.join( ',' ) }`;
 
 	if ( isJetpackCloud() ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

The Jetpack plugin contains URLs that brings users to the pricing page in Jetpack cloud, with their site slug in a query parameter. When they select a product in this page, we want them to land on the checkout page directly, instead of having to see the Jetpack connect site input.

Fixes 1169247016322522-as-1195589446987737

### Testing instructions

- Download the PR locally and start Calypso
- Start Cloud concurrently with `yarn start-jetpack-cloud-p`
- Check that the selector, details, and upsell pages still work as expected in Calypso, and that you can checkout with an item in your cart
- In Jetpack cloud
    - Visit `/pricing` and select a product that has no option, such as Anti-spam. Check that you land on `wordpress.com/jetpack/connect/:product-slug`.
    - Visit `/pricing?site=:site-slug` and `/pricing/:site-slug`, and select the same product. Check that you land on `wordpress.com/checkout/:site-slug/:product-slug`.
    - Repeat these steps for the details and upsell pages (e.g. with Backup).