### PR TITLE
Plans: Create three-column grid layout for new product selector page

### DIFF
--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -90,6 +90,7 @@
 	color: var( --color-primary );
 
 	font-size: $font-body-extra-small;
+	font-style: italic;
 
 	@include break-mobile {
 		display: inline;

--- a/client/my-sites/plans-v2/products-grid-alt/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-alt/index.tsx
@@ -1,0 +1,156 @@
+/**
+ * External dependencies
+ */
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { getMonthlyPlanByYearly, getYearlyPlanByMonthly } from 'calypso/lib/plans';
+import { JETPACK_LEGACY_PLANS } from 'calypso/lib/plans/constants';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card';
+import { SELECTOR_PLANS } from '../constants';
+import {
+	getAllOptionsFromSlug,
+	getJetpackDescriptionWithOptions,
+	slugToSelectorProduct,
+} from '../utils';
+import useGetPlansGridProducts from '../use-get-plans-grid-products';
+import ProductCard from '../product-card';
+
+/**
+ * Type dependencies
+ */
+import type { SelectorProduct } from '../types';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+// Map over all plan slugs and convert them to SelectorProduct types.
+const getPlansToDisplay = ( { duration, currentPlanSlug } ) => {
+	const currentPlanTerms = currentPlanSlug
+		? [ getMonthlyPlanByYearly( currentPlanSlug ), getYearlyPlanByMonthly( currentPlanSlug ) ]
+		: [];
+
+	const currentPlanOptions = currentPlanSlug ? getAllOptionsFromSlug( currentPlanSlug ) : [];
+
+	const plansToDisplay = SELECTOR_PLANS.map( slugToSelectorProduct )
+		// Remove plans that don't fit the filters or have invalid data.
+		.filter(
+			( product: SelectorProduct | null ): product is SelectorProduct =>
+				!! product &&
+				product.term === duration &&
+				// Don't include a plan the user already owns, regardless of the term
+				! currentPlanTerms.includes( product.productSlug ) &&
+				// Don't include a plan option if the user already owns a related option
+				! currentPlanOptions.includes( product.productSlug )
+		)
+		.map( ( product: SelectorProduct ) => ( {
+			...product,
+			description: getJetpackDescriptionWithOptions( product ),
+		} ) );
+
+	if (
+		JETPACK_LEGACY_PLANS.includes( currentPlanSlug ) ||
+		SELECTOR_PLANS.includes( currentPlanSlug )
+	) {
+		return [ slugToSelectorProduct( currentPlanSlug ), ...plansToDisplay ];
+	}
+
+	return plansToDisplay;
+};
+
+const getProductsToDisplay = ( {
+	duration,
+	availableProducts,
+	purchasedProducts,
+	includedInPlanProducts,
+} ) => {
+	// Products that have not been directly purchased must honor the current filter
+	// selection since they exist in both monthly and yearly version.
+	const filteredProducts = [ ...includedInPlanProducts, ...availableProducts ]
+		// Remove products that don't match the selected duration
+		.filter( ( product ): product is SelectorProduct => product?.term === duration );
+	return (
+		[ ...purchasedProducts, ...filteredProducts ]
+			// Make sure we don't allow any null or invalid products
+			.filter( ( product ): product is SelectorProduct => !! product )
+			.map( ( product ) => ( {
+				...product,
+				description: getJetpackDescriptionWithOptions( product as SelectorProduct ),
+			} ) )
+	);
+};
+
+const ProductsGridAlt = ( { duration, onSelectProduct, urlQueryArgs } ) => {
+	const siteId = useSelector( getSelectedSiteId );
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+
+	const { availableProducts, purchasedProducts, includedInPlanProducts } = useGetPlansGridProducts(
+		siteId
+	);
+
+	const currentPlanSlug =
+		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
+
+	const plansToDisplay = useMemo( () => getPlansToDisplay( { duration, currentPlanSlug } ), [
+		duration,
+		currentPlanSlug,
+	] );
+	const productsToDisplay = useMemo(
+		() =>
+			getProductsToDisplay( {
+				duration,
+				availableProducts,
+				purchasedProducts,
+				includedInPlanProducts,
+			} ),
+		[ duration, availableProducts, includedInPlanProducts, purchasedProducts ]
+	);
+
+	const isInConnectFlow = useMemo(
+		() =>
+			/jetpack\/connect\/plans/.test( window.location.href ) ||
+			/source=jetpack-connect-plans/.test( window.location.href ),
+		[]
+	);
+	const showJetpackFreeCard = isInConnectFlow || isJetpackCloud();
+
+	return (
+		<div className="products-grid-alt">
+			{ plansToDisplay.map( ( plan ) => (
+				<ProductCard
+					// iconSlug has the same value for all durations.
+					// Using this value as a key prevents unnecessary DOM updates.
+					key={ plan.iconSlug }
+					item={ plan }
+					siteId={ siteId }
+					onClick={ onSelectProduct }
+					currencyCode={ currencyCode }
+					selectedTerm={ duration }
+				/>
+			) ) }
+			{ productsToDisplay.map( ( product ) => (
+				<ProductCard
+					// iconSlug has the same value for all durations.
+					// Using this value as a key prevents unnecessary DOM updates.
+					key={ product.iconSlug }
+					item={ product }
+					onClick={ onSelectProduct }
+					siteId={ siteId }
+					currencyCode={ currencyCode }
+				/>
+			) ) }
+			{ showJetpackFreeCard && <JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } /> }
+		</div>
+	);
+};
+
+export default ProductsGridAlt;

--- a/client/my-sites/plans-v2/products-grid-alt/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-alt/index.tsx
@@ -21,7 +21,7 @@ import {
 	slugToSelectorProduct,
 } from '../utils';
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
-import ProductCard from '../product-card';
+import ProductCardAlt from '../product-card-alt';
 
 /**
  * Type dependencies
@@ -149,7 +149,7 @@ const ProductsGridAlt = ( {
 	return (
 		<div className="products-grid-alt">
 			{ plansToDisplay.map( ( plan ) => (
-				<ProductCard
+				<ProductCardAlt
 					// iconSlug has the same value for all durations.
 					// Using this value as a key prevents unnecessary DOM updates.
 					key={ plan.iconSlug }
@@ -161,7 +161,7 @@ const ProductsGridAlt = ( {
 				/>
 			) ) }
 			{ productsToDisplay.map( ( product ) => (
-				<ProductCard
+				<ProductCardAlt
 					// iconSlug has the same value for all durations.
 					// Using this value as a key prevents unnecessary DOM updates.
 					key={ product.iconSlug }

--- a/client/my-sites/plans-v2/products-grid-alt/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-alt/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useMemo } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
@@ -26,7 +26,7 @@ import ProductCard from '../product-card';
 /**
  * Type dependencies
  */
-import type { SelectorProduct } from '../types';
+import type { Duration, PurchaseCallback, QueryArgs, SelectorProduct } from '../types';
 
 /**
  * Style dependencies
@@ -34,7 +34,13 @@ import type { SelectorProduct } from '../types';
 import './style.scss';
 
 // Map over all plan slugs and convert them to SelectorProduct types.
-const getPlansToDisplay = ( { duration, currentPlanSlug } ) => {
+const getPlansToDisplay = ( {
+	duration,
+	currentPlanSlug,
+}: {
+	duration: Duration;
+	currentPlanSlug: string | null;
+} ): SelectorProduct[] => {
 	const currentPlanTerms = currentPlanSlug
 		? [ getMonthlyPlanByYearly( currentPlanSlug ), getYearlyPlanByMonthly( currentPlanSlug ) ]
 		: [];
@@ -58,10 +64,14 @@ const getPlansToDisplay = ( { duration, currentPlanSlug } ) => {
 		} ) );
 
 	if (
-		JETPACK_LEGACY_PLANS.includes( currentPlanSlug ) ||
-		SELECTOR_PLANS.includes( currentPlanSlug )
+		currentPlanSlug &&
+		( JETPACK_LEGACY_PLANS.includes( currentPlanSlug ) ||
+			SELECTOR_PLANS.includes( currentPlanSlug ) )
 	) {
-		return [ slugToSelectorProduct( currentPlanSlug ), ...plansToDisplay ];
+		const currentPlanSelectorProduct = slugToSelectorProduct( currentPlanSlug );
+		if ( currentPlanSelectorProduct ) {
+			return [ currentPlanSelectorProduct, ...plansToDisplay ];
+		}
 	}
 
 	return plansToDisplay;
@@ -72,6 +82,11 @@ const getProductsToDisplay = ( {
 	availableProducts,
 	purchasedProducts,
 	includedInPlanProducts,
+}: {
+	duration: Duration;
+	availableProducts: ( SelectorProduct | null )[];
+	purchasedProducts: ( SelectorProduct | null )[];
+	includedInPlanProducts: ( SelectorProduct | null )[];
 } ) => {
 	// Products that have not been directly purchased must honor the current filter
 	// selection since they exist in both monthly and yearly version.
@@ -89,7 +104,15 @@ const getProductsToDisplay = ( {
 	);
 };
 
-const ProductsGridAlt = ( { duration, onSelectProduct, urlQueryArgs } ) => {
+const ProductsGridAlt = ( {
+	duration,
+	onSelectProduct,
+	urlQueryArgs,
+}: {
+	duration: Duration;
+	onSelectProduct: PurchaseCallback;
+	urlQueryArgs: QueryArgs;
+} ): ReactElement => {
 	const siteId = useSelector( getSelectedSiteId );
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 

--- a/client/my-sites/plans-v2/products-grid-alt/style.scss
+++ b/client/my-sites/plans-v2/products-grid-alt/style.scss
@@ -1,0 +1,36 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
+.products-grid-alt {
+	/*
+	 * Create a grid with cells that are evenly sized,
+	 * with a minimum width of 300px each.
+	 * Each cell should be vertically top-aligned,
+	 * and the gap between them should always be 16px.
+	 */
+	display: grid;
+	grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
+	grid-gap: 16px;
+	align-items: start;
+
+	& > .jetpack-free-card {
+		/*
+		 * To match its top border with the top border
+		 * of the product cards next to it
+		 */
+		margin-block-start: calc( 24px + 32.5px );
+
+		/*
+		 * The Free card takes up two columns
+		 * when the screen is wide enough to support it
+		 */
+		@include break-small {
+			grid-column-end: span 2;
+		}
+	}
+
+	& .formatted-header__title {
+		font-size: 1.25rem;
+		color: var( --studio-color-gray-70 );
+	}
+}

--- a/client/my-sites/plans-v2/products-grid-alt/style.scss
+++ b/client/my-sites/plans-v2/products-grid-alt/style.scss
@@ -5,13 +5,13 @@
 	/*
 	 * Create a grid with cells that are evenly sized,
 	 * with a minimum width of 300px each.
-	 * Each cell should be vertically top-aligned,
-	 * and the gap between them should always be 16px.
+	 * Each cell should take up as much vertical space as it's allowed,
+	 * and the horizontal/vertical gap between them should always be 16px.
 	 */
 	display: grid;
 	grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
 	grid-gap: 16px;
-	align-items: start;
+	align-items: stretch;
 
 	& > .jetpack-free-card {
 		/*

--- a/client/my-sites/plans-v2/selector-alt.tsx
+++ b/client/my-sites/plans-v2/selector-alt.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import page from 'page';
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 /**
@@ -10,14 +10,11 @@ import { useDispatch, useSelector } from 'react-redux';
  */
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import PlansFilterBar from './plans-filter-bar';
-import PlansColumn from './plans-column';
-import ProductsColumn from './products-column';
-import { EXTERNAL_PRODUCTS_LIST, ALL } from './constants';
+import { EXTERNAL_PRODUCTS_LIST } from './constants';
 import { getPathToDetails, getPathToUpsell, checkout } from './utils';
 import QueryProducts from './query-products';
 import useHasProductUpsell from './use-has-product-upsell';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getYearlyPlanByMonthly } from 'calypso/lib/plans';
 import { TERM_ANNUALLY } from 'calypso/lib/plans/constants';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -26,7 +23,7 @@ import Main from 'calypso/components/main';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QuerySites from 'calypso/components/data/query-sites';
 import QueryProductsList from 'calypso/components/data/query-products-list';
-import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card';
+import ProductsGridAlt from './products-grid-alt';
 
 /**
  * Type dependencies
@@ -150,15 +147,6 @@ const SelectorAltPage = ( {
 		setDuration( selectedDuration );
 	};
 
-	const isInConnectFlow = useMemo(
-		() =>
-			/jetpack\/connect\/plans/.test( window.location.href ) ||
-			/source=jetpack-connect-plans/.test( window.location.href ),
-		[]
-	);
-
-	const showJetpackFreeCard = isInConnectFlow || isJetpackCloud();
-
 	const viewTrackerPath = siteId ? `${ rootUrl }/:site` : rootUrl;
 	const viewTrackerProps = siteId ? { site: siteSlug } : {};
 
@@ -173,27 +161,12 @@ const SelectorAltPage = ( {
 				onDurationChange={ trackDurationChange }
 				duration={ currentDuration }
 			/>
-			<div className="plans-v2__columns">
-				<PlansColumn
-					duration={ currentDuration }
-					onPlanClick={ selectProduct }
-					productType={ ALL }
-					siteId={ siteId }
-				/>
-				<ProductsColumn
-					duration={ currentDuration }
-					onProductClick={ selectProduct }
-					productType={ ALL }
-					siteId={ siteId }
-				/>
-			</div>
 
-			{ showJetpackFreeCard && (
-				<>
-					<div className="selector-alt__divider" />
-					<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
-				</>
-			) }
+			<ProductsGridAlt
+				duration={ currentDuration }
+				onSelectProduct={ selectProduct }
+				urlQueryArgs={ urlQueryArgs }
+			/>
 
 			<QueryProductsList />
 			<QueryProducts />

--- a/client/my-sites/plans-v2/selector-alt.tsx
+++ b/client/my-sites/plans-v2/selector-alt.tsx
@@ -33,7 +33,7 @@ import type { ProductSlug } from 'calypso/lib/products-values/types';
 
 import './style.scss';
 
-const SelectorAltPage = ( {
+const SelectorPageAlt = ( {
 	defaultDuration = TERM_ANNUALLY,
 	siteSlug: siteSlugProp,
 	rootUrl,
@@ -177,4 +177,4 @@ const SelectorAltPage = ( {
 	);
 };
 
-export default SelectorAltPage;
+export default SelectorPageAlt;

--- a/client/my-sites/plans-v2/selector-alt.tsx
+++ b/client/my-sites/plans-v2/selector-alt.tsx
@@ -12,7 +12,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import PlansFilterBar from './plans-filter-bar';
 import PlansColumn from './plans-column';
 import ProductsColumn from './products-column';
-import { EXTERNAL_PRODUCTS_LIST, SECURITY } from './constants';
+import { EXTERNAL_PRODUCTS_LIST, ALL } from './constants';
 import { getPathToDetails, getPathToUpsell, checkout } from './utils';
 import QueryProducts from './query-products';
 import useHasProductUpsell from './use-has-product-upsell';
@@ -31,13 +31,7 @@ import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card';
 /**
  * Type dependencies
  */
-import type {
-	Duration,
-	ProductType,
-	SelectorPageProps,
-	SelectorProduct,
-	PurchaseCallback,
-} from './types';
+import type { Duration, SelectorPageProps, SelectorProduct, PurchaseCallback } from './types';
 import type { ProductSlug } from 'calypso/lib/products-values/types';
 
 import './style.scss';
@@ -56,7 +50,6 @@ const SelectorAltPage = ( {
 	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const siteSlug = siteSlugProp || siteSlugState;
 	const hasUpsell = useHasProductUpsell();
-	const [ productType, setProductType ] = useState< ProductType >( SECURITY );
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
 
 	useEffect( () => {
@@ -143,20 +136,6 @@ const SelectorAltPage = ( {
 		checkout( siteSlug, product.productSlug, urlQueryArgs );
 	};
 
-	const trackProductTypeChange = ( selectedType: ProductType ) => {
-		if ( selectedType === productType ) {
-			return;
-		}
-
-		dispatch(
-			recordTracksEvent( 'calypso_plans_type_change', {
-				site_id: siteId || undefined,
-				product_type: selectedType,
-			} )
-		);
-		setProductType( selectedType );
-	};
-
 	const trackDurationChange = ( selectedDuration: Duration ) => {
 		if ( selectedDuration === currentDuration ) {
 			return;
@@ -187,11 +166,10 @@ const SelectorAltPage = ( {
 		<Main className="selector-alt__main" wideLayout>
 			<PageViewTracker path={ viewTrackerPath } properties={ viewTrackerProps } title="Plans" />
 			{ header }
+
 			<PlansFilterBar
 				showDiscountMessage
 				showDurations
-				onProductTypeChange={ trackProductTypeChange }
-				productType={ productType }
 				onDurationChange={ trackDurationChange }
 				duration={ currentDuration }
 			/>
@@ -199,13 +177,13 @@ const SelectorAltPage = ( {
 				<PlansColumn
 					duration={ currentDuration }
 					onPlanClick={ selectProduct }
-					productType={ productType }
+					productType={ ALL }
 					siteId={ siteId }
 				/>
 				<ProductsColumn
 					duration={ currentDuration }
 					onProductClick={ selectProduct }
-					productType={ productType }
+					productType={ ALL }
 					siteId={ siteId }
 				/>
 			</div>

--- a/client/my-sites/plans-v2/selector-alt.tsx
+++ b/client/my-sites/plans-v2/selector-alt.tsx
@@ -153,6 +153,7 @@ const SelectorPageAlt = ( {
 	return (
 		<Main className="selector-alt__main" wideLayout>
 			<PageViewTracker path={ viewTrackerPath } properties={ viewTrackerProps } title="Plans" />
+
 			{ header }
 
 			<PlansFilterBar
@@ -172,6 +173,7 @@ const SelectorPageAlt = ( {
 			<QueryProducts />
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			{ siteId && <QuerySites siteId={ siteId } /> }
+
 			{ footer }
 		</Main>
 	);

--- a/client/my-sites/plans-v2/selector-alt.tsx
+++ b/client/my-sites/plans-v2/selector-alt.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import page from 'page';
-import React, { useState, useEffect } from 'react';
+import React, { ReactElement, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 /**
@@ -40,7 +40,7 @@ const SelectorPageAlt = ( {
 	urlQueryArgs,
 	header,
 	footer,
-}: SelectorPageProps ) => {
+}: SelectorPageProps ): ReactElement => {
 	const dispatch = useDispatch();
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -497,14 +497,14 @@ export function getOptionFromSlug( slug: string ): string | null {
 
 /**
  * Returns all options, both yearly and monthly, given a slug. If the slug
- * is not related to any option, it returns null.
+ * has no related to option, it returns an empty array.
  * e.g. jetpack_security_daily -> [ jetpack_security_monthly, jetpack_security ]
- * e.g. jetpack_scan -> null
+ * e.g. jetpack_scan -> []
  *
  * @param slug string
- * @returns string[] | null
+ * @returns string[]
  */
-export function getAllOptionsFromSlug( slug: string ): string[] | null {
+export function getAllOptionsFromSlug( slug: string ): string[] {
 	if ( JETPACK_BACKUP_PRODUCTS.includes( slug ) ) {
 		return [ OPTIONS_JETPACK_BACKUP, OPTIONS_JETPACK_BACKUP_MONTHLY ];
 	}
@@ -513,7 +513,7 @@ export function getAllOptionsFromSlug( slug: string ): string[] | null {
 		return [ OPTIONS_JETPACK_SECURITY, OPTIONS_JETPACK_SECURITY_MONTHLY ];
 	}
 
-	return null;
+	return [];
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes `1196341175636977-as-1198071178569633`.

All of the following is visible on `SelectorPageAlt`, but only if the `plans/alternate-selector` feature flag is enabled:

* Rename `SelectorAltPage` to `SelectorPageAlt`, for consistency with other `Alt`-suffixed components on this project.
* Remove the product type dropdown.
* Show plans and products of every type.
* Remove the `Alternative` debug text now that it's visibly different from `SelectorPage`.
* Create `ProductsGridAlt` component to handle showing all products and plans on the new product selector page.
* Use `ProductsGridAlt` to render the product listing instead of `PlansColumn` and `ProductsColumn`.
* In `utils.js`, make `getAllOptionsFromSlug` return an empty array instead of null if a product slug does not have any options.

#### Known issues

* We still have some CSS to touch up here and there in general, across the entire selector page.
* Product cards fade into the background a little in Calypso.
* Screen width breakpoints don't exactly match up with the way the grid re-flows itself.
* The "Show features" dropdowns don't line up across product cards (I think bottom-aligning them will look better.)
* The sizing of the Jetpack Free card may need to change to look its best on different screen widths and during window resizing.

#### Testing instructions

**Important:** Test these changes on both Calypso and Jetpack Cloud, with a range of screen widths. I recommend using the responsive design mode in your browser's DevTools to simulate mobile phones, tablets, and computer screen widths.

Verify the following:

* The existing product selector page still appears and behaves exactly as it does in production. (Add `?flags=plans/alternate-selector` to your browser URL to disable the flag manually.)
* All products and plans are shown on the new product selection grid.
* The product type dropdown is no longer visible, but the Monthly/Annually duration toggle is still visible.
* The product grid responds to growing and shrinking screen width by transitioning from 1 to 3 columns as appropriate.
* Grid items are aligned and sized appropriately.
* Colors and styles on the page are appropriate for the environment in which you're viewing them.
* The font size, color, and style of the discount message are correct (12px, "accent" color, italic).
* On Jetpack Cloud, the **Jetpack Free** plan card is visible at the bottom of the grid.

#### Screenshots

##### Calypso

<img width="242" alt="image" src="https://user-images.githubusercontent.com/670067/95625969-06e7bd00-0a3f-11eb-8601-e77556f9244c.png">

<img width="394" alt="image" src="https://user-images.githubusercontent.com/670067/95625883-ddc72c80-0a3e-11eb-86bc-b3db172189ca.png">

<img width="536" alt="image" src="https://user-images.githubusercontent.com/670067/95625859-d30c9780-0a3e-11eb-9e75-0213d93f547c.png">
##### Jetpack Cloud

##### Jetpack Cloud

<img width="237" alt="image" src="https://user-images.githubusercontent.com/670067/95626048-2bdc3000-0a3f-11eb-846b-26a2c1460a91.png">

<img width="412" alt="image" src="https://user-images.githubusercontent.com/670067/95626092-3d253c80-0a3f-11eb-9d07-c0f683675ff5.png">

<img width="543" alt="image" src="https://user-images.githubusercontent.com/670067/95626167-6219af80-0a3f-11eb-9889-04cbcb60129a.png">