### PR TITLE
Purchases: Fix purchase details page crash for deleted/disconnected sites w/ old Jetpack plans

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -660,7 +660,7 @@ class ManagePurchase extends Component {
 				<HeaderCake backHref={ this.props.purchaseListUrl }>{ this.props.cardTitle }</HeaderCake>
 				{ showExpiryNotice ? (
 					<Notice status="is-info" text={ <PlanRenewalMessage /> } showDismiss={ false }>
-						<NoticeAction href={ `/plans/${ site.slug || '' }` }>
+						<NoticeAction href={ `/plans/${ siteSlug || '' }` }>
 							{ translate( 'View plans' ) }
 						</NoticeAction>
 					</Notice>


### PR DESCRIPTION
Fixes a user-reported issue.

#### Changes proposed in this Pull Request

* On the purchase details page, for sites with old Jetpack plans that need to see the "We launched new plans" notice, use `siteSlug` instead of `site.slug` to build the `View plans` link.

**Implementation note:** It appears that the `site` object wasn't available, since the site was no longer in the user's sites list.

#### Testing instructions

**Prerequisite:**  Purchase a legacy Jetpack plan (i.e., Personal, Premium, or Professional) for a non-WordPress.com site, then completely remove that site from your WordPress.com account. It should no longer be associated with any site owner.

* From the account that originally purchased the upgrade, go to your account profile and then to **Manage Purchases**.
* Click on the upgrade for the disconnected site to see its details.
* Before applying this PR: clicking the upgrade for the first time should redirect you back to the **Manage Purchases** page. Clicking again should attempt to load the page and fail with an error in the DevTools console.
* After applying this PR: clicking the upgrade should load the purchase details page (`/me/purchases/<site>/<purchase_id>`) successfully.
