### PR TITLE
Add products to the checkout URL in Jetpack cloud

### DIFF
--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -497,7 +497,7 @@ export function checkout(
 	// step of the flow. Since purchases of multiple products are allowed, we need
 	// to pass all products separated by comma in the URL.
 	const path = siteSlug
-		? `/checkout/${ siteSlug }`
+		? `/checkout/${ siteSlug }/${ isJetpackCloud() ? productsArray.join( ',' ) : '' }`
 		: `/jetpack/connect/${ productsArray.join( ',' ) }`;
 
 	if ( isJetpackCloud() ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes an unfortunate merging error. The original issue is #45936.

### Testing instructions

_Instructions copied from the original issue_

- Download the PR locally and start Calypso
- Start Cloud concurrently with `yarn start-jetpack-cloud-p`
- Check that the selector, details, and upsell pages still work as expected in Calypso, and that you can checkout with an item in your cart
- In Jetpack cloud
    - Visit `/pricing` and select a product that has no option, such as Anti-spam. Check that you land on `wordpress.com/jetpack/connect/:product-slug`.
    - Visit `/pricing?site=:site-slug` and `/pricing/:site-slug`, and select the same product. Check that you land on `wordpress.com/checkout/:site-slug/:product-slug`.
    - Repeat these steps for the details and upsell pages (e.g. with Backup).