### PR TITLE
Plans: Update Jetpack CRM link

### DIFF
--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -311,7 +311,7 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 		),
 	},
 	hidePrice: true,
-	externalUrl: 'https://jetpackcrm.com/pricing/',
+	externalUrl: 'https://jetpackcrm.com/download-wordpress-crm/',
 };
 
 export const EXTERNAL_PRODUCT_CRM_MONTHLY: SelectorProduct = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use a link that points to a page that offers the free version of Jetpack CRM.

#### Testing instructions

* Run this PR.
* Visit the Plans page in any environment.
* Click on the Jetpack CRM CTA.
* Verify that you are redirected to `https://jetpackcrm.com/download-wordpress-crm/`.

Fixes 1196341175636977-as-1198207343968511

#### Demo
![Kapture 2020-10-13 at 15 11 06](https://user-images.githubusercontent.com/3418513/95899082-66f3a180-0d66-11eb-8508-81d3ae6d2a0b.gif)
