### PR TITLE
Change Premium Content Block Category

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/new-blocks-showcase.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/new-blocks-showcase.js
@@ -23,7 +23,6 @@ const NEW_CATEGORY = {
  */
 const NEW_BLOCKS = [
 	'jetpack/podcast-player',
-	'premium-content/container',
 	'jetpack/calendly',
 	'jetpack/eventbrite',
 	'jetpack/opentable',

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/index.js
@@ -15,7 +15,7 @@ import save from './save';
 import { getCategoryWithFallbacks } from '../../../block-helpers';
 
 const name = 'premium-content/container';
-const category = getCategoryWithFallbacks( 'design', 'common' );
+const category = getCategoryWithFallbacks( 'earn', 'common' );
 
 const blockContainsPremiumBlock = ( block ) => {
 	if ( block.name.indexOf( 'premium-content/' ) === 0 ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, the Premium Content block does not show up in the "Earn" category whenever you search for "Earn" or "Premium Content" in the block search. However, it shows up in the "New" category.
* This PR removes the Premium Content block from the "New" category, and adds it to the "Earn" category.

#### Testing instructions

* Go to https://wordpress.com/block-editor and select a site
* Click on the "+" button at the top left corner of the block editor to search for available Blocks you can use
* Type in "Earn" or "Premium Content". You should see the Premium Content block under the "Earn" category

#### GIFs

![2020-09-28 19 41 43](https://user-images.githubusercontent.com/66652282/94498575-83210b80-01c8-11eb-9a89-705ee24d8fb7.gif)


Fixes 232-gh-dotcom-manage