### PR TITLE
Importers: Add hover and cursor styles to importer file upload

### DIFF
--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -7,18 +7,21 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { defer, flow, includes, noop, truncate } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-import { startMappingAuthors, startUpload } from 'lib/importer/actions';
-import { appStates } from 'state/imports/constants';
-import { getUploadFilename, getUploadPercentComplete } from 'state/imports/uploads/selectors';
-import DropZone from 'components/drop-zone';
+import { startMappingAuthors, startUpload } from 'calypso/lib/importer/actions';
+import { appStates } from 'calypso/state/imports/constants';
+import {
+	getUploadFilename,
+	getUploadPercentComplete,
+} from 'calypso/state/imports/uploads/selectors';
+import DropZone from 'calypso/components/drop-zone';
+import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
+import ImporterCloseButton from 'calypso/my-sites/importer/importer-action-buttons/close-button';
 import { ProgressBar } from '@automattic/components';
-import ImporterActionButtonContainer from 'my-sites/importer/importer-action-buttons/container';
-import ImporterCloseButton from 'my-sites/importer/importer-action-buttons/close-button';
 
 /**
  * Style dependencies
@@ -148,7 +151,7 @@ class UploadingPane extends React.PureComponent {
 					onKeyPress={ isReadyForImport ? this.handleKeyPress : null }
 				>
 					<div className={ importerStatusClasses }>
-						<Gridicon className="importer__upload-icon" icon="cloud-upload" />
+						<Gridicon size="48" className="importer__upload-icon" icon="cloud-upload" />
 						{ this.getMessage() }
 					</div>
 					{ isReadyForImport && (

--- a/client/my-sites/importer/uploading-pane.scss
+++ b/client/my-sites/importer/uploading-pane.scss
@@ -1,9 +1,11 @@
 .importer__uploading-pane {
+	cursor: pointer;
 	position: relative;
 	height: 150px;
 	margin-bottom: 1.5em;
 
-	border: 5px solid var( --color-neutral-0 );
+	border: 2px dashed var( --color-neutral-light );
+	transition: all 200ms ease-out, color 100ms ease-out;
 	fill: var( --color-neutral-20 );
 	font-size: $font-body-small;
 	font-weight: 600;
@@ -16,6 +18,12 @@
 
 	.accessible-focus &:focus {
 		border-color: var( --color-neutral-20 );
+	}
+
+	&:hover {
+		border-color: var( --color-neutral-70 );
+		transform: translate3d( 0, -1px, 0 );
+		box-shadow: 0 2px 4px var( --color-neutral-10 );
 	}
 }
 

--- a/client/my-sites/importer/uploading-pane.scss
+++ b/client/my-sites/importer/uploading-pane.scss
@@ -4,6 +4,7 @@
 	height: 150px;
 	margin-bottom: 1.5em;
 
+	background-color: var( --color-neutral-0 );
 	border: 2px dashed var( --color-neutral-light );
 	transition: all 200ms ease-out, color 100ms ease-out;
 	fill: var( --color-neutral-20 );

--- a/client/my-sites/importer/uploading-pane.scss
+++ b/client/my-sites/importer/uploading-pane.scss
@@ -1,16 +1,15 @@
 .importer__uploading-pane {
 	cursor: pointer;
 	position: relative;
-	height: 150px;
+	height: 180px;
 	margin-bottom: 1.5em;
 
 	background-color: var( --color-neutral-0 );
 	border: 2px dashed var( --color-neutral-light );
 	transition: all 200ms ease-out, color 100ms ease-out;
 	fill: var( --color-neutral-20 );
-	font-size: $font-body-small;
-	font-weight: 600;
-	color: var( --color-neutral-light );
+	font-size: $font-body;
+	color: var( --color-neutral-70 );
 	text-align: center;
 
 	input {
@@ -26,6 +25,18 @@
 		transform: translate3d( 0, -1px, 0 );
 		box-shadow: 0 2px 4px var( --color-neutral-10 );
 	}
+
+	p {
+		margin-top: -0.5em;
+	}
+
+	.importer__upload-icon {
+	    color: var( --color-neutral-light );
+	}
+}
+
+.importer__uploading-pane:hover .importer__upload-content .importer__upload-icon {
+	color: var( --color-neutral-70 );
 }
 
 .importer__uploading-pane-description {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a hover state and cursor styles to the importers file uploader to indicate the file upload panel is click-able.
* This mimics the hover styles for the plugin and theme uploaders for slightly better consistency. Ideally, I think we should use the same component for both elements, but this is a quick stylistic fix.

**Before**

<img width="777" alt="Screen Shot 2020-10-14 at 10 45 42 AM" src="https://user-images.githubusercontent.com/2124984/96005642-a378d900-0e0a-11eb-97f1-85f3074c2fd7.png">


**After**

<img width="769" alt="Screen Shot 2020-10-14 at 11 11 39 AM" src="https://user-images.githubusercontent.com/2124984/96009000-20f21880-0e0e-11eb-84ee-d285cc8cd69f.png">


#### Testing instructions

* Switch to this PR and navigate to `/import`
* Click on Blogger, Medium, or Squarespace
* Note the style changes on the file upload panel

Fixes #44319
