### PR TITLE
Trigger E2E tests for Gutenberg edge (v9.1.1)

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -164,7 +164,7 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 	}
 
 	async tagEventuallyDisplayed( tag ) {
-		const selector = await driverHelper.getElementByText( this.driver, By.css( 'span' ), tag );
+		const selector = By.xpath( `//span[text()='${ tag }']` );
 		return await driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
 	}
 


### PR DESCRIPTION
Running again as we recently updated v9.1.0 to v9.1.1.

Tracking issue: https://github.com/Automattic/wp-calypso/issues/45772