### PR TITLE
Media: fix runtime TypeError when navigating to page with null selected site

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -423,8 +423,8 @@ class Media extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { mediaId, site } ) => {
-	const siteId = getSelectedSiteId( state ) || site.ID;
+const mapStateToProps = ( state, { mediaId } ) => {
+	const siteId = getSelectedSiteId( state );
 
 	return {
 		selectedSite: getSelectedSite( state ),


### PR DESCRIPTION
Fixes a bug that I believe was introduced in #41961.

**Steps to reproduce:**
1. Go to `/media/site.blog` for any of your sites.
2. In the sidebar, click "Switch Site" and then "Add New Site" at the bottom

Expected result: Calypso navigates to the new site flow at `/start`
Actual result: Calypso crashes during the navigation:

<img width="637" alt="Screenshot 2020-10-01 at 09 23 47" src="https://user-images.githubusercontent.com/664258/94780309-884ca900-03c8-11eb-9049-a03989bb28ab.png">

The crash happens because the navigation to signup dispatches a `setSelectedSite( null )` action, triggering a rerender of the Media page -- the Signup UI is rendered only a while later, in one of the following _page.js_ handlers. Then, the `mapStateToProps` tries to access `site.ID` property of the `site` prop, but the `MediaComponent` never gets a `site` prop from its parent.

@tyxla @saramarcondes do you remember why the `{ site }` prop and `site.ID` were added in #41961? It doesn't seem to do anything useful.