### PR TITLE
[e2e] Installchromedriver before running e2e tests

### DIFF
--- a/test/e2e/test/mocha.env.js
+++ b/test/e2e/test/mocha.env.js
@@ -1,1 +1,27 @@
 process.env.SELENIUM_PROMISE_MANAGER = '0';
+
+/**
+ * External dependencies (can also be listed in the root package.json)
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+const execa = require( 'execa' );
+
+// Make sure that puppeteer and chromedriver are installed before running tests
+try {
+	execa.sync( 'node', [ require.resolve( 'puppeteer/install' ) ], {
+		env: {
+			PUPPETEER_SKIP_DOWNLOAD: '',
+			PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: '',
+		},
+		stdio: 'inherit',
+	} );
+
+	execa.sync( 'node', [ require.resolve( 'chromedriver/install' ) ], {
+		env: {
+			CHROMEDRIVER_SKIP_DOWNLOAD: '',
+		},
+		stdio: 'inherit',
+	} );
+} catch ( error ) {
+	console.error( error );
+}

--- a/test/e2e/test/mocha.env.js
+++ b/test/e2e/test/mocha.env.js
@@ -6,16 +6,8 @@ process.env.SELENIUM_PROMISE_MANAGER = '0';
 // eslint-disable-next-line import/no-extraneous-dependencies
 const execa = require( 'execa' );
 
-// Make sure that puppeteer and chromedriver are installed before running tests
+// Make sure that chromedriver is installed before running tests
 try {
-	execa.sync( 'node', [ require.resolve( 'puppeteer/install' ) ], {
-		env: {
-			PUPPETEER_SKIP_DOWNLOAD: '',
-			PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: '',
-		},
-		stdio: 'inherit',
-	} );
-
 	execa.sync( 'node', [ require.resolve( 'chromedriver/install' ) ], {
 		env: {
 			CHROMEDRIVER_SKIP_DOWNLOAD: '',


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Force-install  `chromedriver` when running e2e tests
* This is achieved by triggering the install process (and overriding certain `env` variables when doing so) in `test/e2e/test/mocha.env.js` — a file that is automatically run by `mocha` during its setup

### Testing instructions

#### Without PR applied:
1. Clear the `./node-modules` folder
2. Run `yarn calypso-doctor` and make suggested amends to your `env` variables
3. Run `yarn install`
4. Setup e2e tests locally, including using the encrypted configuration (refer to the field guide for detailed instructions)
5. Run a test, e.g. `cd test/e2e && ./node_modules/.bin/mocha specs/wp-signup-spec.js`
6. Terminal should show an error about missing `chromedriver` dependency

#### With PR applied:
1. Same instructions from 1 to 5
6. Tests should run correctly, no error in the terminal about missing `chromedriver`

Fixes #45537
