### PR TITLE
gutenframe/media: store iframePort in state & use it to pass media …

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -4,7 +4,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { get, map, partial, pickBy, startsWith, isArray, flowRight } from 'lodash';
+import { map, partial, pickBy, isArray, flowRight } from 'lodash';
 /* eslint-disable no-restricted-imports */
 import url from 'url';
 import { localize, LocalizeProps } from 'i18n-calypso';
@@ -540,26 +540,6 @@ class CalypsoifyIframe extends Component<
 			action: 'pressThis',
 			payload: pressThis,
 		} );
-	};
-
-	updateImageBlocks = ( action: { data: { mime_type: string; URL: string }; type: string } ) => {
-		if (
-			! this.iframePort ||
-			! action ||
-			! startsWith( action.data.mime_type, 'image/' ) ||
-			startsWith( action.data.URL, 'blob:' )
-		) {
-			return;
-		}
-		const payload = {
-			id: get( action, 'data.ID' ),
-			height: get( action, 'data.height' ),
-			status: 'REMOVE_MEDIA_ITEM' === action.type ? 'deleted' : 'updated',
-			transientId: get( action, 'id' ),
-			url: get( action, 'data.URL' ),
-			width: get( action, 'data.width' ),
-		};
-		this.iframePort.postMessage( { action: 'updateImageBlocks', payload } );
 	};
 
 	openPreviewModal = ( postUrl: string, previewPort: MessagePort ) => {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -12,7 +12,6 @@ import { localize, LocalizeProps } from 'i18n-calypso';
  * Internal dependencies
  */
 import AsyncLoad from 'calypso/components/async-load';
-import MediaStore from 'calypso/lib/media/store';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
 	getCustomizerUrl,
@@ -152,7 +151,6 @@ class CalypsoifyIframe extends Component<
 	waitForIframeToLoad: ReturnType< typeof setTimeout > | undefined = undefined;
 
 	componentDidMount() {
-		MediaStore.on( 'change', this.updateImageBlocks );
 		window.addEventListener( 'message', this.onMessage, false );
 
 		const isDesktop = config.isEnabled( 'desktop' );
@@ -184,7 +182,6 @@ class CalypsoifyIframe extends Component<
 	}
 
 	componentWillUnmount() {
-		MediaStore.off( 'change', this.updateImageBlocks );
 		window.removeEventListener( 'message', this.onMessage, false );
 	}
 
@@ -222,7 +219,7 @@ class CalypsoifyIframe extends Component<
 			this.pressThis();
 
 			// Notify external listeners that the iframe has loaded
-			this.props.setEditorIframeLoaded();
+			this.props.setEditorIframeLoaded( true, this.iframePort );
 
 			return;
 		}

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -8,15 +8,15 @@ import { toPairs, isEqual, omit } from 'lodash';
  */
 
 import debug from 'debug';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import {
 	MEDIA_REQUEST,
 	MEDIA_ITEM_REQUEST,
 	MEDIA_ITEM_UPDATE,
 	MEDIA_ITEM_EDIT,
 	MEDIA_ITEM_DELETE,
-} from 'state/action-types';
+} from 'calypso/state/action-types';
 import {
 	deleteMedia,
 	failMediaItemRequest,
@@ -25,8 +25,8 @@ import {
 	setNextPageHandle,
 	successMediaItemRequest,
 	successMediaRequest,
-} from 'state/media/actions';
-import { requestMediaStorage } from 'state/sites/media-storage/actions';
+} from 'calypso/state/media/actions';
+import { requestMediaStorage } from 'calypso/state/sites/media-storage/actions';
 import {
 	dispatchFluxUpdateMediaItemSuccess,
 	dispatchFluxUpdateMediaItemError,
@@ -35,10 +35,10 @@ import {
 	dispatchFluxRequestMediaItemSuccess,
 	dispatchFluxRequestMediaItemError,
 	dispatchFluxRequestMediaItemsSuccess,
-} from 'state/media/utils/flux-adapter';
+} from 'calypso/state/media/utils/flux-adapter';
 
-import { registerHandlers } from 'state/data-layer/handler-registry';
-import getNextPageQuery from 'state/selectors/get-next-page-query';
+import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+import getNextPageQuery from 'calypso/state/selectors/get-next-page-query';
 import { gutenframeUpdateImageBlocks } from 'calypso/state/media/thunks';
 
 /**
@@ -176,7 +176,7 @@ export const requestDeleteMedia = ( action ) => {
 	];
 };
 
-export const deleteMediaSuccess = ( { siteId }, mediaItem ) => ( dispatch, getState ) => {
+export const deleteMediaSuccess = ( { siteId }, mediaItem ) => ( dispatch ) => {
 	dispatch( deleteMedia( siteId, mediaItem.ID ) );
 	dispatch( requestMediaStorage( siteId ) );
 	dispatch( gutenframeUpdateImageBlocks( mediaItem, 'deleted' ) );

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -39,20 +39,12 @@ import {
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import getNextPageQuery from 'state/selectors/get-next-page-query';
-import { isEditorIframeLoaded, getEditorIframePort } from 'calypso/state/editor/selectors';
+import { gutenframeUpdateImageBlocks } from 'calypso/state/media/thunks';
 
 /**
  * Module variables
  */
 const log = debug( 'calypso:middleware-media' );
-
-const createMediaGutenframePayload = ( status, mediaItem ) => ( {
-	id: mediaItem.ID,
-	height: mediaItem.height,
-	status,
-	url: mediaItem.URL,
-	width: mediaItem.width,
-} );
 
 export function updateMedia( action ) {
 	const { siteId, item } = action;
@@ -70,14 +62,9 @@ export function updateMedia( action ) {
 	];
 }
 
-export const updateMediaSuccess = ( { siteId }, mediaItem ) => ( dispatch, getState ) => {
+export const updateMediaSuccess = ( { siteId }, mediaItem ) => ( dispatch ) => {
 	dispatch( receiveMedia( siteId, mediaItem ) );
-
-	if ( isEditorIframeLoaded( getState() ) ) {
-		const iframePort = getEditorIframePort( getState() );
-		const payload = createMediaGutenframePayload( 'updated', mediaItem );
-		iframePort.postMessage( { action: 'updateImageBlocks', payload } );
-	}
+	dispatch( gutenframeUpdateImageBlocks( mediaItem, 'updated' ) );
 
 	dispatchFluxUpdateMediaItemSuccess( siteId, mediaItem );
 };
@@ -192,12 +179,7 @@ export const requestDeleteMedia = ( action ) => {
 export const deleteMediaSuccess = ( { siteId }, mediaItem ) => ( dispatch, getState ) => {
 	dispatch( deleteMedia( siteId, mediaItem.ID ) );
 	dispatch( requestMediaStorage( siteId ) );
-
-	if ( isEditorIframeLoaded( getState() ) ) {
-		const iframePort = getEditorIframePort( getState() );
-		const payload = createMediaGutenframePayload( 'deleted', mediaItem );
-		iframePort.postMessage( { action: 'updateImageBlocks', payload } );
-	}
+	dispatch( gutenframeUpdateImageBlocks( mediaItem, 'deleted' ) );
 
 	dispatchFluxRemoveMediaItemSuccess( siteId, mediaItem );
 };

--- a/client/state/data-layer/wpcom/sites/media/test/index.js
+++ b/client/state/data-layer/wpcom/sites/media/test/index.js
@@ -9,8 +9,8 @@ import {
 	requestMediaError,
 	requestMediaSuccess,
 } from '../';
-import { MEDIA_ITEM_REQUEST } from 'state/action-types';
-import { http } from 'state/data-layer/wpcom-http/actions';
+import { MEDIA_ITEM_REQUEST } from 'calypso/state/action-types';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import {
 	failMediaItemRequest,
 	failMediaRequest,
@@ -18,7 +18,7 @@ import {
 	setNextPageHandle,
 	successMediaItemRequest,
 	successMediaRequest,
-} from 'state/media/actions';
+} from 'calypso/state/media/actions';
 
 describe( 'media request', () => {
 	test( 'should dispatch SUCCESS action when request completes', () => {

--- a/client/state/editor/actions.js
+++ b/client/state/editor/actions.js
@@ -156,9 +156,10 @@ export function saveConfirmationSidebarPreference( siteId, isEnabled = true ) {
 	};
 }
 
-export const setEditorIframeLoaded = ( isIframeLoaded = true ) => ( {
+export const setEditorIframeLoaded = ( isIframeLoaded = true, iframePort = null ) => ( {
 	type: EDITOR_IFRAME_LOADED,
 	isIframeLoaded,
+	iframePort,
 } );
 
 export const editorAutosaveReset = () => ( {

--- a/client/state/editor/actions.js
+++ b/client/state/editor/actions.js
@@ -6,7 +6,7 @@ import { defaults, filter, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
+import wpcom from 'calypso/lib/wp';
 import {
 	EDITOR_AUTOSAVE,
 	EDITOR_AUTOSAVE_RESET,
@@ -22,15 +22,15 @@ import {
 	EDITOR_EDIT_RAW_CONTENT,
 	EDITOR_RESET_RAW_CONTENT,
 	EDITOR_INIT_RAW_CONTENT,
-} from 'state/action-types';
-import { ModalViews } from 'state/ui/media-modal/constants';
-import { setMediaModalView } from 'state/ui/media-modal/actions';
-import { withAnalytics, bumpStat, recordTracksEvent } from 'state/analytics/actions';
-import { savePreference } from 'state/preferences/actions';
-import { getPreference } from 'state/preferences/selectors';
-import { editPost } from 'state/posts/actions';
+} from 'calypso/state/action-types';
+import { ModalViews } from 'calypso/state/ui/media-modal/constants';
+import { setMediaModalView } from 'calypso/state/ui/media-modal/actions';
+import { withAnalytics, bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { editPost } from 'calypso/state/posts/actions';
 
-import 'state/editor/init';
+import 'calypso/state/editor/init';
 
 /**
  * Constants

--- a/client/state/editor/reducer.js
+++ b/client/state/editor/reducer.js
@@ -75,6 +75,17 @@ export function isIframeLoaded( state = false, action ) {
 	return state;
 }
 
+export function iframePort( state = null, action ) {
+	switch ( action.type ) {
+		case EDITOR_IFRAME_LOADED: {
+			const loaded = action.isIframeLoaded;
+			return loaded ? action.iframePort : null;
+		}
+	}
+
+	return state;
+}
+
 export function isAutosaving( state = false, action ) {
 	switch ( action.type ) {
 		case EDITOR_AUTOSAVE:
@@ -106,6 +117,7 @@ const combinedReducer = combineReducers( {
 	loadingError,
 	isLoading,
 	isIframeLoaded,
+	iframePort,
 	isAutosaving,
 	autosavePreviewUrl,
 	imageEditor,

--- a/client/state/editor/reducer.js
+++ b/client/state/editor/reducer.js
@@ -17,7 +17,7 @@ import {
 	EDITOR_STOP,
 	POST_SAVE_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, withStorageKey } from 'state/utils';
+import { combineReducers, withoutPersistence, withStorageKey } from 'state/utils';
 import imageEditor from './image-editor/reducer';
 import videoEditor from './video-editor/reducer';
 import lastDraft from './last-draft/reducer';
@@ -75,7 +75,7 @@ export function isIframeLoaded( state = false, action ) {
 	return state;
 }
 
-export function iframePort( state = null, action ) {
+export const iframePort = withoutPersistence( ( state = null, action ) => {
 	switch ( action.type ) {
 		case EDITOR_IFRAME_LOADED: {
 			const loaded = action.isIframeLoaded;
@@ -84,7 +84,7 @@ export function iframePort( state = null, action ) {
 	}
 
 	return state;
-}
+} );
 
 export function isAutosaving( state = false, action ) {
 	switch ( action.type ) {

--- a/client/state/editor/reducer.js
+++ b/client/state/editor/reducer.js
@@ -79,7 +79,7 @@ export const iframePort = withoutPersistence( ( state = null, action ) => {
 	switch ( action.type ) {
 		case EDITOR_IFRAME_LOADED: {
 			const loaded = action.isIframeLoaded;
-			return loaded ? action.iframePort : null;
+			return loaded && action.iframePort ? action.iframePort : null;
 		}
 	}
 

--- a/client/state/editor/reducer.js
+++ b/client/state/editor/reducer.js
@@ -16,8 +16,8 @@ import {
 	EDITOR_START,
 	EDITOR_STOP,
 	POST_SAVE_SUCCESS,
-} from 'state/action-types';
-import { combineReducers, withoutPersistence, withStorageKey } from 'state/utils';
+} from 'calypso/state/action-types';
+import { combineReducers, withoutPersistence, withStorageKey } from 'calypso/state/utils';
 import imageEditor from './image-editor/reducer';
 import videoEditor from './video-editor/reducer';
 import lastDraft from './last-draft/reducer';

--- a/client/state/editor/selectors.js
+++ b/client/state/editor/selectors.js
@@ -161,6 +161,10 @@ export function isEditorIframeLoaded( state ) {
 	return state.editor.isIframeLoaded;
 }
 
+export function getEditorIframePort( state ) {
+	return state.editor.iframePort;
+}
+
 export function getEditorPublishButtonStatus( state ) {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );

--- a/client/state/editor/test/reducer.js
+++ b/client/state/editor/test/reducer.js
@@ -16,6 +16,7 @@ describe( 'reducer', () => {
 			'loadingError',
 			'isLoading',
 			'isIframeLoaded',
+			'iframePort',
 			'isAutosaving',
 			'autosavePreviewUrl',
 			'lastDraft',

--- a/client/state/editor/test/reducer.js
+++ b/client/state/editor/test/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import reducer, { postId, iframePort } from '../reducer';
-import { EDITOR_START, POST_SAVE_SUCCESS, EDITOR_IFRAME_LOADED } from 'state/action-types';
+import { EDITOR_START, POST_SAVE_SUCCESS, EDITOR_IFRAME_LOADED } from 'calypso/state/action-types';
 
 describe( 'reducer', () => {
 	test( 'should export expected reducer keys', () => {

--- a/client/state/editor/test/reducer.js
+++ b/client/state/editor/test/reducer.js
@@ -1,17 +1,12 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
-import reducer, { postId } from '../reducer';
-import { EDITOR_START, POST_SAVE_SUCCESS } from 'state/action-types';
+import reducer, { postId, iframePort } from '../reducer';
+import { EDITOR_START, POST_SAVE_SUCCESS, EDITOR_IFRAME_LOADED } from 'state/action-types';
 
 describe( 'reducer', () => {
 	test( 'should export expected reducer keys', () => {
-		expect( reducer( undefined, {} ) ).to.have.keys( [
+		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual( [
 			'postId',
 			'loadingError',
 			'isLoading',
@@ -19,10 +14,10 @@ describe( 'reducer', () => {
 			'iframePort',
 			'isAutosaving',
 			'autosavePreviewUrl',
-			'lastDraft',
-			'contactForm',
 			'imageEditor',
 			'videoEditor',
+			'lastDraft',
+			'contactForm',
 			'saveBlockers',
 			'rawContent',
 		] );
@@ -32,7 +27,7 @@ describe( 'reducer', () => {
 		test( 'should default to null', () => {
 			const state = postId( undefined, {} );
 
-			expect( state ).to.be.null;
+			expect( state ).toBeNull();
 		} );
 
 		test( 'should update the tracked id when starting the editor', () => {
@@ -42,7 +37,7 @@ describe( 'reducer', () => {
 				postId: 184,
 			} );
 
-			expect( state ).to.equal( 184 );
+			expect( state ).toEqual( 184 );
 		} );
 
 		test( 'should update the tracked post id if we save a draft post', () => {
@@ -56,7 +51,7 @@ describe( 'reducer', () => {
 				post: {},
 			} );
 
-			expect( state ).to.equal( 184 );
+			expect( state ).toEqual( 184 );
 		} );
 
 		test( 'should not update the tracked post id if we save a draft post but we already switched the tracked post ID', () => {
@@ -70,7 +65,47 @@ describe( 'reducer', () => {
 				post: {},
 			} );
 
-			expect( state ).to.equal( 10 );
+			expect( state ).toEqual( 10 );
+		} );
+	} );
+
+	describe( ' #iframePort', () => {
+		test( 'should default to null', () => {
+			const state = iframePort( undefined, {} );
+
+			expect( state ).toBeNull();
+		} );
+
+		test( 'should return null if the iframe editor is not loaded', () => {
+			const iframePortObject = {};
+			const state = iframePort( undefined, {
+				type: EDITOR_IFRAME_LOADED,
+				isIframeLoaded: false,
+				iframePort: iframePortObject,
+			} );
+
+			expect( state ).toBeNull();
+		} );
+
+		test( 'should return null if no iframePort object was given', () => {
+			const state = iframePort( undefined, {
+				type: EDITOR_IFRAME_LOADED,
+				isIframeLoaded: true,
+				iframePort: undefined,
+			} );
+
+			expect( state ).toBeNull();
+		} );
+
+		test( 'should return the iframePort object if the iframe editor is loaded', () => {
+			const iframePortObject = {};
+			const state = iframePort( undefined, {
+				type: EDITOR_IFRAME_LOADED,
+				isIframeLoaded: true,
+				iframePort: iframePortObject,
+			} );
+
+			expect( state ).toBe( iframePortObject );
 		} );
 	} );
 } );

--- a/client/state/media/thunks/gutenframe-update-image-blocks.js
+++ b/client/state/media/thunks/gutenframe-update-image-blocks.js
@@ -3,7 +3,7 @@
  */
 import { isEditorIframeLoaded, getEditorIframePort } from 'calypso/state/editor/selectors';
 
-export const createMediaGutenframePayload = ( status, mediaItem ) => ( {
+const createMediaGutenframePayload = ( status, mediaItem ) => ( {
 	id: mediaItem.ID,
 	height: mediaItem.height,
 	status,

--- a/client/state/media/thunks/gutenframe-update-image-blocks.js
+++ b/client/state/media/thunks/gutenframe-update-image-blocks.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { isEditorIframeLoaded, getEditorIframePort } from 'calypso/state/editor/selectors';
+
+export const createMediaGutenframePayload = ( status, mediaItem ) => ( {
+	id: mediaItem.ID,
+	height: mediaItem.height,
+	status,
+	url: mediaItem.URL,
+	width: mediaItem.width,
+} );
+
+export const gutenframeUpdateImageBlocks = ( mediaItem, action ) => ( dispatch, getState ) => {
+	const state = getState();
+
+	if ( isEditorIframeLoaded( state ) ) {
+		const iframePort = getEditorIframePort( state );
+
+		if ( ! ( iframePort && iframePort.postMessage ) ) {
+			return;
+		}
+
+		const payload = createMediaGutenframePayload( action, mediaItem );
+		iframePort.postMessage( { action: 'updateImageBlocks', payload } );
+	}
+};

--- a/client/state/media/thunks/index.js
+++ b/client/state/media/thunks/index.js
@@ -8,3 +8,4 @@ export { fetchMediaItem } from './fetch-media-item';
 export { addWoocommerceProductImage } from './add-woocommerce-product-image';
 export { fetchNextMediaPage } from './fetch-next-media-page';
 export { default as getMediaItem } from './get-media-item';
+export { gutenframeUpdateImageBlocks } from './gutenframe-update-image-blocks';

--- a/client/state/media/thunks/test/gutenframe-update-image-blocks.js
+++ b/client/state/media/thunks/test/gutenframe-update-image-blocks.js
@@ -1,0 +1,76 @@
+/**
+ * Internal dependencies
+ */
+import { gutenframeUpdateImageBlocks as gutenframeUpdateImageBlocksThunk } from 'calypso/state/media/thunks/gutenframe-update-image-blocks';
+
+describe( 'media - thunks - gutenframeUpdateImageBlocks', () => {
+	const dispatch = jest.fn();
+	const getState = jest.fn();
+
+	const gutenframeUpdateImageBlocks = ( ...args ) =>
+		gutenframeUpdateImageBlocksThunk( ...args )( dispatch, getState );
+
+	test( "shouldn't do anything at all if the iframe editor isn't loaded", () => {
+		const postMessage = jest.fn();
+		getState.mockReturnValueOnce( {
+			editor: {
+				isIframeLoaded: false,
+				iframePort: {
+					postMessage,
+				},
+			},
+		} );
+
+		gutenframeUpdateImageBlocks( { ID: 1234 }, 'deleted' );
+
+		expect( postMessage ).not.toHaveBeenCalled();
+	} );
+
+	test( "should call post message with 'deleted' payload", () => {
+		const mediaItem = {
+			ID: 1234,
+		};
+		const postMessage = jest.fn();
+		getState.mockReturnValueOnce( {
+			editor: {
+				isIframeLoaded: true,
+				iframePort: {
+					postMessage,
+				},
+			},
+		} );
+		gutenframeUpdateImageBlocks( mediaItem, 'deleted' );
+
+		expect( postMessage ).toHaveBeenCalledWith( {
+			action: 'updateImageBlocks',
+			payload: expect.objectContaining( {
+				id: mediaItem.ID,
+				status: 'deleted',
+			} ),
+		} );
+	} );
+
+	test( "should call post message with 'updated' payload", () => {
+		const mediaItem = {
+			ID: 1234,
+		};
+		const postMessage = jest.fn();
+		getState.mockReturnValueOnce( {
+			editor: {
+				isIframeLoaded: true,
+				iframePort: {
+					postMessage,
+				},
+			},
+		} );
+		gutenframeUpdateImageBlocks( mediaItem, 'updated' );
+
+		expect( postMessage ).toHaveBeenCalledWith( {
+			action: 'updateImageBlocks',
+			payload: expect.objectContaining( {
+				id: mediaItem.ID,
+				status: 'updated',
+			} ),
+		} );
+	} );
+} );


### PR DESCRIPTION
…actions via thunks

This is an alternative approach to #46359. In this case I store the `iframePort` reference, which is needed to pass on messages to Gutenframe, in the redux store and use it in `deleteMediaSuccess | updateMediaSuccess` handlers to pass on the `updateImageBlocks` action with the needed payload. 

**Note:** this is very rough around the edges and can probably see some more cleanup!

#### Changes proposed in this Pull Request

* Remove the Flux `MediaStore` from Gutenframe
* Store a reference to the `iframePort` in `state.editor.iframePort` in case Gutenframe is loaded
* Create `updateImageBlocks` actions (`deleted | updated`) in the data layer success handlers for that specific action

#### Testing instructions

* Follow all the testing instructions provided in #46359
