### PR TITLE
Checkout: Fix Safari processing animation

### DIFF
--- a/packages/composite-checkout/src/components/button.tsx
+++ b/packages/composite-checkout/src/components/button.tsx
@@ -98,7 +98,7 @@ const CallToAction = styled( 'button' )< CallToActionProps >`
 			${ getBackgroundAccentColor } 72%,
 			${ getBackgroundColor } 72%
 		);
-		background-size: 200px;
+		background-size: 200px 100%;
 		opacity: 1;
 	}
 

--- a/packages/composite-checkout/src/components/button.tsx
+++ b/packages/composite-checkout/src/components/button.tsx
@@ -10,50 +10,6 @@ import styled from '../lib/styled';
 import joinClasses from '../lib/join-classes';
 import { Theme } from '../lib/theme';
 
-type ButtonType = 'primary' | 'secondary' | 'text-button' | 'borderless' | 'paypal';
-
-const Button: React.FC< ButtonProps & React.ButtonHTMLAttributes< HTMLButtonElement > > = ( {
-	className,
-	buttonType,
-	isBusy,
-	children,
-	fullWidth,
-	...props
-} ) => {
-	const classNames = joinClasses( [
-		'checkout-button',
-		...( buttonType ? [ 'is-status-' + buttonType ] : [] ),
-		...( isBusy ? [ 'is-busy' ] : [] ),
-		...( className ? [ className ] : [] ),
-	] );
-
-	return (
-		<CallToAction
-			fullWidth={ fullWidth }
-			buttonType={ buttonType }
-			className={ classNames }
-			{ ...props }
-		>
-			{ children }
-		</CallToAction>
-	);
-};
-
-export default Button;
-
-export interface ButtonProps {
-	className?: string;
-	buttonType?: ButtonType;
-	isBusy?: boolean;
-	fullWidth?: boolean;
-}
-
-interface CallToActionProps {
-	fullWidth?: boolean;
-	buttonType?: ButtonType;
-	disabled?: boolean;
-}
-
 const CallToAction = styled( 'button' )< CallToActionProps >`
 	display: block;
 	width: ${ ( props: CallToActionProps ) => ( props.fullWidth ? '100%' : 'auto' ) };
@@ -108,6 +64,50 @@ const CallToAction = styled( 'button' )< CallToActionProps >`
 		}
 	}
 `;
+
+interface CallToActionProps {
+	fullWidth?: boolean;
+	buttonType?: ButtonType;
+	disabled?: boolean;
+}
+
+type ButtonType = 'primary' | 'secondary' | 'text-button' | 'borderless' | 'paypal';
+
+const Button: React.FC< ButtonProps & React.ButtonHTMLAttributes< HTMLButtonElement > > = ( {
+	className,
+	buttonType,
+	isBusy,
+	children,
+	fullWidth,
+	...props
+} ) => {
+	const classNames = joinClasses( [
+		'checkout-button',
+		...( buttonType ? [ 'is-status-' + buttonType ] : [] ),
+		...( isBusy ? [ 'is-busy' ] : [] ),
+		...( className ? [ className ] : [] ),
+	] );
+
+	return (
+		<CallToAction
+			fullWidth={ fullWidth }
+			buttonType={ buttonType }
+			className={ classNames }
+			{ ...props }
+		>
+			{ children }
+		</CallToAction>
+	);
+};
+
+export default Button;
+
+export interface ButtonProps {
+	className?: string;
+	buttonType?: ButtonType;
+	isBusy?: boolean;
+	fullWidth?: boolean;
+}
 
 function getImageFilter( { buttonType }: { buttonType?: ButtonType } ) {
 	return `grayscale( ${


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a visual bug with the processing animation in checkout.

**Before**
![image](https://user-images.githubusercontent.com/6981253/95604277-69cc5a80-0a25-11eb-8bae-94c4b7490d9d.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/95604319-73ee5900-0a25-11eb-856c-bfa169124b6a.png)

#### Testing instructions

* Visit checkout in Safari and any other browser you can test.
* Complete a purchase and make sure the animation doesn't have zig-zags.


