### PR TITLE
Add Jetpack backup-simplified-screens Feature Flag.

### DIFF
--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -9,6 +9,7 @@ import { isArray } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import { applySiteOffset } from 'lib/site/timezone';
 import { Card } from '@automattic/components';
 import { isSuccessfulDailyBackup, isSuccessfulRealtimeBackup } from 'lib/jetpack/backup-utils';
@@ -75,6 +76,9 @@ DailyBackupStatus.propTypes = {
 
 const Wrapper = ( props ) => (
 	<Card className="daily-backup-status">
+		{ isEnabled( 'jetpack/backup-simplified-screens' ) && (
+			<p style={ { color: 'red' } }>Feature Flag: jetpack/backup-simplified-screens is ON</p>
+		) }
 		<DailyBackupStatus { ...props } />
 	</Card>
 );

--- a/config/development.json
+++ b/config/development.json
@@ -91,6 +91,7 @@
 		"jetpack/scan-product": true,
 		"jetpack/anti-spam-product": true,
 		"jetpack/backups-restore": true,
+		"jetpack/backup-simplified-screens": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/personal-plan": false,
 		"jitms": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,6 +58,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/search-product": true,
 		"jetpack/backups-restore": true,
+		"jetpack/backup-simplified-screens": true,
 		"jetpack/anti-spam-product": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/personal-plan": false,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -21,7 +21,7 @@
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
-		"jetpack/backup-simplified-screens": false,
+		"jetpack/backup-simplified-screens": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": false,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -21,6 +21,7 @@
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
+		"jetpack/backup-simplified-screens": false,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -18,6 +18,7 @@
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
+		"jetpack/backup-simplified-screens": false,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -18,7 +18,7 @@
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
-		"jetpack/backup-simplified-screens": false,
+		"jetpack/backup-simplified-screens": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -20,6 +20,7 @@
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
+		"jetpack/backup-simplified-screens": false,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -19,6 +19,7 @@
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
+		"jetpack/backup-simplified-screens": false,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -19,7 +19,7 @@
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
-		"jetpack/backup-simplified-screens": false,
+		"jetpack/backup-simplified-screens": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": false,

--- a/config/production.json
+++ b/config/production.json
@@ -48,6 +48,7 @@
 		"i18n/translation-scanner": true,
 		"ive/use-external-assignment": true,
 		"jetpack/api-cache": false,
+		"jetpack/backup-simplified-screens": false,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -53,6 +53,7 @@
 		"i18n/empathy-mode": true,
 		"ive/use-external-assignment": true,
 		"jetpack/api-cache": true,
+		"jetpack/backup-simplified-screens": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a feature flag in order to enable/disable upcoming features proposed in: 

Project thread: p1HpG7-amG-p2

### Testing instructions

1. Checkout this branch and start calypso & jetpack cloud.
    a. First open terminal and run `yarn start` and wait for calypso to build and start.
    b. Then in a new terminal run `yarn start-jetpack-cloud-p`

2. In browser, go to: `http://jetpack.cloud.localhost:3001/backup`

3. Select a site that has backups. (a site with Jetpack Security, Complete, or Backup product)

4. In the Backup Status Card, verify you can see the red text, "Feature Flag: jetpack/backup-simplified-screens is ON" (See Screenshot)

![Markup 2020-10-05 at 12 49 17](https://user-images.githubusercontent.com/11078128/95125034-3cbc3700-0709-11eb-8ec9-cf5d946959f1.png)

6. Next, test the feature flag in Calypso:
    a. Go to: `http://calypso.localhost:3000/backup/:SITE`  (replace :SITE with your site)

7. Verify you can see the red text, "Feature Flag: jetpack/backup-simplified-screens is ON" (See Screenshot)

![Markup 2020-10-05 at 13 01 07](https://user-images.githubusercontent.com/11078128/95126175-e3ed9e00-070a-11eb-9841-429e219a6bf4.png)


Fixes: 1197351014149633-as-1197360555544593/f