### PR TITLE
Plans: launch the new 3 column Plans page

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -78,7 +78,7 @@
 		"nav-unification": false,
 		"oauth": true,
 		"persist-redux": true,
-		"plans/alternate-selector": false,
+		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -29,7 +29,7 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"plans/alternate-selector": false,
+		"plans/alternate-selector": true,
 		"oauth": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -28,7 +28,7 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"plans/alternate-selector": false,
+		"plans/alternate-selector": true,
 		"oauth": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/production.json
+++ b/config/production.json
@@ -106,7 +106,7 @@
 		"nps-survey/dev-trigger": false,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/alternate-selector": false,
+		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -114,7 +114,7 @@
 		"page/export": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/alternate-selector": false,
+		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/test.json
+++ b/config/test.json
@@ -83,7 +83,7 @@
 		"network-connection": true,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/alternate-selector": false,
+		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/image-editor": true,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,7 +119,7 @@
 		"nps-survey/dev-trigger": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/alternate-selector": false,
+		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set to `true` the `plans/alternate-selector` feature on all environments.

#### Testing instructions

* Code review since you won't be able to test this in prod without deploying it.

Fixes 1196341175636977-as-1198189456928818