### PR TITLE
Rename version to appVersion

### DIFF
--- a/client/server/middleware/logger.js
+++ b/client/server/middleware/logger.js
@@ -32,7 +32,7 @@ const logRequest = ( req, res, options ) => {
 			( Number( process.hrtime.bigint() - requestStart ) * NS_TO_MS ).toFixed( 3 )
 		),
 		httpVersion: req.httpVersion,
-		version,
+		appVersion: version,
 		env,
 		userAgent: parseUA( req.get( 'user-agent' ) ),
 		rawUserAgent: req.get( 'user-agent' ),

--- a/client/server/middleware/test/logger.js
+++ b/client/server/middleware/test/logger.js
@@ -147,7 +147,7 @@ it( 'Adds the COMMIT_SHA as version', () => {
 
 	expect( mockLogger.info ).toHaveBeenCalledWith(
 		expect.objectContaining( {
-			version: 'abcd1234',
+			appVersion: 'abcd1234',
 		} )
 	);
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request

In server logs, rename `version` to `appVersion`. `version` was too generic.

### Testing instructions

Start the server with COMMIT_SHA=1234 NODE_ENV=production yarn start and go to local calypso. In the console verify there is a field `appVersion:1234`
