### PR TITLE
Jetpack Cloud credentials, hide key verification for FTP

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
@@ -441,36 +441,40 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 				) }
 			</FormFieldset>
 
-			<div className="credentials-form__mode-control">
-				<div className="credentials-form__support-info">
-					<SegmentedControl disabled={ disabled }>
-						<SegmentedControl.Item
-							selected={ formMode === FormMode.Password }
-							onClick={ () => onModeChange( FormMode.Password ) }
-						>
-							{ translate( 'Use password' ) }
-						</SegmentedControl.Item>
-						<SegmentedControl.Item
-							selected={ formMode === FormMode.PrivateKey }
-							onClick={ () => onModeChange( FormMode.PrivateKey ) }
-						>
-							{ translate( 'Use private key' ) }
-						</SegmentedControl.Item>
-					</SegmentedControl>
-					{ hostInfo?.inline?.mode && (
-						<InfoPopover>
-							<InlineInfo
-								field="mode"
-								host={ host }
-								info={ hostInfo.inline.mode }
-								protocol={ formState.protocol }
-							/>
-						</InfoPopover>
-					) }
+			{ 'ftp' !== formState.protocol && (
+				<div className="credentials-form__mode-control">
+					<div className="credentials-form__support-info">
+						<SegmentedControl disabled={ disabled }>
+							<SegmentedControl.Item
+								selected={ formMode === FormMode.Password }
+								onClick={ () => onModeChange( FormMode.Password ) }
+							>
+								{ translate( 'Use password' ) }
+							</SegmentedControl.Item>
+							<SegmentedControl.Item
+								selected={ formMode === FormMode.PrivateKey }
+								onClick={ () => onModeChange( FormMode.PrivateKey ) }
+							>
+								{ translate( 'Use private key' ) }
+							</SegmentedControl.Item>
+						</SegmentedControl>
+						{ hostInfo?.inline?.mode && (
+							<InfoPopover>
+								<InlineInfo
+									field="mode"
+									host={ host }
+									info={ hostInfo.inline.mode }
+									protocol={ formState.protocol }
+								/>
+							</InfoPopover>
+						) }
+					</div>
 				</div>
-			</div>
+			) }
 
-			{ formMode === FormMode.Password ? renderPasswordForm() : renderPrivateKeyForm() }
+			{ formMode === FormMode.Password || 'ftp' === formState.protocol
+				? renderPasswordForm()
+				: renderPrivateKeyForm() }
 
 			<FormFieldset className="credentials-form__buttons">{ children }</FormFieldset>
 		</div>

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
@@ -59,6 +59,7 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 		switch ( currentTarget.name ) {
 			case 'protocol':
 				onFormStateChange( { ...formState, protocol: currentTarget.value as 'ftp' | 'ssh' } );
+				onModeChange( FormMode.Password );
 				break;
 			case 'host':
 				setFormInteractions( { ...interactions, host: true } );
@@ -472,9 +473,7 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 				</div>
 			) }
 
-			{ formMode === FormMode.Password || 'ftp' === formState.protocol
-				? renderPasswordForm()
-				: renderPrivateKeyForm() }
+			{ formMode === FormMode.Password ? renderPasswordForm() : renderPrivateKeyForm() }
 
 			<FormFieldset className="credentials-form__buttons">{ children }</FormFieldset>
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When selecting FTP for credentials, I don't believe we need to provide key verification as an option.

**Before:**

![Screenshot 2020-10-13 at 12 29 03](https://user-images.githubusercontent.com/411945/95849399-b7133980-0d4f-11eb-91df-024dc2df4a09.png)

**After:**

![Screenshot 2020-10-13 at 12 28 05](https://user-images.githubusercontent.com/411945/95849441-c2666500-0d4f-11eb-9227-848c258e6835.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit cloud.jetpack.com and use the flag `flags=+jetpack/server-credentials-advanced-flow`
