### PR TITLE
Nav Unification - updates Ad Control in static data to match canonical WPCom menu item name

### DIFF
--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -486,7 +486,7 @@ export default function buildFallbackResponse( { siteDomain = '' } = {} ) {
 					{
 						parent: 'options-general.php',
 						slug: 'options-ad-control',
-						title: translate( 'Ad Control' ),
+						title: translate( 'AdControl' ),
 						type: 'submenu-item',
 						url: `https://${ siteDomain }/wp-admin/options-general.php?page=adcontrol`,
 					},


### PR DESCRIPTION
Updates menu item `Ad Control` to be `AdControl` in the static data in order to better match the menu text in the WPCom code which will create the real menu.

See https://github.com/Automattic/wp-calypso/issues/45995

cc @davemart-in - just an FYI this is happening and why.


#### Changes proposed in this Pull Request

* Updates `Ad Control` in the static menu data to match the canonical `AdControl` title from WPCom.

#### Testing instructions

* Comment out this line of code 
https://github.com/Automattic/wp-calypso/blob/ebde236ec9b21ea9621c0b0523bd5ea185523731/client/my-sites/sidebar-unified/use-site-menu-items.js#L24
* Apply blog sticker - see `paYJgx-Zj-p2`
* Build calypso - yarn && yarn start.
* Visit http://calypso.localhost:3000/?flags=nav-unification.
* You should see the menu rendered from the static fallback data.
* Click "Settings" and see the menu expand. 
* See the text reads `AdControl` not `Ad Control`.

https://github.com/Automattic/wp-calypso/issues/45995
