### PR TITLE
Server build: move Babel cache dir to the common .cache folder

### DIFF
--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -32,6 +32,7 @@ const devTarget = process.env.DEV_TARGET || 'evergreen';
 const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'false';
 const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
 const shouldConcatenateModules = process.env.CONCATENATE_MODULES !== 'false';
+const cacheDirectory = path.resolve( '.cache', 'babel-server' );
 
 const fileLoader = FileConfig.loader( {
 	publicPath: isDevelopment ? `/calypso/${ devTarget }/images/` : '/calypso/images/',
@@ -110,14 +111,14 @@ const webpackConfig = {
 			TranspileConfig.loader( {
 				workerCount,
 				configFile: path.resolve( 'babel.config.js' ),
-				cacheDirectory: path.join( buildDir, '.babel-server-cache' ),
+				cacheDirectory,
 				cacheIdentifier,
 				exclude: /node_modules\//,
 			} ),
 			TranspileConfig.loader( {
 				workerCount,
 				presets: [ require.resolve( '@automattic/calypso-build/babel/dependencies' ) ],
-				cacheDirectory: path.join( buildDir, '.babel-server-cache' ),
+				cacheDirectory,
 				cacheIdentifier,
 				include: shouldTranspileDependency,
 			} ),


### PR DESCRIPTION
Updates the webpack config for the Desktop server build, too. In this case, we are also replacing the custom `babel-loader` configs with standardized configs from the `calypso-build` package. That makes the Babel setup for both servers (web and desktop) exactly the same.

**How to test:**
- build web server: `NODE_ENV=production yarn run build-server`
- build desktop server: `NODE_ENV=production yarn run build-desktop:server` (the `build-desktop:config` task should have been run previously at least once, too)

Verify that the builds create caches in `.cache/babel-server` and `.cache/babel-desktop`. And verify that the caches are used: the second build should be significantly faster. I get 24s vs 16s for web and 46s to 11s for desktop.
