### PR TITLE
Adds a css validator stylelint rule so that we avoid invalid CSS values

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,5 +1,5 @@
 {
-	"plugins": ["@signal-noise/stylelint-scales"],
+	"plugins": ["@signal-noise/stylelint-scales","stylelint-csstree-validator"],
 	"rules": {
 		"scales/font-weight": [[ 400, 600, 700, "normal", "bold", "inherit" ]],
 		"scales/font-size": [[ 0.75, 0.875, 1, 1.25, 1.5, 2, 2.25, 3, 3.375 ], { unit: "rem" }],
@@ -7,6 +7,8 @@
 
 		"color-hex-case": "lower",
 		"color-no-invalid-hex": true,
+
+		"csstree/validator": true,
 
 		"function-calc-no-unspaced-operator": true,
 		"function-comma-space-after": "always-single-line",

--- a/package.json
+++ b/package.json
@@ -372,6 +372,7 @@
 		"stacktrace-gps": "^3.0.3",
 		"style-loader": "^1.2.1",
 		"stylelint": "^13.7.0",
+		"stylelint-csstree-validator": "^1.8.0",
 		"supertest": "^4.0.2",
 		"svgstore-cli": "^1.3.1",
 		"terser": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10386,6 +10386,14 @@ css-tree@1.0.0-alpha.37:
     mdn-data "2.0.4"
     source-map "^0.6.1"
 
+css-tree@1.0.0-alpha.38:
+  version "1.0.0-alpha.38"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.38.tgz#a75431f4162da84dbdb3c4804e79ad784aa7593c"
+  integrity sha512-pWuxS4kaECFopOc1NZff+dYdw+brc1Tt0UAuTiw56/Trtae4NdHtbDH24311UWfMmcpZe7jLy0e64ZeJg9t7bQ==
+  dependencies:
+    mdn-data "2.0.6"
+    source-map "^0.6.1"
+
 css-what@2.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
@@ -18662,6 +18670,11 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
+mdn-data@2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.6.tgz#852dc60fcaa5daa2e8cf6c9189c440ed3e042978"
+  integrity sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA==
+
 mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
@@ -26433,6 +26446,13 @@ stylelint-config-wordpress@^17.0.0:
     stylelint-config-recommended "^3.0.0"
     stylelint-config-recommended-scss "^4.2.0"
     stylelint-scss "^3.17.2"
+
+stylelint-csstree-validator@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/stylelint-csstree-validator/-/stylelint-csstree-validator-1.8.0.tgz#f8e0179ba115b82249344b16f737968dc21cd408"
+  integrity sha512-S9PAu3/HTkRstKOHgD6Bm6pgf2u/u0jwCOFEq4tmnnvlHchL2SGFgifPl4gTDOQwMxcV12WmXMgsn8NH+2ttRw==
+  dependencies:
+    css-tree "1.0.0-alpha.38"
 
 stylelint-scss@^3.17.2:
   version "3.18.0"


### PR DESCRIPTION
There are some invalid values set in css properties that are not validated and browsers do not understand them eg
`min-width: none;`
`width: calc( 100% - var( --someVar) )` -> -var( --someVar) is an implied calculation 

We may get that kind of erratic values when we are mass replacing variables eg
https://github.com/Automattic/wp-calypso/pull/45893/files
making a refactor dreadful

#### Changes proposed in this Pull Request

* add `stylelint-csstree-validator` and rules in `.stylelintrc` so that we get an error before invalid CSS values are committed. 

**Drawbacks:**
- currently there is no support for .scss magic. Meaning that, functions (eg `rem()`) and calculations (eg `width: 30px*3`) are regarded as errors. There are some open issues here https://github.com/csstree/stylelint-validator/issues
- it overlaps with `unit-no-unknown` eg `width: 3x` will trigger both rules (and one more `unit-allowed-list`)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run `yarn`
* run `yarn stylelint client/my-sites/domains/components/domain-warnings/style.scss --syntax scss`

You should get an error that `min-width: none;` is not a valid CSS value.

