### PR TITLE
Components: Update FormToggle to use FormLabel

### DIFF
--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -14,6 +14,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 
 /**
  * Style dependencies
@@ -99,7 +100,7 @@ export default class FormToggle extends PureComponent {
 					readOnly={ true }
 					disabled={ this.props.disabled }
 				/>
-				<label className="form-toggle__label" htmlFor={ id }>
+				<FormLabel className="form-toggle__label" htmlFor={ id }>
 					<span
 						className="form-toggle__switch"
 						onClick={ this.onClick }
@@ -116,7 +117,7 @@ export default class FormToggle extends PureComponent {
 						</span>
 						/* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
 					) }
-				</label>
+				</FormLabel>
 			</span>
 		);
 	}

--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -42,8 +42,9 @@
 	}
 }
 
-.form-toggle__label {
+.form-toggle__label.form-label {
 	cursor: pointer;
+	font-weight: 400;
 
 	.is-disabled & {
 		cursor: default;
@@ -57,15 +58,15 @@
 
 .form-toggle {
 	.accessible-focus &:focus {
-		+ .form-toggle__label .form-toggle__switch {
+		+ .form-toggle__label.form-label .form-toggle__switch {
 			box-shadow: 0 0 0 2px var( --color-primary );
 		}
-		&:checked + .form-toggle__label .form-toggle__switch {
+		&:checked + .form-toggle__label.form-label .form-toggle__switch {
 			box-shadow: 0 0 0 2px var( --color-primary-light );
 		}
 	}
 
-	& + .form-toggle__label .form-toggle__switch {
+	& + .form-toggle__label.form-label .form-toggle__switch {
 		background: var( --color-neutral-20 );
 	}
 
@@ -76,7 +77,7 @@
 	}
 
 	&:checked {
-		+ .form-toggle__label .form-toggle__switch {
+		+ .form-toggle__label.form-label .form-toggle__switch {
 			background: var( --color-primary );
 
 			&::after {
@@ -92,18 +93,18 @@
 	}
 
 	&:disabled {
-		+ label.form-toggle__label span.form-toggle__switch {
+		+ label.form-toggle__label.form-label span.form-toggle__switch {
 			opacity: 0.25;
 			cursor: default;
 		}
 	}
 
 	&.is-toggling {
-		+ .form-toggle__label {
+		+ .form-toggle__label.form-label {
 			color: var( --color-neutral );
 			animation: loading-fade 1.6s ease-in-out infinite;
 		}
-		+ .form-toggle__label .form-toggle__switch {
+		+ .form-toggle__label.form-label .form-toggle__switch {
 			background: var( --color-primary );
 			animation: loading-fade 1.6s ease-in-out infinite;
 			&::after {
@@ -111,7 +112,7 @@
 			}
 		}
 		&:checked {
-			+ .form-toggle__label .form-toggle__switch {
+			+ .form-toggle__label.form-label .form-toggle__switch {
 				background: var( --color-neutral-10 );
 				animation: loading-fade 1.6s ease-in-out infinite;
 				&::after {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Components: Update FormToggle to use FormLabel

#### Testing instructions

* Test toggle labels on the following toggle-heavy pages against production and ensure that they match stylistically and functionally:
  * `/settings/writing/:site`
  * `/settings/discussion/:site`
  * `/me/privacy`
  * `/earn/ads-settings/:site`

#### Notes

There is a subtle difference on the Privacy page, which is in favor of being consistent with other toggle fields throughout Calypso.

Also, there are a couple of differences on the Ads Settings page, which I consider improvement because now the label looks like the labels on the radio buttons above:

Before:
![](https://cldup.com/kQOeufrE9R.png)

After:
![](https://cldup.com/q71jd23xkM.png)
