### PR TITLE
Jetpack cloud credentials typography

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
@@ -318,7 +318,7 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 	return (
 		<div className="credentials-form">
 			<h3>{ translate( 'Provide your SSH, SFTP or FTP server credentials' ) }</h3>
-			<p>{ getSubHeaderText() }</p>
+			<p class="credentials-form__intro-text">{ getSubHeaderText() }</p>
 			{ renderCredentialLinks() }
 			<FormFieldset className="credentials-form__protocol-type">
 				<div className="credentials-form__support-info">

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/style.scss
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/style.scss
@@ -14,6 +14,15 @@
 		background: initial;
 	}
 
+	h3 {
+		margin-bottom: 4px;
+	}
+
+	.credentials-form__intro-text {
+		color: var(--color-text-subtle);
+		font-size: $font-body;
+	}
+
 	&__buttons {
 		display: flex;
 		flex-direction: row;

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/style.scss
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/style.scss
@@ -20,7 +20,13 @@
 
 	.credentials-form__intro-text {
 		color: var(--color-text-subtle);
-		font-size: $font-body;
+		font-size: $font-body-small;
+	}
+
+	@media (min-width: 661px) {
+		.credentials-form__intro-text {
+			font-size: $font-body;
+		}
 	}
 
 	&__buttons {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update typography on new Jetpack credentials flow.

**Before:**

![Screenshot 2020-10-13 at 10 40 11](https://user-images.githubusercontent.com/411945/95837875-685ea300-0d41-11eb-88a1-5c95310b3b02.png)

**After:**

![Screenshot 2020-10-13 at 10 36 12](https://user-images.githubusercontent.com/411945/95837952-7e6c6380-0d41-11eb-8ff7-e27a06c083e4.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with flag: `?flags=+jetpack/server-credentials-advanced-flow` on cloud.jetpack.com
