### PR TITLE
Comments: hide 'load more' if we don't have comments loaded to display

### DIFF
--- a/client/blocks/comments/comment-likes.jsx
+++ b/client/blocks/comments/comment-likes.jsx
@@ -12,10 +12,10 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import LikeButton from 'blocks/like-button/button';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import { likeComment, unlikeComment } from 'state/comments/actions';
-import { getCommentLike } from 'state/comments/selectors';
+import LikeButton from 'calypso/blocks/like-button/button';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { likeComment, unlikeComment } from 'calypso/state/comments/actions';
+import { getCommentLike } from 'calypso/state/comments/selectors';
 
 class CommentLikeButtonContainer extends React.Component {
 	constructor() {
@@ -62,7 +62,7 @@ CommentLikeButtonContainer.propTypes = {
 	postId: PropTypes.number.isRequired,
 	commentId: PropTypes.number.isRequired,
 	showZeroCount: PropTypes.bool,
-	tagName: PropTypes.string,
+	tagName: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
 
 	// connected props:
 	commentLike: PropTypes.object,

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -17,19 +17,23 @@ import {
 	getActiveReplyCommentId,
 	getCommentById,
 	getPostCommentsTree,
-} from 'state/comments/selectors';
-import { requestPostComments, requestComment, setActiveReply } from 'state/comments/actions';
-import { NUMBER_OF_COMMENTS_PER_FETCH } from 'state/comments/constants';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+} from 'calypso/state/comments/selectors';
+import {
+	requestPostComments,
+	requestComment,
+	setActiveReply,
+} from 'calypso/state/comments/actions';
+import { NUMBER_OF_COMMENTS_PER_FETCH } from 'calypso/state/comments/constants';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
 import PostComment from './post-comment';
 import PostCommentFormRoot from './form-root';
 import CommentCount from './comment-count';
-import SegmentedControl from 'components/segmented-control';
-import Gridicon from 'components/gridicon';
-import ConversationFollowButton from 'blocks/conversation-follow-button';
-import { shouldShowConversationFollowButton } from 'blocks/conversation-follow-button/helper';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import canCurrentUser from 'state/selectors/can-current-user';
+import SegmentedControl from 'calypso/components/segmented-control';
+import Gridicon from 'calypso/components/gridicon';
+import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
+import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
 
 /**
  * Style dependencies
@@ -403,9 +407,10 @@ class PostCommentList extends React.Component {
 		// Note: we might show fewer comments than commentsCount because some comments might be
 		// orphans (parent deleted/unapproved), that comment will become unreachable but still counted.
 		const showViewMoreComments =
-			size( commentsTree.children ) > amountOfCommentsToTake ||
-			haveEarlierCommentsToFetch ||
-			haveLaterCommentsToFetch;
+			( size( commentsTree.children ) > amountOfCommentsToTake ||
+				haveEarlierCommentsToFetch ||
+				haveLaterCommentsToFetch ) &&
+			displayedCommentsCount > 0;
 
 		// If we're not yet fetched all comments from server, we can only rely on server's count.
 		// once we got all the comments tree, we can calculate the count of reachable comments

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -24,7 +24,7 @@ class LikeButton extends PureComponent {
 		showZeroCount: PropTypes.bool,
 		likeCount: PropTypes.number,
 		showLabel: PropTypes.bool,
-		tagName: PropTypes.string,
+		tagName: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
 		onLikeToggle: PropTypes.func,
 		likedLabel: PropTypes.string,
 		iconSize: PropTypes.number,

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -13,21 +13,20 @@ import {
 	COMMENTS_UPDATES_RECEIVE,
 	COMMENTS_COUNT_RECEIVE,
 	COMMENTS_DELETE,
-} from 'state/action-types';
-import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { errorNotice, successNotice } from 'state/notices/actions';
-import { getSitePost } from 'state/posts/selectors';
-import { requestCommentsList } from 'state/comments/actions';
+} from 'calypso/state/action-types';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { getSitePost } from 'calypso/state/posts/selectors';
+import { requestCommentsList } from 'calypso/state/comments/actions';
 import {
 	getPostOldestCommentDate,
 	getPostNewestCommentDate,
 	getPostCommentsCountAtDate,
 	getSiteComment,
-} from 'state/comments/selectors';
-import { decodeEntities } from 'lib/formatting';
-
-import { registerHandlers } from 'state/data-layer/handler-registry';
+} from 'calypso/state/comments/selectors';
+import { decodeEntities } from 'calypso/lib/formatting';
+import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 
 export const commentsFromApi = ( comments ) =>
 	map( comments, ( comment ) =>
@@ -119,7 +118,7 @@ export const announceFailure = ( { siteId, postId } ) => ( dispatch, getState ) 
 	const postTitle = post && post.title && post.title.trim().slice( 0, 20 ).trim().concat( '…' );
 	const error = postTitle
 		? translate( 'Could not retrieve comments for “%(postTitle)s”', { args: { postTitle } } )
-		: translate( 'Could not retrieve comments for requested post' );
+		: translate( 'Could not retrieve comments for post' );
 
 	dispatch( errorNotice( error, { duration: 5000 } ) );
 };

--- a/client/state/data-layer/wpcom/comments/test/index.js
+++ b/client/state/data-layer/wpcom/comments/test/index.js
@@ -13,9 +13,9 @@ import {
 	COMMENTS_UPDATES_RECEIVE,
 	COMMENTS_COUNT_RECEIVE,
 	NOTICE_CREATE,
-} from 'state/action-types';
-import { NUMBER_OF_COMMENTS_PER_FETCH } from 'state/comments/constants';
-import { http } from 'state/data-layer/wpcom-http/actions';
+} from 'calypso/state/action-types';
+import { NUMBER_OF_COMMENTS_PER_FETCH } from 'calypso/state/comments/constants';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 
 describe( 'wpcom-api', () => {
 	describe( 'post comments request', () => {
@@ -201,7 +201,7 @@ describe( 'wpcom-api', () => {
 						type: NOTICE_CREATE,
 						notice: expect.objectContaining( {
 							status: 'is-error',
-							text: 'Could not retrieve comments for requested post',
+							text: 'Could not retrieve comments for post',
 							duration: 5000,
 						} ),
 					} )

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -11,14 +11,13 @@ import {
 	READER_FOLLOW,
 	READER_FOLLOWS_SYNC_START,
 	READER_FOLLOWS_SYNC_PAGE,
-} from 'state/reader/action-types';
-import { receiveFollows, syncComplete } from 'state/reader/follows/actions';
-import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { errorNotice } from 'state/notices/actions';
+} from 'calypso/state/reader/action-types';
+import { receiveFollows, syncComplete } from 'calypso/state/reader/follows/actions';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { isValidApiResponse, subscriptionsFromApi } from './utils';
-
-import { registerHandlers } from 'state/data-layer/handler-registry';
+import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 
 const ITEMS_PER_PAGE = 200;
 const MAX_ITEMS = 2000;
@@ -96,7 +95,9 @@ export const receivePage = ( action, apiResponse ) => ( dispatch ) => {
 
 export function receiveError() {
 	syncingFollows = false;
-	return errorNotice( translate( 'Sorry, we had a problem fetching your Reader subscriptions.' ) );
+	return errorNotice( translate( 'Sorry, we had a problem fetching your Reader subscriptions.' ), {
+		duration: 5000,
+	} );
 }
 
 const syncPage = dispatchRequest( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're were recently experiencing an issue displaying comments from Jetpack sites in the Reader (see https://github.com/Automattic/wp-calypso/issues/46284), which is being worked on separately. When comments are unable to load due to a 400 response, @mreishus observed we were still displaying the 'load more' link in the comment section (p9dueE-1Zi-p2):

<img width="759" alt="Screen Shot 2020-10-09 at 15 13 01" src="https://user-images.githubusercontent.com/17325/95534827-516b3880-0a43-11eb-9fb0-37cc17d194eb.png">

This PR adds some logic to only display that link if we've actually got comments to display.

#### Testing instructions

Sandbox the API and roll back your working copy to r214867-wpcom (before the fix was deployed).
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Try this post, which will fail to load comments:

http://calypso.localhost:3000/read/feeds/107218703/posts/2952355248

Check that the 'load more' link is absent:

<img width="751" alt="Screen Shot 2020-10-09 at 15 26 42" src="https://user-images.githubusercontent.com/17325/95535036-e2daaa80-0a43-11eb-8a13-8e623c5db386.png">

Now go to a post with lots of comments. Ensure you still see the load more link, and that it still works:

http://calypso.localhost:3000/read/blogs/82798297/posts/82

<img width="770" alt="Screen Shot 2020-10-09 at 15 27 41" src="https://user-images.githubusercontent.com/17325/95535077-fd148880-0a43-11eb-867a-82dbd437f8e4.png">

#### Future changes

Ideally it'd be good to remove the error notice here, and show a message inline indicating that we can't fetch comments right now.

We could also implement a retry policy in the data layer so we don't keep requesting comments indefinitely if we're consistently receiving an error.
