### PR TITLE
Plans: new Jetpack Product card UI

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt/features-item.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt/features-item.tsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { isObject } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'calypso/components/gridicon';
+import InfoPopover from 'calypso/components/info-popover';
+import { preventWidows } from 'calypso/lib/formatting';
+
+/**
+ * Type dependencies
+ */
+import type { ProductCardFeaturesItem } from './types';
+
+export type Props = {
+	item: ProductCardFeaturesItem;
+};
+
+type IconComponent = FunctionComponent< { icon: string; className?: string } >;
+
+const DEFAULT_ICON = 'checkmark';
+
+const JetpackProductCardFeaturesItem: FunctionComponent< Props > = ( { item } ) => {
+	const { icon, text, description, subitems } = item;
+	const iconName = ( isObject( icon ) ? icon?.icon : icon ) || DEFAULT_ICON;
+	const Icon = ( ( isObject( icon ) && icon?.component ) || Gridicon ) as IconComponent;
+
+	return (
+		<li className="jetpack-product-card-alt__features-item">
+			<div className="jetpack-product-card-alt__features-main">
+				<div className="jetpack-product-card-alt__features-summary">
+					<Icon className="jetpack-product-card-alt__features-icon" icon={ iconName } />
+					<p className="jetpack-product-card-alt__features-text">{ preventWidows( text ) }</p>
+				</div>
+				{ description && <InfoPopover>{ preventWidows( description ) }</InfoPopover> }
+			</div>
+			{ subitems && subitems?.length > 0 && (
+				<ul className="jetpack-product-card-alt__features-subitems">
+					{ subitems.map( ( subitem, index ) => (
+						<JetpackProductCardFeaturesItem key={ index } item={ subitem } />
+					) ) }
+				</ul>
+			) }
+		</li>
+	);
+};
+
+export default JetpackProductCardFeaturesItem;

--- a/client/components/jetpack/card/jetpack-product-card-alt/features.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt/features.tsx
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import React, { useState, useCallback, FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'calypso/components/external-link';
+import FoldableCard from 'calypso/components/foldable-card';
+import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import FeaturesItem from './features-item';
+
+/**
+ * Type dependencies
+ */
+import type {
+	ProductCardFeatures,
+	ProductCardFeaturesSection,
+	ProductCardFeaturesItem,
+} from './types';
+
+export type Props = {
+	className?: string;
+	features: ProductCardFeatures;
+	isExpanded?: boolean;
+	productSlug?: string;
+};
+
+const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
+	className,
+	features,
+	isExpanded: isExpandedByDefault,
+	productSlug,
+} ) => {
+	const trackProps = productSlug ? { product_slug: productSlug } : {};
+	const trackShowFeatures = useTrackCallback(
+		undefined,
+		'calypso_product_features_open',
+		trackProps
+	);
+	const trackHideFeatures = useTrackCallback(
+		undefined,
+		'calypso_product_features_close',
+		trackProps
+	);
+	const [ isExpanded, setExpanded ] = useState( !! isExpandedByDefault );
+	const onOpen = useCallback( () => {
+		setExpanded( true );
+		trackShowFeatures();
+	}, [ setExpanded, trackShowFeatures ] );
+	const onClose = useCallback( () => {
+		setExpanded( false );
+		trackHideFeatures();
+	}, [ setExpanded, trackHideFeatures ] );
+	const translate = useTranslate();
+
+	const { items, more } = features;
+
+	return (
+		<FoldableCard
+			className={ className }
+			header={ isExpanded ? translate( 'Hide features' ) : translate( 'Show features' ) }
+			clickableHeader
+			expanded={ isExpanded }
+			onOpen={ onOpen }
+			onClose={ onClose }
+		>
+			<ul className="jetpack-product-card-alt__features-list">
+				{ ( items as ( ProductCardFeaturesItem | ProductCardFeaturesSection )[] ).map(
+					( item, i ) => {
+						if ( 'heading' in item && 'list' in item ) {
+							return (
+								<li key={ i }>
+									<p className="jetpack-product-card-alt__features-category">{ item.heading }</p>
+									<ul className="jetpack-product-card-alt__features-list">
+										{ item.list.map( ( subitem, j ) => (
+											<FeaturesItem key={ j } item={ subitem } />
+										) ) }
+									</ul>
+								</li>
+							);
+						}
+
+						return <FeaturesItem key={ i } item={ item } />;
+					}
+				) }
+			</ul>
+			{ more && (
+				<div className="jetpack-product-card-alt__feature-more">
+					<ExternalLink icon={ true } href={ more.url }>
+						{ more.label }
+					</ExternalLink>
+				</div>
+			) }
+		</FoldableCard>
+	);
+};
+
+export default JetpackProductCardFeatures;

--- a/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
@@ -39,6 +39,8 @@ type OwnProps = {
 	withStartingPrice?: boolean;
 	billingTimeFrame: TranslateResult;
 	buttonLabel: TranslateResult;
+	buttonPrimary: boolean;
+	badgeLabel: TranslateResult;
 	onButtonClick: () => void;
 	cancelLabel?: TranslateResult;
 	onCancelClick?: () => void;
@@ -66,6 +68,8 @@ const JetpackProductCardAlt = ( {
 	withStartingPrice,
 	billingTimeFrame,
 	buttonLabel,
+	buttonPrimary,
+	badgeLabel,
 	onButtonClick,
 	cancelLabel,
 	onCancelClick,
@@ -172,7 +176,12 @@ const JetpackProductCardAlt = ( {
 				) }
 			</header>
 			<div className="jetpack-product-card-alt__body">
-				<Button primary className="jetpack-product-card-alt__button" onClick={ onButtonClick }>
+				<span className="jetpack-product-card-alt__badge">{ badgeLabel }</span>
+				<Button
+					primary={ buttonPrimary }
+					className="jetpack-product-card-alt__button"
+					onClick={ onButtonClick }
+				>
 					{ buttonLabel }
 				</Button>
 				{ cancelLabel && (

--- a/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
@@ -1,0 +1,197 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { isFinite, isNumber } from 'lodash';
+import React, { createElement, ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Button, ProductIcon } from '@automattic/components';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { preventWidows } from 'calypso/lib/formatting';
+import PlanPrice from 'calypso/my-sites/plan-price';
+import JetpackProductCardFeatures, { Props as FeaturesProps } from './features';
+
+/**
+ * Type dependencies
+ */
+import type { Moment } from 'moment';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+type OwnProps = {
+	className?: string;
+	iconSlug: string;
+	productName: TranslateResult;
+	productType?: string;
+	headingLevel?: number;
+	subheadline?: TranslateResult;
+	description?: ReactNode;
+	currencyCode: string | null;
+	originalPrice: number;
+	discountedPrice?: number;
+	withStartingPrice?: boolean;
+	billingTimeFrame: TranslateResult;
+	buttonLabel: TranslateResult;
+	onButtonClick: () => void;
+	cancelLabel?: TranslateResult;
+	onCancelClick?: () => void;
+	children?: ReactNode;
+	isHighlighted?: boolean;
+	isOwned?: boolean;
+	isDeprecated?: boolean;
+	expiryDate?: Moment;
+	hidePrice?: boolean;
+};
+
+export type Props = OwnProps & Partial< FeaturesProps >;
+
+const JetpackProductCardAlt = ( {
+	className,
+	iconSlug,
+	productName,
+	productType,
+	headingLevel,
+	subheadline,
+	description,
+	currencyCode,
+	originalPrice,
+	discountedPrice,
+	withStartingPrice,
+	billingTimeFrame,
+	buttonLabel,
+	onButtonClick,
+	cancelLabel,
+	onCancelClick,
+	children,
+	isHighlighted,
+	isOwned,
+	isDeprecated,
+	expiryDate,
+	features,
+	isExpanded,
+	hidePrice,
+	productSlug,
+}: Props ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
+	const isDiscounted = isFinite( discountedPrice );
+	const parsedHeadingLevel = isNumber( headingLevel )
+		? Math.min( Math.max( Math.floor( headingLevel ), 1 ), 6 )
+		: 2;
+	const parsedExpiryDate =
+		moment.isMoment( expiryDate ) && expiryDate.isValid() ? expiryDate : null;
+
+	const renderBillingTimeFrame = (
+		productExpiryDate: Moment | null,
+		billingTerm: TranslateResult
+	) => {
+		return productExpiryDate ? (
+			<time
+				className="jetpack-product-card-alt__expiration-date"
+				dateTime={ productExpiryDate.format( 'YYYY-DD-YY' ) }
+			>
+				{ translate( 'expires %(date)s', {
+					args: {
+						date: productExpiryDate.format( 'L' ),
+					},
+				} ) }
+			</time>
+		) : (
+			<span className="jetpack-product-card-alt__billing-time-frame">{ billingTerm }</span>
+		);
+	};
+
+	return (
+		<div
+			className={ classNames( className, 'jetpack-product-card-alt', {
+				'is-owned': isOwned,
+				'is-deprecated': isDeprecated,
+				'is-featured': isHighlighted,
+			} ) }
+			data-icon={ iconSlug }
+		>
+			<header className="jetpack-product-card-alt__header">
+				<ProductIcon className="jetpack-product-card-alt__icon" slug={ iconSlug } />
+				{ createElement(
+					`h${ parsedHeadingLevel }`,
+					{ className: 'jetpack-product-card-alt__product-name' },
+					<>
+						{ preventWidows( productName ) }
+						{ productType && (
+							<span className="jetpack-product-card-alt__product-type">
+								{ ' ' }
+								{ preventWidows( productType ) }
+							</span>
+						) }
+					</>
+				) }
+
+				{ subheadline && (
+					<p className="jetpack-product-card-alt__subheadline">{ preventWidows( subheadline ) }</p>
+				) }
+
+				{ ! hidePrice && (
+					<div className="jetpack-product-card-alt__price">
+						{ currencyCode && originalPrice ? (
+							<span className="jetpack-product-card-alt__raw-price">
+								{ withStartingPrice && (
+									<span className="jetpack-product-card-alt__from">{ translate( 'from' ) }</span>
+								) }
+
+								{ isDiscounted ? (
+									<PlanPrice
+										rawPrice={ discountedPrice }
+										discounted
+										currencyCode={ currencyCode }
+									/>
+								) : (
+									<PlanPrice
+										rawPrice={ originalPrice }
+										original={ isDiscounted }
+										currencyCode={ currencyCode }
+									/>
+								) }
+							</span>
+						) : (
+							<div className="jetpack-product-card-alt__price-placeholder" />
+						) }
+						{ currencyCode && originalPrice ? (
+							renderBillingTimeFrame( parsedExpiryDate, billingTimeFrame )
+						) : (
+							<div className="jetpack-product-card-alt__time-frame-placeholder" />
+						) }
+					</div>
+				) }
+			</header>
+			<div className="jetpack-product-card-alt__body">
+				<Button primary className="jetpack-product-card-alt__button" onClick={ onButtonClick }>
+					{ buttonLabel }
+				</Button>
+				{ cancelLabel && (
+					<Button className="jetpack-product-card-alt__cancel" onClick={ onCancelClick }>
+						{ cancelLabel }
+					</Button>
+				) }
+				{ description && <p className="jetpack-product-card-alt__description">{ description }</p> }
+				{ children && <div className="jetpack-product-card-alt__children">{ children }</div> }
+			</div>
+			{ features && features.items.length > 0 && (
+				<JetpackProductCardFeatures
+					features={ features }
+					productSlug={ productSlug }
+					isExpanded={ isExpanded }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default JetpackProductCardAlt;

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -238,8 +238,7 @@ $jetpack-product-card-alt-icon-size: 55px;
 }
 
 .jetpack-product-card-alt__children {
-	margin-top: -16px;
-	margin-bottom: 24px;
+	margin: 0;
 }
 
 .jetpack-product-card-alt .foldable-card.is-expanded {

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -210,6 +210,21 @@ $jetpack-product-card-alt-icon-size: 55px;
 	font-style: italic;
 }
 
+.jetpack-product-card-alt__badge {
+	display: block;
+
+	margin: -10px 0 10px;
+
+	min-height: 12px;
+
+	color: var( --color-primary );
+
+	font-size: $font-body-extra-small;
+	font-style: italic;
+	line-height: 1;
+	text-align: center;
+}
+
 .jetpack-product-card-alt .button {
 	width: 100%;
 	margin-bottom: 30px;

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -1,0 +1,307 @@
+$jetpack-product-card-alt-color: var( --studio-wordpress-blue-30 );
+$jetpack-product-card-alt-circle-size: 65px;
+$jetpack-product-card-alt-icon-size: 55px;
+
+.jetpack-product-card-alt {
+	position: relative;
+
+	box-sizing: border-box;
+	margin: calc( 24px + #{$jetpack-product-card-alt-circle-size/2} ) 0 24px;
+
+	background: var( --studio-gray-0 );
+	border: 1px solid var( --color-border-subtle );
+	border-left: none;
+	border-right: none;
+
+	// Top circle
+	&::before {
+		content: '';
+
+		position: absolute;
+		top: -$jetpack-product-card-alt-circle-size/2;
+		left: calc( 50% - #{$jetpack-product-card-alt-circle-size/2} );
+
+		display: block;
+		box-sizing: border-box;
+		width: $jetpack-product-card-alt-circle-size;
+		height: $jetpack-product-card-alt-circle-size;
+
+		background: inherit;
+		border: 1px solid var( --color-border-subtle );
+		border-radius: 50%;
+	}
+
+	// Mask for the bottom half of the circle
+	&::after {
+		content: '';
+
+		position: absolute;
+		top: 0;
+		left: calc( 50% - #{$jetpack-product-card-alt-circle-size/2} );
+
+		display: block;
+		width: $jetpack-product-card-alt-circle-size;
+		height: $jetpack-product-card-alt-circle-size/2;
+
+		background: inherit;
+	}
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+
+	.foldable-card {
+		margin-bottom: 0;
+
+		font-size: $font-body;
+
+		background: var( --color-gray-0 );
+
+		box-shadow: none;
+	}
+
+	@media ( min-width: 660px ) {
+		border-left: 1px solid var( --color-border-subtle );
+		border-right: 1px solid var( --color-border-subtle );
+
+		&:not( .with-nudge ) .foldable-card {
+			border-bottom-left-radius: 2px;
+			border-bottom-right-radius: 2px;
+		}
+
+		.foldable-card--square-border {
+			border-radius: 0;
+		}
+	}
+}
+
+.jetpack-product-card-alt__header {
+	position: relative;
+
+	padding: 42px 16px 12px;
+
+	text-align: center;
+}
+
+.jetpack-product-card-alt .product-icon {
+	position: absolute;
+	top: -$jetpack-product-card-alt-icon-size/2;
+	left: calc( 50% - #{$jetpack-product-card-alt-icon-size/2} );
+	z-index: 1;
+
+	width: $jetpack-product-card-alt-icon-size;
+}
+
+.jetpack-product-card-alt__product-name {
+	margin-bottom: 6px;
+
+	font-size: $font-title-medium;
+	font-weight: 600;
+	line-height: rem( 30px ) / $font-title-medium;
+}
+
+.jetpack-product-card-alt__product-type {
+	font-style: italic;
+	font-weight: 400;
+}
+
+.jetpack-product-card-alt__subheadline {
+	margin-bottom: 16px;
+
+	color: var( --color-neutral-50 );
+
+	font-size: $font-body-extra-small;
+	line-height: rem( 16px ) / $font-body-extra-small;
+
+	@media ( min-width: 660px ) {
+		font-size: $font-body-small;
+	}
+}
+
+.jetpack-product-card-alt__price {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+
+	margin-bottom: 20px;
+}
+
+.jetpack-product-card-alt__from,
+.jetpack-product-card-alt__billing-time-frame,
+.jetpack-product-card-alt__expiration-date {
+	display: block;
+
+	color: var( --color-text-subtle );
+
+	font-size: $font-body-extra-small;
+	font-style: italic;
+	line-height: 1;
+}
+
+.jetpack-product-card-alt__expiration-date {
+	margin-top: 10px;
+
+	color: var( --studio-pink-50 );
+
+	text-align: right;
+}
+
+.jetpack-product-card-alt__from {
+	margin: 0 8px 8px 0;
+}
+
+.jetpack-product-card-alt__raw-price {
+	display: flex;
+	justify-content: center;
+	align-items: flex-end;
+	margin-bottom: 4px;
+
+	:last-child {
+		margin-right: 0;
+	}
+}
+
+.jetpack-product-card-alt .plan-price {
+	position: relative;
+
+	border-color: $jetpack-product-card-alt-color;
+
+	sup {
+		position: absolute;
+		top: 13px;
+
+		font-size: $font-title-small;
+		font-weight: 400;
+	}
+
+	sup.plan-price__currency-symbol {
+		left: -13px;
+	}
+
+	&.is-original::before {
+		// Enable the overwrite of the border color by setting it to .plan-price
+		border-color: inherit;
+	}
+
+	&.is-discounted {
+		color: var( --color-text );
+
+		.plan-price__currency-symbol {
+			color: inherit;
+		}
+	}
+}
+
+.jetpack-product-card-alt .plan-price__integer {
+	font-size: $font-headline-medium;
+	font-weight: 600;
+}
+
+.jetpack-product-card-alt__body {
+	padding: 0 16px;
+}
+
+.jetpack-product-card-alt__discount-message {
+	margin: -20px 0 16px;
+
+	color: var( --color-success-40 );
+
+	font-style: italic;
+}
+
+.jetpack-product-card-alt .button {
+	width: 100%;
+	margin-bottom: 30px;
+
+	font-size: $font-body;
+}
+
+.jetpack-product-card-alt__description {
+	margin-bottom: 10px;
+	padding: 0 4px;
+}
+
+.jetpack-product-card-alt__children {
+	margin-top: -16px;
+	margin-bottom: 24px;
+}
+
+.jetpack-product-card-alt .foldable-card.is-expanded {
+	margin-bottom: 0;
+}
+
+.jetpack-product-card-alt .foldable-card.is-expanded .foldable-card__content {
+	padding: 0 16px 16px;
+
+	border-top: none;
+}
+
+.jetpack-product-card-alt__features-category {
+	margin: 8px 0 12px;
+	padding-bottom: 6px;
+
+	border-bottom: solid 1px var( --color-border-subtle );
+	color: var( --studio-gray-70 );
+
+	font-weight: 600;
+}
+
+.jetpack-product-card-alt__features-list {
+	margin: 0;
+
+	list-style-type: none;
+}
+
+.jetpack-product-card-alt__features-main {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 12px 0;
+}
+
+.jetpack-product-card-alt__features-subitems {
+	margin-left: 36px;
+
+	list-style-type: none;
+}
+
+.jetpack-product-card-alt__features-summary {
+	display: flex;
+	align-items: flex-start;
+}
+
+.jetpack-product-card-alt__features-text {
+	flex: 1;
+	margin: 0 16px 0 0;
+}
+
+.jetpack-product-card-alt__features-icon {
+	margin-right: 14px;
+
+	fill: var( --studio-gray-50 );
+
+	&.gridicons-checkmark {
+		fill: $jetpack-product-card-alt-color;
+	}
+}
+
+.jetpack-product-card-alt__feature-more {
+	padding-top: 16px;
+}
+
+/* Prices Loading state */
+.jetpack-product-card-alt__price-placeholder {
+	@include placeholder( --color-neutral-10 );
+
+	width: 100px;
+	min-height: 72px;
+	margin-bottom: 4px;
+}
+
+.jetpack-product-card-alt__time-frame-placeholder {
+	@include placeholder( --color-neutral-10 );
+
+	width: 100px;
+	height: 12px;
+}

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -88,6 +88,12 @@
 		}
 	}
 
+	.jetpack-product-card-alt {
+		.foldable-card {
+			font-size: $font-body;
+		}
+	}
+
 	.foldable-card {
 		font-size: rem( 13px );
 	}

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -15,11 +15,11 @@ import {
 	slugToSelectorProduct,
 } from '../utils';
 import ProductCard from '../product-card';
-import { getMonthlyPlanByYearly, getYearlyPlanByMonthly } from 'lib/plans';
-import { JETPACK_LEGACY_PLANS, PLAN_JETPACK_FREE } from 'lib/plans/constants';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import getSitePlan from 'state/sites/selectors/get-site-plan';
-import FormattedHeader from 'components/formatted-header';
+import { getMonthlyPlanByYearly, getYearlyPlanByMonthly } from 'calypso/lib/plans';
+import { JETPACK_LEGACY_PLANS, PLAN_JETPACK_FREE } from 'calypso/lib/plans/constants';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Type dependencies

--- a/client/my-sites/plans-v2/product-card-alt/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt/index.tsx
@@ -15,13 +15,13 @@ import {
 	slugIsFeaturedProduct,
 } from '../utils';
 import PlanRenewalMessage from '../plan-renewal-message';
+import RecordsDetailsAlt from '../records-details-alt';
 import useItemPrice from '../use-item-price';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import JetpackProductCardAlt from 'calypso/components/jetpack/card/jetpack-product-card-alt';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { planHasFeature } from 'calypso/lib/plans';
 import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
 import { JETPACK_SEARCH_PRODUCTS } from 'calypso/lib/products-values/constants';
@@ -94,8 +94,8 @@ const ProductCardAltWrapper = ( {
 	const isUpgradeableToYearly =
 		isOwned && selectedTerm === TERM_ANNUALLY && item.term === TERM_MONTHLY;
 
-	// We only want to show Jetpack Search price in the Pricing page (Calypso Green)
-	const hidePrice = JETPACK_SEARCH_PRODUCTS.includes( item.productSlug ) && ! isJetpackCloud();
+	const description = showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description;
+	const showRecordsDetails = JETPACK_SEARCH_PRODUCTS.includes( item.productSlug ) && siteId;
 
 	return (
 		<JetpackProductCardAlt
@@ -103,7 +103,7 @@ const ProductCardAltWrapper = ( {
 			iconSlug={ item.iconSlug }
 			productName={ item.displayName }
 			subheadline={ item.tagline }
-			description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description }
+			description={ ! showRecordsDetails ? description : null }
 			currencyCode={ currencyCode }
 			billingTimeFrame={ durationToText( item.term ) }
 			buttonLabel={ productButtonLabel( item, isOwned, isUpgradeableToYearly, sitePlan ) }
@@ -124,9 +124,11 @@ const ProductCardAltWrapper = ( {
 			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
 			isHighlighted={ isHighlighted }
 			isExpanded={ isHighlighted && ! isMobile }
-			hidePrice={ hidePrice }
+			hidePrice={ false }
 			productSlug={ item.productSlug }
-		/>
+		>
+			{ showRecordsDetails && <RecordsDetailsAlt productSlug={ item.productSlug } /> }
+		</JetpackProductCardAlt>
 	);
 };
 

--- a/client/my-sites/plans-v2/product-card-alt/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt/index.tsx
@@ -1,0 +1,130 @@
+/**
+ * External dependencies
+ */
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+
+/**
+ * Internal dependencies
+ */
+import { EXTERNAL_PRODUCTS_LIST } from '../constants';
+import { durationToText, productButtonLabel, slugIsFeaturedProduct } from '../utils';
+import PlanRenewalMessage from '../plan-renewal-message';
+import useItemPrice from '../use-item-price';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
+import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import JetpackProductCardAlt from 'calypso/components/jetpack/card/jetpack-product-card-alt';
+import { planHasFeature } from 'calypso/lib/plans';
+import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
+import { JETPACK_SEARCH_PRODUCTS } from 'calypso/lib/products-values/constants';
+import { isCloseToExpiration } from 'calypso/lib/purchases';
+import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
+
+/**
+ * Type dependencies
+ */
+import type { Duration, PurchaseCallback, SelectorProduct } from '../types';
+
+interface ProductCardProps {
+	item: SelectorProduct;
+	onClick: PurchaseCallback;
+	siteId: number | null;
+	currencyCode: string | null;
+	className?: string;
+	highlight?: boolean;
+	selectedTerm?: Duration;
+}
+
+const ProductCardAltWrapper = ( {
+	item,
+	onClick,
+	siteId,
+	currencyCode,
+	className,
+	highlight = false,
+	selectedTerm,
+}: ProductCardProps ) => {
+	// Determine whether product is owned.
+	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
+	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
+	const isOwned = useMemo( () => {
+		if ( sitePlan && sitePlan.product_slug === item.productSlug ) {
+			return true;
+		} else if ( siteProducts ) {
+			return siteProducts
+				.filter( ( product ) => ! product.expired )
+				.map( ( product ) => product.productSlug )
+				.includes( item.productSlug );
+		}
+		return false;
+	}, [ item.productSlug, sitePlan, siteProducts ] );
+
+	// Calculate the product price.
+	const { originalPrice, discountedPrice } = useItemPrice(
+		siteId,
+		item,
+		item?.monthlyProductSlug || ''
+	);
+
+	// Handles expiry.
+	const moment = useLocalizedMoment();
+	const purchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+
+	// If item is a plan feature, use the plan purchase object.
+	const isItemPlanFeature = sitePlan && planHasFeature( sitePlan.product_slug, item.productSlug );
+	const purchase = isItemPlanFeature
+		? getPurchaseByProductSlug( purchases, sitePlan?.product_slug || '' )
+		: getPurchaseByProductSlug( purchases, item.productSlug );
+
+	const isExpiring = purchase && isCloseToExpiration( purchase );
+	const showExpiryNotice = item.legacy && isExpiring;
+
+	// Is highlighted?
+	const isMobile: boolean = useMobileBreakpoint();
+	const isHighlighted = highlight && ! isOwned && slugIsFeaturedProduct( item.productSlug );
+
+	const isUpgradeableToYearly =
+		isOwned && selectedTerm === TERM_ANNUALLY && item.term === TERM_MONTHLY;
+
+	// Don't hide price if siteId is not defined, since it most likely won't be shown
+	// in other parts of the card (e.g. Jetpack Search)
+	// Jetpack CRM is an external product and we don't have access to its price, therefore,
+	// we hide it.
+	const hidePrice =
+		EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ) || ( !! siteId && item.hidePrice );
+
+	return (
+		<JetpackProductCardAlt
+			headingLevel={ 3 }
+			iconSlug={ item.iconSlug }
+			productName={ item.displayName }
+			subheadline={ item.tagline }
+			description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description }
+			currencyCode={ currencyCode }
+			billingTimeFrame={ durationToText( item.term ) }
+			buttonLabel={ productButtonLabel( item, isOwned, isUpgradeableToYearly, sitePlan ) }
+			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
+			features={ item.features }
+			children={ item.children }
+			originalPrice={ originalPrice }
+			discountedPrice={ discountedPrice }
+			withStartingPrice={
+				// Search has several pricing tiers
+				item.subtypes.length > 0 || JETPACK_SEARCH_PRODUCTS.includes( item.productSlug )
+			}
+			isOwned={ isOwned }
+			isDeprecated={ item.legacy }
+			className={ className }
+			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
+			isHighlighted={ isHighlighted }
+			isExpanded={ isHighlighted && ! isMobile }
+			hidePrice={ hidePrice }
+			productSlug={ item.productSlug }
+		/>
+	);
+};
+
+export default ProductCardAltWrapper;

--- a/client/my-sites/plans-v2/product-card-alt/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt/index.tsx
@@ -8,8 +8,12 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 /**
  * Internal dependencies
  */
-import { EXTERNAL_PRODUCTS_LIST } from '../constants';
-import { durationToText, productButtonLabel, slugIsFeaturedProduct } from '../utils';
+import {
+	durationToText,
+	productBadgeLabelAlt,
+	productButtonLabel,
+	slugIsFeaturedProduct,
+} from '../utils';
 import PlanRenewalMessage from '../plan-renewal-message';
 import useItemPrice from '../use-item-price';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
@@ -17,6 +21,7 @@ import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import JetpackProductCardAlt from 'calypso/components/jetpack/card/jetpack-product-card-alt';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { planHasFeature } from 'calypso/lib/plans';
 import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
 import { JETPACK_SEARCH_PRODUCTS } from 'calypso/lib/products-values/constants';
@@ -89,12 +94,8 @@ const ProductCardAltWrapper = ( {
 	const isUpgradeableToYearly =
 		isOwned && selectedTerm === TERM_ANNUALLY && item.term === TERM_MONTHLY;
 
-	// Don't hide price if siteId is not defined, since it most likely won't be shown
-	// in other parts of the card (e.g. Jetpack Search)
-	// Jetpack CRM is an external product and we don't have access to its price, therefore,
-	// we hide it.
-	const hidePrice =
-		EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ) || ( !! siteId && item.hidePrice );
+	// We only want to show Jetpack Search price in the Pricing page (Calypso Green)
+	const hidePrice = JETPACK_SEARCH_PRODUCTS.includes( item.productSlug ) && ! isJetpackCloud();
 
 	return (
 		<JetpackProductCardAlt
@@ -106,6 +107,8 @@ const ProductCardAltWrapper = ( {
 			currencyCode={ currencyCode }
 			billingTimeFrame={ durationToText( item.term ) }
 			buttonLabel={ productButtonLabel( item, isOwned, isUpgradeableToYearly, sitePlan ) }
+			buttonPrimary={ ! ( isOwned || isItemPlanFeature ) }
+			badgeLabel={ productBadgeLabelAlt( item, isOwned, sitePlan ) }
 			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
 			features={ item.features }
 			children={ item.children }

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -12,8 +12,8 @@ import { getJetpackDescriptionWithOptions } from '../utils';
 import { PRODUCTS_TYPES } from '../constants';
 import ProductCard from '../product-card';
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
-import FormattedHeader from 'components/formatted-header';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 
 /**
  * Type dependencies

--- a/client/my-sites/plans-v2/records-details-alt/index.tsx
+++ b/client/my-sites/plans-v2/records-details-alt/index.tsx
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import { useTranslate, numberFormat } from 'i18n-calypso';
+import React, { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { slugToSelectorProduct } from '../utils';
+import InfoPopover from 'calypso/components/info-popover';
+import { preventWidows } from 'calypso/lib/formatting';
+import { getJetpackProducts } from 'calypso/lib/products-values/translations';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import { getAvailableProductsBySiteId } from 'calypso/state/sites/products/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+/**
+ * Type dependencies
+ */
+import type { ProductTranslations } from 'calypso/lib/products-values/types';
+
+type Props = {
+	productSlug: string;
+};
+
+const RecordsDetailsAlt: FunctionComponent< Props > = ( { productSlug } ) => {
+	const selectorProduct = slugToSelectorProduct( productSlug );
+
+	const translate = useTranslate();
+	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const products = useSelector(
+		( state ) => siteId && getAvailableProductsBySiteId( state, siteId )
+	)?.data;
+
+	if ( ! selectorProduct || ! currencyCode || ! siteId ) {
+		return null;
+	}
+
+	const searchProduct = products?.[ productSlug ];
+
+	if ( ! searchProduct ) {
+		return null;
+	}
+
+	const recordCount = searchProduct?.price_tier_usage_quantity;
+	const translations = getJetpackProducts().find( ( p ) => p.slugs.includes( productSlug ) ) as
+		| ProductTranslations
+		| undefined;
+	const tier = translations?.optionShortNamesCallback?.( searchProduct );
+
+	return (
+		<div className="records-details-alt">
+			<div className="records-details-alt__records">
+				{ translate(
+					'Your site has %(recordCount)s record',
+					'Your site has %(recordCount)s records',
+					{
+						count: recordCount,
+						args: {
+							recordCount: numberFormat( recordCount, 0 ),
+						},
+						comment: '%(recordCount)s is the number of search records of the site',
+					}
+				) }
+				<InfoPopover>
+					{ preventWidows(
+						translate(
+							'Records are all posts, pages, custom post types and other types of content indexed by Jetpack Search. {{link}}Learn more.{{/link}}',
+							{
+								components: {
+									link: <a href="https://jetpack.com/upgrade/search/"></a>,
+								},
+							}
+						)
+					) }
+				</InfoPopover>
+			</div>
+			<div className="records-details-alt__details">
+				<p className="records-details-alt__tier">{ tier }</p>
+			</div>
+		</div>
+	);
+};
+
+export default RecordsDetailsAlt;

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -141,13 +141,15 @@
  * Record slider
  */
 
-.records-details {
+.records-details,
+.records-details-alt {
 	background-color: var( --studio-gray-0 );
 	border: solid 1px var( --studio-wordpress-blue-30 );
 	color: var( --color-text-subtle );
 }
 
-.records-details__records {
+.records-details__records,
+.records-details-alt__records {
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -164,13 +166,25 @@
 	}
 }
 
-.records-details__details {
+.records-details-alt__records {
+	padding: 14px 14px 0;
+
+	border-bottom: none;
+}
+
+.records-details__details,
+.records-details-alt__details {
 	padding: 16px;
 
 	text-align: center;
 }
 
-.records-details__tier {
+.records-details-alt__details {
+	padding: 10px 14px 14px;
+}
+
+.records-details__tier,
+.records-details-alt__tier {
 	margin-bottom: 8px;
 
 	color: var( --color-text );

--- a/client/my-sites/plans-v2/use-item-price.ts
+++ b/client/my-sites/plans-v2/use-item-price.ts
@@ -6,13 +6,17 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
-import { getProductCost } from 'state/products-list/selectors/get-product-cost';
-import { TERM_MONTHLY } from 'lib/plans/constants';
+import { isProductsListFetching } from 'calypso/state/products-list/selectors/is-products-list-fetching';
+import { getProductCost } from 'calypso/state/products-list/selectors/get-product-cost';
+import { TERM_MONTHLY } from 'calypso/lib/plans/constants';
 import {
 	getSiteAvailableProductCost,
 	isRequestingSiteProducts,
-} from 'state/sites/products/selectors';
+} from 'calypso/state/sites/products/selectors';
+import {
+	PRODUCT_JETPACK_CRM,
+	PRODUCT_JETPACK_CRM_MONTHLY,
+} from 'calypso/lib/products-values/constants';
 
 /**
  * Type dependencies
@@ -103,6 +107,12 @@ const useItemPrice = (
 			originalPrice = monthlyItemCost;
 			discountedPrice = itemCost / 12;
 		}
+	}
+
+	// Jetpack CRM price won't come from the API, so we need to hard-code it.
+	if ( [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes( item.productSlug ) ) {
+		discountedPrice = 11;
+		originalPrice = 132;
 	}
 
 	return {

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -9,7 +9,7 @@ import React, { createElement, Fragment } from 'react';
 /**
  * Internal dependencies
  */
-import { getFeatureByKey, getFeatureCategoryByKey } from 'lib/plans/features-list';
+import { getFeatureByKey, getFeatureCategoryByKey } from 'calypso/lib/plans/features-list';
 import {
 	DAILY_PLAN_TO_REALTIME_PLAN,
 	DAILY_PRODUCTS,
@@ -31,9 +31,9 @@ import {
 	UPSELL_PRODUCT_MATRIX,
 } from './constants';
 import RecordsDetails from './records-details';
-import { addItems } from 'lib/cart/actions';
-import { jetpackProductItem } from 'lib/cart-values/cart-items';
-import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
+import { addItems } from 'calypso/lib/cart/actions';
+import { jetpackProductItem } from 'calypso/lib/cart-values/cart-items';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
@@ -41,26 +41,31 @@ import {
 	JETPACK_LEGACY_PLANS,
 	JETPACK_RESET_PLANS,
 	JETPACK_SECURITY_PLANS,
-} from 'lib/plans/constants';
-import { getPlan, getMonthlyPlanByYearly, getYearlyPlanByMonthly, planHasFeature } from 'lib/plans';
+} from 'calypso/lib/plans/constants';
+import {
+	getPlan,
+	getMonthlyPlanByYearly,
+	getYearlyPlanByMonthly,
+	planHasFeature,
+} from 'calypso/lib/plans';
 import {
 	JETPACK_SEARCH_PRODUCTS,
 	JETPACK_PRODUCT_PRICE_MATRIX,
 	JETPACK_BACKUP_PRODUCTS,
-} from 'lib/products-values/constants';
+} from 'calypso/lib/products-values/constants';
 import {
 	Product,
 	JETPACK_PRODUCTS_LIST,
 	objectIsProduct,
 	PRODUCTS_LIST,
-} from 'lib/products-values/products-list';
-import { getJetpackProductDisplayName } from 'lib/products-values/get-jetpack-product-display-name';
-import { getJetpackProductTagline } from 'lib/products-values/get-jetpack-product-tagline';
-import { getJetpackProductCallToAction } from 'lib/products-values/get-jetpack-product-call-to-action';
-import { getJetpackProductDescription } from 'lib/products-values/get-jetpack-product-description';
-import { getJetpackProductShortName } from 'lib/products-values/get-jetpack-product-short-name';
-import { MORE_FEATURES_LINK } from 'my-sites/plans-v2/constants';
-import { addQueryArgs } from 'lib/route';
+} from 'calypso/lib/products-values/products-list';
+import { getJetpackProductDisplayName } from 'calypso/lib/products-values/get-jetpack-product-display-name';
+import { getJetpackProductTagline } from 'calypso/lib/products-values/get-jetpack-product-tagline';
+import { getJetpackProductCallToAction } from 'calypso/lib/products-values/get-jetpack-product-call-to-action';
+import { getJetpackProductDescription } from 'calypso/lib/products-values/get-jetpack-product-description';
+import { getJetpackProductShortName } from 'calypso/lib/products-values/get-jetpack-product-short-name';
+import { MORE_FEATURES_LINK } from 'calypso/my-sites/plans-v2/constants';
+import { addQueryArgs } from 'calypso/lib/route';
 
 /**
  * Type dependencies
@@ -80,9 +85,9 @@ import type {
 	Plan,
 	JetpackPlanCardFeature,
 	JetpackPlanCardFeatureSection,
-} from 'lib/plans/types';
-import type { JetpackProductSlug } from 'lib/products-values/types';
-import type { SitePlan } from 'state/sites/selectors/get-site-plan';
+} from 'calypso/lib/plans/types';
+import type { JetpackProductSlug } from 'calypso/lib/products-values/types';
+import type { SitePlan } from 'calypso/state/sites/selectors/get-site-plan';
 
 /**
  * Duration utils.
@@ -173,6 +178,20 @@ export function productBadgeLabel(
 	}
 }
 
+export function productBadgeLabelAlt(
+	product: SelectorProduct,
+	isOwned: boolean,
+	currentPlan?: SitePlan | null
+): TranslateResult | undefined {
+	if ( isOwned ) {
+		return translate( 'You own this' );
+	}
+
+	if ( currentPlan && planHasFeature( currentPlan.product_slug, product.productSlug ) ) {
+		return translate( 'Included in your plan' );
+	}
+}
+
 /**
  * Type guards.
  */
@@ -204,7 +223,9 @@ export function slugToItem( slug: string ): Plan | Product | SelectorProduct | n
 	return null;
 }
 
-function objectIsSelectorProduct( item: object ): item is SelectorProduct {
+function objectIsSelectorProduct(
+	item: Record< string, unknown > | SelectorProduct
+): item is SelectorProduct {
 	const requiredKeys = [
 		'productSlug',
 		'iconSlug',
@@ -215,7 +236,8 @@ function objectIsSelectorProduct( item: object ): item is SelectorProduct {
 	];
 	return requiredKeys.every( ( k ) => k in item );
 }
-function objectIsPlan( item: object ): item is Plan {
+
+function objectIsPlan( item: Record< string, unknown > | Plan ): item is Plan {
 	const requiredKeys = [
 		'group',
 		'type',
@@ -236,7 +258,7 @@ function objectIsPlan( item: object ): item is Plan {
  * @returns SelectorProduct
  */
 export function itemToSelectorProduct(
-	item: Plan | Product | SelectorProduct | object
+	item: Plan | Product | SelectorProduct | Record< string, unknown >
 ): SelectorProduct | null {
 	if ( objectIsSelectorProduct( item ) ) {
 		return item;
@@ -323,6 +345,8 @@ export function itemToSelectorProduct(
  *
  * @param {JetpackPlanCardFeature} featureKey Key of the feature
  * @param {object?} options Options
+ * @param {string?} options.withoutDescription Whether to build the card with a description
+ * @param {string?} options.withoutIcon Whether to build the card with an icon
  * @returns {SelectorProductFeaturesItem} Feature item
  */
 export function buildCardFeatureItemFromFeatureKey(
@@ -364,7 +388,7 @@ export function buildCardFeatureItemFromFeatureKey(
  */
 export function buildCardFeaturesFromFeatureKeys(
 	features: JetpackPlanCardFeature[] | JetpackPlanCardFeatureSection,
-	options?: object
+	options?: Record< string, unknown >
 ): SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[] {
 	// Without sections (JetpackPlanCardFeature[])
 	if ( isArray( features ) ) {
@@ -403,8 +427,8 @@ export function buildCardFeaturesFromFeatureKeys(
  * @returns {SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[]} Features
  */
 export function buildCardFeaturesFromItem(
-	item: Plan | Product | object,
-	options?: object
+	item: Plan | Product | Record< string, unknown >,
+	options?: Record< string, unknown >
 ): SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[] {
 	if ( objectIsPlan( item ) ) {
 		const features = item.getPlanCardFeatures?.();
@@ -538,7 +562,7 @@ export function getPathToSelector(
 	urlQueryArgs: QueryArgs,
 	duration?: Duration,
 	siteSlug?: string
-) {
+): string {
 	const strDuration = duration ? durationToString( duration ) : null;
 	const path = [ rootUrl, strDuration, siteSlug ].filter( Boolean ).join( '/' );
 
@@ -563,7 +587,7 @@ export function getPathToDetails(
 	productSlug: string,
 	duration: Duration,
 	siteSlug?: string
-) {
+): string {
 	const strDuration = durationToString( duration );
 	const path = [ rootUrl, productSlug, strDuration, 'details', siteSlug ]
 		.filter( Boolean )
@@ -590,7 +614,7 @@ export function getPathToUpsell(
 	productSlug: string,
 	duration: Duration,
 	siteSlug?: string
-) {
+): string {
 	const strDuration = durationToString( duration );
 	const path = [ rootUrl, productSlug, strDuration, 'additions', siteSlug ]
 		.filter( Boolean )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce the new simplified version of the `JetpackProductCard` component.

#### Notes

There are still things to do, but I prefer to get this merged so others can start contributing as well. The things we are missing are:

* Make sure the copy is up-to-date.
* Use new icons for features.
* Make single product icons darker blue (`#2271B1`).

#### Caveats

* This PR doesn't deal with the layout of the page so don't expect to see the 3 columns yet. The size of the cards might be affected by this.
* We still have options cards instead of daily ones (you can navigate to the Options page) because this PR won't deal with that.
* Upsell are still in place. We will deal with them in another PR.

#### Testing instructions

* Run this PR locally (run both Calypsos).
* Replace line 17 of `client/my-sites/plans-v2/plans-column/index.tsx` with `import ProductCard from '../product-card-alt';`. We want to use the alternative version of the `ProductCard` component.
* Replace line 13 of `client/my-sites/plans-v2/products-column/index.tsx` with `import ProductCard from '../product-card-alt';`. We want to use the alternative version of the `ProductCard` component.
* Visit `http://jetpack.cloud.localhost:3001/pricing`.
* Make sure the product cards look as per design (remember there is still work to do).
* Visit `http://calypso.localhost:3000/plans/:site`.

**Take your time to verify that nothing from the previous version of the cards has been affected. Everything should work and look the same if you undo the changes made to the two files mentioned above.**

Fixes 1196341175636977-as-1198071178569629

#### Demo
##### cloud.jetpack.com/pricing
![image](https://user-images.githubusercontent.com/3418513/95603178-4e188280-0a2c-11eb-8216-8d12aab48a2f.png)

##### wordpress.com/plans
![image](https://user-images.githubusercontent.com/3418513/95603123-3b05b280-0a2c-11eb-8f84-264f40b8aa94.png)

##### wordpress.com/plans
![image](https://user-images.githubusercontent.com/3418513/95603058-26c1b580-0a2c-11eb-92ba-90c9afd40886.png)


