### PR TITLE
Notifications: Remove Restriction that First Element Cannot Be Nested

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -321,17 +321,9 @@ function recurse_convert( text, ranges, options ) {
 	// to smallest gives us the proper order for descending recursively.
 	for ( i = 0; i < ranges_copy.length; i++ ) {
 		id = find_largest_range( ranges_copy );
-		if ( ranges[ id ].indices[ 1 ] === 0 && ranges[ id ].indices[ 1 ] === 0 ) {
-			// Indices covering 0,0 are special cases only. They always go at the very
-			// beginning of the document, are never nested, and are always "empty"
-			// If there are multiple zero-length ranges, they will return in the order
-			// they appear.
-			container.appendChild( render_range( '', [], ranges[ id ], ranges, options ) );
-		} else {
-			range_len = ranges[ id ].indices[ 1 ] - ranges[ id ].indices[ 0 ];
-			for ( n = ranges[ id ].indices[ 0 ]; n <= ranges[ id ].indices[ 1 ]; n++ ) {
-				t[ n ].index.push( { id: id, len: range_len } );
-			}
+		range_len = ranges[ id ].indices[ 1 ] - ranges[ id ].indices[ 0 ];
+		for ( n = ranges[ id ].indices[ 0 ]; n <= ranges[ id ].indices[ 1 ]; n++ ) {
+			t[ n ].index.push( { id: id, len: range_len } );
 		}
 		// Clear out the currently-selected range so that it won't
 		// return as the largest range in the next loop iteration


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, notifications parser contains specific logic that restricts the first element to contain any nested elements. This prevents appropriate styling and ordering of elements to be applied, which results in the content of a notification to render differently than in a post.

#### Testing instructions

1. See the"Creating post notification" section in the README at https://github.com/Automattic/wp-calypso/blob/master/apps/notifications/src/doc/note-rendering.md
2. Use the "Follow" button that appears in the bottom right corner of the blog to add it to your Reader subscriptions:
3. Then navigate to https://wordpress.com/following/manage and enable "Notify me of new posts" for the blog. With this enabled, future posts on that blog will appear as notifications in your masterbar.
4. Create a post for the blog you're following a block that has nested elements, like multiple buttons for the Button Block. 5. Ensure this is the first element in your post. Inspect this element and see that there are nested elements in the block.
5. Go to your masterbar and select the notification that contains the block. If you use the browser Inspector, you'll see that the elements for that block are not nested, as they are be in a post.

#### Screenshots

Before | After
--- | ---
<img width="659" alt="Screen Shot 2020-10-14 at 7 16 42 PM" src="https://user-images.githubusercontent.com/66652282/96056042-98966680-0e53-11eb-880b-bc22bf8b91bd.png"> | <img width="663" alt="Screen Shot 2020-10-14 at 7 16 22 PM" src="https://user-images.githubusercontent.com/66652282/96056047-9fbd7480-0e53-11eb-837c-35fb0f4c4844.png">

Note: This before/after comparison shows changes from a sandboxed environment, not yet applied in production of the YouTube block, but still relevant to these changes.

Fixes #46469 
