### PR TITLE
Revert "Layout: AsyncLoad GdprBanner in LayoutLoggedOut"

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -22,6 +22,7 @@ import getCurrentQueryArguments from 'state/selectors/get-current-query-argument
 import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
 import { getSection, masterbarIsVisible } from 'state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
+import GdprBanner from 'blocks/gdpr-banner';
 import wooDnaConfig from 'jetpack-connect/woo-dna-config';
 
 /**
@@ -119,9 +120,7 @@ const LayoutLoggedOut = ( {
 					{ secondary }
 				</div>
 			</div>
-			{ config.isEnabled( 'gdpr-banner' ) && (
-				<AsyncLoad require="blocks/gdpr-banner" placeholder={ null } />
-			) }
+			{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
 		</div>
 	);
 };

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -1,6 +1,6 @@
 .site-setup-list {
-	padding: 0 !important;
-	display: flex !important;
+	padding: 0;
+	display: flex;
 
 	@include breakpoint-deprecated( '<960px' ) {
 		display: block;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#46133
And https://github.com/Automattic/wp-calypso/pull/46208 that was caused by it.

Looks like it might the culprit behind https://github.com/Automattic/wp-calypso/issues/46206 and https://github.com/Automattic/wp-calypso/issues/46211

### Testing

Same as for https://github.com/Automattic/wp-calypso/pull/46212 (which will then be not needed)

Visit `/domains/manage/` and make sure the layout is correct:

<img width="1071" alt="Screenshot 2020-10-06 at 18 55 44" src="https://user-images.githubusercontent.com/3392497/95247580-9013af80-0805-11eb-81eb-9985d864d89a.png">