### PR TITLE
http-data: store only results of fromApi, fire change event only once 

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -178,14 +178,11 @@ const exported = {
 
 	feedDiscovery( context, next ) {
 		if ( ! context.params.feed_id.match( /^\d+$/ ) ) {
-			waitForHttpData( () => ( { feeds: requestFeedDiscovery( context.params.feed_id ) } ) )
-				.then( ( { feeds } ) => {
-					const feed = feeds?.data?.feeds?.[ 0 ];
-					if ( feed && feed.feed_ID ) {
-						return page.redirect( `/read/feeds/${ feed.feed_ID }` );
-					}
+			waitForHttpData( () => ( { feedId: requestFeedDiscovery( context.params.feed_id ) } ) )
+				.then( ( { feedId } ) => {
+					page.redirect( `/read/feeds/${ feedId.data }` );
 				} )
-				.catch( function () {
+				.catch( () => {
 					renderFeedError( context, next );
 				} );
 		} else {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -132,7 +132,7 @@ export default {
 
 			waitForHttpData( () => ( { geo: requestGeoLocation() } ) )
 				.then( ( { geo } ) => {
-					const countryCode = geo.data.body.country_short;
+					const countryCode = geo.data;
 					if (
 						( ! user() || ! user().get() ) &&
 						-1 === context.pathname.indexOf( 'free' ) &&

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -196,7 +196,7 @@ export const requestFeedDiscovery = ( feedId ) => {
 			{}
 		),
 		{
-			fromApi: () => ( { feeds } ) => [ [ requestId, feeds ] ],
+			fromApi: () => ( response ) => [ [ requestId, response.feeds[ 0 ].feed_ID ] ],
 		}
 	);
 };

--- a/client/state/data-layer/http-data.ts
+++ b/client/state/data-layer/http-data.ts
@@ -61,7 +61,7 @@ export const subscribe = ( f: () => void ): ( () => void ) => {
 	return () => void listeners.delete( f );
 };
 
-export const updateData = ( id: DataId, state: DataState, data: unknown ): typeof httpData => {
+export const updateData = ( id: DataId, state: DataState, data?: unknown ): typeof httpData => {
 	const lastUpdated: TimestampMS = Date.now();
 	const item = httpData.get( id ) || empty;
 
@@ -105,16 +105,14 @@ export const updateData = ( id: DataId, state: DataState, data: unknown ): typeo
 
 export const resetHttpData = ( id: DataId ) => httpData.set( id, empty );
 
-export const update = ( id: DataId, state: DataState, data?: unknown ) => {
-	const updated = updateData( id, state, data );
-
+function fireChangeEvents() {
 	listeners.forEach( ( f ) => f() );
-
-	return updated;
-};
+	return { type: HTTP_DATA_TICK };
+}
 
 const fetch = ( action: HttpDataAction ) => {
-	update( action.id, DataState.Pending );
+	updateData( action.id, DataState.Pending );
+	const tickAction = fireChangeEvents();
 
 	return [
 		{
@@ -123,60 +121,25 @@ const fetch = ( action: HttpDataAction ) => {
 			onFailure: action,
 			onProgress: action,
 		},
-		{ type: HTTP_DATA_TICK },
+		tickAction,
 	];
 };
 
 const onError = ( action: HttpDataAction, error: unknown ) => {
-	update( action.id, DataState.Failure, error );
-
-	return { type: HTTP_DATA_TICK };
-};
-
-type SuccessfulParse = [ undefined, ReturnType< ResponseParser > ];
-type FailedParse = [ unknown, undefined ];
-type ParseResult = SuccessfulParse | FailedParse;
-
-/**
- * Transforms API response data into storable data
- * Returns pairs of data ids and data plus an error indicator
- *
- * [ error?, [ [ id, data ], [ id, data ], … ] ]
- *
- * @example
- *   --input--
- *   { data: { sites: {
- *     14: { is_active: true, name: 'foo' },
- *     19: { is_active: false, name: 'bar' }
- *   } } }
- *
- *   --output--
- *   [ [ 'site-names-14', 'foo' ] ]
- *
- * @param data - input data from API response
- * @param fromApi - transforms API response data
- * @returns output data to store
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const parseResponse = ( data: any, fromApi: ResponseParser ): ParseResult => {
-	try {
-		return [ undefined, fromApi( data ) ];
-	} catch ( error ) {
-		return [ error, undefined ];
-	}
+	updateData( action.id, DataState.Failure, error );
+	return fireChangeEvents();
 };
 
 const onSuccess = ( action: HttpDataAction, apiData: unknown ) => {
-	const [ error, data ] = parseResponse( apiData, action.fromApi() );
-
-	if ( undefined === data ) {
+	try {
+		const data = action.fromApi()( apiData );
+		for ( const [ id, resource ] of data ) {
+			updateData( id, DataState.Success, resource );
+		}
+		return fireChangeEvents();
+	} catch ( error ) {
 		return onError( action, error );
 	}
-
-	update( action.id, DataState.Success, apiData );
-	data.forEach( ( [ id, resource ] ) => update( id, DataState.Success, resource ) );
-
-	return { type: HTTP_DATA_TICK };
 };
 
 export default {


### PR DESCRIPTION
Before this patch, the `onSuccess` handler in `http-data` saved the raw response under the request ID key, and then looped through the array returned from `fromApi` to store additional IDs.

After this patch, we store only results from `fromApi`. The default implementation simply returns the raw response, so in this case the result was previously stored twice.

With non-default `fromApi` implementation, it could happen that two results (raw and from `fromApi`) could be stored in quick succession under the same ID.

The second thing this patch does is to call the listeners only after all updates are done, and not after each update separately.

This change modifies the behavior of `waitForHttpData`, which was previously somewhat counter-intuitive: storing the raw response under `requestId` immediately fired the change event and resolved the `waitForHttpData` promise, so the consumer got the raw response. But immediately after this, the non-raw response from `fromApi` was stored under the same ID. The original `waitForHttpData` never saw this.

But if you called the same `waitForHttpData` again, it would return a different (cached) response, not the same one as the first call. That's a bug that wasn't happening in production, but was still present and dangerous.

The fact that we trigger the listeners only once will help us build a `useHttpData` hook that will remove a big chunk of Redux from the `http-data` library -- no more `HTTP_DATA_TICK` action, as the hook will subscribe a `http-data` listener.

There are two more commits that clean up the usages of `waitForHttpData` and align the expected shapes of data.

**How to test:**
- `waitForHttpData` in Reader: go to `/read/feeds/site.slug` and verify that you're redirected to a numeric feed ID URL
- `waitForHttpData` in Signup: I tested this by commenting out various conditions in the `redirectTests` controller and verified with debugger that the geolocation returned is correct when handing a `/start/*` route.
