### PR TITLE
Email: Show Titan Mail indicator in enhanced navigation and domains list

### DIFF
--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -4,22 +4,22 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
-import { withLocalizedMoment } from 'components/localized-moment';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	getDomainTypeText,
 	isSubdomain,
 	isDomainUpdateable,
 	isDomainInGracePeriod,
-} from 'lib/domains';
-import VerticalNav from 'components/vertical-nav';
-import VerticalNavItem from 'components/vertical-nav/item';
-import MaterialIcon from 'components/material-icon';
+} from 'calypso/lib/domains';
+import VerticalNav from 'calypso/components/vertical-nav';
+import VerticalNavItem from 'calypso/components/vertical-nav/item';
+import MaterialIcon from 'calypso/components/material-icon';
 import {
 	domainAddNew,
 	domainManagementNameServers,
@@ -32,18 +32,19 @@ import {
 	domainTransferIn,
 	domainManagementSecurity,
 	isUnderDomainManagementAll,
-} from 'my-sites/domains/paths';
-import { emailManagement } from 'my-sites/email/paths';
-import { type as domainTypes, transferStatus, sslStatuses } from 'lib/domains/constants';
-import { recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
-import { isCancelable } from 'lib/purchases';
-import { cancelPurchase } from 'me/purchases/paths';
-import { getUnmappedUrl } from 'lib/site/utils';
-import { withoutHttp } from 'lib/url';
-import RemovePurchase from 'me/purchases/remove-purchase';
-import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'lib/gsuite';
-import getCurrentRoute from 'state/selectors/get-current-route';
-import { isRecentlyRegistered } from 'lib/domains/utils';
+} from 'calypso/my-sites/domains/paths';
+import { emailManagement } from 'calypso/my-sites/email/paths';
+import { type as domainTypes, transferStatus, sslStatuses } from 'calypso/lib/domains/constants';
+import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { isCancelable } from 'calypso/lib/purchases';
+import { cancelPurchase } from 'calypso/me/purchases/paths';
+import { getUnmappedUrl } from 'calypso/lib/site/utils';
+import { withoutHttp } from 'calypso/lib/url';
+import RemovePurchase from 'calypso/me/purchases/remove-purchase';
+import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
+import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
 
 import './style.scss';
 
@@ -108,6 +109,8 @@ class DomainManagementNavigationEnhanced extends React.Component {
 					comment: 'The number of GSuite mailboxes active for the current domain',
 				}
 			);
+		} else if ( hasTitanMailWithUs( domain ) ) {
+			navigationDescription = translate( 'Titan Mail' );
 		} else if ( emailForwardsCount > 0 ) {
 			navigationDescription = translate(
 				'%(emailForwardsCount)d forward',

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import page from 'page';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 
@@ -13,23 +13,23 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { Button, CompactCard } from '@automattic/components';
-import FormCheckbox from 'components/forms/form-checkbox';
-import FormRadio from 'components/forms/form-radio';
-import DomainNotice from 'my-sites/domains/domain-management/components/domain-notice';
-import EllipsisMenu from 'components/ellipsis-menu';
-import PopoverMenuItem from 'components/popover/menu-item';
-import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'lib/gsuite';
-import { withoutHttp } from 'lib/url';
-import { type as domainTypes } from 'lib/domains/constants';
-import { handleRenewNowClick } from 'lib/purchases';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormRadio from 'calypso/components/forms/form-radio';
+import DomainNotice from 'calypso/my-sites/domains/domain-management/components/domain-notice';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
+import { withoutHttp } from 'calypso/lib/url';
+import { type as domainTypes } from 'calypso/lib/domains/constants';
+import { handleRenewNowClick } from 'calypso/lib/purchases';
 import {
 	resolveDomainStatus,
 	isDomainInGracePeriod,
 	isDomainUpdateable,
 	getDomainTypeText,
-} from 'lib/domains';
-import InfoPopover from 'components/info-popover';
-import { emailManagement } from 'my-sites/email/paths';
+} from 'calypso/lib/domains';
+import InfoPopover from 'calypso/components/info-popover';
+import { emailManagement } from 'calypso/my-sites/email/paths';
 import {
 	domainManagementChangeSiteAddress,
 	domainManagementContactsPrivacy,
@@ -37,10 +37,11 @@ import {
 	domainManagementTransfer,
 	domainManagementDns,
 	domainManagementSecurity,
-} from 'my-sites/domains/paths';
-import Spinner from 'components/spinner';
-import TrackComponentView from 'lib/analytics/track-component-view';
-import { recordTracksEvent } from 'state/analytics/actions';
+} from 'calypso/my-sites/domains/paths';
+import Spinner from 'calypso/components/spinner';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
 
 class DomainItem extends PureComponent {
 	static propTypes = {
@@ -297,6 +298,10 @@ class DomainItem extends PureComponent {
 				},
 				comment: 'The number of GSuite mailboxes active for the current domain',
 			} );
+		}
+
+		if ( hasTitanMailWithUs( domainDetails ) ) {
+			return translate( 'Titan Mail' );
 		}
 
 		if ( domainDetails?.emailForwardsCount > 0 ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR shows Titan Mail in the enhanced navigation menu of a domain, as well as in the domains list, when a domain has an active Titan Mail subscription.

#### Testing instructions

- Hack `hasTitanMailWithUs()` to return `true` for a specific domain
- Ensure Titan Mail shows under the Email column for that domain in the domains list like the screenshot below
- Verify that Titan Mail appears in the enhanced navigation menu when viewing a specific domain

In the enhanced navigation menu:

<img width="722" alt="Screenshot 2020-10-09 at 6 55 48 PM" src="https://user-images.githubusercontent.com/13062352/95610739-0cee9580-0a61-11eb-98c7-5e80addc06b8.png">

In the domains list:

<img width="1046" alt="Screenshot 2020-10-09 at 6 57 06 PM" src="https://user-images.githubusercontent.com/13062352/95610839-3c050700-0a61-11eb-8650-800f19f85e9f.png">
