### PR TITLE
Site-level billing: Add receipt view

### DIFF
--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -8,7 +8,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import { billingHistoryReceipt } from 'calypso/me/purchases/paths';
 import TransactionsTable from './transactions-table';
 import isSendingBillingReceiptEmail from 'calypso/state/selectors/is-sending-billing-receipt-email';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -51,13 +50,13 @@ class BillingHistoryTable extends React.Component {
 	};
 
 	renderTransaction = ( transaction ) => {
-		const { translate } = this.props;
+		const { translate, getReceiptUrlFor } = this.props;
 
 		return (
 			<div className="billing-history__transaction-links">
 				<a
 					className="billing-history__view-receipt"
-					href={ billingHistoryReceipt( transaction.id ) }
+					href={ getReceiptUrlFor( transaction.id ) }
 					onClick={ this.handleReceiptLinkClick }
 				>
 					{ translate( 'View receipt' ) }

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -7,6 +7,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { billingHistoryReceipt } from 'me/purchases/paths';
 import { Card } from '@automattic/components';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import config from 'calypso/config';
@@ -23,10 +24,10 @@ import QueryBillingTransactions from 'calypso/components/data/query-billing-tran
  */
 import './style.scss';
 
-export function BillingHistoryList( { siteId = null } ) {
+export function BillingHistoryList( { siteId = null, getReceiptUrlFor = billingHistoryReceipt } ) {
 	return (
 		<Card className="billing-history__receipts">
-			<BillingHistoryTable siteId={ siteId } />
+			<BillingHistoryTable siteId={ siteId } getReceiptUrlFor={ getReceiptUrlFor } />
 		</Card>
 	);
 }

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -7,7 +7,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { billingHistoryReceipt } from 'me/purchases/paths';
+import { billingHistoryReceipt } from 'calypso/me/purchases/paths';
 import { Card } from '@automattic/components';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import config from 'calypso/config';

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -70,7 +70,7 @@ class BillingReceipt extends React.Component {
 				/>
 				<QueryBillingTransaction transactionId={ transactionId } />
 
-				<ReceiptTitle />
+				<ReceiptTitle backHref={ billingHistory } />
 
 				{ transaction ? (
 					<ReceiptBody
@@ -305,9 +305,9 @@ function ReceiptLabels() {
 	);
 }
 
-function ReceiptTitle() {
+export function ReceiptTitle( { backHref } ) {
 	const translate = useTranslate();
-	return <HeaderCake backHref={ billingHistory }>{ translate( 'Billing History' ) }</HeaderCake>;
+	return <HeaderCake backHref={ backHref }>{ translate( 'Billing History' ) }</HeaderCake>;
 }
 
 export default connect(

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ import TextareaAutosize from 'calypso/components/textarea-autosize';
 import DocumentHead from 'calypso/components/data/document-head';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { withLocalizedMoment, useLocalizedMoment } from 'calypso/components/localized-moment';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { billingHistory } from 'calypso/me/purchases/paths';
 import QueryBillingTransaction from 'calypso/components/data/query-billing-transaction';
@@ -58,235 +58,6 @@ class BillingReceipt extends React.Component {
 		page.redirect( billingHistory );
 	}
 
-	ref() {
-		const { transaction, translate } = this.props;
-
-		if ( ! transaction.pay_ref ) {
-			return null;
-		}
-
-		return (
-			<li>
-				<strong>{ translate( 'Transaction ID' ) }</strong>
-				<span>{ transaction.pay_ref }</span>
-			</li>
-		);
-	}
-
-	paymentMethod() {
-		const { transaction, translate } = this.props;
-		let text;
-
-		if ( transaction.pay_part === PARTNER_PAYPAL_EXPRESS ) {
-			text = translate( 'PayPal' );
-		} else if ( 'XXXX' !== transaction.cc_num ) {
-			text = translate( '%(cardType)s ending in %(cardNum)s', {
-				args: {
-					cardType: transaction.cc_type.toUpperCase(),
-					cardNum: transaction.cc_num,
-				},
-			} );
-		} else {
-			return null;
-		}
-
-		return (
-			<li>
-				<strong>{ translate( 'Payment Method' ) }</strong>
-				<span>{ text }</span>
-			</li>
-		);
-	}
-
-	renderTitle() {
-		const { translate } = this.props;
-
-		return <HeaderCake backHref={ billingHistory }>{ translate( 'Billing History' ) }</HeaderCake>;
-	}
-
-	renderPlaceholder() {
-		return (
-			<Card compact className="billing-history__receipt-card is-placeholder">
-				<div className="billing-history__app-overview">
-					<div className="billing-history__placeholder-image" />
-					<div className="billing-history__placeholder-title" />
-				</div>
-
-				<div className="billing-history__receipt-links">
-					<div className="billing-history__placeholder-link" />
-					<div className="billing-history__placeholder-link" />
-				</div>
-			</Card>
-		);
-	}
-
-	renderBillingDetailsLabels() {
-		const { translate } = this.props;
-		return (
-			<div>
-				<label htmlFor="billing-history__billing-details-textarea">
-					<strong>{ translate( 'Billing Details' ) }</strong>
-				</label>
-				<div
-					className="billing-history__billing-details-description"
-					id="billing-history__billing-details-description"
-				>
-					{ translate(
-						'Use this field to add your billing information (eg. VAT number, business address) before printing.'
-					) }
-				</div>
-			</div>
-		);
-	}
-
-	renderBillingDetails() {
-		const { transaction } = this.props;
-		if ( ! transaction.cc_name && ! transaction.cc_email ) {
-			return null;
-		}
-
-		return (
-			<li className="billing-history__billing-details">
-				{ this.renderBillingDetailsLabels() }
-				<TextareaAutosize
-					className="billing-history__billing-details-editable"
-					aria-labelledby="billing-history__billing-details-description"
-					id="billing-history__billing-details-textarea"
-					rows="1"
-					defaultValue={ transaction.cc_name + '\n' + transaction.cc_email }
-				/>
-			</li>
-		);
-	}
-
-	renderEmptyBillingDetails() {
-		return (
-			<li className="billing-history__billing-details">
-				{ this.renderBillingDetailsLabels() }
-				<TextareaAutosize
-					className="billing-history__billing-details-editable"
-					aria-labelledby="billing-history__billing-details-description"
-					id="billing-history__billing-details-textarea"
-					rows="1"
-				/>
-			</li>
-		);
-	}
-
-	renderLineItems() {
-		const { transaction, translate } = this.props;
-		const groupedTransactionItems = groupDomainProducts( transaction.items, translate );
-
-		const items = groupedTransactionItems.map( ( item ) => {
-			const termLabel = getPlanTermLabel( item.wpcom_product_slug, translate );
-			return (
-				<tr key={ item.id }>
-					<td className="billing-history__receipt-item-name">
-						<span>{ item.variation }</span>
-						<small>({ item.type_localized })</small>
-						{ termLabel ? <em>{ termLabel }</em> : null }
-						<br />
-						<em>{ item.domain }</em>
-					</td>
-					<td className={ 'billing-history__receipt-amount ' + transaction.credit }>
-						{ item.amount }
-						{ transaction.credit && (
-							<span className="billing-history__credit-badge">{ translate( 'Refund' ) }</span>
-						) }
-					</td>
-				</tr>
-			);
-		} );
-
-		return (
-			<div className="billing-history__receipt">
-				<h4>{ translate( 'Order summary' ) }</h4>
-				<table className="billing-history__receipt-line-items">
-					<thead>
-						<tr>
-							<th className="billing-history__receipt-desc">{ translate( 'Description' ) }</th>
-							<th className="billing-history__receipt-amount">{ translate( 'Amount' ) }</th>
-						</tr>
-					</thead>
-					<tfoot>
-						<tr>
-							<td className="billing-history__receipt-desc">
-								<strong>{ translate( 'Total' ) }:</strong>
-							</td>
-							<td
-								className={
-									'billing-history__receipt-amount billing-history__total-amount ' +
-									transaction.credit
-								}
-							>
-								{ renderTransactionAmount( transaction, { translate } ) }
-							</td>
-						</tr>
-					</tfoot>
-					<tbody>{ items }</tbody>
-				</table>
-			</div>
-		);
-	}
-
-	renderBillingHistory() {
-		const { transaction, translate, moment } = this.props;
-		const title = translate( 'Visit %(url)s', { args: { url: transaction.url } } );
-		const serviceLink = <a href={ transaction.url } title={ title } />;
-
-		return (
-			<div>
-				<Card compact className="billing-history__receipt-card">
-					<div className="billing-history__app-overview">
-						<img
-							src={ transaction.icon }
-							title={ transaction.service }
-							alt={ transaction.service }
-						/>
-						<h2>
-							{ ' ' }
-							{ translate( '{{link}}%(service)s{{/link}} {{small}}by %(organization)s{{/small}}', {
-								components: {
-									link: serviceLink,
-									small: <small />,
-								},
-								args: {
-									service: transaction.service,
-									organization: transaction.org,
-								},
-								comment:
-									'This string is "Service by Organization". ' +
-									'The {{link}} and {{small}} add html styling and attributes. ' +
-									'Screenshot: https://cloudup.com/isX-WEFYlOs',
-							} ) }
-							<div className="billing-history__transaction-date">
-								{ moment( transaction.date ).format( 'll' ) }
-							</div>
-						</h2>
-					</div>
-					<ul className="billing-history__receipt-details group">
-						<li>
-							<strong>{ translate( 'Receipt ID' ) }</strong>
-							<span>{ transaction.id }</span>
-						</li>
-						{ this.ref() }
-						{ this.paymentMethod() }
-						{ transaction.cc_num !== 'XXXX'
-							? this.renderBillingDetails()
-							: this.renderEmptyBillingDetails() }
-					</ul>
-					{ this.renderLineItems() }
-				</Card>
-
-				<Card compact className="billing-history__receipt-links">
-					<Button primary onClick={ this.handlePrintLinkClick }>
-						{ translate( 'Print Receipt' ) }
-					</Button>
-				</Card>
-			</div>
-		);
-	}
-
 	render() {
 		const { transaction, transactionId, translate } = this.props;
 
@@ -299,12 +70,244 @@ class BillingReceipt extends React.Component {
 				/>
 				<QueryBillingTransaction transactionId={ transactionId } />
 
-				{ this.renderTitle() }
+				<ReceiptTitle />
 
-				{ transaction ? this.renderBillingHistory() : this.renderPlaceholder() }
+				{ transaction ? (
+					<ReceiptBody
+						transaction={ transaction }
+						handlePrintLinkClick={ this.handlePrintLinkClick }
+					/>
+				) : (
+					<ReceiptPlaceholder />
+				) }
 			</Main>
 		);
 	}
+}
+
+export function ReceiptBody( { transaction, handlePrintLinkClick } ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const title = translate( 'Visit %(url)s', { args: { url: transaction.url } } );
+	const serviceLink = <a href={ transaction.url } title={ title } />;
+
+	return (
+		<div>
+			<Card compact className="billing-history__receipt-card">
+				<div className="billing-history__app-overview">
+					<img src={ transaction.icon } title={ transaction.service } alt={ transaction.service } />
+					<h2>
+						{ ' ' }
+						{ translate( '{{link}}%(service)s{{/link}} {{small}}by %(organization)s{{/small}}', {
+							components: {
+								link: serviceLink,
+								small: <small />,
+							},
+							args: {
+								service: transaction.service,
+								organization: transaction.org,
+							},
+							comment:
+								'This string is "Service by Organization". ' +
+								'The {{link}} and {{small}} add html styling and attributes. ' +
+								'Screenshot: https://cloudup.com/isX-WEFYlOs',
+						} ) }
+						<div className="billing-history__transaction-date">
+							{ moment( transaction.date ).format( 'll' ) }
+						</div>
+					</h2>
+				</div>
+				<ul className="billing-history__receipt-details group">
+					<li>
+						<strong>{ translate( 'Receipt ID' ) }</strong>
+						<span>{ transaction.id }</span>
+					</li>
+					<ReceiptTransactionId transaction={ transaction } />
+					<ReceiptPaymentMethod transaction={ transaction } />
+					{ transaction.cc_num !== 'XXXX' ? (
+						<ReceiptDetails transaction={ transaction } />
+					) : (
+						<EmptyReceiptDetails />
+					) }
+				</ul>
+				<ReceiptLineItems transaction={ transaction } />
+			</Card>
+
+			<Card compact className="billing-history__receipt-links">
+				<Button primary onClick={ handlePrintLinkClick }>
+					{ translate( 'Print Receipt' ) }
+				</Button>
+			</Card>
+		</div>
+	);
+}
+
+function ReceiptTransactionId( { transaction } ) {
+	const translate = useTranslate();
+	if ( ! transaction.pay_ref ) {
+		return null;
+	}
+
+	return (
+		<li>
+			<strong>{ translate( 'Transaction ID' ) }</strong>
+			<span>{ transaction.pay_ref }</span>
+		</li>
+	);
+}
+
+function ReceiptPaymentMethod( { transaction } ) {
+	const translate = useTranslate();
+	let text;
+
+	if ( transaction.pay_part === PARTNER_PAYPAL_EXPRESS ) {
+		text = translate( 'PayPal' );
+	} else if ( 'XXXX' !== transaction.cc_num ) {
+		text = translate( '%(cardType)s ending in %(cardNum)s', {
+			args: {
+				cardType: transaction.cc_type.toUpperCase(),
+				cardNum: transaction.cc_num,
+			},
+		} );
+	} else {
+		return null;
+	}
+
+	return (
+		<li>
+			<strong>{ translate( 'Payment Method' ) }</strong>
+			<span>{ text }</span>
+		</li>
+	);
+}
+
+function ReceiptLineItems( { transaction } ) {
+	const translate = useTranslate();
+	const groupedTransactionItems = groupDomainProducts( transaction.items, translate );
+
+	const items = groupedTransactionItems.map( ( item ) => {
+		const termLabel = getPlanTermLabel( item.wpcom_product_slug, translate );
+		return (
+			<tr key={ item.id }>
+				<td className="billing-history__receipt-item-name">
+					<span>{ item.variation }</span>
+					<small>({ item.type_localized })</small>
+					{ termLabel ? <em>{ termLabel }</em> : null }
+					<br />
+					<em>{ item.domain }</em>
+				</td>
+				<td className={ 'billing-history__receipt-amount ' + transaction.credit }>
+					{ item.amount }
+					{ transaction.credit && (
+						<span className="billing-history__credit-badge">{ translate( 'Refund' ) }</span>
+					) }
+				</td>
+			</tr>
+		);
+	} );
+
+	return (
+		<div className="billing-history__receipt">
+			<h4>{ translate( 'Order summary' ) }</h4>
+			<table className="billing-history__receipt-line-items">
+				<thead>
+					<tr>
+						<th className="billing-history__receipt-desc">{ translate( 'Description' ) }</th>
+						<th className="billing-history__receipt-amount">{ translate( 'Amount' ) }</th>
+					</tr>
+				</thead>
+				<tfoot>
+					<tr>
+						<td className="billing-history__receipt-desc">
+							<strong>{ translate( 'Total' ) }:</strong>
+						</td>
+						<td
+							className={
+								'billing-history__receipt-amount billing-history__total-amount ' +
+								transaction.credit
+							}
+						>
+							{ renderTransactionAmount( transaction, { translate } ) }
+						</td>
+					</tr>
+				</tfoot>
+				<tbody>{ items }</tbody>
+			</table>
+		</div>
+	);
+}
+
+function ReceiptDetails( { transaction } ) {
+	if ( ! transaction.cc_name && ! transaction.cc_email ) {
+		return null;
+	}
+
+	return (
+		<li className="billing-history__billing-details">
+			<ReceiptLabels />
+			<TextareaAutosize
+				className="billing-history__billing-details-editable"
+				aria-labelledby="billing-history__billing-details-description"
+				id="billing-history__billing-details-textarea"
+				rows="1"
+				defaultValue={ transaction.cc_name + '\n' + transaction.cc_email }
+			/>
+		</li>
+	);
+}
+
+function EmptyReceiptDetails() {
+	return (
+		<li className="billing-history__billing-details">
+			<ReceiptLabels />
+			<TextareaAutosize
+				className="billing-history__billing-details-editable"
+				aria-labelledby="billing-history__billing-details-description"
+				id="billing-history__billing-details-textarea"
+				rows="1"
+			/>
+		</li>
+	);
+}
+
+export function ReceiptPlaceholder() {
+	return (
+		<Card compact className="billing-history__receipt-card is-placeholder">
+			<div className="billing-history__app-overview">
+				<div className="billing-history__placeholder-image" />
+				<div className="billing-history__placeholder-title" />
+			</div>
+
+			<div className="billing-history__receipt-links">
+				<div className="billing-history__placeholder-link" />
+				<div className="billing-history__placeholder-link" />
+			</div>
+		</Card>
+	);
+}
+
+function ReceiptLabels() {
+	const translate = useTranslate();
+	return (
+		<div>
+			<label htmlFor="billing-history__billing-details-textarea">
+				<strong>{ translate( 'Billing Details' ) }</strong>
+			</label>
+			<div
+				className="billing-history__billing-details-description"
+				id="billing-history__billing-details-description"
+			>
+				{ translate(
+					'Use this field to add your billing information (eg. VAT number, business address) before printing.'
+				) }
+			</div>
+		</div>
+	);
+}
+
+function ReceiptTitle() {
+	const translate = useTranslate();
+	return <HeaderCake backHref={ billingHistory }>{ translate( 'Billing History' ) }</HeaderCake>;
 }
 
 export default connect(

--- a/client/me/billing-history/transactions-header.jsx
+++ b/client/me/billing-history/transactions-header.jsx
@@ -219,7 +219,7 @@ TransactionsHeader.propTypes = {
 	filter: PropTypes.object.isRequired,
 	//own props
 	transactionType: PropTypes.string.isRequired,
-	siteId: PropTypes.string,
+	siteId: PropTypes.number,
 };
 
 export default connect(

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
@@ -21,9 +21,8 @@ import getPastBillingTransaction from 'state/selectors/get-past-billing-transact
 import { ReceiptBody, ReceiptPlaceholder, ReceiptTitle } from 'me/billing-history/receipt';
 import FormattedHeader from 'components/formatted-header';
 import { getReceiptUrlFor, getBillingHistoryUrlFor } from '../paths';
-import isPastBillingTransactionError from 'state/selectors/is-past-billing-transaction-error';
-import { clearBillingTransactionError } from 'state/billing-transactions/individual-transactions/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
+import useRedirectToHistoryPageOnInvalidTransaction from './use-redirect-to-history-page-on-invalid-transaction';
 
 export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -93,23 +92,4 @@ export function ReceiptView( { siteSlug, receiptId }: { siteSlug: string; receip
 			) }
 		</Main>
 	);
-}
-
-function useRedirectToHistoryPageOnInvalidTransaction( siteSlug: string, receiptId: number ) {
-	const transactionFetchError = useSelector( ( state ) =>
-		isPastBillingTransactionError( state, receiptId )
-	);
-	const reduxDispatch = useDispatch();
-	const didRedirect = useRef( false );
-
-	useEffect( () => {
-		if ( didRedirect.current ) {
-			return;
-		}
-		if ( transactionFetchError ) {
-			didRedirect.current = true;
-			reduxDispatch( clearBillingTransactionError( receiptId ) );
-			page.redirect( getBillingHistoryUrlFor( siteSlug ) );
-		}
-	}, [ transactionFetchError, receiptId, reduxDispatch, siteSlug ] );
 }

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -18,7 +18,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { CompactCard } from '@automattic/components';
 import QueryBillingTransaction from 'components/data/query-billing-transaction';
 import getPastBillingTransaction from 'state/selectors/get-past-billing-transaction';
-import { ReceiptBody, ReceiptPlaceholder } from 'me/billing-history/receipt';
+import { ReceiptBody, ReceiptPlaceholder, ReceiptTitle } from 'me/billing-history/receipt';
 import FormattedHeader from 'components/formatted-header';
 import { getReceiptUrlFor, getBillingHistoryUrlFor } from '../paths';
 import isPastBillingTransactionError from 'state/selectors/is-past-billing-transaction-error';
@@ -68,8 +68,6 @@ export function ReceiptView( { siteSlug, receiptId }: { siteSlug: string; receip
 		window.print();
 	};
 
-	// TODO: add back button in header
-
 	return (
 		<Main className="purchases billing-history">
 			<DocumentHead title={ translate( 'Billing History' ) } />
@@ -85,6 +83,8 @@ export function ReceiptView( { siteSlug, receiptId }: { siteSlug: string; receip
 				headerText={ translate( 'Billing' ) }
 				align="left"
 			/>
+
+			<ReceiptTitle backHref={ getBillingHistoryUrlFor( siteSlug ) } />
 
 			{ transaction ? (
 				<ReceiptBody transaction={ transaction } handlePrintLinkClick={ handlePrintLinkClick } />

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -20,10 +20,14 @@ import QueryBillingTransaction from 'components/data/query-billing-transaction';
 import getPastBillingTransaction from 'state/selectors/get-past-billing-transaction';
 import { ReceiptBody, ReceiptPlaceholder } from 'me/billing-history/receipt';
 import FormattedHeader from 'components/formatted-header';
+import { getReceiptUrlFor } from '../paths';
 
-export function BillingHistory() {
+export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const translate = useTranslate();
+
+	const getReceiptUrlForReceiptId = ( targetReceiptId: string | number ) =>
+		getReceiptUrlFor( siteSlug, targetReceiptId );
 
 	return (
 		<Main className="purchases billing-history is-wide-layout">
@@ -37,7 +41,10 @@ export function BillingHistory() {
 				headerText={ translate( 'Billing' ) }
 				align="left"
 			/>
-			<BillingHistoryList siteId={ selectedSiteId } />
+			<BillingHistoryList
+				siteId={ selectedSiteId }
+				getReceiptUrlFor={ getReceiptUrlForReceiptId }
+			/>
 			<CompactCard href="/me/purchases/billing">
 				{ translate( 'View all billing history and receipts' ) }
 			</CompactCard>

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -69,7 +69,7 @@ export function ReceiptView( { siteSlug, receiptId }: { siteSlug: string; receip
 	};
 
 	return (
-		<Main className="purchases billing-history">
+		<Main className="purchases billing-history is-wide-layout">
 			<DocumentHead title={ translate( 'Billing History' ) } />
 			<PageViewTracker
 				path="/purchases/billing-history/:site/:receipt"

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import MySitesSidebarNavigation from 'my-sites/sidebar-navigation';
+import Main from 'components/main';
+import DocumentHead from 'components/data/document-head';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QueryBillingTransactions from 'components/data/query-billing-transactions';
+import { BillingHistoryList } from 'me/billing-history/main';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { CompactCard } from '@automattic/components';
+import QueryBillingTransaction from 'components/data/query-billing-transaction';
+import getPastBillingTransaction from 'state/selectors/get-past-billing-transaction';
+import { ReceiptBody, ReceiptPlaceholder } from 'me/billing-history/receipt';
+import FormattedHeader from 'components/formatted-header';
+
+export function BillingHistory() {
+	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const translate = useTranslate();
+
+	return (
+		<Main className="purchases billing-history is-wide-layout">
+			<MySitesSidebarNavigation />
+			<DocumentHead title={ translate( 'Billing History' ) } />
+			<PageViewTracker path="/purchases/billing-history" title="Billing History" />
+			<QueryBillingTransactions />
+			<FormattedHeader
+				brandFont
+				className="billing-history__page-heading"
+				headerText={ translate( 'Billing' ) }
+				align="left"
+			/>
+			<BillingHistoryList siteId={ selectedSiteId } />
+			<CompactCard href="/me/purchases/billing">
+				{ translate( 'View all billing history and receipts' ) }
+			</CompactCard>
+		</Main>
+	);
+}
+
+export function ReceiptView( { receiptId }: { receiptId: number } ) {
+	const translate = useTranslate();
+	const transaction = useSelector( ( state ) => getPastBillingTransaction( state, receiptId ) );
+	// TODO: handle error redirects
+	// const transactionFetchError = useSelector( ( state ) =>
+	// 	isPastBillingTransactionError( state, receiptId )
+	// );
+
+	// TODO: handle clicks
+	const handlePrintLinkClick = () => {
+		window.print();
+	};
+
+	// TODO: add back button in header
+
+	return (
+		<Main className="purchases billing-history">
+			<DocumentHead title={ translate( 'Billing History' ) } />
+			<PageViewTracker
+				path="/purchases/billing-history/:site/:receipt"
+				title="Billing History > Receipt"
+			/>
+			<QueryBillingTransaction transactionId={ receiptId } />
+
+			<FormattedHeader
+				brandFont
+				className="billing-history__page-heading"
+				headerText={ translate( 'Billing' ) }
+				align="left"
+			/>
+
+			{ transaction ? (
+				<ReceiptBody transaction={ transaction } handlePrintLinkClick={ handlePrintLinkClick } />
+			) : (
+				<ReceiptPlaceholder />
+			) }
+		</Main>
+	);
+}

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -23,6 +23,7 @@ import FormattedHeader from 'components/formatted-header';
 import { getReceiptUrlFor, getBillingHistoryUrlFor } from '../paths';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import useRedirectToHistoryPageOnInvalidTransaction from './use-redirect-to-history-page-on-invalid-transaction';
+import useRedirectToHistoryPageOnWrongSiteForTransaction from './use-redirect-to-history-page-on-wrong-site-for-transaction';
 
 export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -60,6 +61,11 @@ export function ReceiptView( { siteSlug, receiptId }: { siteSlug: string; receip
 	const reduxDispatch = useDispatch();
 
 	useRedirectToHistoryPageOnInvalidTransaction( siteSlug, receiptId );
+	const isCorrectSite = useRedirectToHistoryPageOnWrongSiteForTransaction(
+		siteSlug,
+		receiptId,
+		transaction
+	);
 
 	const handlePrintLinkClick = () => {
 		const action = 'Print Receipt Button in Billing History Receipt';
@@ -85,7 +91,7 @@ export function ReceiptView( { siteSlug, receiptId }: { siteSlug: string; receip
 
 			<ReceiptTitle backHref={ getBillingHistoryUrlFor( siteSlug ) } />
 
-			{ transaction ? (
+			{ transaction && isCorrectSite ? (
 				<ReceiptBody transaction={ transaction } handlePrintLinkClick={ handlePrintLinkClick } />
 			) : (
 				<ReceiptPlaceholder />

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -23,6 +23,7 @@ import FormattedHeader from 'components/formatted-header';
 import { getReceiptUrlFor, getBillingHistoryUrlFor } from '../paths';
 import isPastBillingTransactionError from 'state/selectors/is-past-billing-transaction-error';
 import { clearBillingTransactionError } from 'state/billing-transactions/individual-transactions/actions';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -57,11 +58,13 @@ export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 export function ReceiptView( { siteSlug, receiptId }: { siteSlug: string; receiptId: number } ) {
 	const translate = useTranslate();
 	const transaction = useSelector( ( state ) => getPastBillingTransaction( state, receiptId ) );
+	const reduxDispatch = useDispatch();
 
 	useRedirectToHistoryPageOnInvalidTransaction( siteSlug, receiptId );
 
-	// TODO: handle clicks
 	const handlePrintLinkClick = () => {
+		const action = 'Print Receipt Button in Billing History Receipt';
+		reduxDispatch( recordGoogleEvent( 'Me', 'Clicked on ' + action ) );
 		window.print();
 	};
 

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -4,24 +4,24 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
+import { CompactCard } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
-import MySitesSidebarNavigation from 'my-sites/sidebar-navigation';
-import Main from 'components/main';
-import DocumentHead from 'components/data/document-head';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryBillingTransactions from 'components/data/query-billing-transactions';
-import { BillingHistoryList } from 'me/billing-history/main';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { CompactCard } from '@automattic/components';
-import QueryBillingTransaction from 'components/data/query-billing-transaction';
-import getPastBillingTransaction from 'state/selectors/get-past-billing-transaction';
-import { ReceiptBody, ReceiptPlaceholder, ReceiptTitle } from 'me/billing-history/receipt';
-import FormattedHeader from 'components/formatted-header';
+import MySitesSidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import Main from 'calypso/components/main';
+import DocumentHead from 'calypso/components/data/document-head';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
+import { BillingHistoryList } from 'calypso/me/billing-history/main';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import QueryBillingTransaction from 'calypso/components/data/query-billing-transaction';
+import getPastBillingTransaction from 'calypso/state/selectors/get-past-billing-transaction';
+import { ReceiptBody, ReceiptPlaceholder, ReceiptTitle } from 'calypso/me/billing-history/receipt';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { getReceiptUrlFor, getBillingHistoryUrlFor } from '../paths';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import useRedirectToHistoryPageOnInvalidTransaction from './use-redirect-to-history-page-on-invalid-transaction';
 import useRedirectToHistoryPageOnWrongSiteForTransaction from './use-redirect-to-history-page-on-wrong-site-for-transaction';
 

--- a/client/my-sites/purchases/billing-history/use-redirect-to-history-page-on-invalid-transaction.tsx
+++ b/client/my-sites/purchases/billing-history/use-redirect-to-history-page-on-invalid-transaction.tsx
@@ -3,6 +3,7 @@
  */
 import { useEffect, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import page from 'page';
 
 /**
  * Internal dependencies

--- a/client/my-sites/purchases/billing-history/use-redirect-to-history-page-on-invalid-transaction.tsx
+++ b/client/my-sites/purchases/billing-history/use-redirect-to-history-page-on-invalid-transaction.tsx
@@ -9,8 +9,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { getBillingHistoryUrlFor } from '../paths';
-import isPastBillingTransactionError from 'state/selectors/is-past-billing-transaction-error';
-import { clearBillingTransactionError } from 'state/billing-transactions/individual-transactions/actions';
+import isPastBillingTransactionError from 'calypso/state/selectors/is-past-billing-transaction-error';
+import { clearBillingTransactionError } from 'calypso/state/billing-transactions/individual-transactions/actions';
 
 export default function useRedirectToHistoryPageOnInvalidTransaction(
 	siteSlug: string,

--- a/client/my-sites/purchases/billing-history/use-redirect-to-history-page-on-invalid-transaction.tsx
+++ b/client/my-sites/purchases/billing-history/use-redirect-to-history-page-on-invalid-transaction.tsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getBillingHistoryUrlFor } from '../paths';
+import isPastBillingTransactionError from 'state/selectors/is-past-billing-transaction-error';
+import { clearBillingTransactionError } from 'state/billing-transactions/individual-transactions/actions';
+
+export default function useRedirectToHistoryPageOnInvalidTransaction(
+	siteSlug: string,
+	receiptId: number
+) {
+	const transactionFetchError = useSelector( ( state ) =>
+		isPastBillingTransactionError( state, receiptId )
+	);
+	const reduxDispatch = useDispatch();
+	const didRedirect = useRef( false );
+
+	useEffect( () => {
+		if ( didRedirect.current ) {
+			return;
+		}
+		if ( transactionFetchError ) {
+			didRedirect.current = true;
+			reduxDispatch( clearBillingTransactionError( receiptId ) );
+			page.redirect( getBillingHistoryUrlFor( siteSlug ) );
+		}
+	}, [ transactionFetchError, receiptId, reduxDispatch, siteSlug ] );
+}

--- a/client/my-sites/purchases/billing-history/use-redirect-to-history-page-on-wrong-site-for-transaction.tsx
+++ b/client/my-sites/purchases/billing-history/use-redirect-to-history-page-on-wrong-site-for-transaction.tsx
@@ -8,7 +8,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getBillingHistoryUrlFor } from '../paths';
 
 export default function useRedirectToHistoryPageOnWrongSiteForTransaction(

--- a/client/my-sites/purchases/billing-history/use-redirect-to-history-page-on-wrong-site-for-transaction.tsx
+++ b/client/my-sites/purchases/billing-history/use-redirect-to-history-page-on-wrong-site-for-transaction.tsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getBillingHistoryUrlFor } from '../paths';
+
+export default function useRedirectToHistoryPageOnWrongSiteForTransaction(
+	siteSlug: string,
+	receiptId: number,
+	transaction: Transaction
+): boolean {
+	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const reduxDispatch = useDispatch();
+	const didRedirect = useRef( false );
+	const doesTransactionExist = !! transaction;
+	const doesTransactionMatchSite =
+		doesTransactionExist &&
+		selectedSiteId &&
+		transaction.items.some(
+			( receiptItem ) => String( receiptItem.site_id ) === String( selectedSiteId )
+		);
+
+	useEffect( () => {
+		if ( ! doesTransactionExist || ! selectedSiteId ) {
+			// We may still be loading the transaction or site id
+			return;
+		}
+		if ( didRedirect.current ) {
+			return;
+		}
+		if ( ! doesTransactionMatchSite ) {
+			didRedirect.current = true;
+			page.redirect( getBillingHistoryUrlFor( siteSlug ) );
+		}
+	}, [
+		receiptId,
+		reduxDispatch,
+		siteSlug,
+		selectedSiteId,
+		doesTransactionExist,
+		doesTransactionMatchSite,
+	] );
+
+	return !! doesTransactionMatchSite;
+}
+
+// Ideally these should be defined elsewhere with all their properties, but
+// we'll define what we need here.
+interface Transaction {
+	items: TransactionItem[];
+}
+interface TransactionItem {
+	site_id: number | null;
+}

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -14,9 +14,8 @@ import {
 	PurchaseCancelDomain,
 	PurchaseAddPaymentMethod,
 	PurchaseEditPaymentMethod,
-	BillingHistory,
-	ReceiptView,
-} from 'my-sites/purchases/main.tsx';
+} from 'my-sites/purchases/main';
+import { BillingHistory, ReceiptView } from 'my-sites/purchases/billing-history';
 
 export function redirectToPurchases( context ) {
 	const siteDomain = context.params.site;

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -14,8 +14,8 @@ import {
 	PurchaseCancelDomain,
 	PurchaseAddPaymentMethod,
 	PurchaseEditPaymentMethod,
-} from 'my-sites/purchases/main';
-import { BillingHistory, ReceiptView } from 'my-sites/purchases/billing-history';
+} from 'calypso/my-sites/purchases/main';
+import { BillingHistory, ReceiptView } from 'calypso/my-sites/purchases/billing-history';
 
 export function redirectToPurchases( context ) {
 	const siteDomain = context.params.site;

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -89,6 +89,8 @@ export const billingHistory = ( context, next ) => {
 };
 
 export const receiptView = ( context, next ) => {
-	context.primary = <ReceiptView receiptId={ context.params.receiptId } />;
+	context.primary = (
+		<ReceiptView receiptId={ context.params.receiptId } siteSlug={ context.params.site } />
+	);
 	next();
 };

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -84,7 +84,7 @@ export const purchaseEditPaymentMethod = ( context, next ) => {
 };
 
 export const billingHistory = ( context, next ) => {
-	context.primary = <BillingHistory />;
+	context.primary = <BillingHistory siteSlug={ context.params.site } />;
 	next();
 };
 

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -15,6 +15,7 @@ import {
 	PurchaseAddPaymentMethod,
 	PurchaseEditPaymentMethod,
 	BillingHistory,
+	ReceiptView,
 } from 'my-sites/purchases/main.tsx';
 
 export function redirectToPurchases( context ) {
@@ -85,5 +86,10 @@ export const purchaseEditPaymentMethod = ( context, next ) => {
 
 export const billingHistory = ( context, next ) => {
 	context.primary = <BillingHistory />;
+	next();
+};
+
+export const receiptView = ( context, next ) => {
+	context.primary = <ReceiptView receiptId={ context.params.receiptId } />;
 	next();
 };

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -6,8 +6,8 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { makeLayout, render as clientRender } from 'controller';
-import { navigation, siteSelection, sites } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
 	purchases,
 	redirectToPurchases,

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -17,6 +17,7 @@ import {
 	purchaseAddPaymentMethod,
 	purchaseEditPaymentMethod,
 	billingHistory,
+	receiptView,
 } from './controller';
 
 export default ( router ) => {
@@ -84,6 +85,15 @@ export default ( router ) => {
 		siteSelection,
 		navigation,
 		billingHistory,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/purchases/billing-history/:site/:receiptId',
+		siteSelection,
+		navigation,
+		receiptView,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -22,7 +22,7 @@ import {
 	getManagePurchaseUrlFor,
 	getAddPaymentMethodUrlFor,
 } from './paths';
-import { getEditPaymentMethodUrlFor } from './utils';
+import { getEditOrAddPaymentMethodUrlFor } from './utils';
 import AddCardDetails from 'me/purchases/payment/add-card-details';
 import EditCardDetails from 'me/purchases/payment/edit-card-details';
 
@@ -72,7 +72,7 @@ export function PurchaseDetails( {
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 				getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
 				getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
-				getEditPaymentMethodUrlFor={ getEditPaymentMethodUrlFor }
+				getEditPaymentMethodUrlFor={ getEditOrAddPaymentMethodUrlFor }
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 			/>
 		</Main>

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -10,7 +9,6 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Main from 'components/main';
 import Subscriptions from './subscriptions';
-import { BillingHistoryList } from 'me/billing-history/main';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import ManagePurchase from 'me/purchases/manage-purchase';
@@ -27,13 +25,6 @@ import {
 import { getEditPaymentMethodUrlFor } from './utils';
 import AddCardDetails from 'me/purchases/payment/add-card-details';
 import EditCardDetails from 'me/purchases/payment/edit-card-details';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryBillingTransactions from 'components/data/query-billing-transactions';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { CompactCard } from '@automattic/components';
-import QueryBillingTransaction from 'components/data/query-billing-transaction';
-import getPastBillingTransaction from 'state/selectors/get-past-billing-transaction';
-import { ReceiptBody, ReceiptPlaceholder } from 'me/billing-history/receipt';
 
 export function Purchases() {
 	const translate = useTranslate();
@@ -206,70 +197,6 @@ export function PurchaseCancelDomain( {
 				getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 			/>
-		</Main>
-	);
-}
-
-export function BillingHistory() {
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const translate = useTranslate();
-
-	return (
-		<Main className="purchases billing-history is-wide-layout">
-			<MySitesSidebarNavigation />
-			<DocumentHead title={ translate( 'Billing History' ) } />
-			<PageViewTracker path="/purchases/billing-history" title="Billing History" />
-			<QueryBillingTransactions />
-			<FormattedHeader
-				brandFont
-				className="purchases__page-heading"
-				headerText={ translate( 'Billing' ) }
-				align="left"
-			/>
-			<BillingHistoryList siteId={ selectedSiteId } />
-			<CompactCard href="/me/purchases/billing">
-				{ translate( 'View all billing history and receipts' ) }
-			</CompactCard>
-		</Main>
-	);
-}
-
-export function ReceiptView( { receiptId }: { receiptId: number } ) {
-	const translate = useTranslate();
-	const transaction = useSelector( ( state ) => getPastBillingTransaction( state, receiptId ) );
-	// TODO: handle error redirects
-	// const transactionFetchError = useSelector( ( state ) =>
-	// 	isPastBillingTransactionError( state, receiptId )
-	// );
-
-	// TODO: handle clicks
-	const handlePrintLinkClick = () => {
-		window.print();
-	};
-
-	// TODO: add back button in header
-
-	return (
-		<Main className="purchases billing-history">
-			<DocumentHead title={ translate( 'Billing History' ) } />
-			<PageViewTracker
-				path="/purchases/billing-history/:site/:receipt"
-				title="Billing History > Receipt"
-			/>
-			<QueryBillingTransaction transactionId={ receiptId } />
-
-			<FormattedHeader
-				brandFont
-				className="purchases__page-heading"
-				headerText={ translate( 'Billing' ) }
-				align="left"
-			/>
-
-			{ transaction ? (
-				<ReceiptBody transaction={ transaction } handlePrintLinkClick={ handlePrintLinkClick } />
-			) : (
-				<ReceiptPlaceholder />
-			) }
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -31,6 +31,9 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { CompactCard } from '@automattic/components';
+import QueryBillingTransaction from 'components/data/query-billing-transaction';
+import getPastBillingTransaction from 'state/selectors/get-past-billing-transaction';
+import { ReceiptBody, ReceiptPlaceholder } from 'me/billing-history/receipt';
 
 export function Purchases() {
 	const translate = useTranslate();
@@ -227,6 +230,46 @@ export function BillingHistory() {
 			<CompactCard href="/me/purchases/billing">
 				{ translate( 'View all billing history and receipts' ) }
 			</CompactCard>
+		</Main>
+	);
+}
+
+export function ReceiptView( { receiptId }: { receiptId: number } ) {
+	const translate = useTranslate();
+	const transaction = useSelector( ( state ) => getPastBillingTransaction( state, receiptId ) );
+	// TODO: handle error redirects
+	// const transactionFetchError = useSelector( ( state ) =>
+	// 	isPastBillingTransactionError( state, receiptId )
+	// );
+
+	// TODO: handle clicks
+	const handlePrintLinkClick = () => {
+		window.print();
+	};
+
+	// TODO: add back button in header
+
+	return (
+		<Main className="purchases billing-history">
+			<DocumentHead title={ translate( 'Billing History' ) } />
+			<PageViewTracker
+				path="/purchases/billing-history/:site/:receipt"
+				title="Billing History > Receipt"
+			/>
+			<QueryBillingTransaction transactionId={ receiptId } />
+
+			<FormattedHeader
+				brandFont
+				className="purchases__page-heading"
+				headerText={ translate( 'Billing' ) }
+				align="left"
+			/>
+
+			{ transaction ? (
+				<ReceiptBody transaction={ transaction } handlePrintLinkClick={ handlePrintLinkClick } />
+			) : (
+				<ReceiptPlaceholder />
+			) }
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -7,14 +7,14 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
+import Main from 'calypso/components/main';
 import Subscriptions from './subscriptions';
-import DocumentHead from 'components/data/document-head';
-import FormattedHeader from 'components/formatted-header';
-import ManagePurchase from 'me/purchases/manage-purchase';
-import CancelPurchase from 'me/purchases/cancel-purchase';
-import ConfirmCancelDomain from 'me/purchases/confirm-cancel-domain';
-import MySitesSidebarNavigation from 'my-sites/sidebar-navigation';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import ManagePurchase from 'calypso/me/purchases/manage-purchase';
+import CancelPurchase from 'calypso/me/purchases/cancel-purchase';
+import ConfirmCancelDomain from 'calypso/me/purchases/confirm-cancel-domain';
+import MySitesSidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import {
 	getPurchaseListUrlFor,
 	getCancelPurchaseUrlFor,
@@ -23,8 +23,8 @@ import {
 	getAddPaymentMethodUrlFor,
 } from './paths';
 import { getEditOrAddPaymentMethodUrlFor } from './utils';
-import AddCardDetails from 'me/purchases/payment/add-card-details';
-import EditCardDetails from 'me/purchases/payment/edit-card-details';
+import AddCardDetails from 'calypso/me/purchases/payment/add-card-details';
+import EditCardDetails from 'calypso/me/purchases/payment/edit-card-details';
 
 export function Purchases() {
 	const translate = useTranslate();

--- a/client/my-sites/purchases/paths.ts
+++ b/client/my-sites/purchases/paths.ts
@@ -21,7 +21,7 @@ export const getAddPaymentMethodUrlFor = (
 	targetPurchase: { id: string | number }
 ) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchase }/payment/add`;
 
-export const editPaymentMethod = (
+export const getEditPaymentMethodUrlFor = (
 	targetSiteSlug: string,
 	targetPurchase: { id: string | number },
 	targetCardId: { id: string | number }

--- a/client/my-sites/purchases/paths.ts
+++ b/client/my-sites/purchases/paths.ts
@@ -27,3 +27,6 @@ export const editPaymentMethod = (
 	targetCardId: { id: string | number }
 ) =>
 	`/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchase }/payment/edit/${ targetCardId }`;
+
+export const getReceiptUrlFor = ( targetSiteSlug: string, targetReceiptId: string | number ) =>
+	`/purchases/billing-history/${ targetSiteSlug }/${ targetReceiptId }`;

--- a/client/my-sites/purchases/paths.ts
+++ b/client/my-sites/purchases/paths.ts
@@ -30,3 +30,6 @@ export const editPaymentMethod = (
 
 export const getReceiptUrlFor = ( targetSiteSlug: string, targetReceiptId: string | number ) =>
 	`/purchases/billing-history/${ targetSiteSlug }/${ targetReceiptId }`;
+
+export const getBillingHistoryUrlFor = ( targetSiteSlug: string ) =>
+	`/purchases/billing-history/${ targetSiteSlug }`;

--- a/client/my-sites/purchases/utils.js
+++ b/client/my-sites/purchases/utils.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getAddPaymentMethodUrlFor, getEditPaymentMethodUrlFor } from './paths';
-import { isPaidWithCreditCard } from 'lib/purchases';
+import { isPaidWithCreditCard } from 'calypso/lib/purchases';
 
 export function getEditOrAddPaymentMethodUrlFor( siteSlug, purchase ) {
 	if ( isPaidWithCreditCard( purchase ) ) {

--- a/client/my-sites/purchases/utils.js
+++ b/client/my-sites/purchases/utils.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getAddPaymentMethodUrlFor, editPaymentMethod } from './paths';
+import { getAddPaymentMethodUrlFor, getEditPaymentMethodUrlFor } from './paths';
 import { isPaidWithCreditCard } from 'lib/purchases';
 
 export function getEditOrAddPaymentMethodUrlFor( siteSlug, purchase ) {
@@ -10,7 +10,7 @@ export function getEditOrAddPaymentMethodUrlFor( siteSlug, purchase ) {
 			payment: { creditCard },
 		} = purchase;
 
-		return editPaymentMethod( siteSlug, purchase.id, creditCard.id );
+		return getEditPaymentMethodUrlFor( siteSlug, purchase.id, creditCard.id );
 	}
 	return getAddPaymentMethodUrlFor( siteSlug, purchase.id );
 }

--- a/client/my-sites/purchases/utils.js
+++ b/client/my-sites/purchases/utils.js
@@ -4,7 +4,7 @@
 import { getAddPaymentMethodUrlFor, editPaymentMethod } from './paths';
 import { isPaidWithCreditCard } from 'lib/purchases';
 
-function getEditPaymentMethodUrlFor( siteSlug, purchase ) {
+export function getEditOrAddPaymentMethodUrlFor( siteSlug, purchase ) {
 	if ( isPaidWithCreditCard( purchase ) ) {
 		const {
 			payment: { creditCard },
@@ -14,5 +14,3 @@ function getEditPaymentMethodUrlFor( siteSlug, purchase ) {
 	}
 	return getAddPaymentMethodUrlFor( siteSlug, purchase.id );
 }
-
-export { getEditPaymentMethodUrlFor };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the site-level version of the receipt page at the url `/purchases/billing-history/:siteSlug/:receiptId` building on the site-level billing-history section added in https://github.com/Automattic/wp-calypso/pull/46175.

Fixes https://github.com/Automattic/wp-calypso/issues/46203

Main project thread: pbOQVh-sc-p2

#### Screenshots

![Screen Shot 2020-10-07 at 4 33 42 PM](https://user-images.githubusercontent.com/2036909/95384896-41285180-08bb-11eb-93c0-0b09e4f9194c.png)

#### To do

- [x] Add route
- [x] Add page
- [x] Add link to receipt page from history page
- [x] Add Back button and header
- [x] Add redirect for invalid receipts
- [x] Add redirect for invalid site
- [x] Add analytics calls (eg: Print button)

#### Testing instructions

First, because this modifies the account-level receipt page (for easier re-use), we should test that to be sure it is not broken.

- Visit `http://calypso.localhost:3000/me/purchases/billing`.
- Click on "View receipt" for any purchase.
- Verify that you see the correct receipt.
- Verify that the sidebar remains at the account-level.
- Click the "Back" link in the header and verify that you're taken back to the account-level billing history page.

Then we can test the site-level receipt page.

- Visit `http://calypso.localhost:3000/purchases/billing-history/:siteSlug`.
- Click on "View receipt" for any purchase.
- Verify that you see the correct receipt.
- Verify that the sidebar remains at the site-level.
- Click the "Back" link in the header and verify that you're taken back to the site-level billing history page.
- Visit the receipt page again.
- Verify that the "Print" button causes the browser to open a print dialog.
- Manually visit the URL of a receipt that doesn't exist and verify that you are redirected to the site-level billing history page for that site.
- Manually visit the URL of a receipt that _does exist_ but one that exists for a different site than the slug in the URL and verify that you are redirected to the site-level billing history page for the site in the URL.