### PR TITLE
Fix Calypso main sidebar rerendering due to JITMs

### DIFF
--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -11,7 +11,7 @@ import debugFactory from 'debug';
  */
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSectionName } from 'calypso/state/ui/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getTopJITM } from 'calypso/state/jitm/selectors';
 import { dismissJITM, setupDevTool } from 'calypso/state/jitm/actions';
@@ -83,7 +83,6 @@ function useDevTool( { currentSite }, dispatch ) {
 export function JITM( props ) {
 	const { jitm, currentSite, messagePath, isJetpack } = props;
 	const dispatch = useDispatch();
-
 	useDevTool( props, dispatch );
 
 	if ( ! currentSite || ! messagePath ) {
@@ -121,11 +120,15 @@ JITM.defaultProps = {
 
 const mapStateToProps = ( state, ownProps ) => {
 	const currentSite = getSelectedSite( state );
-
+	const sectionName = getSectionName( state );
+	const messagePath = `calypso:${ sectionName }:sidebar_notice`;
+	const topJITM = getTopJITM( state, messagePath );
+	console.log( messagePath, topJITM );
 	return {
 		currentSite,
-		jitm: getTopJITM( state, ownProps.messagePath ),
+		jitm: topJITM,
 		isJetpack: currentSite && isJetpackSite( state, currentSite.ID ),
+		messagePath,
 	};
 };
 

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -39,7 +39,7 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
 import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
 import { getSectionName } from 'calypso/state/ui/selectors';
-import { getTopJITM } from 'calypso/state/jitm/selectors';
+import { hasJITM } from 'calypso/state/jitm/selectors';
 import AsyncLoad from 'calypso/components/async-load';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -305,7 +305,7 @@ export default connect(
 			domainUpsellNudgeDismissedDate: getPreference( state, DOMAIN_UPSELL_NUDGE_DISMISS_KEY ),
 			isSiteWPForTeams: isSiteWPForTeams( state, siteId ),
 			isMigrationInProgress,
-			hasJITM: true, //getTopJITM( state, messagePath ),
+			hasJITM: hasJITM( state, messagePath ),
 		};
 	},
 	( dispatch ) => {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -7,40 +7,43 @@ import url from 'url';
 import moment from 'moment';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import config, { isEnabled } from 'config';
+import config, { isEnabled } from 'calypso/config';
 import { get, reject, transform } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import getActiveDiscount from 'state/selectors/get-active-discount';
-import { domainManagementList } from 'my-sites/domains/paths';
-import { hasDomainCredit, isCurrentUserCurrentPlanOwner } from 'state/sites/plans/selectors';
-import canCurrentUser from 'state/selectors/can-current-user';
-import isDomainOnlySite from 'state/selectors/is-domain-only-site';
-import isEligibleForFreeToPaidUpsell from 'state/selectors/is-eligible-for-free-to-paid-upsell';
-import { recordTracksEvent } from 'state/analytics/actions';
-import QuerySitePlans from 'components/data/query-site-plans';
-import QueryActivePromotions from 'components/data/query-active-promotions';
-import { getDomainsBySiteId } from 'state/sites/domains/selectors';
-import { getProductsList } from 'state/products-list/selectors';
-import QueryProductsList from 'components/data/query-products-list';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getUnformattedDomainPrice, getUnformattedDomainSalePrice } from 'lib/domains';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import getActiveDiscount from 'calypso/state/selectors/get-active-discount';
+import { domainManagementList } from 'calypso/my-sites/domains/paths';
+import {
+	hasDomainCredit,
+	isCurrentUserCurrentPlanOwner,
+} from 'calypso/state/sites/plans/selectors';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import isEligibleForFreeToPaidUpsell from 'calypso/state/selectors/is-eligible-for-free-to-paid-upsell';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getProductsList } from 'calypso/state/products-list/selectors';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import { getUnformattedDomainPrice, getUnformattedDomainSalePrice } from 'calypso/lib/domains';
 import formatCurrency from '@automattic/format-currency/src';
-import { getPreference } from 'state/preferences/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
-import { savePreference } from 'state/preferences/actions';
-import isSiteMigrationInProgress from 'state/selectors/is-site-migration-in-progress';
-import isSiteMigrationActiveRoute from 'state/selectors/is-site-migration-active-route';
-import { getSectionName } from 'state/ui/selectors';
-import { getTopJITM } from 'state/jitm/selectors';
-import AsyncLoad from 'components/async-load';
-import UpsellNudge from 'blocks/upsell-nudge';
-import { preventWidows } from 'lib/formatting';
-import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
+import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
+import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
+import { getSectionName } from 'calypso/state/ui/selectors';
+import { getTopJITM } from 'calypso/state/jitm/selectors';
+import AsyncLoad from 'calypso/components/async-load';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { preventWidows } from 'calypso/lib/formatting';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 
 const DOMAIN_UPSELL_NUDGE_DISMISS_KEY = 'domain_upsell_nudge_dismiss';
 
@@ -250,7 +253,7 @@ export class SiteNotice extends React.Component {
 	}
 
 	render() {
-		const { site, isMigrationInProgress, messagePath, hasJITM } = this.props;
+		const { site, isMigrationInProgress, hasJITM } = this.props;
 		if ( ! site || isMigrationInProgress ) {
 			return <div className="current-site__notices" />;
 		}
@@ -269,12 +272,7 @@ export class SiteNotice extends React.Component {
 				<QueryActivePromotions />
 				{ siteRedirectNotice }
 				{ showJitms && (
-					<AsyncLoad
-						require="blocks/jitm"
-						messagePath={ messagePath }
-						template="sidebar-banner"
-						placeholder={ null }
-					/>
+					<AsyncLoad require="calypso/blocks/jitm" template="sidebar-banner" placeholder={ null } />
 				) }
 				<QuerySitePlans siteId={ site.ID } />
 				{ ! hasJITM && domainCreditNotice }
@@ -307,8 +305,7 @@ export default connect(
 			domainUpsellNudgeDismissedDate: getPreference( state, DOMAIN_UPSELL_NUDGE_DISMISS_KEY ),
 			isSiteWPForTeams: isSiteWPForTeams( state, siteId ),
 			isMigrationInProgress,
-			hasJITM: getTopJITM( state, messagePath ),
-			messagePath,
+			hasJITM: true, //getTopJITM( state, messagePath ),
 		};
 	},
 	( dispatch ) => {

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -16,17 +16,17 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import CurrentSite from 'my-sites/current-site';
+import CurrentSite from 'calypso/my-sites/current-site';
 import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
 import useSiteMenuItems from './use-site-menu-items';
 import useDomainsViewStatus from './use-domains-view-status';
-import { getIsRequestingAdminMenu } from 'state/admin-menu/selectors';
-import Sidebar from 'layout/sidebar';
-import SidebarSeparator from 'layout/sidebar/separator';
-import 'layout/sidebar-unified/style.scss';
-import 'state/admin-menu/init';
-import Spinner from 'components/spinner';
+import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
+import Sidebar from 'calypso/layout/sidebar';
+import SidebarSeparator from 'calypso/layout/sidebar/separator';
+import 'calypso/layout/sidebar-unified/style.scss';
+import 'calypso/state/admin-menu/init';
+import Spinner from 'calypso/components/spinner';
 import { itemLinkMatches } from '../sidebar/utils';
 import './style.scss';
 
@@ -67,14 +67,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 					);
 				}
 
-				return (
-					<MySitesSidebarUnifiedItem
-						key={ item.slug }
-						path={ path }
-						selected={ isSelected }
-						{ ...item }
-					/>
-				);
+				return <MySitesSidebarUnifiedItem key={ item.slug } selected={ isSelected } { ...item } />;
 			} ) }
 		</Sidebar>
 	);

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -8,7 +8,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { memo } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -31,15 +31,15 @@ export const MySitesSidebarUnifiedItem = ( {
 	selected = false,
 	isSubItem = false,
 } ) => {
-	const selectedSiteId = useSelector( getSelectedSiteId );
+	// const selectedSiteId = useSelector( getSelectedSiteId );
 
-	let children = null;
+	const children = null;
 
-	// "Stats" item has sparkline inside of it
-	const isStats = typeof slug === 'string' && slug.includes( '-comstats' );
-	if ( isStats && selectedSiteId ) {
-		children = <StatsSparkline className="sidebar-unified__sparkline" siteId={ selectedSiteId } />;
-	}
+	// // "Stats" item has sparkline inside of it
+	// const isStats = typeof slug === 'string' && slug.includes( '-comstats' );
+	// if ( isStats && selectedSiteId ) {
+	// 	children = <StatsSparkline className="sidebar-unified__sparkline" siteId={ selectedSiteId } />;
+	// }
 
 	return (
 		<SidebarItem
@@ -62,4 +62,4 @@ MySitesSidebarUnifiedItem.propTypes = {
 	url: PropTypes.string,
 };
 
-export default MySitesSidebarUnifiedItem;
+export default memo( MySitesSidebarUnifiedItem );

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -23,6 +23,17 @@ import StatsSparkline from 'calypso/blocks/stats-sparkline';
 
 const onNav = () => null;
 
+const MySitesSidebarUnifiedStatsSparkline = memo( ( { slug } ) => {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const isStats = typeof slug === 'string' && slug.includes( '-comstats' );
+
+	if ( isStats && selectedSiteId ) {
+		return null;
+	}
+
+	return <StatsSparkline className="sidebar-unified__sparkline" siteId={ selectedSiteId } />;
+} );
+
 export const MySitesSidebarUnifiedItem = ( {
 	title,
 	icon,
@@ -31,16 +42,6 @@ export const MySitesSidebarUnifiedItem = ( {
 	selected = false,
 	isSubItem = false,
 } ) => {
-	// const selectedSiteId = useSelector( getSelectedSiteId );
-
-	const children = null;
-
-	// // "Stats" item has sparkline inside of it
-	// const isStats = typeof slug === 'string' && slug.includes( '-comstats' );
-	// if ( isStats && selectedSiteId ) {
-	// 	children = <StatsSparkline className="sidebar-unified__sparkline" siteId={ selectedSiteId } />;
-	// }
-
 	return (
 		<SidebarItem
 			label={ title }
@@ -51,7 +52,7 @@ export const MySitesSidebarUnifiedItem = ( {
 			forceInternalLink
 			className={ isSubItem ? 'sidebar__menu-item--child' : 'sidebar__menu-item-parent' }
 		>
-			{ children }
+			<MySitesSidebarUnifiedStatsSparkline slug={ slug } />
 		</SidebarItem>
 	);
 };

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -16,10 +16,10 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 
-import { getSelectedSiteId } from 'state/ui/selectors';
-import SidebarItem from 'layout/sidebar/item';
-import SidebarCustomIcon from 'layout/sidebar/custom-icon';
-import StatsSparkline from 'blocks/stats-sparkline';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import SidebarItem from 'calypso/layout/sidebar/item';
+import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
+import StatsSparkline from 'calypso/blocks/stats-sparkline';
 
 const onNav = () => null;
 
@@ -57,7 +57,6 @@ export const MySitesSidebarUnifiedItem = ( {
 };
 
 MySitesSidebarUnifiedItem.propTypes = {
-	path: PropTypes.string,
 	title: PropTypes.string,
 	icon: PropTypes.string,
 	url: PropTypes.string,

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -69,7 +69,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 				}
 				reduxDispatch( toggleSection( sectionId ) );
 			} }
-			expanded={ isExpanded || selected }
+			expanded={ isExpanded }
 			title={ title }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
 			className={ ( selected || childIsSelected ) && 'sidebar__menu--selected' }

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -16,16 +16,16 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
+import { isSidebarSectionOpen } from 'calypso/state/my-sites/sidebar/selectors';
 import {
 	toggleMySitesSidebarSection as toggleSection,
 	expandMySitesSidebarSection as expandSection,
-} from 'state/my-sites/sidebar/actions';
-import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+} from 'calypso/state/my-sites/sidebar/actions';
+import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import MySitesSidebarUnifiedItem from './item';
-import SidebarCustomIcon from 'layout/sidebar/custom-icon';
-import { isExternal } from 'lib/url';
-import { externalRedirect } from 'lib/route/path';
+import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
+import { isExternal } from 'calypso/lib/url';
+import { externalRedirect } from 'calypso/lib/route/path';
 import { itemLinkMatches } from '../sidebar/utils';
 
 export const MySitesSidebarUnifiedMenu = ( {
@@ -79,7 +79,6 @@ export const MySitesSidebarUnifiedMenu = ( {
 				return (
 					<MySitesSidebarUnifiedItem
 						key={ item.slug }
-						path={ path }
 						{ ...item }
 						selected={ isSelected }
 						isSubItem={ true }

--- a/client/state/jitm/selectors.js
+++ b/client/state/jitm/selectors.js
@@ -49,3 +49,7 @@ export const getTopJITM = ( state, messagePath ) => {
 	// Return results.
 	return jitms[ 0 ];
 };
+
+export const hasJITM = ( state, messagePath ) => {
+	return !! getTopJITM( state, messagePath );
+};

--- a/client/state/jitm/selectors.js
+++ b/client/state/jitm/selectors.js
@@ -4,7 +4,7 @@
 import { get } from 'lodash';
 
 /** Internal dependencies */
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**
  * Get the list of available jitms for the current site/section
@@ -14,7 +14,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
  * @returns {Array} An array of jitms
  */
 export const getJITM = ( state, messagePath ) =>
-	get( state, [ 'jitm', 'sitePathJITM', messagePath + getSelectedSiteId( state ) ], [] );
+	get( state, [ 'jitm', 'sitePathJITM', messagePath + getSelectedSiteId( state ) ], null );
 
 /**
  * Get the top jitm available for the current site/section
@@ -23,12 +23,29 @@ export const getJITM = ( state, messagePath ) =>
  * @param {string} messagePath The jitm message path (ex: calypso:comments:admin_notices)
  * @returns {object} A jitm
  */
+
+let JITMCache = [];
+
 export const getTopJITM = ( state, messagePath ) => {
 	const jitms = getJITM( state, messagePath );
 
-	if ( jitms.length === 0 ) {
+	// If we have yet to populate the JITM state for the
+	// given message path then return from the previous JITM
+	// cache until JITMS can be fulfilled from network.
+	if ( jitms === null ) {
+		return JITMCache[ 0 ] || null;
+	}
+
+	// If having fullfilled we still have no JITMs then
+	// clear the cache and return null to signify empty.
+	if ( ! jitms.length ) {
+		JITMCache = [];
 		return null;
 	}
 
+	// Cache the results.
+	JITMCache = Array.from( jitms );
+
+	// Return results.
 	return jitms[ 0 ];
 };


### PR DESCRIPTION
The aim of this PR is to remove the layout shift that occurs when navigating to _new_ routes using the left sidebar.

The principal cause of this shift is that the "Nudges and Notices" panel is shown conditionally based on props which change on changing to new route. The principle prop in question is the state of the JITM (Just In Time Messages) which is stored (effectively) on a per route basis. 

Every time you navigate to a new route the result of calling `getTopJITM()` returns `null` and then flips to the fulfilled `Array` of messages. Often these messages are **_identical_ between routes**. However, React see's these as new objects and so a full re-render of the displayed Notices/Nudge occurs. This causes a noticeable layout shift in the sidebar as you navigate to a new route.

To fix this I'm proposing two changes to the way we handle JITMs:

1. Introduce a primitive cache mechanism which will display the previous JITMs if the state of the current route's JITMs is unfulfilled (ie: `null`). Once the JITMs are fulfilled from the network for the current route the cache is updated and the new messages are displayed.
2. Set the default state for JITMs to `null` (rather than `[]`) to better communicate the "unfulfilled" state. 

This means that on navigating to a new route, we continue to return the previous route's JITMs until we have fulfilled the data layer request for JITMs for the new route. This avoids the need to re-render and thus stops the layout shift.

This PR also contains some optimisations for the menu components themselves which may be better split out into separate PRs.

#### Changes proposed in this Pull Request

* Add primitive cache to `getTopJITM` selector.
* Add dedicated `hasJITM` selector to improve optimisation of retrieving status of JITMs.
* Move `messagePath` prop down to lower level JITM component to avoid full re-render of heavy `SiteNotice` which is occurring on _every_ route change.
* Memozie stats chart component to avoid re-rendering.
* Remove redundant `path` prop from menu components which don't make use of it.

#### Testing instructions

TBC

Fixes https://github.com/Automattic/wp-calypso/issues/46091
