### PR TITLE
Menu Icon: Account for image URLs as icons.

### DIFF
--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -30,7 +30,7 @@ const SidebarCustomIcon = ( { alt, className, icon, ...rest } ) => {
 			/>
 		);
 	}
-	if ( icon.indexOf( 'data:image' ) === 0 ) {
+	if ( icon.indexOf( 'data:image' ) === 0 || icon.indexOf( 'http' ) === 0 ) {
 		return (
 			<img
 				alt={ alt || '' }

--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -1,8 +1,7 @@
 /**
  * SidebarCustomIcon -
- *   Renders an <img> tag with props supplied if icon is a data image
- *   or a dashicon in other case. If icon is not supplied or undefined
- *   returns a blank SVG
+ *   Handles Dashicons, SVGs, or image URLs and passes on the supplied props.
+ *   Returns a blank SVG, if icon is not supplied or undefined.
  *   Adds className="sidebar__menu-icon" to the supplied className.
  *
  *   Purpose: To display a custom icon in the sidebar when using a

--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -35,6 +35,7 @@ const SidebarCustomIcon = ( { alt, className, icon, ...rest } ) => {
 				alt={ alt || '' }
 				className={ 'sidebar__menu-icon ' + ( className || '' ) }
 				src={ icon }
+				width="20"
 				{ ...rest }
 			/>
 		);

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -112,7 +112,6 @@ $font-size: rem( 14px );
 
 		.sidebar__menu-icon {
 			color: var( --color-sidebar-gridicon-fill );
-			min-width: 20px;
 		}
 	}
 

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -112,6 +112,7 @@ $font-size: rem( 14px );
 
 		.sidebar__menu-icon {
 			color: var( --color-sidebar-gridicon-fill );
+			min-width: 20px;
 		}
 	}
 


### PR DESCRIPTION
This will bring parity with WP Admin's menu, that accepts image URLs, SVGs, and dashicon slugs.

#### Changes proposed in this Pull Request

* Expands `SidebarCustomIcon` to also render image URLs in `<img>` tags.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D50296-code
* Visit http://calypso.localhost:3000/?flags=nav-unification and select an a8c-internal site, like your team p2.
* Make sure the VIP cloud shows up as expected.