### PR TITLE
Editing Toolkit: Load patterns from the rest API endpoint v3

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-api.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Block Patterns file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+/**
+ * Class Block_Patterns
+ */
+class Block_Patterns_From_API {
+
+	const PATTERN_NAMESPACE = 'a8c/';
+
+	/**
+	 * Class instance.
+	 *
+	 * @var Block_Patterns
+	 */
+	private static $instance = null;
+
+	/**
+	 * Cache key for patterns array.
+	 *
+	 * @var string
+	 */
+	private $patterns_cache_key;
+
+	/**
+	 * Block_Patterns constructor.
+	 */
+	private function __construct() {
+		$this->patterns_cache_key = sha1(
+			implode(
+				'_',
+				array(
+					'block_patterns',
+					PLUGIN_VERSION,
+					$this->get_iso_639_locale(),
+				)
+			)
+		);
+
+		$this->register_patterns();
+	}
+
+	/**
+	 * Creates instance.
+	 *
+	 * @return \A8C\FSE\Block_Patterns
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Register FSE block patterns and categories.
+	 */
+	private function register_patterns() {
+		if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {
+			// Remove core patterns.
+			foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
+				if ( 'core/' === substr( $pattern['name'], 0, 5 ) ) {
+					unregister_block_pattern( $pattern['name'] );
+				}
+			}
+		}
+
+		$pattern_categories = array();
+		$block_patterns     = $this->get_patterns();
+
+		foreach ( (array) $this->get_patterns() as $pattern ) {
+			foreach ( (array) $pattern['categories'] as $slug => $category ) {
+				$pattern_categories[ $slug ] = $category['title'];
+			}
+		}
+
+		// Order categories alphabetically and register them.
+		asort( $pattern_categories );
+		foreach ( (array) $pattern_categories as $slug => $label ) {
+			register_block_pattern_category( $slug, array( 'label' => $label ) );
+		}
+
+		foreach ( (array) $this->get_patterns() as $pattern ) {
+			register_block_pattern(
+				Block_Patterns_From_API::PATTERN_NAMESPACE . $pattern['name'],
+				array(
+					'title'         => $pattern['title'],
+					'description'   => $pattern['title'],
+					'content'       => $pattern['html'],
+					'viewportWidth' => 1280,
+					'categories'    => array_keys(
+						$pattern['categories']
+					),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Returns a list of patterns.
+	 *
+	 * @return array
+	 */
+	private function get_patterns() {
+		$block_patterns = wp_cache_get( $this->patterns_cache_key, 'ptk_patterns' );
+
+		// Load fresh data if we don't have any patterns.
+		if ( false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
+			$request_url = esc_url_raw( add_query_arg(
+				array(
+					'language' => $this->get_iso_639_locale(),
+					'tags'     => 'pattern',
+				),
+				'https://public-api.wordpress.com/rest/v1/ptk/patterns'
+			) );
+
+			$args = array( 'timeout' => 20 );
+
+			if ( function_exists( 'wpcom_json_api_get' ) ) {
+				$response = wpcom_json_api_get( $request_url, $args );
+			} else {
+				$response = wp_remote_get( $request_url, $args );
+			}
+
+			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+				return array();
+			}
+			$block_patterns = json_decode( wp_remote_retrieve_body( $response ), true );
+			wp_cache_set( $this->patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
+		}
+
+		return $block_patterns;
+	}
+
+	/**
+	 * Returns ISO 639 conforming locale string.
+	 *
+	 * @return string ISO 639 locale string
+	 */
+	private function get_iso_639_locale() {
+		// Make sure to get blog locale, not user locale.
+		$language = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
+		$language = strtolower( $language );
+
+		if ( in_array( $language, array( 'pt_br', 'pt-br', 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ), true ) ) {
+			$language = str_replace( '_', '-', $language );
+		} else {
+			$language = preg_replace( '/([-_].*)$/i', '', $language );
+		}
+
+		if ( empty( $language ) ) {
+			return 'en';
+		}
+
+		return $language;
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-api.php
@@ -8,7 +8,7 @@
 namespace A8C\FSE;
 
 /**
- * Class Block_Patterns
+ * Class Block_Patterns_From_API
  */
 class Block_Patterns_From_API {
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -116,10 +116,9 @@ class Block_Patterns_From_API {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
-						'language' => $this->get_iso_639_locale(),
-						'tags'     => 'pattern',
+						'tags' => 'pattern',
 					),
-					'https://public-api.wordpress.com/rest/v1/ptk/patterns'
+					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->get_iso_639_locale()
 				)
 			);
 
@@ -135,7 +134,7 @@ class Block_Patterns_From_API {
 				return array();
 			}
 			$block_patterns = json_decode( wp_remote_retrieve_body( $response ), true );
-			wp_cache_set( $this->patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
+			wp_cache_add( $this->patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
 		}
 
 		return $block_patterns;

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -113,13 +113,15 @@ class Block_Patterns_From_API {
 
 		// Load fresh data if we don't have any patterns.
 		if ( false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
-			$request_url = esc_url_raw( add_query_arg(
-				array(
-					'language' => $this->get_iso_639_locale(),
-					'tags'     => 'pattern',
-				),
-				'https://public-api.wordpress.com/rest/v1/ptk/patterns'
-			) );
+			$request_url = esc_url_raw(
+				add_query_arg(
+					array(
+						'language' => $this->get_iso_639_locale(),
+						'tags'     => 'pattern',
+					),
+					'https://public-api.wordpress.com/rest/v1/ptk/patterns'
+				)
+			);
 
 			$args = array( 'timeout' => 20 );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -295,7 +295,7 @@ function load_block_patterns_from_api( $current_screen ) {
 		return;
 	}
 
-	require_once __DIR__ . '/block-patterns/class-block-patterns-api.php';
+	require_once __DIR__ . '/block-patterns/class-block-patterns-from-api.php';
 	Block_Patterns_From_API::get_instance();
 }
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -262,7 +262,11 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_nux' );
 /**
  * Load editing toolkit block patterns
  */
-function load_block_patterns() {
+function load_local_block_patterns() {
+	if ( apply_filters( 'a8c_enable_block_patterns_api', false ) ) {
+		return;
+	}
+
 	if ( ! function_exists( '\gutenberg_load_block_pattern' ) ) {
 		return;
 	}
@@ -271,7 +275,30 @@ function load_block_patterns() {
 
 	Block_Patterns::get_instance();
 }
-add_action( 'init', __NAMESPACE__ . '\load_block_patterns', 20 );
+add_action( 'init', __NAMESPACE__ . '\load_local_block_patterns', 20 );
+
+/**
+ * Load editing toolkit block patterns from the API
+ *
+ * @param obj $current_screen The current screen object.
+ */
+function load_block_patterns_from_api( $current_screen ) {
+	if ( ! apply_filters( 'a8c_enable_block_patterns_api', false ) ) {
+		return;
+	}
+
+	if ( ! function_exists( '\gutenberg_load_block_pattern' ) ) {
+		return;
+	}
+
+	if ( ! $current_screen->is_block_editor ) {
+		return;
+	}
+
+	require_once __DIR__ . '/block-patterns/class-block-patterns-api.php';
+	Block_Patterns_From_API::get_instance();
+}
+add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
 
 /**
  * Load Premium Content Block


### PR DESCRIPTION
This is a replacement for #46422 and addresses feedback in that PR. Fixes are:

* Split the old local patterns loading from the API patterns loading and keep the API loading off by default.
* Add a `a8c_enable_block_patterns_api` filter that will allow the API loading to be turned on.
* Make use of global cache group and `wp_cache_set` and `wp_cache_get`.
* Load the API code only on the block editor screen.
* Use the `wpcom_json_api_get` function when available.
* Remove code that scrubs core categories since it is not needed.
* Order patterns by their label not the slug so ordering works in all languages.
* Return a default `en` locale if `get_iso_639_locale` does not get a valid locale. 

#### Testing instructions

In order to test API loading you will need to add the following filter:

`add_filter( 'a8c_enable_block_patterns_api', '__return_true' );`

Please test this with and without this filter to ensure that patterns load from the local source and the API source correctly. 

* Test in a simple test.
* Test in an Atomic site.
* Check that all patterns are rendering previews correctly and not throwing block validation errors
* Test in all languages, ensuring the API always returns a 200 response and no invalid requests are sent (this is to address a comment p58i-9yt-p2#comment-47651 where there were 400 responses in the previous implementation).
* Test that the API request to get patterns is only being performed once per page load
* Test that the API request does not occur on non-Gutenberg admin pages, nor on the front end
* Test that there is no noticeable performance impact from switching on this feature

Hat tip @andrewserong on the testing list.