### PR TITLE
Layout: provide current route info in React context and prefer it over Redux state

### DIFF
--- a/client/components/route/index.js
+++ b/client/components/route/index.js
@@ -1,0 +1,37 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+const RouteContext = React.createContext( {
+	currentSection: null,
+	currentRoute: '',
+	currentQuery: false,
+} );
+
+export function RouteProvider( {
+	currentSection = null,
+	currentRoute = '',
+	currentQuery = false,
+	children,
+} ) {
+	// modify the `currentRouteInfo` object (and trigger rerender of consumers) only if any
+	// of its properties really changes.
+	const currentRouteInfo = React.useMemo(
+		() => ( { currentSection, currentRoute, currentQuery } ),
+		[ currentSection, currentRoute, currentQuery ]
+	);
+	return <RouteContext.Provider value={ currentRouteInfo }>{ children }</RouteContext.Provider>;
+}
+
+export function useCurrentRoute() {
+	return React.useContext( RouteContext );
+}
+
+export const withCurrentRoute = createHigherOrderComponent( ( Wrapped ) => {
+	return function WithCurrentRoute( props ) {
+		const currentRouteInfo = useCurrentRoute();
+		return <Wrapped { ...props } { ...currentRouteInfo } />;
+	};
+}, 'WithCurrentRoute' );

--- a/client/components/route/index.js
+++ b/client/components/route/index.js
@@ -5,13 +5,16 @@ import React from 'react';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 const RouteContext = React.createContext( {
-	currentSection: null,
+	// TODO: a `null` value would be a better fit here, but existing code might access
+	// the properties of `currentSection` without guarding for `null`. Accessing properties
+	// of a boolean value is OK -- it's an object.
+	currentSection: false,
 	currentRoute: '',
 	currentQuery: false,
 } );
 
 export function RouteProvider( {
-	currentSection = null,
+	currentSection = false,
 	currentRoute = '',
 	currentQuery = false,
 	children,

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -10,17 +10,32 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { makeLayoutMiddleware } from './shared.js';
 import LayoutLoggedOut from 'layout/logged-out';
 import CalypsoI18nProvider from 'components/calypso-i18n-provider';
+import { RouteProvider } from 'components/route';
 
 /**
  * Re-export
  */
 export { setSectionMiddleware, setLocaleMiddleware } from './shared.js';
 
-const ProviderWrappedLoggedOutLayout = ( { store, primary, secondary, redirectUri } ) => (
+const ProviderWrappedLoggedOutLayout = ( {
+	store,
+	currentSection,
+	currentRoute,
+	currentQuery,
+	primary,
+	secondary,
+	redirectUri,
+} ) => (
 	<CalypsoI18nProvider>
-		<ReduxProvider store={ store }>
-			<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
-		</ReduxProvider>
+		<RouteProvider
+			currentSection={ currentSection }
+			currentRoute={ currentRoute }
+			currentQuery={ currentQuery }
+		>
+			<ReduxProvider store={ store }>
+				<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
+			</ReduxProvider>
+		</RouteProvider>
 	</CalypsoI18nProvider>
 );
 

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -15,6 +15,7 @@ import LayoutLoggedOut from 'layout/logged-out';
 import EmptyContent from 'components/empty-content';
 import CalypsoI18nProvider from 'components/calypso-i18n-provider';
 import MomentProvider from 'components/localized-moment/provider';
+import { RouteProvider } from 'components/route';
 import { login } from 'lib/paths';
 import { makeLayoutMiddleware } from './shared.js';
 import { isUserLoggedIn } from 'state/current-user/selectors';
@@ -28,7 +29,15 @@ import { hydrate } from './web-util.js';
 export { setSectionMiddleware, setLocaleMiddleware } from './shared.js';
 export { render, hydrate, redirectLoggedIn } from './web-util.js';
 
-export const ProviderWrappedLayout = ( { store, primary, secondary, redirectUri } ) => {
+export const ProviderWrappedLayout = ( {
+	store,
+	currentSection,
+	currentRoute,
+	currentQuery,
+	primary,
+	secondary,
+	redirectUri,
+} ) => {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
 
@@ -40,9 +49,15 @@ export const ProviderWrappedLayout = ( { store, primary, secondary, redirectUri 
 
 	return (
 		<CalypsoI18nProvider>
-			<ReduxProvider store={ store }>
-				<MomentProvider>{ layout }</MomentProvider>
-			</ReduxProvider>
+			<RouteProvider
+				currentSection={ currentSection }
+				currentRoute={ currentRoute }
+				currentQuery={ currentQuery }
+			>
+				<ReduxProvider store={ store }>
+					<MomentProvider>{ layout }</MomentProvider>
+				</ReduxProvider>
+			</RouteProvider>
 		</CalypsoI18nProvider>
 	);
 };

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -15,13 +15,16 @@ import { isTranslatedIncompletely } from 'lib/i18n-utils/utils';
 
 export function makeLayoutMiddleware( LayoutComponent ) {
 	return ( context, next ) => {
-		const { store, primary, secondary } = context;
+		const { store, section, pathname, query, primary, secondary } = context;
 
 		// On server, only render LoggedOutLayout when logged-out.
 		if ( ! context.isServerSide || ! getCurrentUser( context.store.getState() ) ) {
 			context.layout = (
 				<LayoutComponent
 					store={ store }
+					currentSection={ section }
+					currentRoute={ pathname }
+					currentQuery={ query }
 					primary={ primary }
 					secondary={ secondary }
 					redirectUri={ context.originalUrl }

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -21,8 +21,9 @@ import { performanceTrackerStart } from 'lib/performance-tracking';
 import sections from './sections';
 receiveSections( sections );
 
-function activateSection( sectionDefinition, context ) {
-	context.store.dispatch( setSection( sectionDefinition ) );
+function activateSection( section, context ) {
+	context.section = section;
+	context.store.dispatch( setSection( section ) );
 	context.store.dispatch( activateNextLayoutFocus() );
 }
 


### PR DESCRIPTION
Proof of concept that tries to address visual and other glitches when navigating between routes, as described in #46084. Followup to @ciampo 's #45784 that tries to address the issue in The Right Way™.

The current route info is put into a React context, and the `Layout` component consumes this info from this context instead of getting it from Redux.

This avoids several rerenders of the `Layout` component as the Redux updates are dispatched, and makes the render happen only once, when rendering the new route's React UI.

There is still a very long way from here: all usages of the Redux selectors that use the routing info should be eliminated from the codebase.

To make the rendering even more reliable, we should pass `selectedSiteId` in context, too, and remove it from Redux. But the `getSelectedSiteId` selector is literally everywhere, with approx 500 usages 😨 