### PR TITLE
Plans: Adjust screen breakpoints to play nicely with existing legacy breakpoints

### DIFF
--- a/client/my-sites/plans-v2/products-grid-alt/style.scss
+++ b/client/my-sites/plans-v2/products-grid-alt/style.scss
@@ -2,17 +2,6 @@
 @import '~@wordpress/base-styles/mixins';
 
 .products-grid-alt {
-	/*
-	 * Create a grid with cells that are evenly sized,
-	 * with a minimum width of 300px each.
-	 * Each cell should take up as much vertical space as it's allowed,
-	 * and the horizontal/vertical gap between them should always be 16px.
-	 */
-	display: grid;
-	grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
-	grid-gap: 16px;
-	align-items: stretch;
-
 	& > .jetpack-free-card-alt {
 		/*
 		 * To match its top and bottom border with the borders
@@ -20,18 +9,36 @@
 		 */
 		margin-block-start: calc( 24px + 32.5px );
 		margin-bottom: 24px;
-
-		/*
-		 * The Free card takes up two columns
-		 * when the screen is wide enough to support it
-		 */
-		@include break-small {
-			grid-column-end: span 2;
-		}
 	}
 
 	& .formatted-header__title {
 		font-size: 1.25rem;
 		color: var( --studio-color-gray-70 );
+	}
+}
+
+/*
+ * We really should be using @include break-small here,
+ * but Calypso's main Layout component doesn't play nicely with it yet.
+ */
+@include breakpoint-deprecated( '>660px' ) {
+	.products-grid-alt {
+		/*
+		 * Once the screen is wide enough to support it,
+		 * create a grid with cells that are evenly sized,
+		 * with a minimum width of 300px each.
+		 * Each cell should take up as much vertical space as it's allowed,
+		 * and the horizontal/vertical gap between them should always be 16px.
+		 */
+		@include breakpoint-deprecated( '>660px' ) {
+			display: grid;
+			grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
+			grid-gap: 16px;
+			align-items: stretch;
+		}
+
+		& > .jetpack-free-card-alt {
+			grid-column-end: span 2;
+		}
 	}
 }


### PR DESCRIPTION
Fixes `p1602520630011400-slack-CQXNTE9K9`.

#### Changes proposed in this Pull Request

* Adjust screen size breakpoint from `$break-small` to `>660px` (deprecated), so that it meshes correctly with Calypso's `Layout` component.
* Move screen size-specific rules to the bottom of the SCSS file for `ProductsGridAlt`, to keep them all together.

#### Testing instructions

* In your testing environment, open the Plans page in Calypso and the Pricing page on Jetpack.com.
* Use your browser's development console to switch to responsive design mode, or view these pages on devices with various screen sizes; specifically, target mobiles, tablets, and desktops.
* Verify that for mobile layouts, only one column is displayed. Product cards should span the full width of the screen (excluding the site navigation panel, if it's visible), with no exterior padding.
* Verify that for tablet and desktop layouts, you see 2 or 3 columns -- whichever's most appropriate for the screen size.
* Verify that as the screen width changes, the layout adapts in a way that makes intuitive sense to you. The grid should not flip back and forth between 1 to 2 or 2 to 3 columns more than once while the screen size steadily shrinks or grows.

#### Screenshots

##### WordPress.com

<img width="336" alt="image" src="https://user-images.githubusercontent.com/670067/95778948-bebed980-0c8e-11eb-87f9-d3eb73caab64.png">

<img width="485" alt="image" src="https://user-images.githubusercontent.com/670067/95778987-d26a4000-0c8e-11eb-89ea-aa26a58314d4.png">

<img width="641" alt="image" src="https://user-images.githubusercontent.com/670067/95779042-eca41e00-0c8e-11eb-8bce-572063250bba.png">

##### Jetpack.com

<img width="336" alt="image" src="https://user-images.githubusercontent.com/670067/95779105-0ba2b000-0c8f-11eb-84cc-d7ca0de920f4.png">

<img width="486" alt="image" src="https://user-images.githubusercontent.com/670067/95779122-178e7200-0c8f-11eb-806f-b2ccbad08c88.png">

<img width="508" alt="image" src="https://user-images.githubusercontent.com/670067/95779149-26752480-0c8f-11eb-8b74-f56e1715db86.png">