### PR TITLE
Checkout: Update Free and Full credits payment processors to use automated responses

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -239,7 +239,11 @@ export async function freePurchaseProcessor(
 			postalCode: null,
 		},
 		wpcomTransaction
-	).then( saveTransactionResponseToWpcomStore );
+	)
+		.then( saveTransactionResponseToWpcomStore )
+		.then( ( response ) => {
+			return { type: 'SUCCESS', payload: response };
+		} );
 }
 
 export async function fullCreditsProcessor(

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -241,9 +241,7 @@ export async function freePurchaseProcessor(
 		wpcomTransaction
 	)
 		.then( saveTransactionResponseToWpcomStore )
-		.then( ( response ) => {
-			return { type: 'SUCCESS', payload: response };
-		} );
+		.then( makeSuccessResponse );
 }
 
 export async function fullCreditsProcessor(
@@ -264,9 +262,7 @@ export async function fullCreditsProcessor(
 		transactionOptions
 	)
 		.then( saveTransactionResponseToWpcomStore )
-		.then( ( response ) => {
-			return { type: 'SUCCESS', payload: response };
-		} );
+		.then( makeSuccessResponse );
 }
 
 export async function payPalProcessor(

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -262,7 +262,11 @@ export async function fullCreditsProcessor(
 		},
 		wpcomTransaction,
 		transactionOptions
-	).then( saveTransactionResponseToWpcomStore );
+	)
+		.then( saveTransactionResponseToWpcomStore )
+		.then( ( response ) => {
+			return { type: 'SUCCESS', payload: response };
+		} );
 }
 
 export async function payPalProcessor(

--- a/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
+++ b/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
@@ -8,13 +8,7 @@ import { useI18n } from '@automattic/react-i18n';
  * Internal dependencies
  */
 import Button from '../../components/button';
-import {
-	FormStatus,
-	useLineItems,
-	useEvents,
-	useTransactionStatus,
-	usePaymentProcessor,
-} from '../../public-api';
+import { FormStatus, useLineItems, useEvents } from '../../public-api';
 import { useFormStatus } from '../form-status';
 
 export function createFreePaymentMethod() {
@@ -37,35 +31,22 @@ function FreePurchaseLabel() {
 	);
 }
 
-function FreePurchaseSubmitButton( { disabled } ) {
+function FreePurchaseSubmitButton( { disabled, onClick } ) {
 	const [ items ] = useLineItems();
-	const {
-		setTransactionComplete,
-		setTransactionError,
-		setTransactionPending,
-	} = useTransactionStatus();
 	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
-	const submitTransaction = usePaymentProcessor( 'free-purchase' );
 
-	const onClick = () => {
-		setTransactionPending();
+	const handleButtonPress = () => {
 		onEvent( { type: 'FREE_TRANSACTION_BEGIN' } );
-		submitTransaction( {
+		onClick( 'free-purchase', {
 			items,
-		} )
-			.then( () => {
-				setTransactionComplete();
-			} )
-			.catch( ( error ) => {
-				setTransactionError( error.message );
-			} );
+		} );
 	};
 
 	return (
 		<Button
 			disabled={ disabled }
-			onClick={ onClick }
+			onClick={ handleButtonPress }
 			buttonType="primary"
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -9,13 +9,7 @@ import { useI18n } from '@automattic/react-i18n';
  * Internal dependencies
  */
 import Button from '../../components/button';
-import {
-	FormStatus,
-	useTransactionStatus,
-	usePaymentProcessor,
-	useLineItems,
-	useEvents,
-} from '../../public-api';
+import { FormStatus, useLineItems, useEvents } from '../../public-api';
 import { useFormStatus } from '../form-status';
 
 export function createFullCreditsMethod() {
@@ -39,35 +33,22 @@ function FullCreditsLabel() {
 	);
 }
 
-function FullCreditsSubmitButton( { disabled } ) {
+function FullCreditsSubmitButton( { disabled, onClick } ) {
 	const [ items, total ] = useLineItems();
-	const {
-		setTransactionComplete,
-		setTransactionError,
-		setTransactionPending,
-	} = useTransactionStatus();
 	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
-	const submitTransaction = usePaymentProcessor( 'full-credits' );
 
-	const onClick = () => {
-		setTransactionPending();
+	const handleButtonPress = () => {
 		onEvent( { type: 'FULL_CREDITS_TRANSACTION_BEGIN' } );
-		submitTransaction( {
+		onClick( 'full-credits', {
 			items,
-		} )
-			.then( () => {
-				setTransactionComplete();
-			} )
-			.catch( ( error ) => {
-				setTransactionError( error.message );
-			} );
+		} );
 	};
 
 	return (
 		<Button
 			disabled={ disabled }
-			onClick={ onClick }
+			onClick={ handleButtonPress }
 			buttonType="primary"
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to #46337 which converts the Free and Full Credits payment processors to use the new system.

#### Testing instructions

- Test free payment method
  - Add a coupon to your cart that gives a 100% discount.
  - Attempt a purchase using composite checkout with the "free" payment method.
  - Verify that the purchase is successful.
- Test full credits payment method
  - Attempt a purchase using composite checkout when you have sufficient credits to cover the entire transaction.
  - Verify that the transaction completes successfully.