### PR TITLE
babel-plugin-transform-wpcalypso-async: add ignore option that removes async-loaded modules from build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,7 @@ const isBrowser = process.env.BROWSERSLIST_ENV !== 'server';
 
 const babelConfig = {
 	presets: [ '@automattic/calypso-build/babel/default' ],
-	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: isBrowser } ] ],
+	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: true, ignore: ! isBrowser } ] ],
 	env: {
 		production: {
 			plugins: [ 'babel-plugin-transform-react-remove-prop-types' ],

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -21,19 +21,12 @@ export default class AsyncLoad extends Component {
 		placeholder: <div className="async-load__placeholder" />,
 	};
 
-	constructor() {
-		super( ...arguments );
+	state = { component: null };
 
-		this.state = {
-			require: null,
-			component: null,
-		};
-	}
-
-	componentDidMount = () => {
+	componentDidMount() {
 		this.mounted = true;
 		this.require();
-	};
+	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( this.mounted && this.props.require !== nextProps.require ) {

--- a/packages/babel-plugin-transform-wpcalypso-async/README.md
+++ b/packages/babel-plugin-transform-wpcalypso-async/README.md
@@ -24,8 +24,9 @@ See [Babel options documentation](http://babeljs.io/docs/usage/options/) for mor
 
 `asyncRequire` will transform to one of:
 
-- `require.ensure` if `async` plugin option is true
-- `require` if `async` plugin option is false or unset
+- dynamic `import()` if `async` plugin option is `true`
+- static `require` if `async` plugin option is `false` or unset
+- nothing (will be removed and no module will be imported) if the `ignore` plugin option is `true`
 
 `asyncRequire` expects one required argument, with an optional callback:
 
@@ -55,4 +56,5 @@ asyncRequire( 'components/accordion', ( Accordion ) => {
 
 ## Options
 
-The plugin accepts a single option, `async`, which controls whether transformations applied by the plugin should should [Webpack code-splitting `require.ensure`](https://webpack.github.io/docs/code-splitting.html) or the synchronous CommonJS `require` function. This defaults to `false`.
+- `async` - controls whether transformations applied by the plugin should use a dynamic ESM `import` statement that enables [webpack code-splitting](https://webpack.github.io/docs/code-splitting.html) or the synchronous CommonJS `require` function. This defaults to `false`.
+- `ignore` - if set to `true`, the `asyncRequire` call will be completely removed, and `AsyncLoad` will show the placeholder forever and won't do any import. Useful for server side rendering where the render is one-pass and doesn't wait for any imports to finish.

--- a/packages/babel-plugin-transform-wpcalypso-async/index.js
+++ b/packages/babel-plugin-transform-wpcalypso-async/index.js
@@ -78,7 +78,8 @@ module.exports = ( { types: t } ) => {
 					return path.remove();
 				}
 
-				// Determine async from Babel plugin options
+				// Determine mode from Babel plugin options
+				const isIgnore = state.opts.ignore;
 				const isAsync = state.opts.async;
 
 				// In both asynchronous and synchronous case, we'll finish by
@@ -89,7 +90,9 @@ module.exports = ( { types: t } ) => {
 				// the transformation
 				const callback = path.node.arguments[ 1 ];
 
-				if ( isAsync ) {
+				if ( isIgnore ) {
+					path.remove();
+				} else if ( isAsync ) {
 					// Generate a chunk name based on the module path
 					const chunkName = 'async-load-' + kebabCase( argument.value );
 


### PR DESCRIPTION
Calypso app uses `<AsyncLoad require="components/foo" />` React components or `asyncRequire( 'components/foo', module => {} )` calls with a callback to asynchronously load (or preload) React UI components.

On the server, during SSR, these dynamic imports will never get actually executed, because they happen in a `componentDidMount` method that is never called by the SSR renderer. They will always render only the `AsyncLoad` placeholder and nothing else.

But yet, webpack still sees the imports and will add them to the server bundle. That's a waste that can be optimized out.

This PR adds a `ignore` option to the `babel-plugin-transform-wpcalypso-async` that causes the `AsyncLoad` instances to be transpiled in such a way that the import code is never generated. `AsyncLoad` instances render only the placeholder, and `asyncRequire` instances will simply be removed.

Showing only the placeholder is a correct thing in SSR -- the server render should be isomorphic, i.e., exactly the same as the initial DOM render in the browser. And the initial render of `AsyncLoad` will always show the placeholder. Only after the import is triggered and resolved, there is a `setState` call tha rerenders the component with the loaded UI.

**Results:**

Server build before:
```
$ ls -l build/
-rw-r--r--  1 jsnajdr  staff  4056334 Oct  1 16:37 server.js
-rw-r--r--  1 jsnajdr  staff  5827737 Oct  1 16:37 server.js.map
```

Server build after:
```
$ ls -l build/
-rw-r--r--  1 jsnajdr  staff  2809061 Oct  1 16:39 server.js
-rw-r--r--  1 jsnajdr  staff  3990499 Oct  1 16:39 server.js.map
```

Desktop build before:
```
$ ls -l desktop/build/
-rw-r--r--  1 jsnajdr  staff  6655312 Oct  1 17:15 desktop.js
```

Desktop build after:
```
$ ls -l desktop/build/
-rw-r--r--  1 jsnajdr  staff  5686136 Oct  1 17:14 desktop.js
```

Web server bundle size is reduced by 30% (doesn't bundle `node_modules`, is not minifed), Desktop server bundle is reduced by 15% (bundles `node_modules`, minifies the code)