### PR TITLE
http-data: fix the default implementation of fromApi

### DIFF
--- a/client/state/data-layer/http-data.ts
+++ b/client/state/data-layer/http-data.ts
@@ -230,6 +230,10 @@ interface RequestHttpDataOptions {
 	freshness?: number;
 }
 
+function defaultFromApi( requestId: DataId ): Lazy< ResponseParser > {
+	return () => ( data: any ) => [ [ requestId, data ] ];
+}
+
 /**
  * Fetches data from a fetchable action
  *
@@ -243,7 +247,7 @@ interface RequestHttpDataOptions {
 export const requestHttpData = (
 	requestId: DataId,
 	fetchAction: Lazy< AnyAction > | AnyAction,
-	{ fromApi, freshness = Infinity }: RequestHttpDataOptions
+	{ fromApi = defaultFromApi( requestId ), freshness = Infinity }: RequestHttpDataOptions
 ): Resource => {
 	const data = getHttpData( requestId );
 	const { state, lastUpdated } = data;
@@ -260,8 +264,7 @@ export const requestHttpData = (
 			type: HTTP_DATA_REQUEST,
 			id: requestId,
 			fetch: 'function' === typeof fetchAction ? fetchAction() : fetchAction,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			fromApi: 'function' === typeof fromApi ? fromApi : () => ( a: any ) => a,
+			fromApi,
 		};
 
 		dispatch ? dispatch( action ) : dispatchQueue.push( action );


### PR DESCRIPTION
The `fromApi` function is supposed to convert the REST response to an array of `ResponsePair`s, i.e., `[ key, data ]` tuples that are used to store cached pieces of data under corresponding keys. The `ResponseParser` type is pretty clear about that.

The default implementation, however, is simply an identity function that returns the `apiData` unchanged. That doesn't make much sense, and will crash the code that iterates the `fromApi` result with `data.forEach`.

So far, we were lucky that almost all `requestHttpData` usages supply their own `fromApi` implementation and that the default one is almost never used.

This patch changes the default `fromApi` to save the response under the supplied request ID key.

**How to test:**
The only usage of the default `fromApi` I found is in `MasterbarLoggedIn`, where it's resetting site migration when "My Sites" is clicked.

And it indeed fails with error before this patch:
<img width="636" alt="Screenshot 2020-10-06 at 11 37 58" src="https://user-images.githubusercontent.com/664258/95189996-f204f280-07ce-11eb-9cc3-4b04ff9b0b79.png">

As the `/reset-migration` request is fire-and-forget, the response isn't read by anyone and the failure doesn't cause any actual troubles.

To test, verify that this request stores a correct response to `window.httpData`. The best way to test is to comment out the `migrationStatus === 'error'` check in code and the click on "My Sites" in masterbar.