### PR TITLE
Purchases: update upcoming renewal link

### DIFF
--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -758,6 +758,7 @@ class PurchaseNotice extends Component {
 					isVisible={ this.state.showUpcomingRenewalsDialog }
 					purchases={ renewableSitePurchases }
 					site={ selectedSite }
+					getManagePurchaseUrl={ getManagePurchaseUrlFor }
 					onConfirm={ this.handleExpiringNoticeRenewSelection }
 					onClose={ this.closeUpcomingRenewalsDialog }
 				/>

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -758,7 +758,7 @@ class PurchaseNotice extends Component {
 					isVisible={ this.state.showUpcomingRenewalsDialog }
 					purchases={ renewableSitePurchases }
 					site={ selectedSite }
-					getManagePurchaseUrl={ getManagePurchaseUrlFor }
+					getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 					onConfirm={ this.handleExpiringNoticeRenewSelection }
 					onClose={ this.closeUpcomingRenewalsDialog }
 				/>

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -84,6 +84,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 	onConfirm,
 	submitButtonText = '',
 	showManagePurchaseLinks = true,
+	getManagePurchaseUrl = managePurchase,
 } ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
@@ -166,7 +167,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 								</div>
 								{ showManagePurchaseLinks && (
 									<div className="upcoming-renewals-dialog__renewal-settings-link">
-										<a onClick={ onClose } href={ managePurchase( site.slug, purchase.id ) }>
+										<a onClick={ onClose } href={ getManagePurchaseUrl( site.slug, purchase.id ) }>
 											{ translate( 'Manage purchase' ) }
 										</a>
 									</div>

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -46,6 +46,7 @@ interface Props {
 	onConfirm: ( purchases: Purchase[] ) => void;
 	submitButtonText?: string | TranslateResult;
 	showManagePurchaseLinks?: boolean;
+	getManagePurchaseUrlFor: ( siteSlug: string, purchaseId: number ) => string;
 }
 
 function getExpiresText(
@@ -84,7 +85,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 	onConfirm,
 	submitButtonText = '',
 	showManagePurchaseLinks = true,
-	getManagePurchaseUrl = managePurchase,
+	getManagePurchaseUrlFor = managePurchase,
 } ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
@@ -167,7 +168,10 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 								</div>
 								{ showManagePurchaseLinks && (
 									<div className="upcoming-renewals-dialog__renewal-settings-link">
-										<a onClick={ onClose } href={ getManagePurchaseUrl( site.slug, purchase.id ) }>
+										<a
+											onClick={ onClose }
+											href={ getManagePurchaseUrlFor( site.slug, purchase.id ) }
+										>
 											{ translate( 'Manage purchase' ) }
 										</a>
 									</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the links in the upcoming renewals modal so that they retain the site or account context depending on where they were clicked.

**Before** 
![image](https://user-images.githubusercontent.com/6981253/94743160-ec2d8e00-0344-11eb-8071-fad56a31ac3d.png)

**After**

![image](https://user-images.githubusercontent.com/6981253/94743192-fbacd700-0344-11eb-9244-b4db1b2a5313.png)


#### Testing instructions
For this PR to work, you are going to need multiple products on a site with one of them close to expiry. 

* Make sure you have the `site-level-billing` flag enabled.
* Navigate to the site-level billing screen for a site that has multiple subscriptions and at least one of them about to expire.
* Click on the "Other upgrades" link in the notice.
* Click on the "Manage product" link in the modal and make sure you retain the site context. 
* Now go to the account section and try the same — making sure you retain the account level context. 

Related to: https://github.com/Automattic/wp-calypso/issues/45181