### PR TITLE
Build apps in production mode

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -336,7 +336,7 @@ object RunAllUnitTests : BuildType({
 			scriptContent = """
 				set -e
 				export HOME="/calypso"
-				export NODE_ENV="test"
+				export NODE_ENV="production"
 
 				# Update node
 				. "${'$'}NVM_DIR/nvm.sh" --no-use


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use `NODE_ENV=production` when building apps in TeamCity

#### Testing instructions

* Open TeamCity build, go to 'Artifacts' and verify the apps generate minified files.
