### PR TITLE
Domains: Group mapping and transfers together to reduce confusion

### DIFF
--- a/client/lib/domains/get-domain-type-text.js
+++ b/client/lib/domains/get-domain-type-text.js
@@ -22,7 +22,7 @@ export function getDomainTypeText( domain = {} ) {
 			return 'Default Site Domain';
 
 		case domainTypes.TRANSFER:
-			return 'Transfer';
+			return 'Domain Transfer';
 
 		default:
 			return '';

--- a/client/lib/domains/get-selection-domain.js
+++ b/client/lib/domains/get-selection-domain.js
@@ -8,7 +8,7 @@ import { find } from 'lodash';
  */
 import { type as domainTypes } from './constants';
 
-export function getSelectedDomain( { domains, selectedDomainName, isTransfer, isSiteRedirect } ) {
+export function getSelectedDomain( { domains, selectedDomainName, isSiteRedirect = false } ) {
 	return find( domains, ( domain ) => {
 		const isType = ( type ) => domain.type === type;
 
@@ -16,13 +16,10 @@ export function getSelectedDomain( { domains, selectedDomainName, isTransfer, is
 			return false;
 		}
 
-		if (
-			( isTransfer && isType( domainTypes.TRANSFER ) ) ||
-			( isSiteRedirect && isType( domainTypes.SITE_REDIRECT ) )
-		) {
+		if ( isSiteRedirect && isType( domainTypes.SITE_REDIRECT ) ) {
 			return true;
 		}
 
-		return ! ( isType( domainTypes.TRANSFER ) || isType( domainTypes.SITE_REDIRECT ) );
+		return ! isType( domainTypes.SITE_REDIRECT );
 	} );
 }

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -607,6 +607,8 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		return (
 			<React.Fragment>
 				{ this.getManageSite() }
+				{ this.getDnsRecords() }
+				{ this.getSecurity() }
 				{ this.getDeleteDomain() }
 			</React.Fragment>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a domain is pending transfer (pending_registry), we automatically add a domain mapping to ensure the domain starts working with the WPCOM site ASAP. However, that leads to a confusing UX:
<img width="1063" alt="Screenshot 2020-09-30 at 16 48 12" src="https://user-images.githubusercontent.com/3392497/94715360-e338be80-033c-11eb-97c5-effbbbc4a981.png">

It's also causing an unnecessary alert in the sidebar:
<img width="279" alt="Screenshot 2020-09-30 at 16 48 26" src="https://user-images.githubusercontent.com/3392497/94715596-3448b280-033d-11eb-83c1-f47ad70b734e.png">


In this PR, I'm trying to get rid of the extra mapping row and instead let the transfer one take over some of its functions. Most importantly: setting the DNS records.

#### Testing instructions

This patch requires backend changes: D50440-code.

Find a domain pending transfer (see the backend patch for details). Make sure you only see the transfer domain in Calypso:
<img width="1059" alt="Screenshot 2020-09-30 at 16 45 39" src="https://user-images.githubusercontent.com/3392497/94715558-272bc380-033d-11eb-83c7-68af80294ce2.png">

There should be no alerts (unless related to the transfer-in).

When viewing details of the transfer-in, you should have the option to manage DNS records:
<img width="764" alt="Screenshot 2020-09-30 at 16 46 53" src="https://user-images.githubusercontent.com/3392497/94715637-46c2ec00-033d-11eb-9f0a-61d2a6df53ac.png">

This should give them a clear idea where to migrate their existing DNS records so that they are ready to change nameservers when the transfer is complete. Or, if they changed the nameservers before transfer-in, they can easily manage DNS records (without having to look for that option in the domain mapping).

If the domain is pointing to our servers, there should also be the usual information about SSL ceritifcate.
