### PR TITLE
Add "gutenboarding/persistent-launch-button" feature flag

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -754,11 +754,18 @@ function getGutenboardingStatus( calypsoPort ) {
 		[ port2 ]
 	);
 	port1.onmessage = ( { data } ) => {
-		const { isGutenboarding, frankenflowUrl, isNewLaunchMobile, isExperimental } = data;
+		const {
+			isGutenboarding,
+			frankenflowUrl,
+			isNewLaunchMobile,
+			isExperimental,
+			isPersistentLaunchButton,
+		} = data;
 		calypsoifyGutenberg.isGutenboarding = isGutenboarding;
 		calypsoifyGutenberg.frankenflowUrl = frankenflowUrl;
 		calypsoifyGutenberg.isNewLaunchMobile = isNewLaunchMobile;
 		calypsoifyGutenberg.isExperimental = isExperimental;
+		calypsoifyGutenberg.isPersistentLaunchButton = isPersistentLaunchButton;
 		// Hook necessary if message recieved after editor has loaded.
 		window.wp.hooks.doAction( 'setGutenboardingStatus', isGutenboarding );
 	};

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -376,12 +376,14 @@ class CalypsoifyIframe extends Component<
 			const frankenflowUrl = `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteSlug }&source=editor`;
 			const isNewLaunchMobile = config.isEnabled( 'gutenboarding/new-launch-mobile' );
 			const isExperimental = config.isEnabled( 'gutenboarding/feature-picker' );
+			const isPersistentLaunchButton = config.isEnabled( 'gutenboarding/persistent-launch-button' );
 
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
 				frankenflowUrl,
 				isNewLaunchMobile,
 				isExperimental,
+				isPersistentLaunchButton,
 			} );
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -66,6 +66,7 @@
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": false,
+		"gutenboarding/persistent-launch-button": true,
 		"gutenboarding/show-vertical-input": false,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
This is part of a series of PRs looking at implementing the Persistent launch button in the editor (see pbAok1-1y7-p2 for details).

This PR adds a new `gutenboarding/persistent-launch-button` flag, which will be used in a later PR.

Related phab patch: D51268-code

## Changes proposed in this Pull Request

* Adds `gutenboarding/persistent-launch-button` feature flag (only enabled in dev for now)
* Passes the value of the flag to gutenframe and makes it available to the Editing Toolkit plugin (this part will be added via a future PR)

## Testing instructions

In theory, **the changes introduced by the PR should only add unused code**, without causing any changes to the behavior of the "Complete setup" buttons. The following testing instructions are meant to **check for regressions**.

### How to build
* On root folder, run `yarn start`.
* On `apps/wpcom-block-editor`, run `yarn dev --sync`.

### How to test
1. Clean and enable sandbox (both on the wordpress.com site and `widgets.wp.com`)
2. Create an unlaunched test site using Gutenboarding (`/new`)
3. On local calypso, open the home page in the block editor
   * If the page is loaded on desktop screens, clicking "Complete Setup" should open the launch modal without any page redirect (do not launch the site)
   * If the page is loaded on mobile screens, clicking "Launch" should redirect to the new launch flow, also known as _frankenflow_ — `/start/new-launch` (do not launch the site)
4. Now, on local calypso, open again the home page in the block editor — but this time, append `?flags=gutenboarding/new-launch-mobile` to the URL
   * If the page is loaded on desktop screens, clicking "Complete Setup" should open the launch modal without any page redirect (do not launch the site)
   * If the page is loaded on mobile screens, clicking "Launch" should open the launch modal without any page redirect (do not launch the site)
