### PR TITLE
Site level billing management: Update links to add/edit card route

### DIFF
--- a/client/blocks/credit-card-form/loading-placeholder.jsx
+++ b/client/blocks/credit-card-form/loading-placeholder.jsx
@@ -12,9 +12,9 @@ import CreditCardFormFieldsLoadingPlaceholder from 'components/credit-card-form-
 import FormButton from 'components/forms/form-button';
 import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
 
-const CreditCardFormLoadingPlaceholder = ( { title, isSiteLevelBilling } ) => {
+const CreditCardFormLoadingPlaceholder = ( { title, isFullWidth } ) => {
 	return (
-		<LoadingPlaceholder title={ title } isSiteLevelBilling={ isSiteLevelBilling }>
+		<LoadingPlaceholder title={ title } isFullWidth={ isFullWidth }>
 			<Card className="credit-card-form__content">
 				<CreditCardFormFieldsLoadingPlaceholder />
 			</Card>

--- a/client/blocks/credit-card-form/loading-placeholder.jsx
+++ b/client/blocks/credit-card-form/loading-placeholder.jsx
@@ -12,9 +12,9 @@ import CreditCardFormFieldsLoadingPlaceholder from 'components/credit-card-form-
 import FormButton from 'components/forms/form-button';
 import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
 
-const CreditCardFormLoadingPlaceholder = ( { title } ) => {
+const CreditCardFormLoadingPlaceholder = ( { title, isSiteLevelBilling } ) => {
 	return (
-		<LoadingPlaceholder title={ title }>
+		<LoadingPlaceholder title={ title } isSiteLevelBilling={ isSiteLevelBilling }>
 			<Card className="credit-card-form__content">
 				<CreditCardFormFieldsLoadingPlaceholder />
 			</Card>

--- a/client/me/purchases/components/loading-placeholder/index.jsx
+++ b/client/me/purchases/components/loading-placeholder/index.jsx
@@ -22,7 +22,7 @@ class LoadingPlaceholder extends React.Component {
 	static propTypes = {
 		path: PropTypes.string,
 		title: PropTypes.string.isRequired,
-		isSiteLevelBilling: PropTypes.bool.isRequired,
+		isFullWidth: PropTypes.bool.isRequired,
 	};
 
 	goBack = () => {
@@ -31,7 +31,7 @@ class LoadingPlaceholder extends React.Component {
 
 	render() {
 		const classes = classnames( 'loading-placeholder', {
-			'is-wide-layout': this.props.isSiteLevelBilling,
+			'is-wide-layout': this.props.isFullWidth,
 		} );
 
 		return (

--- a/client/me/purchases/components/loading-placeholder/index.jsx
+++ b/client/me/purchases/components/loading-placeholder/index.jsx
@@ -21,6 +21,7 @@ class LoadingPlaceholder extends React.Component {
 	static propTypes = {
 		path: PropTypes.string,
 		title: PropTypes.string.isRequired,
+		isSiteLevelBilling: PropTypes.bool.isRequired,
 	};
 
 	goBack = () => {
@@ -29,7 +30,11 @@ class LoadingPlaceholder extends React.Component {
 
 	render() {
 		return (
-			<Main className="loading-placeholder">
+			<Main
+				className={
+					'loading-placeholder' + ( this.props.isSiteLevelBilling ? ' is-wide-layout' : '' )
+				}
+			>
 				<HeaderCake className="loading-placeholder__header" onClick={ this.goBack }>
 					{ this.props.title }
 				</HeaderCake>

--- a/client/me/purchases/components/loading-placeholder/index.jsx
+++ b/client/me/purchases/components/loading-placeholder/index.jsx
@@ -5,6 +5,7 @@
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -29,12 +30,12 @@ class LoadingPlaceholder extends React.Component {
 	};
 
 	render() {
+		const classes = classnames( 'loading-placeholder', {
+			'is-wide-layout': this.props.isSiteLevelBilling,
+		} );
+
 		return (
-			<Main
-				className={
-					'loading-placeholder' + ( this.props.isSiteLevelBilling ? ' is-wide-layout' : '' )
-				}
-			>
+			<Main className={ classes }>
 				<HeaderCake className="loading-placeholder__header" onClick={ this.goBack }>
 					{ this.props.title }
 				</HeaderCake>

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -122,6 +122,8 @@ export function editCardDetails( context, next ) {
 			cardId={ context.params.cardId }
 			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 			siteSlug={ context.params.site }
+			getManagePurchaseUrlFor={ managePurchaseUrl }
+			purchaseListUrl={ purchasesRoot }
 		/>
 	);
 	next();

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -61,7 +61,7 @@ export function addCardDetails( context, next ) {
 				siteSlug={ context.params.site }
 				getManagePurchaseUrlFor={ managePurchaseUrl }
 				purchaseListUrl={ purchasesRoot }
-				isSiteLevelBilling={ false }
+				isFullWidth={ false }
 			/>
 		</Main>
 	);
@@ -125,7 +125,7 @@ export function editCardDetails( context, next ) {
 			siteSlug={ context.params.site }
 			getManagePurchaseUrlFor={ managePurchaseUrl }
 			purchaseListUrl={ purchasesRoot }
-			isSiteLevelBilling={ false }
+			isFullWidth={ false }
 		/>
 	);
 	next();

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -61,6 +61,7 @@ export function addCardDetails( context, next ) {
 				siteSlug={ context.params.site }
 				getManagePurchaseUrlFor={ managePurchaseUrl }
 				purchaseListUrl={ purchasesRoot }
+				isSiteLevelBilling={ false }
 			/>
 		</Main>
 	);
@@ -124,6 +125,7 @@ export function editCardDetails( context, next ) {
 			siteSlug={ context.params.site }
 			getManagePurchaseUrlFor={ managePurchaseUrl }
 			purchaseListUrl={ purchasesRoot }
+			isSiteLevelBilling={ false }
 		/>
 	);
 	next();

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -39,10 +39,12 @@ class AutoRenewToggle extends Component {
 		withTextStatus: PropTypes.bool,
 		toggleSource: PropTypes.string,
 		siteSlug: PropTypes.string,
+		getAddPaymentMethodUrlFor: PropTypes.func,
 	};
 
 	static defaultProps = {
 		fetchingUserPurchases: false,
+		getAddPaymentMethodUrlFor: getEditCardDetailsPath,
 	};
 
 	state = {
@@ -86,7 +88,7 @@ class AutoRenewToggle extends Component {
 			toggle_source: toggleSource,
 		} );
 
-		page( getEditCardDetailsPath( siteSlug, purchase ) );
+		page( this.props.getAddPaymentMethodUrlFor( siteSlug, purchase ) );
 	};
 
 	onCloseAutoRenewPaymentMethodDialog = () => {

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -39,12 +39,13 @@ class AutoRenewToggle extends Component {
 		withTextStatus: PropTypes.bool,
 		toggleSource: PropTypes.string,
 		siteSlug: PropTypes.string,
-		getAddPaymentMethodUrlFor: PropTypes.func,
+		getEditPaymentMethodUrlFor: PropTypes.func,
+		paymentMethodUrl: PropTypes.string,
 	};
 
 	static defaultProps = {
 		fetchingUserPurchases: false,
-		getAddPaymentMethodUrlFor: getEditCardDetailsPath,
+		getEditPaymentMethodUrlFor: getEditCardDetailsPath,
 	};
 
 	state = {
@@ -79,7 +80,14 @@ class AutoRenewToggle extends Component {
 	}
 
 	goToUpdatePaymentMethod = () => {
-		const { purchase, siteSlug, productSlug, isAtomicSite, toggleSource } = this.props;
+		const {
+			purchase,
+			siteSlug,
+			productSlug,
+			isAtomicSite,
+			toggleSource,
+			getEditPaymentMethodUrlFor,
+		} = this.props;
 		this.closeAutoRenewPaymentMethodDialog();
 
 		this.props.recordTracksEvent( 'calypso_auto_renew_no_payment_method_dialog_add_click', {
@@ -88,7 +96,7 @@ class AutoRenewToggle extends Component {
 			toggle_source: toggleSource,
 		} );
 
-		page( this.props.getAddPaymentMethodUrlFor( siteSlug, purchase ) );
+		page( getEditPaymentMethodUrlFor( siteSlug, purchase ) );
 	};
 
 	onCloseAutoRenewPaymentMethodDialog = () => {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -457,7 +457,7 @@ class ManagePurchase extends Component {
 	}
 
 	renderPlaceholder() {
-		const { siteSlug, getManagePurchaseUrlFor } = this.props;
+		const { siteSlug, getManagePurchaseUrlFor, getAddPaymentMethodUrlFor } = this.props;
 
 		return (
 			<Fragment>
@@ -477,6 +477,7 @@ class ManagePurchase extends Component {
 						purchaseId={ false }
 						siteSlug={ siteSlug }
 						getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+						getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
 					/>
 				</Card>
 				<PurchasePlanDetails isPlaceholder />
@@ -509,6 +510,7 @@ class ManagePurchase extends Component {
 			isProductOwner,
 			getManagePurchaseUrlFor,
 			siteSlug,
+			getAddPaymentMethodUrlFor,
 		} = this.props;
 
 		const classes = classNames( 'manage-purchase__info', {
@@ -556,6 +558,7 @@ class ManagePurchase extends Component {
 							purchaseId={ purchase.id }
 							siteSlug={ siteSlug }
 							getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+							getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
 						/>
 					) }
 					{ isProductOwner && preventRenewal && this.renderSelectNewButton() }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -104,6 +104,7 @@ class ManagePurchase extends Component {
 		purchaseListUrl: PropTypes.string,
 		getCancelPurchaseUrlFor: PropTypes.func,
 		getAddPaymentMethodUrlFor: PropTypes.func,
+		getEditPaymentMethodUrlFor: PropTypes.func,
 		getManagePurchaseUrlFor: PropTypes.func,
 		cardTitle: PropTypes.string,
 		hasLoadedDomains: PropTypes.bool,
@@ -124,6 +125,7 @@ class ManagePurchase extends Component {
 		showHeader: true,
 		purchaseListUrl: purchasesRoot,
 		getAddPaymentMethodUrlFor: getEditCardDetailsPath,
+		getEditPaymentMethodUrlFor: getEditCardDetailsPath,
 		cardTitle: titles.managePurchase,
 		getCancelPurchaseUrlFor: cancelPurchase,
 		getManagePurchaseUrlFor: managePurchase,
@@ -242,14 +244,14 @@ class ManagePurchase extends Component {
 	}
 
 	renderEditPaymentMethodNavItem() {
-		const { purchase, translate } = this.props;
+		const { purchase, translate, siteSlug, getEditPaymentMethodUrlFor } = this.props;
 
 		if ( ! this.props.site ) {
 			return null;
 		}
 
 		if ( canEditPaymentDetails( purchase ) ) {
-			const path = this.props.getAddPaymentMethodUrlFor( this.props.siteSlug, purchase );
+			const path = getEditPaymentMethodUrlFor( siteSlug, purchase );
 			const renewing = isRenewing( purchase );
 
 			if (
@@ -457,7 +459,13 @@ class ManagePurchase extends Component {
 	}
 
 	renderPlaceholder() {
-		const { siteSlug, getManagePurchaseUrlFor, getAddPaymentMethodUrlFor } = this.props;
+		const {
+			siteSlug,
+			getManagePurchaseUrlFor,
+			getAddCardDetailsPathFor,
+			getAddPaymentMethodUrlFor,
+			getEditCardDetailsPathFor,
+		} = this.props;
 
 		return (
 			<Fragment>
@@ -477,6 +485,8 @@ class ManagePurchase extends Component {
 						purchaseId={ false }
 						siteSlug={ siteSlug }
 						getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+						getAddCardDetailsPathFor={ getAddCardDetailsPathFor }
+						getEditCardDetailsPathFor={ getEditCardDetailsPathFor }
 						getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
 					/>
 				</Card>
@@ -510,7 +520,7 @@ class ManagePurchase extends Component {
 			isProductOwner,
 			getManagePurchaseUrlFor,
 			siteSlug,
-			getAddPaymentMethodUrlFor,
+			getEditPaymentMethodUrlFor,
 		} = this.props;
 
 		const classes = classNames( 'manage-purchase__info', {
@@ -558,7 +568,7 @@ class ManagePurchase extends Component {
 							purchaseId={ purchase.id }
 							siteSlug={ siteSlug }
 							getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
-							getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
+							getEditPaymentMethodUrlFor={ getEditPaymentMethodUrlFor }
 						/>
 					) }
 					{ isProductOwner && preventRenewal && this.renderSelectNewButton() }
@@ -593,12 +603,13 @@ class ManagePurchase extends Component {
 			translate,
 			getManagePurchaseUrlFor,
 			getAddPaymentMethodUrlFor,
+			getEditPaymentMethodUrlFor,
 			isProductOwner,
 		} = this.props;
 
 		let editCardDetailsPath = false;
 		if ( ! isDataLoading( this.props ) && site && canEditPaymentDetails( purchase ) ) {
-			editCardDetailsPath = getAddPaymentMethodUrlFor( siteSlug, purchase );
+			editCardDetailsPath = getEditPaymentMethodUrlFor( siteSlug, purchase );
 		}
 
 		let showExpiryNotice = false;

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -589,12 +589,13 @@ class ManagePurchase extends Component {
 			isPurchaseTheme,
 			translate,
 			getManagePurchaseUrlFor,
+			getAddPaymentMethodUrlFor,
 			isProductOwner,
 		} = this.props;
 
 		let editCardDetailsPath = false;
 		if ( ! isDataLoading( this.props ) && site && canEditPaymentDetails( purchase ) ) {
-			editCardDetailsPath = getEditCardDetailsPath( siteSlug, purchase );
+			editCardDetailsPath = getAddPaymentMethodUrlFor( siteSlug, purchase );
 		}
 
 		let showExpiryNotice = false;

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -645,6 +645,7 @@ class ManagePurchase extends Component {
 						editCardDetailsPath={ editCardDetailsPath }
 						getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 						isProductOwner={ isProductOwner }
+						getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
 					/>
 				) }
 				<AsyncLoad

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -12,6 +12,7 @@ import { isEmpty, merge, minBy } from 'lodash';
  */
 import { recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
+import { getEditCardDetailsPath } from '../utils';
 import {
 	canExplicitRenew,
 	creditCardExpiresBeforeSubscription,
@@ -64,11 +65,13 @@ class PurchaseNotice extends Component {
 		selectedSite: PropTypes.object,
 		editCardDetailsPath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		getManagePurchaseUrlFor: PropTypes.func,
+		getAddPaymentMethodUrlFor: PropTypes.func,
 		isProductOwner: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		getManagePurchaseUrlFor: managePurchase,
+		getAddPaymentMethodUrlFor: getEditCardDetailsPath,
 	};
 
 	state = {
@@ -338,6 +341,7 @@ class PurchaseNotice extends Component {
 			selectedSite,
 			renewableSitePurchases,
 			getManagePurchaseUrlFor,
+			getAddPaymentMethodUrlFor,
 		} = this.props;
 
 		if ( ! config.isEnabled( 'upgrades/upcoming-renewals-notices' ) ) {
@@ -643,7 +647,7 @@ class PurchaseNotice extends Component {
 				);
 			} else {
 				noticeStatus = showCreditCardExpiringWarning( currentPurchase ) ? 'is-error' : 'is-info';
-				noticeActionHref = '/me/purchases/add-credit-card';
+				noticeActionHref = getAddPaymentMethodUrlFor( selectedSite.slug, currentPurchase );
 				noticeActionOnClick = this.handleExpiringCardNoticeUpdateAll;
 				noticeActionText = translate( 'Update all' );
 				noticeImpressionName = 'current-renews-soon-others-renew-soon-cc-expiring';
@@ -737,7 +741,7 @@ class PurchaseNotice extends Component {
 				);
 			} else {
 				noticeStatus = 'is-info';
-				noticeActionHref = '/me/purchases/add-credit-card';
+				noticeActionHref = getAddPaymentMethodUrlFor( selectedSite.slug, currentPurchase );
 				noticeActionOnClick = this.handleExpiringCardNoticeUpdateAll;
 				noticeActionText = translate( 'Update all' );
 				noticeImpressionName = 'current-renews-later-others-renew-soon-cc-expiring';

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -339,6 +339,7 @@ class PurchaseMeta extends Component {
 			isAutorenewalEnabled,
 			isProductOwner,
 			hideAutoRenew,
+			getAddPaymentMethodUrlFor,
 		} = this.props;
 
 		if ( isDomainTransfer( purchase ) ) {
@@ -391,6 +392,7 @@ class PurchaseMeta extends Component {
 								siteSlug={ site.slug }
 								purchase={ purchase }
 								toggleSource="manage-purchase"
+								getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
 							/>
 						</span>
 					) }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -62,6 +62,7 @@ class PurchaseMeta extends Component {
 		site: PropTypes.object,
 		siteSlug: PropTypes.string.isRequired,
 		getManagePurchaseUrlFor: PropTypes.func,
+		getAddPaymentMethodUrlFor: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -69,6 +70,7 @@ class PurchaseMeta extends Component {
 		hasLoadedUserPurchasesFromServer: false,
 		purchaseId: false,
 		getManagePurchaseUrlFor: managePurchase,
+		getAddPaymentMethodUrlFor: getEditCardDetailsPath,
 	};
 
 	renderPrice() {
@@ -227,7 +229,7 @@ class PurchaseMeta extends Component {
 	}
 
 	renderPaymentDetails() {
-		const { purchase, translate } = this.props;
+		const { purchase, translate, getAddPaymentMethodUrlFor } = this.props;
 
 		if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
 			return null;
@@ -251,7 +253,9 @@ class PurchaseMeta extends Component {
 
 		return (
 			<li>
-				<a href={ getEditCardDetailsPath( this.props.siteSlug, purchase ) }>{ paymentDetails }</a>
+				<a href={ getAddPaymentMethodUrlFor( this.props.siteSlug, purchase ) }>
+					{ paymentDetails }
+				</a>
 			</li>
 		);
 	}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -49,7 +49,7 @@ import PaymentLogo from 'components/payment-logo';
 import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'lib/url/support';
 import UserItem from 'components/user';
 import { withLocalizedMoment } from 'components/localized-moment';
-import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '../utils';
+import { canEditPaymentDetails, isDataLoading } from '../utils';
 import { TERM_BIENNIALLY, TERM_MONTHLY, JETPACK_LEGACY_PLANS } from 'lib/plans/constants';
 import { getCurrentUserId } from 'state/current-user/selectors';
 
@@ -62,7 +62,7 @@ class PurchaseMeta extends Component {
 		site: PropTypes.object,
 		siteSlug: PropTypes.string.isRequired,
 		getManagePurchaseUrlFor: PropTypes.func,
-		getAddPaymentMethodUrlFor: PropTypes.func,
+		getEditPaymentMethodUrlFor: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -70,7 +70,6 @@ class PurchaseMeta extends Component {
 		hasLoadedUserPurchasesFromServer: false,
 		purchaseId: false,
 		getManagePurchaseUrlFor: managePurchase,
-		getAddPaymentMethodUrlFor: getEditCardDetailsPath,
 	};
 
 	renderPrice() {
@@ -229,7 +228,7 @@ class PurchaseMeta extends Component {
 	}
 
 	renderPaymentDetails() {
-		const { purchase, translate, getAddPaymentMethodUrlFor } = this.props;
+		const { purchase, translate, getEditPaymentMethodUrlFor, siteSlug } = this.props;
 
 		if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
 			return null;
@@ -253,9 +252,7 @@ class PurchaseMeta extends Component {
 
 		return (
 			<li>
-				<a href={ getAddPaymentMethodUrlFor( this.props.siteSlug, purchase ) }>
-					{ paymentDetails }
-				</a>
+				<a href={ getEditPaymentMethodUrlFor( siteSlug, purchase ) }>{ paymentDetails }</a>
 			</li>
 		);
 	}
@@ -339,7 +336,7 @@ class PurchaseMeta extends Component {
 			isAutorenewalEnabled,
 			isProductOwner,
 			hideAutoRenew,
-			getAddPaymentMethodUrlFor,
+			getEditPaymentMethodUrlFor,
 		} = this.props;
 
 		if ( isDomainTransfer( purchase ) ) {
@@ -372,7 +369,6 @@ class PurchaseMeta extends Component {
 								dateSpan,
 							},
 					  } );
-
 			return (
 				<li>
 					<em className="manage-purchase__detail-label">{ translate( 'Subscription Renewal' ) }</em>
@@ -392,7 +388,7 @@ class PurchaseMeta extends Component {
 								siteSlug={ site.slug }
 								purchase={ purchase }
 								toggleSource="manage-purchase"
-								getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
+								getEditPaymentMethodUrlFor={ getEditPaymentMethodUrlFor }
 							/>
 						</span>
 					) }

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -42,7 +42,7 @@ function AddCardDetails( props ) {
 
 				<CreditCardFormLoadingPlaceholder
 					title={ titles.addCardDetails }
-					isSiteLevelBilling={ props.isSiteLevelBilling }
+					isFullWidth={ props.isFullWidth }
 				/>
 			</Fragment>
 		);
@@ -98,7 +98,7 @@ AddCardDetails.propTypes = {
 	selectedSite: PropTypes.object,
 	siteSlug: PropTypes.string.isRequired,
 	userId: PropTypes.number,
-	isSiteLevelBilling: PropTypes.bool.isRequired,
+	isFullWidth: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = ( state, { purchaseId } ) => ( {

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -40,7 +40,10 @@ function AddCardDetails( props ) {
 			<Fragment>
 				<QueryUserPurchases userId={ props.userId } />
 
-				<CreditCardFormLoadingPlaceholder title={ titles.addCardDetails } />
+				<CreditCardFormLoadingPlaceholder
+					title={ titles.addCardDetails }
+					isSiteLevelBilling={ props.isSiteLevelBilling }
+				/>
 			</Fragment>
 		);
 	}
@@ -95,6 +98,7 @@ AddCardDetails.propTypes = {
 	selectedSite: PropTypes.object,
 	siteSlug: PropTypes.string.isRequired,
 	userId: PropTypes.number,
+	isSiteLevelBilling: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = ( state, { purchaseId } ) => ( {

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -43,7 +43,10 @@ function EditCardDetails( props ) {
 
 				<QueryUserPurchases userId={ props.userId } />
 
-				<CreditCardFormLoadingPlaceholder title={ titles.editCardDetails } />
+				<CreditCardFormLoadingPlaceholder
+					title={ titles.editCardDetails }
+					isSiteLevelBilling={ props.isSiteLevelBilling }
+				/>
 			</Fragment>
 		);
 	}
@@ -103,6 +106,7 @@ EditCardDetails.propTypes = {
 	userId: PropTypes.number,
 	purchaseListUrl: PropTypes.string.isRequired,
 	getManagePurchaseUrlFor: PropTypes.func.isRequired,
+	isSiteLevelBilling: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = ( state, { cardId, purchaseId } ) => ( {

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -12,7 +12,6 @@ import { connect } from 'react-redux';
 import CreditCardForm from 'blocks/credit-card-form';
 import CreditCardFormLoadingPlaceholder from 'blocks/credit-card-form/loading-placeholder';
 import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryStoredCards from 'components/data/query-stored-cards';
 import QueryUserPurchases from 'components/data/query-user-purchases';
@@ -25,7 +24,6 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getStoredCardById, hasLoadedStoredCardsFromServer } from 'state/stored-cards/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
-import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { StripeHookProvider } from 'lib/stripe';
 
@@ -35,7 +33,7 @@ function EditCardDetails( props ) {
 
 	if ( ! isDataLoading && ! isDataValid( props ) ) {
 		// Redirect if invalid data
-		page( purchasesRoot );
+		page( props.purchaseListUrl );
 	}
 
 	if ( isDataLoading || ! props.hasLoadedStoredCardsFromServer ) {
@@ -58,13 +56,13 @@ function EditCardDetails( props ) {
 	const successCallback = () => {
 		const { id } = props.purchase;
 		props.clearPurchases();
-		page( managePurchase( props.siteSlug, id ) );
+		page( props.getManagePurchaseUrlFor( props.siteSlug, id ) );
 	};
 
 	const createCardUpdateToken = ( ...args ) => createCardToken( 'card_update', ...args );
 
 	return (
-		<Main>
+		<Fragment>
 			<TrackPurchasePageView
 				eventName="calypso_edit_card_details_purchase_view"
 				purchaseId={ props.purchaseId }
@@ -73,7 +71,7 @@ function EditCardDetails( props ) {
 				path="/me/purchases/:site/:purchaseId/payment/edit/:cardId"
 				title="Purchases > Edit Card Details"
 			/>
-			<HeaderCake backHref={ managePurchase( props.siteSlug, props.purchaseId ) }>
+			<HeaderCake backHref={ props.getManagePurchaseUrlFor( props.siteSlug, props.purchaseId ) }>
 				{ titles.editCardDetails }
 			</HeaderCake>
 
@@ -88,7 +86,7 @@ function EditCardDetails( props ) {
 					successCallback={ successCallback }
 				/>
 			</StripeHookProvider>
-		</Main>
+		</Fragment>
 	);
 }
 
@@ -103,6 +101,8 @@ EditCardDetails.propTypes = {
 	selectedSite: PropTypes.object,
 	siteSlug: PropTypes.string.isRequired,
 	userId: PropTypes.number,
+	purchaseListUrl: PropTypes.string.isRequired,
+	getManagePurchaseUrlFor: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = ( state, { cardId, purchaseId } ) => ( {

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -45,7 +45,7 @@ function EditCardDetails( props ) {
 
 				<CreditCardFormLoadingPlaceholder
 					title={ titles.editCardDetails }
-					isSiteLevelBilling={ props.isSiteLevelBilling }
+					isFullWidth={ props.isFullWidth }
 				/>
 			</Fragment>
 		);
@@ -106,7 +106,7 @@ EditCardDetails.propTypes = {
 	userId: PropTypes.number,
 	purchaseListUrl: PropTypes.string.isRequired,
 	getManagePurchaseUrlFor: PropTypes.func.isRequired,
-	isSiteLevelBilling: PropTypes.bool.isRequired,
+	isFullWidth: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = ( state, { cardId, purchaseId } ) => ( {

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -13,6 +13,7 @@ import {
 	PurchaseCancel,
 	PurchaseCancelDomain,
 	PurchaseAddPaymentMethod,
+	PurchaseEditPaymentMethod,
 } from 'my-sites/purchases/main.tsx';
 
 export function redirectToPurchases( context ) {
@@ -63,6 +64,17 @@ export const purchaseCancelDomain = ( context, next ) => {
 export const purchaseAddPaymentMethod = ( context, next ) => {
 	context.primary = (
 		<PurchaseAddPaymentMethod
+			siteSlug={ context.params.site }
+			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+		/>
+	);
+	next();
+};
+
+export const purchaseEditPaymentMethod = ( context, next ) => {
+	context.primary = (
+		<PurchaseEditPaymentMethod
+			cardId={ context.params.cardId }
 			siteSlug={ context.params.site }
 			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 		/>

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -15,6 +15,7 @@ import {
 	purchaseCancel,
 	purchaseCancelDomain,
 	purchaseAddPaymentMethod,
+	purchaseEditPaymentMethod,
 } from './controller';
 import config from 'config';
 import legacyRouter from 'me/purchases';
@@ -72,6 +73,14 @@ export default ( router ) => {
 		siteSelection,
 		navigation,
 		purchaseAddPaymentMethod,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/purchases/subscriptions/:site/:purchaseId/payment/edit/:cardId',
+		siteSelection,
+		navigation,
+		purchaseEditPaymentMethod,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -131,7 +131,7 @@ export function PurchaseAddPaymentMethod( {
 				siteSlug={ siteSlug }
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
-				isSiteLevelBilling={ true }
+				isFullWidth={ true }
 			/>
 		</Main>
 	);
@@ -161,7 +161,7 @@ export function PurchaseEditPaymentMethod( {
 				siteSlug={ siteSlug }
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
-				isSiteLevelBilling={ true }
+				isFullWidth={ true }
 			/>
 		</Main>
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -21,7 +21,9 @@ import {
 	getManagePurchaseUrlFor,
 	getAddPaymentMethodUrlFor,
 } from './paths';
+import { getEditPaymentMethodUrlFor } from './utils';
 import AddCardDetails from 'me/purchases/payment/add-card-details';
+import EditCardDetails from 'me/purchases/payment/edit-card-details';
 
 export function Purchases() {
 	const translate = useTranslate();
@@ -68,6 +70,7 @@ export function PurchaseDetails( {
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 				getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
 				getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
+				getEditPaymentMethodUrlFor={ getEditPaymentMethodUrlFor }
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 			/>
 		</Main>
@@ -124,6 +127,35 @@ export function PurchaseAddPaymentMethod( {
 			/>
 
 			<AddCardDetails
+				purchaseId={ purchaseId }
+				siteSlug={ siteSlug }
+				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
+			/>
+		</Main>
+	);
+}
+
+export function PurchaseEditPaymentMethod( {
+	purchaseId,
+	siteSlug,
+}: {
+	purchaseId: number;
+	siteSlug: string;
+} ) {
+	const translate = useTranslate();
+
+	return (
+		<Main className="purchases is-wide-layout">
+			<DocumentHead title={ translate( 'Billing' ) } />
+			<FormattedHeader
+				brandFont
+				className="purchases__page-heading"
+				headerText={ translate( 'Billing' ) }
+				align="left"
+			/>
+
+			<EditCardDetails
 				purchaseId={ purchaseId }
 				siteSlug={ siteSlug }
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -131,6 +131,7 @@ export function PurchaseAddPaymentMethod( {
 				siteSlug={ siteSlug }
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
+				isSiteLevelBilling={ true }
 			/>
 		</Main>
 	);
@@ -160,6 +161,7 @@ export function PurchaseEditPaymentMethod( {
 				siteSlug={ siteSlug }
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
+				isSiteLevelBilling={ true }
 			/>
 		</Main>
 	);

--- a/client/my-sites/purchases/paths.ts
+++ b/client/my-sites/purchases/paths.ts
@@ -19,4 +19,11 @@ export const getPurchaseListUrlFor = ( targetSiteSlug: string ) =>
 export const getAddPaymentMethodUrlFor = (
 	targetSiteSlug: string,
 	targetPurchase: { id: string | number }
-) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchase.id }/payment/add`;
+) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchase }/payment/add`;
+
+export const editPaymentMethod = (
+	targetSiteSlug: string,
+	targetPurchase: { id: string | number },
+	targetCardId: { id: string | number }
+) =>
+	`/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchase }/payment/edit/${ targetCardId }`;

--- a/client/my-sites/purchases/utils.js
+++ b/client/my-sites/purchases/utils.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { getAddPaymentMethodUrlFor, editPaymentMethod } from './paths';
+import { isPaidWithCreditCard } from 'lib/purchases';
+
+function getEditPaymentMethodUrlFor( siteSlug, purchase ) {
+	if ( isPaidWithCreditCard( purchase ) ) {
+		const {
+			payment: { creditCard },
+		} = purchase;
+
+		return editPaymentMethod( siteSlug, purchase.id, creditCard.id );
+	}
+	return getAddPaymentMethodUrlFor( siteSlug, purchase.id );
+}
+
+export { getEditPaymentMethodUrlFor };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In any component which uses the `getEditCardDetailsPath` helper function, turn that function into a prop. This allows us to use the same components in either a site-level or account-level context depending on the caller's preference.

## Testing instructions
Start by enabling the `site-level-billing` flag.

**Turn on auto-renew**
- Visit a subscription setting screen at the site-level for a product purchased with credits.
- Click the Auto-renew toggle to on and confirm the credit card field shows in the site-level context.
- Add your credit card and save.
- On the settings screen, click the credit card icon to see the add credit card field again in the site-level context.
- Try this at the account level.

**Expiring card notice**
- Visit a subscription setting screen at the site-level for a product purchased with a credit card that expires before the plan expires. 
- Click the link in the notice to make sure the site-level context remains
- Try this at the account level.

**Add credit card notice**
- Visit a subscription setting screen at the site-level for a product purchased with a credits and has auto-renew disabled. 
- Click the link in the notice to make sure the site-level context remains
- Try this at the account level.

**Add credit card**
- Visit a subscription setting screen at the site-level for a purchase that has no credit card
- Click the Add Credit card button and confirm you're taken to the add credit card form
- Try this at the account level.

**Change credit card**
- Visit a subscription setting screen at the site-level for a purchase that has a credit card
- Click the Change Payment Method button and confirm you're taken to the change credit card form
- Try this at the account level.

Fixes part of #45181