### PR TITLE
Use masterbar height var instead of explicit values

### DIFF
--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -6,7 +6,7 @@
 
 #wpnc-panel {
 	position: fixed;
-	top: 47px;
+	top: var( --masterbar-height );
 	right: 0;
 	bottom: 0;
 	min-width: 400px;
@@ -37,13 +37,13 @@
 	}
 
 	&.wpnc__main .wpnc__single-view {
-			left: inherit;
-			width: 400px;
+		left: inherit;
+		width: 400px;
 
-			@include breakpoint-deprecated( '<800px' ) {
-		    	left: 0;
-				width: auto;
-		  }
+		@include breakpoint-deprecated( '<800px' ) {
+			left: 0;
+			width: auto;
+		}
 	}
 
 	@include breakpoint-deprecated( '<800px' ) {

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -44,12 +44,12 @@
 	}
 
 	// client/layout/masterbar/style.scss
-
 	.masterbar__item-new,
 	.masterbar__toggle-drafts.button.is-borderless {
 		height: 24px;
 		margin: 4px 8px;
-		border-radius: 2px;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 5px;
 	}
 
 	.masterbar__item-new {

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -11,38 +11,29 @@
  */
 
 .is-nav-unification {
+	// breakpoint used in wp-admin
+	@media only screen and ( min-width: 782px ) {
+		--masterbar-height: 32px;
+	}
 	$nav-unification-primary: #23282d;
 	$nav-unification-secondary: #101517;
-	$nav-unification-masterbar-height: 32px;
-	$nav-unification-masterbar-height-mobile: 46px;
 	$nav-unification-masterbar-font-size: 13px;
 
 	// packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
 	--color-masterbar-background: #101517;
+	--color-masterbar-border: #333;
 	--color-masterbar-item-hover-background: #333;
 	--color-masterbar-item-active-background: #23282d;
 
-	// client/layout/style.scss
-	.layout__secondary {
-		top: $nav-unification-masterbar-height;
-	}
-
 	// client/layout/masterbar/style.scss
 	.masterbar {
-		height: $nav-unification-masterbar-height;
-		border-bottom: none;
 		font-size: $nav-unification-masterbar-font-size;
-		-webkit-box-shadow: inset 0 -1px 0 var( --color-masterbar-item-hover-background );
-		-moz-box-shadow: inset 0 -1px 0 var( --color-masterbar-item-hover-background );
-		box-shadow: inset 0 -1px 0 var( --color-masterbar-item-hover-background );
 	}
 
 	// client/layout/masterbar/style.scss
 	.masterbar__item {
-		height: $nav-unification-masterbar-height;
 		padding: 0 8px;
 		font-size: $nav-unification-masterbar-font-size;
-		line-height: $nav-unification-masterbar-height;
 	}
 
 	// client/layout/masterbar/style.scss
@@ -57,7 +48,7 @@
 	.masterbar__toggle-drafts.button.is-borderless {
 		height: 24px;
 		margin: 4px 8px;
-		border-radius: 5px;
+		border-radius: 2px;
 	}
 
 	.masterbar__item-new {
@@ -115,11 +106,6 @@
 		}
 	}
 
-	// apps/notifications/style.scss
-	#wpnc-panel {
-		top: $nav-unification-masterbar-height;
-	}
-
 	// client/layout/masterbar/style.scss
 	.masterbar__item-notifications .masterbar__notifications-bubble {
 		top: 3px;
@@ -141,24 +127,9 @@
 			padding: 71px 24px 24px;
 		}
 
-		.layout__secondary {
-			top: $nav-unification-masterbar-height-mobile;
-		}
-
 		.layout.focus-sites:not( .is-section-post-editor ) .layout__primary .main,
 		.layout.focus-sidebar:not( .is-section-post-editor ) .layout__primary .main {
 			transform: translateX( 100% );
-		}
-
-		// client/layout/masterbar/style.scss
-		.masterbar {
-			height: $nav-unification-masterbar-height-mobile;
-		}
-
-		// client/layout/masterbar/style.scss
-		.masterbar__item {
-			height: $nav-unification-masterbar-height-mobile;
-			line-height: $nav-unification-masterbar-height-mobile;
 		}
 
 		// client/layout/masterbar/style.scss
@@ -174,11 +145,6 @@
 			.masterbar__item-content {
 				display: block;
 			}
-		}
-
-		// apps/notifications/style.scss
-		#wpnc-panel {
-			top: $nav-unification-masterbar-height-mobile;
 		}
 
 		// client/layout/masterbar/style.scss

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -13,6 +13,7 @@
 .is-nav-unification {
 	// breakpoint used in wp-admin
 	@media only screen and ( min-width: 782px ) {
+		// client/assets/stylesheets/shared/_variables.scss
 		--masterbar-height: 32px;
 	}
 	$nav-unification-primary: #23282d;

--- a/client/assets/stylesheets/shared/_variables.scss
+++ b/client/assets/stylesheets/shared/_variables.scss
@@ -3,6 +3,9 @@
 // =======================
 
 :root {
+	// Masterbar
+	--masterbar-height: 46px;
+
 	// Sidebar size limits
 	--sidebar-width-max: 272px;
 	--sidebar-width-min: 228px;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -1,5 +1,3 @@
-
-
 // Styles targeted at story content
 @import './_content.scss';
 
@@ -63,7 +61,7 @@
 	@include breakpoint-deprecated( '>660px' ) {
 		border: 0;
 		position: absolute;
-		top: 47px;
+		top: var( --masterbar-height );
 		z-index: 0;
 	}
 

--- a/client/components/back-button/style.scss
+++ b/client/components/back-button/style.scss
@@ -1,8 +1,8 @@
 .back-button {
 	margin: 0;
 	position: fixed;
-		top: 47px;
-		left: 0;
+	top: var( --masterbar-height );
+	left: 0;
 	z-index: z-index( '.masterbar', '.reader-back' );
 
 	.button.is-compact.is-borderless {
@@ -24,7 +24,7 @@
 }
 
 .back-button__label {
-	@include breakpoint-deprecated( '<660px') {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -4,27 +4,27 @@
 
 	z-index: z-index( 'root', '.global-notices' );
 	position: fixed;
-		top: auto;
-		right: 0;
-		bottom: 0;
-		left: 0;
+	top: auto;
+	right: 0;
+	bottom: 0;
+	left: 0;
 
 	@include breakpoint-deprecated( '>660px' ) {
-			top: 47px + 16px;
-			right: 16px;
-			bottom: auto;
-			left: auto;
+		top: calc( var( --masterbar-height ) + 16px );
+		right: 16px;
+		bottom: auto;
+		left: auto;
 		max-width: calc( 100% - 32px );
 	}
 
 	@include breakpoint-deprecated( '>960px' ) {
-			top: 47px + 24px;
-			right: 24px;
+		top: calc( var( --masterbar-height ) + 24px );
+		right: 24px;
 		max-width: calc( 100% - 48px );
 	}
 
 	@include breakpoint-deprecated( '>1040px' ) {
-			right: 32px;
+		right: 32px;
 		max-width: calc( 100% - 64px );
 	}
 }
@@ -48,6 +48,7 @@
 		border-radius: 2px;
 
 		.notice__icon-wrapper {
+			/* stylelint-disable-next-line scales/radii */
 			border-radius: 2px 0 0 3px;
 		}
 	}

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -48,7 +48,7 @@
 		& > .mce-toolbar-grp,
 		&::after {
 			position: fixed;
-			top: 47px;
+			top: var( --masterbar-height );
 		}
 
 		& > .mce-toolbar-grp {
@@ -179,6 +179,7 @@
 	}
 }
 
+/* stylelint-disable-next-line selector-combinator-space-before */
 .mce-toolbar
 	.mce-btn-group
 	.mce-btn.mce-toolbar-segment-end:not( .mce-hidden )

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -13,7 +13,7 @@
 	border-bottom: 1px solid var( --color-neutral-10 );
 	position: fixed;
 	z-index: z-index( 'root', '.sticky-panel.is-sticky .sticky-panel__content' );
-	top: 47px;
+	top: var( --masterbar-height );
 	left: 0;
 
 	@include breakpoint-deprecated( '>480px' ) {
@@ -57,7 +57,8 @@
 		color: var( --color-neutral-40 );
 		margin: 2px 0 -3px;
 
-		a, a:hover {
+		a,
+		a:hover {
 			color: var( --color-neutral-40 );
 		}
 	}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -155,7 +155,7 @@
 			padding-left: 7px;
 			position: fixed;
 			width: 100%;
-			top: 47px;
+			top: var( --masterbar-height );
 			left: 0;
 			min-height: 46px;
 			z-index: z-index( 'root', '.sticky-panel.is-sticky .sticky-panel__content' );

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1,4 +1,3 @@
-$masterbar-height: 46px;
 $autobar-height: 20px;
 
 // The WordPress.com Masterbar
@@ -8,7 +7,7 @@ $autobar-height: 20px;
 	color: var( --color-masterbar-text );
 	font-size: $font-body;
 	display: flex;
-	height: $masterbar-height;
+	height: var( --masterbar-height );
 	margin: 0;
 	position: fixed;
 	left: 0;
@@ -17,6 +16,7 @@ $autobar-height: 20px;
 	z-index: z-index( 'root', '.masterbar' );
 	-webkit-font-smoothing: subpixel-antialiased;
 	transition: transform 0.2s ease-out;
+	box-sizing: border-box;
 
 	.is-support-session & {
 		// Use generic colors so that they override whatever theme colors the user has picked.
@@ -104,8 +104,8 @@ $autobar-height: 20px;
 	position: relative;
 	color: var( --color-masterbar-text );
 	font-size: $font-body-small;
-	height: $masterbar-height;
-	line-height: $masterbar-height;
+	height: var( --masterbar-height );
+	line-height: var( --masterbar-height );
 	padding: 0 15px;
 	text-decoration: none;
 	cursor: default;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -96,7 +96,7 @@
 // the site-selector elements.
 .layout__secondary {
 	position: fixed;
-	top: 47px;
+	top: var( --masterbar-height );
 	left: 0;
 	bottom: 0;
 	color: var( --color-sidebar-text );

--- a/client/lib/directly/style.scss
+++ b/client/lib/directly/style.scss
@@ -6,7 +6,7 @@
 .directly-rtm:not( .is-minimized ) {
 	padding: 0 !important;
 	max-height: none !important;
-	top: 47px;
+	top: var( --masterbar-height );
 	height: auto !important;
 	box-shadow: -3px 1px 10px rgba( 46, 68, 83, 0.1 );
 	border-left: 1px solid #d9e3ea;

--- a/client/me/happychat/style.scss
+++ b/client/me/happychat/style.scss
@@ -12,32 +12,26 @@
 	flex-direction: column;
 	box-sizing: border-box;
 	top: 0;
-	margin-top: 47px;
+	margin-top: var( --masterbar-height );
 	left: 273px;
 	right: 0;
 	bottom: 0;
 }
 
 @include breakpoint-deprecated( '>1040px' ) {
-
 	.happychat__page .happychat__timeline-message {
 		max-width: 80%;
 	}
-
 }
 
 @include breakpoint-deprecated( '<960px' ) {
-
 	.happychat__page {
 		left: 229px;
 	}
-
 }
 
 @include breakpoint-deprecated( '<660px' ) {
-
 	.happychat__page {
-			left: 0;
+		left: 0;
 	}
-
 }

--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -86,9 +86,7 @@
 
 .plans-filter-bar.sticky {
 	position: fixed;
-
-	// This is the height of the masterbar
-	top: 47px;
+	top: var( --masterbar-height );
 
 	width: 100%;
 	max-width: 1040px;

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -1,6 +1,6 @@
 .editor-sidebar {
 	position: fixed;
-	top: 46px;
+	top: var( --masterbar-height );
 	right: calc( -1 * var( --sidebar-width-max ) );
 	bottom: 0;
 	display: flex;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -16,7 +16,7 @@
 	background-color: var( --color-surface );
 	position: fixed;
 	top: 0;
-	margin-top: 47px; // masterbar is exactly 47px
+	margin-top: var( --masterbar-height );
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
 

--- a/packages/components/src/dialog/style.scss
+++ b/packages/components/src/dialog/style.scss
@@ -11,12 +11,12 @@
 	justify-content: center;
 	position: fixed;
 	right: 0;
-	top: 46px;
+	top: var( --masterbar-height );
 	transition: background-color 0.2s ease-in;
 	z-index: z-index(
-        'root',
-        '.dialog__backdrop'
-    ); // try to ensure that dialogs are on top of everything else
+		'root',
+		'.dialog__backdrop'
+	); // try to ensure that dialogs are on top of everything else
 
 	// covers the masterbar as well
 	&.is-full-screen {
@@ -54,6 +54,7 @@
 
 	h1 {
 		color: var( --color-neutral-70 );
+		/* stylelint-disable-next-line scales/font-size */
 		font-size: 1.375em;
 		font-weight: 600;
 		margin-bottom: 0.5em;


### PR DESCRIPTION
There are many parts that depend on masterbar height and they are hardcoded, making the testing and implementation of nav unification difficult. This PR attempts to alleviate this by using a global var for masterbar

#### Changes proposed in this Pull Request

* introduces `--masterbar-height: 46px` var
* adds `box-sizing: border-box` so that the 1px border is calculated to masterbars height
* replaces all instances of elements being `fixed` with `top: 47px` to `var (--masterbar-height )
* edits `apps/notifications/style.scss` accordingly by removing not needed rules anymore

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Repeat below steps with both the flag `?flags=nav-unification` and without it
* load calypso check that sidebar, notifications panel etc appear correctly both in desktop and responsive

**Known Issue** with `?flags=nav-unification` 
![](https://cln.sh/Qkj6NX+)
This type of gaps will be resolved once we move 
```
@media only screen and ( min-width: 782px ) {
  --masterbar-height: 32px;
}
```
to the `:root`
