### PR TITLE
Components: Use FormTextarea in TextareaAutosize

### DIFF
--- a/client/components/forms/form-textarea/index.jsx
+++ b/client/components/forms/form-textarea/index.jsx
@@ -4,13 +4,14 @@
 import React from 'react';
 import classnames from 'classnames';
 
-const FormTextarea = ( { className, isError, isValid, children, ...otherProps } ) => (
+const FormTextarea = ( { className, isError, isValid, children, forwardedRef, ...otherProps } ) => (
 	<textarea
 		{ ...otherProps }
 		className={ classnames( className, 'form-textarea', {
 			'is-error': isError,
 			'is-valid': isValid,
 		} ) }
+		ref={ forwardedRef }
 	>
 		{ children }
 	</textarea>

--- a/client/components/textarea-autosize/index.jsx
+++ b/client/components/textarea-autosize/index.jsx
@@ -1,11 +1,15 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import autosize from 'autosize';
+
+/**
+ * Internal dependencies
+ */
+import FormTextarea from 'components/forms/form-textarea';
 
 /**
  * Style dependencies
@@ -17,12 +21,14 @@ export default class TextareaAutosize extends Component {
 		className: PropTypes.string,
 	};
 
+	textareaRef = React.createRef();
+
 	componentDidMount() {
-		autosize( this.refs.textarea );
+		autosize( this.textareaRef.current );
 	}
 
 	componentWillUnmount() {
-		autosize.destroy( this.refs.textarea );
+		autosize.destroy( this.textareaRef.current );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -32,12 +38,14 @@ export default class TextareaAutosize extends Component {
 	}
 
 	resize() {
-		autosize.update( this.refs.textarea );
+		autosize.update( this.textareaRef.current );
 	}
 
 	render() {
 		const classes = classnames( 'textarea-autosize', this.props.className );
 
-		return <textarea ref="textarea" { ...this.props } className={ classes } />;
+		return (
+			<FormTextarea { ...this.props } className={ classes } forwardedRef={ this.textareaRef } />
+		);
 	}
 }


### PR DESCRIPTION
This updates  `<TextareaAutosize />` to use `<FormTextarea />` instead of a `<textarea />`. Part of #45259.

#### Changes proposed in this Pull Request

* Components: Use `<FormTextarea />` in `<TextareaAutosize />`

#### Testing instructions

* Go to `/devdocs/design/textarea-autosize` and verify:
  * The textarea field is visually unchanged.
  * Autosize functionality still works well.
* Go to `/devdocs/design/form-fields` and verify regular textarea fields still work and look well.