### PR TITLE
Components: Use FormLabel in CreditCardFormFields

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -1,27 +1,26 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { isEmpty, noop } from 'lodash';
+import PropTypes from 'prop-types';
 import { CardCvcElement, CardExpiryElement, CardNumberElement } from 'react-stripe-elements';
+import { isEmpty, noop } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import CreditCardNumberInput from 'components/upgrades/credit-card-number-input';
-import PaymentCountrySelect from 'components/payment-country-select';
 import CountrySpecificPaymentFields from 'my-sites/checkout/checkout/country-specific-payment-fields';
-import { Input } from 'my-sites/domains/components/form';
+import CreditCardNumberInput from 'components/upgrades/credit-card-number-input';
+import FormInputValidation from 'components/forms/form-input-validation';
 import InfoPopover from 'components/info-popover';
+import notices from 'notices';
+import PaymentCountrySelect from 'components/payment-country-select';
+import { Input } from 'my-sites/domains/components/form';
 import { maskField, unmaskField, getCreditCardType } from 'lib/checkout';
 import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-specific';
-import FormInputValidation from 'components/forms/form-input-validation';
 import { useStripe } from 'lib/stripe';
-import notices from 'notices';
 
 const CardNumberElementWithValidation = withStripeElementValidation( CardNumberElement );
 const CardExpiryElementWithValidation = withStripeElementValidation( CardExpiryElement );

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -11,16 +11,16 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import CountrySpecificPaymentFields from 'my-sites/checkout/checkout/country-specific-payment-fields';
-import CreditCardNumberInput from 'components/upgrades/credit-card-number-input';
-import FormInputValidation from 'components/forms/form-input-validation';
-import InfoPopover from 'components/info-popover';
-import notices from 'notices';
-import PaymentCountrySelect from 'components/payment-country-select';
-import { Input } from 'my-sites/domains/components/form';
-import { maskField, unmaskField, getCreditCardType } from 'lib/checkout';
-import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-specific';
-import { useStripe } from 'lib/stripe';
+import CountrySpecificPaymentFields from 'calypso/my-sites/checkout/checkout/country-specific-payment-fields';
+import CreditCardNumberInput from 'calypso/components/upgrades/credit-card-number-input';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import InfoPopover from 'calypso/components/info-popover';
+import notices from 'calypso/notices';
+import PaymentCountrySelect from 'calypso/components/payment-country-select';
+import { Input } from 'calypso/my-sites/domains/components/form';
+import { maskField, unmaskField, getCreditCardType } from 'calypso/lib/checkout';
+import { shouldRenderAdditionalCountryFields } from 'calypso/lib/checkout/processor-specific';
+import { useStripe } from 'calypso/lib/stripe';
 
 const CardNumberElementWithValidation = withStripeElementValidation( CardNumberElement );
 const CardExpiryElementWithValidation = withStripeElementValidation( CardExpiryElement );
@@ -34,8 +34,8 @@ import './style.scss';
 /**
  * Image assets
  */
-import creditCardSecurityBackImage from 'assets/images/upgrades/cc-cvv-back.svg';
-import creditCardSecurityFrontImage from 'assets/images/upgrades/cc-cvv-front.svg';
+import creditCardSecurityBackImage from 'calypso/assets/images/upgrades/cc-cvv-back.svg';
+import creditCardSecurityFrontImage from 'calypso/assets/images/upgrades/cc-cvv-front.svg';
 
 function CvvPopover( { translate, card } ) {
 	const brand = getCreditCardType( card.number );

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import CountrySpecificPaymentFields from 'calypso/my-sites/checkout/checkout/country-specific-payment-fields';
 import CreditCardNumberInput from 'calypso/components/upgrades/credit-card-number-input';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormLabel from 'calypso/components/forms/form-label';
 import InfoPopover from 'calypso/components/info-popover';
 import notices from 'calypso/notices';
 import PaymentCountrySelect from 'calypso/components/payment-country-select';
@@ -123,14 +124,14 @@ function CreditCardNumberField( { translate, createField, getErrorMessage, card 
 		};
 		return (
 			<div className="credit-card-form-fields__field number">
-				<label className="credit-card-form-fields__label form-label">
+				<FormLabel className="credit-card-form-fields__label">
 					{ cardNumberLabel }
 					<CardNumberElementWithValidation
 						fieldName="card_number"
 						getErrorMessage={ getErrorMessage }
 						classes={ elementClasses }
 					/>
-				</label>
+				</FormLabel>
 			</div>
 		);
 	}
@@ -181,24 +182,24 @@ function CreditCardExpiryAndCvvFields( { translate, createField, getErrorMessage
 		return (
 			<React.Fragment>
 				<div className="credit-card-form-fields__field expiration-date">
-					<label className="credit-card-form-fields__label form-label">
+					<FormLabel className="credit-card-form-fields__label">
 						{ expiryLabel }
 						<CardExpiryElementWithValidation
 							fieldName="card_expiry"
 							getErrorMessage={ getErrorMessage }
 							classes={ elementClasses }
 						/>
-					</label>
+					</FormLabel>
 				</div>
 				<div className="credit-card-form-fields__field cvv">
-					<label className="credit-card-form-fields__label form-label">
+					<FormLabel className="credit-card-form-fields__label">
 						{ cvcLabel }
 						<CardCvcElementWithValidation
 							fieldName="card_cvc"
 							getErrorMessage={ getErrorMessage }
 							classes={ elementClasses }
 						/>
-					</label>
+					</FormLabel>
 				</div>
 			</React.Fragment>
 		);

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -7,7 +7,6 @@ import React, { useState } from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { isEmpty, noop } from 'lodash';
-import notices from 'notices';
 import { CardCvcElement, CardExpiryElement, CardNumberElement } from 'react-stripe-elements';
 
 /**
@@ -22,6 +21,7 @@ import { maskField, unmaskField, getCreditCardType } from 'lib/checkout';
 import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-specific';
 import FormInputValidation from 'components/forms/form-input-validation';
 import { useStripe } from 'lib/stripe';
+import notices from 'notices';
 
 const CardNumberElementWithValidation = withStripeElementValidation( CardNumberElement );
 const CardExpiryElementWithValidation = withStripeElementValidation( CardExpiryElement );


### PR DESCRIPTION
This updates all the label instances in `<CreditCardFormFields />` to use the `<FormLabel />` component. Part of #45259.

#### Changes proposed in this Pull Request

* Components: Use `<FormLabel />` instead of `<label />` in `<CreditCardFormFields />`.
* Use the opportunity to sort imports alphabetically and update them to be relative to the root of Calypso.

#### Testing instructions

* Go to Me > Purchases and select a purchase.
* Add a new payment method by clicking the button at the bottom.
* Compare the labels on the form with the ones in production and verify they look the same way.
