### PR TITLE
Add/coming soon add flag on create and disable it on launch

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -126,6 +126,7 @@ function disable_coming_soon_on_privacy_change( $old_value, $value ) {
 }
 add_action( 'update_option_blog_public', __NAMESPACE__ . '\disable_coming_soon_on_privacy_change', 10, 2 );
 
+// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed
 /**
  * Adds the `wpcom_public_coming_soon` option to new sites
  *
@@ -136,7 +137,6 @@ add_action( 'update_option_blog_public', __NAMESPACE__ . '\disable_coming_soon_o
  * @param int    $site_id    Site ID.
  * @param array  $meta       Meta data. Used to set initial site options.
  */
-// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed
 function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $site_id, $meta ) {
 	if ( 0 === $meta['public'] && 1 === (int) $meta['options']['wpcom_public_coming_soon'] ) {
 		add_blog_option( $blog_id, 'wpcom_public_coming_soon', 1 );
@@ -144,6 +144,7 @@ function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $site_id, $
 		add_blog_option( $blog_id, 'wpcom_public_coming_soon', 0 );
 	}
 }
+// phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed
 add_action( 'wpmu_new_blog', __NAMESPACE__ . '\add_option_to_new_site', 10, 6 );
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -110,6 +110,43 @@ function add_coming_soon_page_to_new_site() {
 add_action( 'signup_finished', __NAMESPACE__ . '\add_coming_soon_page_to_new_site', 10, 1 );
 
 /**
+ * Launch the site when the privacy mode changes from public-not-indexed
+ * This can happen due to clicking the launch button from the banner
+ * Or due to manually updating the setting in wp-admin or calypso settings page.
+ *
+ * @param string $old_value the old value of blog_public.
+ * @param string $value     the new value of blog_public.
+ */
+function disable_coming_soon_on_privacy_change( $old_value, $value ) {
+	if ( 0 !== (int) $old_value || 0 === (int) $value ) {
+		// Do nothing if not moving from public-not-indexed.
+		return;
+	}
+	update_option( 'wpcom_public_coming_soon', 0 );
+}
+add_action( 'update_option_blog_public', __NAMESPACE__ . '\disable_coming_soon_on_privacy_change', 10, 2 );
+
+/**
+ * Adds the `wpcom_public_coming_soon` option to new sites
+ *
+ * @param int    $blog_id    Blog ID.
+ * @param int    $user_id    User ID.
+ * @param string $domain     Site domain.
+ * @param string $path       Site path.
+ * @param int    $site_id    Site ID.
+ * @param array  $meta       Meta data. Used to set initial site options.
+ */
+// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed
+function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $site_id, $meta ) {
+	if ( 0 === $meta['public'] && 1 === (int) $meta['options']['wpcom_public_coming_soon'] ) {
+		add_blog_option( $blog_id, 'wpcom_public_coming_soon', 1 );
+	} else {
+		add_blog_option( $blog_id, 'wpcom_public_coming_soon', 0 );
+	}
+}
+add_action( 'wpmu_new_blog', __NAMESPACE__ . '\add_option_to_new_site', 10, 6 );
+
+/**
  * Decides whether to redirect to the site's coming soon page and performs
  * the redirect.
  */

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -89,7 +89,7 @@ export function* createSite(
 			selected_features: selectedFeatures,
 			...( isEnabled( 'coming-soon-v2' ) &&
 				visibility === Site.Visibility.PublicNotIndexed && {
-					public_coming_soon: true,
+					wpcom_public_coming_soon: true,
 				} ),
 		},
 		...( bearerToken && { authToken: bearerToken } ),

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -58,7 +58,7 @@ export interface CreateSiteParams {
 		font_base?: string;
 		use_patterns?: boolean;
 		selected_features?: string[];
-		public_coming_soon?: boolean;
+		wpcom_public_coming_soon?: boolean;
 	};
 }
 


### PR DESCRIPTION
Moved from D50753-code
On creating a new site, if wpcom_public_coming_soon is passed in, apply this as a site option

When changing the privacy mode of a site (e.g. when launching a site) disable public coming soon if it is enabled.

Also consolidate the naming for the wpcom_public_coming_soon flag.

### Testing instructions
Check out this branch and sync to your sandbox with `yarn dev --sync` 
Ensure `define('WPCOM_PUBLIC_COMING_SOON', true);` is in your sandbox.php
Go to the `/start/domains?flags=coming-soon-v2` endpoint (enable coming-soon-v2 flag)
Create a site
The site should have wpcom_public_coming_soon set to 1
`wp option --url=https://yourtestsite.wordpress.com get wpcom_public_coming_soon`


Create a site from the `/new?flags=coming-soon-v2` endpoint
Check `wpcom_public_coming_soon` before launching the site, it should be 1
Launch the site
`wpcom_public_coming_soon` should be set to 0

Also, with an unlaunched site, go to `/wp-admin/options-reading.php` and change it to public
The `wpcom_public_coming_soon` flag should also be updated


