### PR TITLE
Site Settings: Fix styles of number fields

### DIFF
--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -27,7 +27,7 @@
 		margin-top: 24px; // Give labels some margin when they immediately follow a select
 	}
 
-	input[type='number'] {
+	input[type='number'].form-text-input {
 		padding: 0;
 		width: 50px;
 		text-align: center;


### PR DESCRIPTION
Site settings define styles for some fields a bit invasively. Under some circumstances (it appears to be hard to reproduce), when the settings stylesheet is loaded first, we're seeing this:

![](https://cldup.com/5jKm_DyiLD.png)

while it should always be looking like this:

![](https://cldup.com/92ML7e0PVM.png)

This PR updates the style specificity to address this.

#### Changes proposed in this Pull Request

* Site Settings: Fix styles of number fields

#### Testing instructions

* Go to `/settings/discussion/:site`
* Verify all number fields are looking good.

