### PR TITLE
E2E: Don't log error for Chromedriver already being available.

### DIFF
--- a/test/e2e/test/mocha.env.js
+++ b/test/e2e/test/mocha.env.js
@@ -12,8 +12,10 @@ try {
 		env: {
 			CHROMEDRIVER_SKIP_DOWNLOAD: '',
 		},
-		stdio: 'inherit',
 	} );
 } catch ( error ) {
-	console.error( error );
+	if ( ! error.toString().includes( 'ChromeDriver is already available' )  ) {
+		console.log(error.message);
+		console.error(error);
+	}
 }

--- a/test/e2e/test/mocha.env.js
+++ b/test/e2e/test/mocha.env.js
@@ -14,7 +14,7 @@ try {
 		},
 	} );
 } catch ( error ) {
-	if ( ! error.toString().includes( 'ChromeDriver is already available' )  ) {
+	if ( !error.toString().includes( 'ChromeDriver is already available' )  ) {
 		console.error( error );
 	}
 }

--- a/test/e2e/test/mocha.env.js
+++ b/test/e2e/test/mocha.env.js
@@ -15,7 +15,6 @@ try {
 	} );
 } catch ( error ) {
 	if ( ! error.toString().includes( 'ChromeDriver is already available' )  ) {
-		console.log(error.message);
-		console.error(error);
+		console.error( error );
 	}
 }

--- a/test/e2e/test/mocha.env.js
+++ b/test/e2e/test/mocha.env.js
@@ -14,7 +14,7 @@ try {
 		},
 	} );
 } catch ( error ) {
-	if ( !error.toString().includes( 'ChromeDriver is already available' )  ) {
+	if ( ! error.toString().includes( 'ChromeDriver is already available' ) ) {
 		console.error( error );
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

* This PR makes changes to a recently added piece of the mocha script that installs ChromeDriver since yarn doctor was suggesting changes that make it so Chromedriver isn't installed. This was fine, but when ChromeDriver was already installed, it prints out an error that isn't really needed and makes you think something is wrong when it isn't. I am now only logging if the error is something other than "ChromeDriver is already available"

#### Testing instructions

* Make sure tests pass in CI. 
* Run mocha test locally and make sure that the error isn't printed if ChromeDriver is already installed.
