### PR TITLE
Settings: re-enable premium themes upsell and update its copy

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -16,13 +16,15 @@ import FormattedHeader from 'components/formatted-header';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import AutoLoadingHomepageModal from 'my-sites/themes/auto-loading-homepage-modal';
 import config from 'config';
-import { shouldShowOfferResetFlow } from 'lib/plans/config';
 import { isPartnerPurchase } from 'lib/purchases';
 import JetpackReferrerMessage from './jetpack-referrer-message';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import { connectOptions } from './theme-options';
 import UpsellNudge from 'blocks/upsell-nudge';
-import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_JETPACK_BUSINESS } from 'lib/plans/constants';
+import {
+	FEATURE_UNLIMITED_PREMIUM_THEMES,
+	PLAN_JETPACK_SECURITY_REALTIME,
+} from 'lib/plans/constants';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
@@ -36,6 +38,7 @@ import {
 	hasJetpackSiteJetpackThemesExtendedFeatures,
 	isJetpackSiteMultiSite,
 } from 'state/sites/selectors';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 const ConnectedThemesSelection = connectOptions( ( props ) => {
 	return (
@@ -69,6 +72,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 		translate,
 		hasUnlimitedPremiumThemes,
 		requestingSitePlans,
+		siteSlug,
 	} = props;
 	const jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
 
@@ -97,24 +101,19 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 				align="left"
 			/>
 			<CurrentTheme siteId={ siteId } />
-			{ ! shouldShowOfferResetFlow() &&
-				! requestingSitePlans &&
-				currentPlan &&
-				! hasUnlimitedPremiumThemes &&
-				! isPartnerPlan && (
-					<UpsellNudge
-						forceDisplay
-						plan={ PLAN_JETPACK_BUSINESS }
-						title={ translate( 'Access all our premium themes with our Professional plan!' ) }
-						description={ translate(
-							'In addition to our collection of premium themes, ' +
-								'get Elasticsearch-powered site search, real-time offsite backups, ' +
-								'and security scanning.'
-						) }
-						event="themes_plans_free_personal_premium"
-						showIcon={ true }
-					/>
-				) }
+			{ ! requestingSitePlans && currentPlan && ! hasUnlimitedPremiumThemes && ! isPartnerPlan && (
+				<UpsellNudge
+					forceDisplay
+					title={ translate( 'Get unlimited premium themes' ) }
+					description={ translate(
+						'In addition to our collection of premium themes, get comprehensive WordPress' +
+							' security, real-time backups, and unlimited video hosting.'
+					) }
+					event="themes_plans_free_personal_premium"
+					showIcon={ true }
+					href={ `/checkout/${ siteSlug }/${ PLAN_JETPACK_SECURITY_REALTIME }` }
+				/>
+			) }
 			<ThemeShowcase
 				{ ...props }
 				siteId={ siteId }
@@ -162,6 +161,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 } );
 
 export default connect( ( state, { siteId, tier } ) => {
+	const siteSlug = getSelectedSiteSlug( state );
 	const currentPlan = getCurrentPlan( state, siteId );
 	const isMultisite = isJetpackSiteMultiSite( state, siteId );
 	const showWpcomThemesList =
@@ -184,5 +184,6 @@ export default connect( ( state, { siteId, tier } ) => {
 		isMultisite,
 		hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 		requestingSitePlans: isRequestingSitePlans( state, siteId ),
+		siteSlug,
 	};
 } )( ConnectedSingleSiteJetpack );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Re-enable video premium themes upsell and update its copy.

#### Testing instructions

- Run this PR.
- Select a site with Jetpack Free.
- Visit `/themes/:site`.
- Verify that you see an upsell (see capture below) titled "Get unlimited premium themes".
- Verify that the upsell's copy look like the one in the capture.
- Click the upsell.
- Verify that you end up in checkout with Jetpack Security Real-time in the cart.
- Do the same with a site that has either Jetpack Security Real-time or Jetpack Complete.
- Verify that you don't see the upsell.

Fixes 1196341175636977-as-1196925364225706

#### Demo
![image](https://user-images.githubusercontent.com/3418513/95122445-e6f68780-0726-11eb-99c6-10f2a460937e.png)

