### PR TITLE
Notifications: Support more elements and styling from block editor customizations

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -78,8 +78,12 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 		case 'p':
 		case 'div':
 		case 'code':
+		case 'span':
 		case 'strong':
 		case 'em':
+		case 'sub':
+		case 'sup':
+		case 's':
 		case 'list':
 		case 'h1':
 		case 'h2':

--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -28,6 +28,41 @@
 		text-align: left;
 	}
 
+	.uppercase {
+		text-transform: uppercase;
+	}
+
+	.has-drop-cap:not( :focus )::first-letter {
+		font-weight: bold;
+		line-height: 0.66;
+		text-transform: uppercase;
+		font-style: normal;
+		float: left;
+		font-size: calc( 2 * 2.25rem );
+		margin: 0.05em 0.1em 0 0;
+	}
+
+	.has-drop-cap:not( :focus )::after {
+		content: '';
+		display: table;
+		clear: both;
+		padding-top: 14px;
+	}
+
+	.wpnc__sub {
+		font-size: smaller;
+		vertical-align: sub;
+	}
+
+	.wpnc__sup {
+		font-size: smaller;
+		vertical-align: super;
+	}
+
+	.wpnc__em {
+		font-style: italic;
+	}
+
 	h1,
 	h2,
 	h3,

--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -28,6 +28,10 @@
 		text-align: left;
 	}
 
+	.has-text-align-justify {
+		text-align: justify;
+	}
+
 	.uppercase {
 		text-transform: uppercase;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*Currently, `p` elements, or paragraphs that are customized with certain styles are not reflected in specific notifications when a user clicks on the notifications button at the top right of the screen on the Home page.
*This PR supports the following styling made in the block editor (and applied to a post), when viewed as a notification

1. Left alignment
2. Center alignment
3. Right alignment
4. Justified paragraphs
5. Italics
6. Strikethrough
7. Text color
8. Underline
9. Subscript
10. Superscript
11. Uppercase
12. Drop cap paragraphs

#### Outstanding
1. Body font color in the body of the post is inconsistent with the body of the notification
2. Paragraph background color is applied via a single class, but the style varies
3. Paragraph text color is applied via a single class, but the style varies

Can we somehow get the styles of a class and transfer those styles to the `style` attribute of an element? Welcoming suggestions!

#### Testing instructions
1. Apply D50602-code
2. See the"Creating post notification" section in README at `apps/notifications/src/doc/note-rendering.md`
3. Use the "Follow" button that appears in the bottom right corner of the blog to add it to your Reader subscriptions:
4. Then navigate to https://wordpress.com/following/manage and enable "Notify me of new posts" for the blog. With this enabled, future posts on that blog will appear as notifications in your masterbar.
5. Create a post for the blog you're following with text/paragraphs with the styling listed above.
6. Go to your masterbar and select the notification that contains the styling. Confirm the styling is consistent with with post styling.

Before | After
--- | ---
<img width="500" alt="Screen Shot 2020-10-01 at 12 58 51 PM" src="https://user-images.githubusercontent.com/349751/94857877-0a4bca80-03e7-11eb-97e1-1fb5079ae2b0.png"> | <img width="522" alt="Screen Shot 2020-10-03 at 6 09 36 PM" src="https://user-images.githubusercontent.com/66652282/95002945-868d0c00-05a7-11eb-879f-1b396d3d07e2.png"> <img width="522" alt="Screen Shot 2020-10-03 at 6 09 44 PM" src="https://user-images.githubusercontent.com/66652282/95002946-87be3900-05a7-11eb-843e-514428f6704e.png">


Fixes #46109