### PR TITLE
Plans: create an alternative Selector Page

### DIFF
--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -8,6 +8,7 @@ import React from 'react';
  */
 import { isEnabled } from 'calypso/config';
 import SelectorPage from './selector';
+import SelectorPageAlt from './selector-alt';
 import DetailsPage from './details';
 import UpsellPage from './upsell';
 import { stringToDuration } from './utils';
@@ -34,7 +35,7 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 		// right now we're showing exactly the same page
 		// as when the flag is disabled
 		context.primary = (
-			<SelectorPage
+			<SelectorPageAlt
 				defaultDuration={ duration }
 				rootUrl={ rootUrl }
 				siteSlug={ context.params.site || context.query.site }

--- a/client/my-sites/plans-v2/selector-alt.tsx
+++ b/client/my-sites/plans-v2/selector-alt.tsx
@@ -1,0 +1,230 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+import React, { useState, useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import PlansFilterBar from './plans-filter-bar';
+import PlansColumn from './plans-column';
+import ProductsColumn from './products-column';
+import { EXTERNAL_PRODUCTS_LIST, SECURITY } from './constants';
+import { getPathToDetails, getPathToUpsell, checkout } from './utils';
+import QueryProducts from './query-products';
+import useHasProductUpsell from './use-has-product-upsell';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { getYearlyPlanByMonthly } from 'calypso/lib/plans';
+import { TERM_ANNUALLY } from 'calypso/lib/plans/constants';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { managePurchase } from 'calypso/me/purchases/paths';
+import Main from 'calypso/components/main';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import QuerySites from 'calypso/components/data/query-sites';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card';
+
+/**
+ * Type dependencies
+ */
+import type {
+	Duration,
+	ProductType,
+	SelectorPageProps,
+	SelectorProduct,
+	PurchaseCallback,
+} from './types';
+import type { ProductSlug } from 'calypso/lib/products-values/types';
+
+import './style.scss';
+
+const SelectorAltPage = ( {
+	defaultDuration = TERM_ANNUALLY,
+	siteSlug: siteSlugProp,
+	rootUrl,
+	urlQueryArgs,
+	header,
+	footer,
+}: SelectorPageProps ) => {
+	const dispatch = useDispatch();
+
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const siteSlug = siteSlugProp || siteSlugState;
+	const hasUpsell = useHasProductUpsell();
+	const [ productType, setProductType ] = useState< ProductType >( SECURITY );
+	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
+
+	useEffect( () => {
+		setDuration( defaultDuration );
+	}, [ defaultDuration ] );
+
+	// Sends a user to a page based on whether there are subtypes.
+	const selectProduct: PurchaseCallback = (
+		product: SelectorProduct,
+		isUpgradeableToYearly = false,
+		purchase
+	) => {
+		if ( EXTERNAL_PRODUCTS_LIST.includes( product.productSlug ) ) {
+			dispatch(
+				recordTracksEvent( 'calypso_product_external_click', {
+					site_id: siteId || undefined,
+					product_slug: product.productSlug,
+					duration: currentDuration,
+				} )
+			);
+			window.location.href = product.externalUrl || '';
+			return;
+		}
+
+		if ( purchase && isUpgradeableToYearly ) {
+			dispatch(
+				recordTracksEvent( 'calypso_product_checkout_click', {
+					site_id: siteId || undefined,
+					product_slug: product.productSlug,
+					duration: currentDuration,
+				} )
+			);
+			checkout( siteSlug, getYearlyPlanByMonthly( product.productSlug ), urlQueryArgs );
+			return;
+		}
+
+		if ( purchase ) {
+			dispatch(
+				recordTracksEvent( 'calypso_product_manage_click', {
+					site_id: siteId || undefined,
+					product_slug: product.productSlug,
+					duration: currentDuration,
+				} )
+			);
+			page( managePurchase( siteSlug, purchase.id ) );
+			return;
+		}
+
+		if ( product.subtypes.length ) {
+			dispatch(
+				recordTracksEvent( 'calypso_product_subtypes_click', {
+					site_id: siteId || undefined,
+					product_slug: product.productSlug,
+					duration: currentDuration,
+				} )
+			);
+			page(
+				getPathToDetails( rootUrl, urlQueryArgs, product.productSlug, currentDuration, siteSlug )
+			);
+			return;
+		}
+
+		if ( hasUpsell( product.productSlug as ProductSlug ) ) {
+			dispatch(
+				recordTracksEvent( 'calypso_product_upsell_click', {
+					site_id: siteId || undefined,
+					product_slug: product.productSlug,
+					duration: currentDuration,
+				} )
+			);
+			page(
+				getPathToUpsell( rootUrl, urlQueryArgs, product.productSlug, currentDuration, siteSlug )
+			);
+			return;
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_product_checkout_click', {
+				site_id: siteId || undefined,
+				product_slug: product.productSlug,
+				duration: currentDuration,
+			} )
+		);
+		checkout( siteSlug, product.productSlug, urlQueryArgs );
+	};
+
+	const trackProductTypeChange = ( selectedType: ProductType ) => {
+		if ( selectedType === productType ) {
+			return;
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_plans_type_change', {
+				site_id: siteId || undefined,
+				product_type: selectedType,
+			} )
+		);
+		setProductType( selectedType );
+	};
+
+	const trackDurationChange = ( selectedDuration: Duration ) => {
+		if ( selectedDuration === currentDuration ) {
+			return;
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_plans_duration_change', {
+				site_id: siteId || undefined,
+				duration: selectedDuration,
+			} )
+		);
+		setDuration( selectedDuration );
+	};
+
+	const isInConnectFlow = useMemo(
+		() =>
+			/jetpack\/connect\/plans/.test( window.location.href ) ||
+			/source=jetpack-connect-plans/.test( window.location.href ),
+		[]
+	);
+
+	const showJetpackFreeCard = isInConnectFlow || isJetpackCloud();
+
+	const viewTrackerPath = siteId ? `${ rootUrl }/:site` : rootUrl;
+	const viewTrackerProps = siteId ? { site: siteSlug } : {};
+
+	return (
+		<Main className="selector-alt__main" wideLayout>
+			<PageViewTracker path={ viewTrackerPath } properties={ viewTrackerProps } title="Plans" />
+			<p>Alternative</p>
+			{ header }
+			<PlansFilterBar
+				showDurations
+				showProductTypes
+				onProductTypeChange={ trackProductTypeChange }
+				productType={ productType }
+				onDurationChange={ trackDurationChange }
+				duration={ currentDuration }
+			/>
+			<div className="plans-v2__columns">
+				<PlansColumn
+					duration={ currentDuration }
+					onPlanClick={ selectProduct }
+					productType={ productType }
+					siteId={ siteId }
+				/>
+				<ProductsColumn
+					duration={ currentDuration }
+					onProductClick={ selectProduct }
+					productType={ productType }
+					siteId={ siteId }
+				/>
+			</div>
+
+			{ showJetpackFreeCard && (
+				<>
+					<div className="selector-alt__divider" />
+					<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
+				</>
+			) }
+
+			<QueryProductsList />
+			<QueryProducts />
+			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+			{ siteId && <QuerySites siteId={ siteId } /> }
+			{ footer }
+		</Main>
+	);
+};
+
+export default SelectorAltPage;

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -32,11 +32,13 @@
 	color: var( --studio-color-gray-70 );
 }
 
-.selector__main {
+.selector__main,
+.selector-alt__main {
 	position: relative;
 }
 
-.selector__divider {
+.selector__divider,
+.selector-alt__divider {
 	margin: 40px 0;
 
 	border-bottom: solid 1px var( --color-border-subtle );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a copy of the current Selector page to be the basis of the new Plans grid.

#### Testing instructions

* Run this PR.
* Check that the current plans page has not been affected.
* Activate the `plans/alternate-selector` flag.
* Make sure the new Selector page is visible (see capture below).

Fixes 1196341175636977-as-1198071178569627

#### Demo
![image](https://user-images.githubusercontent.com/3418513/95487902-493fca00-096b-11eb-809d-637320d3a795.png)