### PR TITLE
Plans: add discount message to filter bar (new UI)

### DIFF
--- a/client/my-sites/plans-v2/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar/index.tsx
@@ -95,7 +95,9 @@ const PlansFilterBar = ( {
 			) }
 			{ showDiscountMessage && (
 				<span className="plans-filter-bar__discount-message">
-					{ translate( 'You save 20% by paying yearly' ) }
+					{ translate( 'You save %(discount)s by paying yearly', {
+						args: { discount: '17%' },
+					} ) }
 				</span>
 			) }
 		</div>

--- a/client/my-sites/plans-v2/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar/index.tsx
@@ -9,11 +9,11 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import SegmentedControl from 'components/segmented-control';
-import SelectDropdown from 'components/select-dropdown';
-import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
-import { TERM_MONTHLY, TERM_ANNUALLY } from 'lib/plans/constants';
-import { masterbarIsVisible } from 'state/ui/selectors';
+import SegmentedControl from 'calypso/components/segmented-control';
+import SelectDropdown from 'calypso/components/select-dropdown';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
+import { masterbarIsVisible } from 'calypso/state/ui/selectors';
 import { PRODUCT_TYPE_OPTIONS } from '../constants';
 import useDetectWindowBoundary from '../use-detect-window-boundary';
 
@@ -28,18 +28,20 @@ import type { Duration, ProductType } from '../types';
 import './style.scss';
 
 interface Props {
+	showDiscountMessage?: boolean;
 	showDurations?: boolean;
 	showProductTypes?: boolean;
 	duration?: Duration;
 	productType?: ProductType;
-	onDurationChange?: Function;
-	onProductTypeChange?: Function;
+	onDurationChange?: ( arg0: Duration ) => void;
+	onProductTypeChange?: ( arg0: Duration ) => void;
 }
 
 const CALYPSO_MASTERBAR_HEIGHT = 47;
 const CLOUD_MASTERBAR_HEIGHT = 94;
 
 const PlansFilterBar = ( {
+	showDiscountMessage,
 	showDurations,
 	showProductTypes,
 	duration,
@@ -90,6 +92,11 @@ const PlansFilterBar = ( {
 						{ translate( 'Yearly' ) }
 					</SegmentedControl.Item>
 				</SegmentedControl>
+			) }
+			{ showDiscountMessage && (
+				<span className="plans-filter-bar__discount-message">
+					{ translate( 'You save 20% by paying yearly' ) }
+				</span>
 			) }
 		</div>
 	);

--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -84,6 +84,18 @@
 	}
 }
 
+.plans-filter-bar__discount-message {
+	display: none;
+
+	color: var( --color-primary );
+
+	font-size: $font-body-extra-small;
+
+	@include break-mobile {
+		display: inline;
+	}
+}
+
 .plans-filter-bar.sticky {
 	position: fixed;
 	top: var( --masterbar-height );

--- a/client/my-sites/plans-v2/selector-alt.tsx
+++ b/client/my-sites/plans-v2/selector-alt.tsx
@@ -190,7 +190,6 @@ const SelectorAltPage = ( {
 			{ header }
 			<PlansFilterBar
 				showDurations
-				showProductTypes
 				onProductTypeChange={ trackProductTypeChange }
 				productType={ productType }
 				onDurationChange={ trackDurationChange }

--- a/client/my-sites/plans-v2/selector-alt.tsx
+++ b/client/my-sites/plans-v2/selector-alt.tsx
@@ -186,9 +186,9 @@ const SelectorAltPage = ( {
 	return (
 		<Main className="selector-alt__main" wideLayout>
 			<PageViewTracker path={ viewTrackerPath } properties={ viewTrackerProps } title="Plans" />
-			<p>Alternative</p>
 			{ header }
 			<PlansFilterBar
+				showDiscountMessage
 				showDurations
 				onProductTypeChange={ trackProductTypeChange }
 				productType={ productType }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the filter bar, hide the product type filter and show a discount message.

#### Testing instructions

* Run this PR locally (both envs).
* Visit `http://calypso.localhost:3000/plans/:site`.
* Verify that nothing has changed.
* Add `flags=plans/alternate-selector` to the URL.
* Verify that the filter bar no longer shows the product type filter and that there is a discount message.
* Repeat the exercise in `http://jetpack.cloud.localhost:3001/pricing`.

Fixes 1196341175636977-as-1198055517794771

#### Demo
Calypso Blue
![image](https://user-images.githubusercontent.com/3418513/95618600-be7ece00-0a43-11eb-8006-13ca89c4e2bf.png)

Calypso Green
![image](https://user-images.githubusercontent.com/3418513/95617877-7f03b200-0a42-11eb-976a-89f02e9085cf.png)
