### PR TITLE
Pattern Tracking: Tidy up pattern insertion tracking functions

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -113,17 +113,17 @@ const getBlocksTracker = ( eventName ) => ( blockIds ) => {
  * a track event for it. The recorded event will also reflect whether the
  * inserted pattern replaced blocks.
  *
- * @param {Array} args Data supplied to block insertion or replacement tracking functions.
+ * @param {Array} actionData Data supplied to block insertion or replacement tracking functions.
  * @returns {string} Pattern name being inserted if available.
  */
-const trackPatternInsertion = ( args ) => {
-	const meta = find( args, ( arg ) => arg?.patternName );
+const maybeTrackPatternInsertion = ( actionData ) => {
+	const meta = find( actionData, ( item ) => item?.patternName );
 	const patternName = meta?.patternName;
 
 	if ( patternName ) {
 		tracksRecordEvent( 'wpcom_pattern_inserted', {
 			pattern_name: patternName,
-			blocks_replaced: args.blocks_replaced,
+			blocks_replaced: actionData?.blocks_replaced,
 		} );
 	}
 
@@ -138,7 +138,7 @@ const trackPatternInsertion = ( args ) => {
  * @returns {void}
  */
 const trackBlockInsertion = ( blocks, ...args ) => {
-	const patternName = trackPatternInsertion( { ...args, blocks_replaced: false } );
+	const patternName = maybeTrackPatternInsertion( { ...args, blocks_replaced: false } );
 
 	trackBlocksHandler( blocks, 'wpcom_block_inserted', ( { name } ) => ( {
 		block_name: name,
@@ -168,7 +168,7 @@ const trackBlockRemoval = ( blocks ) => {
  * @returns {void}
  */
 const trackBlockReplacement = ( originalBlockIds, blocks, ...args ) => {
-	const patternName = trackPatternInsertion( { ...args, blocks_replaced: true } );
+	const patternName = maybeTrackPatternInsertion( { ...args, blocks_replaced: true } );
 
 	trackBlocksHandler( blocks, 'wpcom_block_picker_block_inserted', ( { name } ) => ( {
 		block_name: name,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename pattern tracking function to more clearly communicate what it does and make code a little more robust

_Based on feedback from https://github.com/Automattic/wp-calypso/pull/45720#pullrequestreview-499205295_

#### Testing instructions

1. Checkout this PR
2. Build wpcom-block-editor
3. Sync the built files to your sandbox's widget directory
4. Ensure your sandbox is using Guteneberg 9.1 or later ( if not sync a build of Gutenberg )
5. Ensure you have widgets.wp.com sandboxed
6. Visit a sandboxed site's block editor:
7. https://YOUR-SANDBOX-DOMAIN/wp-admin/post.php?post=YOUR-POST-ID&action=edit
8. Open dev tools console and turn on tracking debugging via localStorage value:
9. localStorage.setItem( 'debug', 'wpcom-block-editor:*' );
10. Reload the editor page
11. Now add a block pattern to the page.
12. In the console, you should see two events tracked wpcom_pattern_inserted & wpcom_block_inserted
<img width="1049" alt="Screen Shot 2020-09-17 at 6 56 45 pm" src="https://user-images.githubusercontent.com/60436221/93449054-9f46c200-f917-11ea-8171-98de55f02c8d.png">
13. Now add an empty paragraph block to the post and click within it to leave the cursor inside the block.
14. Now add another block pattern
15. In the console, you should see the `replaceBlocks` action was triggered and another `wpcom_pattern_inserted` event.
<img width="970" alt="Screen Shot 2020-09-18 at 1 24 36 pm" src="https://user-images.githubusercontent.com/60436221/93552384-b5a25b80-f9b3-11ea-9776-20b8ce9faa83.png">

16. After a couple of minutes the new `wpcom_pattern_inserted` event should also appear within the Tracks Live View
