### PR TITLE
Nav Unification: don't return icon if not supplied

### DIFF
--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -1,7 +1,7 @@
 /**
  * SidebarCustomIcon -
  *   Handles Dashicons, SVGs, or image URLs and passes on the supplied props.
- *   Returns a blank SVG, if icon is not supplied or undefined.
+ *   Returns null if icon is not supplied or undefined.
  *   Adds className="sidebar__menu-icon" to the supplied className.
  *
  *   Purpose: To display a custom icon in the sidebar when using a
@@ -13,22 +13,11 @@
  */
 import React from 'react';
 
-const blankSvg =
-	"data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E";
-const blankSvgStyle = { height: '20px', width: '20px' };
-
 const SidebarCustomIcon = ( { alt, className, icon, ...rest } ) => {
 	if ( ! icon ) {
-		return (
-			<img
-				alt={ alt || '' }
-				className={ 'sidebar__menu-icon ' + ( className || '' ) }
-				src={ blankSvg }
-				style={ blankSvgStyle }
-				{ ...rest }
-			/>
-		);
+		return null;
 	}
+
 	if ( icon.indexOf( 'data:image' ) === 0 || icon.indexOf( 'http' ) === 0 ) {
 		return (
 			<img


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* if icon is undefined or not supplied, doesn't return an icon

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply blog sticker `nav-unification` to test site.
* Run calypso - `yarn && ENTRY_LIMIT=entry-main SECTION_LIMIT=home yarn start`
* Visit http://calypso.localhost:3000/?flags=nav-unification.
* Submenus should not have an icon either visually or in the html

Before | After
-------|------
![](https://cln.sh/SIKj7G+) | ![](https://cln.sh/kLIIhq+)