### PR TITLE
Checkout: Add calypso_checkout_composite_plan_length_change event and use it (1)

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -483,6 +483,17 @@ export default function CompositeCheckout( {
 
 	const products = useSelector( ( state ) => getProductsList( state ) );
 
+	const changePlanLength = useCallback(
+		( uuidToReplace, newProductSlug, newProductId ) => {
+			recordEvent( {
+				type: 'CART_CHANGE_PLAN_LENGTH',
+				payload: { newProductSlug },
+			} );
+			changeItemVariant( uuidToReplace, newProductSlug, newProductId );
+		},
+		[ changeItemVariant, recordEvent ]
+	);
+
 	// Often products are added using just the product_slug but missing the
 	// product_id; this adds it.
 	const addItemWithEssentialProperties = useCallback(
@@ -633,7 +644,7 @@ export default function CompositeCheckout( {
 						submitCoupon={ submitCoupon }
 						removeCoupon={ removeCoupon }
 						couponStatus={ couponStatus }
-						changePlanLength={ changeItemVariant }
+						changePlanLength={ changePlanLength }
 						siteId={ siteId }
 						siteUrl={ siteSlug }
 						countriesList={ countriesList }

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -391,6 +391,13 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				case 'CART_ADD_ITEM': {
 					return recordAddEvent( action.payload );
 				}
+				case 'CART_CHANGE_PLAN_LENGTH': {
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_plan_length_change', {
+							new_product_slug: action.payload?.newProductSlug,
+						} )
+					);
+				}
 				case 'THANK_YOU_URL_GENERATED':
 					return reduxDispatch(
 						logStashEventAction( 'thank you url generated', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new tracks event that fires when the term length of a cart item is changed.

#### Testing instructions

First, enable debug logs in the JS console using `localStorage.setItem('debug', 'calypso:composite-checkout:*,composite-checkout:*')` and refresh the page.

1. Enter checkout with a new purchase that has multiple term length options - the simplest is a plan. (Changing the term length is not available for renewals.)
2. Click to `Edit` the cart contents and change the term length of a product, e.g. from 1 year to 2 years.
3. Watch the JS console for a `heard checkout event` notice with type `CART_CHANGE_PLAN_LENGTH`.

![image](https://user-images.githubusercontent.com/9310939/94620023-891ff680-0273-11eb-9ba0-cab40b9bf21f.png)

4. Watch for your event named `calypso_checkout_composite_plan_length_change` to appear in tracks; this will take a few minutes.

![image](https://user-images.githubusercontent.com/9310939/94620054-963ce580-0273-11eb-9183-2e9b83a8e0b4.png)

5. Verify that changing the term length works as expected in checkout (e.g. changes the displayed price and updates the selected term length in the radio buttons)