### PR TITLE
Reader: if an image URL can't be made safe, discard it before the post card type is chosen

### DIFF
--- a/client/lib/post-normalizer/rule-keep-valid-images.js
+++ b/client/lib/post-normalizer/rule-keep-valid-images.js
@@ -1,22 +1,22 @@
 /**
  * External dependencies
  */
-
 import { filter } from 'lodash';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
+import safeImageUrl from 'lib/safe-image-url';
 
-function imageHasMinWidthAndHeight( width, height ) {
+function isValidImage( width, height ) {
 	return function ( image ) {
-		return image.width >= width && image.height >= height;
+		return image.width >= width && image.height >= height && safeImageUrl( image.src );
 	};
 }
 
 export default function keepValidImages( minWidth, minHeight ) {
 	return function keepValidImagesForWidthAndHeight( post ) {
-		const imageFilter = imageHasMinWidthAndHeight( minWidth, minHeight );
+		const imageFilter = isValidImage( minWidth, minHeight );
 		if ( post.images ) {
 			post.images = filter( post.images, imageFilter );
 		}

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -589,9 +589,9 @@ describe( 'index', () => {
 	} );
 
 	describe( 'keepValidImages', () => {
-		test( 'should filter post.images based on size', () => {
+		test( 'should filter post.images and post.content_images based on size', () => {
 			function fakeImage( width, height ) {
-				return { width, height };
+				return { width, height, src: 'http://example.com/giraffe.jpg' };
 			}
 
 			const post = {
@@ -608,6 +608,32 @@ describe( 'index', () => {
 
 			expect( normalized.images ).toHaveLength( 1 );
 			expect( normalized.content_images ).toHaveLength( 2 );
+		} );
+
+		test( 'should filter post.images and post.content_images for unsafe URLs', () => {
+			function fakeImage( src ) {
+				return { width: 500, height: 500, src };
+			}
+
+			const goodSrc = 'http://example.com/giraffe.jpg';
+			// External images with query string parameters that aren't related to image formatting
+			// should be omitted
+			const badSrc = 'http://example.com/adserver?ad=123456';
+
+			const post = {
+				images: [ fakeImage( goodSrc ), fakeImage( goodSrc ), fakeImage( badSrc ) ],
+				content_images: [
+					fakeImage( goodSrc ),
+					fakeImage( goodSrc ),
+					fakeImage( goodSrc ),
+					fakeImage( badSrc ),
+				],
+			};
+
+			const normalized = keepValidImages( 100, 200 )( post );
+
+			expect( normalized.images ).toHaveLength( 2 );
+			expect( normalized.content_images ).toHaveLength( 3 );
 		} );
 	} );
 

--- a/client/lib/post-normalizer/test/mocks/lib/safe-image-url.js
+++ b/client/lib/post-normalizer/test/mocks/lib/safe-image-url.js
@@ -11,6 +11,9 @@ let returnValue;
 
 function makeSafe( url ) {
 	const parts = getUrlParts( url );
+	if ( parts.searchParams.get( 'ad' ) ) {
+		return null;
+	}
 	if ( ! parts.protocol ) {
 		parts.protocol = 'fake';
 	}

--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -54,6 +54,10 @@ export default function safeImageUrl( url ) {
 		return null;
 	}
 
+	if ( url.length < 1 ) {
+		return null;
+	}
+
 	if ( REGEX_EXEMPT_URL.test( url ) ) {
 		return url;
 	}
@@ -83,6 +87,7 @@ export default function safeImageUrl( url ) {
 		if ( ! parsedUrl?.protocol ) {
 			parsedUrl.protocol = 'https';
 		}
+
 		url = getUrlFromParts( parsedUrl ).toString();
 	}
 


### PR DESCRIPTION
Discussed in p5PDj3-4Up-p2.

#### Changes proposed in this Pull Request

As of https://github.com/Automattic/wp-calypso/pull/45503, Reader's image filtering discards any image that has a query string _after_ we’ve taken off known Photon size parameters like `w` and `quality`.

However, we don't do this check until quite late in the rendering process, after we've chosen what type of card to display. If there are images that don't meet the standard, they remain in `post.images` and we end up with missing images displayed like this:

<img width="743" alt="screen-shot-2020-10-05-at-16 50 51" src="https://user-images.githubusercontent.com/17325/95042744-52e0ec00-0737-11eb-9c5a-10e416d0c5e6.png">

This PR adds an earlier `safeImageUrl` check to the 'keep valid images' rule, so any URL that we can't make safe is removed from `post.images` and `post.content_images` before we choose a post card type.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit https://wordpress.com/read/feeds/98993195.

Without the PR, there'll be a bunch of empty images (all ads from a8.net with a query string):

<img width="743" alt="screen-shot-2020-10-05-at-16 51 08" src="https://user-images.githubusercontent.com/17325/95042928-cd117080-0737-11eb-8ac5-fa34ee9bae48.png">

With the PR applied, there'll be fewer gallery cards, but no missing images.

<img width="835" alt="Screen Shot 2020-10-05 at 18 24 23" src="https://user-images.githubusercontent.com/17325/95042990-0649e080-0738-11eb-876c-ea37e724ba21.png">

You can also run the unit tests with `yarn test-client client/lib/post-normalizer`.