### PR TITLE
Calypsoify: Move site request before rendering CalypsoifyIframe

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -43,7 +43,6 @@ import { editPost, trashPost } from 'state/posts/actions';
 import { getEditorPostId } from 'state/editor/selectors';
 import { protectForm, ProtectedFormProps } from 'lib/protect-form';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QuerySites from 'components/data/query-sites';
 import config from 'config';
 import EditorDocumentHead from 'post-editor/editor-document-head';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
@@ -657,7 +656,7 @@ class CalypsoifyIframe extends Component<
 	};
 
 	render() {
-		const { iframeUrl, siteId, shouldLoadIframe } = this.props;
+		const { iframeUrl, shouldLoadIframe } = this.props;
 		const {
 			classicBlockEditorId,
 			isMediaModalVisible,
@@ -675,7 +674,6 @@ class CalypsoifyIframe extends Component<
 
 		return (
 			<Fragment>
-				<QuerySites siteId={ siteId } />
 				<PageViewTracker
 					path={ this.getStatsPath() }
 					title={ this.getStatsTitle() }

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -32,6 +32,7 @@ import isSiteUsingCoreSiteEditor from 'state/selectors/is-site-using-core-site-e
 import getSiteEditorUrl from 'state/selectors/get-site-editor-url';
 import { REASON_BLOCK_EDITOR_JETPACK_REQUIRES_SSO } from 'state/desktop/window-events';
 import { notifyDesktopCannotOpenEditor } from 'state/desktop/actions';
+import { requestSite } from 'state/sites/actions';
 
 function determinePostType( context ) {
 	if ( context.path.startsWith( '/block-editor/post/' ) ) {
@@ -116,6 +117,15 @@ export const authenticate = ( context, next ) => {
 	}
 
 	if ( isAuthenticated ) {
+		/*
+		 * Make sure we have an up-to-date frame nonce.
+		 *
+		 * By requesting the site here instead of using <QuerySites /> we avoid a race condition, where
+		 * if a render occurs before the site is requested, the first request for retrieving the iframe
+		 * will get aborted.
+		 */
+		context.store.dispatch( requestSite( siteId ) );
+
 		globalThis.sessionStorage.setItem( storageKey, 'true' );
 		return next();
 	}


### PR DESCRIPTION
This PR moves the site request before the initial rendering of `<CalypsoifyIframe />`.

By requesting the site there instead of using `<QuerySites />` we avoid a race condition, where if a render occurs before the site is requested, the first request for retrieving the iframe will get aborted. For the protocol, this render will always happen once between the component mount and requesting the site.

Reported by @scinos - thanks!

#### Changes proposed in this Pull Request

* Calypsoify: Move site request before rendering `<CalypsoifyIframe />`.

#### Testing instructions

* Click to edit a post in Calypso.
* Observe network requests.
* Verify you don't get an aborted request to the iframe URL anymore.
