### PR TITLE
Presales Chat: Open to all plan purchases

### DIFF
--- a/client/my-sites/checkout/checkout/payment-chat-button.jsx
+++ b/client/my-sites/checkout/checkout/payment-chat-button.jsx
@@ -12,10 +12,15 @@ import Gridicon from 'components/gridicon';
  */
 import HappychatButton from 'components/happychat/button';
 import { recordTracksEvent } from 'state/analytics/actions';
+import getSupportLevel from 'state/selectors/get-support-level';
 
 export class PaymentChatButton extends Component {
 	chatButtonClicked = () => {
-		this.props.recordTracksEvent( 'calypso_presales_chat_click' );
+		const { plan, supportLevel } = this.props;
+		this.props.recordTracksEvent( 'calypso_presales_chat_click', {
+			plan,
+			supportLevel,
+		} );
 	};
 
 	render() {
@@ -30,4 +35,6 @@ export class PaymentChatButton extends Component {
 	}
 }
 
-export default connect( null, { recordTracksEvent } )( localize( PaymentChatButton ) );
+export default connect( ( state ) => ( { supportLevel: getSupportLevel( state ) } ), {
+	recordTracksEvent,
+} )( localize( PaymentChatButton ) );

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -24,6 +24,7 @@ import { get } from 'lodash';
 import { showInlineHelpPopover } from 'state/inline-help/actions';
 import PaymentChatButton from 'my-sites/checkout/checkout/payment-chat-button';
 import getSupportVariation, {
+	SUPPORT_HAPPYCHAT,
 	SUPPORT_FORUM,
 	SUPPORT_DIRECTLY,
 } from 'state/selectors/get-inline-help-support-variation';
@@ -263,18 +264,12 @@ function CheckoutSummaryHelp() {
 	const plans = useLineItemsOfType( 'plan' );
 
 	const supportVariationDetermined = useSelector( isSupportVariationDetermined );
+	const supportVariation = useSelector( getSupportVariation );
 
 	const happyChatAvailable = useSelector( isHappychatAvailable );
 	const presalesChatAvailable = useSelector( isPresalesChatAvailable );
 	const presalesEligiblePlanLabel = getHighestWpComPlanLabel( plans );
 	const isPresalesChatEligible = presalesChatAvailable && presalesEligiblePlanLabel;
-
-	const isSupportChatUser = useSelector( ( state ) => {
-		return (
-			SUPPORT_FORUM !== getSupportVariation( state ) &&
-			SUPPORT_DIRECTLY !== getSupportVariation( state )
-		);
-	} );
 
 	const onEvent = useEvents();
 	const handleHelpButtonClicked = () => {
@@ -284,8 +279,10 @@ function CheckoutSummaryHelp() {
 
 	// If chat is available and the cart has a pre-sales plan or is already eligible for chat.
 	const shouldRenderPaymentChatButton =
-		happyChatAvailable &&
-		( isPresalesChatEligible || ( supportVariationDetermined && isSupportChatUser ) );
+		happyChatAvailable && ( isPresalesChatEligible || supportVariation === SUPPORT_HAPPYCHAT );
+
+	const hasDirectSupport =
+		supportVariation !== SUPPORT_DIRECTLY && supportVariation !== SUPPORT_FORUM;
 
 	// If chat isn't available, use the inline help button instead.
 	return (
@@ -297,7 +294,7 @@ function CheckoutSummaryHelp() {
 			) : (
 				supportVariationDetermined && (
 					<CheckoutSummaryHelpButton onClick={ handleHelpButtonClicked }>
-						{ isSupportChatUser
+						{ hasDirectSupport
 							? translate( 'Questions? {{underline}}Ask a Happiness Engineer{{/underline}}', {
 									components: {
 										underline: <span />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We have a help link on the checkout form, which opens Chat if the user is purchasing a Business or eCommerce plan (or if they're eligible for live chat anyways). This PR enables presales chat on _all_ plan purchases.

#### Testing instructions

You'll need to make sure Happy Chat has availability for the "Chat with us" button to show. By default Calypso hooks up to our staging Happy Chat environment, so you should be able to sign in at https://hud-staging.happychat.io/ and make sure:

- Your status is 🟢 All Chats
- Preferences > General > Throttle is more than 0
- Preferences > Skills > English is checked
- Preferences > Skills > WordPress.com is checked

Then sign into your dev WordPress.com with a free user (you can create a new throwaway account) and test the following product purchases:

- http://calypso.localhost:3000/checkout/tedsanders.net/theme:maxwell
- http://calypso.localhost:3000/checkout/tedsanders.net/personal
- http://calypso.localhost:3000/checkout/tedsanders.net/premium
- http://calypso.localhost:3000/checkout/tedsanders.net/business
- http://calypso.localhost:3000/checkout/tedsanders.net/ecommerce

The sidebar of the first link (a theme purchase) should have the link "Questions? Read more about plans and purchases".

For the other plan purchase links, you should get the "Need help? Chat with us" link. Clicking that link should open Happy Chat, and fire a tracks event `calypso_presales_chat_click` with params `plan` and `supportLevel`.
