### PR TITLE
Jetpack Offer Reset: Refactor Calls to Translate Out of Constants File

### DIFF
--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { translate } from 'i18n-calypso';
-
-/**
  * Internal dependencies
  */
 import {
@@ -65,65 +60,6 @@ export const SECURITY = 'security';
 export const PLAN_COMPARISON_PAGE = 'https://jetpack.com/features/comparison/';
 
 /**
- * Link to plan comparison page.
- */
-export const MORE_FEATURES_LINK = {
-	url: PLAN_COMPARISON_PAGE,
-	label: translate( 'See all features' ),
-};
-
-/**
- * Define properties with translatable strings getters.
- */
-Object.defineProperties( MORE_FEATURES_LINK, {
-	label: {
-		get: () => translate( 'See all features' ),
-	},
-} );
-
-/*
- * Options displayed in the Product Type filter in the Plans page.
- */
-export const PRODUCT_TYPE_OPTIONS = {
-	[ SECURITY ]: {
-		id: SECURITY,
-		label: translate( 'Security' ),
-	},
-	[ PERFORMANCE ]: {
-		id: PERFORMANCE,
-		label: translate( 'Performance' ),
-	},
-	[ ALL ]: {
-		id: ALL,
-		label: translate( 'All' ),
-	},
-};
-
-/**
- * Define properties with translatable strings getters.
- */
-Object.defineProperties( PRODUCT_TYPE_OPTIONS, {
-	[ SECURITY ]: {
-		get: () => ( {
-			id: SECURITY,
-			label: translate( 'Security' ),
-		} ),
-	},
-	[ PERFORMANCE ]: {
-		get: () => ( {
-			id: PERFORMANCE,
-			label: translate( 'Performance' ),
-		} ),
-	},
-	[ ALL ]: {
-		get: () => ( {
-			id: ALL,
-			label: translate( 'All' ),
-		} ),
-	},
-} );
-
-/**
  * Plans and products that have options and can't be purchased themselves.
  */
 export const OPTIONS_JETPACK_SECURITY = 'jetpack_security';
@@ -141,6 +77,8 @@ export const PRODUCTS_WITH_OPTIONS = [
 	OPTIONS_JETPACK_SECURITY_MONTHLY,
 	OPTIONS_JETPACK_BACKUP,
 	OPTIONS_JETPACK_BACKUP_MONTHLY,
+	PRODUCT_JETPACK_CRM,
+	PRODUCT_JETPACK_CRM_MONTHLY,
 ] as const;
 
 // Jetpack Security
@@ -154,15 +92,6 @@ export const OPTION_PLAN_SECURITY: SelectorProduct = {
 	costProductSlug: PLAN_JETPACK_SECURITY_DAILY,
 	monthlyProductSlug: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 	iconSlug: 'jetpack_security_v2',
-	displayName: translate( 'Jetpack Security' ),
-	shortName: translate( 'Security', {
-		comment: 'Short name of the Jetpack Security generic plan',
-	} ),
-	tagline: translate( 'Comprehensive WordPress protection' ),
-	description: translate(
-		'Enjoy the peace of mind of complete site security. ' +
-			'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
-	),
 	features: {
 		items: buildCardFeaturesFromItem( {
 			[ FEATURE_CATEGORY_SECURITY ]: [
@@ -179,7 +108,6 @@ export const OPTION_PLAN_SECURITY: SelectorProduct = {
 				FEATURE_PRIORITY_SUPPORT_V2,
 			],
 		} ),
-		more: MORE_FEATURES_LINK,
 	},
 };
 export const OPTION_PLAN_SECURITY_MONTHLY: SelectorProduct = {
@@ -189,31 +117,6 @@ export const OPTION_PLAN_SECURITY_MONTHLY: SelectorProduct = {
 	subtypes: [ PLAN_JETPACK_SECURITY_DAILY_MONTHLY, PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ],
 	costProductSlug: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 };
-
-/**
- * Define properties with translatable strings getters.
- */
-[ OPTION_PLAN_SECURITY, OPTION_PLAN_SECURITY_MONTHLY ].forEach( ( target ) => {
-	Object.defineProperties( target, {
-		displayName: {
-			get: () => translate( 'Jetpack Security' ),
-		},
-		shortName: {
-			get: () =>
-				translate( 'Security', {
-					comment: 'Short name of the Jetpack Security generic plan',
-				} ),
-		},
-		tagline: { get: () => translate( 'Comprehensive WordPress protection' ) },
-		description: {
-			get: () =>
-				translate(
-					'Enjoy the peace of mind of complete site security. ' +
-						'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
-				),
-		},
-	} );
-} );
 
 // Jetpack Backup
 export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
@@ -226,13 +129,6 @@ export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
 	costProductSlug: PRODUCT_JETPACK_BACKUP_DAILY,
 	monthlyProductSlug: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 	iconSlug: 'jetpack_backup_v2',
-	displayName: translate( 'Jetpack Backup' ),
-	shortName: translate( 'Backup', {
-		comment: 'Short name of the Jetpack Backup generic product',
-	} ),
-	tagline: translate( 'Recommended for all sites' ),
-	description: translate( 'Never lose a word, image, page, or time worrying about your site.' ),
-	buttonLabel: translate( 'Get Backup' ),
 	features: {
 		items: buildCardFeaturesFromItem(
 			[
@@ -255,28 +151,6 @@ export const OPTION_PRODUCT_BACKUP_MONTHLY: SelectorProduct = {
 	costProductSlug: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 };
 
-/**
- * Define properties with translatable strings getters.
- */
-[ OPTION_PRODUCT_BACKUP, OPTION_PRODUCT_BACKUP_MONTHLY ].forEach( ( target ) => {
-	Object.defineProperties( target, {
-		displayName: {
-			get: () => translate( 'Jetpack Backup' ),
-		},
-		shortName: {
-			get: () =>
-				translate( 'Backup', {
-					comment: 'Short name of the Jetpack Backup generic product',
-				} ),
-		},
-		tagline: { get: () => translate( 'Recommended for all sites' ) },
-		description: {
-			get: () => translate( 'Never lose a word, image, page, or time worrying about your site.' ),
-		},
-		buttonLabel: { get: () => translate( 'Get Backup' ) },
-	} );
-} );
-
 // Jetpack CRM
 export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 	productSlug: PRODUCT_JETPACK_CRM,
@@ -286,15 +160,6 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 	costProductSlug: PRODUCT_JETPACK_CRM,
 	monthlyProductSlug: PRODUCT_JETPACK_CRM,
 	iconSlug: 'jetpack_crm',
-	displayName: translate( 'Jetpack CRM' ),
-	shortName: translate( 'CRM', {
-		comment: 'Short name of the Jetpack CRM',
-	} ),
-	tagline: translate( 'Manage contacts effortlessly' ),
-	description: translate(
-		'The most simple and powerful WordPress CRM. Improve customer relationships and increase profits.'
-	),
-	buttonLabel: translate( 'Get CRM' ),
 	features: {
 		items: buildCardFeaturesFromItem(
 			[

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -23,6 +23,7 @@ import {
 	getPathToSelector,
 	getPathToUpsell,
 	getPathToDetails,
+	getSelectorProductCopy,
 	checkout,
 } from './utils';
 import QueryProducts from './query-products';
@@ -107,7 +108,7 @@ const DetailsPage = ( {
 		page( getPathToDetails( rootUrl, newProductSlug as string, newDuration, siteSlug ) );
 	};
 
-	const { shortName } = product;
+	const { shortName } = getSelectorProductCopy( product.productSlug, translate );
 	const isBundle = [ OPTIONS_JETPACK_SECURITY, OPTIONS_JETPACK_SECURITY_MONTHLY ].includes(
 		productSlug
 	);

--- a/client/my-sites/plans-v2/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useRef } from 'react';
 import { useSelector } from 'react-redux';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import classNames from 'classnames';
 
 /**
@@ -14,7 +14,7 @@ import SelectDropdown from 'components/select-dropdown';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import { TERM_MONTHLY, TERM_ANNUALLY } from 'lib/plans/constants';
 import { masterbarIsVisible } from 'state/ui/selectors';
-import { PRODUCT_TYPE_OPTIONS } from '../constants';
+import { getProductTypeOptions } from '../utils';
 import useDetectWindowBoundary from '../use-detect-window-boundary';
 
 /**
@@ -47,6 +47,8 @@ const PlansFilterBar = ( {
 	onDurationChange,
 	onProductTypeChange,
 }: Props ) => {
+	const translate = useTranslate();
+
 	const isCloud = isJetpackCloud();
 	const masterbarSelector = isCloud ? '.jpcom-masterbar' : '.masterbar';
 	const masterbarDefaultHeight = isCloud ? CLOUD_MASTERBAR_HEIGHT : CALYPSO_MASTERBAR_HEIGHT;
@@ -59,11 +61,13 @@ const PlansFilterBar = ( {
 	const masterbarOffset = isMasterbarVisible || isCloud ? masterbarHeight : 0;
 	const hasCrossed = useDetectWindowBoundary( barRef, masterbarOffset );
 
+	const productTypeOptions = getProductTypeOptions( translate );
+
 	return (
 		<div ref={ barRef } className={ classNames( 'plans-filter-bar', { sticky: hasCrossed } ) }>
 			{ showProductTypes && (
-				<SelectDropdown selectedText={ productType && PRODUCT_TYPE_OPTIONS[ productType ].label }>
-					{ Object.values( PRODUCT_TYPE_OPTIONS ).map( ( option ) => (
+				<SelectDropdown selectedText={ productType && productTypeOptions[ productType ].label }>
+					{ Object.values( productTypeOptions ).map( ( option ) => (
 						<SelectDropdown.Item
 							key={ option.id }
 							selected={ productType === option.id }

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -3,6 +3,7 @@
  */
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 
 /**
@@ -16,12 +17,13 @@ import {
 } from '../constants';
 import {
 	durationToText,
-	productButtonLabel,
-	isUpgradeable,
 	getRealtimeFromDaily,
-	slugToSelectorProduct,
+	getSelectorProductCopy,
+	isUpgradeable,
 	productBadgeLabel,
+	productButtonLabel,
 	slugIsFeaturedProduct,
+	slugToSelectorProduct,
 } from '../utils';
 import PlanRenewalMessage from '../plan-renewal-message';
 import useItemPrice from '../use-item-price';
@@ -64,6 +66,8 @@ interface UpgradeNudgeProps {
 }
 
 const UpgradeNudgeWrapper = ( { siteId, item, currencyCode, onClick }: UpgradeNudgeProps ) => {
+	const translate = useTranslate();
+
 	const upgradeToProductSlug =
 		getRealtimeFromDaily( item.costProductSlug || item.productSlug ) || '';
 	const selectorProductToUpgrade = slugToSelectorProduct( upgradeToProductSlug );
@@ -80,7 +84,7 @@ const UpgradeNudgeWrapper = ( { siteId, item, currencyCode, onClick }: UpgradeNu
 
 	return (
 		<JetpackProductCardUpgradeNudge
-			billingTimeFrame={ durationToText( selectorProductToUpgrade.term ) }
+			billingTimeFrame={ durationToText( selectorProductToUpgrade.term, translate ) }
 			currencyCode={ currencyCode }
 			discountedPrice={ discountedPrice }
 			originalPrice={ originalPrice }
@@ -109,6 +113,8 @@ const ProductCardWrapper = ( {
 	highlight = false,
 	selectedTerm,
 }: ProductCardProps ) => {
+	const translate = useTranslate();
+
 	// Determine whether product is owned.
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
@@ -160,6 +166,8 @@ const ProductCardWrapper = ( {
 	const hidePrice =
 		EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ) || ( !! siteId && item.hidePrice );
 
+	const itemCopy = getSelectorProductCopy( item.productSlug, translate );
+
 	const UpgradeNudge = isOwned ? (
 		<UpgradeNudgeWrapper
 			siteId={ siteId }
@@ -172,13 +180,19 @@ const ProductCardWrapper = ( {
 		<CardComponent
 			headingLevel={ 3 }
 			iconSlug={ item.iconSlug }
-			productName={ item.displayName }
-			subheadline={ item.tagline }
-			description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description }
+			productName={ itemCopy.displayName }
+			subheadline={ itemCopy.tagline }
+			description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : itemCopy.description }
 			currencyCode={ currencyCode }
-			billingTimeFrame={ durationToText( item.term ) }
-			buttonLabel={ productButtonLabel( item, isOwned, isUpgradeableToYearly, sitePlan ) }
-			badgeLabel={ productBadgeLabel( item, isOwned, highlight, sitePlan ) }
+			billingTimeFrame={ durationToText( item.term, translate ) }
+			buttonLabel={ productButtonLabel(
+				item,
+				isOwned,
+				isUpgradeableToYearly,
+				translate,
+				sitePlan
+			) }
+			badgeLabel={ productBadgeLabel( item, isOwned, highlight, translate, sitePlan ) }
 			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
 			features={ item.features }
 			children={ item.children }

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -90,18 +90,21 @@ export interface SelectorProduct extends SelectorProductCost {
 	type: ItemType;
 	costProductSlug?: string;
 	monthlyProductSlug?: string;
-	displayName: TranslateResult;
-	shortName: TranslateResult;
-	tagline: TranslateResult;
-	description: TranslateResult | ReactNode;
 	children?: ReactNode;
 	term: Duration;
-	buttonLabel?: TranslateResult;
 	features: SelectorProductFeatures;
 	subtypes: string[];
 	legacy?: boolean;
 	hidePrice?: boolean;
 	externalUrl?: string;
+}
+
+export interface SelectorProductCopy {
+	displayName: TranslateResult;
+	shortName: TranslateResult;
+	tagline: TranslateResult;
+	description: TranslateResult | ReactNode;
+	buttonLabel?: TranslateResult;
 }
 
 export interface AvailableProductData {

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -28,6 +28,7 @@ import {
 	getProductUpsell,
 	getPathToSelector,
 	getPathToDetails,
+	getSelectorProductCopy,
 	slugToSelectorProduct,
 	checkout,
 } from './utils';
@@ -75,8 +76,12 @@ const UpsellComponent = ( {
 		upsellProduct.monthlyProductSlug || ''
 	);
 
-	const { shortName: mainProductName } = mainProduct;
-	const { shortName: upsellProductName, productSlug: upsellSlug } = upsellProduct;
+	const mainProductCopy = getSelectorProductCopy( mainProduct.productSlug, translate );
+	const upsellProductCopy = getSelectorProductCopy( upsellProduct.productSlug, translate );
+
+	const { shortName: mainProductName } = mainProductCopy;
+	const { shortName: upsellProductName } = upsellProductCopy;
+	const upsellSlug = upsellProduct.productSlug;
 
 	const isScanProduct = useMemo(
 		() => JETPACK_SCAN_PRODUCTS.some( ( slug ) => slug === upsellSlug ),
@@ -153,11 +158,11 @@ const UpsellComponent = ( {
 				<div className="upsell__product-card">
 					<JetpackProductCard
 						iconSlug={ upsellProduct.iconSlug }
-						productName={ upsellProduct.displayName }
-						subheadline={ upsellProduct.tagline }
-						description={ upsellProduct.description }
+						productName={ upsellProductCopy.displayName }
+						subheadline={ upsellProductCopy.tagline }
+						description={ upsellProductCopy.description }
 						currencyCode={ currencyCode }
-						billingTimeFrame={ durationToText( upsellProduct.term ) }
+						billingTimeFrame={ durationToText( upsellProduct.term, translate ) }
 						buttonLabel={ translate( 'Yes, add {{name/}}', {
 							components: {
 								name: <>{ upsellProductName }</>,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a followup to https://github.com/Automattic/wp-calypso/pull/45727, which was made to quickly fix an issue where usage of translated strings was not reactive. Although that solution worked, it is not ideal in the long term.

This PR re-works the Offer Reset copy that was being passed to `translate()` in the constants file so that they are instead retrieved through a function in `utils` that requires passing `translate`. Components that use this method will ideally use the `useTranslate()` hook to pass `translate`, and thus retrieve the copy in a reactive way.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

TODO

Fixes #1169247016322522-as-1194900844047779