### PR TITLE
Comments: Use FormTextarea for all comment content fields

### DIFF
--- a/client/blocks/comments/form-textarea.jsx
+++ b/client/blocks/comments/form-textarea.jsx
@@ -6,17 +6,18 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import FormTextarea from 'components/forms/form-textarea';
 import withUserMentions from 'blocks/user-mentions/index';
 import withPasteToLink from 'lib/paste-to-link';
 import { isEnabled } from 'config';
 
 /* eslint-disable jsx-a11y/no-autofocus */
 const PostCommentFormTextarea = React.forwardRef( ( props, ref ) => (
-	<textarea
+	<FormTextarea
 		className="comments__form-textarea"
 		value={ props.value }
 		placeholder={ props.placeholder }
-		ref={ ref }
+		forwardedRef={ ref }
 		onKeyUp={ props.onKeyUp }
 		onKeyDown={ props.onKeyDown }
 		onFocus={ props.onFocus }

--- a/client/my-sites/comments/comment/comment-html-editor/index.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/index.jsx
@@ -12,6 +12,7 @@ import { delay, each, get, map, reduce, reject } from 'lodash';
  */
 import AddImageDialog from 'my-sites/comments/comment/comment-html-editor/add-image-dialog';
 import AddLinkDialog from 'my-sites/comments/comment/comment-html-editor/add-link-dialog';
+import FormTextarea from 'components/forms/form-textarea';
 import { Button } from '@automattic/components';
 import { withLocalizedMoment } from 'components/localized-moment';
 
@@ -86,7 +87,7 @@ export class CommentHtmlEditor extends Component {
 			return this.insertContent( closer, options.adjustCursorPosition );
 		}
 
-		if ( !! fragments[ 1 ] ) {
+		if ( fragments[ 1 ] ) {
 			this.setState( ( { openTags } ) => ( { openTags: openTags.concat( tag ) } ) );
 		}
 		return this.insertContent( opener, options.adjustCursorPosition );
@@ -218,11 +219,11 @@ export class CommentHtmlEditor extends Component {
 					) ) }
 				</div>
 
-				<textarea
-					className="comment-html-editor__textarea form-textarea"
+				<FormTextarea
+					className="comment-html-editor__textarea"
 					disabled={ this.props.disabled }
 					onChange={ onChange }
-					ref={ this.storeTextareaRef }
+					forwardedRef={ this.storeTextareaRef }
 					value={ commentContent }
 				/>
 

--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -12,6 +12,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import AutoDirection from 'components/auto-direction';
+import FormTextarea from 'components/forms/form-textarea';
 import { Button } from '@automattic/components';
 import { decodeEntities } from 'lib/formatting';
 import {
@@ -155,14 +156,14 @@ export class CommentReply extends Component {
 		return (
 			<form className="comment__reply">
 				<AutoDirection>
-					<textarea
+					<FormTextarea
 						className={ textareaClasses }
 						onBlur={ this.blurReply }
 						onChange={ this.updateTextarea }
 						onFocus={ this.focusReply }
 						onKeyDown={ this.keyDownHandler }
 						placeholder={ this.getPlaceholder() }
-						ref={ this.storeTextareaRef }
+						forwardedRef={ this.storeTextareaRef }
 						style={ textareaStyle }
 						value={ replyContent }
 					/>


### PR DESCRIPTION
This updates all comment content fields to use `<FormTextarea />` instead of a `<textarea />`. Part of #45259.

#### Changes proposed in this Pull Request

* Components: Use `<FormTextarea />` in `<PostCommentFormTextarea />`
* Components: Use `<FormTextarea />` in `<CommentReply />`
* Components: Use `<FormTextarea />` in `<CommentHtmlEditor />`

#### Testing instructions

* Compare the comment content fields in these instances and verify they look and function as they did before:
  * Open a post in the Reader, and click the button to reply with a comment - `<PostCommentFormTextarea />`.
  * Go to `/comments/all/:site` where `:site` is a site with some comments available on it.
    * Click "Reply" to open the comment form for replying to a comment - `<CommentReply />`.
    * Click "Edit" to open the comment editing form - `<CommentHtmlEditor />`.

#### Notes

This PR also takes the opportunity to fix a lint error with a redundant double negation.