### PR TITLE
Jetpack Cloud: Fix crash to white screen on settings page for off-line site

### DIFF
--- a/client/components/jetpack/sidebar/index.jsx
+++ b/client/components/jetpack/sidebar/index.jsx
@@ -83,7 +83,12 @@ class JetpackCloudSidebar extends Component {
 }
 
 const getJetpackAdminUrl = ( state, siteId ) => {
-	const parts = getUrlParts( getSiteAdminUrl( state, siteId ) + 'admin.php' );
+	const siteAdminUrl = getSiteAdminUrl( state, siteId );
+	if ( null === siteAdminUrl ) {
+		return undefined;
+	}
+
+	const parts = getUrlParts( siteAdminUrl + 'admin.php' );
 	parts.searchParams.set( 'page', 'jetpack' );
 
 	return formatUrl( getUrlFromParts( parts ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* don't assume adminUrl exists 

#### Testing instructions

1. introduce a delay to the `me/sites` endpoint ( I added a `sleep(3);` in the appropriate place in my sandbox )
2. navigate to `/settings/:siteSlug` on production for an offline site. It may require a reload to get crash to appear
3. try from branch, verifying settings no longer crashes
