### PR TITLE
Site level payment management: Add cancel domain page

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -34,6 +34,7 @@ class CancelPurchaseButton extends Component {
 	static propTypes = {
 		purchase: PropTypes.object.isRequired,
 		purchaseListUrl: PropTypes.string,
+		getConfirmCancelDomainUrlFor: PropTypes.func,
 		selectedSite: PropTypes.object,
 		siteSlug: PropTypes.string.isRequired,
 		cancelBundledDomain: PropTypes.bool.isRequired,
@@ -43,6 +44,7 @@ class CancelPurchaseButton extends Component {
 
 	static defaultProps = {
 		purchaseListUrl: purchasesRoot,
+		getConfirmCancelDomainUrlFor: confirmCancelDomain,
 	};
 
 	state = {
@@ -83,7 +85,7 @@ class CancelPurchaseButton extends Component {
 		const { id } = this.props.purchase,
 			slug = this.props.siteSlug;
 
-		page( confirmCancelDomain( slug, id ) );
+		page( this.props.getConfirmCancelDomainUrlFor( slug, id ) );
 	};
 
 	cancelPurchase = () => {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -48,6 +48,7 @@ class CancelPurchase extends React.Component {
 	static propTypes = {
 		purchaseListUrl: PropTypes.string,
 		getManagePurchaseUrlFor: PropTypes.func,
+		getConfirmCancelDomainUrlFor: PropTypes.func,
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		includedDomainPurchase: PropTypes.object,
@@ -226,6 +227,7 @@ class CancelPurchase extends React.Component {
 						siteSlug={ this.props.siteSlug }
 						cancelBundledDomain={ this.state.cancelBundledDomain }
 						purchaseListUrl={ this.props.purchaseListUrl }
+						getConfirmCancelDomainUrlFor={ this.props.getConfirmCancelDomainUrlFor }
 					/>
 				</CompactCard>
 			</Fragment>

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -30,7 +30,6 @@ import { isDataLoading } from '../utils';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isDomainRegistration } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
-import Main from 'components/main';
 import notices from 'notices';
 import { cancelPurchase, purchasesRoot } from 'me/purchases/paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
@@ -264,7 +263,7 @@ class ConfirmCancelDomain extends React.Component {
 		const domain = getDomainName( purchase );
 
 		return (
-			<Main className="confirm-cancel-domain">
+			<React.Fragment>
 				<TrackPurchasePageView
 					eventName="calypso_confirm_cancel_domain_purchase_view"
 					purchaseId={ this.props.purchaseId }
@@ -305,7 +304,7 @@ class ConfirmCancelDomain extends React.Component {
 					{ this.renderConfirmationCheckbox() }
 					{ this.renderSubmitButton() }
 				</Card>
-			</Main>
+			</React.Fragment>
 		);
 	}
 }

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -49,6 +49,8 @@ import FormSelect from 'components/forms/form-select';
 
 class ConfirmCancelDomain extends React.Component {
 	static propTypes = {
+		purchaseListUrl: PropTypes.string,
+		getCancelPurchaseUrlFor: PropTypes.func,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		isDomainOnlySite: PropTypes.bool,
 		purchaseId: PropTypes.number.isRequired,
@@ -67,6 +69,11 @@ class ConfirmCancelDomain extends React.Component {
 		submitting: false,
 	};
 
+	static defaultProps = {
+		purchaseListUrl: purchasesRoot,
+		getCancelPurchaseUrlFor: cancelPurchase,
+	};
+
 	componentDidMount() {
 		this.redirectIfDataIsInvalid( this.props );
 	}
@@ -83,7 +90,7 @@ class ConfirmCancelDomain extends React.Component {
 		const { purchase } = props;
 
 		if ( ! purchase || ! isDomainRegistration( purchase ) || ! props.selectedSite ) {
-			page.redirect( purchasesRoot );
+			page.redirect( this.props.purchaseListUrl );
 		}
 	};
 
@@ -150,7 +157,7 @@ class ConfirmCancelDomain extends React.Component {
 				product_slug: purchase.productSlug,
 			} );
 
-			page.redirect( purchasesRoot );
+			page.redirect( this.props.purchaseListUrl );
 		} );
 	};
 
@@ -272,7 +279,12 @@ class ConfirmCancelDomain extends React.Component {
 					path="/me/purchases/:site/:purchaseId/confirm-cancel-domain"
 					title="Purchases > Confirm Cancel Domain"
 				/>
-				<HeaderCake backHref={ cancelPurchase( this.props.siteSlug, this.props.purchaseId ) }>
+				<HeaderCake
+					backHref={ this.props.getCancelPurchaseUrlFor(
+						this.props.siteSlug,
+						this.props.purchaseId
+					) }
+				>
 					{ titles.confirmCancelDomain }
 				</HeaderCake>
 				<Card>

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -84,6 +84,7 @@ export function cancelPurchase( context, next ) {
 
 export function confirmCancelDomain( context, next ) {
 	const state = context.store.getState();
+	const classes = 'confirm-cancel-domain';
 
 	if ( userHasNoSites( state ) ) {
 		return noSites( context, '/me/purchases/:site/:purchaseId/confirm-cancel-domain' );
@@ -92,10 +93,12 @@ export function confirmCancelDomain( context, next ) {
 	setTitle( context, titles.confirmCancelDomain );
 
 	context.primary = (
-		<ConfirmCancelDomain
-			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			siteSlug={ context.params.site }
-		/>
+		<Main className={ classes }>
+			<ConfirmCancelDomain
+				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+				siteSlug={ context.params.site }
+			/>
+		</Main>
 	);
 	next();
 }

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -7,7 +7,12 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { Purchases, PurchaseDetails, PurchaseCancel } from 'my-sites/purchases/main.tsx';
+import {
+	Purchases,
+	PurchaseDetails,
+	PurchaseCancel,
+	PurchaseCancelDomain,
+} from 'my-sites/purchases/main.tsx';
 
 export function redirectToPurchases( context ) {
 	const siteDomain = context.params.site;
@@ -37,6 +42,16 @@ export const purchaseDetails = ( context, next ) => {
 export const purchaseCancel = ( context, next ) => {
 	context.primary = (
 		<PurchaseCancel
+			siteSlug={ context.params.site }
+			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+		/>
+	);
+	next();
+};
+
+export const purchaseCancelDomain = ( context, next ) => {
+	context.primary = (
+		<PurchaseCancelDomain
 			siteSlug={ context.params.site }
 			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 		/>

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -8,7 +8,13 @@ import page from 'page';
  */
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import { purchases, redirectToPurchases, purchaseDetails, purchaseCancel } from './controller';
+import {
+	purchases,
+	redirectToPurchases,
+	purchaseDetails,
+	purchaseCancel,
+	purchaseCancelDomain,
+} from './controller';
 import config from 'config';
 import legacyRouter from 'me/purchases';
 
@@ -49,6 +55,14 @@ export default ( router ) => {
 		siteSelection,
 		navigation,
 		purchaseCancel,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/purchases/subscriptions/:site/:purchaseId/confirm-cancel-domain',
+		siteSelection,
+		navigation,
+		purchaseCancelDomain,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -14,6 +14,12 @@ import FormattedHeader from 'components/formatted-header';
 import ManagePurchase from 'me/purchases/manage-purchase';
 import CancelPurchase from 'me/purchases/cancel-purchase';
 import ConfirmCancelDomain from 'me/purchases/confirm-cancel-domain';
+import {
+	getPurchaseListUrlFor,
+	getCancelPurchaseUrlFor,
+	getConfirmCancelDomainUrlFor,
+	getManagePurchaseUrlFor,
+} from './paths';
 
 export function Purchases() {
 	const translate = useTranslate();
@@ -42,9 +48,6 @@ export function PurchaseDetails( {
 } ) {
 	const translate = useTranslate();
 
-	const getCancelPurchaseUrlFor = ( targetSiteSlug: string, targetPurchaseId: string | number ) =>
-		`/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/cancel`;
-
 	return (
 		<Main className="purchases is-wide-layout">
 			<DocumentHead title={ translate( 'Billing' ) } />
@@ -60,7 +63,7 @@ export function PurchaseDetails( {
 				purchaseId={ purchaseId }
 				siteSlug={ siteSlug }
 				showHeader={ false }
-				purchaseListUrl={ `/purchases/subscriptions/${ siteSlug }` }
+				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 				getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
 			/>
 		</Main>
@@ -75,14 +78,6 @@ export function PurchaseCancel( {
 	siteSlug: string;
 } ) {
 	const translate = useTranslate();
-
-	const getManagePurchaseUrlFor = ( targetSiteSlug: string, targetPurchaseId: string | number ) =>
-		`/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }`;
-
-	const getConfirmCancelDomainUrlFor = (
-		targetSiteSlug: string,
-		targetPurchaseId: string | number
-	) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/confirm-cancel-domain`;
 
 	return (
 		<Main className="purchases is-wide-layout">
@@ -99,7 +94,7 @@ export function PurchaseCancel( {
 				siteSlug={ siteSlug }
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 				getConfirmCancelDomainUrlFor={ getConfirmCancelDomainUrlFor }
-				purchaseListUrl={ `/purchases/subscriptions/${ siteSlug }` }
+				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 			/>
 		</Main>
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -79,6 +79,11 @@ export function PurchaseCancel( {
 	const getManagePurchaseUrlFor = ( targetSiteSlug: string, targetPurchaseId: string | number ) =>
 		`/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }`;
 
+	const getConfirmCancelDomainUrlFor = (
+		targetSiteSlug: string,
+		targetPurchaseId: string | number
+	) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/confirm-cancel-domain`;
+
 	return (
 		<Main className="purchases is-wide-layout">
 			<DocumentHead title={ translate( 'Cancel purchase' ) } />
@@ -93,6 +98,7 @@ export function PurchaseCancel( {
 				purchaseId={ purchaseId }
 				siteSlug={ siteSlug }
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+				getConfirmCancelDomainUrlFor={ getConfirmCancelDomainUrlFor }
 				purchaseListUrl={ `/purchases/subscriptions/${ siteSlug }` }
 			/>
 		</Main>

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -119,7 +119,12 @@ export function PurchaseCancelDomain( {
 				align="left"
 			/>
 
-			<ConfirmCancelDomain purchaseId={ purchaseId } siteSlug={ siteSlug } />
+			<ConfirmCancelDomain
+				purchaseId={ purchaseId }
+				siteSlug={ siteSlug }
+				getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
+				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
+			/>
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -13,6 +13,7 @@ import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import ManagePurchase from 'me/purchases/manage-purchase';
 import CancelPurchase from 'me/purchases/cancel-purchase';
+import ConfirmCancelDomain from 'me/purchases/confirm-cancel-domain';
 
 export function Purchases() {
 	const translate = useTranslate();
@@ -94,6 +95,30 @@ export function PurchaseCancel( {
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 				purchaseListUrl={ `/purchases/subscriptions/${ siteSlug }` }
 			/>
+		</Main>
+	);
+}
+
+export function PurchaseCancelDomain( {
+	purchaseId,
+	siteSlug,
+}: {
+	purchaseId: number;
+	siteSlug: string;
+} ) {
+	const translate = useTranslate();
+
+	return (
+		<Main className="purchases is-wide-layout">
+			<DocumentHead title={ translate( 'Cancel domain' ) } />
+			<FormattedHeader
+				brandFont
+				className="purchases__page-heading"
+				headerText={ translate( 'Cancel domain' ) }
+				align="left"
+			/>
+
+			<ConfirmCancelDomain purchaseId={ purchaseId } siteSlug={ siteSlug } />
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/paths.ts
+++ b/client/my-sites/purchases/paths.ts
@@ -1,0 +1,17 @@
+export const getManagePurchaseUrlFor = (
+	targetSiteSlug: string,
+	targetPurchaseId: string | number
+) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }`;
+
+export const getConfirmCancelDomainUrlFor = (
+	targetSiteSlug: string,
+	targetPurchaseId: string | number
+) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/confirm-cancel-domain`;
+
+export const getCancelPurchaseUrlFor = (
+	targetSiteSlug: string,
+	targetPurchaseId: string | number
+) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/cancel`;
+
+export const getPurchaseListUrlFor = ( targetSiteSlug: string ) =>
+	`/purchases/subscriptions/${ targetSiteSlug }`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a missing piece of the cancel flow to the work committed in https://github.com/Automattic/wp-calypso/pull/45974.

This implements the site-level view for a single domain subscription cancelation flow at the route `/purchases/subscriptions/:site/:purchaseId/confirm-cancel-domain`, mirroring the account-level route for a single subscription which exists at the route `/me/purchases/:site/:purchaseId/confirm-cancel-domain`.

The new route will be available only with the feature flag `site-level-billing`, which is enabled for development and horizon only.

Main project thread: pbOQVh-sc-p2

#### Screenshots

![Screen Shot 2020-09-29 at 5 52 06 PM](https://user-images.githubusercontent.com/2036909/94620527-cb016a80-027c-11eb-97b8-a4b5b50001ff.png)

#### Testing instructions

- Visit `/purchases/subscriptions`.
- If you have multiple sites, verify that you see a site picker and that picking a site adds the site slug to the URL.
- Click on a recent domain purchase in the list.
- Verify that you are redirected to `/purchases/subscriptions/:site/:purchaseId`, and that you see the purchase listed.
- Click on "Cancel subscription and refund" (NOTE: this must be a refundable purchase for this flow to work!)
- Verify that you are redirected to `/purchases/subscriptions/:site/:purchaseId/cancel`, that the sidebar remains at the site-level, and that you see the purchase listed.
- Click the "Back" button in the header inside the page, and verify that you are redirected back to the site-level purchase.
- Verify that the "Cancel Subscription" button redirects you to `/purchases/subscriptions/:site/:purchaseId/confirm-cancel-domain`.
- Click the "Back" button in the header inside the page, and verify that you are redirected back to the site-level purchase.
- Complete the cancelation and verify that you are returned to the site-level purchases page.

Partially addresses #45679