### PR TITLE
Launch: Boilerplate for launch package.

### DIFF
--- a/client/blocks/editor-launch-modal/index.tsx
+++ b/client/blocks/editor-launch-modal/index.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Launch from '@automattic/launch';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const EditorLaunchModal: React.FunctionComponent = () => {
+	const [ isClosed, setIsClosed ] = React.useState( false );
+
+	const handleClose = () => {
+		setIsClosed( true );
+	};
+
+	return (
+		<div className="editor-launch-modal" hidden={ isClosed }>
+			<Launch onClose={ handleClose }></Launch>
+		</div>
+	);
+};
+
+export default EditorLaunchModal;

--- a/client/blocks/editor-launch-modal/style.scss
+++ b/client/blocks/editor-launch-modal/style.scss
@@ -1,0 +1,9 @@
+.editor-launch-modal {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background: rgba( 255, 255, 255, 0.7 );
+	z-index: 99999;
+}

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -714,6 +714,7 @@ class CalypsoifyIframe extends Component<
 
 		const isUsingClassicBlock = !! classicBlockEditorId;
 		const isCheckoutOverlayEnabled = config.isEnabled( 'post-editor/checkout-overlay' );
+		const isLaunchOverlayEnabled = config.isEnabled( 'post-editor/launch-overlay' );
 
 		return (
 			<Fragment>
@@ -760,6 +761,7 @@ class CalypsoifyIframe extends Component<
 						isOpen
 					/>
 				) }
+				{ isLaunchOverlayEnabled && <AsyncLoad require="calypso/blocks/editor-launch-modal" /> }
 				<EditorRevisionsDialog loadRevision={ this.loadRevision } />
 				<WebPreview
 					externalUrl={ postUrl }

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
 		"@automattic/load-script": "^1.0.0",
 		"@automattic/material-design-icons": "^1.0.0",
 		"@automattic/onboarding": "^1.0.0",
+		"@automattic/launch": "^1.0.0",
 		"@automattic/plans-grid": "^1.0.0-alpha.0",
 		"@automattic/popup-monitor": "^1.0.0",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",

--- a/config/development.json
+++ b/config/development.json
@@ -146,6 +146,7 @@
 		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,
+		"post-editor/launch-overlay": false,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"press-this": true,

--- a/packages/launch/README.md
+++ b/packages/launch/README.md
@@ -1,0 +1,9 @@
+# Launch
+
+`@automattic/launch` contains components for launching sites on WordPress.com.
+
+## Installation
+
+```sh
+yarn add @automattic/launch
+```

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@automattic/launch",
+	"version": "1.0.0",
+	"description": "Launch components for WordPress.com",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/launch"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"types": "dist/types",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
+		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json && copy-assets && npx copyfiles ./styles/** dist",
+		"prepublish": "yarn run clean",
+		"watch": "tsc --project ./tsconfig.json --watch"
+	},
+	"dependencies": {
+		"@automattic/react-i18n": "^1.0.0-alpha.0",
+		"@automattic/data-stores": "^1.0.0-alpha.1",
+		"@wordpress/components": "^10.0.5",
+		"@wordpress/icons": "^2.4.0",
+		"classnames": "^2.2.6"
+	},
+	"devDependencies": {
+		"@automattic/typography": "^1.0.0",
+		"@wordpress/base-styles": "^2.0.1",
+		"copyfiles": "^2.3.0"
+	},
+	"peerDependencies": {
+		"@wordpress/i18n": "^3.14.0",
+		"react": "^16.8"
+	},
+	"private": true
+}

--- a/packages/launch/src/index.tsx
+++ b/packages/launch/src/index.tsx
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+export { default } from './launch';

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useI18n } from '@automattic/react-i18n';
+import { Button } from '@wordpress/components';
+import { Icon, close } from '@wordpress/icons';
+import classnames from 'classnames';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	onClose?: () => void;
+}
+
+const Launch: React.FunctionComponent< Props > = ( { onClose } ) => {
+	const { __ } = useI18n();
+
+	return (
+		<div className={ classnames( 'nux-launch' ) }>
+			<p>{ __( 'Launch' ) }</p>
+			<Button onClick={ onClose }>
+				<Icon icon={ close } size={ 24 } />
+			</Button>
+		</div>
+	);
+};
+
+export default Launch;

--- a/packages/launch/src/launch/style.scss
+++ b/packages/launch/src/launch/style.scss
@@ -1,0 +1,7 @@
+@import '~@automattic/calypso-color-schemes';
+@import '~@automattic/onboarding/styles/mixins';
+@import '~@automattic/typography/styles/fonts';
+
+.nux-launch {
+	// Your stylesheet here
+}

--- a/packages/launch/tsconfig-cjs.json
+++ b/packages/launch/tsconfig-cjs.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"declaration": false,
+		"declarationDir": null,
+		"outDir": "dist/cjs",
+		"composite": false,
+		"incremental": true
+	}
+}

--- a/packages/launch/tsconfig.json
+++ b/packages/launch/tsconfig.json
@@ -1,0 +1,36 @@
+{
+	"compilerOptions": {
+		"target": "ES5",
+		"lib": [ "DOM", "ES2015" ],
+
+		"baseUrl": ".",
+		"module": "esnext",
+		"allowJs": false,
+		"jsx": "react",
+		"declaration": true,
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src",
+
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+
+		"moduleResolution": "node",
+		"esModuleInterop": true,
+
+		"forceConsistentCasingInFileNames": true,
+
+		"typeRoots": [ "../../node_modules/@types" ],
+		"types": [],
+
+		"importsNotUsedAsValues": "error",
+		"importHelpers": true,
+		"composite": true
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/test/*" ],
+	"references": [ {} ]
+}


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Added boilerplate for launch packages.
  * `packages/launch`
  * `@automattic/launch`
* Added `EditorLaunchModal` which renders the boilerplate launch component on the parent calypso frame.

## Testing instructions

* Run `yarn` on root folder to install/rebuild packages (you will see an entry for `@automattic/launch` in the build log).
* Run `yarn start`.
* Open `calypso.localhost:3000/block-editor/post/YOUR_SITE_HERE.wordpress.com?flags=post-editor/launch-overlay`.

With the feature flag on the URL, the launch overlay will display.

## Screenshot
![image](https://user-images.githubusercontent.com/1287077/96236438-5593da80-0f9c-11eb-8cb4-141cc9e6e355.png)

