### PR TITLE
Activity Log: remove redundant fromApi options from theme/core upgrade requests

### DIFF
--- a/client/my-sites/activity/activity-log-tasklist/index.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/index.jsx
@@ -534,7 +534,6 @@ const updateTheme = ( siteId, themeId ) =>
 			body: { action: 'update', themes: themeId },
 		} ),
 		{
-			fromApi: () => ( { themes } ) => themes.map( ( { id } ) => [ id, true ] ),
 			freshness: -Infinity,
 		}
 	);
@@ -555,9 +554,6 @@ const updateCore = ( siteId ) =>
 			// No need to pass version: if it's missing, WP will be updated to latest core version.
 		} ),
 		{
-			fromApi: () => ( { version } ) => {
-				return [ [ version, true ] ];
-			},
 			freshness: -Infinity,
 		}
 	);


### PR DESCRIPTION
Removes a redundant `fromApi` argument from the `requestHttpData` calls that upgrade theme or Core on a Jetpack site.

The code uses only the plain response that's [automatically stored by the `http-data` module](https://github.com/Automattic/wp-calypso/blob/e8e3fed4056b9f3da100876592a0e992577cdf90/client/state/data-layer/http-data.ts#L176) under the `core-update-*` and `theme-update-*` keys. The keys stored by the `fromApi` handlers are not used, and are rather weird anyway: the "theme ID" and "Core version" values are used as keys, with no prefix, which can lead to conflicts in a global key-value store.

**How to test:**
Test on a Jetpack site with outdated Core and/or theme version. Attempt to trigger upgrade from the Activity Log Task List.
