### PR TITLE
Reader: add NZ vote banner

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -6,27 +6,27 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import { initial, flatMap, trim } from 'lodash';
 import { connect, useDispatch } from 'react-redux';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies
  */
-import BlankSuggestions from 'reader/components/reader-blank-suggestions';
-import Stream from 'reader/stream';
+import BlankSuggestions from 'calypso/reader/components/reader-blank-suggestions';
+import Stream from 'calypso/reader/stream';
 import { CompactCard, Button } from '@automattic/components';
-import SearchInput from 'components/search';
-import { recordTrack } from 'reader/stats';
-import Suggestion from 'reader/search-stream/suggestion';
-import SuggestionProvider from 'reader/search-stream/suggestion-provider';
+import SearchInput from 'calypso/components/search';
+import { recordTrack } from 'calypso/reader/stats';
+import Suggestion from 'calypso/reader/search-stream/suggestion';
+import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import FollowingIntro from './intro';
-import { getSearchPlaceholderText } from 'reader/search/utils';
-import Banner from 'components/banner';
-import { getCurrentUserCountryCode } from 'state/current-user/selectors';
-import SectionHeader from 'components/section-header';
-import { requestMarkAllAsSeen } from 'state/reader/seen-posts/actions';
-import { SECTION_FOLLOWING } from 'state/reader/seen-posts/constants';
-import { getReaderOrganizationFeedsInfo } from 'state/reader/organizations/selectors';
-import { NO_ORG_ID } from 'state/reader/organizations/constants';
+import { getSearchPlaceholderText } from 'calypso/reader/search/utils';
+import Banner from 'calypso/components/banner';
+import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
+import SectionHeader from 'calypso/components/section-header';
+import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
+import { SECTION_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
+import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizations/selectors';
+import { NO_ORG_ID } from 'calypso/state/reader/organizations/constants';
 
 /**
  * Style dependencies
@@ -43,7 +43,7 @@ function handleSearch( query ) {
 	}
 }
 
-const lastDayForVoteBanner = new Date( '2018-11-07T00:00:00' );
+const lastDayForVoteBanner = new Date( '2020-10-18T00:00:00' );
 
 const FollowingStream = ( props ) => {
 	const suggestionList =
@@ -56,7 +56,7 @@ const FollowingStream = ( props ) => {
 		);
 	const placeholderText = getSearchPlaceholderText();
 	const now = new Date();
-	const showRegistrationMsg = props.userInUSA && now < lastDayForVoteBanner;
+	const showRegistrationMsg = props.userInNZ && now < lastDayForVoteBanner;
 	const { translate } = props;
 	const dispatch = useDispatch();
 
@@ -72,14 +72,14 @@ const FollowingStream = ( props ) => {
 			{ showRegistrationMsg && (
 				<Banner
 					className="following__reader-vote"
-					title="Election Day: Tuesday November 6th"
+					title="NZ Election Day: Saturday 17 October"
 					callToAction="How to vote"
-					description="Remember to vote."
-					dismissPreferenceName="reader-vote-prompt"
+					description="You can vote from 3 October to election day, 17 October."
 					event="reader-vote-prompt"
-					href="https://www.usa.gov/election-office"
+					href="https://vote.nz/"
 					icon="star"
 					horizontal
+					target="_blank"
 				/>
 			) }
 			<CompactCard className="following__search">
@@ -111,6 +111,6 @@ const FollowingStream = ( props ) => {
 };
 
 export default connect( ( state ) => ( {
-	userInUSA: getCurrentUserCountryCode( state ) === 'US',
+	userInNZ: getCurrentUserCountryCode( state ) === 'NZ',
 	feedsInfo: getReaderOrganizationFeedsInfo( state, NO_ORG_ID ),
 } ) )( SuggestionProvider( localize( FollowingStream ) ) );

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -43,7 +43,7 @@ function handleSearch( query ) {
 	}
 }
 
-const hideVoteBannerDate = new Date( '2020-10-18T00:00:00' );
+const hideVoteBannerDate = new Date( '2020-10-17T19:00:00' );
 
 const FollowingStream = ( props ) => {
 	const suggestionList =

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -43,7 +43,7 @@ function handleSearch( query ) {
 	}
 }
 
-const lastDayForVoteBanner = new Date( '2020-10-18T00:00:00' );
+const hideVoteBannerDate = new Date( '2020-10-18T00:00:00' );
 
 const FollowingStream = ( props ) => {
 	const suggestionList =
@@ -56,7 +56,7 @@ const FollowingStream = ( props ) => {
 		);
 	const placeholderText = getSearchPlaceholderText();
 	const now = new Date();
-	const showRegistrationMsg = props.userInNZ && now < lastDayForVoteBanner;
+	const showRegistrationMsg = props.userInNZ && now < hideVoteBannerDate;
 	const { translate } = props;
 	const dispatch = useDispatch();
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We often add a 'vote' banner to the top of Reader for the US election. I thought it'd be good to do the same for the upcoming NZ election on 17th October.

<img width="881" alt="Screen Shot 2020-10-13 at 12 13 17" src="https://user-images.githubusercontent.com/17325/95798322-2c7e0a80-0d4e-11eb-97f4-972572246c1d.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

As a user in NZ, ensure that the vote banner appears at the top of your Following feed: http://calypso.localhost:3000/read. Internal users may need to unproxy because your proxied IP address may show you as being in Australia, not New Zealand.

As a user outside NZ, ensure you do not see the banner at all.
