### PR TITLE
Plans: Add feature flag to facilitate work on a new product selector page

### DIFF
--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -6,20 +6,21 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'calypso/config';
 import SelectorPage from './selector';
 import DetailsPage from './details';
 import UpsellPage from './upsell';
 import { stringToDuration } from './utils';
-import getCurrentPlanTerm from 'state/selectors/get-current-plan-term';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { TERM_ANNUALLY } from 'lib/plans/constants';
+import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { TERM_ANNUALLY } from 'calypso/lib/plans/constants';
 
 /**
  * Type dependencies
  */
 import type { Duration, QueryArgs } from './types';
 
-export const productSelect = ( rootUrl: string ) => ( context: PageJS.Context, next: Function ) => {
+export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, next ) => {
 	// Get the selected site's current plan term, and set it as default duration
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
@@ -28,23 +29,37 @@ export const productSelect = ( rootUrl: string ) => ( context: PageJS.Context, n
 		( TERM_ANNUALLY as Duration );
 	const urlQueryArgs: QueryArgs = context.query;
 
-	context.primary = (
-		<SelectorPage
-			defaultDuration={ duration }
-			rootUrl={ rootUrl }
-			siteSlug={ context.params.site || context.query.site }
-			urlQueryArgs={ urlQueryArgs }
-			header={ context.header }
-			footer={ context.footer }
-		/>
-	);
+	if ( isEnabled( 'plans/alternate-selector' ) ) {
+		// TODO: Implement new product selector page;
+		// right now we're showing exactly the same page
+		// as when the flag is disabled
+		context.primary = (
+			<SelectorPage
+				defaultDuration={ duration }
+				rootUrl={ rootUrl }
+				siteSlug={ context.params.site || context.query.site }
+				urlQueryArgs={ urlQueryArgs }
+				header={ context.header }
+				footer={ context.footer }
+			/>
+		);
+	} else {
+		context.primary = (
+			<SelectorPage
+				defaultDuration={ duration }
+				rootUrl={ rootUrl }
+				siteSlug={ context.params.site || context.query.site }
+				urlQueryArgs={ urlQueryArgs }
+				header={ context.header }
+				footer={ context.footer }
+			/>
+		);
+	}
+
 	next();
 };
 
-export const productDetails = ( rootUrl: string ) => (
-	context: PageJS.Context,
-	next: Function
-) => {
+export const productDetails = ( rootUrl: string ): PageJS.Callback => ( context, next ): void => {
 	const productType: string = context.params.product;
 	const duration: Duration = stringToDuration( context.params.duration ) || TERM_ANNUALLY;
 	const urlQueryArgs: QueryArgs = context.query;
@@ -62,7 +77,7 @@ export const productDetails = ( rootUrl: string ) => (
 	next();
 };
 
-export const productUpsell = ( rootUrl: string ) => ( context: PageJS.Context, next: Function ) => {
+export const productUpsell = ( rootUrl: string ): PageJS.Callback => ( context, next ) => {
 	const productSlug: string = context.params.product;
 	const duration: Duration = stringToDuration( context.params.duration ) || TERM_ANNUALLY;
 	const urlQueryArgs: QueryArgs = context.query;

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -104,6 +104,7 @@
 		"oauth": true,
 		"perfmon": false,
 		"persist-redux": true,
+		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -78,6 +78,7 @@
 		"nav-unification": false,
 		"oauth": true,
 		"persist-redux": true,
+		"plans/alternate-selector": false,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,

--- a/config/development.json
+++ b/config/development.json
@@ -142,6 +142,7 @@
 		"page/export": true,
 		"perfmon": false,
 		"persist-redux": true,
+		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": false,
 		"post-editor/html-toolbar": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -99,6 +99,7 @@
 		"network-connection": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -30,6 +30,7 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
+		"plans/alternate-selector": true,
 		"oauth": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -27,6 +27,7 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
+		"plans/alternate-selector": true,
 		"oauth": false,
 		"site-indicator": false,
 		"support-user": true

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -29,6 +29,7 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
+		"plans/alternate-selector": false,
 		"oauth": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -28,6 +28,7 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
+		"plans/alternate-selector": false,
 		"oauth": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/production.json
+++ b/config/production.json
@@ -106,6 +106,7 @@
 		"nps-survey/dev-trigger": false,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/alternate-selector": false,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -113,6 +113,7 @@
 		"page/export": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/alternate-selector": false,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/test.json
+++ b/config/test.json
@@ -83,6 +83,7 @@
 		"network-connection": true,
 		"perfmon": false,
 		"persist-redux": true,
+		"plans/alternate-selector": false,
 		"plans/personal-plan": true,
 		"post-editor/image-editor": true,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -118,6 +118,7 @@
 		"nps-survey/dev-trigger": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/alternate-selector": false,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,


### PR DESCRIPTION
Fixes `1196341175636977-as-1198071178569625`.

#### Changes proposed in this Pull Request

* Add a new feature flag, `plans/alternate-selector`, to allow for development of an alternate product selector page.
* Set aforementioned feature flag to `true` in all development and horizon environments.

#### Testing instructions

* No visible changes as yet. Verify that everything looks the same on the product selector page whether the flag is enabled or disabled. (Add the query parameter `flags=plans/alternate-selector` to manually enable, or `flags=-plans/alternate-selector` to manually disable.)

<img width="1058" alt="image" src="https://user-images.githubusercontent.com/670067/95481776-fc4ff980-0952-11eb-92fe-781313fb6980.png">