### PR TITLE
Nav Unification: redirect to url when clicking a top level menu

### DIFF
--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -54,7 +54,14 @@ export const MySitesSidebarUnified = ( { path } ) => {
 				}
 
 				if ( item?.children?.length ) {
-					return <MySitesSidebarUnifiedMenu key={ item.slug } path={ path } { ...item } />;
+					return (
+						<MySitesSidebarUnifiedMenu
+							key={ item.slug }
+							path={ path }
+							link={ item.url }
+							{ ...item }
+						/>
+					);
 				}
 
 				return <MySitesSidebarUnifiedItem key={ item.slug } path={ path } { ...item } />;

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -54,9 +54,11 @@ export const MySitesSidebarUnifiedMenu = ( { slug, title, icon, children, path, 
 
 MySitesSidebarUnifiedMenu.propTypes = {
 	path: PropTypes.string,
+	slug: PropTypes.string,
 	title: PropTypes.string,
 	icon: PropTypes.string,
 	children: PropTypes.array.isRequired,
+	link: PropTypes.string,
 	/*
 	Example of children shape:
 	[

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -31,12 +31,14 @@ export const MySitesSidebarUnifiedMenu = ( { slug, title, icon, children, path, 
 	return (
 		<ExpandableSidebarMenu
 			onClick={ () => {
-				if ( isExternal( link ) ) {
-					// If the URL is external, page() will fail to replace state between different domains
-					document.location.href = link;
-					return;
+				if ( link ) {
+					if ( isExternal( link ) ) {
+						// If the URL is external, page() will fail to replace state between different domains
+						document.location.href = link;
+						return;
+					}
+					page( link );
 				}
-				page( link );
 				reduxDispatch( toggleSection( sectionId ) );
 			} }
 			expanded={ isExpanded }

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -11,6 +11,7 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -20,15 +21,24 @@ import { toggleMySitesSidebarSection as toggleSection } from 'state/my-sites/sid
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import MySitesSidebarUnifiedItem from './item';
 import SidebarCustomIcon from 'layout/sidebar/custom-icon';
+import { isExternal } from 'lib/url';
 
-export const MySitesSidebarUnifiedMenu = ( { slug, title, icon, children, path } ) => {
+export const MySitesSidebarUnifiedMenu = ( { slug, title, icon, children, path, link } ) => {
 	const reduxDispatch = useDispatch();
 	const sectionId = 'SIDEBAR_SECTION_' + slug;
 	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
 
 	return (
 		<ExpandableSidebarMenu
-			onClick={ () => reduxDispatch( toggleSection( sectionId ) ) }
+			onClick={ () => {
+				if ( isExternal( link ) ) {
+					// If the URL is external, page() will fail to replace state between different domains
+					document.location.href = link;
+					return;
+				}
+				page( link );
+				reduxDispatch( toggleSection( sectionId ) );
+			} }
 			expanded={ isExpanded }
 			title={ title }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* redirect user when clicking a top level menu if link exists

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run calyspo 
* Add ?flags=nav-unification to the url
* Click on `Posts` or `Pages` UI should load `posts` and `pages` accordingly
* Click on Setting, you should be redirected to wp-admin

![SS 2020-09-29 at 18 33 16](https://user-images.githubusercontent.com/12430020/94580338-7660ee00-0282-11eb-9264-1f2ff746cc85.gif)


Fixes #45963
