### PR TITLE
Email: Update billing frequency label for Titan

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -10,25 +10,28 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import PromoCard from 'components/promo-section/promo-card';
+import PromoCard from 'calypso/components/promo-section/promo-card';
 import EmailProviderDetails from './email-provider-details';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getProductBySlug } from 'state/products-list/selectors';
-import { GSUITE_BASIC_SLUG } from 'lib/gsuite/constants';
-import { getAnnualPrice } from 'lib/gsuite';
-import { hasDiscount } from 'components/gsuite/gsuite-price';
-import getCurrentRoute from 'state/selectors/get-current-route';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
-import { emailManagementForwarding, emailManagementNewGSuiteAccount } from 'my-sites/email/paths';
-import wpcom from 'lib/wp';
-import { errorNotice } from 'state/notices/actions';
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import TrackComponentView from 'lib/analytics/track-component-view';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import { GSUITE_BASIC_SLUG } from 'calypso/lib/gsuite/constants';
+import { getAnnualPrice } from 'calypso/lib/gsuite';
+import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	emailManagementForwarding,
+	emailManagementNewGSuiteAccount,
+} from 'calypso/my-sites/email/paths';
+import wpcom from 'calypso/lib/wp';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import formatCurrency from '@automattic/format-currency';
-import emailIllustration from 'assets/images/email-providers/email-illustration.svg';
-import titanLogo from 'assets/images/email-providers/titan.svg';
-import gSuiteLogo from 'assets/images/email-providers/gsuite.svg';
-import forwardingIcon from 'assets/images/email-providers/forwarding.svg';
+import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
+import titanLogo from 'calypso/assets/images/email-providers/titan.svg';
+import gSuiteLogo from 'calypso/assets/images/email-providers/gsuite.svg';
+import forwardingIcon from 'calypso/assets/images/email-providers/forwarding.svg';
 
 /**
  * Style dependencies
@@ -155,7 +158,7 @@ class EmailProvidersComparison extends React.Component {
 				) }
 				image={ { path: titanLogo } }
 				features={ [
-					translate( 'Monthly billing' ),
+					translate( 'Annual or monthly billing' ),
 					translate( 'Send and receive from your custom domain' ),
 					translate( '10GB storage' ),
 					translate( 'Email, calendars, and contacts' ),

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -170,7 +170,7 @@ class EmailProvidersComparison extends React.Component {
 				features={ [
 					billingFrequency,
 					translate( 'Send and receive from your custom domain' ),
-					translate( '10GB storage' ),
+					translate( '30GB storage' ),
 					translate( 'Email, calendars, and contacts' ),
 					translate( 'One-click import of existing emails and contacts' ),
 					translate( 'Read receipts to track email opens' ),

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -3,16 +3,21 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import page from 'page';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import config from 'calypso/config';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import EmailProviderDetails from './email-provider-details';
-import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import {
+	getCurrentUserCurrencyCode,
+	getCurrentUserLocale,
+} from 'calypso/state/current-user/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { GSUITE_BASIC_SLUG } from 'calypso/lib/gsuite/constants';
 import { getAnnualPrice } from 'calypso/lib/gsuite';
@@ -148,7 +153,12 @@ class EmailProvidersComparison extends React.Component {
 	}
 
 	renderTitanDetails( className ) {
-		const { translate } = this.props;
+		const { currentUserLocale, translate } = this.props;
+		const isEnglish = includes( config( 'english_locales' ), currentUserLocale );
+		const billingFrequency =
+			isEnglish || i18n.hasTranslation( 'Annual or monthly billing' )
+				? translate( 'Annual or monthly billing' )
+				: translate( 'Monthly billing' );
 
 		return (
 			<EmailProviderDetails
@@ -158,7 +168,7 @@ class EmailProvidersComparison extends React.Component {
 				) }
 				image={ { path: titanLogo } }
 				features={ [
-					translate( 'Annual or monthly billing' ),
+					billingFrequency,
 					translate( 'Send and receive from your custom domain' ),
 					translate( '10GB storage' ),
 					translate( 'Email, calendars, and contacts' ),
@@ -243,6 +253,7 @@ export default connect(
 	( state ) => {
 		return {
 			currencyCode: getCurrentUserCurrencyCode( state ),
+			currentUserLocale: getCurrentUserLocale( state ),
 			gSuiteProduct: getProductBySlug( state, GSUITE_BASIC_SLUG ),
 			currentRoute: getCurrentRoute( state ),
 			selectedSiteSlug: getSelectedSiteSlug( state ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the billing frequency label for Titan, from "Monthly billing" to "Annual or monthly billing".

#### Testing instructions

* Go to /email with the `email/titan-mvp` flag enabled
* Verify that the label has been updated

<img width="293" alt="Screenshot 2020-10-15 at 11 13 25 AM" src="https://user-images.githubusercontent.com/13062352/96103001-73e3d280-0ed7-11eb-9c91-d74b871bf929.png">

