### PR TITLE
Performance: Track site ID in the default collector

### DIFF
--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -6,14 +6,14 @@ import { start, stop } from '@automattic/browser-data-collector';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
-import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
+import config from 'calypso/config';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isJetpackSite, isSingleUserSite } from 'calypso/state/sites/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import {
 	getCurrentUserSiteCount,
 	getCurrentUserVisibleSiteCount,
-} from 'state/current-user/selectors';
+} from 'calypso/state/current-user/selectors';
 
 /**
  * This reporter is added to _all_ performance tracking metrics.

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -30,6 +30,7 @@ const buildDefaultCollector = ( state ) => {
 	const sitesVisibleCount = getCurrentUserVisibleSiteCount( state );
 
 	return ( report ) => {
+		report.data.set( 'siteId', siteId );
 		report.data.set( 'siteIsJetpack', siteIsJetpack );
 		report.data.set( 'siteIsSingleUser', siteIsSingleUser );
 		report.data.set( 'siteIsAtomic', siteIsAtomic );


### PR DESCRIPTION
Tracking the site ID in RUM is going to be very informative in diagnosing low-hanging fruits in performance.

#### Changes proposed in this Pull Request

* Performance: Track site ID in the default collector

#### Testing instructions

* Run Calypso with `yarn start`
* Edit a page or post.
* Check the network tab in Dev Tools for requests to `/logstash`. Inspect the payload, it should now have `siteId: 1234` where `1234` is the ID of the site you're editing a post/page for.
