### PR TITLE
Update toolkit plugin to v2.7

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.6.1
+ * Version: 2.7
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.6.1' );
+define( 'PLUGIN_VERSION', '2.7' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.6.1
+Stable tag: 2.7
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.7 =
+* Update post blocks from Newspack to v1.13, fixing bugs related to grid mode.
+* Add new coming soon page patterns.
 
 = 2.6.1 =
 * Fixed an error in the Premium Content token subscription service that causing some fatal errors if the auth token was missing (https://github.com/Automattic/wp-calypso/pull/45878)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -41,7 +41,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 2.7 =
-* Update post blocks from Newspack to v1.13, fixing bugs related to grid mode.
+* Update post blocks from Newspack to v1.13.1, fixing bugs related to grid mode and adding alignment options to post carousel.
 * Add new coming soon page patterns.
 
 = 2.6.1 =

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -41,7 +41,6 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 2.7 =
-* Begin loading patterns from an API. (https://github.com/Automattic/wp-calypso/pull/45926)
 * Improve styles of premium content login button. (https://github.com/Automattic/wp-calypso/pull/46227)
 * Add new coming soon page pattern. (https://github.com/Automattic/wp-calypso/pull/46179)
 * Improve styles of recurring payments block. (https://github.com/Automattic/wp-calypso/pull/46125)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -41,8 +41,12 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 2.7 =
-* Update post blocks from Newspack to v1.13.1, fixing bugs related to grid mode and adding alignment options to post carousel.
-* Add new coming soon page patterns.
+* Begin loading patterns from an API. (https://github.com/Automattic/wp-calypso/pull/45926)
+* Improve styles of premium content login button. (https://github.com/Automattic/wp-calypso/pull/46227)
+* Add new coming soon page pattern. (https://github.com/Automattic/wp-calypso/pull/46179)
+* Improve styles of recurring payments block. (https://github.com/Automattic/wp-calypso/pull/46125)
+* Add extra space to the first block when the page title is hidden. (https://github.com/Automattic/wp-calypso/pull/46003)
+* Update the category of the premium content block. (https://github.com/Automattic/wp-calypso/pull/45978)
 
 = 2.6.1 =
 * Fixed an error in the Premium Content token subscription service that causing some fatal errors if the auth token was missing (https://github.com/Automattic/wp-calypso/pull/45878)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.6.1",
+	"version": "2.7.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Update toolkit plugin to v2.7.

Includes these changes (see https://github.com/Automattic/wp-calypso/commits/master/apps/editing-toolkit)
* ~Begin loading patterns from an API. (https://github.com/Automattic/wp-calypso/pull/45926)~ (reverted)
* New checkout style. (https://github.com/Automattic/wp-calypso/pull/46169)
* Improve styles of premium content login button. (https://github.com/Automattic/wp-calypso/pull/46227)
* Add new coming soon page pattern. (https://github.com/Automattic/wp-calypso/pull/46179)
* Improve styles of recurring payments block. (https://github.com/Automattic/wp-calypso/pull/46125)
* Add extra space to the first block when the page title is hidden. (https://github.com/Automattic/wp-calypso/pull/46003)
* Update the category of the premium content block. (https://github.com/Automattic/wp-calypso/pull/45978)


cc @roo2 @arcangelini @krymson24

#### Testing instructions
- Ensure the above PRs work on both simple and atomic sites.
