### PR TITLE
Site level billing: Only load site-level purchases

### DIFF
--- a/client/components/data/query-site-purchases/index.jsx
+++ b/client/components/data/query-site-purchases/index.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import { useEffect, useRef } from 'react';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -12,41 +12,31 @@ import { connect } from 'react-redux';
 import { isFetchingSitePurchases } from 'state/purchases/selectors';
 import { fetchSitePurchases } from 'state/purchases/actions';
 
-class QuerySitePurchases extends Component {
-	requestSitePurchases( props = this.props ) {
-		if ( props.siteId && ! props.requesting ) {
-			this.props.fetchSitePurchases( props.siteId );
-		}
-	}
+const debug = debugFactory( 'calypso:query-site-purchases' );
 
-	UNSAFE_componentWillMount() {
-		this.requestSitePurchases();
-	}
+export default function QuerySitePurchases( { siteId } ) {
+	const isRequesting = useSelector( ( state ) => isFetchingSitePurchases( state ) );
+	const reduxDispatch = useDispatch();
+	const previousSiteId = useRef();
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId === nextProps.siteId ) {
+	useEffect( () => {
+		if ( ! siteId || isRequesting ) {
 			return;
 		}
+		if ( siteId === previousSiteId.current ) {
+			return;
+		}
+		debug(
+			`siteId "${ siteId }" has changed from previous "${ previousSiteId.current }"; fetching site purchases`
+		);
+		previousSiteId.current = siteId;
 
-		this.requestSitePurchases( nextProps );
-	}
+		reduxDispatch( fetchSitePurchases( siteId ) );
+	}, [ siteId, reduxDispatch, isRequesting ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
 
 QuerySitePurchases.propTypes = {
 	siteId: PropTypes.number,
-	requesting: PropTypes.bool,
-	fetchSitePurchases: PropTypes.func.isRequired,
 };
-
-export default connect(
-	( state ) => {
-		return {
-			requesting: isFetchingSitePurchases( state ),
-		};
-	},
-	{ fetchSitePurchases }
-)( QuerySitePurchases );

--- a/client/my-sites/purchases/subscriptions/index.tsx
+++ b/client/my-sites/purchases/subscriptions/index.tsx
@@ -11,19 +11,19 @@ import { useTranslate } from 'i18n-calypso';
 import Main from 'components/main';
 import MySitesSidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import { getCurrentUserId } from 'state/current-user/selectors';
+import QuerySitePurchases from 'components/data/query-site-purchases';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import SubscriptionsContent from './subscriptions-content';
 import AccountLevelPurchaseLinks from './account-level-purchase-links';
 import SectionHeader from 'components/section-header';
 
 export default function Subscriptions() {
-	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const translate = useTranslate();
 
 	return (
 		<Main className="subscriptions is-wide-layout">
-			<QueryUserPurchases userId={ userId } />
+			<QuerySitePurchases siteId={ selectedSiteId } />
 			<PageViewTracker path="/purchases/subscriptions" title="Subscriptions" />
 			<MySitesSidebarNavigation />
 			<SectionHeader label={ translate( 'Subscriptions' ) } />

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -27,10 +27,8 @@ export default function SubscriptionsContent() {
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
 
-	// If we are loading purchases, show the placeholder
-	if ( ! hasLoadedPurchases || isFetchingPurchases ) {
-		return <PurchasesSite isPlaceholder />;
-	}
+	const getManagePurchaseUrlFor = ( siteSlug: string, purchaseId: number ) =>
+		`/purchases/subscriptions/${ siteSlug }/${ purchaseId }`;
 
 	// If there is no selected site, show the "no sites" page
 	if ( ! selectedSiteId ) {
@@ -41,9 +39,6 @@ export default function SubscriptionsContent() {
 	if ( ! selectedSite?.ID ) {
 		return <PurchasesSite isPlaceholder />;
 	}
-
-	const getManagePurchaseUrlFor = ( siteSlug: string, purchaseId: number ) =>
-		`/purchases/subscriptions/${ siteSlug }/${ purchaseId }`;
 
 	// If there are purchases, show them
 	if ( purchases.length ) {
@@ -59,6 +54,11 @@ export default function SubscriptionsContent() {
 				purchases={ purchases }
 			/>
 		);
+	}
+
+	// If we are loading purchases, show the placeholder
+	if ( ! hasLoadedPurchases || isFetchingPurchases ) {
+		return <PurchasesSite isPlaceholder />;
 	}
 
 	// If there is selected site data but no purchases, show the "no purchases" page

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -9,7 +9,7 @@ import { useTranslate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import PurchasesSite from 'me/purchases/purchases-site/index.jsx';
-import { getSitePurchases, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
+import { getSitePurchases, hasLoadedSitePurchasesFromServer } from 'state/purchases/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
 import { CompactCard } from '@automattic/components';
@@ -17,7 +17,7 @@ import EmptyContent from 'components/empty-content';
 import './style.scss';
 
 export default function SubscriptionsContent() {
-	const hasLoadedPurchases = useSelector( ( state ) => hasLoadedUserPurchasesFromServer( state ) );
+	const hasLoadedPurchases = useSelector( ( state ) => hasLoadedSitePurchasesFromServer( state ) );
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -9,11 +9,7 @@ import { useTranslate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import PurchasesSite from 'me/purchases/purchases-site/index.jsx';
-import {
-	getSitePurchases,
-	hasLoadedUserPurchasesFromServer,
-	isFetchingUserPurchases,
-} from 'state/purchases/selectors';
+import { getSitePurchases, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
 import { CompactCard } from '@automattic/components';
@@ -21,14 +17,13 @@ import EmptyContent from 'components/empty-content';
 import './style.scss';
 
 export default function SubscriptionsContent() {
-	const isFetchingPurchases = useSelector( ( state ) => isFetchingUserPurchases( state ) );
 	const hasLoadedPurchases = useSelector( ( state ) => hasLoadedUserPurchasesFromServer( state ) );
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
 
 	// If we are loading purchases, show the placeholder
-	if ( isFetchingPurchases && ! hasLoadedPurchases ) {
+	if ( ! hasLoadedPurchases ) {
 		return <PurchasesSite isPlaceholder />;
 	}
 
@@ -46,7 +41,7 @@ export default function SubscriptionsContent() {
 		`/purchases/subscriptions/${ siteSlug }/${ purchaseId }`;
 
 	// If there are purchases, show them
-	if ( hasLoadedPurchases && purchases.length ) {
+	if ( purchases.length ) {
 		return (
 			<PurchasesSite
 				showHeader={ false }

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -9,7 +9,11 @@ import { useTranslate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import PurchasesSite from 'me/purchases/purchases-site/index.jsx';
-import { getSitePurchases, hasLoadedSitePurchasesFromServer } from 'state/purchases/selectors';
+import {
+	getSitePurchases,
+	hasLoadedSitePurchasesFromServer,
+	isFetchingSitePurchases,
+} from 'state/purchases/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
 import { CompactCard } from '@automattic/components';
@@ -17,13 +21,14 @@ import EmptyContent from 'components/empty-content';
 import './style.scss';
 
 export default function SubscriptionsContent() {
+	const isFetchingPurchases = useSelector( ( state ) => isFetchingSitePurchases( state ) );
 	const hasLoadedPurchases = useSelector( ( state ) => hasLoadedSitePurchasesFromServer( state ) );
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
 
 	// If we are loading purchases, show the placeholder
-	if ( ! hasLoadedPurchases ) {
+	if ( ! hasLoadedPurchases || isFetchingPurchases ) {
 		return <PurchasesSite isPlaceholder />;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies site-level subscriptions list (added in https://github.com/Automattic/wp-calypso/pull/45601 and still behind the `site-level-billing` feature flag) so that it only loads data for the site rather than for the user.

Fixes https://github.com/Automattic/wp-calypso/issues/46012 (I hope)

#### Testing instructions

- Visit `/purchases` and verify that you see the "Plan" menu in the sidebar, that it shows the currently active plan (unless it's a Jetpack site, where the active plan will be empty), and that its submenu includes "Plans" and "Billing".
- If you have multiple sites, verify that you see a site picker and that picking a site adds the site slug to the URL.
- Verify that if you have no purchases on that site, you see the "Upgrade now" upsell.
- Verify that if you have purchases on that site, you see them all listed (note that clicking on them will bring you to `/me/purchases`; that will be changed in a later PR).
