### PR TITLE
Email: Display domains with Titan when managing email

### DIFF
--- a/client/lib/titan/has-titan-mail-with-us.js
+++ b/client/lib/titan/has-titan-mail-with-us.js
@@ -1,0 +1,4 @@
+export function hasTitanMailWithUs() {
+	// TODO: make the actual check
+	return false;
+}

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -33,7 +33,7 @@ import './style.scss';
 
 class GSuiteUsersCard extends React.Component {
 	canAddUsers( domainName ) {
-		this.props.domainsAsList.some(
+		return this.props.domainsAsList.some(
 			( domain ) =>
 				domain &&
 				domain.name === domainName &&

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -90,7 +90,7 @@ class GSuiteUsersCard extends React.Component {
 
 	renderDomain( domain, users ) {
 		if ( hasTitanMailWithUs( domain ) ) {
-			return <TitanControlPanelLoginCard domain={ domain } />;
+			return <TitanControlPanelLoginCard domain={ domain } key={ `titan-${ domain.name }` } />;
 		}
 
 		return this.renderDomainWithGSuite( domain.name, users );
@@ -156,9 +156,9 @@ class GSuiteUsersCard extends React.Component {
 					/>
 				) }
 
-				{ this.getDomainsAsList().map( ( domain ) =>
-					this.renderDomain( domain, usersByDomain[ domain.name ] )
-				) }
+				{ this.getDomainsAsList()
+					.filter( ( domain ) => domain.name in usersByDomain || hasTitanMailWithUs( domain ) )
+					.map( ( domain ) => this.renderDomain( domain, usersByDomain[ domain.name ] ) ) }
 			</div>
 		);
 	}

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -55,20 +55,20 @@ class GSuiteUsersCard extends React.Component {
 		this.props.addGoogleAppsUserClick( this.props.selectedDomainName );
 	};
 
-	renderDomainWithGSuite( domain, users ) {
+	renderDomainWithGSuite( domainName, users ) {
 		// The product name is same for all users as product license is associated to domain
 		// Hence a snapshot of the product name from the first user is sufficient
 		const license = users[ 0 ].product_name;
 		// This ensures display consistency if the API is not ready yet
-		const label = license ? `${ license }: ${ domain }` : domain;
+		const label = license ? `${ license }: ${ domainName }` : domainName;
 		return (
-			<div key={ `google-apps-user-${ domain }` } className="gsuite-users-card__container">
+			<div key={ `google-apps-user-${ domainName }` } className="gsuite-users-card__container">
 				<SectionHeader label={ label }>
-					{ this.canAddUsers( domain ) && (
+					{ this.canAddUsers( domainName ) && (
 						<Button
 							primary
 							compact
-							href={ emailManagementAddGSuiteUsers( this.props.selectedSiteSlug, domain ) }
+							href={ emailManagementAddGSuiteUsers( this.props.selectedSiteSlug, domainName ) }
 							onClick={ this.goToAddGoogleApps }
 						>
 							{ this.props.translate( 'Add New User' ) }

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { find, get, groupBy, keyBy } from 'lodash';
+import { find, get, groupBy } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -205,7 +205,6 @@ export default connect(
 		return {
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 			user: getCurrentUser( state ),
-			domainsByName: keyBy( domainsList, 'name' ),
 			domainsAsList: domainsList,
 		};
 	},

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -32,12 +32,8 @@ import TitanControlPanelLoginCard from 'calypso/my-sites/email/email-management/
 import './style.scss';
 
 class GSuiteUsersCard extends React.Component {
-	getDomainsAsList() {
-		return this.props.domainsAsList;
-	}
-
 	canAddUsers( domainName ) {
-		return this.getDomainsAsList().some(
+		this.props.domainsAsList.some(
 			( domain ) =>
 				domain &&
 				domain.name === domainName &&
@@ -141,8 +137,8 @@ class GSuiteUsersCard extends React.Component {
 	}
 
 	render() {
-		const { gsuiteUsers, selectedSiteSlug } = this.props;
-		const pendingDomains = this.getDomainsAsList().filter( hasPendingGSuiteUsers );
+		const { domainsAsList, gsuiteUsers, selectedSiteSlug } = this.props;
+		const pendingDomains = domainsAsList.filter( hasPendingGSuiteUsers );
 		const usersByDomain = groupBy( gsuiteUsers, 'domain' );
 
 		return (
@@ -156,7 +152,7 @@ class GSuiteUsersCard extends React.Component {
 					/>
 				) }
 
-				{ this.getDomainsAsList()
+				{ domainsAsList
 					.filter( ( domain ) => domain.name in usersByDomain || hasTitanMailWithUs( domain ) )
 					.map( ( domain ) => this.renderDomain( domain, usersByDomain[ domain.name ] ) ) }
 			</div>

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -45,6 +45,7 @@ import { localizeUrl } from 'lib/i18n-utils';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import EmailProvidersComparison from '../email-providers-comparison';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
 
 /**
  * Style dependencies
@@ -130,7 +131,7 @@ class EmailManagement extends React.Component {
 
 		const domainList = selectedDomainName ? [ getSelectedDomain( this.props ) ] : domains;
 
-		if ( domainList.some( hasGSuiteWithUs ) ) {
+		if ( domainList.some( hasGSuiteWithUs ) || domainList.some( hasTitanMailWithUs ) ) {
 			return this.googleAppsUsersCard();
 		}
 

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -14,6 +14,11 @@ import { errorNotice } from 'state/notices/actions';
 import { Button, CompactCard } from '@automattic/components';
 import SectionHeader from 'components/section-header';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class TitanControlPanelLoginCard extends React.Component {
 	state = {
 		isFetchingAutoLoginLink: false,
@@ -61,7 +66,7 @@ class TitanControlPanelLoginCard extends React.Component {
 		};
 
 		return (
-			<div>
+			<div className="titan-control-panel-login-card">
 				<SectionHeader label={ translate( 'Titan Mail: %(domainName)s', translateArgs ) }>
 					<Button
 						primary

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/style.scss
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/style.scss
@@ -1,0 +1,3 @@
+.titan-control-panel-login-card {
+	margin-bottom: 10px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the email management page to show domains with Titan subscription alongside G Suite ones. The component name was not changed to keep it simple since we'd have to update the CSS as well – we can do that in a separate PR.

When a domain has been selected:

<img width="1052" alt="Screenshot 2020-09-30 at 1 39 38 PM" src="https://user-images.githubusercontent.com/13062352/94681645-191d7900-0324-11eb-9342-c1e1fe697259.png">

When a domain has not been selected:

<img width="1056" alt="Screenshot 2020-09-30 at 1 47 38 PM" src="https://user-images.githubusercontent.com/13062352/94681658-1d499680-0324-11eb-949a-fae00c290d7b.png">


#### Testing instructions

* Ensure that existing functionality is not broken, i.e. G Suite users/domains are properly shown
* Hack `hasTitanMailWithUs()` to return `true` for a specific domain, and verify that the Titan auto login card is shown for that domain
