### PR TITLE
Plans: support free products in the JetpackProductCard

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
@@ -50,7 +50,8 @@ type OwnProps = {
 	isOwned?: boolean;
 	isDeprecated?: boolean;
 	expiryDate?: Moment;
-	hidePrice?: boolean;
+	isFree?: boolean;
+	isFreeMessage?: TranslateResult;
 };
 
 export type Props = OwnProps & Partial< FeaturesProps >;
@@ -81,7 +82,8 @@ const JetpackProductCardAlt = ( {
 	expiryDate,
 	features,
 	isExpanded,
-	hidePrice,
+	isFree,
+	isFreeMessage,
 	productSlug,
 }: Props ) => {
 	const translate = useTranslate();
@@ -143,43 +145,49 @@ const JetpackProductCardAlt = ( {
 					<p className="jetpack-product-card-alt__subheadline">{ preventWidows( subheadline ) }</p>
 				) }
 
-				{ ! hidePrice && (
+				{ isFree ? (
+					<div className="jetpack-product-card-alt__price">
+						<h4 className="jetpack-product-card-alt__free-product">{ translate( 'Free' ) }</h4>
+						<div className="jetpack-product-card-alt__billing-time-frame">{ isFreeMessage }</div>
+					</div>
+				) : (
 					<div className="jetpack-product-card-alt__price">
 						{ currencyCode && originalPrice ? (
-							<span className="jetpack-product-card-alt__raw-price">
-								{ withStartingPrice && (
-									<span className="jetpack-product-card-alt__from">{ translate( 'from' ) }</span>
-								) }
+							<>
+								<span className="jetpack-product-card-alt__raw-price">
+									{ withStartingPrice && (
+										<span className="jetpack-product-card-alt__from">{ translate( 'from' ) }</span>
+									) }
 
-								{ isDiscounted ? (
-									<PlanPrice
-										rawPrice={ discountedPrice }
-										discounted
-										currencyCode={ currencyCode }
-									/>
-								) : (
-									<PlanPrice
-										rawPrice={ originalPrice }
-										original={ isDiscounted }
-										currencyCode={ currencyCode }
-									/>
-								) }
-								{ searchRecordsDetails && (
-									<InfoPopover
-										className="jetpack-product-card-alt__search-price-popover"
-										position="right"
-									>
-										{ searchRecordsDetails }
-									</InfoPopover>
-								) }
-							</span>
+									{ isDiscounted ? (
+										<PlanPrice
+											rawPrice={ discountedPrice }
+											discounted
+											currencyCode={ currencyCode }
+										/>
+									) : (
+										<PlanPrice
+											rawPrice={ originalPrice }
+											original={ isDiscounted }
+											currencyCode={ currencyCode }
+										/>
+									) }
+									{ searchRecordsDetails && (
+										<InfoPopover
+											className="jetpack-product-card-alt__search-price-popover"
+											position="right"
+										>
+											{ searchRecordsDetails }
+										</InfoPopover>
+									) }
+								</span>
+								{ renderBillingTimeFrame( parsedExpiryDate, billingTimeFrame ) }
+							</>
 						) : (
-							<div className="jetpack-product-card-alt__price-placeholder" />
-						) }
-						{ currencyCode && originalPrice ? (
-							renderBillingTimeFrame( parsedExpiryDate, billingTimeFrame )
-						) : (
-							<div className="jetpack-product-card-alt__time-frame-placeholder" />
+							<>
+								<div className="jetpack-product-card-alt__price-placeholder" />
+								<div className="jetpack-product-card-alt__time-frame-placeholder" />
+							</>
 						) }
 					</div>
 				) }

--- a/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
@@ -14,6 +14,7 @@ import InfoPopover from 'calypso/components/info-popover';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { preventWidows } from 'calypso/lib/formatting';
 import PlanPrice from 'calypso/my-sites/plan-price';
+import PlanPriceFree from 'calypso/my-sites/plan-price-free';
 import JetpackProductCardFeatures, { Props as FeaturesProps } from './features';
 
 /**
@@ -51,7 +52,6 @@ type OwnProps = {
 	isDeprecated?: boolean;
 	expiryDate?: Moment;
 	isFree?: boolean;
-	isFreeMessage?: TranslateResult;
 };
 
 export type Props = OwnProps & Partial< FeaturesProps >;
@@ -83,7 +83,6 @@ const JetpackProductCardAlt = ( {
 	features,
 	isExpanded,
 	isFree,
-	isFreeMessage,
 	productSlug,
 }: Props ) => {
 	const translate = useTranslate();
@@ -146,10 +145,7 @@ const JetpackProductCardAlt = ( {
 				) }
 
 				{ isFree ? (
-					<div className="jetpack-product-card-alt__price">
-						<h4 className="jetpack-product-card-alt__free-product">{ translate( 'Free' ) }</h4>
-						<div className="jetpack-product-card-alt__billing-time-frame">{ isFreeMessage }</div>
-					</div>
+					<PlanPriceFree productSlug={ productSlug } />
 				) : (
 					<div className="jetpack-product-card-alt__price">
 						{ currencyCode && originalPrice ? (

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -122,6 +122,7 @@ $jetpack-product-card-alt-icon-size: 55px;
 	padding-bottom: 4px;
 
 	font-size: $font-headline-medium;
+	font-weight: 600;
 	line-height: 1.5;
 	color: var( --color-neutral-70 );
 

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -118,6 +118,18 @@ $jetpack-product-card-alt-icon-size: 55px;
 	}
 }
 
+.jetpack-product-card-alt__free-product {
+	padding-bottom: 4px;
+
+	font-size: $font-headline-medium;
+	line-height: 1.5;
+	color: var( --color-neutral-70 );
+
+	@include breakpoint-deprecated( '<960px' ) {
+		font-size: $font-title-medium;
+	}
+}
+
 .jetpack-product-card-alt__price {
 	display: flex;
 	flex-direction: column;

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -118,19 +118,6 @@ $jetpack-product-card-alt-icon-size: 55px;
 	}
 }
 
-.jetpack-product-card-alt__free-product {
-	padding-bottom: 4px;
-
-	font-size: $font-headline-medium;
-	font-weight: 600;
-	line-height: 1.5;
-	color: var( --color-neutral-70 );
-
-	@include breakpoint-deprecated( '<960px' ) {
-		font-size: $font-title-medium;
-	}
-}
-
 .jetpack-product-card-alt__price {
 	display: flex;
 	flex-direction: column;

--- a/client/my-sites/plan-price-free/index.tsx
+++ b/client/my-sites/plan-price-free/index.tsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+
+import React, { FC } from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	PRODUCT_JETPACK_CRM,
+	PRODUCT_JETPACK_CRM_MONTHLY,
+} from 'calypso/lib/products-values/constants';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	productSlug?: string;
+}
+
+const PlanPriceFree: FC< Props > = ( { productSlug } ) => {
+	const translate = useTranslate();
+
+	let content;
+	switch ( productSlug ) {
+		case PRODUCT_JETPACK_CRM:
+		case PRODUCT_JETPACK_CRM_MONTHLY:
+			content = translate( 'Start managing contacts now' );
+			break;
+		default:
+			content = null;
+	}
+
+	return (
+		<div className="plan-price-free">
+			<h4 className="plan-price-free__main">{ translate( 'Free' ) }</h4>
+			<div className="plan-price-free__content">{ content }</div>
+		</div>
+	);
+};
+
+export default PlanPriceFree;

--- a/client/my-sites/plan-price-free/style.scss
+++ b/client/my-sites/plan-price-free/style.scss
@@ -1,0 +1,31 @@
+.plan-price-free {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+
+	margin-bottom: 20px;
+}
+
+.plan-price-free__main {
+	padding-bottom: 4px;
+
+	font-size: $font-headline-medium;
+	font-weight: 600;
+	line-height: 1.5;
+	color: var( --color-neutral-70 );
+
+	@include breakpoint-deprecated( '<960px' ) {
+		font-size: $font-title-medium;
+	}
+}
+
+.plan-price-free__content {
+	display: block;
+
+	color: var( --color-text-subtle );
+
+	font-size: $font-body-extra-small;
+	font-style: italic;
+	line-height: 1;
+}

--- a/client/my-sites/plan-price-free/style.scss
+++ b/client/my-sites/plan-price-free/style.scss
@@ -11,7 +11,7 @@
 	padding-bottom: 4px;
 
 	font-size: $font-headline-medium;
-	font-weight: 600;
+	font-weight: 400;
 	line-height: 1.5;
 	color: var( --color-neutral-70 );
 

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -6,6 +6,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'calypso/config';
 import {
 	JETPACK_SCAN_PRODUCTS,
 	JETPACK_ANTI_SPAM_PRODUCTS,
@@ -294,7 +295,9 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 	description: translate(
 		'The most simple and powerful WordPress CRM. Improve customer relationships and increase profits.'
 	),
-	buttonLabel: translate( 'Get CRM' ),
+	buttonLabel: isEnabled( 'plans/alternate-selector' )
+		? translate( 'Start using CRM for free' )
+		: translate( 'Get CRM' ),
 	features: {
 		items: buildCardFeaturesFromItem(
 			[

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -336,6 +336,7 @@ export const EXTERNAL_PRODUCTS_LIST = [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM
 // External Product slugs to SelectorProduct.
 export const EXTERNAL_PRODUCTS_SLUG_MAP: Record< string, SelectorProduct > = {
 	[ PRODUCT_JETPACK_CRM ]: EXTERNAL_PRODUCT_CRM,
+	[ PRODUCT_JETPACK_CRM_MONTHLY ]: EXTERNAL_PRODUCT_CRM_MONTHLY,
 };
 
 /**

--- a/client/my-sites/plans-v2/product-card-alt/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt/index.tsx
@@ -4,6 +4,7 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -24,7 +25,11 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import JetpackProductCardAlt from 'calypso/components/jetpack/card/jetpack-product-card-alt';
 import { planHasFeature } from 'calypso/lib/plans';
 import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
-import { JETPACK_SEARCH_PRODUCTS } from 'calypso/lib/products-values/constants';
+import {
+	PRODUCT_JETPACK_CRM,
+	PRODUCT_JETPACK_CRM_MONTHLY,
+	JETPACK_SEARCH_PRODUCTS,
+} from 'calypso/lib/products-values/constants';
 import { isCloseToExpiration } from 'calypso/lib/purchases';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 
@@ -52,6 +57,7 @@ const ProductCardAltWrapper = ( {
 	highlight = false,
 	selectedTerm,
 }: ProductCardProps ) => {
+	const translate = useTranslate();
 	// Determine whether product is owned.
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
@@ -73,6 +79,14 @@ const ProductCardAltWrapper = ( {
 		item,
 		item?.monthlyProductSlug || ''
 	);
+
+	const isFree = originalPrice === -1 && discountedPrice === -1;
+	// TODO: we should move this text to where we keep translations for products and plans.
+	const isFreeMessage = [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes(
+		item.productSlug
+	)
+		? translate( 'Start managing contacts now' )
+		: null;
 
 	// Handles expiry.
 	const moment = useLocalizedMoment();
@@ -120,13 +134,14 @@ const ProductCardAltWrapper = ( {
 				// Search has several pricing tiers
 				item.subtypes.length > 0 || JETPACK_SEARCH_PRODUCTS.includes( item.productSlug )
 			}
+			isFree={ isFree }
+			isFreeMessage={ isFreeMessage }
 			isOwned={ isOwned }
 			isDeprecated={ item.legacy }
 			className={ className }
 			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
 			isHighlighted={ isHighlighted }
 			isExpanded={ isHighlighted && ! isMobile }
-			hidePrice={ false }
 			productSlug={ item.productSlug }
 		/>
 	);

--- a/client/my-sites/plans-v2/product-card-alt/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt/index.tsx
@@ -4,7 +4,6 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -25,11 +24,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import JetpackProductCardAlt from 'calypso/components/jetpack/card/jetpack-product-card-alt';
 import { planHasFeature } from 'calypso/lib/plans';
 import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
-import {
-	PRODUCT_JETPACK_CRM,
-	PRODUCT_JETPACK_CRM_MONTHLY,
-	JETPACK_SEARCH_PRODUCTS,
-} from 'calypso/lib/products-values/constants';
+import { JETPACK_SEARCH_PRODUCTS } from 'calypso/lib/products-values/constants';
 import { isCloseToExpiration } from 'calypso/lib/purchases';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 
@@ -57,7 +52,6 @@ const ProductCardAltWrapper = ( {
 	highlight = false,
 	selectedTerm,
 }: ProductCardProps ) => {
-	const translate = useTranslate();
 	// Determine whether product is owned.
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
@@ -81,12 +75,6 @@ const ProductCardAltWrapper = ( {
 	);
 
 	const isFree = originalPrice === -1 && discountedPrice === -1;
-	// TODO: we should move this text to where we keep translations for products and plans.
-	const isFreeMessage = [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes(
-		item.productSlug
-	)
-		? translate( 'Start managing contacts now' )
-		: null;
 
 	// Handles expiry.
 	const moment = useLocalizedMoment();
@@ -135,7 +123,6 @@ const ProductCardAltWrapper = ( {
 				item.subtypes.length > 0 || JETPACK_SEARCH_PRODUCTS.includes( item.productSlug )
 			}
 			isFree={ isFree }
-			isFreeMessage={ isFreeMessage }
 			isOwned={ isOwned }
 			isDeprecated={ item.legacy }
 			className={ className }

--- a/client/my-sites/plans-v2/use-item-price.ts
+++ b/client/my-sites/plans-v2/use-item-price.ts
@@ -111,8 +111,8 @@ const useItemPrice = (
 
 	// Jetpack CRM price won't come from the API, so we need to hard-code it for now.
 	if ( item && [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes( item.productSlug ) ) {
-		discountedPrice = 11;
-		originalPrice = 132;
+		discountedPrice = -1;
+		originalPrice = -1;
 	}
 
 	return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add support for free products.
* Hardcode Jetpack CRM price at -1 (to enable the free price section).

#### Implementation notes

* I will address the technical debt in a follow-up.

#### Testing instructions

* Run this PR (any environment).
* Visit the Plans page.
* Verify that the Jetpack CRM card looks like the capture below.

Fixes 1196341175636977-as-1198189456928808

#### Demo
![Kapture 2020-10-13 at 10 58 02](https://user-images.githubusercontent.com/3418513/95870614-1159cd80-0d43-11eb-8d5a-78d9207f2cf0.gif)

![image](https://user-images.githubusercontent.com/3418513/95870331-c2139d00-0d42-11eb-957b-a4d84c1156dc.png)
![image](https://user-images.githubusercontent.com/3418513/95870369-cc359b80-0d42-11eb-8250-f77b0135c293.png)
![image](https://user-images.githubusercontent.com/3418513/95870419-d5bf0380-0d42-11eb-959e-c7024ef62b5f.png)

