### PR TITLE
Do not automatically run builds on changes to Pull Requests

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -339,7 +339,10 @@ object RunAllUnitTests : BuildType({
 
 	triggers {
 		vcs {
-			branchFilter = "+:*"
+			branchFilter = """
+				+:*
+				-:pull*
+			""".trimIndent()
 		}
 	}
 
@@ -452,7 +455,10 @@ object CheckCodeStyle : BuildType({
 
 	triggers {
 		vcs {
-			branchFilter = "+:*"
+			branchFilter = """
+				+:*
+				-:pull*
+			""".trimIndent()
 		}
 	}
 


### PR DESCRIPTION
#### Background

TeamCity is triggering build every time a branch changes (expected) and when a Pull Request changes (unexpected). We don't want to trigger changes when the Pull Request changes to avoid running tests automatically for external contributors.

Broken since #46391

#### Changes

Do not trigger automatic builds on changes to open Pull Requests.

#### Testing instructions

- Can't be tested until merged in master.
- As a sanity check, verify the TC build for this branch doesn't throw syntax errors when parsing the DSL