### PR TITLE
Update the test data to use subdir instead of subdomain for HE and KO

### DIFF
--- a/test/e2e/localization-data.json
+++ b/test/e2e/localization-data.json
@@ -95,7 +95,7 @@
 		"currency_symbol": "$",
 		"nux_landing_page_string": "שלב",
 		"wpcom_landing_page_string": "להתחבר",
-		"wpcom_base_url": "he.wordpress.com",
+		"wpcom_base_url": "wordpress.com/he",
 
 		"google_searches": [
 			{
@@ -163,7 +163,7 @@
 		"currency_symbol": "$",
 		"nux_landing_page_string": "단계",
 		"wpcom_landing_page_string": "로그인",
-		"wpcom_base_url": "ko.wordpress.com",
+		"wpcom_base_url": "wordpress.com/ko",
 
 		"google_searches": [
 			{
@@ -231,7 +231,7 @@
 		"currency_symbol": "€",
 		"nux_landing_page_string": "Steg",
 		"wpcom_landing_page_string": "Logga in",
-		"wpcom_base_url": "sv.wordpress.com",
+		"wpcom_base_url": "wordpress.com/sv",
 
 		"google_searches": [
 			{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With the recent introduction of subdirs for locales instead of subdomains and fully enabling el/he/ro/ko locales, the e2e tests should be updated to use wordpress.com/he instead of he.wordpress.com and wordpress.com/ko instead of ko.wordpress.com

#### Testing instructions

1. Follow the steps at https://github.com/Automattic/wp-calypso/blob/master/test/e2e/README.md and https://github.com/Automattic/wp-calypso/blob/master/test/e2e/docs/running-tests.md#getting-started to prepare for running e2e tests locally
2. Within local Calypso instance `cd test/e2e` and run `./run.sh -I`
3. Confirm that `logged-out-redirect-i18n-spec.js e2e test (should redirect to the correct url for wordpress.com (he))` and `logged-out-redirect-i18n-spec.js e2e test (should redirect to the correct url for wordpress.com (ko))` have passed successfully
