### PR TITLE
PoC: Use `@wordpress/components` form toggles instead of Calypso ones

### DIFF
--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -9,6 +9,11 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 /**
+ * WordPress dependencies
+ */
+import { ToggleControl } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
@@ -16,7 +21,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import ExternalLink from 'calypso/components/external-link';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormToggle from 'calypso/components/forms/form-toggle';
 import Main from 'calypso/components/main';
 import observe from 'calypso/lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
 import { protectForm } from 'calypso/lib/protect-form';
@@ -133,12 +137,11 @@ const Privacy = createReactClass( {
 							</p>
 							<hr />
 							<p>
-								<FormToggle
+								<ToggleControl
 									id="tracks_opt_out"
 									checked={ isSendingTracksEvent }
 									onChange={ this.updateTracksOptOut }
-								>
-									{ translate(
+									label={ translate(
 										'Share information with our analytics tool about your use of services while ' +
 											'logged in to your WordPress.com account. {{cookiePolicyLink}}Learn more' +
 											'{{/cookiePolicyLink}}.',
@@ -148,7 +151,7 @@ const Privacy = createReactClass( {
 											},
 										}
 									) }
-								</FormToggle>
+								/>
 							</p>
 						</FormFieldset>
 

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -2,9 +2,14 @@
  * External dependencies
  */
 
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { flowRight, pick } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Disabled, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -50,29 +55,29 @@ class SiteSettingsFormDiscussion extends Component {
 			isSavingSettings,
 			translate,
 		} = this.props;
+		const DisabledComponent = isRequestingSettings || isSavingSettings ? Disabled : Fragment;
+
 		return (
 			<FormFieldset>
-				<CompactFormToggle
-					checked={ !! fields.default_pingback_flag }
-					disabled={ isRequestingSettings || isSavingSettings }
-					onChange={ handleAutosavingToggle( 'default_pingback_flag' ) }
-				>
-					{ translate( 'Attempt to notify any blogs linked to from the article' ) }
-				</CompactFormToggle>
-				<CompactFormToggle
-					checked={ !! fields.default_ping_status }
-					disabled={ isRequestingSettings || isSavingSettings }
-					onChange={ handleAutosavingToggle( 'default_ping_status' ) }
-				>
-					{ translate( 'Allow link notifications from other blogs (pingbacks and trackbacks)' ) }
-				</CompactFormToggle>
-				<CompactFormToggle
-					checked={ !! fields.default_comment_status }
-					disabled={ isRequestingSettings || isSavingSettings }
-					onChange={ handleAutosavingToggle( 'default_comment_status' ) }
-				>
-					{ translate( 'Allow people to post comments on new articles' ) }
-				</CompactFormToggle>
+				<DisabledComponent>
+					<ToggleControl
+						checked={ !! fields.default_pingback_flag }
+						onChange={ handleAutosavingToggle( 'default_pingback_flag' ) }
+						label={ translate( 'Attempt to notify any blogs linked to from the article' ) }
+					/>
+					<ToggleControl
+						checked={ !! fields.default_ping_status }
+						onChange={ handleAutosavingToggle( 'default_ping_status' ) }
+						label={ translate(
+							'Allow link notifications from other blogs (pingbacks and trackbacks)'
+						) }
+					/>
+					<ToggleControl
+						checked={ !! fields.default_comment_status }
+						onChange={ handleAutosavingToggle( 'default_comment_status' ) }
+						label={ translate( 'Allow people to post comments on new articles' ) }
+					/>
+				</DisabledComponent>
 				<FormSettingExplanation>
 					{ translate( 'These settings may be overridden for individual articles.' ) }
 				</FormSettingExplanation>

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -44,6 +44,15 @@
 		font-weight: 700;
 	}
 
+	.components-toggle-control__label {
+		font-weight: 400;
+		margin-bottom: 1px;
+	}
+
+	.components-toggle-control .components-base-control__field {
+		margin-bottom: 7px;
+	}
+
 	legend + label,
 	label + label,
 	li label,


### PR DESCRIPTION
This PR is a proof of concept to demonstrate replacing Calypso form toggles with the `@wordpress/components` ones. We're replacing them in a couple of places.

I'm summoning folks from some of our design teams and would love to hear all your thoughts, questions and concerns.

#### Changes proposed in this Pull Request

**Use `@wordpress/components` `ToggleControl` in Me -> Privacy**

Before:
![](https://cldup.com/xijOrDqcpY.png)

After:
![](https://cldup.com/_9PyeyTgXv.png)

**Use `@wordpress/components` `ToggleControl` in Settings -> Discussion**

Before:
![](https://cldup.com/k31EDnmnwY.png)

After:
![](https://cldup.com/jmybZGWaql.png)

#### Testing instructions

* Navigate to `/me/privacy` and play with the privacy toggle.
* Navigate to `/settings/discussion/:site` (where `:site` is the slug of your site) and play with the 3 toggles at the top.

#### Notes

Ignore the style changes and ESLint warnings. This PR is not meant to be merged and should serve only as a proof of concept for demonstration purposes.