### PR TITLE
Jetpack Offer Reset^2: Add JetpackFreeCardAlt

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card-alt/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card-alt/index.tsx
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FeaturesItem from '../jetpack-product-card-alt/features-item';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import { addQueryArgs } from 'calypso/lib/route';
+import getJetpackWpAdminUrl from 'calypso/state/selectors/get-jetpack-wp-admin-url';
+import { JPC_PATH_REMOTE_INSTALL } from 'calypso/jetpack-connect/constants';
+
+/**
+ * Type dependencies
+ */
+import type { JetpackFreeProps } from 'calypso/my-sites/plans-v2/types';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const JetpackFreeCardAlt = ( { siteId, urlQueryArgs }: JetpackFreeProps ) => {
+	const translate = useTranslate();
+	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
+
+	const startHref = isJetpackCloud()
+		? addQueryArgs( urlQueryArgs, `https://wordpress.com${ JPC_PATH_REMOTE_INSTALL }` )
+		: wpAdminUrl || JPC_PATH_REMOTE_INSTALL;
+
+	const onClickTrack = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
+		site_id: siteId || undefined,
+	} );
+
+	const freeFeaturesOne = [
+		{
+			text: translate( 'Site stats' ),
+		},
+		{
+			text: translate( 'Brute force attack protection' ),
+		},
+		{
+			text: translate( 'Content Delivery Network' ),
+		},
+	];
+
+	const freeFeaturesTwo = [
+		{
+			text: translate( 'Automated social media posting' ),
+		},
+		{
+			text: translate( 'Downtime monitoring' ),
+		},
+		{
+			text: translate( 'Activity Log' ),
+		},
+	];
+
+	return (
+		<div className="jetpack-free-card-alt">
+			<div className="jetpack-free-card-alt__main">
+				<header>
+					<h2>{ translate( 'Jetpack Free' ) }</h2>
+					<div className="jetpack-free-card-alt__subheadline">
+						{ translate( 'Included for free with all products' ) }
+					</div>
+				</header>
+				<Button primary href={ startHref } onClick={ onClickTrack }>
+					{ translate( 'Start for free' ) }
+				</Button>
+			</div>
+			<div className="jetpack-free-card-alt__features">
+				<ul className="jetpack-free-card-alt__features-list">
+					{ freeFeaturesOne.map( ( feature, index ) => (
+						<FeaturesItem key={ index } item={ feature } />
+					) ) }
+				</ul>
+				<ul className="jetpack-free-card-alt__features-list">
+					{ freeFeaturesTwo.map( ( feature, index ) => (
+						<FeaturesItem key={ index } item={ feature } />
+					) ) }
+				</ul>
+			</div>
+		</div>
+	);
+};
+
+export default JetpackFreeCardAlt;

--- a/client/components/jetpack/card/jetpack-free-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card-alt/style.scss
@@ -25,6 +25,7 @@
 
 	@include break-small {
 		flex-direction: row;
+		text-align: left;
 	}
 
 	margin-bottom: 40px;

--- a/client/components/jetpack/card/jetpack-free-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card-alt/style.scss
@@ -18,7 +18,15 @@
 
 .jetpack-free-card-alt__main {
 	position: relative;
+
 	display: flex;
+	flex-direction: column;
+	text-align: center;
+
+	@include break-small {
+		flex-direction: row;
+	}
+
 	margin-bottom: 40px;
 
 	header {

--- a/client/components/jetpack/card/jetpack-free-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card-alt/style.scss
@@ -1,0 +1,65 @@
+.jetpack-free-card-alt {
+	position: relative;
+
+	box-sizing: border-box;
+
+	background: var( --studio-gray-0 );
+	border: 1px solid var( --color-border-subtle );
+	padding: 24px;
+
+	@media ( min-width: 660px ) {
+		border-left: 1px solid var( --color-border-subtle );
+		border-right: 1px solid var( --color-border-subtle );
+	}
+}
+
+.jetpack-free-card-alt__main {
+	position: relative;
+	display: flex;
+	margin-bottom: 40px;
+
+	header {
+		width: 100%;
+	}
+
+	h2 {
+		font-size: $font-title-medium;
+		font-weight: 600;
+		line-height: rem( 30px ) / $font-title-medium;
+
+		margin-bottom: 6px;
+	}
+
+	.jetpack-free-card-alt__subheadline {
+		color: var( --color-neutral-50 );
+
+		font-size: $font-body-extra-small;
+		line-height: rem( 16px ) / $font-body-extra-small;
+
+		@media ( min-width: 660px ) {
+			font-size: $font-body-small;
+		}
+	}
+
+	.button {
+		width: 100%;
+		height: 40px;
+		margin-top: 7px;
+	}
+}
+
+.jetpack-free-card-alt__features {
+	display: flex;
+	flex-direction: column;
+
+	@media ( min-width: 660px ) {
+		flex-direction: row;
+	}
+}
+
+.jetpack-free-card-alt__features-list {
+	margin: 0;
+	width: 100%;
+
+	list-style-type: none;
+}

--- a/client/components/jetpack/card/jetpack-free-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card-alt/style.scss
@@ -56,7 +56,11 @@
 	.button {
 		width: 100%;
 		height: 40px;
-		margin-top: 7px;
+		margin-top: 40px;
+
+		@include break-small {
+			margin-top: 7px;
+		}
 	}
 }
 

--- a/client/components/jetpack/card/jetpack-free-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card-alt/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .jetpack-free-card-alt {
 	position: relative;
 
@@ -7,7 +10,7 @@
 	border: 1px solid var( --color-border-subtle );
 	padding: 24px;
 
-	@media ( min-width: 660px ) {
+	@include break-small {
 		border-left: 1px solid var( --color-border-subtle );
 		border-right: 1px solid var( --color-border-subtle );
 	}
@@ -36,7 +39,7 @@
 		font-size: $font-body-extra-small;
 		line-height: rem( 16px ) / $font-body-extra-small;
 
-		@media ( min-width: 660px ) {
+		@include break-small {
 			font-size: $font-body-small;
 		}
 	}
@@ -52,7 +55,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@media ( min-width: 660px ) {
+	@include break-small {
 		flex-direction: row;
 	}
 }

--- a/client/my-sites/plans-v2/products-grid-alt/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-alt/index.tsx
@@ -13,7 +13,7 @@ import { JETPACK_LEGACY_PLANS } from 'calypso/lib/plans/constants';
 import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
-import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card';
+import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card-alt';
 import { SELECTOR_PLANS_ALT } from '../constants';
 import {
 	getAllOptionsFromSlug,

--- a/client/my-sites/plans-v2/products-grid-alt/style.scss
+++ b/client/my-sites/plans-v2/products-grid-alt/style.scss
@@ -13,12 +13,13 @@
 	grid-gap: 16px;
 	align-items: stretch;
 
-	& > .jetpack-free-card {
+	& > .jetpack-free-card-alt {
 		/*
-		 * To match its top border with the top border
+		 * To match its top and bottom border with the borders
 		 * of the product cards next to it
 		 */
 		margin-block-start: calc( 24px + 32.5px );
+		margin-bottom: 24px;
 
 		/*
 		 * The Free card takes up two columns


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements the alternate free card for Offer Reset^2.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit cloud.localhost:3001/pricing. Verify that the free card shows and resize the page to test responsiveness. Verify that the CTA link is correct and fires a Tracks event.
2. Test the connect flow and verify that the CTA link returns you to wp-admin.
3. Visit calypso.localhost:3000/plans/:site. Verify that the free card shows and resize the page to test responsiveness. Verify that the CTA link is correct and fires a Tracks event.

Fixes #1196341175636977-as-1198071178569631