### PR TITLE
Drop field `hostname` in server logs

### DIFF
--- a/client/server/lib/logger/index.js
+++ b/client/server/lib/logger/index.js
@@ -23,7 +23,7 @@ const filteredStream = ( fields, destination ) => {
 		// Set object mode to receive unserialized JSON objects
 		objectMode: true,
 		transform( data, encoding, callback ) {
-			// Make a copye of `data`, excluding any field in `fields`
+			// Make a copy of `data`, excluding any field in `fields`
 			const filteredData = Object.entries( data )
 				.filter( ( [ key ] ) => ! fields.includes( key ) )
 				.reduce( ( record, [ key, value ] ) => {

--- a/client/server/lib/logger/index.js
+++ b/client/server/lib/logger/index.js
@@ -1,7 +1,50 @@
+/* eslint jsdoc/no-undefined-types:["error", {definedTypes: ["stream"]}] */
+
 /**
  * External dependencies
  */
 import bunyan from 'bunyan';
+import fs from 'fs';
+import { Transform } from 'stream';
+import { EOL } from 'os';
+
+/**
+ * Creates a stream that filters out some fields.
+ *
+ * This is required because `bunyan` does not implement an option to disable core fields.
+ * We want to disable `hostname` because our logging system already adds `host` with the same
+ * info.
+ *
+ * @param {string[]} fields List of fields to filter out
+ * @param {stream.Writable} destination Stream to write the filtered fields to
+ */
+const filteredStream = ( fields, destination ) => {
+	const transformStream = new Transform( {
+		// Set object mode to receive unserialized JSON objects
+		objectMode: true,
+		transform( data, encoding, callback ) {
+			// Make a copye of `data`, excluding any field in `fields`
+			const filteredData = Object.entries( data )
+				.filter( ( [ key ] ) => ! fields.includes( key ) )
+				.reduce( ( record, [ key, value ] ) => {
+					record[ key ] = value;
+					return record;
+				}, {} );
+
+			if ( destination.writableObjectMode ) {
+				callback( null, transformStream );
+			} else {
+				try {
+					callback( null, JSON.stringify( filteredData ) + EOL );
+				} catch ( err ) {
+					callback( err );
+				}
+			}
+		},
+	} );
+	transformStream.pipe( destination );
+	return transformStream;
+};
 
 let logger;
 
@@ -10,15 +53,20 @@ const createLogger = () => {
 		name: 'calypso',
 		streams: [
 			{
-				stream: process.stdout,
+				type: 'raw',
 				level: 'info',
+				stream: filteredStream( [ 'hostname' ], process.stdout ),
 			},
 		],
 	} );
 	if ( process.env.CALYPSO_LOGFILE ) {
 		logger.addStream( {
-			path: process.env.CALYPSO_LOGFILE,
+			type: 'raw',
 			level: 'info',
+			stream: filteredStream(
+				[ 'hostname' ],
+				fs.createWriteStream( process.env.CALYPSO_LOGFILE, { flags: 'a', encoding: 'utf8' } )
+			),
 		} );
 	}
 };

--- a/client/server/lib/logger/test/index.js
+++ b/client/server/lib/logger/test/index.js
@@ -8,6 +8,15 @@ import fs from 'fs';
 let mockStdout;
 let getLogger;
 
+const withEnvironment = ( name, value ) => {
+	const current = process.env[ name ];
+	process.env[ name ] = value;
+
+	afterAll( () => {
+		process.env[ name ] = current;
+	} );
+};
+
 beforeEach( () => {
 	( { getLogger } = require( '../index' ) );
 	mockStdout = mockProcessStdout();
@@ -53,7 +62,7 @@ it( 'Logs info and above levels to stdout', () => {
 } );
 
 it( 'Logs info and above levels to the filesystem when the env variable is present', async () => {
-	process.env.CALYPSO_LOGFILE = '/tmp/calypso.log';
+	withEnvironment( 'CALYPSO_LOGFILE', '/tmp/calypso.log' );
 	const logger = getLogger();
 
 	logger.trace( 'trace' ); // not logged
@@ -80,4 +89,28 @@ it( 'Reuses the same logger', () => {
 	const logger2 = getLogger();
 
 	expect( logger1 ).toEqual( logger2 );
+} );
+
+it( 'Does not log the hostname to stdout', () => {
+	const logger = getLogger();
+
+	logger.info( 'info' );
+
+	// Fetch the first logged line
+	const loggedMessages = mockStdout.mock.calls.map( ( args ) => JSON.parse( args[ 0 ] ) )[ 0 ];
+	expect( Object.keys( loggedMessages ) ).not.toContain( 'hostname' );
+} );
+
+it( 'Does not log the hostname to a file', async () => {
+	withEnvironment( 'CALYPSO_LOGFILE', '/tmp/calypso.log' );
+	const logger = getLogger();
+
+	logger.info( 'info' );
+
+	// Fetch the first logged line
+	const logLines = ( await fs.promises.readFile( '/tmp/calypso.log', 'utf8' ) )
+		.split( '\n' )
+		.filter( ( line ) => line.length > 0 )
+		.map( JSON.parse )[ 0 ];
+	expect( Object.keys( logLines ) ).not.toContain( 'hostname' );
 } );


### PR DESCRIPTION
### Background

Bunyan has a set of [core fields](https://github.com/trentm/node-bunyan#core-fields) that can't be disabled, including `hostname`. Our log system already adds a field `host` when parsing the logs that contains the same info than `hostname`, wasting storage with duplicated info.

### Changes

Use a [Transform stream](https://nodejs.org/api/stream.html#stream_class_stream_transform) to intercept the log lines before they are sent to stdout/file, and remove the field `hostname`.

Relevant docs:

* [Bunyan streams](https://github.com/trentm/node-bunyan#streams)
* [Transform stream](https://nodejs.org/api/stream.html#stream_class_stream_transform)
* [Object mode](https://nodejs.org/api/stream.html#stream_object_mode)

### Testing instructions

Build the server with `yarn build-server`. Then run it with `CALYPSO_LOGFILE=/tmp/calypso.log node ./build/server.js`. 
* Verify there is no `hostname` field in the output
* Verify there is no `hostname` field in the file `/tmp/calypso.log`

