### PR TITLE
Nav Unification: Drop support for "object of objects" adminMenu state shape

### DIFF
--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -53,7 +53,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 					return <SidebarSeparator key={ i } />;
 				}
 
-				if ( item?.children && Object.keys( item.children ).length ) {
+				if ( item?.children?.length ) {
 					return <MySitesSidebarUnifiedMenu key={ item.slug } path={ path } { ...item } />;
 				}
 

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -44,31 +44,9 @@ MySitesSidebarUnifiedMenu.propTypes = {
 	path: PropTypes.string,
 	title: PropTypes.string,
 	icon: PropTypes.string,
-	children: PropTypes.oneOfType( [ PropTypes.object, PropTypes.array ] ).isRequired,
+	children: PropTypes.array.isRequired,
 	/*
-	Example of children shape (object):
-	{
-		"1": {
-			"title": "Feedback",
-			"url": "https://wp.com",
-			"icon": null,
-			"type": "menu-item"
-		},
-		"2": {
-			"title": "Polls",
-			"url": "https://wp.com",
-			"icon": null,
-			"type": "menu-item"
-		},
-		"3": {
-			"title": "Ratings",
-			"url": "https://wp.com",
-			"icon": null,
-			"type": "menu-item"
-		}
-	}
-
-	Example of children shape (array):
+	Example of children shape:
 	[
 		{
 			"title": "Settings",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* No functional changes

Sometimes we would get back menu specifications like:
```
{ "1": {MenuItem},
  "2": {MenuItem},
  "3": {MenuItem},
}
```

Now it's always
`[ {MenuItem}, {MenuItem}, {MenuItem} ]`

We already dropped support for it, but I found two extra places it can
be simplified.

#### Testing instructions

* Visit http://calypso.localhost:3000/plans/example.com?flags=nav-unification
* Ensure the unified sidebar continues to render and also displays children elements as appropriate (for example, Posts should expand to show sub-menu-items under)

related to #45435
