### PR TITLE
Components: Remove global email field styles

### DIFF
--- a/client/assets/stylesheets/shared/_forms.scss
+++ b/client/assets/stylesheets/shared/_forms.scss
@@ -3,7 +3,6 @@
 // Global form elements
 // ==========================================================================
 input[type='text'],
-input[type='email'],
 textarea {
 	@extend %form-field;
 }
@@ -13,13 +12,7 @@ textarea {
 }
 
 input[type='text'],
-input[type='email'],
 textarea,
 label {
 	box-sizing: border-box;
-}
-
-input[type='email'] {
-	/*!rtl:ignore*/
-	direction: ltr;
 }

--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -2,6 +2,7 @@
 	@at-root {
 		input[type='url']#{&},
 		input[type='password']#{&},
+		input[type='email']#{&},
 		input[type='tel']#{&},
 		input[type='number']#{&},
 		input[type='search']#{&} {
@@ -10,6 +11,7 @@
 
 		input[type='url']#{&},
 		input[type='password']#{&},
+		input[type='email']#{&},
 		input[type='search']#{&} {
 			/*!rtl:ignore*/
 			direction: ltr;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove global form `input[type='email']` styles in favor of more specific component-level styling. See #45259.

#### Testing instructions

* Test the following against production and ensure that they match stylistically and functionally:
  * `/start/user` - the email field
  * `/start/simple` - the email field
  * `/me/security/account-recovery` - the email field when you click "Add"
* Verify all `<input type="email" />` instances use either `<FormTextInput />` (disregard Gutenboarding and Composite Checkout - they have their own sets of resets).
