### PR TITLE
Checkout: Open wechat redirect in a new tab

### DIFF
--- a/client/my-sites/checkout/checkout/wechat-payment-qrcode.jsx
+++ b/client/my-sites/checkout/checkout/wechat-payment-qrcode.jsx
@@ -106,7 +106,9 @@ export class WechatPaymentQRCode extends Component {
 					{ translate(
 						'On mobile? To open and pay with the WeChat Pay app directly, {{a}}click here{{/a}}.',
 						{
-							components: { a: <a href={ this.props.redirectUrl } /> },
+							components: {
+								a: <a target={ '_blank' } rel={ 'noreferrer' } href={ this.props.redirectUrl } />,
+							},
 							comment:
 								'Asking if mobile detection has failed and they would like to open and be redirected directly into the WeChat app in order to pay.',
 						}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, if the user clicks to open WeChat in checkout, it opens in the current browsing context. This leads to an awkward state where the purchase completes but the user is never actually redirected back to checkout to complete the flow, and if they try using the back button checkout attempts to load with the product that was just purchased. (Or worse, the payment fails and the checkout flow silently fails.)

This PR just makes this link open in a separate tab to prevent this.

#### Testing instructions

Taken without shame from #46060

- Use D45650-code (internal server-side change) to force WeChat to be returned by the API
- Enter checkout and confirm that WeChat is one of the available payment methods
- Select it, then go through the process of paying with it (in store sandbox mode) using the "To open and pay with the WeChat Pay app directly, click here" link that appears on the page.
- Make sure the stripe test purchase page opens in a new tab and that the purchase is successful.