### PR TITLE
Signup Framework : Refactor dependency-store reducer so that stale dependencies in signup flow

### DIFF
--- a/client/state/signup/dependency-store/reducer.js
+++ b/client/state/signup/dependency-store/reducer.js
@@ -9,8 +9,23 @@ import {
 } from 'state/action-types';
 import { dependencyStoreSchema } from './schema';
 import { withSchemaValidation } from 'state/utils';
-
+import steps from 'signup/config/steps-pure';
 const EMPTY = {};
+
+function getStateDependenciesNotInStep( state, stepName ) {
+	const { providesDependencies: currentStepDependencySchemaArray = [] } = steps[ stepName ] ?? {};
+
+	const otherDependenciesInFlow = Object.keys( state ).reduce( ( otherDeps, dep ) => {
+		if ( ! currentStepDependencySchemaArray.includes( dep ) ) {
+			return {
+				...otherDeps,
+				[ dep ]: state[ dep ],
+			};
+		}
+		return otherDeps;
+	}, {} );
+	return otherDependenciesInFlow;
+}
 
 function reducer( state = EMPTY, action ) {
 	switch ( action.type ) {
@@ -19,11 +34,15 @@ function reducer( state = EMPTY, action ) {
 
 		case SIGNUP_PROGRESS_SUBMIT_STEP:
 		case SIGNUP_PROGRESS_COMPLETE_STEP: {
-			const { providedDependencies } = action.step;
-			if ( ! providedDependencies ) {
-				return state;
-			}
-			return { ...state, ...providedDependencies };
+			const { stepName, providedDependencies: dependenciesProvidedByCurrentStep } = action.step;
+			/**
+			 * This is to allow the removal of a given dependency which is supposed to be provided by the current step
+			 * Therefore, optional dependencies in a given step can now be removed when moving back and forth across a given flow
+			 * The assumption is if a step provides a dependency it should be specified in the action, otherwise it is removed.
+			 */
+			const otherDependenciesInFlow = getStateDependenciesNotInStep( state, stepName );
+			const finalState = { ...otherDependenciesInFlow, ...dependenciesProvidedByCurrentStep };
+			return finalState;
 		}
 
 		case SIGNUP_COMPLETE_RESET:

--- a/client/state/signup/dependency-store/test/reducer.js
+++ b/client/state/signup/dependency-store/test/reducer.js
@@ -16,10 +16,21 @@ describe( 'reducer', () => {
 	} );
 
 	test( 'should not store dependencies if none are included in the action', () => {
-		const prevState = {};
+		const prevState = { bearer_token: 'TOKENX' };
 		const action = { type: SIGNUP_PROGRESS_SUBMIT_STEP, step: { stepName: 'userCreation' } };
 		const nextState = signupDependencyStore( prevState, action );
-		expect( nextState ).toBe( prevState );
+		expect( nextState ).toEqual( prevState );
+	} );
+
+	test( 'should remove dependencies not provided in current step', () => {
+		//TODO: write a test by mocking the step definitions
+		//
+		// const prevState = { bearer_token: 'TOKENX' };
+		// const action = { type: SIGNUP_PROGRESS_SUBMIT_STEP, step: { stepName: 'userCreation' } };
+		// const nextState = signupDependencyStore( prevState, action );
+
+		// console.log( { prevState, nextState } );
+		expect( true ).toEqual( true );
 	} );
 
 	test( 'should store dependencies if they are provided in either signup action', () => {


### PR DESCRIPTION
The problem was first faced at #45618. The following is a simplified/similar example of the problems that may arise with this behaviour.

Let's assume there is a signup flow with 3 steps.
```javascript
	flows.nextgen = {
		steps: [ 'user','domains', 'plans' ],
		description: "The next generation flow with 3 steps",
		lastModified: '2018-11-14',
	};
```

Here let's assume each step looks like below. ( notice the optional dependency on domains )
```javascript
	user: {
		stepName: 'user',
		providesDependencies: [ 'bearer_token', 'username', 'marketing_price_group' ],
	},
       domains: {
		stepName: 'domains',
		providesDependencies: [
			'domainItem',
			'freeDomain',
		],
		optionalDependencies: [ 'freeDomain' ],
	},
	plans: {
		stepName: 'plans',
		providesDependencies: [ 'cartItem' ],
	},
```

Now let's assume I am on the domains step. As shown, my business logic is such that I will (optionally) provide a "freeDomain" dependency, if the user selects the free domain option from the domains list. Failure which, the step wont be providing such a dependency.  So if this "freeDomain" dependency is not provided, in the next step, I will hide a ui link which allows to select a free plan.

**So consider this sequence of actions**

1. Signup and proceed to the domains step
2. I select the free domain option which carries me to the plans step with the param ("freeDomain") 
[dependency _freeDomain_ added to the store]
3. Realising that I can afford a personal plan, I select back and come back to the domains page
4. Now I select a paid domain which carries me to the plans step 
(this technically should not pass the dependency - freeDomain, But because of the way our reducer logic is structured when I do not pass this optional dependency it will load a stale dependency from the previous state of the redux store and I will still be able to see the UI change dependent on it.)
[stale dependency _freeDomain_ loaded from store]
5. In the domain step, Free domain still exists as a dependency and the UI link will be visible

#### Changes proposed in this Pull Request

I am proposing a change to the reducers in the dependency-store. The change assumes that any dependency designated to be provided by a given step should come iff it is provided by the relevant action payload and not the previous redux state.

This means, if we consider the above scenario, as the domains step has _freeDomain_ as a designated step in its step schema. All dependencies should be provided in the action. Meanwhile other dependencies unrelated to the current step will be "passed through" by simply loading them from the previous step.

#### Testing instructions
TBD
Fixes TBD
