### PR TITLE
Gutenboarding: Add fieldset styles to signup form.

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -181,7 +181,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 				<h1 className="signup-form__title">{ __( 'Save your progress' ) }</h1>
 
 				<form onSubmit={ handleSignUp }>
-					<fieldset>
+					<fieldset className="signup-form__fieldset">
 						<legend className="signup-form__legend">
 							<p>{ __( 'Enter an email and password to save your progress and continue.' ) }</p>
 						</legend>

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -63,6 +63,18 @@
 		}
 	}
 
+	.signup-form__fieldset {
+		border: 0;
+		font-family: inherit;
+		font-size: 100%;
+		font-style: inherit;
+		font-weight: inherit;
+		margin: 0;
+		outline: 0;
+		padding: 0;
+		vertical-align: baseline;
+	}
+
 	.components-text-control__input {
 		padding: 18px 14px;
 		font-size: $font-body;

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -65,10 +65,6 @@
 
 	.signup-form__fieldset {
 		border: 0;
-		font-family: inherit;
-		font-size: 100%;
-		font-style: inherit;
-		font-weight: inherit;
 		margin: 0;
 		outline: 0;
 		padding: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the fieldset styles into the Gutenboarding signup form as they were removed globally in PR https://github.com/Automattic/wp-calypso/pull/45577 and because we are unable to use `<Fieldset>` component from `client` in Gutenboarding.

**Before**
![Screenshot 2020-10-05 at 14 54 55](https://user-images.githubusercontent.com/8639742/95088385-c9bbbc00-071a-11eb-9817-5db56cb2dd73.png)


**After**
![Screenshot 2020-10-05 at 14 53 44](https://user-images.githubusercontent.com/8639742/95088247-9e38d180-071a-11eb-9f7d-bb3d3776e79a.png)

#### Testing instructions

* Head over to `/new` for Gutenboarding experience in Incognito or unauthenticated.
* Go through the process until you reach Plans step, and click "Free".
* This should trigger the Signup Form modal to appear.
* Form should not have border.

Fixes https://github.com/Automattic/wp-calypso/issues/46137
