### PR TITLE
Gutenboarding: Load translations before render

### DIFF
--- a/client/landing/gutenboarding/components/locale-context/index.tsx
+++ b/client/landing/gutenboarding/components/locale-context/index.tsx
@@ -49,7 +49,7 @@ export const ChangeLocaleContextConsumer = ChangeLocaleContext.Consumer;
 
 export const LocaleContext: React.FunctionComponent = ( { children } ) => {
 	const [ contextLocaleData, setContextLocaleData ] = React.useState< LocaleData | undefined >();
-	const [ localeDataLoaded, setLocaleDataLoaded ] = React.useState< boolean >( false );
+	const [ localeDataLoaded, setLocaleDataLoaded ] = React.useState( false );
 
 	const setLocale = ( newLocaleData: LocaleData | undefined ) => {
 		// Translations done within react are made using the localData passed to the <I18nProvider/>.

--- a/client/landing/gutenboarding/components/locale-context/index.tsx
+++ b/client/landing/gutenboarding/components/locale-context/index.tsx
@@ -31,7 +31,7 @@ interface AppWindow extends Window {
 	installedChunks?: string[];
 	i18nLocaleStrings?: string;
 	__requireChunkCallback__?: {
-		add( callback: Function ): void;
+		add( callback: Function ): void; // eslint-disable-line @typescript-eslint/ban-types
 		getInstalledChunks(): string[];
 	};
 	updateLocale: ( newLocale: string ) => Promise< void >; // fixme: this is just for demonstration purposes


### PR DESCRIPTION
This PR updated eliminates the flash of English text by updating the `LocaleContext` to render `null` until after `setLocale()` is called for the first time.

![no-flash-of-english](https://user-images.githubusercontent.com/5952255/96070035-be1e8100-0ee2-11eb-86f3-66b5e48c0c90.gif)

I've also moved the `loadInitalLocale()` call up into the `setState()` in order to have it trigger a fraction of a second earlier, as `useEffect()` waits for the first render to finish before it even starts fetching the translations. `setState()` provides the consuming function, so it's a natural limit within `LocaleContext`. (We have options to load it sooner than this, but we should do it in a separate performance-focused PR if we decide we need to).

#### Testing instructions

- load up a localized site (e.g. http://calypso.localhost:3000/new/ko) and watch for the flicker.
- load up the en site http://calypso.localhost:3000/new and make sure that it still loads ;)
- introduce an error to the locale load and make sure the page still loads, abeit in english (devtools->network->block request URL is convenient, or you can modify the slug passed to `getLanguageFile()`).

Note while you're watching closely that we've got a flash of unstyled content regardless of locale, so in an unusual reversal of fortunes, the non-en sites may look better as the delay for translations can buy time for the styles to load too.

Part of https://github.com/Automattic/wp-calypso/issues/37665
