### PR TITLE
Jetpack Plans: Fix Jetpack Free card background color

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card-alt/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card-alt/style.scss
@@ -6,7 +6,7 @@
 
 	box-sizing: border-box;
 
-	background: var( --studio-gray-0 );
+	background: var( --color-surface );
 	border: 1px solid var( --color-border-subtle );
 	padding: 24px;
 

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -99,6 +99,10 @@
 		}
 	}
 
+	.jetpack-free-card-alt {
+		background: var( --studio-gray-0 );
+	}
+
 	.foldable-card {
 		font-size: rem( 13px );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Jetpack Free card had a background of `--studio-gray-0` instead of `--color-surface`. This resulted in an improper display in Calypso. This PR fixes that.

Before:
<img width="804" alt="image" src="https://user-images.githubusercontent.com/42627630/96029399-3a03c500-0e20-11eb-9a51-ef840991648e.png">

After:
<img width="799" alt="image" src="https://user-images.githubusercontent.com/42627630/96029372-2fe1c680-0e20-11eb-8d94-0500484f7fa8.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up this PR.
2. In Calypso, visit `/plans/:site?site=:site&source=jetpack-connect-plans`.
3. Verify that the background color of the Free card is the same as the rest of the product cards.
4. In Jetpack Cloud, visit `/pricing`.
5. Verify that the background color of the Free card is the same as the rest of the product cards.

Fixes #1196341175636977-as-1198217247692085