### PR TITLE
Cleanup package.json part 1: build packages exactly once

### DIFF
--- a/bin/install-if-deps-outdated.js
+++ b/bin/install-if-deps-outdated.js
@@ -55,7 +55,8 @@ function install() {
 	const installResult = spawnSync( 'yarn', [ 'install', '--frozen-lockfile' ], {
 		shell: true,
 		stdio: 'inherit',
-		env: { PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true', ...process.env },
+		// we won't need postinstall because everything in it will run in "build" script, which will run soon
+		env: { PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true', ...process.env, DISABLEPOSTINSTALL: 1 },
 	} );
 	if ( installResult.status ) {
 		console.error( 'failed to install: exited with code %d', installResult.status );

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 		"lint:js": "yarn run install-if-deps-outdated && eslint --cache .",
 		"lint:mixedindent": "mixedindentlint --ignore-comments \"client/**/*.scss\" \"assets/**/*.scss\" \"**/*.js\" \"**/*.jsx\" \"**/*.tsx\" \"**/*.tsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\" \"!client/config/index.js\"",
 		"lint:package-json": "npmPkgJsonLint './package.json' './client/package.json' './packages/*/package.json' './apps/*/package.json'",
-		"prestart": "npx check-node-version --package && yarn run install-if-deps-outdated && node bin/welcome.js",
+		"prestart": "npx check-node-version --package && node bin/welcome.js",
 		"start": "yarn run -s build",
 		"poststart": "run-p -s start-build-if-web start-build-if-desktop build-packages:watch",
 		"start-fallback": "DEV_TARGET=fallback yarn run start",


### PR DESCRIPTION
#### Intro

Our packages.json file is very hard to parse for humans. I try to follow scripts then I get caught by "pre" and "post" hooks, JS files in bin, and so on. Makes it very hard to track repetitive script runs.

I built a dirty tool parse it for us and generate the scripts' dependency graph, and then checks and warns you if any of the scripts calls a script more than once. My tool is fairly complicated and dirty, hence prone to error. But I verified two of these outputs, and they seem accurate:

```sh
"build" has extraneous calls
"build-css" has extraneous calls
"build-desktop:app" has extraneous calls
"build-client-both" has extraneous calls
"build-client-if-prod" has extraneous calls
"start" has extraneous calls
"start-fallback" has extraneous calls
```

In this PR, I'm mostly concerned with `yarn start`, because it's taking way too long to start Calypso. And I will work on other PRs later.

```sh
yarn start 1094.08s user 372.06s system 273% cpu 8:55.58 total
```

I finally was able to pin down why packages are being built twice sometimes. 

**Issue 1:**

Our `yarn start` simply calls `yarn build`, and

```sh
		"prebuild": "yarn run install-if-deps-outdated",
		"prestart": "yarn run install-if-deps-outdated",
```
As you can see "install-if-deps-outdated" is called twice. 

**Issue 2:**

When deps are outdated, `install-if-deps-outdated` calls `yarn run distclean` and `yarn run install`. And

```sh
		"postinstall": "test -n \"$DISABLEPOSTINSTALL\" || ((node -e \"process.exit(process.env.CALYPSO_DOCTOR_SKIP !== 'true')\" || yarn run calypso-doctor) && yarn run build-packages)",
```

As you can see, `postinstall` builds packages. And this all comes from `prebuild`. Which is followed by `build` and that builds everything.

#### Changes

1. Disable `postinstall` call in `install-if-deps-outdated` and leave building packages to `build` command.
2. Don't call `install-if-deps-outdated` in prestart, since it's called in `prebuild` anyways.

**After this change**

```sh
yarn start 521.07s user 203.47s system 215% cpu 5:36.89 total
```

<summary>
Code of the tool and raw output `[[scriptName, scriptDeps]]`
<details>

```json
[
	[ "install", "postinstall", "calypso-doctor", "build-packages" ],
	[ "analyze-bundles", "build-client-stats", "build-client-evergreen", "build-client-do" ],
	[ "analyze-bundles:server", "build-server-stats", "build-server", "prebuild-server" ],
	[ "analyze-icfy", "build-client-stats", "build-client-evergreen", "build-client-do" ],
	[ "autoprefixer" ],
	[ "postcss" ],
	[
		"prebuild",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[
		"build",
		"prebuild",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages",
		"build-devdocs:search-index",
		"build-client-if-desktop",
		"build-client-fallback",
		"build-client-do",
		"postbuild-client-fallback",
		"validate-fallback-es5",
		"download-languages-meta",
		"build-static",
		"build-packages",
		"build-css",
		"build-css:directly",
		"postcss",
		"build-css:editor",
		"postcss",
		"build-css:reader-mobile",
		"postcss"
	],
	[
		"build-css",
		"build-css:directly",
		"postcss",
		"build-css:editor",
		"postcss",
		"build-css:reader-mobile",
		"postcss"
	],
	[ "build-css:directly", "postcss" ],
	[ "build-css:editor", "postcss" ],
	[ "build-css:reader-mobile", "postcss" ],
	[ "build-devdocs:search-index" ],
	[ "build-desktop" ],
	[ "build-desktop:source" ],
	[ "build-desktop:config" ],
	[ "build-desktop:server" ],
	[ "build-desktop:client", "build-client-evergreen", "build-client-do" ],
	[ "build-desktop:static" ],
	[ "build-desktop:install-app-deps" ],
	[
		"build-desktop:app",
		"build",
		"prebuild",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages",
		"build-devdocs:search-index",
		"build-client-if-desktop",
		"build-client-fallback",
		"build-client-do",
		"postbuild-client-fallback",
		"validate-fallback-es5",
		"download-languages-meta",
		"build-static",
		"build-packages",
		"build-css",
		"build-css:directly",
		"postcss",
		"build-css:editor",
		"postcss",
		"build-css:reader-mobile",
		"postcss"
	],
	[ "test-desktop:e2e" ],
	[ "build-docker" ],
	[ "build-static" ],
	[ "prebuild-server" ],
	[ "build-server", "prebuild-server" ],
	[ "build-server-stats", "build-server", "prebuild-server" ],
	[ "build-client", "build-client-evergreen", "build-client-do" ],
	[ "build-client-do" ],
	[
		"build-client-fallback",
		"build-client-do",
		"postbuild-client-fallback",
		"validate-fallback-es5"
	],
	[ "postbuild-client-fallback", "validate-fallback-es5" ],
	[ "build-client-evergreen", "build-client-do" ],
	[
		"build-client-both",
		"build-client-fallback",
		"build-client-do",
		"postbuild-client-fallback",
		"validate-fallback-es5",
		"build-client-evergreen",
		"build-client-do"
	],
	[
		"build-client-if-prod",
		"build-client-both",
		"build-client-fallback",
		"build-client-do",
		"postbuild-client-fallback",
		"validate-fallback-es5",
		"build-client-evergreen",
		"build-client-do",
		"build-languages-if-enabled",
		"build-languages",
		"translate"
	],
	[
		"build-client-if-desktop",
		"build-client-fallback",
		"build-client-do",
		"postbuild-client-fallback",
		"validate-fallback-es5"
	],
	[ "build-client-stats", "build-client-evergreen", "build-client-do" ],
	[ "build-packages" ],
	[ "build-packages:watch" ],
	[ "build-languages", "translate" ],
	[ "build-languages-if-enabled", "build-languages", "translate" ],
	[ "calypso-doctor" ],
	[ "clean", "clean:packages", "clean:build", "clean:public", "clean:translations" ],
	[ "clean:build" ],
	[ "clean:packages" ],
	[ "clean:public" ],
	[ "clean:translations" ],
	[ "distclean", "clean", "clean:packages", "clean:build", "clean:public", "clean:translations" ],
	[ "docker" ],
	[ "docker-jetpack-cloud" ],
	[ "download-languages-meta" ],
	[ "eslint-branch" ],
	[ "install-if-deps-outdated" ],
	[ "install-if-no-packages" ],
	[ "postinstall", "calypso-doctor", "build-packages" ],
	[ "lint" ],
	[ "lint:config-defaults" ],
	[ "lint:css" ],
	[
		"lint:js",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[ "lint:mixedindent" ],
	[ "lint:package-json" ],
	[ "prestart" ],
	[
		"start",
		"prestart",
		"build",
		"prebuild",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages",
		"build-devdocs:search-index",
		"build-client-if-desktop",
		"build-client-fallback",
		"build-client-do",
		"postbuild-client-fallback",
		"validate-fallback-es5",
		"download-languages-meta",
		"build-static",
		"build-packages",
		"build-css",
		"build-css:directly",
		"postcss",
		"build-css:editor",
		"postcss",
		"build-css:reader-mobile",
		"postcss",
		"poststart",
		"build-packages:watch"
	],
	[ "poststart", "build-packages:watch" ],
	[
		"start-fallback",
		"start",
		"prestart",
		"build",
		"prebuild",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages",
		"build-devdocs:search-index",
		"build-client-if-desktop",
		"build-client-fallback",
		"build-client-do",
		"postbuild-client-fallback",
		"validate-fallback-es5",
		"download-languages-meta",
		"build-static",
		"build-packages",
		"build-css",
		"build-css:directly",
		"postcss",
		"build-css:editor",
		"postcss",
		"build-css:reader-mobile",
		"postcss",
		"poststart",
		"build-packages:watch"
	],
	[ "start-jetpack-cloud" ],
	[
		"start-jetpack-cloud-p",
		"build-server",
		"prebuild-server",
		"poststart-jetpack-cloud-p",
		"start-build-web",
		"start-build-web-if-evergreen",
		"start-build-evergreen",
		"start-build-do"
	],
	[
		"poststart-jetpack-cloud-p",
		"start-build-web",
		"start-build-web-if-evergreen",
		"start-build-evergreen",
		"start-build-do"
	],
	[ "reformat-files" ],
	[ "start-build-do" ],
	[ "start-build-fallback", "start-build-do" ],
	[ "start-build-evergreen", "start-build-do" ],
	[ "start-build-if-desktop", "start-build-fallback", "start-build-do" ],
	[
		"start-build-if-web",
		"start-build-web",
		"start-build-web-if-evergreen",
		"start-build-evergreen",
		"start-build-do"
	],
	[ "start-build-web", "start-build-web-if-evergreen", "start-build-evergreen", "start-build-do" ],
	[ "start-build-web-if-fallback", "start-build-fallback", "start-build-do" ],
	[ "start-build-web-if-evergreen", "start-build-evergreen", "start-build-do" ],
	[
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[
		"test",
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[
		"pretest-client",
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[
		"test-client",
		"pretest-client",
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[
		"test-client:watch",
		"test-client",
		"pretest-client",
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[
		"test-e2e",
		"test",
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[ "encrypt-e2e-config" ],
	[ "decrypt-e2e-config" ],
	[
		"pretest-integration",
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[
		"test-integration",
		"pretest-integration",
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[
		"test-integration:watch",
		"test-integration",
		"pretest-integration",
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[ "test-packages" ],
	[ "test-packages:watch" ],
	[
		"pretest-server",
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[
		"test-server",
		"pretest-server",
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[
		"test-server:coverage",
		"test-server",
		"pretest-server",
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[
		"test-server:watch",
		"test-server",
		"pretest-server",
		"pretest",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations",
		"install",
		"postinstall",
		"calypso-doctor",
		"build-packages"
	],
	[ "translate" ],
	[ "tsc" ],
	[ "typecheck", "tsc" ],
	[
		"update-deps",
		"distclean",
		"clean",
		"clean:packages",
		"clean:build",
		"clean:public",
		"clean:translations"
	],
	[ "validate-fallback-es5" ],
	[ "prewhybundled", "build-client-evergreen", "build-client-do" ],
	[ "whybundled", "prewhybundled", "build-client-evergreen", "build-client-do" ],
	[ "prewhybundled:server", "build-server", "prebuild-server" ],
	[ "whybundled:server", "prewhybundled:server", "build-server", "prebuild-server" ],
	[ "composite-checkout-demo" ],
	[ "components:storybook:start" ],
	[ "media-library:storybook:start" ]
]

```

```js
const { flattenDeep } = require( 'lodash' );
const minimatch = require( 'minimatch' );
const { scripts } = require( '../package.json' );
const chalk = require( 'chalk' );

const tree = {};

// add "install" script just to pickup preinstall and postinstall scripts
Object.entries( { install: '', ...scripts } ).forEach( ( [ scriptName, scriptCode ] ) => {
	if ( ! tree[ scriptName ] ) {
		tree[ scriptName ] = [];
		if ( scripts[ 'pre' + scriptName ] ) {
			tree[ scriptName ].push( 'pre' + scriptName );
		}
	}

	const runPMatches = scriptCode.matchAll( /run-p -s (([\w|\-|:|*]+) ?)+/g );
	const yarnMatches = scriptCode.matchAll( /yarn run (-s )?(([\w|\-|:|*]+))+/g );
	const matches = [ ...runPMatches, ...yarnMatches ];
	for ( const match of matches ) {
		const calledScriptName = match[ 2 ].trim();
		tree[ scriptName ].push( calledScriptName );
	}
	if ( scripts[ 'post' + scriptName ] ) {
		tree[ scriptName ].push( 'post' + scriptName );
	}
} );

const allScripts = Object.keys( tree );

Object.entries( tree ).forEach( ( [ script, deps ] ) => {
	tree[ script ] = deps.flatMap( ( dep ) => {
		if ( dep.includes( '*' ) ) {
			const matches = minimatch.match( allScripts, dep );
			return matches;
			// install-if-deps-outdated runs distclean then install, replace it with that
		} else if ( dep === 'install-if-deps-outdated' ) {
			return [ 'distclean', 'install' ];
		}
		return dep;
	} );
} );

const expandedTree = {};

function resolveScriptDeps( script, calls = [] ) {
	if ( tree[ script ] ) {
		if ( tree[ script ] ) {
			const callsScripts = tree[ script ].map( ( calledScript ) =>
				resolveScriptDeps( calledScript )
			);

			calls.push( script, ...callsScripts );
		}
	} else {
		calls.push( script );
	}
	return calls;
}

Object.entries( tree ).forEach( ( [ scriptName, dependencies ] ) => {
	expandedTree[ scriptName ] = dependencies.reduce( ( acc, script ) => {
		acc.push( ...resolveScriptDeps( script ) );
		return acc;
	}, [] );
} );

const allScriptsAndTheirDeps = [];

for ( const [ scriptName, scriptDeps ] of Object.entries( expandedTree ) ) {
	allScriptsAndTheirDeps.push( [ scriptName, ...flattenDeep( scriptDeps ) ] );
}

allScriptsAndTheirDeps.forEach( ( script ) => {
	if ( new Set( script ).size !== script.length ) {
		console.warn( chalk.yellow( chalk.bold( script[ 0 ] ) + ` has extraneous calls!` ) );
	}
} );

console.log( JSON.stringify( allScriptsAndTheirDeps ) );
```

</details>


</summary