### PR TITLE
Reenable WeChat as a payment method

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -566,9 +566,8 @@ export function getPostalCode() {
 }
 
 function isPaymentMethodLegallyRestricted( paymentMethodId ) {
-	const restrictedPaymentMethods = [
-		'wechat', // whitehouse.gov/presidential-actions/executive-order-addressing-threat-posed-wechat/
-	];
+	// Add the names of any legally-restricted payment methods to this list.
+	const restrictedPaymentMethods = [];
 
 	return restrictedPaymentMethods.includes( paymentMethodId );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request reactivates WeChat as an allowed payment method on WordPress.com (see #45706 for where it was disabled).  Recent court injunctions in the United States mean that there are no restrictions on WeChat payments, at least for now.

Internal discussion: p2y3YZ-48E-p2

#### Testing instructions

- Use D45650-code (internal server-side change) to force WeChat to be returned by the API
- Enter checkout and confirm that WeChat is one of the available payment methods
- Select it, then go through the process of paying with it (in store sandbox mode) using the "To open and pay with the WeChat Pay app directly, click here" link that appears on the page.
- Make sure the purchase is successful.