### PR TITLE
Podcasting: add deprecation notice to podcast keywords field

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -10,22 +10,22 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { PLAN_PERSONAL, FEATURE_AUDIO_UPLOADS } from 'lib/plans/constants';
-import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
-import { decodeEntities } from 'lib/formatting';
-import scrollTo from 'lib/scroll-to';
-import { isRequestingSitePlans } from 'state/sites/plans/selectors';
+import { PLAN_PERSONAL, FEATURE_AUDIO_UPLOADS } from 'calypso/lib/plans/constants';
+import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form';
+import { decodeEntities } from 'calypso/lib/formatting';
+import scrollTo from 'calypso/lib/scroll-to';
+import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { Button, Card } from '@automattic/components';
-import DocumentHead from 'components/data/document-head';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormInput from 'components/forms/form-text-input';
-import FormLabel from 'components/forms/form-label';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormSelect from 'components/forms/form-select';
-import FormTextarea from 'components/forms/form-textarea';
-import HeaderCake from 'components/header-cake';
-import Notice from 'components/notice';
-import PodcastCoverImageSetting from 'my-sites/site-settings/podcast-cover-image-setting';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormInput from 'calypso/components/forms/form-text-input';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormSelect from 'calypso/components/forms/form-select';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import HeaderCake from 'calypso/components/header-cake';
+import Notice from 'calypso/components/notice';
+import PodcastCoverImageSetting from 'calypso/my-sites/site-settings/podcast-cover-image-setting';
 import PodcastFeedUrl from './feed-url';
 import PodcastingPrivateSiteMessage from './private-site';
 import PodcastingNoPermissionsMessage from './no-permissions';
@@ -33,21 +33,21 @@ import PodcastingNotSupportedMessage from './not-supported';
 import PodcastingPublishNotice from './publish-notice';
 import PodcastingSupportLink from './support-link';
 import podcastingTopics from './topics';
-import TermTreeSelector from 'blocks/term-tree-selector';
-import UpsellNudge from 'blocks/upsell-nudge';
+import TermTreeSelector from 'calypso/blocks/term-tree-selector';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 /**
  * Selectors, actions, and query components
  */
-import QueryTerms from 'components/data/query-terms';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import isPrivateSite from 'state/selectors/is-private-site';
-import isSiteComingSoon from 'state/selectors/is-site-coming-soon';
-import canCurrentUser from 'state/selectors/can-current-user';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import { isJetpackSite } from 'state/sites/selectors';
-import { isRequestingTermsForQueryIgnoringPage } from 'state/terms/selectors';
-import { isSavingSiteSettings } from 'state/site-settings/selectors';
+import QueryTerms from 'calypso/components/data/query-terms';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import isPrivateSite from 'calypso/state/selectors/is-private-site';
+import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isRequestingTermsForQueryIgnoringPage } from 'calypso/state/terms/selectors';
+import { isSavingSiteSettings } from 'calypso/state/site-settings/selectors';
 
 /**
  * Style dependencies
@@ -375,6 +375,9 @@ class PodcastingDetails extends Component {
 				{ this.renderTextField( {
 					key: 'podcasting_keywords',
 					label: translate( 'Keywords' ),
+					explanation: translate(
+						'The keywords setting has been deprecated. This field is for reference only.'
+					),
 				} ) }
 				{ isPodcastingEnabled && this.renderSaveButton( true ) }
 			</Fragment>


### PR DESCRIPTION
Apple has deprecated and dropped support for the `itunes:keyword` tag. This just adds a notice for the user - we can handle removing the field (if empty) in a different change.

ref: p1602699974038200-slack-podcasting-async-workshop-content

**To test:**
- on a site with podcasting enabled
- visit the podcast settings page, Settings > Writing > Podcasting
- verify that the following explanation is shown for the keywords setting: "The keywords setting has been deprecated. This field is for reference only."