### PR TITLE
[GB upgrade e2e] Fix after block race condition 

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -242,14 +242,6 @@ async function startNewPost( siteURL ) {
 	await gEditorComponent.initEditor();
 }
 
-after( async function () {
-	if ( process.env.GUTENBERG_EDGE === 'true' ) {
-		await Promise.all(
-			sampleImages.map( ( fileDetails ) => mediaHelper.deleteFile( fileDetails ) )
-		);
-	}
-} );
-
 describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most popular themes (${ screenSize })`, function () {
 	before( async function () {
 		if ( process.env.GUTENBERG_EDGE === 'true' ) {
@@ -259,6 +251,14 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 			sampleImages = times( 5, () => mediaHelper.createFile() );
 		} else {
 			this.skip();
+		}
+	} );
+
+	after( async function () {
+		if ( process.env.GUTENBERG_EDGE === 'true' ) {
+			await Promise.all(
+				sampleImages.map( ( fileDetails ) => mediaHelper.deleteFile( fileDetails ) )
+			);
 		}
 	} );
 


### PR DESCRIPTION
The after block was outside the test (describe), so it was causing a race condition where the `sampleImages` wasn't initialized when the after block was called, causing it to call `map` on `undefined` (TypeError). 

This wasn't happening locally if you run directly with a single-process `mocha`, but would manifest when the test was running as part of a bigger suite.

#### Changes proposed in this Pull Request

* Move the after block for the GB upgrade E2E inside the main test (describe)

#### Testing instructions

* Tests should pass on CI