### PR TITLE
Lint all files in the default branch

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -438,9 +438,17 @@ object CheckCodeStyle : BuildType({
 				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
-				# Code style
-				FILES_TO_LINT=${'$'}(git diff --name-only --diff-filter=d refs/remotes/origin/master...HEAD | grep -E '^(client/|packages/|apps/)' | grep -E '\.[jt]sx?${'$'}' || exit 0)
+				# Find files to lint
+				if [[ "%teamcity.build.branch.is_default%" == "true" ]]; then
+					FILES_TO_LINT="."
+				else
+					FILES_TO_LINT=${'$'}(git diff --name-only --diff-filter=d refs/remotes/origin/master...HEAD | grep -E '(\.[jt]sx?|\.md)${'$'}' || exit 0)
+				fi
+				echo "Files to lint:"
 				echo ${'$'}FILES_TO_LINT
+				echo ""
+
+				# Lint files
 				if [ ! -z "${'$'}FILES_TO_LINT" ]; then
 					yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/results.xml" ${'$'}FILES_TO_LINT
 				fi


### PR DESCRIPTION
### Background

We have a build in TeamCity to run `eslint` when there are changes in the branch, linting the files that have changed compared to master.

### Changes

* Update the build script so it lints all files when run in `master`.
* Bonus: also lint `.md` files for all branches.

### Testing instructions

Verify the job 'Check code style' doesn't fail for this branch.