### PR TITLE
Coming Soon: update Gutenboarding coming soon flag

### DIFF
--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -54,7 +54,7 @@ export function useNewSiteVisibility(): Site.Visibility {
 
 	if ( isEcommerce ) {
 		return Site.Visibility.PublicIndexed;
-	} else if ( isEnabled( 'gutenboarding/public-coming-soon' ) ) {
+	} else if ( isEnabled( 'coming-soon-v2' ) ) {
 		return Site.Visibility.PublicNotIndexed;
 	}
 

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -41,7 +41,7 @@ export function* createSite(
 	username: string,
 	languageSlug: string,
 	bearerToken?: string,
-	visibility: number = isEnabled( 'gutenboarding/public-coming-soon' )
+	visibility: number = isEnabled( 'coming-soon-v2' )
 		? Site.Visibility.PublicNotIndexed
 		: Site.Visibility.Private
 ) {
@@ -87,7 +87,7 @@ export function* createSite(
 			} ),
 			use_patterns: true,
 			selected_features: selectedFeatures,
-			...( isEnabled( 'gutenboarding/public-coming-soon' ) &&
+			...( isEnabled( 'coming-soon-v2' ) &&
 				visibility === Site.Visibility.PublicNotIndexed && {
 					public_coming_soon: true,
 				} ),


### PR DESCRIPTION
## Changes proposed in this Pull Request

Somewhere along the line, the feature flag became `coming-soon-v2` in other commits. This just standardizes it for Gutenboarding.

Question: does it make sense? 

## Testing instructions

Follow the test instructions in https://github.com/Automattic/wp-calypso/pull/45428 but instead of using `/new?flags=gutenboarding/public-coming-soon` use the new flag: `/new?flags=coming-soon-v2`

