### PR TITLE
Only add 'a8c.wpcom-block-editor.openCheckoutModal' action when featu…

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -913,16 +913,30 @@ async function preselectParentPage() {
 }
 
 function handleCheckoutModal( calypsoPort ) {
-	addAction(
-		'a8c.wpcom-block-editor.openCheckoutModal',
-		'a8c/wpcom-block-editor/openCheckoutModal',
-		( data ) => {
-			calypsoPort.postMessage( {
-				action: 'openCheckoutModal',
-				payload: data,
-			} );
-		}
+	const { port1, port2 } = new MessageChannel();
+	calypsoPort.postMessage(
+		{
+			action: 'getCheckoutModalStatus',
+			payload: {},
+		},
+		[ port2 ]
 	);
+	port1.onmessage = ( message ) => {
+		const { isCheckoutOverlayEnabled } = message.data;
+
+		if ( isCheckoutOverlayEnabled ) {
+			addAction(
+				'a8c.wpcom-block-editor.openCheckoutModal',
+				'a8c/wpcom-block-editor/openCheckoutModal',
+				( data ) => {
+					calypsoPort.postMessage( {
+						action: 'openCheckoutModal',
+						payload: data,
+					} );
+				}
+			);
+		}
+	};
 }
 
 function initPort( message ) {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -101,6 +101,7 @@ enum EditorActions {
 	CloseEditor = 'closeEditor',
 	OpenMediaModal = 'openMediaModal',
 	OpenCheckoutModal = 'openCheckoutModal',
+	GetCheckoutModalStatus = 'getCheckoutModalStatus',
 	OpenRevisions = 'openRevisions',
 	PostStatusChange = 'postStatusChange',
 	PreviewPost = 'previewPost',
@@ -281,6 +282,14 @@ class CalypsoifyIframe extends Component<
 
 		if ( EditorActions.OpenCheckoutModal === action ) {
 			this.setState( { isCheckoutModalVisible: true, cartData: payload } );
+		}
+
+		if ( EditorActions.GetCheckoutModalStatus === action ) {
+			const isCheckoutOverlayEnabled = config.isEnabled( 'post-editor/checkout-overlay' );
+
+			ports[ 0 ].postMessage( {
+				isCheckoutOverlayEnabled,
+			} );
 		}
 
 		if ( EditorActions.SetDraftId === action && ! this.props.postId ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Only adds the action `a8c.wpcom-block-editor.openCheckoutModal` when the feature flag `?flags=post-editor/checkout-overlay` is enabled

#### Testing instructions

* Enable Sandbox.
* Run `yarn dev --sync` on `apps/wpcom-block-editor`.
* Open block editor of the free site with the feature flag `?flags=post-editor/checkout-overlay`, e.g. `calypso.localhost:3000/block-editor/post/your_sandboxed_free_site.wordpress.com?flags=post-editor/checkout-overlay`
* Open up developer tools > console, change the frame to `post.php` and run the following snippet in your console `wp.hooks.hasAction( 'a8c.wpcom-block-editor.openCheckoutModal' );` this should return `true`
* Remove the flag `?flags=post-editor/checkout-overlay` from your URL, refresh the page and run the snippet again (making sure to change the frame to `post.php`). This should return `false`
