### PR TITLE
Nav unification: add flyout menu to sidebar

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -28,7 +28,6 @@
 
 	// client/layout/style.scss
 	.layout__secondary {
-		top: $nav-unification-masterbar-height;
 		border-right: none;
 	}
 

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -25,6 +25,7 @@
 	// client/layout/style.scss
 	.layout__secondary {
 		top: $nav-unification-masterbar-height;
+		border-right: none;
 	}
 
 	// client/layout/masterbar/style.scss

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -167,8 +167,8 @@ $font-size: rem( 14px );
 	}
 }
 
-// Flyout menu showing from >660px
-@include breakpoint-deprecated( '>660px' ) {
+// Flyout menu (showing from >782px)
+@media screen and ( min-width: 783px ) {
 	.is-nav-unification {
 
 		// client/layout/style.scss

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -144,9 +144,13 @@ $font-size: rem( 14px );
 		// Is toggled open
 		.sidebar__menu.is-toggle-open {
 			.sidebar__heading {
-				//background: #32373c;
-				background: var( --color-sidebar-menu-selected-background );
-				color: white;
+				background: var( --color-sidebar-menu-hover-heading-background );
+
+				&:hover {
+					.sidebar__menu-icon {
+						color: var( --color-sidebar-menu-hover );
+					}
+				}
 
 				&::after {
 					display: block;
@@ -156,10 +160,14 @@ $font-size: rem( 14px );
 					color: #fff;
 				}
 
-				// Is toggled open and selected
-				&.sidebar__menu--selected .sidebar__heading {
-					background: var( --color-sidebar-menu-selected-background );
-					color: white;
+			}
+			// Is toggled open and selected
+			&.sidebar__menu--selected .sidebar__heading {
+				background: var( --color-sidebar-menu-selected-background );
+				color: white;
+
+				.sidebar__menu-icon {
+					color: #fff;
 				}
 			}
 		}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -13,6 +13,7 @@
 	--color-sidebar-menu-hover-background-rgb: rgb( #32373c );
 	--color-sidebar-menu-hover-heading-background: #1a1e23;
 	--color-sidebar-menu-hover: #00b9eb;
+	--color-sidebar-menu-hover-text: #00b9eb;
 	--color-sidebar-menu-selected-background: #0073aa;
 	--color-sidebar-border: #333333;
 	--color-sidebar-text: #eee;

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -206,6 +206,10 @@ $font-size: rem( 14px );
 				top: 0;
 				left: var( --sidebar-width-max );
 				width: 160px;
+
+				.sidebar__menu-link:hover {
+					font-weight: normal;
+				}
 			}
 		}
 	}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -97,6 +97,19 @@ $font-size: rem( 14px );
 			color: var( --color-sidebar-gridicon-fill );
 		}
 
+		.sidebar__menu-item-parent {
+			&.selected {
+				.sidebar__menu-link {
+					background: var( --color-sidebar-menu-selected-background );
+					color: white;
+
+					.sidebar__menu-icon {
+						color: white;
+					}
+				}
+			}
+		}
+
 		.sidebar__menu,
 		.sidebar__menu-item-parent {
 			&:hover {
@@ -104,7 +117,7 @@ $font-size: rem( 14px );
 					color: var( --color-sidebar-menu-hover );
 				}
 			}
-		}		
+		}
 
 		// Is togglable but closed
 		.sidebar__menu.is-togglable {
@@ -145,7 +158,7 @@ $font-size: rem( 14px );
 
 				// Is toggled open and selected
 				&.sidebar__menu--selected .sidebar__heading {
-					background: #0073aa;
+					background: var( --color-sidebar-menu-selected-background );
 					color: white;
 				}
 			}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -11,8 +11,9 @@
 	--color-sidebar-background-rgb: 35, 40, 45;
 	--color-sidebar-menu-hover-background: #32373c;
 	--color-sidebar-menu-hover-background-rgb: rgb( #32373c );
-	--color-sidebar-menu-hover: var ( --color-sidebar-text );
-	--color-sidebar-menu-selected-background: #006fad;
+	--color-sidebar-menu-hover-heading-background: #1a1e23;
+	--color-sidebar-menu-hover: #00b9eb;
+	--color-sidebar-menu-selected-background: #0073aa;
 	--color-sidebar-border: #333333;
 	--color-sidebar-text: #eee;
 	--color-sidebar-text-alternative: #a2aab2;
@@ -45,7 +46,7 @@ $font-size: rem( 14px );
 
 			&:hover,
 			&:focus {
-				background-color: var( --color-sidebar-menu-hover-background );
+				background-color: var( --color-sidebar-menu-hover-heading-background );
 				color: var( --color-sidebar-menu-hover );
 			}
 		}
@@ -60,49 +61,6 @@ $font-size: rem( 14px );
 			display: none;
 			width: 20px;
 			height: 20px;
-		}
-		.sidebar__menu.is-togglable {
-			.sidebar__heading {
-				padding: 0 0 0 8px;
-				font-weight: 400;
-
-				&:hover,
-				&:focus {
-					background-color: var( --color-sidebar-menu-hover-background );
-					color: var( --color-sidebar-menu-hover );
-				}
-			}
-		}
-
-		.sidebar__menu.is-toggle-open {
-
-			// Open
-			.sidebar__heading {
-				background: #32373c;
-
-				&::after {
-					right: 0;
-					border: solid 8px transparent;
-					content: ' ';
-					height: 0;
-					width: 0;
-					position: absolute;
-					pointer-events: none;
-					border-right-color: #f1f1f1;
-					top: 50%;
-					margin-top: -8px;
-				}
-
-				.sidebar__menu-icon {
-					color: #fff;
-				}
-			}
-
-			// Open and selected
-			&.sidebar__menu--selected .sidebar__heading {
-				background: #0073aa;
-				color: white;
-			}
 		}
 
 		.sidebar__expandable-content {
@@ -120,8 +78,7 @@ $font-size: rem( 14px );
 				&:hover,
 				&:focus {
 					background-color: transparent;
-					color: white;
-					font-weight: 600;
+					color: var( --color-sidebar-menu-hover );
 				}
 			}
 
@@ -139,6 +96,60 @@ $font-size: rem( 14px );
 		.sidebar__menu-icon {
 			color: var( --color-sidebar-gridicon-fill );
 		}
+
+		.sidebar__menu,
+		.sidebar__menu-item-parent {
+			&:hover {
+				.sidebar__menu-icon {
+					color: var( --color-sidebar-menu-hover );
+				}
+			}
+		}		
+
+		// Is togglable but closed
+		.sidebar__menu.is-togglable {
+			.sidebar__heading {
+				padding: 0 0 0 8px;
+				font-weight: 400;
+
+				&::after {
+					display: none;
+					right: 0;
+					border: solid 8px transparent;
+					content: ' ';
+					height: 0;
+					width: 0;
+					position: absolute;
+					pointer-events: none;
+					border-right-color: #f1f1f1;
+					top: 50%;
+					margin-top: -8px;
+				}
+			}
+		}
+
+		// Is toggled open
+		.sidebar__menu.is-toggle-open {
+			.sidebar__heading {
+				//background: #32373c;
+				background: var( --color-sidebar-menu-selected-background );
+				color: white;
+
+				&::after {
+					display: block;
+				}
+
+				.sidebar__menu-icon {
+					color: #fff;
+				}
+
+				// Is toggled open and selected
+				&.sidebar__menu--selected .sidebar__heading {
+					background: #0073aa;
+					color: white;
+				}
+			}
+		}
 	}
 
 	//client/components/site-selector/style.scss
@@ -153,6 +164,50 @@ $font-size: rem( 14px );
 
 	.site__badge {
 		background: var( --color-sidebar-text );
+	}
+}
+
+// Flyout menu showing from >660px
+@include breakpoint-deprecated( '>660px' ) {
+	.is-nav-unification {
+
+		// client/layout/style.scss
+		// layout/sidebar/style.scss
+		// TODO: For prototype only, this prevents the sidebar from being scrollable.
+		// In wp-admin there's custom JS to a) position the sidebar based on the scroll
+		// position and b) position the flyout menu based on available screen space.
+		&.focus-content,
+		&.focus-sidebar {
+			.sidebar,
+			.layout__secondary {
+				z-index: 1;
+				overflow: initial;
+			}
+		}
+
+		.sidebar__menu.is-togglable:not( .is-toggle-open ):hover {
+			position: relative;
+
+			.sidebar__heading {
+				background-color: var( --color-sidebar-menu-hover-heading-background );
+				color: var( --color-sidebar-menu-hover );
+			}
+
+			// indicator arrow
+			.sidebar__heading::after {
+				display: block;
+				border-right-color: var( --color-sidebar-menu-hover-background );
+			}
+
+			// flyout content
+			.sidebar__expandable-content {
+				display: block;
+				position: absolute;
+				top: 0;
+				left: var( --sidebar-width-max );
+				width: 160px;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a flyout menu that appears on hover to the Calypso sidebar.

For details and design see issue https://github.com/Automattic/wp-calypso/issues/45676

#### Known issues

This is an initial prototype implementation for the flyout. It's meant to give us an initial feel for how the flyout in Calypso.

There are two known issues, that we'll have to address next:

- Right now in Calypso the sidebar container is `position:fixed` and it's content is scrollable. The `overflow:auto` on the sidebar prevents the flyout from being visible. We're deactivating it here but this has two side effects: a) the sidebar container isn't scrollable anymore and b) when using the site switcher, the overflow is visible when selecting a site. wp-admin gets around the first issue by not having a scrollable sidebar container but instead adjusting the sidebar positioning via JS based on scroll state. The second issue is not present in wp-admin as there's no in-page site switcher.

- On nav elements towards the bottom of the page flyouts get cut off. In wp-admin the flyouts are positioned higher via JS if the content doesn’t fit the screen.

- Flyout menus with a lot of items also get cut off. This is an issue with the reader in particular. In wp-admin the same can happen if there are too many items in a menu.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run `yarn && yarn start` or use the calypso.live link
* add `?flags=nav-unification`  to the URL
* interact with the sidebar and confirm all works as expected

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/1562646/94691069-2a20b700-0331-11eb-82b3-a1fa1bbb9eea.gif)
