### PR TITLE
[eslint] Fix jest/expect-expect rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -171,6 +171,7 @@ module.exports = {
 
 					// Chai
 					'chai.assert',
+					'chai.assert.*',
 					'assert',
 					'assert.*',
 					'equal',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -162,6 +162,28 @@ module.exports = {
 		// TODO: why did we turn this off?
 		'jest/valid-expect': 'off',
 
+		'jest/expect-expect': [
+			'error',
+			{
+				assertFunctionNames: [
+					// Jest
+					'expect',
+
+					// Chai
+					'chai.assert',
+					'assert',
+					'assert.*',
+					'equal',
+					'ok',
+					'deepStrictEqual',
+					'chaiExpect',
+
+					// Sinon
+					'sinon.assert.*',
+				],
+			},
+		],
+
 		// Only use known tag names plus `jest-environment`.
 		'jsdoc/check-tag-names': [ 'error', { definedTags: [ 'jest-environment' ] } ],
 

--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -92,6 +92,7 @@ describe( 'DailyPostButton', () => {
 			assert.isTrue( pageSpy.calledWithMatch( /post\/apps.wordpress.com?/ ) );
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		test( 'shows the site selector if the user has more than one site', () => {
 			const dailyPostButton = shallow(
 				<DailyPostButton

--- a/client/components/domains/registrant-extra-info/test/ca-form.js
+++ b/client/components/domains/registrant-extra-info/test/ca-form.js
@@ -20,6 +20,7 @@ const mockProps = {
 };
 
 describe( 'ca-form', () => {
+	// eslint-disable-next-line jest/expect-expect
 	test( 'should render without errors when extra is empty', () => {
 		const testProps = {
 			...mockProps,

--- a/client/components/forms/range/test/index.jsx
+++ b/client/components/forms/range/test/index.jsx
@@ -1,7 +1,8 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["TestUtils.*"] }] */
+
 /**
  * @jest-environment jsdom
  */
-
 /**
  * External dependencies
  */

--- a/client/components/forms/range/test/index.jsx
+++ b/client/components/forms/range/test/index.jsx
@@ -1,8 +1,9 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["TestUtils.*"] }] */
-
 /**
  * @jest-environment jsdom
  */
+
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["TestUtils.*"] }] */
+
 /**
  * External dependencies
  */

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -24,8 +24,6 @@ import {
 	getUpdatedCursorPosition,
 } from '../phone-number';
 
-/* eslint-disable jest/expect-expect */
-
 describe( 'metadata:', () => {
 	describe( 'data assertions:', () => {
 		const countriesShareDialCode = pickBy(

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -1,8 +1,8 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["testOnBlur", "expect.*"] }] */
-
 /**
  * @jest-environment jsdom
  */
+
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["testOnBlur", "expect.*"] }] */
 
 /**
  * External dependencies

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -1,3 +1,5 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["testOnBlur", "expect.*"] }] */
+
 /**
  * @jest-environment jsdom
  */

--- a/client/components/translatable/test/proptype.js
+++ b/client/components/translatable/test/proptype.js
@@ -1,3 +1,5 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["assertPasses", "assertFails"] }] */
+
 /**
  * @jest-environment jsdom
  */

--- a/client/components/translatable/test/proptype.js
+++ b/client/components/translatable/test/proptype.js
@@ -1,8 +1,8 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["assertPasses", "assertFails"] }] */
-
 /**
  * @jest-environment jsdom
  */
+
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["assertPasses", "assertFails"] }] */
 
 /**
  * External dependencies

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
@@ -354,6 +354,7 @@ describe( 'Shipping label Actions', () => {
 			} );
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		it( 'Validation request failure returns a false promise', () => {
 			// Mock an unsuccessful response
 			mockNormalizationRequest( false );

--- a/client/lib/directly/test/index.js
+++ b/client/lib/directly/test/index.js
@@ -74,6 +74,7 @@ describe( 'index', () => {
 					.then( () => done() );
 			} );
 
+			// eslint-disable-next-line jest/expect-expect
 			test( 'resolves the returned promise if the library load succeeds', ( done ) => {
 				directly.initialize().then( () => done() );
 			} );

--- a/client/lib/media/test/store.js
+++ b/client/lib/media/test/store.js
@@ -117,6 +117,7 @@ describe( 'MediaStore', () => {
 			expect( MediaStore.dispatchToken ).to.be.a( 'string' );
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		test( 'should emit a change event when receiving updates', () => {
 			return new Promise( ( done ) => {
 				MediaStore.once( 'change', done );

--- a/client/lib/mixins/data-observe/test/index.js
+++ b/client/lib/mixins/data-observe/test/index.js
@@ -1,7 +1,8 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["assertMixin", "assert.*"] }] */
+
 /**
  * External dependencies
  */
-
 import { assert } from 'chai';
 
 /**

--- a/client/lib/plans/test/plan-levels-match.js
+++ b/client/lib/plans/test/plan-levels-match.js
@@ -1,3 +1,5 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["testPlansArrayIndependentOfOrder"] }] */
+
 /**
  * External dependencies
  */

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -114,11 +114,13 @@ describe( 'flow-controller', () => {
 			} );
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		test( 'should call apiRequestFunction on steps with that property', ( done ) => {
 			store.dispatch( submitSignupStep( { stepName: 'userCreation' }, { bearer_token: 'TOKEN' } ) );
 			store.dispatch( submitSignupStep( { stepName: 'asyncStep', done } ) );
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		test( 'should not call apiRequestFunction multiple times', ( done ) => {
 			store.dispatch( submitSignupStep( { stepName: 'userCreation' }, { bearer_token: 'TOKEN' } ) );
 			store.dispatch( submitSignupStep( { stepName: 'asyncStep', done } ) );
@@ -227,6 +229,7 @@ describe( 'flow-controller', () => {
 			} ).toThrow();
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		test( 'should run `onComplete` once all steps are submitted without an error', ( done ) => {
 			const store = createSignupStore();
 			signupFlowController = new SignupFlowController( {
@@ -241,6 +244,7 @@ describe( 'flow-controller', () => {
 	} );
 
 	describe( 'controlling a flow with optional dependencies', () => {
+		// eslint-disable-next-line jest/expect-expect
 		test( 'should run `onComplete` once all steps are submitted, including optional dependency', ( done ) => {
 			const store = createSignupStore();
 			signupFlowController = new SignupFlowController( {
@@ -264,6 +268,7 @@ describe( 'flow-controller', () => {
 			);
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		test( 'should run `onComplete` once all steps are submitted, excluding optional dependency', ( done ) => {
 			const store = createSignupStore();
 			signupFlowController = new SignupFlowController( {

--- a/client/lib/track-element-size/test/index.js
+++ b/client/lib/track-element-size/test/index.js
@@ -53,6 +53,7 @@ describe( 'useWindowResizeCallback', () => {
 		container = null;
 	} );
 
+	// eslint-disable-next-line jest/expect-expect
 	it( 'does not throw an error there is no callback', () => {
 		const TestComponent = function () {
 			const ref = useWindowResizeCallback();

--- a/client/my-sites/checkout/checkout/test/web-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/web-payment-box.js
@@ -61,6 +61,7 @@ describe( 'WebPaymentBox', () => {
 		getState: () => ( { ui: { checkout: { showCartOnMobile: false } } } ),
 	};
 
+	// eslint-disable-next-line jest/expect-expect
 	test( 'should render', () => {
 		shallow( <WebPaymentBox { ...defaultProps } /> );
 	} );

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -1,3 +1,5 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expectSelectedItems", "expect"] }] */
+
 /**
  * @jest-environment jsdom
  */

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -1,8 +1,8 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expectSelectedItems", "expect"] }] */
-
 /**
  * @jest-environment jsdom
  */
+
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expectSelectedItems", "expect"] }] */
 
 /**
  * External dependencies

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -22,6 +22,7 @@ jest.mock( 'lib/user', () => () => {
 } );
 
 describe( 'index', () => {
+	// eslint-disable-next-line jest/expect-expect
 	test( 'should not have overlapping step/flow names', () => {
 		const overlappingNames = intersection( keys( steps ), keys( flows.getFlows() ) );
 

--- a/client/state/account-recovery/settings/test/utils/index.js
+++ b/client/state/account-recovery/settings/test/utils/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable jest/expect-expect */
+
 /**
  * Internal dependencies
  */

--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -104,8 +104,6 @@ describe( 'WPCOM HTTP Data Layer', () => {
 
 			expect( next ).toMatchObject( { dogs: { lastUpdated: 1000 } } );
 		} );
-
-		test( 'should not care if pending flag is persisted', () => {} );
 	} );
 
 	describe( '#trackRequests', () => {

--- a/client/state/immediate-login/test/utils.js
+++ b/client/state/immediate-login/test/utils.js
@@ -11,6 +11,7 @@ import { REASONS_FOR_MANUAL_RENEWAL } from '../constants';
 
 describe( 'immediate-login/utils', () => {
 	describe( 'createPathWithoutImmediateLoginInformation', () => {
+		// eslint-disable-next-line jest/expect-expect
 		test( 'should be possible to call', () => {
 			createPathWithoutImmediateLoginInformation( '', {} );
 		} );
@@ -109,6 +110,7 @@ describe( 'immediate-login/utils', () => {
 	} );
 
 	describe( 'createImmediateLoginMessage', () => {
+		// eslint-disable-next-line jest/expect-expect
 		test( 'should be possible to call', () => {
 			createImmediateLoginMessage( '', '' );
 		} );

--- a/client/state/reader/posts/test/normalization-rules.js
+++ b/client/state/reader/posts/test/normalization-rules.js
@@ -1,3 +1,5 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["verifyClassification", "expect"] }] */
+
 /**
  * External dependencies
  */

--- a/client/state/signup/steps/site-vertical/test/reducer.js
+++ b/client/state/signup/steps/site-vertical/test/reducer.js
@@ -6,7 +6,6 @@ import { JETPACK_CONNECT_AUTHORIZE } from 'state/jetpack-connect/action-types';
 import { SIGNUP_STEPS_SITE_VERTICAL_SET } from 'state/action-types';
 
 describe( 'reducer', () => {
-	test( 'should return default  state', () => {} );
 	test( 'should update the site vertical and merge with state', () => {
 		const siteVertical = {
 			name: 'glücklich',

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1,5 +1,3 @@
-/* eslint jest/expect-expect: [ "error", { "assertFunctionNames": [ "expect", "chaiExpect" ] } ] */
-
 /**
  * External dependencies
  */

--- a/client/test-helpers/use-nock/integration/index.js
+++ b/client/test-helpers/use-nock/integration/index.js
@@ -13,6 +13,7 @@ describe( 'useNock', () => {
 	useNock();
 
 	describe( 'Messy without useNock', () => {
+		// eslint-disable-next-line jest/expect-expect
 		test( 'sets up a persistent interceptor', () => {
 			nock( 'wordpress.com' ).persist().get( '/me' ).reply( 200, { id: 42 } );
 		} );

--- a/packages/photon/test/index.js
+++ b/packages/photon/test/index.js
@@ -1,4 +1,4 @@
-/* eslint jest/expect-expect: [ "error", { "assertFunctionNames": [ "expect", "expectPathname", "expectQuery", "expectHostedOnPhoton", "expectHostedOnPhotonInsecurely" ] } ] */
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expectHostedOnPhoton", "expectHostedOnPhotonInsecurely", "expectPathname", "expectQuery", "expect"] }] */
 
 /**
  * Internal dependencies

--- a/packages/viewport-react/test/index.js
+++ b/packages/viewport-react/test/index.js
@@ -1,7 +1,8 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["runComponentTests", "expect"] }] */
 /**
  * @jest-environment jsdom
  */
+
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["runComponentTests", "expect"] }] */
 
 /**
  * External dependencies

--- a/packages/viewport-react/test/index.js
+++ b/packages/viewport-react/test/index.js
@@ -1,3 +1,4 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["runComponentTests", "expect"] }] */
 /**
  * @jest-environment jsdom
  */
@@ -144,7 +145,6 @@ describe( '@automattic/viewport-react', () => {
 			expect( container.textContent ).toBe( 'undefined' );
 		} );
 
-		// eslint-disable-next-line jest/expect-expect
 		test( 'returns the current breakpoint state for a valid breakpoint', () => {
 			function TestComponent() {
 				const isActive = helpers.useBreakpoint( '<960px' );
@@ -206,7 +206,6 @@ describe( '@automattic/viewport-react', () => {
 	} );
 
 	describe( 'useMobileBreakpoint', () => {
-		// eslint-disable-next-line jest/expect-expect
 		test( 'returns the current breakpoint state for the mobile breakpoint', () => {
 			function TestComponent() {
 				const isActive = helpers.useMobileBreakpoint();
@@ -218,7 +217,6 @@ describe( '@automattic/viewport-react', () => {
 	} );
 
 	describe( 'useDesktopBreakpoint', () => {
-		// eslint-disable-next-line jest/expect-expect
 		test( 'returns the current breakpoint state for the desktop breakpoint', () => {
 			function TestComponent() {
 				const isActive = helpers.useDesktopBreakpoint();
@@ -257,7 +255,6 @@ describe( '@automattic/viewport-react', () => {
 			expect( container.textContent ).toBe( 'undefined' );
 		} );
 
-		// eslint-disable-next-line jest/expect-expect
 		test( 'returns the current breakpoint state for a valid breakpoint', () => {
 			const TestComponent = helpers.withBreakpoint( '<960px' )( BaseComponent );
 			runComponentTests( TestComponent, '(max-width: 960px)' );
@@ -265,7 +262,6 @@ describe( '@automattic/viewport-react', () => {
 	} );
 
 	describe( 'withMobileBreakpoint', () => {
-		// eslint-disable-next-line jest/expect-expect
 		test( 'returns the current breakpoint state for the mobile breakpoint', () => {
 			const TestComponent = helpers.withMobileBreakpoint( BaseComponent );
 			runComponentTests( TestComponent, '(max-width: 480px)' );
@@ -273,7 +269,6 @@ describe( '@automattic/viewport-react', () => {
 	} );
 
 	describe( 'withDesktopBreakpoint', () => {
-		// eslint-disable-next-line jest/expect-expect
 		test( 'returns the current breakpoint state for the desktop breakpoint', () => {
 			const TestComponent = helpers.withDesktopBreakpoint( BaseComponent );
 			runComponentTests( TestComponent, '(min-width: 961px)' );

--- a/packages/wpcom.js/test-need-complete-access-origin/test.wpcom.site.settings.js
+++ b/packages/wpcom.js/test-need-complete-access-origin/test.wpcom.site.settings.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/expect-expect */
 /**
  * Module dependencies
  */

--- a/packages/wpcom.js/test/test.wpcom.me.js
+++ b/packages/wpcom.js/test/test.wpcom.me.js
@@ -112,6 +112,7 @@ describe( 'wpcom.me', function () {
 	} );
 
 	describe( 'wpcom.me.sites', function () {
+		// eslint-disable-next-line jest/expect-expect
 		it( 'should require user sites object', ( done ) => {
 			me.sites()
 				.then( () => done() )

--- a/packages/wpcom.js/test/test.wpcom.promises.js
+++ b/packages/wpcom.js/test/test.wpcom.promises.js
@@ -19,6 +19,7 @@ describe( 'wpcom', function () {
 	var wpcom = util.wpcomPublic();
 
 	describe( 'wpcom.promises', function () {
+		// eslint-disable-next-line jest/expect-expect
 		it( 'should fail when slower than timeout', ( done ) => {
 			wpcom
 				.site( util.site() )
@@ -28,6 +29,7 @@ describe( 'wpcom', function () {
 				.catch( trueAssertion( done ) );
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		it( 'should still catch() with timeout()', ( done ) => {
 			wpcom
 				.site( util.site() )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Configure `jest/expect-expect` to support all assert styles across the repo: jest, chai and sinon.
* Remove outdated exceptions and customizations of `jest/expect-expect`
* Add new exceptions for tests that don't assert anything
* Add customizations for tests that define an assert helper function

After this change there are still 19 occurrences of `// eslint-disable-next-line jest/expect-expect` in 13 files.

#### Testing instructions

* Verify unit tests still pass. Ignore lint tests.
* Run `./node_modules/.bin/eslint-nibble --ext .js,.jsx,.ts,.tsx .` in this branch and check there are no more violations of `jest/expect-expect` (warning: it takes several minutes)

In master:
![image](https://user-images.githubusercontent.com/975703/94577115-778c1e00-0276-11eb-8160-b2e7c451f91e.png)

In this branch:
![image](https://user-images.githubusercontent.com/975703/94578751-5fb59980-0278-11eb-9785-d5963c4d9349.png)

