### PR TITLE
Post Editor: Use FormLabel instead of <label />

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -11,6 +11,7 @@ import Gridicon from 'components/gridicon';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
+import FormLabel from 'components/forms/form-label';
 import FormToggle from 'components/forms/form-toggle/compact';
 import * as postUtils from 'state/posts/utils';
 import InfoPopover from 'components/info-popover';
@@ -94,7 +95,7 @@ export class EditPostStatus extends Component {
 				{ this.renderPostScheduling() }
 				{ this.renderPostVisibility() }
 				{ showSticky && (
-					<label className="edit-post-status__sticky">
+					<FormLabel className="edit-post-status__sticky">
 						<span className="edit-post-status__label-text">
 							{ translate( 'Stick to the top of the blog' ) }
 							<InfoPopover position="top right" gaEventCategory="Editor" popoverName="Sticky Post">
@@ -106,10 +107,10 @@ export class EditPostStatus extends Component {
 							onChange={ this.toggleStickyStatus }
 							aria-label={ translate( 'Stick post to the front page' ) }
 						/>
-					</label>
+					</FormLabel>
 				) }
 				{ showPending && (
-					<label className="edit-post-status__pending-review">
+					<FormLabel className="edit-post-status__pending-review">
 						<span className="edit-post-status__label-text">
 							{ translate( 'Pending review' ) }
 							<InfoPopover position="top right">
@@ -121,7 +122,7 @@ export class EditPostStatus extends Component {
 							onChange={ this.togglePendingStatus }
 							aria-label={ translate( 'Request review for post' ) }
 						/>
-					</label>
+					</FormLabel>
 				) }
 				{ showRevertToDraft && (
 					<Button

--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -1,9 +1,10 @@
-.edit-post-status__sticky,
-.edit-post-status__pending-review {
+.edit-post-status__sticky.form-label,
+.edit-post-status__pending-review.form-label {
 	align-content: center;
 	display: flex;
 	justify-content: space-between;
 	margin: 8px 0;
+	font-weight: 400;
 
 	.gridicon {
 		margin-top: 2px;

--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
  */
 import EditorFieldset from 'post-editor/editor-fieldset';
 import FormCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import { recordEditorEvent, recordEditorStat } from 'state/posts/stats';
@@ -106,7 +107,7 @@ export class EditorDiscussion extends React.Component {
 
 		return (
 			<EditorFieldset legend={ this.props.translate( 'Discussion' ) }>
-				<label>
+				<FormLabel>
 					<FormCheckbox
 						name="comment_status"
 						checked={ statusToBoolean( discussion.comment_status ) }
@@ -126,8 +127,8 @@ export class EditorDiscussion extends React.Component {
 							) }
 						</InfoPopover>
 					</span>
-				</label>
-				<label>
+				</FormLabel>
+				<FormLabel>
 					<FormCheckbox
 						name="ping_status"
 						checked={ statusToBoolean( discussion.ping_status ) }
@@ -166,7 +167,7 @@ export class EditorDiscussion extends React.Component {
 							) }
 						</InfoPopover>
 					</span>
-				</label>
+				</FormLabel>
 			</EditorFieldset>
 		);
 	}

--- a/client/post-editor/editor-drawer/label.jsx
+++ b/client/post-editor/editor-drawer/label.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import FormLabel from 'components/forms/form-label';
 import InfoPopover from 'components/info-popover';
 
 /**
@@ -17,13 +18,13 @@ import './label.scss';
 
 export default function EditorDrawerLabel( { children, labelText, helpText } ) {
 	return (
-		<label className="editor-drawer__label">
+		<FormLabel className="editor-drawer__label">
 			<span className="editor-drawer__label-text">
 				{ labelText }
 				{ helpText && <InfoPopover position="top left">{ helpText }</InfoPopover> }
 			</span>
 			{ children }
-		</label>
+		</FormLabel>
 	);
 }
 

--- a/client/post-editor/editor-drawer/label.scss
+++ b/client/post-editor/editor-drawer/label.scss
@@ -6,8 +6,8 @@
 	color: var( --color-text );
 	display: block;
 	font-size: $font-body-extra-small;
+	font-weight: 400;
 	line-height: 18px;
-	margin-bottom: 4px;
 }
 
 .editor-drawer__label-text .info-popover {

--- a/client/post-editor/editor-fieldset/style.scss
+++ b/client/post-editor/editor-fieldset/style.scss
@@ -11,7 +11,8 @@
 }
 
 .editor-fieldset__legend,
-.editor-fieldset__option {
+.editor-fieldset__option,
+.editor-fieldset__option .form-label {
 	margin: 4px 0;
 	font-size: $font-body-extra-small;
 }

--- a/client/post-editor/editor-page-order/index.jsx
+++ b/client/post-editor/editor-page-order/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import AccordionSection from 'components/accordion/section';
+import FormLabel from 'components/forms/form-label';
 import TextInput from 'components/forms/form-text-input';
 import { recordEditorEvent, recordEditorStat } from 'state/posts/stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -61,7 +62,7 @@ class EditorPageOrder extends Component {
 
 		return (
 			<AccordionSection className="editor-page-order">
-				<label>
+				<FormLabel>
 					<span className="editor-page-order__label-text">
 						{ translate( 'Order', { context: 'Editor: Field label for menu order.' } ) }
 					</span>
@@ -73,7 +74,7 @@ class EditorPageOrder extends Component {
 						onBlur={ this.editMenuOrder }
 						className="editor-page-order__input"
 					/>
-				</label>
+				</FormLabel>
 			</AccordionSection>
 		);
 	}

--- a/client/post-editor/editor-page-order/style.scss
+++ b/client/post-editor/editor-page-order/style.scss
@@ -6,6 +6,7 @@
 	color: var( --color-neutral-light );
 	display: block;
 	font-size: $font-body-extra-small;
+	font-weight: 400;
 	margin-bottom: 4px;
 	text-transform: uppercase;
 }

--- a/client/post-editor/editor-page-parent/style.scss
+++ b/client/post-editor/editor-page-parent/style.scss
@@ -15,6 +15,7 @@
 	color: var( --color-neutral-light );
 	display: block;
 	font-size: $font-body-extra-small;
+	font-weight: 400;
 	margin-bottom: 4px;
 	text-transform: uppercase;
 }

--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -13,6 +13,7 @@ import { includes, reduce } from 'lodash';
  * Internal dependencies
  */
 import Accordion from 'components/accordion';
+import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import PostMetadata from 'lib/post-metadata';
 import Sharing from './';
@@ -76,9 +77,9 @@ class EditorSharingAccordion extends React.Component {
 
 		return (
 			<div className={ classes }>
-				<label className="editor-sharing__shortlink-label" htmlFor="shortlink-field">
+				<FormLabel className="editor-sharing__shortlink-label" htmlFor="shortlink-field">
 					{ this.props.translate( 'Shortlink' ) }
-				</label>
+				</FormLabel>
 				<FormTextInput
 					className="editor-sharing__shortlink-field"
 					id="shortlink-field"

--- a/client/post-editor/editor-sharing/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/publicize-connection.jsx
@@ -12,6 +12,7 @@ import Gridicon from 'components/gridicon';
  * Internal dependencies
  */
 import FormCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 import PostMetadata from 'lib/post-metadata';
 import { addSiteFragment } from 'lib/route';
 import { recordEditorStat, recordEditorEvent } from 'state/posts/stats';
@@ -200,14 +201,14 @@ export class EditorSharingPublicizeConnection extends React.Component {
 		return (
 			<div className="editor-sharing__publicize-connection">
 				<QueryKeyringConnections />
-				<label>
+				<FormLabel>
 					<FormCheckbox
 						checked={ ! this.isConnectionSkipped() }
 						disabled={ this.isDisabled() }
 						onChange={ this.onChange }
 					/>
 					<span data-e2e-service={ label }>{ connection && connection.external_display }</span>
-				</label>
+				</FormLabel>
 				{ this.renderFacebookProfileWarning() }
 				{ this.renderBrokenConnection() }
 				{ this.renderMustReauthConnection() }

--- a/client/post-editor/editor-sharing/sharing-like-options.jsx
+++ b/client/post-editor/editor-sharing/sharing-like-options.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
  */
 import EditorFieldset from 'post-editor/editor-fieldset';
 import FormCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 import { recordEditorStat, recordEditorEvent } from 'state/posts/stats';
 import { isEditorNewPost, getEditorPostId } from 'state/editor/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -34,14 +35,14 @@ class SharingLikeOptions extends React.Component {
 		}
 
 		return (
-			<label>
+			<FormLabel>
 				<FormCheckbox
 					name="sharing_enabled"
 					checked={ this.props.isShowingSharingButtons }
 					onChange={ this.onChange }
 				/>
 				<span>{ this.props.translate( 'Show Sharing Buttons', { context: 'Post Editor' } ) }</span>
-			</label>
+			</FormLabel>
 		);
 	}
 
@@ -51,14 +52,14 @@ class SharingLikeOptions extends React.Component {
 		}
 
 		return (
-			<label>
+			<FormLabel>
 				<FormCheckbox
 					name="likes_enabled"
 					checked={ this.props.isShowingLikeButton }
 					onChange={ this.onChange }
 				/>
 				<span>{ this.props.translate( 'Show Like Button', { context: 'Post Editor' } ) }</span>
-			</label>
+			</FormLabel>
 		);
 	}
 

--- a/client/post-editor/editor-sharing/style.scss
+++ b/client/post-editor/editor-sharing/style.scss
@@ -21,8 +21,11 @@
 	}
 }
 
-.editor-sharing__shortlink-label {
+.editor-sharing__shortlink-label.form-label {
 	padding: 8px 0;
+	font-size: $font-body-extra-small;
+	font-weight: 400;
+	margin-bottom: 0;
 	display: block;
 	user-select: none;
 }
@@ -41,6 +44,12 @@ input[type='text'].form-text-input.editor-sharing__shortlink-field {
 	display: block;
 	font-size: $font-body-extra-small;
 	padding: 2px 0;
+
+	.form-label {
+		margin-bottom: 0;
+		font-size: $font-body-extra-small;
+		font-weight: 400;
+	}
 
 	label input[disabled] + span {
 		opacity: 0.5;

--- a/client/post-editor/media-modal/gallery-help.jsx
+++ b/client/post-editor/media-modal/gallery-help.jsx
@@ -13,6 +13,7 @@ import Gridicon from 'components/gridicon';
  * Internal dependencies
  */
 import Popover from 'components/popover';
+import FormLabel from 'components/forms/form-label';
 import FormCheckbox from 'components/forms/form-checkbox';
 import { Button } from '@automattic/components';
 import { setPreference, savePreference } from 'state/preferences/actions';
@@ -88,13 +89,13 @@ class EditorMediaModalGalleryHelp extends React.PureComponent {
 						</span>
 					</div>
 					<div className="editor-media-modal__gallery-help-actions">
-						<label className="editor-media-modal__gallery-help-remember-dismiss">
+						<FormLabel className="editor-media-modal__gallery-help-remember-dismiss">
 							<FormCheckbox
 								checked={ this.state.rememberDismiss }
 								onChange={ this.toggleRememberDismiss }
 							/>
 							<span>{ this.props.translate( "Don't show again" ) }</span>
-						</label>
+						</FormLabel>
 						<Button
 							onClick={ () => this.dismiss( { remember: this.state.rememberDismiss } ) }
 							compact


### PR DESCRIPTION
This PR replaces all raw `<label />` instances with `<FormLabel />` in the post editor section. Part of #45259.

#### Changes proposed in this Pull Request

* Post Editor: Use `<FormLabel />` instead of `<label />`.

#### Testing instructions

* Use the Calypso classic editor and test the following, ensuring they look and work as they did before (or better 😉 ):
  * Status - "Stick to the top of the blog" and "Pending review" labels
  * Discussion options labels
  * All labels inside "Other options"
  * Page Settings -> Page Attributes - "Parent Page" and "Order" labels
  * Sharing settings - "Shortlink" label, the label for each Publicize connection, labels for each of the "Sharing Buttons & Likes" options.
  * Media modal gallery help "Do not show again" checkbox label - you might need to delete the `mediaModalGalleryInstructionsDismissed` preference first.
