### PR TITLE
Email: Add warning that Titan email will stop working when canceling domain

### DIFF
--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -4,6 +4,7 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -17,6 +18,9 @@ import FormInputValidation from 'calypso/components/forms/form-input-validation'
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import { MOVE_DOMAIN } from 'calypso/lib/url/support';
 import { getName } from 'calypso/lib/purchases';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSelectedDomain } from 'calypso/lib/domains';
+import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
 
 class RemoveDomainDialog extends Component {
 	static propTypes = {
@@ -35,7 +39,7 @@ class RemoveDomainDialog extends Component {
 	};
 
 	renderDomainDeletionWarning( productName ) {
-		const { translate } = this.props;
+		const { translate, hasTitanWithUs } = this.props;
 
 		return (
 			<p>
@@ -48,6 +52,11 @@ class RemoveDomainDialog extends Component {
 						components: { strong: <strong /> },
 					}
 				) }
+				{ hasTitanWithUs &&
+					translate(
+						' You also have an active Titan Mail subscription for this domain, and your email will stop ' +
+							'working if you cancel your domain.'
+					) }
 			</p>
 		);
 	}
@@ -67,7 +76,7 @@ class RemoveDomainDialog extends Component {
 				{ this.renderDomainDeletionWarning( productName ) }
 
 				<p>
-					{ translate( 'If you want to use this domain with another service, DO NOT delete it.' ) }{ ' ' }
+					{ translate( 'If you want to use this domain with another service, do not delete it.' ) }{ ' ' }
 					{ translate(
 						'Instead, keep the domain. You can then {{a}}move or point your domain to a different service.{{/a}}',
 						{
@@ -208,4 +217,11 @@ class RemoveDomainDialog extends Component {
 	}
 }
 
-export default localize( RemoveDomainDialog );
+export default connect( ( state, ownProps ) => {
+	const domains = getDomainsBySiteId( state, ownProps.purchase.siteId );
+	const selectedDomainName = getName( ownProps.purchase );
+	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
+	return {
+		hasTitanWithUs: hasTitanMailWithUs( selectedDomain ),
+	};
+} )( localize( RemoveDomainDialog ) );

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -55,7 +55,7 @@ class RemoveDomainDialog extends Component {
 				{ hasTitanWithUs &&
 					translate(
 						' You also have an active Titan Mail subscription for this domain, and your email will stop ' +
-							'working if you cancel your domain.'
+							'working if you delete your domain.'
 					) }
 			</p>
 		);

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -53,10 +53,11 @@ class RemoveDomainDialog extends Component {
 					}
 				) }
 				{ hasTitanWithUs &&
-					translate(
-						' You also have an active Titan Mail subscription for this domain, and your email will stop ' +
-							'working if you delete your domain.'
-					) }
+					' ' +
+						translate(
+							'You also have an active Titan Mail subscription for this domain, and your emails will stop ' +
+								'working if you delete your domain.'
+						) }
 			</p>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a warning when canceling a domain with an active Titan Mail subscription, like in the screenshot below:

<img width="1033" alt="Screenshot 2020-10-09 at 7 44 23 PM" src="https://user-images.githubusercontent.com/13062352/95615036-d7997600-0a67-11eb-8bbb-2ae07f700789.png">

#### Testing instructions

* Hack `hasTitanMailWithUs()` to return true for a specific domain
* Turn off auto renew for that domain if it's on
* Try to cancel the domain by clicking the `Delete your domain permanently` button
* Verify that the email warning is shown as in the screenshot attached
* Verify that this is not shown for non Titan domains

