### PR TITLE
Upgrade Backup successful state design

### DIFF
--- a/client/components/activity-card/activity-actor.tsx
+++ b/client/components/activity-card/activity-actor.tsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
+import { translate } from 'i18n-calypso';
 import React, { FunctionComponent } from 'react';
 
 /**
  * Internal dependencies
  */
-import { translate } from 'i18n-calypso';
+import { isEnabled } from 'config';
 import Gravatar from 'components/gravatar';
 import Gridicon from 'components/gridicon';
 import JetpackLogo from 'components/jetpack-logo';
@@ -17,7 +18,7 @@ import SocialLogo from 'components/social-logo';
  */
 const JETPACK_ACTOR = (
 	<div className="activity-card__actor">
-		<JetpackLogo size={ 40 } />
+		{ ! isEnabled( 'jetpack/backup-simplified-screens' ) && <JetpackLogo size={ 40 } /> }
 		<div className="activity-card__actor-info">
 			<div className="activity-card__actor-name">Jetpack</div>
 		</div>
@@ -26,7 +27,7 @@ const JETPACK_ACTOR = (
 
 const HAPPINESS_ACTOR = (
 	<div className="activity-card__actor">
-		<JetpackLogo size={ 40 } />
+		{ ! isEnabled( 'jetpack/backup-simplified-screens' ) && <JetpackLogo size={ 40 } /> }
 		<div className="activity-card__actor-info">
 			<div className="activity-card__actor-name">Happiness Engineer</div>
 		</div>

--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -14,6 +14,10 @@
 			flex-direction: row;
 			flex-wrap: wrap;
 			margin-left: 8px;
+
+			&:first-child {
+				margin-left: 0;
+			}
 			> *:not( :last-child ) {
 				margin-right: 8px;
 			}

--- a/client/components/jetpack/backup-delta/style.scss
+++ b/client/components/jetpack/backup-delta/style.scss
@@ -3,22 +3,22 @@
 }
 
 .backup-delta__realtime .activity-log-item__actor {
-    margin-left: 0;
+	margin-left: 0;
 }
 
 .backup-delta__realtime .button.is-borderless.is-primary {
-    float: none;
-    display: inline-block;
+	float: none;
+	display: inline-block;
 }
 
 .backup-delta__realtime-cards {
-    margin: 0 1rem;
+	margin: 0 1rem;
 }
 
 .backup-delta__realtime-header {
-    font-size: $font-body;
-    font-weight: 600;
-    margin: 32px 0 0.5rem;
+	font-size: $font-body;
+	font-weight: 600;
+	margin: 32px 0 0.5rem;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 16px;
@@ -26,7 +26,7 @@
 }
 
 .backup-delta__realtime-emptyday {
-    margin-top: 1rem;
+	margin-top: 1rem;
 }
 
 /* WordPress.com-only styles */
@@ -39,5 +39,15 @@
 
 	.backup-delta__realtime-header {
 		margin-top: initial;
+	}
+}
+
+/* Jetpack.com-only changes */
+.is_jetpackcom {
+	.backup-delta {
+		@include breakpoint-deprecated( '>660px' ) {
+			margin-right: 0;
+			margin-left: 0;
+		}
 	}
 }

--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -1,21 +1,22 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import { useTranslate } from 'i18n-calypso';
+import { isEnabled } from 'config';
+import ExternalLink from 'components/external-link';
+import Button from 'components/forms/form-button';
 import { settingsPath } from 'lib/jetpack/paths';
 import { backupDownloadPath, backupRestorePath } from 'my-sites/backup/paths';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import getDoesRewindNeedCredentials from 'state/selectors/get-does-rewind-need-credentials';
-import Button from 'components/forms/form-button';
-import ExternalLink from 'components/external-link';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
 /**
  * Style dependencies
@@ -69,7 +70,9 @@ const RestoreButton = ( { disabled, rewindId } ) => {
 			onClick={ onRestore }
 		>
 			<div className="daily-backup-status__restore-button-icon">
-				{ needsCredentials && <img src={ missingCredentialsIcon } alt="" role="presentation" /> }
+				{ needsCredentials && ! isEnabled( 'jetpack/backup-simplified-screens' ) && (
+					<img src={ missingCredentialsIcon } alt="" role="presentation" />
+				) }
 				<div>{ translate( 'Restore to this point' ) }</div>
 			</div>
 		</Button>
@@ -131,7 +134,9 @@ const ActionButtons = ( { rewindId, disabled } ) => {
 		<>
 			<DownloadButton disabled={ disabled || ! rewindId } rewindId={ rewindId } />
 			<RestoreButton disabled={ disabled || ! rewindId } rewindId={ rewindId } />
-			{ ! hasCredentials && <MissingCredentials /> }
+			{ ! hasCredentials && ! isEnabled( 'jetpack/backup-simplified-screens' ) && (
+				<MissingCredentials />
+			) }
 		</>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -1,14 +1,16 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { get, isArray } from 'lodash';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { get, isArray } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { useTranslate } from 'i18n-calypso';
+import { isEnabled } from 'config';
 import { applySiteOffset } from 'lib/site/timezone';
 import { useLocalizedMoment } from 'components/localized-moment';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -73,7 +75,11 @@ const BackupSuccessful = ( { backup, deltas, selectedDate } ) => {
 			<div className="status-card__meta">{ meta }</div>
 			<ActionButtons rewindId={ backup.rewindId } />
 			{ showBackupDetails && (
-				<div className="status-card__realtime-details">
+				<div
+					className={ classNames( 'status-card__realtime-details', {
+						'is-simplified': isEnabled( 'jetpack/backup-simplified-screens' ),
+					} ) }
+				>
 					<div className="status-card__realtime-details-card">
 						<ActivityCard activity={ backup } summarize />
 					</div>

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -52,6 +52,7 @@
 	font-size: $font-body-small;
 }
 
+<<<<<<< HEAD
 .status-card__link-list {
 	margin: 40px 0 0;
 	padding: 0;
@@ -63,6 +64,8 @@
 	}
 }
 
+=======
+>>>>>>> Upgrade Backup successful screen
 /* Buttons */
 .daily-backup-status .form-button.status-card__support-button {
 	margin: 32px 0;
@@ -78,6 +81,10 @@
 .status-card__realtime-details {
 	margin-top: 24px;
 	text-align: left;
+
+	&.is-simplified {
+		margin-top: 48px;
+	}
 }
 
 .status-card__realtime-details-card .activity-card .card {

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -52,7 +52,6 @@
 	font-size: $font-body-small;
 }
 
-<<<<<<< HEAD
 .status-card__link-list {
 	margin: 40px 0 0;
 	padding: 0;
@@ -64,8 +63,6 @@
 	}
 }
 
-=======
->>>>>>> Upgrade Backup successful screen
 /* Buttons */
 .daily-backup-status .form-button.status-card__support-button {
 	margin: 32px 0;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the Backup successful screen to minimize the number of call-to-actions.

Fixes 1197351014149633-as-1197360555544603

### Implementation notes

- I left post links in their original colour instead of black, for accessibility concerns

### Testing instructions

- Download the PR
- Run Calypso with `yarn start`
- Run Jetpack cloud concurrently with `yarn start-jetpack-cloud-p`
- Pick a self-hosted Jetpack site that already has a backup
- Visit `/backup/:site`
- Check that you see the updates in both environments (see captures below)

### Screenshots

#### Jetpack cloud

Before
<img width="736" alt="Screen Shot 2020-10-06 at 1 53 17 PM" src="https://user-images.githubusercontent.com/1620183/95241486-cfc5a180-07db-11eb-89d1-dcf141bd3d36.png">
<img width="739" alt="Screen Shot 2020-10-06 at 2 16 49 PM" src="https://user-images.githubusercontent.com/1620183/95244432-f08ff600-07df-11eb-966a-c1b9eaeef055.png">


After
![screenshot (1)](https://user-images.githubusercontent.com/1620183/95241829-567a7e80-07dc-11eb-9f50-d1d43654909a.png)
![screenshot](https://user-images.githubusercontent.com/1620183/95244545-1fa66780-07e0-11eb-856c-89b916764774.png)





#### Calypso

Before
<img width="737" alt="Screen Shot 2020-10-06 at 1 53 26 PM" src="https://user-images.githubusercontent.com/1620183/95241498-d6ecaf80-07db-11eb-8a4a-14e83915b901.png">
<img width="738" alt="Screen Shot 2020-10-06 at 2 16 19 PM" src="https://user-images.githubusercontent.com/1620183/95244404-e8d05180-07df-11eb-95dd-1844e28a8735.png">


After
![screenshot](https://user-images.githubusercontent.com/1620183/95241752-38148300-07dc-11eb-8212-a7ed1d555204.png)
![screenshot (1)](https://user-images.githubusercontent.com/1620183/95244597-30ef7400-07e0-11eb-8b74-7b11278f8fa3.png)


