### PR TITLE
Add vertical space above the first content block when the page title is hidden

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
@@ -3,8 +3,8 @@ body.hide-homepage-title {
 		display: none;
 	}
 
-	// If the title is hidden in the block editor, leave enough space
-	// above the first block for the toolbar to show correctly.
+	// When the title is hidden in the block editor while editing the homepage,
+	// leave enough space above the first block for the toolbar to show correctly.
 	.block-editor-block-list__layout.is-root-container > .wp-block:first-child {
 		margin-top: 64px;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
@@ -2,4 +2,10 @@ body.hide-homepage-title {
 	.editor-post-title {
 		display: none;
 	}
+
+	// If the title is hidden in the block editor, leave enough space
+	// above the first block for the toolbar to show correctly.
+	.block-editor-block-list__layout.is-root-container > .wp-block:first-child {
+		margin-top: 64px;
+	}
 }


### PR DESCRIPTION
### Description

In Calypso, when working with certain themes (Seedlet and Balasana so far) and editing the homepage in the block editor, the toolbar is not shown to the user when editing the first block on the page.

This issue is the result of a combination of factors:
- in Calypso, [if the theme requires it, the title of a post is hidden for the homepage](https://github.com/Automattic/wp-calypso/blob/720b5dad4f5217adc9c1de3e2d706b56f6bb7cf9/apps/editing-toolkit/editing-toolkit-plugin/common/index.php#L50-L90). Normally the post/page title adds enough space before the first editor block; but when the title is hidden, there isn't enough space left
- Calypso is currently using version 9.0 of Gutenberg. The upcoming [version 9.1 contains a change](https://github.com/WordPress/gutenberg/pull/25527/files) that partially improves this issue, but still doesn't fix it completely (see screenshots below)


### Changes proposed in this Pull Request

Added a CSS rule that forces a taller `margin-top` for the first block in the editor, if the post title is being hidden when editing the homepage's contents.


### Testing instructions

1. Clean your sandbox, and apply the auto-generated patch for this change (D50347-code, see comment below)
2. Sandbox the WordPress.com test site
3. In Calypso, open the test WordPress site
4. Change the theme to Seedlet or Balasana
5. Edit the homepage in the block editor
6. Make sure you're using the sandboxed version of the `wpcom-FSE plugin` (you can do so in the block editor, by clicking the `⋮` button in the top right of the screen and checking the plugin version at the bottom of the newly opened menu)
7. Delete all of the page content, then add a new block as the first block of the page
8. Notice how the toolbar is shown to the user

**Before:**

<img width="1176" alt="Screenshot 2020-09-29 at 15 16 27" src="https://user-images.githubusercontent.com/1083581/94564951-e1053000-0268-11eb-86e8-8d5ca1f09641.png">

**Before, but using the Gutenberg edge sticker (Gutenberg 9.1):**

<img width="1176" alt="wpcom-gutenberg-edge" src="https://user-images.githubusercontent.com/1083581/94564774-abf8dd80-0268-11eb-89aa-497ec765457d.png">

**After applying PR changes:**

<img width="1175" alt="Screenshot 2020-09-29 at 15 15 39" src="https://user-images.githubusercontent.com/1083581/94564989-ec585b80-0268-11eb-890d-8b49c335bff2.png">

Fixes #45967
