### PR TITLE
Jetpack: allow long filenames in threats to break into new lines

### DIFF
--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -17,6 +17,10 @@
 			font-size: $font-title-small;
 		}
 	}
+	
+	.threat-item-header__alert-filename {
+		word-break: break-all;
+	}
 
 	.log-item__subheader {
 		color: var( --studio-gray-60 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allow long filenames in threats to break into new lines.

#### Before / After
![image](https://user-images.githubusercontent.com/390760/95587434-f4b75000-0a39-11eb-983b-c616b375cd2f.png)


![image](https://user-images.githubusercontent.com/390760/95587407-ebc67e80-0a39-11eb-92be-dc2c07ddcc8f.png)


#### Testing instructions

* Fire up this PR.
* Visit Jetpack Cloud > Scan.
* Ensure any threats with long filenames don't fall out of bounds.

Fixes issue reported in pbuNQi-Fu-p2