### PR TITLE
Components: Fix PostSelector and use FormLabel in it

### DIFF
--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -24,6 +24,7 @@ import {
 /**
  * Internal dependencies
  */
+import FormLabel from 'calypso/components/forms/form-label';
 import NoResults from './no-results';
 import QueryPosts from 'calypso/components/data/query-posts';
 import QueryPostTypes from 'calypso/components/data/query-post-types';
@@ -310,7 +311,7 @@ class PostSelectorPosts extends React.Component {
 
 		return (
 			<div key={ item.global_ID } ref={ setItemRef } className="post-selector__list-item">
-				<label>
+				<FormLabel>
 					<input
 						name="posts"
 						type={ this.props.multiple ? 'checkbox' : 'radio' }
@@ -334,7 +335,7 @@ class PostSelectorPosts extends React.Component {
 							</span>
 						) }
 					</span>
-				</label>
+				</FormLabel>
 				{ children.length > 0 && (
 					<div className="post-selector__nested-list">
 						{ children.map( ( child ) => this.renderItem( child, true ) ) }
@@ -376,14 +377,14 @@ class PostSelectorPosts extends React.Component {
 
 		return (
 			<div key="placeholder" className="post-selector__list-item is-placeholder">
-				<label>
+				<FormLabel>
 					<input
 						type={ this.props.multiple ? 'checkbox' : 'radio' }
 						disabled
 						className="post-selector__input"
 					/>
 					<span className="post-selector__label">{ this.props.translate( 'Loading…' ) }</span>
-				</label>
+				</FormLabel>
 			</div>
 		);
 	};

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -25,18 +25,18 @@ import {
  * Internal dependencies
  */
 import NoResults from './no-results';
-import { gaRecordEvent } from 'lib/analytics/ga';
+import QueryPosts from 'calypso/components/data/query-posts';
+import QueryPostTypes from 'calypso/components/data/query-post-types';
 import Search from './search';
-import { decodeEntities } from 'lib/formatting';
+import { decodeEntities } from 'calypso/lib/formatting';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import {
 	getPostsForQueryIgnoringPage,
-	isRequestingPostsForQueryIgnoringPage,
 	getPostsFoundForQuery,
 	getPostsLastPageForQuery,
-} from 'state/posts/selectors';
-import { getPostTypes } from 'state/post-types/selectors';
-import QueryPostTypes from 'components/data/query-post-types';
-import QueryPosts from 'components/data/query-posts';
+	isRequestingPostsForQueryIgnoringPage,
+} from 'calypso/state/posts/selectors';
+import { getPostTypes } from 'calypso/state/post-types/selectors';
 
 /**
  * Constants

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -24,7 +24,9 @@ import {
 /**
  * Internal dependencies
  */
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
+import FormRadio from 'calypso/components/forms/form-radio';
 import NoResults from './no-results';
 import QueryPosts from 'calypso/components/data/query-posts';
 import QueryPostTypes from 'calypso/components/data/query-post-types';
@@ -308,13 +310,13 @@ class PostSelectorPosts extends React.Component {
 		const onChange = ( ...args ) => this.props.onChange( item, ...args );
 		const setItemRef = ( ...args ) => this.setItemRef( item, ...args );
 		const children = this.getPostChildren( item.ID );
+		const InputComponent = this.props.multiple ? FormInputCheckbox : FormRadio;
 
 		return (
 			<div key={ item.global_ID } ref={ setItemRef } className="post-selector__list-item">
 				<FormLabel>
-					<input
+					<InputComponent
 						name="posts"
-						type={ this.props.multiple ? 'checkbox' : 'radio' }
 						value={ item.ID }
 						onChange={ onChange }
 						checked={ this.props.selected === item.ID }
@@ -375,14 +377,12 @@ class PostSelectorPosts extends React.Component {
 			return this.renderItem( item );
 		}
 
+		const InputComponent = this.props.multiple ? FormInputCheckbox : FormRadio;
+
 		return (
 			<div key="placeholder" className="post-selector__list-item is-placeholder">
 				<FormLabel>
-					<input
-						type={ this.props.multiple ? 'checkbox' : 'radio' }
-						disabled
-						className="post-selector__input"
-					/>
+					<InputComponent disabled className="post-selector__input" />
 					<span className="post-selector__label">{ this.props.translate( 'Loading…' ) }</span>
 				</FormLabel>
 			</div>

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -35,7 +35,7 @@ input[type=radio].post-selector__input,
 input[type=checkbox].post-selector__input {
 	margin-top: 4px;
 
-	& + label {
+	& + .form-label {
 		display: block;
 		margin-left: 24px;
 		transition: all 200ms ease-out;
@@ -67,6 +67,10 @@ input[type=checkbox].post-selector__input {
 	position: relative;
 	padding: 2px 8px;
 	font-size: $font-body-small;
+
+	.form-label {
+		margin-bottom: 0;
+	}
 
 	&.is-empty {
 		padding-top: 4px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `<FormLabel />` instead of `<label />` in `<PostSelector />` as part of #45259.
* Fix `<PostSelector />` inputs that we likely broke in #45198.

#### Testing instructions
* Go to `/devdocs/blocks/post-selector`
* Verify post selector looks good, and as shown on the After screenshot below.

Before:
![](https://cldup.com/_zSovLZ5lS.png)

After:
![](https://cldup.com/iOOfmQXqO4.png)



