### PR TITLE
Simple Payments: Use FormLabel instead of label in the dialog

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
@@ -11,12 +11,12 @@ import { getCurrencyObject } from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
-import { CompactCard } from '@automattic/components';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import FormRadio from 'calypso/components/forms/form-radio';
 import log from 'calypso/lib/catch-js-errors/log';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import ProductImage from './product-image';
+import { CompactCard } from '@automattic/components';
 import { DEFAULT_CURRENCY } from 'calypso/lib/simple-payments/constants';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
@@ -12,6 +12,7 @@ import { getCurrencyObject } from '@automattic/format-currency';
  * Internal dependencies
  */
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import log from 'calypso/lib/catch-js-errors/log';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
@@ -77,10 +78,10 @@ class ProductListItem extends Component {
 					checked={ isSelected }
 					onChange={ this.handleRadioChange }
 				/>
-				<label className={ labelClasses } htmlFor={ radioId }>
+				<FormLabel className={ labelClasses } htmlFor={ radioId }>
 					<div className="editor-simple-payments-modal__list-name">{ title }</div>
 					<div>{ this.formatPrice( price, currency ) }</div>
-				</label>
+				</FormLabel>
 				<ProductImage siteId={ siteId } imageId={ featuredImageId } />
 				<EllipsisMenu
 					className="editor-simple-payments-modal__list-menu"

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -239,11 +239,13 @@
 	}
 }
 
-.editor-simple-payments-modal__list-label {
+.editor-simple-payments-modal__list-label.form-label {
 	flex: auto;
 	min-width: 0;
 	font-family: $serif;
 	font-weight: 600;
+	font-size: 1rem;
+	margin-bottom: 0;
 
 	&.is-error {
 		color: var( --color-error );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Simple Payments: Use FormLabel instead of a label in the dialog. See #45259.
* Make imports relative to Calypso's root and sort them alphabetically.

#### Testing instructions

* Open a post in the classic Calypso editor.
* Insert a simple payments button.
* Ensure you have at least one product there.
* Verify the label inside the dialog has visual or functional changes.
