### PR TITLE
Checkout: Update loading placeholder

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -503,6 +503,7 @@ const CheckoutSummaryBody = styled.div`
 		display: block;
 		max-width: 328px;
 		position: fixed;
+		width: 100%;
 	}
 `;
 

--- a/packages/composite-checkout/src/components/loading-content.tsx
+++ b/packages/composite-checkout/src/components/loading-content.tsx
@@ -36,9 +36,9 @@ export default function LoadingContent() {
 			</LoadingContentUi>
 
 			<LoadingSideBarUi>
-				<LoadingCopy />
-				<LoadingCopy />
-				<LoadingCopy />
+				<SideBarLoadingCopy />
+				<SideBarLoadingCopy />
+				<SideBarLoadingCopy />
 			</LoadingSideBarUi>
 		</LoadingContentWrapperUi>
 	);
@@ -72,6 +72,7 @@ const LoadingSideBarUi = styled.div`
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		display: block;
 		padding: 24px;
+		box-sizing: border-box;
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 		max-width: 326px;
 		background: ${ ( props ) => props.theme.colors.surface };
@@ -149,6 +150,17 @@ const LoadingCopy = styled.p`
 	.rtl & {
 		margin: 8px 35px 0 0;
 	}
+`;
+
+const SideBarLoadingCopy = styled.p`
+	font-size: 14px;
+	height: 16px;
+	content: '';
+	background: ${ ( props ) => props.theme.colors.borderColorLight };
+	color: ${ ( props ) => props.theme.colors.borderColorLight };
+	margin: 8px 0 0 0;
+	padding: 0;
+	animation: ${ pulse } 2s ease-in-out infinite;
 `;
 
 const LoadingFooter = styled.div`

--- a/packages/composite-checkout/src/components/loading-content.tsx
+++ b/packages/composite-checkout/src/components/loading-content.tsx
@@ -14,39 +14,68 @@ export default function LoadingContent() {
 	const { __ } = useI18n();
 
 	return (
-		<LoadingContentWrapperUI>
-			<LoadingCard>
-				<LoadingTitle>{ __( 'Loading checkout' ) }</LoadingTitle>
+		<LoadingContentWrapperUi>
+			<LoadingContentUi>
+				<LoadingCard>
+					<LoadingTitle>{ __( 'Loading checkout' ) }</LoadingTitle>
+					<LoadingCopy />
+					<LoadingCopy />
+				</LoadingCard>
+				<LoadingCard>
+					<LoadingTitle />
+					<LoadingCopy />
+					<LoadingCopy />
+				</LoadingCard>
+				<LoadingCard>
+					<LoadingTitle />
+				</LoadingCard>
+				<LoadingCard>
+					<LoadingTitle />
+				</LoadingCard>
+				<LoadingFooter />
+			</LoadingContentUi>
+
+			<LoadingSideBarUi>
 				<LoadingCopy />
 				<LoadingCopy />
-			</LoadingCard>
-			<LoadingCard>
-				<LoadingTitle />
 				<LoadingCopy />
-				<LoadingCopy />
-			</LoadingCard>
-			<LoadingCard>
-				<LoadingTitle />
-			</LoadingCard>
-			<LoadingCard>
-				<LoadingTitle />
-			</LoadingCard>
-			<LoadingFooter />
-		</LoadingContentWrapperUI>
+			</LoadingSideBarUi>
+		</LoadingContentWrapperUi>
 	);
 }
 
-const LoadingContentWrapperUI = styled.div`
+const LoadingContentWrapperUi = styled.div`
+	display: flex;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		align-items: flex-start;
+		flex-direction: row;
+		justify-content: center;
+		width: 100%;
+	}
+`;
+
+const LoadingContentUi = styled.div`
 	background: ${ ( props ) => props.theme.colors.surface };
 	width: 100%;
-	box-sizing: border-box;
-	margin-bottom: 0;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-		margin: 32px auto;
-		box-sizing: border-box;
 		max-width: 556px;
+	}
+`;
+
+const LoadingSideBarUi = styled.div`
+	display: none;
+	width: 100%;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		display: block;
+		padding: 24px;
+		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+		max-width: 326px;
+		background: ${ ( props ) => props.theme.colors.surface };
+		margin-left: 24px;
 	}
 `;
 

--- a/packages/composite-checkout/src/components/loading-content.tsx
+++ b/packages/composite-checkout/src/components/loading-content.tsx
@@ -14,8 +14,8 @@ export default function LoadingContent() {
 	const { __ } = useI18n();
 
 	return (
-		<LoadingContentWrapperUi>
-			<LoadingContentUi>
+		<LoadingContentWrapperUI>
+			<LoadingContentUI>
 				<LoadingCard>
 					<LoadingTitle>{ __( 'Loading checkout' ) }</LoadingTitle>
 					<LoadingCopy />
@@ -33,18 +33,18 @@ export default function LoadingContent() {
 					<LoadingTitle />
 				</LoadingCard>
 				<LoadingFooter />
-			</LoadingContentUi>
+			</LoadingContentUI>
 
-			<LoadingSideBarUi>
+			<LoadingSideBarUI>
 				<SideBarLoadingCopy />
 				<SideBarLoadingCopy />
 				<SideBarLoadingCopy />
-			</LoadingSideBarUi>
-		</LoadingContentWrapperUi>
+			</LoadingSideBarUI>
+		</LoadingContentWrapperUI>
 	);
 }
 
-const LoadingContentWrapperUi = styled.div`
+const LoadingContentWrapperUI = styled.div`
 	display: flex;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
@@ -55,7 +55,7 @@ const LoadingContentWrapperUi = styled.div`
 	}
 `;
 
-const LoadingContentUi = styled.div`
+const LoadingContentUI = styled.div`
 	background: ${ ( props ) => props.theme.colors.surface };
 	width: 100%;
 
@@ -65,7 +65,7 @@ const LoadingContentUi = styled.div`
 	}
 `;
 
-const LoadingSideBarUi = styled.div`
+const LoadingSideBarUI = styled.div`
 	display: none;
 	width: 100%;
 

--- a/packages/composite-checkout/src/components/loading-content.tsx
+++ b/packages/composite-checkout/src/components/loading-content.tsx
@@ -74,7 +74,7 @@ const LoadingSideBarUi = styled.div`
 		padding: 24px;
 		box-sizing: border-box;
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-		max-width: 326px;
+		max-width: 328px;
 		background: ${ ( props ) => props.theme.colors.surface };
 		margin-left: 24px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the loading placeholder to reflect the two column design.

**Before**
![image](https://user-images.githubusercontent.com/6981253/94948146-daff9100-04ac-11eb-94ef-f2b84f4ff2a1.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/94948173-e6eb5300-04ac-11eb-9aea-c83bcfedbeb8.png)

Nothing changes from a mobile perspective. I tested these changes in Chrome, Firefox, and Safari. 

#### Testing instructions

Load up checkout and confirm that you're seeing a two column preloader that matches the layout of the loaded checkout. 
