### PR TITLE
Site level payment management: Add change payment method route

### DIFF
--- a/client/blocks/credit-card-form/helpers.js
+++ b/client/blocks/credit-card-form/helpers.js
@@ -101,33 +101,37 @@ async function updateCreditCard( {
 		throw new Error( response );
 	}
 
-	if ( purchase && siteSlug && isRenewable( purchase ) ) {
-		let noticeMessage = '';
-		let noticeOptions = {};
-		if ( shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) ) {
-			noticeMessage = translate( 'Your credit card details were successfully updated.' );
-			noticeOptions = {
-				persistent: true,
-			};
-		} else {
-			noticeMessage = translate(
-				'Your credit card details were successfully updated, but your subscription has not been renewed yet.'
-			);
-			noticeOptions = {
-				button: translate( 'Renew Now' ),
-				onClick: function ( event, closeFunction ) {
-					handleRenewNowClick( purchase, siteSlug );
-					closeFunction();
-				},
-				persistent: true,
-			};
-		}
+	const purchaseIsRenewable = purchase && siteSlug && isRenewable( purchase );
+
+	let noticeMessage = response.success;
+	let noticeOptions = { persistent: true };
+
+	if ( purchaseIsRenewable && shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) ) {
+		noticeMessage = translate( 'Your credit card details were successfully updated.' );
+		noticeOptions = {
+			persistent: true,
+		};
+		notices.success( noticeMessage, noticeOptions );
+		return;
+	}
+
+	if ( purchaseIsRenewable && ! shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) ) {
+		noticeMessage = translate(
+			'Your credit card details were successfully updated, but your subscription has not been renewed yet.'
+		);
+		noticeOptions = {
+			button: translate( 'Renew Now' ),
+			onClick: function ( event, closeFunction ) {
+				handleRenewNowClick( purchase, siteSlug );
+				closeFunction();
+			},
+			persistent: true,
+		};
 		notices.info( noticeMessage, noticeOptions );
 		return;
 	}
-	notices.success( response.success, {
-		persistent: true,
-	} );
+
+	notices.success( noticeMessage, noticeOptions );
 }
 
 export function getParamsForApi( cardDetails, cardToken, stripeConfiguration, extraParams = {} ) {

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -23,7 +23,7 @@ import titles from './titles';
 import { makeLayout, render as clientRender } from 'controller';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getCurrentUserSiteCount } from 'state/current-user/selectors';
-import { managePurchase as managePurchaseUrl } from 'me/purchases/paths';
+import { managePurchase as managePurchaseUrl, purchasesRoot } from 'me/purchases/paths';
 
 // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 function setTitle( context, ...title ) {
@@ -60,6 +60,7 @@ export function addCardDetails( context, next ) {
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 				siteSlug={ context.params.site }
 				getManagePurchaseUrlFor={ managePurchaseUrl }
+				purchaseListUrl={ purchasesRoot }
 			/>
 		</Main>
 	);

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -23,6 +23,7 @@ import titles from './titles';
 import { makeLayout, render as clientRender } from 'controller';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getCurrentUserSiteCount } from 'state/current-user/selectors';
+import { managePurchase as managePurchaseUrl } from 'me/purchases/paths';
 
 // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 function setTitle( context, ...title ) {
@@ -54,10 +55,13 @@ export function addCardDetails( context, next ) {
 	setTitle( context, titles.addCardDetails );
 
 	context.primary = (
-		<AddCardDetails
-			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			siteSlug={ context.params.site }
-		/>
+		<Main>
+			<AddCardDetails
+				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+				siteSlug={ context.params.site }
+				getManagePurchaseUrlFor={ managePurchaseUrl }
+			/>
+		</Main>
 	);
 	next();
 }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -103,6 +103,7 @@ class ManagePurchase extends Component {
 		showHeader: PropTypes.bool,
 		purchaseListUrl: PropTypes.string,
 		getCancelPurchaseUrlFor: PropTypes.func,
+		getAddPaymentMethodUrlFor: PropTypes.func,
 		cardTitle: PropTypes.string,
 		hasLoadedDomains: PropTypes.bool,
 		hasLoadedSites: PropTypes.bool.isRequired,
@@ -121,6 +122,7 @@ class ManagePurchase extends Component {
 	static defaultProps = {
 		showHeader: true,
 		purchaseListUrl: purchasesRoot,
+		getAddPaymentMethodUrlFor: getEditCardDetailsPath,
 		cardTitle: titles.managePurchase,
 		getCancelPurchaseUrlFor: cancelPurchase,
 	};
@@ -245,7 +247,7 @@ class ManagePurchase extends Component {
 		}
 
 		if ( canEditPaymentDetails( purchase ) ) {
-			const path = getEditCardDetailsPath( this.props.siteSlug, purchase );
+			const path = this.props.getAddPaymentMethodUrlFor( this.props.siteSlug, purchase );
 			const renewing = isRenewing( purchase );
 
 			if (

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -12,7 +12,6 @@ import { connect } from 'react-redux';
 import CreditCardForm from 'blocks/credit-card-form';
 import CreditCardFormLoadingPlaceholder from 'blocks/credit-card-form/loading-placeholder';
 import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import titles from 'me/purchases/titles';

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -22,7 +22,6 @@ import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchas
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
-import { purchasesRoot } from 'me/purchases/paths';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { StripeHookProvider } from 'lib/stripe';
 
@@ -33,7 +32,7 @@ function AddCardDetails( props ) {
 
 	if ( ! isDataLoading && ! isDataValid( props ) ) {
 		// Redirect if invalid data
-		page( purchasesRoot );
+		page( props.purchaseListUrl );
 	}
 
 	if ( isDataLoading ) {
@@ -87,6 +86,7 @@ function AddCardDetails( props ) {
 
 AddCardDetails.propTypes = {
 	getManagePurchaseUrlFor: PropTypes.func.isRequired,
+	purchaseListUrl: PropTypes.string.isRequired,
 	clearPurchases: PropTypes.func.isRequired,
 	hasLoadedSites: PropTypes.bool.isRequired,
 	hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -22,7 +22,7 @@ import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchas
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
-import { managePurchase, purchasesRoot } from 'me/purchases/paths';
+import { purchasesRoot } from 'me/purchases/paths';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { StripeHookProvider } from 'lib/stripe';
 
@@ -54,7 +54,7 @@ function AddCardDetails( props ) {
 	const successCallback = () => {
 		const { id } = props.purchase;
 		props.clearPurchases();
-		page( managePurchase( props.siteSlug, id ) );
+		page( props.getManagePurchaseUrlFor( props.siteSlug, id ) );
 	};
 
 	return (

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -59,7 +59,7 @@ function AddCardDetails( props ) {
 	};
 
 	return (
-		<Main>
+		<Fragment>
 			<TrackPurchasePageView
 				eventName="calypso_add_card_details_purchase_view"
 				purchaseId={ props.purchaseId }
@@ -68,7 +68,7 @@ function AddCardDetails( props ) {
 				path="/me/purchases/:site/:purchaseId/payment/add"
 				title="Purchases > Add Card Details"
 			/>
-			<HeaderCake backHref={ managePurchase( props.siteSlug, props.purchaseId ) }>
+			<HeaderCake backHref={ props.getManagePurchaseUrlFor( props.siteSlug, props.purchaseId ) }>
 				{ titles.addCardDetails }
 			</HeaderCake>
 
@@ -82,11 +82,12 @@ function AddCardDetails( props ) {
 					successCallback={ successCallback }
 				/>
 			</StripeHookProvider>
-		</Main>
+		</Fragment>
 	);
 }
 
 AddCardDetails.propTypes = {
+	getManagePurchaseUrlFor: PropTypes.func.isRequired,
 	clearPurchases: PropTypes.func.isRequired,
 	hasLoadedSites: PropTypes.bool.isRequired,
 	hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -12,7 +12,13 @@ import {
 	PurchaseDetails,
 	PurchaseCancel,
 	PurchaseCancelDomain,
+	PurchaseAddPaymentMethod,
 } from 'my-sites/purchases/main.tsx';
+
+export const purchases = ( context, next ) => {
+	context.primary = <Purchases />;
+	next();
+};
 
 export function redirectToPurchases( context ) {
 	const siteDomain = context.params.site;
@@ -52,6 +58,16 @@ export const purchaseCancel = ( context, next ) => {
 export const purchaseCancelDomain = ( context, next ) => {
 	context.primary = (
 		<PurchaseCancelDomain
+			siteSlug={ context.params.site }
+			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+		/>
+	);
+	next();
+};
+
+export const purchaseAddPaymentMethod = ( context, next ) => {
+	context.primary = (
+		<PurchaseAddPaymentMethod
 			siteSlug={ context.params.site }
 			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 		/>

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -15,11 +15,6 @@ import {
 	PurchaseAddPaymentMethod,
 } from 'my-sites/purchases/main.tsx';
 
-export const purchases = ( context, next ) => {
-	context.primary = <Purchases />;
-	next();
-};
-
 export function redirectToPurchases( context ) {
 	const siteDomain = context.params.site;
 

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -14,6 +14,7 @@ import {
 	purchaseDetails,
 	purchaseCancel,
 	purchaseCancelDomain,
+	purchaseAddPaymentMethod,
 } from './controller';
 import config from 'config';
 import legacyRouter from 'me/purchases';
@@ -63,6 +64,14 @@ export default ( router ) => {
 		siteSelection,
 		navigation,
 		purchaseCancelDomain,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/purchases/subscriptions/:site/:purchaseId/payment/add',
+		siteSelection,
+		navigation,
+		purchaseAddPaymentMethod,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -19,7 +19,9 @@ import {
 	getCancelPurchaseUrlFor,
 	getConfirmCancelDomainUrlFor,
 	getManagePurchaseUrlFor,
+	getAddPaymentMethodUrlFor,
 } from './paths';
+import AddCardDetails from 'me/purchases/payment/add-card-details';
 
 export function Purchases() {
 	const translate = useTranslate();
@@ -65,6 +67,7 @@ export function PurchaseDetails( {
 				showHeader={ false }
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 				getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
+				getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
 			/>
 		</Main>
 	);
@@ -95,6 +98,34 @@ export function PurchaseCancel( {
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 				getConfirmCancelDomainUrlFor={ getConfirmCancelDomainUrlFor }
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
+			/>
+		</Main>
+	);
+}
+
+export function PurchaseAddPaymentMethod( {
+	purchaseId,
+	siteSlug,
+}: {
+	purchaseId: number;
+	siteSlug: string;
+} ) {
+	const translate = useTranslate();
+
+	return (
+		<Main className="purchases is-wide-layout">
+			<DocumentHead title={ translate( 'Billing' ) } />
+			<FormattedHeader
+				brandFont
+				className="purchases__page-heading"
+				headerText={ translate( 'Billing' ) }
+				align="left"
+			/>
+
+			<AddCardDetails
+				purchaseId={ purchaseId }
+				siteSlug={ siteSlug }
+				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 			/>
 		</Main>
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -126,6 +126,7 @@ export function PurchaseAddPaymentMethod( {
 				purchaseId={ purchaseId }
 				siteSlug={ siteSlug }
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 			/>
 		</Main>
 	);

--- a/client/my-sites/purchases/paths.ts
+++ b/client/my-sites/purchases/paths.ts
@@ -15,3 +15,8 @@ export const getCancelPurchaseUrlFor = (
 
 export const getPurchaseListUrlFor = ( targetSiteSlug: string ) =>
 	`/purchases/subscriptions/${ targetSiteSlug }`;
+
+export const getAddPaymentMethodUrlFor = (
+	targetSiteSlug: string,
+	targetPurchase: { id: string | number }
+) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchase.id }/payment/add`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This implements the site-level view for a single subscription add-payment-method flow at the route `/purchases/subscriptions/:site/:purchaseId/payment/add`, mirroring the account-level route for a single subscription which exists at the route `/me/purchases/:site/:purchaseId/payment/add`.

The new route will be available only with the feature flag `site-level-billing`, which is enabled for development and horizon only.

Related to (and builds upon) the site-level purchases list added in https://github.com/Automattic/wp-calypso/pull/45601 and the subscription view from https://github.com/Automattic/wp-calypso/pull/45922

Main project thread: pbOQVh-sc-p2

Fixes #45679

#### Screenshots

![Screen Shot 2020-09-29 at 6 54 03 PM](https://user-images.githubusercontent.com/2036909/94624782-3fd8a280-0285-11eb-8814-091d2c99e007.png)

#### Testing instructions

To view the new route directly, navigate to /purchases/subscriptions/:site/:purchaseId, where :site is the site URL and :purchaseId is the backend receipt ID (visible in payments admin).

* From the site level management page, select a purchase on the test site
* Select "Change Payment Method" and verify that the my sites nav sidebar remains in view (as opposed to being replaced by the account sidebar).
* Verify that the Back button in the cake header takes you back to the site level management page.
* Verify that after entering new payment details, you are taken back to the site level management page.
