### PR TITLE
Hide plan nav  from non site owners or admins (1)

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -550,8 +550,22 @@ export class MySitesSidebar extends Component {
 	}
 
 	planMenu() {
+		const { canUserManageOptions, site, isWpMobile } = this.props;
+
+		if ( ! site ) {
+			return null;
+		}
+
+		if ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) {
+			return null;
+		}
+
+		if ( ! canUserManageOptions ) {
+			return null;
+		}
+
 		// Hide "Plans" because the App/Play Stores reject apps that present non In-App Purchase flows, even in a WebView
-		if ( this.props.isWpMobile ) {
+		if ( isWpMobile ) {
 			return null;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR hides the plans navigation from non site-owners and non-admins. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/94965339-49eae300-04c9-11eb-8077-f18fc41163c2.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/94965373-5bcc8600-04c9-11eb-83cb-9d33ea18cf7d.png)


#### Testing instructions

* Login as any non admin or non site-owner user type and confirm the Plan navigation is not there.


