### PR TITLE
Purchase: update remove product base url

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -285,7 +285,7 @@ class ManagePurchase extends Component {
 		return (
 			<RemovePurchase
 				hasLoadedSites={ hasLoadedSites }
-				hasLoadedUserPurchasesFromServer={ hasLoadedUserPurchasesFromServer }
+				hasLoadedUserPurchasesFromServer={ this.props.hasLoadedUserPurchasesFromServer }
 				hasNonPrimaryDomainsFlag={ hasNonPrimaryDomainsFlag }
 				hasCustomPrimaryDomain={ hasCustomPrimaryDomain }
 				site={ site }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -273,14 +273,24 @@ class ManagePurchase extends Component {
 	}
 
 	renderRemovePurchaseNavItem() {
+		const {
+			hasLoadedSites,
+			hasNonPrimaryDomainsFlag,
+			hasCustomPrimaryDomain,
+			site,
+			purchase,
+			purchaseListUrl,
+		} = this.props;
+
 		return (
 			<RemovePurchase
-				hasLoadedSites={ this.props.hasLoadedSites }
-				hasLoadedUserPurchasesFromServer={ this.props.hasLoadedUserPurchasesFromServer }
-				hasNonPrimaryDomainsFlag={ this.props.hasNonPrimaryDomainsFlag }
-				hasCustomPrimaryDomain={ this.props.hasCustomPrimaryDomain }
-				site={ this.props.site }
-				purchase={ this.props.purchase }
+				hasLoadedSites={ hasLoadedSites }
+				hasLoadedUserPurchasesFromServer={ hasLoadedUserPurchasesFromServer }
+				hasNonPrimaryDomainsFlag={ hasNonPrimaryDomainsFlag }
+				hasCustomPrimaryDomain={ hasCustomPrimaryDomain }
+				site={ site }
+				purchase={ purchase }
+				purchaseListUrl={ purchaseListUrl }
 			/>
 		);
 	}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -65,6 +65,11 @@ class RemovePurchase extends Component {
 		userId: PropTypes.number.isRequired,
 		useVerticalNavItem: PropTypes.bool,
 		onClickTracks: PropTypes.func,
+		purchaseListUrl: PropTypes.string,
+	};
+
+	static defaultProps = {
+		purchaseListUrl: purchasesRoot,
 	};
 
 	state = {
@@ -127,7 +132,7 @@ class RemovePurchase extends Component {
 
 		this.props.removePurchase( purchase.id, this.props.userId ).then( () => {
 			const productName = getName( purchase );
-			const { purchasesError } = this.props;
+			const { purchasesError, purchaseListUrl } = this.props;
 
 			if ( purchasesError ) {
 				this.setState( { isRemoving: false } );
@@ -158,7 +163,7 @@ class RemovePurchase extends Component {
 					);
 				}
 
-				page( purchasesRoot );
+				page( purchaseListUrl );
 			}
 		} );
 	};

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -125,7 +125,7 @@ class RemovePurchase extends Component {
 		} );
 	};
 
-	removePurchase = ( closeDialog ) => {
+	removePurchase = () => {
 		this.setState( { isRemoving: true } );
 
 		const { isDomainOnlySite, purchase, translate } = this.props;
@@ -137,7 +137,7 @@ class RemovePurchase extends Component {
 			if ( purchasesError ) {
 				this.setState( { isRemoving: false } );
 
-				closeDialog();
+				this.closeDialog();
 
 				notices.error( purchasesError );
 			} else {


### PR DESCRIPTION
### Changes proposed in this Pull Request
This PR makes the hardcoded base url a prop so we can pass it from the site-level billing screens. 

### Testing instructions

**To test the page redirect fix:**
* With the `site-level-billing` flag enabled and store _not_ sandboxed
* Add a plan to your site via Store Admin
* In Calypso, visit Plan > Billing > click on the purchase > click "remove {product}"
* Fill out the pre-removal prompts and click "remove now"
* Verify that the plan is removed, the dialog closes, and you remain on the same screen

**To test the closeDialog fix:**
* In either calypso or on the backend, edit the `/me/purchases/{purchaseId}/delete` endpoint to return an error
* With the `site-level-billing` flag enabled
* On a site with a purchase, visit Plan > Billing > click on the purchase > click "remove {product}"
* Fill out the pre-removal prompts and click "remove now"
* Verify that the dialog closes, and you remain on the same screen

Related: https://github.com/Automattic/wp-calypso/issues/45181