### PR TITLE
Site-level billing management: Add cancel payment method page (2)

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -33,11 +33,16 @@ import { getDowngradePlanFromPurchase } from 'state/purchases/selectors';
 class CancelPurchaseButton extends Component {
 	static propTypes = {
 		purchase: PropTypes.object.isRequired,
+		purchaseListUrl: PropTypes.string,
 		selectedSite: PropTypes.object,
 		siteSlug: PropTypes.string.isRequired,
 		cancelBundledDomain: PropTypes.bool.isRequired,
 		includedDomainPurchase: PropTypes.object,
 		disabled: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		purchaseListUrl: purchasesRoot,
 	};
 
 	state = {
@@ -109,7 +114,7 @@ class CancelPurchaseButton extends Component {
 					{ persistent: true }
 				);
 
-				page( purchasesRoot );
+				page( this.props.purchaseListUrl );
 			} else {
 				notices.error(
 					translate(
@@ -149,7 +154,7 @@ class CancelPurchaseButton extends Component {
 
 		this.props.clearPurchases();
 
-		page.redirect( purchasesRoot );
+		page.redirect( this.props.purchaseListUrl );
 	};
 
 	cancelAndRefund = () => {
@@ -177,7 +182,7 @@ class CancelPurchaseButton extends Component {
 
 				this.props.clearPurchases();
 
-				page.redirect( purchasesRoot );
+				page.redirect( this.props.purchaseListUrl );
 			}
 		);
 	};
@@ -212,7 +217,7 @@ class CancelPurchaseButton extends Component {
 
 				this.props.clearPurchases();
 
-				page.redirect( purchasesRoot );
+				page.redirect( this.props.purchaseListUrl );
 			}
 		);
 	};

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -46,6 +46,7 @@ import './style.scss';
 
 class CancelPurchase extends React.Component {
 	static propTypes = {
+		purchaseListUrl: PropTypes.string,
 		getManagePurchaseUrlFor: PropTypes.func,
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
@@ -222,6 +223,7 @@ class CancelPurchase extends React.Component {
 						selectedSite={ this.props.site }
 						siteSlug={ this.props.siteSlug }
 						cancelBundledDomain={ this.state.cancelBundledDomain }
+						purchaseListUrl={ this.props.purchaseListUrl }
 					/>
 				</CompactCard>
 			</Fragment>

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -65,6 +65,7 @@ class CancelPurchase extends React.Component {
 
 	static defaultProps = {
 		getManagePurchaseUrlFor: managePurchase,
+		purchaseListUrl: purchasesRoot,
 	};
 
 	UNSAFE_componentWillMount() {
@@ -96,7 +97,7 @@ class CancelPurchase extends React.Component {
 
 	redirect = ( props ) => {
 		const { purchase, siteSlug } = props;
-		let redirectPath = purchasesRoot;
+		let redirectPath = this.props.purchaseListUrl;
 
 		if ( siteSlug && purchase && ( ! isCancelable( purchase ) || isDomainTransfer( purchase ) ) ) {
 			redirectPath = this.props.getManagePurchaseUrlFor( siteSlug, purchase.id );

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -157,6 +157,7 @@ class CancelPurchase extends React.Component {
 					<CancelPurchaseLoadingPlaceholder
 						purchaseId={ this.props.purchaseId }
 						siteSlug={ this.props.siteSlug }
+						getManagePurchaseUrlFor={ this.props.getManagePurchaseUrlFor }
 					/>
 				</div>
 			);

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 
 /**
  * Internal Dependencies
@@ -31,7 +31,6 @@ import {
 import HeaderCake from 'components/header-cake';
 import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
 import { isRequestingSites, getSite } from 'state/sites/selectors';
-import Main from 'components/main';
 import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import { withLocalizedMoment } from 'components/localized-moment';
@@ -176,7 +175,7 @@ class CancelPurchase extends React.Component {
 		}
 
 		return (
-			<Main className="cancel-purchase">
+			<Fragment>
 				<TrackPurchasePageView
 					eventName="calypso_cancel_purchase_purchase_view"
 					purchaseId={ this.props.purchaseId }
@@ -215,7 +214,7 @@ class CancelPurchase extends React.Component {
 						cancelBundledDomain={ this.state.cancelBundledDomain }
 					/>
 				</CompactCard>
-			</Main>
+			</Fragment>
 		);
 	}
 }

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -46,6 +46,7 @@ import './style.scss';
 
 class CancelPurchase extends React.Component {
 	static propTypes = {
+		getManagePurchaseUrlFor: PropTypes.func,
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		includedDomainPurchase: PropTypes.object,
@@ -59,6 +60,10 @@ class CancelPurchase extends React.Component {
 	state = {
 		cancelBundledDomain: false,
 		confirmCancelBundledDomain: false,
+	};
+
+	static defaultProps = {
+		getManagePurchaseUrlFor: managePurchase,
 	};
 
 	UNSAFE_componentWillMount() {
@@ -93,7 +98,7 @@ class CancelPurchase extends React.Component {
 		let redirectPath = purchasesRoot;
 
 		if ( siteSlug && purchase && ( ! isCancelable( purchase ) || isDomainTransfer( purchase ) ) ) {
-			redirectPath = managePurchase( siteSlug, purchase.id );
+			redirectPath = this.props.getManagePurchaseUrlFor( siteSlug, purchase.id );
 		}
 
 		page.redirect( redirectPath );
@@ -180,7 +185,12 @@ class CancelPurchase extends React.Component {
 					eventName="calypso_cancel_purchase_purchase_view"
 					purchaseId={ this.props.purchaseId }
 				/>
-				<HeaderCake backHref={ managePurchase( this.props.siteSlug, this.props.purchaseId ) }>
+				<HeaderCake
+					backHref={ this.props.getManagePurchaseUrlFor(
+						this.props.siteSlug,
+						this.props.purchaseId
+					) }
+				>
 					{ titles.cancelPurchase }
 				</HeaderCake>
 

--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -10,18 +10,17 @@ import React from 'react';
  */
 import { Button, Card, CompactCard } from '@automattic/components';
 import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
-import { managePurchase } from 'me/purchases/paths';
 import titles from 'me/purchases/titles';
 
-const CancelPurchaseLoadingPlaceholder = ( { purchaseId, siteSlug } ) => {
+const CancelPurchaseLoadingPlaceholder = ( { purchaseId, siteSlug, getManagePurchaseUrlFor } ) => {
 	let path;
 
 	if ( siteSlug ) {
-		path = managePurchase( siteSlug, purchaseId );
+		path = getManagePurchaseUrlFor( siteSlug, purchaseId );
 	}
 
+	/* eslint-disable wpcalypso/jsx-classname-namespace, jsx-a11y/heading-has-content */
 	return (
-		/* eslint-disable */
 		<LoadingPlaceholder title={ titles.cancelPurchase } path={ path }>
 			<Card className="cancel-purchase-loading-placeholder__card">
 				<h2 className="loading-placeholder__content cancel-purchase-loading-placeholder__header" />
@@ -34,13 +33,14 @@ const CancelPurchaseLoadingPlaceholder = ( { purchaseId, siteSlug } ) => {
 				<Button className="cancel-purchase-loading-placeholder__cancel-button" />
 			</CompactCard>
 		</LoadingPlaceholder>
-		/* eslint-enable */
 	);
 };
+/* eslint-enable wpcalypso/jsx-classname-namespace, jsx-a11y/heading-has-content */
 
 CancelPurchaseLoadingPlaceholder.propTypes = {
 	purchaseId: PropTypes.number.isRequired,
 	siteSlug: PropTypes.string.isRequired,
+	getManagePurchaseUrlFor: PropTypes.func.isRequired,
 };
 
 export default CancelPurchaseLoadingPlaceholder;

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -69,12 +69,15 @@ export function addCreditCard( context, next ) {
 
 export function cancelPurchase( context, next ) {
 	setTitle( context, titles.cancelPurchase );
+	const classes = 'cancel-purchase';
 
 	context.primary = (
-		<CancelPurchase
-			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			siteSlug={ context.params.site }
-		/>
+		<Main className={ classes }>
+			<CancelPurchase
+				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+				siteSlug={ context.params.site }
+			/>
+		</Main>
 	);
 	next();
 }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -102,6 +102,7 @@ class ManagePurchase extends Component {
 	static propTypes = {
 		showHeader: PropTypes.bool,
 		purchaseListUrl: PropTypes.string,
+		getCancelPurchaseUrlFor: PropTypes.func,
 		cardTitle: PropTypes.string,
 		hasLoadedDomains: PropTypes.bool,
 		hasLoadedSites: PropTypes.bool.isRequired,
@@ -121,6 +122,7 @@ class ManagePurchase extends Component {
 		showHeader: true,
 		purchaseListUrl: purchasesRoot,
 		cardTitle: titles.managePurchase,
+		getCancelPurchaseUrlFor: cancelPurchase,
 	};
 
 	state = {
@@ -325,7 +327,7 @@ class ManagePurchase extends Component {
 		}
 
 		let text,
-			link = cancelPurchase( this.props.siteSlug, id );
+			link = this.props.getCancelPurchaseUrlFor( this.props.siteSlug, id );
 
 		if ( isAtomicSite && isSubscription( purchase ) && ! isGoogleApps( purchase ) ) {
 			text = translate( 'Contact Support to Cancel your Subscription' );

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -7,12 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { Purchases, PurchaseDetails } from 'my-sites/purchases/main.tsx';
-
-export const purchases = ( context, next ) => {
-	context.primary = <Purchases />;
-	next();
-};
+import { Purchases, PurchaseDetails, PurchaseCancel } from 'my-sites/purchases/main.tsx';
 
 export function redirectToPurchases( context ) {
 	const siteDomain = context.params.site;
@@ -24,9 +19,24 @@ export function redirectToPurchases( context ) {
 	return page.redirect( '/purchases' );
 }
 
+export const purchases = ( context, next ) => {
+	context.primary = <Purchases />;
+	next();
+};
+
 export const purchaseDetails = ( context, next ) => {
 	context.primary = (
 		<PurchaseDetails
+			siteSlug={ context.params.site }
+			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+		/>
+	);
+	next();
+};
+
+export const purchaseCancel = ( context, next ) => {
+	context.primary = (
+		<PurchaseCancel
 			siteSlug={ context.params.site }
 			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 		/>

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  */
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import { purchases, redirectToPurchases, purchaseDetails } from './controller';
+import { purchases, redirectToPurchases, purchaseDetails, purchaseCancel } from './controller';
 import config from 'config';
 import legacyRouter from 'me/purchases';
 
@@ -41,6 +41,14 @@ export default ( router ) => {
 		siteSelection,
 		navigation,
 		purchaseDetails,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/purchases/subscriptions/:site/:purchaseId/cancel',
+		siteSelection,
+		navigation,
+		purchaseCancel,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -76,7 +76,7 @@ export function PurchaseCancel( {
 	const translate = useTranslate();
 
 	const getManagePurchaseUrlFor = ( targetSiteSlug: string, targetPurchaseId: string | number ) =>
-		`/purchases/${ targetSiteSlug }/${ targetPurchaseId }`;
+		`/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }`;
 
 	return (
 		<Main className="purchases is-wide-layout">

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -12,6 +12,7 @@ import Subscriptions from './subscriptions';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import ManagePurchase from 'me/purchases/manage-purchase';
+import CancelPurchase from 'me/purchases/cancel-purchase';
 
 export function Purchases() {
 	const translate = useTranslate();
@@ -56,6 +57,37 @@ export function PurchaseDetails( {
 				siteSlug={ siteSlug }
 				showHeader={ false }
 				purchaseListUrl={ `/purchases/subscriptions/${ siteSlug }` }
+			/>
+		</Main>
+	);
+}
+
+export function PurchaseCancel( {
+	purchaseId,
+	siteSlug,
+}: {
+	purchaseId: number;
+	siteSlug: string;
+} ) {
+	const translate = useTranslate();
+
+	const getManagePurchaseUrlFor = ( targetSiteSlug: string, targetPurchaseId: string | number ) =>
+		`/purchases/${ targetSiteSlug }/${ targetPurchaseId }`;
+
+	return (
+		<Main className="purchases is-wide-layout">
+			<DocumentHead title={ translate( 'Cancel purchase' ) } />
+			<FormattedHeader
+				brandFont
+				className="purchases__page-heading"
+				headerText={ translate( 'Cancel purchase' ) }
+				align="left"
+			/>
+
+			<CancelPurchase
+				purchaseId={ purchaseId }
+				siteSlug={ siteSlug }
+				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 			/>
 		</Main>
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -41,6 +41,9 @@ export function PurchaseDetails( {
 } ) {
 	const translate = useTranslate();
 
+	const getCancelPurchaseUrlFor = ( targetSiteSlug: string, targetPurchaseId: string | number ) =>
+		`/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/cancel`;
+
 	return (
 		<Main className="purchases is-wide-layout">
 			<DocumentHead title={ translate( 'Billing' ) } />
@@ -57,6 +60,7 @@ export function PurchaseDetails( {
 				siteSlug={ siteSlug }
 				showHeader={ false }
 				purchaseListUrl={ `/purchases/subscriptions/${ siteSlug }` }
+				getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
 			/>
 		</Main>
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -92,6 +92,7 @@ export function PurchaseCancel( {
 				purchaseId={ purchaseId }
 				siteSlug={ siteSlug }
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+				purchaseListUrl={ `/purchases/subscriptions/${ siteSlug }` }
 			/>
 		</Main>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This implements the site-level view for a single subscription cancelation flow at the route ` /purchases/subscriptions/:site/:purchaseId/cancel`, mirroring the account-level route for a single subscription which exists at the route `/me/purchases/:site/:purchaseId/cancel`.

The new route will be available only with the feature flag `site-level-billing`, which is enabled for development and horizon only.

Related to (and builds upon) the site-level purchases list added in https://github.com/Automattic/wp-calypso/pull/45601 and the subscription view from https://github.com/Automattic/wp-calypso/pull/45922

Main project thread: pbOQVh-sc-p2

#### Screenshots

![Screen Shot 2020-09-28 at 7 02 00 PM](https://user-images.githubusercontent.com/2036909/94494445-384dc680-01bd-11eb-8ed1-820567b7f4c6.png)


#### Testing instructions

- Visit `/purchases/subscriptions`.
- If you have multiple sites, verify that you see a site picker and that picking a site adds the site slug to the URL.
- Click on a purchase in the list.
- Verify that you are redirected to ` /purchases/subscriptions/:site/:purchaseId`, and that you see the purchase listed.
- Click on "Cancel subscription and refund" (NOTE: this must be a refundable purchase to see that link!)
- Verify that you are redirected to ` /purchases/subscriptions/:site/:purchaseId/cancel`, that the sidebar remains at the site-level, and that you see the purchase listed.
- Click the "Back" button in the header inside the page, and verify that you are redirected back to the site-level purchase.
- Verify that the "Cancel Subscription" button works and that you are redirected back to a site-level purchases page.
- (TBD) Test the other links in the cancel flow.

Partially addresses #45679