### PR TITLE
P2+: add Activity Log in menu

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -21,12 +21,15 @@ import QueryScanState from 'calypso/components/data/query-jetpack-scan';
 import ScanBadge from 'calypso/components/jetpack/scan-badge';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import { isEnabled } from 'calypso/config';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 
 export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug ) ?? '';
+
+	const isWPForTeamsSite = useSelector( ( state ) => isSiteWPForTeams( state, siteId ) );
 
 	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 	const scanProgress = useSelector( ( state ) => getSiteScanProgress( state, siteId ) );
@@ -59,7 +62,7 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 			{
 				// Backup does not work in wp-desktop. Disable in the desktop app until
 				// it can be revisited: https://github.com/Automattic/wp-desktop/issues/943
-				! isDesktop && (
+				! isDesktop && ! isWPForTeamsSite && (
 					<SidebarItem
 						materialIcon={ showIcons ? 'backup' : undefined }
 						materialIconStyle="filled"
@@ -71,7 +74,7 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 					/>
 				)
 			}
-			{ ! isWPCOM && (
+			{ ! isWPCOM && ! isWPForTeamsSite && (
 				<SidebarItem
 					materialIcon={ showIcons ? 'security' : undefined }
 					materialIconStyle="filled"

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -286,7 +286,7 @@ export const TYPE_ECOMMERCE = 'TYPE_ECOMMERCE';
 export const TYPE_SECURITY_DAILY = 'TYPE_SECURITY_DAILY';
 export const TYPE_SECURITY_REALTIME = 'TYPE_SECURITY_REALTIME';
 export const TYPE_ALL = 'TYPE_ALL';
-export const TYPE_P2 = 'TYPE_P2';
+export const TYPE_P2_PLUS = 'TYPE_P2_PLUS';
 
 export function isMonthly( plan ) {
 	return plan === PLAN_BUSINESS_MONTHLY || JETPACK_MONTHLY_PLANS.includes( plan );

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -6,11 +6,16 @@ import { difference, get, has, includes, pick, values, isFunction } from 'lodash
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
-import { isFreeJetpackPlan } from 'lib/products-values/is-free-jetpack-plan';
-import { isJetpackPlan } from 'lib/products-values/is-jetpack-plan';
-import { isMonthly } from 'lib/products-values/is-monthly';
-import { format as formatUrl, getUrlParts, getUrlFromParts, determineUrlType } from 'lib/url';
+import { isEnabled } from 'calypso/config';
+import { isFreeJetpackPlan } from 'calypso/lib/products-values/is-free-jetpack-plan';
+import { isJetpackPlan } from 'calypso/lib/products-values/is-jetpack-plan';
+import { isMonthly } from 'calypso/lib/products-values/is-monthly';
+import {
+	format as formatUrl,
+	getUrlParts,
+	getUrlFromParts,
+	determineUrlType,
+} from 'calypso/lib/url';
 import {
 	PLAN_FREE,
 	PLAN_PERSONAL,
@@ -31,6 +36,7 @@ import {
 	JETPACK_RESET_PLANS,
 	FEATURE_JETPACK_SEARCH,
 	FEATURE_JETPACK_SEARCH_MONTHLY,
+	TYPE_P2_PLUS,
 } from './constants';
 import { PLANS_LIST } from './plans-list';
 
@@ -333,6 +339,10 @@ export function isJetpackFreePlan( planSlug ) {
 
 export function isJetpackOfferResetPlan( planSlug ) {
 	return JETPACK_RESET_PLANS.includes( planSlug );
+}
+
+export function isP2PlusPlan( planSlug ) {
+	return planMatches( planSlug, { type: TYPE_P2_PLUS } );
 }
 
 /**

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -1339,7 +1339,7 @@ export const PLANS_LIST = {
 
 	[ constants.PLAN_P2_PLUS ]: {
 		group: constants.GROUP_WPCOM,
-		type: constants.TYPE_P2,
+		type: constants.TYPE_P2_PLUS,
 		getTitle: () => i18n.translate( 'P2+' ),
 		getDescription: () => i18n.translate( 'Some long description' ),
 		getShortDescription: () => i18n.translate( 'Some short description' ),

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -87,12 +87,14 @@ import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import { isUnderDomainManagementAll } from 'calypso/my-sites/domains/paths';
 import { isUnderEmailManagementAll } from 'calypso/my-sites/email/paths';
 import JetpackSidebarMenuItems from 'calypso/components/jetpack/sidebar/menu-items/calypso';
+import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
+import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
+import { isP2PlusPlan } from 'calypso/lib/plans';
 
 export class MySitesSidebar extends Component {
 	static propTypes = {
@@ -103,6 +105,7 @@ export class MySitesSidebar extends Component {
 		isDomainOnly: PropTypes.bool,
 		isJetpack: PropTypes.bool,
 		isAtomicSite: PropTypes.bool,
+		sitePlanSlug: PropTypes.string,
 	};
 
 	expandPlanSection = () => this.props.expandSection( SIDEBAR_SECTION_PLAN );
@@ -407,9 +410,13 @@ export class MySitesSidebar extends Component {
 	}
 
 	jetpack() {
-		const { canUserManageOptions, isJetpackSectionOpen, path } = this.props;
+		const { canUserManageOptions, isJetpackSectionOpen, path, sitePlanSlug } = this.props;
 
-		if ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) {
+		if (
+			this.props.isSiteWPForTeams &&
+			( ! isEnabled( 'p2/p2-plus' ) ||
+				( isEnabled( 'p2/p2-plus' ) && ! isP2PlusPlan( sitePlanSlug ) ) )
+		) {
 			return null;
 		}
 
@@ -1117,6 +1124,7 @@ function mapStateToProps( state ) {
 		isCloudEligible: isJetpackCloudEligible( state, siteId ),
 		isAllSitesView: isAllDomainsView || getSelectedSiteId( state ) === null,
 		isWpMobile: isWpMobileApp(), // This doesn't rely on state, but we inject it here for future testability
+		sitePlanSlug: getSitePlanSlug( state, siteId ),
 	};
 }
 

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -89,12 +89,12 @@ import { isUnderEmailManagementAll } from 'calypso/my-sites/email/paths';
 import JetpackSidebarMenuItems from 'calypso/components/jetpack/sidebar/menu-items/calypso';
 import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
 import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
+import { isP2PlusPlan } from 'calypso/lib/plans';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import { isP2PlusPlan } from 'calypso/lib/plans';
 
 export class MySitesSidebar extends Component {
 	static propTypes = {


### PR DESCRIPTION
In this PR, we add Jetpack's Activity Log menu item to P2+ sites.

## Testing instructions

With a non-P2 site, you should see the Calypso sidebar unchanged. With a P2 site without P2+ plan, you shouldn't see the Jetpack section at all (unchanged). Now, upgrade to the P2+ plan on that P2 site. You should see Jetpack in the sidebar with Activity Log. When you open Activity Log, it should work (filtering, etc).