### PR TITLE
Notifications - fix list item rendering

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -85,7 +85,9 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 		case 'sub':
 		case 'sup':
 		case 's':
-		case 'list':
+		case 'ol':
+		case 'ul':
+		case 'li':
 		case 'h1':
 		case 'h2':
 		case 'h3':

--- a/apps/notifications/src/panel/templates/functions.jsx
+++ b/apps/notifications/src/panel/templates/functions.jsx
@@ -43,11 +43,10 @@ const toBlocks = ( text ) =>
 				};
 			}
 
-			const blockquoteRegex = /blockquote(.*)>/i;
-			const containsBlockquoteTag = blockquoteRegex.test( raw );
-
-			// Blockquote start/end tags do not need to be wrapped in div/p
-			if ( containsBlockquoteTag ) {
+			// Blockquote and list start/end tags do not need to be wrapped in div/p
+			const skipRegex = /(blockquote|ol|ul|li)(.*)>/i;
+			const shouldSkipWrap = skipRegex.test( raw );
+			if ( shouldSkipWrap ) {
 				return {
 					out: out + raw,
 					inFence,

--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -112,13 +112,29 @@
 		}
 	}
 
-	blockquote {
-		padding: 0 24px 0 32px;
-		margin: 16px 0 32px;
-		border-left: 3px solid var( --color-neutral-0 );
-		color: var( --color-neutral-50 );
-		font-weight: 400;
-		background: transparent;
+	&.wpnc__main .wpnc__post {
+		blockquote {
+			padding: 0 24px 0 32px;
+			margin: 16px 0 32px;
+			border-left: 3px solid var( --color-neutral-0 );
+			color: var( --color-neutral-50 );
+			font-weight: 400;
+			background: transparent;
+		}
+		ul,
+		ol {
+			margin-left: 1.5em;
+			list-style-position: inside;
+		}
+		ul {
+			list-style-type: disc;
+		}
+		ol {
+			list-style-type: decimal;
+		}
+		li {
+			margin: auto;
+		}
 	}
 }
 

--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -112,7 +112,7 @@
 		}
 	}
 
-	&.wpnc__main .wpnc__post {
+	&.wpnc__main .wpnc__note {
 		blockquote {
 			padding: 0 24px 0 32px;
 			margin: 16px 0 32px;
@@ -128,6 +128,12 @@
 		}
 		ul {
 			list-style-type: disc;
+			ul {
+				list-style-type: circle;
+				ul {
+					list-style-type: square;
+				}
+			}
 		}
 		ol {
 			list-style-type: decimal;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR, along with D50949-code, updates web notifications to properly render list items with appropriate list style and indentation.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D50949-code in your sandbox and make sure the API is sandboxed.
* Apply this change to calypso, navigate to your Calypso dashboard and open a notification for a post with both ordered and unordered lists of multiple depths. Verify that all lists are displayed with correct numbering/discs and appropriate indentation.

Before:

![image](https://user-images.githubusercontent.com/13437011/95608854-620bb680-0a23-11eb-9a9e-471fd6c65107.png)

After:

![image](https://user-images.githubusercontent.com/13437011/95608772-42748e00-0a23-11eb-9023-71019b678aaa.png)


Fixes #46113