### PR TITLE
Remove username test: Re-launch test for plan-specific flows

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1067,17 +1067,11 @@ function TrackRender( { children, eventName } ) {
 export default connect(
 	( state, ownProps ) => {
 		const isDisplayUsernamePropSet = ownProps.hasOwnProperty( 'displayUsernameInput' );
-		const eligibleFlowsForRemoveUsernameTest = [
-			'onboarding',
-			'personal',
-			'premium',
-			'business',
-			'ecommerce',
-		];
+		const eligibleFlowsForRemoveUsernameTest = [ 'personal', 'premium', 'business', 'ecommerce' ];
 		let displayUsernameInput = true;
 
 		if ( eligibleFlowsForRemoveUsernameTest.includes( ownProps.flowName ) ) {
-			abtest( 'usernameAATest' );
+			'control' === abtest( 'removeUsernameInSignup' );
 		} else if ( isDisplayUsernamePropSet ) {
 			displayUsernameInput = ownProps.displayUsernameInput;
 		}

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1071,7 +1071,7 @@ export default connect(
 		let displayUsernameInput = true;
 
 		if ( eligibleFlowsForRemoveUsernameTest.includes( ownProps.flowName ) ) {
-			'control' === abtest( 'removeUsernameInSignup' );
+			displayUsernameInput = 'control' === abtest( 'removeUsernameInSignup' );
 		} else if ( isDisplayUsernamePropSet ) {
 			displayUsernameInput = ownProps.displayUsernameInput;
 		}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -220,7 +220,7 @@ export default {
 		localeTargets: [ 'en' ],
 	},
 	removeUsernameInSignup: {
-		datestamp: '20210914',
+		datestamp: '20200930',
 		variations: {
 			variantRemoveUsername: 50,
 			control: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -228,15 +228,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
-	usernameAATest: {
-		datestamp: '20200921',
-		variations: {
-			variant: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: false,
-	},
 	oneClickUpsell: {
 		datestamp: '20200922',
 		variations: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -220,7 +220,7 @@ export default {
 		localeTargets: [ 'en' ],
 	},
 	removeUsernameInSignup: {
-		datestamp: '20200930',
+		datestamp: '20201002',
 		variations: {
 			variantRemoveUsername: 50,
 			control: 50,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For context, please check pbxNRc-rq#comment-959

* The remove-username test that was launched in https://github.com/Automattic/wp-calypso/pull/45609 came out a winner for the control group in the `onboarding` flow, and we've stopped the test. This PR relaunches the test for the plan-specific flows - /personal, /premium, /business, /ecommerce
* Remove the A/A test that was launched in https://github.com/Automattic/wp-calypso/pull/45770


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Begin signup at the plan-specific flows - http://calypso.localhost:3000/start/personal, http://calypso.localhost:3000/start/premium, http://calypso.localhost:3000/start/business, and http://calypso.localhost:3000/start/ecommerce. 
    * Verify that you are assigned to the test `removeUsernameInSignup`.
    * If in `control, you should see the username field; if in `variantShowUsername` then you should not see the username field.
    * Verify that you can successfully complete signup for both control and variant.
    * Check the username assigned to you - it should be based on your email address.
    * Verify that the account activation email's subject line mentions your full email address.
* Verify that you are _not assigned_ to the test if in the `onboarding` flow, or in Jetpack signup flow.
* Verify that the A/A test `usernameAATest` is removed.
