### PR TITLE
Billing: Remove "upgrades/credit-cards" Config Flag

### DIFF
--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
 import { addCreditCard, billingHistoryReceipt } from 'calypso/me/purchases/paths';
 import { Card } from '@automattic/components';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import config from 'calypso/config';
 import CreditCards from 'calypso/me/purchases/credit-cards';
 import PurchasesHeader from '../purchases/purchases-list/header';
 import BillingHistoryTable from './billing-history-table';
@@ -40,9 +39,7 @@ const BillingHistory = ( { translate } ) => (
 		<QueryBillingTransactions />
 		<PurchasesHeader section={ 'billing' } />
 		<BillingHistoryList />
-		{ config.isEnabled( 'upgrades/credit-cards' ) && (
-			<CreditCards addPaymentMethodUrl={ addCreditCard } />
-		) }
+		<CreditCards addPaymentMethodUrl={ addCreditCard } />
 	</Main>
 );
 

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import config from 'calypso/config';
 import { addCardDetails, editCardDetails } from './paths';
 import {
 	isExpired,
@@ -16,9 +15,6 @@ function isDataLoading( props ) {
 }
 
 function canEditPaymentDetails( purchase ) {
-	if ( ! config.isEnabled( 'upgrades/credit-cards' ) ) {
-		return false;
-	}
 	return (
 		! isExpired( purchase ) &&
 		! isOneTimePurchase( purchase ) &&

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -133,7 +133,6 @@
 		"try/preload": true,
 		"try/single-cdn": true,
 		"upgrades/checkout": true,
-		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -99,7 +99,6 @@
 		"signup/wpforteams": true,
 		"site-indicator": true,
 		"upgrades/checkout": true,
-		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": false,
 		"upgrades/premium-themes": true,

--- a/config/development.json
+++ b/config/development.json
@@ -185,7 +185,6 @@
 		"try/preload": true,
 		"try/single-cdn": true,
 		"upgrades/checkout": true,
-		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -128,7 +128,6 @@
 		"memberships": true,
 		"support-user": true,
 		"upgrades/checkout": true,
-		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,

--- a/config/production.json
+++ b/config/production.json
@@ -139,7 +139,6 @@
 		"support-user": true,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
-		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -146,7 +146,6 @@
 		"support-user": true,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
-		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,

--- a/config/test.json
+++ b/config/test.json
@@ -102,7 +102,6 @@
 		"site-indicator": true,
 		"support-user": true,
 		"upgrades/checkout": true,
-		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -157,7 +157,6 @@
 		"try/preload": true,
 		"try/single-cdn": true,
 		"upgrades/checkout": true,
-		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the config flag for `upgrades/credit-cards` as it's enabled in every environment.

#### Testing instructions

Verify that all cases of the flag for each environment has been removed, along with any usages of it (there should only be two): https://github.com/Automattic/wp-calypso/search?q=upgrades%2Fcredit-cards

Fixes #46313
