### PR TITLE
Settings: re-enable video hosting upsell and update its copy

### DIFF
--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -9,6 +9,7 @@ import React, { createElement, Fragment } from 'react';
 /**
  * Internal dependencies
  */
+import { getFeatureByKey, getFeatureCategoryByKey } from 'lib/plans/features-list';
 import {
 	DAILY_PLAN_TO_REALTIME_PLAN,
 	DAILY_PRODUCTS,
@@ -42,7 +43,6 @@ import {
 	JETPACK_SECURITY_PLANS,
 } from 'lib/plans/constants';
 import { getPlan, getMonthlyPlanByYearly, getYearlyPlanByMonthly, planHasFeature } from 'lib/plans';
-import { getFeatureByKey, getFeatureCategoryByKey } from 'lib/plans/features-list';
 import {
 	JETPACK_SEARCH_PRODUCTS,
 	JETPACK_PRODUCT_PRICE_MATRIX,

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -16,13 +16,13 @@ import filesize from 'filesize';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import SupportInfo from 'components/support-info';
+import { planHasFeature } from 'lib/plans';
 import {
 	FEATURE_VIDEO_UPLOADS,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 	TERM_ANNUALLY,
 } from 'lib/plans/constants';
-import { hasFeature } from 'state/sites/plans/selectors';
 import getMediaStorageLimit from 'state/selectors/get-media-storage-limit';
 import getMediaStorageUsed from 'state/selectors/get-media-storage-used';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
@@ -151,7 +151,11 @@ class MediaSettingsPerformance extends Component {
 	}
 
 	render() {
-		const { isVideoPressAvailable } = this.props;
+		const { isVideoPressAvailable, sitePlanSlug } = this.props;
+
+		if ( ! sitePlanSlug ) {
+			return null;
+		}
 
 		return (
 			<div className="site-settings__module-settings site-settings__media-settings">
@@ -166,9 +170,9 @@ export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
 	const isVideoPressAvailable =
-		hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS ) ||
-		hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ) ||
-		hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS_JETPACK_PRO );
+		planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS ) ||
+		planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ) ||
+		planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PRO );
 
 	return {
 		isVideoPressActive: isJetpackModuleActive( state, selectedSiteId, 'videopress' ),

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -16,12 +16,11 @@ import filesize from 'filesize';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import SupportInfo from 'components/support-info';
-import { shouldShowOfferResetFlow } from 'lib/plans/config';
 import {
-	PLAN_JETPACK_PREMIUM,
 	FEATURE_VIDEO_UPLOADS,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
+	TERM_ANNUALLY,
 } from 'lib/plans/constants';
 import { hasFeature } from 'state/sites/plans/selectors';
 import getMediaStorageLimit from 'state/selectors/get-media-storage-limit';
@@ -32,6 +31,8 @@ import { getSitePlanSlug, getSiteSlug } from 'state/sites/selectors';
 import QueryMediaStorage from 'components/data/query-media-storage';
 import PlanStorageBar from 'blocks/plan-storage/bar';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import { OPTIONS_JETPACK_SECURITY } from 'my-sites/plans-v2/constants';
+import { getPathToDetails } from 'my-sites/plans-v2/utils';
 
 class MediaSettingsPerformance extends Component {
 	static propTypes = {
@@ -125,21 +126,24 @@ class MediaSettingsPerformance extends Component {
 	}
 
 	renderVideoUpgradeNudge() {
-		const { isVideoPressAvailable, translate } = this.props;
+		const { isVideoPressAvailable, siteSlug, translate } = this.props;
 
 		return (
-			! shouldShowOfferResetFlow() &&
 			! isVideoPressAvailable && (
 				<UpsellNudge
+					title={ translate( 'Get unlimited video hosting' ) }
 					description={ translate(
-						'Get high-speed, high-resolution video hosting without ads or watermarks.'
+						'Tired of ads in your videos? Get high-speed video right on your site'
 					) }
 					event={ 'jetpack_video_settings' }
 					feature={ FEATURE_VIDEO_UPLOADS_JETPACK_PRO }
-					plan={ PLAN_JETPACK_PREMIUM }
 					showIcon={ true }
-					title={ translate(
-						'Host video right on your site! Upgrade to Jetpack Premium to get started'
+					href={ getPathToDetails(
+						'/plans',
+						{},
+						OPTIONS_JETPACK_SECURITY,
+						TERM_ANNUALLY,
+						siteSlug
 					) }
 				/>
 			)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Re-enable video hosting upsell and update its copy. 

#### Testing instructions

- Run this PR.
- Select a site with Jetpack Free.
- Visit `/settings/performance/:site`.
- Verify that you see an upsell (see capture below) in the Media panel.
- Verify that the upsell's copy look like the one in the capture.
- Click the upsell.
- Verify that you are redirected to Jetpack Security Options page (you should be able to see both Daily and Real-time option cards).
- Do the same with a site that has either Jetpack Security or Jetpack Complete.
- Verify that you don't see the upsell.

Fixes 1196341175636977-as-1196942190681395

#### Demo
![image](https://user-images.githubusercontent.com/3418513/95120216-97628c80-0723-11eb-91b6-ea85a5d4be00.png)

