### PR TITLE
Plans: new name and tagline for Jetpack Security and Jetpack Backup

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
@@ -42,7 +42,7 @@ type OwnProps = {
 	billingTimeFrame: TranslateResult;
 	buttonLabel: TranslateResult;
 	buttonPrimary: boolean;
-	badgeLabel: TranslateResult;
+	badgeLabel?: TranslateResult;
 	onButtonClick: () => void;
 	cancelLabel?: TranslateResult;
 	onCancelClick?: () => void;

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -385,7 +385,7 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 		),
 	getTagline: () =>
 		isEnabled( 'plans/alternate-selector' )
-			? translate( 'Backup, Scan, and Anti-spam in one bundle' )
+			? translate( 'Backup, Scan, and Anti-spam in one package' )
 			: translate( 'Best for sites with occasional updates' ),
 	getPlanCompareFeatures: () => [],
 	getPlanCardFeatures: () => ( {

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -8,8 +8,8 @@ import i18n, { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import * as constants from './constants';
 import { isEnabled } from 'calypso/config';
+import * as constants from './constants';
 
 const WPComGetBillingTimeframe = () => i18n.translate( 'per month, billed annually' );
 const WPComGetBiennialBillingTimeframe = () => i18n.translate( '/month, billed every two years' );
@@ -383,7 +383,10 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 			'Enjoy the peace of mind of complete site protection. ' +
 				'Great for brochure sites, restaurants, blogs, and resume sites.'
 		),
-	getTagline: () => translate( 'Best for sites with occasional updates' ),
+	getTagline: () =>
+		isEnabled( 'plans/alternate-selector' )
+			? translate( 'Backup, Scan, and Anti-spam in one bundle' )
+			: translate( 'Best for sites with occasional updates' ),
 	getPlanCompareFeatures: () => [],
 	getPlanCardFeatures: () => ( {
 		[ constants.FEATURE_CATEGORY_SECURITY ]: [

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -131,7 +131,7 @@ export const getJetpackProductsCallToAction = () => {
 
 export const getJetpackProductsTaglines = () => {
 	const backupDailyTagline = isEnabled( 'plans/alternate-selector' )
-		? translate( 'Automated backups, one-click restores' )
+		? translate( 'Automated backups with one-click restores' )
 		: translate( 'Best for sites with occasional updates' );
 	const backupRealtimeTagline = translate( 'Best for sites with frequent updates' );
 	const backupOwnedTagline = translate( 'Your site is actively being backed up' );

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -130,7 +130,9 @@ export const getJetpackProductsCallToAction = () => {
 };
 
 export const getJetpackProductsTaglines = () => {
-	const backupDailyTagline = translate( 'Best for sites with occasional updates' );
+	const backupDailyTagline = isEnabled( 'plans/alternate-selector' )
+		? translate( 'Automated backups, one-click restores' )
+		: translate( 'Best for sites with occasional updates' );
 	const backupRealtimeTagline = translate( 'Best for sites with frequent updates' );
 	const backupOwnedTagline = translate( 'Your site is actively being backed up' );
 

--- a/client/my-sites/plans-v2/product-card-alt/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt/index.tsx
@@ -10,9 +10,11 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
  */
 import {
 	durationToText,
+	getOptionFromSlug,
 	productBadgeLabelAlt,
 	productButtonLabel,
 	slugIsFeaturedProduct,
+	slugToSelectorProduct,
 } from '../utils';
 import PlanRenewalMessage from '../plan-renewal-message';
 import RecordsDetailsAlt from '../records-details-alt';
@@ -99,11 +101,23 @@ const ProductCardAltWrapper = ( {
 	const description = showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description;
 	const showRecordsDetails = JETPACK_SEARCH_PRODUCTS.includes( item.productSlug ) && siteId;
 
+	// In the case of products that have ptions (daily versus real-time), we want to display
+	// the name of the option, not the name of one of the variants.
+	const productName = useMemo( () => {
+		const optionSlug = getOptionFromSlug( item.productSlug );
+
+		if ( ! optionSlug ) {
+			return item.displayName;
+		}
+
+		return slugToSelectorProduct( optionSlug )?.displayName || item.displayName;
+	}, [ item ] );
+
 	return (
 		<JetpackProductCardAlt
 			headingLevel={ 3 }
 			iconSlug={ item.iconSlug }
-			productName={ item.displayName }
+			productName={ productName }
 			subheadline={ item.tagline }
 			description={ description }
 			currencyCode={ currencyCode }

--- a/client/my-sites/plans-v2/product-card-alt/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt/index.tsx
@@ -101,7 +101,7 @@ const ProductCardAltWrapper = ( {
 	const description = showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description;
 	const showRecordsDetails = JETPACK_SEARCH_PRODUCTS.includes( item.productSlug ) && siteId;
 
-	// In the case of products that have ptions (daily versus real-time), we want to display
+	// In the case of products that have options (daily and real-time), we want to display
 	// the name of the option, not the name of one of the variants.
 	const productName = useMemo( () => {
 		const optionSlug = getOptionFromSlug( item.productSlug );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Security and Backup product cards with a better name and tagline. Now Jetpack Security is featured as `Jetpack Security` instead of `Security Daily`, and Jetpack Backup is featured as `Jetpack Backup` instead of `Backup Daily`. 

#### Testing instructions

* Run this PR.
* Visit the Plans page (any environment will work).
* Verify that the name in Jetpack Security and Jetpack Backup cards looks like the capture below.
* Verify that the tagline in Jetpack Security and Jetpack Backup cards looks like the capture below.

Fixes 1196341175636977-as-1198202253926309

#### Demo
![image](https://user-images.githubusercontent.com/3418513/95866770-b625dc00-0d3e-11eb-8fe1-32ae277fa44f.png)
![image](https://user-images.githubusercontent.com/3418513/95866801-c047da80-0d3e-11eb-9d1c-df0eae680fd5.png)
![image](https://user-images.githubusercontent.com/3418513/95866840-c938ac00-0d3e-11eb-885b-f7a7e0160e28.png)
