### PR TITLE
Fix/cleanup logs

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -199,6 +199,7 @@
 		"to-title-case": "^1.0.0",
 		"tracekit": "^0.4.5",
 		"twemoji": "^12.1.4",
+		"ua-parser-js": "^0.7.22",
 		"url": "^0.11.0",
 		"use-subscription": "^1.3.0",
 		"utility-types": "^3.10.0",
@@ -218,8 +219,8 @@
 	},
 	"devDependencies": {
 		"autoprefixer": "^9.7.3",
-		"component-event":"^0.1.4",
-		"component-query":"^0.0.3",
+		"component-event": "^0.1.4",
+		"component-query": "^0.0.3",
 		"postcss-custom-properties": "^9.1.1"
 	}
 }

--- a/client/server/middleware/logger.js
+++ b/client/server/middleware/logger.js
@@ -35,6 +35,9 @@ const logRequest = ( req, res, options ) => {
 		version,
 		env,
 		userAgent: parseUA( req.get( 'user-agent' ) ),
+		rawUserAgent: req.get( 'user-agent' ),
+		remoteAddr: req.ip,
+		referrer: req.get( 'referer' ),
 	};
 
 	req.logger.info( fields );

--- a/client/server/middleware/logger.js
+++ b/client/server/middleware/logger.js
@@ -1,14 +1,29 @@
 /**
+ * External dependencies
+ */
+import uaParser from 'ua-parser-js';
+
+/**
  * Internal dependencies
  */
 import { getLogger } from 'server/lib/logger';
+import config from 'config';
 
 const NS_TO_MS = 1e-6;
 
-const logRequest = ( req, res, options ) => {
-	const { requestStart } = options;
+const parseUA = ( rawUA ) => {
+	const parsedUA = uaParser( rawUA );
+	if ( parsedUA.browser.name && parsedUA.browser.version ) {
+		const version = parsedUA.browser.version.split( '.' )[ 0 ];
+		return `${ parsedUA.browser.name } ${ version }`;
+	}
+	return rawUA;
+};
 
-	let fields = {
+const logRequest = ( req, res, options ) => {
+	const { requestStart, env, version } = options;
+
+	const fields = {
 		method: req.method,
 		status: res.statusCode,
 		length: res.get( 'content-length' ),
@@ -16,28 +31,24 @@ const logRequest = ( req, res, options ) => {
 		duration: Number(
 			( Number( process.hrtime.bigint() - requestStart ) * NS_TO_MS ).toFixed( 3 )
 		),
+		httpVersion: req.httpVersion,
+		version,
+		env,
+		userAgent: parseUA( req.get( 'user-agent' ) ),
 	};
-
-	if ( process.env.NODE_ENV === 'production' ) {
-		// Standard Apache combined log output minus the remote-user
-		fields = {
-			...fields,
-			remoteAddr: req.ip,
-			httpVersion: req.httpVersionMajor + '.' + req.httpVersionMinor,
-			referrer: req.get( 'referer' ),
-			userAgent: req.get( 'user-agent' ),
-		};
-	}
 
 	req.logger.info( fields );
 };
 
 export default () => {
 	const logger = getLogger();
+	const env = config( 'env_id' );
+	const version = process.env.COMMIT_SHA;
+
 	return ( req, res, next ) => {
 		req.logger = logger;
 		const requestStart = process.hrtime.bigint();
-		res.on( 'finish', () => logRequest( req, res, { requestStart } ) );
+		res.on( 'finish', () => logRequest( req, res, { requestStart, env, version } ) );
 		next();
 	};
 };

--- a/client/server/middleware/test/logger.js
+++ b/client/server/middleware/test/logger.js
@@ -7,6 +7,7 @@ import EventEmitter from 'events';
  * Internal dependencies
  */
 import loggerMiddleware from '../logger';
+import config from 'config';
 
 const mockLogger = {
 	info: jest.fn(),
@@ -14,20 +15,19 @@ const mockLogger = {
 jest.mock( 'server/lib/logger', () => ( {
 	getLogger: () => mockLogger,
 } ) );
+jest.mock( 'config', () => jest.fn() );
 
-const withRequest = ( { method, url, ip, httpVersionMajor, httpVersionMinor, headers } ) => {
+const fakeRequest = ( { method, url, ip, httpVersion, headers = {} } = {} ) => {
 	const req = new EventEmitter();
 	req.method = method;
 	req.originalUrl = url;
 	req.ip = ip;
 	req.get = ( header ) => headers[ header.toLowerCase() ];
-
-	req.httpVersionMajor = httpVersionMajor;
-	req.httpVersionMinor = httpVersionMinor;
+	req.httpVersion = httpVersion;
 	return req;
 };
 
-const withResponse = ( { statusCode, headers } ) => {
+const fakeResponse = ( { statusCode, headers = {} } = {} ) => {
 	const res = new EventEmitter();
 	res.headersSent = true;
 	res.get = ( header ) => headers[ header.toLowerCase() ];
@@ -35,13 +35,29 @@ const withResponse = ( { statusCode, headers } ) => {
 	return res;
 };
 
-const withNodeEnv = ( env ) => {
-	const current = process.env.NODE_ENV;
-	process.env.NODE_ENV = env;
+const withCommitSha = ( sha ) => {
+	const current = process.env.COMMIT_SHA;
+	process.env.COMMIT_SHA = sha;
 
 	afterAll( () => {
-		process.env.NODE_ENV = current;
+		process.env.COMMIT_SHA = current;
 	} );
+};
+
+const withEnv = ( env ) => {
+	config.mockImplementation( ( key ) => {
+		if ( key === 'env_id' ) return env;
+	} );
+
+	afterAll( () => {
+		config.reset();
+	} );
+};
+
+const simulateRequest = ( { req, res, delay } ) => {
+	loggerMiddleware()( req, res, () => {} );
+	jest.advanceTimersByTime( delay );
+	res.emit( 'finish' );
 };
 
 beforeEach( () => {
@@ -54,75 +70,78 @@ afterEach( () => {
 } );
 
 it( 'Adds a `logger` property to the request', () => {
-	const req = withRequest( {} );
-	const res = withResponse( {} );
-	const next = () => {};
+	const req = fakeRequest();
 
-	loggerMiddleware()( req, res, next );
+	simulateRequest( {
+		req,
+		res: fakeResponse(),
+	} );
 
 	expect( req.logger ).toBe( mockLogger );
 } );
 
-it( 'When the response ends, it logs info about the request in dev mode', () => {
-	withNodeEnv( 'development' );
-	const req = withRequest( {
-		method: 'GET',
-		url: '/example.html',
-	} );
-	const res = withResponse( {
-		statusCode: '200',
-		headers: {
-			'content-length': 123,
-		},
-	} );
+it( 'It logs info about the request', () => {
+	withEnv( 'production' );
 
-	loggerMiddleware()( req, res, () => {} );
-	jest.advanceTimersByTime( 100 );
-	res.emit( 'finish' );
+	simulateRequest( {
+		req: fakeRequest( {
+			method: 'GET',
+			httpVersion: '2.0',
+			headers: {
+				'user-agent':
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36',
+			},
+			url: '/example.html',
+		} ),
+		res: fakeResponse( {
+			statusCode: '200',
+			headers: {
+				'content-length': 123,
+			},
+		} ),
+		delay: 100,
+	} );
 
 	expect( mockLogger.info ).toHaveBeenCalledWith( {
 		length: 123,
 		duration: 100,
 		status: '200',
 		method: 'GET',
+		env: 'production',
 		url: '/example.html',
+		httpVersion: '2.0',
+		userAgent: 'Chrome 85',
 	} );
 } );
 
-it( 'When the response ends, it logs info about the request in production mode', () => {
-	withNodeEnv( 'production' );
-	const req = withRequest( {
-		method: 'GET',
-		url: '/example.html',
-		ip: '127.0.0.1',
-		user: 'foo',
-		httpVersionMajor: 2,
-		httpVersionMinor: 0,
-		headers: {
-			referer: 'http://wordpress.com',
-			'user-agent': 'Chrome',
-		},
-	} );
-	const res = withResponse( {
-		statusCode: '200',
-		headers: {
-			'content-length': 123,
-		},
+it( "Logs raw UserAgent if it can't be parsed", () => {
+	simulateRequest( {
+		req: fakeRequest( {
+			headers: {
+				'user-agent': 'A random browser',
+			},
+		} ),
+		res: fakeResponse(),
 	} );
 
-	loggerMiddleware()( req, res, () => {} );
-	jest.advanceTimersByTime( 100 );
-	res.emit( 'finish' );
+	expect( mockLogger.info ).toHaveBeenCalledWith(
+		expect.objectContaining( {
+			userAgent: 'A random browser',
+		} )
+	);
+} );
 
-	expect( mockLogger.info ).toHaveBeenCalledWith( {
-		length: 123,
-		duration: 100,
-		status: '200',
-		method: 'GET',
-		url: '/example.html',
-		remoteAddr: '127.0.0.1',
-		httpVersion: '2.0',
-		referrer: 'http://wordpress.com',
-		userAgent: 'Chrome',
+it( 'Adds the COMMIT_SHA as version', () => {
+	withCommitSha( 'abcd1234' );
+
+	simulateRequest( {
+		req: fakeRequest(),
+		res: fakeResponse(),
 	} );
+
+	expect( mockLogger.info ).toHaveBeenCalledWith(
+		expect.objectContaining( {
+			version: 'abcd1234',
+		} )
+	);
 } );

--- a/client/server/middleware/test/logger.js
+++ b/client/server/middleware/test/logger.js
@@ -90,8 +90,10 @@ it( 'It logs info about the request', () => {
 			headers: {
 				'user-agent':
 					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36',
+				referer: 'https://wordpress.com',
 			},
 			url: '/example.html',
+			ip: '127.0.0.1',
 		} ),
 		res: fakeResponse( {
 			statusCode: '200',
@@ -111,6 +113,10 @@ it( 'It logs info about the request', () => {
 		url: '/example.html',
 		httpVersion: '2.0',
 		userAgent: 'Chrome 85',
+		rawUserAgent:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36',
+		remoteAddr: '127.0.0.1',
+		referrer: 'https://wordpress.com',
 	} );
 } );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -27787,6 +27787,11 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
   integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
 
+ua-parser-js@^0.7.22:
+  version "0.7.22"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.22.tgz#960df60a5f911ea8f1c818f3747b99c6e177eae3"
+  integrity sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==
+
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Get `httpVersion` [from Node API](https://nodejs.org/api/http.html#http_message_httpversion) instead of composing it ourselves.
* Parse User Agent
* Add commit hash and environment
* Drop remoteAddr and referrer
* Log the same thing in development and production modes

#### Testing instructions

Start the server with `COMMIT_SHA=1234 NODE_ENV=production yarn start` and go to local calypso. In the console, verify:
  * The fields `userAgent` and `httpVersion` are there and the values make sense.
  * The new fields `version` and `env` are also there
  * The fields `remoteAddr` and `referrer` are gone
