### PR TITLE
Components: Use FormLabel in component examples

### DIFF
--- a/client/blocks/post-share/docs/example.jsx
+++ b/client/blocks/post-share/docs/example.jsx
@@ -1,24 +1,23 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
-import { get } from 'lodash';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import FormToggle from 'components/forms/form-toggle/compact';
+import Notice from 'components/notice';
 import PostShare from 'blocks/post-share';
 import QueryPosts from 'components/data/query-posts';
 import QuerySitePlans from 'components/data/query-site-plans';
+import QuerySites from 'components/data/query-sites';
+import { Card } from '@automattic/components';
+import { getCurrentUser } from 'state/current-user/selectors';
 import { getSite, getSitePlanSlug } from 'state/sites/selectors';
 import { getSitePosts } from 'state/posts/selectors';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { Card } from '@automattic/components';
-import QuerySites from 'components/data/query-sites';
-import FormToggle from 'components/forms/form-toggle/compact';
-import Notice from 'components/notice';
 
 class PostShareExample extends Component {
 	state = {

--- a/client/blocks/post-share/docs/example.jsx
+++ b/client/blocks/post-share/docs/example.jsx
@@ -8,16 +8,16 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import FormToggle from 'components/forms/form-toggle/compact';
-import Notice from 'components/notice';
-import PostShare from 'blocks/post-share';
-import QueryPosts from 'components/data/query-posts';
-import QuerySitePlans from 'components/data/query-site-plans';
-import QuerySites from 'components/data/query-sites';
+import FormToggle from 'calypso/components/forms/form-toggle/compact';
+import Notice from 'calypso/components/notice';
+import PostShare from 'calypso/blocks/post-share';
+import QueryPosts from 'calypso/components/data/query-posts';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QuerySites from 'calypso/components/data/query-sites';
 import { Card } from '@automattic/components';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { getSite, getSitePlanSlug } from 'state/sites/selectors';
-import { getSitePosts } from 'state/posts/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getSite, getSitePlanSlug } from 'calypso/state/sites/selectors';
+import { getSitePosts } from 'calypso/state/posts/selectors';
 
 class PostShareExample extends Component {
 	state = {

--- a/client/blocks/post-share/docs/example.jsx
+++ b/client/blocks/post-share/docs/example.jsx
@@ -45,11 +45,9 @@ class PostShareExample extends Component {
 					</p>
 				) }
 
-				<p onClick={ this.toggleEnable }>
-					<label>
-						Enabled: <FormToggle checked={ this.state.isEnabled } />
-					</label>
-				</p>
+				<FormToggle onChange={ this.toggleEnable } checked={ this.state.isEnabled }>
+					Live Sharing Enabled
+				</FormToggle>
 
 				{ this.state.isEnabled && (
 					<Notice

--- a/client/components/global-notices/docs/example.jsx
+++ b/client/components/global-notices/docs/example.jsx
@@ -1,18 +1,17 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
 import ButtonGroup from 'components/button-group';
 import FormCheckbox from 'components/forms/form-checkbox';
 import notices from 'notices';
+import { Button } from '@automattic/components';
 import { createNotice } from 'state/notices/actions';
 
 class GlobalNotices extends Component {

--- a/client/components/global-notices/docs/example.jsx
+++ b/client/components/global-notices/docs/example.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
  */
 import ButtonGroup from 'calypso/components/button-group';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
 import notices from 'calypso/notices';
 import { Button } from '@automattic/components';
 import { createNotice } from 'calypso/state/notices/actions';
@@ -44,10 +45,10 @@ class GlobalNotices extends Component {
 	render() {
 		return (
 			<div>
-				<label>
+				<FormLabel>
 					<FormCheckbox onChange={ this.toggleUseState } checked={ this.state.useState } />
 					<span>Use global application state</span>
-				</label>
+				</FormLabel>
 				<ButtonGroup>
 					<Button onClick={ this.showSuccessNotice }>Show success notice</Button>
 					<Button onClick={ this.showErrorNotice }>Show error notice</Button>

--- a/client/components/global-notices/docs/example.jsx
+++ b/client/components/global-notices/docs/example.jsx
@@ -8,11 +8,11 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import ButtonGroup from 'components/button-group';
-import FormCheckbox from 'components/forms/form-checkbox';
-import notices from 'notices';
+import ButtonGroup from 'calypso/components/button-group';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import notices from 'calypso/notices';
 import { Button } from '@automattic/components';
-import { createNotice } from 'state/notices/actions';
+import { createNotice } from 'calypso/state/notices/actions';
 
 class GlobalNotices extends Component {
 	constructor() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sort imports and make them relative to Calypso root in `PostShareExample`.
* Update `PostShareExample` to use `FormToggle` without direct usage of `<label />`.
* Sort imports and make them relative to Calypso root in `GlobalNotices` example.
* Update `GlobalNotices` example to use `FormLabel` instead of `<label />`.

See #45259 for context.

#### Testing instructions

* Test the following and verify they look well:
  * Go to `/devdocs/blocks/post-share`
  * Verify the toggle label looks good.
  * Go to `/devdocs/design/global-notices`
  * Verify the checkbox label looks good.
* Note that while both instances have visual differences, they actually make the component usage more consistent.

