### PR TITLE
Components: Use textarea components everywhere

### DIFF
--- a/apps/notifications/src/panel/templates/comment-reply-input.jsx
+++ b/apps/notifications/src/panel/templates/comment-reply-input.jsx
@@ -314,6 +314,7 @@ const CommentReplyInput = createReactClass( {
 		return (
 			<div className="wpnc__reply-box">
 				<textarea
+					className="form-textarea"
 					ref={ this.storeReplyInput }
 					rows={ this.state.rowCount }
 					value={ value }

--- a/client/blocks/user-mentions/README.md
+++ b/client/blocks/user-mentions/README.md
@@ -8,10 +8,11 @@ It also provides the components `UserMentionsSuggestionList` and `UserMentionsSu
 ## How to use
 
 ```js
+import FormTextarea from 'components/forms/form-textarea';
 import withUserMentions from 'blocks/user-mentions';
 
 const ExampleInput = React.forwardRef( ( props, ref ) => (
-	<textarea ref={ ref } onKeyUp={ props.onKeyUp } onKeyDown={ props.onKeyDown } />
+	<FormTextarea forwardedRef={ ref } onKeyUp={ props.onKeyUp } onKeyDown={ props.onKeyDown } />
 ) );
 
 export default withUserMentions( ExampleInput );

--- a/client/blocks/user-mentions/docs/example-input.jsx
+++ b/client/blocks/user-mentions/docs/example-input.jsx
@@ -1,15 +1,16 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import addUserMentions from '../add';
+import FormTextarea from 'components/forms/form-textarea';
 
 const UserMentionsExampleInput = React.forwardRef( ( props, ref ) => (
-	<textarea ref={ ref } onKeyUp={ props.onKeyUp } onKeyDown={ props.onKeyDown } />
+	<FormTextarea forwardedRef={ ref } onKeyUp={ props.onKeyUp } onKeyDown={ props.onKeyDown } />
 ) );
 
 export default addUserMentions( UserMentionsExampleInput );

--- a/client/components/happychat/composer.jsx
+++ b/client/components/happychat/composer.jsx
@@ -10,8 +10,9 @@ import { get, isEmpty, throttle } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
+import FormTextarea from 'components/forms/form-textarea';
 import scrollbleed from './scrollbleed';
+import { Button } from '@automattic/components';
 
 /**
  * Style dependencies
@@ -81,9 +82,9 @@ export const Composer = createReactClass( {
 				onMouseLeave={ this.scrollbleedUnlock }
 			>
 				<div className="happychat__message">
-					<textarea
+					<FormTextarea
 						aria-label="Enter your support request"
-						ref={ this.setScrollbleedTarget }
+						forwardedRef={ this.setScrollbleedTarget }
 						onFocus={ onFocus }
 						placeholder={ translate( 'Type a message…' ) }
 						onChange={ this.onChange }

--- a/client/components/happychat/test/composer.jsx
+++ b/client/components/happychat/test/composer.jsx
@@ -1,8 +1,12 @@
 /**
+ * @jest-environment jsdom
+ */
+
+/**
  * External dependencies
  */
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { noop } from 'lodash';
 
 /**
@@ -16,7 +20,7 @@ describe( '<Composer />', () => {
 			const onSendNotTyping = jest.fn();
 			const onSendTyping = jest.fn();
 			const onSetCurrentMessage = jest.fn();
-			const wrapper = shallow(
+			const wrapper = mount(
 				<Composer
 					message={ 'hey' }
 					onSetCurrentMessage={ onSetCurrentMessage }
@@ -35,7 +39,7 @@ describe( '<Composer />', () => {
 			const onSendNotTyping = jest.fn();
 			const onSendTyping = jest.fn();
 			const onSetCurrentMessage = jest.fn();
-			const wrapper = shallow(
+			const wrapper = mount(
 				<Composer
 					message={ '' }
 					onSetCurrentMessage={ onSetCurrentMessage }
@@ -55,7 +59,7 @@ describe( '<Composer />', () => {
 		test( 'should call message and noTyping props if message is not empty', () => {
 			const onSendMessage = jest.fn();
 			const onSendNotTyping = jest.fn();
-			const wrapper = shallow(
+			const wrapper = mount(
 				<Composer
 					message={ 'hey' }
 					onSendMessage={ onSendMessage }
@@ -71,7 +75,7 @@ describe( '<Composer />', () => {
 		test( 'should call message and noTyping props if message is empty', () => {
 			const onSendMessage = jest.fn();
 			const onSendNotTyping = jest.fn();
-			const wrapper = shallow(
+			const wrapper = mount(
 				<Composer
 					message={ '' }
 					onSendMessage={ onSendMessage }

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -82,6 +82,7 @@ import wpEmojiPlugin from './plugins/wpemoji/plugin';
 /**
  * Internal Dependencies
  */
+import FormTextarea from 'components/forms/form-textarea';
 import i18n from './i18n';
 import config from 'config';
 import { decodeEntities, wpautop, removep } from 'lib/formatting';
@@ -573,8 +574,8 @@ export default class TinyMCE extends React.Component {
 						onToolbarChangeContent={ this.onToolbarChangeContent }
 					/>
 				) }
-				<textarea
-					ref={ this.textInput }
+				<FormTextarea
+					forwardedRef={ this.textInput }
 					className={ className }
 					id={ this._id }
 					onChange={ this.onTextAreaChange }

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
@@ -15,6 +15,7 @@ import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSelect from 'calypso/components/forms/form-select';
+import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 
 const textField = ( field, index ) => (
@@ -27,7 +28,7 @@ const textField = ( field, index ) => (
 const textarea = ( field, index ) => (
 	<PreviewFieldset key={ 'contact-form-field-' + index }>
 		<PreviewLegend { ...field } />
-		<textarea />
+		<FormTextarea />
 	</PreviewFieldset>
 );
 

--- a/client/devdocs/design/wordpress-components-gallery/base-control.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/base-control.tsx
@@ -2,15 +2,16 @@
  * External dependencies
  */
 import React from 'react';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { BaseControl } from '@wordpress/components';
+import { BaseControl, TextareaControl } from '@wordpress/components';
 
 const BaseControlExample = () => (
 	<BaseControl id="textarea-1" label="Text" help="Enter some text">
-		<textarea id="textarea-1" />
+		<TextareaControl onChange={ noop } />
 	</BaseControl>
 );
 

--- a/client/extensions/woocommerce/app/reviews/review-reply-create.js
+++ b/client/extensions/woocommerce/app/reviews/review-reply-create.js
@@ -13,9 +13,10 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import FormTextarea from 'components/forms/form-textarea';
+import Gravatar from 'components/gravatar';
 import { createReviewReply } from 'woocommerce/state/sites/review-replies/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
-import Gravatar from 'components/gravatar';
 import { successNotice } from 'state/notices/actions';
 
 // Matches comments reply box heights
@@ -130,13 +131,13 @@ class ReviewReplyCreate extends Component {
 
 		return (
 			<form className="reviews__reply-textarea">
-				<textarea
+				<FormTextarea
 					className={ textareaClasses }
 					onBlur={ this.unsetFocus }
 					onChange={ this.onTextChange }
 					onFocus={ this.setFocus }
 					placeholder={ this.getTextareaPlaceholder() }
-					ref={ this.bindTextareaRef }
+					forwardedRef={ this.bindTextareaRef }
 					style={ textareaStyle }
 					value={ commentText }
 				/>

--- a/client/extensions/woocommerce/app/reviews/review-reply.js
+++ b/client/extensions/woocommerce/app/reviews/review-reply.js
@@ -29,6 +29,7 @@ import {
 	getReviewReplyEdits,
 } from 'woocommerce/state/ui/review-replies/selectors';
 import { getReviewReply } from 'woocommerce/state/sites/review-replies/selectors';
+import FormTextarea from 'components/forms/form-textarea';
 import Gravatar from './gravatar';
 import humanDate from 'lib/human-date';
 
@@ -102,7 +103,7 @@ class ReviewReply extends Component {
 		const { translate, editContent } = this.props;
 		return (
 			<div className="reviews__reply-edit">
-				<textarea onChange={ this.onTextChange } value={ editContent } />
+				<FormTextarea onChange={ this.onTextChange } value={ editContent } />
 
 				<div className="reviews__reply-edit-buttons">
 					<Button compact onClick={ this.onCancel }>

--- a/client/extensions/woocommerce/components/compact-tinymce/index.js
+++ b/client/extensions/woocommerce/components/compact-tinymce/index.js
@@ -11,9 +11,11 @@ import { ReactReduxContext } from 'react-redux';
 import tinymce from 'tinymce/tinymce';
 import 'tinymce/themes/modern/theme.js';
 import 'tinymce/plugins/lists/plugin.js';
+
 /**
  * Internal dependencies
  */
+import FormTextarea from 'components/forms/form-textarea';
 import i18n from 'components/tinymce/i18n';
 import { wpautop } from 'lib/formatting';
 // TinyMCE plugins & dependencies
@@ -169,7 +171,11 @@ class CompactTinyMCE extends Component {
 		const className = classNames( 'compact-tinymce', this.props.className );
 		return (
 			<div className={ className }>
-				<textarea ref={ this.setTextAreaRef } className={ tinyMCEClassName } id={ this._id } />
+				<FormTextarea
+					forwardedRef={ this.setTextAreaRef }
+					className={ tinyMCEClassName }
+					id={ this._id }
+				/>
 			</div>
 		);
 	}


### PR DESCRIPTION
This updates all remaining textarea fields to use `<FormTextarea />` or `<TextareaControl />` instead of a `<textarea />`. 

Part of #45259.

#### Changes proposed in this Pull Request

* Blocks: Update `UserMentions` to use `FormTextarea`
* Happychat: Update `Composer` to use `FormTextarea`
* Extensions: Use `FormTextarea` in WooCommerce extension
* Post Editor: Use `FormTextarea` for primary editor
* Post Editor: Use `FormTextarea` for contact form
* Notifications: Use `FormTextarea` for comment reply input
* DevDocs: Use `TextareaControl` in WP components gallery

#### Testing instructions

Compare the textarea fields in these instances and verify they look and function as they did before:

1. Where we now use `FormTextarea`:
* `/devdocs/blocks/user-mentions` - the textarea inside the example
* `components/happychat/composer.jsx` - enable yourself as a chat agent in https://hud-staging.happychat.io/ and initiate a chat, then compare the textarea for writing a chat message.
* `/store/product/:site/:productId` - for a WooCommerce store, editing the description of a product.
* `/store/reviews/approved/:site` - for a WooCommerce store, replying to a review and editing your own existing reply to a review.
* Classic Calypso editor - inserting a contact form and editing a textarea field.
* Classic Calypso editor - the main editor textarea.

2. Where only a classname is added without the `FormTextarea` component:
* `apps/notifications/src/panel/templates/comment-reply-input.jsx` - part of the notifications app which we don't use Calypso components for.  To test, try replying to a comment you received in the notifications panel.

3. Where we use WordPress components:
* `/devdocs/wordpress-components-gallery` - the textarea inside the Base Control.

#### Notes

* The remaining `<textarea />` instances are all parts of either documentation or tests.
* Linting errors in the notifications app are unrelated and expected.