### PR TITLE
Editing toolkit: Fixes Global Styles plugin translation

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
@@ -338,6 +338,7 @@ class Global_Styles {
 			$version,
 			true
 		);
+		wp_set_script_translations( 'jetpack-global-styles-editor-script', 'full-site-editing' );
 		wp_localize_script(
 			'jetpack-global-styles-editor-script',
 			'JETPACK_GLOBAL_STYLES_EDITOR_CONSTANTS',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes translations of Global Styles inside the editing toolkit.


#### Testing instructions

1. Checkout the diff mentioned below on your sandbox (D51081) and sandbox a test website.
2. Change your account language to one of Mag-16. 
3. Choose one of the new block-based themes.
4. Create a new post or page
5. Click on the A icon in the top right corner to open the Global Styles panel
6. Make sure the Global Styles panel is translated in the selected language

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before:
![image](https://user-images.githubusercontent.com/23708351/95903464-e1401800-0d9e-11eb-8ac7-979de9a0f413.png)


After:
![image](https://user-images.githubusercontent.com/23708351/95903246-91615100-0d9e-11eb-8c31-f42467bb93e7.png)

