### PR TITLE
Plans: set Jetpack CRM CTA link to https://jetpackcrm.com/pricing/

### DIFF
--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -311,7 +311,7 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 		),
 	},
 	hidePrice: true,
-	externalUrl: 'https://jetpackcrm.com/download-wordpress-crm/',
+	externalUrl: 'https://jetpackcrm.com/pricing/',
 };
 
 export const EXTERNAL_PRODUCT_CRM_MONTHLY: SelectorProduct = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the Jetpack CRM CTA redirect users to `https://jetpackcrm.com/pricing/` (Reverts #46417).

#### Testing instructions

* Run this PR.
* Visit the Plans page.
* Click on the Jetpack CRM CTA.
* Verify that you are redirected to `https://jetpackcrm.com/pricing/`.

Fixes 1196341175636977-as-1198302756679926

#### Demo

![Kapture 2020-10-15 at 11 06 11](https://user-images.githubusercontent.com/3418513/96140596-7c87d900-0ed6-11eb-9168-9350221cd170.gif)

