### PR TITLE
Components: Use FormLabel in Community Translator

### DIFF
--- a/client/components/community-translator/translatable-textarea.jsx
+++ b/client/components/community-translator/translatable-textarea.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import FormLabel from 'calypso/components/forms/form-label';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 
 const TranslatableTextarea = ( {
@@ -16,7 +17,7 @@ const TranslatableTextarea = ( {
 	value,
 	disabled,
 } ) => (
-	<label className="community-translator__string-container" htmlFor={ fieldName }>
+	<FormLabel className="community-translator__string-container" htmlFor={ fieldName }>
 		<span className="community-translator__string-description">{ title }</span>
 		<span>
 			<dfn>{ originalString }</dfn>
@@ -28,6 +29,6 @@ const TranslatableTextarea = ( {
 				onChange={ onChange }
 			/>
 		</span>
-	</label>
+	</FormLabel>
 );
 export default TranslatableTextarea;

--- a/client/components/community-translator/translatable-textarea.jsx
+++ b/client/components/community-translator/translatable-textarea.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FormTextarea from 'components/forms/form-textarea';
+import FormTextarea from 'calypso/components/forms/form-textarea';
 
 const TranslatableTextarea = ( {
 	originalString,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Components: Use FormLabel in Community Translator, part of #45259.

#### Testing instructions

* Checkout this branch.
* Change `GP_PROJECT` to always be equal to `wpcom`.
* Change `isCommunityTranslatorEnabled` to always return `true`.
* Access local Calypso with `?flags=i18n/community-translator`
* Right click on a localized string to edit/suggest translation.
* Verify the label inside the dialog is unchanged.
