### PR TITLE
Presales chat button: Fix Tracks property naming

### DIFF
--- a/client/my-sites/checkout/checkout/payment-chat-button.jsx
+++ b/client/my-sites/checkout/checkout/payment-chat-button.jsx
@@ -19,7 +19,7 @@ export class PaymentChatButton extends Component {
 		const { plan, supportLevel } = this.props;
 		this.props.recordTracksEvent( 'calypso_presales_chat_click', {
 			plan,
-			supportLevel,
+			support_level: supportLevel,
 		} );
 	};
 


### PR DESCRIPTION
Corrects the Tracks naming convention for properties, so this event stops getting rejected.