### PR TITLE
Link to site level page in purchases listing action button

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -13,13 +13,23 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { isMonthly } from 'lib/plans/constants';
-import { getPlanClass, planLevelsMatch } from 'lib/plans';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isMonthly } from 'calypso/lib/plans/constants';
+import { getPlanClass, planLevelsMatch } from 'calypso/lib/plans';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
-const PlanFeaturesActions = ( {
+const PlanFeaturesActions = ( props ) => {
+	return (
+		<div className="plan-features__actions">
+			<div className="plan-features__actions-buttons">
+				<PlanFeaturesActionsButton { ...props } />
+			</div>
+		</div>
+	);
+};
+
+const PlanFeaturesActionsButton = ( {
 	availableForPurchase = true,
 	canPurchase,
 	className,
@@ -125,11 +135,7 @@ const PlanFeaturesActions = ( {
 		);
 	}
 
-	return (
-		<div className="plan-features__actions">
-			<div className="plan-features__actions-buttons">{ upgradeButton }</div>
-		</div>
-	);
+	return upgradeButton;
 };
 
 PlanFeaturesActions.propTypes = {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -52,8 +52,6 @@ const PlanFeaturesActionsButton = ( {
 	translate,
 	...props
 } ) => {
-	let upgradeButton;
-
 	const classes = classNames(
 		'plan-features__actions-button',
 		{
@@ -66,12 +64,16 @@ const PlanFeaturesActionsButton = ( {
 	);
 
 	if ( current && ! isInSignup ) {
-		upgradeButton = (
+		return (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				{ canPurchase ? translate( 'Manage plan' ) : translate( 'View plan' ) }
 			</Button>
 		);
-	} else if ( availableForPurchase || isPlaceholder ) {
+	}
+
+	let upgradeButton;
+
+	if ( availableForPurchase || isPlaceholder ) {
 		let buttonText = freePlan
 			? translate( 'Select Free', { context: 'button' } )
 			: translate( 'Upgrade', { context: 'verb' } );

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -124,12 +124,14 @@ const PlanFeaturesActionsButton = ( {
 			buttonText = translate( 'Upgrade to Yearly' );
 		}
 
-		upgradeButton = (
+		return (
 			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
 				{ props.buttonText || buttonText }
 			</Button>
 		);
-	} else if ( ! availableForPurchase && forceDisplayButton ) {
+	}
+
+	if ( ! availableForPurchase && forceDisplayButton ) {
 		upgradeButton = (
 			<Button className={ classes } disabled={ true }>
 				{ props.buttonText }

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -87,14 +87,40 @@ const PlanFeaturesActionsButton = ( {
 	let upgradeButton;
 
 	if ( availableForPurchase || isPlaceholder ) {
-		let buttonText = freePlan
-			? translate( 'Select Free', { context: 'button' } )
-			: translate( 'Upgrade', { context: 'verb' } );
-		if ( isLandingPage ) {
-			buttonText = translate( 'Select', { context: 'button' } );
+		if (
+			isMonthly( currentSitePlanSlug ) &&
+			getPlanClass( planType ) === getPlanClass( currentSitePlanSlug )
+		) {
+			return (
+				<Button
+					className={ classes }
+					onClick={ handleUpgradeButtonClick }
+					disabled={ isPlaceholder }
+				>
+					{ props.buttonText || translate( 'Upgrade to Yearly' ) }
+				</Button>
+			);
+		}
+
+		if ( ! isLaunchPage && isInSignup ) {
+			return (
+				<Button
+					className={ classes }
+					onClick={ handleUpgradeButtonClick }
+					disabled={ isPlaceholder }
+				>
+					{ props.buttonText ||
+						translate( 'Start with %(plan)s', {
+							args: {
+								plan: planName,
+							},
+						} ) }
+				</Button>
+			);
 		}
 
 		if ( isLaunchPage ) {
+			let buttonText = '';
 			if ( freePlan ) {
 				buttonText = translate( 'Keep this plan', {
 					comment:
@@ -110,26 +136,34 @@ const PlanFeaturesActionsButton = ( {
 						'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
 				} );
 			}
+			return (
+				<Button
+					className={ classes }
+					onClick={ handleUpgradeButtonClick }
+					disabled={ isPlaceholder }
+				>
+					{ props.buttonText || buttonText }
+				</Button>
+			);
 		}
 
-		if ( ! isLaunchPage && isInSignup ) {
-			buttonText = translate( 'Start with %(plan)s', {
-				args: {
-					plan: planName,
-				},
-			} );
-		}
-
-		if (
-			isMonthly( currentSitePlanSlug ) &&
-			getPlanClass( planType ) === getPlanClass( currentSitePlanSlug )
-		) {
-			buttonText = translate( 'Upgrade to Yearly' );
+		if ( isLandingPage ) {
+			return (
+				<Button
+					className={ classes }
+					onClick={ handleUpgradeButtonClick }
+					disabled={ isPlaceholder }
+				>
+					{ props.buttonText || translate( 'Select', { context: 'button' } ) }
+				</Button>
+			);
 		}
 
 		return (
 			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
-				{ props.buttonText || buttonText }
+				{ props.buttonText || freePlan
+					? translate( 'Select Free', { context: 'button' } )
+					: translate( 'Upgrade', { context: 'verb' } ) }
 			</Button>
 		);
 	}

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -84,81 +84,64 @@ const PlanFeaturesActionsButton = ( {
 		);
 	}
 
-	let upgradeButton;
+	if (
+		( availableForPurchase || isPlaceholder ) &&
+		isMonthly( currentSitePlanSlug ) &&
+		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug )
+	) {
+		return (
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+				{ props.buttonText || translate( 'Upgrade to Yearly' ) }
+			</Button>
+		);
+	}
+
+	if ( ( availableForPurchase || isPlaceholder ) && ! isLaunchPage && isInSignup ) {
+		return (
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+				{ props.buttonText ||
+					translate( 'Start with %(plan)s', {
+						args: {
+							plan: planName,
+						},
+					} ) }
+			</Button>
+		);
+	}
+
+	if ( ( availableForPurchase || isPlaceholder ) && isLaunchPage ) {
+		let buttonText = '';
+		if ( freePlan ) {
+			buttonText = translate( 'Keep this plan', {
+				comment:
+					'A selection to keep the current plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+			} );
+		} else {
+			buttonText = translate( 'Select %(plan)s', {
+				args: {
+					plan: planName,
+				},
+				context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
+				comment:
+					'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+			} );
+		}
+		return (
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+				{ props.buttonText || buttonText }
+			</Button>
+		);
+	}
+
+	if ( ( availableForPurchase || isPlaceholder ) && isLandingPage ) {
+		return (
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+				{ props.buttonText || translate( 'Select', { context: 'button' } ) }
+			</Button>
+		);
+	}
 
 	if ( availableForPurchase || isPlaceholder ) {
-		if (
-			isMonthly( currentSitePlanSlug ) &&
-			getPlanClass( planType ) === getPlanClass( currentSitePlanSlug )
-		) {
-			return (
-				<Button
-					className={ classes }
-					onClick={ handleUpgradeButtonClick }
-					disabled={ isPlaceholder }
-				>
-					{ props.buttonText || translate( 'Upgrade to Yearly' ) }
-				</Button>
-			);
-		}
-
-		if ( ! isLaunchPage && isInSignup ) {
-			return (
-				<Button
-					className={ classes }
-					onClick={ handleUpgradeButtonClick }
-					disabled={ isPlaceholder }
-				>
-					{ props.buttonText ||
-						translate( 'Start with %(plan)s', {
-							args: {
-								plan: planName,
-							},
-						} ) }
-				</Button>
-			);
-		}
-
-		if ( isLaunchPage ) {
-			let buttonText = '';
-			if ( freePlan ) {
-				buttonText = translate( 'Keep this plan', {
-					comment:
-						'A selection to keep the current plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
-				} );
-			} else {
-				buttonText = translate( 'Select %(plan)s', {
-					args: {
-						plan: planName,
-					},
-					context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
-					comment:
-						'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
-				} );
-			}
-			return (
-				<Button
-					className={ classes }
-					onClick={ handleUpgradeButtonClick }
-					disabled={ isPlaceholder }
-				>
-					{ props.buttonText || buttonText }
-				</Button>
-			);
-		}
-
-		if ( isLandingPage ) {
-			return (
-				<Button
-					className={ classes }
-					onClick={ handleUpgradeButtonClick }
-					disabled={ isPlaceholder }
-				>
-					{ props.buttonText || translate( 'Select', { context: 'button' } ) }
-				</Button>
-			);
-		}
-
 		return (
 			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
 				{ props.buttonText || freePlan
@@ -167,6 +150,8 @@ const PlanFeaturesActionsButton = ( {
 			</Button>
 		);
 	}
+
+	let upgradeButton;
 
 	if ( ! availableForPurchase && forceDisplayButton ) {
 		upgradeButton = (

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -155,17 +155,13 @@ const PlanFeaturesActionsButton = ( {
 		);
 	}
 
-	let upgradeButton;
-
 	if ( ! availableForPurchase && forceDisplayButton ) {
-		upgradeButton = (
+		return (
 			<Button className={ classes } disabled={ true }>
 				{ props.buttonText }
 			</Button>
 		);
 	}
-
-	return upgradeButton;
 };
 
 PlanFeaturesActions.propTypes = {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -162,6 +162,8 @@ const PlanFeaturesActionsButton = ( {
 			</Button>
 		);
 	}
+
+	return null;
 };
 
 PlanFeaturesActions.propTypes = {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -63,6 +63,19 @@ const PlanFeaturesActionsButton = ( {
 		className
 	);
 
+	const handleUpgradeButtonClick = () => {
+		if ( isPlaceholder ) {
+			return;
+		}
+
+		trackTracksEvent( 'calypso_plan_features_upgrade_click', {
+			current_plan: currentSitePlanSlug,
+			upgrading_to: planType,
+		} );
+
+		onUpgradeClick();
+	};
+
 	if ( current && ! isInSignup ) {
 		return (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
@@ -110,19 +123,6 @@ const PlanFeaturesActionsButton = ( {
 		) {
 			buttonText = translate( 'Upgrade to Yearly' );
 		}
-
-		const handleUpgradeButtonClick = () => {
-			if ( isPlaceholder ) {
-				return;
-			}
-
-			trackTracksEvent( 'calypso_plan_features_upgrade_click', {
-				current_plan: currentSitePlanSlug,
-				upgrading_to: planType,
-			} );
-
-			onUpgradeClick();
-		};
 
 		upgradeButton = (
 			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -93,6 +93,7 @@ const PlanFeaturesActionsButton = ( {
 		if ( isLandingPage ) {
 			buttonText = translate( 'Select', { context: 'button' } );
 		}
+
 		if ( isLaunchPage ) {
 			if ( freePlan ) {
 				buttonText = translate( 'Keep this plan', {
@@ -109,7 +110,9 @@ const PlanFeaturesActionsButton = ( {
 						'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
 				} );
 			}
-		} else if ( isInSignup ) {
+		}
+
+		if ( ! isLaunchPage && isInSignup ) {
 			buttonText = translate( 'Start with %(plan)s', {
 				args: {
 					plan: planName,

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -109,42 +109,32 @@ const PlanFeaturesActionsButton = ( {
 		);
 	}
 
-	if ( ( availableForPurchase || isPlaceholder ) && isLaunchPage ) {
-		if ( ! freePlan ) {
-			return (
-				<Button
-					className={ classes }
-					onClick={ handleUpgradeButtonClick }
-					disabled={ isPlaceholder }
-				>
-					{ props.buttonText ||
-						translate( 'Select %(plan)s', {
-							args: {
-								plan: planName,
-							},
-							context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
-							comment:
-								'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
-						} ) }
-				</Button>
-			);
-		}
+	if ( ( availableForPurchase || isPlaceholder ) && isLaunchPage && ! freePlan ) {
+		return (
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+				{ props.buttonText ||
+					translate( 'Select %(plan)s', {
+						args: {
+							plan: planName,
+						},
+						context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
+						comment:
+							'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+					} ) }
+			</Button>
+		);
+	}
 
-		if ( freePlan ) {
-			return (
-				<Button
-					className={ classes }
-					onClick={ handleUpgradeButtonClick }
-					disabled={ isPlaceholder }
-				>
-					{ props.buttonText ||
-						translate( 'Keep this plan', {
-							comment:
-								'A selection to keep the current plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
-						} ) }
-				</Button>
-			);
-		}
+	if ( ( availableForPurchase || isPlaceholder ) && isLaunchPage && freePlan ) {
+		return (
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+				{ props.buttonText ||
+					translate( 'Keep this plan', {
+						comment:
+							'A selection to keep the current plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+					} ) }
+			</Button>
+		);
 	}
 
 	if ( ( availableForPurchase || isPlaceholder ) && isLandingPage ) {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -110,27 +110,41 @@ const PlanFeaturesActionsButton = ( {
 	}
 
 	if ( ( availableForPurchase || isPlaceholder ) && isLaunchPage ) {
-		let buttonText = '';
-		if ( freePlan ) {
-			buttonText = translate( 'Keep this plan', {
-				comment:
-					'A selection to keep the current plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
-			} );
-		} else {
-			buttonText = translate( 'Select %(plan)s', {
-				args: {
-					plan: planName,
-				},
-				context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
-				comment:
-					'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
-			} );
+		if ( ! freePlan ) {
+			return (
+				<Button
+					className={ classes }
+					onClick={ handleUpgradeButtonClick }
+					disabled={ isPlaceholder }
+				>
+					{ props.buttonText ||
+						translate( 'Select %(plan)s', {
+							args: {
+								plan: planName,
+							},
+							context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
+							comment:
+								'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+						} ) }
+				</Button>
+			);
 		}
-		return (
-			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
-				{ props.buttonText || buttonText }
-			</Button>
-		);
+
+		if ( freePlan ) {
+			return (
+				<Button
+					className={ classes }
+					onClick={ handleUpgradeButtonClick }
+					disabled={ isPlaceholder }
+				>
+					{ props.buttonText ||
+						translate( 'Keep this plan', {
+							comment:
+								'A selection to keep the current plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+						} ) }
+				</Button>
+			);
+		}
 	}
 
 	if ( ( availableForPurchase || isPlaceholder ) && isLandingPage ) {

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -13,24 +13,28 @@ import {
 	getCurrentPlan,
 	isCurrentPlanExpiring,
 	isRequestingSitePlans,
-} from 'state/sites/plans/selectors';
-import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { getSitePurchases } from 'state/purchases/selectors';
-import isJetpackCloudEligible from 'state/selectors/is-jetpack-cloud-eligible';
+} from 'calypso/state/sites/plans/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'calypso/state/ui/selectors';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import isJetpackCloudEligible from 'calypso/state/selectors/is-jetpack-cloud-eligible';
 import { Button, Card } from '@automattic/components';
 import MyPlanCard from './my-plan-card';
-import QuerySites from 'components/data/query-sites';
-import QuerySitePlans from 'components/data/query-site-plans';
-import QuerySitePurchases from 'components/data/query-site-purchases';
-import ProductExpiration from 'components/product-expiration';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { managePurchase } from 'me/purchases/paths';
-import { getPlan, planHasFeature } from 'lib/plans';
+import QuerySites from 'calypso/components/data/query-sites';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import ProductExpiration from 'calypso/components/product-expiration';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { managePurchase } from 'calypso/me/purchases/paths';
+import { getPlan, planHasFeature } from 'calypso/lib/plans';
 import {
 	isExpiring,
 	isPartnerPurchase,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
-} from 'lib/purchases';
+} from 'calypso/lib/purchases';
 import {
 	isFreeJetpackPlan,
 	isFreePlan,
@@ -39,17 +43,18 @@ import {
 	getJetpackProductTagline,
 	isJetpackBackup,
 	isJetpackScan,
-} from 'lib/products-values';
+} from 'calypso/lib/products-values';
 import {
 	PRODUCT_JETPACK_BACKUP_DAILY,
 	PRODUCT_JETPACK_SCAN,
 	PRODUCT_JETPACK_BACKUP_REALTIME,
-} from 'lib/products-values/constants';
-import Gridicon from 'components/gridicon';
-import QueryRewindState from 'components/data/query-rewind-state';
+} from 'calypso/lib/products-values/constants';
+import Gridicon from 'calypso/components/gridicon';
+import QueryRewindState from 'calypso/components/data/query-rewind-state';
 
 class PurchasesListing extends Component {
 	static propTypes = {
+		getManagePurchaseUrlFor: PropTypes.func,
 		currentPlan: PropTypes.object,
 		isPlanExpiring: PropTypes.bool,
 		isRequestingPlans: PropTypes.bool,
@@ -197,7 +202,7 @@ class PurchasesListing extends Component {
 		}
 
 		return (
-			<Button href={ managePurchase( selectedSiteSlug, purchase.id ) } compact>
+			<Button href={ this.props.getManagePurchaseUrlFor( selectedSiteSlug, purchase.id ) } compact>
 				{ label }
 			</Button>
 		);
@@ -355,10 +360,14 @@ class PurchasesListing extends Component {
 	}
 }
 
+const getSiteLevelManagePurchaseUrlFor = ( targetSiteSlug, targetPurchaseId ) =>
+	`/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }`;
+
 export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 
 	return {
+		getManagePurchaseUrlFor: selectedSiteId ? getSiteLevelManagePurchaseUrlFor : managePurchase,
 		currentPlan: getCurrentPlan( state, selectedSiteId ),
 		isPlanExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
 		isRequestingPlans: isRequestingSitePlans( state, selectedSiteId ),

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -51,6 +51,7 @@ import {
 } from 'calypso/lib/products-values/constants';
 import Gridicon from 'calypso/components/gridicon';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 
 class PurchasesListing extends Component {
 	static propTypes = {
@@ -360,14 +361,11 @@ class PurchasesListing extends Component {
 	}
 }
 
-const getSiteLevelManagePurchaseUrlFor = ( targetSiteSlug, targetPurchaseId ) =>
-	`/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }`;
-
 export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 
 	return {
-		getManagePurchaseUrlFor: selectedSiteId ? getSiteLevelManagePurchaseUrlFor : managePurchase,
+		getManagePurchaseUrlFor: selectedSiteId ? getManagePurchaseUrlFor : managePurchase,
 		currentPlan: getCurrentPlan( state, selectedSiteId ),
 		isPlanExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
 		isRequestingPlans: isRequestingSitePlans( state, selectedSiteId ),

--- a/client/state/selectors/get-current-plan-purchase-id.js
+++ b/client/state/selectors/get-current-plan-purchase-id.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { get, isNaN } from 'lodash';
+import { isNaN } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 
 /**
  * Returns a site's current plan purchase ID or null if the site doesn't exist or the purchase ID
@@ -21,7 +21,7 @@ import { getCurrentPlan } from 'state/sites/plans/selectors';
  * @returns {?number}        Purchase ID if known
  */
 export default function getCurrentPlanPurchaseId( state, siteId ) {
-	const result = get( getCurrentPlan( state, siteId ), 'id', null );
+	const result = getCurrentPlan( state, siteId )?.id;
 
 	// getCurrentPlan uses an "assembler" which may have NaN in the `id`.
 	if ( isNaN( result ) ) {

--- a/client/state/selectors/get-current-plan-purchase-id.js
+++ b/client/state/selectors/get-current-plan-purchase-id.js
@@ -21,7 +21,7 @@ import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
  * @returns {?number}        Purchase ID if known
  */
 export default function getCurrentPlanPurchaseId( state, siteId ) {
-	const result = getCurrentPlan( state, siteId )?.id;
+	const result = getCurrentPlan( state, siteId )?.id ?? null;
 
 	// getCurrentPlan uses an "assembler" which may have NaN in the `id`.
 	if ( isNaN( result ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the links in `/plans` and `/plans/my-plan` to use site-level routes `/purchases/subscriptions/:siteUrl/:purchaseId` when appropriate

#### Testing instructions

- Select a site with at least one upgrade
- Visit `/plans` and verify that all the "Manage plan" links use the correct site-level route
- Visit `/plans/my-plan` and verify that all the "Manage plan" links use the correct site-level route (watch out- there are two of them!)

Fixes #46219
