### PR TITLE
Remove problematic callback from wpcom-block-editor

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -771,18 +771,6 @@ function getGutenboardingStatus( calypsoPort ) {
 	};
 }
 
-function handleLaunchModal( calypsoPort ) {
-	subscribe( () => {
-		const { isSidebarOpen } = select( 'automattic/launch' ).getState();
-
-		// Hide inline help when launch modal is open
-		calypsoPort.postMessage( {
-			action: 'toggleInlineHelp',
-			payload: { hidden: isSidebarOpen },
-		} );
-	} );
-}
-
 /**
  * Hooks the nav sidebar to change some of its button labels and behaviour.
  *
@@ -1053,8 +1041,6 @@ function initPort( message ) {
 		getCloseButtonUrl( calypsoPort );
 
 		getGutenboardingStatus( calypsoPort );
-
-		handleLaunchModal( calypsoPort );
 
 		getNavSidebarLabels( calypsoPort );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This function seems to be causing issues on Atomic sites. Specifically this code:


```
        Object(F.subscribe) ((function () {
          var t = Object(F.select) ('automattic/launch').getState().isSidebarOpen;
          e.postMessage({
            action: 'toggleInlineHelp',
            payload: {
              hidden: t
            }
          })
        }))
```

with the accompanying error `Object(...)(...) is null`. Since this code runs within a subscribe callback, it will run _every time any data changes in any gutenberg data store._ So I imagine this failure both prevents a lot of things from happening, and also could theoretically make the page unresponsive. 

#### Testing instructions
This code can only be tested after deploying. Thankfully, this simply removes a function call. Therefore, it should be very safe, since nothing is really "expecting" the calypso `toggleInlineHelp` action to be called all the time.
