### PR TITLE
Checkout: Add after_purchase_url to products for use by getThankYouUrl

### DIFF
--- a/client/lib/cart-values/types.ts
+++ b/client/lib/cart-values/types.ts
@@ -1,55 +1,14 @@
 /**
  * Internal dependencies
  */
-import type { GSuiteProductUser } from 'lib/gsuite/new-users';
-import type { DomainContactDetails } from 'my-sites/checkout/composite-checkout/types/backend/domain-contact-details-components';
+import {
+	ResponseCart,
+	ResponseCartProduct,
+	ResponseCartProductExtra,
+} from 'calypso/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types';
 
-export type CartItemValue = {
-	product_id?: number;
-	product_name?: string;
-	product_slug?: string;
-	meta?: string;
-	cost?: number;
-	orig_cost?: number | null;
-	currency?: string;
-	volume?: number;
-	free_trial?: boolean;
-	is_domain_registration?: boolean;
-	extra?: CartItemExtra;
-};
+export type CartItemValue = ResponseCartProduct;
 
-export type CartItemExtra = {
-	context?: string;
-	source?: string;
-	domain_to_bundle?: string;
-	google_apps_users?: GSuiteProductUser[];
-	google_apps_registration_data?: DomainContactDetails;
-	purchaseId?: string;
-	purchaseDomain?: string;
-	purchaseType?: string;
-	includedDomain?: string;
-	privacy?: boolean;
-};
+export type CartItemExtra = ResponseCartProductExtra;
 
-export type CartValue = {
-	blog_id: string | number;
-	products: CartItemValue[];
-	total_cost?: number;
-	temporary?: boolean;
-	currency?: string;
-	coupon?: string;
-	bundled_domain?: string;
-	is_coupon_applied?: boolean;
-	has_bundle_credit?: boolean;
-	next_domain_is_free?: boolean;
-	next_domain_condition?: string;
-	messages?: {
-		errors?: string[];
-		success?: string[];
-	};
-	client_metadata?: ClientMetadata;
-};
-
-export type ClientMetadata = {
-	lastServerResponseDate: string;
-};
+export type CartValue = ResponseCart;

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -1010,11 +1010,7 @@ export default connect(
 			isNewlyCreatedSite: isNewSite( state, selectedSiteId ),
 			contactDetails: getContactDetailsCache( state ),
 			userCountryCode: getCurrentUserCountryCode( state ),
-			isEligibleForSignupDestination: isEligibleForSignupDestination(
-				state,
-				selectedSiteId,
-				props.cart
-			),
+			isEligibleForSignupDestination: isEligibleForSignupDestination( props.cart ),
 			productsList: getProductsList( state ),
 			isProductsListFetching: isProductsListFetching( state ),
 			isPlansListFetching: isRequestingPlans( state ),

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -13,8 +13,12 @@ import { format as formatUrl, parse as parseUrl } from 'url';
 /**
  * Internal dependencies
  */
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import { shouldShowTax, hasPendingPayment, getEnabledPaymentMethods } from 'lib/cart-values';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import {
+	shouldShowTax,
+	hasPendingPayment,
+	getEnabledPaymentMethods,
+} from 'calypso/lib/cart-values';
 import {
 	conciergeSessionItem,
 	domainMapping,
@@ -38,14 +42,14 @@ import {
 	hasOnlyRenewalItems,
 	hasTransferProduct,
 	jetpackProductItem,
-} from 'lib/cart-values/cart-items';
+} from 'calypso/lib/cart-values/cart-items';
 import {
 	isJetpackProductSlug,
 	isJetpackScanSlug,
 	isJetpackBackupSlug,
 	isJetpackCloudProductSlug,
 	isJetpackAntiSpamSlug,
-} from 'lib/products-values';
+} from 'calypso/lib/products-values';
 import {
 	JETPACK_PRODUCTS_LIST,
 	JETPACK_SEARCH_PRODUCTS,
@@ -53,63 +57,67 @@ import {
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 	PRODUCT_WPCOM_SEARCH,
 	PRODUCT_WPCOM_SEARCH_MONTHLY,
-} from 'lib/products-values/constants';
+} from 'calypso/lib/products-values/constants';
 import PendingPaymentBlocker from './pending-payment-blocker';
-import { clearSitePlans } from 'state/sites/plans/actions';
-import { clearPurchases } from 'state/purchases/actions';
+import { clearSitePlans } from 'calypso/state/sites/plans/actions';
+import { clearPurchases } from 'calypso/state/purchases/actions';
 import DomainDetailsForm from './domain-details-form';
-import { fetchReceiptCompleted } from 'state/receipts/actions';
-import { getExitCheckoutUrl } from 'lib/checkout';
-import { hasDomainDetails } from 'lib/transaction/selectors';
-import notices from 'notices';
-import { managePurchase } from 'me/purchases/paths';
-import SubscriptionLengthPicker from 'blocks/subscription-length-picker';
-import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
-import QueryStoredCards from 'components/data/query-stored-cards';
-import QuerySitePlans from 'components/data/query-site-plans';
-import QueryPlans from 'components/data/query-plans';
+import { fetchReceiptCompleted } from 'calypso/state/receipts/actions';
+import { getExitCheckoutUrl } from 'calypso/lib/checkout';
+import { hasDomainDetails } from 'calypso/lib/transaction/selectors';
+import notices from 'calypso/notices';
+import { managePurchase } from 'calypso/me/purchases/paths';
+import SubscriptionLengthPicker from 'calypso/blocks/subscription-length-picker';
+import QueryContactDetailsCache from 'calypso/components/data/query-contact-details-cache';
+import QueryStoredCards from 'calypso/components/data/query-stored-cards';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QueryPlans from 'calypso/components/data/query-plans';
 import SecurePaymentForm from './secure-payment-form';
 import SecurePaymentFormPlaceholder from './secure-payment-form-placeholder';
-import { AUTO_RENEWAL } from 'lib/url/support';
+import { AUTO_RENEWAL } from 'calypso/lib/url/support';
 import {
 	RECEIVED_WPCOM_RESPONSE,
 	SUBMITTING_WPCOM_REQUEST,
-} from 'lib/store-transactions/step-types';
-import { addItem, replaceCartWithItems, replaceItem, applyCoupon } from 'lib/cart/actions';
-import { resetTransaction, setDomainDetails } from 'lib/transaction/actions';
-import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
-import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-from-path';
-import isDomainOnlySite from 'state/selectors/is-domain-only-site';
-import isEligibleForSignupDestination from 'state/selectors/is-eligible-for-signup-destination';
-import { getStoredCards, isFetchingStoredCards } from 'state/stored-cards/selectors';
-import { isValidFeatureKey } from 'lib/plans/features-list';
-import { getPlan, findPlansKeys } from 'lib/plans';
-import { GROUP_WPCOM } from 'lib/plans/constants';
-import { recordViewCheckout } from 'lib/analytics/ad-tracking';
-import { requestSite } from 'state/sites/actions';
-import { isJetpackSite, isNewSite } from 'state/sites/selectors';
-import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { getCurrentUserCountryCode } from 'state/current-user/selectors';
-import { getDomainNameFromReceiptOrCart } from 'lib/domains/cart-utils';
-import { fetchSitesAndUser } from 'lib/signup/step-actions/fetch-sites-and-user';
-import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
-import QueryProducts from 'components/data/query-products-list';
-import { isRequestingSitePlans } from 'state/sites/plans/selectors';
-import { isRequestingPlans } from 'state/plans/selectors';
-import { isApplePayAvailable } from 'lib/web-payment';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import config from 'config';
-import { loadTrackingTool } from 'state/analytics/actions';
+} from 'calypso/lib/store-transactions/step-types';
+import { addItem, replaceCartWithItems, replaceItem, applyCoupon } from 'calypso/lib/cart/actions';
+import { resetTransaction, setDomainDetails } from 'calypso/lib/transaction/actions';
+import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
+import getUpgradePlanSlugFromPath from 'calypso/state/selectors/get-upgrade-plan-slug-from-path';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-for-signup-destination';
+import { getStoredCards, isFetchingStoredCards } from 'calypso/state/stored-cards/selectors';
+import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
+import { getPlan, findPlansKeys } from 'calypso/lib/plans';
+import { GROUP_WPCOM } from 'calypso/lib/plans/constants';
+import { recordViewCheckout } from 'calypso/lib/analytics/ad-tracking';
+import { requestSite } from 'calypso/state/sites/actions';
+import { isJetpackSite, isNewSite } from 'calypso/state/sites/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'calypso/state/ui/selectors';
+import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
+import { getDomainNameFromReceiptOrCart } from 'calypso/lib/domains/cart-utils';
+import { fetchSitesAndUser } from 'calypso/lib/signup/step-actions/fetch-sites-and-user';
+import { getProductsList, isProductsListFetching } from 'calypso/state/products-list/selectors';
+import QueryProducts from 'calypso/components/data/query-products-list';
+import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
+import { isRequestingPlans } from 'calypso/state/plans/selectors';
+import { isApplePayAvailable } from 'calypso/lib/web-payment';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import config from 'calypso/config';
+import { loadTrackingTool } from 'calypso/state/analytics/actions';
 import {
 	persistSignupDestination,
 	retrieveSignupDestination,
 	clearSignupDestinationCookie,
-} from 'signup/storageUtils';
-import { isExternal, addQueryArgs } from 'lib/url';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { abtest } from 'lib/abtest';
-import isPrivateSite from 'state/selectors/is-private-site';
+} from 'calypso/signup/storageUtils';
+import { isExternal, addQueryArgs } from 'calypso/lib/url';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { abtest } from 'calypso/lib/abtest';
+import isPrivateSite from 'calypso/state/selectors/is-private-site';
 
 /**
  * Style dependencies

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import page from 'page';
-import wp from 'lib/wp';
 import React, { useCallback, useMemo } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -13,23 +12,24 @@ import { CheckoutProvider, checkoutTheme, defaultRegistry } from '@automattic/co
 /**
  * Internal dependencies
  */
-import { getProductsList } from 'state/products-list/selectors';
+import wp from 'calypso/lib/wp';
+import { getProductsList } from 'calypso/state/products-list/selectors';
 import {
 	useStoredCards,
 	useIsApplePayAvailable,
 	filterAppropriatePaymentMethods,
 } from './payment-method-helpers';
 import usePrepareProductsForCart from './hooks/use-prepare-products-for-cart';
-import notices from 'notices';
-import { isJetpackSite } from 'state/sites/selectors';
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import isPrivateSite from 'state/selectors/is-private-site';
-import { updateContactDetailsCache } from 'state/domains/management/actions';
-import QuerySitePurchases from 'components/data/query-site-purchases';
-import { StateSelect } from 'my-sites/domains/components/form';
-import { getPlan } from 'lib/plans';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { useStripe } from 'lib/stripe';
+import notices from 'calypso/notices';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import isPrivateSite from 'calypso/state/selectors/is-private-site';
+import { updateContactDetailsCache } from 'calypso/state/domains/management/actions';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import { StateSelect } from 'calypso/my-sites/domains/components/form';
+import { getPlan } from 'calypso/lib/plans';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useStripe } from 'calypso/lib/stripe';
 import CheckoutTerms from '../checkout/checkout-terms.jsx';
 import useCreatePaymentMethods from './use-create-payment-methods';
 import {
@@ -41,23 +41,26 @@ import {
 	payPalProcessor,
 	genericRedirectProcessor,
 } from './payment-method-processors';
-import { useGetThankYouUrl } from './use-get-thank-you-url';
+import useGetThankYouUrl from './use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
-import { fillInSingleCartItemAttributes } from 'lib/cart-values';
-import { hasRenewalItem, getRenewalItems, hasPlan } from 'lib/cart-values/cart-items';
-import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
-import QuerySitePlans from 'components/data/query-site-plans';
-import QueryPlans from 'components/data/query-plans';
-import QueryProducts from 'components/data/query-products-list';
-import { clearPurchases } from 'state/purchases/actions';
-import { fetchReceiptCompleted } from 'state/receipts/actions';
-import { requestSite } from 'state/sites/actions';
-import { fetchSitesAndUser } from 'lib/signup/step-actions/fetch-sites-and-user';
-import { getDomainNameFromReceiptOrCart } from 'lib/domains/cart-utils';
-import { AUTO_RENEWAL } from 'lib/url/support';
-import { useLocalizedMoment } from 'components/localized-moment';
-import isDomainOnlySite from 'state/selectors/is-domain-only-site';
-import { retrieveSignupDestination, clearSignupDestinationCookie } from 'signup/storageUtils';
+import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
+import { hasRenewalItem, getRenewalItems, hasPlan } from 'calypso/lib/cart-values/cart-items';
+import QueryContactDetailsCache from 'calypso/components/data/query-contact-details-cache';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QueryPlans from 'calypso/components/data/query-plans';
+import QueryProducts from 'calypso/components/data/query-products-list';
+import { clearPurchases } from 'calypso/state/purchases/actions';
+import { fetchReceiptCompleted } from 'calypso/state/receipts/actions';
+import { requestSite } from 'calypso/state/sites/actions';
+import { fetchSitesAndUser } from 'calypso/lib/signup/step-actions/fetch-sites-and-user';
+import { getDomainNameFromReceiptOrCart } from 'calypso/lib/domains/cart-utils';
+import { AUTO_RENEWAL } from 'calypso/lib/url/support';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import {
+	retrieveSignupDestination,
+	clearSignupDestinationCookie,
+} from 'calypso/signup/storageUtils';
 import { useProductVariants } from './hooks/product-variants';
 import { CartProvider } from './cart-provider';
 import { translateResponseCartToWPCOMCart } from './lib/translate-cart';
@@ -65,25 +68,25 @@ import useShoppingCartManager from './hooks/use-shopping-cart-manager';
 import useShowAddCouponSuccessMessage from './hooks/use-show-add-coupon-success-message';
 import useCountryList from './hooks/use-country-list';
 import { colors } from '@automattic/color-studio';
-import { needsDomainDetails } from 'my-sites/checkout/composite-checkout/payment-method-helpers';
-import { isGSuiteProductSlug } from 'lib/gsuite';
+import { needsDomainDetails } from 'calypso/my-sites/checkout/composite-checkout/payment-method-helpers';
+import { isGSuiteProductSlug } from 'calypso/lib/gsuite';
 import useCachedDomainContactDetails from './hooks/use-cached-domain-contact-details';
-import CartMessages from 'my-sites/checkout/cart/cart-messages';
+import CartMessages from 'calypso/my-sites/checkout/cart/cart-messages';
 import useActOnceOnStrings from './hooks/use-act-once-on-strings';
 import useRedirectIfCartEmpty from './hooks/use-redirect-if-cart-empty';
 import useRecordCheckoutLoaded from './hooks/use-record-checkout-loaded';
 import useRecordCartLoaded from './hooks/use-record-cart-loaded';
 import useAddProductsFromUrl from './hooks/use-add-products-from-url';
 import useDetectedCountryCode from './hooks/use-detected-country-code';
-import WPCheckout from 'my-sites/checkout/composite-checkout/components/wp-checkout';
-import { useWpcomStore } from 'my-sites/checkout/composite-checkout/hooks/wpcom-store';
-import { areDomainsInLineItems } from 'my-sites/checkout/composite-checkout/hooks/has-domains';
+import WPCheckout from 'calypso/my-sites/checkout/composite-checkout/components/wp-checkout';
+import { useWpcomStore } from 'calypso/my-sites/checkout/composite-checkout/hooks/wpcom-store';
+import { areDomainsInLineItems } from 'calypso/my-sites/checkout/composite-checkout/hooks/has-domains';
 import {
 	emptyManagedContactDetails,
 	applyContactDetailsRequiredMask,
 	domainRequiredContactDetails,
 	taxRequiredContactDetails,
-} from 'my-sites/checkout/composite-checkout/types/wpcom-store-state';
+} from 'calypso/my-sites/checkout/composite-checkout/types/wpcom-store-state';
 
 const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
 
@@ -241,7 +244,7 @@ export default function CompositeCheckout( {
 		showAddCouponSuccessMessage
 	);
 
-	const getThankYouUrl = useGetThankYouUrl( {
+	const getThankYouUrlBase = useGetThankYouUrl( {
 		siteSlug,
 		redirectTo,
 		purchaseId,
@@ -249,10 +252,19 @@ export default function CompositeCheckout( {
 		cart: responseCart,
 		isJetpackNotAtomic,
 		productAliasFromUrl,
-		siteId,
 		hideNudge,
-		recordEvent,
 	} );
+	const getThankYouUrl = useCallback(
+		( ...getThankYouPageUrlArguments ) => {
+			const url = getThankYouUrlBase( ...getThankYouPageUrlArguments );
+			recordEvent( {
+				type: 'THANK_YOU_URL_GENERATED',
+				payload: { arguments: getThankYouPageUrlArguments, url },
+			} );
+			return url;
+		},
+		[ getThankYouUrlBase, recordEvent ]
+	);
 
 	const moment = useLocalizedMoment();
 	const isDomainOnly = useSelector( ( state ) => isDomainOnlySite( state, siteId ) );

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -41,7 +41,7 @@ import {
 	payPalProcessor,
 	genericRedirectProcessor,
 } from './payment-method-processors';
-import useGetThankYouUrl from './use-get-thank-you-url';
+import useGetThankYouUrl from './hooks/use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { hasRenewalItem, getRenewalItems, hasPlan } from 'calypso/lib/cart-values/cart-items';

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.ts
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { defaultRegistry } from '@automattic/composite-checkout';
+import debugFactory from 'debug';
+import { isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-for-signup-destination';
+import type { ResponseCart } from 'calypso/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types';
+import { TransactionResponse } from 'calypso/my-sites/checkout/composite-checkout/types/wpcom-store-state';
+import getThankYouPageUrl from './get-thank-you-page-url';
+
+const { select } = defaultRegistry;
+const debug = debugFactory( 'calypso:composite-checkout:use-get-thank-you-url' );
+
+type GetThankYouUrl = () => string;
+
+export default function useGetThankYouUrl( {
+	siteSlug,
+	redirectTo,
+	purchaseId,
+	feature,
+	cart,
+	isJetpackNotAtomic,
+	productAliasFromUrl,
+	hideNudge,
+}: {
+	siteSlug: string | undefined;
+	redirectTo: string | undefined;
+	purchaseId?: number | undefined;
+	feature: string | undefined;
+	cart: ResponseCart;
+	isJetpackNotAtomic: boolean;
+	productAliasFromUrl: string | undefined;
+	hideNudge: boolean;
+} ): GetThankYouUrl {
+	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
+	const adminUrl = selectedSiteData?.options?.admin_url;
+	const isEligibleForSignupDestinationResult = isEligibleForSignupDestination( cart );
+
+	const getThankYouUrl = useCallback( () => {
+		const transactionResult: TransactionResponse = select( 'wpcom' ).getTransactionResult();
+		debug( 'for getThankYouUrl, transactionResult is', transactionResult );
+		const didPurchaseFail = Object.keys( transactionResult.failed_purchases ?? {} ).length > 0;
+		const receiptId = transactionResult.receipt_id;
+		const orderId = transactionResult.order_id;
+		const isTransactionResultEmpty = isEmpty( transactionResult );
+
+		if ( siteSlug === 'no-user' || ! siteSlug ) {
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+			siteSlug = select( 'wpcom' ).getSiteSlug();
+		}
+
+		const getThankYouPageUrlArguments = {
+			siteSlug,
+			adminUrl,
+			receiptId,
+			orderId,
+			redirectTo,
+			purchaseId,
+			feature,
+			cart,
+			isJetpackNotAtomic,
+			productAliasFromUrl,
+			isEligibleForSignupDestinationResult,
+			hideNudge,
+			didPurchaseFail,
+			isTransactionResultEmpty,
+		};
+		debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );
+		const url = getThankYouPageUrl( getThankYouPageUrlArguments );
+		debug( 'getThankYouUrl returned', url );
+		return url;
+	}, [
+		isEligibleForSignupDestinationResult,
+		siteSlug,
+		adminUrl,
+		isJetpackNotAtomic,
+		productAliasFromUrl,
+		redirectTo,
+		feature,
+		purchaseId,
+		cart,
+		hideNudge,
+	] );
+	return getThankYouUrl;
+}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/shopping-cart-endpoint.ts
@@ -154,7 +154,7 @@ export interface ResponseCartProduct {
 	meta: string;
 	months_per_bill_period: number | null;
 	volume: number;
-	extra: object;
+	extra: CartItemExtra;
 	uuid: string;
 	cost: number;
 	price: number;
@@ -188,7 +188,7 @@ export interface TempResponseCartProduct {
 	months_per_bill_period: number | null;
 	meta: string;
 	volume: number;
-	extra: object;
+	extra: CartItemExtra;
 	uuid: string;
 	cost: null;
 	price: null;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/shopping-cart-endpoint.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import type { CartItemExtra } from 'lib/cart-values/types';
+import type { CartItemExtra } from 'calypso/lib/cart-values/types';
 
 /**
  * There are three different concepts of "cart" relevant to the shopping cart endpoint:

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/shopping-cart-endpoint.ts
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import type { CartItemExtra } from 'calypso/lib/cart-values/types';
+import type { GSuiteProductUser } from 'calypso/lib/gsuite/new-users';
+import type { DomainContactDetails } from 'calypso/my-sites/checkout/composite-checkout/types/backend/domain-contact-details-components';
 
 /**
  * There are three different concepts of "cart" relevant to the shopping cart endpoint:
@@ -48,7 +49,7 @@ export interface RequestCartProduct {
 	product_slug: string;
 	product_id: number;
 	meta: string;
-	extra: CartItemExtra;
+	extra: ResponseCartProductExtra;
 	after_purchase_url?: string;
 }
 
@@ -155,7 +156,7 @@ export interface ResponseCartProduct {
 	meta: string;
 	months_per_bill_period: number | null;
 	volume: number;
-	extra: CartItemExtra;
+	extra: ResponseCartProductExtra;
 	uuid: string;
 	cost: number;
 	price: number;
@@ -190,7 +191,7 @@ export interface TempResponseCartProduct {
 	months_per_bill_period: number | null;
 	meta: string;
 	volume: number;
-	extra: CartItemExtra;
+	extra: ResponseCartProductExtra;
 	uuid: string;
 	cost: null;
 	price: null;
@@ -205,3 +206,16 @@ export interface CartLocation {
 	postalCode: string | null;
 	subdivisionCode: string | null;
 }
+
+export type ResponseCartProductExtra = {
+	context?: string;
+	source?: string;
+	domain_to_bundle?: string;
+	google_apps_users?: GSuiteProductUser[];
+	google_apps_registration_data?: DomainContactDetails;
+	purchaseId?: string;
+	purchaseDomain?: string;
+	purchaseType?: string;
+	includedDomain?: string;
+	privacy?: boolean;
+};

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/shopping-cart-endpoint.ts
@@ -49,6 +49,7 @@ export interface RequestCartProduct {
 	product_id: number;
 	meta: string;
 	extra: CartItemExtra;
+	after_purchase_url?: string;
 }
 
 /**
@@ -162,6 +163,7 @@ export interface ResponseCartProduct {
 	included_domain_purchase_amount: number;
 	is_renewal?: boolean;
 	subscription_id?: string;
+	after_purchase_url?: string;
 }
 
 /**

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/shopping-cart-endpoint.ts
@@ -199,6 +199,7 @@ export interface TempResponseCartProduct {
 	included_domain_purchase_amount: null;
 	is_renewal: undefined;
 	subscription_id: undefined;
+	after_purchase_url: undefined;
 }
 
 export interface CartLocation {

--- a/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
@@ -8,6 +8,7 @@ import { useRef } from 'react';
  */
 import {
 	WpcomStoreState,
+	TransactionResponse,
 	getInitialWpcomStoreState,
 	ManagedContactDetails,
 	ManagedContactDetailsErrors,
@@ -26,7 +27,7 @@ type WpcomStoreAction =
 	| { type: 'UPDATE_DOMAIN_CONTACT_FIELDS'; payload: DomainContactDetails }
 	| { type: 'SET_SITE_ID'; payload: string }
 	| { type: 'SET_SITE_SLUG'; payload: string }
-	| { type: 'TRANSACTION_COMPLETE'; payload: object }
+	| { type: 'TRANSACTION_COMPLETE'; payload: TransactionResponse }
 	| { type: 'SET_RECAPTCHA_CLIENT_ID'; payload: number }
 	| { type: 'UPDATE_VAT_ID'; payload: string }
 	| { type: 'UPDATE_EMAIL'; payload: string }
@@ -41,17 +42,19 @@ type WpcomStoreAction =
 			payload: PossiblyCompleteDomainContactDetails;
 	  };
 
+type WordPressDataStoreListener = () => void;
+
 type WordPressDataStore = {
-	getState: () => object;
-	subscribe: ( listener: Function ) => void;
-	dispatch: ( action: object ) => void;
+	getState: () => WpcomStoreState;
+	subscribe: ( listener: WordPressDataStoreListener ) => void;
+	dispatch: ( action: WpcomStoreAction ) => void;
 };
 
 export function useWpcomStore(
-	registerStore: ( key: string, storeOptions: object ) => WordPressDataStore,
+	registerStore: ( key: string, storeOptions: unknown ) => WordPressDataStore,
 	managedContactDetails: ManagedContactDetails,
 	updateContactDetailsCache: ( _: DomainContactDetails ) => void
-) {
+): void {
 	// Only register once
 	const registerIsComplete = useRef< boolean >( false );
 	if ( registerIsComplete.current ) {
@@ -120,7 +123,10 @@ export function useWpcomStore(
 		}
 	}
 
-	function transactionResultReducer( state: object, action: WpcomStoreAction ): object {
+	function transactionResultReducer(
+		state: TransactionResponse,
+		action: WpcomStoreAction
+	): TransactionResponse {
 		switch ( action.type ) {
 			case 'TRANSACTION_COMPLETE':
 				return action.payload;
@@ -157,7 +163,7 @@ export function useWpcomStore(
 				return { type: 'SET_SITE_SLUG', payload };
 			},
 
-			setTransactionResponse( payload: object ): WpcomStoreAction {
+			setTransactionResponse( payload: TransactionResponse ): WpcomStoreAction {
 				return { type: 'TRANSACTION_COMPLETE', payload };
 			},
 
@@ -217,7 +223,7 @@ export function useWpcomStore(
 				return state.siteSlug;
 			},
 
-			getTransactionResult( state: WpcomStoreState ): object {
+			getTransactionResult( state: WpcomStoreState ): TransactionResponse {
 				return state.transactionResult;
 			},
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -8,7 +8,7 @@
  * Internal dependencies
  */
 import { getThankYouPageUrl } from '../use-get-thank-you-url';
-import { isEnabled } from 'config';
+import { isEnabled } from 'calypso/config';
 
 let mockGSuiteCountryIsValid = true;
 jest.mock( 'lib/user', () =>
@@ -289,6 +289,46 @@ describe( 'getThankYouPageUrl', () => {
 		};
 		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', cart } );
 		expect( url ).toBe( '/me/purchases/foo.bar/123abc' );
+	} );
+
+	it( 'redirects to url from product after_purchase_url if set', () => {
+		const cart = {
+			products: [ { product_slug: 'foo', after_purchase_url: '/custom' } ],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+		} );
+		expect( url ).toBe( '/custom' );
+	} );
+
+	it( 'redirects to url from first product after_purchase_url if multiple are set', () => {
+		const cart = {
+			products: [
+				{ product_slug: 'foo', after_purchase_url: '/custom1' },
+				{ product_slug: 'bar', after_purchase_url: '/custom2' },
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+		} );
+		expect( url ).toBe( '/custom1' );
+	} );
+
+	it( 'redirects to internal redirectTo url if set even if product after_purchase_url is set', () => {
+		const cart = {
+			products: [ { product_slug: 'foo', after_purchase_url: '/custom' } ],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			redirectTo: '/foo/bar',
+			cart,
+		} );
+		expect( url ).toBe( '/foo/bar' );
 	} );
 
 	it( 'does not redirect to url from cookie if isEligibleForSignupDestination is false', () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -7,7 +7,7 @@
 /**
  * Internal dependencies
  */
-import { getThankYouPageUrl } from '../use-get-thank-you-url';
+import getThankYouPageUrl from '../hooks/use-get-thank-you-url/get-thank-you-page-url';
 import { isEnabled } from 'calypso/config';
 
 let mockGSuiteCountryIsValid = true;

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -23,7 +23,7 @@ import {
 	DomainContactValidationRequestExtraFields,
 	DomainContactValidationResponse,
 } from './backend/domain-contact-validation-endpoint';
-import { tryToGuessPostalCodeFormat } from 'lib/postal-code';
+import { tryToGuessPostalCodeFormat } from 'calypso/lib/postal-code';
 import { SignupValidationResponse } from './backend/signup-validation-endpoint';
 
 export type ManagedContactDetailsShape< T > = {
@@ -898,9 +898,17 @@ export type WpcomStoreState = {
 	siteId: string;
 	siteSlug: string;
 	recaptchaClientId: number;
-	transactionResult: object;
+	transactionResult: TransactionResponse;
 	contactDetails: ManagedContactDetails;
 };
+
+export interface TransactionResponse {
+	failed_purchases?: FailedPurchase[];
+	receipt_id?: number;
+	order_id?: number;
+}
+
+type FailedPurchase = unknown;
 
 export const emptyManagedContactDetails: ManagedContactDetails = {
 	firstName: getInitialManagedValue(),

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -351,19 +351,23 @@ function saveUrlToCookieIfEcomm( saveUrlToCookie, cart, destinationUrl ) {
 	}
 }
 
+function modifyUrlIfAtomic( siteSlug, url ) {
+	// If atomic site, then replace wordpress.com with wpcomstaging.com
+	if ( siteSlug?.includes( '.wpcomstaging.com' ) ) {
+		return url.replace( /\b.wordpress.com/, '.wpcomstaging.com' );
+	}
+	return url;
+}
+
 function modifyCookieUrlIfAtomic( getUrlFromCookie, saveUrlToCookie, siteSlug ) {
 	const urlFromCookie = getUrlFromCookie();
 	if ( ! urlFromCookie ) {
 		return;
 	}
+	const updatedUrl = modifyUrlIfAtomic( siteSlug, urlFromCookie );
 
-	// If atomic site, then replace wordpress.com with wpcomstaging.com
-	if ( siteSlug && siteSlug.includes( '.wpcomstaging.com' ) ) {
-		const wpcomStagingDestination = urlFromCookie.replace(
-			/\b.wordpress.com/,
-			'.wpcomstaging.com'
-		);
-		saveUrlToCookie( wpcomStagingDestination );
+	if ( updatedUrl !== urlFromCookie ) {
+		saveUrlToCookie( updatedUrl );
 	}
 }
 

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -114,8 +114,8 @@ export function getThankYouPageUrl( {
 	modifyCookieUrlIfAtomic( getUrlFromCookie, saveUrlToCookie, siteSlug );
 
 	// Fetch the thank-you page url from a cookie if it is set
-	const signupDestination = getUrlFromCookie();
-	debug( 'cookie url is', signupDestination );
+	const urlFromCookie = getUrlFromCookie();
+	debug( 'cookie url is', urlFromCookie );
 
 	if ( hasRenewalItem( cart ) ) {
 		const renewalItem = getRenewalItems( cart )[ 0 ];
@@ -136,14 +136,14 @@ export function getThankYouPageUrl( {
 	// For example, this case arises when a Skip button is clicked on a concierge upsell
 	// nudge opened by a direct link to /offer-support-session.
 	if ( ':receiptId' === pendingOrReceiptId && getAllCartItems( cart ).length === 0 ) {
-		const emptyCartUrl = signupDestination || fallbackUrl;
+		const emptyCartUrl = urlFromCookie || fallbackUrl;
 		debug( 'cart is empty or receipt ID is pending, so returning', emptyCartUrl );
 		return emptyCartUrl;
 	}
 
 	// Domain only flow
 	if ( cart.create_new_blog ) {
-		const newBlogUrl = signupDestination || fallbackUrl;
+		const newBlogUrl = urlFromCookie || fallbackUrl;
 		const newBlogReceiptUrl = `${ newBlogUrl }/${ pendingOrReceiptId }`;
 		debug( 'new blog created, so returning', newBlogReceiptUrl );
 		return newBlogReceiptUrl;
@@ -166,9 +166,9 @@ export function getThankYouPageUrl( {
 	// Display mode is used to show purchase specific messaging, for e.g. the Schedule Session button
 	// when purchasing a concierge session.
 	const displayModeParam = getDisplayModeParamFromCart( cart );
-	if ( isEligibleForSignupDestinationResult && signupDestination ) {
-		debug( 'is eligible for signup destination', signupDestination );
-		return getUrlWithQueryParam( signupDestination, displayModeParam );
+	if ( isEligibleForSignupDestinationResult && urlFromCookie ) {
+		debug( 'is eligible for signup destination', urlFromCookie );
+		return getUrlWithQueryParam( urlFromCookie, displayModeParam );
 	}
 	debug( 'returning fallback url', fallbackUrl );
 	return getUrlWithQueryParam( fallbackUrl, displayModeParam );
@@ -352,14 +352,14 @@ function saveUrlToCookieIfEcomm( saveUrlToCookie, cart, destinationUrl ) {
 }
 
 function modifyCookieUrlIfAtomic( getUrlFromCookie, saveUrlToCookie, siteSlug ) {
-	const signupDestination = getUrlFromCookie();
-	if ( ! signupDestination ) {
+	const urlFromCookie = getUrlFromCookie();
+	if ( ! urlFromCookie ) {
 		return;
 	}
 
 	// If atomic site, then replace wordpress.com with wpcomstaging.com
 	if ( siteSlug && siteSlug.includes( '.wpcomstaging.com' ) ) {
-		const wpcomStagingDestination = signupDestination.replace(
+		const wpcomStagingDestination = urlFromCookie.replace(
 			/\b.wordpress.com/,
 			'.wpcomstaging.com'
 		);

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -379,15 +379,12 @@ export function useGetThankYouUrl( {
 	cart,
 	isJetpackNotAtomic,
 	productAliasFromUrl,
-	siteId,
 	hideNudge,
 	recordEvent,
 } ) {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 	const adminUrl = selectedSiteData?.options?.admin_url;
-	const isEligibleForSignupDestinationResult = useSelector( ( state ) =>
-		isEligibleForSignupDestination( state, siteId, cart )
-	);
+	const isEligibleForSignupDestinationResult = isEligibleForSignupDestination( cart );
 
 	const getThankYouUrl = useCallback( () => {
 		const transactionResult = select( 'wpcom' ).getTransactionResult();

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -56,6 +56,7 @@ export function getThankYouPageUrl( {
 	isTransactionResultEmpty,
 } ) {
 	debug( 'starting getThankYouPageUrl' );
+
 	// If we're given an explicit `redirectTo` query arg, make sure it's either internal
 	// (i.e. on WordPress.com), or a Jetpack or WP.com site's block editor (in wp-admin).
 	// This is required for Jetpack's (and WP.com's) paid blocks Upgrade Nudge.
@@ -84,6 +85,14 @@ export function getThankYouPageUrl( {
 			return sanitizedRedirectTo;
 		}
 		debug( 'ignorning redirectTo', redirectTo );
+	}
+
+	// If any product has an `after_purchase_url` set, redirect to the first one.
+	const productAfterPurchaseUrl = cart?.products?.find( ( product ) => product.after_purchase_url )
+		?.after_purchase_url;
+	if ( productAfterPurchaseUrl ) {
+		debug( 'found product with after_purchase_url', productAfterPurchaseUrl );
+		return productAfterPurchaseUrl;
 	}
 
 	// Note: this function is called early on for redirect-type payment methods, when the receipt isn't set yet.

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -14,8 +14,8 @@ const debug = debugFactory( 'calypso:composite-checkout:use-get-thank-you-url' )
 /**
  * Internal dependencies
  */
-import { isExternal } from 'lib/url';
-import config from 'config';
+import { isExternal } from 'calypso/lib/url';
+import config from 'calypso/config';
 import {
 	hasRenewalItem,
 	getAllCartItems,
@@ -27,15 +27,15 @@ import {
 	hasPremiumPlan,
 	hasBusinessPlan,
 	hasEcommercePlan,
-} from 'lib/cart-values/cart-items';
-import { managePurchase } from 'me/purchases/paths';
-import { isValidFeatureKey } from 'lib/plans/features-list';
-import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
-import { JETPACK_RESET_PLANS } from 'lib/plans/constants';
-import { persistSignupDestination, retrieveSignupDestination } from 'signup/storageUtils';
-import { getSelectedSite } from 'state/ui/selectors';
-import isEligibleForSignupDestination from 'state/selectors/is-eligible-for-signup-destination';
-import { abtest } from 'lib/abtest';
+} from 'calypso/lib/cart-values/cart-items';
+import { managePurchase } from 'calypso/me/purchases/paths';
+import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
+import { JETPACK_PRODUCTS_LIST } from 'calypso/lib/products-values/constants';
+import { JETPACK_RESET_PLANS } from 'calypso/lib/plans/constants';
+import { persistSignupDestination, retrieveSignupDestination } from 'calypso/signup/storageUtils';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-for-signup-destination';
+import { abtest } from 'calypso/lib/abtest';
 
 export function getThankYouPageUrl( {
 	siteSlug,

--- a/client/state/selectors/is-eligible-for-signup-destination.js
+++ b/client/state/selectors/is-eligible-for-signup-destination.js
@@ -5,16 +5,14 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getGoogleApps, hasGoogleApps } from 'lib/cart-values/cart-items';
-import { retrieveSignupDestination } from 'signup/storageUtils';
+import { getGoogleApps, hasGoogleApps } from 'calypso/lib/cart-values/cart-items';
+import { retrieveSignupDestination } from 'calypso/signup/storageUtils';
 
 /**
- * @param {object} state Global state tree
- * @param {number} siteId Site ID
  * @param {object} cart object
  * @returns {boolean} True if current user is able to see the checklist after checkout
  */
-export default function isEligibleForSignupDestination( state, siteId, cart ) {
+export default function isEligibleForSignupDestination( cart ) {
 	if ( hasGoogleApps( cart ) ) {
 		const domainReceiptId = get( getGoogleApps( cart ), '[0].extra.receipt_for_domain', 0 );
 

--- a/client/state/ui/selectors/get-selected-site.js
+++ b/client/state/ui/selectors/get-selected-site.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import getSite from 'state/sites/selectors/get-site';
+import getSite from 'calypso/state/sites/selectors/get-site';
 import getSelectedSiteId from './get-selected-site-id';
 
 /**
@@ -12,6 +12,13 @@ import getSelectedSiteId from './get-selected-site-id';
  * @property {string} slug
  * @property {string} domain
  * @property {string} locale
+ * @property {SiteDataOptions} [options]
+ * TODO: fill this out and/or move it to a TS file
+ */
+
+/**
+ * @typedef {object} SiteDataOptions
+ * @property {string|undefined} admin_url
  * TODO: fill this out and/or move it to a TS file
  */
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a new optional property to each `ResponseCartProduct` as returned by the shopping cart endpoint: `after_purchase_url`. If set, this property is used to override the redirect url generated by `getThankYouUrl`, which is used at the end of checkout (or earlier, for redirect payment methods) to determine the URL to visit after checkout is complete.

Requires D51029-code to add this new property to the back-end.

#### To do

- [ ] Replace using the cookie in signup with adding the url to the cart (not sure where this would be done just yet).
- [x] This also refactors the thank-you function to TS so I was more easily able to check for error states, but that can be moved to its own PR. https://github.com/Automattic/wp-calypso/pull/46423

#### Testing instructions

TBD