### PR TITLE
Jetpack Offer Reset: Refactor Calls to Translate Out of Constants File

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/features.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/features.tsx
@@ -17,6 +17,7 @@ import FeaturesItem from './features-item';
  */
 import type {
 	ProductCardFeatures,
+	ProductCardMoreFeatures,
 	ProductCardFeaturesSection,
 	ProductCardFeaturesItem,
 } from './types';
@@ -24,6 +25,7 @@ import type {
 export type Props = {
 	className?: string;
 	features: ProductCardFeatures;
+	moreFeatures?: ProductCardMoreFeatures;
 	isExpanded?: boolean;
 	productSlug?: string;
 };
@@ -31,6 +33,7 @@ export type Props = {
 const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
 	className,
 	features,
+	moreFeatures,
 	isExpanded: isExpandedByDefault,
 	productSlug,
 } ) => {
@@ -56,7 +59,7 @@ const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
 	}, [ setExpanded, trackHideFeatures ] );
 	const translate = useTranslate();
 
-	const { items, more } = features;
+	const { items } = features;
 
 	return (
 		<FoldableCard
@@ -87,10 +90,10 @@ const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
 					}
 				) }
 			</ul>
-			{ more && (
+			{ moreFeatures && (
 				<div className="jetpack-product-card__feature-more">
-					<ExternalLink icon={ true } href={ more.url }>
-						{ more.label }
+					<ExternalLink icon={ true } href={ moreFeatures.url }>
+						{ moreFeatures.label }
 					</ExternalLink>
 				</div>
 			) }

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -81,6 +81,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	isDeprecated,
 	expiryDate,
 	features,
+	moreFeatures,
 	isExpanded,
 	UpgradeNudge,
 	hidePrice,
@@ -210,8 +211,9 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 			</div>
 			{ features && features.items.length > 0 && (
 				<JetpackProductCardFeatures
-					features={ features }
 					productSlug={ productSlug }
+					features={ features }
+					moreFeatures={ moreFeatures }
 					isExpanded={ isExpanded }
 				/>
 			) }

--- a/client/components/jetpack/card/jetpack-product-card/types.ts
+++ b/client/components/jetpack/card/jetpack-product-card/types.ts
@@ -9,8 +9,10 @@ import type {
 	SelectorProductFeaturesItem,
 	SelectorProductFeaturesSection,
 	SelectorProductFeatures,
+	SelectorProductMoreFeatures,
 } from 'calypso/my-sites/plans-v2/types';
 
 export type ProductCardFeaturesItem = SelectorProductFeaturesItem;
 export type ProductCardFeaturesSection = SelectorProductFeaturesSection;
 export type ProductCardFeatures = SelectorProductFeatures;
+export type ProductCardMoreFeatures = SelectorProductMoreFeatures;

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,6 +18,7 @@ import JetpackComMasterbar from '../jpcom-masterbar';
 import './style.scss';
 
 const Header = () => {
+	const translate = useTranslate();
 	const isAlternateSelector = isEnabled( 'plans/alternate-selector' );
 	const header = isAlternateSelector
 		? translate( 'Security, performance, and growth tools for WordPress' )

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useRef, useState } from 'react';
 import classNames from 'classnames';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -20,7 +20,7 @@ import useDetectWindowBoundary from 'calypso/my-sites/plans-v2/use-detect-window
 import './style.scss';
 
 const JETPACK_COM_BASE_URL = 'https://jetpack.com';
-const MENU_ITEMS = [
+const getMenuItems = ( translate: ReturnType< typeof useTranslate > ) => [
 	{
 		title: translate( 'Product Tour' ),
 		path: 'features',
@@ -40,6 +40,7 @@ const MENU_ITEMS = [
 ];
 
 const JetpackComMasterbar = () => {
+	const translate = useTranslate();
 	const [ isMenuOpen, setIsMenuOpen ] = useState( false );
 	const barRef = useRef< HTMLDivElement | null >( null );
 	const hasCrossed = useDetectWindowBoundary( barRef );
@@ -78,7 +79,7 @@ const JetpackComMasterbar = () => {
 				</Button>
 
 				<ul className={ classNames( 'jpcom-masterbar__nav', { 'is-open': isMenuOpen } ) }>
-					{ MENU_ITEMS.map( ( { title, path }, index ) => (
+					{ getMenuItems( translate ).map( ( { title, path }, index ) => (
 						<li className="jpcom-masterbar__nav-item" key={ index }>
 							<a
 								className={ path === 'pricing' ? 'current' : '' }

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { translate } from 'i18n-calypso';
-
-/**
  * Internal dependencies
  */
 import { isEnabled } from 'calypso/config';
@@ -66,65 +61,6 @@ export const SECURITY = 'security';
 export const PLAN_COMPARISON_PAGE = 'https://jetpack.com/features/comparison/';
 
 /**
- * Link to plan comparison page.
- */
-export const MORE_FEATURES_LINK = {
-	url: PLAN_COMPARISON_PAGE,
-	label: translate( 'See all features' ),
-};
-
-/**
- * Define properties with translatable strings getters.
- */
-Object.defineProperties( MORE_FEATURES_LINK, {
-	label: {
-		get: () => translate( 'See all features' ),
-	},
-} );
-
-/*
- * Options displayed in the Product Type filter in the Plans page.
- */
-export const PRODUCT_TYPE_OPTIONS = {
-	[ SECURITY ]: {
-		id: SECURITY,
-		label: translate( 'Security' ),
-	},
-	[ PERFORMANCE ]: {
-		id: PERFORMANCE,
-		label: translate( 'Performance' ),
-	},
-	[ ALL ]: {
-		id: ALL,
-		label: translate( 'All' ),
-	},
-};
-
-/**
- * Define properties with translatable strings getters.
- */
-Object.defineProperties( PRODUCT_TYPE_OPTIONS, {
-	[ SECURITY ]: {
-		get: () => ( {
-			id: SECURITY,
-			label: translate( 'Security' ),
-		} ),
-	},
-	[ PERFORMANCE ]: {
-		get: () => ( {
-			id: PERFORMANCE,
-			label: translate( 'Performance' ),
-		} ),
-	},
-	[ ALL ]: {
-		get: () => ( {
-			id: ALL,
-			label: translate( 'All' ),
-		} ),
-	},
-} );
-
-/**
  * Plans and products that have options and can't be purchased themselves.
  */
 export const OPTIONS_JETPACK_SECURITY = 'jetpack_security';
@@ -155,15 +91,6 @@ export const OPTION_PLAN_SECURITY: SelectorProduct = {
 	costProductSlug: PLAN_JETPACK_SECURITY_DAILY,
 	monthlyProductSlug: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 	iconSlug: 'jetpack_security_v2',
-	displayName: translate( 'Jetpack Security' ),
-	shortName: translate( 'Security', {
-		comment: 'Short name of the Jetpack Security generic plan',
-	} ),
-	tagline: translate( 'Comprehensive WordPress protection' ),
-	description: translate(
-		'Enjoy the peace of mind of complete site security. ' +
-			'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
-	),
 	features: {
 		items: buildCardFeaturesFromItem( {
 			[ FEATURE_CATEGORY_SECURITY ]: [
@@ -180,7 +107,6 @@ export const OPTION_PLAN_SECURITY: SelectorProduct = {
 				FEATURE_PRIORITY_SUPPORT_V2,
 			],
 		} ),
-		more: MORE_FEATURES_LINK,
 	},
 };
 export const OPTION_PLAN_SECURITY_MONTHLY: SelectorProduct = {
@@ -190,31 +116,6 @@ export const OPTION_PLAN_SECURITY_MONTHLY: SelectorProduct = {
 	subtypes: [ PLAN_JETPACK_SECURITY_DAILY_MONTHLY, PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ],
 	costProductSlug: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 };
-
-/**
- * Define properties with translatable strings getters.
- */
-[ OPTION_PLAN_SECURITY, OPTION_PLAN_SECURITY_MONTHLY ].forEach( ( target ) => {
-	Object.defineProperties( target, {
-		displayName: {
-			get: () => translate( 'Jetpack Security' ),
-		},
-		shortName: {
-			get: () =>
-				translate( 'Security', {
-					comment: 'Short name of the Jetpack Security generic plan',
-				} ),
-		},
-		tagline: { get: () => translate( 'Comprehensive WordPress protection' ) },
-		description: {
-			get: () =>
-				translate(
-					'Enjoy the peace of mind of complete site security. ' +
-						'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
-				),
-		},
-	} );
-} );
 
 // Jetpack Backup
 export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
@@ -227,13 +128,6 @@ export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
 	costProductSlug: PRODUCT_JETPACK_BACKUP_DAILY,
 	monthlyProductSlug: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 	iconSlug: 'jetpack_backup_v2',
-	displayName: translate( 'Jetpack Backup' ),
-	shortName: translate( 'Backup', {
-		comment: 'Short name of the Jetpack Backup generic product',
-	} ),
-	tagline: translate( 'Recommended for all sites' ),
-	description: translate( 'Never lose a word, image, page, or time worrying about your site.' ),
-	buttonLabel: translate( 'Get Backup' ),
 	features: {
 		items: buildCardFeaturesFromItem(
 			[
@@ -256,28 +150,6 @@ export const OPTION_PRODUCT_BACKUP_MONTHLY: SelectorProduct = {
 	costProductSlug: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 };
 
-/**
- * Define properties with translatable strings getters.
- */
-[ OPTION_PRODUCT_BACKUP, OPTION_PRODUCT_BACKUP_MONTHLY ].forEach( ( target ) => {
-	Object.defineProperties( target, {
-		displayName: {
-			get: () => translate( 'Jetpack Backup' ),
-		},
-		shortName: {
-			get: () =>
-				translate( 'Backup', {
-					comment: 'Short name of the Jetpack Backup generic product',
-				} ),
-		},
-		tagline: { get: () => translate( 'Recommended for all sites' ) },
-		description: {
-			get: () => translate( 'Never lose a word, image, page, or time worrying about your site.' ),
-		},
-		buttonLabel: { get: () => translate( 'Get Backup' ) },
-	} );
-} );
-
 // Jetpack CRM
 export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 	productSlug: PRODUCT_JETPACK_CRM,
@@ -287,17 +159,6 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 	costProductSlug: PRODUCT_JETPACK_CRM,
 	monthlyProductSlug: PRODUCT_JETPACK_CRM,
 	iconSlug: 'jetpack_crm',
-	displayName: translate( 'Jetpack CRM' ),
-	shortName: translate( 'CRM', {
-		comment: 'Short name of the Jetpack CRM',
-	} ),
-	tagline: translate( 'Manage contacts effortlessly' ),
-	description: translate(
-		'The most simple and powerful WordPress CRM. Improve customer relationships and increase profits.'
-	),
-	buttonLabel: isEnabled( 'plans/alternate-selector' )
-		? translate( 'Get Jetpack CRM' )
-		: translate( 'Get CRM' ),
 	features: {
 		items: buildCardFeaturesFromItem(
 			[

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -25,6 +25,7 @@ import {
 	getPathToSelector,
 	getPathToUpsell,
 	getPathToDetails,
+	getSelectorProductCopy,
 	checkout,
 } from './utils';
 import QueryProducts from './query-products';
@@ -133,7 +134,7 @@ const DetailsPage = ( {
 		);
 	};
 
-	const { shortName } = product;
+	const { shortName } = getSelectorProductCopy( product.productSlug, translate );
 	const isBundle = [ OPTIONS_JETPACK_SECURITY, OPTIONS_JETPACK_SECURITY_MONTHLY ].includes(
 		productSlug
 	);

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -9,9 +9,9 @@ import { useDispatch, useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { TERM_MONTHLY } from 'lib/plans/constants';
-import { recordTracksEvent } from 'state/analytics/actions/record';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { TERM_MONTHLY } from 'calypso/lib/plans/constants';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import {
 	OPTIONS_JETPACK_SECURITY,
 	OPTIONS_JETPACK_SECURITY_MONTHLY,
@@ -25,25 +25,25 @@ import {
 	getPathToSelector,
 	getPathToUpsell,
 	getPathToDetails,
-	getSelectorProductCopy,
 	checkout,
 } from './utils';
 import QueryProducts from './query-products';
+import { getSelectorProductCopy } from './translated-copy';
 import useIsLoading from './use-is-loading';
 import useHasProductUpsell from './use-has-product-upsell';
-import ProductCardPlaceholder from 'components/jetpack/card/product-card-placeholder';
-import FormattedHeader from 'components/formatted-header';
-import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
+import ProductCardPlaceholder from 'calypso/components/jetpack/card/product-card-placeholder';
+import FormattedHeader from 'calypso/components/formatted-header';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import withRedirectToSelector from './with-redirect-to-selector';
 
 /**
  * Type dependencies
  */
 import type { Duration, DetailsPageProps, PurchaseCallback, SelectorProduct } from './types';
-import type { ProductSlug } from 'lib/products-values/types';
+import type { ProductSlug } from 'calypso/lib/products-values/types';
 
 import './style.scss';
 

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -9,11 +9,7 @@ import { useSelector } from 'react-redux';
  * Internal dependencies
  */
 import { PRODUCTS_TYPES, SELECTOR_PLANS } from '../constants';
-import {
-	getAllOptionsFromSlug,
-	getJetpackDescriptionWithOptions,
-	slugToSelectorProduct,
-} from '../utils';
+import { getAllOptionsFromSlug, slugToSelectorProduct } from '../utils';
 import ProductCard from '../product-card';
 import { getMonthlyPlanByYearly, getYearlyPlanByMonthly } from 'calypso/lib/plans';
 import { JETPACK_LEGACY_PLANS, PLAN_JETPACK_FREE } from 'calypso/lib/plans/constants';
@@ -60,11 +56,7 @@ const PlansColumn = ( { duration, onPlanClick, productType, siteId }: PlanColumn
 					! currentPlanAllTerms.includes( product.productSlug ) &&
 					// Don't include a generic/option card if the user already owns a subtype
 					! optionsFromCurrentPlan.includes( product.productSlug )
-			)
-			.map( ( product: SelectorProduct ) => ( {
-				...product,
-				description: getJetpackDescriptionWithOptions( product, translate ),
-			} ) );
+			);
 
 		// If the user owns a plan, get it and insert it on the top of the plan array.
 		if (

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -34,6 +34,8 @@ interface PlanColumnType {
 }
 
 const PlansColumn = ( { duration, onPlanClick, productType, siteId }: PlanColumnType ) => {
+	const translate = useTranslate();
+
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
 	const currentPlan =
 		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
@@ -61,7 +63,7 @@ const PlansColumn = ( { duration, onPlanClick, productType, siteId }: PlanColumn
 			)
 			.map( ( product: SelectorProduct ) => ( {
 				...product,
-				description: getJetpackDescriptionWithOptions( product ),
+				description: getJetpackDescriptionWithOptions( product, translate ),
 			} ) );
 
 		// If the user owns a plan, get it and insert it on the top of the plan array.

--- a/client/my-sites/plans-v2/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useRef } from 'react';
 import { useSelector } from 'react-redux';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import classNames from 'classnames';
 
 /**
@@ -14,8 +14,8 @@ import SelectDropdown from 'calypso/components/select-dropdown';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
 import { masterbarIsVisible } from 'calypso/state/ui/selectors';
-import { PRODUCT_TYPE_OPTIONS } from '../constants';
 import useDetectWindowBoundary from '../use-detect-window-boundary';
+import { getProductTypeOptions } from '../utils';
 
 /**
  * Type dependencies
@@ -49,6 +49,8 @@ const PlansFilterBar = ( {
 	onDurationChange,
 	onProductTypeChange,
 }: Props ) => {
+	const translate = useTranslate();
+
 	const isCloud = isJetpackCloud();
 	const masterbarSelector = isCloud ? '.jpcom-masterbar' : '.masterbar';
 	const masterbarDefaultHeight = isCloud ? CLOUD_MASTERBAR_HEIGHT : CALYPSO_MASTERBAR_HEIGHT;
@@ -61,11 +63,13 @@ const PlansFilterBar = ( {
 	const masterbarOffset = isMasterbarVisible || isCloud ? masterbarHeight : 0;
 	const hasCrossed = useDetectWindowBoundary( barRef, masterbarOffset );
 
+	const productTypeOptions = getProductTypeOptions( translate );
+
 	return (
 		<div ref={ barRef } className={ classNames( 'plans-filter-bar', { sticky: hasCrossed } ) }>
 			{ showProductTypes && (
-				<SelectDropdown selectedText={ productType && PRODUCT_TYPE_OPTIONS[ productType ].label }>
-					{ Object.values( PRODUCT_TYPE_OPTIONS ).map( ( option ) => (
+				<SelectDropdown selectedText={ productType && productTypeOptions[ productType ].label }>
+					{ Object.values( productTypeOptions ).map( ( option ) => (
 						<SelectDropdown.Item
 							key={ option.id }
 							selected={ productType === option.id }

--- a/client/my-sites/plans-v2/product-card-alt/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt/index.tsx
@@ -4,6 +4,7 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ import {
 } from '../utils';
 import PlanRenewalMessage from '../plan-renewal-message';
 import RecordsDetailsAlt from '../records-details-alt';
+import { getSelectorProductCopy } from '../translated-copy';
 import useItemPrice from '../use-item-price';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
@@ -53,6 +55,8 @@ const ProductCardAltWrapper = ( {
 	highlight = false,
 	selectedTerm,
 }: ProductCardProps ) => {
+	const translate = useTranslate();
+
 	// Determine whether product is owned.
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
@@ -97,7 +101,10 @@ const ProductCardAltWrapper = ( {
 	const isUpgradeableToYearly =
 		isOwned && selectedTerm === TERM_ANNUALLY && item.term === TERM_MONTHLY;
 
-	const description = showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description;
+	const selectorProductCopy = getSelectorProductCopy( item.productSlug, translate );
+
+	const description =
+		showExpiryNotice && purchase ? <PlanRenewalMessage /> : selectorProductCopy.description;
 	const showRecordsDetails = JETPACK_SEARCH_PRODUCTS.includes( item.productSlug ) && siteId;
 
 	// In the case of products that have options (daily and real-time), we want to display
@@ -109,10 +116,10 @@ const ProductCardAltWrapper = ( {
 			headingLevel={ 3 }
 			iconSlug={ item.iconSlug }
 			productName={ productName }
-			subheadline={ item.tagline }
+			subheadline={ selectorProductCopy.tagline }
 			description={ description }
 			currencyCode={ currencyCode }
-			billingTimeFrame={ durationToText( item.term ) }
+			billingTimeFrame={ durationToText( item.term, translate ) }
 			buttonLabel={ productButtonLabelAlt(
 				item,
 				isOwned,
@@ -121,7 +128,7 @@ const ProductCardAltWrapper = ( {
 				sitePlan
 			) }
 			buttonPrimary={ ! ( isOwned || isItemPlanFeature ) }
-			badgeLabel={ productBadgeLabelAlt( item, isOwned, sitePlan ) }
+			badgeLabel={ productBadgeLabelAlt( item, isOwned, translate, sitePlan ) }
 			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
 			features={ item.features }
 			searchRecordsDetails={

--- a/client/my-sites/plans-v2/product-card-alt/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt/index.tsx
@@ -125,6 +125,7 @@ const ProductCardAltWrapper = ( {
 				isOwned,
 				isItemPlanFeature,
 				isUpgradeableToYearly,
+				translate,
 				sitePlan
 			) }
 			buttonPrimary={ ! ( isOwned || isItemPlanFeature ) }

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -3,6 +3,7 @@
  */
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 
 /**
@@ -16,11 +17,13 @@ import {
 } from '../constants';
 import {
 	durationToText,
-	productButtonLabel,
-	isUpgradeable,
+	getMoreFeaturesLink,
 	getRealtimeFromDaily,
-	slugToSelectorProduct,
+	getSelectorProductCopy,
+	isUpgradeable,
 	productBadgeLabel,
+	productButtonLabel,
+	slugToSelectorProduct,
 	slugIsFeaturedProduct,
 } from '../utils';
 import PlanRenewalMessage from '../plan-renewal-message';
@@ -64,6 +67,8 @@ interface UpgradeNudgeProps {
 }
 
 const UpgradeNudgeWrapper = ( { siteId, item, currencyCode, onClick }: UpgradeNudgeProps ) => {
+	const translate = useTranslate();
+
 	const upgradeToProductSlug =
 		getRealtimeFromDaily( item.costProductSlug || item.productSlug ) || '';
 	const selectorProductToUpgrade = slugToSelectorProduct( upgradeToProductSlug );
@@ -80,7 +85,7 @@ const UpgradeNudgeWrapper = ( { siteId, item, currencyCode, onClick }: UpgradeNu
 
 	return (
 		<JetpackProductCardUpgradeNudge
-			billingTimeFrame={ durationToText( selectorProductToUpgrade.term ) }
+			billingTimeFrame={ durationToText( selectorProductToUpgrade.term, translate ) }
 			currencyCode={ currencyCode }
 			discountedPrice={ discountedPrice }
 			originalPrice={ originalPrice }
@@ -109,6 +114,8 @@ const ProductCardWrapper = ( {
 	highlight = false,
 	selectedTerm,
 }: ProductCardProps ) => {
+	const translate = useTranslate();
+
 	// Determine whether product is owned.
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
@@ -150,6 +157,8 @@ const ProductCardWrapper = ( {
 
 	const CardComponent = itemToCard( item ); // Get correct card component.
 
+	const itemCopy = getSelectorProductCopy( item.productSlug, translate );
+
 	const isUpgradeableToYearly =
 		isOwned && selectedTerm === TERM_ANNUALLY && item.term === TERM_MONTHLY;
 
@@ -173,15 +182,22 @@ const ProductCardWrapper = ( {
 		<CardComponent
 			headingLevel={ 3 }
 			iconSlug={ item.iconSlug }
-			productName={ item.displayName }
-			subheadline={ item.tagline }
-			description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description }
+			productName={ itemCopy.displayName }
+			subheadline={ itemCopy.tagline }
+			description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : itemCopy.description }
 			currencyCode={ currencyCode }
-			billingTimeFrame={ durationToText( item.term ) }
-			buttonLabel={ productButtonLabel( item, isOwned, isUpgradeableToYearly, sitePlan ) }
-			badgeLabel={ productBadgeLabel( item, isOwned, highlight, sitePlan ) }
+			billingTimeFrame={ durationToText( item.term, translate ) }
+			buttonLabel={ productButtonLabel(
+				item,
+				isOwned,
+				isUpgradeableToYearly,
+				translate,
+				sitePlan
+			) }
+			badgeLabel={ productBadgeLabel( item, isOwned, highlight, translate, sitePlan ) }
 			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
 			features={ item.features }
+			moreFeatures={ getMoreFeaturesLink( item.productSlug, translate ) }
 			children={ item.children }
 			originalPrice={ originalPrice }
 			discountedPrice={ discountedPrice }

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -19,28 +19,28 @@ import {
 	durationToText,
 	getMoreFeaturesLink,
 	getRealtimeFromDaily,
-	getSelectorProductCopy,
 	isUpgradeable,
 	productBadgeLabel,
 	productButtonLabel,
 	slugToSelectorProduct,
 	slugIsFeaturedProduct,
 } from '../utils';
+import { getSelectorProductCopy } from '../translated-copy';
 import PlanRenewalMessage from '../plan-renewal-message';
 import useItemPrice from '../use-item-price';
-import { getSitePurchases } from 'state/purchases/selectors';
-import getSitePlan from 'state/sites/selectors/get-site-plan';
-import getSiteProducts from 'state/sites/selectors/get-site-products';
-import { useLocalizedMoment } from 'components/localized-moment';
-import JetpackPlanCard from 'components/jetpack/card/jetpack-plan-card';
-import JetpackBundleCard from 'components/jetpack/card/jetpack-bundle-card';
-import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
-import JetpackProductCardUpgradeNudge from 'components/jetpack/card/jetpack-product-card/upgrade-nudge';
-import { planHasFeature } from 'lib/plans';
-import { TERM_MONTHLY, TERM_ANNUALLY } from 'lib/plans/constants';
-import { JETPACK_SEARCH_PRODUCTS } from 'lib/products-values/constants';
-import { isCloseToExpiration } from 'lib/purchases';
-import { getPurchaseByProductSlug } from 'lib/purchases/utils';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
+import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import JetpackPlanCard from 'calypso/components/jetpack/card/jetpack-plan-card';
+import JetpackBundleCard from 'calypso/components/jetpack/card/jetpack-bundle-card';
+import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
+import JetpackProductCardUpgradeNudge from 'calypso/components/jetpack/card/jetpack-product-card/upgrade-nudge';
+import { planHasFeature } from 'calypso/lib/plans';
+import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
+import { JETPACK_SEARCH_PRODUCTS } from 'calypso/lib/products-values/constants';
+import { isCloseToExpiration } from 'calypso/lib/purchases';
+import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 
 /**
  * Type dependencies

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -33,6 +33,8 @@ const ProductsColumn = ( {
 	productType,
 	siteId,
 }: ProductsColumnType ) => {
+	const translate = useTranslate();
+
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
 
 	const { availableProducts, purchasedProducts, includedInPlanProducts } = useGetPlansGridProducts(
@@ -54,7 +56,7 @@ const ProductsColumn = ( {
 				)
 				.map( ( product ) => ( {
 					...product,
-					description: getJetpackDescriptionWithOptions( product as SelectorProduct ),
+					description: getJetpackDescriptionWithOptions( product as SelectorProduct, translate ),
 				} ) )
 		);
 	}, [ duration, availableProducts, includedInPlanProducts, purchasedProducts, productType ] );

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -8,7 +8,6 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getJetpackDescriptionWithOptions } from '../utils';
 import { PRODUCTS_TYPES } from '../constants';
 import ProductCard from '../product-card';
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
@@ -54,10 +53,6 @@ const ProductsColumn = ( {
 					( product ): product is SelectorProduct =>
 						!! product && PRODUCTS_TYPES[ productType ].includes( product.productSlug )
 				)
-				.map( ( product ) => ( {
-					...product,
-					description: getJetpackDescriptionWithOptions( product as SelectorProduct, translate ),
-				} ) )
 		);
 	}, [ duration, availableProducts, includedInPlanProducts, purchasedProducts, productType ] );
 

--- a/client/my-sites/plans-v2/products-grid-alt/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-alt/index.tsx
@@ -20,7 +20,7 @@ import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card-alt';
 import { SELECTOR_PLANS_ALT } from '../constants';
-import { getJetpackDescriptionWithOptions, slugToSelectorProduct } from '../utils';
+import { slugToSelectorProduct } from '../utils';
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
 import PRODUCTS_ORDER_BY_SLUG from './products-order';
 import ProductCardAlt from '../product-card-alt';
@@ -60,11 +60,7 @@ const getPlansToDisplay = ( {
 					JETPACK_SECURITY_PLANS.includes( currentPlanSlug ) &&
 					JETPACK_SECURITY_PLANS.includes( product.productSlug )
 				)
-		)
-		.map( ( product: SelectorProduct ) => ( {
-			...product,
-			description: getJetpackDescriptionWithOptions( product ),
-		} ) );
+		);
 
 	if ( currentPlanSlug && JETPACK_RESET_PLANS.includes( currentPlanSlug ) ) {
 		const currentPlanSelectorProduct = slugToSelectorProduct( currentPlanSlug );
@@ -96,10 +92,6 @@ const getProductsToDisplay = ( {
 		[ ...purchasedProducts, ...filteredProducts ]
 			// Make sure we don't allow any null or invalid products
 			.filter( ( product ): product is SelectorProduct => !! product )
-			.map( ( product ) => ( {
-				...product,
-				description: getJetpackDescriptionWithOptions( product as SelectorProduct ),
-			} ) )
 	);
 };
 

--- a/client/my-sites/plans-v2/records-details/index.tsx
+++ b/client/my-sites/plans-v2/records-details/index.tsx
@@ -99,7 +99,9 @@ const RecordsDetails: FunctionComponent< Props > = ( { productSlug } ) => {
 						<PlanPrice rawPrice={ discountedPrice } discounted currencyCode={ currencyCode } />
 					) }
 				</div>
-				<p className="records-details__timeframe">{ durationToText( selectorProduct.term ) }</p>
+				<p className="records-details__timeframe">
+					{ durationToText( selectorProduct.term, translate ) }
+				</p>
 			</div>
 		</div>
 	);

--- a/client/my-sites/plans-v2/translated-copy.tsx
+++ b/client/my-sites/plans-v2/translated-copy.tsx
@@ -1,0 +1,228 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	OPTIONS_JETPACK_BACKUP,
+	OPTIONS_JETPACK_BACKUP_MONTHLY,
+	OPTIONS_JETPACK_SECURITY,
+	OPTIONS_JETPACK_SECURITY_MONTHLY,
+} from './constants';
+import {
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+} from 'calypso/lib/plans/constants';
+import {
+	PRODUCT_JETPACK_ANTI_SPAM,
+	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_DAILY,
+	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_REALTIME,
+	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+	PRODUCT_JETPACK_CRM,
+	PRODUCT_JETPACK_CRM_MONTHLY,
+	PRODUCT_JETPACK_SCAN,
+	PRODUCT_JETPACK_SCAN_MONTHLY,
+	PRODUCT_JETPACK_SEARCH,
+	PRODUCT_JETPACK_SEARCH_MONTHLY,
+	PRODUCT_WPCOM_SEARCH,
+	PRODUCT_WPCOM_SEARCH_MONTHLY,
+} from 'calypso/lib/products-values/constants';
+
+/**
+ * Type dependencies
+ */
+import type { SelectorProductCopy } from './types';
+
+export function getSelectorProductCopy(
+	productSlug: string,
+	translate: ReturnType< typeof useTranslate >
+): SelectorProductCopy {
+	switch ( productSlug ) {
+		case PRODUCT_JETPACK_ANTI_SPAM:
+		case PRODUCT_JETPACK_ANTI_SPAM_MONTHLY:
+			return {
+				displayName: translate( 'Jetpack Anti-spam' ),
+				shortName: translate( 'Anti-spam', {
+					comment: 'Short name of Jetpack Anti-spam',
+				} ),
+				tagline: translate( 'Block spam automatically' ),
+				description: translate(
+					'Automated spam protection for comments and forms. Save time, get more responses, and give your visitors a better experience.'
+				),
+				buttonLabel: translate( 'Get Anti-spam' ),
+			};
+		case OPTIONS_JETPACK_BACKUP:
+		case OPTIONS_JETPACK_BACKUP_MONTHLY:
+			return {
+				displayName: translate( 'Jetpack Backup' ),
+				shortName: translate( 'Backup', {
+					comment: 'Short name of the Jetpack Backup generic product',
+				} ),
+				tagline: translate( 'Recommended for all sites' ),
+				description: translate(
+					'Never lose a word, image, page, or time worrying about your site. {{em}}Available options: Real-time or Daily.{{/em}}',
+					{
+						components: {
+							em: <em />,
+						},
+					}
+				),
+				buttonLabel: translate( 'Get Backup' ),
+			};
+		case PRODUCT_JETPACK_BACKUP_DAILY:
+		case PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY:
+			return {
+				displayName: translate( 'Backup {{em}}Daily{{/em}}', {
+					components: {
+						em: <em />,
+					},
+				} ),
+				shortName: translate( 'Backup Daily', {
+					comment: 'Short name of the Jetpack Backup Daily product',
+				} ),
+				tagline: translate( 'Best for sites with occasional updates' ),
+				description: translate(
+					'Never lose a word, image, page, or time worrying about your site.'
+				),
+				buttonLabel: translate( 'Get Backup {{em}}Daily{{/em}}', {
+					components: {
+						em: <em />,
+					},
+				} ),
+			};
+
+		case PRODUCT_JETPACK_BACKUP_REALTIME:
+		case PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY:
+			return {
+				displayName: translate( 'Backup {{em}}Real-Time{{/em}}', {
+					components: {
+						em: <em />,
+					},
+				} ),
+				shortName: translate( 'Backup Real-time', {
+					comment: 'Short name of the Jetpack Backup Real-time product',
+				} ),
+				tagline: translate( 'Best for sites with frequent updates' ),
+				description: translate(
+					'Real-time backups save every change and one-click restores get you back online quickly.'
+				),
+				buttonLabel: translate( 'Get Backup {{em}}Real-Time{{/em}}', {
+					components: {
+						em: <em />,
+					},
+				} ),
+			};
+		case PLAN_JETPACK_COMPLETE:
+		case PLAN_JETPACK_COMPLETE_MONTHLY:
+			return {
+				displayName: translate( 'Jetpack Complete' ),
+				shortName: translate( 'Complete', {
+					comment: 'Short name of Jetpack Complete',
+				} ),
+				tagline: translate( 'For best-in-class WordPress sites' ),
+				description: translate(
+					'Superpower your site with everything Jetpack has to offer: real-time security, enhanced search, CRM, and marketing, growth, and design tools.'
+				),
+				buttonLabel: translate( 'Get Jetpack Complete' ),
+			};
+		case PRODUCT_JETPACK_CRM:
+		case PRODUCT_JETPACK_CRM_MONTHLY:
+			return {
+				displayName: translate( 'Jetpack CRM' ),
+				shortName: translate( 'CRM', {
+					comment: 'Short name of the Jetpack CRM',
+				} ),
+				tagline: translate( 'Manage contacts effortlessly' ),
+				description: translate(
+					'The most simple and powerful WordPress CRM. Improve customer relationships and increase profits.'
+				),
+				buttonLabel: translate( 'Get CRM' ),
+			};
+		case PRODUCT_JETPACK_SCAN:
+		case PRODUCT_JETPACK_SCAN_MONTHLY:
+			return {
+				displayName: translate( 'Jetpack Scan' ),
+				shortName: translate( 'Scan', {
+					comment: 'Short name of Jetpack Scan',
+				} ),
+				tagline: translate( 'Protect your site' ),
+				description: translate(
+					'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
+				),
+				buttonLabel: translate( 'Get Scan' ),
+			};
+		case PRODUCT_JETPACK_SEARCH:
+		case PRODUCT_JETPACK_SEARCH_MONTHLY:
+		case PRODUCT_WPCOM_SEARCH:
+		case PRODUCT_WPCOM_SEARCH_MONTHLY:
+			return {
+				displayName: translate( 'Jetpack Search' ),
+				shortName: translate( 'Search', {
+					comment: 'Short name of Jetpack Search',
+				} ),
+				tagline: translate( 'Recommended for sites with lots of products or content' ),
+				description: translate(
+					'Help your site visitors find answers instantly so they keep reading and buying.'
+				),
+				buttonLabel: translate( 'Get Search' ),
+			};
+		case OPTIONS_JETPACK_SECURITY:
+		case OPTIONS_JETPACK_SECURITY_MONTHLY:
+			return {
+				displayName: translate( 'Jetpack Security' ),
+				shortName: translate( 'Security', {
+					comment: 'Short name of the Jetpack Security generic plan',
+				} ),
+				tagline: translate( 'Comprehensive WordPress protection' ),
+				description: translate(
+					'Enjoy the peace of mind of complete site security. ' +
+						'Easy-to-use, powerful security tools guard your site, so you can focus on your business. ' +
+						'{{em}}Available options: Real-time or Daily.{{/em}}',
+					{ components: { em: <em /> } }
+				),
+				buttonLabel: translate( 'Get Jetpack Security' ),
+			};
+		case PLAN_JETPACK_SECURITY_DAILY:
+		case PLAN_JETPACK_SECURITY_DAILY_MONTHLY:
+			return {
+				displayName: translate( 'Security {{em}}Daily{{/em}}', { components: { em: <em /> } } ),
+				shortName: translate( 'Security Daily', {
+					comment: 'Short name of the Jetpack Security Daily plan',
+				} ),
+				tagline: translate( 'Comprehensive WordPress protection' ),
+				description: translate(
+					'Enjoy the peace of mind of complete site protection. ' +
+						'Great for brochure sites, restaurants, blogs, and resume sites.'
+				),
+				buttonLabel: translate( 'Get Security {{em}}Daily{{/em}}', { components: { em: <em /> } } ),
+			};
+		case PLAN_JETPACK_SECURITY_REALTIME:
+		case PLAN_JETPACK_SECURITY_REALTIME_MONTHLY:
+			return {
+				displayName: translate( 'Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } ),
+				shortName: translate( 'Security Real-time', {
+					comment: 'Short name of the Jetpack Security Real-time plan',
+				} ),
+				tagline: translate( 'Comprehensive WordPress protection' ),
+				description: translate(
+					'Additional security for sites with 24/7 activity. ' +
+						'Recommended for eCommerce stores, news organizations, and online forums.'
+				),
+				buttonLabel: translate( 'Get Security {{em}}Real-time{{/em}}', {
+					components: { em: <em /> },
+				} ),
+			};
+		default:
+			throw `Unknown SelectorProductSlug: ${ productSlug }`;
+	}
+}

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -87,10 +87,11 @@ export type SelectorProductFeaturesSection = {
 
 export type SelectorProductFeatures = {
 	items: SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[];
-	more?: {
-		url: string;
-		label: TranslateResult;
-	};
+};
+
+export type SelectorProductMoreFeatures = {
+	url: string;
+	label: TranslateResult;
 };
 
 export interface SelectorProduct extends SelectorProductCost {
@@ -101,18 +102,21 @@ export interface SelectorProduct extends SelectorProductCost {
 	type: ItemType;
 	costProductSlug?: string;
 	monthlyProductSlug?: string;
-	displayName: TranslateResult;
-	shortName: TranslateResult;
-	tagline: TranslateResult;
-	description: TranslateResult | ReactNode;
 	children?: ReactNode;
 	term: Duration;
-	buttonLabel?: TranslateResult;
 	features: SelectorProductFeatures;
 	subtypes: string[];
 	legacy?: boolean;
 	hidePrice?: boolean;
 	externalUrl?: string;
+}
+
+export interface SelectorProductCopy {
+	displayName: TranslateResult;
+	shortName: TranslateResult;
+	tagline: TranslateResult;
+	description: TranslateResult | ReactNode;
+	buttonLabel?: TranslateResult;
 }
 
 export interface AvailableProductData {

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -25,14 +25,16 @@ import QueryProducts from './query-products';
 import useIsLoading from './use-is-loading';
 import useItemPrice from './use-item-price';
 import {
+	checkout,
 	durationToString,
 	durationToText,
+	getMoreFeaturesLink,
 	getOptionFromSlug,
 	getProductUpsell,
 	getPathToSelector,
 	getPathToDetails,
+	getSelectorProductCopy,
 	slugToSelectorProduct,
-	checkout,
 } from './utils';
 import withRedirectToSelector from './with-redirect-to-selector';
 
@@ -80,9 +82,10 @@ const UpsellComponent = ( {
 		upsellProduct.monthlyProductSlug || ''
 	);
 
-	const { shortName: mainProductName } = mainProduct;
-	const { shortName: upsellProductName, productSlug: upsellSlug } = upsellProduct;
+	const mainProductCopy = getSelectorProductCopy( mainProduct.productSlug, translate );
+	const upsellProductCopy = getSelectorProductCopy( upsellProduct.productSlug, translate );
 
+	const upsellSlug = upsellProduct.productSlug;
 	const isScanProduct = useMemo(
 		() => JETPACK_SCAN_PRODUCTS.some( ( slug ) => slug === upsellSlug ),
 		[ upsellSlug ]
@@ -109,7 +112,7 @@ const UpsellComponent = ( {
 						headerText={ preventWidows(
 							translate( 'Would you like to add {{name/}}?', {
 								components: {
-									name: <>{ upsellProductName }</>,
+									name: <>{ upsellProductCopy.shortName }</>,
 								},
 								comment:
 									'{{name/}} is the name of a product such as Jetpack Scan or Jetpack Backup',
@@ -130,8 +133,8 @@ const UpsellComponent = ( {
 											'Combine {{mainName/}} and {{upsellName/}} to give your site comprehensive protection from malware and other threats.',
 											{
 												components: {
-													mainName: <>{ mainProductName }</>,
-													upsellName: <>{ upsellProductName }</>,
+													mainName: <>{ mainProductCopy.shortName }</>,
+													upsellName: <>{ upsellProductCopy.shortName }</>,
 												},
 												comment:
 													"{{mainName/}} refers to the product the customer is purchasing (Backup in that case), {{upsellName/}} to the product we're upselling (Scan in that case)",
@@ -141,8 +144,8 @@ const UpsellComponent = ( {
 											'Combine {{mainName/}} and {{upsellName/}} to be able to save every change and restore your site in one click.',
 											{
 												components: {
-													mainName: <>{ mainProductName }</>,
-													upsellName: <>{ upsellProductName }</>,
+													mainName: <>{ mainProductCopy.shortName }</>,
+													upsellName: <>{ upsellProductCopy.shortName }</>,
 												},
 												comment:
 													"{{mainName/}} refers to the product the customer is purchasing (Scan in that case), {{upsellName/}} to the product we're upselling (Backup in that case)",
@@ -159,25 +162,26 @@ const UpsellComponent = ( {
 				<div className="upsell__product-card">
 					<JetpackProductCard
 						iconSlug={ upsellProduct.iconSlug }
-						productName={ upsellProduct.displayName }
-						subheadline={ upsellProduct.tagline }
-						description={ upsellProduct.description }
+						productName={ upsellProductCopy.displayName }
+						subheadline={ upsellProductCopy.tagline }
+						description={ upsellProductCopy.description }
 						currencyCode={ currencyCode }
-						billingTimeFrame={ durationToText( upsellProduct.term ) }
+						billingTimeFrame={ durationToText( upsellProduct.term, translate ) }
 						buttonLabel={ translate( 'Yes, add {{name/}}', {
 							components: {
-								name: <>{ upsellProductName }</>,
+								name: <>{ upsellProductCopy.shortName }</>,
 							},
 							comment:
 								'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',
 						} ) }
 						features={ upsellProduct.features }
+						moreFeatures={ getMoreFeaturesLink( upsellProduct.productSlug, translate ) }
 						discountedPrice={ discountedPrice }
 						originalPrice={ originalPrice }
 						onButtonClick={ onPurchaseBothProducts }
 						cancelLabel={ translate( 'No, I do not want {{name/}}', {
 							components: {
-								name: <>{ upsellProductName }</>,
+								name: <>{ upsellProductCopy.shortName }</>,
 							},
 							comment:
 								'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -10,17 +10,20 @@ import { useSelector } from 'react-redux';
  * Internal dependencies
  */
 import { ProductIcon } from '@automattic/components';
-import Gridicon from 'components/gridicon';
-import FormattedHeader from 'components/formatted-header';
-import HeaderCake from 'components/header-cake';
-import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
-import Main from 'components/main';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { preventWidows } from 'lib/formatting';
-import useTrackCallback from 'lib/jetpack/use-track-callback';
-import { JETPACK_SCAN_PRODUCTS, JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
+import Gridicon from 'calypso/components/gridicon';
+import FormattedHeader from 'calypso/components/formatted-header';
+import HeaderCake from 'calypso/components/header-cake';
+import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { preventWidows } from 'calypso/lib/formatting';
+import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import {
+	JETPACK_SCAN_PRODUCTS,
+	JETPACK_BACKUP_PRODUCTS,
+} from 'calypso/lib/products-values/constants';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import QueryProducts from './query-products';
 import useIsLoading from './use-is-loading';
 import useItemPrice from './use-item-price';
@@ -33,9 +36,9 @@ import {
 	getProductUpsell,
 	getPathToSelector,
 	getPathToDetails,
-	getSelectorProductCopy,
 	slugToSelectorProduct,
 } from './utils';
+import { getSelectorProductCopy } from './translated-copy';
 import withRedirectToSelector from './with-redirect-to-selector';
 
 /**

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import { TranslateResult } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { compact, isArray, isObject } from 'lodash';
 import page from 'page';
-import React, { createElement, Fragment } from 'react';
+import { createElement, Fragment } from 'react';
 
 /**
  * Internal dependencies
@@ -13,7 +13,6 @@ import { getFeatureByKey, getFeatureCategoryByKey } from 'calypso/lib/plans/feat
 import {
 	ALL,
 	DAILY_PLAN_TO_REALTIME_PLAN,
-	DAILY_PRODUCTS,
 	EXTERNAL_PRODUCTS_LIST,
 	EXTERNAL_PRODUCTS_SLUG_MAP,
 	FEATURED_PRODUCTS,
@@ -28,13 +27,13 @@ import {
 	PERFORMANCE,
 	PLAN_COMPARISON_PAGE,
 	PRODUCTS_WITH_OPTIONS,
-	REALTIME_PRODUCTS,
 	SECURITY,
 	SUBTYPE_TO_OPTION,
 	UPGRADEABLE_WITH_NUDGE,
 	UPSELL_PRODUCT_MATRIX,
 } from './constants';
 import RecordsDetails from './records-details';
+import { getSelectorProductCopy } from './translated-copy';
 import { addItems } from 'calypso/lib/cart/actions';
 import { jetpackProductItem } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -62,12 +61,6 @@ import {
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_PRODUCT_PRICE_MATRIX,
 	JETPACK_SEARCH_PRODUCTS,
-	PRODUCT_JETPACK_ANTI_SPAM,
-	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
-	PRODUCT_JETPACK_CRM,
-	PRODUCT_JETPACK_CRM_MONTHLY,
-	PRODUCT_JETPACK_SCAN,
-	PRODUCT_JETPACK_SCAN_MONTHLY,
 } from 'calypso/lib/products-values/constants';
 import {
 	Product,
@@ -83,7 +76,6 @@ import { addQueryArgs } from 'calypso/lib/route';
 import type {
 	Duration,
 	SelectorProduct,
-	SelectorProductCopy,
 	SelectorProductSlug,
 	DurationString,
 	SelectorProductFeaturesItem,
@@ -122,10 +114,13 @@ export function durationToString( duration: Duration ): DurationString {
 	return duration === TERM_MONTHLY ? 'monthly' : 'annual';
 }
 
-export function durationToText( duration: Duration, translateFn: Function ): TranslateResult {
+export function durationToText(
+	duration: Duration,
+	translate: ReturnType< typeof useTranslate >
+): TranslateResult {
 	return duration === TERM_MONTHLY
-		? translateFn( 'per month, billed monthly' )
-		: translateFn( 'per month, billed yearly' );
+		? translate( 'per month, billed monthly' )
+		: translate( 'per month, billed yearly' );
 }
 
 // In the case of products that have options (daily and real-time), we want to display
@@ -152,11 +147,11 @@ export function productButtonLabel(
 	product: SelectorProduct,
 	isOwned: boolean,
 	isUpgradeableToYearly: boolean,
-	translateFn: Function,
+	translate: ReturnType< typeof useTranslate >,
 	currentPlan?: SitePlan | null
 ): TranslateResult {
 	if ( isUpgradeableToYearly ) {
-		return translateFn( 'Upgrade to Yearly' );
+		return translate( 'Upgrade to Yearly' );
 	}
 
 	if (
@@ -164,15 +159,15 @@ export function productButtonLabel(
 		( currentPlan && planHasFeature( currentPlan.product_slug, product.productSlug ) )
 	) {
 		return product.type !== ITEM_TYPE_PRODUCT
-			? translateFn( 'Manage Plan' )
-			: translateFn( 'Manage Subscription' );
+			? translate( 'Manage Plan' )
+			: translate( 'Manage Subscription' );
 	}
 
-	const { buttonLabel, displayName } = getSelectorProductCopy( product.productSlug, translateFn );
+	const { buttonLabel, displayName } = getSelectorProductCopy( product.productSlug, translate );
 
 	return (
 		buttonLabel ??
-		translateFn( 'Get {{name/}}', {
+		translate( 'Get {{name/}}', {
 			components: {
 				name: createElement( Fragment, {}, displayName ),
 			},
@@ -234,25 +229,28 @@ export function productBadgeLabel(
 	product: SelectorProduct,
 	isOwned: boolean,
 	highlight: boolean,
-	translateFn: Function,
+	translate: ReturnType< typeof useTranslate >,
 	currentPlan?: SitePlan | null
 ): TranslateResult | undefined {
 	if ( isOwned ) {
 		return slugIsJetpackPlanSlug( product.productSlug )
-			? translateFn( 'Your plan' )
-			: translateFn( 'You own this' );
+			? translate( 'Your plan' )
+			: translate( 'You own this' );
 	}
 
 	if ( currentPlan && planHasFeature( currentPlan.product_slug, product.productSlug ) ) {
-		return translateFn( 'Included in your plan' );
+		return translate( 'Included in your plan' );
 	}
 
 	if ( highlight && slugIsFeaturedProduct( product.productSlug ) ) {
-		return translateFn( 'Best Value' );
+		return translate( 'Best Value' );
 	}
 }
 
-export function getMoreFeaturesLink( productSlug: string, translateFn: Function ) {
+export function getMoreFeaturesLink(
+	productSlug: string,
+	translate: ReturnType< typeof useTranslate >
+) {
 	switch ( productSlug ) {
 		case OPTIONS_JETPACK_SECURITY:
 		case OPTIONS_JETPACK_SECURITY_MONTHLY:
@@ -264,131 +262,34 @@ export function getMoreFeaturesLink( productSlug: string, translateFn: Function 
 		case PLAN_JETPACK_COMPLETE_MONTHLY:
 			return {
 				url: PLAN_COMPARISON_PAGE,
-				label: translateFn( 'See all features' ),
+				label: translate( 'See all features' ),
 			};
 		default:
 			return undefined;
 	}
 }
 
-export function getProductTypeOptions( translateFn: Function ) {
+export function getProductTypeOptions( translate: ReturnType< typeof useTranslate > ) {
 	return {
 		[ SECURITY ]: {
 			id: SECURITY,
-			label: translateFn( 'Security' ),
+			label: translate( 'Security' ),
 		},
 		[ PERFORMANCE ]: {
 			id: PERFORMANCE,
-			label: translateFn( 'Performance' ),
+			label: translate( 'Performance' ),
 		},
 		[ ALL ]: {
 			id: ALL,
-			label: translateFn( 'All' ),
+			label: translate( 'All' ),
 		},
 	};
-}
-
-export function getSelectorProductCopy(
-	productSlug: string,
-	translateFn: Function
-): SelectorProductCopy {
-	const securityCopy = {
-		displayName: translateFn( 'Jetpack Security' ),
-		shortName: translateFn( 'Security', {
-			comment: 'Short name of the Jetpack Security generic plan',
-		} ),
-		tagline: translateFn( 'Comprehensive WordPress protection' ),
-		description: translateFn(
-			'Enjoy the peace of mind of complete site security. ' +
-				'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
-		),
-	};
-
-	const backupCopy = {
-		displayName: translateFn( 'Jetpack Backup' ),
-		shortName: translateFn( 'Backup', {
-			comment: 'Short name of the Jetpack Backup generic product',
-		} ),
-		tagline: translateFn( 'Recommended for all sites' ),
-		description: translateFn( 'Never lose a word, image, page, or time worrying about your site.' ),
-		buttonLabel: translateFn( 'Get Backup' ),
-	};
-
-	const crmCopy = {
-		displayName: translateFn( 'Jetpack CRM' ),
-		shortName: translateFn( 'CRM', {
-			comment: 'Short name of the Jetpack CRM',
-		} ),
-		tagline: translateFn( 'Manage contacts effortlessly' ),
-		description: translateFn(
-			'The most simple and powerful WordPress CRM. Improve customer relationships and increase profits.'
-		),
-		buttonLabel: translateFn( 'Get CRM' ),
-	};
-
-	const completeCopy = {
-		displayName: translateFn( 'Jetpack Complete' ),
-		shortName: translateFn( 'Complete', {
-			comment: 'Short name of Jetpack Complete',
-		} ),
-		tagline: translateFn( 'For best-in-class WordPress sites' ),
-		description: translateFn(
-			'Superpower your site with everything Jetpack has to offer: real-time security, enhanced search, CRM, and marketing, growth, and design tools.'
-		),
-		buttonLabel: translateFn( 'Get Jetpack Complete' ),
-	};
-
-	const scanCopy = {
-		displayName: translateFn( 'Jetpack Scan' ),
-		shortName: translateFn( 'Scan', {
-			comment: 'Short name of Jetpack Scan',
-		} ),
-		tagline: translateFn( 'Protect your site' ),
-		description: translateFn(
-			'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
-		),
-		buttonLabel: translateFn( 'Get Scan' ),
-	};
-
-	const antiSpamCopy = {
-		displayName: translateFn( 'Jetpack Anti-spam' ),
-		shortName: translateFn( 'Anti-spam', {
-			comment: 'Short name of Jetpack Anti-spam',
-		} ),
-		tagline: translateFn( 'Block spam automatically' ),
-		description: translateFn(
-			'Automated spam protection for comments and forms. Save time, get more responses, and give your visitors a better experience.'
-		),
-		buttonLabel: translateFn( 'Get Anti-spam' ),
-	};
-
-	switch ( productSlug ) {
-		case OPTIONS_JETPACK_SECURITY:
-		case OPTIONS_JETPACK_SECURITY_MONTHLY:
-			return securityCopy;
-		case OPTIONS_JETPACK_BACKUP:
-		case OPTIONS_JETPACK_BACKUP_MONTHLY:
-			return backupCopy;
-		case PRODUCT_JETPACK_CRM:
-		case PRODUCT_JETPACK_CRM_MONTHLY:
-			return crmCopy;
-		case PLAN_JETPACK_COMPLETE:
-		case PLAN_JETPACK_COMPLETE_MONTHLY:
-			return completeCopy;
-		case PRODUCT_JETPACK_SCAN:
-		case PRODUCT_JETPACK_SCAN_MONTHLY:
-			return scanCopy;
-		case PRODUCT_JETPACK_ANTI_SPAM:
-		case PRODUCT_JETPACK_ANTI_SPAM_MONTHLY:
-			return antiSpamCopy;
-		default:
-			throw `Unknown SelectorProductSlug: ${ productSlug }`;
-	}
 }
 
 export function productBadgeLabelAlt(
 	product: SelectorProduct,
 	isOwned: boolean,
+	translate: ReturnType< typeof useTranslate >,
 	currentPlan?: SitePlan | null
 ): TranslateResult | undefined {
 	if ( isOwned ) {
@@ -813,34 +714,3 @@ export function getPathToUpsell(
 
 	return addQueryArgs( urlQueryArgs, path );
 }
-
-/**
- * Append "Available Options: Real-time and Daily" to the product description.
- *
- * @param product SelectorProduct
- * @param translateFn Function The translate function, ideally retrieved from useTranslate().
- *
- * @returns ReactNode | TranslateResult
- */
-export const getJetpackDescriptionWithOptions = (
-	product: SelectorProduct,
-	translateFn: Function
-): React.ReactNode | TranslateResult => {
-	const em = React.createElement( 'em', null, null );
-
-	const { description } = getSelectorProductCopy( product.productSlug, translateFn );
-
-	// If the product has 'subtypes' (containing daily and real-time product slugs).
-	// then append "Available options: Real-time or Daily" to the product description.
-	return product.subtypes.some( ( subtype ) => DAILY_PRODUCTS.includes( subtype ) ) &&
-		product.subtypes.some( ( subtype ) => REALTIME_PRODUCTS.includes( subtype ) )
-		? translateFn( '%(productDescription)s {{em}}Available options: Real-time or Daily.{{/em}}', {
-				args: {
-					productDescription: description,
-				},
-				components: {
-					em,
-				},
-		  } )
-		: description;
-};

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -181,6 +181,7 @@ export function productButtonLabelAlt(
 	isOwned: boolean,
 	isItemPlanFeature: boolean,
 	isUpgradeableToYearly: boolean,
+	translate: ReturnType< typeof useTranslate >,
 	currentPlan?: SitePlan | null
 ): TranslateResult {
 	if ( isUpgradeableToYearly ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a followup to https://github.com/Automattic/wp-calypso/pull/45727, which was made to quickly fix an issue where usage of translated strings was not reactive. Although that solution worked, it is not ideal in the long term.

This PR re-works the Offer Reset copy that was being passed to `translate()` in the constants file so that they are instead retrieved through a function in `utils` or `translated-copy` that requires passing `translate`. Components that use this method will ideally use the `useTranslate()` hook to pass `translate`, and thus retrieve the copy in a reactive way.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout the branch and start up Calypso and Jetpack Cloud.
2. In Calypso, visit the plans page. Verify that everything looks the same as it does on the production version of the plans page. Be sure to check the flows that include the details page and the upsell page.
3. Visit the plans page in another language and verify that every string on the page is translated.
4. In Jetpack Cloud, visit the pricing page. Verify that everything looks the same as it does on the production version of the pricing page.
5. Visit a localized version such as http://cloud.localhost:3001/es/pricing and verify that every string on the page is translated.

Fixes #1169247016322522-as-1194900844047779