### PR TITLE
Checkout: Make sure WPOrderReviewList never renders undefined

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -322,11 +322,13 @@ export function WPOrderReviewLineItems( {
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
 			{ items
 				.filter( ( item ) => item.label ) // remove items without a label
-				.map( ( item ) => {
+				.filter( ( item ) => {
 					if ( isSummary && ! shouldLineItemBeShownWhenStepInactive( item ) ) {
-						return;
+						return false;
 					}
-
+					return true;
+				} )
+				.map( ( item ) => {
 					return (
 						<WPOrderReviewListItem key={ item.id }>
 							<LineItemUI


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`WPOrderReviewList` uses a `map` to render each line item, but that callback function has an early `return` if the item shouldn't be displayed. That returned value (`undefined`) will still return from the `map`, and React will attempt to render it. React cannot render `undefined`, though; it can only render a component, a string, or `null`.

This doesn't actually cause an error, though, for reasons I don't fully understand; possibly related to [the ability to use false in JSX](https://react-cn.github.io/react/tips/false-in-jsx.html).

In this PR, I change that early return to a `filter` so that items that should not be included will be removed from the list.

#### Testing instructions

- Visit checkout when there are line items that include at least one line item with the `tax` type (should be any checkout in a taxable postal code, eg: `10001` and `US`).
- Verify that there are no React fatal errors and that you see the line items displayed in the (non-active) first review step, and that you do not see the taxes line item displayed unless you click to edit the cart.