### PR TITLE
Set the redirect URL back to the editor when users finish the plan purchase

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -23,7 +23,12 @@ import './style.scss';
 
 const wpcom = wp.undocumented();
 
-interface CartData {
+type Site = {
+	ID: number;
+	slug: string;
+};
+
+export interface CartData {
 	products: Array< {
 		product_id: number;
 		product_slug: string;
@@ -75,6 +80,7 @@ class EditorCheckoutModal extends Component< Props > {
 				</div>
 				<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>
 					<CompositeCheckout
+						isInEditor
 						siteId={ site.ID }
 						siteSlug={ site.slug }
 						getCart={ this.getCart.bind( this ) }

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -36,10 +36,7 @@ export interface CartData {
 }
 
 type Props = {
-	site: {
-		ID: string;
-		slug: string;
-	};
+	site: Site;
 	cartData: CartData;
 	onClose: () => void;
 	isOpen: boolean;

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -57,6 +57,7 @@ import { REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE } from 'calypso/state/de
 import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
 import { fetchMediaItem, getMediaItem } from 'calypso/state/media/thunks';
 import Iframe from './iframe';
+import type { CartData } from 'calypso/client/blocks/editor-checkout-modal';
 /**
  * Types
  */
@@ -93,7 +94,7 @@ interface State {
 	multiple?: any;
 	postUrl?: T.URL;
 	previewUrl: T.URL;
-	cartData?: any;
+	cartData?: CartData;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -751,8 +752,9 @@ class CalypsoifyIframe extends Component<
 					<AsyncLoad
 						require="calypso/blocks/editor-checkout-modal"
 						onClose={ this.closeCheckoutModal }
-						isOpen={ isCheckoutModalVisible }
 						cartData={ cartData }
+						placeholder={ null }
+						isOpen
 					/>
 				) }
 				<EditorRevisionsDialog loadRevision={ this.loadRevision } />

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -689,6 +689,7 @@ CompositeCheckout.propTypes = {
 	plan: PropTypes.string,
 	cart: PropTypes.object,
 	transaction: PropTypes.object,
+	isInEditor: PropTypes.bool,
 };
 
 function getPlanProductSlugs(

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -254,7 +254,6 @@ export default function CompositeCheckout( {
 		isJetpackNotAtomic,
 		productAliasFromUrl,
 		hideNudge,
-		recordEvent,
 		isInEditor,
 	} );
 	const getThankYouUrl = useCallback(

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -120,6 +120,7 @@ export default function CompositeCheckout( {
 	isLoggedOutCart,
 	isNoSiteCart,
 	infoMessage,
+	isInEditor,
 } ) {
 	const translate = useTranslate();
 	const isJetpackNotAtomic = useSelector(
@@ -253,6 +254,8 @@ export default function CompositeCheckout( {
 		isJetpackNotAtomic,
 		productAliasFromUrl,
 		hideNudge,
+		recordEvent,
+		isInEditor,
 	} );
 	const getThankYouUrl = useCallback(
 		( ...getThankYouPageUrlArguments ) => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -68,6 +68,7 @@ export default function getThankYouPageUrl( {
 	hideNudge: boolean;
 	didPurchaseFail: boolean;
 	isTransactionResultEmpty: boolean;
+	isInEditor?: boolean
 } ): string {
 	debug( 'starting getThankYouPageUrl' );
 
@@ -117,6 +118,13 @@ export default function getThankYouPageUrl( {
 	debug( 'fallbackUrl is', fallbackUrl );
 
 	saveUrlToCookieIfEcomm( saveUrlToCookie, cart, fallbackUrl );
+
+	// If the user is making a purchase/upgrading within the editor,
+	// we want to return them back to the editor after the purchase is successful.
+	if ( isInEditor && ! hasEcommercePlan( cart ) ) {
+		saveUrlToCookie( window?.location.href );
+	}
+
 	modifyCookieUrlIfAtomic( getUrlFromCookie, saveUrlToCookie, siteSlug );
 
 	// Fetch the thank-you page url from a cookie if it is set

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -51,6 +51,7 @@ export default function getThankYouPageUrl( {
 	hideNudge,
 	didPurchaseFail,
 	isTransactionResultEmpty,
+	isInEditor,
 }: {
 	siteSlug: string | undefined;
 	adminUrl: string | undefined;
@@ -68,7 +69,7 @@ export default function getThankYouPageUrl( {
 	hideNudge: boolean;
 	didPurchaseFail: boolean;
 	isTransactionResultEmpty: boolean;
-	isInEditor?: boolean
+	isInEditor?: boolean;
 } ): string {
 	debug( 'starting getThankYouPageUrl' );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.ts
@@ -30,6 +30,7 @@ export default function useGetThankYouUrl( {
 	isJetpackNotAtomic,
 	productAliasFromUrl,
 	hideNudge,
+	isInEditor,
 }: {
 	siteSlug: string | undefined;
 	redirectTo: string | undefined;
@@ -39,6 +40,7 @@ export default function useGetThankYouUrl( {
 	isJetpackNotAtomic: boolean;
 	productAliasFromUrl: string | undefined;
 	hideNudge: boolean;
+	isInEditor?: boolean;
 } ): GetThankYouUrl {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 	const adminUrl = selectedSiteData?.options?.admin_url;
@@ -72,6 +74,7 @@ export default function useGetThankYouUrl( {
 			hideNudge,
 			didPurchaseFail,
 			isTransactionResultEmpty,
+			isInEditor,
 		};
 		debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );
 		const url = getThankYouPageUrl( getThankYouPageUrlArguments );

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -6,7 +6,7 @@ import {
 	makeSuccessResponse,
 	makeRedirectResponse,
 } from '@automattic/composite-checkout';
-import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
+import { format as formatUrl, parse as parseUrl, resolve as resolveUrl } from 'url'; // eslint-disable-line no-restricted-imports
 
 /**
  * Internal dependencies
@@ -268,12 +268,9 @@ export async function payPalProcessor(
 ) {
 	const { createUserAndSiteBeforeTransaction } = transactionOptions;
 	const { protocol, hostname, port, pathname } = parseUrl( window.location.href, true );
-	const successUrl = formatUrl( {
-		protocol,
-		hostname,
-		port,
-		pathname: getThankYouUrl(),
-	} );
+
+	const successUrl = resolveUrl( window.location.href, getThankYouUrl() );
+
 	const cancelUrl = formatUrl( {
 		protocol,
 		hostname,

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -9,6 +9,7 @@
  */
 import getThankYouPageUrl from '../hooks/use-get-thank-you-url/get-thank-you-page-url';
 import { isEnabled } from 'calypso/config';
+import { PLAN_ECOMMERCE } from '../../../../lib/plans/constants';
 
 let mockGSuiteCountryIsValid = true;
 jest.mock( 'lib/user', () =>
@@ -334,6 +335,47 @@ describe( 'getThankYouPageUrl', () => {
 			isEligibleForSignupDestination: true,
 		} );
 		expect( url ).toBe( '/cookie' );
+	} );
+
+	it( 'Should store the current URL in the redirect cookie when called from the editor', () => {
+		const saveUrlToCookie = jest.fn();
+		const cart = {
+			products: [],
+		};
+		const url = 'http://localhost/editor';
+		Object.defineProperty( window, 'location', {
+			value: {
+				href: url,
+			},
+		} );
+		getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+			isInEditor: true,
+			saveUrlToCookie,
+		} );
+		expect( saveUrlToCookie ).toBeCalledWith( url );
+	} );
+
+	it( 'Should store the thank you URL in the redirect cookie when called from the editor with an e-commerce plan', () => {
+		const saveUrlToCookie = jest.fn();
+		const cart = {
+			products: [
+				{
+					product_slug: PLAN_ECOMMERCE,
+				},
+			],
+		};
+		window.one = 1;
+		getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+			isInEditor: true,
+			saveUrlToCookie,
+		} );
+		expect( saveUrlToCookie ).toBeCalledWith( '/checkout/thank-you/foo.bar/:receiptId' );
 	} );
 
 	it( 'redirects to url from cookie followed by purchase id if create_new_blog is set', () => {


### PR DESCRIPTION
This PR sets the block editor URL as a post-checkout redirect URL. It doesn't however try to fix the stale cookie problem explained in pbOQVh-lb-p2.

#### Testing instructions

* Enable Sandbox.
* Run `yarn dev --sync` on `apps/wpcom-block-editor`.
* Open block editor of the free site with the feature flag `?flags=post-editor/checkout-overlay`, e.g. `calypso.localhost:3000/block-editor/post/your_sandboxed_free_site.wordpress.com?flags=post-editor/checkout-overlay`
* Open up developer tools > console, and run the following code:

```js
let cartData = { products: [{
    product_id: 1009,
    product_slug: 'personal-bundle',
}] };
window.wp.hooks.doAction('a8c.wpcom-block-editor.openCheckoutModal', cartData);
```

* Finish the payment process
* You should be redirected back to the editor.

Fixed: #46362 and supersedes https://github.com/Automattic/wp-calypso/pull/45902
