### PR TITLE
Fix/purchases mobile navigation

### DIFF
--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -14,6 +14,7 @@ import FormattedHeader from 'components/formatted-header';
 import ManagePurchase from 'me/purchases/manage-purchase';
 import CancelPurchase from 'me/purchases/cancel-purchase';
 import ConfirmCancelDomain from 'me/purchases/confirm-cancel-domain';
+import MySitesSidebarNavigation from 'my-sites/sidebar-navigation';
 import {
 	getPurchaseListUrlFor,
 	getCancelPurchaseUrlFor,
@@ -28,6 +29,7 @@ export function Purchases() {
 
 	return (
 		<Main className="purchases is-wide-layout">
+			<MySitesSidebarNavigation />
 			<DocumentHead title={ translate( 'Billing' ) } />
 			<FormattedHeader
 				brandFont
@@ -52,6 +54,7 @@ export function PurchaseDetails( {
 
 	return (
 		<Main className="purchases is-wide-layout">
+			<MySitesSidebarNavigation />
 			<DocumentHead title={ translate( 'Billing' ) } />
 			<FormattedHeader
 				brandFont
@@ -85,6 +88,7 @@ export function PurchaseCancel( {
 
 	return (
 		<Main className="purchases is-wide-layout">
+			<MySitesSidebarNavigation />
 			<DocumentHead title={ translate( 'Cancel purchase' ) } />
 			<FormattedHeader
 				brandFont
@@ -115,6 +119,7 @@ export function PurchaseAddPaymentMethod( {
 
 	return (
 		<Main className="purchases is-wide-layout">
+			<MySitesSidebarNavigation />
 			<DocumentHead title={ translate( 'Billing' ) } />
 			<FormattedHeader
 				brandFont
@@ -144,6 +149,7 @@ export function PurchaseCancelDomain( {
 
 	return (
 		<Main className="purchases is-wide-layout">
+			<MySitesSidebarNavigation />
 			<DocumentHead title={ translate( 'Cancel domain' ) } />
 			<FormattedHeader
 				brandFont

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -54,7 +54,6 @@ export function PurchaseDetails( {
 
 	return (
 		<Main className="purchases is-wide-layout">
-			<MySitesSidebarNavigation />
 			<DocumentHead title={ translate( 'Billing' ) } />
 			<FormattedHeader
 				brandFont
@@ -88,7 +87,6 @@ export function PurchaseCancel( {
 
 	return (
 		<Main className="purchases is-wide-layout">
-			<MySitesSidebarNavigation />
 			<DocumentHead title={ translate( 'Cancel purchase' ) } />
 			<FormattedHeader
 				brandFont
@@ -119,7 +117,6 @@ export function PurchaseAddPaymentMethod( {
 
 	return (
 		<Main className="purchases is-wide-layout">
-			<MySitesSidebarNavigation />
 			<DocumentHead title={ translate( 'Billing' ) } />
 			<FormattedHeader
 				brandFont
@@ -149,7 +146,6 @@ export function PurchaseCancelDomain( {
 
 	return (
 		<Main className="purchases is-wide-layout">
-			<MySitesSidebarNavigation />
 			<DocumentHead title={ translate( 'Cancel domain' ) } />
 			<FormattedHeader
 				brandFont

--- a/client/my-sites/purchases/subscriptions/index.tsx
+++ b/client/my-sites/purchases/subscriptions/index.tsx
@@ -9,7 +9,6 @@ import { useTranslate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import Main from 'components/main';
-import MySitesSidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -25,7 +24,6 @@ export default function Subscriptions() {
 		<Main className="subscriptions is-wide-layout">
 			<QueryUserPurchases userId={ userId } />
 			<PageViewTracker path="/purchases/subscriptions" title="Subscriptions" />
-			<MySitesSidebarNavigation />
 			<SectionHeader label={ translate( 'Subscriptions' ) } />
 			<SubscriptionsContent />
 			<AccountLevelPurchaseLinks />


### PR DESCRIPTION
#### Changes proposed in this Pull Request
While browsing these screens on a mobile device, I noticed the mobile navigation header appeared out of place. This PR fixes it by placing it above the title like it is on all our other screens.

![image](https://user-images.githubusercontent.com/6981253/94757474-5146ab00-0368-11eb-9e68-5f6d85a2919f.png)


#### Testing instructions

* Make sure the `site-level-billing` flag is enable
* Visit the site level billing screen and toggle between desktop and mobile views to make sure the site navigation is always visible. 
