### PR TITLE
Site level billing: Add billing history page

### DIFF
--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -91,14 +91,16 @@ class BillingHistoryTable extends React.Component {
 	}
 }
 
+function getIsSendingReceiptEmail( state ) {
+	return function isSendingBillingReceiptEmailForReceiptId( receiptId ) {
+		return isSendingBillingReceiptEmail( state, receiptId );
+	};
+}
+
 export default connect(
 	( state ) => {
-		const sendingBillingReceiptEmail = ( receiptId ) => {
-			return isSendingBillingReceiptEmail( state, receiptId );
-		};
-
 		return {
-			sendingBillingReceiptEmail,
+			sendingBillingReceiptEmail: getIsSendingReceiptEmail( state ),
 		};
 	},
 	{

--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -77,6 +77,7 @@ class BillingHistoryTable extends React.Component {
 
 		return (
 			<TransactionsTable
+				siteId={ this.props.siteId }
 				transactionType="past"
 				header
 				emptyTableText={ emptyTableText }

--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -41,9 +41,12 @@ class BillingHistoryTable extends React.Component {
 		}
 
 		return (
-			<a href="#" onClick={ this.getEmailReceiptLinkClickHandler( receiptId ) }>
+			<button
+				className="billing-history__email-button"
+				onClick={ this.getEmailReceiptLinkClickHandler( receiptId ) }
+			>
 				{ translate( 'Email receipt' ) }
-			</a>
+			</button>
 		);
 	};
 

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -23,10 +23,10 @@ import QueryBillingTransactions from 'components/data/query-billing-transactions
  */
 import './style.scss';
 
-export function BillingHistoryList() {
+export function BillingHistoryList( { siteId = null } ) {
 	return (
 		<Card className="billing-history__receipts">
-			<BillingHistoryTable />
+			<BillingHistoryTable siteId={ siteId } />
 		</Card>
 	);
 }

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -23,6 +23,14 @@ import QueryBillingTransactions from 'components/data/query-billing-transactions
  */
 import './style.scss';
 
+export function BillingHistoryList() {
+	return (
+		<Card className="billing-history__receipts">
+			<BillingHistoryTable />
+		</Card>
+	);
+}
+
 const BillingHistory = ( { translate } ) => (
 	<Main className="billing-history">
 		<DocumentHead title={ translate( 'Billing History' ) } />
@@ -30,9 +38,7 @@ const BillingHistory = ( { translate } ) => (
 		<MeSidebarNavigation />
 		<QueryBillingTransactions />
 		<PurchasesHeader section={ 'billing' } />
-		<Card className="billing-history__receipts">
-			<BillingHistoryTable />
-		</Card>
+		<BillingHistoryList />
 		{ config.isEnabled( 'upgrades/credit-cards' ) && <CreditCards /> }
 	</Main>
 );

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -40,7 +40,7 @@
 	width: 100px;
 	padding: 3px 9px;
 	background-color: var( --color-surface );
-	border-radius: 15px;
+	border-radius: 2px;
 	border: 1px solid var( --color-neutral-0 );
 	transition: width 0.25s ease-out;
 	outline: 0;

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -358,6 +358,10 @@ textarea.billing-history__billing-details-editable {
 	padding: 0;
 }
 
+.billing-history {
+	min-height: 500px;
+}
+
 .billing-history .search-card.card,
 .billing-history__upcoming-charges .search-card.card {
 	margin: 0;

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -146,6 +146,12 @@
 	}
 }
 
+.billing-history__email-button {
+	color: var( --color-link );
+	cursor: pointer;
+	font-size: inherit;
+}
+
 // View Receipt
 .billing-history__app-overview {
 	min-height: 65px;

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -150,6 +150,10 @@
 	color: var( --color-link );
 	cursor: pointer;
 	font-size: inherit;
+
+	&:focus {
+		outline: thin dotted;
+	}
 }
 
 // View Receipt

--- a/client/me/billing-history/transactions-header.jsx
+++ b/client/me/billing-history/transactions-header.jsx
@@ -219,12 +219,13 @@ TransactionsHeader.propTypes = {
 	filter: PropTypes.object.isRequired,
 	//own props
 	transactionType: PropTypes.string.isRequired,
+	siteId: PropTypes.string,
 };
 
 export default connect(
-	( state, { transactionType } ) => ( {
-		appFilters: getBillingTransactionAppFilterValues( state, transactionType ),
-		dateFilters: getBillingTransactionDateFilterValues( state, transactionType ),
+	( state, { transactionType, siteId } ) => ( {
+		appFilters: getBillingTransactionAppFilterValues( state, transactionType, siteId ),
+		dateFilters: getBillingTransactionDateFilterValues( state, transactionType, siteId ),
 		filter: getBillingTransactionFilters( state, transactionType ),
 	} ),
 	{

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -199,6 +199,7 @@ TransactionsTable.propTypes = {
 	total: PropTypes.number.isRequired,
 	transactions: PropTypes.array,
 	//own props
+	siteId: PropTypes.number,
 	transactionType: PropTypes.string.isRequired,
 	//array allows to accept the output of translate() with components in the string
 	emptyTableText: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ).isRequired,
@@ -208,8 +209,8 @@ TransactionsTable.propTypes = {
 };
 
 export default connect(
-	( state, { transactionType } ) => {
-		const filteredTransactions = getFilteredBillingTransactions( state, transactionType );
+	( state, { transactionType, siteId } ) => {
+		const filteredTransactions = getFilteredBillingTransactions( state, transactionType, siteId );
 		const filter = getBillingTransactionFilters( state, transactionType );
 		return {
 			app: filter.app,

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -42,7 +42,12 @@ class TransactionsTable extends React.Component {
 		let header;
 
 		if ( false !== this.props.header ) {
-			header = <TransactionsHeader transactionType={ this.props.transactionType } />;
+			header = (
+				<TransactionsHeader
+					transactionType={ this.props.transactionType }
+					siteId={ this.props.siteId }
+				/>
+			);
 		}
 
 		return (

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -84,6 +84,6 @@ export const purchaseEditPaymentMethod = ( context, next ) => {
 };
 
 export const billingHistory = ( context, next ) => {
-	context.primary = <BillingHistory siteSlug={ context.params.site } />;
+	context.primary = <BillingHistory />;
 	next();
 };

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -14,6 +14,7 @@ import {
 	PurchaseCancelDomain,
 	PurchaseAddPaymentMethod,
 	PurchaseEditPaymentMethod,
+	BillingHistory,
 } from 'my-sites/purchases/main.tsx';
 
 export function redirectToPurchases( context ) {
@@ -79,5 +80,10 @@ export const purchaseEditPaymentMethod = ( context, next ) => {
 			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 		/>
 	);
+	next();
+};
+
+export const billingHistory = ( context, next ) => {
+	context.primary = <BillingHistory siteSlug={ context.params.site } />;
 	next();
 };

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -16,6 +16,7 @@ import {
 	purchaseCancelDomain,
 	purchaseAddPaymentMethod,
 	purchaseEditPaymentMethod,
+	billingHistory,
 } from './controller';
 
 export default ( router ) => {
@@ -74,6 +75,15 @@ export default ( router ) => {
 		siteSelection,
 		navigation,
 		purchaseEditPaymentMethod,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/purchases/billing-history/:site',
+		siteSelection,
+		navigation,
+		billingHistory,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -30,6 +30,7 @@ import EditCardDetails from 'me/purchases/payment/edit-card-details';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { CompactCard } from '@automattic/components';
 
 export function Purchases() {
 	const translate = useTranslate();
@@ -223,6 +224,9 @@ export function BillingHistory() {
 				align="left"
 			/>
 			<BillingHistoryList siteId={ selectedSiteId } />
+			<CompactCard href="/me/purchases/billing">
+				{ translate( 'View all billing history and receipts' ) }
+			</CompactCard>
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -9,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Main from 'components/main';
 import Subscriptions from './subscriptions';
+import { BillingHistoryList } from 'me/billing-history/main';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import ManagePurchase from 'me/purchases/manage-purchase';
@@ -25,6 +26,8 @@ import {
 import { getEditPaymentMethodUrlFor } from './utils';
 import AddCardDetails from 'me/purchases/payment/add-card-details';
 import EditCardDetails from 'me/purchases/payment/edit-card-details';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QueryBillingTransactions from 'components/data/query-billing-transactions';
 
 export function Purchases() {
 	const translate = useTranslate();
@@ -197,6 +200,26 @@ export function PurchaseCancelDomain( {
 				getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 			/>
+		</Main>
+	);
+}
+
+export function BillingHistory() {
+	const translate = useTranslate();
+
+	return (
+		<Main className="purchases billing-history">
+			<MySitesSidebarNavigation />
+			<DocumentHead title={ translate( 'Billing History' ) } />
+			<PageViewTracker path="/purchases/billing-history" title="Billing History" />
+			<QueryBillingTransactions />
+			<FormattedHeader
+				brandFont
+				className="purchases__page-heading"
+				headerText={ translate( 'Billing' ) }
+				align="left"
+			/>
+			<BillingHistoryList />
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -28,6 +29,7 @@ import AddCardDetails from 'me/purchases/payment/add-card-details';
 import EditCardDetails from 'me/purchases/payment/edit-card-details';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 export function Purchases() {
 	const translate = useTranslate();
@@ -205,6 +207,7 @@ export function PurchaseCancelDomain( {
 }
 
 export function BillingHistory() {
+	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const translate = useTranslate();
 
 	return (
@@ -219,7 +222,7 @@ export function BillingHistory() {
 				headerText={ translate( 'Billing' ) }
 				align="left"
 			/>
-			<BillingHistoryList />
+			<BillingHistoryList siteId={ selectedSiteId } />
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -212,7 +212,7 @@ export function BillingHistory() {
 	const translate = useTranslate();
 
 	return (
-		<Main className="purchases billing-history">
+		<Main className="purchases billing-history is-wide-layout">
 			<MySitesSidebarNavigation />
 			<DocumentHead title={ translate( 'Billing History' ) } />
 			<PageViewTracker path="/purchases/billing-history" title="Billing History" />

--- a/client/state/selectors/get-billing-transaction-app-filter-values.js
+++ b/client/state/selectors/get-billing-transaction-app-filter-values.js
@@ -16,13 +16,22 @@ import 'state/billing-transactions/init';
  *
  * @param  {object}  state           Global state tree
  * @param  {string}  transactionType Transaction type
+ * @param   {string}  [siteId]        Optional site id
  * @returns {Array}                   App filter metadata
  */
 export default createSelector(
-	( state, transactionType ) => {
-		const transactions = getBillingTransactionsByType( state, transactionType );
+	( state, transactionType, siteId = null ) => {
+		let transactions = getBillingTransactionsByType( state, transactionType );
 		if ( ! transactions ) {
 			return [];
+		}
+
+		if ( siteId ) {
+			transactions = transactions.filter( ( transaction ) => {
+				return transaction.items.some( ( receiptItem ) => {
+					return String( receiptItem.site_id ) === String( siteId );
+				} );
+			} );
 		}
 
 		const appGroups = groupBy( transactions, 'service' );

--- a/client/state/selectors/get-billing-transaction-date-filter-values.js
+++ b/client/state/selectors/get-billing-transaction-date-filter-values.js
@@ -17,11 +17,12 @@ import 'state/billing-transactions/init';
  *
  * @param   {object}  state           Global state tree
  * @param   {string}  transactionType Transaction type
+ * @param   {string}  [siteId]        Optional site id
  * @returns {Array}                   Date filter metadata
  */
 export default createSelector(
-	( state, transactionType ) => {
-		const transactions = getBillingTransactionsByType( state, transactionType );
+	( state, transactionType, siteId = null ) => {
+		let transactions = getBillingTransactionsByType( state, transactionType );
 
 		if ( ! transactions ) {
 			return [];
@@ -41,6 +42,14 @@ export default createSelector(
 			value: { month: lastMonth, operator: 'before' },
 			count: 0,
 		} );
+
+		if ( siteId ) {
+			transactions = transactions.filter( ( transaction ) => {
+				return transaction.items.some( ( receiptItem ) => {
+					return String( receiptItem.site_id ) === String( siteId );
+				} );
+			} );
+		}
 
 		transactions.forEach( ( transaction ) => {
 			const transactionDateString = moment( transaction.date )

--- a/client/state/selectors/get-filtered-billing-transactions.js
+++ b/client/state/selectors/get-filtered-billing-transactions.js
@@ -65,10 +65,11 @@ function search( transactions, searchQuery ) {
  *
  * @param   {object}  state           Global state tree
  * @param   {string}  transactionType Transaction type
+ * @param   {string}  [siteId]        An optional siteId on which to filter results (in addition to the other filters)
  * @returns {object}                  Filtered results in format {transactions, total, pageSize}
  */
 export default createSelector(
-	( state, transactionType ) => {
+	( state, transactionType, siteId = null ) => {
 		const transactions = getBillingTransactionsByType( state, transactionType );
 		if ( ! transactions ) {
 			return {
@@ -94,6 +95,14 @@ export default createSelector(
 
 		if ( app && app !== 'all' ) {
 			results = results.filter( ( transaction ) => transaction.service === app );
+		}
+
+		if ( siteId ) {
+			results = results.filter( ( transaction ) => {
+				return transaction.items.some( ( receiptItem ) => {
+					return receiptItem.site_id === siteId;
+				} );
+			} );
 		}
 
 		const total = results.length;

--- a/client/state/selectors/get-filtered-billing-transactions.js
+++ b/client/state/selectors/get-filtered-billing-transactions.js
@@ -100,7 +100,7 @@ export default createSelector(
 		if ( siteId ) {
 			results = results.filter( ( transaction ) => {
 				return transaction.items.some( ( receiptItem ) => {
-					return receiptItem.site_id === siteId;
+					return String( receiptItem.site_id ) === String( siteId );
 				} );
 			} );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the "Billing history" page to the site-level billing section (initially added by https://github.com/Automattic/wp-calypso/pull/45601), at the URL `http://calypso.localhost:3000/purchases/billing-history/:siteSlug`.

This PR does not link to that page or link back from it in any way. That navigation will be added by the solution to https://github.com/Automattic/wp-calypso/issues/46210.

Also note that the "View receipt" links still go to the account-level pages. That will be handled in the solution to https://github.com/Automattic/wp-calypso/issues/46203.

Requires D50680-code (now merged) to allow filtering receipts by site ID.

Fixes https://github.com/Automattic/wp-calypso/issues/45598

Main project thread: pbOQVh-sc-p2

#### Screenshots

![Screen Shot 2020-10-06 at 5 57 51 PM](https://user-images.githubusercontent.com/2036909/95264571-8f771b00-07fd-11eb-8602-07216babd0a2.png)

#### To do

- [x] Add new page and route.
- [x] Filter receipts by site ID.
- [x] Fix numbers in filter menus.
- [x] Add bottom link to "View all billing history"

#### Testing instructions

- Visit `http://calypso.localhost:3000/purchases/billing-history/:siteSlug`.
- Verify that you see the my-sites sidebar associated with your site.
- Verify that the page lists purchases _only_ for the site in question, or shows "No receipts found." if there are none for that particular site.
- Verify that pagination works as expected.
- Click the date and apps filter drop-downs and verify that the preview numbers they display next to each filter option match the number of receipts that are shown if that option is clicked.
- Try using the search field to search for a receipt. Verify that it only shows results matching the site in question.