### PR TITLE
Coming Soon: Remove old coming-soon copy now that translations are complete

### DIFF
--- a/client/blocks/eligibility-warnings/has-localized-text.js
+++ b/client/blocks/eligibility-warnings/has-localized-text.js
@@ -1,9 +1,0 @@
-/**
- * External dependencies
- */
-import i18n from 'i18n-calypso';
-
-export const hasLocalizedText = ( message ) =>
-	i18n.state.localeSlug === i18n.defaultLocaleSlug || i18n.hasTranslation( message );
-
-export default hasLocalizedText;

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import hasLocalizedText from './has-localized-text';
 import { Button } from '@automattic/components';
 import CardHeading from 'components/card-heading';
 import Gridicon from 'components/gridicon';
@@ -21,31 +20,17 @@ import { localizeUrl } from 'lib/i18n-utils';
 function getHoldMessages( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		NO_BUSINESS_PLAN: {
-			title: hasLocalizedText( 'Upgrade to a Business plan' )
-				? translate( 'Upgrade to a Business plan' )
-				: translate( 'Upgrade to Business' ),
+			title: translate( 'Upgrade to a Business plan' ),
 			description: ( function () {
 				if ( context === 'themes' ) {
-					return hasLocalizedText(
+					return translate(
 						"You'll also get to install custom plugins, have more storage, and access live support."
-					)
-						? translate(
-								"You'll also get to install custom plugins, have more storage, and access live support."
-						  )
-						: translate(
-								'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
-						  );
+					);
 				}
 
-				return hasLocalizedText(
+				return translate(
 					"You'll also get to install custom themes, have more storage, and access live support."
-				)
-					? translate(
-							"You'll also get to install custom themes, have more storage, and access live support."
-					  )
-					: translate(
-							'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
-					  );
+				);
 			} )(),
 			supportUrl: null,
 		},
@@ -110,15 +95,9 @@ function getHoldMessages( context: string | null, translate: LocalizeProps[ 'tra
 export function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		BLOCKED_ATOMIC_TRANSFER: {
-			message: hasLocalizedText(
+			message: translate(
 				'This site is not currently eligible to install themes and plugins, or activate hosting access. Please contact our support team for help.'
-			)
-				? translate(
-						'This site is not currently eligible to install themes and plugins, or activate hosting access. Please contact our support team for help.'
-				  )
-				: translate(
-						'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
-				  ),
+			),
 			status: 'is-error',
 			contactUrl: localizeUrl( 'https://wordpress.com/help/contact' ),
 		},
@@ -140,26 +119,16 @@ export function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 			contactUrl: null,
 		},
 		SITE_GRAYLISTED: {
-			message: hasLocalizedText(
+			message: translate(
 				"There's an ongoing site dispute. Contact us to review your site's standing and resolve the dispute."
-			)
-				? translate(
-						"There's an ongoing site dispute. Contact us to review your site's standing and resolve the dispute."
-				  )
-				: translate( "Contact us to review your site's standing and resolve the dispute." ),
+			),
 			status: 'is-error',
 			contactUrl: localizeUrl( 'https://wordpress.com/support/suspended-blogs/' ),
 		},
 		NO_SSL_CERTIFICATE: {
-			message: hasLocalizedText(
+			message: translate(
 				'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
-			)
-				? translate(
-						'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
-				  )
-				: translate(
-						'Hold tight! We are setting up a digital certificate to allow secure browsing on your site, using "HTTPS". Please try again in a few minutes.\''
-				  ),
+			),
 			status: null,
 			contactUrl: null,
 		},
@@ -276,28 +245,17 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 };
 
 function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
-	const defaultCopy = translate( "To continue you'll need to:" );
 	switch ( context ) {
 		case 'plugins':
-			return hasLocalizedText( "To install plugins you'll need to:" )
-				? translate( "To install plugins you'll need to:" )
-				: defaultCopy;
+			return translate( "To install plugins you'll need to:" );
 		case 'themes':
-			return hasLocalizedText( "To install themes you'll need to:" )
-				? translate( "To install themes you'll need to:" )
-				: defaultCopy;
+			return translate( "To install themes you'll need to:" );
 		case 'hosting':
-			return hasLocalizedText( "To activate hosting access you'll need to:" )
-				? translate( "To activate hosting access you'll need to:" )
-				: defaultCopy;
+			return translate( "To activate hosting access you'll need to:" );
 		case 'performance':
-			return hasLocalizedText( "To activate Performance Features you'll need to:" )
-				? translate( "To activate Performance Features you'll need to:" )
-				: defaultCopy;
+			return translate( "To activate Performance Features you'll need to:" );
 		default:
-			return hasLocalizedText( "To continue you'll need to:" )
-				? translate( "To continue you'll need to:" )
-				: defaultCopy;
+			return translate( "To continue you'll need to:" );
 	}
 }
 

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -12,7 +12,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import hasLocalizedText from './has-localized-text';
 import {
 	FEATURE_UPLOAD_PLUGINS,
 	FEATURE_PERFORMANCE,
@@ -156,43 +155,29 @@ function getSiteIsEligibleMessage(
 	context: string | null,
 	translate: LocalizeProps[ 'translate' ]
 ) {
-	const defaultCopy = translate( 'This site is eligible to install plugins and upload themes.' );
 	switch ( context ) {
 		case 'plugins':
 		case 'themes':
-			return hasLocalizedText( 'This site is eligible to install plugins and upload themes.' )
-				? translate( 'This site is eligible to install plugins and upload themes.' )
-				: defaultCopy;
+			return translate( 'This site is eligible to install plugins and upload themes.' );
 		case 'hosting':
-			return hasLocalizedText( 'This site is eligible to activate hosting access.' )
-				? translate( 'This site is eligible to activate hosting access.' )
-				: defaultCopy;
+			return translate( 'This site is eligible to activate hosting access.' );
 		default:
-			return hasLocalizedText( 'This site is eligible to continue.' )
-				? translate( 'This site is eligible to continue.' )
-				: defaultCopy;
+			return translate( 'This site is eligible to continue.' );
 	}
 }
 
 function getProceedButtonText( holds: string[], translate: LocalizeProps[ 'translate' ] ) {
-	const defaultCopy = translate( 'Proceed' );
 	if ( siteRequiresUpgrade( holds ) ) {
-		return hasLocalizedText( 'Upgrade and continue' )
-			? translate( 'Upgrade and continue' )
-			: defaultCopy;
+		return translate( 'Upgrade and continue' );
 	}
 	if ( siteRequiresLaunch( holds ) ) {
-		return hasLocalizedText( 'Launch your site and continue' )
-			? translate( 'Launch your site and continue' )
-			: defaultCopy;
+		return translate( 'Launch your site and continue' );
 	}
 	if ( siteRequiresGoingPublic( holds ) ) {
-		return hasLocalizedText( 'Make your site public and continue' )
-			? translate( 'Make your site public and continue' )
-			: defaultCopy;
+		return translate( 'Make your site public and continue' );
 	}
 
-	return hasLocalizedText( 'Continue' ) ? translate( 'Continue' ) : defaultCopy;
+	return translate( 'Continue' );
 }
 
 function isProceedButtonDisabled( isEligible: boolean, holds: string[] ) {

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -9,7 +9,6 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
-import hasLocalizedText from './has-localized-text';
 import ExternalLink from 'components/external-link';
 import ActionPanelLink from 'components/action-panel/link';
 
@@ -50,24 +49,14 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 
 		<div className="eligibility-warnings__warning">
 			<div className="eligibility-warnings__message">
-				<span className="eligibility-warnings__message-title">
-					{ hasLocalizedText( 'Questions?' )
-						? translate( 'Questions?' )
-						: translate( 'Any Questions?' ) }
-				</span>
+				<span className="eligibility-warnings__message-title">{ translate( 'Questions?' ) }</span>
 				:&nbsp;
 				<span className="eligibility-warnings__message-description">
-					{ hasLocalizedText( '{{a}}Contact support{{/a}} for help.' ) ? (
-						translate( '{{a}}Contact support{{/a}} for help.', {
-							components: {
-								a: <ActionPanelLink href="/help/contact" />,
-							},
-						} )
-					) : (
-						<ActionPanelLink href="/help/contact">
-							{ translate( 'Contact support' ) }
-						</ActionPanelLink>
-					) }
+					{ translate( '{{a}}Contact support{{/a}} for help.', {
+						components: {
+							a: <ActionPanelLink href="/help/contact" />,
+						},
+					} ) }
 				</span>
 			</div>
 		</div>
@@ -89,46 +78,34 @@ function getWarningDescription(
 	);
 	switch ( context ) {
 		case 'plugins':
-			return hasLocalizedText(
-				'By installing a plugin the following change will be made to the site:'
-			)
-				? translate(
-						'By installing a plugin the following change will be made to the site:',
-						'By installing a plugin the following changes will be made to the site:',
-						{
-							count: warningCount,
-							args: warningCount,
-						}
-				  )
-				: defaultCopy;
+			return translate(
+				'By installing a plugin the following change will be made to the site:',
+				'By installing a plugin the following changes will be made to the site:',
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
 
 		case 'themes':
-			return hasLocalizedText(
-				'By installing a theme the following change will be made to the site:'
-			)
-				? translate(
-						'By installing a theme the following change will be made to the site:',
-						'By installing a theme the following changes will be made to the site:',
-						{
-							count: warningCount,
-							args: warningCount,
-						}
-				  )
-				: defaultCopy;
+			return translate(
+				'By installing a theme the following change will be made to the site:',
+				'By installing a theme the following changes will be made to the site:',
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
 
 		case 'hosting':
-			return hasLocalizedText(
-				'By activating hosting access the following change will be made to the site:'
-			)
-				? translate(
-						'By activating hosting access the following change will be made to the site:',
-						'By activating hosting access the following changes will be made to the site:',
-						{
-							count: warningCount,
-							args: warningCount,
-						}
-				  )
-				: defaultCopy;
+			return translate(
+				'By activating hosting access the following change will be made to the site:',
+				'By activating hosting access the following changes will be made to the site:',
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
 
 		default:
 			return defaultCopy;

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -43,7 +43,6 @@ import { launchSite } from 'state/sites/launch/actions';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import FormInputCheckbox from 'components/forms/form-checkbox';
-import { hasLocalizedText } from 'blocks/eligibility-warnings/has-localized-text';
 import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 
 export class SiteSettingsFormGeneral extends Component {
@@ -328,13 +327,9 @@ export class SiteSettingsFormGeneral extends Component {
 							/>
 						</FormLabel>
 						<FormSettingExplanation isIndented>
-							{ hasLocalizedText(
+							{ translate(
 								'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
-							)
-								? translate(
-										'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
-								  )
-								: translate( "Your site is hidden from visitors until it's ready for viewing." ) }
+							) }
 						</FormSettingExplanation>
 					</>
 				) }
@@ -399,15 +394,9 @@ export class SiteSettingsFormGeneral extends Component {
 							/>
 						</FormLabel>
 						<FormSettingExplanation isIndented>
-							{ hasLocalizedText(
+							{ translate(
 								'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-							)
-								? translate(
-										'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-								  )
-								: translate(
-										'Your site is only visible to you and logged-in members you approve.'
-								  ) }
+							) }
 						</FormSettingExplanation>
 					</>
 				) }
@@ -493,10 +482,7 @@ export class SiteSettingsFormGeneral extends Component {
 				<Card className="site-settings__general-settings-launch-site">
 					<div className="site-settings__general-settings-launch-site-text">
 						<p>
-							{ isComingSoon &&
-							hasLocalizedText(
-								'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
-							)
+							{ isComingSoon
 								? translate(
 										'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
 								  )


### PR DESCRIPTION
A redo of #46168 that had to be reverted in #46178

#### Changes proposed in this Pull Request

We were using a `hasLocalizedText()` helper function so we could show the updated Coming Soon copy to English speakers before it was available in all languages. All these strings have been translated now so we can remove the now unused strings from the code.

The strings were changed as part of the coming soon v1 work done by Zelda.

Edit: also removed old AT eligibility copy which was also updated as part of the coming soon work. Did it all in one PR to make it easier to then delete the now unused `hasLocalizedText` helper.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that the new strings are available in all languages now (I used translate.wordpress.com)
* Check that the boolean logic isn't wrong such that it causes some text to disappear :)
