### PR TITLE
Checkout: Add renewal text to renewal items

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -72,6 +72,7 @@ import { shouldShowOfferResetFlow } from 'lib/plans/config';
 
 /**
  * @typedef { import("./types").CartItemValue} CartItemValue
+ * @typedef { import("./types").CartItemExtra} CartItemExtra
  * @typedef { import("./types").CartValue } CartValue
  */
 
@@ -1126,7 +1127,7 @@ export function isPartialCredits( cartItem ) {
 /**
  * Determines whether a cart item is a renewal
  *
- * @param {CartItemValue} cartItem - `CartItemValue` object
+ * @param {{extra?: CartItemExtra}} cartItem - object with `CartItemExtra` `extra` property
  * @returns {boolean} true if item is a renewal
  */
 export function isRenewal( cartItem ) {

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -24,7 +24,7 @@ import emailValidator from 'email-validator';
 /**
  * Internal dependencies
  */
-import { GSUITE_BASIC_SLUG, GSUITE_EXTRA_LICENSE_SLUG } from 'lib/gsuite/constants';
+import { GSUITE_BASIC_SLUG, GSUITE_EXTRA_LICENSE_SLUG } from 'calypso/lib/gsuite/constants';
 import {
 	formatProduct,
 	getDomain,
@@ -54,10 +54,10 @@ import {
 	isUnlimitedThemes,
 	isVideoPress,
 	isConciergeSession,
-} from 'lib/products-values';
-import sortProducts from 'lib/products-values/sort';
-import { getTld } from 'lib/domains';
-import { domainProductSlugs } from 'lib/domains/constants';
+} from 'calypso/lib/products-values';
+import sortProducts from 'calypso/lib/products-values/sort';
+import { getTld } from 'calypso/lib/domains';
+import { domainProductSlugs } from 'calypso/lib/domains/constants';
 import {
 	getPlan,
 	isBloggerPlan,
@@ -66,9 +66,9 @@ import {
 	isPremiumPlan,
 	isWpComFreePlan,
 	isWpComBloggerPlan,
-} from 'lib/plans';
-import { getTermDuration } from 'lib/plans/constants';
-import { shouldShowOfferResetFlow } from 'lib/plans/config';
+} from 'calypso/lib/plans';
+import { getTermDuration } from 'calypso/lib/plans/constants';
+import { shouldShowOfferResetFlow } from 'calypso/lib/plans/config';
 
 /**
  * @typedef { import("./types").CartItemValue} CartItemValue

--- a/client/my-sites/checkout/composite-checkout/hooks/has-renewal.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/has-renewal.ts
@@ -13,5 +13,5 @@ export function isRenewalInLineItems( items ) {
 }
 
 export function isLineItemARenewal( item ) {
-	return 'renewal' === ( item.wpcom_meta?.extra?.purchaseType ?? '' );
+	return 'renewal' === ( ( item.wpcom_meta ?? item )?.extra?.purchaseType ?? '' );
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/has-renewal.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/has-renewal.ts
@@ -13,5 +13,5 @@ export function isRenewalInLineItems( items ) {
 }
 
 export function isLineItemARenewal( item ) {
-	return 'renewal' === ( ( item.wpcom_meta ?? item )?.extra?.purchaseType ?? '' );
+	return 'renewal' === ( item.wpcom_meta?.extra?.purchaseType ?? '' );
 }

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -24,7 +24,7 @@ import {
 	WPCOMPaymentMethodClass,
 } from '../types/backend/payment-method';
 import { isPlan, isDomainTransferProduct, isDomainProduct } from 'lib/products-values';
-import { isLineItemARenewal } from 'calypso/my-sites/checkout/composite-checkout/hooks/has-renewal';
+import { isRenewal } from 'lib/cart-values/cart-items';
 
 /**
  * Translate a cart object as returned by the WPCOM cart endpoint to
@@ -191,7 +191,7 @@ function translateReponseCartProductToWPCOMCartItem(
 	let label = product_name || '';
 	let sublabel;
 	if ( isPlan( serverCartItem ) ) {
-		if ( isLineItemARenewal( serverCartItem ) ) {
+		if ( isRenewal( serverCartItem ) ) {
 			sublabel = String( translate( 'Plan Renewal' ) );
 		} else {
 			sublabel = String( translate( 'Plan Subscription' ) );
@@ -204,7 +204,7 @@ function translateReponseCartProductToWPCOMCartItem(
 	) {
 		label = meta;
 		sublabel = product_name || '';
-		if ( isLineItemARenewal( serverCartItem ) ) {
+		if ( isRenewal( serverCartItem ) ) {
 			sublabel += ( sublabel ? ' ' : '' ) + String( translate( 'Renewal' ) );
 		}
 	}

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -203,9 +203,16 @@ function translateReponseCartProductToWPCOMCartItem(
 		( isDomainProduct( serverCartItem ) || isDomainTransferProduct( serverCartItem ) )
 	) {
 		label = meta;
-		sublabel = product_name || '';
 		if ( isRenewal( serverCartItem ) ) {
-			sublabel += ( sublabel ? ' ' : '' ) + String( translate( 'Renewal' ) );
+			if ( product_name ) {
+				sublabel = String(
+					translate( '%(productName)s Renewal', { args: { productName: product_name } } )
+				);
+			} else {
+				sublabel = String( translate( 'Renewal' ) );
+			}
+		} else {
+			sublabel = product_name || '';
 		}
 	}
 

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -203,15 +203,15 @@ function translateReponseCartProductToWPCOMCartItem(
 		( isDomainProduct( serverCartItem ) || isDomainTransferProduct( serverCartItem ) )
 	) {
 		label = meta;
-		if ( isRenewal( serverCartItem ) ) {
-			if ( product_name ) {
-				sublabel = String(
-					translate( '%(productName)s Renewal', { args: { productName: product_name } } )
-				);
-			} else {
-				sublabel = String( translate( 'Renewal' ) );
-			}
-		} else {
+		if ( isRenewal( serverCartItem ) && product_name ) {
+			sublabel = String(
+				translate( '%(productName)s Renewal', { args: { productName: product_name } } )
+			);
+		}
+		if ( isRenewal( serverCartItem ) && ! product_name ) {
+			sublabel = String( translate( 'Renewal' ) );
+		}
+		if ( ! isRenewal( serverCartItem ) ) {
 			sublabel = product_name || '';
 		}
 	}

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -24,6 +24,7 @@ import {
 	WPCOMPaymentMethodClass,
 } from '../types/backend/payment-method';
 import { isPlan, isDomainTransferProduct, isDomainProduct } from 'lib/products-values';
+import { isLineItemARenewal } from 'calypso/my-sites/checkout/composite-checkout/hooks/has-renewal';
 
 /**
  * Translate a cart object as returned by the WPCOM cart endpoint to
@@ -190,7 +191,11 @@ function translateReponseCartProductToWPCOMCartItem(
 	let label = product_name || '';
 	let sublabel;
 	if ( isPlan( serverCartItem ) ) {
-		sublabel = String( translate( 'Plan Subscription' ) );
+		if ( isLineItemARenewal( serverCartItem ) ) {
+			sublabel = String( translate( 'Plan Renewal' ) );
+		} else {
+			sublabel = String( translate( 'Plan Subscription' ) );
+		}
 	} else if ( 'premium_theme' === product_slug || 'concierge-session' === product_slug ) {
 		sublabel = '';
 	} else if (
@@ -199,6 +204,9 @@ function translateReponseCartProductToWPCOMCartItem(
 	) {
 		label = meta;
 		sublabel = product_name || '';
+		if ( isLineItemARenewal( serverCartItem ) ) {
+			sublabel += ( sublabel ? ' ' : '' ) + String( translate( 'Renewal' ) );
+		}
 	}
 
 	const type = isPlan( serverCartItem ) ? 'plan' : product_slug;

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -23,8 +23,8 @@ import {
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
 	WPCOMPaymentMethodClass,
 } from '../types/backend/payment-method';
-import { isPlan, isDomainTransferProduct, isDomainProduct } from 'lib/products-values';
-import { isRenewal } from 'lib/cart-values/cart-items';
+import { isPlan, isDomainTransferProduct, isDomainProduct } from 'calypso/lib/products-values';
+import { isRenewal } from 'calypso/lib/cart-values/cart-items';
 
 /**
  * Translate a cart object as returned by the WPCOM cart endpoint to

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -214,6 +214,8 @@ function translateReponseCartProductToWPCOMCartItem(
 		if ( ! isRenewal( serverCartItem ) ) {
 			sublabel = product_name || '';
 		}
+	} else if ( isRenewal( serverCartItem ) ) {
+		sublabel = String( translate( 'Renewal' ) );
 	}
 
 	const type = isPlan( serverCartItem ) ? 'plan' : product_slug;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `isLineItemARenewal` to work before `extra` is moved behind `wpcom_meta`
* Replace "Subscription" with "Renewal" if item is a renewal
* Add "Renewal" after product name if item is a renewal

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Renew a plan and verify it says "Plan Renewal" under the plan name (see screenshot)
* Renew a domain name and verify it says "Renewal" after "Domain Registration"

<img width="584" alt="Screen Shot 2020-10-07 at 10 08 57 AM" src="https://user-images.githubusercontent.com/38750/95374142-95bfd280-08a3-11eb-96cf-aabbb04edef2.png">
<img width="574" alt="Screen Shot 2020-10-07 at 1 11 50 PM" src="https://user-images.githubusercontent.com/38750/95374156-98222c80-08a3-11eb-8f91-e7cd01af9194.png">


Fixes #44877
