### PR TITLE
Notifications - adding fallback behavior for tables in post content

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -107,6 +108,27 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 				new_container.setAttribute( 'style', range_info.style );
 			}
 			build_chunks( new_sub_text, new_sub_range, range_data, new_container, options );
+			break;
+		case 'figure':
+			if ( range_info.hasOwnProperty( 'class' ) && range_info.class.includes( 'wp-block-table' ) ) {
+				new_container = document.createElement( 'a' );
+				new_container.setAttribute( 'href', options.sourceUrl );
+				new_container.setAttribute( 'target', '_blank' );
+				new_container.setAttribute( 'rel', 'noopener noreferrer' );
+				new_classes.push( 'table-fallback-link' );
+				new_container.innerHTML = i18n.translate( 'Click here to view table.', {
+					comment: 'Fallback text when viewing a table in a subscribed post notification',
+				} );
+			} else {
+				new_container = document.createElement( range_info_type );
+				if ( range_info.hasOwnProperty( 'class' ) ) {
+					new_classes.push( range_info.class );
+				}
+				if ( range_info.hasOwnProperty( 'style' ) ) {
+					new_container.setAttribute( 'style', range_info.style );
+				}
+				build_chunks( new_sub_text, new_sub_range, range_data, new_container, options );
+			}
 			break;
 		case 'gridicon':
 			// Gridicons have special text, and are thus not recursed into

--- a/apps/notifications/src/panel/templates/block-post.jsx
+++ b/apps/notifications/src/panel/templates/block-post.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * Exernal dependencies
  */
@@ -9,6 +10,8 @@ import React from 'react';
 import { html } from '../indices-to-html';
 import { p } from './functions';
 
-const PostBlock = ( { block } ) => <div className="wpnc__post">{ p( html( block ) ) }</div>;
+const PostBlock = ( { block, postUrl } ) => (
+	<div className="wpnc__post">{ p( html( block, { sourceUrl: postUrl } ) ) }</div>
+);
 
 export default PostBlock;

--- a/apps/notifications/src/panel/templates/body.jsx
+++ b/apps/notifications/src/panel/templates/body.jsx
@@ -1,8 +1,8 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -24,36 +24,33 @@ class ReplyBlock extends React.Component {
 	render() {
 		// explicitly send className of '' here so we don't get the default of
 		// "paragraph"
-		var replyText = p( html( this.props.block ), '' );
-
+		const replyText = p( html( this.props.block ), '' );
 		return <div className="wpnc__reply">{ replyText }</div>;
 	}
 }
 
-export const NoteBody = createReactClass( {
-	displayName: 'NoteBody',
+export class NoteBody extends React.Component {
+	constructor() {
+		super();
+		this.displayName = 'NoteBody';
+		this.state = { reply: null };
+	}
 
-	getInitialState: function () {
-		return {
-			reply: null,
-		};
-	},
-
-	componentDidMount: function () {
+	componentDidMount() {
 		bumpStat( 'notes-click-type', this.props.note.type );
-	},
+	}
 
-	replyLoaded: function ( error, data ) {
-		if ( error || ! this.isMounted() ) {
+	replyLoaded( error, data ) {
+		if ( error ) {
 			return;
 		}
 
 		this.setState( { reply: data } );
-	},
+	}
 
-	UNSAFE_componentWillMount: function () {
-		var note = this.props.note,
-			hasReplyBlock;
+	UNSAFE_componentWillMount() {
+		const note = this.props.note;
+		let hasReplyBlock;
 
 		if ( note.meta && note.meta.ids.reply_comment ) {
 			hasReplyBlock =
@@ -61,7 +58,7 @@ export const NoteBody = createReactClass( {
 					return (
 						block.ranges &&
 						block.ranges.length > 1 &&
-						block.ranges[ 1 ].id == note.meta.ids.reply_comment
+						block.ranges[ 1 ].id === note.meta.ids.reply_comment
 					);
 				} ).length > 0;
 
@@ -72,16 +69,16 @@ export const NoteBody = createReactClass( {
 					.get( this.replyLoaded );
 			}
 		}
-	},
+	}
 
-	render: function () {
-		var blocks = zipWithSignature( this.props.note.body, this.props.note );
-		var actions = '';
-		var preface = '';
-		var replyBlock = null;
-		var replyMessage;
-		var firstNonTextIndex;
-		var i;
+	render() {
+		let blocks = zipWithSignature( this.props.note.body, this.props.note );
+		let actions = '';
+		let preface = '';
+		let replyBlock = null;
+		let replyMessage;
+		let firstNonTextIndex;
+		let i;
 
 		for ( i = 0; i < blocks.length; i++ ) {
 			if ( 'text' !== blocks[ i ].signature.type ) {
@@ -95,10 +92,10 @@ export const NoteBody = createReactClass( {
 			blocks = blocks.slice( i );
 		}
 
-		var body = [];
+		const body = [];
 		for ( i = 0; i < blocks.length; i++ ) {
-			var block = blocks[ i ];
-			var blockKey = 'block-' + this.props.note.id + '-' + i;
+			const block = blocks[ i ];
+			const blockKey = 'block-' + this.props.note.id + '-' + i;
 
 			if ( block.block.actions && 'user' !== block.signature.type ) {
 				actions = (
@@ -130,7 +127,12 @@ export const NoteBody = createReactClass( {
 					break;
 				case 'post':
 					body.push(
-						<Post key={ blockKey } block={ block.block } meta={ this.props.note.meta } />
+						<Post
+							key={ blockKey }
+							block={ block.block }
+							meta={ this.props.note.meta }
+							postUrl={ this.props.note.url }
+						/>
 					);
 					break;
 				case 'reply':
@@ -173,7 +175,7 @@ export const NoteBody = createReactClass( {
 				{ actions }
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default localize( NoteBody );

--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -153,6 +153,10 @@
 		li {
 			margin: auto;
 		}
+		.table-fallback-link {
+			display: block;
+			margin-bottom: 15px;
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR, along with D51025-code, updates notification rendering to provide a fallback link rather than try to render tables in post content.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D51025-code in your sandbox and make sure the API is sandboxed.
* Apply this change to calypso, navigate to your Calypso dashboard and open a notification for a post with that contains a table block in its content. Verify that the post instead displays fallback text which links to the post in a new tab.

Before:
![image](https://user-images.githubusercontent.com/13437011/96043936-43e3f300-0e35-11eb-8e6f-de4da497d6d9.png)

After: 
![image](https://user-images.githubusercontent.com/13437011/96043981-52caa580-0e35-11eb-8204-f75e95bdfc52.png)

Fixes #45093