### PR TITLE
Domains: Prevent first character from being lost when replacing search term in signup

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -726,7 +726,7 @@ class RegisterDomainStep extends React.Component {
 		const loadingResults = Boolean( cleanedQuery );
 		const isInitialQueryActive = searchQuery === this.props.suggestion;
 
-		if ( isEmpty( cleanedQuery ) && ! this.props.isSignupStep ) {
+		if ( isEmpty( cleanedQuery ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #43304
Fixes #46403

#### Changes proposed in this Pull Request

Looks like there's a bug in signup's domains step where the first character is lost when replacing search term.

Kudos to @pottedmeat in https://github.com/Automattic/wp-calypso/issues/43304#issuecomment-673629485 where he did amazing sleuthing 🕵️ 👏 

#### Testing instructions

Start a new site:
http://calypso.localhost:3000/start/domains

On the domains step try different search queries - make sure that when you replace a whole query (select it all and type something else) no characters are lost, especially the first one.
Make sure there are no regressions - only 2 and more character queries should trigger the search.
Be sure to check domain search in Domain Management _and_ in the launch flow for regressions as well.
