### PR TITLE
State: Remove dropWhile usage in post likes reducer

### DIFF
--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -1,20 +1,20 @@
 /**
  * External dependencies
  */
-import { dropWhile, some } from 'lodash';
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import itemSchema from './schema';
-import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation } from 'calypso/state/utils';
 import {
 	POST_LIKES_ADD_LIKER,
 	POST_LIKES_RECEIVE,
 	POST_LIKES_REMOVE_LIKER,
 	POST_LIKE,
 	POST_UNLIKE,
-} from 'state/action-types';
+} from 'calypso/state/action-types';
 
 /**
  * Returns the updated items state after an action has been dispatched. The
@@ -104,7 +104,7 @@ export const itemReducer = withSchemaValidation(
 
 				let likes = state.likes;
 				if ( hasLiker ) {
-					likes = dropWhile( state.likes, ( l ) => liker.ID === l.ID );
+					likes = state.likes.filter( ( l ) => liker.ID !== l.ID );
 				}
 
 				return {

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -7,9 +7,9 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import reducer, { items, itemReducer } from '../reducer';
-import { POST_LIKES_RECEIVE, SERIALIZE, DESERIALIZE } from 'state/action-types';
+import { POST_LIKES_RECEIVE, SERIALIZE, DESERIALIZE } from 'calypso/state/action-types';
 import { addLiker, removeLiker, like, unlike } from '../actions';
-import { useFakeTimers, useSandbox } from 'test-helpers/use-sinon';
+import { useFakeTimers, useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
 	useSandbox( ( sandbox ) => {
@@ -461,14 +461,14 @@ describe( 'reducer', () => {
 				expect(
 					itemReducer(
 						deepFreeze( {
-							likes: [ liker ],
+							likes: [ { ID: 123 }, liker, { ID: 456 } ],
 							found: 5,
 							iLike: false,
 						} ),
 						removeLiker( 1, 1, 5, liker )
 					)
 				).toEqual( {
-					likes: [],
+					likes: [ { ID: 123 }, { ID: 456 } ],
 					found: 5,
 					iLike: false,
 				} );


### PR DESCRIPTION
Lodash's `dropWhile` is used in a single location in the entire codebase, and that usage is simple enough to allow removal by inverting the logic and using a filter. That's what this PR does.

#### Changes proposed in this Pull Request

* State: Remove `dropWhile` usage in post likes reducer

#### Testing instructions

* Verify all tests still pass: `yarn run test-client client/state/posts/likes/test/reducer.js`