### PR TITLE
Components: Use FormTextarea for TranslatableTextarea

### DIFF
--- a/client/components/community-translator/translatable-textarea.jsx
+++ b/client/components/community-translator/translatable-textarea.jsx
@@ -3,6 +3,11 @@
  */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
+import FormTextarea from 'components/forms/form-textarea';
+
 const TranslatableTextarea = ( {
 	originalString,
 	title,
@@ -15,7 +20,7 @@ const TranslatableTextarea = ( {
 		<span className="community-translator__string-description">{ title }</span>
 		<span>
 			<dfn>{ originalString }</dfn>
-			<textarea
+			<FormTextarea
 				id={ fieldName }
 				name={ fieldName }
 				value={ value }


### PR DESCRIPTION
This updates  `<TranslatableTextarea />` to use `<FormTextarea />` instead of a `<textarea />`. Part of #45259.

#### Changes proposed in this Pull Request

* Components: Use `<FormTextarea />` in `<TranslatableTextarea />`

#### Testing instructions

* Cherry-pick the commit in #46088
* Follow the test instructions in #46088
* Verify the textarea appears and functions like it did before.