### PR TITLE
Plans: show the real name of the product if it's owned

### DIFF
--- a/client/my-sites/plans-v2/product-card-alt/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt/index.tsx
@@ -101,17 +101,17 @@ const ProductCardAltWrapper = ( {
 	const description = showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description;
 	const showRecordsDetails = JETPACK_SEARCH_PRODUCTS.includes( item.productSlug ) && siteId;
 
-	// In the case of products that have options (daily and real-time), we want to display
-	// the name of the option, not the name of one of the variants.
+	// In the case of products that have options (daily and real-time) and that are not owned,
+	// we want to display the name of the option, not the name of one of the variants.
 	const productName = useMemo( () => {
 		const optionSlug = getOptionFromSlug( item.productSlug );
 
-		if ( ! optionSlug ) {
+		if ( ! optionSlug || isOwned ) {
 			return item.displayName;
 		}
 
 		return slugToSelectorProduct( optionSlug )?.displayName || item.displayName;
-	}, [ item ] );
+	}, [ isOwned, item ] );
 
 	return (
 		<JetpackProductCardAlt


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the case of products with options, we show the name of the option instead of the name of the product. This doesn't work well when the product is owned (we don't want to say `Jetpack Backup` when a site has `Jetpack Backup Real-time`). With this PR, we take into account if the product is owned by the site.

#### Testing instructions

* Run this PR.
* Select a site with Jetpack Backup Real-time or Jetpack Security Real-time (any product with options works).
* Visit the Plans page in Calypso Blue.
* Make sure that the card of the product displays the real the of the product. In the case of Jetpack Security, it should say `Security Real-time` and not `Jetpack Security`. In the case of Jetpack Backup, it should say `Backup Real-time` and not `Jetpack Backup`. 

#### Demo
##### Before
![image](https://user-images.githubusercontent.com/3418513/95883667-95b34d00-0d51-11eb-8aed-5af019299c3f.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/95883731-a499ff80-0d51-11eb-96b0-9b54ef444ea6.png)
