### PR TITLE
Site-level billing: Add payment methods page

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -6,28 +6,28 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { camelCase, values } from 'lodash';
 import { connect } from 'react-redux';
-import Gridicon from 'components/gridicon';
 import debugFactory from 'debug';
+import { Card, CompactCard } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
-import { Card, CompactCard } from '@automattic/components';
-import CreditCardFormFields from 'components/credit-card-form-fields';
-import FormButton from 'components/forms/form-button';
-import notices from 'notices';
-import { validatePaymentDetails } from 'lib/checkout';
-import ValidationErrorList from 'notices/validation-error-list';
-import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'lib/url/support';
-import getCountries from 'state/selectors/get-countries';
-import QueryPaymentCountries from 'components/data/query-countries/payments';
-import { localizeUrl } from 'lib/i18n-utils';
+import Gridicon from 'calypso/components/gridicon';
+import CreditCardFormFields from 'calypso/components/credit-card-form-fields';
+import FormButton from 'calypso/components/forms/form-button';
+import notices from 'calypso/notices';
+import { validatePaymentDetails } from 'calypso/lib/checkout';
+import ValidationErrorList from 'calypso/notices/validation-error-list';
+import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'calypso/lib/url/support';
+import getCountries from 'calypso/state/selectors/get-countries';
+import QueryPaymentCountries from 'calypso/components/data/query-countries/payments';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 import {
 	createStripeSetupIntent,
 	StripeSetupIntentError,
 	StripeValidationError,
 	useStripe,
-} from 'lib/stripe';
+} from 'calypso/lib/stripe';
 import {
 	getInitializedFields,
 	camelCaseFormFields,
@@ -50,16 +50,16 @@ export function CreditCardForm( {
 	apiParams = {},
 	createCardToken,
 	countriesList,
-	initialValues,
-	purchase,
+	initialValues = undefined,
+	purchase = undefined,
 	recordFormSubmitEvent,
 	saveStoredCard = null,
-	siteSlug,
+	siteSlug = undefined,
 	successCallback,
 	showUsedForExistingPurchasesInfo = false,
 	autoFocus = true,
-	heading,
-	onCancel,
+	heading = undefined,
+	onCancel = undefined,
 	translate,
 } ) {
 	const { stripe, stripeConfiguration, setStripeError } = useStripe();

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -10,8 +10,8 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getStripeConfiguration } from 'lib/store-transactions';
-import { getCurrentUserLocale } from 'state/current-user/selectors';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 
 const debug = debugFactory( 'calypso:stripe' );
 
@@ -298,7 +298,11 @@ function StripeHookProviderInnerWrapper( { stripe, stripeData, children } ) {
 }
 const StripeInjectedWrapper = injectStripe( StripeHookProviderInnerWrapper );
 
-export function StripeHookProvider( { children, configurationArgs, fetchStripeConfiguration } ) {
+export function StripeHookProvider( {
+	children,
+	configurationArgs,
+	fetchStripeConfiguration = null,
+} ) {
 	debug( 'rendering StripeHookProvider' );
 	const { stripeConfiguration, setStripeError } = useStripeConfiguration(
 		configurationArgs,

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -7,7 +7,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { billingHistoryReceipt } from 'calypso/me/purchases/paths';
+import { addCreditCard, billingHistoryReceipt } from 'calypso/me/purchases/paths';
 import { Card } from '@automattic/components';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import config from 'calypso/config';
@@ -40,7 +40,9 @@ const BillingHistory = ( { translate } ) => (
 		<QueryBillingTransactions />
 		<PurchasesHeader section={ 'billing' } />
 		<BillingHistoryList />
-		{ config.isEnabled( 'upgrades/credit-cards' ) && <CreditCards /> }
+		{ config.isEnabled( 'upgrades/credit-cards' ) && (
+			<CreditCards addPaymentMethodUrl={ addCreditCard } />
+		) }
 	</Main>
 );
 

--- a/client/me/purchases/credit-cards/index.jsx
+++ b/client/me/purchases/credit-cards/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import {
 	isFetchingStoredCards,
 } from 'calypso/state/stored-cards/selectors';
 import QueryStoredCards from 'calypso/components/data/query-stored-cards';
-import { addCreditCard } from 'calypso/me/purchases/paths';
 import SectionHeader from 'calypso/components/section-header';
 
 /**
@@ -52,9 +52,9 @@ class CreditCards extends Component {
 		} );
 	}
 
-	goToAddCreditCard() {
-		page( addCreditCard );
-	}
+	goToAddCreditCard = () => {
+		page( this.props.addPaymentMethodUrl );
+	};
 
 	renderAddCreditCardButton() {
 		if ( ! config.isEnabled( 'manage/payment-methods' ) ) {
@@ -91,6 +91,15 @@ class CreditCards extends Component {
 		);
 	}
 }
+
+CreditCards.propTypes = {
+	addPaymentMethodUrl: PropTypes.string.isRequired,
+	// From connect:
+	cards: PropTypes.array.isRequired,
+	paymentAgreements: PropTypes.array.isRequired,
+	hasLoadedFromServer: PropTypes.bool,
+	isFetching: PropTypes.bool,
+};
 
 export default connect( ( state ) => ( {
 	cards: getStoredCards( state ),

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -16,7 +16,7 @@ import {
 	PurchaseEditPaymentMethod,
 } from 'calypso/my-sites/purchases/main';
 import { BillingHistory, ReceiptView } from 'calypso/my-sites/purchases/billing-history';
-import { PaymentMethods } from 'calypso/my-sites/purchases/payment-methods';
+import { PaymentMethods, AddNewPaymentMethod } from 'calypso/my-sites/purchases/payment-methods';
 
 export function redirectToPurchases( context ) {
 	const siteDomain = context.params.site;
@@ -86,6 +86,11 @@ export const purchaseEditPaymentMethod = ( context, next ) => {
 
 export const paymentMethods = ( context, next ) => {
 	context.primary = <PaymentMethods siteSlug={ context.params.site } />;
+	next();
+};
+
+export const addCreditCard = ( context, next ) => {
+	context.primary = <AddNewPaymentMethod siteSlug={ context.params.site } />;
 	next();
 };
 

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -16,6 +16,7 @@ import {
 	PurchaseEditPaymentMethod,
 } from 'calypso/my-sites/purchases/main';
 import { BillingHistory, ReceiptView } from 'calypso/my-sites/purchases/billing-history';
+import { PaymentMethods } from 'calypso/my-sites/purchases/payment-methods';
 
 export function redirectToPurchases( context ) {
 	const siteDomain = context.params.site;
@@ -80,6 +81,11 @@ export const purchaseEditPaymentMethod = ( context, next ) => {
 			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 		/>
 	);
+	next();
+};
+
+export const paymentMethods = ( context, next ) => {
+	context.primary = <PaymentMethods siteSlug={ context.params.site } />;
 	next();
 };
 

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -18,6 +18,7 @@ import {
 	purchaseEditPaymentMethod,
 	billingHistory,
 	receiptView,
+	paymentMethods,
 } from './controller';
 
 export default ( router ) => {
@@ -94,6 +95,15 @@ export default ( router ) => {
 		siteSelection,
 		navigation,
 		receiptView,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/purchases/payment-methods/:site',
+		siteSelection,
+		navigation,
+		paymentMethods,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -19,6 +19,7 @@ import {
 	billingHistory,
 	receiptView,
 	paymentMethods,
+	addCreditCard,
 } from './controller';
 
 export default ( router ) => {
@@ -104,6 +105,15 @@ export default ( router ) => {
 		siteSelection,
 		navigation,
 		paymentMethods,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/purchases/add-credit-card/:site',
+		siteSelection,
+		navigation,
+		addCreditCard,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/purchases/navigation.tsx
+++ b/client/my-sites/purchases/navigation.tsx
@@ -35,6 +35,12 @@ export default function PurchasesNavigation( {
 				>
 					{ translate( 'Billing History' ) }
 				</NavItem>
+				<NavItem
+					path={ `/purchases/payment-methods/${ siteSlug }` }
+					selected={ sectionTitle === 'Payment Methods' }
+				>
+					{ translate( 'Payment Methods' ) }
+				</NavItem>
 			</NavTabs>
 		</SectionNav>
 	);

--- a/client/my-sites/purchases/paths.ts
+++ b/client/my-sites/purchases/paths.ts
@@ -21,6 +21,9 @@ export const getAddPaymentMethodUrlFor = (
 	targetPurchase: { id: string | number }
 ) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchase }/payment/add`;
 
+export const getAddNewPaymentMethod = ( targetSiteSlug: string ) =>
+	`/purchases/add-credit-card/${ targetSiteSlug }`;
+
 export const getEditPaymentMethodUrlFor = (
 	targetSiteSlug: string,
 	targetPurchase: { id: string | number },

--- a/client/my-sites/purchases/paths.ts
+++ b/client/my-sites/purchases/paths.ts
@@ -24,6 +24,9 @@ export const getAddPaymentMethodUrlFor = (
 export const getAddNewPaymentMethod = ( targetSiteSlug: string ) =>
 	`/purchases/add-credit-card/${ targetSiteSlug }`;
 
+export const getPaymentMethodsUrlFor = ( targetSiteSlug: string ) =>
+	`/purchases/payment-methods/${ targetSiteSlug }`;
+
 export const getEditPaymentMethodUrlFor = (
 	targetSiteSlug: string,
 	targetPurchase: { id: string | number },

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -11,10 +13,17 @@ import MySitesSidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import Main from 'calypso/components/main';
 import DocumentHead from 'calypso/components/data/document-head';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
 import FormattedHeader from 'calypso/components/formatted-header';
 import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
 import CreditCards from 'calypso/me/purchases/credit-cards';
+import HeaderCake from 'calypso/components/header-cake';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getAddNewPaymentMethod, getBillingHistoryUrlFor } from '../paths';
+import { StripeHookProvider } from 'calypso/lib/stripe';
+import CreditCardForm from 'calypso/blocks/credit-card-form';
+import { createCardToken } from 'calypso/lib/store-transactions';
+import titles from 'calypso/me/purchases/titles';
+import { addStoredCard } from 'calypso/state/stored-cards/actions';
 
 export function PaymentMethods( { siteSlug }: { siteSlug: string } ) {
 	const translate = useTranslate();
@@ -24,7 +33,6 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ) {
 			<MySitesSidebarNavigation />
 			<DocumentHead title={ translate( 'Payment Methods' ) } />
 			<PageViewTracker path="/purchases/payment-methods" title="Payment Methods" />
-			<QueryBillingTransactions />
 			<FormattedHeader
 				brandFont
 				className="payment-methods__page-heading"
@@ -33,7 +41,35 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ) {
 			/>
 			<PurchasesNavigation sectionTitle={ 'Payment Methods' } siteSlug={ siteSlug } />
 
-			<CreditCards />
+			<CreditCards addPaymentMethodUrl={ getAddNewPaymentMethod( siteSlug ) } />
+		</Main>
+	);
+}
+
+export function AddNewPaymentMethod( { siteSlug }: { siteSlug: string } ) {
+	const translate = useTranslate();
+	const createAddCardToken = ( ...args: unknown[] ) => createCardToken( 'card_add', ...args );
+	const goToBillingHistory = () => page( getBillingHistoryUrlFor( siteSlug ) );
+	const recordFormSubmitEvent = () => recordTracksEvent( 'calypso_add_credit_card_form_submit' );
+	const reduxDispatch = useDispatch();
+	const saveStoredCard = ( ...args: unknown[] ) => reduxDispatch( addStoredCard( ...args ) );
+
+	return (
+		<Main className="purchases payment-methods is-wide-layout">
+			<MySitesSidebarNavigation />
+			<PageViewTracker path="/purchases/add-credit-card" title="Add Credit Card" />
+			<DocumentHead title={ translate( 'Add Credit Card' ) } />
+
+			<HeaderCake onClick={ goToBillingHistory }>{ titles.addCreditCard }</HeaderCake>
+			<StripeHookProvider configurationArgs={ { needs_intent: true } }>
+				<CreditCardForm
+					createCardToken={ createAddCardToken }
+					recordFormSubmitEvent={ recordFormSubmitEvent }
+					saveStoredCard={ saveStoredCard }
+					successCallback={ goToBillingHistory }
+					showUsedForExistingPurchasesInfo={ true }
+				/>
+			</StripeHookProvider>
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -59,6 +59,12 @@ export function AddNewPaymentMethod( { siteSlug }: { siteSlug: string } ) {
 			<MySitesSidebarNavigation />
 			<PageViewTracker path="/purchases/add-credit-card" title="Add Credit Card" />
 			<DocumentHead title={ translate( 'Add Credit Card' ) } />
+			<FormattedHeader
+				brandFont
+				className="payment-methods__page-heading"
+				headerText={ translate( 'Billing' ) }
+				align="left"
+			/>
 
 			<HeaderCake onClick={ goToBillingHistory }>{ titles.addCreditCard }</HeaderCake>
 			<StripeHookProvider configurationArgs={ { needs_intent: true } }>

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import MySitesSidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import Main from 'calypso/components/main';
+import DocumentHead from 'calypso/components/data/document-head';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
+import FormattedHeader from 'calypso/components/formatted-header';
+import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
+import CreditCards from 'calypso/me/purchases/credit-cards';
+
+export function PaymentMethods( { siteSlug }: { siteSlug: string } ) {
+	const translate = useTranslate();
+
+	return (
+		<Main className="purchases payment-methods is-wide-layout">
+			<MySitesSidebarNavigation />
+			<DocumentHead title={ translate( 'Payment Methods' ) } />
+			<PageViewTracker path="/purchases/payment-methods" title="Payment Methods" />
+			<QueryBillingTransactions />
+			<FormattedHeader
+				brandFont
+				className="payment-methods__page-heading"
+				headerText={ translate( 'Billing' ) }
+				align="left"
+			/>
+			<PurchasesNavigation sectionTitle={ 'Payment Methods' } siteSlug={ siteSlug } />
+
+			<CreditCards />
+		</Main>
+	);
+}

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -18,7 +18,7 @@ import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
 import CreditCards from 'calypso/me/purchases/credit-cards';
 import HeaderCake from 'calypso/components/header-cake';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { getAddNewPaymentMethod, getBillingHistoryUrlFor } from '../paths';
+import { getAddNewPaymentMethod, getPaymentMethodsUrlFor } from '../paths';
 import { StripeHookProvider } from 'calypso/lib/stripe';
 import CreditCardForm from 'calypso/blocks/credit-card-form';
 import { createCardToken } from 'calypso/lib/store-transactions';
@@ -49,7 +49,7 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ) {
 export function AddNewPaymentMethod( { siteSlug }: { siteSlug: string } ) {
 	const translate = useTranslate();
 	const createAddCardToken = ( ...args: unknown[] ) => createCardToken( 'card_add', ...args );
-	const goToBillingHistory = () => page( getBillingHistoryUrlFor( siteSlug ) );
+	const goToBillingHistory = () => page( getPaymentMethodsUrlFor( siteSlug ) );
 	const recordFormSubmitEvent = () => recordTracksEvent( 'calypso_add_credit_card_form_submit' );
 	const reduxDispatch = useDispatch();
 	const saveStoredCard = ( ...args: unknown[] ) => reduxDispatch( addStoredCard( ...args ) );

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -25,11 +25,12 @@ import { createCardToken } from 'calypso/lib/store-transactions';
 import titles from 'calypso/me/purchases/titles';
 import { addStoredCard } from 'calypso/state/stored-cards/actions';
 
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 export function PaymentMethods( { siteSlug }: { siteSlug: string } ) {
 	const translate = useTranslate();
 
 	return (
-		<Main className="purchases payment-methods is-wide-layout">
+		<Main className="purchases is-wide-layout">
 			<MySitesSidebarNavigation />
 			<DocumentHead title={ translate( 'Payment Methods' ) } />
 			<PageViewTracker path="/purchases/payment-methods" title="Payment Methods" />
@@ -55,7 +56,7 @@ export function AddNewPaymentMethod( { siteSlug }: { siteSlug: string } ) {
 	const saveStoredCard = ( ...args: unknown[] ) => reduxDispatch( addStoredCard( ...args ) );
 
 	return (
-		<Main className="purchases payment-methods is-wide-layout">
+		<Main className="purchases is-wide-layout">
 			<MySitesSidebarNavigation />
 			<PageViewTracker path="/purchases/add-credit-card" title="Add Credit Card" />
 			<DocumentHead title={ translate( 'Add Credit Card' ) } />
@@ -79,3 +80,4 @@ export function AddNewPaymentMethod( { siteSlug }: { siteSlug: string } ) {
 		</Main>
 	);
 }
+/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/purchases/subscriptions/account-level-purchase-links.tsx
+++ b/client/my-sites/purchases/subscriptions/account-level-purchase-links.tsx
@@ -14,9 +14,6 @@ export default function AccountLevelPurchaseLinks() {
 	return (
 		<>
 			<CompactCard href="/me/purchases">{ translate( 'View all subscriptions' ) }</CompactCard>
-			<CompactCard href="/me/purchases/billing">
-				{ translate( 'Manage payment methods' ) }
-			</CompactCard>
 		</>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds new routes to site-level billing for listing payment methods (all of them, since there's no such thing as site-level payment methods) and adding a new credit card.

Fixes https://github.com/Automattic/wp-calypso/issues/45599

Main project thread: pbOQVh-sc-p2

##### Screenshots

![list-credit-cards](https://user-images.githubusercontent.com/2036909/95530186-32b96300-09ab-11eb-96a7-203519523d50.png)

![add-credit-card](https://user-images.githubusercontent.com/2036909/95530193-3816ad80-09ab-11eb-9547-f70cb803ed68.png)

#### Testing instructions

- Visit any site-level billing page (eg: click Plan > Billing in the site-level sidebar).
- Click "Payment Methods" in the page navigation.
- Verify that you see all saved payment methods you have on your account.
- Verify that the sidebar remains at the site-level.
- Click "Add credit card".
- Verify that you see the "Add credit card" form.
- Verify that the sidebar remains at the site-level.
- Click the "Back" button in the page header.
- Verify that you return to the site-level payment methods list.
- Click "Add credit card" again.
- Add a new credit card and save it.
- Verify that you return to the site-level payment methods list.
