### PR TITLE
[TeamCity] - Do not fail build if there are eslint warnings

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -133,6 +133,7 @@ object RunAllUnitTests : BuildType({
 
 	artifactRules = """
 		test_results => test_results
+		checkstyle_results => checkstyle_results
 		artifacts => artifacts
 	""".trimIndent()
 
@@ -209,7 +210,7 @@ object RunAllUnitTests : BuildType({
 				FILES_TO_LINT=${'$'}(git diff --name-only --diff-filter=d refs/remotes/origin/master...HEAD | grep -E '^(client/|server/|packages/)' | grep -E '\.[jt]sx?${'$'}' || exit 0)
 				echo ${'$'}FILES_TO_LINT
 				if [ ! -z "${'$'}FILES_TO_LINT" ]; then
-					yarn run eslint --format junit --output-file "./test_results/eslint/results.xml" ${'$'}FILES_TO_LINT
+					yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/results.xml" ${'$'}FILES_TO_LINT
 				fi
 			""".trimIndent()
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
@@ -373,6 +374,12 @@ object RunAllUnitTests : BuildType({
 			type = "xml-report-plugin"
 			param("xmlReportParsing.reportType", "junit")
 			param("xmlReportParsing.reportDirs", "test_results/**/*.xml")
+		}
+		feature {
+			type = "xml-report-plugin"
+			param("xmlReportParsing.reportType", "checkstyle")
+			param("xmlReportParsing.reportDirs", "checkstyle_results/**/*.xml")
+			param("xmlReportParsing.verboseOutput", "true")
 		}
 		perfmon {
 		}


### PR DESCRIPTION
### Background

Our TeamCity build has a step to run `eslint`. It dumps the result in `junit` format. However, this format doesn't allow to distinguish between warnings and errors, and everything becomes a failed test. When there are eslint _warnings_, TeamCity will see it as a failed test and will fail the build.

### Changes proposed in this Pull Request

Use `checkstyle` instead of `junit`. TeamCity interpret this as code style checks and not as failed tests. It allow us to have a better UI to visualize the style errors and not fail the build if there are only warnings. The build will still fail if there are eslint errors because `eslint` exits with a non 0 exit code.

### Testing instructions

Create a new branch using this one as base. Introduce a few eslint errors, both warnings (eg: use the word "master") and errors (eg: change a `const` with `var`). Create a draft PR with your branch and see the results of the TeamCity job.

It should show a new tab "Code Inspection" with something like:

![image](https://user-images.githubusercontent.com/975703/94687265-5980f500-032c-11eb-9106-2f30e44277f4.png)

Now fix the eslint errors (you can leave the warnings) and push your changes. TeamCity should not fail.
