### PR TITLE
Email: Remove orphans in email provider features

### DIFF
--- a/client/my-sites/email/email-providers-comparison/email-provider-details/email-provider-feature.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-details/email-provider-feature.jsx
@@ -2,13 +2,15 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 export default ( { title } ) => {
+	const deorphanedTitle =
+		'string' === typeof title ? title.replace( /([^ ]) ([^ ]+)$/, '$1\u00a0$2' ) : title;
 	return (
 		<span className="email-provider-details__feature">
 			<Gridicon icon="checkmark" size="18" />
-			{ title }
+			{ deorphanedTitle }
 		</span>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes orphans from email provider features, putting at least two words in the last line where space allows for it. This should only work when a string is passed, and not fragments.

#### Testing instructions


* Load Calypso with the email/titan-mvp flag enabled (append ?flags=email/titan-mvp to the URL)
* Go to your site domains, and click "Add" under the email column for one of your domains
* Confirm there are no orphans in email provider features, like in the screenshots below
* Try this with different languages, the result should be the same with both LTR and RTL languages

Before:

<img width="277" alt="Screenshot 2020-10-08 at 5 39 59 PM" src="https://user-images.githubusercontent.com/13062352/95481454-4fdf3900-098d-11eb-8f61-19a1dcd602b6.png">

After:

<img width="277" alt="Screenshot 2020-10-08 at 5 41 00 PM" src="https://user-images.githubusercontent.com/13062352/95481584-70a78e80-098d-11eb-889a-318a929f07ee.png">

