### PR TITLE
Add/coming soon editable page to all sites

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon-page-template.json
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon-page-template.json
@@ -1,8 +1,0 @@
-{
-	"post_title": "Coming soon",
-	"post_slug": "coming-soon",
-	"category": "coming-soon",
-	"post_content": "<!-- wp:cover {\"customOverlayColor\":\"#117ac9\",\"minHeight\":858,\"contentPosition\":\"center left\",\"align\":\"full\",\"className\":\"is-style-default\"} -->\n<div class=\"wp-block-cover alignfull has-background-dim has-custom-content-position is-position-center-left is-style-default\" style=\"background-color:#117ac9;min-height:858px\"><div class=\"wp-block-cover__inner-container\"><!-- wp:heading {\"align\":\"left\",\"level\":1,\"style\":{\"typography\":{\"fontSize\":60,\"lineHeight\":\"1\"}}} -->\n<h1 class=\"has-text-align-left\" style=\"font-size:60px;line-height:1\">Coming Soon</h1>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"left\"} -->\n<p class=\"has-text-align-left\">This site is coming soon</p>\n<!-- /wp:paragraph --></div></div>\n<!-- /wp:cover -->",
-	"hs_template_preview": "https://headstartdata.files.wordpress.com/2020/09/coming-soon.png?w=332",
-	"hs_template_description": "A simple page to let visitors know that your site is coming soon"
-}

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon-page-template.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon-page-template.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Coming Soon page template
+ *
+ * @package A8C\FSE\Coming_soon
+ */
+
+namespace A8C\FSE\Coming_soon;
+
+const COMING_SOON_PAGE_TEMPLATE = array(
+	'post_title'              => 'Coming soon',
+	'post_slug'               => 'coming-soon',
+	'category'                => 'coming-soon',
+	'post_content'            => "<!-- wp:cover {\"customOverlayColor\":\"#117ac9\",\"minHeight\":858,\"contentPosition\":\"center left\",\"align\":\"full\",\"className\":\"is-style-default\"} -->\n<div class=\"wp-block-cover alignfull has-background-dim has-custom-content-position is-position-center-left is-style-default\" style=\"background-color:#117ac9;min-height:858px\"><div class=\"wp-block-cover__inner-container\"><!-- wp:heading {\"align\":\"left\",\"level\":1,\"style\":{\"typography\":{\"fontSize\":60,\"lineHeight\":\"1\"}}} -->\n<h1 class=\"has-text-align-left\" style=\"font-size:60px;line-height:1\">Coming Soon</h1>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"left\"} -->\n<p class=\"has-text-align-left\">This site is coming soon</p>\n<!-- /wp:paragraph --></div></div>\n<!-- /wp:cover -->",
+	'hs_template_preview'     => 'https://headstartdata.files.wordpress.com/2020/09/coming-soon.png?w=332',
+	'hs_template_description' => 'A simple page to let visitors know that your site is coming soon',
+);
+

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -101,26 +101,10 @@ function add_public_coming_soon_page_template( $templates ) : array {
 }
 add_filter( 'vertical_templates', __NAMESPACE__ . '\add_public_coming_soon_page_template' );
 
-// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed
 /**
- * Adds an editable coming soon page to a site if no coming soon page exists and
- * a paid plan is purchased
- *
- * @param int $blog_id current blog id.
- * @param int $user_id current user id.
- * @param int $product_id the id of the plan that was just purchased.
+ * Adds an editable coming soon page to a site
  */
-function add_coming_soon_page_to_paid_site( $blog_id, $user_id, $product_id ) {
-	if ( ! \WPCOM_Store::is_wpcom_plan( $product_id ) ) {
-		return;
-	}
-
-	// if there is an existing coming soon page don't add a new one.
-	$existing_page_id = (int) get_option( 'wpcom_public_coming_soon_page_id', 0 );
-	if ( $existing_page_id ) {
-		return;
-	}
-
+function add_coming_soon_page_to_new_site() {
 	$coming_soon_template = get_coming_soon_page_template();
 	$new_page_id          = wp_insert_post(
 		array(
@@ -134,7 +118,7 @@ function add_coming_soon_page_to_paid_site( $blog_id, $user_id, $product_id ) {
 	);
 	add_option( 'wpcom_public_coming_soon_page_id', $new_page_id );
 }
-add_action( 'subscription_changed', __NAMESPACE__ . '\add_coming_soon_page_to_new_site', 10, 3 );
+add_action( 'signup_finished', __NAMESPACE__ . '\add_coming_soon_page_to_new_site', 10, 1 );
 
 /**
  * Decides whether to redirect to the site's coming soon page and performs

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -7,18 +7,7 @@
 
 namespace A8C\FSE\Coming_soon;
 
-/**
- * Load the coming soon page tempalate object
- *
- * @return object
- */
-function get_coming_soon_page_template() {
-	return json_decode(
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		file_get_contents( __DIR__ . '/coming-soon-page-template.json' ),
-		false
-	);
-}
+require_once __DIR__ . '/coming-soon-page-template.php';
 
 /**
  * Determines whether the coming soon page should be shown.
@@ -96,7 +85,7 @@ add_filter( 'rest_api_update_site_settings', __NAMESPACE__ . '\add_public_coming
  * @return array The updated $templates array
  */
 function add_public_coming_soon_page_template( $templates ) : array {
-	$templates[] = get_coming_soon_page_template();
+	$templates[] = (object) COMING_SOON_PAGE_TEMPLATE;
 	return $templates;
 }
 add_filter( 'vertical_templates', __NAMESPACE__ . '\add_public_coming_soon_page_template' );
@@ -105,11 +94,11 @@ add_filter( 'vertical_templates', __NAMESPACE__ . '\add_public_coming_soon_page_
  * Adds an editable coming soon page to a site
  */
 function add_coming_soon_page_to_new_site() {
-	$coming_soon_template = get_coming_soon_page_template();
+	$coming_soon_template = COMING_SOON_PAGE_TEMPLATE;
 	$new_page_id          = wp_insert_post(
 		array(
-			'post_title'     => $coming_soon_template->post_title,
-			'post_content'   => $coming_soon_template->post_content,
+			'post_title'     => $coming_soon_template['post_title'],
+			'post_content'   => $coming_soon_template['post_content'],
 			'post_status'    => 'publish',
 			'post_type'      => 'page',
 			'comment_status' => 'closed',


### PR DESCRIPTION
Currently the page is only added for new sites with a paid plan, this change adds the page for all sites and also converts the new page json to PHP so that it can be translated in the future.

Continuing on from https://github.com/Automattic/wp-calypso/pull/45775
and https://github.com/Automattic/wp-calypso/pull/45950 

### Testing instructions
Create a new site with a free plan
It should have a coming soon page.

Testing the coming soon page template is much more difficult because there is php code which calls the production public API ignoring the sandboxing set up in your hosts file, and also a layer of caching. Since the code is behind the WPCOM_PUBLIC_COMING_SOON feature flag, I think it is acceptable to test it fully once merged, otherwise it can be done by setting up wp-env AND syncing the code changes to your sandbox following these instructions https://github.com/Automattic/wp-calypso/pull/45950 