### PR TITLE
Editor Controller: Update authentication check logic

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -106,7 +106,7 @@ export const authenticate = ( context, next ) => {
 
 	let isAuthenticated =
 		globalThis.sessionStorage.getItem( storageKey ) || // Previously authenticated.
-		! isJetpack || // Simple sites users are always authenticated.
+		! isJetpack || // If the site is not Jetpack (Atomic or self hosted) then it's a simple site and users are always authenticated.
 		( isJetpack && isSSOEnabled( state, siteId ) ) || // Assume we can authenticate with SSO
 		isDesktop || // The desktop app can store third-party cookies.
 		context.query.authWpAdmin; // Redirect back from the WP Admin login page to Calypso.

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -22,7 +22,6 @@ import {
 	isJetpackSite,
 	isSSOEnabled,
 } from 'calypso/state/sites/selectors';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isEnabled } from 'calypso/config';
 import { Placeholder } from './placeholder';
 import { makeLayout, render } from 'calypso/controller';
@@ -101,16 +100,18 @@ export const authenticate = ( context, next ) => {
 	const state = context.store.getState();
 
 	const siteId = getSelectedSiteId( state );
+	const isJetpack = isJetpackSite( state, siteId );
 	const isDesktop = isEnabled( 'desktop' );
 	const storageKey = `gutenframe_${ siteId }_is_authenticated`;
 
 	let isAuthenticated =
 		globalThis.sessionStorage.getItem( storageKey ) || // Previously authenticated.
-		! isSiteWpcomAtomic( state, siteId ) || // Simple sites users are always authenticated.
+		! isJetpack || // Simple sites users are always authenticated.
+		( isJetpack && isSSOEnabled( state, siteId ) ) || // Assume we can authenticate with SSO
 		isDesktop || // The desktop app can store third-party cookies.
 		context.query.authWpAdmin; // Redirect back from the WP Admin login page to Calypso.
 
-	if ( isDesktop && isJetpackSite( state, siteId ) && ! isSSOEnabled( state, siteId ) ) {
+	if ( isDesktop && isJetpack && ! isSSOEnabled( state, siteId ) ) {
 		isAuthenticated = false;
 	}
 


### PR DESCRIPTION
While testing some changes to the state we made after deprecating the
Calypso editor, we noticed that Atomic sites would not redirect properly
in the editor iframe when accessed on a version of Calypso not on
wordpress.com or calypso.localhost.

This occurred because these are the domains that are allowed by
`wp_safe_redirect` and for Atomic sites we were always redirecting to
`wp-login.php` with a return address of the iframe in Calypso. This
could be on hosts like calypso.live, or horizon.wordpress.com. In those
cases the `wp_safe_redirect check would fail, and we would be sent to
the `wp-admin` dashboard.

Jetpack sites did not exhibit the same behaviour, and it was because we
were treating those like simple sites, assuming we were authenticated or
could authenticate via SSO.

There are a couple of solutions to this. The first is to allow more
domains to be used with `wp_safe_redirect` on Atomic sites. We could
bring this in alignment to the checks we have on WordPress.com. I've
started exploring that, but decided that to implement the second
option. That is to treat Atomic sites like we are currently treating
other Jetpack sites.

#### Changes proposed in this Pull Request

This change updates the logic in the authentication check of the
editor's controller to assume that we are authenticated (or can
authenticate) if the site is a Jetpack site with SSO enabled. If it's
not a Jetpack site, then it's a simple site and similarly we are alwys
authenticated.

#### Testing instructions

* With an Atomic site that is eligible for Gutenframe (you can check that the editor loads in production on wordpress.com/block-editor), try to create a post while using Calypso on horizon.wordpress.com. You will be redirected to `/wp-admin/'.
* Try to create a post using the calypso.live link on this PR and it should load correctly in the Gutenframe.
* Check other site types, Jetpack, Simple, Atomic with denied plugins etc. The loading of the editor should behave in the same way as it does currently in production.