### PR TITLE
Framework: Remove lodash endsWith in favor of String.endsWith

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { endsWith, get, map } from 'lodash';
+import { get, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,10 +20,10 @@ const EditorTemplateClasses = withSelect( ( select ) => {
 			'name',
 			''
 		);
-		if ( endsWith( typeName, '-header' ) ) {
+		if ( typeName.endsWith( '-header' ) ) {
 			return 'fse-header';
 		}
-		if ( endsWith( typeName, '-footer' ) ) {
+		if ( typeName.endsWith( '-footer' ) ) {
 			return 'fse-footer';
 		}
 	} );

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -3,15 +3,15 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { startsWith, endsWith, noop, get } from 'lodash';
+import { startsWith, noop, get } from 'lodash';
+import { localize } from 'i18n-calypso';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import Gravatar from 'calypso/components/gravatar';
 import SiteIcon from 'calypso/blocks/site-icon';
-import { localize } from 'i18n-calypso';
-import classnames from 'classnames';
 import safeImageUrl from 'calypso/lib/safe-image-url';
 
 /**
@@ -33,7 +33,7 @@ const ReaderAvatar = ( {
 	let fakeSite;
 
 	// don't show the default favicon for some sites
-	if ( endsWith( feedIcon, 'wp.com/i/buttonw-com.png' ) ) {
+	if ( feedIcon?.endsWith( 'wp.com/i/buttonw-com.png' ) ) {
 		feedIcon = null;
 	}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
 	compact,
-	endsWith,
 	find,
 	flatten,
 	get,
@@ -1022,7 +1021,7 @@ class RegisterDomainStep extends React.Component {
 
 	handleSubdomainSuggestions = ( domain, vendor, timestamp ) => ( subdomainSuggestions ) => {
 		subdomainSuggestions = subdomainSuggestions.map( ( suggestion ) => {
-			suggestion.fetch_algo = endsWith( suggestion.domain_name, '.wordpress.com' )
+			suggestion.fetch_algo = suggestion.domain_name.endsWith( '.wordpress.com' )
 				? '/domains/search/wpcom'
 				: '/domains/search/dotblogsub';
 			suggestion.vendor = vendor;

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -143,7 +143,7 @@ class TransferDomainStep extends React.Component {
 		}
 
 		let buildMapDomainUrl;
-		const basePathForMapping = basePath.endsWith( '/transfer' )
+		const basePathForMapping = basePath?.endsWith( '/transfer' )
 			? basePath.substring( 0, basePath.length - 9 )
 			: basePath;
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { endsWith, get, isEmpty, noop } from 'lodash';
+import { get, isEmpty, noop } from 'lodash';
 import page from 'page';
 import { stringify } from 'qs';
 import classnames from 'classnames';
@@ -32,7 +32,11 @@ import DomainRegistrationSuggestion from 'calypso/components/domains/domain-regi
 import { getCurrentUser, getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import Notice from 'calypso/components/notice';
-import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import TransferDomainPrecheck from './transfer-domain-precheck';
@@ -139,7 +143,7 @@ class TransferDomainStep extends React.Component {
 		}
 
 		let buildMapDomainUrl;
-		const basePathForMapping = endsWith( basePath, '/transfer' )
+		const basePathForMapping = basePath.endsWith( '/transfer' )
 			? basePath.substring( 0, basePath.length - 9 )
 			: basePath;
 

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { endsWith, get, isEmpty, noop } from 'lodash';
+import { get, isEmpty, noop } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 import page from 'page';
 import { stringify } from 'qs';
@@ -23,11 +23,19 @@ import {
 import { Card, Button } from '@automattic/components';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { CALYPSO_CONTACT, INCOMING_DOMAIN_TRANSFER, MAP_EXISTING_DOMAIN } from 'calypso/lib/url/support';
+import {
+	CALYPSO_CONTACT,
+	INCOMING_DOMAIN_TRANSFER,
+	MAP_EXISTING_DOMAIN,
+} from 'calypso/lib/url/support';
 import HeaderCake from 'calypso/components/header-cake';
 import { errorNotice } from 'calypso/state/notices/actions';
 import QueryProducts from 'calypso/components/data/query-products-list';
-import { getDomainPrice, getDomainProductSlug, getDomainTransferSalePrice } from 'calypso/lib/domains';
+import {
+	getDomainPrice,
+	getDomainProductSlug,
+	getDomainTransferSalePrice,
+} from 'calypso/lib/domains';
 import {
 	isDomainBundledWithPlan,
 	isDomainMappingFree,
@@ -98,7 +106,7 @@ class UseYourDomainStep extends React.Component {
 		}
 
 		let buildMapDomainUrl;
-		const basePathForMapping = endsWith( basePath, '/use-your-domain' )
+		const basePathForMapping = basePath.endsWith( '/use-your-domain' )
 			? basePath.substring( 0, basePath.length - 16 )
 			: basePath;
 
@@ -127,7 +135,7 @@ class UseYourDomainStep extends React.Component {
 		}
 
 		let buildTransferDomainUrl;
-		const basePathForTransfer = endsWith( basePath, '/use-your-domain' )
+		const basePathForTransfer = basePath.endsWith( '/use-your-domain' )
 			? basePath.substring( 0, basePath.length - 16 )
 			: basePath;
 

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -106,7 +106,7 @@ class UseYourDomainStep extends React.Component {
 		}
 
 		let buildMapDomainUrl;
-		const basePathForMapping = basePath.endsWith( '/use-your-domain' )
+		const basePathForMapping = basePath?.endsWith( '/use-your-domain' )
 			? basePath.substring( 0, basePath.length - 16 )
 			: basePath;
 
@@ -135,7 +135,7 @@ class UseYourDomainStep extends React.Component {
 		}
 
 		let buildTransferDomainUrl;
-		const basePathForTransfer = basePath.endsWith( '/use-your-domain' )
+		const basePathForTransfer = basePath?.endsWith( '/use-your-domain' )
 			? basePath.substring( 0, basePath.length - 16 )
 			: basePath;
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -4,7 +4,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { endsWith, get, map, partial, pickBy, startsWith, isArray, flowRight } from 'lodash';
+import { get, map, partial, pickBy, startsWith, isArray, flowRight } from 'lodash';
 /* eslint-disable no-restricted-imports */
 import url from 'url';
 import { localize, LocalizeProps } from 'i18n-calypso';
@@ -303,7 +303,7 @@ class CalypsoifyIframe extends Component<
 			const { postId } = payload;
 			const { siteId, currentRoute, postType } = this.props;
 
-			if ( ! endsWith( currentRoute, `/${ postId }` ) ) {
+			if ( ! currentRoute.endsWith( `/${ postId }` ) ) {
 				this.props.replaceHistory( `${ currentRoute }/${ postId }`, true );
 				this.props.setRoute( `${ currentRoute }/${ postId }` );
 

--- a/client/lib/followers/store.js
+++ b/client/lib/followers/store.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { endsWith, omit } from 'lodash';
+import { omit } from 'lodash';
 import deterministicStringify from 'fast-json-stable-stringify';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:wpcom-followers-store' );
@@ -9,8 +9,8 @@ const debug = debugFactory( 'calypso:wpcom-followers-store' );
 /**
  * Internal dependencies
  */
-import Dispatcher from 'dispatcher';
-import emitter from 'lib/mixins/emitter';
+import Dispatcher from 'calypso/dispatcher';
+import emitter from 'calypso/lib/mixins/emitter';
 
 const _fetchingFollowersByNamespace = {}; // store fetching state (boolean)
 const _followersBySite = {}; // store user objects
@@ -110,7 +110,7 @@ function getNamespace( fetchOptions ) {
 function decrementPaginationData( siteId, followerId ) {
 	Object.keys( _followerIDsByNamespace ).forEach( function ( namespace ) {
 		if (
-			endsWith( namespace, 'siteId=' + siteId ) &&
+			namespace.endsWith( 'siteId=' + siteId ) &&
 			_followerIDsByNamespace[ namespace ].has( followerId )
 		) {
 			_totalFollowersByNamespace[ namespace ]--;
@@ -123,7 +123,7 @@ function decrementPaginationData( siteId, followerId ) {
 function incrementPaginationData( siteId, followerId ) {
 	Object.keys( _followerIDsByNamespace ).forEach( function ( namespace ) {
 		if (
-			endsWith( namespace, 'siteId=' + siteId ) &&
+			namespace.endsWith( 'siteId=' + siteId ) &&
 			_followerIDsByNamespace[ namespace ].has( followerId )
 		) {
 			_totalFollowersByNamespace[ namespace ]++;
@@ -144,7 +144,7 @@ function removeFollowerFromSite( siteId, followerId ) {
 function removeFollowerFromNamespaces( siteId, followerId ) {
 	Object.keys( _followerIDsByNamespace ).forEach( function ( namespace ) {
 		if (
-			endsWith( namespace, 'siteId=' + siteId ) &&
+			namespace.endsWith( 'siteId=' + siteId ) &&
 			_followerIDsByNamespace[ namespace ].has( followerId )
 		) {
 			delete _followerIDsByNamespace[ namespace ][ followerId ];

--- a/client/lib/gsuite/can-domain-add-gsuite.js
+++ b/client/lib/gsuite/can-domain-add-gsuite.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { endsWith } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
@@ -15,7 +10,7 @@ import { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
  * @returns {boolean} - true if G Suite is allowed, false otherwise
  */
 export function canDomainAddGSuite( domainName ) {
-	if ( endsWith( domainName, '.wpcomstaging.com' ) ) {
+	if ( domainName.endsWith( '.wpcomstaging.com' ) ) {
 		return false;
 	}
 

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-import { find, isString, map, pickBy, includes, endsWith } from 'lodash';
+import { find, isString, map, pickBy, includes } from 'lodash';
 import i18n, { getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import config from 'config';
-import { languages } from 'languages';
-import { getUrlParts, getUrlFromParts } from 'lib/url/url-parts';
+import config from 'calypso/config';
+import { languages } from 'calypso/languages';
+import { getUrlParts, getUrlFromParts } from 'calypso/lib/url/url-parts';
 
 /**
  * a locale can consist of three component
@@ -252,7 +252,7 @@ export function localizeUrl( fullUrl, locale ) {
 	// Let's use `host` for everything.
 	delete urlParts.hostname;
 
-	if ( ! endsWith( urlParts.pathname, '.php' ) ) {
+	if ( ! urlParts.pathname.endsWith( '.php' ) ) {
 		urlParts.pathname = ( urlParts.pathname + '/' ).replace( /\/+$/, '/' );
 	}
 

--- a/client/lib/post-normalizer/rule-content-make-embeds-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-embeds-safe.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { some, forEach, startsWith, endsWith } from 'lodash';
-import { iframeIsAllowed } from './utils';
-import { getUrlParts } from 'lib/url';
+import { some, forEach, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { iframeIsAllowed } from './utils';
+import { getUrlParts } from 'calypso/lib/url';
 
 /** Given an iframe, is it okay to have it run without a sandbox?
  *
@@ -26,7 +26,7 @@ function doesNotNeedSandbox( iframe ) {
 	const hostName = iframe.src && getUrlParts( iframe.src ).hostname;
 	const iframeHost = hostName && hostName.toLowerCase();
 
-	return some( trustedHosts, ( trustedHost ) => endsWith( '.' + iframeHost, '.' + trustedHost ) );
+	return some( trustedHosts, ( trustedHost ) => `.${ iframeHost }`.endsWith( '.' + trustedHost ) );
 }
 
 export default function makeEmbedsSafe( post, dom ) {

--- a/client/lib/post-normalizer/utils/iframe-is-allowed.js
+++ b/client/lib/post-normalizer/utils/iframe-is-allowed.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { some, endsWith } from 'lodash';
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -53,6 +53,6 @@ export function iframeIsAllowed( iframe ) {
 	const hostName = iframe.src && getUrlParts( iframe.src ).hostname;
 	const iframeSrc = hostName && hostName.toLowerCase();
 	return some( allowedIframeHosts, function ( allowedHost ) {
-		return endsWith( '.' + iframeSrc, '.' + allowedHost );
+		return `.${ iframeSrc }`.endsWith( '.' + allowedHost );
 	} );
 }

--- a/client/lib/post-normalizer/utils/is-url-likely-an-image.js
+++ b/client/lib/post-normalizer/utils/is-url-likely-an-image.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { some, endsWith } from 'lodash';
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getUrlParts } from 'lib/url';
+import { getUrlParts } from 'calypso/lib/url';
 
 /** Determine if url is likely pointed to an image
  *
@@ -19,5 +19,5 @@ export function isUrlLikelyAnImage( uri ) {
 	}
 
 	const withoutQuery = getUrlParts( uri ).pathname;
-	return some( [ '.jpg', '.jpeg', '.png', '.gif' ], ( ext ) => endsWith( withoutQuery, ext ) );
+	return some( [ '.jpg', '.jpeg', '.png', '.gif' ], ( ext ) => withoutQuery.endsWith( ext ) );
 }

--- a/client/lib/users/store.js
+++ b/client/lib/users/store.js
@@ -2,15 +2,15 @@
  * External dependencies
  */
 import deterministicStringify from 'fast-json-stable-stringify';
-import { endsWith, find, omit } from 'lodash';
+import { find, omit } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:users:store' );
 
 /**
  * Internal dependencies
  */
-import Dispatcher from 'dispatcher';
-import emitter from 'lib/mixins/emitter';
+import Dispatcher from 'calypso/dispatcher';
+import emitter from 'calypso/lib/mixins/emitter';
 
 const _fetchingUsersByNamespace = {}; // store fetching state (boolean)
 const _fetchingUpdatedUsersByNamespace = {}; // store fetching state (boolean)
@@ -99,7 +99,7 @@ function updateUser( siteId, id, user ) {
 function decrementPaginationData( siteId, userId ) {
 	Object.keys( _userIDsByNamespace ).forEach( function ( namespace ) {
 		if (
-			endsWith( namespace, 'siteId=' + siteId ) &&
+			namespace.endsWith( 'siteId=' + siteId ) &&
 			_userIDsByNamespace[ namespace ].has( userId )
 		) {
 			_totalUsersByNamespace[ namespace ]--;
@@ -111,7 +111,7 @@ function decrementPaginationData( siteId, userId ) {
 function incrementPaginationData( siteId, userId ) {
 	Object.keys( _userIDsByNamespace ).forEach( function ( namespace ) {
 		if (
-			endsWith( namespace, 'siteId=' + siteId ) &&
+			namespace.endsWith( 'siteId=' + siteId ) &&
 			_userIDsByNamespace[ namespace ].has( userId )
 		) {
 			_totalUsersByNamespace[ namespace ]++;
@@ -131,7 +131,7 @@ function deleteUserFromSite( siteId, userId ) {
 function deleteUserFromNamespaces( siteId, userId ) {
 	Object.keys( _userIDsByNamespace ).forEach( function ( namespace ) {
 		if (
-			endsWith( namespace, 'siteId=' + siteId ) &&
+			namespace.endsWith( 'siteId=' + siteId ) &&
 			_userIDsByNamespace[ namespace ].has( userId )
 		) {
 			_userIDsByNamespace[ namespace ].delete( userId );

--- a/client/my-sites/domains/domain-management/dns/dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-record.jsx
@@ -1,11 +1,8 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-import { endsWith } from 'lodash';
-import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -13,6 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import { Button } from '@automattic/components';
 import DnsRecordsListItem from '../dns-records/item';
+import Gridicon from 'calypso/components/gridicon';
 
 class DnsRecord extends React.Component {
 	static propTypes = {
@@ -92,7 +90,7 @@ class DnsRecord extends React.Component {
 			return `_${ service }._${ protocol }.${ isRoot ? '' : name + '.' }${ domain }`;
 		}
 
-		if ( endsWith( name, '.' ) ) {
+		if ( name.endsWith( '.' ) ) {
 			return name.slice( 0, -1 );
 		}
 

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-dns-record.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { endsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,7 +26,7 @@ class DomainConnectDnsRecord extends Component {
 			return `${ service }.${ protocol }.${ isRoot ? '' : name + '.' }${ domain }`;
 		}
 
-		if ( endsWith( name, '.' ) ) {
+		if ( name.endsWith( '.' ) ) {
 			return name.slice( 0, -1 );
 		}
 

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import page from 'page';
-import { endsWith, get, isEmpty, isEqual, includes, snakeCase } from 'lodash';
+import { get, isEmpty, isEqual, includes, snakeCase } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -12,26 +12,29 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Card, Dialog } from '@automattic/components';
-import FormCheckbox from 'components/forms/form-checkbox';
-import FormLabel from 'components/forms/form-label';
-import notices from 'notices';
-import { domainManagementContactsPrivacy, domainManagementEdit } from 'my-sites/domains/paths';
-import wp from 'lib/wp';
-import { successNotice } from 'state/notices/actions';
-import { UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES } from 'lib/url/support';
-import { registrar as registrarNames } from 'lib/domains/constants';
-import DesignatedAgentNotice from 'my-sites/domains/domain-management/components/designated-agent-notice';
-import { getCurrentUser } from 'state/current-user/selectors';
-import ContactDetailsFormFields from 'components/domains/contact-details-form-fields';
-import { requestWhois, saveWhois } from 'state/domains/management/actions';
-import { fetchSiteDomains } from 'state/sites/domains/actions';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
+import notices from 'calypso/notices';
+import {
+	domainManagementContactsPrivacy,
+	domainManagementEdit,
+} from 'calypso/my-sites/domains/paths';
+import wp from 'calypso/lib/wp';
+import { successNotice } from 'calypso/state/notices/actions';
+import { UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES } from 'calypso/lib/url/support';
+import { registrar as registrarNames } from 'calypso/lib/domains/constants';
+import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/components/designated-agent-notice';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import ContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields';
+import { requestWhois, saveWhois } from 'calypso/state/domains/management/actions';
+import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
 import {
 	isUpdatingWhois,
 	getWhoisData,
 	getWhoisSaveError,
 	getWhoisSaveSuccess,
-} from 'state/domains/management/selectors';
-import { findRegistrantWhois } from 'lib/domains/whois/utils';
+} from 'calypso/state/domains/management/selectors';
+import { findRegistrantWhois } from 'calypso/lib/domains/whois/utils';
 import getPreviousPath from '../../../../state/selectors/get-previous-path';
 
 const wpcom = wp.undocumented();
@@ -249,7 +252,7 @@ class EditContactInfoFormCard extends React.Component {
 		const NETHERLANDS_TLD = '.nl';
 		const { fax } = this.getContactFormFieldValues();
 
-		return endsWith( this.props.selectedDomain.name, NETHERLANDS_TLD ) || !! fax;
+		return this.props.selectedDomain.name.endsWith( NETHERLANDS_TLD ) || !! fax;
 	}
 
 	onTransferLockOptOutChange = ( event ) =>

--- a/client/my-sites/marketing/buttons/preview-action.jsx
+++ b/client/my-sites/marketing/buttons/preview-action.jsx
@@ -5,21 +5,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { omit, startsWith, endsWith } from 'lodash';
+import { omit, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 const SharingButtonsPreviewAction = ( props ) => {
 	const { active, position, icon, children } = props;
 	const classes = classNames( 'sharing-buttons-preview-action', {
 		'is-active': active,
 		'is-top': startsWith( position, 'top' ),
-		'is-right': endsWith( position, '-right' ),
+		'is-right': position.endsWith( '-right' ),
 		'is-bottom': startsWith( position, 'bottom' ),
-		'is-left': endsWith( position, '-left' ),
+		'is-left': position.endsWith( '-left' ),
 	} );
 
 	return (

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -5,19 +5,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { get, endsWith } from 'lodash';
+import { get } from 'lodash';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { translate } from 'i18n-calypso';
-import FollowButton from 'reader/follow-button';
+import FollowButton from 'calypso/reader/follow-button';
 import { getLinkProps } from './helper';
 import { recordFollowToggle, recordSiteClick } from './stats';
-import { getSiteUrl, getSourceFollowUrl, getSourceData } from 'reader/discover/helper';
-import SiteIcon from 'blocks/site-icon';
-import { getSite } from 'state/reader/sites/selectors';
-import QueryReaderSite from 'components/data/query-reader-site';
+import { getSiteUrl, getSourceFollowUrl, getSourceData } from 'calypso/reader/discover/helper';
+import SiteIcon from 'calypso/blocks/site-icon';
+import { getSite } from 'calypso/state/reader/sites/selectors';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
 
 /**
  * Style dependencies
@@ -44,7 +44,7 @@ class DiscoverSiteAttribution extends React.Component {
 
 		let avatarUrl = attribution.avatar_url;
 		// Drop default avatar
-		if ( endsWith( avatarUrl, 'defaultavatar.png' ) ) {
+		if ( avatarUrl.endsWith( 'defaultavatar.png' ) ) {
 			avatarUrl = null;
 		}
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -9,7 +9,7 @@ import crypto from 'crypto';
 import { execSync } from 'child_process';
 import cookieParser from 'cookie-parser';
 import debugFactory from 'debug';
-import { endsWith, get, includes, pick, snakeCase, split } from 'lodash';
+import { get, includes, pick, snakeCase, split } from 'lodash';
 import bodyParser from 'body-parser';
 // eslint-disable-next-line no-restricted-imports
 import superagent from 'superagent'; // Don't have Node.js fetch lib yet.
@@ -526,7 +526,7 @@ const renderServerError = ( entrypoint = 'entry-main' ) => ( err, req, res, next
  * @returns {Function|undefined} res.redirect if not logged in
  */
 function handleLocaleSubdomains( req, res, next ) {
-	const langSlug = endsWith( req.hostname, config( 'hostname' ) )
+	const langSlug = req.hostname?.endsWith( config( 'hostname' ) )
 		? split( req.hostname, '.' )[ 0 ]
 		: null;
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -4,53 +4,57 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { defer, endsWith, get, includes, isEmpty } from 'lodash';
+import { defer, get, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import MapDomainStep from 'components/domains/map-domain-step';
-import TransferDomainStep from 'components/domains/transfer-domain-step';
-import UseYourDomainStep from 'components/domains/use-your-domain-step';
-import RegisterDomainStep from 'components/domains/register-domain-step';
-import CartData from 'components/data/cart';
-import { getStepUrl } from 'signup/utils';
-import StepWrapper from 'signup/step-wrapper';
+import MapDomainStep from 'calypso/components/domains/map-domain-step';
+import TransferDomainStep from 'calypso/components/domains/transfer-domain-step';
+import UseYourDomainStep from 'calypso/components/domains/use-your-domain-step';
+import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
+import CartData from 'calypso/components/data/cart';
+import { getStepUrl } from 'calypso/signup/utils';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import {
 	domainRegistration,
 	themeItem,
 	domainMapping,
 	domainTransfer,
-} from 'lib/cart-values/cart-items';
+} from 'calypso/lib/cart-values/cart-items';
 import {
 	recordAddDomainButtonClick,
 	recordAddDomainButtonClickInMapDomain,
 	recordAddDomainButtonClickInTransferDomain,
 	recordAddDomainButtonClickInUseYourDomain,
-} from 'state/domains/actions';
-import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
-import { domainManagementRoot } from 'my-sites/domains/paths';
-import Notice from 'components/notice';
-import { getDesignType } from 'state/signup/steps/design-type/selectors';
-import { setDesignType } from 'state/signup/steps/design-type/actions';
-import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
-import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import { getDomainProductSlug } from 'lib/domains';
-import QueryProductsList from 'components/data/query-products-list';
-import { getAvailableProductsList } from 'state/products-list/selectors';
-import { getSuggestionsVendor } from 'lib/domains/suggestions';
-import { getSite } from 'state/sites/selectors';
-import { getVerticalForDomainSuggestions } from 'state/signup/steps/site-vertical/selectors';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
-import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
-import { isDomainStepSkippable } from 'signup/config/steps';
-import { fetchUsernameSuggestion } from 'state/signup/optional-dependencies/actions';
-import { isSitePreviewVisible } from 'state/signup/preview/selectors';
-import { hideSitePreview, showSitePreview } from 'state/signup/preview/actions';
-import { abtest, getABTestVariation } from 'lib/abtest';
-import getSitesItems from 'state/selectors/get-sites-items';
+} from 'calypso/state/domains/actions';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'calypso/state/analytics/actions';
+import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
+import Notice from 'calypso/components/notice';
+import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
+import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
+import { getSiteGoals } from 'calypso/state/signup/steps/site-goals/selectors';
+import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
+import { getDomainProductSlug } from 'calypso/lib/domains';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
+import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getVerticalForDomainSuggestions } from 'calypso/state/signup/steps/site-vertical/selectors';
+import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { isDomainStepSkippable } from 'calypso/signup/config/steps';
+import { fetchUsernameSuggestion } from 'calypso/state/signup/optional-dependencies/actions';
+import { isSitePreviewVisible } from 'calypso/state/signup/preview/selectors';
+import { hideSitePreview, showSitePreview } from 'calypso/state/signup/preview/actions';
+import { abtest, getABTestVariation } from 'calypso/lib/abtest';
+import getSitesItems from 'calypso/state/selectors/get-sites-items';
 
 /**
  * Style dependencies
@@ -728,7 +732,7 @@ const submitDomainStepSelection = ( suggestion, section ) => {
 	let domainType = 'domain_reg';
 	if ( suggestion.is_free ) {
 		domainType = 'wpcom_subdomain';
-		if ( endsWith( suggestion.domain_name, '.blog' ) ) {
+		if ( suggestion.domain_name.endsWith( '.blog' ) ) {
 			domainType = 'dotblog_subdomain';
 		}
 	}

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { endsWith, filter, includes, mapValues, trimStart } from 'lodash';
+import { filter, includes, mapValues, trimStart } from 'lodash';
 
 function validateAllFields( fieldValues, domainName ) {
 	return mapValues( fieldValues, ( value, fieldName ) => {
@@ -91,7 +91,7 @@ function getNormalizedData( record, selectedDomainName ) {
 }
 
 function getNormalizedName( name, type, selectedDomainName ) {
-	const endsWithDomain = endsWith( name, '.' + selectedDomainName );
+	const endsWithDomain = name.endsWith( '.' + selectedDomainName );
 
 	if ( isRootDomain( name, selectedDomainName ) && canBeRootDomain( type ) ) {
 		return selectedDomainName + '.';

--- a/client/state/selectors/get-menu-item-types.js
+++ b/client/state/selectors/get-menu-item-types.js
@@ -2,14 +2,14 @@
  * External dependencies
  */
 
-import { endsWith, filter, find, get } from 'lodash';
+import { filter, find, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getSiteAdminUrl } from 'state/sites/selectors';
-import getRawSite from 'state/selectors/get-raw-site';
-import { getPostTypes } from 'state/post-types/selectors';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import getRawSite from 'calypso/state/selectors/get-raw-site';
+import { getPostTypes } from 'calypso/state/post-types/selectors';
 
 function getDefaultItemTypes( state, siteId ) {
 	const site = getRawSite( state, siteId );
@@ -97,7 +97,7 @@ export default function getMenuItemTypes( state, siteId ) {
 			show: true,
 			label: type.label, //FIXME: how do we handle i18n here?
 			notFoundLabel:
-				notFoundLabel && endsWith( notFoundLabel, '.' ) ? notFoundLabel : notFoundLabel + '.',
+				notFoundLabel && notFoundLabel.endsWith( '.' ) ? notFoundLabel : notFoundLabel + '.',
 			createLink: `/edit/${ type.name }/${ site.slug }`, // TODO: Use the getEditorNewPostPath() selector.
 			gaEventLabel: type.label,
 		};

--- a/client/state/themes/actions/install-theme.js
+++ b/client/state/themes/actions/install-theme.js
@@ -1,21 +1,16 @@
 /**
- * External dependencies
- */
-import { endsWith } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
+import wpcom from 'calypso/lib/wp';
 import {
 	THEME_INSTALL,
 	THEME_INSTALL_SUCCESS,
 	THEME_INSTALL_FAILURE,
-} from 'state/themes/action-types';
-import { receiveTheme } from 'state/themes/actions/receive-theme';
-import { getWpcomParentThemeId } from 'state/themes/selectors';
+} from 'calypso/state/themes/action-types';
+import { receiveTheme } from 'calypso/state/themes/actions/receive-theme';
+import { getWpcomParentThemeId } from 'calypso/state/themes/selectors';
 
-import 'state/themes/init';
+import 'calypso/state/themes/init';
 
 /**
  * Triggers a network request to install a WordPress.org or WordPress.com theme on a Jetpack site.
@@ -46,7 +41,7 @@ export function installTheme( themeId, siteId ) {
 				} );
 
 				// Install parent theme if theme requires one
-				if ( endsWith( themeId, '-wpcom' ) ) {
+				if ( themeId.endsWith( '-wpcom' ) ) {
 					const parentThemeId = getWpcomParentThemeId(
 						getState(),
 						themeId.replace( '-wpcom', '' )


### PR DESCRIPTION
We'll likely all agree that we're using `lodash` far more than we should. Especially, there are cases that can completely be replaced with their native alternatives. One of them is `_.endsWith()` - it can be replaced with `String.prototype.endsWith()` without any additional cost.

The only thing we need to account for is the fact that if we call `endsWith` on a `null` or `undefined` item, it'll error out, so we need to tighten up those instances.

This PR updates all `_.endsWith` instances to use the native `String.prototype.endsWith()` and changes a couple of them to be safer, considering the possibility for them to be `null` or `undefined`.

By removing `endsWith` lodash usage it will also be removed from all the relevant chunks, making them slightly smaller. Going further with this approach, we might be able to completely remove lodash one day!

#### Changes proposed in this Pull Request

* Remove lodash `endsWith` in favor of `String.prototype.endsWith`

#### Testing instructions

* Verify all tests still pass.
* Smoke test Calypso, including domains, reader and marketing settings.
