### PR TITLE
Emails: Update features and pricing on email providers comparison page 

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -149,7 +149,6 @@ class EmailProvidersComparison extends React.Component {
 		return (
 			<EmailProviderDetails
 				title={ translate( 'Titan Mail' ) }
-				badge={ translate( 'Recommended' ) }
 				description={ translate(
 					'Easy-to-use email with incredibly powerful features. Manage your email and more on any device.'
 				) }
@@ -162,7 +161,7 @@ class EmailProvidersComparison extends React.Component {
 				] }
 				formattedPrice={ translate( '{{price/}} /user /month', {
 					components: {
-						price: <span>$4</span>,
+						price: <span>$3.50</span>,
 					},
 					comment: '{{price/}} is the formatted price, e.g. $20',
 				} ) }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -24,6 +24,7 @@ import wpcom from 'lib/wp';
 import { errorNotice } from 'state/notices/actions';
 import { recordTracksEvent } from 'lib/analytics/tracks';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import formatCurrency from '@automattic/format-currency';
 import emailIllustration from 'assets/images/email-providers/email-illustration.svg';
 import titanLogo from 'assets/images/email-providers/titan.svg';
 import gSuiteLogo from 'assets/images/email-providers/gsuite.svg';
@@ -158,10 +159,12 @@ class EmailProvidersComparison extends React.Component {
 					translate( 'Send and receive from your custom domain' ),
 					translate( '10GB storage' ),
 					translate( 'Email, calendars, and contacts' ),
+					translate( 'One-click import of existing emails and contacts' ),
+					translate( 'Read receipts to track email opens' ),
 				] }
 				formattedPrice={ translate( '{{price/}} /user /month', {
 					components: {
-						price: <span>$3.50</span>,
+						price: <span>{ formatCurrency( 3.5, 'USD' ) }</span>,
 					},
 					comment: '{{price/}} is the formatted price, e.g. $20',
 				} ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the price and features of Titan in the email providers comparison page.

<img width="1048" alt="Screenshot 2020-10-07 at 4 45 19 PM" src="https://user-images.githubusercontent.com/13062352/95361485-15ae6280-08cd-11eb-914a-8fbe53896b0a.png">


#### Testing instructions

* Load Calypso with the `email/titan-mvp` flag enabled (append `?flags=email/titan-mvp` to the URL)
* Go to your site domains, and click "Add" under the email column for one of your domains
* Confirm you see the same thing as the screenshot above
