### PR TITLE
Checkout: Remove AUTHORIZING transactionStatus

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -72,19 +72,14 @@ export default function CreditCardPayButton( { disabled, store, stripe, stripeCo
 								if ( stripeResponse?.message?.payment_intent_client_secret ) {
 									debug( 'showing stripe authentication modal' );
 									onEvent( { type: 'SHOW_MODAL_AUTHORIZATION' } );
-									showStripeModalAuth( {
+									return showStripeModalAuth( {
 										stripeConfiguration,
 										response: stripeResponse,
-									} )
-										.then( ( authenticationResponse ) => {
-											debug( 'stripe authentication is complete', authenticationResponse );
-											setTransactionComplete();
-										} )
-										.catch( ( error ) => {
-											setTransactionError( error.message );
-										} );
-									return;
+									} );
 								}
+								return stripeResponse;
+							} )
+							.then( ( stripeResponse ) => {
 								// Redirect required
 								if ( stripeResponse?.redirect_url ) {
 									debug( 'stripe transaction requires redirect' );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/wechat.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/wechat.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import debugFactory from 'debug';
 import { sprintf } from '@wordpress/i18n';
@@ -22,15 +22,15 @@ import {
 /**
  * Internal dependencies
  */
-import { PaymentMethodLogos } from 'my-sites/checkout/composite-checkout/components/payment-method-logos';
-import Field from 'my-sites/checkout/composite-checkout/components/field';
+import { PaymentMethodLogos } from 'calypso/my-sites/checkout/composite-checkout/components/payment-method-logos';
+import Field from 'calypso/my-sites/checkout/composite-checkout/components/field';
 import {
 	SummaryLine,
 	SummaryDetails,
-} from 'my-sites/checkout/composite-checkout/components/summary-details';
-import WeChatPaymentQRcodeUnstyled from 'my-sites/checkout/checkout/wechat-payment-qrcode';
-import { useCart } from 'my-sites/checkout/composite-checkout/cart-provider';
-import userAgent from 'lib/user-agent';
+} from 'calypso/my-sites/checkout/composite-checkout/components/summary-details';
+import WeChatPaymentQRcodeUnstyled from 'calypso/my-sites/checkout/checkout/wechat-payment-qrcode';
+import { useCart } from 'calypso/my-sites/checkout/composite-checkout/cart-provider';
+import userAgent from 'calypso/lib/user-agent';
 
 const debug = debugFactory( 'calypso:composite-checkout:wechat-payment-method' );
 
@@ -146,28 +146,25 @@ function WeChatPayButton( { disabled, store, stripe, stripeConfiguration, siteSl
 	const { formStatus } = useFormStatus();
 	const {
 		setTransactionRedirecting,
-		setTransactionAuthorizing,
 		setTransactionError,
 		setTransactionPending,
-		transactionStatus,
-		transactionLastResponse,
-		resetTransaction,
 	} = useTransactionStatus();
 	const submitTransaction = usePaymentProcessor( 'wechat' );
 	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'wechat' ).getCustomerName() );
 	const cart = useCart();
+	const [ stripeResponseWithCode, setStripeResponseWithCode ] = useState( null );
 
-	useScrollQRCodeIntoView( transactionStatus === 'authorizing' );
+	useScrollQRCodeIntoView( !! stripeResponseWithCode );
 
-	if ( transactionStatus === 'authorizing' ) {
+	if ( stripeResponseWithCode ) {
 		return (
 			<WeChatPaymentQRcode
-				orderId={ transactionLastResponse.order_id }
+				orderId={ stripeResponseWithCode.order_id }
 				cart={ cart }
-				redirectUrl={ transactionLastResponse.redirect_url }
+				redirectUrl={ stripeResponseWithCode.redirect_url }
 				slug={ siteSlug }
-				reset={ resetTransaction }
+				reset={ () => setStripeResponseWithCode( null ) }
 			/>
 		);
 	}
@@ -205,7 +202,7 @@ function WeChatPayButton( { disabled, store, stripe, stripeConfiguration, siteSl
 							}
 
 							// For desktop, display the QR code
-							setTransactionAuthorizing( stripeResponse );
+							setStripeResponseWithCode( stripeResponse );
 						} )
 						.catch( ( error ) => {
 							setTransactionError( error.message );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/wechat.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/wechat.js
@@ -148,6 +148,7 @@ function WeChatPayButton( { disabled, store, stripe, stripeConfiguration, siteSl
 		setTransactionRedirecting,
 		setTransactionError,
 		setTransactionPending,
+		resetTransaction,
 	} = useTransactionStatus();
 	const submitTransaction = usePaymentProcessor( 'wechat' );
 	const onEvent = useEvents();
@@ -164,7 +165,10 @@ function WeChatPayButton( { disabled, store, stripe, stripeConfiguration, siteSl
 				cart={ cart }
 				redirectUrl={ stripeResponseWithCode.redirect_url }
 				slug={ siteSlug }
-				reset={ () => setStripeResponseWithCode( null ) }
+				reset={ () => {
+					resetTransaction();
+					setStripeResponseWithCode( null );
+				} }
 			/>
 		);
 	}

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -103,9 +103,9 @@ When the `submitButton` component has been clicked, it should do the following:
 
 1. Call `setTransactionPending()` from [useTransactionStatus](#useTransactionStatus). This will change the [form status](#useFormStatus) to [`.SUBMITTING`](#FormStatus) and disable the form.
 2. Call the payment processor function returned from [usePaymentProcessor](#usePaymentProcessor]), passing whatever data that function requires. Each payment processor will be different, so you'll need to know the API of that function explicitly.
-3. Payment processor functions return a `Promise`. When the `Promise` resolves, call `setTransactionComplete()` from [useTransactionStatus](#useTransactionStatus) if the transaction was a success. Depending on the payment processor, some transactions might require additional actions before they are complete. If the transaction requires a redirect, call `setTransactionRedirecting(url: string)` instead. If the transaction requires 3DS auth, use `setTransactionAuthorizing(response: object)`.
+3. Payment processor functions return a `Promise`. When the `Promise` resolves, call `setTransactionComplete()` from [useTransactionStatus](#useTransactionStatus) if the transaction was a success. Depending on the payment processor, some transactions might require additional actions before they are complete. If the transaction requires a redirect, call `setTransactionRedirecting(url: string)` instead.
 4. If the `Promise` rejects, call `setTransactionError(message: string)`.
-5. At this point the [CheckoutProvider](#CheckoutProvider) will automatically take action if the transaction status is [`.COMPLETE`](#TransactionStatus) (call [onPaymentComplete](#CheckoutProvider)), [`.ERROR`](#TransactionStatus) (display the error and re-enable the form), or [`.REDIRECTING`](#TransactionStatus) (redirect to the url). No action will be taken if the status is [`.AUTHORIZING`](#TransactionStatus); the payment method must handle that status manually and eventually set one of the other statuses. If for some reason the transaction should be cancelled, call `resetTransaction()`.
+5. At this point the [CheckoutProvider](#CheckoutProvider) will automatically take action if the transaction status is [`.COMPLETE`](#TransactionStatus) (call [onPaymentComplete](#CheckoutProvider)), [`.ERROR`](#TransactionStatus) (display the error and re-enable the form), or [`.REDIRECTING`](#TransactionStatus) (redirect to the url). If for some reason the transaction should be cancelled, call `resetTransaction()`.
 
 ## Line Items
 
@@ -303,7 +303,6 @@ An enum that holds the values of the [transaction status](#useTransactionStatus)
 
 - `.NOT_STARTED`
 - `.PENDING`
-- `.AUTHORIZING`
 - `.COMPLETE`
 - `.REDIRECTING`
 - `.ERROR`
@@ -479,13 +478,12 @@ A React Hook that returns an object with the following properties to be used by 
 - `previousTransactionStatus: `[`TransactionStatus.`](#TransactionStatus). The last status of the transaction.
 - `transactionError: string | null`. The most recent error message encountered by the transaction if its status is [`.ERROR`](#TransactionStatus).
 - `transactionRedirectUrl: string | null`. The redirect url to use if the transaction status is [`.REDIRECTING`](#TransactionStatus).
-- `transactionLastResponse: object | null`. The most recent full response object as returned by the transaction's endpoint and passed to `setTransactionAuthorizing` or `setTransactionComplete`.
+- `transactionLastResponse: object | null`. The most recent full response object as returned by the transaction's endpoint and passed to `setTransactionComplete`.
 - `resetTransaction: () => void`. Function to change the transaction status to [`.NOT_STARTED`](#TransactionStatus).
 - `setTransactionComplete: ( object ) => void`. Function to change the transaction status to [`.COMPLETE`](#TransactionStatus) and save the response object in `transactionLastResponse`.
 - `setTransactionError: ( string ) => void`. Function to change the transaction status to [`.ERROR`](#TransactionStatus) and save the error in `transactionError`.
 - `setTransactionPending: () => void`. Function to change the transaction status to [`.PENDING`](#TransactionStatus).
 - `setTransactionRedirecting: ( string ) => void`. Function to change the transaction status to [`.REDIRECTING`](#TransactionStatus) and save the redirect URL in `transactionRedirectUrl`.
-- `setTransactionAuthorizing: ( object ) => void`. Function to change the transaction status to [`.AUTHORIZING`](#TransactionStatus) and save the response object in `transactionLastResponse`.
 
 ## FAQ
 

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -22,7 +22,6 @@ const defaultTransactionStatusManager: TransactionStatusManager = {
 	setTransactionComplete: noop,
 	setTransactionPending: noop,
 	setTransactionRedirecting: noop,
-	setTransactionAuthorizing: noop,
 };
 
 interface CheckoutContext {

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -143,27 +143,25 @@ function ExistingCardPayButton( {
 					paymentPartnerProcessorId,
 				} )
 					.then( ( stripeResponse ) => {
+						// 3DS authentication required
 						if ( stripeResponse?.message?.payment_intent_client_secret ) {
-							debug( 'stripe transaction requires auth' );
+							debug( 'showing stripe authentication modal' );
 							onEvent( { type: 'SHOW_MODAL_AUTHORIZATION' } );
-							showStripeModalAuth( {
+							return showStripeModalAuth( {
 								stripeConfiguration,
 								response: stripeResponse,
-							} )
-								.then( ( authenticationResponse ) => {
-									debug( 'auth is complete', authenticationResponse );
-									setTransactionComplete( authenticationResponse );
-								} )
-								.catch( ( error ) => {
-									setTransactionError( error.message );
-								} );
-							return;
+							} );
 						}
+						return stripeResponse;
+					} )
+					.then( ( stripeResponse ) => {
+						// Redirect required
 						if ( stripeResponse?.redirect_url ) {
 							debug( 'stripe transaction requires redirect' );
 							setTransactionRedirecting( stripeResponse.redirect_url );
 							return;
 						}
+						// Nothing more required
 						debug( 'stripe transaction is successful' );
 						setTransactionComplete();
 					} )

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -414,27 +414,25 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 						stripeConfiguration,
 					} )
 						.then( ( stripeResponse ) => {
+							// 3DS authentication required
 							if ( stripeResponse?.message?.payment_intent_client_secret ) {
-								debug( 'stripe transaction requires auth' );
+								debug( 'showing stripe authentication modal' );
 								onEvent( { type: 'SHOW_MODAL_AUTHORIZATION' } );
-								showStripeModalAuth( {
+								return showStripeModalAuth( {
 									stripeConfiguration,
 									response: stripeResponse,
-								} )
-									.then( ( authenticationResponse ) => {
-										debug( 'stripe auth is complete', authenticationResponse );
-										setTransactionComplete();
-									} )
-									.catch( ( error ) => {
-										setTransactionError( error.message );
-									} );
-								return;
+								} );
 							}
+							return stripeResponse;
+						} )
+						.then( ( stripeResponse ) => {
+							// Redirect required
 							if ( stripeResponse?.redirect_url ) {
 								debug( 'stripe transaction requires redirect' );
 								setTransactionRedirecting( stripeResponse.redirect_url );
 								return;
 							}
+							// Nothing more required
 							debug( 'stripe transaction is successful' );
 							setTransactionComplete();
 						} )

--- a/packages/composite-checkout/src/lib/transaction-status.ts
+++ b/packages/composite-checkout/src/lib/transaction-status.ts
@@ -70,16 +70,6 @@ export function useTransactionStatusManager(): TransactionStatusManager {
 			} ),
 		[]
 	);
-	const setTransactionAuthorizing = useCallback<
-		TransactionStatusManager[ 'setTransactionAuthorizing' ]
-	>(
-		( response ) =>
-			dispatch( {
-				type: 'STATUS_SET',
-				payload: { status: TransactionStatus.AUTHORIZING, response },
-			} ),
-		[]
-	);
 
 	const {
 		transactionStatus,
@@ -101,7 +91,6 @@ export function useTransactionStatusManager(): TransactionStatusManager {
 			setTransactionComplete,
 			setTransactionPending,
 			setTransactionRedirecting,
-			setTransactionAuthorizing,
 		} ),
 		[
 			transactionStatus,
@@ -114,7 +103,6 @@ export function useTransactionStatusManager(): TransactionStatusManager {
 			setTransactionComplete,
 			setTransactionPending,
 			setTransactionRedirecting,
-			setTransactionAuthorizing,
 		]
 	);
 }

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -109,7 +109,6 @@ export type PaymentProcessorFunction = (
 export enum TransactionStatus {
 	NOT_STARTED = 'not-started',
 	PENDING = 'pending',
-	AUTHORIZING = 'authorizing',
 	COMPLETE = 'complete',
 	REDIRECTING = 'redirecting',
 	ERROR = 'error',
@@ -140,11 +139,6 @@ export interface TransactionStatusPayloadPending
 	status: TransactionStatus.PENDING;
 }
 
-export interface TransactionStatusPayloadAuthorizing
-	extends Required< Pick< TransactionStatusPayloads, 'status' | 'response' > > {
-	status: TransactionStatus.AUTHORIZING;
-}
-
 export interface TransactionStatusPayloadComplete
 	extends Required< Pick< TransactionStatusPayloads, 'status' | 'response' > > {
 	status: TransactionStatus.COMPLETE;
@@ -163,7 +157,6 @@ export interface TransactionStatusPayloadError
 export type TransactionStatusPayload =
 	| TransactionStatusPayloadNotStarted
 	| TransactionStatusPayloadPending
-	| TransactionStatusPayloadAuthorizing
 	| TransactionStatusPayloadComplete
 	| TransactionStatusPayloadRedirecting
 	| TransactionStatusPayloadError;
@@ -176,7 +169,6 @@ export interface TransactionStatusManager extends TransactionStatusState {
 	setTransactionComplete: ( response: PaymentProcessorResponse ) => void;
 	setTransactionPending: () => void;
 	setTransactionRedirecting: ( url: string ) => void;
-	setTransactionAuthorizing: ( response: PaymentProcessorResponse ) => void;
 }
 
 export interface LineItemsState {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The transaction status manager in the composite-checkout package has several statuses for the lifecycle of a transaction, and each one has a semantic meaning which triggers some generalized behavior. For example, the "completed" status redirects to the thank-you page, the "error" status displays an error, and the "redirect" status redirects to an external URL. However, there is one status with no specific meaning, "authorizing".

The "authorizing" status was added originally to represent the need to display 3D Secure authentication for a Stripe credit card. However, since composite-checkout is agnostic to payment methods, it was created instead as a generic "doing something" status that a payment method could use for its own purposes. This allowed the credit card payment method to use it for 3D Secure and later it was used to display the WeChat QR code.

After thinking about this some more, I realized that both of these use-cases are very specific to their payment method and don't really require having a new status to represent them. They can each manage their behavior inline or with local state.

This PR alters these payment methods to remove the "authorizing" status and then removes that status entirely.

#### Testing instructions

- Complete checkout with a non-3DS card (eg: `4242 4242 4242 4242`) and verify that everything works as expected.
- Complete checkout with a 3DS card (eg: `4000 0027 6000 3184`) and verify that everything works as expected, including the 3DS prompt.
- Complete checkout with a non-3DS saved payment method and verify that everything works as expected.
- Complete checkout with a 3DS saved payment method and verify that everything works as expected, including the 3DS prompt.
- Complete checkout with the WeChat payment method (not on mobile where the QR code would not be displayed). See below for instructions:

#### WeChat testing

- Apply D45650-code to force WeChat Pay to be available and sandbox the store.
- Add a plan to your cart and visit checkout. 
- Verify that "WeChat Pay" is an option displayed in the final payment step.
- Fill out the "Name" field and submit the payment.
- Verify that you see a QR code appear and it is scrolled into view.
- In a *new window or tab* open the link at the bottom that reads "To open and pay with the wechat pay app directly, click here".
- In the new window, you should see a Stripe test page.
- Click to accept the payment and verify that the payment completes successfully in the original window and that the plan is purchased.