### PR TITLE
Fix spacing of the "enable restores" banner

### DIFF
--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -41,9 +41,6 @@
 	margin-left: -16px;
 	margin-right: -16px;
 
-	div:last-child {
-		flex-grow: 1;
-	}
 	@include breakpoint-deprecated( '>660px' ) {
 		height: auto;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes the layout of the top banner in the _Backup_ section.

Fixes 1197351014149633-as-1198169024171322

### Implementation notes

I'm not sure about the purpose of the rule I removed. It didn't change anything in the rest of the page. Anyway, this kind of selector must be avoided.

### Testing instructions

- Select a Jetpack site that has Backup and no server credentials set
- Visit `/backup/:site`
- Check that the button in the banner is aligned to the right (see capture)

### Screenshots

#### Before
<img width="685" alt="Screen Shot 2020-10-09 at 9 31 32 AM" src="https://user-images.githubusercontent.com/1620183/95589521-dc800a80-0a12-11eb-94a6-62ee63964249.png">

#### After
<img width="683" alt="Screen Shot 2020-10-09 at 9 31 38 AM" src="https://user-images.githubusercontent.com/1620183/95589529-e0139180-0a12-11eb-8a27-0ef8dd4ce1ba.png">