### PR TITLE
Checkout: Replace existing cart products when adding renewals from URL

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
@@ -17,7 +17,7 @@ import { isLineItemADomain } from '../hooks/has-domains';
 
 export default function WPCheckoutOrderReview( {
 	className,
-	removeItem,
+	removeProductFromCart,
 	removeCoupon,
 	couponStatus,
 	couponFieldStateProps,
@@ -51,7 +51,7 @@ export default function WPCheckoutOrderReview( {
 			<WPOrderReviewSection>
 				<WPOrderReviewLineItems
 					items={ items }
-					removeItem={ removeItem }
+					removeProductFromCart={ removeProductFromCart }
 					removeCoupon={ removeCouponAndClearField }
 					getItemVariants={ getItemVariants }
 					onChangePlanLength={ onChangePlanLength }
@@ -74,7 +74,7 @@ export default function WPCheckoutOrderReview( {
 WPCheckoutOrderReview.propTypes = {
 	isSummary: PropTypes.bool,
 	className: PropTypes.string,
-	removeItem: PropTypes.func,
+	removeProductFromCart: PropTypes.func,
 	removeCoupon: PropTypes.func,
 	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -85,7 +85,7 @@ const OrderReviewTitle = () => {
 const paymentMethodStep = getDefaultPaymentMethodStep();
 
 export default function WPCheckout( {
-	removeItem,
+	removeProductFromCart,
 	updateLocation,
 	applyCoupon,
 	removeCoupon,
@@ -310,7 +310,7 @@ export default function WPCheckout( {
 					goToNextStep={ () => setIsOrderReviewActive( ! isOrderReviewActive ) }
 					activeStepContent={
 						<WPCheckoutOrderReview
-							removeItem={ removeItem }
+							removeProductFromCart={ removeProductFromCart }
 							couponStatus={ couponStatus }
 							couponFieldStateProps={ couponFieldStateProps }
 							removeCoupon={ removeCoupon }

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -38,7 +38,7 @@ function WPLineItem( {
 	item,
 	className,
 	hasDeleteButton,
-	removeItem,
+	removeProductFromCart,
 	getItemVariants,
 	onChangePlanLength,
 	isSummary,
@@ -121,7 +121,7 @@ function WPLineItem( {
 							setIsModalVisible( false );
 						} }
 						primaryAction={ () => {
-							removeItem( item.wpcom_meta.uuid );
+							removeProductFromCart( item.wpcom_meta.uuid );
 							onEvent( {
 								type: 'a8c_checkout_delete_product',
 								payload: {
@@ -157,7 +157,7 @@ WPLineItem.propTypes = {
 	total: PropTypes.bool,
 	isSummary: PropTypes.bool,
 	hasDeleteButton: PropTypes.bool,
-	removeItem: PropTypes.func,
+	removeProductFromCart: PropTypes.func,
 	item: PropTypes.shape( {
 		label: PropTypes.string,
 		amount: PropTypes.shape( {
@@ -309,7 +309,7 @@ export function WPOrderReviewLineItems( {
 	items,
 	className,
 	isSummary,
-	removeItem,
+	removeProductFromCart,
 	removeCoupon,
 	getItemVariants,
 	onChangePlanLength,
@@ -331,7 +331,9 @@ export function WPOrderReviewLineItems( {
 							<LineItemUI
 								item={ item }
 								hasDeleteButton={ ! isSummary && canItemBeDeleted( item ) }
-								removeItem={ item.type === 'coupon' ? removeCoupon : removeItem }
+								removeProductFromCart={
+									item.type === 'coupon' ? removeCoupon : removeProductFromCart
+								}
 								getItemVariants={ getItemVariants }
 								onChangePlanLength={ onChangePlanLength }
 								isSummary={ isSummary }
@@ -347,7 +349,7 @@ export function WPOrderReviewLineItems( {
 WPOrderReviewLineItems.propTypes = {
 	className: PropTypes.string,
 	isSummary: PropTypes.bool,
-	removeItem: PropTypes.func,
+	removeProductFromCart: PropTypes.func,
 	removeCoupon: PropTypes.func,
 	items: PropTypes.arrayOf(
 		PropTypes.shape( {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -198,6 +198,7 @@ export default function CompositeCheckout( {
 		loadingError: cartLoadingError,
 		loadingErrorType: cartLoadingErrorType,
 		addProductsToCart,
+		replaceProductsInCart,
 	} = useShoppingCartManager( {
 		cartKey: isLoggedOutCart || isNoSiteCart ? siteSlug : siteId,
 		canInitializeCart: ! isLoadingCartSynchronizer,
@@ -214,6 +215,7 @@ export default function CompositeCheckout( {
 		couponCodeFromUrl,
 		applyCoupon,
 		addProductsToCart,
+		replaceProductsInCart,
 	} );
 
 	useRecordCartLoaded( {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -186,7 +186,7 @@ export default function CompositeCheckout( {
 	} );
 
 	const {
-		removeItem,
+		removeProductFromCart,
 		couponStatus,
 		applyCoupon,
 		removeCoupon,
@@ -633,7 +633,7 @@ export default function CompositeCheckout( {
 					theme={ theme }
 				>
 					<WPCheckout
-						removeItem={ removeItem }
+						removeProductFromCart={ removeProductFromCart }
 						updateLocation={ updateLocation }
 						applyCoupon={ applyCoupon }
 						removeCoupon={ removeCoupon }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -174,6 +174,7 @@ export default function CompositeCheckout( {
 
 	const {
 		productsForCart,
+		renewalsForCart,
 		isLoading: areCartProductsPreparing,
 		error: cartProductPrepError,
 	} = usePrepareProductsForCart( {
@@ -208,6 +209,7 @@ export default function CompositeCheckout( {
 		isLoadingCart,
 		isCartPendingUpdate,
 		productsForCart,
+		renewalsForCart,
 		areCartProductsPreparing,
 		couponCodeFromUrl,
 		applyCoupon,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -17,18 +17,22 @@ export default function useAddProductsFromUrl( {
 	isLoadingCart,
 	isCartPendingUpdate,
 	productsForCart,
+	renewalsForCart,
 	areCartProductsPreparing,
 	couponCodeFromUrl,
 	applyCoupon,
 	addProductsToCart,
+	replaceProductsInCart,
 }: {
 	isLoadingCart: boolean;
 	isCartPendingUpdate: boolean;
 	productsForCart: RequestCartProduct[];
+	renewalsForCart: RequestCartProduct[];
 	areCartProductsPreparing: boolean;
 	couponCodeFromUrl: string | null | undefined;
 	applyCoupon: ( couponId: string ) => void;
 	addProductsToCart: ( products: RequestCartProduct[] ) => void;
+	replaceProductsInCart: ( products: RequestCartProduct[] ) => void;
 } ): isPendingAddingProductsFromUrl {
 	const [ isLoading, setIsLoading ] = useState< boolean >( true );
 	const hasRequestedInitialProducts = useRef< boolean >( false );
@@ -42,6 +46,7 @@ export default function useAddProductsFromUrl( {
 		if (
 			! areCartProductsPreparing &&
 			productsForCart.length === 0 &&
+			renewalsForCart.length === 0 &&
 			! couponCodeFromUrl &&
 			! isLoadingCart &&
 			! isCartPendingUpdate
@@ -56,6 +61,7 @@ export default function useAddProductsFromUrl( {
 		isLoadingCart,
 		areCartProductsPreparing,
 		productsForCart.length,
+		renewalsForCart.length,
 		couponCodeFromUrl,
 	] );
 
@@ -89,6 +95,16 @@ export default function useAddProductsFromUrl( {
 		if ( productsForCart.length > 0 ) {
 			addProductsToCart( productsForCart );
 		}
+		debug( 'adding initial renewal products to cart', renewalsForCart );
+		if ( renewalsForCart.length > 0 ) {
+			if ( productsForCart.length > 0 ) {
+				throw new Error(
+					'Renewals and non-renewals cannot be added to the cart from the URL at the same time'
+				);
+			}
+			// Note that adding renewals replaces any existing products in the cart
+			replaceProductsInCart( renewalsForCart );
+		}
 		debug( 'adding initial coupon to cart', couponCodeFromUrl );
 		if ( couponCodeFromUrl ) {
 			applyCoupon( couponCodeFromUrl );
@@ -101,7 +117,9 @@ export default function useAddProductsFromUrl( {
 		couponCodeFromUrl,
 		applyCoupon,
 		productsForCart,
+		renewalsForCart,
 		addProductsToCart,
+		replaceProductsInCart,
 	] );
 
 	debug( 'useAddProductsFromUrl isLoading', isLoading );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -30,6 +30,7 @@ const debug = debugFactory( 'calypso:composite-checkout:use-prepare-products-for
 
 interface PreparedProductsForCart {
 	productsForCart: RequestCartProduct[];
+	renewalsForCart: RequestCartProduct[];
 	isLoading: boolean;
 	error: string | null;
 }
@@ -37,6 +38,7 @@ interface PreparedProductsForCart {
 const initialPreparedProductsState = {
 	isLoading: true,
 	productsForCart: [],
+	renewalsForCart: [],
 	error: null,
 };
 
@@ -112,6 +114,7 @@ export default function usePrepareProductsForCart( {
 
 type PreparedProductsAction =
 	| { type: 'PRODUCTS_ADD'; products: RequestCartProduct[] }
+	| { type: 'RENEWALS_ADD'; products: RequestCartProduct[] }
 	| { type: 'PRODUCTS_ADD_ERROR'; message: string };
 
 function preparedProductsReducer(
@@ -123,7 +126,14 @@ function preparedProductsReducer(
 			if ( ! state.isLoading ) {
 				return state;
 			}
-			return { ...state, productsForCart: action.products, isLoading: false };
+			// Note that products and renewals are mutually exclusive; they cannot both be in the cart at the same time
+			return { ...state, productsForCart: action.products, renewalsForCart: [], isLoading: false };
+		case 'RENEWALS_ADD':
+			if ( ! state.isLoading ) {
+				return state;
+			}
+			// Note that products and renewals are mutually exclusive; they cannot both be in the cart at the same time
+			return { ...state, productsForCart: [], renewalsForCart: action.products, isLoading: false };
 		case 'PRODUCTS_ADD_ERROR':
 			if ( ! state.isLoading ) {
 				return state;
@@ -213,7 +223,7 @@ function useAddRenewalItems( {
 			return;
 		}
 		debug( 'preparing renewals requested in url', productsForCart );
-		dispatch( { type: 'PRODUCTS_ADD', products: productsForCart } );
+		dispatch( { type: 'RENEWALS_ADD', products: productsForCart } );
 	}, [
 		translate,
 		isLoading,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/cart-functions.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/cart-functions.ts
@@ -140,6 +140,19 @@ export function addItemsToResponseCart(
 	};
 }
 
+export function replaceAllItemsInResponseCart(
+	responseCart: ResponseCart,
+	products: RequestCartProduct[]
+): ResponseCart {
+	const responseCartProducts: TempResponseCartProduct[] = products.map(
+		convertRequestCartProductToResponseCartProduct
+	);
+	return {
+		...responseCart,
+		products: [ ...responseCartProducts ],
+	};
+}
+
 export function replaceItemInResponseCart(
 	cart: ResponseCart,
 	uuidToReplace: string,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
@@ -61,6 +61,13 @@ export default function useShoppingCartManager( {
 		[ hookDispatch ]
 	);
 
+	const replaceProductsInCart: ( products: RequestCartProduct[] ) => void = useCallback(
+		( products ) => {
+			hookDispatch( { type: 'CART_PRODUCTS_REPLACE_ALL', products } );
+		},
+		[ hookDispatch ]
+	);
+
 	const removeItem: ( uuidToRemove: string ) => void = useCallback(
 		( uuidToRemove ) => {
 			hookDispatch( { type: 'REMOVE_CART_ITEM', uuidToRemove } );
@@ -105,6 +112,7 @@ export default function useShoppingCartManager( {
 		couponStatus,
 		updateLocation,
 		replaceProductInCart,
+		replaceProductsInCart,
 		responseCart,
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
@@ -68,7 +68,7 @@ export default function useShoppingCartManager( {
 		[ hookDispatch ]
 	);
 
-	const removeItem: ( uuidToRemove: string ) => void = useCallback(
+	const removeProductFromCart: ( uuidToRemove: string ) => void = useCallback(
 		( uuidToRemove ) => {
 			hookDispatch( { type: 'REMOVE_CART_ITEM', uuidToRemove } );
 		},
@@ -106,7 +106,7 @@ export default function useShoppingCartManager( {
 		loadingErrorType,
 		isPendingUpdate: cacheStatus !== 'valid',
 		addProductsToCart,
-		removeItem,
+		removeProductFromCart,
 		applyCoupon,
 		removeCoupon,
 		couponStatus,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
@@ -24,13 +24,14 @@ export interface ShoppingCartManager {
 	loadingError: string | null | undefined;
 	loadingErrorType: ShoppingCartError | undefined;
 	isPendingUpdate: boolean;
-	addProductsToCart: ( products: RequestCartProduct[] ) => void;
+	addProductsToCart: AddProductsToCart;
 	removeItem: ( uuidToRemove: string ) => void;
 	applyCoupon: ( couponId: string ) => void;
 	removeCoupon: () => void;
 	couponStatus: CouponStatus;
 	updateLocation: ( arg0: CartLocation ) => void;
 	replaceProductInCart: ReplaceProductInCart;
+	replaceProductsInCart: ReplaceProductsInCart;
 	responseCart: ResponseCart;
 }
 
@@ -38,6 +39,10 @@ export type ReplaceProductInCart = (
 	uuidToReplace: string,
 	productPropertiesToChange: Partial< RequestCartProduct >
 ) => void;
+
+export type ReplaceProductsInCart = ( products: RequestCartProduct[] ) => void;
+
+export type AddProductsToCart = ( products: RequestCartProduct[] ) => void;
 
 /**
  * The custom hook keeps a cached version of the server cart, as well as a
@@ -66,6 +71,7 @@ export type ShoppingCartAction =
 	| { type: 'CLEAR_QUEUED_ACTIONS' }
 	| { type: 'REMOVE_CART_ITEM'; uuidToRemove: string }
 	| { type: 'CART_PRODUCTS_ADD'; products: RequestCartProduct[] }
+	| { type: 'CART_PRODUCTS_REPLACE_ALL'; products: RequestCartProduct[] }
 	| { type: 'SET_LOCATION'; location: CartLocation }
 	| {
 			type: 'CART_PRODUCT_REPLACE';

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
@@ -25,11 +25,11 @@ export interface ShoppingCartManager {
 	loadingErrorType: ShoppingCartError | undefined;
 	isPendingUpdate: boolean;
 	addProductsToCart: AddProductsToCart;
-	removeItem: ( uuidToRemove: string ) => void;
-	applyCoupon: ( couponId: string ) => void;
-	removeCoupon: () => void;
+	removeItem: RemoveProductFromCart;
+	applyCoupon: ApplyCouponToCart;
+	removeCoupon: RemoveCouponFromCart;
 	couponStatus: CouponStatus;
-	updateLocation: ( arg0: CartLocation ) => void;
+	updateLocation: UpdateTaxLocationInCart;
 	replaceProductInCart: ReplaceProductInCart;
 	replaceProductsInCart: ReplaceProductsInCart;
 	responseCart: ResponseCart;
@@ -43,6 +43,14 @@ export type ReplaceProductInCart = (
 export type ReplaceProductsInCart = ( products: RequestCartProduct[] ) => void;
 
 export type AddProductsToCart = ( products: RequestCartProduct[] ) => void;
+
+export type RemoveCouponFromCart = () => void;
+
+export type ApplyCouponToCart = ( couponId: string ) => void;
+
+export type RemoveProductFromCart = ( uuidToRemove: string ) => void;
+
+export type UpdateTaxLocationInCart = ( location: CartLocation ) => void;
 
 /**
  * The custom hook keeps a cached version of the server cart, as well as a

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
@@ -25,7 +25,7 @@ export interface ShoppingCartManager {
 	loadingErrorType: ShoppingCartError | undefined;
 	isPendingUpdate: boolean;
 	addProductsToCart: AddProductsToCart;
-	removeItem: RemoveProductFromCart;
+	removeProductFromCart: RemoveProductFromCart;
 	applyCoupon: ApplyCouponToCart;
 	removeCoupon: RemoveCouponFromCart;
 	couponStatus: CouponStatus;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-shopping-cart-reducer.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-shopping-cart-reducer.ts
@@ -10,6 +10,7 @@ import debugFactory from 'debug';
 import {
 	removeItemFromResponseCart,
 	addItemsToResponseCart,
+	replaceAllItemsInResponseCart,
 	replaceItemInResponseCart,
 	addCouponToResponseCart,
 	removeCouponFromResponseCart,
@@ -90,6 +91,14 @@ function shoppingCartReducer(
 			return {
 				...state,
 				responseCart: addItemsToResponseCart( state.responseCart, action.products ),
+				cacheStatus: 'invalid',
+			};
+		}
+		case 'CART_PRODUCTS_REPLACE_ALL': {
+			debug( 'replacing items in cart with', action.products );
+			return {
+				...state,
+				responseCart: replaceAllItemsInResponseCart( state.responseCart, action.products ),
 				cacheStatus: 'invalid',
 			};
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When adding products from the URL, if the products are renewals, old checkout [replaced the cart items with the new items](https://github.com/Automattic/wp-calypso/blob/2da3281420d335f95d78a315af0bb6eb7c7e76b2/client/my-sites/checkout/checkout/index.jsx#L273). That behavior was not copied into new checkout. This PR adds that behavior.

#### Testing instructions

- You'll need a site that already has an existing purchase, like a plan.
- Visit checkout with a URL that includes a new plan like `/checkout/example.com/premium` (you can do this by clicking to purchase a product from the `/plans` page).
- Verify that checkout loads with the newly added product displayed.
- Now that there is a plan in the cart, add another product, like a domain mapping (the url would be something like `/checkout/example.com/domain-mapping:example.com`).
- Verify that checkout loads with the newly added product displayed in addition to the previously added product.
- Add a renewal for an existing purchase to the cart with a URL like `/checkout/personal_bundle/renew/1111/example.com`.
- Verify that checkout loads with _only_ the renewal displayed; all other items should have been removed.
- Remove the renewal product from the cart.
- Verify that the cart loads (briefly) with the item removed and that you are then redirected away from checkout because the cart is now empty.