### PR TITLE
Uses framework function for external redirect

### DIFF
--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -25,6 +25,7 @@ import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import MySitesSidebarUnifiedItem from './item';
 import SidebarCustomIcon from 'layout/sidebar/custom-icon';
 import { isExternal } from 'lib/url';
+import { externalRedirect } from 'lib/route/path';
 import { itemLinkMatches } from '../sidebar/utils';
 
 export const MySitesSidebarUnifiedMenu = ( {
@@ -61,7 +62,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 				if ( link ) {
 					if ( isExternal( link ) ) {
 						// If the URL is external, page() will fail to replace state between different domains
-						document.location.href = link;
+						externalRedirect( link );
 						return;
 					}
 					page( link );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* use the framework function externalRedirect() as discussed here https://github.com/Automattic/wp-calypso/pull/46008#discussion_r498697080

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run `wp blog-stickers add --sticker=nav-unification --who=<username> --blog_id=<blog_id>` to a site
* load calypso with `?flags=nav-unification` and select the above site
* try navigating to Settings, it should redirect to `wp-admin` withouth any errors in the console