### PR TITLE
Support: Disable presales chat on Personal and Premium plans

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -31,12 +31,7 @@ import getSupportVariation, {
 import { useHasDomainsInCart, useDomainsInCart } from '../hooks/has-domains';
 import { useHasPlanInCart, usePlanInCart } from '../hooks/has-plan';
 import { useHasRenewalInCart } from '../hooks/has-renewal';
-import {
-	isWpComBusinessPlan,
-	isWpComEcommercePlan,
-	isWpComPersonalPlan,
-	isWpComPremiumPlan,
-} from 'lib/plans';
+import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import isPresalesChatAvailable from 'state/happychat/selectors/is-presales-chat-available';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import QuerySupportTypes from 'blocks/inline-help/inline-help-query-support-types';
@@ -246,8 +241,6 @@ function getHighestWpComPlanLabel( plans ) {
 	const planMatchersInOrder = [
 		{ label: 'WordPress.com eCommerce', matcher: isWpComEcommercePlan },
 		{ label: 'WordPress.com Business', matcher: isWpComBusinessPlan },
-		{ label: 'WordPress.com Premium', matcher: isWpComPremiumPlan },
-		{ label: 'WordPress.com Personal', matcher: isWpComPersonalPlan },
 	];
 	for ( const { label, matcher } of planMatchersInOrder ) {
 		for ( const plan of plans ) {


### PR DESCRIPTION
We recently launched changes to presales chats so that all plan purchases are eligible for all users (see pbvpgB-Gx-p2). Next week we'll also ramp up all Personal chat. In light of that, we may decide we want to revert this decision — but I plan to be AFK next week. 

So this is an emergency lever which disables presales chats for Personal and Premium purchases, essentially a revert of [the work I shipped a few days ago](https://github.com/Automattic/wp-calypso/pull/45941). It's been well-tested and can be deployed if @lettergrade or @krystinmcg asks for it.

If you want to manually gut-check this yourself, first you'll need to make sure Happy Chat has availability for the "Chat with us" button to show. By default Calypso hooks up to our staging Happy Chat environment, so you should be able to sign in at https://hud-staging.happychat.io/ and make sure:

- Your status is 🟢 All Chats
- Preferences > General > Throttle is more than 0
- Preferences > Skills > English is checked
- Preferences > Skills > WordPress.com is checked

Then, to test:
- Create a new test account on a Free plan
- Start the upgrade to eCommerce — on the checkout page the "Chat with us" button should show
- Cancel and start the upgrade to Business — on the checkout page the "Chat with us" button should show
- Cancel and start the upgrade to Premium — on the checkout page the "Chat with us" button should NOT show
- Cancel and start the upgrade to Personal — on the checkout page the "Chat with us" button should NOT show