### PR TITLE
Components: Update SelectDropdown to use FormLabel

### DIFF
--- a/client/components/select-dropdown/label.jsx
+++ b/client/components/select-dropdown/label.jsx
@@ -3,13 +3,18 @@
  */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
+import FormLabel from 'components/forms/form-label';
+
 // Prevents the event from bubbling up the DOM tree
 const stopPropagation = ( event ) => event.stopPropagation();
 
 export default function SelectDropdownLabel( { children } ) {
 	return (
 		<li onClick={ stopPropagation } role="presentation" className="select-dropdown__label">
-			<label>{ children }</label>
+			<FormLabel>{ children }</FormLabel>
 		</li>
 	);
 }

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -278,8 +278,11 @@ $compact-header-height: 35;
 	color: var( --color-text-subtle );
 	line-height: 20px;
 
-	label {
+	.form-label {
 		font-size: $font-body-extra-small;
+		font-weight: 400;
 		padding: 0 #{$side-margin}px;
+		margin-bottom: 0;
+		display: inline;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Components: Update SelectDropdown to use FormLabel as part of #45259

#### Testing instructions

* Go to `/devdocs/design/select-dropdown`
* Verify the "Statuses" label at the top of the first dropdown looks unchanged.
