### PR TITLE
http-data: rename the waitForData function and modify its API

### DIFF
--- a/client/components/async-loader/README.md
+++ b/client/components/async-loader/README.md
@@ -55,11 +55,11 @@ export default ( props ) =>
 	React.createElement(
 		asyncLoader( {
 			promises: {
-				data: waitForData( {
+				data: waitForHttpData( () => ( {
 					plan: requestPlan( props.userId ),
 					site: requestSiteInfo( props.siteId ),
 					user: requestUserInfo( props.userId ),
-				} ),
+				} ) ),
 			},
 			loading: () => <div>Loading profile information…</div>,
 			success: ( { data: { plan, site, user } } ) => (
@@ -82,9 +82,9 @@ Thus we're not passing any data to the success component.
 import { asyncLoader } from 'components/async-loader';
 
 const getTranslations = ( slug ) =>
-	waitForData( {
+	waitForHttpData( () => ( {
 		translations: requestTranslations( slug ),
-	} );
+	} ) );
 
 const Panel = asyncLoader( {
 	promises: {

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -22,7 +22,7 @@ import StreamComponent from 'reader/following/main';
 import { getPrettyFeedUrl, getPrettySiteUrl } from 'reader/route';
 import { recordTrack } from 'reader/stats';
 import { requestFeedDiscovery } from 'state/data-getters';
-import { waitForData } from 'state/data-layer/http-data';
+import { waitForHttpData } from 'state/data-layer/http-data';
 import AsyncLoad from 'components/async-load';
 import { isFollowingOpen } from 'state/reader-ui/sidebar/selectors';
 import { toggleReaderSidebarFollowing } from 'state/reader-ui/sidebar/actions';
@@ -178,9 +178,7 @@ const exported = {
 
 	feedDiscovery( context, next ) {
 		if ( ! context.params.feed_id.match( /^\d+$/ ) ) {
-			waitForData( {
-				feeds: () => requestFeedDiscovery( context.params.feed_id ),
-			} )
+			waitForHttpData( () => ( { feeds: requestFeedDiscovery( context.params.feed_id ) } ) )
 				.then( ( { feeds } ) => {
 					const feed = feeds?.data?.feeds?.[ 0 ];
 					if ( feed && feed.feed_ID ) {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -38,7 +38,7 @@ import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { setSiteType } from 'state/signup/steps/site-type/actions';
 import { login } from 'lib/paths';
-import { waitForData } from 'state/data-layer/http-data';
+import { waitForHttpData } from 'state/data-layer/http-data';
 import { requestGeoLocation } from 'state/data-getters';
 import { getDotBlogVerticalId } from './config/dotblog-verticals';
 import { abtest } from 'lib/abtest';
@@ -130,9 +130,7 @@ export default {
 				return;
 			}
 
-			waitForData( {
-				geo: () => requestGeoLocation(),
-			} )
+			waitForHttpData( () => ( { geo: requestGeoLocation() } ) )
 				.then( ( { geo } ) => {
 					const countryCode = geo.data.body.country_short;
 					if (

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -19,9 +19,9 @@ import fromActivityTypeApi from 'state/data-layer/wpcom/sites/activity-types/fro
  * Fetches content from a URL with a GET request
  *
  * @example
- * waitForData( {
+ * waitForHttpData( () => ( {
  *     planets: requestFromUrl( 'https://swapi.co/api/planets/' ),
- * } ).then( ( { planets } ) => {
+ * } ) ).then( ( { planets } ) => {
  *     console.log( planets.data );
  * } );
  *


### PR DESCRIPTION
Changes the name of the `waitForData` function to `waitForHttpData`, making it consistent with `getHttpData` and `requestHttpData`.

Also changes the shape of the first argument from:
```js
( {
  a: () => requestA(),
  b: () => requestB(),
} )
```
to
```js
() => ( {
  a: requestA(),
  b: requestB(),
} )
```
i.e., instead of a "lazy requestor" function for every field, the whole argument
is one "lazy" function that calls all the `request*` function at one.

This new API is more similar to things like Redux `useSelector`:
```js
useSelector( ( state ) => ( {
  a: getA( state ),
  b: getB( state ),
} );
```

or `@wordpress/data` and its `useSelect`:
```js
useSelect( ( select ) => ( {
  a: select( 'a' ).get(),
  b: select( 'b' ).get(),
} );
```

It hints at some deeper analogies between all these libraries 💭 

Also note that in almost all documentation examples, `waitForData` was used incorrectly 🙂 

**How to test:**
The easiest way to test is to navigate to `/read/feeds/some.site.blog` and verify that it redirects to `/read/feeds/123456`, with numerical ID of the feed in the URL. `waitForHttpData` is used by the Reader route handler to send a REST request to convert the slug to ID, and wait for results before proceeding.