### PR TITLE
Pauses the signup reskin test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -192,7 +192,7 @@ export default {
 		countryCodeTargets: [ 'US', 'CA' ],
 	},
 	reskinSignupFlow: {
-		datestamp: '20200928',
+		datestamp: '20300928',
 		variations: {
 			reskinned: 50,
 			control: 50,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the datestamp so that users are not assigned to either control or variant.

#### Testing instructions

* Using private browsing mode, go to https://wordpress.com/start using a EN locale. You should not be assigned to the `reskinSignupFlow` abtest.
* `localstorage.ABTests` should not contain`reskinSignupFlow`.