### PR TITLE
Plans: color tweaks for the new 3 columns Plans grid

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -256,6 +256,10 @@ $jetpack-product-card-alt-icon-size: 55px;
 	border-top: none;
 }
 
+.jetpack-product-card-alt .foldable-card .foldable-card__header {
+	color: var( --studio-gray-50 );
+}
+
 .jetpack-product-card-alt__features-category {
 	margin: 8px 0 12px;
 	padding-bottom: 6px;

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -258,6 +258,10 @@ $jetpack-product-card-alt-icon-size: 55px;
 
 .jetpack-product-card-alt .foldable-card .foldable-card__header {
 	color: var( --studio-gray-50 );
+
+	.gridicon {
+		fill: var( --studio-gray-50 );
+	}
 }
 
 .jetpack-product-card-alt__features-category {

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -3,6 +3,9 @@
 @import '~@automattic/typography/styles/fonts';
 
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing {
+	--color-accent: var( --studio-jetpack-green-40 );
+	--color-primary: var( --studio-jetpack-green-40 );
+
 	background-color: var( --color-surface );
 
 	font-family: 'Noto Sans', $sans;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1297,3 +1297,9 @@ body.is-section-jetpack-connect .layout {
 .layout.is-section-jetpack-connect .upsell .upsell__header .formatted-header {
 	color: inherit;
 }
+
+// The new Plans grid uses as primary color a darker version Jetpack's green.
+.is-section-jetpack-connect .selector-alt__main {
+	--color-accent: var( --studio-jetpack-green-40 );
+	--color-primary: var( --studio-jetpack-green-40 );
+}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1302,4 +1302,10 @@ body.is-section-jetpack-connect .layout {
 .is-section-jetpack-connect .selector-alt__main {
 	--color-accent: var( --studio-jetpack-green-40 );
 	--color-primary: var( --studio-jetpack-green-40 );
+
+	.plans-filter-bar__discount-message {
+		color: var( --color-surface );
+
+		font-weight: 600;
+	}
 }

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -37,6 +37,14 @@
 	position: relative;
 }
 
+.selector-alt__main {
+	.plans-filter-bar,
+	.products-grid-alt {
+		--color-accent: var( --studio-jetpack-green-40 );
+		--color-primary: var( --studio-jetpack-green-40 );
+	}
+}
+
 .selector__divider,
 .selector-alt__divider {
 	margin: 40px 0;

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -37,11 +37,16 @@
 	position: relative;
 }
 
+// Override WordPress.com primary colors with Jetpack Cloud primary colors.
+// This only affects the Plans grid and the Filter bar.
 .selector-alt__main {
 	.plans-filter-bar,
 	.products-grid-alt {
 		--color-accent: var( --studio-jetpack-green-40 );
 		--color-primary: var( --studio-jetpack-green-40 );
+		--color-accent-60: var( --studio-jetpack-green-60 );
+		--color-primary-light: var( --studio-jetpack-green-60 );
+		--color-primary-dark: var( --studio-jetpack-green-40 );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Give buttons a darker version of Jetpack Green color.
* Give the Features section header a lighter gray color.
* Use Jetpack Green as the primary color in Wordpress.com.

#### Testing instructions

* Run this PR in both environments.
* Visit the three Plans pages: wordpress.com/plans, wordpress.com/jetpack/connect/store, and cloud.jetpack.com/pricing (in your local environment).
* Make sure that all three pages look like in the captures below.
* Remove the flag with `?flags=-plans/alternate-selector`.
* Make sure that all Plans pages look like in production.

Fixes 1196341175636977-as-1198189456928801

#### Demo

##### wordpress.com/plans
![Kapture 2020-10-12 at 16 06 02](https://user-images.githubusercontent.com/3418513/95781840-fe90bb80-0ca4-11eb-9dfc-6789ad43d6c6.gif)
![image](https://user-images.githubusercontent.com/3418513/95781854-08b2ba00-0ca5-11eb-85de-c24157ac05eb.png)

##### wordpress.com/jetpack/connect/store
![image](https://user-images.githubusercontent.com/3418513/95781788-ecaf1880-0ca4-11eb-9a63-fd44d9484869.png)


##### cloud.jetpack.com/pricing
![image](https://user-images.githubusercontent.com/3418513/95781825-f89ada80-0ca4-11eb-9867-52492360a5e4.png)

