### PR TITLE
Nav Unification: Improve 'selected' detection

### DIFF
--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import { itemLinkMatches } from '../sidebar/utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarCustomIcon from 'layout/sidebar/custom-icon';
@@ -26,7 +27,7 @@ const onNav = () => null;
 
 export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const selected = path === url;
+	const selected = itemLinkMatches( url, path );
 
 	let children = null;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the method that `<MySitesSidebarUnifiedItem>` uses to detect "selected" items

Example
```:
path = "/posts/example.com?flags=nav-unification"
url = "/posts/example.com"
```

`path === url` was not true in this case, but `itemLinkMatches(url, path)` is.


#### Testing instructions

* Visit http://calypso.localhost:3000/plans/example.com?flags=nav-unification
* The purchases menu item should be darker than the rest
![2020-09-28_16-46](https://user-images.githubusercontent.com/937354/94489539-3cbcb400-01aa-11eb-90c2-fdd415c90147.png)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


Related to #45435
