### PR TITLE
Payments: Remove unused notice code

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -473,24 +473,6 @@ class MembershipsSection extends Component {
 						</NoticeAction>
 					</Notice>
 				) }
-				{ this.props.query.stripe_connect_success === 'gutenberg' && (
-					<Notice
-						status="is-success"
-						showDismiss={ false }
-						text={ this.props.translate(
-							'Congrats! Your site is now connected to Stripe. You can now close this window, click "Re-check connection" and add your first payment plan.'
-						) }
-					>
-						<NoticeAction
-							href={ localizeUrl(
-								'https://wordpress.com/support/recurring-payments-button/#stripe-account-connected'
-							) }
-							icon="external"
-						>
-							{ this.props.translate( 'Learn how' ) }
-						</NoticeAction>
-					</Notice>
-				) }
 				{ this.renderEarnings() }
 				{ this.renderSubscriberList() }
 				{ this.renderManagePlans() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove unused Notice code that showed a message to a user coming to `/earn/payments` from Gutenberg after a successful Stripe connection. We no longer send users from the editor to `/earn/payments` as of #45204 so this Notice is unnecessary.

#### Testing instructions

* Switch to this PR
* Follow the instructions in the FG for sandboxing the store
* Go to `/earn/` and connect to Stripe. You should be redirected back to `/earn/payments` with a successful notice like this:
<img width="1084" alt="Screen Shot 2020-10-06 at 3 11 43 PM" src="https://user-images.githubusercontent.com/2124984/95250575-4ec0d700-07e8-11eb-984f-fb2e61d5e79f.png">

* Disconnect Stripe
* Go to a Post or Page and add a premium block that requires a Stripe connection, like the Donations block
* Connect to Stripe again; you should be redirected back to the post/page editor after a successful connection.

Fixes #45018
