### PR TITLE
Add performance marks and measures to RUM data

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -687,7 +687,6 @@ class CalypsoifyIframe extends Component<
 				<div className="main main-column calypsoify is-iframe" role="main">
 					{ ! isIframeLoaded && <Placeholder /> }
 					{ ( shouldLoadIframe || isIframeLoaded ) && (
-						/* eslint-disable jsx-a11y/iframe-has-title */
 						<Iframe
 							ref={ this.iframeRef }
 							src={ isIframeLoaded ? currentIFrameUrl : iframeUrl }
@@ -697,7 +696,6 @@ class CalypsoifyIframe extends Component<
 								this.onIframeLoaded( iframeUrl );
 							} }
 						/>
-						/* eslint-enable jsx-a11y/iframe-has-title */
 					) }
 				</div>
 				<EditorMediaModal

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -52,7 +52,7 @@ import { REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE } from 'state/desktop/wi
 import inEditorDeprecationGroup from 'state/editor-deprecation-group/selectors/in-editor-deprecation-group';
 import { setMediaLibrarySelectedItems } from 'state/media/actions';
 import { fetchMediaItem, getMediaItem } from 'state/media/thunks';
-
+import Iframe from './iframe';
 /**
  * Types
  */
@@ -653,6 +653,7 @@ class CalypsoifyIframe extends Component<
 				return;
 			}
 		}
+		window.performance?.mark( 'iframe_loaded' );
 		this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } );
 	};
 
@@ -687,7 +688,7 @@ class CalypsoifyIframe extends Component<
 					{ ! isIframeLoaded && <Placeholder /> }
 					{ ( shouldLoadIframe || isIframeLoaded ) && (
 						/* eslint-disable jsx-a11y/iframe-has-title */
-						<iframe
+						<Iframe
 							ref={ this.iframeRef }
 							src={ isIframeLoaded ? currentIFrameUrl : iframeUrl }
 							// Iframe url needs to be kept in state to prevent editor reloading if frame_nonce changes

--- a/client/gutenberg/editor/iframe.tsx
+++ b/client/gutenberg/editor/iframe.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React, { forwardRef, useEffect, DetailedHTMLProps, IframeHTMLAttributes } from 'react';
+
+type IframeProps = DetailedHTMLProps<
+	IframeHTMLAttributes< HTMLIFrameElement >,
+	HTMLIFrameElement
+>;
+
+const Iframe = forwardRef< HTMLIFrameElement, IframeProps >( function IFrame( props, ref ) {
+	useEffect( () => {
+		window.performance?.mark( 'iframe_rendered' );
+	}, [ props.src ] );
+
+	// eslint-disable-next-line jsx-a11y/iframe-has-title
+	return <iframe { ...props } ref={ ref } />;
+} );
+
+export default Iframe;

--- a/packages/browser-data-collector/src/api/user-timing.ts
+++ b/packages/browser-data-collector/src/api/user-timing.ts
@@ -1,0 +1,5 @@
+export const getMarks = (): PerformanceEntry[] =>
+	( window?.performance?.getEntriesByType( 'mark' ) as PerformanceEntry[] ) || [];
+
+export const getMeasures = (): PerformanceEntry[] =>
+	( window?.performance?.getEntriesByType( 'measure' ) as PerformanceEntry[] ) || [];

--- a/packages/browser-data-collector/src/collectors/index.ts
+++ b/packages/browser-data-collector/src/collectors/index.ts
@@ -12,3 +12,5 @@ export {
 	collectorStop as pageVisibilityStop,
 } from './page-visibility';
 export { collector as blockingResources } from './blocking-resources';
+export { collector as performanceMarks } from './performance-marks';
+export { collector as performanceMeasures } from './performance-measures';

--- a/packages/browser-data-collector/src/collectors/performance-marks.ts
+++ b/packages/browser-data-collector/src/collectors/performance-marks.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { getMarks } from '../api/user-timing';
+
+export const collector: Collector = ( report ) => {
+	const marks = getMarks();
+
+	// All data in the report is expected to be relative to `navigationStart`.
+	//
+	// mark.startTime is when the mark was craeted relative to the "time origin", which should
+	// be recorded in `performance.timeOrigin` but not all browsers supports it. However,
+	// `navigationStart` is reasonably close, therefore we don't need to correct `startTime`
+	marks.forEach( ( mark ) => {
+		report.data.set(
+			'mark__' + mark.name.toLowerCase().replace( /\W/g, '_' ),
+			Math.round( mark.startTime )
+		);
+	} );
+
+	return report;
+};

--- a/packages/browser-data-collector/src/collectors/performance-marks.ts
+++ b/packages/browser-data-collector/src/collectors/performance-marks.ts
@@ -12,10 +12,10 @@ export const collector: Collector = ( report ) => {
 	// be recorded in `performance.timeOrigin` but not all browsers supports it. However,
 	// `navigationStart` is reasonably close, therefore we don't need to correct `startTime`
 	marks.forEach( ( mark ) => {
-		report.data.set(
-			'mark__' + mark.name.toLowerCase().replace( /\W/g, '_' ),
-			Math.round( mark.startTime )
-		);
+		const name = 'mark__' + mark.name.toLowerCase().replace( /\W/g, '_' );
+		if ( ! report.data.has( name ) ) {
+			report.data.set( name, Math.round( mark.startTime ) );
+		}
 	} );
 
 	return report;

--- a/packages/browser-data-collector/src/collectors/performance-measures.ts
+++ b/packages/browser-data-collector/src/collectors/performance-measures.ts
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { getMeasures } from '../api/user-timing';
+
+export const collector: Collector = ( report ) => {
+	const measures = getMeasures();
+
+	// As we don't know if any of the startMark or endMark are within this report timespan, we can't
+	// filter them out.
+	measures.forEach( ( measure ) => {
+		report.data.set(
+			'measure__' + measure.name.toLowerCase().replace( /\W/g, '_' ),
+			Math.round( measure.duration )
+		);
+	} );
+
+	return report;
+};

--- a/packages/browser-data-collector/src/collectors/performance-measures.ts
+++ b/packages/browser-data-collector/src/collectors/performance-measures.ts
@@ -9,10 +9,10 @@ export const collector: Collector = ( report ) => {
 	// As we don't know if any of the startMark or endMark are within this report timespan, we can't
 	// filter them out.
 	measures.forEach( ( measure ) => {
-		report.data.set(
-			'measure__' + measure.name.toLowerCase().replace( /\W/g, '_' ),
-			Math.round( measure.duration )
-		);
+		const name = 'measure__' + measure.name.toLowerCase().replace( /\W/g, '_' );
+		if ( ! report.data.has( name ) ) {
+			report.data.set( name, Math.round( measure.duration ) );
+		}
 	} );
 
 	return report;

--- a/packages/browser-data-collector/src/report.ts
+++ b/packages/browser-data-collector/src/report.ts
@@ -11,6 +11,8 @@ import {
 	pageVisibilityStart,
 	pageVisibilityStop,
 	blockingResources,
+	performanceMarks,
+	performanceMeasures,
 } from './collectors';
 
 export class ReportImpl implements Report {
@@ -35,19 +37,22 @@ export class ReportImpl implements Report {
 
 	private constructor( id: string, isInitial: boolean ) {
 		this.id = id;
+		const commonStartCollectors = [ pageVisibilityStart ];
+		const commonStopCollectors = [
+			deviceMemory,
+			environment,
+			pageVisibilityStop,
+			networkInformation,
+			performanceMarks,
+			performanceMeasures,
+		];
+
 		if ( isInitial ) {
-			this.startCollectors = [ fullPageStart, pageVisibilityStart ];
-			this.stopCollectors = [
-				deviceMemory,
-				performanceTiming,
-				environment,
-				pageVisibilityStop,
-				networkInformation,
-				blockingResources,
-			];
+			this.startCollectors = [ fullPageStart, ...commonStartCollectors ];
+			this.stopCollectors = [ performanceTiming, blockingResources, ...commonStopCollectors ];
 		} else {
-			this.startCollectors = [ inlineStart, pageVisibilityStart ];
-			this.stopCollectors = [ deviceMemory, environment, pageVisibilityStop, networkInformation ];
+			this.startCollectors = [ inlineStart, ...commonStartCollectors ];
+			this.stopCollectors = [ ...commonStopCollectors ];
 		}
 	}
 


### PR DESCRIPTION
### Changes

* Adds performance marks and measures from the [User Timing API](https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API) to RUM reports.

### Testing instructions

* Load gutenberg-editor.
* Open the Network tab in the Devtools and search for a request to `/logstash`
* They payload should contain `mark__iframe_loaded` and `mark__iframe_mounted`.
