### PR TITLE
Billing: add site-level billing section nav

### DIFF
--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -24,6 +24,7 @@ import { getReceiptUrlFor, getBillingHistoryUrlFor } from '../paths';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import useRedirectToHistoryPageOnInvalidTransaction from './use-redirect-to-history-page-on-invalid-transaction';
 import useRedirectToHistoryPageOnWrongSiteForTransaction from './use-redirect-to-history-page-on-wrong-site-for-transaction';
+import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
 
 export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -44,6 +45,8 @@ export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 				headerText={ translate( 'Billing' ) }
 				align="left"
 			/>
+			<PurchasesNavigation sectionTitle={ 'Billing History' } siteSlug={ siteSlug } />
+
 			<BillingHistoryList
 				siteId={ selectedSiteId }
 				getReceiptUrlFor={ getReceiptUrlForReceiptId }
@@ -81,7 +84,6 @@ export function ReceiptView( { siteSlug, receiptId }: { siteSlug: string; receip
 				title="Billing History > Receipt"
 			/>
 			<QueryBillingTransaction transactionId={ receiptId } />
-
 			<FormattedHeader
 				brandFont
 				className="billing-history__page-heading"
@@ -90,7 +92,6 @@ export function ReceiptView( { siteSlug, receiptId }: { siteSlug: string; receip
 			/>
 
 			<ReceiptTitle backHref={ getBillingHistoryUrlFor( siteSlug ) } />
-
 			{ transaction && isCorrectSite ? (
 				<ReceiptBody transaction={ transaction } handlePrintLinkClick={ handlePrintLinkClick } />
 			) : (

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -25,9 +26,12 @@ import {
 import { getEditOrAddPaymentMethodUrlFor } from './utils';
 import AddCardDetails from 'calypso/me/purchases/payment/add-card-details';
 import EditCardDetails from 'calypso/me/purchases/payment/edit-card-details';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
 
 export function Purchases() {
 	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	return (
 		<Main className="purchases is-wide-layout">
@@ -39,6 +43,7 @@ export function Purchases() {
 				headerText={ translate( 'Billing' ) }
 				align="left"
 			/>
+			<PurchasesNavigation sectionTitle={ 'Purchases' } siteSlug={ siteSlug } />
 
 			<Subscriptions />
 		</Main>

--- a/client/my-sites/purchases/navigation.tsx
+++ b/client/my-sites/purchases/navigation.tsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+
+export default function PurchasesNavigation( {
+	sectionTitle,
+	siteSlug,
+}: {
+	sectionTitle: string;
+	siteSlug: string | null;
+} ) {
+	const translate = useTranslate();
+
+	return (
+		<SectionNav selectedText={ sectionTitle }>
+			<NavTabs label="Section" selectedText={ sectionTitle }>
+				<NavItem
+					path={ `/purchases/subscriptions/${ siteSlug }` }
+					selected={ sectionTitle === 'Purchases' }
+				>
+					{ translate( 'Purchases' ) }
+				</NavItem>
+				<NavItem
+					path={ `/purchases/billing-history/${ siteSlug }` }
+					selected={ sectionTitle === 'Billing History' }
+				>
+					{ translate( 'Billing History' ) }
+				</NavItem>
+			</NavTabs>
+		</SectionNav>
+	);
+}

--- a/client/my-sites/purchases/navigation.tsx
+++ b/client/my-sites/purchases/navigation.tsx
@@ -7,9 +7,9 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavItem from 'components/section-nav/item';
+import SectionNav from 'calypso/components/section-nav';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import NavItem from 'calypso/components/section-nav/item';
 
 export default function PurchasesNavigation( {
 	sectionTitle,

--- a/client/my-sites/purchases/subscriptions/account-level-purchase-links.tsx
+++ b/client/my-sites/purchases/subscriptions/account-level-purchase-links.tsx
@@ -15,9 +15,6 @@ export default function AccountLevelPurchaseLinks() {
 		<>
 			<CompactCard href="/me/purchases">{ translate( 'View all subscriptions' ) }</CompactCard>
 			<CompactCard href="/me/purchases/billing">
-				{ translate( 'View billing history and receipts' ) }
-			</CompactCard>
-			<CompactCard href="/me/purchases/billing">
 				{ translate( 'Manage payment methods' ) }
 			</CompactCard>
 		</>

--- a/client/my-sites/purchases/subscriptions/index.tsx
+++ b/client/my-sites/purchases/subscriptions/index.tsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -14,17 +13,14 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import SubscriptionsContent from './subscriptions-content';
 import AccountLevelPurchaseLinks from './account-level-purchase-links';
-import SectionHeader from 'components/section-header';
 
 export default function Subscriptions() {
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const translate = useTranslate();
 
 	return (
 		<Main className="subscriptions is-wide-layout">
 			<QuerySitePurchases siteId={ selectedSiteId } />
 			<PageViewTracker path="/purchases/subscriptions" title="Subscriptions" />
-			<SectionHeader label={ translate( 'Subscriptions' ) } />
 			<SubscriptionsContent />
 			<AccountLevelPurchaseLinks />
 		</Main>

--- a/client/my-sites/purchases/subscriptions/index.tsx
+++ b/client/my-sites/purchases/subscriptions/index.tsx
@@ -7,10 +7,10 @@ import { useSelector } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import Main from 'components/main';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QuerySitePurchases from 'components/data/query-site-purchases';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SubscriptionsContent from './subscriptions-content';
 import AccountLevelPurchaseLinks from './account-level-purchase-links';
 


### PR DESCRIPTION
This adds a sectionsNav to the new site-level billing screens. It includes #46175, which adds a second "section" (Billing History) to site-level billing. Those commits will be rebased out after #46175 merges.

We should hold on merging this until #46224 is complete.

<img width="1486" alt="Screen Shot 2020-10-07 at 11 35 06 AM" src="https://user-images.githubusercontent.com/942359/95353354-2e008c00-0891-11eb-9280-b9024e5faa4b.png">

Fixes: #46210 

**To test:**
- Navigate to the new site-level billing section: _Plan > Billing_ in the sidebar
- Verify that the sectionNav is displayed
- Verify that the "Purchases" item is selected by default
- Verify that clicking "Billing History" takes you to the site-level billing history screen
- Verify that clicking "Purchases" takes you back to the subscriptions screen
- Verify that you don't see a link to "View all billing history" at the bottom of the subscriptions screen