### PR TITLE
"Ungreedify" error handler middleware in isomorphic router

### DIFF
--- a/client/my-sites/theme/index.node.js
+++ b/client/my-sites/theme/index.node.js
@@ -2,8 +2,8 @@
  * Internal dependencies
  */
 
-import config from 'config';
-import { makeLayout } from 'controller';
+import config from 'calypso/config';
+import { makeLayout } from 'calypso/controller';
 import { details, fetchThemeDetailsData, notFoundError } from './controller';
 
 export default function ( router ) {
@@ -13,8 +13,10 @@ export default function ( router ) {
 			'/theme/:slug/:section(setup|support)?/:site_id?',
 			fetchThemeDetailsData,
 			details,
-			makeLayout
+			makeLayout,
+
+			// Error handlers
+			notFoundError
 		);
-		router( notFoundError );
 	}
 }

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -37,6 +37,9 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 					req.logger.warn( err );
 				}
 				serverRender( req, res, next );
+				// Keep propagating the error to ensure regular middleware doesn't get executed.
+				// In particular, without this we'll try to render a 404 page.
+				next( err );
 			}
 		);
 	};

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -34,7 +34,7 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 				if ( err.status >= 500 ) {
 					req.logger.error( err );
 				} else {
-					req.logger.info( err );
+					req.logger.warn( err );
 				}
 				serverRender( req, res, next );
 			}

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -86,13 +86,17 @@ function applyMiddlewares( context, ...middlewares ) {
 	// at any point a middleware calls `next(error)`, only middlewares that declare
 	// 3 arguments (aka error handlers) will be called from that point.
 	const liftedMiddlewares = middlewares.map( ( middleware ) => ( next, err ) => {
-		if ( ! err && middleware.length === 2 ) {
-			// No errors so far, call next middleware
-			return middleware( context, next );
-		}
-		if ( err && middleware.length === 3 ) {
-			// There is an error and this middleware can handle errors
-			return middleware( err, context, next );
+		try {
+			if ( ! err && middleware.length !== 3 ) {
+				// No errors so far, call next middleware
+				return middleware( context, next );
+			}
+			if ( err && middleware.length === 3 ) {
+				// There is an error and this middleware can handle errors
+				return middleware( err, context, next );
+			}
+		} catch ( error ) {
+			next( error );
 		}
 
 		// At this point we are in either of these scenarios:

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -98,15 +98,16 @@ function applyMiddlewares( context, ...middlewares ) {
 				// There is an error and this middleware can handle errors
 				return middleware( err, context, next );
 			}
+			// At this point we are in either of these scenarios:
+			// * There is an error but this middlware is not an error handler
+			// * There is not an error but this middleware is an error handler
+			// In both cases this middleware shouldn't run, so we just skip to the next one.
+			next( err );
 		} catch ( error ) {
+			// The middleware throw an error, capture it and pass it to the next
+			// middleware in the chain.
 			next( error );
 		}
-
-		// At this point we are in either of these scenarios:
-		// * There is an error but this middlware is not an error handler
-		// * There is not an error but this middleware is an error handler
-		// In both cases this middleware shouldn't run, so we just skip to the next one.
-		next( err );
 	} );
 
 	compose( ...liftedMiddlewares )();

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -505,8 +505,10 @@ const render404 = ( entrypoint = 'entry-main' ) => ( req, res ) => {
 	 eslint-disable. */
 // eslint-disable-next-line no-unused-vars
 const renderServerError = ( entrypoint = 'entry-main' ) => ( err, req, res, next ) => {
-	if ( process.env.NODE_ENV !== 'production' ) {
-		console.error( err );
+	try {
+		req.logger.error( err );
+	} catch ( error ) {
+		console.error( error );
 	}
 
 	const ctx = {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -505,6 +505,10 @@ const render404 = ( entrypoint = 'entry-main' ) => ( req, res ) => {
 	 eslint-disable. */
 // eslint-disable-next-line no-unused-vars
 const renderServerError = ( entrypoint = 'entry-main' ) => ( err, req, res, next ) => {
+	// If the response is not writable it means someone else already rendered a page, do nothing
+	// Hopefully they logged the error as well.
+	if ( res.writableEnded ) return;
+
 	try {
 		req.logger.error( err );
 	} catch ( error ) {

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -125,7 +125,7 @@ import cloneDeep from 'lodash/cloneDeep';
 /**
  * Internal dependencies
  */
-import sections from 'sections';
+import sections from 'calypso/sections';
 
 /**
  * Builds an app for an specific environment.
@@ -155,7 +155,7 @@ const buildApp = ( environment ) => {
 		// When the app requries these modules, they are loaded from its isolated registry.
 		// Requiring them here will give us the same instance used by the app, this will allow
 		// us to change the mock implementation later or make assertions about it.
-		mocks.config = require( 'config' );
+		mocks.config = require( 'calypso/config' );
 		mocks.matchesUA = require( 'browserslist-useragent' ).matchesUA;
 		const {
 			attachBuildTimestamp,
@@ -163,15 +163,15 @@ const buildApp = ( environment ) => {
 			attachHead,
 			renderJsx,
 			serverRender,
-		} = require( 'server/render' );
+		} = require( 'calypso/server/render' );
 		mocks = { ...mocks, attachBuildTimestamp, attachI18n, attachHead, renderJsx, serverRender };
 		mocks.sanitize = require( 'sanitize' );
-		mocks.createReduxStore = require( 'state' ).createReduxStore;
+		mocks.createReduxStore = require( 'calypso/state' ).createReduxStore;
 		mocks.execSync = require( 'child_process' ).execSync;
-		mocks.login = require( 'lib/paths' ).login;
-		mocks.getBootstrappedUser = require( 'server/user-bootstrap' );
-		mocks.setCurrentUser = require( 'state/current-user/actions' ).setCurrentUser;
-		mocks.analytics = require( 'server/lib/analytics' );
+		mocks.login = require( 'calypso/lib/paths' ).login;
+		mocks.getBootstrappedUser = require( 'calypso/server/user-bootstrap' );
+		mocks.setCurrentUser = require( 'calypso/state/current-user/actions' ).setCurrentUser;
+		mocks.analytics = require( 'calypso/server/lib/analytics' );
 
 		// Set the environment. This has to be done before requiring `../index.js`
 		mocks.config.mockImplementation(
@@ -332,6 +332,9 @@ const buildApp = ( environment ) => {
 					method: 'GET',
 					get: jest.fn(),
 					connection: {},
+					logger: {
+						error: jest.fn(),
+					},
 					...request,
 				};
 
@@ -1699,11 +1702,9 @@ describe( 'main app', () => {
 		} );
 
 		it( 'logs the error in development mode', async () => {
-			app.withMockedVariable( process.env, 'NODE_ENV', 'development' );
+			const { request } = await forceError();
 
-			await forceError();
-
-			expect( console.error ).toHaveBeenCalledWith( { error: 'fake error' } );
+			expect( request.logger.error ).toHaveBeenCalledWith( { error: 'fake error' } );
 		} );
 	} );
 } );

--- a/docs/isomorphic-routing.md
+++ b/docs/isomorphic-routing.md
@@ -54,7 +54,7 @@ We support error handling middleware on the server side. Among other things, thi
 so that server-side rendered sections can set an HTTP error status, such as 404 if something isn't found.
 
 An error handling middleware takes three instead of just two arguments, `err, context, next`.
-Invoke it with `router` at the end of your route definitions:
+Invoke it by adding it at the end of your route definitions:
 
 ```js
 export function notFoundError( err, context, next ) {
@@ -67,14 +67,12 @@ export function notFoundError( err, context, next ) {
 }
 
 export default function( router ) {
-  router( '/themes/:slug/:section?/:site_id?', details, makeLayout );
-  router( themeNotFound );
+  router( '/themes/:slug/:section?/:site_id?', details, makeLayout, themeNotFound );
 }
 ```
 
-Note that in `notFoundError`, `err` is passed as an argument to `next`. This is how error middleware chains skip regular middlewares. The rendering middleware that is implicitly called on the server after all other middlewares are invoked uses `err.status` to set the HTTP error status.
-
-On the other hand, an error-handling middleware like `themeNotFound` will be called if any other middleware before it calls `next` with an error object:
+Note that you can have multiple error-handling middlewares in your route defintion. When any of the regular middlewares throw an error (or call `next(err)`), only error-handling will be called from that point. This is how error middleware chains skip regular middlewares. The endering middleware that is implicitly called on the server after all other middlewares are invoked uses `err.status` to set the HTTP error status. It will also log an error in the server log, using
+severity `error` if status is >= 500, `info` otherwhise.
 
 ```js
 function details( context, next ) ) {
@@ -85,7 +83,7 @@ function details( context, next ) ) {
       message: 'Theme Not Found',
       context.params.slug
     };
-    return next( err );
+	return next( err );
   }
   /* Render theme section */
   next();


### PR DESCRIPTION
## Background

In #12863 we introduced the capability of having error handlers for the isomorphic router. These handlers are designed to capture errors form all routes. Because their position in the middleware chain, they are the first error handler, meaning it will capture all errors thrown by any Express middleware, Express handler or any isomorphic middleware.

It makes them too generic, and as they don't forward the error, it blocks the capability of having generic error handlers in Express.

The way they work is by adding another `route` call with the error handler:

```js
export default function( router ) {
  router( '/my-url', myHandler );
  router( errorHandler );
}
```


## Changes

This PR reworks the idea of error handlers for the isomorphic router. Instead of being a standalone handler, now they are expected to come last in the chain of handlers for a route:

```js
export default function( router ) {
  router( '/my-url', myHandler, errorHandler );
}
```

Then, when any of the handlers in the chain (`myHandler` in this case) throws an error (or calls `next(error)`) the rest of the regular handlers will be skip and all error handlers in the chain will be called.

Following the previous design, these error handlers are expected to change `req.context` and the router will implicitly call the server rendering function at the end. That part has not changed.


## Testing


### Preparation

Add `console.log( 'notFoundError called' );` to the function `notFoundError` in `client/my-sites/theme/controller.jsx`. We'll use this log line to verify the function is not called.

Build all required artifacts by running these commands. You only need to run them once.

```
yarn distclean
yarn
yarn build-static
yarn build-client-evergreen
NODE_ENV=production ENABLE_FEATURES=use-translation-chunks yarn build-server
```

Start the server with `DISABLE_FEATURES=use-translation-chunks yarn start-build-do`. Despite what the log says,
the server will be available in http://calypso.localhost:3000/

When you need to restart the server to pick new changes, run `NODE_ENV=production yarn build-server && DISABLE_FEATURES=use-translation-chunks yarn start-build-do`. It should only take a few seconds.

For the following tests, you should use an incognito window and disable JavaScript (as they are focused on the SSR output)

### See the error

This test should be done in master. It will show what the problems are.

* Edit the function `setupLoggedInContext` in `client/server/pages/index.js` and make it throw an error
* Change `renderServerError` in `client/server/pages/index.js` to always log the error

Restart the server and go to http://calypso.localhost:3000/log-in. You'll see the following **wrong** behaviour:

* The log in the server log is about `Cannot read property 'store' of undefined`, unrelated to the fake error you added.
* `notFoundError` is called, but the error has nothing to do with themes.


### Test the fix

#### Isomorphic pages

Verify the following pages are SSRed correctly

http://calypso.localhost:3000/theme/seedlet
http://calypso.localhost:3000/log-in
http://calypso.localhost:3000/themes


#### Invalid theme

Go to http://calypso.localhost:3000/theme/asdf

* You should see the `Looking for great WordPress designs?` error page
* The server logs should show something like this. Ensure the message, status and level fields are the same:

	```
	{"name":"calypso","hostname":"sergio.lan","pid":59280,"level":40,"status":404,"message":"Theme Not    Found","themeSlug":"asdf","msg":"","time":"2020-10-09T10:46:46.415Z","v":0}
	```
* `notFoundError` is called


#### Express middleware error

Edit the function `setupLoggedInContext` in `client/server/pages/index.js` and make it throw an error. Restart the server and go to:

* http://calypso.localhost:3000/log-in
* http://calypso.localhost:3000/themes
* http://calypso.localhost:3000/theme/asdf

Verify these are true for both pages:

* You should get a generic "We're sorry, but an unexpected error has occurred" error page
* The server logs shows an error with `level:50` and the stack trace.
* Function `notFoundError` is not called.

#### Isomorphic middleware error

Edit the function `fetchThemeDetailsData` in `client/my-sites/theme/controller.jsx` and make it throw an error. Restart the server and go to http://calypso.localhost:3000/theme/seedlet

Verify these are true:

* You should get the `Looking for great WordPress designs?` error page.
* The server logs should show an error with `level:40` and the stack trace.
* Function `notFoundError` is called.