### PR TITLE
Nav Unification - enable toggling (open/closed) of individual sidebar menu sections

### DIFF
--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -16,16 +16,16 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
+import { isSidebarSectionOpen } from 'calypso/state/my-sites/sidebar/selectors';
 import {
 	toggleMySitesSidebarSection as toggleSection,
 	expandMySitesSidebarSection as expandSection,
-} from 'state/my-sites/sidebar/actions';
-import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+} from 'calypso/state/my-sites/sidebar/actions';
+import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import MySitesSidebarUnifiedItem from './item';
-import SidebarCustomIcon from 'layout/sidebar/custom-icon';
-import { isExternal } from 'lib/url';
-import { externalRedirect } from 'lib/route/path';
+import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
+import { isExternal } from 'calypso/lib/url';
+import { externalRedirect } from 'calypso/lib/route/path';
 import { itemLinkMatches } from '../sidebar/utils';
 
 export const MySitesSidebarUnifiedMenu = ( {
@@ -69,7 +69,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 				}
 				reduxDispatch( toggleSection( sectionId ) );
 			} }
-			expanded={ isExpanded || selected }
+			expanded={ isExpanded }
 			title={ title }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
 			className={ ( selected || childIsSelected ) && 'sidebar__menu--selected' }

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -142,6 +142,31 @@ $font-size: rem( 14px );
 			}
 		}
 
+		// Is selected
+		.sidebar__menu.sidebar__menu--selected {
+			.sidebar__heading {
+				background: var( --color-sidebar-menu-selected-background );
+
+				&:hover,
+				&:focus {
+					color: var(--color-sidebar-text);
+					background: var( --color-sidebar-menu-selected-background ); // retain selected color
+
+					.sidebar__menu-icon {
+						color: var( --color-sidebar-menu-hover );
+					}
+				}
+
+				&::after {
+					display: block;
+				}
+
+				.sidebar__menu-icon {
+					color: #fff;
+				}
+			}
+		}
+
 		// Is toggled open
 		.sidebar__menu.is-toggle-open {
 			.sidebar__heading {
@@ -162,7 +187,8 @@ $font-size: rem( 14px );
 				}
 
 			}
-			// Is toggled open and selected
+
+			// Is toggled open *and* selected
 			&.sidebar__menu--selected .sidebar__heading {
 				background: var( --color-sidebar-menu-selected-background );
 				color: white;


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Allow for toggling of sidebar menu sections by clicking.
* Don't allow for "selected" state to determine toggle state of menu - rely on triggering the toggle based on the selected state (see the existing `useRef` implementation).

## Screenshots

![Screen Capture on 2020-10-14 at 11-00-57](https://user-images.githubusercontent.com/444434/95974222-9bba3400-0e0c-11eb-9343-eeebefb0a86c.gif)


## Testing instructions

* run `yarn && yarn start`
* add `?flags=nav-unification` to the URL

#### On Master 
* Click on `Posts`. See menu expand.
* Click on `Posts` again. See menu remain in expanded state. 

Note it is impossible to toggle open/closed.

#### On this PR

* Click on `Posts`. See menu expand.
* Click on `Posts` again. See menu collapse.
* `Posts` menu item should remain visually "selected".
* Should be able to toggle open/closed `Posts` section at will.
* Should also be able to toggle other sections as per the above.


Fixes https://github.com/Automattic/wp-calypso/issues/46089
