### PR TITLE
Add missing dependencies to packages/domain-picker

### DIFF
--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -44,11 +44,16 @@
 		"use-debounce": "^3.1.0",
 		"uuid": "^7.0.2"
 	},
+	"devDependencies": {
+		"@testing-library/react": "^10.0.5",
+		"react": "^16.12.0",
+		"react-dom": "^16.12.0"
+	},
 	"peerDependencies": {
 		"@wordpress/data": "^4.22.3",
 		"@wordpress/element": "^2.16.0",
 		"@wordpress/i18n": "^3.14.0",
-		"react": "^16.8"
+		"react": "^16.12.0"
 	},
 	"private": true
 }


### PR DESCRIPTION
### Background

There are a few undeclared dependencies, found by running `npx @yarnpkg/doctor`:

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/domain-picker/package.json
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepare") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepublish") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/domain-picker/test/suggestion-item.tsx:10:1: Undeclared dependency on @testing-library/react
➤ YN0000: └ Completed in 1.74s
```

### Changes

* Adds missing `devDependencies`: `@testing-library/react`, `react` and `react-dom`. All three libraries are required to be installed to run tests for this package.
* Update `react` version range as peerDependency to match what we use in the repo. The actual version installed has not changed.

### Testing instructions

Run `cd packages/domain-picker && npx @yarnpkg/doctor` and check the warnings about missing dependencies are gone