### PR TITLE
Sharing: Use FormLabel in SharingConnection

### DIFF
--- a/client/my-sites/marketing/connections/connection.jsx
+++ b/client/my-sites/marketing/connections/connection.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import Gridicon from 'calypso/components/gridicon';
 import UsersStore from 'calypso/lib/users/store';
@@ -213,7 +214,11 @@ class SharingConnection extends Component {
 		}
 
 		if ( content.length ) {
-			return <label className="sharing-connection__account-sitewide-connection">{ content }</label>;
+			return (
+				<FormLabel className="sharing-connection__account-sitewide-connection">
+					{ content }
+				</FormLabel>
+			);
 		}
 	}
 

--- a/client/my-sites/marketing/connections/connection.jsx
+++ b/client/my-sites/marketing/connections/connection.jsx
@@ -1,26 +1,25 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import FormInputCheckbox from 'components/forms/form-checkbox';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
+import Gridicon from 'calypso/components/gridicon';
+import UsersStore from 'calypso/lib/users/store';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { ScreenReaderText } from '@automattic/components';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import canCurrentUser from 'state/selectors/can-current-user';
-import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
-import UsersStore from 'lib/users/store';
 
 class SharingConnection extends Component {
 	static propTypes = {

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -401,8 +401,10 @@
 	color: var( --color-neutral-light );
 }
 
-.sharing-connection__account-sitewide-connection {
+.sharing-connection__account-sitewide-connection.form-label {
 	display: block;
+	margin-bottom: 0;
+	font-size: 1rem;
 }
 
 .sharing-connection__account-sitewide-connection input[type='checkbox'] {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sharing: Use `FormLabel` in `SharingConnection` - see #45259 for details.
* Sort imports and make them relative to Calypso's root

#### Testing instructions

* Go to `/marketing/connections/:site`
* Expand a Publicize connection, like Twitter for example.
* Verify the label next to the "available to all admins etc." checkbox looks the same way.

#### Notes

Linting errors are expected.