### PR TITLE
e2e: Fix publish panel and inline help tests

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -72,7 +72,12 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await this.driver.executeScript( 'arguments[0].click();', button );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
 		if ( closePanel ) {
-			await this.closePublishedPanel();
+			try {
+				await this.closePublishedPanel();
+
+			} catch ( e ) {
+				console.log( 'Publish panel already closed' );
+			}
 		}
 		await this.waitForSuccessViewPostNotice();
 		const url = await this.driver.findElement( snackBarNoticeLinkSelector ).getAttribute( 'href' );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -86,7 +86,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			const snackbar = await this.driver.findElement( snackBarNoticeLinkSelector );
 			await this.driver.executeScript( 'arguments[0].click();', snackbar );
 		}
-
+		await this.driver.sleep( 1000 );
 		await driverHelper.acceptAlertIfPresent( this.driver );
 		return url;
 	}

--- a/test/e2e/specs/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec.js
@@ -81,7 +81,7 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, async function
 
 		step( 'Displays contextual search results by default', async function () {
 			const resultsCount = await supportSearchComponent.getDefaultResultsCount();
-			assert.equal( resultsCount, 5, 'There are no contextual results displayed' );
+			assert.equal( resultsCount, 6, 'There are no contextual results displayed' );
 		} );
 
 		step( 'Returns search results for valid search query', async function () {
@@ -105,7 +105,7 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, async function
 
 			const resultsCount = await supportSearchComponent.getDefaultResultsCount();
 
-			assert.equal( resultsCount, 5, 'There are no contextual results displayed' );
+			assert.equal( resultsCount, 6, 'There are no contextual results displayed' );
 		} );
 
 		step(
@@ -120,7 +120,7 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, async function
 
 				assert.equal( hasNoResultsMessage, true, 'The "No results" message was not displayed.' );
 
-				assert.equal( resultsCount, 5, 'There are no contextual results displayed.' );
+				assert.equal( resultsCount, 6, 'There are no contextual results displayed.' );
 			}
 		);
 

--- a/test/e2e/specs/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/wp-my-home-support-search-spec.js
@@ -64,7 +64,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 	step( 'Displays Default Results initially', async function () {
 		supportSearchComponent = await SupportSearchComponent.Expect( driver );
 		const resultsCount = await supportSearchComponent.getDefaultResultsCount();
-		assert.equal( resultsCount, 5, 'There are not 5 Default Results displayed.' );
+		assert.equal( resultsCount, 6, 'There are not 6 Default Results displayed.' );
 	} );
 
 	step( 'Returns API Search Results for valid search query', async function () {
@@ -117,7 +117,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 
 		assert.equal( adminResults, true, 'The Admin Results are not displayed.' );
 
-		assert.equal( defaultResultsCount, 5, 'The 5 Default Results are not displayed.' );
+		assert.equal( defaultResultsCount, 6, 'The 6 Default Results are not displayed.' );
 	} );
 
 	step(
@@ -137,7 +137,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 
 			assert.equal( hasNoResultsMessage, true, 'The "No results" message was not displayed.' );
 
-			assert.equal( resultsCount, 5, 'The 5 default Error Results are not displayed.' );
+			assert.equal( resultsCount, 6, 'The 6 default Error Results are not displayed.' );
 		}
 	);
 
@@ -150,7 +150,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 
 		assert.equal( errorResults, true, 'The default Error Results are not displayed.' );
 
-		assert.equal( resultsCount, 5, 'The 5 Default Results are not displayed.' );
+		assert.equal( resultsCount, 6, 'The 6 Default Results are not displayed.' );
 	} );
 
 	step( 'Does not request API Search Results for empty search queries', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The publish panel is now closing on it's own after publishing. The test wants to close it so I made it so that it won't fail if the publish panel isn't there when it tries to close it. 
* It also adjust the item count in inline help after this change https://github.com/Automattic/wp-calypso/pull/45408

#### Testing instructions

* Make sure tests pass in CI
