### PR TITLE
Add a comment to registering hook

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -924,6 +924,7 @@ function handleCheckoutModal( calypsoPort ) {
 	port1.onmessage = ( message ) => {
 		const { isCheckoutOverlayEnabled } = message.data;
 
+		// Conditionally add the hook if the feature flag is enabled.
 		if ( isCheckoutOverlayEnabled ) {
 			addAction(
 				'a8c.wpcom-block-editor.openCheckoutModal',


### PR DESCRIPTION
(Note: We're doing this because the previous PR https://github.com/Automattic/wp-calypso/pull/46241 was merged too early without rebase so we are triggering a new phab patch and merge the new one instead.)

#### Changes proposed in this Pull Request

* Add a comment to explain the conditional registration of the hook added for the checkout overlay.

#### Testing instructions

* Enable Sandbox.
* Run `yarn dev --sync` on `apps/wpcom-block-editor`.
* Open block editor of the free site with the feature flag `?flags=post-editor/checkout-overlay`, e.g. `calypso.localhost:3000/block-editor/post/your_sandboxed_free_site.wordpress.com?flags=post-editor/checkout-overlay`
* Open up developer tools > console, change the frame to `post.php` and run the following snippet in your console `wp.hooks.hasAction( 'a8c.wpcom-block-editor.openCheckoutModal' );` this should return `true`
* Remove the flag `?flags=post-editor/checkout-overlay` from your URL, refresh the page and run the snippet again (making sure to change the frame to `post.php`). This should return `false`
