### PR TITLE
E2E: Keep viewport size when switching to new window

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -10,6 +10,7 @@ import { forEach } from 'lodash';
  */
 import * as SlackNotifier from './slack-notifier.js';
 import * as dataHelper from './data-helper';
+import * as driverManager from './driver-manager';
 
 const explicitWaitMS = config.get( 'explicitWaitMS' );
 const by = webdriver.By;
@@ -434,8 +435,11 @@ export function waitForInfiniteListLoad( driver, elementSelector, { numElements 
 }
 
 export async function switchToWindowByIndex( driver, index ) {
+	const currentScreenSize = driverManager.currentScreenSize();
 	const handles = await driver.getAllWindowHandles();
-	return await driver.switchTo().window( handles[ index ] );
+	await driver.switchTo().window( handles[ index ] );
+	// Resize target window to ensure we stay in the same viewport size:
+	await driverManager.resizeBrowser( driver, currentScreenSize );
 }
 
 export async function numberOfOpenWindows( driver ) {

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -12,6 +12,7 @@ import LoginFlow from '../lib/flows/login-flow.js';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar';
 
+import * as driverHelper from '../lib/driver-helper.js';
 import * as driverManager from '../lib/driver-manager.js';
 import * as dataHelper from '../lib/data-helper.js';
 
@@ -59,20 +60,15 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 
 			await this.loginFlow.loginAndSelectWPAdmin();
 
-			//Wait for the new window or tab
-			await driver.wait( async () => ( await driver.getAllWindowHandles() ).length === 2, 10000 );
-
-			//Loop through until we find a new window handle
-			const windows = await driver.getAllWindowHandles();
-
-			await driver.switchTo().window( windows[ 1 ] );
+			await driverHelper.waitForNumberOfWindows( driver, 2, 10000 );
+			await driverHelper.switchToWindowByIndex( driver, 1 );
 
 			const wpadminSidebarComponent = await WPAdminSidebar.Expect( driver );
 			await wpadminSidebarComponent.selectNewPost();
 		} );
 
 		step( 'Check for presence of e2e specific tracking events stack on global', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver, 'wp-admin' );
+			await GutenbergEditorComponent.Expect( driver, 'wp-admin' );
 			const eventsStack = await driver.executeScript( `return window._e2eEventsStack;` );
 			// Check evaluates to truthy
 			assert( eventsStack, 'Tracking events stack missing from window._e2eEventsStack' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update E2E helper so that when opening new windows they have the same viewport set. This is mainly for mobile suites where a new window is open in desktop size:

From mpg artifact (before):

| Original viewport  | New window |
| ------------- | ------------- |
| <img width="1440" alt="Screenshot 2020-10-01 at 15 38 15" src="https://user-images.githubusercontent.com/1451471/94817535-67527b00-03fd-11eb-9b34-7a3b2a941dc7.png"> | <img width="1440" alt="Screenshot 2020-10-01 at 15 38 37" src="https://user-images.githubusercontent.com/1451471/94817251-1e022b80-03fd-11eb-9685-e1ff66f13ed7.png"> |


#### Testing instructions

* Run a (mobile) spec where a new window is being open, i.e. `BROWSERSIZE=mobile ./node_modules/.bin/mocha specs/wp-calypso-gutenberg-editor-tracking-spec.js `;
* Notice how new window, when open, is being resized to the correct viewport.
