### PR TITLE
Avoid multiple selected menu items

### DIFF
--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -27,7 +27,7 @@ import SidebarSeparator from 'layout/sidebar/separator';
 import 'layout/sidebar-unified/style.scss';
 import 'state/admin-menu/init';
 import Spinner from 'components/spinner';
-
+import { itemLinkMatches } from '../sidebar/utils';
 import './style.scss';
 
 export const MySitesSidebarUnified = ( { path } ) => {
@@ -49,6 +49,8 @@ export const MySitesSidebarUnified = ( { path } ) => {
 		<Sidebar>
 			<CurrentSite forceAllSitesView={ isAllDomainsView } />
 			{ menuItems.map( ( item, i ) => {
+				const isSelected = item?.url && itemLinkMatches( item.url, path );
+
 				if ( 'separator' === item?.type ) {
 					return <SidebarSeparator key={ i } />;
 				}
@@ -59,12 +61,20 @@ export const MySitesSidebarUnified = ( { path } ) => {
 							key={ item.slug }
 							path={ path }
 							link={ item.url }
+							selected={ isSelected }
 							{ ...item }
 						/>
 					);
 				}
 
-				return <MySitesSidebarUnifiedItem key={ item.slug } path={ path } { ...item } />;
+				return (
+					<MySitesSidebarUnifiedItem
+						key={ item.slug }
+						path={ path }
+						selected={ isSelected }
+						{ ...item }
+					/>
+				);
 			} ) }
 		</Sidebar>
 	);

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -49,7 +49,7 @@ export const MySitesSidebarUnifiedItem = ( {
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
 			forceInternalLink
-			className={ isSubItem ? 'sidebar__menu-link--sub' : 'sidebar__menu-link--parent' }
+			className={ isSubItem ? 'sidebar__menu-item--child' : 'sidebar__menu-item-parent' }
 		>
 			{ children }
 		</SidebarItem>

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { itemLinkMatches } from '../sidebar/utils';
+
 import { getSelectedSiteId } from 'state/ui/selectors';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarCustomIcon from 'layout/sidebar/custom-icon';
@@ -23,11 +23,15 @@ import StatsSparkline from 'blocks/stats-sparkline';
 
 const onNav = () => null;
 
-// selected={ itemLinkMatches( [ '/domains', '/email' ], path ) }
-
-export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) => {
+export const MySitesSidebarUnifiedItem = ( {
+	title,
+	icon,
+	url,
+	slug,
+	selected = false,
+	isSubItem = false,
+} ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const selected = itemLinkMatches( url, path );
 
 	let children = null;
 
@@ -45,6 +49,7 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) =>
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
 			forceInternalLink
+			className={ isSubItem ? 'sidebar__menu-link--sub' : 'sidebar__menu-link--parent' }
 		>
 			{ children }
 		</SidebarItem>

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -55,7 +55,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 			expanded={ isExpanded || selected }
 			title={ title }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
-			className={ selected && 'selected' }
+			className={ selected && 'sidebar__menu--selected' }
 		>
 			{ children.map( ( item ) => {
 				const isSelected = selectedMenuItem?.url === item.url;

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -8,7 +8,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import page from 'page';
@@ -17,7 +17,10 @@ import page from 'page';
  * Internal dependencies
  */
 import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
-import { toggleMySitesSidebarSection as toggleSection } from 'state/my-sites/sidebar/actions';
+import {
+	toggleMySitesSidebarSection as toggleSection,
+	expandMySitesSidebarSection as expandSection,
+} from 'state/my-sites/sidebar/actions';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import MySitesSidebarUnifiedItem from './item';
 import SidebarCustomIcon from 'layout/sidebar/custom-icon';
@@ -38,6 +41,13 @@ export const MySitesSidebarUnifiedMenu = ( {
 	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
 	const selectedMenuItem =
 		children && children.find( ( menuItem ) => itemLinkMatches( menuItem.url, path ) );
+	const childIsSelected = !! selectedMenuItem;
+
+	useEffect( () => {
+		if ( selected || childIsSelected ) {
+			reduxDispatch( expandSection( sectionId ) );
+		}
+	}, [ selected, childIsSelected, reduxDispatch, sectionId ] );
 
 	return (
 		<ExpandableSidebarMenu
@@ -55,7 +65,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 			expanded={ isExpanded || selected }
 			title={ title }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
-			className={ selected && 'sidebar__menu--selected' }
+			className={ ( selected || childIsSelected ) && 'sidebar__menu--selected' }
 		>
 			{ children.map( ( item ) => {
 				const isSelected = selectedMenuItem?.url === item.url;

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -8,7 +8,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import page from 'page';
@@ -36,6 +36,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	link,
 	selected,
 } ) => {
+	const hasAutoExpanded = useRef( false );
 	const reduxDispatch = useDispatch();
 	const sectionId = 'SIDEBAR_SECTION_' + slug;
 	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
@@ -43,9 +44,14 @@ export const MySitesSidebarUnifiedMenu = ( {
 		children && children.find( ( menuItem ) => itemLinkMatches( menuItem.url, path ) );
 	const childIsSelected = !! selectedMenuItem;
 
+	/**
+	 * One time only, auto-expand the currently active section, or the section
+	 * which contains the current active item.
+	 */
 	useEffect( () => {
-		if ( selected || childIsSelected ) {
+		if ( ! hasAutoExpanded.current && ( selected || childIsSelected ) ) {
 			reduxDispatch( expandSection( sectionId ) );
+			hasAutoExpanded.current = true;
 		}
 	}, [ selected, childIsSelected, reduxDispatch, sectionId ] );
 

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -22,11 +22,22 @@ import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import MySitesSidebarUnifiedItem from './item';
 import SidebarCustomIcon from 'layout/sidebar/custom-icon';
 import { isExternal } from 'lib/url';
+import { itemLinkMatches } from '../sidebar/utils';
 
-export const MySitesSidebarUnifiedMenu = ( { slug, title, icon, children, path, link } ) => {
+export const MySitesSidebarUnifiedMenu = ( {
+	slug,
+	title,
+	icon,
+	children,
+	path,
+	link,
+	selected,
+} ) => {
 	const reduxDispatch = useDispatch();
 	const sectionId = 'SIDEBAR_SECTION_' + slug;
 	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
+	const selectedMenuItem =
+		children && children.find( ( menuItem ) => itemLinkMatches( menuItem.url, path ) );
 
 	return (
 		<ExpandableSidebarMenu
@@ -41,13 +52,23 @@ export const MySitesSidebarUnifiedMenu = ( { slug, title, icon, children, path, 
 				}
 				reduxDispatch( toggleSection( sectionId ) );
 			} }
-			expanded={ isExpanded }
+			expanded={ isExpanded || selected }
 			title={ title }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
+			className={ selected && 'selected' }
 		>
-			{ children.map( ( item ) => (
-				<MySitesSidebarUnifiedItem key={ item.slug } path={ path } { ...item } />
-			) ) }
+			{ children.map( ( item ) => {
+				const isSelected = selectedMenuItem?.url === item.url;
+				return (
+					<MySitesSidebarUnifiedItem
+						key={ item.slug }
+						path={ path }
+						{ ...item }
+						selected={ isSelected }
+						isSubItem={ true }
+					/>
+				);
+			} ) }
 		</ExpandableSidebarMenu>
 	);
 };

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -74,25 +74,34 @@ $font-size: rem( 14px );
 			}
 		}
 
-		.sidebar__menu.is-toggle-open .sidebar__heading {
-			background: #0073aa;
-			color: white;
+		.sidebar__menu.is-toggle-open {
 
-			&::after {
-				right: 0;
-				border: solid 8px transparent;
-				content: ' ';
-				height: 0;
-				width: 0;
-				position: absolute;
-				pointer-events: none;
-				border-right-color: #f1f1f1;
-				top: 50%;
-				margin-top: -8px;
+			// Open
+			.sidebar__heading {
+				background: #32373c;
+
+				&::after {
+					right: 0;
+					border: solid 8px transparent;
+					content: ' ';
+					height: 0;
+					width: 0;
+					position: absolute;
+					pointer-events: none;
+					border-right-color: #f1f1f1;
+					top: 50%;
+					margin-top: -8px;
+				}
+
+				.sidebar__menu-icon {
+					color: #fff;
+				}
 			}
 
-			.sidebar__menu-icon {
-				color: #fff;
+			// Open and selected
+			&.sidebar__menu--selected .sidebar__heading {
+				background: #0073aa;
+				color: white;
 			}
 		}
 
@@ -114,6 +123,12 @@ $font-size: rem( 14px );
 					color: white;
 					font-weight: 600;
 				}
+			}
+
+			.selected .sidebar__menu-link {
+				background-color: transparent;
+				color: white;
+				font-weight: 600;
 			}
 
 			.sidebar__menu-link-text {


### PR DESCRIPTION
As described in [this Issue](https://github.com/Automattic/wp-calypso/issues/46039) it is possible to arrive at a state whereby several menu items appear to be "selected" at once.

This PR adjusts things so that only one menu item ever appears in the "blue" selected state. Moreover the logic for deciding which item is "selected" is moved upward in order that:

* We can apply a class to style the _parent_ menu item if a _child_ is selected.
* We can _automatically_ toggle open the menu section if a child of that section is selected.

Moreover, an appropriate "selected" style is added to child selected links to match WPAdmin.

#### Screenshots

📺 You can [watch this demo video](https://d.pr/v/2YTV3I).

#### Testing instructions

* Checkout this PR.
* Apply blog sticker.
* Run calypso
* Visit http://calypso.localhost:3000/?flags=nav-unification.
* You should see "Home" menu item in a selected state.
* Click "Posts" menu item. You should see the top level "Posts" item selected.
* Click "Posts" menu item. You should see the selected state transfer to the top level "Pages" item. You should see the `Posts` section remains expanded, but _not_ selected.
* Click `Tools -> Earn`. You shoud see the sub-item "Earn" in a selected state **as well as** the top level "Tools" item (note this exactly matches the WPAdmin experience - go try it out!).
* You should see the `Posts` and `Pages` sections remain expanded, but _not_ selected.
* Reload the page on the earn URL (note you may need to manually add `?flags=nav-unification` to the URL). You should see the `Tools` section auto-expanded and the `Earn` item should be selected.

Fixes https://github.com/Automattic/wp-calypso/issues/46039

