### PR TITLE
Premium Content: Fix logged-out view button alignment 

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/editor.css
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/editor.css
@@ -127,7 +127,7 @@
 
 .wp-block-buttons .wp-block[data-type='jetpack/recurring-payments'] {
 	display: inline-block;
-	margin: 0 8px 0 0;
+	margin: 0 .5em 0 0;
 }
 
 .editor-styles-wrapper

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/style.css
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/style.css
@@ -10,6 +10,12 @@
 	margin: 0;
 }
 
+/** Subscribe button **/
+.wp-block-premium-content-logged-out-view .wp-block-jetpack-recurring-payments {
+	display: inline-block;
+	margin-right: .5em;
+}
+
 /* Login button */
 
 .wp-block-premium-content-login-button {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set inline block styles on the jetpack Recurring Payments block from within Premium Content styles.
* Add a right margin to the button on both front end and back end.
* I went back and forth on where this change should live, but ended up in Premium Content because it appears to be specific to this block, I can't test the Premium Content block on a Jetpack site, and I don't want to conflict with existing uses of Recurring Payments. 😥 
* I tested the styles in a bunch of different themes and did not notice any issues, but it's probably worth taking the block for a spin.

**Before**

<img width="652" alt="Screen Shot 2020-10-02 at 12 49 21 PM" src="https://user-images.githubusercontent.com/2124984/94950032-eacca480-04af-11eb-9c41-9129abbda2b2.png">


**After**

<img width="648" alt="Screen Shot 2020-10-02 at 12 17 33 PM" src="https://user-images.githubusercontent.com/2124984/94948519-709b2080-04ad-11eb-8113-b46fdc03d64f.png">

<img width="612" alt="Screen Shot 2020-10-02 at 12 19 25 PM" src="https://user-images.githubusercontent.com/2124984/94948520-7133b700-04ad-11eb-9058-2816f27562ea.png">

<img width="724" alt="Screen Shot 2020-10-02 at 12 26 21 PM" src="https://user-images.githubusercontent.com/2124984/94948521-71cc4d80-04ad-11eb-8b50-1016166a51f8.png">


#### Testing instructions

* For local development, you'll need to follow the instructions for Editing Toolkit Development in the FG, but it's much easier if you can test the block with calypso.live
* Add a Premium Content block to your site
* Check out the button styles on the front end and in the editor; they should be side by side rather than one on top of the other

Fixes #45477
