### PR TITLE
Site level billing: Update copy in no purchases component

### DIFF
--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -75,7 +75,9 @@ class BillingHistoryTable extends React.Component {
 				components: { link: <a href="/plans" /> },
 			}
 		);
-		const noFilterResultsText = translate( 'No receipts found.' );
+		const noFilterResultsText = this.props.siteId
+			? translate( 'You have made no purchases for this site.' )
+			: translate( 'No receipts found.' );
 
 		return (
 			<TransactionsTable

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -8,16 +8,16 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import PurchasesSite from 'me/purchases/purchases-site/index.jsx';
+import PurchasesSite from 'calypso/me/purchases/purchases-site/index.jsx';
 import {
 	getSitePurchases,
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
-} from 'state/purchases/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import NoSitesMessage from 'components/empty-content/no-sites-message';
+} from 'calypso/state/purchases/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import { CompactCard } from '@automattic/components';
-import EmptyContent from 'components/empty-content';
+import EmptyContent from 'calypso/components/empty-content';
 import './style.scss';
 import { Purchase } from 'calypso/lib/purchases/types';
 
@@ -97,9 +97,7 @@ function NoPurchasesMessage() {
 		<CompactCard className="subscriptions__list--empty">
 			<EmptyContent
 				title={ translate( 'Looking to upgrade?' ) }
-				line={ translate(
-					'Our plans give your site the power to thrive. Find the plan that works for you.'
-				) }
+				line={ translate( 'You have made no purchases for this site.' ) }
 				action={ translate( 'Upgrade now' ) }
 				actionURL={ selectedSite ? `/plans/${ selectedSite.slug }` : '/plans' }
 				illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the copy in the empty purchases component and the billing history components at the site level.

#### Testing instructions

- Visit the site level subscription page for a site with no upgrades (`purchases/subscriptions/:siteurl`). Verify that the copy in the no-purchases component is updated and that there are no errors in the console (since this also includes some relative import fixes).
- Visit the site level billing history page for a site with no upgrades (`purchases/billing-history/:siteurl`). Verify that the copy in the history list component is updated.
- Visit the account level billing history page. Verify that the copy is _not_ updated.

Site-level subscriptions:
![image](https://user-images.githubusercontent.com/9310939/95509482-32ed3a80-097a-11eb-9ace-29f90027e66d.png)

Site-level billing history:
![image](https://user-images.githubusercontent.com/9310939/95509502-3a144880-097a-11eb-95a4-20e11a4b05c0.png)

Account-level billing history:
![image](https://user-images.githubusercontent.com/9310939/95510028-ec4c1000-097a-11eb-8305-0a129200753d.png)
