### PR TITLE
Components: Update SubscriptionLengthOption to use FormLabel

### DIFF
--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { uniqueId } from 'lodash';
 import PropTypes from 'prop-types';
@@ -11,10 +10,10 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-
-import Badge from 'components/badge';
-import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
+import Badge from 'calypso/components/badge';
+import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
+import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'calypso/lib/plans/constants';
 
 const TYPE_NEW_SALE = 'new-sale';
 const TYPE_UPGRADE = 'upgrade';
@@ -54,7 +53,7 @@ export class SubscriptionLengthOption extends React.Component {
 			'is-active': checked,
 		} );
 		return (
-			<label className={ className } htmlFor={ this.htmlId }>
+			<FormLabel className={ className } htmlFor={ this.htmlId }>
 				<div className="subscription-length-picker__option-radio-wrapper">
 					<FormRadio
 						id={ this.htmlId }
@@ -67,7 +66,7 @@ export class SubscriptionLengthOption extends React.Component {
 				<div className="subscription-length-picker__option-content">
 					{ type === TYPE_NEW_SALE ? this.renderNewSaleContent() : this.renderUpgradeContent() }
 				</div>
-			</label>
+			</FormLabel>
 		);
 	}
 

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -38,7 +38,11 @@
 	width: 100%;
 	cursor: pointer;
 
+	font-size: $font-body;
+	font-weight: 400;
+
 	padding: $padding-size;
+	margin-bottom: 0;
 	border-radius: 2px;
 
 	background: var( --color-surface );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Components: Update `SubscriptionLengthOption` to use `FormLabel`, see #45259 for context.

#### Testing instructions

* Go to `/devdocs/blocks/subscription-length-picker`
* Verify it looks and works the same way as in production.