### PR TITLE
Plans: avoid having product cards stretch vertically

### DIFF
--- a/client/my-sites/plans-v2/products-grid-alt/style.scss
+++ b/client/my-sites/plans-v2/products-grid-alt/style.scss
@@ -27,14 +27,13 @@
 		 * Once the screen is wide enough to support it,
 		 * create a grid with cells that are evenly sized,
 		 * with a minimum width of 300px each.
-		 * Each cell should take up as much vertical space as it's allowed,
-		 * and the horizontal/vertical gap between them should always be 16px.
+		 * The horizontal/vertical gap between each cell should always be 16px.
 		 */
 		@include breakpoint-deprecated( '>660px' ) {
 			display: grid;
 			grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
 			grid-gap: 16px;
-			align-items: stretch;
+			align-items: flex-start;
 		}
 
 		& > .jetpack-free-card-alt {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Avoid having product cards stretch to entire available height.

#### Testing instructions

* Spin up this PR.
* Visit the Jetpack pricing pages.
* Ensure you can expand any product on desktop without affecting other columns on their sides.

#### Screenshots

Before
![2020-10-13 15 58 25](https://user-images.githubusercontent.com/390760/95878785-7f1aef00-0d6d-11eb-88b8-e94f3bf0c40d.gif)


After
![2020-10-13 15 58 49](https://user-images.githubusercontent.com/390760/95878798-817d4900-0d6d-11eb-89ba-dd2b646d6782.gif)

