### PR TITLE
Checkout: Convert all stripe redirect payment processors to use automated responses

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -40,6 +40,7 @@ import {
 	existingCardProcessor,
 	payPalProcessor,
 	genericRedirectProcessor,
+	weChatProcessor,
 } from './payment-method-processors';
 import useGetThankYouUrl from './hooks/use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
@@ -553,8 +554,7 @@ export default function CompositeCheckout( {
 				genericRedirectProcessor( 'bancontact', transactionData, dataForRedirectProcessor ),
 			giropay: ( transactionData ) =>
 				genericRedirectProcessor( 'giropay', transactionData, dataForRedirectProcessor ),
-			wechat: ( transactionData ) =>
-				genericRedirectProcessor( 'wechat', transactionData, dataForRedirectProcessor ),
+			wechat: ( transactionData ) => weChatProcessor( transactionData, dataForRedirectProcessor ),
 			netbanking: ( transactionData ) =>
 				genericRedirectProcessor( 'netbanking', transactionData, dataForRedirectProcessor ),
 			id_wallet: ( transactionData ) =>

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -74,7 +74,11 @@ export async function genericRedirectProcessor(
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		},
 		wpcomTransaction
-	).then( saveTransactionResponseToWpcomStore );
+	)
+		.then( saveTransactionResponseToWpcomStore )
+		.then( ( response ) => {
+			return { type: 'REDIRECT', payload: response?.redirect_url };
+		} );
 }
 
 export async function applePayProcessor(

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -5,7 +5,7 @@ import {
 	defaultRegistry,
 	makeSuccessResponse,
 	makeRedirectResponse,
-	makeNoopResponse,
+	makeManualResponse,
 } from '@automattic/composite-checkout';
 import { format as formatUrl, parse as parseUrl, resolve as resolveUrl } from 'url'; // eslint-disable-line no-restricted-imports
 
@@ -134,7 +134,7 @@ export async function weChatProcessor(
 			if ( userAgent.isMobile ) {
 				return makeRedirectResponse( response?.redirect_url );
 			}
-			return makeNoopResponse();
+			return makeManualResponse( response );
 		} );
 }
 

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -28,6 +28,7 @@ import {
 } from './payment-method-helpers';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
 import { showStripeModalAuth } from 'calypso/lib/stripe';
+import userAgent from 'calypso/lib/user-agent';
 
 const { select, dispatch } = defaultRegistry;
 
@@ -78,6 +79,61 @@ export async function genericRedirectProcessor(
 		.then( saveTransactionResponseToWpcomStore )
 		.then( ( response ) => {
 			return { type: 'REDIRECT', payload: response?.redirect_url };
+		} );
+}
+
+export async function weChatProcessor(
+	submitData,
+	{ getThankYouUrl, siteSlug, includeDomainDetails, includeGSuiteDetails }
+) {
+	const paymentMethodId = 'wechat';
+	const { protocol, hostname, port, pathname } = parseUrl(
+		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com',
+		true
+	);
+	const cancelUrlQuery = {};
+	const redirectToSuccessUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname: getThankYouUrl(),
+	} );
+	const successUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname: `/checkout/thank-you/${ siteSlug || 'no-site' }/pending`,
+		query: { redirectTo: redirectToSuccessUrl },
+	} );
+	const cancelUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname,
+		query: cancelUrlQuery,
+	} );
+	return submitRedirectTransaction(
+		paymentMethodId,
+		{
+			...submitData,
+			successUrl,
+			cancelUrl,
+			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+			postalCode: submitData.postalCode || getPostalCode(),
+			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		},
+		wpcomTransaction
+	)
+		.then( saveTransactionResponseToWpcomStore )
+		.then( ( response ) => {
+			// The WeChat payment type should only redirect when on mobile as redirect urls
+			// are mobile app urls: e.g. weixin://wxpay/bizpayurl?pr=RaXzhu4
+			if ( userAgent.isMobile ) {
+				return { type: 'REDIRECT', payload: response?.redirect_url };
+			}
+			return { type: 'NOOP' };
 		} );
 }
 

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -5,6 +5,7 @@ import {
 	defaultRegistry,
 	makeSuccessResponse,
 	makeRedirectResponse,
+	makeNoopResponse,
 } from '@automattic/composite-checkout';
 import { format as formatUrl, parse as parseUrl, resolve as resolveUrl } from 'url'; // eslint-disable-line no-restricted-imports
 
@@ -78,7 +79,7 @@ export async function genericRedirectProcessor(
 	)
 		.then( saveTransactionResponseToWpcomStore )
 		.then( ( response ) => {
-			return { type: 'REDIRECT', payload: response?.redirect_url };
+			return makeRedirectResponse( response?.redirect_url );
 		} );
 }
 
@@ -131,9 +132,9 @@ export async function weChatProcessor(
 			// The WeChat payment type should only redirect when on mobile as redirect urls
 			// are mobile app urls: e.g. weixin://wxpay/bizpayurl?pr=RaXzhu4
 			if ( userAgent.isMobile ) {
-				return { type: 'REDIRECT', payload: response?.redirect_url };
+				return makeRedirectResponse( response?.redirect_url );
 			}
-			return { type: 'NOOP' };
+			return makeNoopResponse();
 		} );
 }
 

--- a/client/my-sites/checkout/composite-checkout/payment-methods/id-wallet.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/id-wallet.js
@@ -8,8 +8,6 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import {
 	Button,
-	usePaymentProcessor,
-	useTransactionStatus,
 	useLineItems,
 	useEvents,
 	useFormStatus,
@@ -22,16 +20,16 @@ import { camelCase } from 'lodash';
 /**
  * Internal dependencies
  */
-import notices from 'notices';
-import { validatePaymentDetails } from 'lib/checkout/validation';
-import useCountryList from 'my-sites/checkout/composite-checkout/hooks/use-country-list';
-import Field from 'my-sites/checkout/composite-checkout/components/field';
+import notices from 'calypso/notices';
+import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
+import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
+import Field from 'calypso/my-sites/checkout/composite-checkout/components/field';
 import {
 	SummaryLine,
 	SummaryDetails,
-} from 'my-sites/checkout/composite-checkout/components/summary-details';
-import { PaymentMethodLogos } from 'my-sites/checkout/composite-checkout/components/payment-method-logos';
-import { maskField } from 'lib/checkout';
+} from 'calypso/my-sites/checkout/composite-checkout/components/summary-details';
+import { PaymentMethodLogos } from 'calypso/my-sites/checkout/composite-checkout/components/payment-method-logos';
+import { maskField } from 'calypso/lib/checkout';
 import CountrySpecificPaymentFields from '../components/country-specific-payment-fields';
 
 const debug = debugFactory( 'composite-checkout:id-wallet-payment-method' );
@@ -212,16 +210,10 @@ const IdWalletField = styled( Field )`
 	}
 `;
 
-function IdWalletPayButton( { disabled, store } ) {
+function IdWalletPayButton( { disabled, onClick, store } ) {
 	const { __ } = useI18n();
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const {
-		setTransactionRedirecting,
-		setTransactionError,
-		setTransactionPending,
-	} = useTransactionStatus();
-	const submitTransaction = usePaymentProcessor( 'id_wallet' );
 	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'id_wallet' ).getCustomerName() );
 	const fields = useSelect( ( select ) => select( 'id_wallet' ).getFields() );
@@ -239,33 +231,17 @@ function IdWalletPayButton( { disabled, store } ) {
 			onClick={ () => {
 				if ( isFormValid( store, contactCountryCode, __ ) ) {
 					debug( 'submitting id wallet payment' );
-					setTransactionPending();
 					onEvent( {
 						type: 'REDIRECT_TRANSACTION_BEGIN',
 						payload: { paymentMethodId: 'id_wallet' },
 					} );
-					submitTransaction( {
+					onClick( 'id_wallet', {
 						...massagedFields,
 						name: customerName?.value,
 						address: massagedFields?.address1,
 						items,
 						total,
-					} )
-						.then( ( transactionResponse ) => {
-							if ( ! transactionResponse?.redirect_url ) {
-								setTransactionError(
-									__(
-										'There was an error processing your payment. Please try again or contact support.'
-									)
-								);
-								return;
-							}
-							debug( 'id wallet transaction requires redirect', transactionResponse.redirect_url );
-							setTransactionRedirecting( transactionResponse.redirect_url );
-						} )
-						.catch( ( error ) => {
-							setTransactionError( error.message );
-						} );
+					} );
 				}
 			} }
 			buttonType="primary"

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -9,8 +9,6 @@ import { useI18n } from '@automattic/react-i18n';
 import {
 	Button,
 	FormStatus,
-	usePaymentProcessor,
-	useTransactionStatus,
 	useLineItems,
 	useEvents,
 	useFormStatus,
@@ -23,16 +21,16 @@ import { camelCase } from 'lodash';
 /**
  * Internal dependencies
  */
-import notices from 'notices';
-import { validatePaymentDetails } from 'lib/checkout/validation';
-import useCountryList from 'my-sites/checkout/composite-checkout/hooks/use-country-list';
-import Field from 'my-sites/checkout/composite-checkout/components/field';
+import notices from 'calypso/notices';
+import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
+import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
+import Field from 'calypso/my-sites/checkout/composite-checkout/components/field';
 import {
 	SummaryLine,
 	SummaryDetails,
-} from 'my-sites/checkout/composite-checkout/components/summary-details';
-import { PaymentMethodLogos } from 'my-sites/checkout/composite-checkout/components/payment-method-logos';
-import { maskField } from 'lib/checkout';
+} from 'calypso/my-sites/checkout/composite-checkout/components/summary-details';
+import { PaymentMethodLogos } from 'calypso/my-sites/checkout/composite-checkout/components/payment-method-logos';
+import { maskField } from 'calypso/lib/checkout';
 import CountrySpecificPaymentFields from '../components/country-specific-payment-fields';
 
 const debug = debugFactory( 'composite-checkout:netbanking-payment-method' );
@@ -213,16 +211,10 @@ const NetBankingField = styled( Field )`
 	}
 `;
 
-function NetBankingPayButton( { disabled, store } ) {
+function NetBankingPayButton( { disabled, onClick, store } ) {
 	const { __ } = useI18n();
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const {
-		setTransactionRedirecting,
-		setTransactionError,
-		setTransactionPending,
-	} = useTransactionStatus();
-	const submitTransaction = usePaymentProcessor( 'netbanking' );
 	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'netbanking' ).getCustomerName() );
 	const fields = useSelect( ( select ) => select( 'netbanking' ).getFields() );
@@ -240,33 +232,17 @@ function NetBankingPayButton( { disabled, store } ) {
 			onClick={ () => {
 				if ( isFormValid( store, contactCountryCode, __ ) ) {
 					debug( 'submitting netbanking payment' );
-					setTransactionPending();
 					onEvent( {
 						type: 'REDIRECT_TRANSACTION_BEGIN',
 						payload: { paymentMethodId: 'netbanking' },
 					} );
-					submitTransaction( {
+					onClick( 'netbanking', {
 						...massagedFields,
 						name: customerName?.value,
 						address: massagedFields?.address1,
 						items,
 						total,
-					} )
-						.then( ( transactionResponse ) => {
-							if ( ! transactionResponse?.redirect_url ) {
-								setTransactionError(
-									__(
-										'There was an error processing your payment. Please try again or contact support.'
-									)
-								);
-								return;
-							}
-							debug( 'netbanking transaction requires redirect', transactionResponse.redirect_url );
-							setTransactionRedirecting( transactionResponse.redirect_url );
-						} )
-						.catch( ( error ) => {
-							setTransactionError( error.message );
-						} );
+					} );
 				}
 			} }
 			buttonType="primary"

--- a/client/my-sites/checkout/composite-checkout/payment-methods/wechat.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/wechat.js
@@ -179,7 +179,7 @@ function WeChatPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 						total,
 						stripeConfiguration,
 					} ).then( ( processorResponse ) => {
-						if ( processorResponse.type === PaymentProcessorResponseType.MANUAL ) {
+						if ( processorResponse?.type === PaymentProcessorResponseType.MANUAL ) {
 							setStripeResponseWithCode( processorResponse.payload );
 						}
 					} );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/wechat.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/wechat.js
@@ -16,6 +16,7 @@ import {
 	registerStore,
 	useSelect,
 	useDispatch,
+	PaymentProcessorResponseType,
 } from '@automattic/composite-checkout';
 
 /**
@@ -177,6 +178,10 @@ function WeChatPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 						items,
 						total,
 						stripeConfiguration,
+					} ).then( ( processorResponse ) => {
+						if ( processorResponse.type === PaymentProcessorResponseType.MANUAL ) {
+							setStripeResponseWithCode( processorResponse.payload );
+						}
 					} );
 				}
 			} }

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -104,7 +104,7 @@ Payment method components (probably the `submitButton`) can access these functio
 
 If you use the `onClick` function, the payment processor function's response will control what happens next. Each payment processor function must return a Promise that either resolves to one of three results on success (see [makeManualResponse](#makeManualResponse), [makeRedirectResponse](#makeRedirectResponse), or [makeSuccessResponse](#makeSuccessResponse)), or rejects on failure.
 
-If not using the `onClick` function, or if the `MANUAL` result is returned by the payment processor, when the `submitButton` component has been clicked, it should do the following (these are normally handled by `onClick`):
+If not using the `onClick` function, when the `submitButton` component has been clicked, it should do the following (these are normally handled by `onClick`):
 
 1. Call `setTransactionPending()` from [useTransactionStatus](#useTransactionStatus). This will change the [form status](#useFormStatus) to [`.SUBMITTING`](#FormStatus) and disable the form.
 2. Call the payment processor function returned from [usePaymentProcessor](#usePaymentProcessor]), passing whatever data that function requires. Each payment processor will be different, so you'll need to know the API of that function explicitly.
@@ -400,15 +400,15 @@ Returns a step object whose properties can be added to a [CheckoutStep](Checkout
 
 ### makeManualResponse
 
-An action creator function to be used by a [payment processor function](#payment-methods) for a MANUAL response; it will do nothing but pass along its argument as a `payload` property to the resolved Promise of the `onClick` function.
+An action creator function to be used by a [payment processor function](#payment-methods) for a [MANUAL](#PaymentProcessorResponseType) response; it will do nothing but pass along its argument as a `payload` property to the resolved Promise of the `onClick` function.
 
 ### makeRedirectResponse
 
-An action creator function to be used by a [payment processor function](#payment-methods) for a REDIRECT response. It takes one string argument and will cause the page to redirect to the URL in that string.
+An action creator function to be used by a [payment processor function](#payment-methods) for a [REDIRECT](#PaymentProcessorResponseType) response. It takes one string argument and will cause the page to redirect to the URL in that string.
 
 ### makeSuccessResponse
 
-An action creator function to be used by a [payment processor function](#payment-methods) for a SUCCESS response. It takes one object argument which is the transaction response. It will cause checkout to mark the payment as complete and run the `onPaymentComplete` function on the [CheckoutProvider](#CheckoutProvider).
+An action creator function to be used by a [payment processor function](#payment-methods) for a [SUCCESS](#PaymentProcessorResponseType) response. It takes one object argument which is the transaction response. It will cause checkout to mark the payment as complete and run the `onPaymentComplete` function on the [CheckoutProvider](#CheckoutProvider).
 
 ### registerStore
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -102,9 +102,9 @@ When a payment method is ready to submit its data, it can use an appropriate "pa
 
 Payment method components (probably the `submitButton`) can access these functions using the [usePaymentProcessor](#usePaymentProcessor) hook, passing the key used for that function in `paymentProcessors` as an argument. However, for convenience, the `submitButton` will be provided with an `onClick` handler that can do this automatically. The `onClick` function takes two arguments, a string which is the key of the payment processor to be used, and an object that contains the data needed by the payment processor.
 
-If you use the `onClick` function, the payment processor function's response will control what happens next. Each payment processor function must return a Promise that either resolves to one of three results on success (see [makeNoopResponse](#makeNoopResponse), [makeRedirectResponse](#makeRedirectResponse), or [makeSuccessResponse](#makeSuccessResponse)), or rejects on failure.
+If you use the `onClick` function, the payment processor function's response will control what happens next. Each payment processor function must return a Promise that either resolves to one of three results on success (see [makeManualResponse](#makeManualResponse), [makeRedirectResponse](#makeRedirectResponse), or [makeSuccessResponse](#makeSuccessResponse)), or rejects on failure.
 
-If not using the `onClick` function, or if the `NOOP` result is returned by the payment processor, when the `submitButton` component has been clicked, it should do the following (these are normally handled by `onClick`):
+If not using the `onClick` function, or if the `MANUAL` result is returned by the payment processor, when the `submitButton` component has been clicked, it should do the following (these are normally handled by `onClick`):
 
 1. Call `setTransactionPending()` from [useTransactionStatus](#useTransactionStatus). This will change the [form status](#useFormStatus) to [`.SUBMITTING`](#FormStatus) and disable the form.
 2. Call the payment processor function returned from [usePaymentProcessor](#usePaymentProcessor]), passing whatever data that function requires. Each payment processor will be different, so you'll need to know the API of that function explicitly.
@@ -390,9 +390,9 @@ Returns a step object whose properties can be added to a [CheckoutStep](Checkout
 
 Returns a step object whose properties can be added to a [CheckoutStep](CheckoutStep) (and customized) to display a way to select a payment method. The payment methods displayed are those provided to the [CheckoutProvider](#checkoutprovider).
 
-### makeNoopResponse
+### makeManualResponse
 
-An action creator function to be used by a [payment processor function](#payment-methods) for a NOOP response; it will do nothing.
+An action creator function to be used by a [payment processor function](#payment-methods) for a MANUAL response; it will do nothing but pass along its argument as a `payload` property to the resolved Promise of the `onClick` function.
 
 ### makeRedirectResponse
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -298,6 +298,14 @@ Renders the `total` prop like a line item, but with different styling.
 
 An optional boolean prop, `collapsed`, can be used to simplify the output for when the review section is collapsed.
 
+### PaymentProcessorResponseType
+
+An enum that holds the values of the [payment processor function return value's `type` property](#payment-methods) (each payment processor function returns a Promise that resolves to `{type: PaymentProcessorResponseType, payload: string | unknown }` where the payload varies based on the response type).
+
+- `.SUCCESS` (the payload will be an `unknown` object that is the server response).
+- `.REDIRECT` (the payload will be a `string` that is the redirect URL).
+- `.MANUAL` (the payload will be an `unknown` object that is determined by the payment processor function).
+
 ### SubmitButtonWrapper
 
 A styled div, controlled by the [theme](#checkoutTheme), that's used as the inner wrapper for the submit button that's rendered by each [CheckoutStepArea](#CheckoutStepArea) component. You shouldn't need to use this manually.

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -49,11 +49,11 @@ export default function CheckoutSubmitButton( {
 							throw new Error( redirectErrorMessage );
 						}
 						setTransactionRedirecting( processorResponse.payload );
-						return;
+						return processorResponse;
 					}
 					if ( processorResponse.type === PaymentProcessorResponseType.SUCCESS ) {
 						setTransactionComplete( processorResponse.payload );
-						return;
+						return processorResponse;
 					}
 					if ( processorResponse.type === PaymentProcessorResponseType.MANUAL ) {
 						return processorResponse;

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -10,7 +10,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import joinClasses from '../lib/join-classes';
 import { usePaymentMethod, usePaymentProcessors, useTransactionStatus } from '../public-api';
-import { PaymentProcessorResponse } from '../types';
+import { PaymentProcessorResponse, PaymentProcessorResponseType } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout-submit-button' );
 
@@ -44,19 +44,19 @@ export default function CheckoutSubmitButton( {
 			return paymentProcessors[ paymentProcessorId ]( submitData )
 				.then( ( processorResponse: PaymentProcessorResponse ) => {
 					debug( 'payment processor function response', processorResponse );
-					if ( processorResponse.type === 'REDIRECT' ) {
+					if ( processorResponse.type === PaymentProcessorResponseType.REDIRECT ) {
 						if ( ! processorResponse.payload ) {
 							throw new Error( redirectErrorMessage );
 						}
 						setTransactionRedirecting( processorResponse.payload );
 						return;
 					}
-					if ( processorResponse.type === 'SUCCESS' ) {
+					if ( processorResponse.type === PaymentProcessorResponseType.SUCCESS ) {
 						setTransactionComplete( processorResponse.payload );
 						return;
 					}
-					if ( processorResponse.type === 'NOOP' ) {
-						return;
+					if ( processorResponse.type === PaymentProcessorResponseType.MANUAL ) {
+						return processorResponse;
 					}
 					throw new Error(
 						`Unknown payment processor response for processor "${ paymentProcessorId }"`

--- a/packages/composite-checkout/src/lib/payment-methods/alipay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/alipay.js
@@ -12,13 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Field from '../../components/field';
 import Button from '../../components/button';
-import {
-	FormStatus,
-	usePaymentProcessor,
-	useTransactionStatus,
-	useLineItems,
-	useEvents,
-} from '../../public-api';
+import { FormStatus, useLineItems, useEvents } from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
@@ -131,16 +125,9 @@ const AlipayField = styled( Field )`
 	}
 `;
 
-function AlipayPayButton( { disabled, store, stripe, stripeConfiguration } ) {
-	const { __ } = useI18n();
+function AlipayPayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const {
-		setTransactionRedirecting,
-		setTransactionError,
-		setTransactionPending,
-	} = useTransactionStatus();
-	const submitTransaction = usePaymentProcessor( 'alipay' );
 	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'alipay' ).getCustomerName() );
 
@@ -150,30 +137,14 @@ function AlipayPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting alipay payment' );
-					setTransactionPending();
 					onEvent( { type: 'REDIRECT_TRANSACTION_BEGIN', payload: { paymentMethodId: 'alipay' } } );
-					submitTransaction( {
+					onClick( 'alipay', {
 						stripe,
 						name: customerName?.value,
 						items,
 						total,
 						stripeConfiguration,
-					} )
-						.then( ( stripeResponse ) => {
-							if ( ! stripeResponse?.redirect_url ) {
-								setTransactionError(
-									__(
-										'There was an error processing your payment. Please try again or contact support.'
-									)
-								);
-								return;
-							}
-							debug( 'alipay transaction requires redirect', stripeResponse.redirect_url );
-							setTransactionRedirecting( stripeResponse.redirect_url );
-						} )
-						.catch( ( error ) => {
-							setTransactionError( error.message );
-						} );
+					} );
 				}
 			} }
 			buttonType="primary"

--- a/packages/composite-checkout/src/lib/payment-methods/bancontact.js
+++ b/packages/composite-checkout/src/lib/payment-methods/bancontact.js
@@ -12,13 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Field from '../../components/field';
 import Button from '../../components/button';
-import {
-	FormStatus,
-	usePaymentProcessor,
-	useTransactionStatus,
-	useLineItems,
-	useEvents,
-} from '../../public-api';
+import { FormStatus, useLineItems, useEvents } from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
@@ -133,16 +127,9 @@ const BancontactField = styled( Field )`
 	}
 `;
 
-function BancontactPayButton( { disabled, store, stripe, stripeConfiguration } ) {
-	const { __ } = useI18n();
+function BancontactPayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const {
-		setTransactionRedirecting,
-		setTransactionError,
-		setTransactionPending,
-	} = useTransactionStatus();
-	const submitTransaction = usePaymentProcessor( 'bancontact' );
 	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'bancontact' ).getCustomerName() );
 
@@ -152,33 +139,17 @@ function BancontactPayButton( { disabled, store, stripe, stripeConfiguration } )
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting bancontact payment' );
-					setTransactionPending();
 					onEvent( {
 						type: 'REDIRECT_TRANSACTION_BEGIN',
 						payload: { paymentMethodId: 'bancontact' },
 					} );
-					submitTransaction( {
+					onClick( 'bancontact', {
 						stripe,
 						name: customerName?.value,
 						items,
 						total,
 						stripeConfiguration,
-					} )
-						.then( ( stripeResponse ) => {
-							if ( ! stripeResponse?.redirect_url ) {
-								setTransactionError(
-									__(
-										'There was an error processing your payment. Please try again or contact support.'
-									)
-								);
-								return;
-							}
-							debug( 'bancontact transaction requires redirect', stripeResponse.redirect_url );
-							setTransactionRedirecting( stripeResponse.redirect_url );
-						} )
-						.catch( ( error ) => {
-							setTransactionError( error.message );
-						} );
+					} );
 				}
 			} }
 			buttonType="primary"

--- a/packages/composite-checkout/src/lib/payment-methods/ideal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/ideal.js
@@ -12,13 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Field from '../../components/field';
 import Button from '../../components/button';
-import {
-	FormStatus,
-	usePaymentProcessor,
-	useTransactionStatus,
-	useLineItems,
-	useEvents,
-} from '../../public-api';
+import { FormStatus, useLineItems, useEvents } from '../../public-api';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { useFormStatus } from '../form-status';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
@@ -202,16 +196,9 @@ const SelectWrapper = styled.div`
 	}
 `;
 
-function IdealPayButton( { disabled, store, stripe, stripeConfiguration } ) {
-	const { __ } = useI18n();
+function IdealPayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const {
-		setTransactionRedirecting,
-		setTransactionError,
-		setTransactionPending,
-	} = useTransactionStatus();
-	const submitTransaction = usePaymentProcessor( 'ideal' );
 	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'ideal' ).getCustomerName() );
 	const customerBank = useSelect( ( select ) => select( 'ideal' ).getCustomerBank() );
@@ -222,31 +209,15 @@ function IdealPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting ideal payment' );
-					setTransactionPending();
 					onEvent( { type: 'REDIRECT_TRANSACTION_BEGIN', payload: { paymentMethodId: 'ideal' } } );
-					submitTransaction( {
+					onClick( 'ideal', {
 						stripe,
 						name: customerName?.value,
 						idealBank: customerBank?.value,
 						items,
 						total,
 						stripeConfiguration,
-					} )
-						.then( ( stripeResponse ) => {
-							if ( ! stripeResponse?.redirect_url ) {
-								setTransactionError(
-									__(
-										'There was an error processing your payment. Please try again or contact support.'
-									)
-								);
-								return;
-							}
-							debug( 'ideal transaction requires redirect', stripeResponse.redirect_url );
-							setTransactionRedirecting( stripeResponse.redirect_url );
-						} )
-						.catch( ( error ) => {
-							setTransactionError( error.message );
-						} );
+					} );
 				}
 			} }
 			buttonType="primary"

--- a/packages/composite-checkout/src/lib/payment-methods/p24.js
+++ b/packages/composite-checkout/src/lib/payment-methods/p24.js
@@ -12,13 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Field from '../../components/field';
 import Button from '../../components/button';
-import {
-	FormStatus,
-	usePaymentProcessor,
-	useTransactionStatus,
-	useLineItems,
-	useEvents,
-} from '../../public-api';
+import { FormStatus, useLineItems, useEvents } from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
@@ -148,16 +142,9 @@ const P24Field = styled( Field )`
 	}
 `;
 
-function P24PayButton( { disabled, store, stripe, stripeConfiguration } ) {
-	const { __ } = useI18n();
+function P24PayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const {
-		setTransactionRedirecting,
-		setTransactionError,
-		setTransactionPending,
-	} = useTransactionStatus();
-	const submitTransaction = usePaymentProcessor( 'p24' );
 	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'p24' ).getCustomerName() );
 	const customerEmail = useSelect( ( select ) => select( 'p24' ).getCustomerEmail() );
@@ -168,34 +155,18 @@ function P24PayButton( { disabled, store, stripe, stripeConfiguration } ) {
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting p24 payment' );
-					setTransactionPending();
 					onEvent( {
 						type: 'REDIRECT_TRANSACTION_BEGIN',
 						payload: { paymentMethodId: 'p24' },
 					} );
-					submitTransaction( {
+					onClick( 'p24', {
 						stripe,
 						name: customerName?.value,
 						email: customerEmail?.value,
 						items,
 						total,
 						stripeConfiguration,
-					} )
-						.then( ( stripeResponse ) => {
-							if ( ! stripeResponse?.redirect_url ) {
-								setTransactionError(
-									__(
-										'There was an error processing your payment. Please try again or contact support.'
-									)
-								);
-								return;
-							}
-							debug( 'p24 transaction requires redirect', stripeResponse.redirect_url );
-							setTransactionRedirecting( stripeResponse.redirect_url );
-						} )
-						.catch( ( error ) => {
-							setTransactionError( error.message );
-						} );
+					} );
 				}
 			} }
 			buttonType="primary"

--- a/packages/composite-checkout/src/lib/payment-methods/sofort.js
+++ b/packages/composite-checkout/src/lib/payment-methods/sofort.js
@@ -12,13 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Field from '../../components/field';
 import Button from '../../components/button';
-import {
-	FormStatus,
-	usePaymentProcessor,
-	useTransactionStatus,
-	useLineItems,
-	useEvents,
-} from '../../public-api';
+import { FormStatus, useLineItems, useEvents } from '../../public-api';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { useFormStatus } from '../form-status';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
@@ -131,16 +125,9 @@ const SofortField = styled( Field )`
 	}
 `;
 
-function SofortPayButton( { disabled, store, stripe, stripeConfiguration } ) {
-	const { __ } = useI18n();
+function SofortPayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const {
-		setTransactionRedirecting,
-		setTransactionError,
-		setTransactionPending,
-	} = useTransactionStatus();
-	const submitTransaction = usePaymentProcessor( 'sofort' );
 	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'sofort' ).getCustomerName() );
 
@@ -150,30 +137,14 @@ function SofortPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting sofort payment' );
-					setTransactionPending();
 					onEvent( { type: 'REDIRECT_TRANSACTION_BEGIN', payload: { paymentMethodId: 'sofort' } } );
-					submitTransaction( {
+					onClick( 'sofort', {
 						stripe,
 						name: customerName?.value,
 						items,
 						total,
 						stripeConfiguration,
-					} )
-						.then( ( stripeResponse ) => {
-							if ( ! stripeResponse?.redirect_url ) {
-								setTransactionError(
-									__(
-										'There was an error processing your payment. Please try again or contact support.'
-									)
-								);
-								return;
-							}
-							debug( 'sofort transaction requires redirect', stripeResponse.redirect_url );
-							setTransactionRedirecting( stripeResponse.redirect_url );
-						} )
-						.catch( ( error ) => {
-							setTransactionError( error.message );
-						} );
+					} );
 				}
 			} }
 			buttonType="primary"

--- a/packages/composite-checkout/src/lib/payment-processors.ts
+++ b/packages/composite-checkout/src/lib/payment-processors.ts
@@ -12,7 +12,7 @@ import {
 	PaymentProcessorResponseData,
 	PaymentProcessorSuccess,
 	PaymentProcessorRedirect,
-	PaymentProcessorNoop,
+	PaymentProcessorManual,
 } from '../types';
 
 export function usePaymentProcessor( key: string ): PaymentProcessorFunction {
@@ -38,6 +38,6 @@ export function makeRedirectResponse( url: string ): PaymentProcessorRedirect {
 	return { type: 'REDIRECT', payload: url };
 }
 
-export function makeNoopResponse(): PaymentProcessorNoop {
-	return { type: 'NOOP' };
+export function makeManualResponse( payload: unknown ): PaymentProcessorManual {
+	return { type: 'MANUAL', payload };
 }

--- a/packages/composite-checkout/src/lib/payment-processors.ts
+++ b/packages/composite-checkout/src/lib/payment-processors.ts
@@ -13,6 +13,7 @@ import {
 	PaymentProcessorSuccess,
 	PaymentProcessorRedirect,
 	PaymentProcessorManual,
+	PaymentProcessorResponseType,
 } from '../types';
 
 export function usePaymentProcessor( key: string ): PaymentProcessorFunction {
@@ -31,13 +32,13 @@ export function usePaymentProcessors(): Record< string, PaymentProcessorFunction
 export function makeSuccessResponse(
 	transaction: PaymentProcessorResponseData
 ): PaymentProcessorSuccess {
-	return { type: 'SUCCESS', payload: transaction };
+	return { type: PaymentProcessorResponseType.SUCCESS, payload: transaction };
 }
 
 export function makeRedirectResponse( url: string ): PaymentProcessorRedirect {
-	return { type: 'REDIRECT', payload: url };
+	return { type: PaymentProcessorResponseType.REDIRECT, payload: url };
 }
 
 export function makeManualResponse( payload: unknown ): PaymentProcessorManual {
-	return { type: 'MANUAL', payload };
+	return { type: PaymentProcessorResponseType.MANUAL, payload };
 }

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -77,7 +77,7 @@ import { useTransactionStatus } from './lib/transaction-status';
 import {
 	usePaymentProcessor,
 	usePaymentProcessors,
-	makeNoopResponse,
+	makeManualResponse,
 	makeSuccessResponse,
 	makeRedirectResponse,
 } from './lib/payment-processors';
@@ -138,7 +138,7 @@ export {
 	getDefaultOrderSummary,
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,
-	makeNoopResponse,
+	makeManualResponse,
 	makeRedirectResponse,
 	makeSuccessResponse,
 	registerStore,

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -82,7 +82,7 @@ import {
 	makeRedirectResponse,
 } from './lib/payment-processors';
 import checkoutTheme from './lib/theme';
-import { FormStatus, TransactionStatus } from './types';
+import { FormStatus, TransactionStatus, PaymentProcessorResponseType } from './types';
 
 // Re-export the public API
 export {
@@ -108,6 +108,7 @@ export {
 	OrderReviewLineItems,
 	OrderReviewSection,
 	OrderReviewTotal,
+	PaymentProcessorResponseType,
 	SubmitButtonWrapper,
 	TransactionStatus,
 	checkoutTheme,

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -104,12 +104,12 @@ export type PaymentProcessorResponseData = unknown;
 
 export type PaymentProcessorSuccess = { type: 'SUCCESS'; payload: PaymentProcessorResponseData };
 export type PaymentProcessorRedirect = { type: 'REDIRECT'; payload: string };
-export type PaymentProcessorNoop = { type: 'NOOP' };
+export type PaymentProcessorManual = { type: 'MANUAL'; payload: unknown };
 
 export type PaymentProcessorResponse =
 	| PaymentProcessorSuccess
 	| PaymentProcessorRedirect
-	| PaymentProcessorNoop;
+	| PaymentProcessorManual;
 
 export type PaymentProcessorFunction = (
 	submitData: unknown

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -102,9 +102,18 @@ export interface PaymentProcessorProp {
 
 export type PaymentProcessorResponseData = unknown;
 
-export type PaymentProcessorSuccess = { type: 'SUCCESS'; payload: PaymentProcessorResponseData };
-export type PaymentProcessorRedirect = { type: 'REDIRECT'; payload: string };
-export type PaymentProcessorManual = { type: 'MANUAL'; payload: unknown };
+export type PaymentProcessorSuccess = {
+	type: PaymentProcessorResponseType.SUCCESS;
+	payload: PaymentProcessorResponseData;
+};
+export type PaymentProcessorRedirect = {
+	type: PaymentProcessorResponseType.REDIRECT;
+	payload: string;
+};
+export type PaymentProcessorManual = {
+	type: PaymentProcessorResponseType.MANUAL;
+	payload: unknown;
+};
 
 export type PaymentProcessorResponse =
 	| PaymentProcessorSuccess

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -108,7 +108,7 @@ export type PaymentProcessorSuccess = {
 };
 export type PaymentProcessorRedirect = {
 	type: PaymentProcessorResponseType.REDIRECT;
-	payload: string;
+	payload: string | undefined;
 };
 export type PaymentProcessorManual = {
 	type: PaymentProcessorResponseType.MANUAL;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -115,6 +115,12 @@ export type PaymentProcessorFunction = (
 	submitData: unknown
 ) => Promise< PaymentProcessorResponse >;
 
+export enum PaymentProcessorResponseType {
+	SUCCESS = 'SUCCESS',
+	REDIRECT = 'REDIRECT',
+	MANUAL = 'MANUAL',
+}
+
 export enum TransactionStatus {
 	NOT_STARTED = 'not-started',
 	PENDING = 'pending',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/46337 which converts all the Stripe redirect payment processors to use the new system.

It also splits the WeChat payment processor into its own processor because on desktop it has quite a different behavior. That behavior remains mostly encoded into the WeChat button, but in order to use the `onClick` handler, we need to tell the processor function to do nothing with the response. (I also made a mistake in the original PR where I assumed that a NOOP response would be sufficient for a payment method to do its own success/failure handling, but it's not because we also need the transaction response, so this PR replaces NOOP with MANUAL.)

#### Testing instructions

Since all these payment methods use the same payment processor function, they will all need to be tested in this one PR.

- WeChat: see https://github.com/Automattic/wp-calypso/pull/43765
- NetBanking: see https://github.com/Automattic/wp-calypso/pull/44952
- IdWallet: see https://github.com/Automattic/wp-calypso/pull/45257
- EbanxTef: see https://github.com/Automattic/wp-calypso/pull/44752
- Sofort: https://github.com/Automattic/wp-calypso/pull/43710
- P24: https://github.com/Automattic/wp-calypso/pull/43744
- Ideal: https://github.com/Automattic/wp-calypso/pull/43162
- Giropay: https://github.com/Automattic/wp-calypso/pull/43598
- Eps: see https://github.com/Automattic/wp-calypso/pull/43734
- BanContact: see https://github.com/Automattic/wp-calypso/pull/43651
- Alipay: see https://github.com/Automattic/wp-calypso/pull/43653
