### PR TITLE
Update the test data to use subdir instead of subdomain for SV

### DIFF
--- a/test/e2e/localization-data.json
+++ b/test/e2e/localization-data.json
@@ -231,7 +231,7 @@
 		"currency_symbol": "€",
 		"nux_landing_page_string": "Steg",
 		"wpcom_landing_page_string": "Logga in",
-		"wpcom_base_url": "sv.wordpress.com",
+		"wpcom_base_url": "wordpress.com/sv",
 
 		"google_searches": [
 			{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With the recent introduction of subdirs for locales instead of subdomains and fully enabling SV, the e2e tests should be updated to use wordpress.com/sv instead of sv.wordpress.com.

#### Testing instructions

1. Follow the steps at https://github.com/Automattic/wp-calypso/blob/master/test/e2e/README.md and https://github.com/Automattic/wp-calypso/blob/master/test/e2e/docs/running-tests.md#getting-started to prepare for running e2e tests locally
2. Within local Calypso instance `cd test/e2e` and run `./run.sh -I`
3. Confirm that logged-out-redirect-i18n-spec.js e2e test (should redirect to the correct url for wordpress.com (sv)) has passed successfully
