### PR TITLE
Unify the premium domain color

### DIFF
--- a/client/components/domains/premium-badge/style.scss
+++ b/client/components/domains/premium-badge/style.scss
@@ -1,5 +1,5 @@
 div.premium-badge {
-	background-color: var( --color-link );
+	background-color: var( --color-premium-domain );
 	padding-right: 6px;
 	color: var( --color-text-inverted );
 	.info-popover {

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -76,7 +76,7 @@
 		@include domain_status_color( var( --color-error ) );
 	}
 	.status-premium {
-		@include domain_status_color( var( --color-link ) );
+		@include domain_status_color( var( --color-premium-domain ) );
 	}
 
 	.domain-status__card {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -244,7 +244,7 @@ input[type='radio'].domain-management-list-item__radio {
 }
 
 .domain-item__status-premium {
-	border-left: 3px solid var( --color-link );
+	border-left: 3px solid var( --color-premium-domain );
 }
 
 .domain-item__status {

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
@@ -102,6 +102,8 @@
 	--color-link-100-rgb: var( --studio-blue-100-rgb );
 
 	/* Component Properties */
+	--color-premium-domain: var( --studio-gray-100 );
+
 	--color-masterbar-background: var( --studio-gray-100 );
 	--color-masterbar-border: var( --studio-gray-90 );
 	--color-masterbar-text: var( --studio-white );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -245,7 +245,7 @@
 	--color-plan-premium: var( --studio-yellow-30 );
 	--color-plan-business: var( --studio-orange-30 );
 	--color-plan-ecommerce: var( --studio-purple-30 );
-	--color-premium-domain: var( --studio-blue-50 );
+	--color-premium-domain: var( --studio-wordpress-blue-60 );
 
 	--color-jetpack-plan-free: var( --studio-blue-30 );
 	--color-jetpack-plan-personal: var( --studio-yellow-30 );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -245,6 +245,7 @@
 	--color-plan-premium: var( --studio-yellow-30 );
 	--color-plan-business: var( --studio-orange-30 );
 	--color-plan-ecommerce: var( --studio-purple-30 );
+	--color-premium-domain: var( --studio-blue-50 );
 
 	--color-jetpack-plan-free: var( --studio-blue-30 );
 	--color-jetpack-plan-personal: var( --studio-yellow-30 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a premium domain color variable in the calypso color scheme and use that for premium badge and premium status color
* @fditrapani will propose color overrides for the different color schemes

#### Testing instructions

* Visually nothing will change, but this will allow us to override the color if you chose another Calypso color scheme

Update: 
Here's how the premium badge and a premium domain status screen looks with the updated colors:
<img width="753" alt="Screenshot 2020-10-02 at 11 51 28" src="https://user-images.githubusercontent.com/1355045/94905581-c8ce2480-04a5-11eb-8e18-1b0699ece8db.png">
<img width="1075" alt="Screenshot 2020-10-02 at 11 51 47" src="https://user-images.githubusercontent.com/1355045/94905584-cb307e80-04a5-11eb-9fe0-e63d5c306002.png">
