### PR TITLE
Plans: update Jetpack Search card tagline

### DIFF
--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -7,8 +7,8 @@ import { numberFormat, translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
-import { shouldShowOfferResetFlow } from 'lib/plans/config';
+import { isEnabled } from 'calypso/config';
+import { shouldShowOfferResetFlow } from 'calypso/lib/plans/config';
 import * as CONSTANTS from './constants.js';
 
 // Translatable strings
@@ -133,7 +133,10 @@ export const getJetpackProductsTaglines = () => {
 	const backupDailyTagline = translate( 'Best for sites with occasional updates' );
 	const backupRealtimeTagline = translate( 'Best for sites with frequent updates' );
 	const backupOwnedTagline = translate( 'Your site is actively being backed up' );
-	const searchTagline = translate( 'Recommended for sites with lots of products or content' );
+
+	const searchTagline = isEnabled( 'plans/alternate-selector' )
+		? translate( 'Great for sites with a lot of content' )
+		: translate( 'Recommended for sites with lots of products or content' );
 	const scanTagline = translate( 'Protect your site' );
 	const scanOwnedTagline = translate( 'Your site is actively being scanned for malicious threats' );
 	const antiSpamTagline = translate( 'Block spam automatically' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the new 3 columns grid, we want to display a shorter version of Jetpack Search card tagline.

#### Testing instructions

* Run this PR.
* Visit the Plans page (in any environment). Activate the `flags=plans/alternate-selector` flag if necessary.
* Verify that the Jetpack Search card tagline looks like in the capture below.

Fixes 1196341175636977-as-1198189456928793

#### Demo

#### Before
![image](https://user-images.githubusercontent.com/3418513/95754296-33871900-0c79-11eb-8ff4-6f11caba10a9.png)

#### After
![image](https://user-images.githubusercontent.com/3418513/95754211-12bec380-0c79-11eb-92aa-7e0a1ef6e194.png)
