### PR TITLE
Domains: Improve the TLD not supported message

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -118,7 +118,12 @@ class DomainSearchResults extends React.Component {
 			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
 
 			// If the domain is available we shouldn't offer to let people purchase mappings for it.
-			if ( TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE === lastDomainStatus ) {
+			if (
+				includes(
+					[ TLD_NOT_SUPPORTED, TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE ],
+					lastDomainStatus
+				)
+			) {
 				if ( isDomainMappingFree( selectedSite ) || isNextDomainFree( this.props.cart ) ) {
 					offer = translate(
 						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for free.{{/small}}',
@@ -143,10 +148,13 @@ class DomainSearchResults extends React.Component {
 			}
 
 			let domainUnavailableMessage = includes( [ TLD_NOT_SUPPORTED, UNKNOWN ], lastDomainStatus )
-				? translate( '{{strong}}.%(tld)s{{/strong}} domains are not offered on WordPress.com.', {
-						args: { tld: getTld( domain ) },
-						components: { strong: <strong /> },
-				  } )
+				? translate(
+						'{{strong}}.%(tld)s{{/strong}} domains are not available for registration on WordPress.com.',
+						{
+							args: { tld: getTld( domain ) },
+							components: { strong: <strong /> },
+						}
+				  )
 				: translate( '{{strong}}%(domain)s{{/strong}} is taken.', {
 						args: { domain },
 						components: { strong: <strong /> },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The TLD_NOT_SUPPORTED case needs a better message - in D50792-code we are precising it as "TLD that we don't support registrations for, but you can probably map it if you purchased the domain somewhere else".

#### Testing instructions

Easiest to test with D50792-code.

Before:
<img width="1068" alt="Screenshot 2020-10-13 at 17 24 16" src="https://user-images.githubusercontent.com/3392497/95894718-0326a400-0d79-11eb-9ab6-fc0351992168.png">
<img width="991" alt="Screenshot 2020-10-13 at 17 24 46" src="https://user-images.githubusercontent.com/3392497/95894723-0457d100-0d79-11eb-9ad0-799cb44a66f8.png">


After (whether the mapping is free or not depends if the site has paid plan):

<img width="1062" alt="Screenshot 2020-10-13 at 17 20 08" src="https://user-images.githubusercontent.com/3392497/95894618-dffbf480-0d78-11eb-9915-cee2e097ac81.png">
<img width="1070" alt="Screenshot 2020-10-13 at 17 20 25" src="https://user-images.githubusercontent.com/3392497/95894621-e12d2180-0d78-11eb-9dcf-bd71a77ddd5e.png">
<img width="989" alt="Screenshot 2020-10-13 at 17 20 43" src="https://user-images.githubusercontent.com/3392497/95894624-e1c5b800-0d78-11eb-9466-777050cc7abd.png">

