### PR TITLE
Earn: Change the referral link to the localized version

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -427,7 +427,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		};
 
 		if ( peerReferralLink ) {
-			cta.component = <ClipboardButtonInput value={ peerReferralLink } />;
+			cta.component = <ClipboardButtonInput value={ localizeUrl( peerReferralLink ) } />;
 		}
 
 		return {

--- a/client/my-sites/earn/refer-a-friend/index.tsx
+++ b/client/my-sites/earn/refer-a-friend/index.tsx
@@ -11,6 +11,7 @@ import { compact } from 'lodash';
 import wp from 'lib/wp';
 import { SiteSlug } from 'types';
 import { useTranslate } from 'i18n-calypso';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import getSiteBySlug from 'state/sites/selectors/get-site-by-slug';
@@ -79,7 +80,7 @@ const ReferAFriendSection: FunctionComponent< ConnectedProps > = ( {
 		};
 
 		if ( peerReferralLink ) {
-			cta.component = <ClipboardButtonInput value={ peerReferralLink } />;
+			cta.component = <ClipboardButtonInput value={ localizeUrl( peerReferralLink ) } />;
 		}
 
 		return {


### PR DESCRIPTION
* Also localize the referral link on the stand-alone /earn/refer-a-friend page

### Changes proposed in this Pull Request

In the Earn section of Calypso, there is a card for referring a friend and an option to copy the link. The link goes to the English version of the page instead of the localized versions.

![image](https://user-images.githubusercontent.com/23708351/94553134-b31bed80-0260-11eb-97db-bf463c34401e.png)

The referral link should include the locale subdomain. For example, French should be
http://fr.wordpress.com/refer-a-friend/6kvPP1RioVR730bbl0AZ

instead of

http://wordpress.com/refer-a-friend/6kvPP1RioVR730bbl0AZ

The same applies to the stand-alone page https://wordpress.com/earn/refer-a-friend

### Testing instructions

Testing Instructions
Change user language to a mag-16 language

Scenario 1 

Go to https://wordpress.com/earn and find the referral card
Copy the referral link and paste in a browser
Link should redirect to localized version the /create-blog landing page with referral banner. i.e. https://[xx].wordpress.com/create-blog/?aff=[xxxxx]&sid=[xxxxxxx]

Scenario 2 
Go to https://wordpress.com/earn/refer-a-friend

Copy the referral link and paste in a browser
Link should redirect to localized version the /create-blog landing page with referral banner. i.e. https://[xx].wordpress.com/create-blog/?aff=[xxxxx]&sid=[xxxxxxx]