### PR TITLE
Login: Use FormLabel instead of label in Magic Login

### DIFF
--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -154,7 +154,7 @@ class RequestLoginEmailForm extends React.Component {
 					<FormFieldset className="magic-login__email-fields">
 						<FormTextInput
 							autoCapitalize="off"
-							autoFocus="true"
+							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 							disabled={ isFetching || emailRequested }
 							value={ usernameOrEmail }
 							name="usernameOrEmail"

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -6,29 +6,29 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { defer, get } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { hideMagicLoginRequestNotice } from 'state/login/magic-login/actions';
-import getMagicLoginCurrentView from 'state/selectors/get-magic-login-current-view';
-import getMagicLoginRequestedEmailSuccessfully from 'state/selectors/get-magic-login-requested-email-successfully';
-import getMagicLoginRequestEmailError from 'state/selectors/get-magic-login-request-email-error';
-import isFetchingMagicLoginEmail from 'state/selectors/is-fetching-magic-login-email';
-import { getRedirectToOriginal } from 'state/login/selectors';
-import { CHECK_YOUR_EMAIL_PAGE } from 'state/login/magic-login/constants';
-import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
-import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import EmailedLoginLinkSuccessfully from './emailed-login-link-successfully';
-import FormButton from 'components/forms/form-button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormTextInput from 'components/forms/form-text-input';
-import LoggedOutForm from 'components/logged-out-form';
-import Notice from 'components/notice';
-import { localize } from 'i18n-calypso';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { sendEmailLogin } from 'state/auth/actions';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
+import getMagicLoginRequestedEmailSuccessfully from 'calypso/state/selectors/get-magic-login-requested-email-successfully';
+import getMagicLoginRequestEmailError from 'calypso/state/selectors/get-magic-login-request-email-error';
+import isFetchingMagicLoginEmail from 'calypso/state/selectors/is-fetching-magic-login-email';
+import LoggedOutForm from 'calypso/components/logged-out-form';
+import Notice from 'calypso/components/notice';
+import { CHECK_YOUR_EMAIL_PAGE } from 'calypso/state/login/magic-login/constants';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getRedirectToOriginal } from 'calypso/state/login/selectors';
+import { hideMagicLoginRequestNotice } from 'calypso/state/login/magic-login/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+import { sendEmailLogin } from 'calypso/state/auth/actions';
 
 class RequestLoginEmailForm extends React.Component {
 	static propTypes = {

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import EmailedLoginLinkSuccessfully from './emailed-login-link-successfully';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
@@ -147,9 +148,9 @@ class RequestLoginEmailForm extends React.Component {
 								'with your account to log in instantly without your password.'
 						) }
 					</p>
-					<label htmlFor="usernameOrEmail" className="magic-login__form-label">
+					<FormLabel htmlFor="usernameOrEmail" className="magic-login__form-label">
 						{ this.props.translate( 'Email Address' ) }
-					</label>
+					</FormLabel>
 					<FormFieldset className="magic-login__email-fields">
 						<FormTextInput
 							autoCapitalize="off"

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -148,7 +148,7 @@ class RequestLoginEmailForm extends React.Component {
 								'with your account to log in instantly without your password.'
 						) }
 					</p>
-					<FormLabel htmlFor="usernameOrEmail" className="magic-login__form-label">
+					<FormLabel htmlFor="usernameOrEmail">
 						{ this.props.translate( 'Email Address' ) }
 					</FormLabel>
 					<FormFieldset className="magic-login__email-fields">

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -63,15 +63,6 @@
 	margin: 0;
 }
 
-.magic-login__form-label {
-	color: var( --color-neutral-70 );
-	display: block;
-	font-size: $font-body-small;
-	line-height: 1.5;
-	font-weight: 600;
-	margin-bottom: 5px;
-}
-
 .magic-login__form-action {
 	margin-top: 20px;
 	overflow: auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sort imports and make them relative to Calypso's root in `RequestLoginEmailForm`.
* Use `FormLabel` instead of `label` in `RequestLoginEmailForm` - see #45259 for details.
* Remove unnecessary label styles in `RequestLoginEmailForm`
* Consciously ignore the `autoFocus` linting error for now.

#### Testing instructions

* Go to `/log-in/link` as a logged-out user.
* Compare against production to ensure there are no visual/functional differences in the label.
