### PR TITLE
Try: simple single page signup flow

### DIFF
--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -9,7 +9,7 @@ import { useI18n } from '@automattic/react-i18n';
 /**
  * Internal dependencies
  */
-import { Step, usePath, useCurrentStep, useSinglePageQueryParam, StepType } from '../path';
+import { Step, usePath, useCurrentStep, useFlowRouteParam, StepType } from '../path';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
 import { useNewSiteVisibility, useHasPaidPlanFromPath } from './use-selected-plan';
@@ -30,7 +30,7 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	const makePath = usePath();
 	const history = useHistory();
 	const currentStep = useCurrentStep();
-	const isSinglePageFlow = useSinglePageQueryParam();
+	const flow = useFlowRouteParam();
 	const { i18nLocale } = useI18n();
 
 	// If the user enters a site title on Intent Capture step we are showing Domains step next.
@@ -94,7 +94,7 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	}
 
 	// Experimental, simple, single page -site flow
-	if ( isSinglePageFlow ) {
+	if ( flow === 'single-page' ) {
 		steps = [ Step.DesignSelection ];
 	}
 

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -9,7 +9,7 @@ import { useI18n } from '@automattic/react-i18n';
 /**
  * Internal dependencies
  */
-import { Step, usePath, useCurrentStep, StepType } from '../path';
+import { Step, usePath, useCurrentStep, useSinglePageQueryParam, StepType } from '../path';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
 import { useNewSiteVisibility, useHasPaidPlanFromPath } from './use-selected-plan';
@@ -30,6 +30,7 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	const makePath = usePath();
 	const history = useHistory();
 	const currentStep = useCurrentStep();
+	const isSinglePageFlow = useSinglePageQueryParam();
 	const { i18nLocale } = useI18n();
 
 	// If the user enters a site title on Intent Capture step we are showing Domains step next.
@@ -90,6 +91,11 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 		( ! steps.includes( Step.Features ) && plan && ! hasUsedPlansStep )
 	) {
 		steps = steps.filter( ( step ) => step !== Step.Plans && step !== Step.Features );
+	}
+
+	// Experimental, simple, single page -site flow
+	if ( isSinglePageFlow ) {
+		steps = [ Step.DesignSelection ];
 	}
 
 	const currentStepIndex = steps.findIndex( ( step ) => step === Step[ currentStep ] );

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -96,3 +96,8 @@ export function useCurrentStep() {
 export function useNewQueryParam() {
 	return new URLSearchParams( useLocation().search ).has( 'new' );
 }
+
+// Returns true if the url has a `?single-page`
+export function useSinglePageQueryParam() {
+	return new URLSearchParams( useLocation().search ).has( 'single-page' );
+}

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -36,6 +36,7 @@ const routeFragments = {
 	step: `:step(${ steps.join( '|' ) })?`,
 	plan: `:plan(${ plansPaths.join( '|' ) })?`,
 	lang: getLanguageRouteParam(),
+	flow: `:flow(single-page)?`,
 };
 
 export const path = [ '', ...Object.values( routeFragments ) ].join( '/' );
@@ -46,14 +47,16 @@ export type StepNameType = keyof typeof Step;
 export function usePath() {
 	const langParam = useLangRouteParam();
 	const planParam = usePlanRouteParam();
+	const flowParam = useFlowRouteParam();
 
-	return ( step?: StepType, lang?: string, plan?: string ) => {
+	return ( step?: StepType, lang?: string, plan?: string, flow?: string ) => {
 		// When lang is null, remove lang.
 		// When lang is empty or undefined, get lang from route param.
 		lang = lang === null ? '' : lang || langParam;
 		plan = plan === null ? '' : plan || planParam;
+		flow = flow === null ? '' : flow || flowParam;
 
-		if ( ! step && ! lang && ! plan ) {
+		if ( ! step && ! lang && ! plan && ! flow ) {
 			return '/';
 		}
 
@@ -62,6 +65,7 @@ export function usePath() {
 				step,
 				plan,
 				lang,
+				flow,
 			} );
 		} catch {
 			// If we get an invalid lang or plan, `generatePath` throws a TypeError.
@@ -85,6 +89,12 @@ export function usePlanRouteParam() {
 	return match?.params.plan;
 }
 
+// Returns true if the url has e.g. `*/single-page` flow name
+export function useFlowRouteParam() {
+	const match = useRouteMatch< { flow?: string } >( path );
+	return match?.params.flow;
+}
+
 export function useCurrentStep() {
 	const stepRouteParam = useStepRouteParam();
 	return findKey( Step, ( step ) => step === stepRouteParam ) as StepNameType;
@@ -95,9 +105,4 @@ export function useCurrentStep() {
 // be triggered.
 export function useNewQueryParam() {
 	return new URLSearchParams( useLocation().search ).has( 'new' );
-}
-
-// Returns true if the url has a `?single-page`
-export function useSinglePageQueryParam() {
-	return new URLSearchParams( useLocation().search ).has( 'single-page' );
 }

--- a/config/development.json
+++ b/config/development.json
@@ -67,6 +67,7 @@
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch": true,
 		"gutenboarding/show-vertical-input": false,
+		"gutenboarding/site-editor": true,
 		"help": true,
 		"help/courses": true,
 		"home/layout-dev": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,6 +53,7 @@
 		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch": true,
+		"gutenboarding/site-editor": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
Experimental flow for:
- Enter a site name
- Pick FSE design
- Signup/login if not already
- Land in the editor

Try via `/new/single-page?fresh`

Context p4hfux-5in-p2