### PR TITLE
Purchases: unset isLoading and set hasLoaded when an error occurs

### DIFF
--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -19,14 +19,21 @@ import NoSitesMessage from 'components/empty-content/no-sites-message';
 import { CompactCard } from '@automattic/components';
 import EmptyContent from 'components/empty-content';
 import './style.scss';
+import { Purchase } from 'calypso/lib/purchases/types';
 
-export default function SubscriptionsContent() {
-	const isFetchingPurchases = useSelector( ( state ) => isFetchingSitePurchases( state ) );
-	const hasLoadedPurchases = useSelector( ( state ) => hasLoadedSitePurchasesFromServer( state ) );
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
-	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
-
+function SubscriptionsContent( {
+	isFetchingPurchases,
+	hasLoadedPurchases,
+	selectedSiteId,
+	selectedSite,
+	purchases,
+}: {
+	isFetchingPurchases: boolean;
+	hasLoadedPurchases: boolean;
+	selectedSiteId: number | null;
+	selectedSite: null | { ID: number; name: string; domain: string; slug: string };
+	purchases: Purchase[];
+} ) {
 	const getManagePurchaseUrlFor = ( siteSlug: string, purchaseId: number ) =>
 		`/purchases/subscriptions/${ siteSlug }/${ purchaseId }`;
 
@@ -63,6 +70,24 @@ export default function SubscriptionsContent() {
 
 	// If there is selected site data but no purchases, show the "no purchases" page
 	return <NoPurchasesMessage />;
+}
+
+export default function SubscriptionsContentWrapper() {
+	const isFetchingPurchases = useSelector( ( state ) => isFetchingSitePurchases( state ) );
+	const hasLoadedPurchases = useSelector( ( state ) => hasLoadedSitePurchasesFromServer( state ) );
+	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
+
+	return (
+		<SubscriptionsContent
+			isFetchingPurchases={ isFetchingPurchases }
+			hasLoadedPurchases={ hasLoadedPurchases }
+			selectedSiteId={ selectedSiteId }
+			selectedSite={ selectedSite }
+			purchases={ purchases }
+		/>
+	);
 }
 
 function NoPurchasesMessage() {

--- a/client/state/purchases/reducer.js
+++ b/client/state/purchases/reducer.js
@@ -128,17 +128,21 @@ const reducer = withoutPersistence( ( state = initialState, action ) => {
 			return {
 				...state,
 				error: action.error,
+				hasLoadedSitePurchasesFromServer: true,
+				hasLoadedUserPurchasesFromServer: true,
 			};
 		case PURCHASES_SITE_FETCH_FAILED:
 			return {
 				...state,
 				error: action.error,
+				hasLoadedSitePurchasesFromServer: true,
 				isFetchingSitePurchases: false,
 			};
 		case PURCHASES_USER_FETCH_FAILED:
 			return {
 				...state,
 				error: action.error,
+				hasLoadedUserPurchasesFromServer: true,
 				isFetchingUserPurchases: false,
 			};
 	}

--- a/client/state/purchases/reducer.js
+++ b/client/state/purchases/reducer.js
@@ -85,8 +85,6 @@ function updatePurchases( existingPurchases, action ) {
 	return purchases;
 }
 
-const assignError = ( state, action ) => ( { ...state, error: action.error } );
-
 const reducer = withoutPersistence( ( state = initialState, action ) => {
 	switch ( action.type ) {
 		case PURCHASES_REMOVE:
@@ -127,11 +125,22 @@ const reducer = withoutPersistence( ( state = initialState, action ) => {
 				hasLoadedUserPurchasesFromServer: true,
 			};
 		case PURCHASE_REMOVE_FAILED:
-			return assignError( state, action );
+			return {
+				...state,
+				error: action.error,
+			};
 		case PURCHASES_SITE_FETCH_FAILED:
-			return assignError( state, action );
+			return {
+				...state,
+				error: action.error,
+				isFetchingSitePurchases: false,
+			};
 		case PURCHASES_USER_FETCH_FAILED:
-			return assignError( state, action );
+			return {
+				...state,
+				error: action.error,
+				isFetchingUserPurchases: false,
+			};
 	}
 
 	return state;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The client/state/purchases reducer has actions to set four boolean variables: `isFetchingSitePurchases`, `isFetchingUserPurchases`, `hasLoadedSitePurchases`, and `hasLoadedUserPurchases`. These are changed when fetching starts and ends. However, if there is an error during fetching, they are left in their previous state. This can cause components that rely on their data to think they never finish fetching.

This PR changes the reducer's error actions such that all those booleans are reset when an error occurrs.

#### Testing instructions

- Visit http://calypso.localhost:3000/purchases/subscriptions/:siteSlug for a site that you are an Editor for.
- Verify that you see the "Looking to upgrade" upsell and that the page finishes loading.