### PR TITLE
Updating thank you page with Earn links.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -29,6 +29,7 @@ import conciergeImage from 'assets/images/illustrations/jetpack-concierge.svg';
 import jetpackBackupImage from 'assets/images/illustrations/jetpack-backup.svg';
 import themeImage from 'assets/images/illustrations/themes.svg';
 import updatesImage from 'assets/images/illustrations/updates.svg';
+import earnImage from 'assets/images/customer-home/illustration--task-earn.svg';
 
 function trackOnboardingButtonClick() {
 	recordTracksEvent( 'calypso_checkout_thank_you_onboarding_click' );
@@ -79,18 +80,6 @@ const BusinessPlanDetails = ( {
 		<div>
 			{ googleAppsWasPurchased && <GoogleAppsDetails purchases={ purchases } /> }
 			{ ! hasProductsList && <QueryProductsList /> }
-			{ shouldPromoteJetpack && (
-				<PurchaseDetail
-					icon={ <img alt="" src={ jetpackBackupImage } /> }
-					title={ i18n.translate( 'Check your backups' ) }
-					description={ i18n.translate(
-						'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
-					) }
-					buttonText={ i18n.translate( 'See the latest backup' ) }
-					href={ `/backup/${ selectedSite.slug }` }
-					onClick={ trackOnboardingButtonClick }
-				/>
-			) }
 
 			<CustomDomainPurchaseDetail
 				selectedSite={ selectedSite }
@@ -108,16 +97,27 @@ const BusinessPlanDetails = ( {
 				/>
 			) }
 
-			{ ! selectedFeature && (
+			<PurchaseDetail
+				icon={ <img alt={ i18n.translate( 'Earn Illustration' ) } src={ earnImage } /> }
+				title={ i18n.translate( 'Make money with your website' ) }
+				description={ i18n.translate(
+					'Accept credit card payments today for just about anything – physical and digital goods, services, ' +
+						'donations and tips, or access to your exclusive content.'
+				) }
+				buttonText={ i18n.translate( 'Start Earning' ) }
+				href={ '/earn/' + selectedSite.slug }
+			/>
+
+			{ shouldPromoteJetpack && (
 				<PurchaseDetail
-					icon={ <img alt="" src={ themeImage } /> }
-					title={ i18n.translate( 'Try a New Theme' ) }
+					icon={ <img alt="" src={ jetpackBackupImage } /> }
+					title={ i18n.translate( 'Check your backups' ) }
 					description={ i18n.translate(
-						"You've now got access to every premium theme, at no extra cost - that's hundreds of new options. " +
-							'Give one a try!'
+						'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
 					) }
-					buttonText={ i18n.translate( 'Browse premium themes' ) }
-					href={ '/themes/' + selectedSite.slug }
+					buttonText={ i18n.translate( 'See the latest backup' ) }
+					href={ `/backup/${ selectedSite.slug }` }
+					onClick={ trackOnboardingButtonClick }
 				/>
 			) }
 
@@ -131,6 +131,19 @@ const BusinessPlanDetails = ( {
 					) }
 					buttonText={ i18n.translate( 'Upload a plugin now' ) }
 					href={ '/plugins/manage/' + selectedSite.slug }
+				/>
+			) }
+
+			{ ! selectedFeature && (
+				<PurchaseDetail
+					icon={ <img alt="" src={ themeImage } /> }
+					title={ i18n.translate( 'Try a New Theme' ) }
+					description={ i18n.translate(
+						"You've now got access to every premium theme, at no extra cost - that's hundreds of new options. " +
+							'Give one a try!'
+					) }
+					buttonText={ i18n.translate( 'Browse premium themes' ) }
+					href={ '/themes/' + selectedSite.slug }
 				/>
 			) }
 

--- a/client/my-sites/checkout/checkout-thank-you/personal-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/personal-plan-details.jsx
@@ -19,6 +19,7 @@ import PurchaseDetail from 'components/purchase-detail';
  * Image dependencies
  */
 import adsRemovedImage from 'assets/images/illustrations/removed-ads.svg';
+import earnImage from 'assets/images/customer-home/illustration--task-earn.svg';
 
 const PersonalPlanDetails = ( { translate, selectedSite, sitePlans, purchases } ) => {
 	const plan = find( sitePlans.data, isPersonal );
@@ -31,6 +32,17 @@ const PersonalPlanDetails = ( { translate, selectedSite, sitePlans, purchases } 
 			<CustomDomainPurchaseDetail
 				selectedSite={ selectedSite }
 				hasDomainCredit={ plan && plan.hasDomainCredit }
+			/>
+
+			<PurchaseDetail
+				icon={ <img alt={ translate( 'Earn Illustration' ) } src={ earnImage } /> }
+				title={ translate( 'Make money with your website' ) }
+				description={ translate(
+					'Accept credit card payments today for just about anything – physical and digital goods, services, ' +
+						'donations and tips, or access to your exclusive content.'
+				) }
+				buttonText={ translate( 'Start Earning' ) }
+				href={ '/earn/' + selectedSite.slug }
 			/>
 
 			<PurchaseDetail

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -11,7 +11,6 @@ import { useTranslate } from 'i18n-calypso';
  */
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
-import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
 import { isPremium, isGoogleApps } from 'lib/products-values';
 import { newPost } from 'lib/paths';
 import PurchaseDetail from 'components/purchase-detail';
@@ -23,7 +22,7 @@ import analyticsImage from 'assets/images/illustrations/google-analytics.svg';
 import advertisingRemovedImage from 'assets/images/upgrades/removed-advertising.svg';
 import customizeThemeImage from 'assets/images/upgrades/customize-theme.svg';
 import mediaPostImage from 'assets/images/upgrades/media-post.svg';
-import wordAdsImage from 'assets/images/upgrades/word-ads.svg';
+import earnImage from 'assets/images/customer-home/illustration--task-earn.svg';
 
 const PremiumPlanDetails = ( {
 	selectedSite,
@@ -44,6 +43,17 @@ const PremiumPlanDetails = ( {
 			<CustomDomainPurchaseDetail
 				selectedSite={ selectedSite }
 				hasDomainCredit={ plan && plan.hasDomainCredit }
+			/>
+
+			<PurchaseDetail
+				icon={ <img alt={ translate( 'Earn Illustration' ) } src={ earnImage } /> }
+				title={ translate( 'Make money with your website' ) }
+				description={ translate(
+					'Accept credit card payments today for just about anything – physical and digital goods, services, ' +
+						'donations and tips, or access to your exclusive content.'
+				) }
+				buttonText={ translate( 'Start Earning' ) }
+				href={ '/earn/' + selectedSite.slug }
 			/>
 
 			<PurchaseDetail
@@ -103,18 +113,6 @@ const PremiumPlanDetails = ( {
 				buttonText={ translate( 'Start a new post' ) }
 				href={ newPost( selectedSite ) }
 			/>
-			{ isWordadsInstantActivationEligible( selectedSite ) && (
-				<PurchaseDetail
-					icon={ <img alt={ translate( 'WordAds Illustration' ) } src={ wordAdsImage } /> }
-					title={ translate( 'Easily monetize your site' ) }
-					description={ translate(
-						'Take advantage of WordAds instant activation on your upgraded site. ' +
-							'WordAds lets you earn money by displaying promotional content.'
-					) }
-					buttonText={ translate( 'Start Earning' ) }
-					href={ '/ads/settings/' + selectedSite.slug }
-				/>
-			) }
 		</div>
 	);
 };


### PR DESCRIPTION
Updating the checkout Thank You pages to include Earn cards on the Personal, Premium, and Business plan flows. The card describes Earn features and points users to the Earn page to learn more about the features.

Here are screenshots showing the current versions of the Personal, Premium, and Business plan thank you pages:

![checkout-thankyou-business](https://user-images.githubusercontent.com/35781181/94708957-2716ce00-0313-11eb-9af2-46758c00700a.png)

![checkout-thankyou-personal](https://user-images.githubusercontent.com/35781181/94708965-2aaa5500-0313-11eb-87c3-af3eca104ca5.png)

![screencapture-wordpress-checkout-thank-you-hgh48484-com-49987237-2020-09-29-09_21_33](https://user-images.githubusercontent.com/35781181/94708972-2b42eb80-0313-11eb-94b0-00bf55579ae4.png)

And here are the screens after edits:
![checkout-thankyou-business-new](https://user-images.githubusercontent.com/35781181/94712964-2e8ca600-0318-11eb-9d10-b667a663d0da.png)
![checkout-thankyou-personal-new](https://user-images.githubusercontent.com/35781181/94712984-32202d00-0318-11eb-8b1d-4a3bdc9ddb36.png)
![checkout-thankyou-premium-new](https://user-images.githubusercontent.com/35781181/94712987-32b8c380-0318-11eb-857a-87adb2345b06.png)

#### Testing instructions
* Checkout this PR and build it.
* Select a site on the Free plan and upgrade it to the Personal, Premium, and Business plans to view the checkout Thank You page.
* Confirm that the updated Earn card appears and that it points users to the Earn page.
