### PR TITLE
Plans: in Jetpack Search card show RecordsDetailsAlt as a popover

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
@@ -10,6 +10,7 @@ import React, { createElement, ReactNode } from 'react';
  * Internal dependencies
  */
 import { Button, ProductIcon } from '@automattic/components';
+import InfoPopover from 'calypso/components/info-popover';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { preventWidows } from 'calypso/lib/formatting';
 import PlanPrice from 'calypso/my-sites/plan-price';
@@ -44,7 +45,7 @@ type OwnProps = {
 	onButtonClick: () => void;
 	cancelLabel?: TranslateResult;
 	onCancelClick?: () => void;
-	children?: ReactNode;
+	searchRecordsDetails?: ReactNode;
 	isHighlighted?: boolean;
 	isOwned?: boolean;
 	isDeprecated?: boolean;
@@ -73,7 +74,7 @@ const JetpackProductCardAlt = ( {
 	onButtonClick,
 	cancelLabel,
 	onCancelClick,
-	children,
+	searchRecordsDetails,
 	isHighlighted,
 	isOwned,
 	isDeprecated,
@@ -163,6 +164,11 @@ const JetpackProductCardAlt = ( {
 										currencyCode={ currencyCode }
 									/>
 								) }
+								{ searchRecordsDetails && (
+									<InfoPopover className="jetpack-product-card-alt__search-price-popover">
+										{ searchRecordsDetails }
+									</InfoPopover>
+								) }
 							</span>
 						) : (
 							<div className="jetpack-product-card-alt__price-placeholder" />
@@ -190,7 +196,6 @@ const JetpackProductCardAlt = ( {
 					</Button>
 				) }
 				{ description && <p className="jetpack-product-card-alt__description">{ description }</p> }
-				{ children && <div className="jetpack-product-card-alt__children">{ children }</div> }
 			</div>
 			{ features && features.items.length > 0 && (
 				<JetpackProductCardFeatures

--- a/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
@@ -165,7 +165,10 @@ const JetpackProductCardAlt = ( {
 									/>
 								) }
 								{ searchRecordsDetails && (
-									<InfoPopover className="jetpack-product-card-alt__search-price-popover">
+									<InfoPopover
+										className="jetpack-product-card-alt__search-price-popover"
+										position="right"
+									>
 										{ searchRecordsDetails }
 									</InfoPopover>
 								) }

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -237,8 +237,13 @@ $jetpack-product-card-alt-icon-size: 55px;
 	padding: 0 4px;
 }
 
-.jetpack-product-card-alt__children {
-	margin: 0;
+.jetpack-product-card-alt__search-price-popover {
+	margin-bottom: 40px;
+	margin-left: 24px;
+
+	.gridicon {
+		color: var( --studio-gray-20 );
+	}
 }
 
 .jetpack-product-card-alt .foldable-card.is-expanded {

--- a/client/my-sites/plans-v2/product-card-alt/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt/index.tsx
@@ -103,7 +103,7 @@ const ProductCardAltWrapper = ( {
 			iconSlug={ item.iconSlug }
 			productName={ item.displayName }
 			subheadline={ item.tagline }
-			description={ ! showRecordsDetails ? description : null }
+			description={ description }
 			currencyCode={ currencyCode }
 			billingTimeFrame={ durationToText( item.term ) }
 			buttonLabel={ productButtonLabel( item, isOwned, isUpgradeableToYearly, sitePlan ) }
@@ -111,7 +111,9 @@ const ProductCardAltWrapper = ( {
 			badgeLabel={ productBadgeLabelAlt( item, isOwned, sitePlan ) }
 			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
 			features={ item.features }
-			children={ item.children }
+			searchRecordsDetails={
+				showRecordsDetails && <RecordsDetailsAlt productSlug={ item.productSlug } />
+			}
 			originalPrice={ originalPrice }
 			discountedPrice={ discountedPrice }
 			withStartingPrice={
@@ -126,9 +128,7 @@ const ProductCardAltWrapper = ( {
 			isExpanded={ isHighlighted && ! isMobile }
 			hidePrice={ false }
 			productSlug={ item.productSlug }
-		>
-			{ showRecordsDetails && <RecordsDetailsAlt productSlug={ item.productSlug } /> }
-		</JetpackProductCardAlt>
+		/>
 	);
 };
 

--- a/client/my-sites/plans-v2/records-details-alt/index.tsx
+++ b/client/my-sites/plans-v2/records-details-alt/index.tsx
@@ -9,8 +9,6 @@ import { useSelector } from 'react-redux';
  * Internal dependencies
  */
 import { slugToSelectorProduct } from '../utils';
-import InfoPopover from 'calypso/components/info-popover';
-import { preventWidows } from 'calypso/lib/formatting';
 import { getJetpackProducts } from 'calypso/lib/products-values/translations';
 import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 import { getAvailableProductsBySiteId } from 'calypso/state/sites/products/selectors';
@@ -65,22 +63,8 @@ const RecordsDetailsAlt: FunctionComponent< Props > = ( { productSlug } ) => {
 						comment: '%(recordCount)s is the number of search records of the site',
 					}
 				) }
-				<InfoPopover>
-					{ preventWidows(
-						translate(
-							'Records are all posts, pages, custom post types and other types of content indexed by Jetpack Search. {{link}}Learn more.{{/link}}',
-							{
-								components: {
-									link: <a href="https://jetpack.com/upgrade/search/"></a>,
-								},
-							}
-						)
-					) }
-				</InfoPopover>
 			</div>
-			<div className="records-details-alt__details">
-				<p className="records-details-alt__tier">{ tier }</p>
-			</div>
+			<p className="records-details-alt__tier">{ tier }</p>
 		</div>
 	);
 };

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -143,15 +143,13 @@
  * Record slider
  */
 
-.records-details,
-.records-details-alt {
+.records-details {
 	background-color: var( --studio-gray-0 );
 	border: solid 1px var( --studio-wordpress-blue-30 );
 	color: var( --color-text-subtle );
 }
 
-.records-details__records,
-.records-details-alt__records {
+.records-details__records {
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -168,29 +166,36 @@
 	}
 }
 
-.records-details-alt__records {
-	padding: 14px 14px 0;
-
-	border-bottom: none;
-}
-
-.records-details__details,
-.records-details-alt__details {
+.records-details__details {
 	padding: 16px;
 
 	text-align: center;
 }
 
-.records-details-alt__details {
-	padding: 10px 14px 14px;
-}
-
-.records-details__tier,
-.records-details-alt__tier {
+.records-details__tier {
 	margin-bottom: 8px;
 
 	color: var( --color-text );
 	font-weight: 600;
+}
+
+.records-details-alt {
+	text-align: center;
+
+	color: var( --color-text );
+}
+
+.records-details-alt__records {
+	font-size: $font-body;
+	font-weight: 600;
+}
+
+.records-details-alt__tier {
+	margin: 8px 0 0;
+
+	font-size: $font-body-small;
+
+	color: var( --color-text-subtle );
 }
 
 .records-details__price {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Instead of using an inline box to display the site's records details use a popover.

#### Implementations notes

* Instead of using the generic `children` property to pass an instance of `RecordDetailsAlt`, now we use a new prop called `searchRecordsDetails`. The main reason for this is that the `RecordDetailsAlt` is displayed in a very specific location of the card which is not going to be used by any other purpose (I believe).

#### Testing instructions

* Run this PR in both Calypso Blue and Green.
* Visit the Plans page in each environment.
* Verify that in Calypso Blue, the Jetpack Search card features a popover icon to the left of its price. 
* Click the icon.
* Verify that the content of the popover looks like the capture below.
* Verify that in Calypso Green the popover icon doesn't appear (there is no site in context).

Fixes 1196341175636977-as-1198189456928797

#### Demo

##### Calypso Blue
![image](https://user-images.githubusercontent.com/3418513/95764816-54566b00-0c87-11eb-9d72-dd45227e3c00.png)

##### Calypso Green
![image](https://user-images.githubusercontent.com/3418513/95764558-fe81c300-0c86-11eb-9bb3-663538a3a2b0.png)
