### PR TITLE
G Suite: Update Add G Suite page to support passwords

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -9,8 +9,10 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
+import config from 'calypso/config';
 import GSuiteDomainsSelect from './domains-select';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
@@ -36,6 +38,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 		lastName: { value: lastName, error: lastNameError },
 		mailBox: { value: mailBox, error: mailBoxError },
 		domain: { value: domain, error: domainError },
+		password: { value: password, error: passwordError },
 	},
 } ) => {
 	const translate = useTranslate();
@@ -43,18 +46,20 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 	// use this to control setting the "touched" states below. That way the user will not see a bunch of
 	// "This field is required" errors pop at once
 	const wasValidated =
-		[ firstName, lastName, mailBox ].some( ( value ) => '' !== value ) ||
-		[ firstNameError, lastNameError, mailBoxError, domainError ].some(
+		[ firstName, lastName, mailBox, password ].some( ( value ) => '' !== value ) ||
+		[ firstNameError, lastNameError, mailBoxError, passwordError, domainError ].some(
 			( value ) => null !== value
 		);
 
 	const [ firstNameFieldTouched, setFirstNameFieldTouched ] = useState( false );
 	const [ lastNameFieldTouched, setLastNameFieldTouched ] = useState( false );
 	const [ mailBoxFieldTouched, setMailBoxFieldTouched ] = useState( false );
+	const [ passwordFieldTouched, setPasswordFieldTouched ] = useState( false );
 
 	const hasMailBoxError = mailBoxFieldTouched && null !== mailBoxError;
 	const hasFirstNameError = firstNameFieldTouched && null !== firstNameError;
 	const hasLastNameError = lastNameFieldTouched && null !== lastNameError;
+	const hasPasswordError = passwordFieldTouched && null !== passwordError;
 
 	const emailAddressPlaceholder = translate( 'Email' );
 
@@ -163,6 +168,28 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 
 						{ hasMailBoxError && <FormInputValidation text={ mailBoxError } isError /> }
 					</div>
+
+					{ config.isEnabled( 'gsuite/passwords' ) && (
+						<div className="gsuite-new-user-list__new-user-password-container">
+							<FormPasswordInput
+								autoCapitalize="off"
+								autoCorrect="off"
+								placeholder={ translate( 'Password' ) }
+								value={ password }
+								maxLength={ 100 }
+								isError={ hasPasswordError }
+								onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
+									onUserValueChange( 'password', event.target.value );
+								} }
+								onBlur={ () => {
+									setPasswordFieldTouched( wasValidated );
+								} }
+								onKeyUp={ onReturnKeyPress }
+							/>
+
+							{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
+						</div>
+					) }
 				</div>
 			</FormFieldset>
 		</div>

--- a/client/components/gsuite/gsuite-new-user-list/style.scss
+++ b/client/components/gsuite/gsuite-new-user-list/style.scss
@@ -60,6 +60,10 @@
 	@include breakpoint-deprecated( '>800px' ) {
 		display: flex;
 		justify-content: space-between;
+
+		& > *:not(:first-child) {
+			margin-left: 15px;
+		}
 	}
 }
 
@@ -98,6 +102,25 @@
 	}
 }
 
+.gsuite-new-user-list__new-user-email-container,
+.gsuite-new-user-list__new-user-password-container {
+	@include breakpoint-deprecated( '>800px' ) {
+		margin-bottom: 0;
+	}
+}
+
 .gsuite-new-user-list__new-user-email-container {
-	width: 100%;
+	@include breakpoint-deprecated( '>800px' ) {
+		width: 100%;
+	}
+}
+
+.gsuite-new-user-list__new-user-password-container {
+	margin-top: 15px;
+
+	@include breakpoint-deprecated( '>800px' ) {
+		margin-right: 0;
+		margin-top: 0;
+		width: 50%;
+	}
 }

--- a/client/components/upgrades/gsuite/gsuite-upsell-card/style.scss
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/style.scss
@@ -53,37 +53,39 @@
 	}
 }
 
+// See .gsuite-add-users__buttons as well
 .gsuite-upsell-card__buttons {
 	display: flex;
 	flex-direction: column;
 
 	button {
-		margin: 5px 0 0;
-		width: 100%;
+		margin-top: 10px;
 	}
 
 	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 
 		button {
-			margin: 0 0 0 5px;
-			width: auto;
+			margin-left: 10px;
+			margin-top: 0;
 		}
 	}
 
 	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: column;
+
 		button {
-			margin: 5px 0 0;
-			width: 100%;
+			margin-left: 0;
+			margin-top: 10px;
 		}
 	}
 
 	@include breakpoint-deprecated( '>800px' ) {
 		flex-direction: row;
+
 		button {
-			margin: 0 0 0 5px;
-			width: auto;
+			margin-left: 10px;
+			margin-top: 0;
 		}
 	}
 }

--- a/client/my-sites/email/gsuite-add-users/style.scss
+++ b/client/my-sites/email/gsuite-add-users/style.scss
@@ -1,3 +1,4 @@
+// See .gsuite-upsell-card__buttons as well
 .gsuite-add-users__buttons {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
This pull request updates the Add G Suite page to allow users to specify passwords for their G Suite users. This new flow will only be available for now when the `gsuite/passwords` feature flag is enabled. You'll be able to find more context about that change in D50561-code.

##### Purchasing G Suite with a domain

![Upsell](https://user-images.githubusercontent.com/594356/95872622-4845d880-0d6f-11eb-970c-a94b3c594a06.png)

##### Purchasing G Suite for a domain already registered

![Add](https://user-images.githubusercontent.com/594356/95872641-4d0a8c80-0d6f-11eb-80c1-c960794715a6.png)

#### Testing instructions

1. Run `git checkout add/gsuite-passwords` and start your server, or open a [live branch](https://calypso.live/?branch=add/gsuite-passwords)
2. Apply D50561-code, and follow its testing instructions to set up your environment
3. Open the [`Email` page](http://calypso.localhost:3000/email?flags=gsuite/passwords) with the new flow enabled
4. Proceed to the Add G Suite page
5. Assert that the page is displayed correctly on small viewports
6. Assert that validation rules are correctly enforced for the new `Password` field
7. Assert that the old flow still works
