### PR TITLE
Reader: support loom.com embeds

### DIFF
--- a/client/lib/post-normalizer/utils/iframe-is-allowed.js
+++ b/client/lib/post-normalizer/utils/iframe-is-allowed.js
@@ -6,7 +6,7 @@ import { some, endsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getUrlParts } from 'lib/url';
+import { getUrlParts } from 'calypso/lib/url';
 
 /**
  * Determines if an iframe is from a source we trust. We allow these to be the featured media and also give
@@ -48,6 +48,7 @@ export function iframeIsAllowed( iframe ) {
 		'megaphone.fm',
 		'icloud.com',
 		'read.amazon.com',
+		'loom.com',
 	];
 	const hostName = iframe.src && getUrlParts( iframe.src ).hostname;
 	const iframeSrc = hostName && hostName.toLowerCase();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We just added support for loom.com blocks in our editor:

https://twitter.com/wordpressdotcom/status/1314254687420383233

This PR adds loom.com iframes to the allowed list, so we can display them in Reader too.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit http://calypso.localhost:3000/read/feeds/40474296/posts/2955447786. Ensure that the loom.com embed loads and that you can play and pause the video.

<img width="872" alt="Screen Shot 2020-10-09 at 11 21 43" src="https://user-images.githubusercontent.com/17325/95519472-a0a07180-0a21-11eb-9e36-0e0a346f8fbf.png">
