### PR TITLE
Add fill and outline style to premium content login button

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/login-button/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/login-button/index.js
@@ -64,6 +64,10 @@ const settings = {
 		html: false,
 		lightBlockWrapper: true,
 	},
+	styles: [
+		{ name: 'fill', label: __( 'Fill', 'full-site-editing' ), isDefault: true },
+		{ name: 'outline', label: __( 'Outline', 'full-site-editing' ) },
+	],
 	edit,
 	save,
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Fill and Outline styling options to the Premium Content Login button so match the styling on other buttons

Fixes #44333

#### Testing instructions

* Add a Premium content block to a post/page and save
* Apply this PR and reload the page and ensure the block style loads ok
* Check that the login button now has open to set style to Fill & Outline
* Make sure both styles can be save ok and display correctly in Editor and front end

<img width="732" alt="Screen Shot 2020-10-07 at 3 35 34 PM" src="https://user-images.githubusercontent.com/3629020/95281028-c78c6580-08b2-11eb-86f0-cacf3a144d52.png">
