### PR TITLE
Security: Use FormLabel in Security2faProgressItem

### DIFF
--- a/client/me/security-2fa-progress/progress-item.jsx
+++ b/client/me/security-2fa-progress/progress-item.jsx
@@ -3,21 +3,11 @@
  */
 
 import React from 'react';
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:me:security:2fa-progress' );
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 
 export default class extends React.Component {
 	static displayName = 'Security2faProgressItem';
-
-	componentDidMount() {
-		debug( this.constructor.displayName + ' React component is mounted.' );
-	}
-
-	componentWillUnmount() {
-		debug( this.constructor.displayName + ' React component will unmount.' );
-	}
 
 	highlight = () => {
 		return classNames( {

--- a/client/me/security-2fa-progress/progress-item.jsx
+++ b/client/me/security-2fa-progress/progress-item.jsx
@@ -9,20 +9,16 @@ import classNames from 'classnames';
  */
 import Gridicon from 'calypso/components/gridicon';
 
-export default class extends React.Component {
-	static displayName = 'Security2faProgressItem';
+const Security2faProgressItem = ( { icon, label, step } ) => (
+	<div
+		className={ classNames( 'security-2fa-progress__item', {
+			'is-highlighted': step.isHighlighted,
+			'is-completed': step.isCompleted,
+		} ) }
+	>
+		<Gridicon icon={ icon } />
+		<label>{ label } </label>
+	</div>
+);
 
-	render() {
-		return (
-			<div
-				className={ classNames( 'security-2fa-progress__item', {
-					'is-highlighted': this.props.step.isHighlighted,
-					'is-completed': this.props.step.isCompleted,
-				} ) }
-			>
-				<Gridicon icon={ this.props.icon } />
-				<label>{ this.props.label } </label>
-			</div>
-		);
-	}
-}
+export default Security2faProgressItem;

--- a/client/me/security-2fa-progress/progress-item.jsx
+++ b/client/me/security-2fa-progress/progress-item.jsx
@@ -12,17 +12,14 @@ import Gridicon from 'calypso/components/gridicon';
 export default class extends React.Component {
 	static displayName = 'Security2faProgressItem';
 
-	highlight = () => {
-		return classNames( {
-			'security-2fa-progress__item': true,
-			'is-highlighted': this.props.step.isHighlighted,
-			'is-completed': this.props.step.isCompleted,
-		} );
-	};
-
 	render() {
 		return (
-			<div className={ this.highlight() }>
+			<div
+				className={ classNames( 'security-2fa-progress__item', {
+					'is-highlighted': this.props.step.isHighlighted,
+					'is-completed': this.props.step.isCompleted,
+				} ) }
+			>
 				<Gridicon icon={ this.props.icon } />
 				<label>{ this.props.label } </label>
 			</div>

--- a/client/me/security-2fa-progress/progress-item.jsx
+++ b/client/me/security-2fa-progress/progress-item.jsx
@@ -1,9 +1,12 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
 import Gridicon from 'calypso/components/gridicon';
 
 export default class extends React.Component {

--- a/client/me/security-2fa-progress/progress-item.jsx
+++ b/client/me/security-2fa-progress/progress-item.jsx
@@ -12,8 +12,8 @@ import Gridicon from 'calypso/components/gridicon';
 const Security2faProgressItem = ( { icon, label, step } ) => (
 	<div
 		className={ classNames( 'security-2fa-progress__item', {
-			'is-highlighted': step.isHighlighted,
-			'is-completed': step.isCompleted,
+			'is-highlighted': step?.isHighlighted,
+			'is-completed': step?.isCompleted,
 		} ) }
 	>
 		<Gridicon icon={ icon } />

--- a/client/me/security-2fa-progress/progress-item.jsx
+++ b/client/me/security-2fa-progress/progress-item.jsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import FormLabel from 'calypso/components/forms/form-label';
 import Gridicon from 'calypso/components/gridicon';
 
 const Security2faProgressItem = ( { icon, label, step } ) => (
@@ -17,7 +18,7 @@ const Security2faProgressItem = ( { icon, label, step } ) => (
 		} ) }
 	>
 		<Gridicon icon={ icon } />
-		<label>{ label } </label>
+		<FormLabel>{ label } </FormLabel>
 	</div>
 );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `debug` code from `Security2faProgressItem`.
* Properly arrange `Security2faProgressItem` imports.
* Move `classnames` instance inline in `Security2faProgressItem`.
* Refactor `Security2faProgressItem` to a functional component.
* Update `Security2faProgressItem` step props to be accessed in a safer way.
* Use `FormLabel` in `Security2faProgressItem` - see #45259 for rationale.

#### Testing instructions

* Go to `/me/security/two-step` for a user with 2FA off.
* Start the setup by clicking the button.
* Verify the labels inside the progress area look the same way they did before.
