### PR TITLE
Plans: replace option cards with daily products

### DIFF
--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -7,8 +7,8 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import FormattedHeader from 'components/formatted-header';
-import { preventWidows } from 'lib/formatting';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { preventWidows } from 'calypso/lib/formatting';
 import JetpackComMasterbar from '../jpcom-masterbar';
 
 /**
@@ -23,15 +23,10 @@ const Header = () => (
 			<FormattedHeader
 				className="header__main-title"
 				headerText={ preventWidows(
-					translate( 'Security, performance, and marketing tools for WordPress' )
+					translate( 'Security, performance, and growth tools for WordPress' )
 				) }
 				align="center"
 			/>
-			<p>
-				{ translate(
-					'Get everything your site needs, in one package — so you can focus on your business.'
-				) }
-			</p>
 		</div>
 	</>
 );

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -7,6 +7,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'calypso/config';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { preventWidows } from 'calypso/lib/formatting';
 import JetpackComMasterbar from '../jpcom-masterbar';
@@ -16,19 +17,31 @@ import JetpackComMasterbar from '../jpcom-masterbar';
  */
 import './style.scss';
 
-const Header = () => (
-	<>
-		<JetpackComMasterbar />
-		<div className="header">
-			<FormattedHeader
-				className="header__main-title"
-				headerText={ preventWidows(
-					translate( 'Security, performance, and growth tools for WordPress' )
+const Header = () => {
+	const isAlternateSelector = isEnabled( 'plans/alternate-selector' );
+	const header = isAlternateSelector
+		? translate( 'Security, performance, and growth tools for WordPress' )
+		: translate( 'Security, performance, and marketing tools for WordPress' );
+
+	return (
+		<>
+			<JetpackComMasterbar />
+			<div className="header">
+				<FormattedHeader
+					className="header__main-title"
+					headerText={ preventWidows( header ) }
+					align="center"
+				/>
+				{ ! isAlternateSelector && (
+					<p>
+						{ translate(
+							'Get everything your site needs, in one package — so you can focus on your business.'
+						) }
+					</p>
 				) }
-				align="center"
-			/>
-		</div>
-	</>
-);
+			</div>
+		</>
+	);
+};
 
 export default Header;

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -19,7 +19,7 @@ import {
 	PRODUCT_JETPACK_CRM,
 	PRODUCT_JETPACK_CRM_MONTHLY,
 	JETPACK_BACKUP_PRODUCTS,
-} from 'lib/products-values/constants';
+} from 'calypso/lib/products-values/constants';
 import {
 	PLAN_JETPACK_COMPLETE,
 	PLAN_JETPACK_COMPLETE_MONTHLY,
@@ -48,13 +48,13 @@ import {
 	FEATURE_CRM_TRACK_TRANSACTIONS,
 	FEATURE_CRM_NO_CONTACT_LIMITS,
 	FEATURE_CRM_PRIORITY_SUPPORT,
-} from 'lib/plans/constants';
+} from 'calypso/lib/plans/constants';
 import { buildCardFeaturesFromItem } from './utils';
 
 /**
  * Type dependencies
  */
-import type { JetpackRealtimePlan } from 'lib/plans/types';
+import type { JetpackRealtimePlan } from 'calypso/lib/plans/types';
 import type { SelectorProduct, SelectorProductSlug, ProductType } from './types';
 
 export const ALL = 'all';
@@ -380,6 +380,13 @@ export const SELECTOR_PRODUCTS = [
 export const SELECTOR_PLANS = [
 	OPTIONS_JETPACK_SECURITY,
 	OPTIONS_JETPACK_SECURITY_MONTHLY,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+];
+
+export const SELECTOR_PLANS_ALT = [
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 	PLAN_JETPACK_COMPLETE,
 	PLAN_JETPACK_COMPLETE_MONTHLY,
 ];

--- a/client/my-sites/plans-v2/products-grid-alt/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-alt/index.tsx
@@ -14,7 +14,7 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card';
-import { SELECTOR_PLANS } from '../constants';
+import { SELECTOR_PLANS_ALT } from '../constants';
 import {
 	getAllOptionsFromSlug,
 	getJetpackDescriptionWithOptions,
@@ -47,7 +47,7 @@ const getPlansToDisplay = ( {
 
 	const currentPlanOptions = currentPlanSlug ? getAllOptionsFromSlug( currentPlanSlug ) : [];
 
-	const plansToDisplay = SELECTOR_PLANS.map( slugToSelectorProduct )
+	const plansToDisplay = SELECTOR_PLANS_ALT.map( slugToSelectorProduct )
 		// Remove plans that don't fit the filters or have invalid data.
 		.filter(
 			( product: SelectorProduct | null ): product is SelectorProduct =>
@@ -66,7 +66,7 @@ const getPlansToDisplay = ( {
 	if (
 		currentPlanSlug &&
 		( JETPACK_LEGACY_PLANS.includes( currentPlanSlug ) ||
-			SELECTOR_PLANS.includes( currentPlanSlug ) )
+			SELECTOR_PLANS_ALT.includes( currentPlanSlug ) )
 	) {
 		const currentPlanSelectorProduct = slugToSelectorProduct( currentPlanSlug );
 		if ( currentPlanSelectorProduct ) {

--- a/client/my-sites/plans-v2/selector-alt.tsx
+++ b/client/my-sites/plans-v2/selector-alt.tsx
@@ -11,9 +11,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import PlansFilterBar from './plans-filter-bar';
 import { EXTERNAL_PRODUCTS_LIST } from './constants';
-import { getPathToDetails, getPathToUpsell, checkout } from './utils';
+import { getPathToDetails, checkout } from './utils';
 import QueryProducts from './query-products';
-import useHasProductUpsell from './use-has-product-upsell';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getYearlyPlanByMonthly } from 'calypso/lib/plans';
 import { TERM_ANNUALLY } from 'calypso/lib/plans/constants';
@@ -29,7 +28,6 @@ import ProductsGridAlt from './products-grid-alt';
  * Type dependencies
  */
 import type { Duration, SelectorPageProps, SelectorProduct, PurchaseCallback } from './types';
-import type { ProductSlug } from 'calypso/lib/products-values/types';
 
 import './style.scss';
 
@@ -46,7 +44,6 @@ const SelectorPageAlt = ( {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const siteSlug = siteSlugProp || siteSlugState;
-	const hasUpsell = useHasProductUpsell();
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
 
 	useEffect( () => {
@@ -105,20 +102,6 @@ const SelectorPageAlt = ( {
 			);
 			page(
 				getPathToDetails( rootUrl, urlQueryArgs, product.productSlug, currentDuration, siteSlug )
-			);
-			return;
-		}
-
-		if ( hasUpsell( product.productSlug as ProductSlug ) ) {
-			dispatch(
-				recordTracksEvent( 'calypso_product_upsell_click', {
-					site_id: siteId || undefined,
-					product_slug: product.productSlug,
-					duration: currentDuration,
-				} )
-			);
-			page(
-				getPathToUpsell( rootUrl, urlQueryArgs, product.productSlug, currentDuration, siteSlug )
 			);
 			return;
 		}

--- a/client/my-sites/plans-v2/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans-v2/use-get-plans-grid-products.ts
@@ -6,23 +6,26 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'calypso/config';
 import { slugToSelectorProduct } from './utils';
-import { getPlan } from 'lib/plans';
+import { getPlan } from 'calypso/lib/plans';
 import {
 	JETPACK_ANTI_SPAM_PRODUCTS,
 	JETPACK_BACKUP_PRODUCTS,
+	PRODUCT_JETPACK_BACKUP_DAILY,
+	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 	JETPACK_SCAN_PRODUCTS,
 	JETPACK_SEARCH_PRODUCTS,
 	JETPACK_PRODUCTS_LIST,
 	PRODUCT_JETPACK_CRM,
 	PRODUCT_JETPACK_CRM_MONTHLY,
-} from 'lib/products-values/constants';
+} from 'calypso/lib/products-values/constants';
 import {
 	OPTIONS_JETPACK_BACKUP,
 	OPTIONS_JETPACK_BACKUP_MONTHLY,
-} from 'my-sites/plans-v2/constants';
-import getSitePlan from 'state/sites/selectors/get-site-plan';
-import getSiteProducts from 'state/sites/selectors/get-site-products';
+} from 'calypso/my-sites/plans-v2/constants';
+import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
+import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
 
 const useSelectorPageProducts = ( siteId: number | null ) => {
 	let availableProducts: string[] = [];
@@ -63,11 +66,11 @@ const useSelectorPageProducts = ( siteId: number | null ) => {
 	if (
 		! ownedProducts.some( ( ownedProduct ) => JETPACK_BACKUP_PRODUCTS.includes( ownedProduct ) )
 	) {
-		availableProducts = [
-			...availableProducts,
-			OPTIONS_JETPACK_BACKUP,
-			OPTIONS_JETPACK_BACKUP_MONTHLY,
-		];
+		// The Alternative Selector page include Jetpack Backup Daily rather than the option card.
+		const backupProductsToShow = isEnabled( 'plans/alternate-selector' )
+			? [ PRODUCT_JETPACK_BACKUP_DAILY, PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]
+			: [ OPTIONS_JETPACK_BACKUP, OPTIONS_JETPACK_BACKUP_MONTHLY ];
+		availableProducts = [ ...availableProducts, ...backupProductsToShow ];
 	}
 
 	// If Jetpack Scan is directly or indirectly owned, continue, otherwise make it available.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Instead of showing option/generic cards for Jetpack Security and Jetpack Backup, show the daily version of them.
* Remove upsell step from the flow.
* Update Pricing page header.

#### Testing instructions

* Run this PR locally (both envs).
* Visit the Pricing page `http://jetpack.cloud.localhost:3001/pricing`.
* Verify that the header looks like the capture below (we removed the subtitle).
* Verify that Jetpack Security is no longer an option/generic card and instead it is Jetpack Security Daily.
* Verify that Jetpack Backup is no longer an option/generic card and instead it is Jetpack Backup Daily.
* Click on the Jetpack Backup Daily CTA.
* Verify that you were redirected to the checkout page and that you didn't see the upsell page.
* Repeat the steps in Calypso Blue.

Fixes #

#### Demo
##### WordPress.com/plans
![image](https://user-images.githubusercontent.com/3418513/95639729-f8fe6000-0a6f-11eb-8c5c-781100b71da6.png)

##### Pricing page
![image](https://user-images.githubusercontent.com/3418513/95639662-b8064b80-0a6f-11eb-9344-f7a10b3118a9.png)

