### PR TITLE
New onboarding: Roll out to 100% EN existing users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -201,10 +201,10 @@ export default {
 		allowExistingUsers: false,
 	},
 	existingUsersGutenbergOnboard: {
-		datestamp: '20200911',
+		datestamp: '20201015',
 		variations: {
-			gutenberg: 50,
-			control: 50,
+			gutenberg: 100,
+			control: 0,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For context, check p5uIfZ-af9-p2

* The new onboarding flow will be rolled out to 100% EN existing users. 
* All such users will see the new onboarding flow when they add a new site from an existing account.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**EN locale**
* Log in to a wpcom account in EN locale and navigate to /start in your browser. 
* Verify that you are redirect to /new and that you see the new onboarding flow.

**Non-EN locale**
* Log in to a wpcom account in non-EN locale and navigate to /start in your browser. 
* Verify that you are _not_ shown the new onboarding flow.
* Type `localStorage.ABTests;` in your browser console and confirm that you don't get freshly assigned to the `existingUsersGutenbergOnboard` test.