### PR TITLE
Checkout: convert PayPal payment processor to use automated response

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -298,9 +298,7 @@ export async function payPalProcessor(
 		transactionOptions
 	)
 		.then( saveTransactionResponseToWpcomStore )
-		.then( ( response ) => {
-			return { type: 'REDIRECT', payload: response };
-		} );
+		.then( makeRedirectResponse );
 }
 
 async function saveTransactionResponseToWpcomStore( result ) {

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -296,7 +296,11 @@ export async function payPalProcessor(
 		},
 		wpcomPayPalExpress,
 		transactionOptions
-	).then( saveTransactionResponseToWpcomStore );
+	)
+		.then( saveTransactionResponseToWpcomStore )
+		.then( ( response ) => {
+			return { type: 'REDIRECT', payload: response };
+		} );
 }
 
 async function saveTransactionResponseToWpcomStore( result ) {

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -14,7 +14,6 @@ import {
 	FormStatus,
 	TransactionStatus,
 	useEvents,
-	usePaymentProcessor,
 	useTransactionStatus,
 	useLineItems,
 } from '../../public-api';
@@ -47,44 +46,22 @@ export function PaypalLabel() {
 	);
 }
 
-export function PaypalSubmitButton( { disabled } ) {
+export function PaypalSubmitButton( { disabled, onClick } ) {
 	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
-	const {
-		transactionStatus,
-		setTransactionPending,
-		setTransactionRedirecting,
-		setTransactionError,
-	} = useTransactionStatus();
-	const submitTransaction = usePaymentProcessor( 'paypal' );
+	const { transactionStatus } = useTransactionStatus();
 	const [ items ] = useLineItems();
-	const { __ } = useI18n();
 
-	const onClick = () => {
+	const handleButtonPress = () => {
 		onEvent( { type: 'REDIRECT_TRANSACTION_BEGIN', payload: { paymentMethodId: 'paypal' } } );
-		setTransactionPending();
-		submitTransaction( {
+		onClick( 'paypal', {
 			items,
-		} )
-			.then( ( response ) => {
-				if ( ! response ) {
-					setTransactionError(
-						__(
-							'An error occurred while redirecting to PayPal. Please try again or contact support.'
-						)
-					);
-					return;
-				}
-				setTransactionRedirecting( response );
-			} )
-			.catch( ( error ) => {
-				setTransactionError( error.message );
-			} );
+		} );
 	};
 	return (
 		<Button
 			disabled={ disabled }
-			onClick={ onClick }
+			onClick={ handleButtonPress }
 			buttonType="paypal"
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to #46337 which converts the PayPal payment processor to use the new system.

#### Testing instructions

- Test making a purchase using the PayPal payment method. Be sure you are correctly redirected to PayPal (the rest of the transaction is less important to test because this really only changes the redirect).