### PR TITLE
Gutenboarding i18n: Move feature copy from data store to component

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/features/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/features/index.tsx
@@ -96,8 +96,10 @@ const FeaturesStep: React.FunctionComponent = () => {
 								<FeatureIcon featureId={ feature.id } />
 							</div>
 							<div className="features__item-heading">
-								<div className="features__item-name">{ feature.name }</div>
-								<div className="features__item-description">{ feature.description }</div>
+								<div className="features__item-name">{ getFeatureText( feature.id, __ ).name }</div>
+								<div className="features__item-description">
+									{ getFeatureText( feature.id, __ ).description }
+								</div>
 							</div>
 						</Button>
 					) ) }
@@ -106,5 +108,52 @@ const FeaturesStep: React.FunctionComponent = () => {
 		</div>
 	);
 };
+
+function getFeatureText( featureId: FeatureId, __: ReturnType< typeof useI18n >[ '__' ] ) {
+	switch ( featureId ) {
+		case 'domain':
+			return {
+				name: __( 'Custom domains' ),
+				description: __( 'Help your site stand out. The first year is free with a plan.' ),
+			};
+		case 'store':
+			return {
+				name: __( 'Store' ),
+				description: __(
+					'Sell unlimited products or services with a powerful, flexible online store.'
+				),
+			};
+		case 'seo':
+			return {
+				name: __( 'SEO tools' ),
+				description: __( 'Boost your SEO and connect a Google Analytics account.' ),
+			};
+		case 'plugins':
+			return {
+				name: __( 'Plugins' ),
+				description: __( 'Install plugins to extend the power of your site.' ),
+			};
+		case 'ad-free':
+			return {
+				name: __( 'Ad-free' ),
+				description: __( 'Remove advertisements and own your brand.' ),
+			};
+		case 'image-storage':
+			return {
+				name: __( 'Image storage' ),
+				description: __( 'Extended storage space for hi-res images.' ),
+			};
+		case 'video-storage':
+			return {
+				name: __( 'Video storage' ),
+				description: __( 'Host your own ad-free videos' ),
+			};
+		case 'support':
+			return {
+				name: __( 'Priority support' ),
+				description: __( 'Chat with an expert live.' ),
+			};
+	}
+}
 
 export default FeaturesStep;

--- a/packages/data-stores/src/wpcom-features/features-data.tsx
+++ b/packages/data-stores/src/wpcom-features/features-data.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import * as Plans from '../plans';
-import { translate } from 'i18n-calypso';
 import type { FeatureId, Feature } from './types';
 /**
  * Internal dependencies
@@ -12,54 +11,34 @@ const { PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE } = Plans;
 export const featuresList: Record< FeatureId, Feature > = {
 	domain: {
 		id: 'domain',
-		name: translate( 'Custom domains' ) as string,
-		description: translate(
-			'Help your site stand out. The first year is free with a plan.'
-		) as string,
 		minSupportedPlan: PLAN_PERSONAL,
 	},
 	store: {
 		id: 'store',
-		name: translate( 'Store' ) as string,
-		description: translate(
-			'Sell unlimited products or services with a powerful, flexible online store.'
-		) as string,
 		minSupportedPlan: PLAN_ECOMMERCE,
 	},
 	seo: {
 		id: 'seo',
-		name: translate( 'SEO tools' ) as string,
-		description: translate( 'Boost your SEO and connect a Google Analytics account.' ) as string,
 		minSupportedPlan: PLAN_BUSINESS,
 	},
 	plugins: {
 		id: 'plugins',
-		name: translate( 'Plugins' ) as string,
-		description: translate( 'Install plugins to extend the power of your site.' ) as string,
 		minSupportedPlan: PLAN_BUSINESS,
 	},
 	'ad-free': {
 		id: 'ad-free',
-		name: translate( 'Ad-free' ) as string,
-		description: translate( 'Remove advertisements and own your brand.' ) as string,
 		minSupportedPlan: PLAN_PERSONAL,
 	},
 	'image-storage': {
 		id: 'image-storage',
-		name: translate( 'Image storage' ) as string,
-		description: translate( 'Extended storage space for hi-res images.' ) as string,
 		minSupportedPlan: PLAN_PREMIUM,
 	},
 	'video-storage': {
 		id: 'video-storage',
-		name: translate( 'Video storage' ) as string,
-		description: translate( 'Host your own ad-free videos' ) as string,
 		minSupportedPlan: PLAN_PREMIUM,
 	},
 	support: {
 		id: 'support',
-		name: translate( 'Priority support' ) as string,
-		description: translate( 'Chat with an expert live.' ) as string,
 		minSupportedPlan: PLAN_BUSINESS,
 	},
 };

--- a/packages/data-stores/src/wpcom-features/types.ts
+++ b/packages/data-stores/src/wpcom-features/types.ts
@@ -15,7 +15,5 @@ export type FeatureId =
 
 export interface Feature {
 	id: FeatureId;
-	name: string;
-	description: string;
 	minSupportedPlan: PlanSlug;
 }


### PR DESCRIPTION
Here's an idea for how to quickly translate the features step.

The data store was attempting to use the `i18n-calypso` package to translate the feature copy, but it doesn't seem to work in gutenboarding. By moving the feature copy into the component, it's able to make use of the `useI18n()` hook which is what the rest of gutenboarding uses for translations.

I suspect the reason the copy was in the data store was to model what it would be like if the feature list was served by the back end. In which case we'd get a localised API response back. But given that's not how it works, I actually personally prefer keeping the copy in the view layer anyway.

The code in the data store that's actually shared between gutenboarding and the ETK is the logic about deciding the minimum plan needed given the feature that have been choosen. The copy isn't shared.

#### Changes proposed in this Pull Request

* Move feature copy out of data store
* Add the feature copy to the `<FeaturesStep>` component.

**Before**
<img width="1196" alt="Screenshot 2020-10-14 at 10 11 18 AM" src="https://user-images.githubusercontent.com/1500769/95916736-9f968800-0e05-11eb-802f-566fbc4c8614.png">
Note that the main page copy is translated but the feature descriptions aren't

**After**
<img width="1196" alt="Screenshot 2020-10-14 at 10 05 54 AM" src="https://user-images.githubusercontent.com/1500769/95916574-5ba38300-0e05-11eb-800b-a03e18faa584.png">
Note that not all translations are complete yet

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start at `/new/es` to create a Spanish site (or choose your favourite mag16 language)
* Advance until you get to the features step (`/new/features/es`)
* See that the feature text is generally translated
