### PR TITLE
e2e: Only print console logs when configured to

### DIFF
--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -14,6 +14,7 @@
 	"neverSaveScreenshots": false,
 	"checkForConsoleErrors": false,
 	"logNetworkRequests": false,
+	"printConsoleLogs": false,
 	"reportWarningsToSlack": false,
 	"closeBrowserOnComplete": true,
 	"highlightElements": false,

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -373,13 +373,15 @@ export function checkForConsoleErrors( driver ) {
 }
 
 export function printConsole( driver ) {
-	driver
-		.manage()
-		.logs()
-		.get( 'browser' )
-		.then( ( logs ) => {
-			logs.forEach( ( log ) => console.log( log ) );
-		} );
+	if ( config.get( 'printConsoleLogs' ) === true ) {
+		driver
+			.manage()
+			.logs()
+			.get('browser')
+			.then((logs) => {
+				logs.forEach((log) => console.log(log));
+			});
+	}
 }
 
 export function logPerformance( driver ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change makes it so that the console logs will only print when we want them to. They are too noisy.

#### Testing instructions

* Make sure tests pass and that console logs don't print out when you run the tests locally.