### PR TITLE
Signup: Fix automatic domain search from the typo landing page

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -421,7 +421,7 @@ class DomainsStep extends React.Component {
 
 	domainForm = () => {
 		let initialState = {};
-		if ( this.state ) {
+		if ( this.state?.domainForm ) {
 			initialState = this.state.domainForm;
 		}
 		if ( this.props.step ) {


### PR DESCRIPTION
When visiting a `*.wordpress.com` subdomain that does not exist, you get a landing page like this:

<img width="1440" alt="Screenshot 2020-10-08 at 15 52 02" src="https://user-images.githubusercontent.com/3392497/95482986-3aaede00-097e-11eb-9dfa-5c9ac44a4da3.png">

Link goes to https://wordpress.com/start?ref=typo&new=stgstgsnerkgjneg

But it has stopped working at some point. There's two reasons for that:

 - The `initialState` is `undefined` in this case which leads to the wrong path in the code - fixed in this patch.
 - The URL is missing the `search=yes` parameter - requires backend changes, patch (already merged) in D50861-code.

#### Testing instructions

Visit https://calypso.localhost:3000/start?ref=typo&search=yes&new=examplenonexistingwpcomsubdomain

Verify that `examplenonexistingwpcomsubdomain` was searched for automatically.

Fixes #45750
