### PR TITLE
Enable coming soon v2 for all proxied automatticians.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -320,7 +320,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_sidebar'
  * Coming soon
  */
 function load_coming_soon() {
-	if ( wpcom_is_proxied_request() ) {
+	if (
+		( defined( 'WPCOM_PUBLIC_COMING_SOON' ) && WPCOM_PUBLIC_COMING_SOON ) ||
+		apply_filters( 'a8c_enable_public_coming_soon', false )
+	) {
 		require_once __DIR__ . '/coming-soon/coming-soon.php';
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -320,7 +320,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_sidebar'
  * Coming soon
  */
 function load_coming_soon() {
-	if ( defined( 'WPCOM_PUBLIC_COMING_SOON' ) && WPCOM_PUBLIC_COMING_SOON ) {
+	if ( wpcom_is_proxied_request() ) {
 		require_once __DIR__ . '/coming-soon/coming-soon.php';
 	}
 }


### PR DESCRIPTION
Coming soon v2 sites will only be created using the coming-soon-v2 flag from the frontend

In slack, we had discused using is_automattician rather than is_proxied_request.

I went with is_proxied_request because we also want to be able to test what a non-authenticated user, or a non-blog-owner user sees (only they see the coming soon page).


### testing instructions

With the proxy active, and this code `yarn dev --sync`ed to your sandbox:
Create a test site (without enabling the coming-soon-v2 flag)
It should be created in the private, unlaunched state.
Note that `wpcom_coming_soon` is not set for new sites, this is existing behavior.

You can check the settings on the site like so: 
```
wp option --url=https://your-testing-site.wordpress.com/ get wpcom_coming_soon
wp option --url=https://your-testing-site.wordpress.com/ get wpcom_public_coming_soon
wp option --url=https://your-testing-site.wordpress.com/ get launch-status
wp option --url=https://your-testing-site.wordpress.com/ get blog_public
```
Check that coming soon v1 still works as expected, launch the site, put it back in coming soon mode etc.

Create a site with `?flags=coming-soon-v2` active
The coming soon v2 site should work as expected
