### PR TITLE
Fix NPS survey label class specificity

### DIFF
--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -92,7 +92,7 @@
 	float: right;
 }
 
-.nps-survey__recommendation-option {
+.nps-survey__recommendation-option.form-label {
 	display: inline-block;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes an issue caused by our `FormLabel` migration in the NPS survey options.

Before:
<img width="1255" alt="Captura de Tela 2020-10-08 às 10 13 37" src="https://user-images.githubusercontent.com/24264157/95493107-daee0e00-0950-11eb-99b1-47b397739912.png">

After:
<img width="1255" alt="Captura de Tela 2020-10-08 às 10 26 49" src="https://user-images.githubusercontent.com/24264157/95493113-dd506800-0950-11eb-901f-58e6ac78bfa2.png">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/posts/:site`, And dispatch `{ type: 'NPS_SURVEY_SET_ELIGIBILITY', isSessionPicked: true }` in your Redux console, and the survey will appear

Fixes #
