### PR TITLE
[WIP / Try] Gutenboarding: Switch detailed comparison features of plans grid to use mobile endpoint

### DIFF
--- a/packages/data-stores/src/plans/actions.ts
+++ b/packages/data-stores/src/plans/actions.ts
@@ -1,3 +1,10 @@
+export const setPlansDetails = ( plansDetails: Array< Record< string, unknown > > ) => {
+	return {
+		type: 'SET_PLANS_DETAILS' as const,
+		plansDetails,
+	};
+};
+
 export const setPrices = ( prices: Record< string, string > ) => {
 	return {
 		type: 'SET_PRICES' as const,
@@ -11,4 +18,4 @@ export const resetPlan = () => {
 	};
 };
 
-export type PlanAction = ReturnType< typeof setPrices >;
+export type PlanAction = ReturnType< typeof setPlansDetails | typeof setPrices | typeof resetPlan >;

--- a/packages/data-stores/src/plans/reducer.ts
+++ b/packages/data-stores/src/plans/reducer.ts
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import type { Reducer } from 'redux';
+import { combineReducers } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import { PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE } from './constants';
@@ -10,34 +16,54 @@ type PricesMap = {
 	[ slug in PlanSlug ]: string;
 };
 
-export const supportedPlanSlugs = Object.keys( PLANS_LIST );
-
-const DEFAUlT_STATE: {
-	supportedPlanSlugs: PlanSlug[];
-	prices: PricesMap;
-} = {
-	supportedPlanSlugs,
-	prices: {
-		[ PLAN_FREE ]: '',
-		[ PLAN_PERSONAL ]: '',
-		[ PLAN_PREMIUM ]: '',
-		[ PLAN_BUSINESS ]: '',
-		[ PLAN_ECOMMERCE ]: '',
-	},
+const DEFAULT_PRICES_STATE: PricesMap = {
+	[ PLAN_FREE ]: '',
+	[ PLAN_PERSONAL ]: '',
+	[ PLAN_PREMIUM ]: '',
+	[ PLAN_BUSINESS ]: '',
+	[ PLAN_ECOMMERCE ]: '',
 };
 
-const reducer = function ( state = DEFAUlT_STATE, action: PlanAction ) {
+export const supportedPlanSlugs: Reducer< string[], PlanAction > = (
+	state = Object.keys( PLANS_LIST ),
+	action: PlanAction
+) => {
 	switch ( action.type ) {
-		case 'SET_PRICES':
-			return {
-				...state,
-				prices: action.prices,
-			};
 		default:
 			return state;
 	}
 };
 
-export type State = typeof DEFAUlT_STATE;
+export const prices: Reducer< PricesMap, PlanAction > = (
+	state = DEFAULT_PRICES_STATE,
+	action: PlanAction
+) => {
+	switch ( action.type ) {
+		case 'SET_PRICES':
+			return action.prices;
+		default:
+			return state;
+	}
+};
+
+export const plansDetails: Reducer< Array< Record< string, unknown > >, PlanAction > = (
+	state = [],
+	action
+) => {
+	switch ( action.type ) {
+		case 'SET_PLANS_DETAILS':
+			return action.plansDetails;
+		default:
+			return state;
+	}
+};
+
+const reducer = combineReducers( {
+	supportedPlanSlugs,
+	prices,
+	plansDetails,
+} );
+
+export type State = ReturnType< typeof reducer >;
 
 export default reducer;

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -2,27 +2,31 @@
  * Internal dependencies
  */
 import type { State } from './reducer';
-import { planDetails, PLANS_LIST } from './plans-data';
+import { PLANS_LIST } from './plans-data';
 import { DEFAULT_PAID_PLAN, PLAN_ECOMMERCE, PLAN_FREE } from './constants';
-import type { PlanSlug } from './types';
+import type { Plan, PlanSlug } from './types';
 
 function getPlan( slug: PlanSlug ) {
 	return PLANS_LIST[ slug ];
 }
 
-export const getPlanBySlug = ( _: State, slug: PlanSlug ) => getPlan( slug );
+export const getPlanBySlug = ( _: State, slug: PlanSlug ): Plan => getPlan( slug );
 
-export const getDefaultPaidPlan = () => getPlan( DEFAULT_PAID_PLAN );
+export const getDefaultPaidPlan = (): Plan => getPlan( DEFAULT_PAID_PLAN );
 
-export const getSupportedPlans = ( state: State ) => state.supportedPlanSlugs.map( getPlan );
+export const getSupportedPlans = ( state: State ): Plan[] => {
+	return state.supportedPlanSlugs.map( getPlan );
+};
 
-export const getPlanByPath = ( state: State, path?: string ) =>
-	path && getSupportedPlans( state ).find( ( plan ) => plan?.pathSlug === path );
+export const getPlanByPath = ( state: State, path?: string ): Plan | undefined => {
+	return path ? getSupportedPlans( state ).find( ( plan ) => plan?.pathSlug === path ) : undefined;
+};
 
-export const getPlansDetails = () => planDetails;
+export const getPlansDetails = ( state: State, locale = 'en' ) => state.plansDetails;
 
-export const getPlansPaths = ( state: State ) =>
-	getSupportedPlans( state ).map( ( plan ) => plan?.pathSlug );
+export const getPlansPaths = ( state: State ) => {
+	return getSupportedPlans( state ).map( ( plan ) => plan?.pathSlug );
+};
 
 export const getPrices = ( state: State ) => state.prices;
 

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -87,3 +87,19 @@ export interface APIPlan {
 	tagline: object;
 	currency_code: string;
 }
+
+export type PlanFeature = {
+	id?: string;
+	description?: string;
+	name: string;
+	type: string;
+	data: Array< boolean | string >;
+};
+
+export type PlanDetail = {
+	id: string;
+	name: string | null;
+	features: Array< PlanFeature >;
+};
+
+export type PlanDetails = Array< PlanDetail >;

--- a/packages/plans-grid/src/plans-details/index.tsx
+++ b/packages/plans-grid/src/plans-details/index.tsx
@@ -24,11 +24,13 @@ type Props = {
 };
 
 const PlansDetails: React.FunctionComponent< Props > = ( { onSelect } ) => {
-	const plansDetails = useSelect( ( select ) => select( PLANS_STORE ).getPlansDetails() );
+	const { __, i18nLocale } = useI18n();
+
+	const plansDetails = useSelect( ( select ) =>
+		select( PLANS_STORE ).getPlansDetails( i18nLocale )
+	);
 	const prices = useSelect( ( select ) => select( PLANS_STORE ).getPrices() );
 	const supportedPlans = useSelect( ( select ) => select( PLANS_STORE ).getSupportedPlans() );
-
-	const { __ } = useI18n();
 
 	return (
 		<div className="plans-details">


### PR DESCRIPTION
This PR is an exploration into using the mobile plans endpoint, which includes a translated list of plans features, to source the data for the list of detailed comparison features in the plans grid in Gutenboarding.

The endpoint that includes the list of features is https://public-api.wordpress.com/wpcom/v2/plans/mobile and we can pass it a locale, e.g. https://public-api.wordpress.com/wpcom/v2/plans/mobile?locale=fr

There's a lot that this PR _doesn't_ do yet. Still to be done:

* [ ] Map the features to the particular plan in the list of checkboxes (this hard-codes them all with the tick at the moment)
* [ ] Adjust the sort order of the detailed comparison features
* [ ] Add back in the groupings for the features
* [ ] Improve the loading state, at the moment it looks a bit empty before the features appear
* [ ] Lots of clean-up and fixing TypeScript errors

## Questions

Is this a viable approach to the problem, or do we lose the flexibility of being able to have unique strings for Gutenboarding for these features? Also, the text used from this mobile endpoint is different to that used in Calypso, so we're still not reaching parity between these different areas.

I imagine the main plans grid would continue to use https://public-api.wordpress.com/rest/v1.5/plans for getting plans details, so the plans page might end up doing a couple of separate API calls to get all the info it needs?

## Screenshots

### Korean

![image](https://user-images.githubusercontent.com/14988353/96091732-af04f680-0f15-11eb-9ad3-6989a52de89b.png)

### French

![image](https://user-images.githubusercontent.com/14988353/96092015-030fdb00-0f16-11eb-84a3-e1ea739831c9.png)

#### Changes proposed in this Pull Request

* TBC, but broadly to use https://public-api.wordpress.com/wpcom/v2/plans/mobile to list plans features beneath the plan selector, instead of having them hard coded in the plans data store.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In Gutenboarding, select a language other than English and open up the plans modal:

* Go to http://calypso.localhost:3000/new/plans-modal/ko and the detailed list of features should be displayed in Korean
* Change locale by going to http://calypso.localhost:3000/new/plans-modal/fr — it should now render in French

I also noticed that some strings appear to be missing translations, e.g. `Automated Backup & One‑Click Rewind` in Korean.

Fixes #
