### PR TITLE
Jetpack Cloud hosting selection: inline the requestHostingProviderGuess handler

### DIFF
--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -120,22 +120,6 @@ export const requestActivity = ( siteId, rewindId, { freshness = 5 * 60 * 1000 }
 	);
 };
 
-export const getRequestHosingProviderGuessId = ( siteId ) =>
-	`site-hosting-provider-guess-${ siteId }`;
-
-export const requestHosingProviderGuess = ( siteId ) =>
-	requestHttpData(
-		getRequestHosingProviderGuessId( siteId ),
-		http( {
-			method: 'GET',
-			path: `/sites/${ siteId }/hosting-provider`,
-			apiNamespace: 'wpcom/v2',
-		} ),
-		{
-			fromApi: () => ( data ) => [ [ getRequestHosingProviderGuessId( siteId ), data ] ],
-		}
-	);
-
 const requestExternalContributorsId = ( siteId ) => `site-external-contributors-${ siteId }`;
 
 export const requestExternalContributors = ( siteId ) =>


### PR DESCRIPTION
The `requestHostingProviderGuess` code is used at only one place, so let's move it there. Makes the global `data-getters` module smaller, and the Jetpack Cloud specific code is not shared with any other entrypoints or chunks.

Fixes typo in naming: hosing -> hosting.

Also patches the `fromApi` function to store only the `guess` response field in the cache, instead of the entire response. Makes the later destructuring (`const { data: guess } = ... `) easier.

**How to test:**
The affected Jetpack Cloud flow is not enabled in production: the `jetpack/server-credentials-advanced-flow` is off in all environments.

After enabling it, verify that the hosting provider guess flow is working correctly.