### PR TITLE
Coming Soon v2: adding links to default page

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -25,14 +25,13 @@ function get_current_locale() {
  * @return string The redirect URL
  */
 function get_redirect_to() {
-
 	// Redirect to the current URL.
 	// If, for any reason, the superglobals aren't available, set a default redirect.
 	if ( empty( $_SERVER['HTTP_HOST'] ) || empty( $_SERVER['REQUEST_URI'] ) ) {
 		return get_marketing_home_url();
 	}
 
-	return rawurlencode( 'https://' . wp_unslash( $_SERVER['HTTP_HOST'] ) . wp_unslash( $_SERVER['REQUEST_URI'] ) );
+	return rawurlencode( 'https://' . sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) . sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
 }
 
 /**
@@ -41,8 +40,13 @@ function get_redirect_to() {
  * @return string The login URL
  */
 function get_login_url() {
+	$redirect_to = get_redirect_to();
+
+	if ( function_exists( 'localized_wpcom_url' ) ) {
+		return localized_wpcom_url( rawurlencode( '//wordpress.com/log-in?redirect_to=' . $redirect_to ) );
+	}
+
 	$locale              = get_current_locale();
-	$redirect_to         = get_redirect_to();
 	$locale_url_fragment = 'en' === $locale ? '' : '/' . $locale;
 
 	return '//wordpress.com/log-in' . $locale_url_fragment . '?redirect_to=' . $redirect_to;
@@ -54,6 +58,10 @@ function get_login_url() {
  * @return string The URL
  */
 function get_onboarding_url() {
+	if ( function_exists( 'localized_wpcom_url' ) ) {
+		return localized_wpcom_url( 'https://wordpress.com/?ref=coming_soon' );
+	}
+
 	$locale           = get_current_locale();
 	$locale_subdomain = 'en' === $locale ? '' : $locale . '.';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -10,31 +10,53 @@
 
 namespace A8C\FSE\Coming_soon;
 
-$blog_locale = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
+/**
+ * Returns the current locale
+ *
+ * @return string Language slug
+ */
+function get_current_locale() {
+	return function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
+}
 
+/**
+ * Returns a redirect URL for post-login flow
+ *
+ * @return string The redirect URL
+ */
 function get_redirect_to() {
 
-	// redirect_to is probably never set so this is almost pointless
-	if ( ! empty( $_REQUEST['redirect_to'] ) ) {
-		return rawurlencode( $_REQUEST['redirect_to'] );
-	}
-
-	if ( ! isset( $_SERVER['HTTP_HOST'] ) || ! isset( $_SERVER['REQUEST_URI'] ) ) {
+	// Redirect to the current URL.
+	// If, for any reason, the superglobals aren't available, set a default redirect.
+	if ( empty( $_SERVER['HTTP_HOST'] ) || empty( $_SERVER['REQUEST_URI'] ) ) {
 		return get_marketing_home_url();
 	}
 
-	return rawurlencode( 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ); // This is almost always where we are going
+	return rawurlencode( 'https://' . wp_unslash( $_SERVER['HTTP_HOST'] ) . wp_unslash( $_SERVER['REQUEST_URI'] ) );
 }
 
+/**
+ * Returns a localized login URL with redirect query param
+ *
+ * @return string The login URL
+ */
 function get_login_url() {
-	$locale              = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
+	$locale              = get_current_locale();
 	$redirect_to         = get_redirect_to();
-	$locale_url_fragment = 'en' === \$blog_locale ? '' : '/' . \$blog_locale;
+	$locale_url_fragment = 'en' === $locale ? '' : '/' . $locale;
+
 	return '//wordpress.com/log-in' . $locale_url_fragment . '?redirect_to=' . $redirect_to;
 }
 
-function get_marketing_home_url() {
-	$locale_subdomain = 'en' === \$blog_locale ? '' : \$blog_locale + '.';
+/**
+ * Returns a localized onboarding URL with redirect query param
+ *
+ * @return string The URL
+ */
+function get_onboarding_url() {
+	$locale           = get_current_locale();
+	$locale_subdomain = 'en' === $locale ? '' : $locale . '.';
+
 	return 'https://' . $locale_subdomain . 'wordpress.com/?ref=coming_soon';
 }
 
@@ -222,11 +244,11 @@ function get_marketing_home_url() {
 				<?php if ( ! is_user_logged_in() ) : ?>
 					<div class="marketing-copy">
 						<img src="/wp-content/themes/a8c/domain-landing-page/wpcom-wmark-white.svg" alt="WordPress.com" class="logo" />
-						<p class="copy"><?php echo esc_html( fix_widows( __( 'Build a website. Sell your stuff. Write a blog. And so much more.', 'full-site-editing' ), array( 'mobile_enable' => true ) ) ); ?></p>
+						<p class="copy"><?php esc_html_e( 'Build a website. Sell your stuff. Write a blog. And so much more.', 'full-site-editing' ); ?></p>
 					</div>
 					<div class="marketing-buttons">
 						<p><a class="button button-secondary" href="<?php echo esc_url( get_login_url() ); ?>"><?php esc_html_e( 'Log in', 'full-site-editing' ); ?></a></p>
-						<p><a class="button button-primary " href="<?php echo esc_url( get_marketing_home_url() ); ?>"><?php esc_html_e( 'Start your website', 'full-site-editing' ); ?></a></p>
+						<p><a class="button button-primary " href="<?php echo esc_url( get_onboarding_url() ); ?>"><?php esc_html_e( 'Start your website', 'full-site-editing' ); ?></a></p>
 					</div>
 				<?php endif; ?>
 			</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -10,6 +10,34 @@
 
 namespace A8C\FSE\Coming_soon;
 
+$blog_locale = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
+
+function get_redirect_to() {
+
+	// redirect_to is probably never set so this is almost pointless
+	if ( ! empty( $_REQUEST['redirect_to'] ) ) {
+		return rawurlencode( $_REQUEST['redirect_to'] );
+	}
+
+	if ( ! isset( $_SERVER['HTTP_HOST'] ) || ! isset( $_SERVER['REQUEST_URI'] ) ) {
+		return get_marketing_home_url();
+	}
+
+	return rawurlencode( 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ); // This is almost always where we are going
+}
+
+function get_login_url() {
+	$locale              = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
+	$redirect_to         = get_redirect_to();
+	$locale_url_fragment = 'en' === \$blog_locale ? '' : '/' . \$blog_locale;
+	return '//wordpress.com/log-in' . $locale_url_fragment . '?redirect_to=' . $redirect_to;
+}
+
+function get_marketing_home_url() {
+	$locale_subdomain = 'en' === \$blog_locale ? '' : \$blog_locale + '.';
+	return 'https://' . $locale_subdomain . 'wordpress.com/?ref=coming_soon';
+}
+
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
@@ -197,8 +225,8 @@ namespace A8C\FSE\Coming_soon;
 						<p class="copy"><?php echo esc_html( fix_widows( __( 'Build a website. Sell your stuff. Write a blog. And so much more.', 'full-site-editing' ), array( 'mobile_enable' => true ) ) ); ?></p>
 					</div>
 					<div class="marketing-buttons">
-						<p><a class="button button-secondary" href="<?php echo esc_url( $login_url ); ?>"><?php esc_html_e( 'Log in', 'full-site-editing' ); ?></a></p>
-						<p><a class="button button-primary " href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/?ref=coming_soon' ) ); ?>"><?php esc_html_e( 'Start your website', 'full-site-editing' ); ?></a></p>
+						<p><a class="button button-secondary" href="<?php echo esc_url( get_login_url() ); ?>"><?php esc_html_e( 'Log in', 'full-site-editing' ); ?></a></p>
+						<p><a class="button button-primary " href="<?php echo esc_url( get_marketing_home_url() ); ?>"><?php esc_html_e( 'Start your website', 'full-site-editing' ); ?></a></p>
 					</div>
 				<?php endif; ?>
 			</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -43,7 +43,7 @@ function get_login_url() {
 	$redirect_to = get_redirect_to();
 
 	if ( function_exists( 'localized_wpcom_url' ) ) {
-		return localized_wpcom_url( '//wordpress.com/log-in?redirect_to=' . $redirect_to  );
+		return localized_wpcom_url( '//wordpress.com/log-in?redirect_to=' . $redirect_to );
 	}
 
 	$locale              = get_current_locale();

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -43,7 +43,7 @@ function get_login_url() {
 	$redirect_to = get_redirect_to();
 
 	if ( function_exists( 'localized_wpcom_url' ) ) {
-		return localized_wpcom_url( rawurlencode( '//wordpress.com/log-in?redirect_to=' . $redirect_to ) );
+		return localized_wpcom_url( '//wordpress.com/log-in?redirect_to=' . $redirect_to  );
 	}
 
 	$locale              = get_current_locale();


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR adds localized login and default marketing page links to the buttons.

<img width="1389" alt="Screen Shot 2020-10-15 at 11 59 35 am" src="https://user-images.githubusercontent.com/6458278/96061728-ac87aa00-0edf-11eb-898a-e1ebe10e924e.png">

## Testing instructions

1. Sync this PR to your sandbox by running `yarn dev --sync` in `apps/editing-toolkit` (you might have run `composer install` beforehand
2. Add `define('WPCOM_PUBLIC_COMING_SOON', true)` to 0-sandbox.php
3. Create a new site  at wordpress.com/new?flags=coming-soon-v2
4. Sandbox your new site
5. Visit your new site in an incognito window
6. Click on the **Start your website** button. It should take you to https://wordpress.com/?ref=coming_soon
7. Check that the **Log in button** link takes you to the login page
8. Logging in with a different account should redirect you back to the site's coming soon page
9. Logging in with the same account with which you used to create the site, should redirect you back to a logged-in view of your site

Change the locale of your new site in site settings (`https://wordpress.com/settings/general/yoursiteaddress`) and retest steps 5-7. The links should take you to the corresponding localized pages.


