### PR TITLE
Apply autofix for rule `wpcalypso/no-package-relative-imports` in `./client/blocks`

### DIFF
--- a/client/blocks/all-sites/all-sites-icon.jsx
+++ b/client/blocks/all-sites/all-sites-icon.jsx
@@ -9,7 +9,7 @@ import { union } from 'lodash';
 /**
  * Internal dependencies
  */
-import SiteIcon from 'blocks/site-icon';
+import SiteIcon from 'calypso/blocks/site-icon';
 
 /**
  * Style dependencies

--- a/client/blocks/all-sites/docs/example.jsx
+++ b/client/blocks/all-sites/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import AllSites from 'blocks/all-sites';
+import AllSites from 'calypso/blocks/all-sites';
 import { Card } from '@automattic/components';
 
 const AllSitesExample = () => (

--- a/client/blocks/all-sites/index.jsx
+++ b/client/blocks/all-sites/index.jsx
@@ -13,10 +13,10 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import AllSitesIcon from './all-sites-icon';
-import config from 'config';
-import Count from 'components/count';
-import getSites from 'state/selectors/get-sites';
-import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
+import config from 'calypso/config';
+import Count from 'calypso/components/count';
+import getSites from 'calypso/state/selectors/get-sites';
+import { getCurrentUserVisibleSiteCount } from 'calypso/state/current-user/selectors';
 
 /**
  * Style dependencies

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -13,18 +13,18 @@ import { get, identity, includes, noop } from 'lodash';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
-import { getSectionName, getSelectedSiteId } from 'state/ui/selectors';
-import getCurrentRoute from 'state/selectors/get-current-route';
-import { getPreference, isFetchingPreferences } from 'state/preferences/selectors';
-import isNotificationsOpen from 'state/selectors/is-notifications-open';
+import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
+import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import {
 	bumpStat,
 	composeAnalytics,
 	recordTracksEvent,
 	withAnalytics,
-} from 'state/analytics/actions';
-import { savePreference } from 'state/preferences/actions';
-import TrackComponentView from 'lib/analytics/track-component-view';
+} from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import {
 	ALLOWED_SECTIONS,
 	EDITOR,
@@ -38,9 +38,9 @@ import {
 	isDismissed,
 	APP_BANNER_DISMISS_TIMES_PREFERENCE,
 } from './utils';
-import versionCompare from 'lib/version-compare';
-import { isWpMobileApp } from 'lib/mobile-app';
-import { shouldDisplayTosUpdateBanner } from 'state/selectors/should-display-tos-update-banner';
+import versionCompare from 'calypso/lib/version-compare';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
+import { shouldDisplayTosUpdateBanner } from 'calypso/state/selectors/should-display-tos-update-banner';
 
 /**
  * Style dependencies
@@ -50,10 +50,10 @@ import './style.scss';
 /**
  * Image dependencies
  */
-import editorBannerImage from 'assets/images/illustrations/app-banner-editor.svg';
-import notificationsBannerImage from 'assets/images/illustrations/app-banner-notifications.svg';
-import readerBannerImage from 'assets/images/illustrations/app-banner-reader.svg';
-import statsBannerImage from 'assets/images/illustrations/app-banner-stats.svg';
+import editorBannerImage from 'calypso/assets/images/illustrations/app-banner-editor.svg';
+import notificationsBannerImage from 'calypso/assets/images/illustrations/app-banner-notifications.svg';
+import readerBannerImage from 'calypso/assets/images/illustrations/app-banner-reader.svg';
+import statsBannerImage from 'calypso/assets/images/illustrations/app-banner-stats.svg';
 
 const IOS_REGEX = /iPad|iPod|iPhone/i;
 const ANDROID_REGEX = /Android (\d+(\.\d+)?(\.\d+)?)/i;

--- a/client/blocks/app-banner/test/app-banner.jsx
+++ b/client/blocks/app-banner/test/app-banner.jsx
@@ -5,8 +5,8 @@
 /**
  * Internal dependencies
  */
-import { getiOSDeepLink, buildDeepLinkFragment } from 'blocks/app-banner';
-import { EDITOR, NOTES, READER, STATS, getCurrentSection } from 'blocks/app-banner/utils';
+import { getiOSDeepLink, buildDeepLinkFragment } from 'calypso/blocks/app-banner';
+import { EDITOR, NOTES, READER, STATS, getCurrentSection } from 'calypso/blocks/app-banner/utils';
 
 describe( 'iOS deep link fragments', () => {
 	test( 'properly encodes tricky fragments', () => {

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { identity, noop, sample } from 'lodash';
 import store from 'store';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * WordPress dependencies
@@ -18,16 +18,16 @@ import { Button } from '@wordpress/components';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { Dialog } from '@automattic/components';
-import { fetchUserSettings } from 'state/user-settings/actions';
-import getUserSettings from 'state/selectors/get-user-settings';
-import { sendEmailLogin } from 'state/auth/actions';
+import { fetchUserSettings } from 'calypso/state/user-settings/actions';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import { sendEmailLogin } from 'calypso/state/auth/actions';
 
 /**
  * Image dependencies
  */
-import wordpressLogoImage from 'assets/images/illustrations/logo-jpc.svg';
+import wordpressLogoImage from 'calypso/assets/images/illustrations/logo-jpc.svg';
 
 /**
  * Style dependencies

--- a/client/blocks/author-compact-profile/docs/example.jsx
+++ b/client/blocks/author-compact-profile/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import AuthorCompactProfile from 'blocks/author-compact-profile';
+import AuthorCompactProfile from 'calypso/blocks/author-compact-profile';
 import { Card } from '@automattic/components';
 
 export default class AuthorCompactProfileExample extends React.Component {

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -11,12 +11,12 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import ReaderAvatar from 'blocks/reader-avatar';
-import ReaderAuthorLink from 'blocks/reader-author-link';
-import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
-import ReaderFollowButton from 'reader/follow-button';
-import { getStreamUrl } from 'reader/route';
-import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
+import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
+import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
+import ReaderFollowButton from 'calypso/reader/follow-button';
+import { getStreamUrl } from 'calypso/reader/route';
+import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
 import AuthorCompactProfilePlaceholder from './placeholder';
 
 /**

--- a/client/blocks/author-compact-profile/placeholder.jsx
+++ b/client/blocks/author-compact-profile/placeholder.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderAvatar from 'blocks/reader-avatar';
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
 
 const AuthorCompactProfilePlaceholder = () => {
 	return (

--- a/client/blocks/author-selector/docs/example.jsx
+++ b/client/blocks/author-selector/docs/example.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
  */
 import AuthorSelector from '../';
 import { Card } from '@automattic/components';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 function AuthorSelectorExample( { primarySiteId, displayName } ) {
 	return (

--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -10,7 +10,7 @@ import { trim } from 'lodash';
 /**
  * Internal dependencies
  */
-import SiteUsersFetcher from 'components/site-users-fetcher';
+import SiteUsersFetcher from 'calypso/components/site-users-fetcher';
 import SwitcherShell from './switcher-shell';
 
 /**

--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -5,19 +5,19 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import debugModule from 'debug';
 
 /**
  * Internal dependencies
  */
-import Popover from 'components/popover';
-import PopoverMenuItem from 'components/popover/menu-item';
-import UserItem from 'components/user';
-import InfiniteList from 'components/infinite-list';
-import { fetchUsers } from 'lib/users/actions';
-import Search from 'components/search';
-import { hasTouch } from 'lib/touch-detect';
+import Popover from 'calypso/components/popover';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import UserItem from 'calypso/components/user';
+import InfiniteList from 'calypso/components/infinite-list';
+import { fetchUsers } from 'calypso/lib/users/actions';
+import Search from 'calypso/components/search';
+import { hasTouch } from 'calypso/lib/touch-detect';
 
 /**
  * Module variables

--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -9,13 +9,13 @@ import React from 'react';
  * Internal Dependencies
  */
 import { connect } from 'react-redux';
-import QueryReaderTeams from 'components/data/query-reader-teams';
-import QueryBlogStickers from 'components/data/query-blog-stickers';
-import getBlogStickers from 'state/selectors/get-blog-stickers';
-import { getReaderTeams } from 'state/reader/teams/selectors';
-import BlogStickersList from 'blocks/blog-stickers/list';
-import InfoPopover from 'components/info-popover';
-import { isAutomatticTeamMember } from 'reader/lib/teams';
+import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
+import QueryBlogStickers from 'calypso/components/data/query-blog-stickers';
+import getBlogStickers from 'calypso/state/selectors/get-blog-stickers';
+import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
+import BlogStickersList from 'calypso/blocks/blog-stickers/list';
+import InfoPopover from 'calypso/components/info-popover';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 
 /**
  * Style dependencies

--- a/client/blocks/calendar-button/docs/example.jsx
+++ b/client/blocks/calendar-button/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import CalendarButton from 'blocks/calendar-button';
+import CalendarButton from 'calypso/blocks/calendar-button';
 
 const CalendarButtonExample = () => {
 	const tomorrow = new Date( new Date().getTime() + 24 * 60 * 60 * 1000 );

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
 import { noop, pick } from 'lodash';
 
@@ -11,7 +11,7 @@ import { noop, pick } from 'lodash';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import AsyncLoad from 'components/async-load';
+import AsyncLoad from 'calypso/components/async-load';
 
 class CalendarButton extends Component {
 	static propTypes = {
@@ -98,7 +98,7 @@ class CalendarButton extends Component {
 		return (
 			<AsyncLoad
 				{ ...calendarProperties }
-				require="blocks/calendar-popover"
+				require="calypso/blocks/calendar-popover"
 				placeholder={ null }
 				isVisible
 				context={ this.buttonRef.current }

--- a/client/blocks/calendar-popover/docs/example.jsx
+++ b/client/blocks/calendar-popover/docs/example.jsx
@@ -8,7 +8,7 @@ import moment from 'moment';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import CalendarPopover from 'blocks/calendar-popover';
+import CalendarPopover from 'calypso/blocks/calendar-popover';
 
 const tomorrow = ( date ) => date.date( date.date() + 1 );
 

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -10,10 +10,10 @@ import { noop, pick } from 'lodash';
 /**
  * Internal dependencies
  */
-import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
-import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
-import Popover from 'components/popover';
-import PostSchedule from 'components/post-schedule';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import Popover from 'calypso/components/popover';
+import PostSchedule from 'calypso/components/post-schedule';
 
 /**
  * Style dependencies

--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -6,15 +6,15 @@ import { compact } from 'lodash';
 /**
  * Image dependencies
  */
-import classicBrightImg from 'assets/images/color-schemes/color-scheme-thumbnail-classic-bright.svg';
-import classicBlueImg from 'assets/images/color-schemes/color-scheme-thumbnail-classic-blue.svg';
-import powderSnowImg from 'assets/images/color-schemes/color-scheme-thumbnail-powder-snow.svg';
-import nightfallImg from 'assets/images/color-schemes/color-scheme-thumbnail-nightfall.svg';
-import sakuraImg from 'assets/images/color-schemes/color-scheme-thumbnail-sakura.svg';
-import oceanImg from 'assets/images/color-schemes/color-scheme-thumbnail-ocean.svg';
-import sunsetImg from 'assets/images/color-schemes/color-scheme-thumbnail-sunset.svg';
-import midnightImg from 'assets/images/color-schemes/color-scheme-thumbnail-midnight.svg';
-import contrastImg from 'assets/images/color-schemes/color-scheme-thumbnail-contrast.svg';
+import classicBrightImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-classic-bright.svg';
+import classicBlueImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-classic-blue.svg';
+import powderSnowImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-powder-snow.svg';
+import nightfallImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-nightfall.svg';
+import sakuraImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-sakura.svg';
+import oceanImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-ocean.svg';
+import sunsetImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-sunset.svg';
+import midnightImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-midnight.svg';
+import contrastImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-contrast.svg';
 
 /**
  * !! Note !!

--- a/client/blocks/color-scheme-picker/docs/example.jsx
+++ b/client/blocks/color-scheme-picker/docs/example.jsx
@@ -7,7 +7,7 @@ import React, { PureComponent } from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import ColorSchemePicker from 'blocks/color-scheme-picker';
+import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
 
 class ColorSchemePickerExample extends PureComponent {
 	static displayName = 'ColorSchemePicker';

--- a/client/blocks/color-scheme-picker/index.jsx
+++ b/client/blocks/color-scheme-picker/index.jsx
@@ -10,11 +10,11 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import QueryPreferences from 'components/data/query-preferences';
-import { savePreference, setPreference } from 'state/preferences/actions';
-import { getPreference } from 'state/preferences/selectors';
+import QueryPreferences from 'calypso/components/data/query-preferences';
+import { savePreference, setPreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
 import getColorSchemesData from './constants';
-import FormRadiosBar from 'components/forms/form-radios-bar';
+import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
 
 /**
  * Style dependencies

--- a/client/blocks/comment-button/docs/example.jsx
+++ b/client/blocks/comment-button/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import CommentButton from 'blocks/comment-button';
+import CommentButton from 'calypso/blocks/comment-button';
 import { Card } from '@automattic/components';
 
 export default class CommentButtonExample extends React.Component {

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -11,8 +11,8 @@ import { isNull, noop, omitBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import Gridicon from 'components/gridicon';
-import { getPostTotalCommentsCount } from 'state/comments/selectors';
+import Gridicon from 'calypso/components/gridicon';
+import { getPostTotalCommentsCount } from 'calypso/state/comments/selectors';
 
 /**
  * Style dependencies

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import classnames from 'classnames';
 import { noop } from 'lodash';
 
@@ -16,12 +16,12 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { changeCommentStatus } from 'state/comments/actions';
+import { changeCommentStatus } from 'calypso/state/comments/actions';
 import CommentLikeButtonContainer from './comment-likes';
 import CommentApproveAction from './comment-approve-action';
-import EllipsisMenu from 'components/ellipsis-menu';
-import PopoverMenuItem from 'components/popover/menu-item';
-import PopoverMenuSeparator from 'components/popover/menu-separator';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import PopoverMenuSeparator from 'calypso/components/popover/menu-separator';
 
 /**
  * Style dependencies

--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import classnames from 'classnames';
 
 /**

--- a/client/blocks/comments/comment-edit-form.jsx
+++ b/client/blocks/comments/comment-edit-form.jsx
@@ -13,11 +13,11 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import AutoDirection from 'components/auto-direction';
-import FormFieldset from 'components/forms/form-fieldset';
-import Notice from 'components/notice';
-import { editComment } from 'state/comments/actions';
-import { recordAction, recordGaEvent } from 'reader/stats';
+import AutoDirection from 'calypso/components/auto-direction';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import Notice from 'calypso/components/notice';
+import { editComment } from 'calypso/state/comments/actions';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import PostCommentFormTextarea from './form-textarea';
 
 /**

--- a/client/blocks/comments/docs/post-comment-example.jsx
+++ b/client/blocks/comments/docs/post-comment-example.jsx
@@ -7,8 +7,8 @@ import { repeat } from 'lodash';
 /**
  * Internal dependencies
  */
-import PostComment from 'blocks/comments/post-comment';
-import { POST_COMMENT_DISPLAY_TYPES } from 'state/comments/constants';
+import PostComment from 'calypso/blocks/comments/post-comment';
+import { POST_COMMENT_DISPLAY_TYPES } from 'calypso/state/comments/constants';
 import { Card } from '@automattic/components';
 
 const mockComment = {

--- a/client/blocks/comments/form-textarea.jsx
+++ b/client/blocks/comments/form-textarea.jsx
@@ -6,10 +6,10 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FormTextarea from 'components/forms/form-textarea';
-import withUserMentions from 'blocks/user-mentions/index';
-import withPasteToLink from 'lib/paste-to-link';
-import { isEnabled } from 'config';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import withUserMentions from 'calypso/blocks/user-mentions/index';
+import withPasteToLink from 'calypso/lib/paste-to-link';
+import { isEnabled } from 'calypso/config';
 
 /* eslint-disable jsx-a11y/no-autofocus */
 const PostCommentFormTextarea = React.forwardRef( ( props, ref ) => (

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -12,15 +12,15 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import AutoDirection from 'components/auto-direction';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormInputValidation from 'components/forms/form-input-validation';
-import Gravatar from 'components/gravatar';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { writeComment, deleteComment, replyComment } from 'state/comments/actions';
-import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
-import { isCommentableDiscoverPost } from 'blocks/comments/helper';
-import { ProtectFormGuard } from 'lib/protect-form';
+import AutoDirection from 'calypso/components/auto-direction';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import Gravatar from 'calypso/components/gravatar';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { writeComment, deleteComment, replyComment } from 'calypso/state/comments/actions';
+import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
+import { isCommentableDiscoverPost } from 'calypso/blocks/comments/helper';
+import { ProtectFormGuard } from 'calypso/lib/protect-form';
 import PostCommentFormTextarea from './form-textarea';
 
 /**

--- a/client/blocks/comments/helper.jsx
+++ b/client/blocks/comments/helper.jsx
@@ -4,7 +4,7 @@
 /**
  * Internal dependencies
  */
-import * as DiscoverHelper from 'reader/discover/helper';
+import * as DiscoverHelper from 'calypso/reader/discover/helper';
 
 export function shouldShowComments( post ) {
 	if ( isCommentableDiscoverPost( post ) ) {

--- a/client/blocks/comments/index.jsx
+++ b/client/blocks/comments/index.jsx
@@ -10,8 +10,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PostCommentsList from './post-comment-list';
-import { Interval, EVERY_MINUTE } from 'lib/interval';
-import { requestPostComments } from 'state/comments/actions';
+import { Interval, EVERY_MINUTE } from 'calypso/lib/interval';
+import { requestPostComments } from 'calypso/state/comments/actions';
 
 class PostComments extends React.Component {
 	static propTypes = {

--- a/client/blocks/comments/post-comment-content.jsx
+++ b/client/blocks/comments/post-comment-content.jsx
@@ -9,8 +9,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import AutoDirection from 'components/auto-direction';
-import Emojify from 'components/emojify';
+import AutoDirection from 'calypso/components/auto-direction';
+import Emojify from 'calypso/components/emojify';
 
 /**
  * Style dependencies

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -6,30 +6,30 @@ import PropTypes from 'prop-types';
 import { get, noop, some, flatMap } from 'lodash';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
-import { getCurrentUser } from 'state/current-user/selectors';
-import TimeSince from 'components/time-since';
-import Gravatar from 'components/gravatar';
-import { recordAction, recordGaEvent, recordTrack, recordPermalinkClick } from 'reader/stats';
-import { getStreamUrl } from 'reader/route';
+import { isEnabled } from 'calypso/config';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import TimeSince from 'calypso/components/time-since';
+import Gravatar from 'calypso/components/gravatar';
+import { recordAction, recordGaEvent, recordTrack, recordPermalinkClick } from 'calypso/reader/stats';
+import { getStreamUrl } from 'calypso/reader/route';
 import PostCommentContent from './post-comment-content';
 import PostCommentForm from './form';
 import CommentEditForm from './comment-edit-form';
-import { PLACEHOLDER_STATE, POST_COMMENT_DISPLAY_TYPES } from 'state/comments/constants';
-import { decodeEntities } from 'lib/formatting';
+import { PLACEHOLDER_STATE, POST_COMMENT_DISPLAY_TYPES } from 'calypso/state/comments/constants';
+import { decodeEntities } from 'calypso/lib/formatting';
 import PostCommentWithError from './post-comment-with-error';
 import PostTrackback from './post-trackback';
 import CommentActions from './comment-actions';
-import Emojify from 'components/emojify';
-import ConversationCaterpillar from 'blocks/conversation-caterpillar';
-import withDimensions from 'lib/with-dimensions';
-import { expandComments } from 'state/comments/actions';
+import Emojify from 'calypso/components/emojify';
+import ConversationCaterpillar from 'calypso/blocks/conversation-caterpillar';
+import withDimensions from 'calypso/lib/with-dimensions';
+import { expandComments } from 'calypso/state/comments/actions';
 
 /**
  * Style dependencies

--- a/client/blocks/comments/post-trackback.jsx
+++ b/client/blocks/comments/post-trackback.jsx
@@ -4,13 +4,13 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import TimeSince from 'components/time-since';
+import TimeSince from 'calypso/components/time-since';
 
 /**
  * Style dependencies

--- a/client/blocks/conversation-caterpillar/docs/example.jsx
+++ b/client/blocks/conversation-caterpillar/docs/example.jsx
@@ -7,9 +7,9 @@ import { size } from 'lodash';
 /**
  * Internal dependencies
  */
-import { ConversationCaterpillar } from 'blocks/conversation-caterpillar';
-import { posts } from 'blocks/reader-post-card/docs/fixtures';
-import { comments, commentsTree } from 'blocks/conversation-caterpillar/docs/fixtures';
+import { ConversationCaterpillar } from 'calypso/blocks/conversation-caterpillar';
+import { posts } from 'calypso/blocks/reader-post-card/docs/fixtures';
+import { comments, commentsTree } from 'calypso/blocks/conversation-caterpillar/docs/fixtures';
 import { Card } from '@automattic/components';
 
 const ConversationCaterpillarExample = () => {

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -10,12 +10,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import { getPostCommentsTree, getDateSortedPostComments } from 'state/comments/selectors';
-import { expandComments } from 'state/comments/actions';
-import { POST_COMMENT_DISPLAY_TYPES } from 'state/comments/constants';
-import { isAncestor } from 'blocks/comments/utils';
-import GravatarCaterpillar from 'components/gravatar-caterpillar';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { getPostCommentsTree, getDateSortedPostComments } from 'calypso/state/comments/selectors';
+import { expandComments } from 'calypso/state/comments/actions';
+import { POST_COMMENT_DISPLAY_TYPES } from 'calypso/state/comments/constants';
+import { isAncestor } from 'calypso/blocks/comments/utils';
+import GravatarCaterpillar from 'calypso/components/gravatar-caterpillar';
 
 /**
  * Style dependencies

--- a/client/blocks/conversation-follow-button/button.jsx
+++ b/client/blocks/conversation-follow-button/button.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 class ConversationFollowButton extends React.Component {
 	static propTypes = {

--- a/client/blocks/conversation-follow-button/docs/example.jsx
+++ b/client/blocks/conversation-follow-button/docs/example.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ConversationFollowButton from 'blocks/conversation-follow-button/button';
+import ConversationFollowButton from 'calypso/blocks/conversation-follow-button/button';
 import { CompactCard as Card } from '@automattic/components';
 
 export default class ConversationFollowButtonExample extends React.PureComponent {

--- a/client/blocks/conversation-follow-button/helper.js
+++ b/client/blocks/conversation-follow-button/helper.js
@@ -4,8 +4,8 @@
 /**
  * Internal dependencies
  */
-import { isDiscoverPost } from 'reader/discover/helper';
-import { shouldShowComments } from 'blocks/comments/helper';
+import { isDiscoverPost } from 'calypso/reader/discover/helper';
+import { shouldShowComments } from 'calypso/blocks/comments/helper';
 
 export function shouldShowConversationFollowButton( post ) {
 	return (

--- a/client/blocks/conversation-follow-button/index.jsx
+++ b/client/blocks/conversation-follow-button/index.jsx
@@ -10,10 +10,10 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import ConversationFollowButton from './button';
-import { isFollowingReaderConversation } from 'state/reader/conversations/selectors';
-import { followConversation, muteConversation } from 'state/reader/conversations/actions';
-import { getTracksPropertiesForPost } from 'reader/stats';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { isFollowingReaderConversation } from 'calypso/state/reader/conversations/selectors';
+import { followConversation, muteConversation } from 'calypso/state/reader/conversations/actions';
+import { getTracksPropertiesForPost } from 'calypso/reader/stats';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -7,9 +7,9 @@ import { noop, map, compact } from 'lodash';
 /**
  * Internal dependencies
  */
-import { ConversationCommentList } from 'blocks/conversations/list';
-import { posts } from 'blocks/reader-post-card/docs/fixtures';
-import { commentsTree } from 'blocks/conversations/docs/fixtures';
+import { ConversationCommentList } from 'calypso/blocks/conversations/list';
+import { posts } from 'calypso/blocks/reader-post-card/docs/fixtures';
+import { commentsTree } from 'calypso/blocks/conversations/docs/fixtures';
 
 const ConversationCommentListExample = () => {
 	const post = posts[ 0 ];

--- a/client/blocks/conversations/empty.jsx
+++ b/client/blocks/conversations/empty.jsx
@@ -7,14 +7,14 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import EmptyContent from 'components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import { withPerformanceTrackerStop } from 'lib/performance-tracking';
+import EmptyContent from 'calypso/components/empty-content';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 
 /**
  * Image dependencies
  */
-import charactersImage from 'assets/images/reader/reader-conversations-characters.svg';
+import charactersImage from 'calypso/assets/images/reader/reader-conversations-characters.svg';
 
 class ConversationsEmptyContent extends React.Component {
 	shouldComponentUpdate() {

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -9,8 +9,8 @@ import { map, zipObject, fill, size, filter, get, compact, partition, min, noop 
 /**
  * Internal dependencies
  */
-import PostComment from 'blocks/comments/post-comment';
-import { POST_COMMENT_DISPLAY_TYPES } from 'state/comments/constants';
+import PostComment from 'calypso/blocks/comments/post-comment';
+import { POST_COMMENT_DISPLAY_TYPES } from 'calypso/state/comments/constants';
 import {
 	commentsFetchingStatus,
 	getActiveReplyCommentId,
@@ -19,13 +19,13 @@ import {
 	getExpansionsForPost,
 	getHiddenCommentsForPost,
 	getPostCommentsTree,
-} from 'state/comments/selectors';
-import ConversationCaterpillar from 'blocks/conversation-caterpillar';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import PostCommentFormRoot from 'blocks/comments/form-root';
-import { requestPostComments, requestComment, setActiveReply } from 'state/comments/actions';
-import { getErrorKey } from 'state/comments/utils';
-import { getCurrentUserId } from 'state/current-user/selectors';
+} from 'calypso/state/comments/selectors';
+import ConversationCaterpillar from 'calypso/blocks/conversation-caterpillar';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import PostCommentFormRoot from 'calypso/blocks/comments/form-root';
+import { requestPostComments, requestComment, setActiveReply } from 'calypso/state/comments/actions';
+import { getErrorKey } from 'calypso/state/comments/utils';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 
 /**
  * Style dependencies

--- a/client/blocks/credit-card-form/docs/example.jsx
+++ b/client/blocks/credit-card-form/docs/example.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import CreditCardForm from 'blocks/credit-card-form';
+import CreditCardForm from 'calypso/blocks/credit-card-form';
 
 const createCardToken = ( cardDetails, callback ) => callback( null, 'token' );
 const saveStoredCard = () => Promise.reject( { message: 'This is an example error.' } );

--- a/client/blocks/credit-card-form/helpers.js
+++ b/client/blocks/credit-card-form/helpers.js
@@ -7,13 +7,13 @@ import { camelCase, kebabCase, debounce } from 'lodash';
 /**
  * Internal dependencies
  */
-import notices from 'notices';
+import notices from 'calypso/notices';
 import {
 	handleRenewNowClick,
 	isRenewable,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
-} from 'lib/purchases';
-import wpcomFactory from 'lib/wp';
+} from 'calypso/lib/purchases';
+import wpcomFactory from 'calypso/lib/wp';
 
 const wpcom = wpcomFactory.undocumented();
 

--- a/client/blocks/credit-card-form/loading-placeholder.jsx
+++ b/client/blocks/credit-card-form/loading-placeholder.jsx
@@ -8,9 +8,9 @@ import React from 'react';
  * Internal Dependencies
  */
 import { Card, CompactCard } from '@automattic/components';
-import CreditCardFormFieldsLoadingPlaceholder from 'components/credit-card-form-fields/loading-placeholder';
-import FormButton from 'components/forms/form-button';
-import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
+import CreditCardFormFieldsLoadingPlaceholder from 'calypso/components/credit-card-form-fields/loading-placeholder';
+import FormButton from 'calypso/components/forms/form-button';
+import LoadingPlaceholder from 'calypso/me/purchases/components/loading-placeholder';
 
 const CreditCardFormLoadingPlaceholder = ( { title, isFullWidth } ) => {
 	return (

--- a/client/blocks/credit-card-form/test/index.js
+++ b/client/blocks/credit-card-form/test/index.js
@@ -14,7 +14,7 @@ import React from 'react';
  */
 import { CreditCardForm } from '../';
 import { getParamsForApi } from '../helpers';
-import CreditCardFormFields from 'components/credit-card-form-fields';
+import CreditCardFormFields from 'calypso/components/credit-card-form-fields';
 
 describe( 'Credit Card Form', () => {
 	const defaultProps = {

--- a/client/blocks/daily-post-button/docs/example.jsx
+++ b/client/blocks/daily-post-button/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import DailyPostButton from 'blocks/daily-post-button';
+import DailyPostButton from 'calypso/blocks/daily-post-button';
 const DailyPostButtonExample = () => {
 	return (
 		<div className="design-assets__group">

--- a/client/blocks/daily-post-button/helper.js
+++ b/client/blocks/daily-post-button/helper.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import config from 'config';
+import config from 'calypso/config';
 
 const types = {
 	dp_prompt: 'prompt',

--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -7,22 +7,22 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
 import { get, defer } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 
 /**
  * Internal Dependencies
  */
-import AsyncLoad from 'components/async-load';
+import AsyncLoad from 'calypso/components/async-load';
 import { translate } from 'i18n-calypso';
-import { preloadEditor } from 'sections-preloaders';
+import { preloadEditor } from 'calypso/sections-preloaders';
 import { Button } from '@automattic/components';
-import { markPostSeen } from 'state/reader/posts/actions';
-import { recordGaEvent, recordAction, recordTrackForPost } from 'reader/stats';
+import { markPostSeen } from 'calypso/state/reader/posts/actions';
+import { recordGaEvent, recordAction, recordTrackForPost } from 'calypso/reader/stats';
 import { getDailyPostType } from './helper';
-import getPrimarySiteId from 'state/selectors/get-primary-site-id';
-import { getSiteSlug } from 'state/sites/selectors';
-import { getCurrentUser } from 'state/current-user/selectors';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 /**
  * Style dependencies
@@ -132,7 +132,7 @@ export class DailyPostButton extends React.Component {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<AsyncLoad
-				require="components/sites-popover"
+				require="calypso/components/sites-popover"
 				placeholder={ null }
 				key="menu"
 				header={ <div> { translate( 'Post on' ) } </div> }

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
@@ -13,19 +13,19 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
-import HappychatButton from 'components/happychat/button';
-import QueryRewindState from 'components/data/query-rewind-state';
+import HappychatButton from 'calypso/components/happychat/button';
+import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import {
 	recordGoogleEvent as recordGoogleEventAction,
 	recordTracksEvent as recordTracksEventAction,
 	withAnalytics,
-} from 'state/analytics/actions';
-import { disconnect } from 'state/jetpack/connection/actions';
-import { setAllSitesSelected, navigate } from 'state/ui/actions';
-import { successNotice, errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
-import { getPlanClass } from 'lib/plans';
-import { getSiteSlug, getSiteTitle, getSitePlanSlug } from 'state/sites/selectors';
-import getRewindState from 'state/selectors/get-rewind-state';
+} from 'calypso/state/analytics/actions';
+import { disconnect } from 'calypso/state/jetpack/connection/actions';
+import { setAllSitesSelected, navigate } from 'calypso/state/ui/actions';
+import { successNotice, errorNotice, infoNotice, removeNotice } from 'calypso/state/notices/actions';
+import { getPlanClass } from 'calypso/lib/plans';
+import { getSiteSlug, getSiteTitle, getSitePlanSlug } from 'calypso/state/sites/selectors';
+import getRewindState from 'calypso/state/selectors/get-rewind-state';
 
 /**
  * Style dependencies

--- a/client/blocks/dismissible-card/docs/example.jsx
+++ b/client/blocks/dismissible-card/docs/example.jsx
@@ -12,7 +12,7 @@ import { partial } from 'lodash';
  */
 import { Button } from '@automattic/components';
 import DismissibleCard from '../';
-import { savePreference } from 'state/preferences/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
 
 function DismissibleCardExample( { clearPreference } ) {
 	return (

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -7,15 +7,15 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { noop, flow } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import QueryPreferences from 'components/data/query-preferences';
-import { savePreference, setPreference } from 'state/preferences/actions';
-import { getPreference, hasReceivedRemotePreferences } from 'state/preferences/selectors';
+import QueryPreferences from 'calypso/components/data/query-preferences';
+import { savePreference, setPreference } from 'calypso/state/preferences/actions';
+import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 
 /**
  * Style dependencies

--- a/client/blocks/domain-tip/docs/example.jsx
+++ b/client/blocks/domain-tip/docs/example.jsx
@@ -10,7 +10,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import DomainTip from '../index';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 const DomainTipExample = ( { siteId } ) => (
 	<DomainTip siteId={ siteId } event="domain_app_example" />

--- a/client/blocks/domain-tip/index.jsx
+++ b/client/blocks/domain-tip/index.jsx
@@ -9,16 +9,16 @@ import React, { Fragment } from 'react';
 /**
  * Internal dependencies
  */
-import { getSite, getSiteSlug } from 'state/sites/selectors';
-import { hasDomainCredit } from 'state/sites/plans/selectors';
-import { getDomainsSuggestions } from 'state/domains/suggestions/selectors';
-import { currentUserHasFlag } from 'state/current-user/selectors';
-import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
-import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import UpsellNudge from 'blocks/upsell-nudge';
-import { FEATURE_CUSTOM_DOMAIN } from 'lib/plans/constants';
-import { isFreePlan } from 'lib/products-values';
-import { getSuggestionsVendor } from 'lib/domains/suggestions';
+import { getSite, getSiteSlug } from 'calypso/state/sites/selectors';
+import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
+import { getDomainsSuggestions } from 'calypso/state/domains/suggestions/selectors';
+import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
+import QueryDomainsSuggestions from 'calypso/components/data/query-domains-suggestions';
+import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { FEATURE_CUSTOM_DOMAIN } from 'calypso/lib/plans/constants';
+import { isFreePlan } from 'calypso/lib/products-values';
+import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 
 function getQueryObject( site, siteSlug, vendor ) {
 	if ( ! site || ! siteSlug ) {

--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -7,30 +7,30 @@ import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import path from 'path';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
 import { ALLOWED_FILE_EXTENSIONS } from './constants';
-import { AspectRatios } from 'state/editor/image-editor/constants';
+import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
 import { Dialog } from '@automattic/components';
-import FilePicker from 'components/file-picker';
-import { getCurrentUser } from 'state/current-user/selectors';
-import Gravatar from 'components/gravatar';
-import { isCurrentUserUploadingGravatar } from 'state/current-user/gravatar-status/selectors';
-import { resetAllImageEditorState } from 'state/editor/image-editor/actions';
-import Spinner from 'components/spinner';
+import FilePicker from 'calypso/components/file-picker';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import Gravatar from 'calypso/components/gravatar';
+import { isCurrentUserUploadingGravatar } from 'calypso/state/current-user/gravatar-status/selectors';
+import { resetAllImageEditorState } from 'calypso/state/editor/image-editor/actions';
+import Spinner from 'calypso/components/spinner';
 import {
 	receiveGravatarImageFailed,
 	uploadGravatar,
-} from 'state/current-user/gravatar-status/actions';
-import ImageEditor from 'blocks/image-editor';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
-import VerifyEmailDialog from 'components/email-verification/email-verification-dialog';
-import DropZone from 'components/drop-zone';
-import { recordTracksEvent, recordGoogleEvent, composeAnalytics } from 'state/analytics/actions';
+} from 'calypso/state/current-user/gravatar-status/actions';
+import ImageEditor from 'calypso/blocks/image-editor';
+import InfoPopover from 'calypso/components/info-popover';
+import ExternalLink from 'calypso/components/external-link';
+import VerifyEmailDialog from 'calypso/components/email-verification/email-verification-dialog';
+import DropZone from 'calypso/components/drop-zone';
+import { recordTracksEvent, recordGoogleEvent, composeAnalytics } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/blocks/edit-gravatar/test/index.jsx
+++ b/client/blocks/edit-gravatar/test/index.jsx
@@ -13,8 +13,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { AspectRatios } from 'state/editor/image-editor/constants';
-import { useSandbox } from 'test-helpers/use-sinon';
+import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 jest.mock( 'event', () => require( 'component-event' ), { virtual: true } );
 jest.mock( 'lib/oauth-token', () => ( {
@@ -37,12 +37,12 @@ describe( 'EditGravatar', () => {
 	} );
 
 	beforeAll( function () {
-		EditGravatar = require( 'blocks/edit-gravatar' ).EditGravatar;
-		FilePicker = require( 'components/file-picker' );
-		Gravatar = require( 'components/gravatar' ).default;
-		ImageEditor = require( 'blocks/image-editor' );
-		VerifyEmailDialog = require( 'components/email-verification/email-verification-dialog' );
-		DropZone = require( 'components/drop-zone' ).default;
+		EditGravatar = require( 'calypso/blocks/edit-gravatar' ).EditGravatar;
+		FilePicker = require( 'calypso/components/file-picker' );
+		Gravatar = require( 'calypso/components/gravatar' ).default;
+		ImageEditor = require( 'calypso/blocks/image-editor' );
+		VerifyEmailDialog = require( 'calypso/components/email-verification/email-verification-dialog' );
+		DropZone = require( 'calypso/components/drop-zone' ).default;
 	} );
 
 	describe( 'component rendering', () => {

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -3,16 +3,16 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import wp from 'lib/wp';
+import wp from 'calypso/lib/wp';
 import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import { StripeHookProvider } from 'lib/stripe';
-import { fetchStripeConfiguration } from 'my-sites/checkout/composite-checkout/payment-method-helpers';
-import CompositeCheckout from 'my-sites/checkout/composite-checkout/composite-checkout';
-import { getSelectedSite } from 'state/ui/selectors';
+import { StripeHookProvider } from 'calypso/lib/stripe';
+import { fetchStripeConfiguration } from 'calypso/my-sites/checkout/composite-checkout/payment-method-helpers';
+import CompositeCheckout from 'calypso/my-sites/checkout/composite-checkout/composite-checkout';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 /**
  * Style dependencies

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -10,11 +10,11 @@ import React from 'react';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import CardHeading from 'components/card-heading';
-import Gridicon from 'components/gridicon';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import { localizeUrl } from 'lib/i18n-utils';
+import CardHeading from 'calypso/components/card-heading';
+import Gridicon from 'calypso/components/gridicon';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 // Mapping eligibility holds to messages that will be shown to the user
 function getHoldMessages( context: string | null, translate: LocalizeProps[ 'translate' ] ) {

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { union, includes, noop } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import page from 'page';
 
 /**
@@ -17,19 +17,19 @@ import {
 	FEATURE_PERFORMANCE,
 	FEATURE_UPLOAD_THEMES,
 	FEATURE_SFTP,
-} from 'lib/plans/constants';
-import TrackComponentView from 'lib/analytics/track-component-view';
-import { recordTracksEvent } from 'state/analytics/actions';
-import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+} from 'calypso/lib/plans/constants';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getEligibility, isEligibleForAutomatedTransfer } from 'calypso/state/automated-transfer/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { Button, CompactCard } from '@automattic/components';
-import QueryEligibility from 'components/data/query-atat-eligibility';
+import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import HoldList, { hasBlockingHold } from './hold-list';
 import WarningList from './warning-list';
-import { launchSite } from 'state/sites/launch/actions';
-import { isSavingSiteSettings } from 'state/site-settings/selectors';
-import { saveSiteSettings } from 'state/site-settings/actions';
-import getRequest from 'state/selectors/get-request';
+import { launchSite } from 'calypso/state/sites/launch/actions';
+import { isSavingSiteSettings } from 'calypso/state/site-settings/selectors';
+import { saveSiteSettings } from 'calypso/state/site-settings/actions';
+import getRequest from 'calypso/state/selectors/get-request';
 
 /**
  * Style dependencies

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -4,13 +4,13 @@
 import React from 'react';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
-import ActionPanelLink from 'components/action-panel/link';
+import ExternalLink from 'calypso/components/external-link';
+import ActionPanelLink from 'calypso/components/action-panel/link';
 
 interface ExternalProps {
 	context: string | null;

--- a/client/blocks/extension-redirect/index.jsx
+++ b/client/blocks/extension-redirect/index.jsx
@@ -11,10 +11,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import versionCompare from 'lib/version-compare';
-import { getSiteSlug } from 'state/sites/selectors';
-import { getPluginOnSite, isRequesting } from 'state/plugins/installed/selectors';
-import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
+import versionCompare from 'calypso/lib/version-compare';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getPluginOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 
 class ExtensionRedirect extends Component {
 	static propTypes = {

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Style dependencies

--- a/client/blocks/follow-button/docs/example.jsx
+++ b/client/blocks/follow-button/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FollowButton from 'blocks/follow-button/button';
+import FollowButton from 'calypso/blocks/follow-button/button';
 import { CompactCard as Card } from '@automattic/components';
 
 export default class FollowButtonExample extends React.PureComponent {

--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -10,8 +10,8 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import FollowButton from './button';
-import { isFollowing } from 'state/reader/follows/selectors';
-import { follow, unfollow } from 'state/reader/follows/actions';
+import { isFollowing } from 'calypso/state/reader/follows/selectors';
+import { follow, unfollow } from 'calypso/state/reader/follows/actions';
 
 class FollowButtonContainer extends Component {
 	static propTypes = {

--- a/client/blocks/followers-count/index.jsx
+++ b/client/blocks/followers-count/index.jsx
@@ -11,11 +11,11 @@ import { get, isNumber } from 'lodash';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import Count from 'components/count';
-import QuerySiteStats from 'components/data/query-site-stats';
-import { getSelectedSite } from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
-import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
+import Count from 'calypso/components/count';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 
 class FollowersCount extends Component {
 	render() {

--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -13,11 +13,11 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
-import { localizeUrl } from 'lib/i18n-utils';
-import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
-import { decodeEntities, preventWidows } from 'lib/formatting';
-import { isCurrentUserMaybeInGdprZone } from 'lib/analytics/utils';
-import { isWpMobileApp } from 'lib/mobile-app';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
+import { isCurrentUserMaybeInGdprZone } from 'calypso/lib/analytics/utils';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
 
 /**
  * Internal dependencies

--- a/client/blocks/get-apps/apps-badge.jsx
+++ b/client/blocks/get-apps/apps-badge.jsx
@@ -12,9 +12,9 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { getLocaleSlug } from 'lib/i18n-utils';
-import { recordTracksEvent } from 'state/analytics/actions';
-import TranslatableString from 'components/translatable/proptype';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import TranslatableString from 'calypso/components/translatable/proptype';
 
 /**
  * Style dependencies

--- a/client/blocks/get-apps/desktop-download-card.jsx
+++ b/client/blocks/get-apps/desktop-download-card.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Card, Button } from '@automattic/components';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 const WINDOWS_LINK = 'https://apps.wordpress.com/d/windows?ref=getapps';
 const MAC_LINK = 'https://apps.wordpress.com/d/osx?ref=getapps';

--- a/client/blocks/get-apps/illustration.jsx
+++ b/client/blocks/get-apps/illustration.jsx
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Image dependencies
  */
-import getAppsImage from 'assets/images/illustrations/get-apps-banner.svg';
+import getAppsImage from 'calypso/assets/images/illustrations/get-apps-banner.svg';
 
 const GetAppsIllustration = ( { translate } ) => (
 	<div className="get-apps__illustration">

--- a/client/blocks/get-apps/index.jsx
+++ b/client/blocks/get-apps/index.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import GetAppsIllustration from './illustration.jsx';
 import DesktopDownloadCard from './desktop-download-card.jsx';
 import MobileDownloadCard from './mobile-download-card.jsx';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Style dependencies

--- a/client/blocks/get-apps/mobile-download-card.jsx
+++ b/client/blocks/get-apps/mobile-download-card.jsx
@@ -11,26 +11,26 @@ import i18n, { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import AppsBadge from './apps-badge';
-import ReauthRequired from 'me/reauth-required';
+import ReauthRequired from 'calypso/me/reauth-required';
 import { Card, Button } from '@automattic/components';
-import QuerySmsCountries from 'components/data/query-countries/sms';
-import FormPhoneInput from 'components/forms/form-phone-input';
-import getCountries from 'state/selectors/get-countries';
-import { successNotice, errorNotice } from 'state/notices/actions';
-import { fetchUserSettings } from 'state/user-settings/actions';
-import { accountRecoverySettingsFetch } from 'state/account-recovery/settings/actions';
+import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
+import FormPhoneInput from 'calypso/components/forms/form-phone-input';
+import getCountries from 'calypso/state/selectors/get-countries';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { fetchUserSettings } from 'calypso/state/user-settings/actions';
+import { accountRecoverySettingsFetch } from 'calypso/state/account-recovery/settings/actions';
 import {
 	getAccountRecoveryPhone,
 	isAccountRecoverySettingsReady,
-} from 'state/account-recovery/settings/selectors';
-import getUserSettings from 'state/selectors/get-user-settings';
-import hasUserSettings from 'state/selectors/has-user-settings';
-import { http } from 'state/data-layer/wpcom-http/actions';
-import phoneValidation from 'lib/phone-validation';
-import userAgent from 'lib/user-agent';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
-import { sendEmailLogin } from 'state/auth/actions';
+} from 'calypso/state/account-recovery/settings/selectors';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import hasUserSettings from 'calypso/state/selectors/has-user-settings';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import phoneValidation from 'calypso/lib/phone-validation';
+import userAgent from 'calypso/lib/user-agent';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
+import { sendEmailLogin } from 'calypso/state/auth/actions';
 
 function sendSMS( phone ) {
 	function onSuccess( dispatch ) {

--- a/client/blocks/global-notice/index.js
+++ b/client/blocks/global-notice/index.js
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { infoNotice, removeNotice } from 'state/notices/actions';
+import { infoNotice, removeNotice } from 'calypso/state/notices/actions';
 
 export class GlobalNotice extends Component {
 	static propTypes = {

--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -9,8 +9,8 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import ImageEditor from '../';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { AspectRatios } from 'state/editor/image-editor/constants';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
 
 class ImageEditorExample extends Component {
 	constructor() {

--- a/client/blocks/image-editor/image-editor-buttons.jsx
+++ b/client/blocks/image-editor/image-editor-buttons.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import { getImageEditorFileInfo, imageEditorHasChanges } from 'state/editor/image-editor/selectors';
+import { getImageEditorFileInfo, imageEditorHasChanges } from 'calypso/state/editor/image-editor/selectors';
 
 class ImageEditorButtons extends Component {
 	static propTypes = {

--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -11,18 +11,18 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import ImageEditorCrop from './image-editor-crop';
-import { canvasToBlob } from 'lib/media/utils';
+import { canvasToBlob } from 'calypso/lib/media/utils';
 import {
 	getImageEditorTransform,
 	getImageEditorFileInfo,
 	getImageEditorCrop,
 	isImageEditorImageLoaded,
-} from 'state/editor/image-editor/selectors';
+} from 'calypso/state/editor/image-editor/selectors';
 import {
 	setImageEditorCropBounds,
 	setImageEditorImageHasLoaded,
-} from 'state/editor/image-editor/actions';
-import getImageEditorIsGreaterThanMinimumDimensions from 'state/selectors/get-image-editor-is-greater-than-minimum-dimensions';
+} from 'calypso/state/editor/image-editor/actions';
+import getImageEditorIsGreaterThanMinimumDimensions from 'calypso/state/selectors/get-image-editor-is-greater-than-minimum-dimensions';
 
 export class ImageEditorCanvas extends Component {
 	static propTypes = {

--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -10,18 +10,18 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import Draggable from 'components/draggable';
+import Draggable from 'calypso/components/draggable';
 import {
 	getImageEditorCropBounds,
 	getImageEditorAspectRatio,
 	getImageEditorTransform,
 	getImageEditorCrop,
 	imageEditorHasChanges,
-} from 'state/editor/image-editor/selectors';
-import { AspectRatios } from 'state/editor/image-editor/constants';
-import { imageEditorCrop, imageEditorComputedCrop } from 'state/editor/image-editor/actions';
-import { defaultCrop } from 'state/editor/image-editor/reducer';
-import getImageEditorOriginalAspectRatio from 'state/selectors/get-image-editor-original-aspect-ratio';
+} from 'calypso/state/editor/image-editor/selectors';
+import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
+import { imageEditorCrop, imageEditorComputedCrop } from 'calypso/state/editor/image-editor/actions';
+import { defaultCrop } from 'calypso/state/editor/image-editor/reducer';
+import getImageEditorOriginalAspectRatio from 'calypso/state/selectors/get-image-editor-original-aspect-ratio';
 
 class ImageEditorCrop extends Component {
 	static propTypes = {

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -6,22 +6,22 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { noop, values as objectValues } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import PopoverMenu from 'components/popover/menu';
-import PopoverMenuItem from 'components/popover/menu-item';
-import { AspectRatios, MinimumImageDimensions } from 'state/editor/image-editor/constants';
-import { getImageEditorAspectRatio } from 'state/editor/image-editor/selectors';
+import PopoverMenu from 'calypso/components/popover/menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import { AspectRatios, MinimumImageDimensions } from 'calypso/state/editor/image-editor/constants';
+import { getImageEditorAspectRatio } from 'calypso/state/editor/image-editor/selectors';
 import {
 	imageEditorRotateCounterclockwise,
 	imageEditorFlip,
 	setImageEditorAspectRatio,
-} from 'state/editor/image-editor/actions';
-import getImageEditorIsGreaterThanMinimumDimensions from 'state/selectors/get-image-editor-is-greater-than-minimum-dimensions';
+} from 'calypso/state/editor/image-editor/actions';
+import getImageEditorIsGreaterThanMinimumDimensions from 'calypso/state/selectors/get-image-editor-is-greater-than-minimum-dimensions';
 
 export class ImageEditorToolbar extends Component {
 	static propTypes = {

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -13,26 +13,26 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import CloseOnEscape from 'components/close-on-escape';
-import Notice from 'components/notice';
+import CloseOnEscape from 'calypso/components/close-on-escape';
+import Notice from 'calypso/components/notice';
 import ImageEditorCanvas from './image-editor-canvas';
 import ImageEditorToolbar from './image-editor-toolbar';
 import ImageEditorButtons from './image-editor-buttons';
-import { getMimeType, url } from 'lib/media/utils';
+import { getMimeType, url } from 'calypso/lib/media/utils';
 import {
 	resetImageEditorState,
 	resetAllImageEditorState,
 	setImageEditorFileInfo,
 	setImageEditorDefaultAspectRatio,
-} from 'state/editor/image-editor/actions';
+} from 'calypso/state/editor/image-editor/actions';
 import {
 	getImageEditorFileInfo,
 	isImageEditorImageLoaded,
-} from 'state/editor/image-editor/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSite } from 'state/sites/selectors';
-import QuerySites from 'components/data/query-sites';
-import { AspectRatios, AspectRatiosValues } from 'state/editor/image-editor/constants';
+} from 'calypso/state/editor/image-editor/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
+import QuerySites from 'calypso/components/data/query-sites';
+import { AspectRatios, AspectRatiosValues } from 'calypso/state/editor/image-editor/constants';
 import { getDefaultAspectRatio } from './utils';
 
 /**

--- a/client/blocks/image-editor/test/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/test/image-editor-toolbar.jsx
@@ -14,7 +14,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { ImageEditorToolbar } from '../image-editor-toolbar';
-import { useSandbox } from 'test-helpers/use-sinon';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'ImageEditorToolbar', () => {
 	let defaultProps, wrapper;

--- a/client/blocks/image-editor/test/utils.js
+++ b/client/blocks/image-editor/test/utils.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { AspectRatios } from 'state/editor/image-editor/constants';
+import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
 import { getDefaultAspectRatio } from '../utils';
 
 describe( 'getDefaultAspectRatio', () => {

--- a/client/blocks/image-editor/utils.js
+++ b/client/blocks/image-editor/utils.js
@@ -7,7 +7,7 @@ import { includes, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { AspectRatios, AspectRatiosValues } from 'state/editor/image-editor/constants';
+import { AspectRatios, AspectRatiosValues } from 'calypso/state/editor/image-editor/constants';
 
 /**
  * Returns the default aspect ratio image editor should use.

--- a/client/blocks/image-selector/docs/example.jsx
+++ b/client/blocks/image-selector/docs/example.jsx
@@ -8,8 +8,8 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import ImageSelector from 'blocks/image-selector';
-import { getCurrentUser } from 'state/current-user/selectors';
+import ImageSelector from 'calypso/blocks/image-selector';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 class ImageSelectorExample extends Component {
 	constructor( props ) {

--- a/client/blocks/image-selector/dropzone.jsx
+++ b/client/blocks/image-selector/dropzone.jsx
@@ -10,13 +10,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import DropZone from 'components/drop-zone';
-import { filterItemsByMimePrefix } from 'lib/media/utils';
+import DropZone from 'calypso/components/drop-zone';
+import { filterItemsByMimePrefix } from 'calypso/lib/media/utils';
 import ImageSelectorDropZoneIcon from './dropzone-icon';
 
-import { addMedia } from 'state/media/thunks';
-import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
-import { getSite } from 'state/sites/selectors';
+import { addMedia } from 'calypso/state/media/thunks';
+import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
 
 class ImageSelectorDropZone extends Component {
 	static propTypes = {

--- a/client/blocks/image-selector/index.jsx
+++ b/client/blocks/image-selector/index.jsx
@@ -13,11 +13,11 @@ import { noop } from 'lodash';
  */
 import ImageSelectorPreview from './preview';
 import ImageSelectorDropZone from './dropzone';
-import isDropZoneVisible from 'state/selectors/is-drop-zone-visible';
-import MediaModal from 'post-editor/media-modal';
+import isDropZoneVisible from 'calypso/state/selectors/is-drop-zone-visible';
+import MediaModal from 'calypso/post-editor/media-modal';
 import { localize } from 'i18n-calypso';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { setMediaLibrarySelectedItems } from 'state/media/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
 
 /**
  * Style dependencies

--- a/client/blocks/image-selector/preview.jsx
+++ b/client/blocks/image-selector/preview.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isEqual, uniq } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -14,10 +14,10 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import ImagePreloader from 'components/image-preloader';
-import Spinner from 'components/spinner';
-import { url } from 'lib/media/utils';
-import { fetchMediaItem, getMediaItem } from 'state/media/thunks';
+import ImagePreloader from 'calypso/components/image-preloader';
+import Spinner from 'calypso/components/spinner';
+import { url } from 'calypso/lib/media/utils';
+import { fetchMediaItem, getMediaItem } from 'calypso/state/media/thunks';
 
 export class ImageSelectorPreview extends Component {
 	static propTypes = {

--- a/client/blocks/image-selector/test/index.jsx
+++ b/client/blocks/image-selector/test/index.jsx
@@ -19,7 +19,7 @@ import { ImageSelector } from '../';
 
 jest.mock( 'event', () => {}, { virtual: true } );
 jest.mock( 'lib/media/store', () => ( {
-	dispatchToken: require( 'dispatcher' ).register( () => {} ),
+	dispatchToken: require( 'calypso/dispatcher' ).register( () => {} ),
 	get: ( siteId, itemId ) => require( './fixtures' ).DUMMY_MEDIA[ itemId ],
 	on: () => {},
 } ) );

--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -3,13 +3,13 @@
  */
 import { intersection, words, memoize } from 'lodash';
 import { translate } from 'i18n-calypso';
-import { getCustomizerUrl } from 'state/sites/selectors';
+import { getCustomizerUrl } from 'calypso/state/sites/selectors';
 
 /**
  * Internal Dependencies
  */
-import config from 'config';
-import { getLocaleSlug } from 'lib/i18n-utils';
+import config from 'calypso/config';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { SUPPORT_TYPE_ADMIN_SECTION } from './constants';
 
 /**

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -8,7 +8,7 @@ import i18n, { translate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import { RESULT_TOUR, RESULT_VIDEO } from './constants';
-import { localizeUrl } from 'lib/i18n-utils';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 /**
  * Module variables

--- a/client/blocks/inline-help/dialog.jsx
+++ b/client/blocks/inline-help/dialog.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button, Dialog } from '@automattic/components';
-import ResizableIframe from 'components/resizable-iframe';
+import ResizableIframe from 'calypso/components/resizable-iframe';
 
 /**
  * Style dependencies

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -8,23 +8,23 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import debugFactory from 'debug';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal Dependencies
  */
-import config from 'config';
-import { recordTracksEvent } from 'state/analytics/actions';
-import getGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
+import config from 'calypso/config';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getGlobalKeyboardShortcuts from 'calypso/lib/keyboard-shortcuts/global';
 import { Button, RootChild } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
-import HappychatButton from 'components/happychat/button';
-import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
-import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
-import AsyncLoad from 'components/async-load';
-import { showInlineHelpPopover, hideInlineHelpPopover } from 'state/inline-help/actions';
-import isInlineHelpPopoverVisible from 'state/inline-help/selectors/is-inline-help-popover-visible';
-import isInlineHelpVisible from 'state/selectors/is-inline-help-visible';
+import HappychatButton from 'calypso/components/happychat/button';
+import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
+import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
+import AsyncLoad from 'calypso/components/async-load';
+import { showInlineHelpPopover, hideInlineHelpPopover } from 'calypso/state/inline-help/actions';
+import isInlineHelpPopoverVisible from 'calypso/state/inline-help/selectors/is-inline-help-popover-visible';
+import isInlineHelpVisible from 'calypso/state/selectors/is-inline-help-visible';
 
 /**
  * Style dependencies
@@ -41,11 +41,11 @@ const globalKeyboardShortcuts = globalKeyBoardShortcutsEnabled
 const debug = debugFactory( 'calypso:inline-help' );
 
 const InlineHelpPopover = ( props ) => (
-	<AsyncLoad { ...props } require="blocks/inline-help/popover" placeholder={ null } />
+	<AsyncLoad { ...props } require="calypso/blocks/inline-help/popover" placeholder={ null } />
 );
 
 const InlineHelpDialog = ( props ) => (
-	<AsyncLoad { ...props } require="blocks/inline-help/dialog" placeholder={ null } />
+	<AsyncLoad { ...props } require="calypso/blocks/inline-help/dialog" placeholder={ null } />
 );
 
 class InlineHelp extends Component {
@@ -84,7 +84,7 @@ class InlineHelp extends Component {
 	// Preload the async chunk on mouse hover or touch start
 	preload = () => {
 		if ( ! this.preloaded ) {
-			asyncRequire( 'blocks/inline-help/popover' );
+			asyncRequire( 'calypso/blocks/inline-help/popover' );
 			this.preloaded = true;
 		}
 	};

--- a/client/blocks/inline-help/inline-help-compact-result.jsx
+++ b/client/blocks/inline-help/inline-help-compact-result.jsx
@@ -8,7 +8,7 @@ import { invoke } from 'lodash';
 /**
  * Internal dependencies
  */
-import { decodeEntities, preventWidows } from 'lib/formatting';
+import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 
 class InlineHelpCompactResult extends Component {
 	static propTypes = {

--- a/client/blocks/inline-help/inline-help-compact-results.jsx
+++ b/client/blocks/inline-help/inline-help-compact-results.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import InlineHelpCompactResult from 'blocks/inline-help/inline-help-compact-result';
+import InlineHelpCompactResult from 'calypso/blocks/inline-help/inline-help-compact-result';
 
 class InlineHelpCompactResults extends Component {
 	static propTypes = {

--- a/client/blocks/inline-help/inline-help-contact-view.jsx
+++ b/client/blocks/inline-help/inline-help-contact-view.jsx
@@ -7,15 +7,15 @@ import { connect } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import HelpContact from 'me/help/help-contact';
-import InlineHelpForumView from 'blocks/inline-help/inline-help-forum-view';
-import PlaceholderLines from 'blocks/inline-help/placeholder-lines';
+import HelpContact from 'calypso/me/help/help-contact';
+import InlineHelpForumView from 'calypso/blocks/inline-help/inline-help-forum-view';
+import PlaceholderLines from 'calypso/blocks/inline-help/placeholder-lines';
 import getInlineHelpSupportVariation, {
 	SUPPORT_FORUM,
-} from 'state/selectors/get-inline-help-support-variation';
-import { getHelpSelectedSite } from 'state/help/selectors';
-import isSupportVariationDetermined from 'state/selectors/is-support-variation-determined';
-import TrackComponentView from 'lib/analytics/track-component-view';
+} from 'calypso/state/selectors/get-inline-help-support-variation';
+import { getHelpSelectedSite } from 'calypso/state/help/selectors';
+import isSupportVariationDetermined from 'calypso/state/selectors/is-support-variation-determined';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 
 const InlineHelpContactView = ( {
 	/* eslint-disable no-shadow */

--- a/client/blocks/inline-help/inline-help-forum-view.jsx
+++ b/client/blocks/inline-help/inline-help-forum-view.jsx
@@ -9,9 +9,9 @@ import { identity } from 'lodash';
  * Internal Dependencies
  */
 import { Button } from '@automattic/components';
-import { preventWidows } from 'lib/formatting';
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import { localizeUrl } from 'lib/i18n-utils';
+import { preventWidows } from 'calypso/lib/formatting';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 const trackForumOpen = () =>
 	recordTracksEvent( 'calypso_inlinehelp_forums_open', {

--- a/client/blocks/inline-help/inline-help-query-support-types.jsx
+++ b/client/blocks/inline-help/inline-help-query-support-types.jsx
@@ -7,22 +7,22 @@ import { connect } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import config from 'config';
-import HappychatConnection from 'components/happychat/connection-connected';
-import QueryTicketSupportConfiguration from 'components/data/query-ticket-support-configuration';
-import QueryLanguageNames from 'components/data/query-language-names';
-import QuerySupportHistory from 'components/data/query-support-history';
-import { openChat as openHappychat } from 'state/happychat/ui/actions';
-import { initialize as initializeDirectly } from 'state/help/directly/actions';
-import { getCurrentUserEmail } from 'state/current-user/selectors';
-import { isRequestingSites } from 'state/sites/selectors';
-import { getHelpSelectedSiteId } from 'state/help/selectors';
+import config from 'calypso/config';
+import HappychatConnection from 'calypso/components/happychat/connection-connected';
+import QueryTicketSupportConfiguration from 'calypso/components/data/query-ticket-support-configuration';
+import QueryLanguageNames from 'calypso/components/data/query-language-names';
+import QuerySupportHistory from 'calypso/components/data/query-support-history';
+import { openChat as openHappychat } from 'calypso/state/happychat/ui/actions';
+import { initialize as initializeDirectly } from 'calypso/state/help/directly/actions';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
+import { isRequestingSites } from 'calypso/state/sites/selectors';
+import { getHelpSelectedSiteId } from 'calypso/state/help/selectors';
 import {
 	isTicketSupportConfigurationReady,
 	getTicketSupportRequestError,
-} from 'state/help/ticket/selectors';
-import isHappychatUserEligible from 'state/happychat/selectors/is-happychat-user-eligible';
-import isDirectlyUninitialized from 'state/selectors/is-directly-uninitialized';
+} from 'calypso/state/help/ticket/selectors';
+import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
+import isDirectlyUninitialized from 'calypso/state/selectors/is-directly-uninitialized';
 
 class QueryInlineHelpSupportTypes extends Component {
 	componentDidMount() {

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import classNames from 'classnames';
 import { get, isUndefined, omitBy } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal Dependencies
@@ -22,11 +22,11 @@ import {
 	RESULT_VIDEO,
 } from './constants';
 import { Button } from '@automattic/components';
-import { decodeEntities, preventWidows } from 'lib/formatting';
-import { recordTracksEvent } from 'state/analytics/actions';
-import getSearchQuery from 'state/inline-help/selectors/get-search-query';
-import { requestGuidedTour } from 'state/guided-tours/actions';
-import { openSupportArticleDialog } from 'state/inline-support-article/actions';
+import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
+import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
+import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
 
 const amendYouTubeLink = ( link = '' ) =>
 	link.replace( 'youtube.com/embed/', 'youtube.com/watch?v=' );

--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -11,11 +11,11 @@ import debugFactory from 'debug';
 /**
  * Internal Dependencies
  */
-import { recordTracksEvent } from 'state/analytics/actions';
-import SearchCard from 'components/search-card';
-import getInlineHelpCurrentlySelectedLink from 'state/inline-help/selectors/get-inline-help-currently-selected-link';
-import isRequestingInlineHelpSearchResultsForQuery from 'state/inline-help/selectors/is-requesting-inline-help-search-results-for-query';
-import { setInlineHelpSearchQuery } from 'state/inline-help/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import SearchCard from 'calypso/components/search-card';
+import getInlineHelpCurrentlySelectedLink from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-link';
+import isRequestingInlineHelpSearchResultsForQuery from 'calypso/state/inline-help/selectors/is-requesting-inline-help-search-results-for-query';
+import { setInlineHelpSearchQuery } from 'calypso/state/inline-help/actions';
 
 /**
  * Module variables

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -13,22 +13,22 @@ import { speak } from '@wordpress/a11y';
 /**
  * Internal Dependencies
  */
-import { recordTracksEvent } from 'state/analytics/actions';
-import QueryInlineHelpSearch from 'components/data/query-inline-help-search';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import QueryInlineHelpSearch from 'calypso/components/data/query-inline-help-search';
 import PlaceholderLines from './placeholder-lines';
-import { decodeEntities, preventWidows } from 'lib/formatting';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import { getSectionName } from 'state/ui/selectors';
-import getSearchResultsByQuery from 'state/inline-help/selectors/get-inline-help-search-results-for-query';
-import getSelectedResultIndex from 'state/inline-help/selectors/get-selected-result-index';
-import getInlineHelpCurrentlySelectedResult from 'state/inline-help/selectors/get-inline-help-currently-selected-result';
-import isRequestingInlineHelpSearchResultsForQuery from 'state/inline-help/selectors/is-requesting-inline-help-search-results-for-query';
-import hasInlineHelpAPIResults from 'state/selectors/has-inline-help-api-results';
-import hasCancelableUserPurchases from 'state/selectors/has-cancelable-user-purchases';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { selectResult } from 'state/inline-help/actions';
-import { localizeUrl } from 'lib/i18n-utils';
-import Gridicon from 'components/gridicon';
+import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import { getSectionName } from 'calypso/state/ui/selectors';
+import getSearchResultsByQuery from 'calypso/state/inline-help/selectors/get-inline-help-search-results-for-query';
+import getSelectedResultIndex from 'calypso/state/inline-help/selectors/get-selected-result-index';
+import getInlineHelpCurrentlySelectedResult from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-result';
+import isRequestingInlineHelpSearchResultsForQuery from 'calypso/state/inline-help/selectors/is-requesting-inline-help-search-results-for-query';
+import hasInlineHelpAPIResults from 'calypso/state/selectors/has-inline-help-api-results';
+import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { selectResult } from 'calypso/state/inline-help/actions';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import Gridicon from 'calypso/components/gridicon';
 import {
 	SUPPORT_TYPE_ADMIN_SECTION,
 	SUPPORT_TYPE_API_HELP,

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -7,7 +7,7 @@ import { flowRight as compose, noop } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
 import { __ } from '@wordpress/i18n';
 
@@ -15,17 +15,17 @@ import { __ } from '@wordpress/i18n';
  * Internal Dependencies
  */
 import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
-import { selectResult, resetInlineHelpContactForm } from 'state/inline-help/actions';
+import { selectResult, resetInlineHelpContactForm } from 'calypso/state/inline-help/actions';
 import { Button } from '@automattic/components';
-import Popover from 'components/popover';
+import Popover from 'calypso/components/popover';
 import InlineHelpSearchResults from './inline-help-search-results';
 import InlineHelpSearchCard from './inline-help-search-card';
 import InlineHelpRichResult from './inline-help-rich-result';
-import getSearchQuery from 'state/inline-help/selectors/get-search-query';
-import getInlineHelpCurrentlySelectedResult from 'state/inline-help/selectors/get-inline-help-currently-selected-result';
-import QuerySupportTypes from 'blocks/inline-help/inline-help-query-support-types';
-import InlineHelpContactView from 'blocks/inline-help/inline-help-contact-view';
-import { recordTracksEvent } from 'state/analytics/actions';
+import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
+import getInlineHelpCurrentlySelectedResult from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-result';
+import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
+import InlineHelpContactView from 'calypso/blocks/inline-help/inline-help-contact-view';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {

--- a/client/blocks/inline-help/test/admin-sections.js
+++ b/client/blocks/inline-help/test/admin-sections.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { filterListBySearchTerm } from 'blocks/inline-help/admin-sections';
+import { filterListBySearchTerm } from 'calypso/blocks/inline-help/admin-sections';
 
 describe( 'filterListBySearchTerm()', () => {
 	const mockCollection = [

--- a/client/blocks/jetpack-backup-creds-banner/index.jsx
+++ b/client/blocks/jetpack-backup-creds-banner/index.jsx
@@ -9,13 +9,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { settingsPath } from 'lib/jetpack/paths';
-import Banner from 'components/banner';
-import getRewindState from 'state/selectors/get-rewind-state';
-import QueryRewindState from 'components/data/query-rewind-state';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
-import jetpackDisconnected from 'assets/images/jetpack/disconnected.svg';
+import { settingsPath } from 'calypso/lib/jetpack/paths';
+import Banner from 'calypso/components/banner';
+import getRewindState from 'calypso/state/selectors/get-rewind-state';
+import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import jetpackDisconnected from 'calypso/assets/images/jetpack/disconnected.svg';
 
 /**
  * Style dependencies

--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -9,15 +9,15 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import TrackComponentView from 'lib/analytics/track-component-view';
-import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSite } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
-import { getTopJITM } from 'state/jitm/selectors';
-import { dismissJITM, setupDevTool } from 'state/jitm/actions';
-import AsyncLoad from 'components/async-load';
-import QueryJITM from 'components/data/query-jitm';
-import 'state/data-layer/wpcom/marketing';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getTopJITM } from 'calypso/state/jitm/selectors';
+import { dismissJITM, setupDevTool } from 'calypso/state/jitm/actions';
+import AsyncLoad from 'calypso/components/async-load';
+import QueryJITM from 'calypso/components/data/query-jitm';
+import 'calypso/state/data-layer/wpcom/marketing';
 
 /**
  * Style dependencies
@@ -28,14 +28,14 @@ const debug = debugFactory( 'calypso:jitm' );
 
 function renderTemplate( template, props ) {
 	if ( template === 'notice' ) {
-		return <AsyncLoad { ...props } require="blocks/jitm/templates/notice" />;
+		return <AsyncLoad { ...props } require="calypso/blocks/jitm/templates/notice" />;
 	}
 
 	if ( template === 'sidebar-banner' ) {
-		return <AsyncLoad { ...props } require="blocks/jitm/templates/sidebar-banner" />;
+		return <AsyncLoad { ...props } require="calypso/blocks/jitm/templates/sidebar-banner" />;
 	}
 
-	return <AsyncLoad { ...props } require="blocks/jitm/templates/default" />;
+	return <AsyncLoad { ...props } require="calypso/blocks/jitm/templates/default" />;
 }
 
 function getEventHandlers( props, dispatch ) {

--- a/client/blocks/jitm/templates/default.jsx
+++ b/client/blocks/jitm/templates/default.jsx
@@ -7,7 +7,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import UpsellNudge from 'blocks/upsell-nudge';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 export default function DefaultTemplate( {
 	id,

--- a/client/blocks/jitm/templates/notice.jsx
+++ b/client/blocks/jitm/templates/notice.jsx
@@ -7,7 +7,7 @@ import { assign } from 'lodash';
 /**
  * Internal dependencies
  */
-import UpsellNudge from 'blocks/upsell-nudge';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 export default function NoticeTemplate( { id, CTA, tracks, ...props } ) {
 	const jitmProps = { id, cta_name: id, jitm: true };

--- a/client/blocks/jitm/templates/sidebar-banner.jsx
+++ b/client/blocks/jitm/templates/sidebar-banner.jsx
@@ -6,8 +6,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import UpsellNudge from 'blocks/upsell-nudge';
-import { preventWidows } from 'lib/formatting';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { preventWidows } from 'calypso/lib/formatting';
 
 /**
  * Style dependencies

--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -14,14 +14,14 @@ import { Button } from '@automattic/components';
 import {
 	deleteStoredKeyringConnection,
 	requestKeyringConnections,
-} from 'state/sharing/keyring/actions';
-import { getKeyringServiceByName } from 'state/sharing/services/selectors';
-import QueryKeyringServices from 'components/data/query-keyring-services';
+} from 'calypso/state/sharing/keyring/actions';
+import { getKeyringServiceByName } from 'calypso/state/sharing/services/selectors';
+import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import requestExternalAccess from '@automattic/request-external-access';
 import {
 	getKeyringConnectionsByName,
 	isKeyringConnectionsFetching,
-} from 'state/sharing/keyring/selectors';
+} from 'calypso/state/sharing/keyring/selectors';
 
 class KeyringConnectButton extends Component {
 	static propTypes = {

--- a/client/blocks/legal-updates-banner/index.js
+++ b/client/blocks/legal-updates-banner/index.js
@@ -9,10 +9,10 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { localizeUrl } from 'lib/i18n-utils';
-import { acceptTos, requestLegalData } from 'state/legal/actions';
-import { shouldDisplayTosUpdateBanner } from 'state/selectors/should-display-tos-update-banner';
-import ExternalLink from 'components/external-link';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { acceptTos, requestLegalData } from 'calypso/state/legal/actions';
+import { shouldDisplayTosUpdateBanner } from 'calypso/state/selectors/should-display-tos-update-banner';
+import ExternalLink from 'calypso/components/external-link';
 
 /**
  * Style dependencies

--- a/client/blocks/like-button/docs/example.jsx
+++ b/client/blocks/like-button/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import LikeButton from 'blocks/like-button/button';
+import LikeButton from 'calypso/blocks/like-button/button';
 import { CompactCard as Card } from '@automattic/components';
 
 class SimpleLikeButtonContainer extends React.PureComponent {

--- a/client/blocks/like-button/icons.jsx
+++ b/client/blocks/like-button/icons.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Style dependencies

--- a/client/blocks/like-button/index.jsx
+++ b/client/blocks/like-button/index.jsx
@@ -9,11 +9,11 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { like, unlike } from 'state/posts/likes/actions';
+import { like, unlike } from 'calypso/state/posts/likes/actions';
 import LikeButton from './button';
-import { getPostLikeCount } from 'state/posts/selectors/get-post-like-count';
-import { isLikedPost } from 'state/posts/selectors/is-liked-post';
-import QueryPostLikes from 'components/data/query-post-likes';
+import { getPostLikeCount } from 'calypso/state/posts/selectors/get-post-like-count';
+import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
+import QueryPostLikes from 'calypso/components/data/query-post-likes';
 
 class LikeButtonContainer extends Component {
 	static propTypes = {

--- a/client/blocks/location-search/docs/example.jsx
+++ b/client/blocks/location-search/docs/example.jsx
@@ -8,8 +8,8 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import LocationSearch from 'blocks/location-search';
-import { createNotice } from 'state/notices/actions';
+import LocationSearch from 'calypso/blocks/location-search';
+import { createNotice } from 'calypso/state/notices/actions';
 
 class LocationSearchExample extends Component {
 	static propTypes = {

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { loadScript } from '@automattic/load-script';
-import config from 'config';
+import config from 'calypso/config';
 import { getLocaleSlug } from 'i18n-calypso';
 import { identity, isEmpty, noop } from 'lodash';
 
@@ -12,10 +12,10 @@ import { identity, isEmpty, noop } from 'lodash';
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import SearchCard from 'components/search-card';
-import Search from 'components/search';
+import SearchCard from 'calypso/components/search-card';
+import Search from 'calypso/components/search';
 import Prediction from './prediction';
-import { Input } from 'my-sites/domains/components/form';
+import { Input } from 'calypso/my-sites/domains/components/form';
 
 /**
  * Style dependencies

--- a/client/blocks/location-search/prediction.jsx
+++ b/client/blocks/location-search/prediction.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -10,10 +10,10 @@ import { Button } from '@automattic/components';
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { getCurrentQueryArguments } from 'state/selectors/get-current-query-arguments';
-import Gravatar from 'components/gravatar';
+import wpcom from 'calypso/lib/wp';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
+import Gravatar from 'calypso/components/gravatar';
 
 /**
  * Style dependencies

--- a/client/blocks/login/docs/example.jsx
+++ b/client/blocks/login/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import LoginBlock from 'blocks/login';
+import LoginBlock from 'calypso/blocks/login';
 
 const LoginExample = () => (
 	<React.Fragment>

--- a/client/blocks/login/error-notice.jsx
+++ b/client/blocks/login/error-notice.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies
@@ -16,8 +16,8 @@ import {
 	getTwoFactorAuthRequestError,
 	getCreateSocialAccountError,
 	getRequestSocialAccountError,
-} from 'state/login/selectors';
-import Notice from 'components/notice';
+} from 'calypso/state/login/selectors';
+import Notice from 'calypso/components/notice';
 
 class ErrorNotice extends Component {
 	static propTypes = {

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -12,9 +12,9 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import Gridicon from 'components/gridicon';
-import config from 'config';
-import { sendEmailLogin } from 'state/auth/actions';
+import Gridicon from 'calypso/components/gridicon';
+import config from 'calypso/config';
+import { sendEmailLogin } from 'calypso/state/auth/actions';
 import {
 	getAuthAccountType,
 	getRedirectToOriginal,
@@ -25,29 +25,29 @@ import {
 	isTwoFactorAuthTypeSupported,
 	getSocialAccountIsLinking,
 	getSocialAccountLinkService,
-} from 'state/login/selectors';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { wasManualRenewalImmediateLoginAttempted } from 'state/immediate-login/selectors';
-import { getCurrentOAuth2Client } from 'state/oauth2-clients/ui/selectors';
-import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
-import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
-import { rebootAfterLogin } from 'state/login/actions';
-import { isPasswordlessAccount } from 'state/login/utils';
+} from 'calypso/state/login/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { wasManualRenewalImmediateLoginAttempted } from 'calypso/state/immediate-login/selectors';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
+import { rebootAfterLogin } from 'calypso/state/login/actions';
+import { isPasswordlessAccount } from 'calypso/state/login/utils';
 import {
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isWooOAuth2Client,
-} from 'lib/oauth2-clients';
-import { login } from 'lib/paths';
-import Notice from 'components/notice';
-import AsyncLoad from 'components/async-load';
-import VisitSite from 'blocks/visit-site';
-import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
+} from 'calypso/lib/oauth2-clients';
+import { login } from 'calypso/lib/paths';
+import Notice from 'calypso/components/notice';
+import AsyncLoad from 'calypso/components/async-load';
+import VisitSite from 'calypso/blocks/visit-site';
+import WooCommerceConnectCartHeader from 'calypso/extensions/woocommerce/components/woocommerce-connect-cart-header';
 import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
-import { isWebAuthnSupported } from 'lib/webauthn';
-import JetpackPlusWpComLogo from 'components/jetpack-plus-wpcom-logo';
+import { isWebAuthnSupported } from 'calypso/lib/webauthn';
+import JetpackPlusWpComLogo from 'calypso/components/jetpack-plus-wpcom-logo';
 
 /**
  * Style dependencies
@@ -288,7 +288,7 @@ class Login extends Component {
 								<div className={ classNames( 'login__woocommerce-logo' ) }>
 									<svg width={ 200 } viewBox={ '0 0 1270 170' }>
 										<AsyncLoad
-											require="components/jetpack-header/woocommerce"
+											require="calypso/components/jetpack-header/woocommerce"
 											darkColorScheme={ false }
 											placeholder={ null }
 										/>
@@ -341,7 +341,7 @@ class Login extends Component {
 			preHeader = (
 				<div className="login__jetpack-logo">
 					<AsyncLoad
-						require="components/jetpack-header"
+						require="calypso/components/jetpack-header"
 						placeholder={ null }
 						partnerSlug={ this.props.partnerSlug }
 						isWoo
@@ -362,7 +362,7 @@ class Login extends Component {
 			preHeader = (
 				<div className="login__jetpack-logo">
 					<AsyncLoad
-						require="components/jetpack-header"
+						require="calypso/components/jetpack-header"
 						placeholder={ null }
 						partnerSlug={ this.props.partnerSlug }
 						darkColorScheme
@@ -435,7 +435,7 @@ class Login extends Component {
 		if ( socialConnect ) {
 			return (
 				<AsyncLoad
-					require="blocks/login/social-connect-prompt"
+					require="calypso/blocks/login/social-connect-prompt"
 					onSuccess={ this.handleValidLogin }
 				/>
 			);
@@ -444,7 +444,7 @@ class Login extends Component {
 		if ( twoFactorEnabled ) {
 			return (
 				<AsyncLoad
-					require="blocks/login/two-factor-authentication/two-factor-content"
+					require="calypso/blocks/login/two-factor-authentication/two-factor-content"
 					isBrowserSupported={ this.state.isBrowserSupported }
 					isJetpack={ isJetpack }
 					isGutenboarding={ isGutenboarding }

--- a/client/blocks/login/social-connect-prompt.jsx
+++ b/client/blocks/login/social-connect-prompt.jsx
@@ -16,12 +16,12 @@ import {
 	getSocialAccountLinkAuthInfo,
 	getSocialAccountLinkService,
 	getRedirectToSanitized,
-} from 'state/login/selectors';
-import { connectSocialUser } from 'state/login/actions';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
-import SocialLogo from 'components/social-logo';
-import GoogleIcon from 'components/social-icons/google';
-import AppleIcon from 'components/social-icons/apple';
+} from 'calypso/state/login/selectors';
+import { connectSocialUser } from 'calypso/state/login/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+import SocialLogo from 'calypso/components/social-logo';
+import GoogleIcon from 'calypso/components/social-icons/google';
+import AppleIcon from 'calypso/components/social-icons/apple';
 
 /**
  * Style dependencies

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -5,27 +5,27 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import AppleLoginButton from 'components/social-buttons/apple';
-import GoogleLoginButton from 'components/social-buttons/google';
+import AppleLoginButton from 'calypso/components/social-buttons/apple';
+import GoogleLoginButton from 'calypso/components/social-buttons/google';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import config from 'config';
+import config from 'calypso/config';
 import { Card } from '@automattic/components';
-import { loginSocialUser, createSocialUser, createSocialUserFailed } from 'state/login/actions';
+import { loginSocialUser, createSocialUser, createSocialUserFailed } from 'calypso/state/login/actions';
 import {
 	getCreatedSocialAccountUsername,
 	getCreatedSocialAccountBearerToken,
 	getRedirectToOriginal,
 	isSocialAccountCreating,
-} from 'state/login/selectors';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
-import WpcomLoginForm from 'signup/wpcom-login-form';
-import { InfoNotice } from 'blocks/global-notice';
-import { localizeUrl } from 'lib/i18n-utils';
-import { login } from 'lib/paths';
+} from 'calypso/state/login/selectors';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+import WpcomLoginForm from 'calypso/signup/wpcom-login-form';
+import { InfoNotice } from 'calypso/blocks/global-notice';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { login } from 'calypso/lib/paths';
 
 /**
  * Style dependencies

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -13,15 +13,15 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FormsButton from 'components/forms/form-button';
-import FormPasswordInput from 'components/forms/form-password-input';
-import FormTextInput from 'components/forms/form-text-input';
+import FormsButton from 'calypso/components/forms/form-button';
+import FormPasswordInput from 'calypso/components/forms/form-password-input';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 
 describe( 'LoginForm', () => {
 	let LoginForm;
 
 	beforeAll( () => {
-		LoginForm = require( 'blocks/login/login-form' ).LoginForm;
+		LoginForm = require( 'calypso/blocks/login/login-form' ).LoginForm;
 	} );
 
 	describe( 'component rendering', () => {

--- a/client/blocks/login/two-factor-authentication/push-notification-approval-poller.jsx
+++ b/client/blocks/login/two-factor-authentication/push-notification-approval-poller.jsx
@@ -9,8 +9,8 @@ import { Component } from 'react';
 /**
  * Internal dependencies
  */
-import { startPollAppPushAuth, stopPollAppPushAuth } from 'state/login/actions';
-import { getTwoFactorPushPollSuccess } from 'state/login/selectors';
+import { startPollAppPushAuth, stopPollAppPushAuth } from 'calypso/state/login/actions';
+import { getTwoFactorPushPollSuccess } from 'calypso/state/login/selectors';
 
 class PushNotificationApprovalPoller extends Component {
 	static propTypes = {

--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -9,12 +9,12 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import FormButton from 'components/forms/form-button';
+import FormButton from 'calypso/components/forms/form-button';
 import { localize } from 'i18n-calypso';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
-import { formUpdate, loginUserWithSecurityKey } from 'state/login/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+import { formUpdate, loginUserWithSecurityKey } from 'calypso/state/login/actions';
 import TwoFactorActions from './two-factor-actions';
-import Spinner from 'components/spinner';
+import Spinner from 'calypso/components/spinner';
 
 /**
  * Style dependencies

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -12,10 +12,10 @@ import { connect } from 'react-redux';
 
 import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { isTwoFactorAuthTypeSupported } from 'state/login/selectors';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
-import { sendSmsCode } from 'state/login/actions';
-import { isWebAuthnSupported } from 'lib/webauthn';
+import { isTwoFactorAuthTypeSupported } from 'calypso/state/login/selectors';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+import { sendSmsCode } from 'calypso/state/login/actions';
+import { isWebAuthnSupported } from 'calypso/lib/webauthn';
 
 /**
  * Style dependencies

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -11,19 +11,19 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import FormButton from 'components/forms/form-button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormInputValidation from 'components/forms/form-input-validation';
-import FormLabel from 'components/forms/form-label';
-import FormVerificationCodeInput from 'components/forms/form-verification-code-input';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
 import { localize } from 'i18n-calypso';
-import { getTwoFactorAuthRequestError } from 'state/login/selectors';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
+import { getTwoFactorAuthRequestError } from 'calypso/state/login/selectors';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	formUpdate,
 	loginUserWithTwoFactorVerificationCode,
 	sendSmsCode,
-} from 'state/login/actions';
+} from 'calypso/state/login/actions';
 import TwoFactorActions from './two-factor-actions';
 
 /**

--- a/client/blocks/nps-survey/docs/example.jsx
+++ b/client/blocks/nps-survey/docs/example.jsx
@@ -10,8 +10,8 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import FormInputCheckbox from 'components/forms/form-checkbox';
-import FormLabel from 'components/forms/form-label';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
 import { NpsSurvey } from '../';
 import {
 	isNpsSurveySubmitted,
@@ -21,13 +21,13 @@ import {
 	getNpsSurveyName,
 	getNpsSurveyScore,
 	getNpsSurveyFeedback,
-} from 'state/nps-survey/selectors';
+} from 'calypso/state/nps-survey/selectors';
 import {
 	submitNpsSurvey,
 	submitNpsSurveyWithNoScore,
 	sendNpsSurveyFeedback,
-} from 'state/nps-survey/actions';
-import { successNotice } from 'state/notices/actions';
+} from 'calypso/state/nps-survey/actions';
+import { successNotice } from 'calypso/state/notices/actions';
 
 class NpsSurveyExample extends PureComponent {
 	state = {

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { PureComponent, Fragment } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';
@@ -13,18 +13,18 @@ import { isNumber, noop, trim } from 'lodash';
  * Internal dependencies
  */
 import { Button, Card, ScreenReaderText } from '@automattic/components';
-import FormTextArea from 'components/forms/form-textarea';
+import FormTextArea from 'calypso/components/forms/form-textarea';
 import {
 	submitNpsSurvey,
 	submitNpsSurveyWithNoScore,
 	sendNpsSurveyFeedback,
-} from 'state/nps-survey/actions';
-import { successNotice } from 'state/notices/actions';
-import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
-import { hasAnsweredNpsSurvey, isAvailableForConciergeSession } from 'state/nps-survey/selectors';
-import { CALYPSO_CONTACT } from 'lib/url/support';
-import { bumpStat } from 'lib/analytics/mc';
-import { recordTracksEvent } from 'lib/analytics/tracks';
+} from 'calypso/state/nps-survey/actions';
+import { successNotice } from 'calypso/state/notices/actions';
+import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import { hasAnsweredNpsSurvey, isAvailableForConciergeSession } from 'calypso/state/nps-survey/selectors';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import { bumpStat } from 'calypso/lib/analytics/mc';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import RecommendationSelect from './recommendation-select';
 
 /**

--- a/client/blocks/payment-methods/index.jsx
+++ b/client/blocks/payment-methods/index.jsx
@@ -3,15 +3,15 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { intersection } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-import PaymentLogo, { POSSIBLE_TYPES } from 'components/payment-logo';
-import { getEnabledPaymentMethods } from 'lib/cart-values';
+import PaymentLogo, { POSSIBLE_TYPES } from 'calypso/components/payment-logo';
+import { getEnabledPaymentMethods } from 'calypso/lib/cart-values';
 
 /**
  * Style dependencies

--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -11,8 +11,8 @@ import filesize from 'filesize';
  * Internal dependencies
  */
 import { ProgressBar } from '@automattic/components';
-import { planHasFeature } from 'lib/plans';
-import { FEATURE_UNLIMITED_STORAGE } from 'lib/plans/constants';
+import { planHasFeature } from 'calypso/lib/plans';
+import { FEATURE_UNLIMITED_STORAGE } from 'calypso/lib/plans/constants';
 
 const ALERT_PERCENT = 80;
 const WARN_PERCENT = 60;

--- a/client/blocks/plan-storage/docs/example.jsx
+++ b/client/blocks/plan-storage/docs/example.jsx
@@ -17,9 +17,9 @@ import {
 	PLAN_PREMIUM,
 	PLAN_PERSONAL,
 	PLAN_FREE,
-} from 'lib/plans/constants';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
+} from 'calypso/lib/plans/constants';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 const PlanStorageExample = ( { siteId, siteSlug } ) => {
 	const mediaStorage = {

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -10,13 +10,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import QueryMediaStorage from 'components/data/query-media-storage';
-import { getMediaStorage } from 'state/sites/media-storage/selectors';
-import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import canCurrentUser from 'state/selectors/can-current-user';
-import { planHasFeature, isBusinessPlan, isEcommercePlan } from 'lib/plans';
-import { FEATURE_UNLIMITED_STORAGE } from 'lib/plans/constants';
+import QueryMediaStorage from 'calypso/components/data/query-media-storage';
+import { getMediaStorage } from 'calypso/state/sites/media-storage/selectors';
+import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { planHasFeature, isBusinessPlan, isEcommercePlan } from 'calypso/lib/plans';
+import { FEATURE_UNLIMITED_STORAGE } from 'calypso/lib/plans/constants';
 import PlanStorageBar from './bar';
 import Tooltip from './tooltip';
 

--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -32,7 +32,7 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_FREE,
-} from 'lib/plans/constants';
+} from 'calypso/lib/plans/constants';
 
 /**
  * Internal dependencies

--- a/client/blocks/plan-storage/test/plan-storage.jsx
+++ b/client/blocks/plan-storage/test/plan-storage.jsx
@@ -18,7 +18,7 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_FREE,
-} from 'lib/plans/constants';
+} from 'calypso/lib/plans/constants';
 
 /**
  * Internal dependencies

--- a/client/blocks/plan-thank-you-card/docs/example.jsx
+++ b/client/blocks/plan-thank-you-card/docs/example.jsx
@@ -10,7 +10,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import PlanThankYouCard from '../';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 function PlanThankYouCardExample( { primarySiteId } ) {
 	return <PlanThankYouCard siteId={ primarySiteId } />;

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -12,12 +12,12 @@ import formatCurrency from '@automattic/format-currency';
  * Internal dependencies
  */
 import { ProductIcon } from '@automattic/components';
-import getRawSite from 'state/selectors/get-raw-site';
-import { getCurrentPlan } from 'state/sites/plans/selectors';
-import QuerySites from 'components/data/query-sites';
-import QuerySitePlans from 'components/data/query-site-plans';
-import { getPlan, getPlanClass } from 'lib/plans';
-import ThankYouCard from 'components/thank-you-card';
+import getRawSite from 'calypso/state/selectors/get-raw-site';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import QuerySites from 'calypso/components/data/query-sites';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import { getPlan, getPlanClass } from 'calypso/lib/plans';
+import ThankYouCard from 'calypso/components/thank-you-card';
 
 /**
  * Style dependencies

--- a/client/blocks/post-edit-button/docs/example.jsx
+++ b/client/blocks/post-edit-button/docs/example.jsx
@@ -8,7 +8,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import PostEditButton from 'blocks/post-edit-button';
+import PostEditButton from 'calypso/blocks/post-edit-button';
 
 export default class PostEditButtonExample extends React.PureComponent {
 	static displayName = 'PostEditButtonExample';

--- a/client/blocks/post-edit-button/index.jsx
+++ b/client/blocks/post-edit-button/index.jsx
@@ -4,13 +4,13 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import { getEditURL } from 'state/posts/utils';
+import { getEditURL } from 'calypso/state/posts/utils';
 
 /**
  * Style dependencies

--- a/client/blocks/post-item/docs/example.jsx
+++ b/client/blocks/post-item/docs/example.jsx
@@ -9,11 +9,11 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import QueryPosts from 'components/data/query-posts';
-import QuerySites from 'components/data/query-sites';
+import QueryPosts from 'calypso/components/data/query-posts';
+import QuerySites from 'calypso/components/data/query-sites';
 import PostItem from '../';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { getSitePosts } from 'state/posts/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getSitePosts } from 'calypso/state/posts/selectors';
 
 function PostItemExample( { primarySiteId, globalId } ) {
 	return (

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -11,26 +11,26 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import getEditorUrl from 'state/selectors/get-editor-url';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getNormalizedPost } from 'state/posts/selectors';
-import { isSingleUserSite } from 'state/sites/selectors';
-import areAllSitesSingleUser from 'state/selectors/are-all-sites-single-user';
-import { canCurrentUserEditPost } from 'state/posts/selectors/can-current-user-edit-post';
-import { isSharePanelOpen } from 'state/ui/post-type-list/selectors';
-import { hideActiveSharePanel } from 'state/ui/post-type-list/actions';
-import { bumpStat } from 'state/analytics/actions';
-import ExternalLink from 'components/external-link';
-import PostShare from 'blocks/post-share';
-import PostTypeListPostThumbnail from 'my-sites/post-type-list/post-thumbnail';
-import PostActionCounts from 'my-sites/post-type-list/post-action-counts';
-import PostActionsEllipsisMenu from 'my-sites/post-type-list/post-actions-ellipsis-menu';
-import PostActionsEllipsisMenuEdit from 'my-sites/post-type-list/post-actions-ellipsis-menu/edit';
-import PostActionsEllipsisMenuTrash from 'my-sites/post-type-list/post-actions-ellipsis-menu/trash';
-import PostTypeSiteInfo from 'my-sites/post-type-list/post-type-site-info';
-import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
-import { preloadEditor } from 'sections-preloaders';
-import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
+import getEditorUrl from 'calypso/state/selectors/get-editor-url';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getNormalizedPost } from 'calypso/state/posts/selectors';
+import { isSingleUserSite } from 'calypso/state/sites/selectors';
+import areAllSitesSingleUser from 'calypso/state/selectors/are-all-sites-single-user';
+import { canCurrentUserEditPost } from 'calypso/state/posts/selectors/can-current-user-edit-post';
+import { isSharePanelOpen } from 'calypso/state/ui/post-type-list/selectors';
+import { hideActiveSharePanel } from 'calypso/state/ui/post-type-list/actions';
+import { bumpStat } from 'calypso/state/analytics/actions';
+import ExternalLink from 'calypso/components/external-link';
+import PostShare from 'calypso/blocks/post-share';
+import PostTypeListPostThumbnail from 'calypso/my-sites/post-type-list/post-thumbnail';
+import PostActionCounts from 'calypso/my-sites/post-type-list/post-action-counts';
+import PostActionsEllipsisMenu from 'calypso/my-sites/post-type-list/post-actions-ellipsis-menu';
+import PostActionsEllipsisMenuEdit from 'calypso/my-sites/post-type-list/post-actions-ellipsis-menu/edit';
+import PostActionsEllipsisMenuTrash from 'calypso/my-sites/post-type-list/post-actions-ellipsis-menu/trash';
+import PostTypeSiteInfo from 'calypso/my-sites/post-type-list/post-type-site-info';
+import PostTypePostAuthor from 'calypso/my-sites/post-type-list/post-type-post-author';
+import { preloadEditor } from 'calypso/sections-preloaders';
+import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
 
 /**
  * Style dependencies

--- a/client/blocks/post-likes/docs/example.jsx
+++ b/client/blocks/post-likes/docs/example.jsx
@@ -7,8 +7,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FormLabel from 'components/forms/form-label';
-import FormCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import PostLikes from '../';
 import PostLikesPopover from '../popover';
 import { Button } from '@automattic/components';

--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -9,11 +9,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Gravatar from 'components/gravatar';
-import QueryPostLikes from 'components/data/query-post-likes';
-import { countPostLikes } from 'state/posts/selectors/count-post-likes';
-import { getPostLikes } from 'state/posts/selectors/get-post-likes';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import Gravatar from 'calypso/components/gravatar';
+import QueryPostLikes from 'calypso/components/data/query-post-likes';
+import { countPostLikes } from 'calypso/state/posts/selectors/count-post-likes';
+import { getPostLikes } from 'calypso/state/posts/selectors/get-post-likes';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/blocks/post-likes/popover.jsx
+++ b/client/blocks/post-likes/popover.jsx
@@ -9,10 +9,10 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import Popover from 'components/popover';
+import Popover from 'calypso/components/popover';
 import PostLikes from './index';
-import { getPostLikes } from 'state/posts/selectors/get-post-likes';
-import { countPostLikes } from 'state/posts/selectors/count-post-likes';
+import { getPostLikes } from 'calypso/state/posts/selectors/get-post-likes';
+import { countPostLikes } from 'calypso/state/posts/selectors/count-post-likes';
 
 /**
  * Style dependencies

--- a/client/blocks/post-share/connection.jsx
+++ b/client/blocks/post-share/connection.jsx
@@ -3,14 +3,14 @@
  */
 
 import React from 'react';
-import cssSafeUrl from 'lib/css-safe-url';
+import cssSafeUrl from 'calypso/lib/css-safe-url';
 
 /**
  * Internal dependencies
  */
-import FormToggle from 'components/forms/form-toggle/compact';
+import FormToggle from 'calypso/components/forms/form-toggle/compact';
 import classNames from 'classnames';
-import SocialLogo from 'components/social-logo';
+import SocialLogo from 'calypso/components/social-logo';
 
 const PostShareConnection = ( { connection, isActive, onToggle } ) => {
 	const {

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -7,60 +7,60 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get, includes, map, concat } from 'lodash';
 import { localize } from 'i18n-calypso';
-import { isEnabled } from 'config';
-import Gridicon from 'components/gridicon';
+import { isEnabled } from 'calypso/config';
+import Gridicon from 'calypso/components/gridicon';
 import { current as currentPage } from 'page';
 
 /**
  * Internal dependencies
  */
-import QueryPostTypes from 'components/data/query-post-types';
-import QueryPublicizeConnections from 'components/data/query-publicize-connections';
-import QuerySitePlans from 'components/data/query-site-plans';
+import QueryPostTypes from 'calypso/components/data/query-post-types';
+import QueryPublicizeConnections from 'calypso/components/data/query-publicize-connections';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import { Button } from '@automattic/components';
-import ButtonGroup from 'components/button-group';
-import NoticeAction from 'components/notice/notice-action';
-import { withLocalizedMoment } from 'components/localized-moment';
-import getPostSharePublishedActions from 'state/selectors/get-post-share-published-actions';
-import getPostShareScheduledActions from 'state/selectors/get-post-share-scheduled-actions';
-import getScheduledPublicizeShareActionTime from 'state/selectors/get-scheduled-publicize-share-action-time';
-import isPublicizeEnabled from 'state/selectors/is-publicize-enabled';
-import isSchedulingPublicizeShareAction from 'state/selectors/is-scheduling-publicize-share-action';
-import isSchedulingPublicizeShareActionError from 'state/selectors/is-scheduling-publicize-share-action-error';
-import { getSiteSlug, getSitePlanSlug, isJetpackSite } from 'state/sites/selectors';
-import { getCurrentUserId, getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import ButtonGroup from 'calypso/components/button-group';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import getPostSharePublishedActions from 'calypso/state/selectors/get-post-share-published-actions';
+import getPostShareScheduledActions from 'calypso/state/selectors/get-post-share-scheduled-actions';
+import getScheduledPublicizeShareActionTime from 'calypso/state/selectors/get-scheduled-publicize-share-action-time';
+import isPublicizeEnabled from 'calypso/state/selectors/is-publicize-enabled';
+import isSchedulingPublicizeShareAction from 'calypso/state/selectors/is-scheduling-publicize-share-action';
+import isSchedulingPublicizeShareActionError from 'calypso/state/selectors/is-scheduling-publicize-share-action-error';
+import { getSiteSlug, getSitePlanSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getCurrentUserId, getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 
 import {
 	fetchConnections as requestConnections,
 	sharePost,
 	dismissShareConfirmation,
-} from 'state/sharing/publicize/actions';
-import { schedulePostShareAction } from 'state/sharing/publicize/publicize-actions/actions';
+} from 'calypso/state/sharing/publicize/actions';
+import { schedulePostShareAction } from 'calypso/state/sharing/publicize/publicize-actions/actions';
 import {
 	getSiteUserConnections,
 	hasFetchedConnections as siteHasFetchedConnections,
 	isRequestingSharePost,
 	sharePostFailure,
 	sharePostSuccessMessage,
-} from 'state/sharing/publicize/selectors';
-import PostMetadata from 'lib/post-metadata';
-import PublicizeMessage from 'post-editor/editor-sharing/publicize-message';
-import Notice from 'components/notice';
+} from 'calypso/state/sharing/publicize/selectors';
+import PostMetadata from 'calypso/lib/post-metadata';
+import PublicizeMessage from 'calypso/post-editor/editor-sharing/publicize-message';
+import Notice from 'calypso/components/notice';
 import {
 	hasFeature,
 	isRequestingSitePlans as siteIsRequestingPlans,
-} from 'state/sites/plans/selectors';
-import { FEATURE_REPUBLICIZE } from 'lib/plans/constants';
+} from 'calypso/state/sites/plans/selectors';
+import { FEATURE_REPUBLICIZE } from 'calypso/lib/plans/constants';
 import { UpgradeToPremiumNudge } from './nudges';
 import SharingPreviewModal from './sharing-preview-modal';
 import ConnectionsList from './connections-list';
 import NoConnectionsNotice from './no-connections-notice';
 import ActionsList from './publicize-actions-list';
-import CalendarButton from 'blocks/calendar-button';
-import EventsTooltip from 'components/date-picker/events-tooltip';
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import TrackComponentView from 'lib/analytics/track-component-view';
-import { sectionify } from 'lib/route';
+import CalendarButton from 'calypso/blocks/calendar-button';
+import EventsTooltip from 'calypso/components/date-picker/events-tooltip';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { sectionify } from 'calypso/lib/route';
 
 /**
  * Style dependencies

--- a/client/blocks/post-share/no-connections-notice.jsx
+++ b/client/blocks/post-share/no-connections-notice.jsx
@@ -7,8 +7,8 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 
 const NoConnectionsNotice = ( { siteSlug } ) => {
 	const translate = useTranslate();

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -8,13 +8,13 @@ import formatCurrency from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
-import UpsellNudge from 'blocks/upsell-nudge';
-import { TYPE_PREMIUM, TERM_ANNUALLY } from 'lib/plans/constants';
-import { findFirstSimilarPlanKey } from 'lib/plans';
-import canCurrentUser from 'state/selectors/can-current-user';
-import { getSitePlan } from 'state/sites/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSitePlanRawPrice, getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { TYPE_PREMIUM, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
+import { findFirstSimilarPlanKey } from 'calypso/lib/plans';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { getSitePlan } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSitePlanRawPrice, getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
 
 export const UpgradeToPremiumNudgePure = ( props ) => {
 	const { price, planSlug, translate, userCurrency, canUserUpgrade, isJetpack } = props;

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -5,29 +5,29 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-import getPostSharePublishedActions from 'state/selectors/get-post-share-published-actions';
+import getPostSharePublishedActions from 'calypso/state/selectors/get-post-share-published-actions';
 
-import getPostShareScheduledActions from 'state/selectors/get-post-share-scheduled-actions';
-import QuerySharePostActions from 'components/data/query-share-post-actions/index.jsx';
-import SocialLogo from 'components/social-logo';
-import EllipsisMenu from 'components/ellipsis-menu';
-import PopoverMenuItem from 'components/popover/menu-item';
+import getPostShareScheduledActions from 'calypso/state/selectors/get-post-share-scheduled-actions';
+import QuerySharePostActions from 'calypso/components/data/query-share-post-actions/index.jsx';
+import SocialLogo from 'calypso/components/social-logo';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import { SCHEDULED, PUBLISHED } from './constants';
-import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavItem from 'components/section-nav/item';
-import { isEnabled } from 'config';
+import SectionNav from 'calypso/components/section-nav';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import NavItem from 'calypso/components/section-nav/item';
+import { isEnabled } from 'calypso/config';
 import { Dialog } from '@automattic/components';
-import { deletePostShareAction } from 'state/sharing/publicize/publicize-actions/actions';
-import { recordTracksEvent } from 'lib/analytics/tracks';
+import { deletePostShareAction } from 'calypso/state/sharing/publicize/publicize-actions/actions';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import SharingPreviewModal from './sharing-preview-modal';
-import Notice from 'components/notice';
-import { withLocalizedMoment } from 'components/localized-moment';
+import Notice from 'calypso/components/notice';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 
 class PublicizeActionsList extends PureComponent {
 	static propTypes = {

--- a/client/blocks/post-share/sharing-preview-modal.jsx
+++ b/client/blocks/post-share/sharing-preview-modal.jsx
@@ -3,13 +3,13 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
 import { Dialog } from '@automattic/components';
-import SharingPreviewPane from 'blocks/sharing-preview-pane';
+import SharingPreviewPane from 'calypso/blocks/sharing-preview-pane';
 
 const SharingPreviewModal = ( props ) => {
 	const { isVisible, onClose, ...previewProps } = props;

--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -50,7 +50,7 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
-} from 'lib/plans/constants';
+} from 'calypso/lib/plans/constants';
 
 const props = {
 	translate: ( x ) => x,

--- a/client/blocks/post-status/docs/example.jsx
+++ b/client/blocks/post-status/docs/example.jsx
@@ -9,11 +9,11 @@ import { map, mapValues, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import QueryPosts from 'components/data/query-posts';
+import QueryPosts from 'calypso/components/data/query-posts';
 import { Card } from '@automattic/components';
 import PostStatus from '../';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { getPostsForQuery } from 'state/posts/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getPostsForQuery } from 'calypso/state/posts/selectors';
 
 function PostStatusExample( { queries, primarySiteId, primarySiteUrl, globalIdByQueryLabel } ) {
 	return (

--- a/client/blocks/post-status/index.jsx
+++ b/client/blocks/post-status/index.jsx
@@ -7,12 +7,12 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-import { getNormalizedPost } from 'state/posts/selectors';
+import { getNormalizedPost } from 'calypso/state/posts/selectors';
 
 /**
  * Style dependencies

--- a/client/blocks/post-status/test/index.jsx
+++ b/client/blocks/post-status/test/index.jsx
@@ -3,7 +3,7 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { identity } from 'lodash';
 import React from 'react';
 

--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -10,15 +10,15 @@ import { flowRight as compose, get, identity, noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getHttpData, requestHttpData } from 'state/data-layer/http-data';
-import { http } from 'state/data-layer/wpcom-http/actions';
-import { getPreference, isFetchingPreferences } from 'state/preferences/selectors';
-import { savePreference } from 'state/preferences/actions';
-import getCurrentUserRegisterDate from 'state/selectors/get-current-user-register-date';
-import Banner from 'components/banner';
-import config from 'config';
+import { getHttpData, requestHttpData } from 'calypso/state/data-layer/http-data';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
+import getCurrentUserRegisterDate from 'calypso/state/selectors/get-current-user-register-date';
+import Banner from 'calypso/components/banner';
+import config from 'calypso/config';
 import PrivacyPolicyDialog from './privacy-policy-dialog';
-import { withLocalizedMoment } from 'components/localized-moment';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 
 const AUTOMATTIC_ENTITY = 'automattic';
 const PRIVACY_POLICY_PREFERENCE = 'privacy_policy';

--- a/client/blocks/product-plan-overlap-notices/docs/example.jsx
+++ b/client/blocks/product-plan-overlap-notices/docs/example.jsx
@@ -6,9 +6,9 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import SitesDropdown from 'components/sites-dropdown';
-import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
-import { JETPACK_PLANS } from 'lib/plans/constants';
+import SitesDropdown from 'calypso/components/sites-dropdown';
+import { JETPACK_PRODUCTS_LIST } from 'calypso/lib/products-values/constants';
+import { JETPACK_PLANS } from 'calypso/lib/plans/constants';
 import ProductPlanOverlapNotices from '../';
 
 class ProductPlanOverlapNoticesExample extends Component {

--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -9,18 +9,18 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
-import QueryProductsList from 'components/data/query-products-list';
-import QuerySitePlans from 'components/data/query-site-plans';
-import QuerySitePurchases from 'components/data/query-site-purchases';
-import { getAvailableProductsList } from 'state/products-list/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSitePlanSlug } from 'state/sites/plans/selectors';
-import { getSitePurchases } from 'state/purchases/selectors';
-import { planHasFeature, planHasSuperiorFeature } from 'lib/plans';
-import { managePurchase } from 'me/purchases/paths';
-import { isJetpackProduct } from 'lib/products-values';
-import { recordTracksEvent } from 'state/analytics/actions';
+import Notice from 'calypso/components/notice';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { planHasFeature, planHasSuperiorFeature } from 'calypso/lib/plans';
+import { managePurchase } from 'calypso/me/purchases/paths';
+import { isJetpackProduct } from 'calypso/lib/products-values';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
 

--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -8,12 +8,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 /**
  * Image dependencies
  */
-import adsRemovedImage from 'assets/images/illustrations/removed-ads.svg';
+import adsRemovedImage from 'calypso/assets/images/illustrations/removed-ads.svg';
 
 export default localize( ( { isBusinessPlan, selectedSite, translate } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -9,12 +9,12 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 /**
  * Image dependencies
  */
-import conciergeImage from 'assets/images/illustrations/jetpack-concierge.svg';
+import conciergeImage from 'calypso/assets/images/illustrations/jetpack-concierge.svg';
 
 export default localize( ( { isWpcomPlan, translate, link, onClick = noop } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/custom-css.jsx
+++ b/client/blocks/product-purchase-features-list/custom-css.jsx
@@ -8,13 +8,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
-import { isEnabled } from 'config';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+import { isEnabled } from 'calypso/config';
 
 /**
  * Image dependencies
  */
-import customizeImage from 'assets/images/illustrations/dashboard.svg';
+import customizeImage from 'calypso/assets/images/illustrations/dashboard.svg';
 
 function isCustomizeEnabled() {
 	return isEnabled( 'manage/customize' );

--- a/client/blocks/product-purchase-features-list/custom-domain.jsx
+++ b/client/blocks/product-purchase-features-list/custom-domain.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import CustomDomainPurchaseDetail from 'my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail';
+import CustomDomainPurchaseDetail from 'calypso/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail';
 
 export default function CustomDomainPurchaseDetailItem( {
 	hasDomainCredit,

--- a/client/blocks/product-purchase-features-list/customize-theme.jsx
+++ b/client/blocks/product-purchase-features-list/customize-theme.jsx
@@ -8,13 +8,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
-import { isEnabled } from 'config';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+import { isEnabled } from 'calypso/config';
 
 /**
  * Image dependencies
  */
-import customizeImage from 'assets/images/illustrations/dashboard.svg';
+import customizeImage from 'calypso/assets/images/illustrations/dashboard.svg';
 
 function isCustomizeEnabled() {
 	return isEnabled( 'manage/customize' );

--- a/client/blocks/product-purchase-features-list/find-new-theme.jsx
+++ b/client/blocks/product-purchase-features-list/find-new-theme.jsx
@@ -8,12 +8,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 /**
  * Image dependencies
  */
-import premiumThemesImage from 'assets/images/illustrations/themes.svg';
+import premiumThemesImage from 'calypso/assets/images/illustrations/themes.svg';
 
 export default localize( ( { selectedSite, translate } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/google-analytics-stats.jsx
+++ b/client/blocks/product-purchase-features-list/google-analytics-stats.jsx
@@ -8,12 +8,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 /**
  * Image dependencies
  */
-import googleAnalyticsImage from 'assets/images/illustrations/google-analytics.svg';
+import googleAnalyticsImage from 'calypso/assets/images/illustrations/google-analytics.svg';
 
 export default localize( ( { selectedSite, translate } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/google-my-business.js
+++ b/client/blocks/product-purchase-features-list/google-my-business.js
@@ -8,12 +8,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 /**
  * Image dependencies
  */
-import googleMyBusinessImage from 'assets/images/illustrations/google-my-business-feature.svg';
+import googleMyBusinessImage from 'calypso/assets/images/illustrations/google-my-business-feature.svg';
 
 export default localize( ( { selectedSite, translate } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/google-vouchers.jsx
+++ b/client/blocks/product-purchase-features-list/google-vouchers.jsx
@@ -8,14 +8,14 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import GoogleVoucherDetails from 'my-sites/checkout/checkout-thank-you/google-voucher';
-import PurchaseDetail from 'components/purchase-detail';
-import QuerySiteVouchers from 'components/data/query-site-vouchers';
+import GoogleVoucherDetails from 'calypso/my-sites/checkout/checkout-thank-you/google-voucher';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+import QuerySiteVouchers from 'calypso/components/data/query-site-vouchers';
 
 /**
  * Image dependencies
  */
-import googleAdwordsImage from 'assets/images/illustrations/adwords-google.svg';
+import googleAdwordsImage from 'calypso/assets/images/illustrations/adwords-google.svg';
 
 export default ( { selectedSite } ) => {
 	const translate = useTranslate();

--- a/client/blocks/product-purchase-features-list/happiness-support-card.jsx
+++ b/client/blocks/product-purchase-features-list/happiness-support-card.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import HappinessSupport from 'components/happiness-support';
+import HappinessSupport from 'calypso/components/happiness-support';
 
 export const HappinessSupportCard = ( {
 	isFeatureCard,

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getPlan } from 'lib/plans';
+import { getPlan } from 'calypso/lib/plans';
 import {
 	GROUP_WPCOM,
 	GROUP_JETPACK,
@@ -24,8 +24,8 @@ import {
 	TYPE_SECURITY_DAILY,
 	TYPE_SECURITY_REALTIME,
 	TYPE_ALL,
-} from 'lib/plans/constants';
-import { PLANS_LIST } from 'lib/plans/plans-list';
+} from 'calypso/lib/plans/constants';
+import { PLANS_LIST } from 'calypso/lib/plans/plans-list';
 import FindNewTheme from './find-new-theme';
 import UploadPlugins from './upload-plugins';
 import AdvertisingRemoved from './advertising-removed';
@@ -42,15 +42,15 @@ import JetpackPublicize from './jetpack-publicize';
 import MobileApps from './mobile-apps';
 import SellOnlinePaypal from './sell-online-paypal';
 import SiteActivity from './site-activity';
-import { withLocalizedMoment } from 'components/localized-moment';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import { isEnabled } from 'config';
-import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
-import { hasDomainCredit, getCurrentPlan } from 'state/sites/plans/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
-import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
-import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isEnabled } from 'calypso/config';
+import { isWordadsInstantActivationEligible } from 'calypso/lib/ads/utils';
+import { hasDomainCredit, getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
+import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
 /**
  * Style dependencies
  */

--- a/client/blocks/product-purchase-features-list/jetpack-publicize.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-publicize.jsx
@@ -8,12 +8,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 /**
  * Image dependencies
  */
-import marketingImage from 'assets/images/illustrations/marketing.svg';
+import marketingImage from 'calypso/assets/images/illustrations/marketing.svg';
 
 export default localize( ( { selectedSite, translate } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/mobile-apps.jsx
+++ b/client/blocks/product-purchase-features-list/mobile-apps.jsx
@@ -9,13 +9,13 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
-import { addQueryArgs } from 'lib/route';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+import { addQueryArgs } from 'calypso/lib/route';
 
 /**
  * Image dependencies
  */
-import appsImage from 'assets/images/illustrations/apps.svg';
+import appsImage from 'calypso/assets/images/illustrations/apps.svg';
 
 export default localize( ( { translate, onClick = noop } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/monetize-site.jsx
+++ b/client/blocks/product-purchase-features-list/monetize-site.jsx
@@ -8,12 +8,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 /**
  * Image dependencies
  */
-import wordAdsImage from 'assets/images/illustrations/dotcom-wordads.svg';
+import wordAdsImage from 'calypso/assets/images/illustrations/dotcom-wordads.svg';
 
 export default localize( ( { selectedSite, translate } ) => {
 	const adSettingsUrl = selectedSite.jetpack

--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -8,13 +8,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
-import { localizeUrl } from 'lib/i18n-utils';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 /**
  * Image dependencies
  */
-import paymentsImage from 'assets/images/illustrations/payments.svg';
+import paymentsImage from 'calypso/assets/images/illustrations/payments.svg';
 
 export default localize( ( { isJetpack, translate } ) => {
 	const supportDocLink = localizeUrl(

--- a/client/blocks/product-purchase-features-list/site-activity.jsx
+++ b/client/blocks/product-purchase-features-list/site-activity.jsx
@@ -8,13 +8,13 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 /**
  * Image dependencies
  */
-import siteActivity from 'assets/images/illustrations/site-activity.svg';
+import siteActivity from 'calypso/assets/images/illustrations/site-activity.svg';
 
 const SiteActivity = ( { siteSlug, translate } ) => (
 	<div className="product-purchase-features-list__item">

--- a/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
+++ b/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
@@ -22,7 +22,7 @@ import {
 	PLAN_JETPACK_PREMIUM_MONTHLY,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
-} from 'lib/plans/constants';
+} from 'calypso/lib/plans/constants';
 
 /**
  * Internal dependencies

--- a/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
@@ -23,7 +23,7 @@ import {
 	PLAN_JETPACK_PREMIUM_MONTHLY,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
-} from 'lib/plans/constants';
+} from 'calypso/lib/plans/constants';
 
 /**
  * Internal dependencies

--- a/client/blocks/product-purchase-features-list/upload-plugins.jsx
+++ b/client/blocks/product-purchase-features-list/upload-plugins.jsx
@@ -8,12 +8,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 /**
  * Image dependencies
  */
-import updatesImage from 'assets/images/illustrations/updates.svg';
+import updatesImage from 'calypso/assets/images/illustrations/updates.svg';
 
 export default localize( ( { selectedSite, translate } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -7,14 +7,14 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
-import { newPost } from 'lib/paths';
-import { isWpComBusinessPlan, isWpComEcommercePlan, isWpComPremiumPlan } from 'lib/plans';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+import { newPost } from 'calypso/lib/paths';
+import { isWpComBusinessPlan, isWpComEcommercePlan, isWpComPremiumPlan } from 'calypso/lib/plans';
 
 /**
  * Image dependencies
  */
-import videoImage from 'assets/images/illustrations/video-hosting.svg';
+import videoImage from 'calypso/assets/images/illustrations/video-hosting.svg';
 
 function getDescription( plan, translate ) {
 	if ( isWpComBusinessPlan( plan ) ) {

--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -6,8 +6,8 @@ import React, { Component, Fragment } from 'react';
 /**
  * Internal dependencies
  */
-import SegmentedControl from 'components/segmented-control';
-import SitesDropdown from 'components/sites-dropdown';
+import SegmentedControl from 'calypso/components/segmented-control';
+import SitesDropdown from 'calypso/components/sites-dropdown';
 import ProductSelector from '../';
 
 const products = [

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -7,36 +7,36 @@ import page from 'page';
 import { connect } from 'react-redux';
 import { find, findKey, filter, flowRight as compose, includes, isEmpty, map } from 'lodash';
 import { localize } from 'i18n-calypso';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Internal dependencies
  */
-import { addQueryArgs } from 'lib/route';
-import ExternalLinkWithTracking from 'components/external-link/with-tracking';
-import PlanIntervalDiscount from 'my-sites/plan-interval-discount';
-import ProductCard from 'components/product-card';
-import ProductCardAction from 'components/product-card/action';
-import ProductCardOptions from 'components/product-card/options';
-import ProductCardPromoNudge from 'components/product-card/promo-nudge';
-import QuerySiteProducts from 'components/data/query-site-products';
-import QuerySitePurchases from 'components/data/query-site-purchases';
-import QueryProductsList from 'components/data/query-products-list';
-import ProductExpiration from 'components/product-expiration';
+import { addQueryArgs } from 'calypso/lib/route';
+import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
+import PlanIntervalDiscount from 'calypso/my-sites/plan-interval-discount';
+import ProductCard from 'calypso/components/product-card';
+import ProductCardAction from 'calypso/components/product-card/action';
+import ProductCardOptions from 'calypso/components/product-card/options';
+import ProductCardPromoNudge from 'calypso/components/product-card/promo-nudge';
+import QuerySiteProducts from 'calypso/components/data/query-site-products';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import ProductExpiration from 'calypso/components/product-expiration';
 import { extractProductSlugs, filterByProductSlugs } from './utils';
-import { getAvailableProductsBySiteId } from 'state/sites/products/selectors';
-import { getAvailableProductsList, isProductsListFetching } from 'state/products-list/selectors';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSitePlanSlug, isRequestingSitePlans } from 'state/sites/plans/selectors';
-import { getSitePurchases, isFetchingSitePurchases } from 'state/purchases/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
-import { getPlan, planHasFeature } from 'lib/plans';
-import { isExpiring } from 'lib/purchases';
-import { isRequestingPlans } from 'state/plans/selectors';
-import { TERM_ANNUALLY, TERM_MONTHLY } from 'lib/plans/constants';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { managePurchase } from 'me/purchases/paths';
+import { getAvailableProductsBySiteId } from 'calypso/state/sites/products/selectors';
+import { getAvailableProductsList, isProductsListFetching } from 'calypso/state/products-list/selectors';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSitePlanSlug, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
+import { getSitePurchases, isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getPlan, planHasFeature } from 'calypso/lib/plans';
+import { isExpiring } from 'calypso/lib/purchases';
+import { isRequestingPlans } from 'calypso/state/plans/selectors';
+import { TERM_ANNUALLY, TERM_MONTHLY } from 'calypso/lib/plans/constants';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { managePurchase } from 'calypso/me/purchases/paths';
 
 export class ProductSelector extends Component {
 	static propTypes = {

--- a/client/blocks/reader-author-link/docs/example.jsx
+++ b/client/blocks/reader-author-link/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderAuthorLink from 'blocks/reader-author-link';
+import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import { Card } from '@automattic/components';
 
 const ReaderAuthorLinkExample = () => {

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -9,9 +9,9 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { isAuthorNameBlocked } from 'reader/lib/author-name-blocklist';
-import * as stats from 'reader/stats';
-import Emojify from 'components/emojify';
+import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
+import * as stats from 'calypso/reader/stats';
+import Emojify from 'calypso/components/emojify';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-avatar/docs/example.jsx
+++ b/client/blocks/reader-avatar/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderAvatar from 'blocks/reader-avatar';
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
 
 const ReaderAvatarExample = () => {
 	const author = {

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -8,11 +8,11 @@ import { startsWith, endsWith, noop, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import Gravatar from 'components/gravatar';
-import SiteIcon from 'blocks/site-icon';
+import Gravatar from 'calypso/components/gravatar';
+import SiteIcon from 'calypso/blocks/site-icon';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
-import safeImageUrl from 'lib/safe-image-url';
+import safeImageUrl from 'calypso/lib/safe-image-url';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-combined-card/docs/example.jsx
+++ b/client/blocks/reader-combined-card/docs/example.jsx
@@ -6,8 +6,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { ReaderCombinedCard, combinedCardPostKeyToKeys } from 'blocks/reader-combined-card';
-import { posts, feed, site } from 'blocks/reader-post-card/docs/fixtures';
+import { ReaderCombinedCard, combinedCardPostKeyToKeys } from 'calypso/blocks/reader-combined-card';
+import { posts, feed, site } from 'calypso/blocks/reader-post-card/docs/fixtures';
 
 const postKey = {
 	blogId: site.ID,

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -11,19 +11,19 @@ import { connect } from 'react-redux';
  * Internal Dependencies
  */
 import { Card } from '@automattic/components';
-import { getStreamUrl } from 'reader/route';
-import ReaderAvatar from 'blocks/reader-avatar';
-import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
+import { getStreamUrl } from 'calypso/reader/route';
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
+import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import ReaderCombinedCardPost from './post';
-import { keysAreEqual, keyForPost } from 'reader/post-key';
-import QueryReaderSite from 'components/data/query-reader-site';
-import QueryReaderFeed from 'components/data/query-reader-feed';
-import { recordTrack } from 'reader/stats';
-import { getSiteName } from 'reader/get-helpers';
-import FollowButton from 'reader/follow-button';
-import { getPostsByKeys } from 'state/reader/posts/selectors';
-import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
-import PostBlocked from 'blocks/reader-post-card/blocked';
+import { keysAreEqual, keyForPost } from 'calypso/reader/post-key';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import { recordTrack } from 'calypso/reader/stats';
+import { getSiteName } from 'calypso/reader/get-helpers';
+import FollowButton from 'calypso/reader/follow-button';
+import { getPostsByKeys } from 'calypso/state/reader/posts/selectors';
+import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
+import PostBlocked from 'calypso/blocks/reader-post-card/blocked';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -8,23 +8,23 @@ import ReactDom from 'react-dom';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies
  */
-import AutoDirection from 'components/auto-direction';
-import Emojify from 'components/emojify';
-import ReaderExcerpt from 'blocks/reader-excerpt';
-import ReaderVisitLink from 'blocks/reader-visit-link';
-import ReaderAuthorLink from 'blocks/reader-author-link';
-import { recordPermalinkClick } from 'reader/stats';
-import TimeSince from 'components/time-since';
-import ReaderFeaturedImage from 'blocks/reader-featured-image';
-import ReaderFeaturedVideo from 'blocks/reader-featured-video';
-import ReaderCombinedCardPostPlaceholder from 'blocks/reader-combined-card/placeholders/post';
-import { isAuthorNameBlocked } from 'reader/lib/author-name-blocklist';
-import QueryReaderPost from 'components/data/query-reader-post';
+import AutoDirection from 'calypso/components/auto-direction';
+import Emojify from 'calypso/components/emojify';
+import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
+import ReaderVisitLink from 'calypso/blocks/reader-visit-link';
+import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
+import { recordPermalinkClick } from 'calypso/reader/stats';
+import TimeSince from 'calypso/components/time-since';
+import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
+import ReaderFeaturedVideo from 'calypso/blocks/reader-featured-video';
+import ReaderCombinedCardPostPlaceholder from 'calypso/blocks/reader-combined-card/placeholders/post';
+import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
+import QueryReaderPost from 'calypso/components/data/query-reader-post';
 
 class ReaderCombinedCardPost extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -7,8 +7,8 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
-import AutoDirection from 'components/auto-direction';
-import Emojify from 'components/emojify';
+import AutoDirection from 'calypso/components/auto-direction';
+import Emojify from 'calypso/components/emojify';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-export-button/docs/example.jsx
+++ b/client/blocks/reader-export-button/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderExportButtonBlock from 'blocks/reader-export-button';
+import ReaderExportButtonBlock from 'calypso/blocks/reader-export-button';
 
 const ReaderExportButton = () => (
 	<div className="design-assets__group">

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -10,13 +10,13 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
-import { errorNotice } from 'state/notices/actions';
-import Gridicon from 'components/gridicon';
+import wpcom from 'calypso/lib/wp';
+import { errorNotice } from 'calypso/state/notices/actions';
+import Gridicon from 'calypso/components/gridicon';
 import {
 	READER_EXPORT_TYPE_SUBSCRIPTIONS,
 	READER_EXPORT_TYPE_LIST,
-} from 'blocks/reader-export-button/constants';
+} from 'calypso/blocks/reader-export-button/constants';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -9,8 +9,8 @@ import classnames from 'classnames';
 /**
  * Internal Dependencies
  */
-import cssSafeUrl from 'lib/css-safe-url';
-import resizeImageUrl from 'lib/resize-image-url';
+import cssSafeUrl from 'calypso/lib/css-safe-url';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-featured-video/docs/example.jsx
+++ b/client/blocks/reader-featured-video/docs/example.jsx
@@ -8,7 +8,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import ReaderFeaturedVideoBlock from 'blocks/reader-featured-video';
+import ReaderFeaturedVideoBlock from 'calypso/blocks/reader-featured-video';
 
 const exampleVideo = {
 	autoplayIframe:

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -12,15 +12,15 @@ import classnames from 'classnames';
 /**
  * Internal Dependencies
  */
-import EmbedHelper from 'reader/embed-helper';
-import ReaderFeaturedImage from 'blocks/reader-featured-image';
-import { getThumbnailForIframe } from 'state/reader/thumbnails/selectors';
-import QueryReaderThumbnail from 'components/data/query-reader-thumbnails';
+import EmbedHelper from 'calypso/reader/embed-helper';
+import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
+import { getThumbnailForIframe } from 'calypso/state/reader/thumbnails/selectors';
+import QueryReaderThumbnail from 'calypso/components/data/query-reader-thumbnails';
 
 /**
  * Image dependencies
  */
-import playIconImage from 'assets/images/reader/play-icon.png';
+import playIconImage from 'calypso/assets/images/reader/play-icon.png';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-feed-header/badge.jsx
+++ b/client/blocks/reader-feed-header/badge.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 const ReaderFeedHeaderSiteBadge = ( { site } ) => {
 	/* eslint-disable wpcalypso/jsx-gridicon-size */

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -6,25 +6,25 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Internal Dependencies
  */
 import { Card } from '@automattic/components';
-import ReaderFollowButton from 'reader/follow-button';
-import { isAuthorNameBlocked } from 'reader/lib/author-name-blocklist';
-import HeaderBack from 'reader/header-back';
-import { getSiteDescription, getSiteName, getSiteUrl } from 'reader/get-helpers';
-import SiteIcon from 'blocks/site-icon';
-import BlogStickers from 'blocks/blog-stickers';
+import ReaderFollowButton from 'calypso/reader/follow-button';
+import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
+import HeaderBack from 'calypso/reader/header-back';
+import { getSiteDescription, getSiteName, getSiteUrl } from 'calypso/reader/get-helpers';
+import SiteIcon from 'calypso/blocks/site-icon';
+import BlogStickers from 'calypso/blocks/blog-stickers';
 import ReaderFeedHeaderSiteBadge from './badge';
-import ReaderSiteNotificationSettings from 'blocks/reader-site-notification-settings';
-import getUserSetting from 'state/selectors/get-user-setting';
-import { isFollowing } from 'state/reader/follows/selectors';
-import QueryUserSettings from 'components/data/query-user-settings';
-import Gridicon from 'components/gridicon';
-import { requestMarkAllAsSeen } from 'state/reader/seen-posts/actions';
+import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { isFollowing } from 'calypso/state/reader/follows/selectors';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import Gridicon from 'calypso/components/gridicon';
+import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -5,17 +5,17 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { keys, trim } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-import AutoDirection from 'components/auto-direction';
-import ExternalLink from 'components/external-link';
-import { recordPermalinkClick } from 'reader/stats';
-import TimeSince from 'components/time-since';
+import AutoDirection from 'calypso/components/auto-direction';
+import ExternalLink from 'calypso/components/external-link';
+import { recordPermalinkClick } from 'calypso/reader/stats';
+import TimeSince from 'calypso/components/time-since';
 import ReaderFullPostHeaderTags from './header-tags';
-import { isDiscoverPost } from 'reader/discover/helper';
+import { isDiscoverPost } from 'calypso/reader/discover/helper';
 import ReaderFullPostHeaderPlaceholder from './placeholders/header';
 
 const ReaderFullPostHeader = ( { post, referralPost } ) => {

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -7,72 +7,72 @@ import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import classNames from 'classnames';
 import { get, startsWith, pickBy } from 'lodash';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies
  */
-import AutoDirection from 'components/auto-direction';
-import ReaderMain from 'reader/components/reader-main';
-import EmbedContainer from 'components/embed-container';
-import PostExcerpt from 'components/post-excerpt';
-import { markPostSeen } from 'state/reader/posts/actions';
+import AutoDirection from 'calypso/components/auto-direction';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import EmbedContainer from 'calypso/components/embed-container';
+import PostExcerpt from 'calypso/components/post-excerpt';
+import { markPostSeen } from 'calypso/state/reader/posts/actions';
 import ReaderFullPostHeader from './header';
-import AuthorCompactProfile from 'blocks/author-compact-profile';
-import LikeButton from 'reader/like-button';
-import { isDiscoverPost, isDiscoverSitePick } from 'reader/discover/helper';
-import DiscoverSiteAttribution from 'reader/discover/site-attribution';
-import DailyPostButton from 'blocks/daily-post-button';
-import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
-import { shouldShowLikes } from 'reader/like-helper';
-import { shouldShowComments } from 'blocks/comments/helper';
-import CommentButton from 'blocks/comment-button';
+import AuthorCompactProfile from 'calypso/blocks/author-compact-profile';
+import LikeButton from 'calypso/reader/like-button';
+import { isDiscoverPost, isDiscoverSitePick } from 'calypso/reader/discover/helper';
+import DiscoverSiteAttribution from 'calypso/reader/discover/site-attribution';
+import DailyPostButton from 'calypso/blocks/daily-post-button';
+import { isDailyPostChallengeOrPrompt } from 'calypso/blocks/daily-post-button/helper';
+import { shouldShowLikes } from 'calypso/reader/like-helper';
+import { shouldShowComments } from 'calypso/blocks/comments/helper';
+import CommentButton from 'calypso/blocks/comment-button';
 import {
 	recordAction,
 	recordGaEvent,
 	recordTrackForPost,
 	recordPermalinkClick,
-} from 'reader/stats';
-import Comments from 'blocks/comments';
-import scrollTo from 'lib/scroll-to';
-import PostExcerptLink from 'reader/post-excerpt-link';
-import { getSiteName } from 'reader/get-helpers';
-import KeyboardShortcuts from 'lib/keyboard-shortcuts';
-import ReaderPostActions from 'blocks/reader-post-actions';
-import { RelatedPostsFromSameSite, RelatedPostsFromOtherSites } from 'components/related-posts';
-import { getStreamUrlFromPost } from 'reader/route';
-import { like as likePost, unlike as unlikePost } from 'state/posts/likes/actions';
-import FeaturedImage from 'blocks/reader-full-post/featured-image';
-import { getFeed } from 'state/reader/feeds/selectors';
-import { getSite } from 'state/reader/sites/selectors';
-import QueryReaderSite from 'components/data/query-reader-site';
-import QueryReaderFeed from 'components/data/query-reader-feed';
-import QueryReaderPost from 'components/data/query-reader-post';
-import ExternalLink from 'components/external-link';
-import DocumentHead from 'components/data/document-head';
+} from 'calypso/reader/stats';
+import Comments from 'calypso/blocks/comments';
+import scrollTo from 'calypso/lib/scroll-to';
+import PostExcerptLink from 'calypso/reader/post-excerpt-link';
+import { getSiteName } from 'calypso/reader/get-helpers';
+import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
+import ReaderPostActions from 'calypso/blocks/reader-post-actions';
+import { RelatedPostsFromSameSite, RelatedPostsFromOtherSites } from 'calypso/components/related-posts';
+import { getStreamUrlFromPost } from 'calypso/reader/route';
+import { like as likePost, unlike as unlikePost } from 'calypso/state/posts/likes/actions';
+import FeaturedImage from 'calypso/blocks/reader-full-post/featured-image';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import { getSite } from 'calypso/state/reader/sites/selectors';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import QueryReaderPost from 'calypso/components/data/query-reader-post';
+import ExternalLink from 'calypso/components/external-link';
+import DocumentHead from 'calypso/components/data/document-head';
 import ReaderFullPostUnavailable from './unavailable';
-import BackButton from 'components/back-button';
-import { isFeaturedImageInContent } from 'lib/post-normalizer/utils';
+import BackButton from 'calypso/components/back-button';
+import { isFeaturedImageInContent } from 'calypso/lib/post-normalizer/utils';
 import ReaderFullPostContentPlaceholder from './placeholders/content';
-import { keyForPost } from 'reader/post-key';
-import { showSelectedPost } from 'reader/utils';
-import Emojify from 'components/emojify';
-import { COMMENTS_FILTER_ALL } from 'blocks/comments/comments-filters';
-import { READER_FULL_POST } from 'reader/follow-sources';
-import { getPostByKey } from 'state/reader/posts/selectors';
-import { isLikedPost } from 'state/posts/selectors/is-liked-post';
-import QueryPostLikes from 'components/data/query-post-likes';
-import getCurrentStream from 'state/selectors/get-reader-current-stream';
-import { setViewingFullPostKey, unsetViewingFullPostKey } from 'state/reader/viewing/actions';
-import { getNextItem, getPreviousItem } from 'state/reader/streams/selectors';
+import { keyForPost } from 'calypso/reader/post-key';
+import { showSelectedPost } from 'calypso/reader/utils';
+import Emojify from 'calypso/components/emojify';
+import { COMMENTS_FILTER_ALL } from 'calypso/blocks/comments/comments-filters';
+import { READER_FULL_POST } from 'calypso/reader/follow-sources';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
+import QueryPostLikes from 'calypso/components/data/query-post-likes';
+import getCurrentStream from 'calypso/state/selectors/get-reader-current-stream';
+import { setViewingFullPostKey, unsetViewingFullPostKey } from 'calypso/state/reader/viewing/actions';
+import { getNextItem, getPreviousItem } from 'calypso/state/reader/streams/selectors';
 import {
 	requestMarkAsSeen,
 	requestMarkAsUnseen,
 	requestMarkAsSeenBlog,
 	requestMarkAsUnseenBlog,
-} from 'state/reader/seen-posts/actions';
-import Gridicon from 'components/gridicon';
-import { PerformanceTrackerStop } from 'lib/performance-tracking';
+} from 'calypso/state/reader/seen-posts/actions';
+import Gridicon from 'calypso/components/gridicon';
+import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -3,17 +3,17 @@
  */
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
-import config from 'config';
+import config from 'calypso/config';
 import { localize } from 'i18n-calypso';
 import { noop, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import ReaderMain from 'reader/components/reader-main';
-import DocumentHead from 'components/data/document-head';
-import BackButton from 'components/back-button';
-import ExternalLink from 'components/external-link';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import DocumentHead from 'calypso/components/data/document-head';
+import BackButton from 'calypso/components/back-button';
+import ExternalLink from 'calypso/components/external-link';
 
 const ReaderFullPostUnavailable = ( { post, onBackClick, translate } ) => {
 	const statusCode = get( post, [ 'error', 'statusCode' ] );

--- a/client/blocks/reader-import-button/docs/example.jsx
+++ b/client/blocks/reader-import-button/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderImportButtonBlock from 'blocks/reader-import-button';
+import ReaderImportButtonBlock from 'calypso/blocks/reader-import-button';
 
 const ReaderImportButton = () => (
 	<div className="design-assets__group">

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -5,15 +5,15 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
-import FilePicker from 'components/file-picker';
-import { successNotice, errorNotice } from 'state/notices/actions';
+import wpcom from 'calypso/lib/wp';
+import FilePicker from 'calypso/components/file-picker';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-list-item/connected.jsx
+++ b/client/blocks/reader-list-item/connected.jsx
@@ -9,9 +9,9 @@ import { connect } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import connectSite from 'lib/reader-connect-site';
+import connectSite from 'calypso/lib/reader-connect-site';
 import ReaderListItem from '.';
-import { isFollowing as isFollowingSelector } from 'state/reader/follows/selectors';
+import { isFollowing as isFollowingSelector } from 'calypso/state/reader/follows/selectors';
 
 class ConnectedReaderListItem extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-list-item/docs/example.jsx
+++ b/client/blocks/reader-list-item/docs/example.jsx
@@ -8,8 +8,8 @@ import { map } from 'lodash';
 /**
  * Internal dependencies
  */
-import ConnectedReaderListItem from 'blocks/reader-list-item/connected';
-import ReaderListItemPlaceholder from 'blocks/reader-list-item/placeholder';
+import ConnectedReaderListItem from 'calypso/blocks/reader-list-item/connected';
+import ReaderListItemPlaceholder from 'calypso/blocks/reader-list-item/placeholder';
 import { Card } from '@automattic/components';
 
 const sites = {

--- a/client/blocks/reader-list-item/index.jsx
+++ b/client/blocks/reader-list-item/index.jsx
@@ -9,22 +9,22 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import ReaderAvatar from 'blocks/reader-avatar';
-import FollowButton from 'reader/follow-button';
-import { getStreamUrl } from 'reader/route';
-import ReaderSiteNotificationSettings from 'blocks/reader-site-notification-settings';
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
+import FollowButton from 'calypso/reader/follow-button';
+import { getStreamUrl } from 'calypso/reader/route';
+import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
 import {
 	getSiteName,
 	getSiteDescription,
 	getSiteAuthorName,
 	getFeedUrl,
 	getSiteUrl,
-} from 'reader/get-helpers';
-import ReaderListItemPlaceholder from 'blocks/reader-list-item/placeholder';
-import { recordTrack, recordTrackWithRailcar } from 'reader/stats';
-import ExternalLink from 'components/external-link';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { formatUrlForDisplay } from 'reader/lib/feed-display-helper';
+} from 'calypso/reader/get-helpers';
+import ReaderListItemPlaceholder from 'calypso/blocks/reader-list-item/placeholder';
+import { recordTrack, recordTrackWithRailcar } from 'calypso/reader/stats';
+import ExternalLink from 'calypso/components/external-link';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-list-item/placeholder.jsx
+++ b/client/blocks/reader-list-item/placeholder.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderAvatar from 'blocks/reader-avatar';
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
 
 const ReaderListItemPlaceholder = () => {
 	return (

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -8,18 +8,18 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import CommentButton from 'blocks/comment-button';
-import LikeButton from 'reader/like-button';
-import ShareButton from 'blocks/reader-share';
-import PostEditButton from 'blocks/post-edit-button';
-import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
-import { shouldShowComments } from 'blocks/comments/helper';
-import { shouldShowLikes } from 'reader/like-helper';
-import { shouldShowShare } from 'blocks/reader-share/helper';
-import { userCan } from 'state/posts/utils';
-import * as stats from 'reader/stats';
+import CommentButton from 'calypso/blocks/comment-button';
+import LikeButton from 'calypso/reader/like-button';
+import ShareButton from 'calypso/blocks/reader-share';
+import PostEditButton from 'calypso/blocks/post-edit-button';
+import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
+import { shouldShowComments } from 'calypso/blocks/comments/helper';
+import { shouldShowLikes } from 'calypso/reader/like-helper';
+import { shouldShowShare } from 'calypso/blocks/reader-share/helper';
+import { userCan } from 'calypso/state/posts/utils';
+import * as stats from 'calypso/reader/stats';
 import { localize } from 'i18n-calypso';
-import ReaderVisitLink from 'blocks/reader-visit-link';
+import ReaderVisitLink from 'calypso/blocks/reader-visit-link';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-post-card/blocked.jsx
+++ b/client/blocks/reader-post-card/blocked.jsx
@@ -9,10 +9,10 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { unblockSite } from 'state/reader/site-blocks/actions';
+import { unblockSite } from 'calypso/state/reader/site-blocks/actions';
 import { Card } from '@automattic/components';
-import { recordTrack as recordReaderTrack } from 'reader/stats';
-import { bumpStat, recordGoogleEvent } from 'state/analytics/actions';
+import { recordTrack as recordReaderTrack } from 'calypso/reader/stats';
+import { bumpStat, recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 class PostBlocked extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -4,25 +4,25 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { get, map, take, values } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal Dependencies
  */
-import ReaderAvatar from 'blocks/reader-avatar';
-import TimeSince from 'components/time-since';
-import { getSiteName } from 'reader/get-helpers';
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
+import TimeSince from 'calypso/components/time-since';
+import { getSiteName } from 'calypso/reader/get-helpers';
 import {
 	recordAction,
 	recordGaEvent,
 	recordTrackForPost,
 	recordPermalinkClick,
-} from 'reader/stats';
-import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
-import { getStreamUrl } from 'reader/route';
-import { isAuthorNameBlocked } from 'reader/lib/author-name-blocklist';
-import ReaderAuthorLink from 'blocks/reader-author-link';
-import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
+} from 'calypso/reader/stats';
+import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
+import { getStreamUrl } from 'calypso/reader/route';
+import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
+import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
+import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
 
 const TAGS_TO_SHOW = 3;
 

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -7,10 +7,10 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
-import AutoDirection from 'components/auto-direction';
-import Emojify from 'components/emojify';
-import ReaderExcerpt from 'blocks/reader-excerpt';
-import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
+import AutoDirection from 'calypso/components/auto-direction';
+import Emojify from 'calypso/components/emojify';
+import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
+import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
 import FeaturedAsset from './featured-asset';
 
 const CompactPost = ( { post, postByline, children, isDiscover, onClick } ) => {

--- a/client/blocks/reader-post-card/conversation-post.jsx
+++ b/client/blocks/reader-post-card/conversation-post.jsx
@@ -7,8 +7,8 @@ import PropTypes from 'prop-types';
 /**
  * Internal Dependencies
  */
-import ConversationPostList from 'blocks/conversations/list';
-import CompactPostCard from 'blocks/reader-post-card/compact';
+import ConversationPostList from 'calypso/blocks/conversations/list';
+import CompactPostCard from 'calypso/blocks/reader-post-card/compact';
 
 class ConversationPost extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-post-card/docs/example.jsx
+++ b/client/blocks/reader-post-card/docs/example.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderPostCardBlock from 'blocks/reader-post-card';
+import ReaderPostCardBlock from 'calypso/blocks/reader-post-card';
 import { posts, site } from './fixtures';
 
 const ReaderPostCard = () => (

--- a/client/blocks/reader-post-card/docs/fixtures.js
+++ b/client/blocks/reader-post-card/docs/fixtures.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import DisplayTypes from 'state/reader/posts/display-types';
+import DisplayTypes from 'calypso/state/reader/posts/display-types';
 
 export const posts = [
 	{

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -7,8 +7,8 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
-import ReaderFeaturedVideo from 'blocks/reader-featured-video';
-import ReaderFeaturedImage from 'blocks/reader-featured-image';
+import ReaderFeaturedVideo from 'calypso/blocks/reader-featured-video';
+import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
 
 const FeaturedAsset = ( {
 	canonicalMedia,

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -8,14 +8,14 @@ import { map, take, filter } from 'lodash';
 /**
  * Internal Dependencies
  */
-import AutoDirection from 'components/auto-direction';
-import Emojify from 'components/emojify';
-import resizeImageUrl from 'lib/resize-image-url';
-import cssSafeUrl from 'lib/css-safe-url';
-import { isFeaturedImageInContent } from 'lib/post-normalizer/utils';
-import ReaderExcerpt from 'blocks/reader-excerpt';
-import { imageIsBigEnoughForGallery } from 'state/reader/posts/normalization-rules';
-import { READER_CONTENT_WIDTH } from 'state/reader/posts/sizes';
+import AutoDirection from 'calypso/components/auto-direction';
+import Emojify from 'calypso/components/emojify';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
+import cssSafeUrl from 'calypso/lib/css-safe-url';
+import { isFeaturedImageInContent } from 'calypso/lib/post-normalizer/utils';
+import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
+import { imageIsBigEnoughForGallery } from 'calypso/state/reader/posts/normalization-rules';
+import { READER_CONTENT_WIDTH } from 'calypso/state/reader/posts/sizes';
 
 function getGalleryWorthyImages( post ) {
 	const numberOfImagesToDisplay = 4;

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -8,30 +8,30 @@ import { noop, truncate, get } from 'lodash';
 import classnames from 'classnames';
 import ReactDom from 'react-dom';
 import closest from 'component-closest';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Internal Dependencies
  */
 import { Card } from '@automattic/components';
-import DisplayTypes from 'state/reader/posts/display-types';
-import * as stats from 'reader/stats';
-import ReaderPostActions from 'blocks/reader-post-actions';
+import DisplayTypes from 'calypso/state/reader/posts/display-types';
+import * as stats from 'calypso/reader/stats';
+import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import PostByline from './byline';
 import GalleryPost from './gallery';
 import PhotoPost from './photo';
 import StandardPost from './standard';
 import ConversationPost from './conversation-post';
-import FollowButton from 'reader/follow-button';
-import DailyPostButton from 'blocks/daily-post-button';
-import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
+import FollowButton from 'calypso/reader/follow-button';
+import DailyPostButton from 'calypso/blocks/daily-post-button';
+import { isDailyPostChallengeOrPrompt } from 'calypso/blocks/daily-post-button/helper';
 import {
 	getDiscoverBlogName,
 	getSourceFollowUrl as getDiscoverFollowUrl,
-} from 'reader/discover/helper';
-import DiscoverFollowButton from 'reader/discover/follow-button';
-import { expandCard as expandCardAction } from 'state/reader-ui/card-expansions/actions';
-import isReaderCardExpanded from 'state/selectors/is-reader-card-expanded';
+} from 'calypso/reader/discover/helper';
+import DiscoverFollowButton from 'calypso/reader/discover/follow-button';
+import { expandCard as expandCardAction } from 'calypso/state/reader-ui/card-expansions/actions';
+import isReaderCardExpanded from 'calypso/state/selectors/is-reader-card-expanded';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -9,9 +9,9 @@ import classnames from 'classnames';
 /**
  * Internal Dependencies
  */
-import AutoDirection from 'components/auto-direction';
-import Emojify from 'components/emojify';
-import cssSafeUrl from 'lib/css-safe-url';
+import AutoDirection from 'calypso/components/auto-direction';
+import Emojify from 'calypso/components/emojify';
+import cssSafeUrl from 'calypso/lib/css-safe-url';
 
 class PostPhoto extends React.Component {
 	state = {

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -8,9 +8,9 @@ import { get, partial } from 'lodash';
 /**
  * Internal Dependencies
  */
-import AutoDirection from 'components/auto-direction';
-import Emojify from 'components/emojify';
-import ReaderExcerpt from 'blocks/reader-excerpt';
+import AutoDirection from 'calypso/components/auto-direction';
+import Emojify from 'calypso/components/emojify';
+import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import FeaturedAsset from './featured-asset';
 
 const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpanded, site } ) => {

--- a/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
+++ b/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
@@ -9,8 +9,8 @@ import { connect } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import PopoverMenuItem from 'components/popover/menu-item';
-import { addBlogSticker, removeBlogSticker } from 'state/sites/blog-stickers/actions';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import { addBlogSticker, removeBlogSticker } from 'calypso/state/sites/blog-stickers/actions';
 
 class ReaderPostOptionsMenuBlogStickerMenuItem extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-post-options-menu/blog-stickers.jsx
+++ b/client/blocks/reader-post-options-menu/blog-stickers.jsx
@@ -9,8 +9,8 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import getBlogStickers from 'state/selectors/get-blog-stickers';
-import QueryBlogStickers from 'components/data/query-blog-stickers';
+import getBlogStickers from 'calypso/state/selectors/get-blog-stickers';
+import QueryBlogStickers from 'calypso/components/data/query-blog-stickers';
 import ReaderPostOptionsMenuBlogStickerMenuItem from './blog-sticker-menu-item';
 
 class ReaderPostOptionsMenuBlogStickers extends React.Component {

--- a/client/blocks/reader-post-options-menu/docs/example.jsx
+++ b/client/blocks/reader-post-options-menu/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
+import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
 
 export default class ReaderPostOptionsMenuExample extends React.Component {
 	static displayName = 'ReaderPostOptionsMenuExample';

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -8,35 +8,35 @@ import page from 'page';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies
  */
-import EllipsisMenu from 'components/ellipsis-menu';
-import PopoverMenuItem from 'components/popover/menu-item';
-import { blockSite } from 'state/reader/site-blocks/actions';
-import * as PostUtils from 'state/posts/utils';
-import FollowButton from 'reader/follow-button';
-import * as DiscoverHelper from 'reader/discover/helper';
-import * as stats from 'reader/stats';
-import { getFeed } from 'state/reader/feeds/selectors';
-import { getSite } from 'state/reader/sites/selectors';
-import QueryReaderFeed from 'components/data/query-reader-feed';
-import QueryReaderSite from 'components/data/query-reader-site';
-import QueryReaderTeams from 'components/data/query-reader-teams';
-import { isAutomatticTeamMember } from 'reader/lib/teams';
-import { getReaderTeams } from 'state/reader/teams/selectors';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import { blockSite } from 'calypso/state/reader/site-blocks/actions';
+import * as PostUtils from 'calypso/state/posts/utils';
+import FollowButton from 'calypso/reader/follow-button';
+import * as DiscoverHelper from 'calypso/reader/discover/helper';
+import * as stats from 'calypso/reader/stats';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import { getSite } from 'calypso/state/reader/sites/selectors';
+import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
 import ReaderPostOptionsMenuBlogStickers from './blog-stickers';
-import ConversationFollowButton from 'blocks/conversation-follow-button';
-import { shouldShowConversationFollowButton } from 'blocks/conversation-follow-button/helper';
-import { READER_POST_OPTIONS_MENU } from 'reader/follow-sources';
+import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
+import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
+import { READER_POST_OPTIONS_MENU } from 'calypso/reader/follow-sources';
 import {
 	requestMarkAsSeen,
 	requestMarkAsUnseen,
 	requestMarkAsSeenBlog,
 	requestMarkAsUnseenBlog,
-} from 'state/reader/seen-posts/actions';
+} from 'calypso/state/reader/seen-posts/actions';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -5,16 +5,16 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { map, partial, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import { recordAction, recordTrackWithRailcar, recordTracksRailcarRender } from 'reader/stats';
+import { recordAction, recordTrackWithRailcar, recordTracksRailcarRender } from 'calypso/reader/stats';
 import { Button } from '@automattic/components';
-import { dismissSite } from 'state/reader/site-dismissals/actions';
-import ConnectedListItem from 'blocks/reader-list-item/connected';
+import { dismissSite } from 'calypso/state/reader/site-dismissals/actions';
+import ConnectedListItem from 'calypso/blocks/reader-list-item/connected';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-related-card/docs/example.jsx
+++ b/client/blocks/reader-related-card/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { RelatedPostsFromSameSite, RelatedPostsFromOtherSites } from 'components/related-posts';
+import { RelatedPostsFromSameSite, RelatedPostsFromOtherSites } from 'calypso/components/related-posts';
 import { Card } from '@automattic/components';
 
 const LONGREADS_SITE_ID = 70135762;

--- a/client/blocks/reader-related-card/index.jsx
+++ b/client/blocks/reader-related-card/index.jsx
@@ -10,17 +10,17 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import { getPostById } from 'state/reader/posts/selectors';
-import { getSite } from 'state/reader/sites/selectors';
-import QueryReaderSite from 'components/data/query-reader-site';
+import { getPostById } from 'calypso/state/reader/posts/selectors';
+import { getSite } from 'calypso/state/reader/sites/selectors';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import { CompactCard as Card } from '@automattic/components';
-import Gravatar from 'components/gravatar';
-import FollowButton from 'reader/follow-button';
-import { getPostUrl, getStreamUrl } from 'reader/route';
-import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
-import ReaderFeaturedVideo from 'blocks/reader-featured-video';
-import ReaderFeaturedImage from 'blocks/reader-featured-image';
-import ReaderAuthorLink from 'blocks/reader-author-link';
+import Gravatar from 'calypso/components/gravatar';
+import FollowButton from 'calypso/reader/follow-button';
+import { getPostUrl, getStreamUrl } from 'calypso/reader/route';
+import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
+import ReaderFeaturedVideo from 'calypso/blocks/reader-featured-video';
+import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
+import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-share/docs/example.jsx
+++ b/client/blocks/reader-share/docs/example.jsx
@@ -7,9 +7,9 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderShare from 'blocks/reader-share';
+import ReaderShare from 'calypso/blocks/reader-share';
 import { Card } from '@automattic/components';
-import { posts } from 'blocks/reader-post-card/docs/fixtures';
+import { posts } from 'calypso/blocks/reader-post-card/docs/fixtures';
 
 const ReaderShareExample = () => (
 	<div className="design-assets__group" style={ { width: '100px' } }>

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { defer } from 'lodash';
-import config from 'config';
+import config from 'calypso/config';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import page from 'page';
@@ -13,14 +13,14 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import ReaderPopoverMenu from 'reader/components/reader-popover/menu';
-import PopoverMenuItem from 'components/popover/menu-item';
-import Gridicon from 'components/gridicon';
-import SocialLogo from 'components/social-logo';
-import * as stats from 'reader/stats';
-import { preloadEditor } from 'sections-preloaders';
-import SiteSelector from 'components/site-selector';
-import getPrimarySiteId from 'state/selectors/get-primary-site-id';
+import ReaderPopoverMenu from 'calypso/reader/components/reader-popover/menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import Gridicon from 'calypso/components/gridicon';
+import SocialLogo from 'calypso/components/social-logo';
+import * as stats from 'calypso/reader/stats';
+import { preloadEditor } from 'calypso/sections-preloaders';
+import SiteSelector from 'calypso/components/site-selector';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { Button } from '@automattic/components';
 
 /**

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -10,11 +10,11 @@ import { find, get } from 'lodash';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
-import ReaderPopover from 'reader/components/reader-popover';
-import SegmentedControl from 'components/segmented-control';
-import CompactFormToggle from 'components/forms/form-toggle/compact';
-import { getReaderFollows } from 'state/reader/follows/selectors';
+import Gridicon from 'calypso/components/gridicon';
+import ReaderPopover from 'calypso/reader/components/reader-popover';
+import SegmentedControl from 'calypso/components/segmented-control';
+import CompactFormToggle from 'calypso/components/forms/form-toggle/compact';
+import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import {
 	subscribeToNewPostEmail,
 	updateNewPostEmailSubscription,
@@ -23,10 +23,10 @@ import {
 	unsubscribeToNewCommentEmail,
 	subscribeToNewPostNotifications,
 	unsubscribeToNewPostNotifications,
-} from 'state/reader/follows/actions';
-import { recordTracksEvent } from 'state/analytics/actions';
-import QueryUserSettings from 'components/data/query-user-settings';
-import getUserSetting from 'state/selectors/get-user-setting';
+} from 'calypso/state/reader/follows/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-site-stream-link/docs/example.jsx
+++ b/client/blocks/reader-site-stream-link/docs/example.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
+import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import { Card } from '@automattic/components';
 
 export default class ReaderSiteStreamLinkExample extends React.Component {

--- a/client/blocks/reader-site-stream-link/index.jsx
+++ b/client/blocks/reader-site-stream-link/index.jsx
@@ -8,9 +8,9 @@ import { omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getStreamUrl } from 'reader/route';
-import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
-import Emojify from 'components/emojify';
+import { getStreamUrl } from 'calypso/reader/route';
+import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
+import Emojify from 'calypso/components/emojify';
 
 class ReaderSiteStreamLink extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -9,9 +9,9 @@ import { connect } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import connectSite from 'lib/reader-connect-site';
+import connectSite from 'calypso/lib/reader-connect-site';
 import SubscriptionListItem from '.';
-import { isFollowing as isFollowingSelector } from 'state/reader/follows/selectors';
+import { isFollowing as isFollowingSelector } from 'calypso/state/reader/follows/selectors';
 
 class ConnectedSubscriptionListItem extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -8,8 +8,8 @@ import { map } from 'lodash';
 /**
  * Internal dependencies
  */
-import ConnectedReaderSubscriptionListItem from 'blocks/reader-subscription-list-item/connected';
-import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-list-item/placeholder';
+import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
+import ReaderSubscriptionListItemPlaceholder from 'calypso/blocks/reader-subscription-list-item/placeholder';
 import { Card } from '@automattic/components';
 
 const sites = {

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -9,22 +9,22 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import ReaderAvatar from 'blocks/reader-avatar';
-import FollowButton from 'reader/follow-button';
-import { getStreamUrl } from 'reader/route';
-import ReaderSiteNotificationSettings from 'blocks/reader-site-notification-settings';
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
+import FollowButton from 'calypso/reader/follow-button';
+import { getStreamUrl } from 'calypso/reader/route';
+import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
 import {
 	getSiteName,
 	getSiteDescription,
 	getSiteAuthorName,
 	getFeedUrl,
 	getSiteUrl,
-} from 'reader/get-helpers';
-import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-list-item/placeholder';
-import { recordTrack, recordTrackWithRailcar } from 'reader/stats';
-import ExternalLink from 'components/external-link';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { formatUrlForDisplay } from 'reader/lib/feed-display-helper';
+} from 'calypso/reader/get-helpers';
+import ReaderSubscriptionListItemPlaceholder from 'calypso/blocks/reader-subscription-list-item/placeholder';
+import { recordTrack, recordTrackWithRailcar } from 'calypso/reader/stats';
+import ExternalLink from 'calypso/components/external-link';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
 
 /**
  * Style dependencies

--- a/client/blocks/reader-subscription-list-item/placeholder.jsx
+++ b/client/blocks/reader-subscription-list-item/placeholder.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderAvatar from 'blocks/reader-avatar';
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
 
 const ReaderSubscriptionListItemPlaceholder = () => {
 	return (

--- a/client/blocks/reader-visit-link/index.jsx
+++ b/client/blocks/reader-visit-link/index.jsx
@@ -8,7 +8,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
+import ExternalLink from 'calypso/components/external-link';
 
 /**
  * Style dependencies

--- a/client/blocks/sharing-preview-pane/docs/example.jsx
+++ b/client/blocks/sharing-preview-pane/docs/example.jsx
@@ -9,14 +9,14 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import SharingPreviewPane from 'blocks/sharing-preview-pane';
-import { getCurrentUser } from 'state/current-user/selectors';
-import QueryPosts from 'components/data/query-posts';
-import QueryPublicizeConnections from 'components/data/query-publicize-connections';
-import { getSitePosts } from 'state/posts/selectors';
-import { getSite } from 'state/sites/selectors';
+import SharingPreviewPane from 'calypso/blocks/sharing-preview-pane';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import QueryPosts from 'calypso/components/data/query-posts';
+import QueryPublicizeConnections from 'calypso/components/data/query-publicize-connections';
+import { getSitePosts } from 'calypso/state/posts/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
 import { Card } from '@automattic/components';
-import QuerySites from 'components/data/query-sites';
+import QuerySites from 'calypso/components/data/query-sites';
 
 const SharingPreviewPaneExample = ( { postId, site, siteId } ) => (
 	<div>

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -12,19 +12,19 @@ import { get, find, map } from 'lodash';
  * Internal dependencies
  */
 import { getPostImage, getExcerptForPost, getSummaryForPost } from './utils';
-import FacebookSharePreview from 'components/share/facebook-share-preview';
-import LinkedinSharePreview from 'components/share/linkedin-share-preview';
-import TwitterSharePreview from 'components/share/twitter-share-preview';
-import TumblrSharePreview from 'components/share/tumblr-share-preview';
-import VerticalMenu from 'components/vertical-menu';
-import { SocialItem } from 'components/vertical-menu/items';
-import { getSitePost } from 'state/posts/selectors';
-import { getSeoTitle, getSite, getSiteSlug } from 'state/sites/selectors';
-import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import getSiteIconUrl from 'state/selectors/get-site-icon-url';
+import FacebookSharePreview from 'calypso/components/share/facebook-share-preview';
+import LinkedinSharePreview from 'calypso/components/share/linkedin-share-preview';
+import TwitterSharePreview from 'calypso/components/share/twitter-share-preview';
+import TumblrSharePreview from 'calypso/components/share/tumblr-share-preview';
+import VerticalMenu from 'calypso/components/vertical-menu';
+import { SocialItem } from 'calypso/components/vertical-menu/items';
+import { getSitePost } from 'calypso/state/posts/selectors';
+import { getSeoTitle, getSite, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteUserConnections } from 'calypso/state/sharing/publicize/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import getSiteIconUrl from 'calypso/state/selectors/get-site-icon-url';
 
 /**
  * Style dependencies

--- a/client/blocks/sharing-preview-pane/utils.js
+++ b/client/blocks/sharing-preview-pane/utils.js
@@ -8,9 +8,9 @@ import striptags from 'striptags';
 /**
  * Internal dependencies
  */
-import { formatExcerpt } from 'lib/post-normalizer/rule-create-better-excerpt';
-import PostMetadata from 'lib/post-metadata';
-import { parseHtml } from 'lib/formatting';
+import { formatExcerpt } from 'calypso/lib/post-normalizer/rule-create-better-excerpt';
+import PostMetadata from 'calypso/lib/post-metadata';
+import { parseHtml } from 'calypso/lib/formatting';
 
 const PREVIEW_IMAGE_WIDTH = 512;
 

--- a/client/blocks/shortcode/frame.js
+++ b/client/blocks/shortcode/frame.js
@@ -10,8 +10,8 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import generateEmbedFrameMarkup from 'lib/embed-frame-markup';
-import ResizableIframe from 'components/resizable-iframe';
+import generateEmbedFrameMarkup from 'calypso/lib/embed-frame-markup';
+import ResizableIframe from 'calypso/components/resizable-iframe';
 
 export default class extends React.Component {
 	static displayName = 'ShortcodeFrame';

--- a/client/blocks/shortcode/index.js
+++ b/client/blocks/shortcode/index.js
@@ -10,8 +10,8 @@ import { identity, omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import QueryShortcode from 'components/data/query-shortcode';
-import { getShortcode } from 'state/shortcodes/selectors';
+import QueryShortcode from 'calypso/components/data/query-shortcode';
+import { getShortcode } from 'calypso/state/shortcodes/selectors';
 
 /**
  * Local dependencies

--- a/client/blocks/signup-form/crowdsignal.jsx
+++ b/client/blocks/signup-form/crowdsignal.jsx
@@ -3,20 +3,20 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import AutomatticLogo from 'components/automattic-logo';
+import AutomatticLogo from 'calypso/components/automattic-logo';
 import { Button } from '@automattic/components';
-import FormButton from 'components/forms/form-button';
-import LoggedOutForm from 'components/logged-out-form';
-import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
-import LoggedOutFormFooter from 'components/logged-out-form/footer';
-import WordPressLogo from 'components/wordpress-logo';
+import FormButton from 'calypso/components/forms/form-button';
+import LoggedOutForm from 'calypso/components/logged-out-form';
+import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
+import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
+import WordPressLogo from 'calypso/components/wordpress-logo';
 import SocialSignupForm from './social';
 
 /**

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -23,42 +23,42 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { abtest } from 'lib/abtest';
+import { abtest } from 'calypso/lib/abtest';
 
 /**
  * Internal dependencies
  */
-import { localizeUrl } from 'lib/i18n-utils';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
-import wpcom from 'lib/wp';
-import config from 'config';
-import { recordTracksEvent } from 'lib/analytics/tracks';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import wpcom from 'calypso/lib/wp';
+import config from 'calypso/config';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { Button } from '@automattic/components';
-import FormInputValidation from 'components/forms/form-input-validation';
-import FormLabel from 'components/forms/form-label';
-import FormPasswordInput from 'components/forms/form-password-input';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormTextInput from 'components/forms/form-text-input';
-import FormButton from 'components/forms/form-button';
-import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
-import notices from 'notices';
-import Notice from 'components/notice';
-import LoggedOutForm from 'components/logged-out-form';
-import { login } from 'lib/paths';
-import formState from 'lib/form-state';
-import LoggedOutFormLinks from 'components/logged-out-form/links';
-import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
-import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
-import LoggedOutFormFooter from 'components/logged-out-form/footer';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormPasswordInput from 'calypso/components/forms/form-password-input';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormButton from 'calypso/components/forms/form-button';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import notices from 'calypso/notices';
+import Notice from 'calypso/components/notice';
+import LoggedOutForm from 'calypso/components/logged-out-form';
+import { login } from 'calypso/lib/paths';
+import formState from 'calypso/lib/form-state';
+import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
+import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
+import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
+import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import PasswordlessSignupForm from './passwordless';
 import CrowdsignalSignupForm from './crowdsignal';
 import SocialSignupForm from './social';
-import { recordTracksEventWithClientId } from 'state/analytics/actions';
-import { createSocialUserFailed } from 'state/login/actions';
-import { getCurrentOAuth2Client } from 'state/oauth2-clients/ui/selectors';
-import { getSectionName } from 'state/ui/selectors';
-import TextControl from 'extensions/woocommerce/components/text-control';
-import wooDnaConfig from 'jetpack-connect/woo-dna-config';
+import { recordTracksEventWithClientId } from 'calypso/state/analytics/actions';
+import { createSocialUserFailed } from 'calypso/state/login/actions';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import { getSectionName } from 'calypso/state/ui/selectors';
+import TextControl from 'calypso/extensions/woocommerce/components/text-control';
+import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 
 /**
  * Style dependencies

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -10,20 +10,20 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { getSavedVariations } from 'lib/abtest';
-import wpcom from 'lib/wp';
-import { recordRegistration } from 'lib/analytics/signup';
-import { recordGoogleRecaptchaAction } from 'lib/analytics/recaptcha';
+import { getSavedVariations } from 'calypso/lib/abtest';
+import wpcom from 'calypso/lib/wp';
+import { recordRegistration } from 'calypso/lib/analytics/signup';
+import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 import { Button } from '@automattic/components';
-import FormLabel from 'components/forms/form-label';
-import FormTextInput from 'components/forms/form-text-input';
-import LoggedOutForm from 'components/logged-out-form';
-import LoggedOutFormFooter from 'components/logged-out-form/footer';
-import ValidationFieldset from 'signup/validation-fieldset';
-import { recordTracksEvent } from 'state/analytics/actions';
-import Notice from 'components/notice';
-import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
-import flows from 'signup/config/flows';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import LoggedOutForm from 'calypso/components/logged-out-form';
+import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
+import ValidationFieldset from 'calypso/signup/validation-fieldset';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import Notice from 'calypso/components/notice';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+import flows from 'calypso/signup/config/flows';
 
 class PasswordlessSignupForm extends Component {
 	static propTypes = {

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -9,13 +9,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import AppleLoginButton from 'components/social-buttons/apple';
-import config from 'config';
-import getCurrentRoute from 'state/selectors/get-current-route';
-import GoogleLoginButton from 'components/social-buttons/google';
-import { localizeUrl } from 'lib/i18n-utils';
-import { preventWidows } from 'lib/formatting';
-import { recordTracksEvent } from 'state/analytics/actions';
+import AppleLoginButton from 'calypso/components/social-buttons/apple';
+import config from 'calypso/config';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import GoogleLoginButton from 'calypso/components/social-buttons/google';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { preventWidows } from 'calypso/lib/formatting';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 class SocialSignupForm extends Component {
 	static propTypes = {

--- a/client/blocks/site-address-changer/dialog.jsx
+++ b/client/blocks/site-address-changer/dialog.jsx
@@ -5,15 +5,15 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal Dependencies
  */
 import { Dialog } from '@automattic/components';
-import FormLabel from 'components/forms/form-label';
-import FormInputCheckbox from 'components/forms/form-checkbox';
-import TrackComponentView from 'lib/analytics/track-component-view';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 
 class SiteAddressChangerConfirmationDialog extends PureComponent {
 	static propTypes = {

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -7,31 +7,31 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { debounce, get, flow, inRange, isEmpty } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import FormButton from 'components/forms/form-button';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
-import FormInputValidation from 'components/forms/form-input-validation';
-import FormLabel from 'components/forms/form-label';
-import FormSelect from 'components/forms/form-select';
+import FormButton from 'calypso/components/forms/form-button';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSelect from 'calypso/components/forms/form-select';
 import ConfirmationDialog from './dialog';
-import TrackComponentView from 'lib/analytics/track-component-view';
-import { recordTracksEvent } from 'state/analytics/actions';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	requestSiteAddressChange,
 	requestSiteAddressAvailability,
 	clearValidationError,
-} from 'state/site-address-change/actions';
-import getSiteAddressAvailabilityPending from 'state/selectors/get-site-address-availability-pending';
-import getSiteAddressValidationError from 'state/selectors/get-site-address-validation-error';
-import isRequestingSiteAddressChange from 'state/selectors/is-requesting-site-address-change';
-import { getSelectedSite } from 'state/ui/selectors';
+} from 'calypso/state/site-address-change/actions';
+import getSiteAddressAvailabilityPending from 'calypso/state/selectors/get-site-address-availability-pending';
+import getSiteAddressValidationError from 'calypso/state/selectors/get-site-address-validation-error';
+import isRequestingSiteAddressChange from 'calypso/state/selectors/is-requesting-site-address-change';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 /**
  * Style dependencies

--- a/client/blocks/site-icon/docs/example.jsx
+++ b/client/blocks/site-icon/docs/example.jsx
@@ -10,7 +10,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import SiteIcon from '../';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 /**
  * Site ID of en.blog.wordpress.com, to be used as fallback for SiteIcon if

--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -7,20 +7,20 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-import Image from 'components/image';
-import MediaImage from 'my-sites/media-library/media-image';
-import Spinner from 'components/spinner';
-import QuerySites from 'components/data/query-sites';
-import { getSite } from 'state/sites/selectors';
-import getSiteIconId from 'state/selectors/get-site-icon-id';
-import getSiteIconUrl from 'state/selectors/get-site-icon-url';
-import isTransientMedia from 'state/selectors/is-transient-media';
-import resizeImageUrl from 'lib/resize-image-url';
+import Image from 'calypso/components/image';
+import MediaImage from 'calypso/my-sites/media-library/media-image';
+import Spinner from 'calypso/components/spinner';
+import QuerySites from 'calypso/components/data/query-sites';
+import { getSite } from 'calypso/state/sites/selectors';
+import getSiteIconId from 'calypso/state/selectors/get-site-icon-id';
+import getSiteIconUrl from 'calypso/state/selectors/get-site-icon-url';
+import isTransientMedia from 'calypso/state/selectors/is-transient-media';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
 
 /**
  * Style dependencies

--- a/client/blocks/site-preview/index.jsx
+++ b/client/blocks/site-preview/index.jsx
@@ -9,13 +9,13 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { closePreview } from 'state/ui/preview/actions';
-import { getPreviewSite, getPreviewSiteId, getPreviewUrl } from 'state/ui/preview/selectors';
-import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
-import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
-import { addQueryArgs } from 'lib/route';
-import isDomainOnlySite from 'state/selectors/is-domain-only-site';
-import WebPreview from 'components/web-preview';
+import { closePreview } from 'calypso/state/ui/preview/actions';
+import { getPreviewSite, getPreviewSiteId, getPreviewUrl } from 'calypso/state/ui/preview/selectors';
+import { getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
+import { addQueryArgs } from 'calypso/lib/route';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import WebPreview from 'calypso/components/web-preview';
 
 const debug = debugFactory( 'calypso:site-preview' );
 

--- a/client/blocks/site/docs/example.jsx
+++ b/client/blocks/site/docs/example.jsx
@@ -8,10 +8,10 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import Site from 'blocks/site';
+import Site from 'calypso/blocks/site';
 import { Card } from '@automattic/components';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { getSite } from 'state/sites/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
 
 const SiteExample = ( { site } ) => (
 	<Card style={ { padding: 0 } }>

--- a/client/blocks/site/docs/placeholder-example.jsx
+++ b/client/blocks/site/docs/placeholder-example.jsx
@@ -7,7 +7,7 @@ import React, { PureComponent } from 'react';
 /**
  * Internal dependencies
  */
-import SitePlaceholder from 'blocks/site/placeholder';
+import SitePlaceholder from 'calypso/blocks/site/placeholder';
 
 export default class SitePlaceholderExample extends PureComponent {
 	static displayName = 'SitePlaceholderExample';

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -6,18 +6,18 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { noop } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import { isEnabled } from 'config';
+import { isEnabled } from 'calypso/config';
 
 /**
  * Internal dependencies
  */
-import SiteIcon from 'blocks/site-icon';
-import SiteIndicator from 'my-sites/site-indicator';
-import { getSite, getSiteSlug, isSitePreviewable } from 'state/sites/selectors';
-import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import SiteIcon from 'calypso/blocks/site-icon';
+import SiteIndicator from 'calypso/my-sites/site-indicator';
+import { getSite, getSiteSlug, isSitePreviewable } from 'calypso/state/sites/selectors';
+import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -8,17 +8,17 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import SectionNav from 'components/section-nav';
-import NavItem from 'components/section-nav/item';
-import NavTabs from 'components/section-nav/tabs';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
 import Intervals from './intervals';
-import FollowersCount from 'blocks/followers-count';
-import isGoogleMyBusinessLocationConnectedSelector from 'state/selectors/is-google-my-business-location-connected';
-import isSiteStore from 'state/selectors/is-site-store';
-import { getSiteOption } from 'state/sites/selectors';
-import canCurrentUser from 'state/selectors/can-current-user';
+import FollowersCount from 'calypso/blocks/followers-count';
+import isGoogleMyBusinessLocationConnectedSelector from 'calypso/state/selectors/is-google-my-business-location-connected';
+import isSiteStore from 'calypso/state/selectors/is-site-store';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import { navItems, intervals as intervalConstants } from './constants';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Style dependencies

--- a/client/blocks/stats-navigation/intervals.js
+++ b/client/blocks/stats-navigation/intervals.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import { intervals } from './constants';
-import SegmentedControl from 'components/segmented-control';
+import SegmentedControl from 'calypso/components/segmented-control';
 
 /**
  * Style dependencies

--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -11,9 +11,9 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import QuerySiteStats from 'components/data/query-site-stats';
-import { isJetpackSite, getSiteOption } from 'state/sites/selectors';
-import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { isJetpackSite, getSiteOption } from 'calypso/state/sites/selectors';
+import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 
 const StatsSparkline = ( { isJetpack, siteUrl, className, siteId, highestViews } ) => {
 	const translate = useTranslate();

--- a/client/blocks/subscription-length-picker/docs/example.jsx
+++ b/client/blocks/subscription-length-picker/docs/example.jsx
@@ -7,9 +7,9 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { getPlan } from 'lib/plans';
-import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from 'lib/plans/constants';
-import { SubscriptionLengthPicker } from 'blocks/subscription-length-picker';
+import { getPlan } from 'calypso/lib/plans';
+import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from 'calypso/lib/plans/constants';
+import { SubscriptionLengthPicker } from 'calypso/blocks/subscription-length-picker';
 import PropTypes from 'prop-types';
 
 const productsWithPrices1 = [

--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -10,12 +10,12 @@ import formatCurrency, { CURRENCIES } from '@automattic/format-currency';
  * Internal Dependencies
  */
 import { localize } from 'i18n-calypso';
-import { computeProductsWithPrices } from 'state/products-list/selectors';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { PLANS_LIST } from 'lib/plans/plans-list';
-import QueryPlans from 'components/data/query-plans';
-import QueryProductsList from 'components/data/query-products-list';
+import { computeProductsWithPrices } from 'calypso/state/products-list/selectors';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { PLANS_LIST } from 'calypso/lib/plans/plans-list';
+import QueryPlans from 'calypso/components/data/query-plans';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import SubscriptionLengthOption from './option';
 
 /**

--- a/client/blocks/subscription-length-picker/test/index.js
+++ b/client/blocks/subscription-length-picker/test/index.js
@@ -10,8 +10,8 @@ jest.mock( '../option', () => 'SubscriptionLengthOption' );
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { getPlan } from 'lib/plans';
-import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from 'lib/plans/constants';
+import { getPlan } from 'calypso/lib/plans';
+import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from 'calypso/lib/plans/constants';
 
 /**
  * Internal dependencies

--- a/client/blocks/subscription-length-picker/test/option.js
+++ b/client/blocks/subscription-length-picker/test/option.js
@@ -9,7 +9,7 @@ const translate = ( x ) => x;
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import { TERM_1_YEAR } from 'lib/plans/constants';
+import { TERM_1_YEAR } from 'calypso/lib/plans/constants';
 
 /**
  * Internal dependencies

--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -6,7 +6,7 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { memoize, noop } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal Dependencies
@@ -14,25 +14,25 @@ import Gridicon from 'components/gridicon';
 import { Button, Dialog } from '@automattic/components';
 import SupportArticleHeader from './header';
 import Placeholders from './placeholders';
-import EmbedContainer from 'components/embed-container';
-import Emojify from 'components/emojify';
-import QueryReaderPost from 'components/data/query-reader-post';
-import QueryReaderSite from 'components/data/query-reader-site';
-import QuerySupportArticleAlternates from 'components/data/query-support-article-alternates';
-import { isDefaultLocale } from 'lib/i18n-utils';
-import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
-import { getPostByKey } from 'state/reader/posts/selectors';
-import { SUPPORT_BLOG_ID } from 'blocks/inline-help/constants';
-import getInlineSupportArticlePostId from 'state/selectors/get-inline-support-article-post-id';
-import getInlineSupportArticleActionUrl from 'state/selectors/get-inline-support-article-action-url';
-import getInlineSupportArticleActionLabel from 'state/selectors/get-inline-support-article-action-label';
-import getInlineSupportArticleActionIsExternal from 'state/selectors/get-inline-support-article-action-is-external';
-import { closeSupportArticleDialog as closeDialog } from 'state/inline-support-article/actions';
+import EmbedContainer from 'calypso/components/embed-container';
+import Emojify from 'calypso/components/emojify';
+import QueryReaderPost from 'calypso/components/data/query-reader-post';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import QuerySupportArticleAlternates from 'calypso/components/data/query-support-article-alternates';
+import { isDefaultLocale } from 'calypso/lib/i18n-utils';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import { SUPPORT_BLOG_ID } from 'calypso/blocks/inline-help/constants';
+import getInlineSupportArticlePostId from 'calypso/state/selectors/get-inline-support-article-post-id';
+import getInlineSupportArticleActionUrl from 'calypso/state/selectors/get-inline-support-article-action-url';
+import getInlineSupportArticleActionLabel from 'calypso/state/selectors/get-inline-support-article-action-label';
+import getInlineSupportArticleActionIsExternal from 'calypso/state/selectors/get-inline-support-article-action-is-external';
+import { closeSupportArticleDialog as closeDialog } from 'calypso/state/inline-support-article/actions';
 import {
 	getSupportArticleAlternatesForLocale,
 	isRequestingSupportArticleAlternates,
 	shouldRequestSupportArticleAlternates,
-} from 'state/support-articles-alternates/selectors';
+} from 'calypso/state/support-articles-alternates/selectors';
 
 /**
  * Style Dependencies

--- a/client/blocks/support-article-dialog/docs/example.jsx
+++ b/client/blocks/support-article-dialog/docs/example.jsx
@@ -8,8 +8,8 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import { openSupportArticleDialog } from 'state/inline-support-article/actions';
-import { localizeUrl } from 'lib/i18n-utils';
+import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 const postId = 143180;
 const postUrl = localizeUrl(

--- a/client/blocks/support-article-dialog/header.jsx
+++ b/client/blocks/support-article-dialog/header.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
+import ExternalLink from 'calypso/components/external-link';
 
 const SupportArticleHeader = ( { post, isLoading } ) =>
 	isLoading || ! post ? (

--- a/client/blocks/support-article-dialog/index.jsx
+++ b/client/blocks/support-article-dialog/index.jsx
@@ -7,12 +7,12 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import AsyncLoad from 'components/async-load';
-import isInlineSupportArticleVisible from 'state/selectors/is-inline-support-article-visible';
+import AsyncLoad from 'calypso/components/async-load';
+import isInlineSupportArticleVisible from 'calypso/state/selectors/is-inline-support-article-visible';
 
 function SupportArticleDialogLoader( { isVisible } ) {
 	return (
-		isVisible && <AsyncLoad require="blocks/support-article-dialog/dialog" placeholder={ null } />
+		isVisible && <AsyncLoad require="calypso/blocks/support-article-dialog/dialog" placeholder={ null } />
 	);
 }
 

--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -10,14 +10,14 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import SearchCard from 'components/search-card';
+import SearchCard from 'calypso/components/search-card';
 import { Button } from '@automattic/components';
 import TermsList from './list';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
-import QueryTaxonomies from 'components/data/query-taxonomies';
-import TermFormDialog from 'blocks/term-form-dialog';
-import { recordGoogleEvent, bumpStat } from 'state/analytics/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getPostTypeTaxonomy } from 'calypso/state/post-types/taxonomies/selectors';
+import QueryTaxonomies from 'calypso/components/data/query-taxonomies';
+import TermFormDialog from 'calypso/blocks/term-form-dialog';
+import { recordGoogleEvent, bumpStat } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -9,26 +9,26 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, isUndefined } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-import Count from 'components/count';
+import Count from 'calypso/components/count';
 import { Dialog } from '@automattic/components';
-import EllipsisMenu from 'components/ellipsis-menu';
-import PopoverMenuItem from 'components/popover/menu-item';
-import PopoverMenuSeparator from 'components/popover/menu-separator';
-import Tooltip from 'components/tooltip';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSettings } from 'state/site-settings/selectors';
-import { getSite } from 'state/sites/selectors';
-import { decodeEntities } from 'lib/formatting';
-import { deleteTerm } from 'state/terms/actions';
-import { saveSiteSettings } from 'state/site-settings/actions';
-import { recordGoogleEvent, bumpStat } from 'state/analytics/actions';
-import PodcastIndicator from 'components/podcast-indicator';
-import getPodcastingCategoryId from 'state/selectors/get-podcasting-category-id';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import PopoverMenuSeparator from 'calypso/components/popover/menu-separator';
+import Tooltip from 'calypso/components/tooltip';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSiteSettings } from 'calypso/state/site-settings/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
+import { decodeEntities } from 'calypso/lib/formatting';
+import { deleteTerm } from 'calypso/state/terms/actions';
+import { saveSiteSettings } from 'calypso/state/site-settings/actions';
+import { recordGoogleEvent, bumpStat } from 'calypso/state/analytics/actions';
+import PodcastIndicator from 'calypso/components/podcast-indicator';
+import getPodcastingCategoryId from 'calypso/state/selectors/get-podcasting-category-id';
 
 class TaxonomyManagerListItem extends Component {
 	static propTypes = {

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -13,17 +13,17 @@ import { WindowScroller } from '@automattic/react-virtualized';
 /**
  * Internal dependencies
  */
-import VirtualList from 'components/virtual-list';
+import VirtualList from 'calypso/components/virtual-list';
 import ListItem from './list-item';
 import { CompactCard } from '@automattic/components';
-import QueryTerms from 'components/data/query-terms';
-import QuerySiteSettings from 'components/data/query-site-settings';
+import QueryTerms from 'calypso/components/data/query-terms';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import {
 	isRequestingTermsForQueryIgnoringPage,
 	getTermsLastPageForQuery,
 	getTermsForQueryIgnoringPage,
-} from 'state/terms/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+} from 'calypso/state/terms/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**
  * Constants

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -12,19 +12,19 @@ import { get, find, noop, assign } from 'lodash';
  * Internal dependencies
  */
 import { Dialog } from '@automattic/components';
-import TermTreeSelectorTerms from 'blocks/term-tree-selector/terms';
-import FormInputValidation from 'components/forms/form-input-validation';
-import FormTextarea from 'components/forms/form-textarea';
-import FormTextInput from 'components/forms/form-text-input';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import FormToggle from 'components/forms/form-toggle';
-import FormLegend from 'components/forms/form-legend';
-import FormFieldset from 'components/forms/form-fieldset';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
-import { getTerms } from 'state/terms/selectors';
-import { addTerm, updateTerm } from 'state/terms/actions';
-import { recordGoogleEvent, bumpStat } from 'state/analytics/actions';
+import TermTreeSelectorTerms from 'calypso/blocks/term-tree-selector/terms';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import FormToggle from 'calypso/components/forms/form-toggle';
+import FormLegend from 'calypso/components/forms/form-legend';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getPostTypeTaxonomy } from 'calypso/state/post-types/taxonomies/selectors';
+import { getTerms } from 'calypso/state/terms/selectors';
+import { addTerm, updateTerm } from 'calypso/state/terms/actions';
+import { recordGoogleEvent, bumpStat } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/blocks/term-tree-selector/add-term.jsx
+++ b/client/blocks/term-tree-selector/add-term.jsx
@@ -7,17 +7,17 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { get, noop } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import TermFormDialog from 'blocks/term-form-dialog';
-import QueryTaxonomies from 'components/data/query-taxonomies';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
-import { getTerms } from 'state/terms/selectors';
+import TermFormDialog from 'calypso/blocks/term-form-dialog';
+import QueryTaxonomies from 'calypso/components/data/query-taxonomies';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getPostTypeTaxonomy } from 'calypso/state/post-types/taxonomies/selectors';
+import { getTerms } from 'calypso/state/terms/selectors';
 
 /**
  * Style dependencies

--- a/client/blocks/term-tree-selector/search.jsx
+++ b/client/blocks/term-tree-selector/search.jsx
@@ -4,12 +4,12 @@
 import PropTypes from 'prop-types';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-import FormTextInput from 'components/forms/form-text-input';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 
 /**
  * Style dependencies

--- a/client/blocks/time-mismatch-warning/docs/example.tsx
+++ b/client/blocks/time-mismatch-warning/docs/example.tsx
@@ -6,8 +6,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { TimeMismatchWarning } from 'blocks/time-mismatch-warning';
-import { useLocalizedMoment } from 'components/localized-moment';
+import { TimeMismatchWarning } from 'calypso/blocks/time-mismatch-warning';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 const TimeMismatchWarningExample = () => {
 	const moment = useLocalizedMoment();

--- a/client/blocks/time-mismatch-warning/index.tsx
+++ b/client/blocks/time-mismatch-warning/index.tsx
@@ -8,14 +8,14 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
-import { withApplySiteOffset, applySiteOffsetType } from 'components/site-offset';
-import { useLocalizedMoment } from 'components/localized-moment';
+import Notice from 'calypso/components/notice';
+import { withApplySiteOffset, applySiteOffsetType } from 'calypso/components/site-offset';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 /**
  * Type dependencies
  */
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 interface ConnectedProps {
 	applySiteOffset: applySiteOffsetType;

--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -6,18 +6,18 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import FilePicker from 'components/file-picker';
-import DropZone from 'components/drop-zone';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import notices from 'notices';
+import FilePicker from 'calypso/components/file-picker';
+import DropZone from 'calypso/components/drop-zone';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import notices from 'calypso/notices';
 import debugFactory from 'debug';
-import { MAX_UPLOAD_ZIP_SIZE } from 'lib/automated-transfer/constants';
+import { MAX_UPLOAD_ZIP_SIZE } from 'calypso/lib/automated-transfer/constants';
 
 /**
  * Style dependencies

--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import UpsellNudge from 'blocks/upsell-nudge';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 const UpsellNudgeExample = () => (
 	<>

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies
@@ -16,17 +16,17 @@ import {
 	isPremiumPlan,
 	isBusinessPlan,
 	isEcommercePlan,
-} from 'lib/plans';
-import Banner from 'components/banner';
-import { GROUP_JETPACK, GROUP_WPCOM, FEATURE_NO_ADS } from 'lib/plans/constants';
-import { addQueryArgs } from 'lib/url';
-import { hasFeature } from 'state/sites/plans/selectors';
-import { isFreePlan } from 'lib/products-values';
-import canCurrentUser from 'state/selectors/can-current-user';
-import isVipSite from 'state/selectors/is-vip-site';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { getSite, isJetpackSite } from 'state/sites/selectors';
-import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
+} from 'calypso/lib/plans';
+import Banner from 'calypso/components/banner';
+import { GROUP_JETPACK, GROUP_WPCOM, FEATURE_NO_ADS } from 'calypso/lib/plans/constants';
+import { addQueryArgs } from 'calypso/lib/url';
+import { hasFeature } from 'calypso/state/sites/plans/selectors';
+import { isFreePlan } from 'calypso/lib/products-values';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import isVipSite from 'calypso/state/selectors/is-vip-site';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 
 /**
  * Style dependencies

--- a/client/blocks/upsell-nudge/test/index.jsx
+++ b/client/blocks/upsell-nudge/test/index.jsx
@@ -21,7 +21,7 @@ import {
 	PLAN_JETPACK_PREMIUM_MONTHLY,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
-} from 'lib/plans/constants';
+} from 'calypso/lib/plans/constants';
 
 const props = {
 	callToAction: null,

--- a/client/blocks/upwork-banner/actions.js
+++ b/client/blocks/upwork-banner/actions.js
@@ -1,8 +1,8 @@
 /**
  * Internal Dependencies
  */
-import { getPreference } from 'state/preferences/selectors';
-import { savePreference } from 'state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
 
 export const dismissBanner = ( location ) => ( dispatch, getState ) => {
 	const preference = getPreference( getState(), 'upwork-dismissible-banner' ) || {};

--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
@@ -12,11 +12,11 @@ import React, { PureComponent } from 'react';
  */
 import { Button } from '@automattic/components';
 import { dismissBanner } from './actions';
-import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import isUpworkBannerDismissed from 'state/selectors/is-upwork-banner-dismissed';
-import QueryPreferences from 'components/data/query-preferences';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import isUpworkBannerDismissed from 'calypso/state/selectors/is-upwork-banner-dismissed';
+import QueryPreferences from 'calypso/components/data/query-preferences';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies
@@ -26,7 +26,7 @@ import './style.scss';
 /**
  * Image dependencies
  */
-import builderIllustration from 'assets/images/illustrations/builder-referral.svg';
+import builderIllustration from 'calypso/assets/images/illustrations/builder-referral.svg';
 
 class UpworkBanner extends PureComponent {
 	static propTypes = {

--- a/client/blocks/upwork-banner/test/index.js
+++ b/client/blocks/upwork-banner/test/index.js
@@ -8,8 +8,8 @@ import renderer from 'react-test-renderer';
 /**
  * Internal dependencies
  */
-import { createReduxStore } from 'state';
-import { setStore } from 'state/redux-store';
+import { createReduxStore } from 'calypso/state';
+import { setStore } from 'calypso/state/redux-store';
 import UpworkBanner from '../';
 
 describe( 'UpworkBanner', () => {

--- a/client/blocks/user-mentions/connect.jsx
+++ b/client/blocks/user-mentions/connect.jsx
@@ -3,8 +3,8 @@
  */
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-import QueryUsersSuggestions from 'components/data/query-users-suggestions';
-import { getUserSuggestions } from 'state/users/suggestions/selectors';
+import QueryUsersSuggestions from 'calypso/components/data/query-users-suggestions';
+import { getUserSuggestions } from 'calypso/state/users/suggestions/selectors';
 import PropTypes from 'prop-types';
 
 /**

--- a/client/blocks/user-mentions/docs/example-input.jsx
+++ b/client/blocks/user-mentions/docs/example-input.jsx
@@ -7,7 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import addUserMentions from '../add';
-import FormTextarea from 'components/forms/form-textarea';
+import FormTextarea from 'calypso/components/forms/form-textarea';
 
 const UserMentionsExampleInput = React.forwardRef( ( props, ref ) => (
 	<FormTextarea forwardedRef={ ref } onKeyUp={ props.onKeyUp } onKeyDown={ props.onKeyDown } />

--- a/client/blocks/user-mentions/suggestion-list.jsx
+++ b/client/blocks/user-mentions/suggestion-list.jsx
@@ -9,9 +9,9 @@ import { bind } from 'lodash';
 /**
  * Internal dependencies
  */
-import PopoverMenu from 'components/popover/menu';
-import PopoverMenuItem from 'components/popover/menu-item';
-import UserMentionsSuggestion from 'blocks/user-mentions/suggestion';
+import PopoverMenu from 'calypso/components/popover/menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import UserMentionsSuggestion from 'calypso/blocks/user-mentions/suggestion';
 
 /**
  * Style dependencies

--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -12,13 +12,13 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { ProgressBar } from '@automattic/components';
-import Notice from 'components/notice';
-import DetailPreviewVideo from 'post-editor/media-modal/detail/detail-preview-video';
+import Notice from 'calypso/components/notice';
+import DetailPreviewVideo from 'calypso/post-editor/media-modal/detail/detail-preview-video';
 import VideoEditorControls from './video-editor-controls';
-import { updatePoster } from 'state/editor/video-editor/actions';
-import getPosterUploadProgress from 'state/selectors/get-poster-upload-progress';
-import getPosterUrl from 'state/selectors/get-poster-url';
-import shouldShowVideoEditorError from 'state/selectors/should-show-video-editor-error';
+import { updatePoster } from 'calypso/state/editor/video-editor/actions';
+import getPosterUploadProgress from 'calypso/state/selectors/get-poster-upload-progress';
+import getPosterUrl from 'calypso/state/selectors/get-poster-url';
+import shouldShowVideoEditorError from 'calypso/state/selectors/should-show-video-editor-error';
 
 /**
  * Style dependencies

--- a/client/blocks/video-editor/video-editor-upload-button.js
+++ b/client/blocks/video-editor/video-editor-upload-button.js
@@ -10,7 +10,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import FilePicker from 'components/file-picker';
+import FilePicker from 'calypso/components/file-picker';
 
 class VideoEditorUploadButton extends Component {
 	static propTypes = {

--- a/client/blocks/visit-site/index.jsx
+++ b/client/blocks/visit-site/index.jsx
@@ -7,7 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import wpcom from 'lib/wp';
+import wpcom from 'calypso/lib/wp';
 
 /**
  * Style dependencies


### PR DESCRIPTION
### Background

See #44602

### Changes

Automatically apply fix for eslint rule `wpcalypso/no-package-relative-imports` in `./client/blocks`

Fix applied with `./node_modules/.bin/eslint-nibble --ext .js,.jsx,.ts,.tsx,.md.js,.md.javascript,.md.jsx client/blocks`

### Testing instructions

### Testing instructions

* Check all tests passes (ignore lint errors, there will be a ton).
* Do a smoke test on the live branch
* Verify there are no huge changes in package size in ICFY report.

