### PR TITLE
Update recommended PHP version to 7.4

### DIFF
--- a/client/my-sites/hosting/php-version-card/index.js
+++ b/client/my-sites/hosting/php-version-card/index.js
@@ -36,7 +36,7 @@ const PhpVersionCard = ( {
 } ) => {
 	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState( '' );
 
-	const recommendedValue = '7.3';
+	const recommendedValue = '7.4';
 
 	const changePhpVersion = ( event ) => {
 		const newVersion = event.target.value;
@@ -58,16 +58,16 @@ const PhpVersionCard = ( {
 				disabled: true, // EOL 30th November, 2020
 			},
 			{
-				label: translate( '7.3 (recommended)', {
+				label: translate( '7.3', {
+					comment: 'PHP Version for a version switcher',
+				} ),
+				value: '7.3',
+			},
+			{
+				label: translate( '7.4 (recommended)', {
 					comment: 'PHP Version for a version switcher',
 				} ),
 				value: recommendedValue,
-			},
-			{
-				label: translate( '7.4', {
-					comment: 'PHP Version for a version switcher',
-				} ),
-				value: '7.4',
 			},
 		];
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change recommended PHP version for Atomic. We default creation to 7.4 now.

#### Testing instructions

- Should see `7.4 (recommended)` instead of `7.3 (recommended)`