### PR TITLE
Extensions: Use FormLabel in WooCommerce

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -13,6 +13,7 @@ import formatCurrency from '@automattic/format-currency';
  * Internal dependencies
  */
 import { Button, ScreenReaderText } from '@automattic/components';
+import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
@@ -150,11 +151,11 @@ class OrderDetailsTable extends Component {
 		if ( isEditing ) {
 			return (
 				<Fragment>
-					<label htmlFor={ inputId }>
+					<FormLabel htmlFor={ inputId }>
 						<ScreenReaderText>
 							{ translate( 'Quantity of %(item)s', { args: { item: item.name } } ) }
 						</ScreenReaderText>
-					</label>
+					</FormLabel>
 
 					<FormTextInput
 						type="number"

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -19,6 +19,8 @@
 	}
 
 	.form-label {
+		margin-bottom: 0;
+
 		.form-text-input-with-affixes {
 			font-weight: normal;
 		}

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import {
@@ -154,11 +155,11 @@ class OrderRefundTable extends Component {
 		const inputId = `quantity-${ item.id }`;
 		return (
 			<OrderLineItem key={ item.id } isEditing item={ item } order={ order } site={ site }>
-				<label htmlFor={ inputId }>
+				<FormLabel htmlFor={ inputId }>
 					<ScreenReaderText>
 						{ translate( 'Quantity of %(item)s', { args: { item: item.name } } ) }
 					</ScreenReaderText>
-				</label>
+				</FormLabel>
 
 				<FormTextInput
 					type="number"
@@ -190,11 +191,11 @@ class OrderRefundTable extends Component {
 					</span>
 				</TableItem>
 				<TableItem colSpan="2" className="order-payment__item-total order-details__item-total">
-					<label htmlFor={ inputId }>
+					<FormLabel htmlFor={ inputId }>
 						<ScreenReaderText>
 							{ translate( 'Value of fee %(item)s', { args: { item: item.name } } ) }
 						</ScreenReaderText>
-					</label>
+					</FormLabel>
 					<PriceInput
 						id={ inputId }
 						currency={ order.currency }

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -10,6 +10,10 @@
 		box-sizing: unset;
 	}
 
+	.form-label {
+		margin-bottom: 0;
+	}
+
 	@include breakpoint-deprecated( '>960px' ) {
 		display: flex;
 		flex-wrap: wrap;

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-countries.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-countries.js
@@ -56,7 +56,7 @@ const ShippingZoneLocationDialogCountries = ( { continentCountries, translate, a
 
 		return (
 			<li key={ index } className={ listItemClass }>
-				<label htmlFor={ inputId }>
+				<FormLabel htmlFor={ inputId }>
 					{ isCountry ? (
 						<FormCheckbox
 							id={ inputId }
@@ -78,7 +78,7 @@ const ShippingZoneLocationDialogCountries = ( { continentCountries, translate, a
 					{ isCountry ? <LocationFlag code={ code } /> : null }
 					<span>{ name }</span>
 					{ disabled && <small>{ translate( '(An existing zone covers this location)' ) }</small> }
-				</label>
+				</FormLabel>
 			</li>
 		);
 	};

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js
@@ -71,7 +71,7 @@ const ShippingZoneLocationDialogSettings = ( {
 		}
 
 		const radios = [
-			<label key={ 1 } htmlFor="include-postcodes">
+			<FormLabel key={ 1 } htmlFor="include-postcodes">
 				<FormRadio
 					id="include-postcodes"
 					name="include"
@@ -79,12 +79,12 @@ const ShippingZoneLocationDialogSettings = ( {
 					checked={ filteredByPostcode }
 				/>
 				{ translate( 'Include specific postcodes in the zone' ) }
-			</label>,
+			</FormLabel>,
 		];
 
 		if ( ! countryOwner ) {
 			radios.unshift(
-				<label key={ 0 } htmlFor="include-all">
+				<FormLabel key={ 0 } htmlFor="include-all">
 					<FormRadio
 						id="include-all"
 						name="include"
@@ -92,13 +92,13 @@ const ShippingZoneLocationDialogSettings = ( {
 						checked={ unfiltered }
 					/>
 					{ translate( 'Include entire country in the zone' ) }
-				</label>
+				</FormLabel>
 			);
 		}
 
 		if ( canFilterByState ) {
 			radios.push(
-				<label key={ 2 } htmlFor="include-states">
+				<FormLabel key={ 2 } htmlFor="include-states">
 					<FormRadio
 						id="include-states"
 						name="include"
@@ -106,7 +106,7 @@ const ShippingZoneLocationDialogSettings = ( {
 						checked={ filteredByState }
 					/>
 					{ translate( 'Include specific states in the zone' ) }
-				</label>
+				</FormLabel>
 			);
 		}
 
@@ -128,7 +128,7 @@ const ShippingZoneLocationDialogSettings = ( {
 
 		return (
 			<li key={ index } className="shipping-zone__location-dialog-list-item">
-				<label htmlFor={ inputId }>
+				<FormLabel htmlFor={ inputId }>
 					<FormCheckbox
 						id={ inputId }
 						onChange={ onToggle }
@@ -137,7 +137,7 @@ const ShippingZoneLocationDialogSettings = ( {
 						disabled={ disabled }
 					/>
 					{ name }
-				</label>
+				</FormLabel>
 			</li>
 		);
 	};

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -327,9 +327,11 @@
 	padding: 3px 6px;
 	margin: 1px 0;
 
-	label {
+	.form-label {
 		display: block;
 		cursor: pointer;
+		font-weight: 400;
+		margin-bottom: 0;
 	}
 
 	small {

--- a/client/extensions/woocommerce/components/text-control/index.js
+++ b/client/extensions/woocommerce/components/text-control/index.js
@@ -5,6 +5,11 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import wrapWithClickOutside from 'react-click-outside';
 
+/**
+ * Internal dependencies
+ */
+import FormLabel from 'components/forms/form-label';
+
 /*
  * This component is temporary until we can pull in `@wordpress/components` and merge https://github.com/Automattic/wp-calypso/pull/34277.
  * See https://github.com/Automattic/wp-calypso/pull/34380.
@@ -71,7 +76,7 @@ class MurielTextControl extends Component {
 		return (
 			<div className={ classes }>
 				<div className="text-control__field">
-					{ label && <label className="text-control__label">{ label }</label> }
+					{ label && <FormLabel className="text-control__label">{ label }</FormLabel> }
 					<input
 						className="text-control__input"
 						type={ type || 'text' }

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/predefined-packages.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/predefined-packages.js
@@ -14,6 +14,7 @@ import { forEach } from 'lodash';
 import BulkSelect from 'woocommerce/components/bulk-select';
 import FoldableCard from 'components/foldable-card';
 import FormCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 import PackagesListItem from './packages-list-item';
 import { getCurrentlyEditingPredefinedPackages } from '../../state/packages/selectors';
 
@@ -40,7 +41,7 @@ const PredefinedPackages = ( {
 		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 		return (
 			<div className="packages__group-header">
-				<label htmlFor={ inputId } onClick={ ( event ) => event.stopPropagation() }>
+				<FormLabel htmlFor={ inputId } onClick={ ( event ) => event.stopPropagation() }>
 					<BulkSelect
 						id={ inputId }
 						totalElements={ group.total }
@@ -49,7 +50,7 @@ const PredefinedPackages = ( {
 						className="packages__group-header-checkbox"
 					/>
 					{ group.title }
-				</label>
+				</FormLabel>
 			</div>
 		);
 		/* eslint-enable jsx-a11y/click-events-have-key-events */

--- a/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/entry.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/entry.js
@@ -11,6 +11,7 @@ import { snakeCase } from 'lodash';
  * Internal dependencies
  */
 import Checkbox from 'woocommerce/woocommerce-services/components/checkbox';
+import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import NumberInput from 'woocommerce/woocommerce-services/components/number-field/number-input';
 
@@ -28,10 +29,10 @@ const ShippingServiceEntry = ( props ) => {
 
 	return (
 		<div className={ classNames( 'shipping-services__entry', { 'wcc-error': hasError } ) }>
-			<label className="shipping-services__entry-title" htmlFor={ id }>
+			<FormLabel className="shipping-services__entry-title" htmlFor={ id }>
 				<Checkbox id={ id } checked={ enabled } onChange={ onToggleEnabled } />
 				<span>{ name }</span>
-			</label>
+			</FormLabel>
 			{ hasError ? <Gridicon icon="notice" /> : null }
 			<NumberInput
 				disabled={ ! enabled }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update all WooCommerce `<label />` instances to use `<FormLabel />`.

Part of #45259.

#### Testing instructions

* Grab a test site with a WooCommerce store setup.
* Test the following areas that contain labels and verify they look and work the same way:
  * `/store/order/:site` - creating a new order, select the product and observe the (invisible) label in the quantity column.
  * `/store/settings/shipping/zone/:site` - click Add Locations and observe the label next to each country flag.
  * `/store/settings/shipping/:site` - adding service packages, the label of each group.
  * `/store/settings/shipping/zone/:site/:shippingZoneId` - editing/adding a shipping zone, the Enabled label.

