### PR TITLE
Nav Unification: Don't add menus but replace them.

### DIFF
--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -15,21 +15,21 @@ const showShowThemeOptions = true;
 export default function buildFallbackResponse( { siteDomain = '' } = {} ) {
 	const fallbackResponse = [
 		{
-			icon: 'dashicons-home',
+			icon: 'dashicons-admin-home',
 			slug: 'home',
 			title: translate( 'My Home' ),
 			type: 'menu-item',
 			url: `/home/${ siteDomain }`,
 		},
 		{
-			icon: 'dashicons-home',
+			icon: 'dashicons-chart-bar',
 			slug: 'stats',
 			title: translate( 'Stats' ),
 			type: 'menu-item',
 			url: `/stats/day/${ siteDomain }`,
 		},
 		{
-			icon: 'dashicons-home',
+			icon: 'dashicons-cart',
 			slug: 'purchases',
 			title: translate( 'Purchases' ),
 			type: 'menu-item',
@@ -343,23 +343,7 @@ export default function buildFallbackResponse( { siteDomain = '' } = {} ) {
 			slug: 'plugins',
 			title: translate( 'Plugins' ),
 			type: 'menu-item',
-			url: `https://${ siteDomain }/wp-admin/plugins.php`,
-			children: [
-				{
-					parent: 'plugins.php',
-					slug: 'plugins-installed',
-					title: translate( 'Installed Plugins' ),
-					type: 'menu-item',
-					url: `https://${ siteDomain }/wp-admin/plugins.php`,
-				},
-				{
-					parent: 'plugins.php',
-					slug: 'plugins-add-new',
-					title: translate( 'Add New' ),
-					type: 'menu-item',
-					url: `https://${ siteDomain }/wp-admin/plugin-editor.php`,
-				},
-			],
+			url: `/plugins/${ siteDomain }`,
 		},
 		{
 			icon: 'dashicons-admin-users',

--- a/client/state/admin-menu/reducer.js
+++ b/client/state/admin-menu/reducer.js
@@ -8,7 +8,7 @@ import { ADMIN_MENU_RECEIVE, ADMIN_MENU_REQUEST } from 'state/action-types';
 export const menus = keyedReducer( 'siteId', ( state = [], action ) => {
 	switch ( action.type ) {
 		case ADMIN_MENU_RECEIVE:
-			return [ ...state, ...action.menu ];
+			return action.menu;
 		default:
 			return state;
 	}

--- a/client/state/admin-menu/test/reducer.js
+++ b/client/state/admin-menu/test/reducer.js
@@ -31,17 +31,33 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'updates menu when there already is a menu', () => {
+			const originalMenu = [
+				{
+					icon: 'dashicons-feedback',
+					slug: 'the-original-menu-item',
+					title: 'The Original Menu Item',
+					type: 'menu-item',
+					url: 'https://examplewebsite.wordpress.com/wp-admin/admin.php?page=original',
+				},
+			];
+
+			const newMenu = menuFixture;
+
+			// Populate initial state with a different menu from
+			// the one we will be replacing it with.
+			const initialState = deepFreeze( {
+				123456: originalMenu,
+			} );
+
 			const action = {
 				type: ADMIN_MENU_RECEIVE,
 				siteId: 123456,
-				menu: menuFixture,
+				menu: newMenu,
 			};
-			const initialState = deepFreeze( {
-				123456: menuFixture,
-			} );
 
+			// Check the menu updates to reflect the new menu.
 			expect( menusReducer( initialState, action ) ).toEqual( {
-				123456: menuFixture,
+				123456: newMenu,
 			} );
 		} );
 	} );

--- a/client/state/admin-menu/test/reducer.js
+++ b/client/state/admin-menu/test/reducer.js
@@ -29,6 +29,21 @@ describe( 'reducer', () => {
 				123456: menuFixture,
 			} );
 		} );
+
+		test( 'updates menu when there already is a menu', () => {
+			const action = {
+				type: ADMIN_MENU_RECEIVE,
+				siteId: 123456,
+				menu: menuFixture,
+			};
+			const initialState = deepFreeze( {
+				123456: menuFixture,
+			} );
+
+			expect( menusReducer( initialState, action ) ).toEqual( {
+				123456: menuFixture,
+			} );
+		} );
 	} );
 
 	describe( 'requesting reducer', () => {


### PR DESCRIPTION
Also updates default data little bit.

#### Changes proposed in this Pull Request

* Changes reduce to not append menus but replacing them.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run calyspo
* Add `?flags=nav-unification` to the url.
* Switch between multiple sites.
* Makes sure menus don't get appended but rather replaced.
