### PR TITLE
Plans: make CTAs consistent across JetpackProductCard components

### DIFF
--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -111,9 +111,15 @@ export const getJetpackProductsCallToAction = () => {
 			} ) }
 		</>
 	);
-	const search = translate( 'Get Search' );
-	const scan = translate( 'Get Scan' );
-	const antiSpam = <>{ translate( 'Get Anti-spam' ) }</>;
+	const search = isEnabled( 'plans/alternate-selector' )
+		? translate( 'Get Jetpack Search' )
+		: translate( 'Get Search' );
+	const scan = isEnabled( 'plans/alternate-selector' )
+		? translate( 'Get Jetpack Scan' )
+		: translate( 'Get Scan' );
+	const antiSpam = isEnabled( 'plans/alternate-selector' )
+		? translate( 'Get Jetpack Anti-spam' )
+		: translate( 'Get Anti-spam' );
 
 	return {
 		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_DAILY ]: backupDaily,

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -296,7 +296,7 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 		'The most simple and powerful WordPress CRM. Improve customer relationships and increase profits.'
 	),
 	buttonLabel: isEnabled( 'plans/alternate-selector' )
-		? translate( 'Start using CRM for free' )
+		? translate( 'Get Jetpack CRM' )
 		: translate( 'Get CRM' ),
 	features: {
 		items: buildCardFeaturesFromItem(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make all CTAs follow the same naming convention.

#### Testing instructions

* Run this PR (any environment).
* Visit the Plans page.
* Make sure that all CTAs follow the same pattern: `Get Jetpack [product-name]"`.

Fixes 1196341175636977-as-1198217247616085

#### Demo
##### Before
![image](https://user-images.githubusercontent.com/3418513/96007168-9e208c00-0e14-11eb-902a-4c4180c55d08.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/96007229-a973b780-0e14-11eb-9687-01f9b910514a.png)
