### PR TITLE
Plans: fix currency code position in JetpackProductCard

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt/index.tsx
@@ -160,19 +160,12 @@ const JetpackProductCardAlt = ( {
 											</span>
 										) }
 
-										{ isDiscounted ? (
-											<PlanPrice
-												rawPrice={ discountedPrice }
-												discounted
-												currencyCode={ currencyCode }
-											/>
-										) : (
-											<PlanPrice
-												rawPrice={ originalPrice }
-												original={ isDiscounted }
-												currencyCode={ currencyCode }
-											/>
-										) }
+										<PlanPrice
+											rawPrice={ isDiscounted ? discountedPrice : originalPrice }
+											discounted
+											currencyCode={ currencyCode }
+										/>
+
 										{ searchRecordsDetails && (
 											<InfoPopover
 												className="jetpack-product-card-alt__search-price-popover"

--- a/client/components/jetpack/card/jetpack-product-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt/style.scss
@@ -174,12 +174,12 @@ $jetpack-product-card-alt-icon-size: 55px;
 }
 
 .jetpack-product-card-alt .plan-price {
-	position: relative;
+	display: flex;
 
 	border-color: $jetpack-product-card-alt-color;
 
 	sup {
-		position: absolute;
+		margin-top: 13px;
 		top: 13px;
 
 		font-size: $font-title-small;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When a currency is composed of more than one character, it overlaps with the price featured in the card. This is because we are using absolute positioning.

#### Testing instructions

* Run this PR.
* Visit the Plans page in any environment.
* In Store Admin, change your default currency to other than USD (you can also change the currency code directly in the HTML with dev tools).
* Verify that if you have a currency code with more than one character, it doesn't overlap with the price of the product.

Fixes 1196341175636977-as-1198217247616087

#### Demo
##### Before
<img src="https://user-images.githubusercontent.com/3418513/96001522-80e8bf00-0e0e-11eb-992a-379b0dd29327.png" width="500" />

##### After
<img src="https://user-images.githubusercontent.com/3418513/96001501-7af2de00-0e0e-11eb-82c0-b5586aabbcc7.png" width="500" />
