### PR TITLE
Prevent unnecessary DOM updates when toggling duration the Plans page

### DIFF
--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -84,7 +84,9 @@ const PlansColumn = ( { duration, onPlanClick, productType, siteId }: PlanColumn
 			<FormattedHeader headerText={ translate( 'Plans' ) } isSecondary brandFont />
 			{ planObjects.map( ( plan ) => (
 				<ProductCard
-					key={ plan.productSlug }
+					// iconSlug has the same value for all durations. Using this value as a key
+					// prevents unnecessary DOM updates.
+					key={ plan.iconSlug }
 					item={ plan }
 					siteId={ siteId }
 					onClick={ onPlanClick }

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -64,7 +64,9 @@ const ProductsColumn = ( {
 			<FormattedHeader headerText={ translate( 'Individual Products' ) } isSecondary brandFont />
 			{ productObjects.map( ( product ) => (
 				<ProductCard
-					key={ product.productSlug }
+					// iconSlug has the same value for all durations. Using this value as a key
+					// prevents unnecessary DOM updates.
+					key={ product.iconSlug }
 					item={ product }
 					onClick={ onProductClick }
 					siteId={ siteId }


### PR DESCRIPTION
### Changes proposed in this Pull Request

In the Plans page, when updating the duration, there's some unnecessary DOM updates of the plans/products cards. This is noticeable because of the icons briefly flashing.

Fixes 1196341175636977-as-1191784463854089

### Implementation notes

The card React components used to have a key with a value equal to the exact product slug, e.g. `jetpack_security` or `jetpack_security_monthly`. Having a different key makes the card DOM element to re-render completely. I've replaced the value of the key by the more generic product slug (which is the slug of the yearly product) so that it's the same whether the selected duration is monthly or yearly. Because the key is now the same, React doesn't re-render the whole element during the commit phase.

### Testing instructions

- Visit the _Plans_ page
- Switch the duration from Yearly to Monthly and vice-versa
- Check that the cards in the DOM are not updated as a whole, for instance by checking that the icons (see capture) don't flash
- Make sure that the price and billing timeframe are updated

### Screenshots
![screenshot](https://user-images.githubusercontent.com/1620183/94835258-76c2cb80-03df-11eb-976c-412a59b87285.png)


