### PR TITLE
Notifications: Adding support for spacer blocks to web notification rendering

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -87,6 +87,12 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 					break;
 			}
 			new_container = document.createElement( range_info_type );
+			if ( range_info.hasOwnProperty( 'class' ) ) {
+				new_container.setAttribute( 'class', range_info.class );
+			}
+			if ( range_info.hasOwnProperty( 'style' ) ) {
+				new_container.setAttribute( 'style', range_info.style );
+			}
 			build_chunks( new_sub_text, new_sub_range, range_data, new_container, options );
 			break;
 		case 'gridicon':


### PR DESCRIPTION
### Changes proposed in this Pull Request
This pull request, combined with D50382, updates the notifications app to allow divs marked as spacer blocks to be rendered as allowed tags in web notification previews of posts.

### Testing instructions
* Apply D50382-code in your sandbox and make sure the API is sandboxed.
* Apply this change to calypso, navigate to your Calypso dashboard and open a notification for a post with a spacer block in its content. Verify that the spacer is displayed in the notification post preview. 

Before:
![image](https://user-images.githubusercontent.com/13437011/94611582-8ddead80-0267-11eb-9458-20db8ad372ec.png)

After: 
![image](https://user-images.githubusercontent.com/13437011/94611671-ae0e6c80-0267-11eb-8c22-b139ba3cfc16.png)
