### PR TITLE
Minor support changes

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -52,7 +52,10 @@ import {
 } from 'state/help/directly/actions';
 import { isRequestingSites } from 'state/sites/selectors';
 import getLocalizedLanguageNames from 'state/selectors/get-localized-language-names';
-import getSupportLevel, { SUPPORT_LEVEL_PERSONAL } from 'state/selectors/get-support-level';
+import getSupportLevel, {
+	SUPPORT_LEVEL_PERSONAL,
+	SUPPORT_LEVEL_PERSONAL_WITH_LEGACY_CHAT,
+} from 'state/selectors/get-support-level';
 import hasUserAskedADirectlyQuestion from 'state/selectors/has-user-asked-a-directly-question';
 import isDirectlyReady from 'state/selectors/is-directly-ready';
 import isDirectlyUninitialized from 'state/selectors/is-directly-uninitialized';
@@ -598,9 +601,15 @@ class HelpContact extends React.Component {
 					<ActiveTicketsNotice count={ activeTicketCount } compact={ compact } />
 				) }
 
-				{ isUserAffectedByLiveChatClosure && supportLevel === SUPPORT_LEVEL_PERSONAL && (
-					<ChatCovidLimitedAvailabilityNotice showAt="2020-08-24" compact={ compact } />
-				) }
+				{ isUserAffectedByLiveChatClosure &&
+					( supportLevel === SUPPORT_LEVEL_PERSONAL ||
+						supportLevel === SUPPORT_LEVEL_PERSONAL_WITH_LEGACY_CHAT ) && (
+						<ChatCovidLimitedAvailabilityNotice
+							showAt="2020-08-24"
+							hideAt="2020-10-05"
+							compact={ compact }
+						/>
+					) }
 
 				{ this.shouldShowTicketRequestErrorNotice( supportVariation ) && (
 					<Notice

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -244,15 +244,15 @@ function getPlanFeatures( plan, translate, hasDomainsInCart, hasRenewalInCart ) 
 
 function getHighestWpComPlanLabel( plans ) {
 	const planMatchersInOrder = [
-		isWpComEcommercePlan,
-		isWpComBusinessPlan,
-		isWpComPremiumPlan,
-		isWpComPersonalPlan,
+		{ label: 'WordPress.com eCommerce', matcher: isWpComEcommercePlan },
+		{ label: 'WordPress.com Business', matcher: isWpComBusinessPlan },
+		{ label: 'WordPress.com Premium', matcher: isWpComPremiumPlan },
+		{ label: 'WordPress.com Personal', matcher: isWpComPersonalPlan },
 	];
-	for ( const matcher of planMatchersInOrder ) {
+	for ( const { label, matcher } of planMatchersInOrder ) {
 		for ( const plan of plans ) {
 			if ( matcher( get( plan, 'wpcom_meta.product_slug' ) ) ) {
-				return plan.label;
+				return label;
 			}
 		}
 	}

--- a/client/state/selectors/get-support-level.js
+++ b/client/state/selectors/get-support-level.js
@@ -10,6 +10,7 @@ import 'state/help/init';
 
 export const SUPPORT_LEVEL_FREE = 'free';
 export const SUPPORT_LEVEL_PERSONAL = 'personal';
+export const SUPPORT_LEVEL_PERSONAL_WITH_LEGACY_CHAT = 'personal-with-legacy-chat';
 export const SUPPORT_LEVEL_PREMIUM = 'premium';
 export const SUPPORT_LEVEL_BUSINESS = 'business';
 export const SUPPORT_LEVEL_ECOMMERCE = 'ecommerce';


### PR DESCRIPTION
Makes a few small behind-the-scenes updates in Support pathways:

- Adds new support level for changes to Personal plan
- Updates the chat availability notice to expire when we re-staff for Personal chat
- Adjusts the Tracks plan label sent on presales so it uses consistent labels instead of user-translated labels