### PR TITLE
Login: Fix Woo onboarding login button icon alignment

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -155,6 +155,10 @@
 		margin-right: 3px;
 		vertical-align: text-bottom;
 	}
+
+	&.button.is-borderless .gridicon {
+		top: 3px;
+	}
 }
 
 .login__form .form-input-validation {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Login: Fix Woo onboarding login button icon alignment

Before:
![](https://cldup.com/3IoAOf4TEP.png)

After:
![](https://cldup.com/dGQRrkywA8.png)

Reported originally in https://github.com/Automattic/wp-calypso/pull/46350#pullrequestreview-507168463

#### Testing instructions

* Go to `/log-in?from=woocommerce-onboarding`
* Input your email and go to the next step.
* Verify the "Change your email" button icon is aligned properly, as shown on the after screenshot.
