### PR TITLE
Checkout: Disable business upsell for 3DS

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -267,19 +267,23 @@ function maybeShowPlanBumpOffer( {
 	pendingOrReceiptId,
 	cart,
 	siteSlug,
+	orderId,
 	didPurchaseFail,
 	isTransactionResultEmpty,
 }: {
 	pendingOrReceiptId: string;
+	orderId: number | undefined;
 	cart: ResponseCart | undefined;
 	siteSlug: string | undefined;
 	didPurchaseFail: boolean;
 	isTransactionResultEmpty: boolean;
 } ): string | undefined {
+	if ( orderId ) {
+		return;
+	}
 	if ( hasPremiumPlan( cart ) && ! isTransactionResultEmpty && ! didPurchaseFail ) {
 		return `/checkout/${ siteSlug }/offer-plan-upgrade/business/${ pendingOrReceiptId }`;
 	}
-
 	return;
 }
 
@@ -322,6 +326,7 @@ function getRedirectUrlForConciergeNudge( {
 		const upgradePath = maybeShowPlanBumpOffer( {
 			pendingOrReceiptId,
 			cart,
+			orderId,
 			siteSlug,
 			didPurchaseFail,
 			isTransactionResultEmpty,

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -532,6 +532,24 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/business/1234abcd' );
 	} );
 
+	it( 'redirects to the thank-you pending page with an order id when the business upgrade nudge would normally be included', () => {
+		isEnabled.mockImplementation( ( flag ) => flag === 'upsell/concierge-session' );
+		const cart = {
+			products: [
+				{
+					product_slug: 'value_bundle',
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			orderId: '1234abcd',
+			cart,
+		} );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar/pending/1234abcd' );
+	} );
+
 	it( 'redirects to concierge nudge if concierge and jetpack are not in the cart, blogger is in the cart, and the previous route is not the nudge', () => {
 		isEnabled.mockImplementation( ( flag ) => flag === 'upsell/concierge-session' );
 		const cart = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow up to https://github.com/Automattic/wp-calypso/pull/44623 which disabled the `offer-quickstart-session` URL for 3DS cards. This PR disables the `offer-plan-upgrade`, which was added last month in https://github.com/Automattic/wp-calypso/pull/44590 and is currently broken for 3DS cards.

Fixes https://github.com/Automattic/wp-calypso/issues/46409

#### Testing instructions

- Add a premium plan to your cart.
- Visit checkout.
- Complete checkout using a 3D Secure card.
- Verify that you are redirected to the thank-you page.