### PR TITLE
Fix: don't show Jetpack Search upsell to Jetpack Complete owners

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -29,6 +29,8 @@ import {
 	GROUP_WPCOM,
 	GROUP_JETPACK,
 	JETPACK_RESET_PLANS,
+	FEATURE_JETPACK_SEARCH,
+	FEATURE_JETPACK_SEARCH_MONTHLY,
 } from './constants';
 import { PLANS_LIST } from './plans-list';
 
@@ -566,3 +568,13 @@ export const chooseDefaultCustomerType = ( { currentCustomerType, selectedPlan, 
 
 	return 'personal';
 };
+
+/**
+ * Determines if a plan includes Jetpack Search by looking at the plan's features.
+ *
+ * @param   {string}  planSlug  Slug of the plan.
+ * @returns {boolean}           Whether the specified plan includes Jetpack Search.
+ */
+export const hasPlanJetpackSearch = ( planSlug ) =>
+	planHasFeature( planSlug, FEATURE_JETPACK_SEARCH ) ||
+	planHasFeature( planSlug, FEATURE_JETPACK_SEARCH_MONTHLY );

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -575,6 +575,6 @@ export const chooseDefaultCustomerType = ( { currentCustomerType, selectedPlan, 
  * @param   {string}  planSlug  Slug of the plan.
  * @returns {boolean}           Whether the specified plan includes Jetpack Search.
  */
-export const hasPlanJetpackSearch = ( planSlug ) =>
+export const planHasJetpackSearch = ( planSlug ) =>
 	planHasFeature( planSlug, FEATURE_JETPACK_SEARCH ) ||
 	planHasFeature( planSlug, FEATURE_JETPACK_SEARCH_MONTHLY );

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -34,7 +34,7 @@ import {
 	isJetpackBusiness,
 	isEcommerce,
 } from 'lib/products-values';
-import { hasPlanJetpackSearch } from 'lib/plans';
+import { planHasJetpackSearch } from 'lib/plans';
 import { FEATURE_SEARCH, PLAN_BUSINESS } from 'lib/plans/constants';
 import { PRODUCT_JETPACK_SEARCH, isJetpackSearch } from 'lib/products-values/constants';
 
@@ -269,7 +269,7 @@ export default connect( ( state, { isRequestingSettings } ) => {
 	const siteId = getSelectedSiteId( state );
 	const hasSearchProduct =
 		getSitePurchases( state, siteId ).find( checkForSearchProduct ) ||
-		hasPlanJetpackSearch( site.plan?.product_slug );
+		planHasJetpackSearch( site.plan?.product_slug );
 	const isSearchEligible =
 		( site && site.plan && ( hasBusinessPlan( site.plan ) || isVipPlan( site.plan ) ) ) ||
 		!! hasSearchProduct;

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -34,6 +34,7 @@ import {
 	isJetpackBusiness,
 	isEcommerce,
 } from 'lib/products-values';
+import { hasPlanJetpackSearch } from 'lib/plans';
 import { FEATURE_SEARCH, PLAN_BUSINESS } from 'lib/plans/constants';
 import { PRODUCT_JETPACK_SEARCH, isJetpackSearch } from 'lib/products-values/constants';
 
@@ -266,7 +267,9 @@ const checkForSearchProduct = ( purchase ) =>
 export default connect( ( state, { isRequestingSettings } ) => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
-	const hasSearchProduct = getSitePurchases( state, siteId ).find( checkForSearchProduct );
+	const hasSearchProduct =
+		getSitePurchases( state, siteId ).find( checkForSearchProduct ) ||
+		hasPlanJetpackSearch( site.plan?.product_slug );
 	const isSearchEligible =
 		( site && site.plan && ( hasBusinessPlan( site.plan ) || isVipPlan( site.plan ) ) ) ||
 		!! hasSearchProduct;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Jetpack Complete includes Jetpack Search so we shouldn't display an upsell when site's plan is Jetpack Complete.

#### Testing instructions

* Run this PR.
* In Calypso, select a Jetpack site and purchase Jetpack Complete.
* Visit `/settings/performance/:site`.
* Verify that you see Jetpack Search control panel with two toggles (see capture below).

Fixes 1164141197617539-as-1196848937204201

#### Demo

##### Before
![image](https://user-images.githubusercontent.com/3418513/94870128-2b2f1280-041d-11eb-8d54-6dd939e8239e.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/94870087-13f02500-041d-11eb-86d3-d516eabf9dae.png)