### PR TITLE
Add premium domain tracking

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -81,7 +81,9 @@ class DomainRegistrationSuggestion extends React.Component {
 	recordRender() {
 		if ( this.props.railcarId && isNumber( this.props.uiPosition ) ) {
 			let resultSuffix = '';
-			if ( this.props.suggestion.isRecommended ) {
+			if ( this.props.suggestion.is_premium ) {
+				resultSuffix = '#premium';
+			} else if ( this.props.suggestion.isRecommended ) {
 				resultSuffix = '#recommended';
 			} else if ( this.props.suggestion.isBestAlternative ) {
 				resultSuffix = '#best-alternative';

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -81,12 +81,14 @@ class DomainRegistrationSuggestion extends React.Component {
 	recordRender() {
 		if ( this.props.railcarId && isNumber( this.props.uiPosition ) ) {
 			let resultSuffix = '';
-			if ( this.props.suggestion.is_premium ) {
-				resultSuffix = '#premium';
-			} else if ( this.props.suggestion.isRecommended ) {
+			if ( this.props.suggestion.isRecommended ) {
 				resultSuffix = '#recommended';
 			} else if ( this.props.suggestion.isBestAlternative ) {
 				resultSuffix = '#best-alternative';
+			}
+
+			if ( this.props.suggestion.is_premium ) {
+				resultSuffix = resultSuffix + '#premium';
 			}
 
 			this.props.recordTracksEvent( 'calypso_traintracks_render', {

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -87,16 +87,13 @@ class DomainRegistrationSuggestion extends React.Component {
 				resultSuffix = '#best-alternative';
 			}
 
-			if ( this.props.suggestion.is_premium ) {
-				resultSuffix = resultSuffix + '#premium';
-			}
-
 			this.props.recordTracksEvent( 'calypso_traintracks_render', {
 				railcar: this.props.railcarId,
 				ui_position: this.props.uiPosition,
 				fetch_algo: `${ this.props.fetchAlgo }/${ this.props.suggestion.vendor }`,
 				rec_result: `${ this.props.suggestion.domain_name }${ resultSuffix }`,
 				fetch_query: this.props.query,
+				domain_type: this.props.suggestion.is_premium ? 'premium' : 'standard',
 			} );
 		}
 	}

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -111,9 +111,10 @@ class DomainSearch extends Component {
 			domain_name: domain,
 			product_slug: productSlug,
 			supports_privacy: supportsPrivacy,
+			is_premium: isPremium,
 		} = suggestion;
 
-		this.props.recordAddDomainButtonClick( domain, 'domains' );
+		this.props.recordAddDomainButtonClick( domain, 'domains', isPremium );
 
 		let registration = domainRegistration( {
 			domain,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -190,7 +190,11 @@ class DomainsStep extends React.Component {
 			suggestion,
 		};
 
-		this.props.recordAddDomainButtonClick( suggestion.domain_name, this.getAnalyticsSection() );
+		this.props.recordAddDomainButtonClick(
+			suggestion.domain_name,
+			this.getAnalyticsSection(),
+			suggestion?.is_premium
+		);
 		this.props.saveSignupStep( stepData );
 
 		defer( () => {

--- a/client/state/domains/actions.js
+++ b/client/state/domains/actions.js
@@ -5,7 +5,7 @@ import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/an
 
 import 'state/domains/init';
 
-export const recordAddDomainButtonClick = ( domainName, section ) =>
+export const recordAddDomainButtonClick = ( domainName, section, isPremium = false ) =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Search',
@@ -16,6 +16,7 @@ export const recordAddDomainButtonClick = ( domainName, section ) =>
 		recordTracksEvent( 'calypso_domain_search_add_button_click', {
 			domain_name: domainName,
 			section,
+			is_premium: isPremium,
 		} )
 	);
 


### PR DESCRIPTION
Recently we introduced premium domain purchases in Calypso but we never added any tracking to those so we don't know how often those are suggested or clicked on so here's a small update to fix that.

#### Changes proposed in this Pull Request

* ~Add railcar suffix for premium domains~
* Add is_premium property to the `calypso_domain_search_add_button_click` tracks event
* Add `domain_type` property to the traintracks event

#### Testing instructions

* Verify that when premium domains are rendered there is a `#premium` railcar suffix
* Verify that when you click on a premium domain you'll get `is_premium` set to `true` in `calypso_domain_search_add_button_click`
