### PR TITLE
Plans: synchronize the name of the product with the CTA's label

### DIFF
--- a/client/my-sites/plans-v2/product-card-alt/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt/index.tsx
@@ -10,11 +10,10 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
  */
 import {
 	durationToText,
-	getOptionFromSlug,
+	getProductWithOptionDisplayName,
 	productBadgeLabelAlt,
-	productButtonLabel,
+	productButtonLabelAlt,
 	slugIsFeaturedProduct,
-	slugToSelectorProduct,
 } from '../utils';
 import PlanRenewalMessage from '../plan-renewal-message';
 import RecordsDetailsAlt from '../records-details-alt';
@@ -101,17 +100,9 @@ const ProductCardAltWrapper = ( {
 	const description = showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description;
 	const showRecordsDetails = JETPACK_SEARCH_PRODUCTS.includes( item.productSlug ) && siteId;
 
-	// In the case of products that have options (daily and real-time) and that are not owned,
-	// we want to display the name of the option, not the name of one of the variants.
-	const productName = useMemo( () => {
-		const optionSlug = getOptionFromSlug( item.productSlug );
-
-		if ( ! optionSlug || isOwned ) {
-			return item.displayName;
-		}
-
-		return slugToSelectorProduct( optionSlug )?.displayName || item.displayName;
-	}, [ isOwned, item ] );
+	// In the case of products that have options (daily and real-time), we want to display
+	// the name of the option, not the name of one of the variants.
+	const productName = getProductWithOptionDisplayName( item, isOwned );
 
 	return (
 		<JetpackProductCardAlt
@@ -122,7 +113,7 @@ const ProductCardAltWrapper = ( {
 			description={ description }
 			currencyCode={ currencyCode }
 			billingTimeFrame={ durationToText( item.term ) }
-			buttonLabel={ productButtonLabel( item, isOwned, isUpgradeableToYearly, sitePlan ) }
+			buttonLabel={ productButtonLabelAlt( item, isOwned, isUpgradeableToYearly, sitePlan ) }
 			buttonPrimary={ ! ( isOwned || isItemPlanFeature ) }
 			badgeLabel={ productBadgeLabelAlt( item, isOwned, sitePlan ) }
 			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -117,6 +117,21 @@ export function durationToText( duration: Duration ): TranslateResult {
 		: translate( 'per month, billed yearly' );
 }
 
+// In the case of products that have options (daily and real-time), we want to display
+// the name of the option, not the name of one of the variants.
+export function getProductWithOptionDisplayName(
+	item: SelectorProduct,
+	isOwned: boolean
+): TranslateResult {
+	const optionSlug = getOptionFromSlug( item.productSlug );
+
+	if ( ! optionSlug || isOwned ) {
+		return item.displayName;
+	}
+
+	return slugToSelectorProduct( optionSlug )?.displayName || item.displayName;
+}
+
 /**
  * Product UI utils.
  */
@@ -141,6 +156,50 @@ export function productButtonLabel(
 	}
 
 	const { buttonLabel, displayName } = product;
+
+	return (
+		buttonLabel ??
+		translate( 'Get {{name/}}', {
+			components: {
+				name: createElement( Fragment, {}, displayName ),
+			},
+			comment: '{{name/}} is the name of a product',
+		} )
+	);
+}
+
+export function productButtonLabelAlt(
+	product: SelectorProduct,
+	isOwned: boolean,
+	isUpgradeableToYearly: boolean,
+	currentPlan?: SitePlan | null
+): TranslateResult {
+	if ( isUpgradeableToYearly ) {
+		return translate( 'Upgrade to Yearly' );
+	}
+
+	if (
+		isOwned ||
+		( currentPlan && planHasFeature( currentPlan.product_slug, product.productSlug ) )
+	) {
+		return product.type !== ITEM_TYPE_PRODUCT
+			? translate( 'Manage Plan' )
+			: translate( 'Manage Subscription' );
+	}
+
+	const { buttonLabel } = product;
+
+	// If it's a product with options, we want to use the name of the option
+	// to label the button.
+	const displayName = getProductWithOptionDisplayName( product, isOwned );
+	if ( getOptionFromSlug( product.productSlug ) ) {
+		return translate( 'Get {{name/}}', {
+			components: {
+				name: createElement( Fragment, {}, displayName ),
+			},
+			comment: '{{name/}} is the name of a product',
+		} );
+	}
 
 	return (
 		buttonLabel ??


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the case of product with options, we want to show the generic name of the product in the CTA's label and not the variant.

#### Testing instructions

* Run this PR.
* Visit the Plans page in any environment.
* Make sure that the CTAs of Jetpack Backup and Jetpack Security doesn't mention `Daily` and look like the capture below.

#### Demo
##### Before
![image](https://user-images.githubusercontent.com/3418513/95891660-c7c9ac80-0d5b-11eb-9e11-511b52eb2c19.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/95891582-a668c080-0d5b-11eb-862a-8cab309def3d.png)

