### PR TITLE
Checkout: convert apple pay payment processor to use automated response

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -94,9 +94,7 @@ export async function applePayProcessor(
 		transactionOptions
 	)
 		.then( saveTransactionResponseToWpcomStore )
-		.then( ( response ) => {
-			return { type: 'SUCCESS', payload: response };
-		} );
+		.then( makeSuccessResponse );
 }
 
 export async function stripeCardProcessor(

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -92,7 +92,11 @@ export async function applePayProcessor(
 		},
 		wpcomTransaction,
 		transactionOptions
-	).then( saveTransactionResponseToWpcomStore );
+	)
+		.then( saveTransactionResponseToWpcomStore )
+		.then( ( response ) => {
+			return { type: 'SUCCESS', payload: response };
+		} );
 }
 
 export async function stripeCardProcessor(

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -8,12 +8,7 @@ import { useI18n } from '@automattic/react-i18n';
 /**
  * Internal dependencies
  */
-import {
-	useTransactionStatus,
-	usePaymentProcessor,
-	useLineItems,
-	useEvents,
-} from '../../public-api';
+import { useLineItems, useEvents } from '../../public-api';
 import PaymentRequestButton from '../../components/payment-request-button';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
@@ -44,48 +39,25 @@ export function ApplePayLabel() {
 	);
 }
 
-export function ApplePaySubmitButton( { disabled, stripe, stripeConfiguration } ) {
+export function ApplePaySubmitButton( { disabled, onClick, stripe, stripeConfiguration } ) {
 	const { __ } = useI18n();
 	const paymentRequestOptions = usePaymentRequestOptions( stripeConfiguration );
 	const [ items, total ] = useLineItems();
-	const {
-		setTransactionError,
-		setTransactionComplete,
-		setTransactionPending,
-	} = useTransactionStatus();
 	const onEvent = useEvents();
-	const submitTransaction = usePaymentProcessor( 'apple-pay' );
 	const onSubmit = useCallback(
 		( { name, paymentMethodToken } ) => {
 			debug( 'submitting stripe payment with key', paymentMethodToken );
-			setTransactionPending();
 			onEvent( { type: 'APPLE_PAY_TRANSACTION_BEGIN' } );
-			submitTransaction( {
+			onClick( 'apple-pay', {
 				stripe,
 				paymentMethodToken,
 				name,
 				items,
 				total,
 				stripeConfiguration,
-			} )
-				.then( () => {
-					setTransactionComplete();
-				} )
-				.catch( ( error ) => {
-					setTransactionError( error.message );
-				} );
+			} );
 		},
-		[
-			submitTransaction,
-			setTransactionComplete,
-			setTransactionError,
-			setTransactionPending,
-			onEvent,
-			items,
-			total,
-			stripe,
-			stripeConfiguration,
-		]
+		[ onClick, onEvent, items, total, stripe, stripeConfiguration ]
 	);
 	const { paymentRequest, canMakePayment, isLoading } = useStripePaymentRequest( {
 		paymentRequestOptions,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to #46337 which converts the Apple Pay payment processor to use the new system.

#### Testing instructions

- Test an Apple Pay purchase. Verify that you get the apple pay dialog. Testing the actual purchase is less important.