### PR TITLE
Update: GA upsell banner for Jetpack Security.

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -28,12 +28,12 @@ import { isJetpackSite } from 'state/sites/selectors';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { shouldShowOfferResetFlow } from 'lib/plans/config';
 import { FEATURE_GOOGLE_ANALYTICS, TYPE_PREMIUM, TERM_ANNUALLY } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 import { localizeUrl } from 'lib/i18n-utils';
+import { OPTIONS_JETPACK_SECURITY } from 'calypso/my-sites/plans-v2/constants';
 
 const validateGoogleAnalyticsCode = ( code ) => ! code || code.match( /^UA-\d+-\d+$/i );
 
@@ -108,22 +108,28 @@ export class GoogleAnalyticsForm extends Component {
 		const wooCommerceActive = wooCommercePlugin ? wooCommercePlugin.active : false;
 
 		const nudgeTitle = siteIsJetpack
-			? translate(
-					'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional'
-			  )
+			? translate( 'Connect your site to Google Analytics' )
 			: translate( 'Connect your site to Google Analytics in seconds with the Premium plan' );
 
-		const nudge = shouldShowOfferResetFlow() ? null : (
-			<UpsellNudge
-				description={ translate(
-					"Add your unique tracking ID to monitor your site's performance in Google Analytics."
-				) }
-				event={ 'google_analytics_settings' }
-				feature={ FEATURE_GOOGLE_ANALYTICS }
-				plan={ findFirstSimilarPlanKey( site.plan.product_slug, {
+		const plan = siteIsJetpack
+			? OPTIONS_JETPACK_SECURITY
+			: findFirstSimilarPlanKey( site.plan.product_slug, {
 					type: TYPE_PREMIUM,
 					...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
-				} ) }
+			  } );
+
+		const nudge = (
+			<UpsellNudge
+				description={
+					siteIsJetpack
+						? translate( "Monitor your site's views, clicks, and other important metrics" )
+						: translate(
+								"Add your unique tracking ID to monitor your site's performance in Google Analytics."
+						  )
+				}
+				event={ 'google_analytics_settings' }
+				feature={ FEATURE_GOOGLE_ANALYTICS }
+				plan={ plan }
 				showIcon={ true }
 				title={ nudgeTitle }
 			/>

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -34,6 +34,7 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 import { localizeUrl } from 'lib/i18n-utils';
 import { OPTIONS_JETPACK_SECURITY } from 'calypso/my-sites/plans-v2/constants';
+import { getPathToDetails } from 'my-sites/plans-v2/utils';
 
 const validateGoogleAnalyticsCode = ( code ) => ! code || code.match( /^UA-\d+-\d+$/i );
 
@@ -112,11 +113,15 @@ export class GoogleAnalyticsForm extends Component {
 			: translate( 'Connect your site to Google Analytics in seconds with the Premium plan' );
 
 		const plan = siteIsJetpack
-			? OPTIONS_JETPACK_SECURITY
+			? null
 			: findFirstSimilarPlanKey( site.plan.product_slug, {
 					type: TYPE_PREMIUM,
 					...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
 			  } );
+
+		const href = siteIsJetpack
+			? getPathToDetails( '/plans', {}, OPTIONS_JETPACK_SECURITY, TERM_ANNUALLY, site.slug )
+			: null;
 
 		const nudge = (
 			<UpsellNudge
@@ -130,6 +135,7 @@ export class GoogleAnalyticsForm extends Component {
 				event={ 'google_analytics_settings' }
 				feature={ FEATURE_GOOGLE_ANALYTICS }
 				plan={ plan }
+				href={ href }
 				showIcon={ true }
 				title={ nudgeTitle }
 			/>

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -33,7 +33,7 @@ import { findFirstSimilarPlanKey } from 'lib/plans';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 import { localizeUrl } from 'lib/i18n-utils';
-import { OPTIONS_JETPACK_SECURITY } from 'calypso/my-sites/plans-v2/constants';
+import { OPTIONS_JETPACK_SECURITY } from 'my-sites/plans-v2/constants';
 import { getPathToDetails } from 'my-sites/plans-v2/utils';
 
 const validateGoogleAnalyticsCode = ( code ) => ! code || code.match( /^UA-\d+-\d+$/i );
@@ -113,7 +113,7 @@ export class GoogleAnalyticsForm extends Component {
 			: translate( 'Connect your site to Google Analytics in seconds with the Premium plan' );
 
 		const plan = siteIsJetpack
-			? null
+			? OPTIONS_JETPACK_SECURITY
 			: findFirstSimilarPlanKey( site.plan.product_slug, {
 					type: TYPE_PREMIUM,
 					...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
@@ -123,6 +123,7 @@ export class GoogleAnalyticsForm extends Component {
 			? getPathToDetails( '/plans', {}, OPTIONS_JETPACK_SECURITY, TERM_ANNUALLY, site.slug )
 			: null;
 
+		console.log( plan );
 		const nudge = (
 			<UpsellNudge
 				description={

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -123,7 +123,6 @@ export class GoogleAnalyticsForm extends Component {
 			? getPathToDetails( '/plans', {}, OPTIONS_JETPACK_SECURITY, TERM_ANNUALLY, site.slug )
 			: null;
 
-		console.log( plan );
 		const nudge = (
 			<UpsellNudge
 				description={

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -27,7 +27,6 @@ import {
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
 } from 'lib/plans/constants';
 import { OPTIONS_JETPACK_SECURITY } from 'my-sites/plans-v2/constants';
 

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -29,6 +29,7 @@ import {
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_PREMIUM,
 } from 'lib/plans/constants';
+import { OPTIONS_JETPACK_SECURITY } from 'my-sites/plans-v2/constants';
 
 /**
  * Internal dependencies
@@ -98,7 +99,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 
 	[ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ].forEach(
 		( product_slug ) => {
-			test( `Jetpack Premium for (${ product_slug })`, () => {
+			test( `Jetpack Security for (${ product_slug })`, () => {
 				const comp = shallow(
 					<GoogleAnalyticsForm
 						{ ...myProps }
@@ -108,7 +109,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 				);
 				expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
 				expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ).props().plan ).toBe(
-					PLAN_JETPACK_PREMIUM
+					OPTIONS_JETPACK_SECURITY
 				);
 			} );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently there is not Google Analytics Upsell banner showing for jetpack sites without a paid plan (Jetpack Free)

![Markup 2020-10-05 at 08 46 07](https://user-images.githubusercontent.com/11078128/95102514-55682500-06e8-11eb-9522-d493afb860b1.png)

Upsell banner should be showing like this:

![Markup 2020-10-05 at 08 53 26](https://user-images.githubusercontent.com/11078128/95102641-7761a780-06e8-11eb-9b83-c5187e2d3038.png)


#### Testing instructions

1. Before checkout out his PR, in Calypso select a site without a purchased plan (Jetpack Free), go to: **Tools** > **Marketing** > **Traffic** > Google Analytics, and observe that Google Analytics Upsell banner is not showing.  (This is the undesired behavior)
![Markup 2020-10-05 at 08 46 07](https://user-images.githubusercontent.com/11078128/95103530-8eed6000-06e9-11eb-92aa-2349a75aeef2.png)

2. Checkout this PR, in Calypso select a site without a purchased plan (Jetpack Free), go to: **Tools** > **Marketing** > **Traffic** > Google Analytics, and observe that Google Analytics Upsell banner is now showing:
    - verify that the upsell banner links to: `/plans/:site?feature=google-analytics&plan=jetpack_security`
    - Verify that the copy matches: https://docs.google.com/spreadsheets/d/1O3rYGU0vRrbhijJwWOd_40eehY5CD1tB_gGN7bKukAc/edit#gid=0&range=8:8
![Markup 2020-10-05 at 08 53 26](https://user-images.githubusercontent.com/11078128/95103544-93b21400-06e9-11eb-9d6c-66d5f16508a7.png)

3. Next select a site **with** a paid plan (ie- Jetpack Security), and verify that the Google Analytics options are showing:

![Screenshot on 2020-10-05 at 09-08-24](https://user-images.githubusercontent.com/11078128/95104170-644fd700-06ea-11eb-856c-fd07a745e452.png)


Fixes 1196341175636977-as-1196942190681399/f