### PR TITLE
LanguagePickerModal: make countryCode a connected prop instead of passing from parent

### DIFF
--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
-import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { find, isString, noop } from 'lodash';
@@ -14,7 +13,6 @@ import { find, isString, noop } from 'lodash';
  */
 import config from 'config';
 import LanguagePickerModal from './modal';
-import { requestGeoLocation } from 'state/data-getters';
 import { getLanguageCodeLabels } from './utils';
 
 /**
@@ -29,7 +27,6 @@ export class LanguagePicker extends PureComponent {
 		value: PropTypes.any,
 		onChange: PropTypes.func,
 		onClick: PropTypes.func,
-		countryCode: PropTypes.string,
 		showEmpathyModeControl: PropTypes.bool,
 		empathyMode: PropTypes.bool,
 		getIncompleteLocaleNoticeMessage: PropTypes.func,
@@ -40,7 +37,6 @@ export class LanguagePicker extends PureComponent {
 		valueKey: 'value',
 		onChange: noop,
 		onClick: noop,
-		countryCode: '',
 		showEmpathyModeControl: config.isEnabled( 'i18n/empathy-mode' ),
 		empathyMode: false,
 		useFallbackForIncompleteLanguages: false,
@@ -147,12 +143,7 @@ export class LanguagePicker extends PureComponent {
 			return null;
 		}
 
-		const {
-			countryCode,
-			languages,
-			showEmpathyModeControl,
-			getIncompleteLocaleNoticeMessage,
-		} = this.props;
+		const { languages, showEmpathyModeControl, getIncompleteLocaleNoticeMessage } = this.props;
 
 		return (
 			<LanguagePickerModal
@@ -161,7 +152,6 @@ export class LanguagePicker extends PureComponent {
 				onClose={ this.handleClose }
 				onSelected={ this.selectLanguage }
 				selected={ selectedLanguageSlug }
-				countryCode={ countryCode }
 				showEmpathyModeControl={ showEmpathyModeControl }
 				empathyMode={ this.state.empathyMode }
 				useFallbackForIncompleteLanguages={ this.state.useFallbackForIncompleteLanguages }
@@ -205,6 +195,4 @@ export class LanguagePicker extends PureComponent {
 	}
 }
 
-export default connect( () => ( { countryCode: requestGeoLocation().data } ) )(
-	localize( LanguagePicker )
-);
+export default localize( LanguagePicker );

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -38,6 +38,7 @@ import { getLanguageGroupByCountryCode, getLanguageGroupById } from './utils';
 import { LANGUAGE_GROUPS, DEFAULT_LANGUAGE_GROUP } from './constants';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 import { getLanguage, isDefaultLocale, isTranslatedIncompletely } from 'lib/i18n-utils/utils';
+import { requestGeoLocation } from 'state/data-getters';
 
 /**
  * Style dependencies
@@ -64,7 +65,6 @@ export class LanguagePickerModal extends PureComponent {
 		localizedLanguageNames: {},
 		isVisible: false,
 		selected: 'en',
-		countryCode: '',
 		showEmpathyModeControl: config.isEnabled( 'i18n/empathy-mode' ),
 		empathyMode: false,
 		useFallbackForIncompleteLanguages: false,
@@ -607,6 +607,7 @@ export class LanguagePickerModal extends PureComponent {
 }
 
 export default connect( ( state ) => ( {
+	countryCode: requestGeoLocation().data || '',
 	localizedLanguageNames: getLocalizedLanguageNames( state ),
 	currentUserLocale: getCurrentUserLocale( state ),
 } ) )( localize( LanguagePickerModal ) );


### PR DESCRIPTION
The `countryCode` is not used by the `LanguagePicker` button, so it doesn't need to request it and pass it down. All the relevant code can be moved to the `LanguagePickerModal` component.

**How to test:**
This actually fixes one little bug:
1. Open Calypso with `?flags=quick-language-switcher` query string to enable the Quick Switcher
2. Open the Language Picker modal by clicking on the Quick Switcher button in Masterbar

Before this patch:
- the selected tab is "Popular Languages"

After this patch:
- the selected tab is chosen according to your geolocation. For example, my geolocation resolves to Vienna, Austria (although I'm quite far from there, it's where my proxy is) and the "Western Europe" tab is selected.

This auto-selection didn't work before with the Quick Switcher because it uses `LanguagePickerModal` independently, without the `LanguagePicker` button. And the `countryCode` prop wasn't present in this case.