### PR TITLE
Add colored icons to features list.

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -297,7 +297,7 @@ $jetpack-product-card-alt-icon-size: 55px;
 	&.gridicons-cloud-upload,
 	&.material-icon-security,
 	&.gridicons-bug {
-		background: #2371b1;
+		background: var( --studio-blue );
 		fill: white;
 		border-radius: 50%;
 		padding: 5px;
@@ -305,7 +305,7 @@ $jetpack-product-card-alt-icon-size: 55px;
 		height: 15px;
 	}
 	&.gridicons-lock {
-		background: #984a9c;
+		background: var( --studio-purple-50 );
 	}
 	&.gridicons-checkmark {
 		fill: $jetpack-product-card-alt-color;

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -304,14 +304,11 @@ $jetpack-product-card-alt-icon-size: 55px;
 		width: 15px;
 		height: 15px;
 	}
-	&.gridicons-checkmark {
-		fill: $jetpack-product-card-alt-color;
-	}
-}
-
-.jetpack-product-card-alt__features-icon {
 	&.gridicons-lock {
 		background: #984a9c;
+	}
+	&.gridicons-checkmark {
+		fill: $jetpack-product-card-alt-color;
 	}
 }
 

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -298,7 +298,7 @@ $jetpack-product-card-alt-icon-size: 55px;
 	&.material-icon-security,
 	&.gridicons-bug {
 		background: var( --studio-blue );
-		fill: white;
+		fill: var( --studio-white );
 		border-radius: 50%;
 		padding: 5px;
 		width: 15px;

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -297,10 +297,21 @@ $jetpack-product-card-alt-icon-size: 55px;
 	&.gridicons-cloud-upload,
 	&.material-icon-security,
 	&.gridicons-bug {
-		fill: var( --color-primary );
+		background: #2371b1;
+		fill: white;
+		border-radius: 50%;
+		padding: 5px;
+		width: 15px;
+		height: 15px;
 	}
 	&.gridicons-checkmark {
 		fill: $jetpack-product-card-alt-color;
+	}
+}
+
+.jetpack-product-card-alt__features-icon {
+	&.gridicons-lock {
+		background: #984a9c;
 	}
 }
 

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -292,9 +292,13 @@ $jetpack-product-card-alt-icon-size: 55px;
 
 .jetpack-product-card-alt__features-icon {
 	margin-right: 14px;
-
 	fill: var( --studio-gray-50 );
-
+	&.gridicons-lock,
+	&.gridicons-cloud-upload,
+	&.material-icon-security,
+	&.gridicons-bug {
+		fill: var( --color-primary );
+	}
 	&.gridicons-checkmark {
 		fill: $jetpack-product-card-alt-color;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the icon colors for the main features of a Plan.  Single product features remain the same (default checkmark)


### Testing instructions

- Run this PR locally (both Calypso and Jetpack Cloud)
- Go to the new Plans grid page (`/plans/:site`).
- Turn **off** the feature flag (append `?flags=-plans/alternate-selector` to the url.) and verify the feature icons are grey, without color. (See "Before" images below).
- Next, turn **on** the feature flag (append the `?flags=-plans/alternate-selector` to the url.) and verify the Plans feature lists now have circular icons matching their product and product icon color. (See "After" images below). 
- Verify the circular colored icons are showing in both Calypso(blue) and Jetpack Cloud(green).

### BEFORE ###

Jetpack Security
![Markup 2020-10-12 at 12 37 11](https://user-images.githubusercontent.com/11078128/95784137-1b6ac600-0c88-11eb-89cf-b5b1d82e4067.png)

Jetpack Complete
![Screenshot on 2020-10-12 at 12-37-36](https://user-images.githubusercontent.com/11078128/95784151-245b9780-0c88-11eb-81c0-5f48db2895d2.png)


### AFTER (They should look like these:)

![Screenshot on 2020-10-12 at 15-20-36](https://user-images.githubusercontent.com/11078128/95795801-216ca100-0ca0-11eb-9ff4-100451bf5c63.png)

Jetpack Cloud (Calypso green)
![Screenshot on 2020-10-12 at 15-19-03](https://user-images.githubusercontent.com/11078128/95795813-26315500-0ca0-11eb-8c76-e96520cdf7d2.png)


Fixes: 1196341175636977-as-1198173394037039/f