### PR TITLE
Plans: Remove Live Chat mentions from Personal plan

### DIFF
--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -72,7 +72,7 @@ class DomainToPlanNudge extends Component {
 				href={ `/checkout/${ siteId }/personal` }
 				list={ [
 					translate( 'Remove WordPress.com Ads' ),
-					translate( 'Email & Live Chat Support' ),
+					translate( 'Unlimited Email Support' ),
 					translate( 'Use with your Current Custom Domain' ),
 				] }
 				plan={ PLAN_PERSONAL }

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -72,7 +72,7 @@ class DomainToPlanNudge extends Component {
 				href={ `/checkout/${ siteId }/personal` }
 				list={ [
 					translate( 'Remove WordPress.com Ads' ),
-					translate( 'Unlimited Email Support' ),
+					translate( 'Access unlimited email support' ),
 					translate( 'Use with your Current Custom Domain' ),
 				] }
 				plan={ PLAN_PERSONAL }

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -10,20 +10,20 @@ import formatCurrency from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
-import UpsellNudge from 'blocks/upsell-nudge';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSite } from 'state/sites/selectors';
-import { PLAN_PERSONAL, FEATURE_NO_ADS } from 'lib/plans/constants';
-import { getPlan } from 'lib/plans';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
+import { PLAN_PERSONAL, FEATURE_NO_ADS } from 'calypso/lib/plans/constants';
+import { getPlan } from 'calypso/lib/plans';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 import {
 	getSitePlanRawPrice,
 	getPlanDiscountedRawPrice,
 	getPlanRawDiscount,
 	getPlansBySiteId,
-} from 'state/sites/plans/selectors';
-import QuerySitePlans from 'components/data/query-site-plans';
-import isEligibleForDomainToPaidPlanUpsell from 'state/selectors/is-eligible-for-domain-to-paid-plan-upsell';
+} from 'calypso/state/sites/plans/selectors';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import isEligibleForDomainToPaidPlanUpsell from 'calypso/state/selectors/is-eligible-for-domain-to-paid-plan-upsell';
 
 /**
  * Style dependencies

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -115,7 +115,6 @@ export const FEATURE_200GB_STORAGE = '200gb-storage';
 export const FEATURE_UNLIMITED_STORAGE = 'unlimited-storage';
 export const FEATURE_COMMUNITY_SUPPORT = 'community-support';
 export const FEATURE_EMAIL_SUPPORT = 'email-support';
-export const FEATURE_UNLIMITED_EMAIL_SUPPORT = 'unlimited-email-support';
 export const FEATURE_EMAIL_LIVE_CHAT_SUPPORT = 'email-live-chat-support';
 export const FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS =
 	'email-live-chat-support-business-days';
@@ -156,7 +155,6 @@ export const FEATURE_FREE_DOMAIN = 'free-custom-domain';
 export const FEATURE_FREE_BLOG_DOMAIN = 'free-blog-domain';
 export const FEATURE_UNLIMITED_STORAGE_SIGNUP = 'unlimited-storage-signup';
 export const FEATURE_EMAIL_SUPPORT_SIGNUP = 'email-support-signup';
-export const FEATURE_UNLIMITED_EMAIL_SUPPORT_SIGNUP = 'unlimited-email-support-signup';
 export const FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP = 'email-live-chat-support-signup';
 export const FEATURE_MONETISE = 'monetise-your-site';
 export const FEATURE_WP_SUBDOMAIN_SIGNUP = 'wordpress-subdomain-signup';

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -115,6 +115,7 @@ export const FEATURE_200GB_STORAGE = '200gb-storage';
 export const FEATURE_UNLIMITED_STORAGE = 'unlimited-storage';
 export const FEATURE_COMMUNITY_SUPPORT = 'community-support';
 export const FEATURE_EMAIL_SUPPORT = 'email-support';
+export const FEATURE_UNLIMITED_EMAIL_SUPPORT = 'unlimited-email-support';
 export const FEATURE_EMAIL_LIVE_CHAT_SUPPORT = 'email-live-chat-support';
 export const FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS =
 	'email-live-chat-support-business-days';
@@ -155,6 +156,7 @@ export const FEATURE_FREE_DOMAIN = 'free-custom-domain';
 export const FEATURE_FREE_BLOG_DOMAIN = 'free-blog-domain';
 export const FEATURE_UNLIMITED_STORAGE_SIGNUP = 'unlimited-storage-signup';
 export const FEATURE_EMAIL_SUPPORT_SIGNUP = 'email-support-signup';
+export const FEATURE_UNLIMITED_EMAIL_SUPPORT_SIGNUP = 'unlimited-email-support-signup';
 export const FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP = 'email-live-chat-support-signup';
 export const FEATURE_MONETISE = 'monetise-your-site';
 export const FEATURE_WP_SUBDOMAIN_SIGNUP = 'wordpress-subdomain-signup';

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -212,6 +212,13 @@ export const FEATURES_LIST = {
 			),
 	},
 
+	[ constants.FEATURE_UNLIMITED_EMAIL_SUPPORT_SIGNUP ]: {
+		getSlug: () => constants.FEATURE_UNLIMITED_EMAIL_SUPPORT_SIGNUP,
+		getTitle: () => i18n.translate( 'Unlimited email support' ),
+		getDescription: () =>
+			i18n.translate( 'Email us any time, any day of the week for personalize, expert support.' ),
+	},
+
 	[ constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP ]: {
 		getSlug: () => constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP,
 		getTitle: () => i18n.translate( 'Email and live chat support' ),
@@ -638,6 +645,13 @@ export const FEATURES_LIST = {
 			i18n.translate(
 				'High quality email support to help you get your website up and running and working how you want it.'
 			),
+	},
+
+	[ constants.FEATURE_UNLIMITED_EMAIL_SUPPORT ]: {
+		getSlug: () => constants.FEATURE_UNLIMITED_EMAIL_SUPPORT,
+		getTitle: () => i18n.translate( 'Unlimited email support' ),
+		getDescription: () =>
+			i18n.translate( 'Email us any time, any day of the week for personalize, expert support.' ),
 	},
 
 	[ constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT ]: {

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -207,7 +207,7 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_EMAIL_SUPPORT_SIGNUP,
 		getTitle: () => i18n.translate( 'Unlimited email support' ),
 		getDescription: () =>
-			i18n.translate( 'Email us any time, any day of the week for personalize, expert support.' ),
+			i18n.translate( 'Email us any time, any day of the week for personalized, expert support.' ),
 	},
 
 	[ constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP ]: {
@@ -633,7 +633,7 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_EMAIL_SUPPORT,
 		getTitle: () => i18n.translate( 'Unlimited email support' ),
 		getDescription: () =>
-			i18n.translate( 'Email us any time, any day of the week for personalize, expert support.' ),
+			i18n.translate( 'Email us any time, any day of the week for personalized, expert support.' ),
 	},
 
 	[ constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT ]: {

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -205,15 +205,6 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_EMAIL_SUPPORT_SIGNUP ]: {
 		getSlug: () => constants.FEATURE_EMAIL_SUPPORT_SIGNUP,
-		getTitle: () => i18n.translate( 'Email support' ),
-		getDescription: () =>
-			i18n.translate(
-				'High quality email support to help you get your website up and running and working how you want it.'
-			),
-	},
-
-	[ constants.FEATURE_UNLIMITED_EMAIL_SUPPORT_SIGNUP ]: {
-		getSlug: () => constants.FEATURE_UNLIMITED_EMAIL_SUPPORT_SIGNUP,
 		getTitle: () => i18n.translate( 'Unlimited email support' ),
 		getDescription: () =>
 			i18n.translate( 'Email us any time, any day of the week for personalize, expert support.' ),
@@ -640,15 +631,6 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_EMAIL_SUPPORT ]: {
 		getSlug: () => constants.FEATURE_EMAIL_SUPPORT,
-		getTitle: () => i18n.translate( 'Email support' ),
-		getDescription: () =>
-			i18n.translate(
-				'High quality email support to help you get your website up and running and working how you want it.'
-			),
-	},
-
-	[ constants.FEATURE_UNLIMITED_EMAIL_SUPPORT ]: {
-		getSlug: () => constants.FEATURE_UNLIMITED_EMAIL_SUPPORT,
 		getTitle: () => i18n.translate( 'Unlimited email support' ),
 		getDescription: () =>
 			i18n.translate( 'Email us any time, any day of the week for personalize, expert support.' ),

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -9,10 +9,10 @@ import { invoke } from 'lodash';
  * Internal dependencies
  */
 import * as constants from './constants';
-import MaterialIcon from 'components/material-icon';
-import ExternalLink from 'components/external-link';
-import ExternalLinkWithTracking from 'components/external-link/with-tracking';
-import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'lib/url/support';
+import MaterialIcon from 'calypso/components/material-icon';
+import ExternalLink from 'calypso/components/external-link';
+import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
+import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'calypso/lib/url/support';
 
 export const FEATURE_CATEGORIES = {
 	[ constants.FEATURE_CATEGORY_SECURITY ]: {

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -95,19 +95,19 @@ const getPlanPersonalDetails = () => ( {
 		i18n.translate(
 			'{{strong}}Best for personal use:{{/strong}} Boost your' +
 				' website with a custom domain name, and remove all WordPress.com advertising. ' +
-				'Get access to high-quality email and live chat support.',
+				'Unlock unlimited, expert email support.',
 			plansDescriptionHeadingComponent
 		),
 	getShortDescription: () =>
 		i18n.translate(
 			'Boost your website with a custom domain name, and remove all WordPress.com advertising. ' +
-				'Get access to high-quality email and live chat support.'
+				'Unlock unlimited, expert email support.'
 		),
 	getPlanCompareFeatures: () => [
 		// pay attention to ordering, shared features should align on /plan page
 		constants.FEATURE_CUSTOM_DOMAIN,
 		constants.FEATURE_JETPACK_ESSENTIAL,
-		constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
+		constants.FEATURE_UNLIMITED_EMAIL_SUPPORT,
 		constants.FEATURE_FREE_THEMES,
 		constants.FEATURE_BASIC_DESIGN,
 		constants.FEATURE_6GB_STORAGE,
@@ -116,18 +116,18 @@ const getPlanPersonalDetails = () => ( {
 		constants.FEATURE_PREMIUM_CONTENT_BLOCK,
 	],
 	getSignupFeatures: () => [
-		constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP,
+		constants.FEATURE_UNLIMITED_EMAIL_SUPPORT_SIGNUP,
 		constants.FEATURE_FREE_DOMAIN,
 		constants.FEATURE_FREE_THEMES,
 	],
 	getBlogSignupFeatures: () => [
 		constants.FEATURE_FREE_DOMAIN,
-		constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP,
+		constants.FEATURE_UNLIMITED_EMAIL_SUPPORT_SIGNUP,
 		constants.FEATURE_ALL_FREE_FEATURES,
 	],
 	getPortfolioSignupFeatures: () => [
 		constants.FEATURE_FREE_DOMAIN,
-		constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP,
+		constants.FEATURE_UNLIMITED_EMAIL_SUPPORT_SIGNUP,
 		constants.FEATURE_ALL_FREE_FEATURES,
 	],
 	// Features not displayed but used for checking plan abilities

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -107,7 +107,7 @@ const getPlanPersonalDetails = () => ( {
 		// pay attention to ordering, shared features should align on /plan page
 		constants.FEATURE_CUSTOM_DOMAIN,
 		constants.FEATURE_JETPACK_ESSENTIAL,
-		constants.FEATURE_UNLIMITED_EMAIL_SUPPORT,
+		constants.FEATURE_EMAIL_SUPPORT,
 		constants.FEATURE_FREE_THEMES,
 		constants.FEATURE_BASIC_DESIGN,
 		constants.FEATURE_6GB_STORAGE,
@@ -116,18 +116,18 @@ const getPlanPersonalDetails = () => ( {
 		constants.FEATURE_PREMIUM_CONTENT_BLOCK,
 	],
 	getSignupFeatures: () => [
-		constants.FEATURE_UNLIMITED_EMAIL_SUPPORT_SIGNUP,
+		constants.FEATURE_EMAIL_SUPPORT_SIGNUP,
 		constants.FEATURE_FREE_DOMAIN,
 		constants.FEATURE_FREE_THEMES,
 	],
 	getBlogSignupFeatures: () => [
 		constants.FEATURE_FREE_DOMAIN,
-		constants.FEATURE_UNLIMITED_EMAIL_SUPPORT_SIGNUP,
+		constants.FEATURE_EMAIL_SUPPORT_SIGNUP,
 		constants.FEATURE_ALL_FREE_FEATURES,
 	],
 	getPortfolioSignupFeatures: () => [
 		constants.FEATURE_FREE_DOMAIN,
-		constants.FEATURE_UNLIMITED_EMAIL_SUPPORT_SIGNUP,
+		constants.FEATURE_EMAIL_SUPPORT_SIGNUP,
 		constants.FEATURE_ALL_FREE_FEATURES,
 	],
 	// Features not displayed but used for checking plan abilities

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -142,7 +142,16 @@ function CheckoutSummaryFeaturesList() {
 
 function SupportText( { hasPlanInCart, isJetpackNotAtomic } ) {
 	const translate = useTranslate();
+	const plan = usePlanInCart();
+
 	if ( hasPlanInCart && ! isJetpackNotAtomic ) {
+		if (
+			'personal-bundle' === plan.wpcom_meta?.product_slug ||
+			'personal-bundle-2y' === plan.wpcom_meta?.product_slug
+		) {
+			return <span>{ translate( 'Unlimited email support' ) }</span>;
+		}
+
 		return <span>{ translate( 'Email and live chat support' ) }</span>;
 	}
 	return <span>{ translate( 'Email support' ) }</span>;

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -149,7 +149,7 @@ function SupportText( { hasPlanInCart, isJetpackNotAtomic } ) {
 			'personal-bundle' === plan.wpcom_meta?.product_slug ||
 			'personal-bundle-2y' === plan.wpcom_meta?.product_slug
 		) {
-			return <span>{ translate( 'Unlimited email support' ) }</span>;
+			return <span>{ translate( 'Access unlimited email support' ) }</span>;
 		}
 
 		return <span>{ translate( 'Email and live chat support' ) }</span>;

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -21,13 +21,13 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { showInlineHelpPopover } from 'state/inline-help/actions';
-import PaymentChatButton from 'my-sites/checkout/checkout/payment-chat-button';
+import { showInlineHelpPopover } from 'calypso/state/inline-help/actions';
+import PaymentChatButton from 'calypso/my-sites/checkout/checkout/payment-chat-button';
 import getSupportVariation, {
 	SUPPORT_HAPPYCHAT,
 	SUPPORT_FORUM,
 	SUPPORT_DIRECTLY,
-} from 'state/selectors/get-inline-help-support-variation';
+} from 'calypso/state/selectors/get-inline-help-support-variation';
 import { useHasDomainsInCart, useDomainsInCart } from '../hooks/has-domains';
 import { useHasPlanInCart, usePlanInCart } from '../hooks/has-plan';
 import { useHasRenewalInCart } from '../hooks/has-renewal';
@@ -36,14 +36,14 @@ import {
 	isWpComEcommercePlan,
 	isWpComPersonalPlan,
 	isWpComPremiumPlan,
-} from 'lib/plans';
-import isPresalesChatAvailable from 'state/happychat/selectors/is-presales-chat-available';
-import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
-import QuerySupportTypes from 'blocks/inline-help/inline-help-query-support-types';
-import isSupportVariationDetermined from 'state/selectors/is-support-variation-determined';
-import { isEnabled } from 'config';
-import { isJetpackSite } from 'state/sites/selectors';
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+} from 'calypso/lib/plans';
+import isPresalesChatAvailable from 'calypso/state/happychat/selectors/is-presales-chat-available';
+import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
+import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
+import isSupportVariationDetermined from 'calypso/state/selectors/is-support-variation-determined';
+import { isEnabled } from 'calypso/config';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 
 export default function WPCheckoutOrderSummary() {
 	const translate = useTranslate();


### PR DESCRIPTION
### Changes proposed in this Pull Request

Update plans comparison chart, onboarding plan listing and checkout summary to list 'Unlimited email support' and remove mentioning of Live Chat support.

**Request:** pbBQWj-ne-p2

_**IMPORTANT NOTE:** This PR should not be merged before Oct. 13th. Will rebase and merge on that date, once approved. See pbBQWj-ne-p2#comment-1180 for context._

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Make sure the following changes are reflected:

**Calypso - Site Admin (/plans)**

Changes:

- Replace “Get access to high-quality….” with “Unlock unlimited, expert email support.”
- Replace “email & live chat support” with “Unlimited email support”
- Replace copy in info box with “Email us any time, any day of the week for personalized, expert support.”

<img width="512" alt="screen-shot-2020-09-23-at-11 47 53-am" src="https://user-images.githubusercontent.com/481776/94842409-5bf55480-03e9-11eb-842c-6c6ce79370c6.png">

**Onboarding (/start/plans)**

Changes:

- Replace “Get access to high-quality….” with “Unlock unlimited, expert email support.”
- Replace “email & live chat support” with “Unlimited email support”
- Replace copy in info box with “Email us any time, any day of the week for personalize, expert support.”

<img width="512" alt="screen-shot-2020-09-23-at-11 54 00-am" src="https://user-images.githubusercontent.com/481776/94842430-6283cc00-03e9-11eb-8250-88fb151c1797.png">

**Checkout**

Changes:

- Replace “Email and live chat support” with “Access unlimited email support”

<img width="512" alt="screen-shot-2020-09-23-at-11 56 32-am" src="https://user-images.githubusercontent.com/481776/94842448-69aada00-03e9-11eb-96aa-03364074009d.png">

**Upsell nudge (/domains/manage)**

Changes:

- Replace “Email and live chat support” with “Access unlimited email support”

![Screen Shot 2020-10-02 at 1 08 15 PM](https://user-images.githubusercontent.com/481776/94959643-8580af80-04bf-11eb-9351-1d657a9e8d90.png)

To test this nudge, view `/domains/manage` on an eligible free site. Alternatively, and probably easier, you can comment out `this.isSiteEligible()` condition on the following line:

https://github.com/Automattic/wp-calypso/blob/9d38b9566ae99638e94bbd4f9821b637e3cf53c5/client/blocks/domain-to-plan-nudge/index.jsx#L92

**Fixes:** c/tQbtxjrk-tr