### PR TITLE
Add admin menu browser persistence (via schema)

### DIFF
--- a/client/state/admin-menu/reducer.js
+++ b/client/state/admin-menu/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { flowRight as compose, partial } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { withStorageKey, keyedReducer, combineReducers, withSchemaValidation } from 'state/utils';

--- a/client/state/admin-menu/reducer.js
+++ b/client/state/admin-menu/reducer.js
@@ -1,20 +1,29 @@
 /**
+ * External dependencies
+ */
+import { flowRight as compose, partial } from 'lodash';
+
+/**
  * Internal dependencies
  */
-import { withStorageKey, keyedReducer, combineReducers } from 'state/utils';
+import { withStorageKey, keyedReducer, combineReducers, withSchemaValidation } from 'state/utils';
 import 'state/data-layer/wpcom/sites/admin-menu';
 import { ADMIN_MENU_RECEIVE, ADMIN_MENU_REQUEST } from 'state/action-types';
+import { menusSchema } from './schema';
 
-export const menus = keyedReducer( 'siteId', ( state = [], action ) => {
-	switch ( action.type ) {
-		case ADMIN_MENU_RECEIVE:
-			return action.menu;
-		default:
-			return state;
-	}
-} );
+export const menus = withSchemaValidation(
+	menusSchema,
+	keyedReducer( 'siteId', ( state = [], action ) => {
+		switch ( action.type ) {
+			case ADMIN_MENU_RECEIVE:
+				return action.menu;
+			default:
+				return state;
+		}
+	} )
+);
 
-export function requesting( state = false, action ) {
+export const requesting = ( state = false, action ) => {
 	switch ( action.type ) {
 		case ADMIN_MENU_REQUEST:
 		case ADMIN_MENU_RECEIVE:
@@ -22,7 +31,7 @@ export function requesting( state = false, action ) {
 	}
 
 	return state;
-}
+};
 
 const reducer = combineReducers( {
 	menus,

--- a/client/state/admin-menu/schema.js
+++ b/client/state/admin-menu/schema.js
@@ -1,5 +1,4 @@
 const commonItemPropsSchema = {
-	icon: { type: 'string' },
 	slug: { type: 'string' },
 	title: { type: 'string' },
 	type: { type: 'string' },
@@ -13,6 +12,7 @@ const menuItemsSite = {
 		required: [ 'type' ],
 		properties: {
 			...commonItemPropsSchema,
+			icon: { type: 'string' },
 			children: {
 				type: 'array',
 				items: {

--- a/client/state/admin-menu/schema.js
+++ b/client/state/admin-menu/schema.js
@@ -1,0 +1,37 @@
+const commonItemPropsSchema = {
+	icon: { type: 'string' },
+	slug: { type: 'string' },
+	title: { type: 'string' },
+	type: { type: 'string' },
+	url: { type: 'string' },
+};
+
+const menuItemsSite = {
+	type: 'array',
+	items: {
+		type: 'object',
+		required: [ 'type' ],
+		properties: {
+			...commonItemPropsSchema,
+			children: {
+				type: 'array',
+				items: {
+					type: 'object',
+					required: [ 'type', 'parent' ],
+					properties: {
+						...commonItemPropsSchema,
+						parent: { type: 'string' },
+					},
+				},
+			},
+		},
+	},
+	additionalProperties: false,
+};
+
+export const menusSchema = {
+	type: 'object',
+	patternProperties: {
+		'^\\d+$': menuItemsSite,
+	},
+};

--- a/client/state/admin-menu/test/reducer.js
+++ b/client/state/admin-menu/test/reducer.js
@@ -7,7 +7,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import menuFixture from './fixture/menu-fixture';
-import { ADMIN_MENU_RECEIVE, ADMIN_MENU_REQUEST } from 'state/action-types';
+import { ADMIN_MENU_RECEIVE, ADMIN_MENU_REQUEST, DESERIALIZE, SERIALIZE } from 'state/action-types';
 import { menus as menusReducer, requesting as requestingReducer } from '../reducer';
 
 describe( 'reducer', () => {
@@ -59,6 +59,80 @@ describe( 'reducer', () => {
 			expect( menusReducer( initialState, action ) ).toEqual( {
 				123456: newMenu,
 			} );
+		} );
+
+		describe( 'persistence', () => {
+			test( 'correctly serializes state for persistence', () => {
+				const initialState = deepFreeze( {
+					123456: menuFixture,
+				} );
+
+				const action = { type: SERIALIZE };
+
+				const serializationResult = menusReducer( initialState, action ).root();
+
+				expect( serializationResult ).toEqual( {
+					123456: menuFixture,
+				} );
+			} );
+
+			test( 'correctly loads valid persisted state', () => {
+				const stateToDeserialize = deepFreeze( {
+					123456: menuFixture,
+				} );
+
+				const action = { type: DESERIALIZE };
+
+				expect( menusReducer( stateToDeserialize, action ) ).toEqual( {
+					123456: menuFixture,
+				} );
+			} );
+
+			test.each( [
+				{
+					12345: [
+						{
+							title: 'Menu Item',
+						},
+					],
+				},
+				{
+					12345: [
+						{
+							title: 'Menu Item',
+							type: 'menu-item',
+							children: [
+								{
+									title: 'Child Menu',
+									type: 'sub-menu-item',
+								},
+							],
+						},
+					],
+				},
+				[
+					{
+						title: 'Hello world',
+					},
+				],
+			] )(
+				'loads default state when persisted state fails schema validation',
+				( persistedState ) => {
+					// Disable console here as `isValidStateWithSchema` util emits logs.
+					// see: https://github.com/Automattic/wp-calypso/blob/02c3a452881ff89fce240c09d16874c0c4e4d429/client/state/utils/schema-utils.js#L14
+					jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+
+					// This is the state that will be returned for the `DESERIALIZE` action
+					// if the persisted state fails schema validation
+					const defaultReducerState = deepFreeze( {} );
+
+					// This is the state to be validated against the schema.
+					const stateToDeserialize = deepFreeze( persistedState );
+
+					const state = menusReducer( stateToDeserialize, { type: DESERIALIZE } );
+					expect( state ).toEqual( defaultReducerState );
+				}
+			);
 		} );
 	} );
 


### PR DESCRIPTION
This PR addresses https://github.com/Automattic/wp-calypso/issues/45876 by adding the required schema and HO reducer to enable browser persistence for `menus` portion of the `adminMenu` state slice.

This ensures that once the initial API response is cached in the browser IndexDB there is no (less of a) perceivable lag between Calypso UI "load" and the admin menu being "ready" and "available".

~**Note**: this will require that https://github.com/Automattic/wp-calypso/pull/45939 is merged before we can merge this PR.~ Now merged 🥳 

#### Changes proposed in this Pull Request

* Adds a `schema.json` for the `menus` portion of the `adminMenu` state.
* Wraps the `menus` portion of the `adminMenu` state with the schema validation reducer to enable browser peristence of state.

#### Testing instructions

* Checkout this PR.
* Apply blog sticker ` nav-unification` to test site.
* Run calypso - `yarn && ENTRY_LIMIT=entry-main SECTION_LIMIT=home yarn start`
* Visit http://calypso.localhost:3000/?flags=nav-unification.
* You should see the menu rendered from the static data as per https://github.com/Automattic/wp-calypso/pull/45836
* Once the API request completes you should see the nav re-rendered using the "correct" data from the API endpoint.
* Now reload your browser - this time you should _not_ see the nav rendered from the static data but rather rendered semi-instantly from the cached data in the browser storage. 
* Open DevTools. Goto `Application` tab. Look for `Storage` in the left hand sidebar. Expand the `IndexDB` accordion. Find the `calypso_store` DB entry. Look for `the adminMenu` slice of state persisted in the DB. Make sure it matches what is stored in state (try `state.adminMenu` in the `Console` tab).

![Screen Shot 2020-09-28 at 12 24 36](https://user-images.githubusercontent.com/444434/94426567-ae363b80-0185-11eb-8589-6441c6e25cde.png)


Fixes https://github.com/Automattic/wp-calypso/issues/45876
