### PR TITLE
Add  banner that prompts user to enable restores

### DIFF
--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -191,9 +191,9 @@ class BackupsPage extends Component {
 								<Banner
 									className="backup__restore-banner"
 									callToAction={ translate( 'Enable restores' ) }
-									title={ translate( 'Recover your website anytime by enabling restores.' ) }
+									title={ translate( 'Set up your server credentials to get back online quickly' ) }
 									description={ translate(
-										'Enable one click site restores and get your website back anytime.'
+										'Add SSH, SFTP or FTP credentials to enable one click site restores.'
 									) }
 									href={
 										isJetpackCloud()

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -12,6 +12,8 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
+import Banner from 'components/banner';
 import DocumentHead from 'components/data/document-head';
 import { updateFilter, setFilter } from 'state/activity-log/actions';
 import {
@@ -185,6 +187,23 @@ class BackupsPage extends Component {
 				{ ! isLoadingBackups && (
 					<div className="backup__main-wrap">
 						<div className="backup__last-backup-status">
+							{ isEnabled( 'jetpack/backup-simplified-screens' ) && doesRewindNeedCredentials && (
+								<Banner
+									className="backup__restore-banner"
+									callToAction={ translate( 'Enable restores' ) }
+									title={ translate( 'Recover your website anytime by enabling restores.' ) }
+									description={ translate(
+										'Enable one click site restores and get your website back anytime.'
+									) }
+									href={
+										isJetpackCloud()
+											? `/settings/${ siteSlug }`
+											: `/settings/jetpack/${ siteSlug }#credentials`
+									}
+									icon="cloud-upload"
+								/>
+							) }
+
 							<BackupDatePicker
 								{ ...{
 									onDateChange: this.onDateChange,

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -75,6 +75,12 @@
 	}
 }
 
+.backup__restore-banner {
+	&.banner.card {
+		@include banner-color( var( --color-jetpack ) );
+	}
+}
+
 /* WordPress.com-only styles */
 .wordpressdotcom.backup__page {
 	.backup__main-wrap {

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -147,3 +147,12 @@
 		}
 	}
 }
+
+/* Jetpack.com-only changes */
+.is_jetpackcom {
+	.backup__restore-banner {
+		&.banner.card {
+			@include banner-color( var( --color-primary-40 ) );
+		}
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

As part of the cleaning of some Backup screens (see #46162 and #46165), this PR adds a banner that prompts the user to set up server credentials.

### Testing instructions

- Download the PR
- Run Calypso with `yarn start`
- Run Jetpack cloud concurrently with `yarn start-jetpack-cloud-p`
- Pick a self-hosted Jetpack site with Backup, and server credentials not set yet
- Visit `/backup/:site`
- Check that you see the banner in both environments, and that the copy matches the captures below
- Check that clicking the button redirects you to the credentials form
- Fill the credentials form
- Check that you don't see the banner anymore


### Screenshots

#### Jetpack cloud
_Desktop_
<img width="760" alt="Screen Shot 2020-10-06 at 11 52 38 AM" src="https://user-images.githubusercontent.com/1620183/95227570-435fb280-07cc-11eb-9a49-e773919bd45b.png">
_Mobile_
<img width="473" alt="Screen Shot 2020-10-06 at 11 52 21 AM" src="https://user-images.githubusercontent.com/1620183/95227584-46f33980-07cc-11eb-8a44-a2547bdee9ba.png">

#### Calypso
_Desktop_
<img width="705" alt="Screen Shot 2020-10-06 at 12 07 42 PM" src="https://user-images.githubusercontent.com/1620183/95227860-9fc2d200-07cc-11eb-860a-76457df5da09.png">
_Mobile_
<img width="549" alt="Screen Shot 2020-10-06 at 12 07 55 PM" src="https://user-images.githubusercontent.com/1620183/95227863-9fc2d200-07cc-11eb-8234-357cbbedb19e.png">
