### PR TITLE
Jetpack Product Install: simplify the requestPluginKeys code

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
@@ -84,9 +84,7 @@ export class JetpackProductInstall extends Component< Props, State > {
 
 	fetchPluginKeys = (): void => {
 		if ( this.shouldRequestKeys() ) {
-			requestPluginKeys( this.props.siteId as SiteId, {
-				freshness: PLUGIN_KEY_REFETCH_INTERVAL - 1,
-			} );
+			requestPluginKeys( this.props.siteId as SiteId );
 		}
 	};
 

--- a/client/state/data-getters/wpcom/jetpack-blogs/keys/index.ts
+++ b/client/state/data-getters/wpcom/jetpack-blogs/keys/index.ts
@@ -14,10 +14,7 @@ interface ResponseData {
 	};
 }
 
-export function requestPluginKeys(
-	siteId: SiteId,
-	options: Parameters< typeof requestHttpData >[ 2 ] = {}
-) {
+export function requestPluginKeys( siteId: SiteId ) {
 	requestHttpData(
 		dataKey( siteId ),
 		http( {
@@ -26,10 +23,8 @@ export function requestPluginKeys(
 			apiVersion: '1.1',
 		} ),
 		{
-			// Defaults
 			fromApi: () => ( data: ResponseData ) => [ [ dataKey( siteId ), data.keys ] ],
-			// Allow overwrite
-			...options,
+			freshness: -Infinity,
 		}
 	);
 }


### PR DESCRIPTION
The `requestPluginKeys` function is called imperatively from the `JetpackProductInstall` component, which handles all the retry and refetch logic. The declarative `freshness` is not really used here.

This patch removes the `options` argument and sets `freshness` to `-Infinity`, asking `http-data` to issue the request on every call, and not try to be smart about it :)

Also simplifies the types, removing complicated declarations like `Parameters< typeof requestHttpData >[ 2 ]`

This patch doesn't change any behavior not fix any bug -- just a cleanup opportunity I found while auditing usages of the `http-data` library.