### PR TITLE
Build: write the assets-*.json files to the build/ directory

### DIFF
--- a/bin/loader-stats.js
+++ b/bin/loader-stats.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const path = require( 'path' );
-const stats = require( path.join( __dirname, '..', 'server', 'bundler', 'assets-evergreen.json' ) );
+const stats = require( path.join( __dirname, '..', 'build', 'assets-evergreen.json' ) );
 const _ = require( 'lodash' );
 const gzipSize = require( 'gzip-size' );
 

--- a/client/server/middleware/assets.js
+++ b/client/server/middleware/assets.js
@@ -5,16 +5,11 @@ import fs from 'fs';
 import path from 'path';
 import { defaults, groupBy, flatten } from 'lodash';
 
-const ASSETS_PATH = path.join( __dirname, '../', 'bundler' );
+const ASSETS_PATH = path.resolve( __dirname, '../../../build' );
 const EMPTY_ASSETS = { js: [], 'css.ltr': [], 'css.rtl': [] };
 
-const getAssetsPath = ( target ) => {
-	const result = path.join(
-		ASSETS_PATH,
-		target ? `assets-${ target }.json` : 'assets-fallback.json'
-	);
-	return result;
-};
+const getAssetsPath = ( target ) =>
+	path.join( ASSETS_PATH, `assets-${ target || 'fallback' }.json` );
 
 const getAssetType = ( asset ) => {
 	if ( asset.endsWith( '.rtl.css' ) ) {

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -243,8 +243,8 @@ const buildApp = ( environment ) => {
 				],
 			};
 			mockFs( {
-				'./client/server/bundler/assets-fallback.json': JSON.stringify( assetsFallback ),
-				'./client/server/bundler/assets-evergreen.json': JSON.stringify( assetsFallback ).replace(
+				'./build/assets-fallback.json': JSON.stringify( assetsFallback ),
+				'./build/assets-evergreen.json': JSON.stringify( assetsFallback ).replace(
 					/fallback/g,
 					'evergreen'
 				),

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -292,7 +292,7 @@ const webpackConfig = {
 		} ),
 		new AssetsWriter( {
 			filename: `assets-${ browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv }.json`,
-			path: path.join( outputDir, 'client', 'server', 'bundler' ),
+			path: path.join( outputDir, 'build' ),
 			assetExtraPath: extraPath,
 		} ),
 		shouldCheckForDuplicatePackages && new DuplicatePackageCheckerPlugin(),

--- a/desktop/electron-builder.json
+++ b/desktop/electron-builder.json
@@ -10,10 +10,10 @@
 		"package.json",
 		"build/desktop.js",
 		"build/*.desktop.js",
+		"build/assets-*.json",
 		"public_desktop",
 		"public/**/*",
 		"public/**/*.css.map",
-		"client/server/bundler/assets-*.json",
 		"config/*.json"
 	],
 	"mac": {


### PR DESCRIPTION
Make the Calypso server more self-contained by writing the `assets-*.json` files to the `build/` directory, where the server loads them from, instead of the source directory under `client/server/bundler`.

**How to test:**
Verify that after the `build-client` task, the `assets-*.json` files are in `build/` and that the server can load them at runtime.

Verify also the same thing for the desktop app: after `build-desktop`, the `assets-*.json` files should be in `desktop/build/` and should also be shipped in the app bundle (`Wordpress.com.app` on Mac)

The `assets-evergreen.json` and `assets-fallback.json` files are used by the server to determine which chunks to send to the client when requesting a certain section.

For example, the response for the `/reader` page should include all chunks (JS in `<script>` and CSS in `<link>` tags) that belong to the `entry-main` entrypoint and the `reader` section.
