### PR TITLE
Revert "Coming Soon: Remove old coming-soon copy now that translations are complete"

### DIFF
--- a/client/blocks/eligibility-warnings/has-localized-text.js
+++ b/client/blocks/eligibility-warnings/has-localized-text.js
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import i18n from 'i18n-calypso';
+
+export const hasLocalizedText = ( message ) =>
+	i18n.state.localeSlug === i18n.defaultLocaleSlug || i18n.hasTranslation( message );
+
+export default hasLocalizedText;

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import hasLocalizedText from './has-localized-text';
 import { Button } from '@automattic/components';
 import CardHeading from 'components/card-heading';
 import Gridicon from 'components/gridicon';
@@ -20,17 +21,31 @@ import { localizeUrl } from 'lib/i18n-utils';
 function getHoldMessages( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		NO_BUSINESS_PLAN: {
-			title: translate( 'Upgrade to a Business plan' ),
+			title: hasLocalizedText( 'Upgrade to a Business plan' )
+				? translate( 'Upgrade to a Business plan' )
+				: translate( 'Upgrade to Business' ),
 			description: ( function () {
 				if ( context === 'themes' ) {
-					return translate(
+					return hasLocalizedText(
 						"You'll also get to install custom plugins, have more storage, and access live support."
-					);
+					)
+						? translate(
+								"You'll also get to install custom plugins, have more storage, and access live support."
+						  )
+						: translate(
+								'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
+						  );
 				}
 
-				return translate(
+				return hasLocalizedText(
 					"You'll also get to install custom themes, have more storage, and access live support."
-				);
+				)
+					? translate(
+							"You'll also get to install custom themes, have more storage, and access live support."
+					  )
+					: translate(
+							'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
+					  );
 			} )(),
 			supportUrl: null,
 		},
@@ -95,9 +110,15 @@ function getHoldMessages( context: string | null, translate: LocalizeProps[ 'tra
 export function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		BLOCKED_ATOMIC_TRANSFER: {
-			message: translate(
+			message: hasLocalizedText(
 				'This site is not currently eligible to install themes and plugins, or activate hosting access. Please contact our support team for help.'
-			),
+			)
+				? translate(
+						'This site is not currently eligible to install themes and plugins, or activate hosting access. Please contact our support team for help.'
+				  )
+				: translate(
+						'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
+				  ),
 			status: 'is-error',
 			contactUrl: localizeUrl( 'https://wordpress.com/help/contact' ),
 		},
@@ -119,16 +140,26 @@ export function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 			contactUrl: null,
 		},
 		SITE_GRAYLISTED: {
-			message: translate(
+			message: hasLocalizedText(
 				"There's an ongoing site dispute. Contact us to review your site's standing and resolve the dispute."
-			),
+			)
+				? translate(
+						"There's an ongoing site dispute. Contact us to review your site's standing and resolve the dispute."
+				  )
+				: translate( "Contact us to review your site's standing and resolve the dispute." ),
 			status: 'is-error',
 			contactUrl: localizeUrl( 'https://wordpress.com/support/suspended-blogs/' ),
 		},
 		NO_SSL_CERTIFICATE: {
-			message: translate(
+			message: hasLocalizedText(
 				'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
-			),
+			)
+				? translate(
+						'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
+				  )
+				: translate(
+						'Hold tight! We are setting up a digital certificate to allow secure browsing on your site, using "HTTPS". Please try again in a few minutes.\''
+				  ),
 			status: null,
 			contactUrl: null,
 		},
@@ -245,17 +276,28 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 };
 
 function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
+	const defaultCopy = translate( "To continue you'll need to:" );
 	switch ( context ) {
 		case 'plugins':
-			return translate( "To install plugins you'll need to:" );
+			return hasLocalizedText( "To install plugins you'll need to:" )
+				? translate( "To install plugins you'll need to:" )
+				: defaultCopy;
 		case 'themes':
-			return translate( "To install themes you'll need to:" );
+			return hasLocalizedText( "To install themes you'll need to:" )
+				? translate( "To install themes you'll need to:" )
+				: defaultCopy;
 		case 'hosting':
-			return translate( "To activate hosting access you'll need to:" );
+			return hasLocalizedText( "To activate hosting access you'll need to:" )
+				? translate( "To activate hosting access you'll need to:" )
+				: defaultCopy;
 		case 'performance':
-			return translate( "To activate Performance Features you'll need to:" );
+			return hasLocalizedText( "To activate Performance Features you'll need to:" )
+				? translate( "To activate Performance Features you'll need to:" )
+				: defaultCopy;
 		default:
-			return translate( "To continue you'll need to:" );
+			return hasLocalizedText( "To continue you'll need to:" )
+				? translate( "To continue you'll need to:" )
+				: defaultCopy;
 	}
 }
 

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -12,6 +12,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import hasLocalizedText from './has-localized-text';
 import {
 	FEATURE_UPLOAD_PLUGINS,
 	FEATURE_PERFORMANCE,
@@ -155,29 +156,43 @@ function getSiteIsEligibleMessage(
 	context: string | null,
 	translate: LocalizeProps[ 'translate' ]
 ) {
+	const defaultCopy = translate( 'This site is eligible to install plugins and upload themes.' );
 	switch ( context ) {
 		case 'plugins':
 		case 'themes':
-			return translate( 'This site is eligible to install plugins and upload themes.' );
+			return hasLocalizedText( 'This site is eligible to install plugins and upload themes.' )
+				? translate( 'This site is eligible to install plugins and upload themes.' )
+				: defaultCopy;
 		case 'hosting':
-			return translate( 'This site is eligible to activate hosting access.' );
+			return hasLocalizedText( 'This site is eligible to activate hosting access.' )
+				? translate( 'This site is eligible to activate hosting access.' )
+				: defaultCopy;
 		default:
-			return translate( 'This site is eligible to continue.' );
+			return hasLocalizedText( 'This site is eligible to continue.' )
+				? translate( 'This site is eligible to continue.' )
+				: defaultCopy;
 	}
 }
 
 function getProceedButtonText( holds: string[], translate: LocalizeProps[ 'translate' ] ) {
+	const defaultCopy = translate( 'Proceed' );
 	if ( siteRequiresUpgrade( holds ) ) {
-		return translate( 'Upgrade and continue' );
+		return hasLocalizedText( 'Upgrade and continue' )
+			? translate( 'Upgrade and continue' )
+			: defaultCopy;
 	}
 	if ( siteRequiresLaunch( holds ) ) {
-		return translate( 'Launch your site and continue' );
+		return hasLocalizedText( 'Launch your site and continue' )
+			? translate( 'Launch your site and continue' )
+			: defaultCopy;
 	}
 	if ( siteRequiresGoingPublic( holds ) ) {
-		return translate( 'Make your site public and continue' );
+		return hasLocalizedText( 'Make your site public and continue' )
+			? translate( 'Make your site public and continue' )
+			: defaultCopy;
 	}
 
-	return translate( 'Continue' );
+	return hasLocalizedText( 'Continue' ) ? translate( 'Continue' ) : defaultCopy;
 }
 
 function isProceedButtonDisabled( isEligible: boolean, holds: string[] ) {

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -9,6 +9,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
+import hasLocalizedText from './has-localized-text';
 import ExternalLink from 'components/external-link';
 import ActionPanelLink from 'components/action-panel/link';
 
@@ -49,14 +50,24 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 
 		<div className="eligibility-warnings__warning">
 			<div className="eligibility-warnings__message">
-				<span className="eligibility-warnings__message-title">{ translate( 'Questions?' ) }</span>
+				<span className="eligibility-warnings__message-title">
+					{ hasLocalizedText( 'Questions?' )
+						? translate( 'Questions?' )
+						: translate( 'Any Questions?' ) }
+				</span>
 				:&nbsp;
 				<span className="eligibility-warnings__message-description">
-					{ translate( '{{a}}Contact support{{/a}} for help.', {
-						components: {
-							a: <ActionPanelLink href="/help/contact" />,
-						},
-					} ) }
+					{ hasLocalizedText( '{{a}}Contact support{{/a}} for help.' ) ? (
+						translate( '{{a}}Contact support{{/a}} for help.', {
+							components: {
+								a: <ActionPanelLink href="/help/contact" />,
+							},
+						} )
+					) : (
+						<ActionPanelLink href="/help/contact">
+							{ translate( 'Contact support' ) }
+						</ActionPanelLink>
+					) }
 				</span>
 			</div>
 		</div>
@@ -78,34 +89,46 @@ function getWarningDescription(
 	);
 	switch ( context ) {
 		case 'plugins':
-			return translate(
-				'By installing a plugin the following change will be made to the site:',
-				'By installing a plugin the following changes will be made to the site:',
-				{
-					count: warningCount,
-					args: warningCount,
-				}
-			);
+			return hasLocalizedText(
+				'By installing a plugin the following change will be made to the site:'
+			)
+				? translate(
+						'By installing a plugin the following change will be made to the site:',
+						'By installing a plugin the following changes will be made to the site:',
+						{
+							count: warningCount,
+							args: warningCount,
+						}
+				  )
+				: defaultCopy;
 
 		case 'themes':
-			return translate(
-				'By installing a theme the following change will be made to the site:',
-				'By installing a theme the following changes will be made to the site:',
-				{
-					count: warningCount,
-					args: warningCount,
-				}
-			);
+			return hasLocalizedText(
+				'By installing a theme the following change will be made to the site:'
+			)
+				? translate(
+						'By installing a theme the following change will be made to the site:',
+						'By installing a theme the following changes will be made to the site:',
+						{
+							count: warningCount,
+							args: warningCount,
+						}
+				  )
+				: defaultCopy;
 
 		case 'hosting':
-			return translate(
-				'By activating hosting access the following change will be made to the site:',
-				'By activating hosting access the following changes will be made to the site:',
-				{
-					count: warningCount,
-					args: warningCount,
-				}
-			);
+			return hasLocalizedText(
+				'By activating hosting access the following change will be made to the site:'
+			)
+				? translate(
+						'By activating hosting access the following change will be made to the site:',
+						'By activating hosting access the following changes will be made to the site:',
+						{
+							count: warningCount,
+							args: warningCount,
+						}
+				  )
+				: defaultCopy;
 
 		default:
 			return defaultCopy;

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -43,6 +43,7 @@ import { launchSite } from 'state/sites/launch/actions';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import FormInputCheckbox from 'components/forms/form-checkbox';
+import { hasLocalizedText } from 'blocks/eligibility-warnings/has-localized-text';
 import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 
 export class SiteSettingsFormGeneral extends Component {
@@ -327,9 +328,13 @@ export class SiteSettingsFormGeneral extends Component {
 							/>
 						</FormLabel>
 						<FormSettingExplanation isIndented>
-							{ translate(
+							{ hasLocalizedText(
 								'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
-							) }
+							)
+								? translate(
+										'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+								  )
+								: translate( "Your site is hidden from visitors until it's ready for viewing." ) }
 						</FormSettingExplanation>
 					</>
 				) }
@@ -394,9 +399,15 @@ export class SiteSettingsFormGeneral extends Component {
 							/>
 						</FormLabel>
 						<FormSettingExplanation isIndented>
-							{ translate(
+							{ hasLocalizedText(
 								'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-							) }
+							)
+								? translate(
+										'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+								  )
+								: translate(
+										'Your site is only visible to you and logged-in members you approve.'
+								  ) }
 						</FormSettingExplanation>
 					</>
 				) }
@@ -483,9 +494,15 @@ export class SiteSettingsFormGeneral extends Component {
 					<div className="site-settings__general-settings-launch-site-text">
 						<p>
 							{ isComingSoon &&
-								translate(
-									'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
-								) }
+							hasLocalizedText(
+								'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
+							)
+								? translate(
+										'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
+								  )
+								: translate(
+										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
+								  ) }
 						</p>
 					</div>
 					<div className={ launchSiteClasses }>{ btnComponent }</div>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#46168

Discovered a regression on staging. Some of the coming soon text in the general settings form disappeared. Getting the change off `master` while I figure it out.

Revert was created with GitHub.