### PR TITLE
Reader: check images can be resized with Photon before selecting them as canonical media

### DIFF
--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -7,10 +7,10 @@ import { noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import cssSafeUrl from 'lib/css-safe-url';
-import resizeImageUrl from 'lib/resize-image-url';
+import cssSafeUrl from 'calypso/lib/css-safe-url';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
 
 /**
  * Style dependencies
@@ -32,6 +32,10 @@ const ReaderFeaturedImage = ( {
 
 	// Don't resize image if it was already fetched.
 	const resizedUrl = fetched ? imageUrl : resizeImageUrl( imageUrl, { w: imageWidth } );
+
+	if ( ! resizedUrl ) {
+		return null;
+	}
 
 	const featuredImageStyle = {
 		backgroundImage: 'url(' + cssSafeUrl( resizedUrl ) + ')',

--- a/client/lib/post-normalizer/rule-pick-canonical-image.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-image.js
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-
 import { find } from 'lodash';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { thumbIsLikelyImage, isCandidateForCanonicalImage } from './utils';
 

--- a/client/lib/post-normalizer/rule-pick-canonical-media.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-media.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-
 import { find, get } from 'lodash';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { isUrlLikelyAnImage } from './utils';
+import safeImageUrl from 'calypso/lib/safe-image-url';
 
 /** Returns true if an image is large enough to be a featured asset
  *
@@ -30,7 +30,7 @@ function isCandidateForFeature( media ) {
 	}
 
 	if ( media.mediaType === 'image' ) {
-		return isImageLargeEnoughForFeature( media );
+		return isImageLargeEnoughForFeature( media ) && safeImageUrl( media.src );
 	} else if ( media.mediaType === 'video' ) {
 		// we need to know how to autoplay it which probably means we know how to get a thumbnail
 		return media.autoplayIframe;
@@ -54,7 +54,8 @@ export default function pickCanonicalMedia( post ) {
 	if (
 		isUrlLikelyAnImage( post.featured_image ) &&
 		( ( ! post.post_thumbnail && post.is_jetpack ) || // some jetpack sites dont create post_thumbnail
-			isImageLargeEnoughForFeature( post.post_thumbnail ) )
+			isImageLargeEnoughForFeature( post.post_thumbnail ) ) &&
+		safeImageUrl( post.featured_image )
 	) {
 		post.canonical_media = {
 			src: post.featured_image,

--- a/client/lib/post-normalizer/rule-safe-image-properties.js
+++ b/client/lib/post-normalizer/rule-safe-image-properties.js
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-
 import { forOwn, startsWith } from 'lodash';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { makeImageURLSafe } from './utils';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A user reported seeing a blank image with the background-image src `null` in their Reader. You'll need to set your interface language to Japanese to see it:

https://wordpress.com/read/search?q=%E3%81%AA%E3%81%9C%E5%A4%A7%E6%9D%91%E6%84%9B%E7%9F%A5%E7%9C%8C%E7%9F%A5%E4%BA%8B%E3%82%92%E3%83%AA%E3%82%B3%E3%83%BC%E3%83%AB%E3%81%99%E3%82%8B%E5%BF%85%E8%A6%81%E3%81%8C%E3%81%82%E3%82%8B%E3%81%AE%E3%81%8B

<img width="704" alt="Screen Shot 2020-10-13 at 15 18 36" src="https://user-images.githubusercontent.com/17325/95807945-e170f100-0d67-11eb-80e9-6571d9128859.png">

The image has a query string containing non-resizing parameters (notably `authuser`) so we're not able to resize it with Photon. The image should never have made it to the ReaderFeaturedImage block.

This PR adds a `safeImageUrl` check when selecting the canonical media for a post.

Similar to https://github.com/Automattic/wp-calypso/pull/46144.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit http://calypso.localhost:3000/read/search?q=%E3%81%AA%E3%81%9C%E5%A4%A7%E6%9D%91%E6%84%9B%E7%9F%A5%E7%9C%8C%E7%9F%A5%E4%BA%8B%E3%82%92%E3%83%AA%E3%82%B3%E3%83%BC%E3%83%AB%E3%81%99%E3%82%8B%E5%BF%85%E8%A6%81%E3%81%8C%E3%81%82%E3%82%8B%E3%81%AE%E3%81%8B.

Ensure you don't see an image presented for the top post:

<img width="759" alt="Screen Shot 2020-10-13 at 15 21 12" src="https://user-images.githubusercontent.com/17325/95807893-bf776e80-0d67-11eb-9c6e-767235ee40ab.png">

Ensure that other featured images appear in Reader as normal.

cc @bsanevans 