### PR TITLE
Add track events to the "Enable restores" banner

### DIFF
--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -201,6 +201,9 @@ class BackupsPage extends Component {
 											: `/settings/jetpack/${ siteSlug }#credentials`
 									}
 									icon="cloud-upload"
+									event="calypso_backup_enable_restores_banner"
+									tracksImpressionName="calypso_backup_enable_restores_banner_view"
+									tracksClickName="calypso_backup_enable_restores_banner_click"
 								/>
 							) }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds Tracks events to the "Enable restores" banner in the Backup page.

### Testing instructions

- Run this PR in Calypso or Jetpack cloud
- Select a self-hosted Jetpack site that has Backup, and server credentials **not** set
- In your browser console, run `localStorage.setItem('debug', 'calypso:analytics');` to log the tracks events
- Visit `/backup/:site`
- Check that the event `calypso_backup_enable_restores_banner_view` was triggered
- Click the "Enable restores" button
- Check that the event "calypso_backup_enable_restores_banner_click: was triggered

### Screenshots

<img width="591" alt="Screen Shot 2020-10-07 at 10 13 09 AM" src="https://user-images.githubusercontent.com/1620183/95342705-b842f300-0885-11eb-93d0-78eec875947f.png">
<img width="583" alt="Screen Shot 2020-10-07 at 10 06 59 AM" src="https://user-images.githubusercontent.com/1620183/95342730-be38d400-0885-11eb-86cc-a934b693e8a1.png">
<img width="586" alt="Screen Shot 2020-10-07 at 10 07 12 AM" src="https://user-images.githubusercontent.com/1620183/95342739-c09b2e00-0885-11eb-9233-dce50e782a27.png">

