### PR TITLE
Remove use_patterns flag on template/demo endpoint for Gutenboarding preview

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -80,7 +80,6 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 						font_headings: selectedFonts.headings,
 						font_base: selectedFonts.base,
 					} ),
-					use_patterns: true,
 				} );
 				if ( isEnabled( 'gutenboarding/style-preview-verticals' ) ) {
 					url = addQueryArgs( url, {


### PR DESCRIPTION
This is a tiny janitorial PR: now that D50472-code has landed, remove the `use_patterns` flag from the url for the `template/demo` endpoint since it is no longer needed. (The `use_patterns` flag on the sites/new endpoint is still needed)

#### Changes proposed in this Pull Request

* Remove `use_patterns` flag from `template/demo` endpoint design preview in Gutenboarding

#### Screenshot

![image](https://user-images.githubusercontent.com/14988353/95032955-3083aa00-0708-11eb-9f50-19d4c00ce4ca.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to calypso.localhost:3000/new/ko and preview a few of the Gutenboarding designs (e.g. select Cassel or Stratford), and on the `style` step, make sure that the translated preview is loaded.

Part of #46118 