### PR TITLE
Enable triggering builds for Pull Requests

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,8 +1,10 @@
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.notifications
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.dockerRegistry
@@ -351,6 +353,15 @@ object RunAllUnitTests : BuildType({
 		}
 		perfmon {
 		}
+		pullRequests {
+			vcsRootExtId = "${WpCalypso.id}"
+			provider = github {
+				authType = token {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+				filterAuthorRole = PullRequests.GitHubRoleFilter.EVE
+			}
+		}
 		commitStatusPublisher {
 			vcsRootExtId = "${WpCalypso.id}"
 			publisher = github {
@@ -464,6 +475,15 @@ object CheckCodeStyle : BuildType({
 			param("xmlReportParsing.verboseOutput", "true")
 		}
 		perfmon {
+		}
+		pullRequests {
+			vcsRootExtId = "${WpCalypso.id}"
+			provider = github {
+				authType = token {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+				filterAuthorRole = PullRequests.GitHubRoleFilter.EVE
+			}
 		}
 		commitStatusPublisher {
 			vcsRootExtId = "${WpCalypso.id}"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -359,7 +359,7 @@ object RunAllUnitTests : BuildType({
 				authType = token {
 					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
 				}
-				filterAuthorRole = PullRequests.GitHubRoleFilter.EVE
+				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
 			}
 		}
 		commitStatusPublisher {
@@ -482,7 +482,7 @@ object CheckCodeStyle : BuildType({
 				authType = token {
 					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
 				}
-				filterAuthorRole = PullRequests.GitHubRoleFilter.EVE
+				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
 			}
 		}
 		commitStatusPublisher {


### PR DESCRIPTION
### Background

TeamCity is configured to only trigger builds for branches in our repo. However, external contributors do not create a branch in our repo, so they don't get a TeamCity build.

As TeamCity checks are required to be able to merge to master, this means that PRs for OS contributors can't be merged.

### Changes

Enables TC feature 'Pull Request' (originally disabled in #46262). This will list open Pull Requests as `pull/<id>` inside TeamCity UI.

It won't automatically build Pull Request: when a new external PR is open, an authorized user has to manually create a build for `pull/<id>` and run it when the PR is ready to be tested.

### Testing instructions

Can't be tested until it is merged.
As a sanity check, open the TC build for this branch, check the logs and see there are no problems like syntax errors reading the build config