### PR TITLE
Notifications: Support Button Styling

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -94,6 +94,7 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 		case 'h4':
 		case 'h5':
 		case 'h6':
+		case 'a':
 			switch ( range_info_type ) {
 				case 'list':
 					range_info_type = 'span';

--- a/apps/notifications/src/panel/templates/functions.jsx
+++ b/apps/notifications/src/panel/templates/functions.jsx
@@ -44,7 +44,7 @@ const toBlocks = ( text ) =>
 			}
 
 			// Blockquote and list start/end tags do not need to be wrapped in div/p
-			const skipRegex = /(blockquote|ol|ul|li)(.*)>/i;
+			const skipRegex = /(blockquote|ol|ul|li|div)(.*)>/i;
 			const shouldSkipWrap = skipRegex.test( raw );
 			if ( shouldSkipWrap ) {
 				return {

--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -44,6 +44,29 @@
 		font-size: $font-title-medium;
 	}
 
+	.wp-block-button__link {
+		color: white;
+		font-weight: bold;
+		font-size: 1rem;
+		line-height: 1;
+		background-color: #1279be;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 5px;
+		padding: 16px 24px;
+
+		&:hover {
+			background-color: #303030;
+			cursor: pointer;
+		}
+	}
+
+	.wp-block-buttons
+	.wp-block-button {
+		display: inline-flex;
+		margin-right: 0.5rem;
+		margin-bottom: 0.5rem;
+	}
+
 	.uppercase {
 		text-transform: uppercase;
 	}

--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -44,29 +44,6 @@
 		font-size: $font-title-medium;
 	}
 
-	.wp-block-button__link {
-		color: white;
-		font-weight: bold;
-		font-size: 1rem;
-		line-height: 1;
-		background-color: #1279be;
-		/* stylelint-disable-next-line scales/radii */
-		border-radius: 5px;
-		padding: 16px 24px;
-
-		&:hover {
-			background-color: #303030;
-			cursor: pointer;
-		}
-	}
-
-	.wp-block-buttons
-	.wp-block-button {
-		display: inline-flex;
-		margin-right: 0.5rem;
-		margin-bottom: 0.5rem;
-	}
-
 	.uppercase {
 		text-transform: uppercase;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, Button blocks created in a post, and subsequently rendered in a notification in the master bar renders as a stacked links. To enhance the user experience, this change makes it so that the button block is rendered to look like a button, aligning with the styles from the original post.
* `a` tags are now rendered as the appropriate tags, and `div` tags can now have nested elements.

#### Testing instructions

Note that this branches from https://github.com/Automattic/wp-calypso/pull/46471 and depends on D51180-code

1. Apply this diff D51180-code and ensure you are sandboxed
2. See the"Creating post notification" section in the README at https://github.com/Automattic/wp-calypso/blob/master/apps/notifications/src/doc/note-rendering.md
3. Use the "Follow" button that appears in the bottom right corner of the blog to add it to your Reader subscriptions:
4. Then navigate to https://wordpress.com/following/manage and enable "Notify me of new posts" for the blog. With this enabled, future posts on that blog will appear as notifications in your masterbar.
5. Create a post for the blog you're following with a button block, with multiple buttons.
6. Go to your masterbar and select the notification that contains the buttons. Confirm the buttons are not a stacked list of links, instead they are styled like how they are in the post.

Before | After
--- | ---
<img width="402" alt="Screen Shot 2020-10-14 at 10 49 49 PM" src="https://user-images.githubusercontent.com/66652282/96077171-1f136e00-0e7d-11eb-8ae5-2e05ca814377.png"> | <img width="409" alt="Screen Shot 2020-10-14 at 10 49 32 PM" src="https://user-images.githubusercontent.com/66652282/96077180-23d82200-0e7d-11eb-84db-66544f48fc08.png">


Fixes #46292