### PR TITLE
Jetpack Scan: Don't show '<action> on <date>' if no date is available

### DIFF
--- a/client/components/jetpack/threat-item-subheader/index.tsx
+++ b/client/components/jetpack/threat-item-subheader/index.tsx
@@ -33,6 +33,36 @@ const formatDate = ( date: Date ) => {
 	return moment( date ).format( 'LL' );
 };
 
+const getThreatStatusMessage = ( translate, threat: Threat ) => {
+	const { status, fixedOn } = threat;
+
+	const date = fixedOn && formatDate( fixedOn );
+
+	if ( status === 'fixed' ) {
+		return date
+			? translate( 'Threat fixed on %(date)s', {
+					args: { date },
+					comment: 'Past tense action: a threat was fixed on a specific date',
+			  } )
+			: translate( 'Threat fixed', {
+					comment: 'Past tense action: a threat was fixed on an unspecified date',
+			  } );
+	}
+
+	if ( status === 'ignored' ) {
+		return date
+			? translate( 'Threat ignored on %(date)s', {
+					args: { date },
+					comment: 'Past tense action: a threat was ignored on a specific date',
+			  } )
+			: translate( 'Threat ignored', {
+					comment: 'Past tense action: a threat was ignored on an unspecified date',
+			  } );
+	}
+
+	return null;
+};
+
 // This renders two different kind of sub-headers. One is for current threats (displayed
 // in the Scanner section), and the other for threats in the History section.
 const ThreatItemSubheader: React.FC< Props > = ( { threat } ) => {
@@ -58,26 +88,28 @@ const ThreatItemSubheader: React.FC< Props > = ( { threat } ) => {
 				return <> { getThreatVulnerability( threat ) }</>;
 		}
 	} else {
+		const threatStatusMessage = getThreatStatusMessage( translate, threat );
+
 		return (
 			<>
 				<div className="threat-item-subheader__subheader">
-					<span className="threat-item-subheader__date">
+					<span className="threat-item-subheader__status">
 						{ translate( 'Threat found on %s', {
 							args: formatDate( threat.firstDetected ),
 						} ) }
 					</span>
-					{ threat.fixedOn && <span className="threat-item-subheader__date-separator"></span> }
-					{ threat.fixedOn && (
-						<span
-							className={ classnames(
-								'threat-item-subheader__date',
-								entryActionClassNames( threat )
-							) }
-						>
-							{ translate( 'Threat %(action)s on %(fixedOn)s', {
-								args: { action: threat.status, fixedOn: formatDate( threat.fixedOn ) },
-							} ) }
-						</span>
+					{ threatStatusMessage && (
+						<>
+							<span className="threat-item-subheader__status-separator"></span>
+							<span
+								className={ classnames(
+									'threat-item-subheader__status',
+									entryActionClassNames( threat )
+								) }
+							>
+								{ threatStatusMessage }
+							</span>
+						</>
 					) }
 				</div>
 				<Badge

--- a/client/components/jetpack/threat-item-subheader/index.tsx
+++ b/client/components/jetpack/threat-item-subheader/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import classnames from 'classnames';
 import moment from 'moment';
 
@@ -36,6 +36,8 @@ const formatDate = ( date: Date ) => {
 // This renders two different kind of sub-headers. One is for current threats (displayed
 // in the Scanner section), and the other for threats in the History section.
 const ThreatItemSubheader: React.FC< Props > = ( { threat } ) => {
+	const translate = useTranslate();
+
 	if ( threat.status === 'current' ) {
 		switch ( getThreatType( threat ) ) {
 			case 'file':

--- a/client/components/jetpack/threat-item-subheader/style.scss
+++ b/client/components/jetpack/threat-item-subheader/style.scss
@@ -13,7 +13,7 @@
 		}
 	}
 
-	&__date {
+	&__status {
 		white-space: nowrap;
 
 		&.is-fixed {
@@ -21,7 +21,7 @@
 		}
 	}
 
-	&__date-separator {
+	&__status-separator {
 		display: none;
 
 		@include breakpoint-deprecated( '>1040px' ) {

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -28,8 +28,10 @@ export const formatScanThreat = ( threat ) => ( {
 	signature: threat.signature,
 	description: threat.description,
 	status: threat.status,
-	firstDetected: new Date( threat.first_detected ),
-	fixedOn: new Date( threat.fixed_on ),
+	firstDetected: Number.isFinite( threat.first_detected )
+		? new Date( threat.first_detected )
+		: undefined,
+	fixedOn: Number.isFinite( threat.fixed_on ) ? new Date( threat.fixed_on ) : undefined,
 	fixable: threat.fixable,
 	fixerStatus: threat.fixer_status,
 	filename: threat.filename,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a `Number.isFinite` check to `fixed_on` and `first_detected` API response properties, so that we don't create invalid dates for the UI to display.

#### Testing instructions

* In either Jetpack Cloud or Calypso, select a site that has Jetpack Scan and at least one fixed or ignored threat.
* Navigate to **Jetpack > Scan > History**.
* In React DevTools, check the `status` and `fixedOn` properties of any `ThreatItem` component.
  * Verify that if `fixedOn` is a numeric value, text is displayed to show when action was taken on the threat (see reference screenshots).
  * Verify that if `fixedOn` is undefined or non-numeric, no "<action taken> on <date>" text is displayed.
* Inspect different fixed/ignored threats to ensure behavior is correct in all cases (i.e., fixed and ignored threats, both with and without "fixed on" dates).
* **Alternatively:** In React DevTools, modify the values of a `ThreatItem`'s `status` and `fixedOn` properties to simulate different scenarios.

#### Reference screenshots

<img width="728" alt="Screen Shot 2020-10-07 at 08 40 06" src="https://user-images.githubusercontent.com/670067/95338799-eb32ba00-0878-11eb-9b4c-472e8ecfc955.png">
<img width="728" alt="Screen Shot 2020-10-07 at 08 41 58" src="https://user-images.githubusercontent.com/670067/95338845-fb4a9980-0878-11eb-83cd-7b98e5d9b4fb.png">

<img width="727" alt="Screen Shot 2020-10-07 at 08 43 15" src="https://user-images.githubusercontent.com/670067/95339005-2af9a180-0879-11eb-8ca8-c9f5e3fba6d9.png">
<img width="729" alt="Screen Shot 2020-10-07 at 08 43 05" src="https://user-images.githubusercontent.com/670067/95339011-2d5bfb80-0879-11eb-941b-8acd4f92f1ec.png">