### PR TITLE
Purchases: Hide plan controls for non-owners at site and account-level

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -502,7 +502,14 @@ class ManagePurchase extends Component {
 			return this.renderPlaceholder();
 		}
 
-		const { purchase, siteId, translate, isProductOwner, getManagePurchaseUrlFor, siteSlug } = this.props;
+		const {
+			purchase,
+			siteId,
+			translate,
+			isProductOwner,
+			getManagePurchaseUrlFor,
+			siteSlug,
+		} = this.props;
 
 		const classes = classNames( 'manage-purchase__info', {
 			'is-expired': purchase && isExpired( purchase ),

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -684,6 +684,5 @@ export default connect( ( state, props ) => {
 		isPurchaseTheme,
 		theme: isPurchaseTheme && getCanonicalTheme( state, siteId, purchase.meta ),
 		isAtomicSite: isSiteAtomic( state, siteId ),
-		userId,
 	};
 } )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -580,6 +580,7 @@ class ManagePurchase extends Component {
 			isPurchaseTheme,
 			translate,
 			getManagePurchaseUrlFor,
+			isProductOwner,
 		} = this.props;
 
 		let editCardDetailsPath = false;
@@ -630,6 +631,7 @@ class ManagePurchase extends Component {
 						renewableSitePurchases={ renewableSitePurchases }
 						editCardDetailsPath={ editCardDetailsPath }
 						getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+						isProductOwner={ isProductOwner }
 					/>
 				) }
 				<AsyncLoad

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -92,7 +92,6 @@ import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'state/current-user/constants'
 import { hasCustomDomain } from 'lib/site/utils';
 import { hasLoadedSiteDomains } from 'state/sites/domains/selectors';
 import NonPrimaryDomainDialog from 'me/purchases/non-primary-domain-dialog';
-import { isCurrentUserCurrentPlanOwner } from 'state/sites/plans/selectors';
 
 /**
  * Style dependencies
@@ -656,7 +655,8 @@ export default connect( ( state, props ) => {
 			? getByPurchaseId( state, purchase.attachedToPurchaseId )
 			: null;
 	const siteId = purchase ? purchase.siteId : null;
-	const isProductOwner = isCurrentUserCurrentPlanOwner( state, siteId );
+	const userId = getCurrentUserId( state );
+	const isProductOwner = purchase && purchase.userId === userId;
 	const renewableSitePurchases = getRenewableSitePurchases( state, siteId );
 	const isPurchasePlan = purchase && isPlan( purchase );
 	const isPurchaseTheme = purchase && isTheme( purchase );
@@ -681,6 +681,6 @@ export default connect( ( state, props ) => {
 		isPurchaseTheme,
 		theme: isPurchaseTheme && getCanonicalTheme( state, siteId, purchase.meta ),
 		isAtomicSite: isSiteAtomic( state, siteId ),
-		userId: getCurrentUserId( state ),
+		userId,
 	};
 } )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -554,7 +554,10 @@ class ManagePurchase extends Component {
 					{ isProductOwner && preventRenewal && this.renderSelectNewButton() }
 					{ isProductOwner && ! preventRenewal && this.renderRenewButton() }
 				</Card>
-				<PurchasePlanDetails purchaseId={ this.props.purchaseId } />
+				<PurchasePlanDetails
+					purchaseId={ this.props.purchaseId }
+					isProductOwner={ isProductOwner }
+				/>
 
 				{ isProductOwner && preventRenewal && this.renderSelectNewNavItem() }
 				{ isProductOwner && ! preventRenewal && this.renderRenewNowNavItem() }

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -185,13 +185,9 @@ class PurchaseNotice extends Component {
 	}
 
 	renderRenewNoticeAction( onClick ) {
-		const { editCardDetailsPath, purchase, translate, isProductOwner } = this.props;
+		const { editCardDetailsPath, purchase, translate } = this.props;
 
-		if (
-			! config.isEnabled( 'upgrades/checkout' ) ||
-			! this.props.selectedSite ||
-			! isProductOwner
-		) {
+		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! this.props.selectedSite ) {
 			return null;
 		}
 

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -970,9 +970,8 @@ class PurchaseNotice extends Component {
 			return null;
 		}
 
-		const nonProductOwnerNotice = this.renderNonProductOwnerNotice();
 		if ( ! this.props.isProductOwner ) {
-			return nonProductOwnerNotice;
+			return this.renderNonProductOwnerNotice();
 		}
 
 		const consumedConciergeSessionNotice = this.renderConciergeConsumedNotice();

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -64,6 +64,7 @@ class PurchaseNotice extends Component {
 		selectedSite: PropTypes.object,
 		editCardDetailsPath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		getManagePurchaseUrlFor: PropTypes.func,
+		isProductOwner: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -184,9 +185,13 @@ class PurchaseNotice extends Component {
 	}
 
 	renderRenewNoticeAction( onClick ) {
-		const { editCardDetailsPath, purchase, translate } = this.props;
+		const { editCardDetailsPath, purchase, translate, isProductOwner } = this.props;
 
-		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! this.props.selectedSite ) {
+		if (
+			! config.isEnabled( 'upgrades/checkout' ) ||
+			! this.props.selectedSite ||
+			! isProductOwner
+		) {
 			return null;
 		}
 
@@ -946,6 +951,20 @@ class PurchaseNotice extends Component {
 		);
 	}
 
+	renderNonProductOwnerNotice() {
+		const { translate } = this.props;
+
+		return (
+			<Notice
+				showDismiss={ false }
+				status="is-info"
+				text={ translate(
+					'This product was purchased by a different WordPress.com account. To manage this product, log in to that account or contact the account owner.'
+				) }
+			></Notice>
+		);
+	}
+
 	render() {
 		if ( this.props.isDataLoading ) {
 			return null;
@@ -953,6 +972,11 @@ class PurchaseNotice extends Component {
 
 		if ( isDomainTransfer( this.props.purchase ) ) {
 			return null;
+		}
+
+		const nonProductOwnerNotice = this.renderNonProductOwnerNotice();
+		if ( ! this.props.isProductOwner ) {
+			return nonProductOwnerNotice;
 		}
 
 		const consumedConciergeSessionNotice = this.renderConciergeConsumedNotice();

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -28,6 +28,7 @@ export class PlanBillingPeriod extends Component {
 	static propTypes = {
 		purchase: PropTypes.object,
 		site: PropTypes.object,
+		isProductOwner: PropTypes.bool,
 	};
 
 	handleMonthlyToYearlyButtonClick = () => {
@@ -77,7 +78,7 @@ export class PlanBillingPeriod extends Component {
 	}
 
 	renderBillingPeriod() {
-		const { purchase, site, translate } = this.props;
+		const { purchase, site, translate, isProductOwner } = this.props;
 		if ( ! purchase ) {
 			return;
 		}
@@ -97,7 +98,7 @@ export class PlanBillingPeriod extends Component {
 			<React.Fragment>
 				<FormSettingExplanation>
 					{ translate( 'Billed monthly' ) }
-					{ site && (
+					{ site && isProductOwner && (
 						<Button onClick={ this.handleMonthlyToYearlyButtonClick } primary compact>
 							{ translate( 'Upgrade to yearly billing' ) }
 						</Button>

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -32,6 +32,7 @@ export class PurchasePlanDetails extends Component {
 	static propTypes = {
 		purchaseId: PropTypes.number,
 		isPlaceholder: PropTypes.bool,
+		isProductOwner: PropTypes.bool,
 
 		// Connected props
 		purchase: PropTypes.object,
@@ -69,7 +70,7 @@ export class PurchasePlanDetails extends Component {
 	}
 
 	render() {
-		const { pluginList, purchase, site, siteId, translate } = this.props;
+		const { pluginList, purchase, site, siteId, translate, isProductOwner } = this.props;
 
 		// Short out as soon as we know it's not a Jetpack plan
 		if ( purchase && ( ! isJetpackPlan( purchase ) || isFreeJetpackPlan( purchase ) ) ) {
@@ -96,7 +97,11 @@ export class PurchasePlanDetails extends Component {
 				<SectionHeader label={ headerText } />
 				<Card>
 					{ ! isPartnerPurchase( purchase ) && (
-						<PlanBillingPeriod purchase={ purchase } site={ site } />
+						<PlanBillingPeriod
+							purchase={ purchase }
+							site={ site }
+							isProductOwner={ isProductOwner }
+						/>
 					) }
 
 					{ pluginList.map( ( plugin, i ) => {

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -31,6 +31,7 @@ const props = {
 		ID: 123,
 		name: 'Site Name',
 	},
+	isProductOwner: true,
 	recordTracksEvent: jest.fn(),
 	translate,
 	moment,

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -448,7 +448,6 @@ export default connect( ( state, { purchaseId } ) => {
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		purchase,
 		site: purchase ? getSite( state, purchase.siteId ) : null,
-		userId: getCurrentUserId( state ),
 		isProductOwner,
 		owner: purchase ? getUser( state, purchase.userId ) : null,
 		isAutorenewalEnabled: purchase ? ! isExpiring( purchase ) : null,

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -51,7 +51,7 @@ import UserItem from 'components/user';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '../utils';
 import { TERM_BIENNIALLY, TERM_MONTHLY, JETPACK_LEGACY_PLANS } from 'lib/plans/constants';
-import { isCurrentUserCurrentPlanOwner } from 'state/sites/plans/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 class PurchaseMeta extends Component {
 	static propTypes = {
@@ -441,14 +441,14 @@ class PurchaseMeta extends Component {
 
 export default connect( ( state, { purchaseId } ) => {
 	const purchase = getByPurchaseId( state, purchaseId );
-	const siteId = purchase ? purchase.siteId : null;
-	const isProductOwner = isCurrentUserCurrentPlanOwner( state, siteId );
+	const isProductOwner = purchase && purchase.userId === getCurrentUserId( state );
 
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		purchase,
 		site: purchase ? getSite( state, purchase.siteId ) : null,
+		userId: getCurrentUserId( state ),
 		isProductOwner,
 		owner: purchase ? getUser( state, purchase.userId ) : null,
 		isAutorenewalEnabled: purchase ? ! isExpiring( purchase ) : null,

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -120,7 +120,7 @@ const PlanFeaturesActions = ( {
 	} else if ( ! availableForPurchase && forceDisplayButton ) {
 		upgradeButton = (
 			<Button className={ classes } disabled={ true }>
-				{ props.buttonText } a
+				{ props.buttonText }
 			</Button>
 		);
 	}

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -120,7 +120,7 @@ const PlanFeaturesActions = ( {
 	} else if ( ! availableForPurchase && forceDisplayButton ) {
 		upgradeButton = (
 			<Button className={ classes } disabled={ true }>
-				{ props.buttonText }
+				{ props.buttonText } a
 			</Button>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes the subscription settings screen read-only for non-owners. 

**Before**

![image](https://user-images.githubusercontent.com/6981253/94510358-96da6b00-01e4-11eb-8c9f-4e000673b4aa.png)

**After**

![image](https://user-images.githubusercontent.com/6981253/94609985-9508ba00-026d-11eb-8e44-770fbf89c4a0.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the `site-level-billing` flag
* Visit a product (plan, domain, Jetpack) where you're not the original purchaser
* Confirm that no renew, add/change payment methods, or cancel/delete subscription buttons are visible

Fixes # https://github.com/Automattic/wp-calypso/issues/45838
