### PR TITLE
Payments Management: Show "Add Credit Card" CTA for full-credits purchase warning

### DIFF
--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -940,41 +940,40 @@ class PurchaseNotice extends Component {
 			return null;
 		}
 
-		let noticeText = '';
-		let showNoticeAction = false;
-
-		if ( ! isRenewable( purchase ) ) {
-			if ( ! usePlanInsteadOfIncludedPurchase ) {
-				return null;
-			}
-
-			noticeText = translate(
-				'Your {{managePurchase}}%(purchaseName)s plan{{/managePurchase}} (which includes your %(includedPurchaseName)s subscription) has expired and is no longer in use.',
-				{
-					args: {
-						purchaseName: getName( currentPurchase ),
-						includedPurchaseName: getName( includedPurchase ),
-					},
-					components: {
-						managePurchase: (
-							<a href={ getManagePurchaseUrlFor( selectedSite.slug, currentPurchase.id ) } />
-						),
-					},
-				}
+		if ( isRenewable( purchase ) ) {
+			const noticeText = translate( 'This purchase has expired and is no longer in use.' );
+			return (
+				<Notice showDismiss={ false } status="is-error" text={ noticeText }>
+					{ this.renderRenewNoticeAction( this.handleExpiredNoticeRenewal ) }
+					{ this.trackImpression( 'purchase-expired' ) }
+				</Notice>
 			);
-			// We can't show the action here, because it would try to renew the
-			// included purchase (rather than the plan that it is attached to).
-			// So we have to rely on the user going to the manage purchase page
-			// for the plan to renew it there.
-			showNoticeAction = false;
-		} else {
-			noticeText = translate( 'This purchase has expired and is no longer in use.' );
-			showNoticeAction = true;
 		}
 
+		if ( ! usePlanInsteadOfIncludedPurchase ) {
+			return null;
+		}
+
+		const noticeText = translate(
+			'Your {{managePurchase}}%(purchaseName)s plan{{/managePurchase}} (which includes your %(includedPurchaseName)s subscription) has expired and is no longer in use.',
+			{
+				args: {
+					purchaseName: getName( currentPurchase ),
+					includedPurchaseName: getName( includedPurchase ),
+				},
+				components: {
+					managePurchase: (
+						<a href={ getManagePurchaseUrlFor( selectedSite.slug, currentPurchase.id ) } />
+					),
+				},
+			}
+		);
+		// We can't show the action here, because it would try to renew the
+		// included purchase (rather than the plan that it is attached to).
+		// So we have to rely on the user going to the manage purchase page
+		// for the plan to renew it there.
 		return (
 			<Notice showDismiss={ false } status="is-error" text={ noticeText }>
-				{ showNoticeAction && this.renderRenewNoticeAction( this.handleExpiredNoticeRenewal ) }
 				{ this.trackImpression( 'purchase-expired' ) }
 			</Notice>
 		);

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -953,6 +953,9 @@ class PurchaseNotice extends Component {
 		if ( ! usePlanInsteadOfIncludedPurchase ) {
 			return null;
 		}
+		if ( ! selectedSite ) {
+			return null;
+		}
 
 		const noticeText = translate(
 			'Your {{managePurchase}}%(purchaseName)s plan{{/managePurchase}} (which includes your %(includedPurchaseName)s subscription) has expired and is no longer in use.',

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -209,7 +209,7 @@ class PurchaseNotice extends Component {
 
 		return (
 			! isRechargeable( purchase ) && (
-				<NoticeAction onClick={ onClick }>{ translate( 'Renew now' ) }</NoticeAction>
+				<NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>
 			)
 		);
 	}
@@ -678,7 +678,7 @@ class PurchaseNotice extends Component {
 		) {
 			noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
 			noticeActionOnClick = this.handleExpiringNoticeRenewAll;
-			noticeActionText = translate( 'Renew now' );
+			noticeActionText = translate( 'Renew Now' );
 			noticeImpressionName = 'current-expires-later-others-expire-soon';
 
 			if ( anotherPurchaseIsExpired ) {
@@ -721,7 +721,7 @@ class PurchaseNotice extends Component {
 		) {
 			noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
 			noticeActionOnClick = this.handleExpiringNoticeRenewAll;
-			noticeActionText = translate( 'Renew now' );
+			noticeActionText = translate( 'Renew Now' );
 			noticeImpressionName = 'current-renews-later-others-expire-soon';
 
 			if ( anotherPurchaseIsExpired ) {

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -61,7 +61,7 @@ class PurchaseNotice extends Component {
 		handleRenewMultiplePurchases: PropTypes.func,
 		purchase: PropTypes.object,
 		purchaseAttachedTo: PropTypes.object,
-		renewableSitePurchases: PropTypes.arrayOf( PropTypes.object ),
+		renewableSitePurchases: PropTypes.arrayOf( PropTypes.object ).isRequired,
 		selectedSite: PropTypes.object,
 		changePaymentMethodPath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		getManagePurchaseUrlFor: PropTypes.func,

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -340,11 +340,12 @@ class PurchaseNotice extends Component {
 			noticeStatus = 'is-error';
 		}
 
-		let noticeText = '';
-		let showNoticeAction = false;
+		if ( usePlanInsteadOfIncludedPurchase && ! selectedSite ) {
+			return null;
+		}
 
 		if ( usePlanInsteadOfIncludedPurchase ) {
-			noticeText = translate(
+			const noticeText = translate(
 				'Your {{managePurchase}}%(purchaseName)s plan{{/managePurchase}} (which includes your %(includedPurchaseName)s subscription) will expire and be removed from your site %(expiry)s.',
 				{
 					args: {
@@ -363,12 +364,19 @@ class PurchaseNotice extends Component {
 			// included purchase (rather than the plan that it is attached to).
 			// So we have to rely on the user going to the manage purchase page
 			// for the plan to renew it there.
-			showNoticeAction = false;
-		} else {
-			noticeText = this.getExpiringText( currentPurchase );
-			showNoticeAction = true;
+			return (
+				<Notice
+					className="manage-purchase__purchase-expiring-notice"
+					showDismiss={ false }
+					status={ noticeStatus }
+					text={ noticeText }
+				>
+					{ this.trackImpression( 'purchase-expiring' ) }
+				</Notice>
+			);
 		}
 
+		const noticeText = this.getExpiringText( currentPurchase );
 		return (
 			<Notice
 				className="manage-purchase__purchase-expiring-notice"
@@ -376,7 +384,7 @@ class PurchaseNotice extends Component {
 				status={ noticeStatus }
 				text={ noticeText }
 			>
-				{ showNoticeAction && this.renderRenewNoticeAction( this.handleExpiringNoticeRenewal ) }
+				{ this.renderRenewNoticeAction( this.handleExpiringNoticeRenewal ) }
 				{ this.trackImpression( 'purchase-expiring' ) }
 			</Notice>
 		);

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -209,7 +209,7 @@ class PurchaseNotice extends Component {
 
 		return (
 			! isRechargeable( purchase ) && (
-				<NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>
+				<NoticeAction onClick={ onClick }>{ translate( 'Renew now' ) }</NoticeAction>
 			)
 		);
 	}

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -207,6 +207,21 @@ class PurchaseNotice extends Component {
 			);
 		}
 
+		// isExpiring(), which leads here (along with isExpired()) returns true
+		// when expiring, when auto-renew is disabled, or when the payment method
+		// was credits but we don't want to show "Add Payment Method" if the
+		// subscription is actually expiring or expired; we want to show "Renew
+		// Now" in that case.
+		if ( isPaidWithCredits( purchase ) && purchase.expiryStatus === 'manualRenew' ) {
+			return (
+				<NoticeAction href={ changePaymentMethodPath }>
+					{ config.isEnabled( 'purchases/new-payment-methods' )
+						? translate( 'Add Payment Method' )
+						: translate( 'Add Credit Card' ) }
+				</NoticeAction>
+			);
+		}
+
 		return (
 			! isRechargeable( purchase ) && (
 				<NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -195,8 +195,10 @@ class PurchaseNotice extends Component {
 		}
 
 		if (
-			! hasPaymentMethod( purchase ) &&
-			( ! canExplicitRenew( purchase ) || shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) )
+			isPaidWithCredits( purchase ) ||
+			( ! hasPaymentMethod( purchase ) &&
+				( ! canExplicitRenew( purchase ) ||
+					shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) ) )
 		) {
 			return (
 				<NoticeAction href={ changePaymentMethodPath }>

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -980,17 +980,19 @@ class PurchaseNotice extends Component {
 		);
 	}
 
-	renderConciergeConsumedNotice() {
-		const { purchase, translate } = this.props;
-
+	shouldRenderConciergeConsumedNotice() {
+		const { purchase } = this.props;
 		if ( ! isConciergeSession( purchase ) ) {
-			return null;
+			return false;
 		}
-
 		if ( ! isExpired( purchase ) ) {
-			return null;
+			return false;
 		}
+		return true;
+	}
 
+	renderConciergeConsumedNotice() {
+		const { translate } = this.props;
 		return (
 			<Notice
 				showDismiss={ false }
@@ -1029,9 +1031,8 @@ class PurchaseNotice extends Component {
 			return this.renderNonProductOwnerNotice();
 		}
 
-		const consumedConciergeSessionNotice = this.renderConciergeConsumedNotice();
-		if ( consumedConciergeSessionNotice ) {
-			return consumedConciergeSessionNotice;
+		if ( this.shouldRenderConciergeConsumedNotice() ) {
+			return this.renderConciergeConsumedNotice();
 		}
 
 		const otherRenewablePurchasesNotice = this.renderOtherRenewablePurchasesNotice();

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -194,70 +194,24 @@ class PurchaseNotice extends Component {
 			return null;
 		}
 
-		const renewNowButton = (
-			<NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>
-		);
-		const addCreditCardButton = (
-			<NoticeAction href={ changePaymentMethodPath }>
-				{ config.isEnabled( 'purchases/new-payment-methods' )
-					? translate( 'Add Payment Method' )
-					: translate( 'Add Credit Card' ) }
-			</NoticeAction>
-		);
-
-		const isPurchaseExpiringOrExpired = [ 'expiring', 'expired' ].includes(
-			purchase?.expiryStatus
-		); // We can't use isExpiring because it includes manualRenew
-
-		// If we have a payment method that's not credits, and the purchase is not rechargeable, render "Renew now".
-		if (
-			hasPaymentMethod( purchase ) &&
-			! isPaidWithCredits( purchase ) &&
-			! isRechargeable( purchase )
-		) {
-			return renewNowButton;
-		}
-
-		// If we have a payment method that's credits, and the purchase is neither expiring nor expired, render "Add credit card".
-		if ( isPaidWithCredits( purchase ) && ! isPurchaseExpiringOrExpired ) {
-			return addCreditCardButton;
-		}
-
-		// If we have a payment method that's credits, and the purchase is expiring or expired, and the purchase is not rechargeable, render "Renew now".
-		if (
-			isPaidWithCredits( purchase ) &&
-			isPurchaseExpiringOrExpired &&
-			! isRechargeable( purchase )
-		) {
-			return renewNowButton;
-		}
-
-		// If we have no payment method, and we can't explicitly renew, render "Add credit card".
-		if ( ! hasPaymentMethod( purchase ) && ! canExplicitRenew( purchase ) ) {
-			return addCreditCardButton;
-		}
-
-		// If we have no payment method, but we can explicitly renew, and the expiry date is not within than 3 months, render "Add credit card".
 		if (
 			! hasPaymentMethod( purchase ) &&
-			canExplicitRenew( purchase ) &&
-			shouldAddPaymentSourceInsteadOfRenewingNow( purchase )
+			( ! canExplicitRenew( purchase ) || shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) )
 		) {
-			return addCreditCardButton;
+			return (
+				<NoticeAction href={ changePaymentMethodPath }>
+					{ config.isEnabled( 'purchases/new-payment-methods' )
+						? translate( 'Add Payment Method' )
+						: translate( 'Add Credit Card' ) }
+				</NoticeAction>
+			);
 		}
 
-		// If we have no payment method, but we can explicitly renew, and the expiry date is within 3 months, and the purchase is not rechargeable, render "Renew now".
-		if (
-			! hasPaymentMethod( purchase ) &&
-			canExplicitRenew( purchase ) &&
-			! shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) &&
-			! isRechargeable( purchase )
-		) {
-			return renewNowButton;
-		}
-
-		// Otherwise, render nothing.
-		return null;
+		return (
+			! isRechargeable( purchase ) && (
+				<NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>
+			)
+		);
 	}
 
 	trackImpression( warning ) {

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -152,6 +152,30 @@ describe( 'PurchaseNotice', () => {
 		expect( screen.getByText( 'Add Payment Method' ) ).toBeInTheDocument();
 	} );
 
+	it( 'renders expired purchase text and renew now button if purchase is expired, renewable, not rechargable, and payment method is credits', () => {
+		const purchase = {
+			product_slug: 'value_bundle',
+			isRenewable: true,
+			isRechargeable: false,
+			expiryStatus: 'expired',
+			payment: { type: 'credits' },
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( 'This purchase has expired and is no longer in use.' )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
+	} );
+
 	it( 'renders nothing if purchase is expired, is not renewable, not rechargable, and the payment method is a card', () => {
 		const purchase = {
 			product_slug: 'value_bundle',

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -17,6 +17,10 @@ import PurchaseNotice from '../notices';
 
 describe( 'PurchaseNotice', () => {
 	const store = createReduxStore();
+	const futureYearDate = new Date();
+	futureYearDate.setFullYear( futureYearDate.getFullYear() + 10 );
+	const pastYearDate = new Date();
+	pastYearDate.setFullYear( pastYearDate.getFullYear() - 10 );
 
 	it( 'renders nothing when data is still loading', () => {
 		render(
@@ -67,7 +71,7 @@ describe( 'PurchaseNotice', () => {
 		expect( screen.getByText( 'This session has been used.' ) ).toBeInTheDocument();
 	} );
 
-	// TODO: add tests for renderOtherRenewablePurchasesNotice
+	// TODO: add tests for remaining cases of renderOtherRenewablePurchasesNotice
 	it( 'renders distant product expiry text and add card button if purchase is not expiring soon and the payment method is credits', () => {
 		const purchase = {
 			product_slug: 'value_bundle',
@@ -93,6 +97,42 @@ describe( 'PurchaseNotice', () => {
 			)
 		).toBeInTheDocument();
 		expect( screen.getByText( 'Add Payment Method' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders distant product expiry text and no button if purchase is not expiring soon and the payment method is a card', () => {
+		const purchase = {
+			product_slug: 'value_bundle',
+			productName: 'Premium',
+			isRenewable: true,
+			isRechargeable: true,
+			expiryStatus: 'manualRenew',
+			payment: {
+				type: 'credit_card',
+				creditCard: {
+					expiryDate: '01/' + futureYearDate.getYear(),
+					type: 'visa',
+					number: 1111,
+				},
+			},
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( /Premium will expire and be removed from your site/ )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( /Please enable auto-renewal so you don't lose out on your paid features/ )
+		).toBeInTheDocument();
+		expect( screen.queryByText( 'Add Payment Method' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Renew now' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders expired plan text if purchase is included with a plan, the plan is expired, and the purchase is not renewable', () => {
@@ -372,7 +412,7 @@ describe( 'PurchaseNotice', () => {
 			payment: {
 				type: 'credit_card',
 				creditCard: {
-					expiryDate: '01/12',
+					expiryDate: '01/' + pastYearDate.getYear(),
 					type: 'visa',
 					number: 1111,
 				},
@@ -406,7 +446,7 @@ describe( 'PurchaseNotice', () => {
 			payment: {
 				type: 'credit_card',
 				creditCard: {
-					expiryDate: '01/12',
+					expiryDate: '01/' + pastYearDate.getYear(),
 					type: 'visa',
 					number: 1111,
 				},
@@ -439,7 +479,7 @@ describe( 'PurchaseNotice', () => {
 			payment: {
 				type: 'credit_card',
 				creditCard: {
-					expiryDate: '01/12',
+					expiryDate: '01/' + pastYearDate.getYear(),
 					type: 'visa',
 					number: 1111,
 				},

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -67,7 +67,7 @@ describe( 'PurchaseNotice', () => {
 		expect( screen.getByText( 'This session has been used.' ) ).toBeInTheDocument();
 	} );
 
-	// TODO: come back to this.renderOtherRenewablePurchasesNotice
+	// TODO: add tests for renderOtherRenewablePurchasesNotice
 
 	it( 'renders expired plan text if purchase is included with a plan, the plan is expired, and the purchase is not renewable', () => {
 		const plan = {
@@ -127,6 +127,29 @@ describe( 'PurchaseNotice', () => {
 			screen.getByText( 'This purchase has expired and is no longer in use.' )
 		).toBeInTheDocument();
 		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders expired purchase text and add card button if purchase is expired, renewable, not rechargable, and there is no payment method', () => {
+		const purchase = {
+			product_slug: 'value_bundle',
+			isRenewable: true,
+			isRechargeable: false,
+			expiryStatus: 'expired',
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( 'This purchase has expired and is no longer in use.' )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Add Payment Method' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders nothing if purchase is expired, is not renewable, not rechargable, and the payment method is a card', () => {

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -1,0 +1,336 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { createReduxStore } from 'calypso/state';
+import PurchaseNotice from '../notices';
+
+describe( 'PurchaseNotice', () => {
+	const store = createReduxStore();
+
+	it( 'renders nothing when data is still loading', () => {
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice isDataLoading={ true } renewableSitePurchases={ [] } />
+			</ReduxProvider>
+		);
+		expect( screen.container ).toBeFalsy();
+	} );
+
+	it( 'renders nothing when the purchase is a domain transfer', () => {
+		const purchase = { product_slug: 'domain_transfer' };
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice purchase={ purchase } renewableSitePurchases={ [] } />
+			</ReduxProvider>
+		);
+		expect( screen.container ).toBeFalsy();
+	} );
+
+	it( 'renders non-product-owner message if not product owner', () => {
+		const purchase = { product_slug: 'something_else' };
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ false }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( /This product was purchased by a different WordPress.com account./ )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders concierge session used notice if concierge session has expired', () => {
+		const purchase = { product_slug: 'concierge-session', expiryStatus: 'expired' };
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect( screen.getByText( 'This session has been used.' ) ).toBeInTheDocument();
+	} );
+
+	// TODO: come back to this.renderOtherRenewablePurchasesNotice
+
+	it( 'renders expired plan text if purchase is included with a plan, the plan is expired, and the purchase is not renewable', () => {
+		const plan = {
+			id: 'whatever1',
+			product_slug: 'value_bundle',
+			productName: 'Premium',
+			isRenewable: false,
+			isRechargeable: false,
+			expiryStatus: 'expired',
+			payment: { type: 'credit_card' },
+		};
+		const purchase = {
+			id: 'whatever2',
+			product_slug: 'domain_mapping',
+			productName: 'Domain mapping',
+			isRenewable: false,
+			isRechargeable: false,
+			expiryStatus: 'included',
+			payment: { type: 'credit_card' },
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					purchaseAttachedTo={ plan }
+					isProductOwner={ true }
+					renewableSitePurchases={ [] }
+					selectedSite={ { slug: 'testingsite' } }
+				/>
+			</ReduxProvider>
+		);
+		expect( screen.getByText( 'Premium plan' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /\(which includes your Domain mapping subscription\) has expired/ )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders expired purchase text and renew button if purchase is expired, renewable, not rechargable, and the payment method is a card', () => {
+		const purchase = {
+			product_slug: 'value_bundle',
+			isRenewable: true,
+			isRechargeable: false,
+			expiryStatus: 'expired',
+			payment: { type: 'credit_card' },
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( 'This purchase has expired and is no longer in use.' )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing if purchase is expired, is not renewable, not rechargable, and the payment method is a card', () => {
+		const purchase = {
+			product_slug: 'value_bundle',
+			isRenewable: false,
+			isRechargeable: false,
+			expiryStatus: 'expired',
+			payment: { type: 'credit_card' },
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect( screen.container ).toBeFalsy();
+	} );
+
+	it( 'renders nothing if purchase is not expired, and is a partner purchase', () => {
+		const purchase = {
+			product_slug: 'value_bundle',
+			isRenewable: false,
+			partnerName: 'something',
+			isRechargeable: false,
+			expiryStatus: 'tofu',
+			payment: { type: 'credit_card' },
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect( screen.container ).toBeFalsy();
+	} );
+
+	it( 'renders plan expiring text if purchase is included with a plan, and the plan is expiring', () => {
+		const plan = {
+			id: 'whatever1',
+			product_slug: 'value_bundle',
+			productName: 'Premium',
+			isRenewable: false,
+			isRechargeable: false,
+			expiryStatus: 'expiring',
+			payment: { type: 'credit_card' },
+		};
+		const purchase = {
+			id: 'whatever2',
+			product_slug: 'domain_mapping',
+			productName: 'Domain mapping',
+			isRenewable: false,
+			isRechargeable: false,
+			expiryStatus: 'included',
+			payment: { type: 'credit_card' },
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					purchaseAttachedTo={ plan }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect( screen.getByText( 'Premium plan' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /\(which includes your Domain mapping subscription\) will expire/ )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders product expiring text and renew button if purchase is expiring and payment method is a card', () => {
+		const purchase = {
+			id: 'whatever1',
+			product_slug: 'value_bundle',
+			productName: 'Premium',
+			isRenewable: false,
+			isRechargeable: false,
+			expiryStatus: 'expiring',
+			payment: { type: 'credit_card' },
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( /Premium will expire and be removed from your site/ )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders card expiring notice if card is expiring before subscription', () => {
+		const purchaseExpiry = new Date();
+		purchaseExpiry.setMonth( purchaseExpiry.getMonth() + 4 );
+		const purchase = {
+			id: 'whatever1',
+			product_slug: 'value_bundle',
+			productName: 'Premium',
+			isRenewable: false,
+			isRechargeable: false,
+			expiryStatus: 'tofu',
+			expiryDate: purchaseExpiry.toISOString(),
+			payment: {
+				type: 'credit_card',
+				creditCard: {
+					expiryDate: '01/12',
+					type: 'visa',
+					number: 1111,
+				},
+			},
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect( screen.getByText( /Your VISA ending in 1111 expires/ ) ).toBeInTheDocument();
+		expect( screen.getByText( 'update your payment information' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing if card is expiring before subscription and the purchase is included with a plan', () => {
+		const purchaseExpiry = new Date();
+		purchaseExpiry.setMonth( purchaseExpiry.getMonth() + 4 );
+		const purchase = {
+			id: 'whatever1',
+			product_slug: 'value_bundle',
+			productName: 'Premium',
+			isRenewable: false,
+			isRechargeable: false,
+			expiryStatus: 'included',
+			expiryDate: purchaseExpiry.toISOString(),
+			payment: {
+				type: 'credit_card',
+				creditCard: {
+					expiryDate: '01/12',
+					type: 'visa',
+					number: 1111,
+				},
+			},
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect( screen.container ).toBeFalsy();
+	} );
+
+	it( 'renders nothing if card is expiring before subscription and the purchase is a one-time purchase', () => {
+		const purchaseExpiry = new Date();
+		purchaseExpiry.setMonth( purchaseExpiry.getMonth() + 4 );
+		const purchase = {
+			id: 'whatever1',
+			product_slug: 'value_bundle',
+			productName: 'Premium',
+			isRenewable: false,
+			isRechargeable: false,
+			expiryStatus: 'oneTimePurchase',
+			expiryDate: purchaseExpiry.toISOString(),
+			payment: {
+				type: 'credit_card',
+				creditCard: {
+					expiryDate: '01/12',
+					type: 'visa',
+					number: 1111,
+				},
+			},
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect( screen.container ).toBeFalsy();
+	} );
+} );

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -281,6 +281,57 @@ describe( 'PurchaseNotice', () => {
 		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
 	} );
 
+	it( 'renders product expiring text and renew button if purchase is expiring and payment method is credits', () => {
+		const purchase = {
+			id: 'whatever1',
+			product_slug: 'value_bundle',
+			productName: 'Premium',
+			isRenewable: false,
+			isRechargeable: false,
+			expiryStatus: 'expiring',
+			payment: { type: 'credits' },
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( /Premium will expire and be removed from your site/ )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders product expiring text and add card button if purchase is expiring and there is no payment method', () => {
+		const purchase = {
+			id: 'whatever1',
+			product_slug: 'value_bundle',
+			productName: 'Premium',
+			isRenewable: false,
+			isRechargeable: false,
+			expiryStatus: 'expiring',
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( /Premium will expire and be removed from your site/ )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Add Payment Method' ) ).toBeInTheDocument();
+	} );
+
 	it( 'renders card expiring notice if card is expiring before subscription', () => {
 		const purchaseExpiry = new Date();
 		purchaseExpiry.setMonth( purchaseExpiry.getMonth() + 4 );

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -152,7 +152,7 @@ describe( 'PurchaseNotice', () => {
 		expect(
 			screen.getByText( 'This purchase has expired and is no longer in use.' )
 		).toBeInTheDocument();
-		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Renew now' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders expired purchase text and add card button if purchase is expired, renewable, not rechargable, and there is no payment method', () => {
@@ -178,7 +178,7 @@ describe( 'PurchaseNotice', () => {
 		expect( screen.getByText( 'Add Payment Method' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders expired purchase text and renew now button if purchase is expired, renewable, not rechargable, and payment method is credits', () => {
+	it( 'renders expired purchase text and renew button if purchase is expired, renewable, not rechargable, and payment method is credits', () => {
 		const purchase = {
 			product_slug: 'value_bundle',
 			isRenewable: true,
@@ -199,7 +199,7 @@ describe( 'PurchaseNotice', () => {
 		expect(
 			screen.getByText( 'This purchase has expired and is no longer in use.' )
 		).toBeInTheDocument();
-		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Renew now' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders nothing if purchase is expired, is not renewable, not rechargable, and the payment method is a card', () => {
@@ -304,7 +304,7 @@ describe( 'PurchaseNotice', () => {
 		expect(
 			screen.getByText( /Premium will expire and be removed from your site/ )
 		).toBeInTheDocument();
-		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Renew now' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders product expiring text and renew button if purchase is expiring and payment method is credits', () => {
@@ -330,7 +330,7 @@ describe( 'PurchaseNotice', () => {
 		expect(
 			screen.getByText( /Premium will expire and be removed from your site/ )
 		).toBeInTheDocument();
-		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Renew now' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders product expiring text and add card button if purchase is expiring and there is no payment method', () => {

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -132,7 +132,7 @@ describe( 'PurchaseNotice', () => {
 			screen.getByText( /Please enable auto-renewal so you don't lose out on your paid features/ )
 		).toBeInTheDocument();
 		expect( screen.queryByText( 'Add Payment Method' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Renew now' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Renew Now' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders expired plan text if purchase is included with a plan, the plan is expired, and the purchase is not renewable', () => {
@@ -192,7 +192,7 @@ describe( 'PurchaseNotice', () => {
 		expect(
 			screen.getByText( 'This purchase has expired and is no longer in use.' )
 		).toBeInTheDocument();
-		expect( screen.getByText( 'Renew now' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders expired purchase text and add card button if purchase is expired, renewable, not rechargable, and there is no payment method', () => {
@@ -239,7 +239,7 @@ describe( 'PurchaseNotice', () => {
 		expect(
 			screen.getByText( 'This purchase has expired and is no longer in use.' )
 		).toBeInTheDocument();
-		expect( screen.getByText( 'Renew now' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders nothing if purchase is expired, is not renewable, not rechargable, and the payment method is a card', () => {
@@ -344,7 +344,7 @@ describe( 'PurchaseNotice', () => {
 		expect(
 			screen.getByText( /Premium will expire and be removed from your site/ )
 		).toBeInTheDocument();
-		expect( screen.getByText( 'Renew now' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders product expiring text and renew button if purchase is expiring and payment method is credits', () => {
@@ -370,7 +370,7 @@ describe( 'PurchaseNotice', () => {
 		expect(
 			screen.getByText( /Premium will expire and be removed from your site/ )
 		).toBeInTheDocument();
-		expect( screen.getByText( 'Renew now' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Renew Now' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders product expiring text and add card button if purchase is expiring and there is no payment method', () => {

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -68,6 +68,32 @@ describe( 'PurchaseNotice', () => {
 	} );
 
 	// TODO: add tests for renderOtherRenewablePurchasesNotice
+	it( 'renders distant product expiry text and add card button if purchase is not expiring soon and the payment method is credits', () => {
+		const purchase = {
+			product_slug: 'value_bundle',
+			productName: 'Premium',
+			isRenewable: true,
+			isRechargeable: false,
+			expiryStatus: 'manualRenew',
+			payment: { type: 'credits' },
+		};
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseNotice
+					purchase={ purchase }
+					isProductOwner={ true }
+					selectedSite={ { slug: 'testingsite' } }
+					renewableSitePurchases={ [] }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText(
+				/You purchased Premium with credits. Please update your payment information before your plan expires/
+			)
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Add Payment Method' ) ).toBeInTheDocument();
+	} );
 
 	it( 'renders expired plan text if purchase is included with a plan, the plan is expired, and the purchase is not renewable', () => {
 		const plan = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The button on the warning for full-credits purchases should not show "Renew now" because the purchase may have just been renewed.

Due to the complexity of the logic in this component, it can be hard to reason about the effects of any change. To that end, this PR adds unit tests for many cases of the component's rendering. It doesn't cover all the cases because there are so many, but it does provide a mechanism to test the case of this issue and any case we like in the future, and any test we add will prevent regressions.

Originally reported by @nbloomf here: https://github.com/Automattic/wp-calypso/pull/46069#issuecomment-702327064

Fixes 9-gh-payments-shilling

Before:

<img width="993" alt="Screen Shot 2021-02-03 at 1 30 36 PM" src="https://user-images.githubusercontent.com/2036909/106792431-1e693800-6624-11eb-8ab6-95f49dfc9dee.png">

After:

<img width="992" alt="Screen Shot 2021-02-03 at 1 31 05 PM" src="https://user-images.githubusercontent.com/2036909/106792446-232dec00-6624-11eb-8839-4920e2de8ab0.png">

#### Testing instructions

- Visit `/me/purchases` and select a purchase recently made (or renewed) fully with credits.
- Make sure that you see the warning banner at the top of the subscription page.
- Make sure the button on the warning reads "Add Payment Method".
- Repeat the above steps for a purchase made fully with credits but that will expire soon. Verify that the button reads "Renew Now".