### PR TITLE
Billing History: Use FormLabel in BillingReceipt

### DIFF
--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -10,6 +10,7 @@ import { localize, useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
+import FormLabel from 'calypso/components/forms/form-label';
 import TextareaAutosize from 'calypso/components/textarea-autosize';
 import DocumentHead from 'calypso/components/data/document-head';
 import HeaderCake from 'calypso/components/header-cake';
@@ -290,9 +291,9 @@ function ReceiptLabels() {
 	const translate = useTranslate();
 	return (
 		<div>
-			<label htmlFor="billing-history__billing-details-textarea">
-				<strong>{ translate( 'Billing Details' ) }</strong>
-			</label>
+			<FormLabel htmlFor="billing-history__billing-details-textarea">
+				{ translate( 'Billing Details' ) }
+			</FormLabel>
 			<div
 				className="billing-history__billing-details-description"
 				id="billing-history__billing-details-description"

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -244,7 +244,8 @@ textarea.billing-history__billing-details-editable {
 			margin: 0;
 		}
 
-		strong {
+		strong,
+		.form-label {
 			color: var( --color-neutral-50 );
 			display: block;
 			font-size: $font-body-extra-small;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Billing History: Use `FormLabel` in `BillingReceipt` - part of #45259

#### Testing instructions

* Go to `/me/purchases/billing`
* Click on the "View Receipt" link on a purchase.
* Verify the "Billing Details" label still looks good on the page, and on the print preview screen when you click the "Print Receipt" button.
