### PR TITLE
[WiP] E2E: Replace "getElementByText" helper with xpath selector

### DIFF
--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -20,11 +20,10 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async expandDrawerItem( itemName ) {
-		const selector = driverHelper.getElementByText(
-			this.driver,
-			By.css( '.sidebar__heading' ),
-			itemName
+		const selector = By.xpath(
+			`//h2[contains(@class, 'sidebar__heading') and //text()='${ itemName }']`
 		);
+
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
 		const itemSelector = await this.driver.findElement( selector );
 		const isExpanded = await itemSelector.getAttribute( 'aria-expanded' );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -96,11 +96,10 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 	}
 
 	async _expandOrCollapseSectionByText( text, expand = true ) {
-		const sectionSelector = await driverHelper.getElementByText(
-			this.driver,
-			By.css( '.components-panel__body-toggle' ),
-			text
+		const sectionSelector = By.xpath(
+			`//button[contains(@class, 'components-panel__body-toggle') and text()='${ text }']`
 		);
+
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, sectionSelector );
 		const sectionButton = await this.driver.findElement( sectionSelector );
 		const c = await sectionButton.getAttribute( 'aria-expanded' );
@@ -115,10 +114,8 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 	}
 
 	async setCommentsPreference( { allow = true } = {} ) {
-		const labelSelector = await driverHelper.getElementByText(
-			this.driver,
-			By.css( '.components-checkbox-control__label' ),
-			'Allow comments'
+		const labelSelector = By.xpath(
+			"//label[contains(@class, 'components-checkbox-control__label') and text()='Allow comments']"
 		);
 		const checkBoxSelectorID = await this.driver.findElement( labelSelector ).getAttribute( 'for' );
 		const checkBoxSelector = By.id( checkBoxSelectorID );

--- a/test/e2e/lib/pages/plugins-browser-page.js
+++ b/test/e2e/lib/pages/plugins-browser-page.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import webdriver from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
@@ -10,36 +10,28 @@ import AsyncBaseContainer from '../async-base-container';
 import * as SlackNotifier from '../slack-notifier';
 import * as driverHelper from '../driver-helper';
 
-const by = webdriver.By;
-
 export default class PluginsBrowserPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, by.css( '.plugins-browser__main-header' ) );
+		super( driver, By.css( '.plugins-browser__main-header' ) );
 	}
 
 	async searchForPlugin( searchTerm ) {
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			by.css( '.plugins-browser__main-header .search' )
+			By.css( '.plugins-browser__main-header .search' )
 		);
 		return await driverHelper.setWhenSettable(
 			this.driver,
-			by.css( '.plugins-browser__main-header input[type="search"]' ),
+			By.css( '.plugins-browser__main-header input[type="search"]' ),
 			searchTerm,
 			{ pauseBetweenKeysMS: 100 }
 		);
 	}
 
 	async pluginTitledShown( pluginTitle, searchTerm ) {
-		const selector = async () => {
-			const allElements = await this.driver.findElements(
-				by.css( '.plugins-browser-item__title' )
-			);
-			return await webdriver.promise.filter(
-				allElements,
-				async ( e ) => ( await e.getText() ) === pluginTitle
-			);
-		};
+		const selector = By.xpath(
+			`//div[@class='plugins-browser-item__title' and text()='${ pluginTitle }']`
+		);
 		const shown = await driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
 		if ( shown === true ) {
 			return shown;
@@ -47,13 +39,13 @@ export default class PluginsBrowserPage extends AsyncBaseContainer {
 		SlackNotifier.warn(
 			'The Jetpack Plugins Browser results were not showing the expected result, so trying again'
 		);
-		await driverHelper.clickWhenClickable( this.driver, by.css( '.search__close-icon' ) );
+		await driverHelper.clickWhenClickable( this.driver, By.css( '.search__close-icon' ) );
 		await this.searchForPlugin( searchTerm );
 		return await driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
 	}
 
 	async selectManagePlugins() {
-		const manageButtonSelector = by.css( ".plugins-browser__main a[href*='manage']" );
+		const manageButtonSelector = By.css( ".plugins-browser__main a[href*='manage']" );
 		return await driverHelper.clickWhenClickable( this.driver, manageButtonSelector );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
An attempt to make the `isEventuallyPresentAndDisplayed` a bit more up to date and consistent in the `selector` argument type. 

Sometimes, the `selector` was passed as an async callback that seemed to cause an additional wait time that caused i.e. [this spec](https://github.com/Automattic/wp-calypso/commit/71371187208152c1a69645fd3fd0a15bd99b8ebb) to be flaky. Following up on the aforementioned spec fix, this PR makes sure that the `selector` is always passed as an instance of `By` class, which doesn't cause any additional delays.

#### Testing instructions
All the specs should pass.

#### Related:
https://github.com/Automattic/wp-calypso/pull/46271/commits/71371187208152c1a69645fd3fd0a15bd99b8ebb - this commit fixed the flaky tag presence test that was timing out.