### PR TITLE
P2: Add support access site setting

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -533,6 +533,84 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
+	handleSupportAccessChange = ( { isAllowed } ) => {
+		const SUPPORT_ACCESS_EXPIRY_IN_DAYS = 30;
+		const { updateFields } = this.props;
+		if ( isAllowed ) {
+			const today = new Date();
+			const expiry =
+				( today.setDate( today.getDate() + SUPPORT_ACCESS_EXPIRY_IN_DAYS ) / 1000 ) | 0;
+			updateFields( { support_access_allowed_until: expiry, allow_support_access: 1 } );
+		} else {
+			updateFields( { support_access_allowed_until: '', allow_support_access: 0 } );
+		}
+	};
+
+	supportAccessOptions() {
+		const { fields, isRequestingSettings, translate } = this.props;
+		const isSupportAccessAllowed = fields.allow_support_access === 1;
+
+		return (
+			<FormFieldset>
+				<FormLabel>
+					<FormRadio
+						name="allow_support_access"
+						value="1"
+						checked={ isSupportAccessAllowed }
+						onChange={ () =>
+							this.handleSupportAccessChange( {
+								isAllowed: true,
+							} )
+						}
+						disabled={ isRequestingSettings }
+						label={ translate( 'Allow us to access your P2 to provide support' ) }
+					/>
+				</FormLabel>
+				<FormSettingExplanation isIndented>
+					{ translate( 'This will deactivate automatically in 30 days.' ) }
+				</FormSettingExplanation>
+
+				<FormLabel>
+					<FormRadio
+						name="allow_support_access"
+						value="0"
+						checked={ ! isSupportAccessAllowed }
+						onChange={ () =>
+							this.handleSupportAccessChange( {
+								isAllowed: false,
+							} )
+						}
+						disabled={ isRequestingSettings }
+						label={ translate( "Don't allow (recommended)" ) }
+					/>
+				</FormLabel>
+				<FormSettingExplanation isIndented>
+					{ translate( "We won't be able to access your P2 if you reach out for help." ) }
+				</FormSettingExplanation>
+			</FormFieldset>
+		);
+	}
+
+	supportAccessSettings() {
+		const { isRequestingSettings, translate, handleSubmitForm, isSavingSettings } = this.props;
+
+		return (
+			<>
+				<SettingsSectionHeader
+					disabled={ isRequestingSettings || isSavingSettings }
+					id="support-access-settings"
+					isSaving={ isSavingSettings }
+					onButtonClick={ handleSubmitForm }
+					showButton
+					title={ translate( 'Support Access', { context: 'Support Access settings header' } ) }
+				/>
+				<Card>
+					<form>{ this.supportAccessOptions() }</form>
+				</Card>
+			</>
+		);
+	}
+
 	disablePrivacySettings = ( e ) => {
 		e.target.blur();
 	};
@@ -604,6 +682,8 @@ export class SiteSettingsFormGeneral extends Component {
 				</Card>
 
 				{ this.privacySettingsWrapper() }
+
+				{ isWPForTeamsSite && <>{ this.supportAccessSettings() }</> }
 
 				{ ! isWPForTeamsSite && ! siteIsJetpack && (
 					<div className="site-settings__footer-credit-container">
@@ -690,6 +770,7 @@ const getFormSettings = ( settings ) => {
 		blog_public: '',
 		wpcom_coming_soon: '',
 		admin_url: '',
+		support_access_allowed_until: '',
 	};
 
 	if ( ! settings ) {
@@ -706,6 +787,9 @@ const getFormSettings = ( settings ) => {
 
 		wpcom_coming_soon: settings.wpcom_coming_soon,
 		was_wpcom_coming_soon: settings.wpcom_coming_soon,
+
+		support_access_allowed_until: settings.support_access_allowed_until,
+		allow_support_access: settings.support_access_allowed_until ? 1 : 0,
 	};
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -542,7 +542,7 @@ export class SiteSettingsFormGeneral extends Component {
 				( today.setDate( today.getDate() + SUPPORT_ACCESS_EXPIRY_IN_DAYS ) / 1000 ) | 0;
 			updateFields( { support_access_allowed_until: expiry, allow_support_access: 1 } );
 		} else {
-			updateFields( { support_access_allowed_until: '', allow_support_access: 0 } );
+			updateFields( { support_access_allowed_until: 0, allow_support_access: 0 } );
 		}
 	};
 
@@ -602,7 +602,7 @@ export class SiteSettingsFormGeneral extends Component {
 					isSaving={ isSavingSettings }
 					onButtonClick={ handleSubmitForm }
 					showButton
-					title={ translate( 'Support Access', { context: 'Support Access settings header' } ) }
+					title={ translate( 'Support Access' ) }
 				/>
 				<Card>
 					<form>{ this.supportAccessOptions() }</form>
@@ -770,7 +770,7 @@ const getFormSettings = ( settings ) => {
 		blog_public: '',
 		wpcom_coming_soon: '',
 		admin_url: '',
-		support_access_allowed_until: '',
+		support_access_allowed_until: 0,
 	};
 
 	if ( ! settings ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the input form for a new site setting called `support_access_allowed_until`. This setting is exclusive to P2(020) sites, and allows the site owners to control support access to their private P2s.

#### Testing instructions
* You need to be sandboxed and have access to a P2(020) test site.
* Apply D50514-code to your sandbox. This changeset is required to whitelist the new setting in the Settings API.
* Go to `http://calypso.localhost:3000/settings/general/<your-P2-site-slug>`. You should see a new section called **Support Access**
* Test by changing the setting from one value to another and check via CLI tool: `wp option get support_access_allowed_until --url=<your-P2-site-slug>`
    * If support access is on, the setting value is 30 days from when it was turned on.
    * If support access is off, the setting value does not exist, or is `0`.
* Check that this setting is available only to P2(020) sites.

Fixes 966-gh-p2

Related changesets: D50482-code (enforces the setting)
