### PR TITLE
Plans: increase Jetpack Free CTA font-size to 16px

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card-alt/style.scss
@@ -58,6 +58,8 @@
 		height: 40px;
 		margin-top: 40px;
 
+		font-size: $font-body;
+
 		@include break-small {
 			margin-top: 7px;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Increase Jetpack Free CTA font-size to 16px to make it consistent with the rest of the cards.

#### Testing instructions

* Run this PR in any environment.
* Visit the Plans page (add `?source=jetpack-connect-plans` to the URL if you're in Calypso Blue, otherwise you won't see the Jetpack Free card).
* Verify that the CTA font-size is 16px.

Fixes 1196341175636977-as-1198219469159093

#### Demo
##### Before
![image](https://user-images.githubusercontent.com/3418513/96027886-f4022d80-0e2e-11eb-94c8-dd3faca3b5c2.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/96027771-bd2c1780-0e2e-11eb-84e3-ba2163e53380.png)