### PR TITLE
Sharing: Use FormLabel in AccountDialogAccount

### DIFF
--- a/client/my-sites/marketing/connections/account-dialog-account.jsx
+++ b/client/my-sites/marketing/connections/account-dialog-account.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'components/gridicon';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-import Image from 'components/image';
 import FormRadio from 'calypso/components/forms/form-radio';
+import Gridicon from 'calypso/components/gridicon';
+import Image from 'calypso/components/image';
 
 /**
  * Style dependencies

--- a/client/my-sites/marketing/connections/account-dialog-account.jsx
+++ b/client/my-sites/marketing/connections/account-dialog-account.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import Gridicon from 'calypso/components/gridicon';
 import Image from 'calypso/components/image';
@@ -25,7 +26,7 @@ const AccountDialogAccount = ( { account, conflicting, onChange, selected, defau
 
 	return (
 		<li className={ classes }>
-			<label className="account-dialog-account__label">
+			<FormLabel className="account-dialog-account__label">
 				{ conflicting && <Gridicon icon="notice" /> }
 				{ ! account.isConnected && (
 					<FormRadio
@@ -49,7 +50,7 @@ const AccountDialogAccount = ( { account, conflicting, onChange, selected, defau
 						<div className="account-dialog-account__description">{ account.description }</div>
 					) }
 				</span>
-			</label>
+			</FormLabel>
 		</li>
 	);
 };

--- a/client/my-sites/marketing/connections/account-dialog-account.scss
+++ b/client/my-sites/marketing/connections/account-dialog-account.scss
@@ -13,11 +13,18 @@
 	}
 }
 
-.account-dialog-account__label {
+.account-dialog-account__label.form-label {
 	position: relative;
 	display: block;
 	min-height: 40px;
 	padding-top: 5px;
+	font-weight: 400;
+	font-size: 1rem;
+	margin-bottom: 0;
+}
+
+.account-dialog-account__input.form-radio {
+	margin-right: 2px;
 }
 
 .account-dialog.single-account .account-dialog-account__input {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sharing: Use `FormLabel` in `AccountDialogAccount` - see #45259 for details.
* Sort imports and make them relative to Calypso's root

#### Testing instructions

* Go to `/marketing/connections/:site`
* Expand an existing Publicize connection, like Twitter for example.
* Attempt to connect a new Twitter account and authorize it.
* In the account selection modal, verify the label looks the same way, with a small exception - we're moving one of the labels right a bit, to be properly aligned vertically.
