### PR TITLE
Track missing events in WordPress.com, Jetpack Connect and Cloud's Pricing page

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card/index.tsx
@@ -11,6 +11,7 @@ import { Button } from '@automattic/components';
  */
 import { JPC_PATH_REMOTE_INSTALL } from 'jetpack-connect/constants';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
+import useTrackCallback from 'lib/jetpack/use-track-callback';
 import getJetpackWpAdminUrl from 'state/selectors/get-jetpack-wp-admin-url';
 import { addQueryArgs } from 'lib/route';
 
@@ -24,13 +25,17 @@ import type { JetpackFreeProps } from 'my-sites/plans-v2/types';
  */
 import './style.scss';
 
-const JetpackFreeCard = ( { urlQueryArgs }: JetpackFreeProps ) => {
+const JetpackFreeCard = ( { siteId, urlQueryArgs }: JetpackFreeProps ) => {
 	const translate = useTranslate();
 	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
 
 	const startHref = isJetpackCloud()
 		? addQueryArgs( urlQueryArgs, `https://wordpress.com${ JPC_PATH_REMOTE_INSTALL }` )
 		: wpAdminUrl || JPC_PATH_REMOTE_INSTALL;
+
+	const onClickTrack = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
+		site_id: siteId || undefined,
+	} );
 
 	return (
 		<div className="jetpack-free-card">
@@ -48,7 +53,7 @@ const JetpackFreeCard = ( { urlQueryArgs }: JetpackFreeProps ) => {
 						}
 					) }
 				</p>
-				<Button className="jetpack-free-card__button" href={ startHref }>
+				<Button className="jetpack-free-card__button" href={ startHref } onClick={ onClickTrack }>
 					{ translate( 'Start for free' ) }
 				</Button>
 			</div>

--- a/client/components/jetpack/card/jetpack-product-card/features.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/features.tsx
@@ -25,20 +25,25 @@ export type Props = {
 	className?: string;
 	features: ProductCardFeatures;
 	isExpanded?: boolean;
+	productSlug?: string;
 };
 
 const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
 	className,
 	features,
 	isExpanded: isExpandedByDefault,
+	productSlug,
 } ) => {
+	const trackProps = productSlug ? { product_slug: productSlug } : {};
 	const trackShowFeatures = useTrackCallback(
 		undefined,
-		'calypso_jetpack_show_product_card_features'
+		'calypso_product_features_open',
+		trackProps
 	);
 	const trackHideFeatures = useTrackCallback(
 		undefined,
-		'calypso_jetpack_hide_product_card_features'
+		'calypso_product_features_close',
+		trackProps
 	);
 	const [ isExpanded, setExpanded ] = useState( !! isExpandedByDefault );
 	const onOpen = useCallback( () => {

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -84,6 +84,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	isExpanded,
 	UpgradeNudge,
 	hidePrice,
+	productSlug,
 } ) => {
 	const translate = useTranslate();
 	const priceEl = useRef( null );
@@ -208,7 +209,11 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 				{ children && <div className="jetpack-product-card__children">{ children }</div> }
 			</div>
 			{ features && features.items.length > 0 && (
-				<JetpackProductCardFeatures features={ features } isExpanded={ isExpanded } />
+				<JetpackProductCardFeatures
+					features={ features }
+					productSlug={ productSlug }
+					isExpanded={ isExpanded }
+				/>
 			) }
 			{ UpgradeNudge }
 		</div>

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -69,7 +69,7 @@ const DetailsPage = ( {
 
 	const trackUpsellView = useCallback( () => {
 		dispatch(
-			recordTracksEvent( 'calypso_product_details_click', {
+			recordTracksEvent( 'calypso_product_upsell_click', {
 				site_id: siteId || undefined,
 				product_slug: productSlug,
 				duration,

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -130,14 +130,27 @@ const DetailsPage = ( {
 	const isBundle = [ OPTIONS_JETPACK_SECURITY, OPTIONS_JETPACK_SECURITY_MONTHLY ].includes(
 		productSlug
 	);
-	const backButton = () => page( selectorPageUrl );
+	const backButton = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_plans_subtypes_back_click', {
+				site_id: siteId || undefined,
+				product_slug: productSlug,
+				duration,
+			} )
+		);
+		page( selectorPageUrl );
+	};
+
+	const viewTrackerPath = siteId
+		? `${ rootUrl }/:product/${ durationToString( duration ) }/details/:site`
+		: `${ rootUrl }/:product/${ durationToString( duration ) }/details`;
+	const viewTrackerProps = siteId
+		? { site: siteSlug, product: productSlug }
+		: { product: productSlug };
 
 	return (
 		<Main className="details__main" wideLayout>
-			<PageViewTracker
-				path={ `${ rootUrl }/:product_slug/${ durationToString( duration ) }/details` }
-				title="Details"
-			/>
+			<PageViewTracker path={ viewTrackerPath } properties={ viewTrackerProps } title="Details" />
 			<QueryProducts />
 			{ header }
 			<HeaderCake onClick={ backButton }>

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -115,7 +115,7 @@ const DetailsPage = ( {
 			newDuration === TERM_MONTHLY ? product.monthlyOptionSlug : product.annualOptionSlug;
 
 		dispatch(
-			recordTracksEvent( 'calypso_product_duration_change', {
+			recordTracksEvent( 'calypso_plans_duration_change', {
 				site_id: siteId || undefined,
 				product_slug: newProductSlug,
 				duration: newDuration,
@@ -132,7 +132,7 @@ const DetailsPage = ( {
 	);
 	const backButton = () => {
 		dispatch(
-			recordTracksEvent( 'calypso_plans_subtypes_back_click', {
+			recordTracksEvent( 'calypso_subtypes_back_click', {
 				site_id: siteId || undefined,
 				product_slug: productSlug,
 				duration,

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -104,7 +104,7 @@ const DetailsPage = ( {
 		}
 
 		dispatch(
-			recordTracksEvent( 'calypso_cart_product_add', {
+			recordTracksEvent( 'calypso_product_checkout_click', {
 				site_id: siteId || undefined,
 				product_slug: slug,
 				duration,

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -103,6 +103,13 @@ const DetailsPage = ( {
 			return;
 		}
 
+		dispatch(
+			recordTracksEvent( 'calypso_cart_product_add', {
+				site_id: siteId || undefined,
+				product_slug: slug,
+				duration,
+			} )
+		);
 		checkout( siteSlug, slug, urlQueryArgs );
 	};
 

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -3,12 +3,13 @@
  */
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { TERM_MONTHLY } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions/record';
 import {
@@ -19,6 +20,7 @@ import {
 import PlansFilterBar from './plans-filter-bar';
 import ProductCard from './product-card';
 import {
+	durationToString,
 	slugToSelectorProduct,
 	getPathToSelector,
 	getPathToUpsell,
@@ -65,8 +67,19 @@ const DetailsPage = ( {
 		window.scrollTo( 0, 0 );
 	}, [] );
 
+	const trackUpsellView = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_product_details_click', {
+				site_id: siteId || undefined,
+				product_slug: productSlug,
+				duration,
+			} )
+		);
+	}, [ dispatch, duration, productSlug, siteId ] );
+
 	// If the product slug isn't one that has options, proceed to the upsell.
 	if ( ! ( PRODUCTS_WITH_OPTIONS as readonly string[] ).includes( productSlug ) ) {
+		trackUpsellView();
 		page.redirect(
 			getPathToUpsell( rootUrl, urlQueryArgs, productSlug, duration as Duration, siteSlug )
 		);
@@ -85,6 +98,7 @@ const DetailsPage = ( {
 	// Go to a new page for upsells.
 	const selectProduct: PurchaseCallback = ( { productSlug: slug }: SelectorProduct ) => {
 		if ( hasUpsell( slug as ProductSlug ) ) {
+			trackUpsellView();
 			page( getPathToUpsell( rootUrl, urlQueryArgs, slug, duration as Duration, siteSlug ) );
 			return;
 		}
@@ -120,6 +134,10 @@ const DetailsPage = ( {
 
 	return (
 		<Main className="details__main" wideLayout>
+			<PageViewTracker
+				path={ `${ rootUrl }/:product_slug/${ durationToString( duration ) }/details` }
+				title="Details"
+			/>
 			<QueryProducts />
 			{ header }
 			<HeaderCake onClick={ backButton }>

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -168,6 +168,7 @@ const ProductCardWrapper = ( {
 			onClick={ onClick }
 		/>
 	) : null;
+
 	return (
 		<CardComponent
 			headingLevel={ 3 }
@@ -196,6 +197,7 @@ const ProductCardWrapper = ( {
 			isHighlighted={ isHighlighted }
 			isExpanded={ isHighlighted && ! isMobile }
 			hidePrice={ hidePrice }
+			productSlug={ item.productSlug }
 		/>
 	);
 };

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -82,11 +82,25 @@ const SelectorPage = ( {
 		}
 
 		if ( purchase && isUpgradeableToYearly ) {
+			dispatch(
+				recordTracksEvent( 'calypso_cart_product_add', {
+					site_id: siteId || undefined,
+					product_slug: product.productSlug,
+					duration: currentDuration,
+				} )
+			);
 			checkout( siteSlug, getYearlyPlanByMonthly( product.productSlug ), urlQueryArgs );
 			return;
 		}
 
 		if ( purchase ) {
+			dispatch(
+				recordTracksEvent( 'calypso_product_manage_click', {
+					site_id: siteId || undefined,
+					product_slug: product.productSlug,
+					duration: currentDuration,
+				} )
+			);
 			page( managePurchase( siteSlug, purchase.id ) );
 			return;
 		}
@@ -118,6 +132,14 @@ const SelectorPage = ( {
 			);
 			return;
 		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_cart_product_add', {
+				site_id: siteId || undefined,
+				product_slug: product.productSlug,
+				duration: currentDuration,
+			} )
+		);
 		checkout( siteSlug, product.productSlug, urlQueryArgs );
 	};
 

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -213,7 +213,7 @@ const SelectorPage = ( {
 			{ showJetpackFreeCard && (
 				<>
 					<div className="selector__divider" />
-					<JetpackFreeCard urlQueryArgs={ urlQueryArgs } />
+					<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
 				</>
 			) }
 

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -71,7 +71,7 @@ const SelectorPage = ( {
 	) => {
 		if ( EXTERNAL_PRODUCTS_LIST.includes( product.productSlug ) ) {
 			dispatch(
-				recordTracksEvent( 'calypso_product_crm_click', {
+				recordTracksEvent( 'calypso_product_external_click', {
 					site_id: siteId || undefined,
 					product_slug: product.productSlug,
 					duration: currentDuration,

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -158,9 +158,12 @@ const SelectorPage = ( {
 
 	const showJetpackFreeCard = isInConnectFlow || isJetpackCloud();
 
+	const viewTrackerPath = siteId ? `${ rootUrl }/:site` : rootUrl;
+	const viewTrackerProps = siteId ? { site: siteSlug } : {};
+
 	return (
 		<Main className="selector__main" wideLayout>
-			<PageViewTracker path={ rootUrl } title="Plans" />
+			<PageViewTracker path={ viewTrackerPath } properties={ viewTrackerProps } title="Plans" />
 			{ header }
 			<PlansFilterBar
 				showDurations

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -16,6 +16,7 @@ import { EXTERNAL_PRODUCTS_LIST, SECURITY } from './constants';
 import { getPathToDetails, getPathToUpsell, checkout } from './utils';
 import QueryProducts from './query-products';
 import useHasProductUpsell from './use-has-product-upsell';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import { getYearlyPlanByMonthly } from 'lib/plans';
 import { TERM_ANNUALLY } from 'lib/plans/constants';
@@ -69,6 +70,13 @@ const SelectorPage = ( {
 		purchase
 	) => {
 		if ( EXTERNAL_PRODUCTS_LIST.includes( product.productSlug ) ) {
+			dispatch(
+				recordTracksEvent( 'calypso_product_crm_click', {
+					site_id: siteId || undefined,
+					product_slug: product.productSlug,
+					duration: currentDuration,
+				} )
+			);
 			window.location.href = product.externalUrl || '';
 			return;
 		}
@@ -85,7 +93,7 @@ const SelectorPage = ( {
 
 		if ( product.subtypes.length ) {
 			dispatch(
-				recordTracksEvent( 'calypso_product_subtypes_view', {
+				recordTracksEvent( 'calypso_product_subtypes_click', {
 					site_id: siteId || undefined,
 					product_slug: product.productSlug,
 					duration: currentDuration,
@@ -98,6 +106,13 @@ const SelectorPage = ( {
 		}
 
 		if ( hasUpsell( product.productSlug as ProductSlug ) ) {
+			dispatch(
+				recordTracksEvent( 'calypso_product_upsell_click', {
+					site_id: siteId || undefined,
+					product_slug: product.productSlug,
+					duration: currentDuration,
+				} )
+			);
 			page(
 				getPathToUpsell( rootUrl, urlQueryArgs, product.productSlug, currentDuration, siteSlug )
 			);
@@ -145,6 +160,7 @@ const SelectorPage = ( {
 
 	return (
 		<Main className="selector__main" wideLayout>
+			<PageViewTracker path={ rootUrl } title="Plans" />
 			{ header }
 			<PlansFilterBar
 				showDurations

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -83,7 +83,7 @@ const SelectorPage = ( {
 
 		if ( purchase && isUpgradeableToYearly ) {
 			dispatch(
-				recordTracksEvent( 'calypso_cart_product_add', {
+				recordTracksEvent( 'calypso_product_checkout_click', {
 					site_id: siteId || undefined,
 					product_slug: product.productSlug,
 					duration: currentDuration,
@@ -134,7 +134,7 @@ const SelectorPage = ( {
 		}
 
 		dispatch(
-			recordTracksEvent( 'calypso_cart_product_add', {
+			recordTracksEvent( 'calypso_product_checkout_click', {
 				site_id: siteId || undefined,
 				product_slug: product.productSlug,
 				duration: currentDuration,

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -57,6 +57,7 @@ export interface WithRedirectToSelectorProps extends BasePageProps {
 
 export interface JetpackFreeProps {
 	urlQueryArgs: QueryArgs;
+	siteId?: number;
 }
 
 export type SelectorProductSlug = typeof PRODUCTS_WITH_OPTIONS[ number ];

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -3,7 +3,7 @@
  */
 import page from 'page';
 import { useTranslate } from 'i18n-calypso';
-import React, { ReactNode, useCallback, useEffect, useMemo } from 'react';
+import React, { ReactNode, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
@@ -17,6 +17,7 @@ import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { preventWidows } from 'lib/formatting';
+import useTrackCallback from 'lib/jetpack/use-track-callback';
 import { JETPACK_SCAN_PRODUCTS, JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
@@ -208,20 +209,26 @@ const UpsellPage = ( {
 	const upsellProductSlug = getProductUpsell( productSlug );
 	const upsellProduct = upsellProductSlug && slugToSelectorProduct( upsellProductSlug );
 
-	const checkoutCb = useCallback( ( slugs ) => checkout( siteSlug, slugs, urlQueryArgs ), [
-		siteSlug,
-		urlQueryArgs,
-	] );
-
-	const onPurchaseBothProducts = useCallback(
-		() => checkoutCb( [ productSlug, upsellProductSlug ] ),
-		[ checkoutCb, productSlug, upsellProductSlug ]
+	const onPurchaseBothProducts = useTrackCallback(
+		() => checkout( siteSlug, [ productSlug, upsellProductSlug ], urlQueryArgs ),
+		'calypso_upsell_products_click',
+		{
+			site_id: siteId || undefined,
+			product_slug: productSlug,
+			upsell_product_slug: upsellProductSlug,
+			duration,
+		}
 	);
 
-	const onPurchaseSingleProduct = useCallback( () => checkoutCb( productSlug ), [
-		checkoutCb,
-		productSlug,
-	] );
+	const onPurchaseSingleProduct = useTrackCallback(
+		() => checkout( siteSlug, productSlug, urlQueryArgs ),
+		'calypso_upsell_product_click',
+		{
+			site_id: siteId || undefined,
+			product_slug: productSlug,
+			duration,
+		}
+	);
 
 	const pageTracker = useMemo(
 		() => (

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -15,6 +15,7 @@ import FormattedHeader from 'components/formatted-header';
 import HeaderCake from 'components/header-cake';
 import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
 import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { preventWidows } from 'lib/formatting';
 import { JETPACK_SCAN_PRODUCTS, JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
@@ -23,6 +24,7 @@ import QueryProducts from './query-products';
 import useIsLoading from './use-is-loading';
 import useItemPrice from './use-item-price';
 import {
+	durationToString,
 	durationToText,
 	getOptionFromSlug,
 	getProductUpsell,
@@ -53,6 +55,7 @@ interface Props {
 	onPurchaseBothProducts: () => void;
 	isLoading: boolean;
 	header: ReactNode;
+	pageTracker: ReactNode;
 }
 
 const UpsellComponent = ( {
@@ -65,6 +68,7 @@ const UpsellComponent = ( {
 	upsellProduct,
 	isLoading,
 	header,
+	pageTracker,
 }: Props ) => {
 	const translate = useTranslate();
 
@@ -93,6 +97,7 @@ const UpsellComponent = ( {
 
 	return (
 		<Main className="upsell" wideLayout>
+			{ pageTracker }
 			{ header }
 			<HeaderCake onClick={ onBackButtonClick }>{ translate( 'Product Options' ) }</HeaderCake>
 			{ isLoading ? (
@@ -205,6 +210,7 @@ const UpsellPage = ( {
 
 	const checkoutCb = useCallback( ( slugs ) => checkout( siteSlug, slugs, urlQueryArgs ), [
 		siteSlug,
+		urlQueryArgs,
 	] );
 
 	const onPurchaseBothProducts = useCallback(
@@ -216,6 +222,16 @@ const UpsellPage = ( {
 		checkoutCb,
 		productSlug,
 	] );
+
+	const pageTracker = useMemo(
+		() => (
+			<PageViewTracker
+				path={ `${ rootUrl }/:product_slug/${ durationToString( duration ) }/additions` }
+				title="Details"
+			/>
+		),
+		[ rootUrl, duration ]
+	);
 
 	const selectorPageUrl = getPathToSelector( rootUrl, urlQueryArgs, duration, siteSlug );
 
@@ -254,6 +270,7 @@ const UpsellPage = ( {
 				onBackButtonClick={ onBackButtonClick }
 				isLoading={ isLoading }
 				header={ header }
+				pageTracker={ pageTracker }
 			/>
 		</>
 	);

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -230,17 +230,35 @@ const UpsellPage = ( {
 		}
 	);
 
-	const pageTracker = useMemo(
-		() => (
-			<PageViewTracker
-				path={ `${ rootUrl }/:product_slug/${ durationToString( duration ) }/additions` }
-				title="Details"
-			/>
-		),
-		[ rootUrl, duration ]
+	// Construct a URL to send users to when they click the back button. Since at this moment
+	// there is only one Jetpack Scan option, the back button takes users back to the Selector
+	// page.
+	const productOption = getOptionFromSlug( productSlug );
+	const selectorPageUrl = getPathToSelector( rootUrl, urlQueryArgs, duration, siteSlug );
+	const backUrl = productOption
+		? getPathToDetails( rootUrl, urlQueryArgs, productOption, duration as Duration, siteSlug )
+		: selectorPageUrl;
+
+	const onBackButtonClick = useTrackCallback(
+		() => page( backUrl ),
+		'calypso_plans_upsell_back_click',
+		{
+			site_id: siteId || undefined,
+			product_slug: productSlug,
+			duration,
+		}
 	);
 
-	const selectorPageUrl = getPathToSelector( rootUrl, urlQueryArgs, duration, siteSlug );
+	const viewTrackerPath = siteId
+		? `${ rootUrl }/:product/${ durationToString( duration ) }/additions/:site`
+		: `${ rootUrl }/:product/${ durationToString( duration ) }/additions`;
+	const viewTrackerProps = siteId
+		? { site: siteSlug, product: productSlug }
+		: { product: productSlug };
+
+	const pageTracker = (
+		<PageViewTracker path={ viewTrackerPath } properties={ viewTrackerProps } title="Details" />
+	);
 
 	// If the product is not valid send the user to the selector page.
 	if ( ! mainProduct ) {
@@ -253,16 +271,6 @@ const UpsellPage = ( {
 		onPurchaseSingleProduct();
 		return null;
 	}
-
-	// Construct a URL to send users to when they click the back button. Since at this moment
-	// there is only one Jetpack Scan option, the back button takes users back to the Selector
-	// page.
-	const productOption = getOptionFromSlug( productSlug );
-	const backUrl = productOption
-		? getPathToDetails( rootUrl, urlQueryArgs, productOption, duration as Duration, siteSlug )
-		: selectorPageUrl;
-
-	const onBackButtonClick = () => page( backUrl );
 
 	return (
 		<>

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -211,7 +211,7 @@ const UpsellPage = ( {
 
 	const onPurchaseBothProducts = useTrackCallback(
 		() => checkout( siteSlug, [ productSlug, upsellProductSlug ], urlQueryArgs ),
-		'calypso_product_upsell_confirm_click',
+		'calypso_cart_product_add',
 		{
 			site_id: siteId || undefined,
 			product_slug: productSlug,
@@ -222,7 +222,7 @@ const UpsellPage = ( {
 
 	const onPurchaseSingleProduct = useTrackCallback(
 		() => checkout( siteSlug, productSlug, urlQueryArgs ),
-		'calypso_product_upsell_skipped_click',
+		'calypso_cart_product_add',
 		{
 			site_id: siteId || undefined,
 			product_slug: productSlug,

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -211,7 +211,7 @@ const UpsellPage = ( {
 
 	const onPurchaseBothProducts = useTrackCallback(
 		() => checkout( siteSlug, [ productSlug, upsellProductSlug ], urlQueryArgs ),
-		'calypso_cart_product_add',
+		'calypso_product_checkout_click',
 		{
 			site_id: siteId || undefined,
 			product_slug: productSlug,
@@ -222,7 +222,7 @@ const UpsellPage = ( {
 
 	const onPurchaseSingleProduct = useTrackCallback(
 		() => checkout( siteSlug, productSlug, urlQueryArgs ),
-		'calypso_cart_product_add',
+		'calypso_product_checkout_click',
 		{
 			site_id: siteId || undefined,
 			product_slug: productSlug,

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -211,7 +211,7 @@ const UpsellPage = ( {
 
 	const onPurchaseBothProducts = useTrackCallback(
 		() => checkout( siteSlug, [ productSlug, upsellProductSlug ], urlQueryArgs ),
-		'calypso_upsell_products_click',
+		'calypso_product_upsell_confirm_click',
 		{
 			site_id: siteId || undefined,
 			product_slug: productSlug,
@@ -222,7 +222,7 @@ const UpsellPage = ( {
 
 	const onPurchaseSingleProduct = useTrackCallback(
 		() => checkout( siteSlug, productSlug, urlQueryArgs ),
-		'calypso_upsell_product_click',
+		'calypso_product_upsell_skipped_click',
 		{
 			site_id: siteId || undefined,
 			product_slug: productSlug,
@@ -239,15 +239,11 @@ const UpsellPage = ( {
 		? getPathToDetails( rootUrl, urlQueryArgs, productOption, duration as Duration, siteSlug )
 		: selectorPageUrl;
 
-	const onBackButtonClick = useTrackCallback(
-		() => page( backUrl ),
-		'calypso_plans_upsell_back_click',
-		{
-			site_id: siteId || undefined,
-			product_slug: productSlug,
-			duration,
-		}
-	);
+	const onBackButtonClick = useTrackCallback( () => page( backUrl ), 'calypso_upsell_back_click', {
+		site_id: siteId || undefined,
+		product_slug: productSlug,
+		duration,
+	} );
 
 	const viewTrackerPath = siteId
 		? `${ rootUrl }/:product/${ durationToString( duration ) }/additions/:site`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 1169247016322522-as-1196341175625977

* This PRs add missing tracks to events triggered from Calypso Plans page, Jetpack Connect Plans page, and Calypso Green Plans page (the events are basically the same between these pages).

#### Implementation notes

* Page views are tracked using the `PageViewTracker` component.
* Other events are tracked dispatching an action with `recordTracksEvent`.

#### Events

This is the list of all events (minus page views), and their names, that are being tracked:

- `calypso_cart_product_add`: dispatched when checkout adds a product to the cart (not controlled by us).
- `calypso_plans_duration_change`: dispatched when users change the duration filter (annually vs monthly).
- `calypso_plans_type_change`: dispatched when users change the product type filter (All, Security, Performance).
- `calypso_product_checkout_click`: dispatched when users click a CTA that takes them to the checkout page (the checkout page has dispatches its own event called `calypso_cart_product_add` when the product is added to the cart).
- `calypso_product_external_click`: dispatched when users click on the CRM or any other product card that redirects users outside of Calypso.
- `calypso_product_features_open`: dispatched when users open the features section of a product card.
- `calypso_product_features_close`: dispatched when users close the features section of a product card.
- `calypso_product_jpfree_click`: dispatched when users clicks on Jetpack Free CTA.
- `calypso_product_manage_click`: dispatched when users click on Manage Plan/Subscription CTA.
- `calypso_product_subtypes_click`: dispatched when users clicks on a CTA that takes them to the subtypes/options page (where they have to decide between daily or real-time versions of a product).
- `calypso_product_upsell_click`: dispatched when users clicks on a CTA that takes them to an upsell page.
- `calypso_subtypes_back_click`: dispatched when users clicks on the back button in the subtypes/options page.
- `calypso_upsell_back_click`: dispatched when users clicks on the back button in the upsell page.

#### Testing instructions

* Run this PR locally (`yarn start` and `yarn start-jetpack-cloud-p`).
* Repeat instructions for every environment (Calypso Blue, Jetpack Connect, and Calypso Green).
* Open your browser console and run `localStorage.setItem('debug', 'calypso:analytics');`.
* Follow every possible path in the Plans page making sure the events described above are being tracked. 
* Verify that a page view is tracked every time you land in a page (hard refreshes should be tracked as well).
* Verify that clicks on every CTA are being tracked (product cards, filters, navigation items, etc).

#### Screenshots

A page view being tracked in Calypso Green.
![image](https://user-images.githubusercontent.com/3418513/94711778-f5a3ff80-031e-11eb-8078-5649aa9fce1d.png)
