### PR TITLE
Fix/Remove feature flag text.

### DIFF
--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -9,7 +9,6 @@ import { isArray } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
 import { applySiteOffset } from 'lib/site/timezone';
 import { Card } from '@automattic/components';
 import { isSuccessfulDailyBackup, isSuccessfulRealtimeBackup } from 'lib/jetpack/backup-utils';
@@ -76,9 +75,6 @@ DailyBackupStatus.propTypes = {
 
 const Wrapper = ( props ) => (
 	<Card className="daily-backup-status">
-		{ isEnabled( 'jetpack/backup-simplified-screens' ) && (
-			<p style={ { color: 'red' } }>Feature Flag: jetpack/backup-simplified-screens is ON</p>
-		) }
 		<DailyBackupStatus { ...props } />
 	</Card>
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes text that says, "Feature Flag: jetpack/backup-simplified-screens is ON" in Jetpack -> Backup

(`https://wordpress.com/backup/:site`)

#### Testing instructions

1. Run this PR
2. Go to: `http://calypso.localhost:3000/backup/:site` with a site that has backup as product or included in plan.
3. Verify that you don't see the text, "Feature Flag: jetpack/backup-simplified-screens is ON" in the backup card.


