### PR TITLE
Plans: make the background JetpackProductCard white by default

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -8,7 +8,7 @@ $jetpack-product-card-alt-icon-size: 55px;
 	box-sizing: border-box;
 	margin: calc( 24px + #{$jetpack-product-card-alt-circle-size/2} ) 0 24px;
 
-	background: var( --studio-gray-0 );
+	background: var( --color-surface );
 	border: 1px solid var( --color-border-subtle );
 	border-left: none;
 	border-right: none;

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -89,6 +89,8 @@
 	}
 
 	.jetpack-product-card-alt {
+		background: var( --studio-gray-0 );
+
 		.foldable-card {
 			font-size: $font-body;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the background of the cards white by default and gray in the Pricing page.

#### Testing instructions

* Run this PR locally (both envs).
* Visit `http://jetpack.cloud.localhost:3001/pricing?flags=plans/alternate-selector`.
* Verify that the background of the cards is gray (see capture below).
* Visit `http://calypso.localhost:3000/jetpack/connect/plans/:site?flags=plans/alternate-selector`.
* Verify that the background of the cards is white (see capture below).
* Visit `http://calypso.localhost:3000/plans/:site?flags=plans/alternate-selector`.
* Verify that the background of the cards is white (see capture below).

Fixes 1196341175636977-as-1198173394037049

#### Demo
![image](https://user-images.githubusercontent.com/3418513/95626646-12dc7a80-0a51-11eb-801b-bbfdfe1d3d21.png)

![image](https://user-images.githubusercontent.com/3418513/95626664-1cfe7900-0a51-11eb-8114-d3c22570fa5f.png)

![image](https://user-images.githubusercontent.com/3418513/95626691-2851a480-0a51-11eb-8a95-a03f9c578b14.png)

