### PR TITLE
Purchases: Remove site level billing flag

### DIFF
--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -141,33 +141,4 @@ export default ( router ) => {
 	router( '/me/billing/:receiptId', ( { params: { receiptId } } ) =>
 		page.redirect( paths.billingHistoryReceipt( receiptId ) )
 	);
-
-	// more redirect legacy urls
-	// Note: these routes are being replaced by the /my-sites/purchases section.
-	// They will remain here for now because that section is currently behind a
-	// feature flag (`site-level-billing`), but when that flag is removed, these
-	// should also be removed to prevent confusion. It is also important at that
-	// time to be certain that all these routes still work with the new section!
-	router( '/purchases', () => page.redirect( paths.purchasesRoot ) );
-	router( '/purchases/:siteName/:purchaseId', ( { params: { siteName, purchaseId } } ) =>
-		page.redirect( paths.managePurchase( siteName, purchaseId ) )
-	);
-	router( '/purchases/:siteName/:purchaseId/cancel', ( { params: { siteName, purchaseId } } ) =>
-		page.redirect( paths.cancelPurchase( siteName, purchaseId ) )
-	);
-	router(
-		'/purchases/:siteName/:purchaseId/confirm-cancel-domain',
-		( { params: { siteName, purchaseId } } ) =>
-			page.redirect( paths.confirmCancelDomain( siteName, purchaseId ) )
-	);
-	router(
-		'/purchases/:siteName/:purchaseId/payment/add',
-		( { params: { siteName, purchaseId } } ) =>
-			page.redirect( paths.addCardDetails( siteName, purchaseId ) )
-	);
-	router(
-		'/purchases/:siteName/:purchaseId/payment/edit/:cardId',
-		( { params: { siteName, purchaseId, cardId } } ) =>
-			page.redirect( paths.editCardDetails( siteName, purchaseId, cardId ) )
-	);
 };

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -17,11 +17,8 @@ import {
 	purchaseAddPaymentMethod,
 	purchaseEditPaymentMethod,
 } from './controller';
-import legacyRouter from 'me/purchases';
 
 export default ( router ) => {
-	legacyRouter( router );
-
 	page( '/purchases', siteSelection, navigation, sites, makeLayout, clientRender );
 	page( '/purchases/subscriptions', siteSelection, navigation, sites, makeLayout, clientRender );
 	page(
@@ -79,5 +76,32 @@ export default ( router ) => {
 		purchaseEditPaymentMethod,
 		makeLayout,
 		clientRender
+	);
+
+	// Redirect legacy urls
+	router( '/purchases/:siteName/:purchaseId', ( { params: { siteName, purchaseId } } ) =>
+		page.redirect( `/purchases/subscriptions/${ siteName }/${ purchaseId }` )
+	);
+	router( '/purchases/:siteName/:purchaseId/cancel', ( { params: { siteName, purchaseId } } ) =>
+		page.redirect( `/purchases/subscriptions/${ siteName }/${ purchaseId }/cancel` )
+	);
+	router(
+		'/purchases/:siteName/:purchaseId/confirm-cancel-domain',
+		( { params: { siteName, purchaseId } } ) =>
+			page.redirect(
+				`/purchases/subscriptions/${ siteName }/${ purchaseId }/confirm-cancel-domain`
+			)
+	);
+	router(
+		'/purchases/:siteName/:purchaseId/payment/add',
+		( { params: { siteName, purchaseId } } ) =>
+			page.redirect( `/purchases/subscriptions/${ siteName }/${ purchaseId }/payment/add` )
+	);
+	router(
+		'/purchases/:siteName/:purchaseId/payment/edit/:cardId',
+		( { params: { siteName, purchaseId, cardId } } ) =>
+			page.redirect(
+				`/purchases/subscriptions/${ siteName }/${ purchaseId }/payment/edit/${ cardId }`
+			)
 	);
 };

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -17,15 +17,8 @@ import {
 	purchaseAddPaymentMethod,
 	purchaseEditPaymentMethod,
 } from './controller';
-import config from 'config';
-import legacyRouter from 'me/purchases';
 
-export default ( router ) => {
-	if ( ! config.isEnabled( 'site-level-billing' ) ) {
-		legacyRouter( router );
-		return;
-	}
-
+export default () => {
 	page( '/purchases', siteSelection, navigation, sites, makeLayout, clientRender );
 	page( '/purchases/subscriptions', siteSelection, navigation, sites, makeLayout, clientRender );
 	page(

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -17,8 +17,11 @@ import {
 	purchaseAddPaymentMethod,
 	purchaseEditPaymentMethod,
 } from './controller';
+import legacyRouter from 'me/purchases';
 
-export default () => {
+export default ( router ) => {
+	legacyRouter( router );
+
 	page( '/purchases', siteSelection, navigation, sites, makeLayout, clientRender );
 	page( '/purchases/subscriptions', siteSelection, navigation, sites, makeLayout, clientRender );
 	page(

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -32,7 +32,7 @@ import QueryScanState from 'components/data/query-jetpack-scan';
 import ToolsMenu from './tools-menu';
 import isCurrentPlanPaid from 'state/sites/selectors/is-current-plan-paid';
 import { siteHasJetpackProductPurchase } from 'state/purchases/selectors';
-import { isFreeTrial, isEcommerce } from 'lib/products-values';
+import { isEcommerce } from 'lib/products-values';
 import { isWpMobileApp } from 'lib/mobile-app';
 import isJetpackSectionEnabledForSite from 'state/selectors/is-jetpack-section-enabled-for-site';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -637,90 +637,6 @@ export class MySitesSidebar extends Component {
 					<span className="menu-link-text" data-e2e-sidebar="Plan">
 						{ translate( 'Plans', { context: 'noun' } ) }
 					</span>
-				</a>
-			</li>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
-	}
-
-	plan() {
-		const {
-			canUserManageOptions,
-			hasPaidJetpackPlan,
-			hasPurchasedJetpackProduct,
-			isAtomicSite,
-			isJetpack,
-			isVip,
-			shouldRenderJetpackSection,
-			path,
-			site,
-			translate,
-			isWpMobile,
-		} = this.props;
-
-		if ( ! site ) {
-			return null;
-		}
-
-		if ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) {
-			return null;
-		}
-
-		if ( ! canUserManageOptions ) {
-			return null;
-		}
-
-		let planLink = '/plans' + this.props.siteSuffix;
-
-		// Show plan details for upgraded sites
-		if ( hasPaidJetpackPlan || hasPurchasedJetpackProduct ) {
-			planLink = '/plans/my-plan' + this.props.siteSuffix;
-		}
-
-		const linkClass = classNames( {
-			selected: itemLinkMatches( [ '/plans' ], path ),
-		} );
-
-		const tipTarget = 'plan';
-
-		let planName = site && site.plan.product_name_short;
-
-		if ( site && isFreeTrial( site.plan ) ) {
-			planName = translate( 'Trial', {
-				context: 'Label in the sidebar indicating that the user is on the free trial for a plan.',
-			} );
-		}
-
-		// Hide the plan name only for Jetpack sites that are not Atomic or VIP.
-		const displayPlanName = ! isJetpack || isAtomicSite || isVip;
-
-		let icon = <JetpackLogo size={ 24 } className="sidebar__menu-icon" />;
-		if ( shouldRenderJetpackSection ) {
-			icon = (
-				<Gridicon
-					icon={ hasPaidJetpackPlan || hasPurchasedJetpackProduct ? 'star' : 'star-outline' }
-					className="sidebar__menu-icon"
-					size={ 24 }
-				/>
-			);
-		}
-
-		// Hide "Plans" because the App/Play Stores reject apps that present non In-App Purchase flows, even in a WebView
-		if ( isWpMobile ) {
-			return;
-		}
-
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		return (
-			<li className={ linkClass } data-tip-target={ tipTarget }>
-				<a className="sidebar__menu-link" onClick={ this.trackPlanClick } href={ planLink }>
-					{ icon }
-					<span className="menu-link-text" data-e2e-sidebar="Plan">
-						{ translate( 'Plan', { context: 'noun' } ) }
-					</span>
-					{ displayPlanName && (
-						<span className="sidebar__menu-link-secondary-text">{ planName }</span>
-					) }
 				</a>
 			</li>
 		);

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -1019,7 +1019,7 @@ export class MySitesSidebar extends Component {
 					<ul>
 						{ this.customerHome() }
 						{ this.stats() }
-						{ config.isEnabled( 'site-level-billing' ) ? this.planMenu() : this.plan() }
+						{ this.planMenu() }
 						{ this.store() }
 					</ul>
 				</SidebarMenu>

--- a/config/development.json
+++ b/config/development.json
@@ -175,7 +175,6 @@
 		"signup/wpcc": true,
 		"signup/wpforteams": true,
 		"site-indicator": true,
-		"site-level-billing": false,
 		"memberships": true,
 		"support-user": true,
 		"tools/migrate": true,

--- a/config/development.json
+++ b/config/development.json
@@ -175,7 +175,7 @@
 		"signup/wpcc": true,
 		"signup/wpforteams": true,
 		"site-indicator": true,
-		"site-level-billing": true,
+		"site-level-billing": false,
 		"memberships": true,
 		"support-user": true,
 		"tools/migrate": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -122,7 +122,6 @@
 		"signup/wpcc": true,
 		"signup/wpforteams": true,
 		"site-indicator": true,
-		"site-level-billing": true,
 		"memberships": true,
 		"support-user": true,
 		"upgrades/checkout": true,

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -20,9 +20,9 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async expandDrawerItem( itemName ) {
-		const selector = await driverHelper.getElementByText(
+		const selector = driverHelper.getElementByText(
 			this.driver,
-			By.css( '.sidebar__heading,.menu-link-text' ),
+			By.css( '.sidebar__heading' ),
 			itemName
 		);
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
@@ -31,7 +31,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		if ( isExpanded === 'false' ) {
 			await driverHelper.selectElementByText(
 				this.driver,
-				By.css( '.sidebar__heading,.menu-link-text' ),
+				By.css( '.sidebar__heading' ),
 				itemName
 			);
 		}

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -64,7 +64,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectPlan() {
-		await this.expandDrawerItem( 'Plan' );
+		await this.expandDrawerItem( /^Plan\b/ );
 		return await this._scrollToAndClickMenuItem( 'plan' );
 	}
 

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -22,7 +22,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	async expandDrawerItem( itemName ) {
 		const selector = await driverHelper.getElementByText(
 			this.driver,
-			By.css( '.sidebar__heading' ),
+			By.css( '.sidebar__heading,.menu-link-text' ),
 			itemName
 		);
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
@@ -31,7 +31,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		if ( isExpanded === 'false' ) {
 			await driverHelper.selectElementByText(
 				this.driver,
-				By.css( '.sidebar__heading' ),
+				By.css( '.sidebar__heading,.menu-link-text' ),
 				itemName
 			);
 		}

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -64,6 +64,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectPlan() {
+		await this.expandDrawerItem( 'Plan' );
 		return await this._scrollToAndClickMenuItem( 'plan' );
 	}
 
@@ -183,11 +184,15 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		const sidebarRect = await sidebar.getRect();
 		const sidebarVisible = sidebar.isDisplayed() && sidebarRect.x >= -100;
 
-		if ( ! sidebarVisible  ) {
+		if ( ! sidebarVisible ) {
 			try {
-				await driverHelper.clickWhenClickable(this.driver, allSitesSelector, this.explicitWaitMS / 4);
-			} catch( e ){
-				console.log( 'All sites button did not click')
+				await driverHelper.clickWhenClickable(
+					this.driver,
+					allSitesSelector,
+					this.explicitWaitMS / 4
+				);
+			} catch ( e ) {
+				console.log( 'All sites button did not click' );
 			}
 		}
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, sidebarSelector );

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -378,10 +378,10 @@ export function printConsole( driver ) {
 		driver
 			.manage()
 			.logs()
-			.get('browser')
-			.then((logs) => {
-				logs.forEach((log) => console.log(log));
-			});
+			.get( 'browser' )
+			.then( ( logs ) => {
+				logs.forEach( ( log ) => console.log( log ) );
+			} );
 	}
 }
 

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -522,10 +522,7 @@ export async function scrollIntoView( driver, selector, position = 'center' ) {
 export async function selectElementByText( driver, selector, text ) {
 	const element = async () => {
 		const allElements = await driver.findElements( selector );
-		return await webdriver.promise.filter(
-			allElements,
-			async ( e ) => ( await e.getText() ) === text
-		);
+		return await webdriver.promise.filter( allElements, getInnerTextMatcherFunction( text ) );
 	};
 	return await this.clickWhenClickable( driver, element );
 }
@@ -533,10 +530,7 @@ export async function selectElementByText( driver, selector, text ) {
 export async function verifyTextPresent( driver, selector, text ) {
 	const element = async () => {
 		const allElements = await driver.findElements( selector );
-		return await webdriver.promise.filter(
-			allElements,
-			async ( e ) => ( await e.getText() ) === text
-		);
+		return await webdriver.promise.filter( allElements, getInnerTextMatcherFunction( text ) );
 	};
 	return await this.isElementPresent( driver, element );
 }
@@ -544,10 +538,7 @@ export async function verifyTextPresent( driver, selector, text ) {
 export function getElementByText( driver, selector, text ) {
 	return async () => {
 		const allElements = await driver.findElements( selector );
-		return await webdriver.promise.filter(
-			allElements,
-			async ( e ) => ( await e.getText() ) === text
-		);
+		return await webdriver.promise.filter( allElements, getInnerTextMatcherFunction( text ) );
 	};
 }
 
@@ -581,4 +572,17 @@ export async function acceptAlertIfPresent( driver ) {
 
 export async function waitForAlertPresent( driver ) {
 	return await driver.wait( until.alertIsPresent(), this.explicitWaitMS, 'Alert is not present.' );
+}
+
+function getInnerTextMatcherFunction( match ) {
+	return async ( element ) => {
+		const elementText = await element.getText();
+		if ( typeof match === 'string' ) {
+			return elementText === match;
+		}
+		if ( match.test ) {
+			return match.test( elementText );
+		}
+		throw new Error( 'Unknown matcher type; must be a string or a regular expression' );
+	};
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes the site-level-billing flag.

### Testing instructions

* Test cases documented here: https://github.com/Automattic/wp-calypso/issues/46014#issuecomment-702488897

**To test legacy redirects:**
- visit the site-level view for purchases (`/purchases/subscriptions/:siteName`), remove `/subscriptions` from url, make sure the page is redirected to the one you're currently on
- repeat for a purchase (`/purchases/subscriptions/:siteName/:purchaseId`)
- repeat for a cancellation (`/purchases/subscriptions/:siteName/:purchaseId/cancel`)
- repeat for a domain cancellation (`/purchases/subscriptions/:siteName/:purchaseId/confirm-cancel-domain`)
- repeat for adding a payment method (`/purchases/subscriptions/:siteName/:purchaseId/payment/add`)
- repeat for editing a payment method (`/purchases/subscriptions/:siteName/:purchaseId/payment/edit/:cardId`)

Fixes https://github.com/Automattic/wp-calypso/issues/46014
