### PR TITLE
Jetpack Cloud: Make Backup and Scan unavailable for multi-sites

### DIFF
--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -15,6 +15,8 @@ import BackupPlaceholder from 'components/jetpack/backup-placeholder';
 import FormattedHeader from 'components/formatted-header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import getRewindState from 'state/selectors/get-rewind-state';
+import isJetpackSiteMultiSite from 'state/sites/selectors/is-jetpack-site-multi-site';
+import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 import QueryRewindState from 'components/data/query-rewind-state';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import { isJetpackBackupSlug } from 'lib/products-values';
@@ -41,6 +43,20 @@ export function showUpsellIfNoBackup( context, next ) {
 			</UpsellSwitch>
 		</>
 	);
+	next();
+}
+
+export function showUnavailableForMultisites( context, next ) {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	if ( isJetpackSiteMultiSite( state, siteId ) ) {
+		context.primary = isJetpackCloud() ? (
+			<BackupUpsell reason="multisite_not_supported" />
+		) : (
+			<WPCOMBackupUpsell reason="multisite_not_supported" />
+		);
+	}
+
 	next();
 }
 

--- a/client/my-sites/backup/index.js
+++ b/client/my-sites/backup/index.js
@@ -11,6 +11,7 @@ import {
 	backupRestore,
 	backups,
 	showUpsellIfNoBackup,
+	showUnavailableForMultisites,
 } from 'my-sites/backup/controller';
 import { backupMainPath, backupRestorePath, backupDownloadPath } from './paths';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -44,6 +45,7 @@ export default function () {
 		backupDownload,
 		wrapInSiteOffsetProvider,
 		wpcomUpsellController( WPCOMUpsellPage ),
+		showUnavailableForMultisites,
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
@@ -58,6 +60,7 @@ export default function () {
 			backupRestore,
 			wrapInSiteOffsetProvider,
 			wpcomUpsellController( WPCOMUpsellPage ),
+			showUnavailableForMultisites,
 			notFoundIfNotEnabled,
 			makeLayout,
 			clientRender
@@ -73,6 +76,7 @@ export default function () {
 		wrapInSiteOffsetProvider,
 		showUpsellIfNoBackup,
 		wpcomUpsellController( WPCOMUpsellPage ),
+		showUnavailableForMultisites,
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender

--- a/client/my-sites/scan/controller.js
+++ b/client/my-sites/scan/controller.js
@@ -13,6 +13,8 @@ import ScanUpsellPage from './upsell';
 import WPCOMScanUpsellPage from './wpcom-scan-upsell';
 import getSiteScanRequestStatus from 'state/selectors/get-site-scan-request-status';
 import getSiteScanState from 'state/selectors/get-site-scan-state';
+import isJetpackSiteMultiSite from 'state/sites/selectors/is-jetpack-site-multi-site';
+import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 import QueryJetpackScan from 'components/data/query-jetpack-scan';
 import ScanPlaceholder from 'components/jetpack/scan-placeholder';
 import ScanHistoryPlaceholder from 'components/jetpack/scan-history-placeholder';
@@ -26,6 +28,20 @@ export function showUpsellIfNoScan( context, next ) {
 
 export function showUpsellIfNoScanHistory( context, next ) {
 	context.primary = scanUpsellSwitcher( <ScanHistoryPlaceholder />, context.primary );
+	next();
+}
+
+export function showUnavailableForMultisites( context, next ) {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	if ( isJetpackSiteMultiSite( state, siteId ) ) {
+		context.primary = isJetpackCloud() ? (
+			<ScanUpsellPage reason="multisite_not_supported" />
+		) : (
+			<WPCOMScanUpsellPage reason="multisite_not_supported" />
+		);
+	}
+
 	next();
 }
 

--- a/client/my-sites/scan/index.js
+++ b/client/my-sites/scan/index.js
@@ -16,6 +16,7 @@ import isJetpackSectionEnabledForSite from 'state/selectors/is-jetpack-section-e
 import {
 	showUpsellIfNoScan,
 	showUpsellIfNoScanHistory,
+	showUnavailableForMultisites,
 	scan,
 	scanHistory,
 } from 'my-sites/scan/controller';
@@ -45,6 +46,7 @@ export default function () {
 		wrapInSiteOffsetProvider,
 		showUpsellIfNoScan,
 		wpcomUpsellController( WPCOMScanUpsellPage ),
+		showUnavailableForMultisites,
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
@@ -58,6 +60,7 @@ export default function () {
 		wrapInSiteOffsetProvider,
 		showUpsellIfNoScanHistory,
 		wpcomUpsellController( WPCOMScanUpsellPage ),
+		showUnavailableForMultisites,
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
@@ -71,6 +74,7 @@ export default function () {
 		wrapInSiteOffsetProvider,
 		showUpsellIfNoScan,
 		wpcomUpsellController( WPCOMScanUpsellPage ),
+		showUnavailableForMultisites,
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
Fixes a regression.

#### Changes proposed in this Pull Request

* Add route middlewares to the controllers for both Backup and Scan, so that multi-sites are shown the "unavailable" message regardless of what products or bundles have been purchased.

#### Testing instructions (four scenarios)

##### Scenario 1: Backup for a single site

* Open either Jetpack Cloud or Calypso and select a non-multisite with a bundle or plan that includes Jetpack Backup.
* Go to the **Backup** page.
* Verify that you see the normal, fully-functional Backup page.

##### Scenario 2: Scan for a single site

* Open either Jetpack Cloud or Calypso and select a non-multisite with a bundle or plan that includes Jetpack Scan.
* Go to the **Scan** page.
* Verify that you see the normal, fully-functional Scan page.

##### Scenario 3: Backup for a multi-site

* For both Jetpack Cloud and Calypso, select a multi-site with a bundle or plan that includes Jetpack Backup.
* Go to the **Backup** page.
* Verify that you see the "WordPress multi-sites are not supported" message and not the normal Backup page.
* Verify that styling looks correct for either Jetpack Cloud or Calypso, whichever you're testing.

<img width="399" alt="image" src="https://user-images.githubusercontent.com/670067/94820587-3dca2d00-03c6-11eb-8d3a-93051125189f.png"> <img width="381" alt="image" src="https://user-images.githubusercontent.com/670067/94821680-79192b80-03c7-11eb-9de8-e6f59712d127.png">

##### Scenario 4: Scan for a multi-site

* For both Jetpack Cloud and Calypso, select a multi-site with a bundle or plan that includes Jetpack Scan.
* Go to the **Scan** page.
* Verify that you see the "Your site does not support Jetpack Scan" message and not the normal Scan page.
* Verify that styling looks correct for either Jetpack Cloud or Calypso, whichever you're testing.

<img width="385" alt="image" src="https://user-images.githubusercontent.com/670067/94820637-4e7aa300-03c6-11eb-9de1-92b076a95238.png"> <img width="382" alt="image" src="https://user-images.githubusercontent.com/670067/94821645-6acb0f80-03c7-11eb-9e2c-34eae5adb311.png">