### PR TITLE
Notifications: adding support for rendering line breaks

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -76,6 +76,7 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 		case 'cite':
 		case 'hr':
 		case 'p':
+		case 'br':
 		case 'div':
 		case 'code':
 		case 'strong':


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This pull request, combined with D50168, updates the notifications app so that it respects line breaks when rendering text content from posts.

Fixes https://github.com/Automattic/wp-calypso/issues/46106.

#### Testing instructions
* Apply D50582-code in your sandbox and make sure the API is sandboxed.
* Apply this change to calypso, navigate to your Calypso dashboard and open a notification for a post with line breaks within paragraphs in its content. Verify that the line breaks are respected in the display of the post in the notification.

Before:
![image](https://user-images.githubusercontent.com/13437011/94957330-2f0d7400-04b3-11eb-9b81-894acd10b173.png)

After:
![image](https://user-images.githubusercontent.com/13437011/94957273-1735f000-04b3-11eb-8aed-9b3e604665e8.png)
