### PR TITLE
Settings: Fix date/time format input styles

### DIFF
--- a/client/my-sites/site-settings/date-time-format/style.scss
+++ b/client/my-sites/site-settings/date-time-format/style.scss
@@ -26,7 +26,7 @@
 		margin-top: 12px;
 	}
 
-	.form-text-input {
+	input[type='text'].form-text-input {
 		margin: 0 12px;
 		width: 100px;
 	}


### PR DESCRIPTION
It appears that in #45781 we inadvertently broke the width of the date/time format input fields. This PR fixes that.

#### Changes proposed in this Pull Request

* Settings: Fix date/time format input styles

Before:
![](https://cldup.com/pXy0sYF9BV.png)

After:
![](https://cldup.com/BSjABGX_2E.png)

#### Testing instructions

* Go to `/settings/writing/:site`
* Expand the date format accordion
* Observe the text fields for the custom date/time format, and verify they look as shown on the "After" screenshot.
