### PR TITLE
Email: Update control panel login component to use actual order ID

### DIFF
--- a/client/lib/titan/get-titan-mail-order-id.js
+++ b/client/lib/titan/get-titan-mail-order-id.js
@@ -1,0 +1,3 @@
+export function getTitanMailOrderId( domain ) {
+	return domain.titanMailSubscription?.orderId;
+}

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -13,6 +13,7 @@ import wpcom from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { Button, CompactCard } from '@automattic/components';
 import SectionHeader from 'calypso/components/section-header';
+import { getTitanMailOrderId } from 'calypso/lib/titan/get-titan-mail-order-id';
 
 /**
  * Style dependencies
@@ -43,18 +44,16 @@ class TitanControlPanelLoginCard extends React.Component {
 		const { domain, translate } = this.props;
 		this.setState( { isFetchingAutoLoginLink: true } );
 
-		this.fetchTitanAutoLoginURL( domain.titanMailSubscription.orderId ).then(
-			( { error, loginURL } ) => {
-				this.setState( { isFetchingAutoLoginLink: false } );
-				if ( error ) {
-					this.props.errorNotice(
-						error ?? translate( 'An unknown error occurred. Please try again later.' )
-					);
-				} else {
-					window.location.href = loginURL;
-				}
+		this.fetchTitanAutoLoginURL( getTitanMailOrderId( domain ) ).then( ( { error, loginURL } ) => {
+			this.setState( { isFetchingAutoLoginLink: false } );
+			if ( error ) {
+				this.props.errorNotice(
+					error ?? translate( 'An unknown error occurred. Please try again later.' )
+				);
+			} else {
+				window.location.href = loginURL;
 			}
-		);
+		} );
 	};
 
 	render() {

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -9,10 +9,10 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
-import { errorNotice } from 'state/notices/actions';
+import wpcom from 'calypso/lib/wp';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { Button, CompactCard } from '@automattic/components';
-import SectionHeader from 'components/section-header';
+import SectionHeader from 'calypso/components/section-header';
 
 /**
  * Style dependencies
@@ -40,20 +40,21 @@ class TitanControlPanelLoginCard extends React.Component {
 			return;
 		}
 
-		const { translate } = this.props;
+		const { domain, translate } = this.props;
 		this.setState( { isFetchingAutoLoginLink: true } );
 
-		// TODO: use actual orderID
-		this.fetchTitanAutoLoginURL( 12345 ).then( ( { error, loginURL } ) => {
-			this.setState( { isFetchingAutoLoginLink: false } );
-			if ( error ) {
-				this.props.errorNotice(
-					error ?? translate( 'An unknown error occurred. Please try again later.' )
-				);
-			} else {
-				window.location.href = loginURL;
+		this.fetchTitanAutoLoginURL( domain.titanMailSubscription.orderId ).then(
+			( { error, loginURL } ) => {
+				this.setState( { isFetchingAutoLoginLink: false } );
+				if ( error ) {
+					this.props.errorNotice(
+						error ?? translate( 'An unknown error occurred. Please try again later.' )
+					);
+				} else {
+					window.location.href = loginURL;
+				}
 			}
-		} );
+		);
 	};
 
 	render() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the Titan control panel login component to use the actual order id for a domain.

#### Testing instructions

- Hack the backend to return a Titan subscription for a domain
- Verify the same ID is used when generating the auto login link
