### PR TITLE
Components: Fix z-index of FormTextInputWithAffixes

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -51,6 +51,7 @@ $z-layers: (
 		'.reader-full-post__sidebar-comment-like': 1,
 		'.list-stream__header-follow': 0,
 		'.following__intro-close-icon-bg' : 0,
+		'.form-text-input-with-affixes .form-text-input': 1,
 		'.is-section-signup': 1,
 		'.media-library .search.is-expanded-to-container': 1,
 		'.ribbon': 1,

--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -18,6 +18,8 @@
 	input[type='number'] {
 		flex-grow: 1;
 		border-radius: 0;
+		position: relative;
+		z-index: z-index( 'root', '.form-text-input-with-affixes .form-text-input' );
 
 		&:focus {
 			// Fixes the right border of the box shadow displayed when this input element is focused which appears as


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the z-index of the input field in `<FormTextInputWithAffixes />`

Before:
![](https://cldup.com/T0jVShfWjD.png)

After:
![](https://cldup.com/fDgojY3KQ5.png)

#### Testing instructions

* Checkout this branch.
* Go to `/devdocs/design/form-fields`
* Verify the focused FormTextInputWithAffixes input looks good and is no longer overlapped by the suffix. 
* Test in another location where that field is used, for example `/domains/manage/*.photo.blog/change-site-address/*.photo.blog`.

#### Context

Reported by @klimeryk in https://github.com/Automattic/wp-calypso/pull/45781#pullrequestreview-498354566 
