### PR TITLE
Limit premium domain suggestions to the domain-only flow

### DIFF
--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -16,7 +16,7 @@ export const getSuggestionsVendor = ( options = {} ) => {
 	if ( options?.isSignup && ! options?.isDomainOnly ) {
 		return 'variation4_front';
 	}
-	if ( config.isEnabled( 'domains/premium-domain-purchases' ) ) {
+	if ( options?.isDomainOnly && config.isEnabled( 'domains/premium-domain-purchases' ) ) {
 		return 'variation7_front';
 	}
 	return 'variation2_front';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the logic so that we don't show premium domain suggestions when searching for domains from within Calypso. (This stems from the discussion here: p99Zz8-1qX-p2#comment-4316.)

#### Testing instructions

* Navigate to `/domains` and search for a term like `anna` or `soda`. You should get one or more premium .blog suggestions returned.
* Try to search for a domain via Calypso: Manage > Domains > Add a domain to this site. Use the same searches as above and verify that you _don't_ get any premium .blog suggestions returned.
  - For bonus points, you can also verify that the network call to get suggestions has the search vendor set up as `variation2_front`.