### PR TITLE
Checkout: Update editor checkout modal UI

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -5,6 +5,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import wp from 'calypso/lib/wp';
 import classnames from 'classnames';
+import { Button } from '@wordpress/components';
+import { Icon, close, wordpress } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -60,9 +62,14 @@ class EditorCheckoutModal extends Component< Props > {
 
 		return hasEmptyCart ? null : (
 			<div className={ classnames( 'editor-checkout-modal', isOpen ? 'is-open' : '' ) }>
-				<button type="button" className="editor-checkout-modal__close-button" onClick={ onClose }>
-					[X] Close Sidebar
-				</button>
+				<div className="editor-checkout-modal__header">
+					<div className="editor-checkout-modal__wp-logo">
+						<Icon icon={ wordpress } size={ 36 } />
+					</div>
+					<Button isLink className="editor-checkout-modal__close-button" onClick={ onClose }>
+						<Icon icon={ close } size={ 24 } />
+					</Button>
+				</div>
 				<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>
 					<CompositeCheckout
 						siteId={ site.ID }

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -31,7 +31,10 @@ interface CartData {
 }
 
 type Props = {
-	site: object;
+	site: {
+		ID: string;
+		slug: string;
+	};
 	cartData: CartData;
 	onClose: () => void;
 	isOpen: boolean;
@@ -82,7 +85,7 @@ class EditorCheckoutModal extends Component< Props > {
 	}
 }
 
-function fetchStripeConfigurationWpcom( args: object ) {
+function fetchStripeConfigurationWpcom( args: Record< string, unknown > ) {
 	return fetchStripeConfiguration( args, wpcom );
 }
 

--- a/client/blocks/editor-checkout-modal/style.scss
+++ b/client/blocks/editor-checkout-modal/style.scss
@@ -1,13 +1,15 @@
+
+@import '~@automattic/typography/styles/variables';
+
 .editor-checkout-modal {
 	position: fixed;
 	top: 0;
+	left: 0;
 	right: -100%;
-	z-index: 999999;
-	width: 50%;
+	z-index: 9998;
 	height: 100%;
 	overflow: auto;
-	padding: 30px;
-	border-left: 1px solid black;
+	padding: 60px 30px 30px;
 	background: white;
 	transition: all 0.5s ease-in-out;
 
@@ -16,9 +18,35 @@
 	}
 }
 
-.editor-checkout-modal__close-button {
-	padding: 15px;
-	border: 1px solid #ccc;
-	margin-bottom: 10px;
-	cursor: pointer;
+.editor-checkout-modal__header {
+	position: fixed;
+	top: 0;
+	left: 0;
+	z-index: 9998;
+	width: 100%;
+	height: 0;
+	overflow: visible;
+}
+
+.editor-checkout-modal__wp-logo {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 60px;
+	height: 60px;
+}
+
+.editor-checkout-modal__close-button.components-button.is-link {
+	position: absolute;
+	top: 0;
+	right: 0;
+	z-index: 9999;
+	width: 60px;
+	height: 60px;
+	justify-content: center;
+	color: var( --studio-gray-50 );
+
+	&:hover {
+		color: var( --studio-gray-40 );
+	}
 }

--- a/client/blocks/editor-checkout-modal/style.scss
+++ b/client/blocks/editor-checkout-modal/style.scss
@@ -9,7 +9,7 @@
 	z-index: 9998;
 	height: 100%;
 	overflow: auto;
-	padding: 60px 30px 30px;
+	padding: 80px 30px 30px;
 	background: white;
 	transition: all 0.5s ease-in-out;
 

--- a/config/development.json
+++ b/config/development.json
@@ -146,7 +146,7 @@
 		"persist-redux": true,
 		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
-		"post-editor/checkout-overlay": false,
+		"post-editor/checkout-overlay": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -121,6 +121,7 @@
 		"persist-redux": true,
 		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
+		"post-editor/checkout-overlay": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"post-editor/preview-scroll-to-content": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Update UI for the over-the-editor checkout modal.

#### Testing instructions
* Go to https://calypso.live/?branch=update/checkout-over-editor-ui
* Open the editor for a page or a post of a free site.
* Open up dev console, change the frame to `post.php`, and run the following code.
```js
let cartData = { products: [{
    product_id: 1009,
    product_slug: 'personal-bundle',
}] };

window.wp.hooks.doAction('a8c.wpcom-block-editor.openCheckoutModal', cartData);
```
* Checkout modal should appear.

## Screenshot
<img width="1640" alt="Screenshot 2020-10-13 at 09 34 13" src="https://user-images.githubusercontent.com/14192054/95824205-9343f980-0d37-11eb-8baf-7bdc3fe14add.png">

Fixes https://github.com/Automattic/wp-calypso/issues/46363