### PR TITLE
LanguagePicker: Record tracks event for search vs. non-search selection

### DIFF
--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -433,7 +433,7 @@ export class LanguagePickerModal extends PureComponent {
 		 * moment, and I'm not sure there's a better solution that
 		 * wouldn't be overkill given what we're trying to record here.
 		 */
-		const searched = false === search;
+		const searched = false !== search;
 		this.props.recordTracksEvent( 'calypso_language_picker_language_picked', { searched } );
 	};
 

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -415,10 +415,13 @@ export class LanguagePickerModal extends PureComponent {
 		this.handleClose();
 	};
 
-	recordLanguagePickedEvent = () => {
+	recordLanguagePickedEvent = ( isClosingWithoutSelection ) => {
 		const { selectedLanguageSlug, search } = this.state;
 
-		if ( this.initiallySelectedLanguageSlug === selectedLanguageSlug ) {
+		if (
+			isClosingWithoutSelection ||
+			this.initiallySelectedLanguageSlug === selectedLanguageSlug
+		) {
 			// we don't record an event if the language wasn't changed
 			return;
 		}
@@ -437,8 +440,8 @@ export class LanguagePickerModal extends PureComponent {
 		this.props.recordTracksEvent( 'calypso_language_picker_language_picked', { searched } );
 	};
 
-	handleClose = () => {
-		this.recordLanguagePickedEvent();
+	handleClose = ( isClosingWithoutSelection ) => {
+		this.recordLanguagePickedEvent( isClosingWithoutSelection );
 		this.props.onClose();
 	};
 
@@ -601,7 +604,7 @@ export class LanguagePickerModal extends PureComponent {
 			<Dialog
 				isVisible
 				buttons={ buttons }
-				onClose={ this.handleClose }
+				onClose={ () => this.handleClose( true ) }
 				additionalClassNames="language-picker__modal"
 			>
 				<QueryLanguageNames />

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -254,21 +253,7 @@ export class LanguagePickerModal extends PureComponent {
 		);
 	}
 
-	/**
-	 * Only record a single search event per modal instance
-	 * otherwise we would get a search event per keystroke.
-	 */
-	recordSearchTracksEvent = () => {
-		if ( this.state.recordedTracksSearchEvent ) {
-			return;
-		}
-
-		this.setState( { recordedTracksSearchEvent: true } );
-		this.props.recordTracksEvent( 'calypso_language_picker_searched_language' );
-	};
-
 	selectLanguageFromSearch( search ) {
-		this.recordSearchTracksEvent();
 		const filteredLanguages = this.getFilteredLanguages();
 		const exactMatch = filteredLanguages.find( ( { langSlug } ) => langSlug === search );
 
@@ -430,23 +415,16 @@ export class LanguagePickerModal extends PureComponent {
 		this.handleClose();
 	};
 
-	recordNewLanguagePickedEvent = ( isClosingWithoutSelection ) => {
-		const { selectedLanguageSlug } = this.state;
-
-		if (
-			isClosingWithoutSelection ||
-			this.initiallySelectedLanguageSlug === selectedLanguageSlug
-		) {
-			// we don't record an event if the language wasn't changed
-			return;
-		}
-
-		const searched = this.state.recordedTracksSearchEvent;
-		this.props.recordTracksEvent( 'calypso_language_picker_selected_language', { searched } );
+	recordLanguagePickerEvent = ( isClosingWithoutSelection ) => {
+		this.props.recordTracksEvent( 'calypso_languagepicker_closed', {
+			searched: false !== this.state.search,
+			is_closing_without_selection: isClosingWithoutSelection,
+			did_select_language: this.initiallySelectedLanguageSlug !== this.state.selectedLanguageSlug,
+		} );
 	};
 
 	handleClose = ( isClosingWithoutSelection = false ) => {
-		this.recordNewLanguagePickedEvent( isClosingWithoutSelection );
+		this.recordLanguagePickerEvent( isClosingWithoutSelection );
 		this.props.onClose();
 	};
 

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -264,7 +264,7 @@ export class LanguagePickerModal extends PureComponent {
 		}
 
 		this.setState( { recordedTracksSearchEvent: true } );
-		this.props.recordTracksEvent( 'calypso_language_picker_searched' );
+		this.props.recordTracksEvent( 'calypso_language_picker_searched_language' );
 	};
 
 	selectLanguageFromSearch( search ) {
@@ -442,7 +442,7 @@ export class LanguagePickerModal extends PureComponent {
 		}
 
 		const searched = this.state.recordedTracksSearchEvent;
-		this.props.recordTracksEvent( 'calypso_language_picker_new_language_picked', { searched } );
+		this.props.recordTracksEvent( 'calypso_language_picker_selected_language', { searched } );
 	};
 
 	handleClose = ( isClosingWithoutSelection = false ) => {

--- a/client/components/language-picker/test/modal.js
+++ b/client/components/language-picker/test/modal.js
@@ -473,6 +473,16 @@ describe( 'LanguagePickerModal', () => {
 			expect( recordTracksEvent ).not.toHaveBeenCalled();
 		} );
 
+		test( 'should not fire when dialog is closing due to cancellation', () => {
+			wrapper.instance().handleSearch( 'it' );
+
+			expect( wrapper.state( 'selectedLanguageSlug' ) ).not.toEqual( defaultProps.selected );
+
+			wrapper.instance().handleClose( /* isClosingWithoutSelection = */ true );
+
+			expect( recordTracksEvent ).not.toHaveBeenCalled();
+		} );
+
 		describe( 'when searched', () => {
 			test( 'should fire an event with searched prop set to true', () => {
 				wrapper.instance().handleSearch( 'It' );

--- a/client/components/language-picker/test/modal.js
+++ b/client/components/language-picker/test/modal.js
@@ -23,6 +23,7 @@ describe( 'LanguagePickerModal', () => {
 	const defaultProps = {
 		onSelected: noop,
 		onClose: noop,
+		recordTracksEvent: noop,
 		isVisible: true,
 		languages: [
 			{
@@ -449,6 +450,75 @@ describe( 'LanguagePickerModal', () => {
 			}
 
 			LanguagePickerModal.prototype.getLanguagesListColumnsCount = getLanguagesListColumnsCount;
+		} );
+	} );
+
+	describe( 'search event', () => {
+		let recordTracksEvent;
+		let wrapper;
+
+		beforeEach( () => {
+			recordTracksEvent = jest.fn();
+
+			wrapper = shallow(
+				<LanguagePickerModal { ...defaultProps } recordTracksEvent={ recordTracksEvent } />
+			);
+		} );
+
+		test( 'should not fire when language does not change', () => {
+			expect( wrapper.state( 'selectedLanguageSlug' ) ).toEqual( defaultProps.selected );
+
+			wrapper.instance().handleClose();
+
+			expect( recordTracksEvent ).not.toHaveBeenCalled();
+		} );
+
+		describe( 'when searched', () => {
+			test( 'should fire an event with searched prop set to true', () => {
+				wrapper.instance().handleSearch( 'It' );
+
+				expect( wrapper.state( 'search' ) ).toEqual( 'It' );
+
+				wrapper.instance().handleClose();
+
+				expect( recordTracksEvent ).toHaveBeenCalledWith(
+					'calypso_language_picker_language_picked',
+					{ searched: true }
+				);
+			} );
+
+			test( 'should fire an event with searched prop set to true if search closed', () => {
+				wrapper.instance().handleSearch( 'it' );
+				// pass an empty string to simluate when someone searches and then closes
+				// the search box
+				wrapper.instance().handleSearch( '' );
+
+				expect( wrapper.state( 'search' ) ).toEqual( '' );
+
+				wrapper.instance().handleClose();
+
+				expect( recordTracksEvent ).toHaveBeenCalledWith(
+					'calypso_language_picker_language_picked',
+					{ searched: true }
+				);
+			} );
+		} );
+
+		describe( 'when not searched', () => {
+			test( 'should fire an event with searched prop set to false', () => {
+				expect( wrapper.state( 'search' ) ).toBe( false );
+
+				wrapper.instance().handleLanguageItemClick( 'it', { preventDefault: noop } );
+
+				expect( wrapper.state( 'selectedLanguageSlug' ) ).toEqual( 'it' );
+
+				wrapper.instance().handleClose();
+
+				expect( recordTracksEvent ).toHaveBeenCalledWith(
+					'calypso_language_picker_language_picked',
+					{ searched: false }
+				);
+			} );
 		} );
 	} );
 } );

--- a/client/components/language-picker/test/modal.js
+++ b/client/components/language-picker/test/modal.js
@@ -465,93 +465,79 @@ describe( 'LanguagePickerModal', () => {
 			);
 		} );
 
-		describe( 'searched', () => {
-			test( 'should fire a single time when search', () => {
-				wrapper.instance().handleSearch( 'i' );
-				wrapper.instance().handleSearch( 'it' );
-				wrapper.instance().handleSearch( 'ita' );
+		test( 'should fire when language does not change', () => {
+			expect( wrapper.state( 'selectedLanguageSlug' ) ).toEqual( defaultProps.selected );
 
-				expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
-				expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_language_picker_searched' );
+			wrapper.instance().handleClose();
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_languagepicker_closed', {
+				searched: false,
+				is_closing_without_selection: false,
+				did_select_language: false,
 			} );
 		} );
 
-		describe( 'new language picked', () => {
-			test( 'should not fire when language does not change', () => {
-				expect( wrapper.state( 'selectedLanguageSlug' ) ).toEqual( defaultProps.selected );
+		test( 'should fire when dialog is closing due to cancellation', () => {
+			wrapper.instance().handleSearch( 'it' );
+
+			expect( wrapper.state( 'selectedLanguageSlug' ) ).not.toEqual( defaultProps.selected );
+
+			wrapper.instance().handleClose( /* isClosingWithoutSelection = */ true );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_languagepicker_closed', {
+				searched: true,
+				is_closing_without_selection: true,
+				did_select_language: true,
+			} );
+		} );
+
+		describe( 'when searched', () => {
+			test( 'should fire an event with searched prop set to true', () => {
+				wrapper.instance().handleSearch( 'It' );
+
+				expect( wrapper.state( 'search' ) ).toEqual( 'It' );
 
 				wrapper.instance().handleClose();
 
-				expect( recordTracksEvent ).not.toHaveBeenCalledWith(
-					'calypso_language_picker_new_language_picked',
-					expect.anything()
-				);
+				expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_languagepicker_closed', {
+					searched: true,
+					is_closing_without_selection: false,
+					did_select_language: true,
+				} );
 			} );
 
-			test( 'should not fire when dialog is closing due to cancellation', () => {
+			test( 'should fire an event with searched prop set to true if search closed', () => {
 				wrapper.instance().handleSearch( 'it' );
+				// pass an empty string to simluate when someone searches and then closes
+				// the search box
+				wrapper.instance().handleSearch( '' );
 
-				expect( wrapper.state( 'selectedLanguageSlug' ) ).not.toEqual( defaultProps.selected );
+				expect( wrapper.state( 'search' ) ).toEqual( '' );
 
-				wrapper.instance().handleClose( /* isClosingWithoutSelection = */ true );
+				wrapper.instance().handleClose();
 
-				expect( recordTracksEvent ).not.toHaveBeenCalledWith(
-					'calypso_language_picker_new_language_picked',
-					expect.anything()
-				);
-			} );
-
-			describe( 'when searched', () => {
-				test( 'should fire an event with searched prop set to true', () => {
-					wrapper.instance().handleSearch( 'It' );
-
-					expect( wrapper.state( 'search' ) ).toEqual( 'It' );
-
-					wrapper.instance().handleClose();
-
-					expect( recordTracksEvent ).toHaveBeenCalledWith(
-						'calypso_language_picker_new_language_picked',
-						{
-							searched: true,
-						}
-					);
-				} );
-
-				test( 'should fire an event with searched prop set to true if search closed', () => {
-					wrapper.instance().handleSearch( 'it' );
-					// pass an empty string to simluate when someone searches and then closes
-					// the search box
-					wrapper.instance().handleSearch( '' );
-
-					expect( wrapper.state( 'search' ) ).toEqual( '' );
-
-					wrapper.instance().handleClose();
-
-					expect( recordTracksEvent ).toHaveBeenCalledWith(
-						'calypso_language_picker_new_language_picked',
-						{
-							searched: true,
-						}
-					);
+				expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_languagepicker_closed', {
+					searched: true,
+					is_closing_without_selection: false,
+					did_select_language: true,
 				} );
 			} );
+		} );
 
-			describe( 'when not searched', () => {
-				test( 'should fire an event with searched prop set to false', () => {
-					expect( wrapper.state( 'search' ) ).toBe( false );
+		describe( 'when not searched', () => {
+			test( 'should fire an event with searched prop set to false', () => {
+				expect( wrapper.state( 'search' ) ).toBe( false );
 
-					wrapper.instance().handleLanguageItemClick( 'it', { preventDefault: noop } );
+				wrapper.instance().handleLanguageItemClick( 'it', { preventDefault: noop } );
 
-					expect( wrapper.state( 'selectedLanguageSlug' ) ).toEqual( 'it' );
+				expect( wrapper.state( 'selectedLanguageSlug' ) ).toEqual( 'it' );
 
-					wrapper.instance().handleClose();
+				wrapper.instance().handleClose();
 
-					expect( recordTracksEvent ).toHaveBeenCalledWith(
-						'calypso_language_picker_new_language_picked',
-						{
-							searched: false,
-						}
-					);
+				expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_languagepicker_closed', {
+					searched: false,
+					is_closing_without_selection: false,
+					did_select_language: true,
 				} );
 			} );
 		} );

--- a/client/components/language-picker/test/modal.js
+++ b/client/components/language-picker/test/modal.js
@@ -453,7 +453,7 @@ describe( 'LanguagePickerModal', () => {
 		} );
 	} );
 
-	describe( 'search event', () => {
+	describe( 'events', () => {
 		let recordTracksEvent;
 		let wrapper;
 
@@ -465,69 +465,94 @@ describe( 'LanguagePickerModal', () => {
 			);
 		} );
 
-		test( 'should not fire when language does not change', () => {
-			expect( wrapper.state( 'selectedLanguageSlug' ) ).toEqual( defaultProps.selected );
-
-			wrapper.instance().handleClose();
-
-			expect( recordTracksEvent ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should not fire when dialog is closing due to cancellation', () => {
-			wrapper.instance().handleSearch( 'it' );
-
-			expect( wrapper.state( 'selectedLanguageSlug' ) ).not.toEqual( defaultProps.selected );
-
-			wrapper.instance().handleClose( /* isClosingWithoutSelection = */ true );
-
-			expect( recordTracksEvent ).not.toHaveBeenCalled();
-		} );
-
-		describe( 'when searched', () => {
-			test( 'should fire an event with searched prop set to true', () => {
-				wrapper.instance().handleSearch( 'It' );
-
-				expect( wrapper.state( 'search' ) ).toEqual( 'It' );
-
-				wrapper.instance().handleClose();
-
-				expect( recordTracksEvent ).toHaveBeenCalledWith(
-					'calypso_language_picker_language_picked',
-					{ searched: true }
-				);
-			} );
-
-			test( 'should fire an event with searched prop set to true if search closed', () => {
+		describe( 'searched', () => {
+			test( 'should fire a single time when search', () => {
+				wrapper.instance().handleSearch( 'i' );
 				wrapper.instance().handleSearch( 'it' );
-				// pass an empty string to simluate when someone searches and then closes
-				// the search box
-				wrapper.instance().handleSearch( '' );
+				wrapper.instance().handleSearch( 'ita' );
 
-				expect( wrapper.state( 'search' ) ).toEqual( '' );
-
-				wrapper.instance().handleClose();
-
-				expect( recordTracksEvent ).toHaveBeenCalledWith(
-					'calypso_language_picker_language_picked',
-					{ searched: true }
-				);
+				expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+				expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_language_picker_searched' );
 			} );
 		} );
 
-		describe( 'when not searched', () => {
-			test( 'should fire an event with searched prop set to false', () => {
-				expect( wrapper.state( 'search' ) ).toBe( false );
-
-				wrapper.instance().handleLanguageItemClick( 'it', { preventDefault: noop } );
-
-				expect( wrapper.state( 'selectedLanguageSlug' ) ).toEqual( 'it' );
+		describe( 'new language picked', () => {
+			test( 'should not fire when language does not change', () => {
+				expect( wrapper.state( 'selectedLanguageSlug' ) ).toEqual( defaultProps.selected );
 
 				wrapper.instance().handleClose();
 
-				expect( recordTracksEvent ).toHaveBeenCalledWith(
-					'calypso_language_picker_language_picked',
-					{ searched: false }
+				expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+					'calypso_language_picker_new_language_picked',
+					expect.anything()
 				);
+			} );
+
+			test( 'should not fire when dialog is closing due to cancellation', () => {
+				wrapper.instance().handleSearch( 'it' );
+
+				expect( wrapper.state( 'selectedLanguageSlug' ) ).not.toEqual( defaultProps.selected );
+
+				wrapper.instance().handleClose( /* isClosingWithoutSelection = */ true );
+
+				expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+					'calypso_language_picker_new_language_picked',
+					expect.anything()
+				);
+			} );
+
+			describe( 'when searched', () => {
+				test( 'should fire an event with searched prop set to true', () => {
+					wrapper.instance().handleSearch( 'It' );
+
+					expect( wrapper.state( 'search' ) ).toEqual( 'It' );
+
+					wrapper.instance().handleClose();
+
+					expect( recordTracksEvent ).toHaveBeenCalledWith(
+						'calypso_language_picker_new_language_picked',
+						{
+							searched: true,
+						}
+					);
+				} );
+
+				test( 'should fire an event with searched prop set to true if search closed', () => {
+					wrapper.instance().handleSearch( 'it' );
+					// pass an empty string to simluate when someone searches and then closes
+					// the search box
+					wrapper.instance().handleSearch( '' );
+
+					expect( wrapper.state( 'search' ) ).toEqual( '' );
+
+					wrapper.instance().handleClose();
+
+					expect( recordTracksEvent ).toHaveBeenCalledWith(
+						'calypso_language_picker_new_language_picked',
+						{
+							searched: true,
+						}
+					);
+				} );
+			} );
+
+			describe( 'when not searched', () => {
+				test( 'should fire an event with searched prop set to false', () => {
+					expect( wrapper.state( 'search' ) ).toBe( false );
+
+					wrapper.instance().handleLanguageItemClick( 'it', { preventDefault: noop } );
+
+					expect( wrapper.state( 'selectedLanguageSlug' ) ).toEqual( 'it' );
+
+					wrapper.instance().handleClose();
+
+					expect( recordTracksEvent ).toHaveBeenCalledWith(
+						'calypso_language_picker_new_language_picked',
+						{
+							searched: false,
+						}
+					);
+				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new event, `calypso_language_picker_language_picked` with the `searched` prop indicating whether search was used to make the language selection. We only emit the event when the language is changed from the initially selected language.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure new and existing unit tests pass
* Put a breakpoint in the `recordNewLanguagePickedEvent` and `recordSearchTracksEvent` and verify that they are called when expected, under the following conditions:
    * for `recordNewLanguagePickedEvent`:
        * the following should have `searched === true`
            * If you search for a valid language and then close the search box and then close the modal, ensure that the tracks event is fired
            * If you search for a valid language and type Enter, ensure that the tracks event is fired
            * If you search for a valid language and click confirm to close the modal, ensure the tracks event is 
fired 
        * the following should have `searched === false`
            * If you do not search and use the arrow keys and Enter to select a language
            * If you do not search and use the mouse to click a language and then close the modal using the Enter key
            * If you do not search and use the moust to click a langauge and then close the modal using the confirm button
        * Do everything above but cancel the modal either through the cancel button or the Escape key and verify that no matter what you do, the event is never fired.
    * for `recordSearchTracksEvent`
        * Verify the event is fired only a single time per modal instance (i.e., it isn't fired for every keystroke, just the first one)