### PR TITLE
Update/site level links

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -575,6 +575,7 @@ class ManagePurchase extends Component {
 			purchaseAttachedTo,
 			isPurchaseTheme,
 			translate,
+			getManagePurchaseUrlFor,
 		} = this.props;
 
 		let editCardDetailsPath = false;
@@ -624,6 +625,7 @@ class ManagePurchase extends Component {
 						purchaseAttachedTo={ purchaseAttachedTo }
 						renewableSitePurchases={ renewableSitePurchases }
 						editCardDetailsPath={ editCardDetailsPath }
+						getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 					/>
 				) }
 				<AsyncLoad

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -80,7 +80,7 @@ import QuerySiteDomains from 'components/data/query-site-domains';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import RemovePurchase from '../remove-purchase';
 import VerticalNavItem from 'components/vertical-nav/item';
-import { cancelPurchase, purchasesRoot } from '../paths';
+import { cancelPurchase, managePurchase, purchasesRoot } from '../paths';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import titles from 'me/purchases/titles';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -104,6 +104,7 @@ class ManagePurchase extends Component {
 		purchaseListUrl: PropTypes.string,
 		getCancelPurchaseUrlFor: PropTypes.func,
 		getAddPaymentMethodUrlFor: PropTypes.func,
+		getManagePurchaseUrlFor: PropTypes.func,
 		cardTitle: PropTypes.string,
 		hasLoadedDomains: PropTypes.bool,
 		hasLoadedSites: PropTypes.bool.isRequired,
@@ -125,6 +126,7 @@ class ManagePurchase extends Component {
 		getAddPaymentMethodUrlFor: getEditCardDetailsPath,
 		cardTitle: titles.managePurchase,
 		getCancelPurchaseUrlFor: cancelPurchase,
+		getManagePurchaseUrlFor: managePurchase,
 	};
 
 	state = {
@@ -455,6 +457,8 @@ class ManagePurchase extends Component {
 	}
 
 	renderPlaceholder() {
+		const { siteSlug, getManagePurchaseUrlFor } = this.props;
+
 		return (
 			<Fragment>
 				<PurchaseSiteHeader isPlaceholder />
@@ -469,7 +473,11 @@ class ManagePurchase extends Component {
 						<span className="manage-purchase__settings-link" />
 					</div>
 
-					<PurchaseMeta purchaseId={ false } siteSlug={ this.props.siteSlug } />
+					<PurchaseMeta
+						purchaseId={ false }
+						siteSlug={ siteSlug }
+						getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+					/>
 				</Card>
 				<PurchasePlanDetails isPlaceholder />
 				<VerticalNavItem isPlaceholder />
@@ -494,7 +502,7 @@ class ManagePurchase extends Component {
 			return this.renderPlaceholder();
 		}
 
-		const { purchase, siteId, translate } = this.props;
+		const { purchase, siteId, translate, getManagePurchaseUrlFor, siteSlug } = this.props;
 
 		const classes = classNames( 'manage-purchase__info', {
 			'is-expired': purchase && isExpired( purchase ),
@@ -537,7 +545,11 @@ class ManagePurchase extends Component {
 					</header>
 					{ this.renderPlanDescription() }
 					{ ! isPartnerPurchase( purchase ) && (
-						<PurchaseMeta purchaseId={ purchase.id } siteSlug={ this.props.siteSlug } />
+						<PurchaseMeta
+							purchaseId={ purchase.id }
+							siteSlug={ siteSlug }
+							getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+						/>
 					) }
 					{ preventRenewal ? this.renderSelectNewButton() : this.renderRenewButton() }
 				</Card>

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -63,6 +63,11 @@ class PurchaseNotice extends Component {
 		renewableSitePurchases: PropTypes.arrayOf( PropTypes.object ),
 		selectedSite: PropTypes.object,
 		editCardDetailsPath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+		getManagePurchaseUrlFor: PropTypes.func,
+	};
+
+	static defaultProps = {
+		getManagePurchaseUrlFor: managePurchase,
 	};
 
 	state = {
@@ -248,7 +253,14 @@ class PurchaseNotice extends Component {
 	};
 
 	renderPurchaseExpiringNotice() {
-		const { moment, purchase, purchaseAttachedTo, selectedSite, translate } = this.props;
+		const {
+			moment,
+			purchase,
+			purchaseAttachedTo,
+			selectedSite,
+			translate,
+			getManagePurchaseUrlFor,
+		} = this.props;
 
 		// For purchases included with a plan (for example, a domain mapping
 		// bundled with the plan), the plan purchase is used on this page when
@@ -287,7 +299,9 @@ class PurchaseNotice extends Component {
 						expiry: moment( currentPurchase.expiryDate ).fromNow(),
 					},
 					components: {
-						managePurchase: <a href={ managePurchase( selectedSite.slug, currentPurchase.id ) } />,
+						managePurchase: (
+							<a href={ getManagePurchaseUrlFor( selectedSite.slug, currentPurchase.id ) } />
+						),
 					},
 				}
 			);
@@ -322,6 +336,7 @@ class PurchaseNotice extends Component {
 			purchaseAttachedTo,
 			selectedSite,
 			renewableSitePurchases,
+			getManagePurchaseUrlFor,
 		} = this.props;
 
 		if ( ! config.isEnabled( 'upgrades/upcoming-renewals-notices' ) ) {
@@ -392,7 +407,9 @@ class PurchaseNotice extends Component {
 						onClick={ this.openUpcomingRenewalsDialog }
 					/>
 				),
-				managePurchase: <a href={ managePurchase( selectedSite.slug, currentPurchase.id ) } />,
+				managePurchase: (
+					<a href={ getManagePurchaseUrlFor( selectedSite.slug, currentPurchase.id ) } />
+				),
 			},
 		};
 
@@ -841,7 +858,13 @@ class PurchaseNotice extends Component {
 	};
 
 	renderExpiredRenewNotice() {
-		const { purchase, purchaseAttachedTo, selectedSite, translate } = this.props;
+		const {
+			purchase,
+			purchaseAttachedTo,
+			selectedSite,
+			translate,
+			getManagePurchaseUrlFor,
+		} = this.props;
 
 		// For purchases included with a plan (for example, a domain mapping
 		// bundled with the plan), the plan purchase is used on this page when
@@ -877,7 +900,9 @@ class PurchaseNotice extends Component {
 						includedPurchaseName: getName( includedPurchase ),
 					},
 					components: {
-						managePurchase: <a href={ managePurchase( selectedSite.slug, currentPurchase.id ) } />,
+						managePurchase: (
+							<a href={ getManagePurchaseUrlFor( selectedSite.slug, currentPurchase.id ) } />
+						),
 					},
 				}
 			);

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -61,12 +61,14 @@ class PurchaseMeta extends Component {
 		purchase: PropTypes.object,
 		site: PropTypes.object,
 		siteSlug: PropTypes.string.isRequired,
+		getManagePurchaseUrlFor: PropTypes.func,
 	};
 
 	static defaultProps = {
 		hasLoadedSites: false,
 		hasLoadedUserPurchasesFromServer: false,
 		purchaseId: false,
+		getManagePurchaseUrlFor: managePurchase,
 	};
 
 	renderPrice() {
@@ -163,10 +165,10 @@ class PurchaseMeta extends Component {
 	}
 
 	renderRenewsOrExpiresOn() {
-		const { moment, purchase, siteSlug, translate } = this.props;
+		const { moment, purchase, siteSlug, translate, getManagePurchaseUrlFor } = this.props;
 
 		if ( isIncludedWithPlan( purchase ) ) {
-			const attachedPlanUrl = managePurchase( siteSlug, purchase.attachedToPurchaseId );
+			const attachedPlanUrl = getManagePurchaseUrlFor( siteSlug, purchase.attachedToPurchaseId );
 
 			return (
 				<span>

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -68,6 +68,7 @@ export function PurchaseDetails( {
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 				getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
 				getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
+				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 			/>
 		</Main>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates some links in the payments management screens to retain the context from which they are clicked in. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/94640278-331b7500-02ac-11eb-97e8-c73156c5bb8b.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/94640292-3e6ea080-02ac-11eb-9cad-e51e79a16fae.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the `site-level-billing` flag
* Visit the new site level billing section
* Visit a domain mapping product attached to a plan created with credits
*  Click on the `Renews with Plan` link or the plan link in the notice. Confirm that you remain in the site-level context.
* Do the same from the Account level and confirm that it retains the account level context

Fixes https://github.com/Automattic/wp-calypso/issues/46004
