### PR TITLE
Add coming soon page to new sites

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -8,6 +8,19 @@
 namespace A8C\FSE\Coming_soon;
 
 /**
+ * Load the coming soon page tempalate object
+ *
+ * @return object
+ */
+function get_coming_soon_page_template() {
+	return json_decode(
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		file_get_contents( __DIR__ . '/coming-soon-page-template.json' ),
+		false
+	);
+}
+
+/**
  * Determines whether the coming soon page should be shown.
  *
  * @return boolean
@@ -83,14 +96,28 @@ add_filter( 'rest_api_update_site_settings', __NAMESPACE__ . '\add_public_coming
  * @return array The updated $templates array
  */
 function add_public_coming_soon_page_template( $templates ) : array {
-	$templates[] = json_decode(
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		file_get_contents( __DIR__ . '/coming-soon-page-template.json' ),
-		false
-	);
+	$templates[] = get_coming_soon_page_template();
 	return $templates;
 }
 add_filter( 'vertical_templates', __NAMESPACE__ . '\add_public_coming_soon_page_template' );
+
+/**
+ * Adds an editable coming soon page to a new site.
+ */
+function add_coming_soon_page_to_new_site() {
+	$coming_soon_template = get_coming_soon_page_template();
+	wp_insert_post(
+		array(
+			'post_title'     => $coming_soon_template->post_title,
+			'post_content'   => $coming_soon_template->post_content,
+			'post_status'    => 'publish',
+			'post_type'      => 'page',
+			'comment_status' => 'closed',
+			'ping_status'    => 'closed',
+		)
+	);
+}
+add_action( 'signup_finished', __NAMESPACE__ . '\add_coming_soon_page_to_new_site' );
 
 /**
  * Decides whether to redirect to the site's coming soon page and performs

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -101,12 +101,28 @@ function add_public_coming_soon_page_template( $templates ) : array {
 }
 add_filter( 'vertical_templates', __NAMESPACE__ . '\add_public_coming_soon_page_template' );
 
+// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed
 /**
- * Adds an editable coming soon page to a new site.
+ * Adds an editable coming soon page to a site if no coming soon page exists and
+ * a paid plan is purchased
+ *
+ * @param int $blog_id current blog id.
+ * @param int $user_id current user id.
+ * @param int $product_id the id of the plan that was just purchased.
  */
-function add_coming_soon_page_to_new_site() {
+function add_coming_soon_page_to_paid_site( $blog_id, $user_id, $product_id ) {
+	if ( ! \WPCOM_Store::is_wpcom_plan( $product_id ) ) {
+		return;
+	}
+
+	// if there is an existing coming soon page don't add a new one.
+	$existing_page_id = (int) get_option( 'wpcom_public_coming_soon_page_id', 0 );
+	if ( $existing_page_id ) {
+		return;
+	}
+
 	$coming_soon_template = get_coming_soon_page_template();
-	wp_insert_post(
+	$new_page_id          = wp_insert_post(
 		array(
 			'post_title'     => $coming_soon_template->post_title,
 			'post_content'   => $coming_soon_template->post_content,
@@ -116,8 +132,9 @@ function add_coming_soon_page_to_new_site() {
 			'ping_status'    => 'closed',
 		)
 	);
+	add_option( 'wpcom_public_coming_soon_page_id', $new_page_id );
 }
-add_action( 'signup_finished', __NAMESPACE__ . '\add_coming_soon_page_to_new_site' );
+add_action( 'subscription_changed', __NAMESPACE__ . '\add_coming_soon_page_to_new_site', 10, 3 );
 
 /**
  * Decides whether to redirect to the site's coming soon page and performs


### PR DESCRIPTION
Hooks into the `subscription_changed` action to add the coming soon page to new sites when the user purchases a paid subscription. This event is used because the site is always created as a free site and then the plan is added to the free site in a later step.

### Testing instructions

* Sync this branch to your sandbox with `yarn dev --sync`
* Enable `    define('WPCOM_PUBLIC_COMING_SOON', true);` in your `0-sandbox.php`
* Create a new site with a paid plan

The coming soon page should be added.
If the site uses a free plan or if the WPCOM_PUBLIC_COMING_SOON is false or undefined, the coming soon page should not be added.
