### PR TITLE
Fix the rounding for coupons

### DIFF
--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-package-relative-imports
+// eslint-disable-next-line wpcalypso/no-package-relative-imports
 import config from 'config';
 import assert from 'assert';
 
@@ -126,7 +126,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 
 			const newCartAmount = await securePaymentComponent.cartTotalAmount();
 			const expectedCartAmount =
-				Math.round( ( ( originalCartAmount * .99 ) + Number.EPSILON ) * 100 ) / 100;
+				Math.round( ( originalCartAmount * .99 + Number.EPSILON ) * 100 ) / 100;
 
 			assert.strictEqual( newCartAmount, expectedCartAmount, 'Coupon not applied properly' );
 		} );

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+// eslint-disable-next-line no-package-relative-imports
 import config from 'config';
 import assert from 'assert';
 
@@ -124,7 +125,8 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 			await securePaymentComponent.enterCouponCode( dataHelper.getTestCouponCode() );
 
 			const newCartAmount = await securePaymentComponent.cartTotalAmount();
-			const expectedCartAmount = Math.round( ( ( originalCartAmount * .99 ) + Number.EPSILON ) * 100 ) / 100;
+			const expectedCartAmount =
+				Math.round( ( ( originalCartAmount * .99 ) + Number.EPSILON ) * 100 ) / 100;
 
 			assert.strictEqual( newCartAmount, expectedCartAmount, 'Coupon not applied properly' );
 		} );

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -126,7 +126,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 
 			const newCartAmount = await securePaymentComponent.cartTotalAmount();
 			const expectedCartAmount =
-				Math.round( ( originalCartAmount * .99 + Number.EPSILON ) * 100 ) / 100;
+				Math.round( ( originalCartAmount * 0.99 + Number.EPSILON ) * 100 ) / 100;
 
 			assert.strictEqual( newCartAmount, expectedCartAmount, 'Coupon not applied properly' );
 		} );

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -124,7 +124,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 			await securePaymentComponent.enterCouponCode( dataHelper.getTestCouponCode() );
 
 			const newCartAmount = await securePaymentComponent.cartTotalAmount();
-			const expectedCartAmount = parseFloat( ( originalCartAmount * 0.99 ).toFixed( 2 ) );
+			const expectedCartAmount = Math.round( ( ( originalCartAmount * .99 ) + Number.EPSILON ) * 100 ) / 100;
 
 			assert.strictEqual( newCartAmount, expectedCartAmount, 'Coupon not applied properly' );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The e2e tests for coupon codes are failing because of a difference in calculation rounding. This change fixes that

#### Testing instructions
* Make sure e2e tests pass in CI

