### PR TITLE
Fix a bug in the new checkout e2e tests

### DIFF
--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -357,6 +357,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 	async removeCoupon() {
 		const isCompositeCheckout = await this.isCompositeCheckout();
 
+		// New checkout
 		if ( isCompositeCheckout ) {
 			// Open review step for editing
 			await driverHelper.clickWhenClickable(
@@ -376,7 +377,13 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 				By.css( '.checkout-modal .checkout-button.is-status-primary' )
 			);
 			// Make sure the coupon item is removed
-			return this.waitForCouponToBeRemoved();
+			await this.waitForCouponToBeRemoved();
+			// Close editing review step
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.wp-checkout__review-order-step button.is-status-primary' )
+			);
+			return;
 		}
 
 		// Old checkout - desktop
@@ -397,6 +404,45 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 
 	async removeBusinessPlan() {
 		const productSlug = this.businessPlanSlug;
+		const isCompositeCheckout = await this.isCompositeCheckout();
+
+		// New checkout
+		if ( isCompositeCheckout ) {
+			// Open review step for editing
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.wp-checkout__review-order-step .checkout-step__edit-button' )
+			);
+			// Click delete button on line item
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css(
+					`.checkout-line-item[data-e2e-product-slug="${ productSlug }"] button.checkout-line-item__remove-product`
+				)
+			);
+			// Dismiss confirmation modal
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.checkout-modal .checkout-button.is-status-primary' )
+			);
+			// Make sure the item is removed
+			await driverHelper.waitTillNotPresent(
+				this.driver,
+				By.css( '[data-e2e-cart-is-loading="true"]' )
+			);
+			await driverHelper.waitTillNotPresent(
+				this.driver,
+				By.css( `.checkout-line-item[data-e2e-product-slug="${ productSlug }"]` )
+			);
+			// Close editing review step
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.wp-checkout__review-order-step button.is-status-primary' )
+			);
+			return;
+		}
+
+		// Old checkout
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css(

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -22,6 +22,9 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 			2 * config.get( 'explicitWaitMS' )
 		);
 		this.paymentButtonSelector = By.css(
+			'.credit-card-payment-box button.is-primary:not([disabled]),.composite-checkout .checkout-submit-button button'
+		);
+		this.activePaymentButtonSelector = By.css(
 			'.credit-card-payment-box button.is-primary:not([disabled]),.composite-checkout .checkout-submit-button button:not([disabled])'
 		);
 		this.personalPlanSlug = getJetpackHost() === 'WPCOM' ? 'personal-bundle' : 'jetpack_personal';
@@ -464,10 +467,10 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		return await this.driver.findElement( this.getCartTotalSelector() ).getText();
 	}
 
-	async paymentButtonText() {
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.paymentButtonSelector );
-		await driverHelper.scrollIntoView( this.driver, this.paymentButtonSelector );
-		return await this.driver.findElement( this.paymentButtonSelector ).getText();
+	async activePaymentButtonText() {
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.activePaymentButtonSelector );
+		await driverHelper.scrollIntoView( this.driver, this.activePaymentButtonSelector );
+		return await this.driver.findElement( this.activePaymentButtonSelector ).getText();
 	}
 
 	async _cartContainsProduct( productSlug, expectedQuantity = 1 ) {

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -22,7 +22,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 			2 * config.get( 'explicitWaitMS' )
 		);
 		this.paymentButtonSelector = By.css(
-			'.credit-card-payment-box button.is-primary:not([disabled]),.composite-checkout .checkout-submit-button button'
+			'.credit-card-payment-box button.is-primary:not([disabled]),.composite-checkout .checkout-submit-button button:not([disabled])'
 		);
 		this.personalPlanSlug = getJetpackHost() === 'WPCOM' ? 'personal-bundle' : 'jetpack_personal';
 		this.premiumPlanSlug = getJetpackHost() === 'WPCOM' ? 'value_bundle' : 'jetpack_premium';

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -413,6 +413,10 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 				this.driver,
 				By.css( '.wp-checkout__review-order-step .checkout-step__edit-button' )
 			);
+			const lineItemCount = await driverHelper.getElementCount(
+				this.driver,
+				By.css( '.checkout-line-item button.checkout-line-item__remove-product' )
+			);
 			// Click delete button on line item
 			await driverHelper.clickWhenClickable(
 				this.driver,
@@ -434,11 +438,15 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 				this.driver,
 				By.css( `.checkout-line-item[data-e2e-product-slug="${ productSlug }"]` )
 			);
-			// Close editing review step
-			await driverHelper.clickWhenClickable(
-				this.driver,
-				By.css( '.wp-checkout__review-order-step button.is-status-primary' )
-			);
+			// If the plan is the last item in the cart, then removing it will cause
+			// a redirect, so we won't try to close the review step.
+			if ( lineItemCount > 1 ) {
+				// Close editing review step
+				await driverHelper.clickWhenClickable(
+					this.driver,
+					By.css( '.wp-checkout__review-order-step button.is-status-primary' )
+				);
+			}
 			return;
 		}
 

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -24,9 +24,6 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		this.paymentButtonSelector = By.css(
 			'.credit-card-payment-box button.is-primary:not([disabled]),.composite-checkout .checkout-submit-button button'
 		);
-		this.activePaymentButtonSelector = By.css(
-			'.credit-card-payment-box button.is-primary:not([disabled]),.composite-checkout .checkout-submit-button button:not([disabled])'
-		);
 		this.personalPlanSlug = getJetpackHost() === 'WPCOM' ? 'personal-bundle' : 'jetpack_personal';
 		this.premiumPlanSlug = getJetpackHost() === 'WPCOM' ? 'value_bundle' : 'jetpack_premium';
 		this.businessPlanSlug = getJetpackHost() === 'WPCOM' ? 'business-bundle' : 'jetpack_business';
@@ -467,10 +464,12 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		return await this.driver.findElement( this.getCartTotalSelector() ).getText();
 	}
 
-	async activePaymentButtonText() {
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.activePaymentButtonSelector );
-		await driverHelper.scrollIntoView( this.driver, this.activePaymentButtonSelector );
-		return await this.driver.findElement( this.activePaymentButtonSelector ).getText();
+	async paymentButtonText() {
+		const loadingPaymentButton = By.xpath( "//*[contains(text(), 'Please wait…')]" );
+		await driverHelper.waitTillNotPresent( this.driver, loadingPaymentButton );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.paymentButtonSelector );
+		await driverHelper.scrollIntoView( this.driver, this.paymentButtonSelector );
+		return await this.driver.findElement( this.paymentButtonSelector ).getText();
 	}
 
 	async _cartContainsProduct( productSlug, expectedQuantity = 1 ) {

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -443,7 +443,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 					);
 				}
-				const paymentButtonText = await securePaymentComponent.paymentButtonText();
+				const paymentButtonText = await securePaymentComponent.activePaymentButtonText();
 				return assert(
 					paymentButtonText.includes( expectedCurrencySymbol ),
 					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
@@ -564,7 +564,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 					);
 				}
-				const paymentButtonText = await securePaymentComponent.paymentButtonText();
+				const paymentButtonText = await securePaymentComponent.activePaymentButtonText();
 				return assert(
 					paymentButtonText.includes( expectedCurrencySymbol ),
 					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
@@ -670,7 +670,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 					);
 				}
-				const paymentButtonText = await securePaymentComponent.paymentButtonText();
+				const paymentButtonText = await securePaymentComponent.activePaymentButtonText();
 				return assert(
 					paymentButtonText.includes( expectedCurrencySymbol ),
 					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
@@ -826,7 +826,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 					);
 				}
-				const paymentButtonText = await securePaymentComponent.paymentButtonText();
+				const paymentButtonText = await securePaymentComponent.activePaymentButtonText();
 				return assert(
 					paymentButtonText.includes( expectedCurrencySymbol ),
 					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
@@ -1000,7 +1000,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 					);
 				}
-				const paymentButtonText = await securePaymentComponent.paymentButtonText();
+				const paymentButtonText = await securePaymentComponent.activePaymentButtonText();
 				return assert(
 					paymentButtonText.includes( expectedCurrencySymbol ),
 					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -443,7 +443,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 					);
 				}
-				const paymentButtonText = await securePaymentComponent.activePaymentButtonText();
+				const paymentButtonText = await securePaymentComponent.paymentButtonText();
 				return assert(
 					paymentButtonText.includes( expectedCurrencySymbol ),
 					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
@@ -564,7 +564,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 					);
 				}
-				const paymentButtonText = await securePaymentComponent.activePaymentButtonText();
+				const paymentButtonText = await securePaymentComponent.paymentButtonText();
 				return assert(
 					paymentButtonText.includes( expectedCurrencySymbol ),
 					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
@@ -670,7 +670,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 					);
 				}
-				const paymentButtonText = await securePaymentComponent.activePaymentButtonText();
+				const paymentButtonText = await securePaymentComponent.paymentButtonText();
 				return assert(
 					paymentButtonText.includes( expectedCurrencySymbol ),
 					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
@@ -826,7 +826,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 					);
 				}
-				const paymentButtonText = await securePaymentComponent.activePaymentButtonText();
+				const paymentButtonText = await securePaymentComponent.paymentButtonText();
 				return assert(
 					paymentButtonText.includes( expectedCurrencySymbol ),
 					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
@@ -1000,7 +1000,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
 					);
 				}
-				const paymentButtonText = await securePaymentComponent.activePaymentButtonText();
+				const paymentButtonText = await securePaymentComponent.paymentButtonText();
 				return assert(
 					paymentButtonText.includes( expectedCurrencySymbol ),
 					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`


### PR DESCRIPTION
I needed to run the e2e tests locally against my local environment so I can test some backend change but they failed. Finally I think I found the issue (though I'm not sure why it works that way). Seems like when I'm running the e2e tests locally they use the new checkout flow and the payment button selector selects the disabled "waiting..." button. Anyway - here's a fix for that.

#### Changes proposed in this Pull Request

* Fix the selector for the new checkout payment button

#### Testing instructions

* Run the signup e2e tests against locally running Calypso
