### PR TITLE
Enable simplified backup screens in production

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -20,7 +20,7 @@
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
-		"jetpack/backup-simplified-screens": false,
+		"jetpack/backup-simplified-screens": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": false,

--- a/config/production.json
+++ b/config/production.json
@@ -48,7 +48,7 @@
 		"i18n/translation-scanner": true,
 		"ive/use-external-assignment": true,
 		"jetpack/api-cache": false,
-		"jetpack/backup-simplified-screens": false,
+		"jetpack/backup-simplified-screens": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR applies updates made in #46173, #46165, and #46162 to production (both Calypso and Jetpack cloud)

Fixes 1197351014149633-as-1197406866147385

### Testing instructions

Just review code changes.
