### PR TITLE
Fix: check if item exist before accessing its properties

### DIFF
--- a/client/my-sites/plans-v2/use-item-price.ts
+++ b/client/my-sites/plans-v2/use-item-price.ts
@@ -109,7 +109,7 @@ const useItemPrice = (
 		}
 	}
 
-	// Jetpack CRM price won't come from the API, so we need to hard-code it.
+	// Jetpack CRM price won't come from the API, so we need to hard-code it for now.
 	if ( item && [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes( item.productSlug ) ) {
 		discountedPrice = 11;
 		originalPrice = 132;

--- a/client/my-sites/plans-v2/use-item-price.ts
+++ b/client/my-sites/plans-v2/use-item-price.ts
@@ -110,7 +110,7 @@ const useItemPrice = (
 	}
 
 	// Jetpack CRM price won't come from the API, so we need to hard-code it.
-	if ( [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes( item.productSlug ) ) {
+	if ( item && [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes( item.productSlug ) ) {
 		discountedPrice = 11;
 		originalPrice = 132;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* From within the `useItemPrice` hook, we are accessing a property from a variable that could be `null`, therefore, we need to check first if this variable is not `null` before doing anything with it.

#### Testing instructions

* Code review.
