### PR TITLE
Fix eslint job in TeamCity

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -498,23 +498,6 @@ object CheckCodeStyle : BuildType({
 				}
 			}
 		}
-
-		notifications {
-			notifierSettings = slackNotifier {
-				connection = "PROJECT_EXT_11"
-				sendTo = "#team-calypso-bot"
-				messageFormat = simpleMessageFormat()
-			}
-			branchFilter = """
-				+:master
-				+:trunk
-			""".trimIndent()
-			buildFailedToStart = true
-			buildFailed = true
-			buildFinishedSuccessfully = true
-			firstSuccessAfterFailure = true
-			buildProbablyHanging = true
-		}
 	}
 })
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -439,7 +439,7 @@ object CheckCodeStyle : BuildType({
 				nvm install
 
 				# Find files to lint
-				if [[ "%teamcity.build.branch.is_default%" == "true" ]]; then
+				if [ "%teamcity.build.branch.is_default%" = "true" ]; then
 					FILES_TO_LINT="."
 				else
 					FILES_TO_LINT=${'$'}(git diff --name-only --diff-filter=d refs/remotes/origin/master...HEAD | grep -E '(\.[jt]sx?|\.md)${'$'}' || exit 0)


### PR DESCRIPTION
#### Changes

* Fixed shell errors in linting job: we should use /bin/sh instead of /bin/bash
* Disabled Slack notifications for the linting job, we know it will fail a lot

#### Testing instructions

* Check the 'Check code style' job in TeamCity for this branch, and ensure there are no errors in the log
