### PR TITLE
Jetpack: Update styles for JP Connect and JP Login

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -152,6 +152,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 .purchase-product__site-url-input-container,
 .example-components__site-url-input-container {
 	.jetpack-connect__site-address-container,
+	.jetpack-connect__password-container,
 	.example-components__site-address-container {
 		position: relative;
 
@@ -300,6 +301,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 .example-components__browser-chrome {
 	padding: 8px;
 	background-color: var( --color-neutral-0 );
+	/* stylelint-disable-next-line scales/radii */
 	border-radius: 8px 8px 0 0;
 }
 
@@ -549,9 +551,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	max-width: 360px;
 	margin: 0 auto 16px;
 	border-radius: 2px;
-	box-shadow: 0 5px 5px -3px rgba( var( --color-neutral-100 ), 0.2 ),
-		0 8px 10px 1px rgba( var( --color-neutral-100 ), 0.14 ),
-		3px 14px 2px rgba( var( --color-neutral-100 ), 0.12 );
 }
 
 .jetpack-connect__sso-terms-dialog {
@@ -822,27 +821,11 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
  **/
 .layout.is-section-jetpack-connect:not( .is-jetpack-mobile-flow ),
 .layout.is-section-purchase-product {
-	background-color: var( --color-jetpack-onboarding-background );
 
 	&.layout {
 		position: relative;
 		min-height: calc( 100% - #{$colophon-height} );
 		padding-bottom: $colophon-height;
-	}
-
-	.formatted-header {
-		color: var( --color-jetpack-onboarding-text );
-	}
-
-	.jetpack-logo__text,
-	.wpcom-colophon path {
-		fill: var( --color-jetpack-onboarding-text );
-	}
-
-	.formatted-header__subtitle,
-	.payment-methods,
-	.jetpack-connect__help-button {
-		color: var( --color-neutral-10 );
 	}
 
 	.site__title::after,
@@ -864,7 +847,12 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 	}
 
+	.logged-out-form {
+		box-shadow: 0 0 0 1px var( --color-border-subtle );
+	}
+
 	.jetpack-connect__site-address-container input:focus,
+	.jetpack-connect__password-container input:focus,
 	.logged-out-form input:focus {
 		border-color: var( --color-accent );
 		box-shadow: 0 0 0 2px var( --color-accent-light );
@@ -872,24 +860,13 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 	.jetpack-connect__tos-link a,
 	.signup-form__terms-of-service-link a,
-	.form-input-validation a {
+	.form-input-validation a,
+	.faq a {
 		color: var( --color-accent-dark );
 
 		&:hover,
 		&:focus {
 			color: var( --color-accent );
-		}
-	}
-
-	.logged-out-form__links a,
-	.logged-out-form__link-item,
-	.jetpack-connect__back-button {
-		color: var( --color-neutral-20 );
-		border-bottom-color: var( --color-neutral-70 );
-
-		&:hover,
-		&:focus {
-			color: var( --color-primary-20 );
 		}
 	}
 
@@ -911,11 +888,62 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 	}
 
+	.signup-form__social p {
+		color: var( --color-neutral-60 );
+	}
+
+	.signup-form__social,
+	.login__form-social {
+		padding-bottom: 0;
+		margin-top: 16px;
+		p {
+			font-size: $font-body-extra-small;
+		}
+
+		.signup-form__social-buttons-tos {
+			color: var( --studio-gray-60 );
+			margin-bottom: 16px;
+			a {
+				text-decoration: underline;
+				color: var( --studio-gray-60 );
+			}
+		}
+
+		.social-buttons__button {
+			border: 1px solid var( --color-accent-dark );
+			color: var( --color-accent-dark );
+			box-shadow: none;
+			max-width: 310px;
+			height: 48px;
+			margin-left: auto;
+			margin-right: auto;
+
+			&.disabled {
+				border-color: var( --studio-gray-30 );
+				color: var( --studio-gray-30 );
+			}
+		}
+
+		.card {
+			padding: 0;
+			box-shadow: none;
+		}
+	}
+
+	.logged-out-form__footer,
+	.login__form-footer {
+
+		.button.is-primary {
+			box-shadow: none;
+		}
+	}
+
 	.payment-logo.is-paypal {
 		width: 64px;
 		background-color: var( --color-surface );
 		background-size: 84%;
 		background-position: 50% 45%;
+		/* stylelint-disable-next-line scales/radii */
 		border-radius: 1px;
 	}
 
@@ -928,8 +956,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 	.jetpack-connect__main-error .empty-content {
 		padding-bottom: 24px;
-		background-color: var( --color-surface );
-		border-radius: 2px;
 	}
 
 	.site-topic__content .form-fieldset {
@@ -995,10 +1021,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			fill: var( --color-neutral-0 );
 		}
 
-		.signup-form__social p {
-			color: var( --color-neutral-60 );
-		}
-
 		.formatted-header__title {
 			color: var( --color-neutral-80 );
 		}
@@ -1056,34 +1078,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 		.signup-form__social,
 		.login__form-social {
-			padding-bottom: 0;
-			margin-top: 16px;
-			p {
-				font-size: $font-body-extra-small;
-			}
-
-			.signup-form__social-buttons-tos {
-				color: var( --studio-gray-60 );
-				margin-bottom: 16px;
-				a {
-					text-decoration: underline;
-					color: var( --studio-gray-60 );
-				}
-			}
 
 			.social-buttons__button {
-				border: 1px solid var( --studio-pink-50 );
+				border-color: var( --studio-pink-50 );
 				color: var( --studio-pink-50 );
-				box-shadow: none;
-				max-width: 310px;
-				height: 48px;
-				margin-left: auto;
-				margin-right: auto;
-			}
-
-			.card {
-				padding: 0;
-				box-shadow: none;
 			}
 		}
 
@@ -1266,7 +1264,6 @@ body.is-section-jetpack-connect .layout {
 }
 
 .is-section-jetpack-connect .plans-filter-bar {
-	background: var( --color-jetpack-onboarding-background );
 	border-width: 0;
 
 	&.sticky {
@@ -1276,21 +1273,11 @@ body.is-section-jetpack-connect .layout {
 		width: 100%;
 		max-width: none;
 
-		border-bottom: solid 1px #333;
+		border-bottom: solid 1px var( --studio-gray-10 );
 	}
 
 	.select-dropdown .select-dropdown__header {
 		border-color: var( --color-primary );
-	}
-}
-
-.is-section-jetpack-connect .faq {
-	.faq__heading {
-		color: var( --color-text-inverted );
-	}
-
-	.faq__question {
-		color: var( --color-neutral-10 );
 	}
 }
 
@@ -1304,8 +1291,6 @@ body.is-section-jetpack-connect .layout {
 	--color-primary: var( --studio-jetpack-green-40 );
 
 	.plans-filter-bar__discount-message {
-		color: var( --color-surface );
-
 		font-weight: 600;
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1082,6 +1082,11 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			.social-buttons__button {
 				border-color: var( --studio-pink-50 );
 				color: var( --studio-pink-50 );
+
+				&.disabled {
+					border-color: var( --studio-gray-30 );
+					color: var( --studio-gray-30 );
+				}
 			}
 		}
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -550,7 +550,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 .jetpack-connect__logged-in-card.card {
 	max-width: 360px;
 	margin: 0 auto 16px;
-	border-radius: 2px;
 }
 
 .jetpack-connect__sso-terms-dialog {
@@ -848,6 +847,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	.logged-out-form {
+		border-radius: 0;
 		box-shadow: 0 0 0 1px var( --color-border-subtle );
 	}
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -164,16 +164,6 @@ $image-height: 47px;
 }
 
 .layout.is-jetpack-login {
-	background-color: var( --color-jetpack-onboarding-background );
-
-	.login__form-header,
-	.magic-login__form-header {
-		color: var( --color-jetpack-onboarding-text );
-	}
-
-	.jetpack-logo__text {
-		fill: var( --color-jetpack-onboarding-text );
-	}
 
 	.login__form input:focus,
 	.logged-out-form input:focus {
@@ -193,21 +183,6 @@ $image-height: 47px;
 		}
 	}
 
-	.wp-login__links a,
-	.wp-login__links button,
-	.logged-out-form__links a,
-	.logged-out-form__link-item,
-	.translator-invite__content a,
-	.magic-login__footer a {
-		color: var( --color-neutral-20 );
-		border-bottom-color: var( --color-neutral-70 );
-
-		&:hover,
-		&:focus {
-			color: var( --color-primary-20 );
-		}
-	}
-
 	.translator-invite__content a {
 		border: none;
 	}
@@ -219,8 +194,8 @@ $image-height: 47px;
 	.wp-login__site-return-link::after {
 		background: linear-gradient(
 			to right,
-			rgba( var( --color-jetpack-onboarding-background-rgb ), 0 ),
-			var( --color-jetpack-onboarding-background ) 90%
+			rgba( var( --color-surface-backdrop-rgb ), 0 ),
+			var( --color-surface-backdrop ) 90%
 		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Updates styles for JP Connect and JP Login, gets rid of dark color scheme.
* This PR touches on files that are used in the Woo onboarding flows, though we expect no differences. cc @josemarques @LevinMedia 

### Testing instructions

- Ensure that all views on all possible flows show the light color scheme.
- Ensure that all views are consistent and display no visual errors.

#### Scenario 1: Connect pre-installed Jetpack + New account

* Starting in an incognito browser, go to wp-admin.
* Click “Set up Jetpack”.
* Replace `wordpress.com` by `calypso.localhost:3000` on the URL.
* Fill out details to create a new account.
* Head to the Plans page.

#### Scenario 2: Connect site with no Jetpack + Log in to existing account

* Starting in an incognito browser, go to http://calypso.localhost:3000/jetpack/connect.
* Enter your site URL and hit Continue.
* Enter your WP username and password, and hit Install Jetpack.
* Enter your username and hit Continue.
* Enter your password and hit Log in.
* Finish off authentication via 2FA, if needed.
* Head to the Plans page.

#### Scenario 3: Connect WooCommerce site

* Starting in an incognito browser, go to wp-admin.
* Make sure you have Jetpack (installed, not activated), WooCommerce (activated) and [WooCommerce Shipping & Tax](https://woocommerce.com/products/shipping/) (activated).
* You should see a prompt banner, click “Activate Jetpack and connect”.
* Replace `wordpress.com` by `calypso.localhost:3000` on the URL.
* Login or create a new account.
* Head to the Plans page.

### Screenshots

#### Login

`/log-in/jetpack`
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/96250208-634e5d80-0fa6-11eb-8f31-f1c0652afd17.png) | ![image](https://user-images.githubusercontent.com/390760/96250271-7cefa500-0fa6-11eb-96b3-efdf99ef861e.png)

`/log-in/jetpack/link`
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/96250613-069f7280-0fa7-11eb-919a-6797127e90ef.png) | ![image](https://user-images.githubusercontent.com/390760/96250655-14ed8e80-0fa7-11eb-8c9b-8ca100c869b7.png)

`/log-in/jetpack/push`
Before | After
--|--
————————————————————————————Couldn't get screenshot———————————————————————————— | ![image](https://user-images.githubusercontent.com/390760/96252262-99411100-0fa9-11eb-9dc0-0171e9084fcd.png)

`/log-in/jetpack/authenticator`
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/96252184-76166180-0fa9-11eb-8da5-6743c97c5240.png) | ![image](https://user-images.githubusercontent.com/390760/96252139-6565eb80-0fa9-11eb-9b02-3695dd12be7d.png)

#### Connect

`jetpack/connect`
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/96251633-a6a9cb80-0fa8-11eb-8628-7b6815cf587e.png) | ![image](https://user-images.githubusercontent.com/390760/96251666-b32e2400-0fa8-11eb-8957-6ee75fd9add7.png)

`/jetpack/connect/install`
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/96251479-706c4c00-0fa8-11eb-91a8-49d8cbaf2254.png) | ![image](https://user-images.githubusercontent.com/390760/96251492-782bf080-0fa8-11eb-8358-efc02e19eeb1.png)

`/jetpack/connect/authorize`
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/96253429-7879bb00-0fab-11eb-867b-68c33a1b691d.png) | ![image](https://user-images.githubusercontent.com/390760/96253444-80395f80-0fab-11eb-90b7-d050c62a28a9.png)


`jetpack/connect/authorize?{params}`
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/96250518-dc4db500-0fa6-11eb-944d-cf930279ecd2.png) | ![image](https://user-images.githubusercontent.com/390760/96250543-e40d5980-0fa6-11eb-8f03-f847ea1d87f4.png)

`/jetpack/connect/plans`
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/96252572-18364980-0faa-11eb-900a-71e2d1da92e4.png) | ![image](https://user-images.githubusercontent.com/390760/96252504-ff2d9880-0fa9-11eb-849e-17816b04f88a.png)

