### PR TITLE
Wrap up username step A/A and A/B tests

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1065,34 +1065,15 @@ function TrackRender( { children, eventName } ) {
 }
 
 export default connect(
-	( state, ownProps ) => {
-		const isDisplayUsernamePropSet = ownProps.hasOwnProperty( 'displayUsernameInput' );
-		const eligibleFlowsForRemoveUsernameTest = [
-			'onboarding',
-			'personal',
-			'premium',
-			'business',
-			'ecommerce',
-		];
-		let displayUsernameInput = true;
-
-		if ( eligibleFlowsForRemoveUsernameTest.includes( ownProps.flowName ) ) {
-			abtest( 'usernameAATest' );
-		} else if ( isDisplayUsernamePropSet ) {
-			displayUsernameInput = ownProps.displayUsernameInput;
-		}
-
-		return {
-			oauth2Client: getCurrentOAuth2Client( state ),
-			sectionName: getSectionName( state ),
-			isJetpackWooCommerceFlow:
-				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
-			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
-			from: get( getCurrentQueryArguments( state ), 'from' ),
-			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
-			displayUsernameInput,
-		};
-	},
+	( state ) => ( {
+		oauth2Client: getCurrentOAuth2Client( state ),
+		sectionName: getSectionName( state ),
+		isJetpackWooCommerceFlow:
+			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
+		isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
+		from: get( getCurrentQueryArguments( state ), 'from' ),
+		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
+	} ),
 	{
 		trackLoginMidFlow: () => recordTracksEventWithClientId( 'calypso_signup_login_midflow' ),
 		createSocialUserFailed,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -219,24 +219,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: [ 'en' ],
 	},
-	removeUsernameInSignup: {
-		datestamp: '20210914',
-		variations: {
-			variantRemoveUsername: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: false,
-	},
-	usernameAATest: {
-		datestamp: '20200921',
-		variations: {
-			variant: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: false,
-	},
 	oneClickUpsell: {
 		datestamp: '20200922',
 		variations: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wraps up the remove username test(launched in https://github.com/Automattic/wp-calypso/pull/45609) and username A/A test(launched in https://github.com/Automattic/wp-calypso/pull/45770)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that in /start, you can see the user registration step, and that you are able to complete sign up.


