### PR TITLE
Remove "gutenboarding/new-launch" feature flag and checks

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -51,7 +51,6 @@ function updateEditor() {
 		clearInterval( awaitSettingsBar );
 
 		const isMobile = window.innerWidth < 782;
-		const isNewLaunch = window?.calypsoifyGutenberg?.isNewLaunch;
 		const isNewLaunchMobile = window?.calypsoifyGutenberg?.isNewLaunchMobile;
 		const isExperimental = window?.calypsoifyGutenberg?.isExperimental;
 
@@ -73,7 +72,7 @@ function updateEditor() {
 			// Disable href navigation
 			e.preventDefault();
 
-			const shouldOpenNewFlow = isNewLaunch && ( ! isMobile || ( isMobile && isNewLaunchMobile ) );
+			const shouldOpenNewFlow = ! isMobile || ( isMobile && isNewLaunchMobile );
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click', {
 				is_new_flow: shouldOpenNewFlow,

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -754,16 +754,9 @@ function getGutenboardingStatus( calypsoPort ) {
 		[ port2 ]
 	);
 	port1.onmessage = ( { data } ) => {
-		const {
-			isGutenboarding,
-			frankenflowUrl,
-			isNewLaunch,
-			isNewLaunchMobile,
-			isExperimental,
-		} = data;
+		const { isGutenboarding, frankenflowUrl, isNewLaunchMobile, isExperimental } = data;
 		calypsoifyGutenberg.isGutenboarding = isGutenboarding;
 		calypsoifyGutenberg.frankenflowUrl = frankenflowUrl;
-		calypsoifyGutenberg.isNewLaunch = isNewLaunch;
 		calypsoifyGutenberg.isNewLaunchMobile = isNewLaunchMobile;
 		calypsoifyGutenberg.isExperimental = isExperimental;
 		// Hook necessary if message recieved after editor has loaded.

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -373,14 +373,12 @@ class CalypsoifyIframe extends Component<
 			const isGutenboarding =
 				this.props.siteCreationFlow === 'gutenboarding' && this.props.isSiteUnlaunched;
 			const frankenflowUrl = `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteSlug }&source=editor`;
-			const isNewLaunch = config.isEnabled( 'gutenboarding/new-launch' );
 			const isNewLaunchMobile = config.isEnabled( 'gutenboarding/new-launch-mobile' );
 			const isExperimental = config.isEnabled( 'gutenboarding/feature-picker' );
 
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
 				frankenflowUrl,
-				isNewLaunch,
 				isNewLaunchMobile,
 				isExperimental,
 			} );

--- a/config/development.json
+++ b/config/development.json
@@ -65,7 +65,6 @@
 		"google-drive": true,
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/feature-picker": true,
-		"gutenboarding/new-launch": true,
 		"gutenboarding/new-launch-mobile": false,
 		"gutenboarding/show-vertical-input": false,
 		"help": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -41,7 +41,6 @@
 		"google-my-business": false,
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/feature-picker": true,
-		"gutenboarding/new-launch": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -39,7 +39,6 @@
 		"gdpr-banner": true,
 		"google-my-business": true,
 		"gutenboarding/feature-picker": true,
-		"gutenboarding/new-launch": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,7 +45,6 @@
 		"gutenboarding/style-preview-verticals": false,
 		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,
-		"gutenboarding/new-launch": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -52,7 +52,6 @@
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,
-		"gutenboarding/new-launch": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
The flag is currently enabled in every environment, and can therefore be assumed as a stable feature.

This is the first of a series of PRs looking at implementing the Persistent launch button in the editor (see pbAok1-1y7-p2 for details)

Related phab patches:
- D51131-code (editing-toolkit)
- D51140-code (wpcom-block-editor)

## Changes proposed in this Pull Request

* Removed `gutenboarding/new-launch` from all environments configuration files
* Removed checks in code, assuming the check would always evaluate to `true`

## Testing instructions

In theory, **the changes introduced by the PR should only remove code that is not needed anymore**, without causing any changes to the behavior of the "Complete setup" buttons. The following testing instructions are meant to **check for regressions**.

### How to build
* On root folder, run `yarn start`.
* On `apps/full-site-editing`, run `yarn dev --sync`.
* On `apps/wpcom-block-editor`, run `yarn dev --sync`.

### How to test
1. Enable sandbox (both on the wordpress.com site and `widgets.wp.com`)
2. Create an unlaunched test site using Gutenboarding (`/new`)
3. On local calypso, open the home page in the block editor
   * If the page is loaded on desktop screens, clicking "Complete Setup" should open the launch modal without any page redirect (do not launch the site)
   * If the page is loaded on mobile screens, clicking "Launch" should redirect to the new launch flow, also known as _frankenflow_ — `/start/new-launch` (do not launch the site)
4. Now, on local calypso, open again the home page in the block editor — but this time, append `?flags=gutenboarding/new-launch-mobile` to the URL
   * If the page is loaded on desktop screens, clicking "Complete Setup" should open the launch modal without any page redirect (do not launch the site)
   * If the page is loaded on mobile screens, clicking "Launch" should open the launch modal without any page redirect (do not launch the site)


