### PR TITLE
Typography improvements to credential card in Jetpack Cloud

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/style.scss
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/style.scss
@@ -23,7 +23,7 @@
 		font-size: $font-body-small;
 	}
 
-	@media (min-width: 661px) {
+	@include breakpoint-deprecated( '>660px' ) {
 		.credentials-form__intro-text {
 			font-size: $font-body;
 		}

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
@@ -311,7 +311,7 @@ const AdvancedCredentials: FunctionComponent< Props > = ( { action, host, role }
 				title="Advanced Credentials"
 				properties={ { step: currentStep } }
 			/>
-			<Card className="advanced-credentials__server-connection-status">
+			<Card compact={ true } className="advanced-credentials__server-connection-status">
 				<div className="advanced-credentials__server-connection-status-content">
 					<h3>{ translate( 'Remote server credentials' ) }</h3>
 					<ConnectionStatus state={ statusState } />

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/style.scss
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/style.scss
@@ -44,6 +44,10 @@
 	justify-content: space-between;
 }
 
+.advanced-credentials__server-connection-status-content h3 {
+	font-size: $font-body;
+}
+
 .advanced-credentials__connected {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use correct breakpoint syntax
* Make heading font smaller
* Use compact card

**Before:**

![Screenshot 2020-10-14 at 11 37 25](https://user-images.githubusercontent.com/411945/95971629-c1960780-0e11-11eb-9c3b-74830d356907.png)

**After:**

![Screenshot 2020-10-14 at 11 36 07](https://user-images.githubusercontent.com/411945/95971668-cd81c980-0e11-11eb-93dc-f7a9229453f8.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use `flags=+jetpack/server-credentials-advanced-flow` on cloud.jetpack.com

