### PR TITLE
Make Coming Soon option always show regardless of v1/v2

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -394,15 +394,9 @@ export class SiteSettingsFormGeneral extends Component {
 							/>
 						</FormLabel>
 						<FormSettingExplanation isIndented>
-							{ hasLocalizedText(
+							{ translate(
 								'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-							)
-								? translate(
-										'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-								  )
-								: translate(
-										'Your site is only visible to you and logged-in members you approve.'
-								  ) }
+							) }
 						</FormSettingExplanation>
 					</>
 				) }
@@ -452,13 +446,9 @@ export class SiteSettingsFormGeneral extends Component {
 							/>
 						</FormLabel>
 						<FormSettingExplanation isIndented>
-							{ hasLocalizedText(
+							{ translate(
 								'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
-							)
-								? translate(
-										'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
-								  )
-								: translate( "Your site is hidden from visitors until it's ready for viewing." ) }
+							) }
 						</FormSettingExplanation>
 					</>
 				) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -300,15 +300,11 @@ export class SiteSettingsFormGeneral extends Component {
 		} = this.props;
 		const blogPublic = parseInt( fields.blog_public, 10 );
 		const wpcomComingSoon = 1 === parseInt( fields.wpcom_coming_soon, 10 );
-		const wasWpcomComingSoon = 1 === parseInt( fields.was_wpcom_coming_soon, 10 );
-		const showComingSoonOption =
-			! config.isEnabled( 'coming-soon-v2' ) || wasWpcomComingSoon || wpcomComingSoon;
-
 		const isNonAtomicJetpackSite = siteIsJetpack && ! siteIsAtomic;
 
 		return (
 			<FormFieldset>
-				{ ! isNonAtomicJetpackSite && ! isWPForTeamsSite && showComingSoonOption && (
+				{ ! isNonAtomicJetpackSite && ! isWPForTeamsSite && (
 					<>
 						<FormLabel className="site-settings__visibility-label is-coming-soon">
 							<FormRadio
@@ -319,6 +315,7 @@ export class SiteSettingsFormGeneral extends Component {
 									this.handleVisibilityOptionChange( {
 										blog_public: -1,
 										wpcom_coming_soon: 1,
+										wpcom_public_coming_soon: 0,
 									} )
 								}
 								disabled={ isRequestingSettings }
@@ -343,6 +340,7 @@ export class SiteSettingsFormGeneral extends Component {
 								this.handleVisibilityOptionChange( {
 									blog_public: 1,
 									wpcom_coming_soon: 0,
+									wpcom_public_coming_soon: 0,
 								} )
 							}
 							disabled={ isRequestingSettings }
@@ -363,6 +361,7 @@ export class SiteSettingsFormGeneral extends Component {
 							this.handleVisibilityOptionChange( {
 								blog_public: blogPublic === 0 ? 1 : 0,
 								wpcom_coming_soon: 0,
+								wpcom_public_coming_soon: 0,
 							} )
 						}
 						disabled={ isRequestingSettings }
@@ -386,6 +385,139 @@ export class SiteSettingsFormGeneral extends Component {
 									this.handleVisibilityOptionChange( {
 										blog_public: -1,
 										wpcom_coming_soon: 0,
+										wpcom_public_coming_soon: 0,
+									} )
+								}
+								disabled={ isRequestingSettings }
+								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+								label={ translate( 'Private' ) }
+							/>
+						</FormLabel>
+						<FormSettingExplanation isIndented>
+							{ hasLocalizedText(
+								'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+							)
+								? translate(
+										'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+								  )
+								: translate(
+										'Your site is only visible to you and logged-in members you approve.'
+								  ) }
+						</FormSettingExplanation>
+					</>
+				) }
+			</FormFieldset>
+		);
+	}
+
+	visibilityOptionsComingSoonV2() {
+		const {
+			fields,
+			isRequestingSettings,
+			isWPForTeamsSite,
+			eventTracker,
+			siteIsJetpack,
+			siteIsAtomic,
+			translate,
+		} = this.props;
+		const blogPublic = parseInt( fields.blog_public, 10 );
+
+		const wpcomComingSoon = 1 === parseInt( fields.wpcom_coming_soon, 10 );
+		const wpcomPublicComingSoon = 1 === parseInt( fields.wpcom_public_coming_soon, 10 );
+
+		const isNonAtomicJetpackSite = siteIsJetpack && ! siteIsAtomic;
+
+		return (
+			<FormFieldset>
+				{ ! isNonAtomicJetpackSite && ! isWPForTeamsSite && (
+					<>
+						<FormLabel className="site-settings__visibility-label is-coming-soon">
+							<FormRadio
+								name="blog_public"
+								value="0"
+								checked={
+									( 0 === blogPublic && wpcomPublicComingSoon ) ||
+									( -1 === blogPublic && wpcomComingSoon )
+								}
+								onChange={ () =>
+									this.handleVisibilityOptionChange( {
+										blog_public: 0,
+										wpcom_coming_soon: 0,
+										wpcom_public_coming_soon: 1,
+									} )
+								}
+								disabled={ isRequestingSettings }
+								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+								label={ translate( 'Coming Soon' ) }
+							/>
+						</FormLabel>
+						<FormSettingExplanation isIndented>
+							{ hasLocalizedText(
+								'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+							)
+								? translate(
+										'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+								  )
+								: translate( "Your site is hidden from visitors until it's ready for viewing." ) }
+						</FormSettingExplanation>
+					</>
+				) }
+				{ ! isNonAtomicJetpackSite && (
+					<FormLabel className="site-settings__visibility-label is-public">
+						<FormRadio
+							name="blog_public"
+							value="1"
+							checked={ ( blogPublic === 0 && ! wpcomPublicComingSoon ) || blogPublic === 1 }
+							onChange={ () =>
+								this.handleVisibilityOptionChange( {
+									blog_public: 1,
+									wpcom_coming_soon: 0,
+									wpcom_public_coming_soon: 0,
+								} )
+							}
+							disabled={ isRequestingSettings }
+							onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+							label={ translate( 'Public' ) }
+						/>
+					</FormLabel>
+				) }
+				<FormSettingExplanation isIndented>
+					{ translate( 'Your site is visible to everyone.' ) }
+				</FormSettingExplanation>
+				<FormLabel className="site-settings__visibility-label is-checkbox is-hidden">
+					<FormInputCheckbox
+						name="blog_public"
+						value="0"
+						checked={ 0 === blogPublic && ! wpcomPublicComingSoon }
+						onChange={ () =>
+							this.handleVisibilityOptionChange( {
+								blog_public: wpcomPublicComingSoon || blogPublic === -1 || blogPublic === 1 ? 0 : 1,
+								wpcom_coming_soon: 0,
+								wpcom_public_coming_soon: 0,
+							} )
+						}
+						disabled={ isRequestingSettings }
+						onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+					/>
+					<span>{ translate( 'Discourage search engines from indexing this site' ) }</span>
+					<FormSettingExplanation isIndented>
+						{ translate(
+							'This option does not block access to your site — it is up to search engines to honor your request.'
+						) }
+					</FormSettingExplanation>
+				</FormLabel>
+				{ ! isNonAtomicJetpackSite && (
+					<>
+						<FormLabel className="site-settings__visibility-label is-private">
+							<FormRadio
+								name="blog_public"
+								value="-1"
+								checked={ -1 === blogPublic && ! wpcomComingSoon }
+								onChange={ () =>
+									this.handleVisibilityOptionChange( {
+										blog_public: -1,
+										wpcom_coming_soon: 0,
+										wpcom_public_coming_soon: 0,
 									} )
 								}
 								disabled={ isRequestingSettings }
@@ -404,11 +536,16 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	handleVisibilityOptionChange = ( { blog_public, wpcom_coming_soon } ) => {
+	handleVisibilityOptionChange = ( {
+		blog_public,
+		wpcom_coming_soon,
+		wpcom_public_coming_soon,
+	} ) => {
 		const { trackEvent, updateFields } = this.props;
 		trackEvent( `Set blog_public to ${ blog_public }` );
 		trackEvent( `Set wpcom_coming_soon to ${ wpcom_coming_soon }` );
-		updateFields( { blog_public, wpcom_coming_soon } );
+		trackEvent( `Set wpcom_public_coming_soon to ${ wpcom_public_coming_soon }` );
+		updateFields( { blog_public, wpcom_coming_soon, wpcom_public_coming_soon } );
 	};
 
 	Timezone() {
@@ -513,7 +650,10 @@ export class SiteSettingsFormGeneral extends Component {
 					title={ translate( 'Privacy', { context: 'Privacy Settings header' } ) }
 				/>
 				<Card>
-					<form>{ this.visibilityOptionsComingSoon() }</form>
+					<form>
+						{ ! config.isEnabled( 'coming-soon-v2' ) && this.visibilityOptionsComingSoon() }
+						{ config.isEnabled( 'coming-soon-v2' ) && this.visibilityOptionsComingSoonV2() }
+					</form>
 				</Card>
 			</>
 		);

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -815,6 +815,7 @@ const getFormSettings = ( settings ) => {
 		timezone_string: '',
 		blog_public: '',
 		wpcom_coming_soon: '',
+		wpcom_public_coming_soon: '',
 		admin_url: '',
 	};
 
@@ -831,7 +832,7 @@ const getFormSettings = ( settings ) => {
 		timezone_string: settings.timezone_string,
 
 		wpcom_coming_soon: settings.wpcom_coming_soon,
-		was_wpcom_coming_soon: settings.wpcom_coming_soon,
+		wpcom_public_coming_soon: settings.wpcom_public_coming_soon,
 	};
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -154,25 +154,45 @@ describe( 'SiteSettingsFormGeneral ', () => {
 			expect( container.querySelectorAll( '[name="blog_public"]' ).length ).toBe( 4 );
 		} );
 
-		[
-			[ 'Coming soon', 'Coming Soon', 1, { blog_public: -1, wpcom_coming_soon: 1 } ],
-			[ 'Public', 'Public', -1, { blog_public: 1, wpcom_coming_soon: 0 } ],
+		describe( 'blog_public states (coming-soon-v1)', () => {
 			[
-				'Hidden',
-				'Discourage search engines from indexing this site',
-				-1,
-				{ blog_public: 0, wpcom_coming_soon: 0 },
-			],
-			[ 'Private', 'Private', 1, { blog_public: -1, wpcom_coming_soon: 0 } ],
-		].forEach( ( [ name, text, initialBlogPublic, updatedFields ] ) => {
-			test( `${ name } option should be selectable`, () => {
-				testProps.fields.blog_public = initialBlogPublic;
-				const { getByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
+				[
+					'Coming soon',
+					'Coming Soon',
+					1,
+					{ blog_public: -1, wpcom_coming_soon: 1, wpcom_public_coming_soon: 0 },
+				],
+				[
+					'Public',
+					'Public',
+					-1,
+					{ blog_public: 1, wpcom_coming_soon: 0, wpcom_public_coming_soon: 0 },
+				],
+				[
+					'Hidden',
+					'Discourage search engines from indexing this site',
+					-1,
+					{ blog_public: 0, wpcom_coming_soon: 0, wpcom_public_coming_soon: 0 },
+				],
+				[
+					'Private',
+					'Private',
+					1,
+					{ blog_public: -1, wpcom_coming_soon: 0, wpcom_public_coming_soon: 0 },
+				],
+			].forEach( ( [ name, text, initialBlogPublic, updatedFields ] ) => {
+				test( `${ name } option should be selectable`, () => {
+					config.isEnabled.mockImplementation( configMock( { 'coming-soon-v2': false } ) );
+					testProps.fields.blog_public = initialBlogPublic;
+					const { getByLabelText } = renderWithRedux(
+						<SiteSettingsFormGeneral { ...testProps } />
+					);
 
-				const radioButton = getByLabelText( text, { exact: false } );
-				expect( radioButton ).not.toBeChecked();
-				fireEvent.click( radioButton );
-				expect( testProps.updateFields ).toBeCalledWith( updatedFields );
+					const radioButton = getByLabelText( text, { exact: false } );
+					expect( radioButton ).not.toBeChecked();
+					fireEvent.click( radioButton );
+					expect( testProps.updateFields ).toBeCalledWith( updatedFields );
+				} );
 			} );
 		} );
 
@@ -192,6 +212,7 @@ describe( 'SiteSettingsFormGeneral ', () => {
 			expect( testProps.updateFields ).toBeCalledWith( {
 				blog_public: 0,
 				wpcom_coming_soon: 0,
+				wpcom_public_coming_soon: 0,
 			} );
 		} );
 
@@ -211,46 +232,50 @@ describe( 'SiteSettingsFormGeneral ', () => {
 			expect( testProps.updateFields ).toBeCalledWith( {
 				blog_public: 1,
 				wpcom_coming_soon: 0,
+				wpcom_public_coming_soon: 0,
 			} );
 		} );
 
-		test( 'Check Coming Soon radio option remains clickable with v2 not enabled', () => {
-			config.isEnabled.mockImplementation( configMock( { 'coming-soon-v2': false } ) );
+		describe( 'blog_public states (coming-soon-v2)', () => {
+			[
+				[
+					'Coming soon',
+					'Coming Soon',
+					1,
+					{ blog_public: 0, wpcom_coming_soon: 0, wpcom_public_coming_soon: 1 },
+				],
+				[
+					'Public',
+					'Public',
+					-1,
+					{ blog_public: 1, wpcom_coming_soon: 0, wpcom_public_coming_soon: 0 },
+				],
+				[
+					'Hidden',
+					'Discourage search engines from indexing this site',
+					-1,
+					{ blog_public: 0, wpcom_coming_soon: 0, wpcom_public_coming_soon: 0 },
+				],
+				[
+					'Private',
+					'Private',
+					1,
+					{ blog_public: -1, wpcom_coming_soon: 0, wpcom_public_coming_soon: 0 },
+				],
+			].forEach( ( [ name, text, initialBlogPublic, updatedFields ] ) => {
+				test( `${ name } option should be selectable`, () => {
+					config.isEnabled.mockImplementation( configMock( { 'coming-soon-v2': true } ) );
+					testProps.fields.blog_public = initialBlogPublic;
+					const { getByLabelText } = renderWithRedux(
+						<SiteSettingsFormGeneral { ...testProps } />
+					);
 
-			testProps.fields.blog_public = -1;
-			testProps.fields.wpcom_coming_soon = 0;
-
-			const { getByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
-
-			const radioButton = getByLabelText( 'Coming Soon', { exact: false } );
-
-			expect( radioButton ).not.toBeChecked();
-
-			fireEvent.click( radioButton );
-
-			expect( testProps.updateFields ).toBeCalledWith( { blog_public: -1, wpcom_coming_soon: 1 } );
-		} );
-
-		test( 'Check Coming Soon disappears with v2 enabled', () => {
-			config.isEnabled.mockImplementation( configMock( { 'coming-soon-v2': true } ) );
-
-			testProps.fields.blog_public = -1;
-			testProps.fields.wpcom_coming_soon = 0;
-
-			const { queryByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
-			expect( queryByLabelText( 'Coming Soon', { exact: false } ) ).toBe( null );
-		} );
-
-		test( 'Check Coming Soon disappears with v2 enabled unless Coming Soon is currently set', () => {
-			config.isEnabled.mockImplementation( configMock( { 'coming-soon-v2': true } ) );
-
-			testProps.fields.blog_public = -1; // v1 coming soon requires private
-			testProps.fields.wpcom_coming_soon = 1;
-
-			const { getByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
-
-			const comingSoonRadio1 = getByLabelText( 'Coming Soon', { exact: false } );
-			expect( comingSoonRadio1 ).toBeChecked();
+					const radioButton = getByLabelText( text, { exact: false } );
+					expect( radioButton ).not.toBeChecked();
+					fireEvent.click( radioButton );
+					expect( testProps.updateFields ).toBeCalledWith( updatedFields );
+				} );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Re-enables coming soon toggle option if v2 is enabled. 
* Effectively rolls back #46034 simultaneously enabling v2 support.
* If `coming-soon-v2` is enabled, the Coming Soon option will set the site option `wpcom_public_coming_soon = 1` (v2 opt) and `wpcom_coming_soon = 0` (v1 opt).
* All other options will set both coming soon options `= 0`
* If `coming-soon-v2` is not enabled, the Coming soon option will set the reverse `wpcom_public_coming_soon = 0` (v2 opt) and `wpcom_coming_soon = 1` (v1 opt).

This means, if we enable `coming-soon-v2` in calypso, anyone with v1 site option will stay on v1. To migrate they will need to flip between public / coming soon again in order to change to v2. The reverse process is also true, if we enable it and then disable it, people will remain on the v2 option until they flip between settings and resave.

Also, if v2 is enabled on calypso, we also need to enable v2 on the back end. Doing so is additive and both versions can be enabled at the same time.

#### Testing instructions

I've updated unit tests to cover the existing scenarios and the new v2 variants:

```
yarn run test-client:watch client/my-sites/site-settings/test/form-general.jsx
```

To manually test set the flag locally to see the differences, if you're sandbox has v2 enabled, you should be able to sight the v1 and v2 coming soon pages depending on whether you had the flag enabled in calypso or not when you set the coming soon option on.

```
http://calypso.localhost:3000/settings/general/yourtestsite.w\ordpress.com?flags=coming-soon-v2
```
