### PR TITLE
Don't throw an error if there is a missing protocol in `safeImageUrl`

### DIFF
--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -78,6 +78,9 @@ export default function safeImageUrl( url ) {
 
 		// Ensure we're creating a new URL without the size parameters
 		delete parsedUrl.search;
+
+		// Force https since if there's a missing protocol it'll throw an error
+		parsedUrl.protocol = 'https';
 		url = getUrlFromParts( parsedUrl ).toString();
 	}
 

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -56,6 +56,12 @@ describe( 'safeImageUrl()', () => {
 			expect( safeImageUrl( '//example.com/foo' ) ).toEqual( 'https://i1.wp.com/example.com/foo' );
 		} );
 
+		test( 'should make a non-wpcom protocol relative url with params safe', () => {
+			expect( safeImageUrl( '//example.com/foo?w=100' ) ).toEqual(
+				'https://i1.wp.com/example.com/foo?ssl=1'
+			);
+		} );
+
 		test( 'should promote an http wpcom url to https', () => {
 			expect( safeImageUrl( 'http://files.wordpress.com/' ) ).toEqual(
 				'https://files.wordpress.com/'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `getUrlFromParts` throws an error if there is no protocol, but in the reader we use that function to get a safe image url. So if the reader item url is without a protocol `//example.com/image.png` it breaks the reader. I think we should not throw an error if there is a missing protocol but that might be more complicated than I can do right now so let's un-break the reader by always providing a protocol to the `safeImageUrl` for now.

#### Testing instructions

* You'll have to find a reader post with image that's without protocol `//example.com/imsdisd.png`
* I actually added a test case too