### PR TITLE
G Suite: Refine Add G Suite page and fix display issues

### DIFF
--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -56,7 +56,7 @@
 	background: var( --color-neutral-0 );
 	border: 1px solid var( --color-neutral-10 );
 	color: var( --color-neutral-50 );
-	padding: 8px 14px;
+	padding: 7px 14px;
 	white-space: nowrap;
 	flex: 1 0 auto;
 	font-size: $font-body;

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import React, { Fragment, FunctionComponent, ReactNode } from 'react';
 import { useTranslate } from 'i18n-calypso';
 
@@ -15,7 +15,7 @@ import {
 	GSuiteNewUser as NewUser,
 	sanitizeEmail,
 	validateUsers,
-} from 'lib/gsuite/new-users';
+} from 'calypso/lib/gsuite/new-users';
 
 /**
  * Style dependencies

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import React, { ChangeEvent, Fragment, FunctionComponent, useState } from 'react';
 import { useTranslate } from 'i18n-calypso';
 
@@ -10,11 +10,11 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { Button } from '@automattic/components';
 import GSuiteDomainsSelect from './domains-select';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormTextInput from 'components/forms/form-text-input';
-import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
-import FormInputValidation from 'components/forms/form-input-validation';
-import { GSuiteNewUser as NewUser } from 'lib/gsuite/new-users';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import { GSuiteNewUser as NewUser } from 'calypso/lib/gsuite/new-users';
 
 interface Props {
 	autoFocus: boolean;

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -56,10 +56,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 	const hasFirstNameError = firstNameFieldTouched && null !== firstNameError;
 	const hasLastNameError = lastNameFieldTouched && null !== lastNameError;
 
-	const emailAddressPlaceholder = translate( 'e.g. contact', {
-		comment:
-			'An example of the local-part of an email address: "contact" in "contact@example.com".',
-	} );
+	const emailAddressPlaceholder = translate( 'Email' );
 
 	const renderSingleDomain = () => {
 		return (
@@ -107,9 +104,9 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 	};
 
 	return (
-		<div>
-			<FormFieldset className="gsuite-new-user-list__new-user-name-fieldset">
-				<div className="gsuite-new-user-list__new-user-name">
+		<div className="gsuite-new-user-list__new-user">
+			<FormFieldset>
+				<div className="gsuite-new-user-list__new-user-section">
 					<div className="gsuite-new-user-list__new-user-name-container">
 						<FormTextInput
 							autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
@@ -147,24 +144,26 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 						{ hasLastNameError && <FormInputValidation text={ lastNameError } isError /> }
 					</div>
 
-					<div>
-						<Button
-							className="gsuite-new-user-list__new-user-remove-user-button"
-							onClick={ onUserRemove }
-						>
-							<Gridicon icon="trash" />
-							<span>{ translate( 'Remove user' ) }</span>
-						</Button>
-					</div>
+					<Button
+						className="gsuite-new-user-list__new-user-remove-user-button"
+						onClick={ onUserRemove }
+					>
+						<Gridicon icon="trash" />
+						<span>{ translate( 'Remove user' ) }</span>
+					</Button>
 				</div>
 			</FormFieldset>
 
-			<FormFieldset className="gsuite-new-user-list__new-user-email-fieldset">
-				<div className="gsuite-new-user-list__new-user-email">
-					{ domains.length > 1 ? renderMultiDomain() : renderSingleDomain() }
-				</div>
+			<FormFieldset>
+				<div className="gsuite-new-user-list__new-user-section">
+					<div className="gsuite-new-user-list__new-user-email-container">
+						<div className="gsuite-new-user-list__new-user-email">
+							{ domains.length > 1 ? renderMultiDomain() : renderSingleDomain() }
+						</div>
 
-				{ hasMailBoxError && <FormInputValidation text={ mailBoxError } isError /> }
+						{ hasMailBoxError && <FormInputValidation text={ mailBoxError } isError /> }
+					</div>
+				</div>
 			</FormFieldset>
 		</div>
 	);

--- a/client/components/gsuite/gsuite-new-user-list/style.scss
+++ b/client/components/gsuite/gsuite-new-user-list/style.scss
@@ -1,10 +1,17 @@
-.gsuite-new-user-list__new-user-remove-user-button {
-	width: 100%;
-	@include breakpoint-deprecated( '>800px' ) {
-		width: 75px;
+.gsuite-new-user-list__new-user {
+	fieldset {
+		margin-bottom: 0;
 	}
+}
+
+.gsuite-new-user-list__new-user-remove-user-button {
+	display: none; // TODO: Fix button displayed in the middle of form (see 1165571745647867-as-1198174007918339)
 
 	@include breakpoint-deprecated( '>800px' ) {
+		display: block;
+		height: 40px;
+		width: 50px;
+
 		span {
 			display: none;
 		}
@@ -31,6 +38,7 @@
 
 .gsuite-new-user-list__add-another-user-button {
 	width: 100%;
+
 	@include breakpoint-deprecated( '>480px' ) {
 		width: auto;
 	}
@@ -38,17 +46,17 @@
 
 .gsuite-new-user-list__domain-select {
 	width: 100%;
+
 	@include breakpoint-deprecated( '>800px' ) {
 		width: auto;
 	}
 }
 
 .gsuite-new-user-list__user-divider {
-	width: 100%;
-	margin: 1.5em 0;
+	margin-top: 1.5em;
 }
 
-.gsuite-new-user-list__new-user-name {
+.gsuite-new-user-list__new-user-section {
 	@include breakpoint-deprecated( '>800px' ) {
 		display: flex;
 		justify-content: space-between;
@@ -58,7 +66,6 @@
 .gsuite-new-user-list__new-user-email {
 	display: flex;
 	flex-direction: column;
-	flex: 1;
 
 	select.form-select {
 		width: 100%;
@@ -83,10 +90,14 @@
 .gsuite-new-user-list__new-user-name-container {
 	display: flex;
 	flex-direction: column;
-	margin: 0 0 15px;
+	margin-bottom: 15px;
 
 	@include breakpoint-deprecated( '>800px' ) {
-		margin: 0 15px 0 0;
-		width: 42%;
+		margin-bottom: 20px;
+		width: 44%;
 	}
+}
+
+.gsuite-new-user-list__new-user-email-container {
+	width: 100%;
 }

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import emailValidator from 'email-validator';
-import i18n, { TranslateResult } from 'i18n-calypso';
+import { translate, TranslateResult } from 'i18n-calypso';
 import { countBy, find, includes, groupBy, map, mapValues } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -67,9 +67,7 @@ const removePreviousErrors = ( { value }: GSuiteNewUserField ): GSuiteNewUserFie
 const requiredField = ( { value, error }: GSuiteNewUserField ): GSuiteNewUserField => ( {
 	value,
 	error:
-		! error && ( ! value || '' === value.trim() )
-			? i18n.translate( 'This field is required.' )
-			: error,
+		! error && ( ! value || '' === value.trim() ) ? translate( 'This field is required.' ) : error,
 } );
 
 /*
@@ -79,7 +77,7 @@ const sixtyCharacterField = ( { value, error }: GSuiteNewUserField ): GSuiteNewU
 	value,
 	error:
 		! error && 60 < value.length
-			? i18n.translate( "This field can't be longer than %s characters.", {
+			? translate( "This field can't be longer than %s characters.", {
 					args: '60',
 			  } )
 			: error,
@@ -92,7 +90,7 @@ const validEmailCharacterField = ( { value, error }: GSuiteNewUserField ): GSuit
 	value,
 	error:
 		! error && ! /^[0-9a-z_'-](\.?[0-9a-z_'-])*$/i.test( value )
-			? i18n.translate(
+			? translate(
 					'Only number, letters, dashes, underscores, apostrophes and periods are allowed.'
 			  )
 			: error,
@@ -116,7 +114,7 @@ const validateOverallEmail = (
 	value: mailBox,
 	error:
 		! mailBoxError && ! emailValidator.validate( `${ mailBox }@${ domain }` )
-			? i18n.translate( 'Please provide a valid email address.' )
+			? translate( 'Please provide a valid email address.' )
 			: mailBoxError,
 } );
 
@@ -132,7 +130,7 @@ const validateOverallEmailAgainstExistingEmails = (
 	error:
 		! mailBoxError &&
 		includes( mapValues( existingGSuiteUsers, 'email' ), `${ mailBox }@${ domain }` )
-			? i18n.translate( 'You already have this email address.' )
+			? translate( 'You already have this email address.' )
 			: mailBoxError,
 } );
 
@@ -155,7 +153,7 @@ const validateNewUserMailboxIsUnique = (
 	value: mailBox,
 	error:
 		mailboxesByCount[ mailBox ] > 1
-			? i18n.translate( 'Please use a unique mailbox for each user.' )
+			? translate( 'Please use a unique mailbox for each user.' )
 			: previousError,
 } );
 

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from 'uuid';
 /**
  * Internal dependencies
  */
-import { googleApps, googleAppsExtraLicenses } from 'lib/cart-values/cart-items';
+import { googleApps, googleAppsExtraLicenses } from 'calypso/lib/cart-values/cart-items';
 import { hasGSuiteWithUs } from './has-gsuite-with-us';
 
 // exporting these in the big export below causes trouble
@@ -48,7 +48,7 @@ const getFields = ( user: GSuiteNewUser ): GSuiteNewUserField[] =>
  * @param {object} user - user with a list of fields
  * @param {Function} callback - function to call for each field
  */
-const mapFieldValues = ( user: GSuiteNewUser, callback: Function ): GSuiteNewUser =>
+const mapFieldValues = ( user: GSuiteNewUser, callback ): GSuiteNewUser =>
 	mapValues( user, ( fieldValue, fieldName ) =>
 		'uuid' === fieldName ? fieldValue : callback( fieldValue, fieldName, user )
 	);

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -11,18 +11,22 @@ import React from 'react';
  * Internal dependencies
  */
 import { Button, CompactCard } from '@automattic/components';
-import { CALYPSO_CONTACT } from 'lib/url/support';
-import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
-import { emailManagementAddGSuiteUsers } from 'my-sites/email/paths';
-import { hasPendingGSuiteUsers } from 'lib/gsuite';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { getSelectedDomain } from 'lib/domains';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
-import GSuiteUserItem from 'my-sites/email/email-management/gsuite-user-item';
-import Notice from 'components/notice';
-import PendingGSuiteTosNotice from 'my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
-import SectionHeader from 'components/section-header';
-import { withLocalizedMoment } from 'components/localized-moment';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'calypso/state/analytics/actions';
+import { emailManagementAddGSuiteUsers } from 'calypso/my-sites/email/paths';
+import { hasPendingGSuiteUsers } from 'calypso/lib/gsuite';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getSelectedDomain } from 'calypso/lib/domains';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import GSuiteUserItem from 'calypso/my-sites/email/email-management/gsuite-user-item';
+import Notice from 'calypso/components/notice';
+import PendingGSuiteTosNotice from 'calypso/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
+import SectionHeader from 'calypso/components/section-header';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
 import TitanControlPanelLoginCard from 'calypso/my-sites/email/email-management/titan-control-panel-login-card';
 

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -71,7 +71,7 @@ class GSuiteUsersCard extends React.Component {
 							href={ emailManagementAddGSuiteUsers( this.props.selectedSiteSlug, domainName ) }
 							onClick={ this.goToAddGoogleApps }
 						>
-							{ this.props.translate( 'Add New User' ) }
+							{ this.props.translate( 'Add New Users' ) }
 						</Button>
 					) }
 				</SectionHeader>

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -11,38 +11,38 @@ import React, { Fragment } from 'react';
 /**
  * Internal dependencies
  */
-import { addItems } from 'lib/cart/actions';
+import { addItems } from 'calypso/lib/cart/actions';
 import AddEmailAddressesCardPlaceholder from './add-users-placeholder';
 import { Button, Card } from '@automattic/components';
-import DomainManagementHeader from 'my-sites/domains/domain-management/components/header';
+import DomainManagementHeader from 'calypso/my-sites/domains/domain-management/components/header';
 import {
 	emailManagementAddGSuiteUsers,
 	emailManagementNewGSuiteAccount,
 	emailManagement,
-} from 'my-sites/email/paths';
-import EmailVerificationGate from 'components/email-verification/email-verification-gate';
-import { getDomainsBySiteId, isRequestingSiteDomains } from 'state/sites/domains/selectors';
-import { getDomainsWithForwards } from 'state/selectors/get-email-forwards';
-import { getEligibleGSuiteDomain, getGSuiteSupportedDomains } from 'lib/gsuite';
+} from 'calypso/my-sites/email/paths';
+import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
+import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
+import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';
+import { getEligibleGSuiteDomain, getGSuiteSupportedDomains } from 'calypso/lib/gsuite';
 import {
 	areAllUsersValid,
 	getItemsForCart,
 	newUsers,
 	validateAgainstExistingUsers,
-} from 'lib/gsuite/new-users';
-import { getSelectedSite } from 'state/ui/selectors';
-import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from 'lib/gsuite/constants';
-import GSuiteNewUserList from 'components/gsuite/gsuite-new-user-list';
-import Main from 'components/main';
-import Notice from 'components/notice';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QuerySiteDomains from 'components/data/query-site-domains';
-import SectionHeader from 'components/section-header';
-import QueryEmailForwards from 'components/data/query-email-forwards';
-import QueryGSuiteUsers from 'components/data/query-gsuite-users';
-import getGSuiteUsers from 'state/selectors/get-gsuite-users';
-import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
-import getCurrentRoute from 'state/selectors/get-current-route';
+} from 'calypso/lib/gsuite/new-users';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from 'calypso/lib/gsuite/constants';
+import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
+import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import SectionHeader from 'calypso/components/section-header';
+import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
+import QueryGSuiteUsers from 'calypso/components/data/query-gsuite-users';
+import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
+import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 /**
  * Style dependencies

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -200,7 +200,7 @@ class GSuiteAddUsers extends React.Component {
 					return <QueryEmailForwards key={ domain.domain } domainName={ domain.domain } />;
 				} ) }
 
-				<SectionHeader label={ translate( 'Add G Suite' ) } />
+				<SectionHeader label={ translate( 'Add New Users' ) } />
 
 				{ gsuiteUsers && selectedDomainInfo && ! isRequestingDomains ? (
 					<Card>
@@ -246,7 +246,7 @@ class GSuiteAddUsers extends React.Component {
 						onClick={ this.goToEmail }
 						selectedDomainName={ selectedDomainName }
 					>
-						{ translate( 'Add G Suite' ) }
+						{ translate( 'G Suite' ) }
 					</DomainManagementHeader>
 
 					<EmailVerificationGate

--- a/client/my-sites/email/gsuite-add-users/style.scss
+++ b/client/my-sites/email/gsuite-add-users/style.scss
@@ -3,16 +3,33 @@
 	flex-direction: column;
 
 	button {
-		margin: 5px 0 0;
-		width: 100%;
+		margin-top: 10px;
 	}
 
 	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 
 		button {
-			margin: 0 0 0 5px;
-			width: auto;
+			margin-left: 10px;
+			margin-top: 0;
+		}
+	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		flex-direction: column;
+
+		button {
+			margin-left: 0;
+			margin-top: 10px;
+		}
+	}
+
+	@include breakpoint-deprecated( '>800px' ) {
+		flex-direction: row;
+
+		button {
+			margin-left: 10px;
+			margin-top: 0;
 		}
 	}
 }


### PR DESCRIPTION
This pull request updates the `Add G Suite` page in order to refine a few things, and fix several display issues. More specifically, it:

* Fixes margin and alignment issues on small viewports
* Renames section and page titles to make the user experience more consistent with the previous page
* Fixes a wrong height of input fields with affixes (e.g. the one for the email address)
* Reduces the width of the button with the trash icon
* Temporarily hides this button on small viewports instead of displaying it in the middle of the form
* Changes the placeholder of the email input field to be more descriptive

These changes are preliminary work for #46204.

#### Large viewport

Before | After
------ | -----
![screenshot](https://user-images.githubusercontent.com/594356/95374569-ca9d4b00-08de-11eb-9805-aa385af70fab.png) | ![screenshot](https://user-images.githubusercontent.com/594356/95374490-b0636d00-08de-11eb-9043-284cdebaabb1.png)

#### Small viewport

Before | After
------ | -----
![screenshot](https://user-images.githubusercontent.com/594356/95374685-f1f41800-08de-11eb-851b-83c753a130d0.png) | ![screenshot](https://user-images.githubusercontent.com/594356/95374969-47c8c000-08df-11eb-8e37-aba6b96086cf.png)

#### Testing instructions

1. Run `git checkout update/gsuite-add-user-page` and start your server, or open a [live branch](https://calypso.live/?branch=update/gsuite-add-user-page)
2. Open the [`Site Domains` page](http://calypso.localhost:3000/domains/manage)
3. Navigate to the `Email`page
4. Click the `Add New User` button
6. Assert that it looks like the screenshot above