### PR TITLE
Signup: Fix padding around domain search field

### DIFF
--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -10,7 +10,7 @@
 		}
 	}
 
-	.register-domain-step__search-card {
+	.card.register-domain-step__search-card {
 		padding: 0;
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Signup: Fix padding around domain search field

Before:

![](https://cldup.com/y-fve5IRXK.png)

After:
![](https://cldup.com/l5M4cxE4SP.png)

#### Testing instructions

* Go to `/start` in an incognito session
* Create an account or log in
* On the domains step, verify there is no weird padding around the domain search field.

#### Notes

Reported by @michaeldcain in p1601987964001100-slack-C012K365WR3