### PR TITLE
Layout: AsyncLoad GdprBanner in LayoutLoggedOut

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -22,7 +22,6 @@ import getCurrentQueryArguments from 'state/selectors/get-current-query-argument
 import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
 import { getSection, masterbarIsVisible } from 'state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
-import GdprBanner from 'blocks/gdpr-banner';
 import wooDnaConfig from 'jetpack-connect/woo-dna-config';
 
 /**
@@ -120,7 +119,9 @@ const LayoutLoggedOut = ( {
 					{ secondary }
 				</div>
 			</div>
-			{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
+			{ config.isEnabled( 'gdpr-banner' ) && (
+				<AsyncLoad require="blocks/gdpr-banner" placeholder={ null } />
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
In #38599 we started loading `GdprBanner` asynchronously in the logged-in layout component. This PR is doing it for the logged-out layout component, and that allows us to remove it from the main entry point. This reduces the main entry point (gzipped) by 0.5%.

#### Changes proposed in this Pull Request

* Layout: AsyncLoad `GdprBanner` in `LayoutLoggedOut`.

#### Testing instructions

* Delete the `sensitive_pixel_option` cookie if you have it.
* Go to  http://calypso.localhost:3000?flags=gdpr-banner
* If you're not in a GDPR-enabled country, you will have to enable `isCurrentUserMaybeInGdprZone` to return `true`.
* Verify you can still see the GDPR banner.
