### PR TITLE
i18n: Add form encoding to GlotPress postRequest method

### DIFF
--- a/client/lib/i18n-utils/glotpress.js
+++ b/client/lib/i18n-utils/glotpress.js
@@ -18,19 +18,16 @@ const debug = debugFactory( 'calypso:i18n-utils:glotpress' );
  * @returns {object} request object
  */
 export async function postRequest( glotPressUrl, postFormData ) {
-	let response;
-
-	try {
-		response = await fetch( glotPressUrl, {
-			method: 'POST',
-			credentials: 'include',
-			body: postFormData,
-		} );
-		if ( response.ok ) {
-			return await response.json();
-		}
-	} catch ( err ) {
-		throw err;
+	const response = await window.fetch( glotPressUrl, {
+		method: 'POST',
+		credentials: 'include',
+		body: postFormData,
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+	} );
+	if ( response.ok ) {
+		return await response.json();
 	}
 
 	// Invalid response.


### PR DESCRIPTION
Currently, the community translator component doesn't work, because it sends requests to the WP.com translation API json-encoded, while instead it should be with form encoding. This PR takes care of that, plus a couple more linting fixes:

* Removing an unnecessary `try`/`catch`
* `fetch` -> `window.fetch`

#### Changes proposed in this Pull Request

* i18n: Add form encoding to GlotPress postRequest method

Before:
![](https://cldup.com/pHGX4rKtL4.png)

After:
![](https://cldup.com/jXYVvDIdFF.png)

#### Testing instructions

* Checkout this branch.
* Change `GP_PROJECT` to always be equal to `wpcom`.
* Change `isCommunityTranslatorEnabled` to always return `true`.
* Access local Calypso with `?flags=i18n/community-translator`
* Verify you can retrieve translations with the community translator.

