### PR TITLE
Marketing: re-enable SEO upsell and update its copy

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -299,21 +299,23 @@ export class SeoForm extends React.Component {
 
 		const generalTabUrl = getGeneralTabUrl( slug );
 
-		const jetpackSiteProps = {
-			title: translate( 'Boost your search engine ranking' ),
-			feature: FEATURE_SEO_PREVIEW_TOOLS,
-			href: getPathToDetails( '/plans', {}, OPTIONS_JETPACK_SECURITY, TERM_ANNUALLY, slug ),
-		};
-
-		const wpcomSiteProps = {
-			title: translate(
-				'Boost your search engine ranking with the powerful SEO tools in the Business plan'
-			),
-			feature: FEATURE_ADVANCED_SEO,
-			plan: findFirstSimilarPlanKey( selectedSite.plan.product_slug, {
-				type: TYPE_BUSINESS,
-			} ),
-		};
+		const upsellProps = siteIsJetpack
+			? {
+					title: translate( 'Boost your search engine ranking' ),
+					feature: FEATURE_SEO_PREVIEW_TOOLS,
+					href: getPathToDetails( '/plans', {}, OPTIONS_JETPACK_SECURITY, TERM_ANNUALLY, slug ),
+			  }
+			: {
+					title: translate(
+						'Boost your search engine ranking with the powerful SEO tools in the Business plan'
+					),
+					feature: FEATURE_ADVANCED_SEO,
+					plan:
+						selectedSite.plan &&
+						findFirstSimilarPlanKey( selectedSite.plan.product_slug, {
+							type: TYPE_BUSINESS,
+						} ),
+			  };
 
 		return (
 			<div>
@@ -363,7 +365,7 @@ export class SeoForm extends React.Component {
 					! this.props.hasAdvancedSEOFeature &&
 					selectedSite.plan && (
 						<UpsellNudge
-							{ ...( siteIsJetpack ? jetpackSiteProps : wpcomSiteProps ) }
+							{ ...upsellProps }
 							description={ translate(
 								'Get tools to optimize your site for improved search engine results.'
 							) }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -11,6 +11,8 @@ import { localize } from 'i18n-calypso';
  */
 import { Card, Button } from '@automattic/components';
 import { hasSiteSeoFeature } from './utils';
+import { OPTIONS_JETPACK_SECURITY } from 'my-sites/plans-v2/constants';
+import { getPathToDetails } from 'my-sites/plans-v2/utils';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 import MetaTitleEditor from 'components/seo/meta-title-editor';
 import Notice from 'components/notice';
@@ -42,7 +44,6 @@ import {
 	FEATURE_ADVANCED_SEO,
 	FEATURE_SEO_PREVIEW_TOOLS,
 	TYPE_BUSINESS,
-	TYPE_PREMIUM,
 	TERM_ANNUALLY,
 	JETPACK_RESET_PLANS,
 } from 'lib/plans/constants';
@@ -298,11 +299,21 @@ export class SeoForm extends React.Component {
 
 		const generalTabUrl = getGeneralTabUrl( slug );
 
-		const nudgeTitle = siteIsJetpack
-			? translate( 'Boost your search engine ranking' )
-			: translate(
-					'Boost your search engine ranking with the powerful SEO tools in the Business plan'
-			  );
+		const jetpackSiteProps = {
+			title: translate( 'Boost your search engine ranking' ),
+			feature: FEATURE_SEO_PREVIEW_TOOLS,
+			href: getPathToDetails( '/plans', {}, OPTIONS_JETPACK_SECURITY, TERM_ANNUALLY, slug ),
+		};
+
+		const wpcomSiteProps = {
+			title: translate(
+				'Boost your search engine ranking with the powerful SEO tools in the Business plan'
+			),
+			feature: FEATURE_ADVANCED_SEO,
+			plan: findFirstSimilarPlanKey( selectedSite.plan.product_slug, {
+				type: TYPE_BUSINESS,
+			} ),
+		};
 
 		return (
 			<div>
@@ -352,17 +363,12 @@ export class SeoForm extends React.Component {
 					! this.props.hasAdvancedSEOFeature &&
 					selectedSite.plan && (
 						<UpsellNudge
+							{ ...( siteIsJetpack ? jetpackSiteProps : wpcomSiteProps ) }
 							description={ translate(
 								'Get tools to optimize your site for improved search engine results.'
 							) }
 							event={ 'calypso_seo_settings_upgrade_nudge' }
-							feature={ siteIsJetpack ? FEATURE_SEO_PREVIEW_TOOLS : FEATURE_ADVANCED_SEO }
-							plan={ findFirstSimilarPlanKey( selectedSite.plan.product_slug, {
-								type: siteIsJetpack ? TYPE_PREMIUM : TYPE_BUSINESS,
-								...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
-							} ) }
 							showIcon={ true }
-							title={ nudgeTitle }
 						/>
 					) }
 				<form onChange={ this.props.markChanged } className="seo-settings__seo-form">

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -36,7 +36,6 @@ import isSiteComingSoon from 'state/selectors/is-site-coming-soon';
 import { toApi as seoTitleToApi } from 'components/seo/meta-title-editor/mappings';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestSite } from 'state/sites/actions';
-import { shouldShowOfferResetFlow } from 'lib/plans/config';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { getPlugins } from 'state/plugins/installed/selectors';
 import {
@@ -300,9 +299,7 @@ export class SeoForm extends React.Component {
 		const generalTabUrl = getGeneralTabUrl( slug );
 
 		const nudgeTitle = siteIsJetpack
-			? translate(
-					'Boost your search engine ranking with the powerful SEO tools in Jetpack Premium'
-			  )
+			? translate( 'Boost your search engine ranking' )
 			: translate(
 					'Boost your search engine ranking with the powerful SEO tools in the Business plan'
 			  );
@@ -353,11 +350,10 @@ export class SeoForm extends React.Component {
 
 				{ ! this.props.hasSeoPreviewFeature &&
 					! this.props.hasAdvancedSEOFeature &&
-					selectedSite.plan &&
-					! shouldShowOfferResetFlow() && (
+					selectedSite.plan && (
 						<UpsellNudge
 							description={ translate(
-								'Get tools to optimize your site for improved performance in search engine results.'
+								'Get tools to optimize your site for improved search engine results.'
 							) }
 							event={ 'calypso_seo_settings_upgrade_nudge' }
 							feature={ siteIsJetpack ? FEATURE_SEO_PREVIEW_TOOLS : FEATURE_ADVANCED_SEO }

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -26,8 +26,8 @@ import {
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
 } from 'lib/plans/constants';
+import { OPTIONS_JETPACK_SECURITY } from 'my-sites/plans-v2/constants';
 
 /**
  * Internal dependencies
@@ -194,7 +194,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 
 	[ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ].forEach(
 		( product_slug ) => {
-			test( `Jetpack Premium for (${ product_slug })`, () => {
+			test( `Jetpack Security Daily for (${ product_slug })`, () => {
 				const comp = shallow(
 					<SeoForm
 						{ ...props }
@@ -203,7 +203,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 					/>
 				);
 				expect( comp.find( 'UpsellNudge' ) ).toHaveLength( 1 );
-				expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_JETPACK_PREMIUM );
+				expect( comp.find( 'UpsellNudge' ).props().href ).toContain( OPTIONS_JETPACK_SECURITY );
 			} );
 		}
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Re-enable SEO upsell from Marketing > Traffic section and update its copy.

#### Implementation notes

* Copy for non-Jetpack sites remains untouched.
* Clicking the upsell (Jetpack site only) takes users to Jetpack Security Options page.

#### Testing instructions

- Run this PR.
- Select a site with Jetpack Free.
- Visit /marketing/traffic/:site.
- Verify that you see an upsell (see capture below) in "Search engine optimization" panel.
- Verify that the upsell's copy look like the one in the capture.
- Click the upsell.
- Verify that you are redirected to Jetpack Security Options page (you should be able to see both Daily and Real-time option cards).
- Do the same with a site that has Jetpack Complete.
- Verify that you don't see the upsell.

Fixes 1196341175636977-as-1197426524966358

#### Demo
![image](https://user-images.githubusercontent.com/3418513/95127429-5c198b00-072e-11eb-9856-126a686a2dee.png)
