### PR TITLE
Integrate new backup cards in Backup section

### DIFF
--- a/client/components/activity-card/activity-actor.tsx
+++ b/client/components/activity-card/activity-actor.tsx
@@ -21,66 +21,70 @@ import { Activity } from 'calypso/state/activity-log/types';
 /**
  * Module constants
  */
-const JETPACK_ACTOR = (
-	<div className="activity-card__actor">
-		{ ! isEnabled( 'jetpack/backup-simplified-screens' ) && <JetpackLogo size={ 40 } /> }
-		<div className="activity-card__actor-info">
-			<div className="activity-card__actor-name">Jetpack</div>
-		</div>
-	</div>
-);
+export const SIZE_XS = 18;
+export const SIZE_S = 32;
+export const SIZE_M = 40;
 
-const HAPPINESS_ACTOR = (
-	<div className="activity-card__actor">
-		{ ! isEnabled( 'jetpack/backup-simplified-screens' ) && <JetpackLogo size={ 40 } /> }
-		<div className="activity-card__actor-info">
-			<div className="activity-card__actor-name">Happiness Engineer</div>
-		</div>
-	</div>
-);
-
-const WORDPRESS_ACTOR = (
-	<div className="activity-card__actor">
-		<SocialLogo icon="wordpress" size={ 40 } />
-		<div className="activity-card__actor-info">
-			<div className="activity-card__actor-name">WordPress</div>
-		</div>
-	</div>
-);
-
-const MULTIPLE_ACTORS = (
-	<div className="activity-card__actor">
-		<Gridicon icon="multiple-users" size={ 18 } />
-		<div className="activity-card__actor-info">
-			<div className="activity-card__actor-name">{ translate( 'Multiple users' ) }</div>
-		</div>
-	</div>
-);
-
-type Props = Partial< Activity >;
+type Props = Partial< Activity > & {
+	size?: typeof SIZE_XS | typeof SIZE_S | typeof SIZE_M;
+};
 
 const ActivityActor: FunctionComponent< Props > = ( {
 	actorAvatarUrl,
 	actorName,
 	actorRole,
 	actorType,
+	size = SIZE_M,
 } ) => {
 	if ( actorName === 'WordPress' && actorType === 'Application' ) {
-		return WORDPRESS_ACTOR;
+		return (
+			<div className="activity-card__actor">
+				<SocialLogo icon="wordpress" size={ size } />
+				<div className="activity-card__actor-info">
+					<div className="activity-card__actor-name">WordPress</div>
+				</div>
+			</div>
+		);
 	}
+
 	if ( actorName === 'Jetpack' && actorType === 'Application' ) {
-		return JETPACK_ACTOR;
+		return (
+			<div className="activity-card__actor">
+				{ ( ! isEnabled( 'jetpack/backup-simplified-screens' ) ||
+					isEnabled( 'jetpack/backup-simplified-screens-i4' ) ) && <JetpackLogo size={ size } /> }
+				<div className="activity-card__actor-info">
+					<div className="activity-card__actor-name">Jetpack</div>
+				</div>
+			</div>
+		);
 	}
+
 	if ( actorName === 'Happiness Engineer' && actorType === 'Happiness Engineer' ) {
-		return HAPPINESS_ACTOR;
+		return (
+			<div className="activity-card__actor">
+				{ ( ! isEnabled( 'jetpack/backup-simplified-screens' ) ||
+					isEnabled( 'jetpack/backup-simplified-screens-i4' ) ) && <JetpackLogo size={ size } /> }
+				<div className="activity-card__actor-info">
+					<div className="activity-card__actor-name">Happiness Engineer</div>
+				</div>
+			</div>
+		);
 	}
+
 	if ( actorType === 'Multiple' ) {
-		return MULTIPLE_ACTORS;
+		return (
+			<div className="activity-card__actor">
+				<Gridicon icon="multiple-users" size={ SIZE_XS } />
+				<div className="activity-card__actor-info">
+					<div className="activity-card__actor-name">{ translate( 'Multiple users' ) }</div>
+				</div>
+			</div>
+		);
 	}
 
 	return (
 		<div className="activity-card__actor">
-			<Gravatar user={ { avatar_URL: actorAvatarUrl } } size={ 40 } />
+			<Gravatar user={ { avatar_URL: actorAvatarUrl } } size={ size } />
 			<div className="activity-card__actor-info">
 				<div className="activity-card__actor-name">{ actorName }</div>
 				{ actorRole && <div className="activity-card__actor-role">{ actorRole }</div> }

--- a/client/components/activity-card/activity-actor.tsx
+++ b/client/components/activity-card/activity-actor.tsx
@@ -27,6 +27,7 @@ export const SIZE_M = 40;
 
 type Props = Partial< Activity > & {
 	size?: typeof SIZE_XS | typeof SIZE_S | typeof SIZE_M;
+	withoutInfo?: boolean;
 };
 
 const ActivityActor: FunctionComponent< Props > = ( {
@@ -34,15 +35,18 @@ const ActivityActor: FunctionComponent< Props > = ( {
 	actorName,
 	actorRole,
 	actorType,
+	withoutInfo,
 	size = SIZE_M,
 } ) => {
 	if ( actorName === 'WordPress' && actorType === 'Application' ) {
 		return (
 			<div className="activity-card__actor">
 				<SocialLogo icon="wordpress" size={ size } />
-				<div className="activity-card__actor-info">
-					<div className="activity-card__actor-name">WordPress</div>
-				</div>
+				{ ! withoutInfo && (
+					<div className="activity-card__actor-info">
+						<div className="activity-card__actor-name">WordPress</div>
+					</div>
+				) }
 			</div>
 		);
 	}
@@ -52,9 +56,11 @@ const ActivityActor: FunctionComponent< Props > = ( {
 			<div className="activity-card__actor">
 				{ ( ! isEnabled( 'jetpack/backup-simplified-screens' ) ||
 					isEnabled( 'jetpack/backup-simplified-screens-i4' ) ) && <JetpackLogo size={ size } /> }
-				<div className="activity-card__actor-info">
-					<div className="activity-card__actor-name">Jetpack</div>
-				</div>
+				{ ! withoutInfo && (
+					<div className="activity-card__actor-info">
+						<div className="activity-card__actor-name">Jetpack</div>
+					</div>
+				) }
 			</div>
 		);
 	}
@@ -64,9 +70,11 @@ const ActivityActor: FunctionComponent< Props > = ( {
 			<div className="activity-card__actor">
 				{ ( ! isEnabled( 'jetpack/backup-simplified-screens' ) ||
 					isEnabled( 'jetpack/backup-simplified-screens-i4' ) ) && <JetpackLogo size={ size } /> }
-				<div className="activity-card__actor-info">
-					<div className="activity-card__actor-name">Happiness Engineer</div>
-				</div>
+				{ ! withoutInfo && (
+					<div className="activity-card__actor-info">
+						<div className="activity-card__actor-name">Happiness Engineer</div>
+					</div>
+				) }
 			</div>
 		);
 	}
@@ -75,20 +83,24 @@ const ActivityActor: FunctionComponent< Props > = ( {
 		return (
 			<div className="activity-card__actor">
 				<Gridicon icon="multiple-users" size={ SIZE_XS } />
-				<div className="activity-card__actor-info">
-					<div className="activity-card__actor-name">{ translate( 'Multiple users' ) }</div>
-				</div>
+				{ ! withoutInfo && (
+					<div className="activity-card__actor-info">
+						<div className="activity-card__actor-name">{ translate( 'Multiple users' ) }</div>
+					</div>
+				) }
 			</div>
 		);
 	}
 
 	return (
 		<div className="activity-card__actor">
-			<Gravatar user={ { avatar_URL: actorAvatarUrl } } size={ size } />
-			<div className="activity-card__actor-info">
-				<div className="activity-card__actor-name">{ actorName }</div>
-				{ actorRole && <div className="activity-card__actor-role">{ actorRole }</div> }
-			</div>
+			<Gravatar user={ { avatar_URL: actorAvatarUrl, display_name: actorName } } size={ size } />
+			{ ! withoutInfo && (
+				<div className="activity-card__actor-info">
+					<div className="activity-card__actor-name">{ actorName }</div>
+					{ actorRole && <div className="activity-card__actor-role">{ actorRole }</div> }
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/components/activity-card/activity-actor.tsx
+++ b/client/components/activity-card/activity-actor.tsx
@@ -14,6 +14,11 @@ import JetpackLogo from 'calypso/components/jetpack-logo';
 import SocialLogo from 'calypso/components/social-logo';
 
 /**
+ * Type dependencies
+ */
+import { Activity } from 'calypso/state/activity-log/types';
+
+/**
  * Module constants
  */
 const JETPACK_ACTOR = (
@@ -52,12 +57,7 @@ const MULTIPLE_ACTORS = (
 	</div>
 );
 
-interface Props {
-	actorAvatarUrl?: string;
-	actorName?: string;
-	actorRole?: string;
-	actorType?: string;
-}
+type Props = Partial< Activity >;
 
 const ActivityActor: FunctionComponent< Props > = ( {
 	actorAvatarUrl,

--- a/client/components/activity-card/activity-description.tsx
+++ b/client/components/activity-card/activity-description.tsx
@@ -8,18 +8,10 @@ import React, { FunctionComponent } from 'react';
  */
 import FormattedBlock from 'calypso/components/notes-formatted-block';
 
-// FUTURE WORK: move this to a shared location
-interface Activity {
-	activityDescription: [
-		{
-			intent?: string;
-			section?: string;
-			type?: string;
-			url?: string;
-		}
-	];
-	activityName: string;
-}
+/**
+ * Type dependencies
+ */
+import { Activity } from 'calypso/state/activity-log/types';
 
 interface Props {
 	activity: Activity;

--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -22,11 +22,6 @@
 				margin-right: 8px;
 			}
 		}
-		> img.gravatar,
-		> svg {
-			max-height: 24px;
-			max-width: 24px;
-		}
 	}
 
 	.activity-card__actor-info,

--- a/client/components/jetpack-logo/index.jsx
+++ b/client/components/jetpack-logo/index.jsx
@@ -86,6 +86,7 @@ JetpackLogo.propTypes = {
 	full: PropTypes.bool,
 	monochrome: PropTypes.bool,
 	size: PropTypes.number,
+	className: PropTypes.string,
 };
 
 export default JetpackLogo;

--- a/client/components/jetpack/backup-card/index.tsx
+++ b/client/components/jetpack/backup-card/index.tsx
@@ -17,7 +17,6 @@ import ActivityMedia from 'calypso/components/activity-card/activity-media';
 import Badge from 'calypso/components/badge';
 import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { useApplySiteOffset } from 'calypso/components/site-offset';
 import Tooltip from 'calypso/components/tooltip';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
@@ -32,14 +31,13 @@ import cloudIcon from 'calypso/components/jetpack/daily-backup-status/status-car
 /**
  * Type dependencies
  */
-import { Activity } from 'calypso/state/activity-log/types';
+import type { Activity } from 'calypso/state/activity-log/types';
 
-type Props = { activity: Activity; subActivities: Activity[]; isLatest: boolean };
+type Props = { activity: Activity; subActivities?: Activity[]; isLatest: boolean };
 
 const BackupCard: FunctionComponent< Props > = ( { activity, subActivities, isLatest } ) => {
 	const translate = useTranslate();
 	const getDisplayDate = useGetDisplayDate();
-	const applySiteOffset = useApplySiteOffset();
 	const moment = useLocalizedMoment();
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -58,9 +56,6 @@ const BackupCard: FunctionComponent< Props > = ( { activity, subActivities, isLa
 	] );
 
 	const { activityTs, activityTitle, rewindId } = activity;
-	const dateMoment = applySiteOffset ? applySiteOffset( activityTs ) : moment( activityTs );
-	const dateTime = dateMoment.format();
-	const displayDate = getDisplayDate( activityTs, false );
 
 	return (
 		<Card
@@ -72,7 +67,9 @@ const BackupCard: FunctionComponent< Props > = ( { activity, subActivities, isLa
 				<div className="backup-card__header">
 					<div className="backup-card__header-text">
 						<h2 className="backup-card__date">
-							<time dateTime={ dateTime }>{ displayDate }</time>
+							<time dateTime={ moment( activityTs ).format() }>
+								{ getDisplayDate( activityTs, false ) }
+							</time>
 						</h2>
 						<p className="backup-card__title">
 							<img className="backup-card__icon" src={ cloudIcon } alt="" />
@@ -131,31 +128,33 @@ const BackupCard: FunctionComponent< Props > = ( { activity, subActivities, isLa
 				<h3 className="backup-card__about-heading">{ translate( 'About this backup' ) }</h3>
 				<div className="backup-card__about-content">
 					<ul className="backup-card__about-list">
-						{ ( subActivities?.length > 0 ? subActivities : [ activity ] ).map( ( item ) => (
-							<li key={ item.activityId }>
-								<div className="backup-card__about-media">
-									<ActivityActor
-										actorAvatarUrl={ item.actorAvatarUrl }
-										actorName={ item.actorName }
-										actorRole={ item.actorRole }
-										actorType={ item.actorType }
-										size={ SIZE_S }
-										withoutInfo
-									/>
-								</div>
-								<div className="backup-card__about-body">
-									{ item.activityMedia?.available && (
-										<ActivityMedia
-											name={ item.activityMedia?.name }
-											thumbnail={
-												item.activityMedia?.medium_url || item.activityMedia?.thumbnail_url
-											}
+						{ ( subActivities && subActivities?.length > 0 ? subActivities : [ activity ] ).map(
+							( item ) => (
+								<li key={ item.activityId }>
+									<div className="backup-card__about-media">
+										<ActivityActor
+											actorAvatarUrl={ item.actorAvatarUrl }
+											actorName={ item.actorName }
+											actorRole={ item.actorRole }
+											actorType={ item.actorType }
+											size={ SIZE_S }
+											withoutInfo
 										/>
-									) }
-									<ActivityDescription activity={ item } />
-								</div>
-							</li>
-						) ) }
+									</div>
+									<div className="backup-card__about-body">
+										{ item.activityMedia?.available && (
+											<ActivityMedia
+												name={ item.activityMedia?.name }
+												thumbnail={
+													item.activityMedia?.medium_url || item.activityMedia?.thumbnail_url
+												}
+											/>
+										) }
+										<ActivityDescription activity={ item } />
+									</div>
+								</li>
+							)
+						) }
 					</ul>
 				</div>
 			</div>

--- a/client/components/jetpack/backup-card/index.tsx
+++ b/client/components/jetpack/backup-card/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import React, { useRef, FunctionComponent, useState, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -13,6 +14,7 @@ import { useTranslate } from 'i18n-calypso';
 import ActivityActor, { SIZE_S } from 'calypso/components/activity-card/activity-actor';
 import ActivityDescription from 'calypso/components/activity-card/activity-description';
 import ActivityMedia from 'calypso/components/activity-card/activity-media';
+import Badge from 'calypso/components/badge';
 import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useApplySiteOffset } from 'calypso/components/site-offset';
@@ -32,9 +34,9 @@ import cloudIcon from 'calypso/components/jetpack/daily-backup-status/status-car
  */
 import { Activity } from 'calypso/state/activity-log/types';
 
-type Props = { activity: Activity };
+type Props = { activity: Activity; isLatest: boolean };
 
-const BackupCard: FunctionComponent< Props > = ( { activity } ) => {
+const BackupCard: FunctionComponent< Props > = ( { activity, isLatest } ) => {
 	const translate = useTranslate();
 	const getDisplayDate = useGetDisplayDate();
 	const applySiteOffset = useApplySiteOffset();
@@ -70,15 +72,28 @@ const BackupCard: FunctionComponent< Props > = ( { activity } ) => {
 	const displayDate = getDisplayDate( activityTs, false );
 
 	return (
-		<Card>
+		<Card
+			className={ classNames( 'backup-card', {
+				'is-latest': isLatest,
+			} ) }
+		>
 			<div className="backup-card__main">
-				<h2 className="backup-card__date">
-					<time dateTime={ dateTime }>{ displayDate }</time>
-				</h2>
-				<p className="backup-card__title">
-					<img className="backup-card__icon" src={ cloudIcon } alt="" />
-					{ activityTitle }
-				</p>
+				<div className="backup-card__header">
+					<div className="backup-card__header-text">
+						<h2 className="backup-card__date">
+							<time dateTime={ dateTime }>{ displayDate }</time>
+						</h2>
+						<p className="backup-card__title">
+							<img className="backup-card__icon" src={ cloudIcon } alt="" />
+							{ activityTitle }
+						</p>
+					</div>
+					{ isLatest && (
+						<Badge className="backup-card__badge" type="success">
+							{ translate( 'Latest backup' ) }
+						</Badge>
+					) }
+				</div>
 				{ rewindId && (
 					<ul className="backup-card__actions">
 						<li>

--- a/client/components/jetpack/backup-card/index.tsx
+++ b/client/components/jetpack/backup-card/index.tsx
@@ -34,9 +34,9 @@ import cloudIcon from 'calypso/components/jetpack/daily-backup-status/status-car
  */
 import { Activity } from 'calypso/state/activity-log/types';
 
-type Props = { activity: Activity; isLatest: boolean };
+type Props = { activity: Activity; subActivities: Activity[]; isLatest: boolean };
 
-const BackupCard: FunctionComponent< Props > = ( { activity, isLatest } ) => {
+const BackupCard: FunctionComponent< Props > = ( { activity, subActivities, isLatest } ) => {
 	const translate = useTranslate();
 	const getDisplayDate = useGetDisplayDate();
 	const applySiteOffset = useApplySiteOffset();
@@ -57,16 +57,7 @@ const BackupCard: FunctionComponent< Props > = ( { activity, isLatest } ) => {
 		setTooltipVisibility,
 	] );
 
-	const {
-		activityTs,
-		activityTitle,
-		actorAvatarUrl,
-		actorName,
-		actorRole,
-		actorType,
-		activityMedia,
-		rewindId,
-	} = activity;
+	const { activityTs, activityTitle, rewindId } = activity;
 	const dateMoment = applySiteOffset ? applySiteOffset( activityTs ) : moment( activityTs );
 	const dateTime = dateMoment.format();
 	const displayDate = getDisplayDate( activityTs, false );
@@ -139,25 +130,33 @@ const BackupCard: FunctionComponent< Props > = ( { activity, isLatest } ) => {
 			<div className="backup-card__about">
 				<h3 className="backup-card__about-heading">{ translate( 'About this backup' ) }</h3>
 				<div className="backup-card__about-content">
-					<div className="backup-card__about-media">
-						<ActivityActor
-							actorAvatarUrl={ actorAvatarUrl }
-							actorName={ actorName }
-							actorRole={ actorRole }
-							actorType={ actorType }
-							size={ SIZE_S }
-							withoutInfo
-						/>
-					</div>
-					<div className="backup-card__about-body">
-						{ activityMedia?.available && (
-							<ActivityMedia
-								name={ activityMedia?.name }
-								thumbnail={ activityMedia?.medium_url || activityMedia?.thumbnail_url }
-							/>
-						) }
-						<ActivityDescription activity={ activity } />
-					</div>
+					<ul className="backup-card__about-list">
+						{ ( subActivities?.length > 0 ? subActivities : [ activity ] ).map( ( item ) => (
+							<li key={ item.activityId }>
+								<div className="backup-card__about-media">
+									<ActivityActor
+										actorAvatarUrl={ item.actorAvatarUrl }
+										actorName={ item.actorName }
+										actorRole={ item.actorRole }
+										actorType={ item.actorType }
+										size={ SIZE_S }
+										withoutInfo
+									/>
+								</div>
+								<div className="backup-card__about-body">
+									{ item.activityMedia?.available && (
+										<ActivityMedia
+											name={ item.activityMedia?.name }
+											thumbnail={
+												item.activityMedia?.medium_url || item.activityMedia?.thumbnail_url
+											}
+										/>
+									) }
+									<ActivityDescription activity={ item } />
+								</div>
+							</li>
+						) ) }
+					</ul>
 				</div>
 			</div>
 		</Card>

--- a/client/components/jetpack/backup-card/index.tsx
+++ b/client/components/jetpack/backup-card/index.tsx
@@ -1,0 +1,152 @@
+/**
+ * External dependencies
+ */
+import React, { useRef, FunctionComponent, useState, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import ActivityActor, { SIZE_S } from 'calypso/components/activity-card/activity-actor';
+import ActivityDescription from 'calypso/components/activity-card/activity-description';
+import ActivityMedia from 'calypso/components/activity-card/activity-media';
+import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useApplySiteOffset } from 'calypso/components/site-offset';
+import Tooltip from 'calypso/components/tooltip';
+import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
+import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+import cloudIcon from 'calypso/components/jetpack/daily-backup-status/status-card/icons/cloud-success.svg';
+
+/**
+ * Type dependencies
+ */
+import { Activity } from 'calypso/state/activity-log/types';
+
+type Props = { activity: Activity };
+
+const BackupCard: FunctionComponent< Props > = ( { activity } ) => {
+	const translate = useTranslate();
+	const getDisplayDate = useGetDisplayDate();
+	const applySiteOffset = useApplySiteOffset();
+	const moment = useLocalizedMoment();
+
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const hasCredentials = useSelector(
+		( state ) => ! getDoesRewindNeedCredentials( state, siteId )
+	);
+
+	const restoreRef = useRef( null );
+	const [ isTooltipVisible, setTooltipVisibility ] = useState( false );
+	const onRestoreButtonEnter = useCallback( () => setTooltipVisibility( true ), [
+		setTooltipVisibility,
+	] );
+	const onRestoreButtonLeave = useCallback( () => setTooltipVisibility( false ), [
+		setTooltipVisibility,
+	] );
+
+	const {
+		activityTs,
+		activityTitle,
+		actorAvatarUrl,
+		actorName,
+		actorRole,
+		actorType,
+		activityMedia,
+		rewindId,
+	} = activity;
+	const dateMoment = applySiteOffset ? applySiteOffset( activityTs ) : moment( activityTs );
+	const dateTime = dateMoment.format();
+	const displayDate = getDisplayDate( activityTs, false );
+
+	return (
+		<Card>
+			<div className="backup-card__main">
+				<h2 className="backup-card__date">
+					<time dateTime={ dateTime }>{ displayDate }</time>
+				</h2>
+				<p className="backup-card__title">
+					<img className="backup-card__icon" src={ cloudIcon } alt="" />
+					{ activityTitle }
+				</p>
+				{ rewindId && (
+					<ul className="backup-card__actions">
+						<li>
+							<Button
+								className="backup-card__restore-button"
+								href={ backupRestorePath( siteSlug, rewindId ) }
+								disabled={ ! hasCredentials }
+								primary={ hasCredentials }
+							>
+								{ translate( 'Restore to this point' ) }
+							</Button>
+							{ ! hasCredentials && (
+								<span
+									className="backup-card__restore-area"
+									onMouseEnter={ onRestoreButtonEnter }
+									onMouseLeave={ onRestoreButtonLeave }
+									ref={ restoreRef }
+								></span>
+							) }
+							{ restoreRef.current && (
+								<Tooltip
+									className="backup-card__restore-tooltip"
+									context={ restoreRef.current }
+									isVisible={ isTooltipVisible }
+									showOnMobile
+								>
+									{ translate( 'Add your server credentials to enable one-click restores.' ) }
+								</Tooltip>
+							) }
+						</li>
+						<li>
+							<Button
+								className="backup-card__download-button"
+								href={ backupDownloadPath( siteSlug, rewindId ) }
+								primary={ ! hasCredentials }
+							>
+								{ translate( 'Download backup' ) }
+							</Button>
+						</li>
+					</ul>
+				) }
+			</div>
+			<div className="backup-card__about">
+				<h3 className="backup-card__about-heading">{ translate( 'About this backup' ) }</h3>
+				<div className="backup-card__about-content">
+					<div className="backup-card__about-media">
+						<ActivityActor
+							actorAvatarUrl={ actorAvatarUrl }
+							actorName={ actorName }
+							actorRole={ actorRole }
+							actorType={ actorType }
+							size={ SIZE_S }
+							withoutInfo
+						/>
+					</div>
+					<div className="backup-card__about-body">
+						{ activityMedia?.available && (
+							<ActivityMedia
+								name={ activityMedia?.name }
+								thumbnail={ activityMedia?.medium_url || activityMedia?.thumbnail_url }
+							/>
+						) }
+						<ActivityDescription activity={ activity } />
+					</div>
+				</div>
+			</div>
+		</Card>
+	);
+};
+
+export default BackupCard;

--- a/client/components/jetpack/backup-card/index.tsx
+++ b/client/components/jetpack/backup-card/index.tsx
@@ -35,9 +35,19 @@ import cloudIcon from 'calypso/components/jetpack/daily-backup-status/status-car
  */
 import type { Activity } from 'calypso/state/activity-log/types';
 
-type Props = { activity: Activity; subActivities?: Activity[]; isLatest: boolean };
+type Props = {
+	activity: Activity;
+	subActivities?: Activity[];
+	isLatest: boolean;
+	isFeatured: boolean;
+};
 
-const BackupCard: FunctionComponent< Props > = ( { activity, subActivities, isLatest } ) => {
+const BackupCard: FunctionComponent< Props > = ( {
+	activity,
+	subActivities,
+	isLatest,
+	isFeatured,
+} ) => {
 	const { activityTs, activityTitle, rewindId } = activity;
 
 	const translate = useTranslate();
@@ -68,7 +78,7 @@ const BackupCard: FunctionComponent< Props > = ( { activity, subActivities, isLa
 	return (
 		<Card
 			className={ classNames( 'backup-card', {
-				'is-latest': isLatest,
+				'is-featured': isFeatured,
 			} ) }
 		>
 			<div className="backup-card__main">

--- a/client/components/jetpack/backup-card/index.tsx
+++ b/client/components/jetpack/backup-card/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
+import { noop } from 'lodash';
 import React, { useRef, FunctionComponent, useState, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -18,6 +19,7 @@ import Badge from 'calypso/components/badge';
 import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Tooltip from 'calypso/components/tooltip';
+import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -36,6 +38,8 @@ import type { Activity } from 'calypso/state/activity-log/types';
 type Props = { activity: Activity; subActivities?: Activity[]; isLatest: boolean };
 
 const BackupCard: FunctionComponent< Props > = ( { activity, subActivities, isLatest } ) => {
+	const { activityTs, activityTitle, rewindId } = activity;
+
 	const translate = useTranslate();
 	const getDisplayDate = useGetDisplayDate();
 	const moment = useLocalizedMoment();
@@ -54,8 +58,12 @@ const BackupCard: FunctionComponent< Props > = ( { activity, subActivities, isLa
 	const onRestoreButtonLeave = useCallback( () => setTooltipVisibility( false ), [
 		setTooltipVisibility,
 	] );
-
-	const { activityTs, activityTitle, rewindId } = activity;
+	const onDownloadClick = useTrackCallback( noop, 'calypso_jetpack_backup_download', {
+		rewind_id: rewindId,
+	} );
+	const onRestoreClick = useTrackCallback( noop, 'calypso_jetpack_backup_restore', {
+		rewind_id: rewindId,
+	} );
 
 	return (
 		<Card
@@ -90,6 +98,7 @@ const BackupCard: FunctionComponent< Props > = ( { activity, subActivities, isLa
 								href={ backupRestorePath( siteSlug, rewindId ) }
 								disabled={ ! hasCredentials }
 								primary={ hasCredentials }
+								onClick={ onRestoreClick }
 							>
 								{ translate( 'Restore to this point' ) }
 							</Button>
@@ -117,6 +126,7 @@ const BackupCard: FunctionComponent< Props > = ( { activity, subActivities, isLa
 								className="backup-card__download-button"
 								href={ backupDownloadPath( siteSlug, rewindId ) }
 								primary={ ! hasCredentials }
+								onClick={ onDownloadClick }
 							>
 								{ translate( 'Download backup' ) }
 							</Button>

--- a/client/components/jetpack/backup-card/style.scss
+++ b/client/components/jetpack/backup-card/style.scss
@@ -112,13 +112,24 @@ $cloud-icon-height: 24px;
 }
 
 .backup-card__about-content {
-	display: flex;
-	align-items: center;
-
 	padding: 20px;
 
 	background-color: var( --color-neutral-0 );
 	color: var( --color-neutral-40 );
+}
+
+.backup-card__about-list {
+	margin: -16px 0;
+	padding: 0;
+
+	list-style-type: none;
+
+	> li {
+		display: flex;
+		align-items: flex-start;
+
+		margin: 16px 0;
+	}
 }
 
 .backup-card__about-media {
@@ -129,5 +140,15 @@ $cloud-icon-height: 24px;
 		// Prevent container from being larger than image
 		// Ref. https://stackoverflow.com/questions/11126685/why-does-container-div-insist-on-being-slightly-larger-than-img-or-svg-content
 		display: block;
+	}
+}
+
+.backup-card__about-body {
+	flex: 1;
+	align-self: center;
+
+	.activity-card__activity-media {
+		max-width: 250px;
+		margin-bottom: 4px;
 	}
 }

--- a/client/components/jetpack/backup-card/style.scss
+++ b/client/components/jetpack/backup-card/style.scss
@@ -1,0 +1,108 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
+/* Headings */
+
+$cloud-icon-height: 24px;
+
+.backup-card__date {
+	font-size: 1.25rem;
+	font-weight: 700;
+}
+
+.backup-card__title {
+	display: flex;
+	justify-items: center;
+
+	margin-bottom: 36px;
+
+	color: var( --studio-jetpack-green-50 );
+
+	font-weight: 700;
+	line-height: $cloud-icon-height;
+}
+
+.backup-card__icon {
+	margin-right: 6px;
+	height: $cloud-icon-height;
+}
+
+/* Actions */
+
+.backup-card__actions {
+	display: flex;
+	flex-wrap: wrap;
+
+	margin: 0 0 32px;
+	padding: 0;
+
+	list-style-type: none;
+
+	> li {
+		position: relative;
+
+		margin-right: 24px;
+
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+}
+
+.backup-card__restore-area {
+	position: absolute;
+	top: 0;
+	left: 0;
+
+	width: 100%;
+	height: 100%;
+}
+
+.backup-card__restore-tooltip {
+	max-width: 174px;
+
+	&.tooltip.popover .popover__inner {
+		text-align: center;
+	}
+}
+
+/* About section */
+
+.backup-card__about {
+	// Necessary so that the border takes the full width of the card
+	margin: 0 -16px -16px;
+	padding: 24px;
+
+	border-top: solid 1px var( --color-neutral-5 );
+
+	@include break-mobile {
+		margin: 0 -24px -24px;
+	}
+}
+
+.backup-card__about-heading {
+	margin-bottom: 16px;
+
+	font-weight: 700;
+}
+
+.backup-card__about-content {
+	display: flex;
+	align-items: center;
+
+	padding: 20px;
+
+	background-color: var( --color-neutral-0 );
+	color: var( --color-neutral-40 );
+}
+
+.backup-card__about-media {
+	margin-right: 16px;
+
+	img,
+	svg {
+		// Prevent container from being larger than image
+		// Ref. https://stackoverflow.com/questions/11126685/why-does-container-div-insist-on-being-slightly-larger-than-img-or-svg-content
+		display: block;
+	}
+}

--- a/client/components/jetpack/backup-card/style.scss
+++ b/client/components/jetpack/backup-card/style.scss
@@ -1,13 +1,21 @@
 @import '~@wordpress/base-styles/breakpoints';
 @import '~@wordpress/base-styles/mixins';
 
-/* Headings */
+/* Header */
 
 $cloud-icon-height: 24px;
 
+.backup-card__header {
+	position: relative;
+}
+
 .backup-card__date {
 	font-size: 1.25rem;
-	font-weight: 700;
+	font-weight: 600;
+
+	.is-latest & {
+		font-size: 2.25rem;
+	}
 }
 
 .backup-card__title {
@@ -20,11 +28,28 @@ $cloud-icon-height: 24px;
 
 	font-weight: 700;
 	line-height: $cloud-icon-height;
+
+	.is-latest & {
+		margin-bottom: 100px;
+	}
 }
 
 .backup-card__icon {
 	margin-right: 6px;
 	height: $cloud-icon-height;
+}
+
+.backup-card__badge {
+	position: absolute;
+	top: 0;
+	right: 0;
+
+	&.badge {
+		background-color: var( --studio-jetpack-green-5 );
+		color: var( --color-text );
+
+		font-size: 0.75rem;
+	}
 }
 
 /* Actions */

--- a/client/components/jetpack/backup-card/style.scss
+++ b/client/components/jetpack/backup-card/style.scss
@@ -20,7 +20,7 @@ $cloud-icon-height: 24px;
 	font-weight: 600;
 	line-height: 1;
 
-	.is-latest & {
+	.is-featured & {
 		font-size: 2.25rem;
 	}
 }
@@ -36,7 +36,7 @@ $cloud-icon-height: 24px;
 	font-weight: 700;
 	line-height: $cloud-icon-height;
 
-	.is-latest & {
+	.is-featured & {
 		margin-bottom: 100px;
 	}
 }

--- a/client/components/jetpack/backup-card/style.scss
+++ b/client/components/jetpack/backup-card/style.scss
@@ -6,12 +6,19 @@
 $cloud-icon-height: 24px;
 
 .backup-card__header {
-	position: relative;
+	display: flex;
+}
+
+.backup-card__header-text {
+	flex: 1;
 }
 
 .backup-card__date {
+	margin-bottom: 8px;
+
 	font-size: 1.25rem;
 	font-weight: 600;
+	line-height: 1;
 
 	.is-latest & {
 		font-size: 2.25rem;
@@ -40,9 +47,7 @@ $cloud-icon-height: 24px;
 }
 
 .backup-card__badge {
-	position: absolute;
-	top: 0;
-	right: 0;
+	margin-left: 1rem;
 
 	&.badge {
 		background-color: var( --studio-jetpack-green-5 );

--- a/client/components/jetpack/daily-backup-status/index-alternate.tsx
+++ b/client/components/jetpack/daily-backup-status/index-alternate.tsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
+import { isArray } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import BackupFailed from './status-card/backup-failed';
+import NoBackupsOnSelectedDate from './status-card/no-backups-on-selected-date';
+import BackupScheduled from './status-card/backup-scheduled';
+import NoBackupsYet from './status-card/no-backups-yet';
+import BackupCard from 'calypso/components/jetpack/backup-card';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import {
+	isSuccessfulDailyBackup,
+	isSuccessfulRealtimeBackup,
+} from 'calypso/lib/jetpack/backup-utils';
+import { applySiteOffset } from 'calypso/lib/site/timezone';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
+ * Type dependencies
+ */
+import type { Moment } from 'moment';
+import type { Activity } from 'calypso/state/activity-log/types';
+
+type Props = {
+	selectedDate: Moment;
+	lastBackupDate?: Moment;
+	backup: Activity;
+	dailyDeltas?: Activity[];
+};
+
+const DailyBackupStatusAlternate: FunctionComponent< Props > = ( {
+	selectedDate,
+	lastBackupDate,
+	backup,
+	dailyDeltas,
+} ) => {
+	const moment = useLocalizedMoment();
+
+	const siteId = useSelector( getSelectedSiteId );
+	const capabilities = useSelector( ( state ) =>
+		siteId ? getRewindCapabilities( state, siteId ) : null
+	);
+	const timezone = useSelector( ( state ) =>
+		siteId ? getSiteTimezoneValue( state, siteId ) : null
+	);
+	const gmtOffset = useSelector( ( state ) =>
+		siteId ? getSiteGmtOffset( state, siteId ) : null
+	);
+
+	if ( backup ) {
+		const isSuccessful =
+			isArray( capabilities ) && capabilities.includes( 'backup-realtime' )
+				? isSuccessfulRealtimeBackup
+				: isSuccessfulDailyBackup;
+
+		return isSuccessful( backup ) ? (
+			<BackupCard activity={ backup } subActivities={ dailyDeltas } isLatest />
+		) : (
+			<BackupFailed backup={ backup } />
+		);
+	}
+
+	if ( lastBackupDate ) {
+		const today = applySiteOffset( moment(), {
+			timezone: timezone,
+			gmtOffset: gmtOffset,
+		} );
+
+		return selectedDate.isSame( today, 'day' ) ? (
+			<BackupScheduled lastBackupDate={ lastBackupDate } />
+		) : (
+			<NoBackupsOnSelectedDate selectedDate={ selectedDate } />
+		);
+	}
+
+	return <NoBackupsYet />;
+};
+
+export default DailyBackupStatusAlternate;

--- a/client/components/jetpack/daily-backup-status/index-alternate.tsx
+++ b/client/components/jetpack/daily-backup-status/index-alternate.tsx
@@ -39,6 +39,7 @@ type Props = {
 	selectedDate: Moment;
 	lastBackupDate?: Moment;
 	backup: Activity;
+	isLatestBackup?: boolean;
 	dailyDeltas?: Activity[];
 };
 
@@ -46,6 +47,7 @@ const DailyBackupStatusAlternate: FunctionComponent< Props > = ( {
 	selectedDate,
 	lastBackupDate,
 	backup,
+	isLatestBackup,
 	dailyDeltas,
 } ) => {
 	const moment = useLocalizedMoment();
@@ -68,7 +70,11 @@ const DailyBackupStatusAlternate: FunctionComponent< Props > = ( {
 				: isSuccessfulDailyBackup;
 
 		return isSuccessful( backup ) ? (
-			<BackupCard activity={ backup } subActivities={ dailyDeltas } isLatest />
+			<BackupCard
+				activity={ backup }
+				subActivities={ dailyDeltas }
+				isLatest={ !! isLatestBackup }
+			/>
 		) : (
 			<BackupFailed backup={ backup } />
 		);

--- a/client/components/jetpack/daily-backup-status/index-alternate.tsx
+++ b/client/components/jetpack/daily-backup-status/index-alternate.tsx
@@ -74,6 +74,7 @@ const DailyBackupStatusAlternate: FunctionComponent< Props > = ( {
 				activity={ backup }
 				subActivities={ dailyDeltas }
 				isLatest={ !! isLatestBackup }
+				isFeatured
 			/>
 		) : (
 			<BackupFailed backup={ backup } />

--- a/client/lib/jetpack/backup-utils.js
+++ b/client/lib/jetpack/backup-utils.js
@@ -129,6 +129,25 @@ export const getDailyBackupDeltas = ( logs, date ) => {
 	};
 };
 
+export const getRawDailyBackupDeltas = ( logs, date ) => {
+	return getEventsInDailyBackup( logs, date ).filter( ( { activityName } ) =>
+		[
+			'attachment__uploaded',
+			// 'attachment__updated',
+			'attachment__deleted',
+			'post__published',
+			'post__trashed',
+			'post__published',
+			// 'post__updated',
+			'post__trashed',
+			'plugin__installed',
+			'plugin__deleted',
+			'theme__installed',
+			'theme__deleted',
+		].includes( activityName )
+	);
+};
+
 /**
  * Check if the activity is the type of backup
  *

--- a/client/my-sites/backup/enable-restores-banner.tsx
+++ b/client/my-sites/backup/enable-restores-banner.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import Banner from 'calypso/components/banner';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const EnableRestoresBanner: FunctionComponent = () => {
+	const translate = useTranslate();
+
+	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+
+	return (
+		<Banner
+			className="backup__restore-banner"
+			callToAction={ translate( 'Enable restores' ) as string }
+			title={ translate( 'Set up your server credentials to get back online quickly' ) as string }
+			description={ translate(
+				'Add SSH, SFTP or FTP credentials to enable one click site restores.'
+			) }
+			href={
+				isJetpackCloud() ? `/settings/${ siteSlug }` : `/settings/jetpack/${ siteSlug }#credentials`
+			}
+			icon="cloud-upload"
+			event="calypso_backup_enable_restores_banner"
+			tracksImpressionName="calypso_backup_enable_restores_banner_view"
+			tracksClickName="calypso_backup_enable_restores_banner_click"
+		/>
+	);
+};
+
+export default EnableRestoresBanner;

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -18,6 +18,7 @@ import Banner from 'calypso/components/banner';
 import DocumentHead from 'calypso/components/data/document-head';
 import { updateFilter, setFilter } from 'calypso/state/activity-log/actions';
 import {
+	getRawDailyBackupDeltas,
 	getDailyBackupDeltas,
 	// getMetaDiffForDailyBackup,
 	isActivityBackup,
@@ -33,6 +34,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import BackupDelta from 'calypso/components/jetpack/backup-delta';
 import DailyBackupStatus from 'calypso/components/jetpack/daily-backup-status';
+import DailyBackupStatusAlternate from 'calypso/components/jetpack/daily-backup-status/index-alternate';
 import BackupDatePicker from 'calypso/components/jetpack/backup-date-picker';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
@@ -220,15 +222,26 @@ class BackupsPage extends Component {
 								} }
 							/>
 
-							<DailyBackupStatus
-								{ ...{
-									selectedDate: this.getSelectedDate(),
-									lastBackupDate: lastDateAvailable,
-									backup: lastBackup,
-									deltas,
-									// metaDiff, todo: commented because the non-english account issue
-								} }
-							/>
+							{ isEnabled( 'jetpack/backup-simplified-screens-i4' ) ? (
+								<DailyBackupStatusAlternate
+									{ ...{
+										selectedDate: this.getSelectedDate(),
+										lastBackupDate: lastDateAvailable,
+										backup: lastBackup,
+										dailyDeltas: getRawDailyBackupDeltas( logs, selectedDateString ),
+									} }
+								/>
+							) : (
+								<DailyBackupStatus
+									{ ...{
+										selectedDate: this.getSelectedDate(),
+										lastBackupDate: lastDateAvailable,
+										backup: lastBackup,
+										deltas,
+										// metaDiff, todo: commented because the non-english account issue
+									} }
+								/>
+							) }
 						</div>
 
 						{ hasRealtimeBackups &&

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -12,48 +12,49 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
-import Banner from 'components/banner';
-import DocumentHead from 'components/data/document-head';
-import { updateFilter, setFilter } from 'state/activity-log/actions';
+import { backupMainPath } from './paths';
+import { isEnabled } from 'calypso/config';
+import Banner from 'calypso/components/banner';
+import DocumentHead from 'calypso/components/data/document-head';
+import { updateFilter, setFilter } from 'calypso/state/activity-log/actions';
 import {
 	getDailyBackupDeltas,
 	// getMetaDiffForDailyBackup,
 	isActivityBackup,
 	isSuccessfulRealtimeBackup,
 	INDEX_FORMAT,
-} from 'lib/jetpack/backup-utils';
-import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { requestActivityLogs } from 'state/data-getters';
-import { withLocalizedMoment } from 'components/localized-moment';
-import BackupPlaceholder from 'components/jetpack/backup-placeholder';
-import EmptyContent from 'components/empty-content';
-import FormattedHeader from 'components/formatted-header';
-import BackupDelta from 'components/jetpack/backup-delta';
-import DailyBackupStatus from 'components/jetpack/daily-backup-status';
-import BackupDatePicker from 'components/jetpack/backup-date-picker';
-import getRewindState from 'state/selectors/get-rewind-state';
-import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryRewindState from 'components/data/query-rewind-state';
-import QuerySitePurchases from 'components/data/query-site-purchases';
-import QueryRewindCapabilities from 'components/data/query-rewind-capabilities';
-import Main from 'components/main';
-import SidebarNavigation from 'my-sites/sidebar-navigation';
-import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
-import ActivityCardList from 'components/activity-card-list';
-import canCurrentUser from 'state/selectors/can-current-user';
-import getSiteUrl from 'state/sites/selectors/get-site-url';
-import getDoesRewindNeedCredentials from 'state/selectors/get-does-rewind-need-credentials.js';
-import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
-import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
-import { applySiteOffset } from 'lib/site/timezone';
-import QuerySiteSettings from 'components/data/query-site-settings'; // Required to get site time offset
-import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
-import { backupMainPath } from './paths';
-import { emptyFilter } from 'state/activity-log/reducer';
-import { recordTracksEvent } from 'state/analytics/actions';
+} from 'calypso/lib/jetpack/backup-utils';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { requestActivityLogs } from 'calypso/state/data-getters';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
+import EmptyContent from 'calypso/components/empty-content';
+import FormattedHeader from 'calypso/components/formatted-header';
+import BackupDelta from 'calypso/components/jetpack/backup-delta';
+import DailyBackupStatus from 'calypso/components/jetpack/daily-backup-status';
+import BackupDatePicker from 'calypso/components/jetpack/backup-date-picker';
+import getRewindState from 'calypso/state/selectors/get-rewind-state';
+import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import QueryRewindCapabilities from 'calypso/components/data/query-rewind-capabilities';
+import Main from 'calypso/components/main';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
+import ActivityCardList from 'calypso/components/activity-card-list';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
+import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials.js';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import { applySiteOffset } from 'calypso/lib/site/timezone';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings'; // Required to get site time offset
+import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
+import { emptyFilter } from 'calypso/state/activity-log/reducer';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import BackupCard from 'calypso/components/jetpack/backup-card';
 
 /**
  * Style dependencies
@@ -230,19 +231,29 @@ class BackupsPage extends Component {
 							/>
 						</div>
 
-						{ hasRealtimeBackups && lastBackup && (
-							<BackupDelta
-								{ ...{
-									deltas,
-									realtimeBackups,
-									doesRewindNeedCredentials,
-									allowRestore,
-									moment,
-									siteSlug,
-									isToday,
-								} }
-							/>
-						) }
+						{ hasRealtimeBackups &&
+							lastBackup &&
+							( isEnabled( 'jetpack/backup-simplified-screens-i4' ) ? (
+								<ul className="backup__card-list">
+									{ realtimeBackups.map( ( activity ) => (
+										<li key={ activity.activityId }>
+											<BackupCard activity={ activity } />
+										</li>
+									) ) }
+								</ul>
+							) : (
+								<BackupDelta
+									{ ...{
+										deltas,
+										realtimeBackups,
+										doesRewindNeedCredentials,
+										allowRestore,
+										moment,
+										siteSlug,
+										isToday,
+									} }
+								/>
+							) ) }
 					</div>
 				) }
 			</>

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -135,7 +135,7 @@ class BackupsPage extends Component {
 				// Looking for the last backup on the date (any activity rewindable)
 				if ( ! backupsOnSelectedDate.lastBackup ) {
 					backupsOnSelectedDate.lastBackup = log;
-				} else {
+				} else if ( log ) {
 					backupsOnSelectedDate.rewindableActivities.push( log );
 				}
 			} );

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -46,6 +46,17 @@
 	}
 }
 
+.backup__card-list {
+	margin: 0;
+	padding: 0;
+
+	list-style-type: none;
+
+	> li {
+		margin: 44px 0;
+	}
+}
+
 .backup__search {
 	padding: 0 1rem;
 }

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -54,6 +54,10 @@
 
 	> li {
 		margin: 44px 0;
+
+		&:first-child {
+			margin-top: 0;
+		}
 	}
 }
 
@@ -84,6 +88,8 @@
 }
 
 .backup__restore-banner {
+	width: 100%;
+
 	&.banner.card {
 		@include banner-color( var( --color-jetpack ) );
 	}

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -169,4 +169,8 @@
 			@include banner-color( var( --color-primary-40 ) );
 		}
 	}
+
+	.backup__card-list {
+		margin-top: 32px;
+	}
 }

--- a/client/state/activity-log/types.ts
+++ b/client/state/activity-log/types.ts
@@ -1,4 +1,5 @@
 export type Activity = {
+	activityId: number;
 	activityTs: number;
 	activityName: string;
 	activityTitle: string;

--- a/client/state/activity-log/types.ts
+++ b/client/state/activity-log/types.ts
@@ -1,0 +1,25 @@
+export type Activity = {
+	activityTs: number;
+	activityName: string;
+	activityTitle: string;
+	activityDescription: [
+		{
+			intent?: string;
+			section?: string;
+			type?: string;
+			url?: string;
+		}
+	];
+	activityMedia: {
+		available: boolean;
+		name: string;
+		medium_url: string;
+		thumbnail_url: string;
+	};
+	activityIcon?: string;
+	actorAvatarUrl?: string;
+	actorName?: string;
+	actorRole?: string;
+	actorType?: string;
+	rewindId?: string;
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a new backup card and updates the successful backup screen in Calypso and Jetpack cloud, according to the new iteration of this screen. See mockups labelled `i4` (link is in the board).

Note that it doesn't modify the activity log in Jetpack cloud, which is what you see when you click the search icon in the _Backup_ section in cloud.

Fixes 1197351014149633-as-1197888024354846

### Implementation notes

- Extracted `Activity` types in own file
- Extracted enable restores banner in its own file
- Fixed some TS import errors by prepending paths with `calypso`
- Made `ActivityActor` support multiple avatar sizes and added the possibility to hide the actor info
- Refactored the structure of the Backup page for the new iteration
- Created an alternate component for `DailyBackupStatus` (named `DailyBackupStatusAlternate`). It was easier to decide which one to instanciate in `BackupsPage` rather than adding a ton of conditions in `DailyBackupStatus`.

_TODO: update feature flag name_

### Testing instructions

First part is to do a regression testing and check that the Backup section is behaving as it is in production. Then:

- Visit `/backup/:site/?flags=jetpack/backup-simplified-screens-i4`
- Check that the successful screen looks like the mockups
- Check that the updates make sense, and that no critical information has been lost with this new iteration
- Check that events are tracked when clicking on the restore and download buttons (respectively `calypso_jetpack_backup_restore`, and `calypso_jetpack_backup_download`)

A couple of cases/environments to test:
- Calypso vs. Jetpack cloud
- Desktop vs. mobile
- With and without server credentials
- Backup Daily vs Backup Real-time

### Screenshots

#### Calypso
_Daily backup with changes (before)_
<img width="775" alt="Screen Shot 2020-10-09 at 4 44 46 PM" src="https://user-images.githubusercontent.com/1620183/95638431-9bafe200-0a62-11eb-9c64-8c45bcfa32ec.png">

_Daily backup with changes (after)_
<img width="763" alt="Screen Shot 2020-10-09 at 4 45 00 PM" src="https://user-images.githubusercontent.com/1620183/95638447-a5394a00-0a62-11eb-8f0b-3999be81c6ed.png">

_Daily backup without changes (before)_
<img width="757" alt="Screen Shot 2020-10-09 at 4 45 57 PM" src="https://user-images.githubusercontent.com/1620183/95638498-d6197f00-0a62-11eb-8ac1-68b344288e61.png">

_Daily backup without changes (after)_
<img width="759" alt="Screen Shot 2020-10-09 at 4 46 01 PM" src="https://user-images.githubusercontent.com/1620183/95638505-de71ba00-0a62-11eb-8f39-310fd3a7df96.png">
