### PR TITLE
Checkout: centralize hook selection logic in usePrepareProductsForCart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -189,9 +189,9 @@ function useAddRenewalItems( {
 	dispatch: ( action: PreparedProductsAction ) => void;
 	addHandler: 'addPlanFromSlug' | 'addProductFromSlug' | 'addRenewalItems' | 'doNotAdd';
 } ) {
-	const selectedSiteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
-	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
-	const products = useSelector( ( state ) => getProductsList( state ) );
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const isFetchingProducts = useSelector( isProductsListFetching );
+	const products = useSelector( getProductsList );
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -276,8 +276,8 @@ function useAddPlanFromSlug( {
 	isJetpackNotAtomic: boolean;
 	addHandler: 'addPlanFromSlug' | 'addProductFromSlug' | 'addRenewalItems' | 'doNotAdd';
 } ) {
-	const isFetchingPlans = useSelector( ( state ) => isRequestingPlans( state ) );
-	const plans = useSelector( ( state ) => getPlans( state ) );
+	const isFetchingPlans = useSelector( isRequestingPlans );
+	const plans = useSelector( getPlans );
 	const plan = useSelector( ( state ) => getPlanBySlug( state, planSlug ) );
 	const translate = useTranslate();
 
@@ -336,10 +336,10 @@ function useAddProductFromSlug( {
 	isPrivate: boolean;
 	addHandler: 'addPlanFromSlug' | 'addProductFromSlug' | 'addRenewalItems' | 'doNotAdd';
 } ) {
-	const isFetchingPlans = useSelector( ( state ) => isRequestingPlans( state ) );
-	const plans = useSelector( ( state ) => getPlans( state ) );
-	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
-	const products = useSelector( ( state ) => getProductsList( state ) );
+	const isFetchingPlans = useSelector( isRequestingPlans );
+	const plans = useSelector( getPlans );
+	const isFetchingProducts = useSelector( isProductsListFetching );
+	const products = useSelector( getProductsList );
 	const translate = useTranslate();
 
 	// If `productAliasFromUrl` has a comma ',' in it, we will assume it's because it's
@@ -442,8 +442,8 @@ function useAddProductFromSlug( {
 
 function useFetchPlansIfNotLoaded() {
 	const reduxDispatch = useDispatch();
-	const isFetchingPlans = useSelector( ( state ) => isRequestingPlans( state ) );
-	const plans = useSelector( ( state ) => getPlans( state ) );
+	const isFetchingPlans = useSelector( isRequestingPlans );
+	const plans = useSelector( getPlans );
 	useEffect( () => {
 		if ( ! isFetchingPlans && plans?.length < 1 ) {
 			debug( 'fetching plans list' );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -94,7 +94,6 @@ export default function usePrepareProductsForCart( {
 	// Only one of these three should ever operate. The others should bail if
 	// they think another hook will handle the data.
 	useAddPlanFromSlug( {
-		isLoading: state.isLoading,
 		planSlug,
 		dispatch,
 		isJetpackNotAtomic,
@@ -102,17 +101,13 @@ export default function usePrepareProductsForCart( {
 		addHandler,
 	} );
 	useAddProductFromSlug( {
-		isLoading: state.isLoading,
 		productAlias,
-		planSlug,
 		dispatch,
 		isJetpackNotAtomic,
 		isPrivate,
-		originalPurchaseId,
 		addHandler,
 	} );
 	useAddRenewalItems( {
-		isLoading: state.isLoading,
 		originalPurchaseId,
 		productAlias,
 		dispatch,
@@ -185,13 +180,11 @@ function chooseAddHandler( {
 }
 
 function useAddRenewalItems( {
-	isLoading,
 	originalPurchaseId,
 	productAlias,
 	dispatch,
 	addHandler,
 }: {
-	isLoading: boolean;
 	originalPurchaseId: string | number | null | undefined;
 	productAlias: string | null | undefined;
 	dispatch: ( action: PreparedProductsAction ) => void;
@@ -264,7 +257,6 @@ function useAddRenewalItems( {
 		dispatch( { type: 'RENEWALS_ADD', products: productsForCart } );
 	}, [
 		translate,
-		isLoading,
 		isFetchingProducts,
 		products,
 		originalPurchaseId,
@@ -275,18 +267,14 @@ function useAddRenewalItems( {
 }
 
 function useAddPlanFromSlug( {
-	isLoading,
 	planSlug,
 	dispatch,
 	isJetpackNotAtomic,
-	originalPurchaseId,
 	addHandler,
 }: {
-	isLoading: boolean;
 	planSlug: string | null | undefined;
 	dispatch: ( action: PreparedProductsAction ) => void;
 	isJetpackNotAtomic: boolean;
-	originalPurchaseId: string | number | null | undefined;
 	addHandler: 'addPlanFromSlug' | 'addProductFromSlug' | 'addRenewalItems' | 'doNotAdd';
 } ) {
 	const isFetchingPlans = useSelector( ( state ) => isRequestingPlans( state ) );
@@ -333,36 +321,20 @@ function useAddPlanFromSlug( {
 			cartProduct
 		);
 		dispatch( { type: 'PRODUCTS_ADD', products: [ cartProduct ] } );
-	}, [
-		translate,
-		isLoading,
-		plans,
-		originalPurchaseId,
-		isFetchingPlans,
-		planSlug,
-		plan,
-		isJetpackNotAtomic,
-		dispatch,
-	] );
+	}, [ translate, plans, isFetchingPlans, planSlug, plan, isJetpackNotAtomic, dispatch ] );
 }
 
 function useAddProductFromSlug( {
-	isLoading,
 	productAlias: productAliasFromUrl,
-	planSlug,
 	dispatch,
 	isJetpackNotAtomic,
 	isPrivate,
-	originalPurchaseId,
 	addHandler,
 }: {
-	isLoading: boolean;
 	productAlias: string | undefined | null;
-	planSlug: string | undefined | null;
 	dispatch: ( action: PreparedProductsAction ) => void;
 	isJetpackNotAtomic: boolean;
 	isPrivate: boolean;
-	originalPurchaseId: string | number | undefined | null;
 	addHandler: 'addPlanFromSlug' | 'addProductFromSlug' | 'addRenewalItems' | 'doNotAdd';
 } ) {
 	const isFetchingPlans = useSelector( ( state ) => isRequestingPlans( state ) );
@@ -457,13 +429,10 @@ function useAddProductFromSlug( {
 		dispatch( { type: 'PRODUCTS_ADD', products: cartProducts } );
 	}, [
 		translate,
-		isLoading,
 		isPrivate,
 		plans,
 		products,
-		originalPurchaseId,
 		isFetchingPlans,
-		planSlug,
 		isJetpackNotAtomic,
 		productAliasFromUrl,
 		validProducts,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -9,19 +9,19 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getSelectedSiteSlug } from 'state/ui/selectors';
-import { getRenewalItemFromCartItem, CartItemValue } from 'lib/cart-values/cart-items';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getRenewalItemFromCartItem, CartItemValue } from 'calypso/lib/cart-values/cart-items';
 import {
 	JETPACK_SEARCH_PRODUCTS,
 	PRODUCT_JETPACK_SEARCH,
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 	PRODUCT_WPCOM_SEARCH,
 	PRODUCT_WPCOM_SEARCH_MONTHLY,
-} from 'lib/products-values/constants';
-import { requestPlans } from 'state/plans/actions';
-import { getPlanBySlug, getPlans, isRequestingPlans } from 'state/plans/selectors';
-import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
-import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-from-path';
+} from 'calypso/lib/products-values/constants';
+import { requestPlans } from 'calypso/state/plans/actions';
+import { getPlanBySlug, getPlans, isRequestingPlans } from 'calypso/state/plans/selectors';
+import { getProductsList, isProductsListFetching } from 'calypso/state/products-list/selectors';
+import getUpgradePlanSlugFromPath from 'calypso/state/selectors/get-upgrade-plan-slug-from-path';
 import { createItemToAddToCart } from '../add-items';
 import { RequestCartProduct } from './use-shopping-cart-manager/types';
 import useFetchProductsIfNotLoaded from './use-fetch-products-if-not-loaded';
@@ -142,6 +142,36 @@ function preparedProductsReducer(
 		default:
 			return state;
 	}
+}
+
+function chooseAddHandler( {
+	isLoading,
+	originalPurchaseId,
+	planSlug,
+	productAliasFromUrl,
+}: {
+	isLoading: boolean;
+	originalPurchaseId: string | number | null | undefined;
+	planSlug: string;
+	productAliasFromUrl: string;
+} ): 'addPlanFromSlug' | 'addProductFromSlug' | 'addRenewalItems' | 'doNotAdd' {
+	if ( ! isLoading ) {
+		return 'doNotAdd';
+	}
+
+	if ( originalPurchaseId ) {
+		return 'addRenewalItems';
+	}
+
+	if ( ! originalPurchaseId && planSlug ) {
+		return 'addPlanFromSlug';
+	}
+
+	if ( ! originalPurchaseId && productAliasFromUrl ) {
+		return 'addProductFromSlug';
+	}
+
+	return 'doNotAdd';
 }
 
 function useAddRenewalItems( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -148,6 +148,8 @@ function preparedProductsReducer(
 	}
 }
 
+type AddHandler = 'addPlanFromSlug' | 'addProductFromSlug' | 'addRenewalItems' | 'doNotAdd';
+
 function chooseAddHandler( {
 	isLoading,
 	originalPurchaseId,
@@ -158,7 +160,7 @@ function chooseAddHandler( {
 	originalPurchaseId: string | number | null | undefined;
 	planSlug: string | null;
 	productAliasFromUrl: string | null | undefined;
-} ): 'addPlanFromSlug' | 'addProductFromSlug' | 'addRenewalItems' | 'doNotAdd' {
+} ): AddHandler {
 	if ( ! isLoading ) {
 		return 'doNotAdd';
 	}
@@ -187,7 +189,7 @@ function useAddRenewalItems( {
 	originalPurchaseId: string | number | null | undefined;
 	productAlias: string | null | undefined;
 	dispatch: ( action: PreparedProductsAction ) => void;
-	addHandler: 'addPlanFromSlug' | 'addProductFromSlug' | 'addRenewalItems' | 'doNotAdd';
+	addHandler: AddHandler;
 } ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const isFetchingProducts = useSelector( isProductsListFetching );
@@ -274,7 +276,7 @@ function useAddPlanFromSlug( {
 	planSlug: string | null | undefined;
 	dispatch: ( action: PreparedProductsAction ) => void;
 	isJetpackNotAtomic: boolean;
-	addHandler: 'addPlanFromSlug' | 'addProductFromSlug' | 'addRenewalItems' | 'doNotAdd';
+	addHandler: AddHandler;
 } ) {
 	const isFetchingPlans = useSelector( isRequestingPlans );
 	const plans = useSelector( getPlans );
@@ -334,7 +336,7 @@ function useAddProductFromSlug( {
 	dispatch: ( action: PreparedProductsAction ) => void;
 	isJetpackNotAtomic: boolean;
 	isPrivate: boolean;
-	addHandler: 'addPlanFromSlug' | 'addProductFromSlug' | 'addRenewalItems' | 'doNotAdd';
+	addHandler: AddHandler;
 } ) {
 	const isFetchingPlans = useSelector( isRequestingPlans );
 	const plans = useSelector( getPlans );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -97,7 +97,6 @@ export default function usePrepareProductsForCart( {
 		planSlug,
 		dispatch,
 		isJetpackNotAtomic,
-		originalPurchaseId,
 		addHandler,
 	} );
 	useAddProductFromSlug( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The `usePrepareProductsForCart` hook has an implicit invariant: at most one of the child hooks which add products to the cart based on URL parameters will run. Currently each child hook needs to know enough about its siblings do decide when _not_ to proceed. This PR centralizes that logic in a single function, `chooseAddHandler`, so these hooks are less dependent on the others behaving well.

#### Testing instructions

Test that the various means of adding cart items from the URL work. These are:

- Renewals, using URLs of the form `checkout/$product_slug/renew/$subscription_id/$site_url`
- Adding a plan, using URLs like `checkout/$site_url/premium` (or `personal` or `business`)
- Adding a product, using URLs like `checkout/$site_url/domain-mapping:example.com`