### PR TITLE
Disable CircleCI for internal PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,7 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
+      - only-external-pr
       - prepare
       - run:
           name: TypeScript strict typecheck of individual subprojects
@@ -983,30 +984,70 @@ workflows:
       - build-notifications:
           requires:
             - setup
+          filters:
+            branches:
+              only:
+                # Only run for fork pull requets.
+                - /pull\/[0-9]+/
       - build-o2-blocks:
           requires:
             - setup
+          filters:
+            branches:
+              only:
+                # Only run for fork pull requets.
+                - /pull\/[0-9]+/
       - build-wpcom-block-editor:
           requires:
             - setup
+          filters:
+            branches:
+              only:
+                # Only run for fork pull requets.
+                - /pull\/[0-9]+/
       - translate:
           requires:
             - setup
       - lint:
           requires:
             - setup
+          filters:
+            branches:
+              only:
+                # Only run for fork pull requets.
+                - /pull\/[0-9]+/
       - test-client:
           requires:
             - setup
+          filters:
+            branches:
+              only:
+                # Only run for fork pull requets.
+                - /pull\/[0-9]+/
       - test-packages:
           requires:
             - setup
+          filters:
+            branches:
+              only:
+                # Only run for fork pull requets.
+                - /pull\/[0-9]+/
       - test-server:
           requires:
             - setup
+          filters:
+            branches:
+              only:
+                # Only run for fork pull requets.
+                - /pull\/[0-9]+/
       - typecheck-strict:
           requires:
             - setup
+          filters:
+            branches:
+              only:
+                # Only run for fork pull requets.
+                - /pull\/[0-9]+/
       - wait-calypso-live:
           requires:
             - test-client

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1048,6 +1048,8 @@ workflows:
                 # Only run for fork pull requets.
                 - /pull\/[0-9]+/
       - wait-calypso-live:
+          requires:
+            - setup
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1048,9 +1048,6 @@ workflows:
                 # Only run for fork pull requets.
                 - /pull\/[0-9]+/
       - wait-calypso-live:
-          requires:
-            - test-client
-            - test-server
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,6 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      - only-external-pr
       - prepare
       - run:
           name: TypeScript strict typecheck of individual subprojects


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable jobs running in TeamCity for regular branches. Branches from external forks are labeled `/pull/[0-9]+` and they will still run.
* Do not require client and server unit tests to start calypso.live tests.

#### Testing instructions

* Check that this PR is not running the disabled CI jobs. It should be running `translate` and all e2e tests.
