### PR TITLE
Domains: Self-serve domain mapping transfers to other site

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/main-placeholder.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/main-placeholder.jsx
@@ -22,7 +22,7 @@ class DomainMainPlaceholder extends React.Component {
 	render() {
 		return (
 			<Main className="domain__main-placeholder">
-				<Header onClick={ this.props.goBack } />
+				<Header onClick={ this.props.goBack } backHref={ this.props.backHref } />
 				<VerticalNav>
 					<CompactCard className="domain__main-placeholder-card">
 						<p />

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -283,7 +283,6 @@ export default {
 				component={ DomainManagement.TransferToOtherSite }
 				context={ pageContext }
 				needsDomains
-				needsDomainInfo
 				needsUsers
 				selectedDomainName={ pageContext.params.domain }
 			/>

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -260,6 +260,18 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	}
 
 	getTransferMappedDomain() {
+		const { selectedSite, translate, domain, currentRoute } = this.props;
+
+		return (
+			<DomainManagementNavigationItem
+				path={ domainManagementTransfer( selectedSite.slug, domain.name, currentRoute ) }
+				materialIcon="sync_alt"
+				text={ translate( 'Transfer mapping' ) }
+			/>
+		);
+	}
+
+	getTransferInMappedDomain() {
 		const { selectedSite, domain, translate } = this.props;
 
 		const { isEligibleForInboundTransfer } = domain;
@@ -599,6 +611,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 				{ this.getEmail() }
 				{ this.getDomainConnectMapping() }
 				{ this.getTransferMappedDomain() }
+				{ this.getTransferInMappedDomain() }
 				{ this.getSecurity() }
 				{ this.getSimilarDomains() }
 				{ this.getDeleteDomain() }

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -45,6 +45,8 @@ import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
 import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import isVipSite from 'calypso/state/selectors/is-vip-site';
 
 import './style.scss';
 
@@ -260,7 +262,11 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	}
 
 	getTransferMappedDomain() {
-		const { selectedSite, translate, domain, currentRoute } = this.props;
+		const { selectedSite, translate, domain, currentRoute, isVip } = this.props;
+
+		if ( isVip ) {
+			return null;
+		}
 
 		return (
 			<DomainManagementNavigationItem
@@ -659,9 +665,11 @@ class DomainManagementNavigationEnhanced extends React.Component {
 export default connect(
 	( state ) => {
 		const currentRoute = getCurrentRoute( state );
+		const siteId = getSelectedSiteId( state );
 		return {
 			currentRoute,
 			isManagingAllSites: isUnderDomainManagementAll( currentRoute ),
+			isVip: isVipSite( state, siteId ),
 		};
 	},
 	{ recordTracksEvent, recordGoogleEvent }

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -27,6 +27,7 @@ import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
+import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 
 function Transfer( props ) {
 	const {
@@ -41,7 +42,7 @@ function Transfer( props ) {
 	} = props;
 	const slug = get( selectedSite, 'slug' );
 
-	if ( props.isRequestingSiteDomains ) {
+	if ( props.isRequestingSiteDomains || ! props.hasSiteDomainsLoaded ) {
 		return (
 			<DomainMainPlaceholder
 				backHref={ domainManagementEdit( slug, selectedDomainName, currentRoute ) }
@@ -90,6 +91,7 @@ export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 	return {
 		currentRoute: getCurrentRoute( state ),
+		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, siteId ),
 		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isDomainOnly: isDomainOnlySite( state, siteId ),
 		isMapping: Boolean( domain ) && isMappedDomain( domain ),

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -25,7 +25,8 @@ import {
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { isMappedDomain } from 'calypso/lib/domains';
+import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
+import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 
 function Transfer( props ) {
 	const {
@@ -38,8 +39,15 @@ function Transfer( props ) {
 		currentRoute,
 		translate,
 	} = props;
-
 	const slug = get( selectedSite, 'slug' );
+
+	if ( props.isRequestingSiteDomains ) {
+		return (
+			<DomainMainPlaceholder
+				backHref={ domainManagementEdit( slug, selectedDomainName, currentRoute ) }
+			/>
+		);
+	}
 
 	return (
 		<Main>
@@ -57,7 +65,7 @@ function Transfer( props ) {
 						{ translate( 'Transfer to another registrar' ) }
 					</VerticalNavItem>
 				) }
-				{ ! isDomainOnly && (
+				{ ! isMappedDomain && ! isDomainOnly && (
 					<VerticalNavItem
 						path={ domainManagementTransferToAnotherUser( slug, selectedDomainName, currentRoute ) }
 					>
@@ -78,13 +86,13 @@ function Transfer( props ) {
 }
 
 export default connect( ( state, ownProps ) => {
-	const domain = ownProps.domains.find( domain => domain.name === ownProps.selectedDomainName );
+	const domain = getSelectedDomain( ownProps );
 	const siteId = getSelectedSiteId( state );
 	return {
 		currentRoute: getCurrentRoute( state ),
 		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isDomainOnly: isDomainOnlySite( state, siteId ),
-		isMappedDomain: isMappedDomain( domain ),
+		isMappedDomain: Boolean( domain ) && isMappedDomain( domain ),
 		isPrimaryDomain: isPrimaryDomainBySiteId( state, siteId, ownProps.selectedDomainName ),
 		primaryDomain: getPrimaryDomainBySiteId( state, siteId ),
 	};

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -32,7 +32,7 @@ function Transfer( props ) {
 	const {
 		isAtomic,
 		isDomainOnly,
-		isMappedDomain,
+		isMapping,
 		isPrimaryDomain,
 		selectedSite,
 		selectedDomainName,
@@ -55,17 +55,17 @@ function Transfer( props ) {
 				selectedDomainName={ selectedDomainName }
 				backHref={ domainManagementEdit( slug, selectedDomainName, currentRoute ) }
 			>
-				{ isMappedDomain ? translate( 'Transfer Mapping' ) : translate( 'Transfer Domain' ) }
+				{ isMapping ? translate( 'Transfer Mapping' ) : translate( 'Transfer Domain' ) }
 			</Header>
 			<VerticalNav>
-				{ ! isMappedDomain && (
+				{ ! isMapping && (
 					<VerticalNavItem
 						path={ domainManagementTransferOut( slug, selectedDomainName, currentRoute ) }
 					>
 						{ translate( 'Transfer to another registrar' ) }
 					</VerticalNavItem>
 				) }
-				{ ! isMappedDomain && ! isDomainOnly && (
+				{ ! isMapping && ! isDomainOnly && (
 					<VerticalNavItem
 						path={ domainManagementTransferToAnotherUser( slug, selectedDomainName, currentRoute ) }
 					>
@@ -92,7 +92,7 @@ export default connect( ( state, ownProps ) => {
 		currentRoute: getCurrentRoute( state ),
 		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isDomainOnly: isDomainOnlySite( state, siteId ),
-		isMappedDomain: Boolean( domain ) && isMappedDomain( domain ),
+		isMapping: Boolean( domain ) && isMappedDomain( domain ),
 		isPrimaryDomain: isPrimaryDomainBySiteId( state, siteId, ownProps.selectedDomainName ),
 		primaryDomain: getPrimaryDomainBySiteId( state, siteId ),
 	};

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -55,7 +55,7 @@ function Transfer( props ) {
 				selectedDomainName={ selectedDomainName }
 				backHref={ domainManagementEdit( slug, selectedDomainName, currentRoute ) }
 			>
-				{ ! isMappedDomain ? translate( 'Transfer Domain' ) : translate( 'Transfer Mapping' ) }
+				{ isMappedDomain ? translate( 'Transfer Mapping' ) : translate( 'Transfer Domain' ) }
 			</Header>
 			<VerticalNav>
 				{ ! isMappedDomain && (

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -25,11 +25,13 @@ import {
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { isMappedDomain } from 'calypso/lib/domains';
 
 function Transfer( props ) {
 	const {
 		isAtomic,
 		isDomainOnly,
+		isMappedDomain,
 		isPrimaryDomain,
 		selectedSite,
 		selectedDomainName,
@@ -45,14 +47,16 @@ function Transfer( props ) {
 				selectedDomainName={ selectedDomainName }
 				backHref={ domainManagementEdit( slug, selectedDomainName, currentRoute ) }
 			>
-				{ translate( 'Transfer Domain' ) }
+				{ ! isMappedDomain ? translate( 'Transfer Domain' ) : translate( 'Transfer Mapping' ) }
 			</Header>
 			<VerticalNav>
-				<VerticalNavItem
-					path={ domainManagementTransferOut( slug, selectedDomainName, currentRoute ) }
-				>
-					{ translate( 'Transfer to another registrar' ) }
-				</VerticalNavItem>
+				{ ! isMappedDomain && (
+					<VerticalNavItem
+						path={ domainManagementTransferOut( slug, selectedDomainName, currentRoute ) }
+					>
+						{ translate( 'Transfer to another registrar' ) }
+					</VerticalNavItem>
+				) }
 				{ ! isDomainOnly && (
 					<VerticalNavItem
 						path={ domainManagementTransferToAnotherUser( slug, selectedDomainName, currentRoute ) }
@@ -74,12 +78,14 @@ function Transfer( props ) {
 }
 
 export default connect( ( state, ownProps ) => {
+	const domain = ownProps.domains.find( domain => domain.name === ownProps.selectedDomainName );
 	const siteId = getSelectedSiteId( state );
 	return {
+		currentRoute: getCurrentRoute( state ),
 		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isDomainOnly: isDomainOnlySite( state, siteId ),
-		primaryDomain: getPrimaryDomainBySiteId( state, siteId ),
+		isMappedDomain: isMappedDomain( domain ),
 		isPrimaryDomain: isPrimaryDomainBySiteId( state, siteId, ownProps.selectedDomainName ),
-		currentRoute: getCurrentRoute( state ),
+		primaryDomain: getPrimaryDomainBySiteId( state, siteId ),
 	};
 } )( localize( Transfer ) );

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -16,6 +16,7 @@ import { Dialog } from '@automattic/components';
 
 class TransferConfirmationDialog extends React.PureComponent {
 	static propTypes = {
+		isMappedDomain: PropTypes.bool.isRequired,
 		isVisible: PropTypes.bool.isRequired,
 		targetSiteId: PropTypes.number.isRequired,
 		disableDialogButtons: PropTypes.bool.isRequired,
@@ -28,8 +29,35 @@ class TransferConfirmationDialog extends React.PureComponent {
 		this.props.onConfirmTransfer( this.props.targetSite, closeDialog );
 	};
 
+	getMessage() {
+		const { domainName, isMappedDomain, targetSite, translate } = this.props;
+		const targetSiteTitle = get( targetSite, 'title', '' );
+		if ( isMappedDomain ) {
+			return translate(
+				'Do you want to transfer mapping of {{strong}}%(domainName)s{{/strong}} ' +
+					'to site {{strong}}%(targetSiteTitle)s{{/strong}}?',
+				{
+					args: { domainName, targetSiteTitle },
+					components: { strong: <strong /> },
+				}
+			);
+		}
+
+		return translate(
+			'Do you want to transfer {{strong}}%(domainName)s{{/strong}} ' +
+				'to site {{strong}}%(targetSiteTitle)s{{/strong}}?',
+			{
+				args: { domainName, targetSiteTitle },
+				components: { strong: <strong /> },
+			}
+		);
+	}
+
 	render() {
-		const { domainName, translate } = this.props;
+		const { isMappedDomain, translate } = this.props;
+		const actionLabel = ! isMappedDomain
+			? translate( 'Confirm Transfer' )
+			: translate( 'Confirm Mapping Transfer' );
 		const buttons = [
 			{
 				action: 'cancel',
@@ -38,28 +66,17 @@ class TransferConfirmationDialog extends React.PureComponent {
 			},
 			{
 				action: 'confirm',
-				label: translate( 'Confirm Transfer' ),
+				label: actionLabel,
 				onClick: this.onConfirm,
 				disabled: this.props.disableDialogButtons,
 				isPrimary: true,
 			},
 		];
 
-		const targetSiteTitle = get( this.props.targetSite, 'title', '' );
-
 		return (
 			<Dialog isVisible={ this.props.isVisible } buttons={ buttons } onClose={ this.props.onClose }>
 				<h1>{ translate( 'Confirm Transfer' ) }</h1>
-				<p>
-					{ translate(
-						'Do you want to transfer {{strong}}%(domainName)s{{/strong}} ' +
-							'to site {{strong}}%(targetSiteTitle)s{{/strong}}?',
-						{
-							args: { domainName, targetSiteTitle },
-							components: { strong: <strong /> },
-						}
-					) }
-				</p>
+				<p>{ this.getMessage() }</p>
 			</Dialog>
 		);
 	}

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -56,6 +56,22 @@ class TransferConfirmationDialog extends React.PureComponent {
 		);
 	}
 
+	renderPwpoMessage() {
+		if ( ! this.props.primaryWithPlansOnly || this.props.isTargetSiteOnPaidPlan ) {
+			return null;
+		}
+
+		return (
+			<p>
+				{ this.props.translate(
+					"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
+						'domain mapping subscription when the domain mapping next renews. You will not be able to set it as primary either. ' +
+						'Consider upgrading the target site to a paid plan to get these features for free.'
+				) }
+			</p>
+		);
+	}
+
 	render() {
 		const { isMapping, translate } = this.props;
 		const actionLabel = ! isMapping
@@ -80,14 +96,7 @@ class TransferConfirmationDialog extends React.PureComponent {
 			<Dialog isVisible={ this.props.isVisible } buttons={ buttons } onClose={ this.props.onClose }>
 				<h1>{ translate( 'Confirm Transfer' ) }</h1>
 				<p>{ this.getMessage() }</p>
-				<p>
-					{ this.props.primaryWithPlansOnly &&
-						! this.props.isTargetSiteOnPaidPlan &&
-						translate(
-							"The target site is not a paid plan, so you'll have to pay the full price for the domain mapping subscription on renewal. " +
-								'Consider upgrading the site to a paid plan to have the mapping for free.'
-						) }
-				</p>
+				{ this.renderPwpoMessage() }
 			</Dialog>
 		);
 	}

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -11,8 +11,10 @@ import { get } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { getSite } from 'calypso/state/sites/selectors';
+import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
+import { getSite, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 import { Dialog } from '@automattic/components';
+import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 
 class TransferConfirmationDialog extends React.PureComponent {
 	static propTypes = {
@@ -23,6 +25,7 @@ class TransferConfirmationDialog extends React.PureComponent {
 		domainName: PropTypes.string.isRequired,
 		onConfirmTransfer: PropTypes.func.isRequired,
 		onClose: PropTypes.func.isRequired,
+		primaryWithPlansOnly: PropTypes.bool,
 	};
 
 	onConfirm = ( closeDialog ) => {
@@ -77,6 +80,14 @@ class TransferConfirmationDialog extends React.PureComponent {
 			<Dialog isVisible={ this.props.isVisible } buttons={ buttons } onClose={ this.props.onClose }>
 				<h1>{ translate( 'Confirm Transfer' ) }</h1>
 				<p>{ this.getMessage() }</p>
+				<p>
+					{ this.props.primaryWithPlansOnly &&
+						! this.props.isTargetSiteOnPaidPlan &&
+						translate(
+							"The target site is not a paid plan, so you'll have to pay the full price for the domain mapping subscription on renewal. " +
+								'Consider upgrading the site to a paid plan to have the mapping for free.'
+						) }
+				</p>
 			</Dialog>
 		);
 	}
@@ -84,4 +95,6 @@ class TransferConfirmationDialog extends React.PureComponent {
 
 export default connect( ( state, ownProps ) => ( {
 	targetSite: getSite( state, ownProps.targetSiteId ),
+	isTargetSiteOnPaidPlan: isCurrentPlanPaid( state, ownProps.targetSiteId ),
+	primaryWithPlansOnly: currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS ),
 } ) )( localize( TransferConfirmationDialog ) );

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -34,7 +34,7 @@ class TransferConfirmationDialog extends React.PureComponent {
 
 	getMessage() {
 		const { domainName, isMapping, targetSite, translate } = this.props;
-		const targetSiteTitle = get( targetSite, 'title', '' );
+		const targetSiteTitle = get( targetSite, 'title', translate( 'Site Title' ) );
 		if ( isMapping ) {
 			return translate(
 				'Do you want to transfer mapping of {{strong}}%(domainName)s{{/strong}} ' +

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -16,7 +16,7 @@ import { Dialog } from '@automattic/components';
 
 class TransferConfirmationDialog extends React.PureComponent {
 	static propTypes = {
-		isMappedDomain: PropTypes.bool.isRequired,
+		isMapping: PropTypes.bool.isRequired,
 		isVisible: PropTypes.bool.isRequired,
 		targetSiteId: PropTypes.number.isRequired,
 		disableDialogButtons: PropTypes.bool.isRequired,
@@ -30,9 +30,9 @@ class TransferConfirmationDialog extends React.PureComponent {
 	};
 
 	getMessage() {
-		const { domainName, isMappedDomain, targetSite, translate } = this.props;
+		const { domainName, isMapping, targetSite, translate } = this.props;
 		const targetSiteTitle = get( targetSite, 'title', '' );
-		if ( isMappedDomain ) {
+		if ( isMapping ) {
 			return translate(
 				'Do you want to transfer mapping of {{strong}}%(domainName)s{{/strong}} ' +
 					'to site {{strong}}%(targetSiteTitle)s{{/strong}}?',
@@ -54,8 +54,8 @@ class TransferConfirmationDialog extends React.PureComponent {
 	}
 
 	render() {
-		const { isMappedDomain, translate } = this.props;
-		const actionLabel = ! isMappedDomain
+		const { isMapping, translate } = this.props;
+		const actionLabel = ! isMapping
 			? translate( 'Confirm Transfer' )
 			: translate( 'Confirm Mapping Transfer' );
 		const buttons = [

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -56,17 +56,25 @@ class TransferConfirmationDialog extends React.PureComponent {
 		);
 	}
 
-	renderPwpoMessage() {
-		if ( ! this.props.primaryWithPlansOnly || this.props.isTargetSiteOnPaidPlan ) {
-			return null;
+	renderTargetSiteOnFreePlanWarnings() {
+		if ( this.props.primaryWithPlansOnly ) {
+			return (
+				<p>
+					{ this.props.translate(
+						"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
+							'domain mapping subscription when the domain mapping next renews. You will not be able to set it as primary either. ' +
+							'Consider upgrading the target site to a paid plan to get these features for free.'
+					) }
+				</p>
+			);
 		}
 
 		return (
 			<p>
 				{ this.props.translate(
 					"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
-						'domain mapping subscription when the domain mapping next renews. You will not be able to set it as primary either. ' +
-						'Consider upgrading the target site to a paid plan to get these features for free.'
+						'domain mapping subscription when the domain mapping next renews. ' +
+						'Consider upgrading the target site to a paid plan to get domain mappings and many more features for free.'
 				) }
 			</p>
 		);
@@ -96,7 +104,7 @@ class TransferConfirmationDialog extends React.PureComponent {
 			<Dialog isVisible={ this.props.isVisible } buttons={ buttons } onClose={ this.props.onClose }>
 				<h1>{ translate( 'Confirm Transfer' ) }</h1>
 				<p>{ this.getMessage() }</p>
-				{ this.renderPwpoMessage() }
+				{ ! this.props.isTargetSiteOnPaidPlan && this.renderTargetSiteOnFreePlanWarnings() }
 			</Dialog>
 		);
 	}

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -63,7 +63,7 @@ class TransferConfirmationDialog extends React.PureComponent {
 					{ this.props.translate(
 						"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
 							'domain mapping subscription when the domain mapping next renews. You will not be able to set it as primary either. ' +
-							'Consider upgrading the target site to a paid plan to get these features for free.'
+							'If you upgrade the target site to a paid plan, these features are included in the plan.'
 					) }
 				</p>
 			);
@@ -74,7 +74,7 @@ class TransferConfirmationDialog extends React.PureComponent {
 				{ this.props.translate(
 					"The target site doesn't have a paid plan, so you'll have to pay the full price for a " +
 						'domain mapping subscription when the domain mapping next renews. ' +
-						'Consider upgrading the target site to a paid plan to get domain mappings and many more features for free.'
+						'If you upgrade the target site to a paid plan, domain mappings (and many more features!) are included in our plans.'
 				) }
 			</p>
 		);

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -130,13 +130,13 @@ export class TransferToOtherSite extends React.Component {
 			if ( domainsWithPlansOnly ) {
 				return translate(
 					'Please choose a site with a paid plan ' +
-						"you're an administrator on to transfer mapping of {{strong}}%(domainName)s{{/strong}} to:",
+						"you're an administrator on to transfer domain mapping for {{strong}}%(domainName)s{{/strong}} to:",
 					translateArgs
 				);
 			}
 
 			return translate(
-				"Please choose a site you're an administrator on to transfer mapping of {{strong}}%(domainName)s{{/strong}} to:",
+				"Please choose a site you're an administrator on to transfer domain mapping for {{strong}}%(domainName)s{{/strong}} to:",
 				translateArgs
 			);
 		}

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -125,6 +125,7 @@ export class TransferToOtherSite extends React.Component {
 			translate,
 		} = this.props;
 		const translateArgs = { args: { domainName }, components: { strong: <strong /> } };
+
 		if ( isMappedDomain ) {
 			if ( domainsWithPlansOnly ) {
 				return translate(
@@ -132,12 +133,12 @@ export class TransferToOtherSite extends React.Component {
 						"you're an administrator on to transfer mapping of {{strong}}%(domainName)s{{/strong}} to:",
 					translateArgs
 				);
-			} else {
-				return translate(
-					"Please choose a site you're an administrator on to transfer mapping of {{strong}}%(domainName)s{{/strong}} to:",
-					translateArgs
-				);
 			}
+
+			return translate(
+				"Please choose a site you're an administrator on to transfer mapping of {{strong}}%(domainName)s{{/strong}} to:",
+				translateArgs
+			);
 		}
 
 		if ( domainsWithPlansOnly ) {
@@ -146,12 +147,12 @@ export class TransferToOtherSite extends React.Component {
 					"you're an administrator on to transfer {{strong}}%(domainName)s{{/strong}} to:",
 				translateArgs
 			);
-		} else {
-			return translate(
-				"Please choose a site you're an administrator on to transfer {{strong}}%(domainName)s{{/strong}} to:",
-				translateArgs
-			);
 		}
+
+		return translate(
+			"Please choose a site you're an administrator on to transfer {{strong}}%(domainName)s{{/strong}} to:",
+			translateArgs
+		);
 	}
 
 	render() {
@@ -181,12 +182,7 @@ export class TransferToOtherSite extends React.Component {
 	}
 
 	renderSection() {
-		const {
-			currentUserCanManage,
-			domainsWithPlansOnly,
-			selectedDomainName,
-			translate,
-		} = this.props;
+		const { currentUserCanManage, selectedDomainName } = this.props;
 		if ( ! currentUserCanManage ) {
 			return <NonOwnerCard { ...omit( this.props, [ 'children' ] ) } />;
 		}

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -37,7 +37,7 @@ export class TransferToOtherSite extends React.Component {
 		currentUser: PropTypes.object.isRequired,
 		currentUserCanManage: PropTypes.bool.isRequired,
 		isDomainOnly: PropTypes.bool.isRequired,
-		isMappedDomain: PropTypes.bool.isRequired,
+		isMapping: PropTypes.bool.isRequired,
 		isRequestingSiteDomains: PropTypes.bool.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.object.isRequired,
@@ -121,12 +121,12 @@ export class TransferToOtherSite extends React.Component {
 		const {
 			selectedDomainName: domainName,
 			domainsWithPlansOnly,
-			isMappedDomain,
+			isMapping,
 			translate,
 		} = this.props;
 		const translateArgs = { args: { domainName }, components: { strong: <strong /> } };
 
-		if ( isMappedDomain ) {
+		if ( isMapping ) {
 			if ( domainsWithPlansOnly ) {
 				return translate(
 					'Please choose a site with a paid plan ' +
@@ -156,7 +156,7 @@ export class TransferToOtherSite extends React.Component {
 	}
 
 	render() {
-		const { selectedSite, selectedDomainName, currentRoute, isMappedDomain } = this.props;
+		const { selectedSite, selectedDomainName, currentRoute, isMapping } = this.props;
 		const { slug } = selectedSite;
 		if ( ! this.isDataReady() ) {
 			return (
@@ -172,7 +172,7 @@ export class TransferToOtherSite extends React.Component {
 					selectedDomainName={ selectedDomainName }
 					backHref={ domainManagementTransfer( slug, selectedDomainName, currentRoute ) }
 				>
-					{ isMappedDomain
+					{ isMapping
 						? this.props.translate( 'Transfer Domain Mapping To Another Site' )
 						: this.props.translate( 'Transfer Domain To Another Site' ) }
 				</Header>
@@ -201,7 +201,7 @@ export class TransferToOtherSite extends React.Component {
 					<TransferConfirmationDialog
 						disableDialogButtons={ this.state.disableDialogButtons }
 						domainName={ selectedDomainName }
-						isMappedDomain={ this.props.isMappedDomain }
+						isMapping={ this.props.isMapping }
 						isVisible={ this.state.showConfirmationDialog }
 						onConfirmTransfer={ this.handleConfirmTransfer }
 						onClose={ this.handleDialogClose }
@@ -222,7 +222,7 @@ export default connect(
 			currentUserCanManage: domain && domain.currentUserCanManage,
 			domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 			isDomainOnly: isDomainOnlySite( state, get( ownProps, 'selectedSite.ID', null ) ),
-			isMappedDomain: Boolean( domain ) && isMappedDomain( domain ),
+			isMapping: Boolean( domain ) && isMappedDomain( domain ),
 			sites: getSites( state ),
 		};
 	},

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -171,9 +171,9 @@ export class TransferToOtherSite extends React.Component {
 					selectedDomainName={ selectedDomainName }
 					backHref={ domainManagementTransfer( slug, selectedDomainName, currentRoute ) }
 				>
-					{ ! isMappedDomain
-						? this.props.translate( 'Transfer Domain To Another Site' )
-						: this.props.translate( 'Transfer Domain Mapping To Another Site' ) }
+					{ isMappedDomain
+						? this.props.translate( 'Transfer Domain Mapping To Another Site' )
+						: this.props.translate( 'Transfer Domain To Another Site' ) }
 				</Header>
 				{ this.renderSection() }
 			</Main>
@@ -226,7 +226,7 @@ export default connect(
 			currentUserCanManage: domain && domain.currentUserCanManage,
 			domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 			isDomainOnly: isDomainOnlySite( state, get( ownProps, 'selectedSite.ID', null ) ),
-			isMappedDomain: domain && isMappedDomain( domain ),
+			isMappedDomain: Boolean( domain ) && isMappedDomain( domain ),
 			sites: getSites( state ),
 		};
 	},

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -24,7 +24,6 @@ import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/co
 import TransferConfirmationDialog from './confirmation-dialog';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import wp from 'calypso/lib/wp';
-import { isWpComFreePlan } from 'calypso/lib/plans';
 import { requestSites } from 'calypso/state/sites/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
@@ -115,11 +114,7 @@ export class TransferToOtherSite extends React.Component {
 	};
 
 	getMessage() {
-		const {
-			selectedDomainName: domainName,
-			isMapping,
-			translate,
-		} = this.props;
+		const { selectedDomainName: domainName, isMapping, translate } = this.props;
 		const translateArgs = { args: { domainName }, components: { strong: <strong /> } };
 
 		if ( isMapping ) {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
@@ -69,14 +69,8 @@ const props = {
 };
 
 describe( 'TransferToOtherSite.isSiteEligible()', () => {
-	[ PLAN_FREE ].forEach( ( plan ) => {
-		test( `Should return false for plan ${ plan }`, () => {
-			const instance = new TransferToOtherSite( props );
-			expect( instance.isSiteEligible( { ...site, plan: { product_slug: plan } } ) ).toBe( false );
-		} );
-	} );
-
 	[
+		PLAN_FREE,
 		PLAN_JETPACK_FREE,
 		PLAN_PERSONAL,
 		PLAN_PERSONAL_2_YEARS,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The time is now: self-serve domain mappings 🎉 Splitting the work - this patch adds the ability to move domain mapping to a different site (it's simply easier to adjust this case than the user one).

#### Testing instructions

Requires D51163-code, but it's already been merged 🎉 

Go to Domain Management where you have a mapping you want to transfer. You should see a new action for it - Transfer mapping.
You need to be an admin on at least one other site to be able to transfer the mapping anywhere, of course.
And you need to be the owner of the mapping subscription - so be sure to check that case as well (probably need to adjust the copy there).

Step by step via screenshots:

<img width="751" alt="Screenshot 2020-10-21 at 14 10 11" src="https://user-images.githubusercontent.com/3392497/96732006-69c64600-13a7-11eb-9ed6-719c43dac8e2.png">
<img width="763" alt="Screenshot 2020-10-21 at 14 10 19" src="https://user-images.githubusercontent.com/3392497/96732044-72b71780-13a7-11eb-8383-f2160aaea0e8.png">
<img width="753" alt="Screenshot 2020-10-21 at 14 11 02" src="https://user-images.githubusercontent.com/3392497/96732056-764a9e80-13a7-11eb-9b04-ec9b087b0b0e.png">

For a PWPO user where the target site is not on a paid plan:
<img width="1311" alt="Screenshot 2020-10-28 at 19 45 44" src="https://user-images.githubusercontent.com/3392497/97488586-58a4a880-1956-11eb-8db4-4f832de66e1e.png">


PWPO-exempt user where the target site is not a paid plan:
<img width="1315" alt="Screenshot 2020-10-28 at 19 47 36" src="https://user-images.githubusercontent.com/3392497/97488721-7e31b200-1956-11eb-9182-1a0a68582f55.png">

When the target site is on a paid plan:
<img width="575" alt="Screenshot 2020-10-21 at 14 11 49" src="https://user-images.githubusercontent.com/3392497/96732058-76e33500-13a7-11eb-8216-0faccfba2f36.png">

Make sure you check these views also with an empty cache by adding `?flags=force-sympathy` to the URL.

Because of the special nature of VIP mappings, they are not supported in this initial version.
