### PR TITLE
Clean up sign up steps that are not currently used

### DIFF
--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -41,14 +41,18 @@ describe( 'Signup config steps', () => {
 	test( 'Should not have unused steps configured', () => {
 		const activeSteps = Object.values( flows.getFlows() )
 			.flatMap( ( { steps: stepsArray } ) => stepsArray )
-			.reduce( ( acc, cur ) => ( ! acc.includes( cur ) ? [ ...acc, cur ] : acc ), [] );
+			.filter( ( value, index, self ) => {
+				return self.indexOf( value ) === index;
+			} );
 
 		const deadSteps = Object.entries( steps )
 			.map( ( [ stepKey ] ) => stepKey )
 			.filter( ( stepName ) => ! activeSteps.includes( stepName ) );
 
 		if ( deadSteps.length > 0 ) {
-			throw new Error( 'The following steps do not appear in any flow: [' + deadSteps + '].' );
+			throw new Error(
+				`The following steps do not appear in any flow: ${ JSON.stringify( deadSteps, null, 2 ) }`
+			);
 		}
 	} );
 } );

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -38,6 +38,7 @@ describe( 'Signup config steps', () => {
 		}
 	} );
 
+	// eslint-disable-next-line jest/expect-expect
 	test( 'Should not have unused steps configured', () => {
 		const activeSteps = Object.values( flows.getFlows() )
 			.flatMap( ( { steps: stepsArray } ) => stepsArray )

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -20,8 +20,11 @@ jest.mock( 'lib/user', () => () => {
 		},
 	};
 } );
+jest.mock( 'config', () => ( {
+	isEnabled: () => true,
+} ) );
 
-describe( 'index', () => {
+describe( 'Signup config steps', () => {
 	// eslint-disable-next-line jest/expect-expect
 	test( 'should not have overlapping step/flow names', () => {
 		const overlappingNames = intersection( keys( steps ), keys( flows.getFlows() ) );
@@ -32,6 +35,20 @@ describe( 'index', () => {
 					overlappingNames +
 					'].'
 			);
+		}
+	} );
+
+	test( 'Should not have unused steps configured', () => {
+		const activeSteps = Object.values( flows.getFlows() )
+			.flatMap( ( { steps: stepsArray } ) => stepsArray )
+			.reduce( ( acc, cur ) => ( ! acc.includes( cur ) ? [ ...acc, cur ] : acc ), [] );
+
+		const deadSteps = Object.entries( steps )
+			.map( ( [ stepKey ] ) => stepKey )
+			.filter( ( stepName ) => ! activeSteps.includes( stepName ) );
+
+		if ( deadSteps.length > 0 ) {
+			throw new Error( 'The following steps do not appear in any flow: [' + deadSteps + '].' );
 		}
 	} );
 } );


### PR DESCRIPTION
#### Cleanup required!
There seems to be several steps that do not appear in any sign up flow. The initial idea was to create a unit test to identify these steps and just go ahead and remove these steps. Following are the steps that are currently without inclusion in any of the flows.  

-  survey
-  portfolio-theme
-  test
-  plans-store-nux
-  domains-store
-  jetpack-user
-  displayname
-  clone-jetpack
-  site-topic
-  site-title-without-domains
-  site-style
-  site-style-with-preview


However upon further investigation it is clear it is clear that there are few other areas with deadcode that reference the existence of these steps. For example in  the dead  ‘site-topic’ step, there has has been many instances it has been used to show/hide parts of the UI. but now since the step is no longer used anywhere those just exist as dead code forever returning the same result (because this step is never used in every flow). This means each step would have to be meticulously removed before this reaches production.

So in addition to removing the above steps and adding a unit test to making sure that dead steps cannot exist in the future, we have to go through each step, cleanup any related deadcode and make sure the change does not break any existing behaviours.