### PR TITLE
Update/remove coming soon option

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -300,8 +300,8 @@ export class SiteSettingsFormGeneral extends Component {
 			translate,
 		} = this.props;
 		const blogPublic = parseInt( fields.blog_public, 10 );
-		const wpcomComingSoon = parseInt( fields.wpcom_coming_soon, 10 );
-		const wasWpcomComingSoon = parseInt( fields.was_wpcom_coming_soon, 10 );
+		const wpcomComingSoon = 1 === parseInt( fields.wpcom_coming_soon, 10 );
+		const wasWpcomComingSoon = 1 === parseInt( fields.was_wpcom_coming_soon, 10 );
 		const showComingSoonOption =
 			! config.isEnabled( 'coming-soon-v2' ) || wasWpcomComingSoon || wpcomComingSoon;
 
@@ -315,7 +315,7 @@ export class SiteSettingsFormGeneral extends Component {
 							<FormRadio
 								name="blog_public"
 								value="-1"
-								checked={ -1 === blogPublic && 1 === wpcomComingSoon }
+								checked={ -1 === blogPublic && wpcomComingSoon }
 								onChange={ () =>
 									this.handleVisibilityOptionChange( {
 										blog_public: -1,

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -301,12 +301,15 @@ export class SiteSettingsFormGeneral extends Component {
 		} = this.props;
 		const blogPublic = parseInt( fields.blog_public, 10 );
 		const wpcomComingSoon = parseInt( fields.wpcom_coming_soon, 10 );
+		const wasWpcomComingSoon = parseInt( fields.was_wpcom_coming_soon, 10 );
+		const showComingSoonOption =
+			! config.isEnabled( 'coming-soon-v2' ) || wasWpcomComingSoon || wpcomComingSoon;
 
 		const isNonAtomicJetpackSite = siteIsJetpack && ! siteIsAtomic;
 
 		return (
 			<FormFieldset>
-				{ ! isNonAtomicJetpackSite && ! isWPForTeamsSite && (
+				{ ! isNonAtomicJetpackSite && ! isWPForTeamsSite && showComingSoonOption && (
 					<>
 						<FormLabel className="site-settings__visibility-label is-coming-soon">
 							<FormRadio
@@ -700,9 +703,10 @@ const getFormSettings = ( settings ) => {
 		lang_id: settings.lang_id,
 		blog_public: settings.blog_public,
 		timezone_string: settings.timezone_string,
-	};
 
-	formSettings.wpcom_coming_soon = settings.wpcom_coming_soon;
+		wpcom_coming_soon: settings.wpcom_coming_soon,
+		was_wpcom_coming_soon: settings.wpcom_coming_soon,
+	};
 
 	// handling `gmt_offset` and `timezone_string` values
 	const gmt_offset = settings.gmt_offset;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disables the Coming Soon option in under the site settings privacy section if the config flag `coming-soon-v2` is enabled.

#### Testing instructions

```
yarn run test-client:watch client/my-sites/site-settings/test/form-general.jsx
```

I've added some basic test coverage but this one probably needs some manual testing to double check the transition works properly.

The below should behave the same regardless of v2 being enabled (e.g. `define( 'WPCOM_PUBLIC_COMING_SOON', true );` )


Should show existing coming soon settings, switching to public/private and saving settings should remove the option: 
```
http://calypso.localhost:3000/settings/general/<yourtestsite>.wo\rdpress.com?flags=coming-soon-v2
```

Should behave like production:
```
http://calypso.localhost:3000/settings/general/<yourtestsite>.wo\rdpress.com?flags=coming-soon-v2=false
```

e.g. 

```
http://wordpress.com/settings/general/<yourtestsite>.wo\rdpress.com
```

props: @roo2 / @ramonjd (alot of code got squashed/rebased out of #45606 / #45896
