### PR TITLE
Fix `safeImageUrl` to force protocol only if it's missing

### DIFF
--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -80,7 +80,9 @@ export default function safeImageUrl( url ) {
 		delete parsedUrl.search;
 
 		// Force https since if there's a missing protocol it'll throw an error
-		parsedUrl.protocol = 'https';
+		if ( ! parsedUrl?.protocol ) {
+			parsedUrl.protocol = 'https';
+		}
 		url = getUrlFromParts( parsedUrl ).toString();
 	}
 

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -56,6 +56,12 @@ describe( 'safeImageUrl()', () => {
 			expect( safeImageUrl( '//example.com/foo' ) ).toEqual( 'https://i1.wp.com/example.com/foo' );
 		} );
 
+		test( 'should make a non-wpcom http protocol url with params safe', () => {
+			expect( safeImageUrl( 'http://example.com/foo?w=100' ) ).toEqual(
+				'https://i1.wp.com/example.com/foo'
+			);
+		} );
+
 		test( 'should make a non-wpcom protocol relative url with params safe', () => {
 			expect( safeImageUrl( '//example.com/foo?w=100' ) ).toEqual(
 				'https://i1.wp.com/example.com/foo?ssl=1'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In #45942 I deployed a fix to `safeImageUrl` but when I think about it - we should force https only if the protocol is missing so here's a PR to fix my fix :(

#### Testing instructions

* Added a new test case for that case too - `safeImageUrl` should properly transform url with http protocol to a photon url without ssl param
