### PR TITLE
e2e: Schedule gutenberg edge tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,6 +601,9 @@ jobs:
       slack-webhook:
         type: string
         default: $SLACK_E2E
+      env-vars:
+        type: string
+        default: ''
     steps:
       - prepare
       - run: *set-e2e-variables
@@ -647,7 +650,7 @@ jobs:
       - run:
           name: Run Canary Tests
           command: |
-            env TARGET=<< parameters.test-target >> JETPACKHOST=<< parameters.jetpack-host >> ./run.sh -R << parameters.test-flags >>
+            env TARGET=<< parameters.test-target >> JETPACKHOST=<< parameters.jetpack-host >> << parameters.env-vars >> ./run.sh -R << parameters.test-flags >>
       - run: *move-e2e-artifacts
       - store-artifacts-and-test-results
       - slack/status:
@@ -1145,6 +1148,22 @@ workflows:
           filters:
             branches:
               only: master
+
+  e2e-full-suite-edge-scheduled:
+    jobs:
+    - setup
+    - test-e2e-canary:
+        name: test-e2e-full-suite-edge
+        requires:
+        - setup
+        test-flags: '-g'
+        env-vars: 'SKIP_DOMAIN_TESTS=true GUTENBERG_EDGE=true'
+    #triggers:
+    #- schedule:
+    #    cron: '30 8 * * *'
+    #    filters:
+    #      branches:
+    #        only: master
 
   e2e-jetpack-be-scheduled:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1158,12 +1158,12 @@ workflows:
         - setup
         test-flags: '-g'
         env-vars: 'SKIP_DOMAIN_TESTS=true GUTENBERG_EDGE=true'
-    #triggers:
-    #- schedule:
-    #    cron: '30 8 * * *'
-    #    filters:
-    #      branches:
-    #        only: master
+    triggers:
+    - schedule:
+        cron: '30 8 * * *'
+        filters:
+          branches:
+            only: master
 
   e2e-jetpack-be-scheduled:
     jobs:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR schedules the e2e tests for Gutenberg edge. I had to add in support for some env vars that will be passed so that the script knows that it is for Gutenberg edge and doesn't run domain tests

#### Testing instructions
* Ensure CI tests pass
* Ensure that the test build passes the variables to the Run tests steps- https://app.circleci.com/pipelines/github/Automattic/wp-calypso/75637/workflows/729cb776-a1c9-4f61-8b73-dab2c94df652/jobs/912891


