### PR TITLE
e2e: Print out when a test is skipped and Fix all tests showing passed

### DIFF
--- a/test/e2e/lib/reporter/magellan-reporter.js
+++ b/test/e2e/lib/reporter/magellan-reporter.js
@@ -115,6 +115,11 @@ Reporter.prototype.listenTo = function ( testRun, test, source ) {
 					} );
 				}
 
+				// Print skipped tests
+				if ( test.locator.pending === true ) {
+					console.log( '\x1b[35m', 'TEST SKIPPED: ' + test.locator.name );
+				}
+
 				// Reports
 				fs.readdir( reportDir, ( dirErr, reportFiles ) => {
 					if ( dirErr ) return 1;

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -242,17 +242,6 @@ async function startNewPost( siteURL ) {
 	await gEditorComponent.initEditor();
 }
 
-before( async function () {
-	if ( process.env.GUTENBERG_EDGE === 'true' ) {
-		this.timeout( startBrowserTimeoutMS );
-		driver = await driverManager.startBrowser();
-		loginFlow = new LoginFlow( driver, 'gutenbergUpgradeUser' );
-		sampleImages = times( 5, () => mediaHelper.createFile() );
-	} else {
-		this.skip();
-	}
-} );
-
 after( async function () {
 	if ( process.env.GUTENBERG_EDGE === 'true' ) {
 		await Promise.all(
@@ -262,6 +251,17 @@ after( async function () {
 } );
 
 describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most popular themes (${ screenSize })`, function () {
+	before( async function () {
+		if ( process.env.GUTENBERG_EDGE === 'true' ) {
+			this.timeout( startBrowserTimeoutMS );
+			driver = await driverManager.startBrowser();
+			loginFlow = new LoginFlow( driver, 'gutenbergUpgradeUser' );
+			sampleImages = times( 5, () => mediaHelper.createFile() );
+		} else {
+			this.skip();
+		}
+	} );
+
 	this.timeout( mochaTimeOut );
 	[
 		BlogPostsBlockComponent,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently the way we run tests, the output shows skipped tests as having passed. I looked in to how to change that, but it would involve modifying the package. That creates maintenance issues and it isn't that big  of a deal, so as I workaround, I am printing out in the test results when a test is skipped. It will print in magenta.
* In testing this I realized that all tests were showing passed but none were actually running. I moved a before block in to the test block to fix it.

#### Testing instructions

* Ensure tests pass in CI and that skipped tests are shown in the test run log.
