### PR TITLE
Domains: Quickfix for broken styles

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -8,7 +8,7 @@
 }
 
 .list__header-primary-domain {
-	display: flex;
+	display: flex !important;
 	align-items: center;
 
 	.list__header-primary-domain-info {
@@ -23,7 +23,7 @@
 	}
 
 	.list__header-primary-domain-buttons {
-		display: flex;
+		display: flex !important;
 	}
 }
 
@@ -123,7 +123,7 @@
 }
 
 .domain-management-list-item__upsell, .domain-item__upsell {
-	display: flex;
+	display: flex !important;
 	align-items: center;
 	justify-content: center;
 
@@ -134,7 +134,7 @@
 }
 
 .domain-management-list-item__content {
-	display: flex;
+	display: flex !important;
 	justify-content: space-between;
 
 	@include breakpoint-deprecated( '<960px' ) {
@@ -181,7 +181,7 @@ input[type='radio'].domain-management-list-item__radio {
 }
 
 .domain-item, .list-header {
-	display: flex;
+	display: flex !important;
 	align-items: center;
 }
 
@@ -248,7 +248,7 @@ input[type='radio'].domain-management-list-item__radio {
 }
 
 .domain-item__status {
-	display: flex;
+	display: flex !important;
 	flex-wrap: wrap;
 	margin-left: -4px;
 


### PR DESCRIPTION
Fixes #46211

Similar situation to https://github.com/Automattic/wp-calypso/issues/46206 (fixed in https://github.com/Automattic/wp-calypso/pull/46208)

Visit `/domains/manage/` and make sure the layout is correct:

<img width="1071" alt="Screenshot 2020-10-06 at 18 55 44" src="https://user-images.githubusercontent.com/3392497/95247580-9013af80-0805-11eb-81eb-9985d864d89a.png">
