### PR TITLE
Domains: Drop lodash drop()

### DIFF
--- a/client/lib/domains/utils/parse-domain-against-tld-list.js
+++ b/client/lib/domains/utils/parse-domain-against-tld-list.js
@@ -8,8 +8,7 @@ export function parseDomainAgainstTldList( domainFragment, tldList ) {
 	}
 
 	const parts = domainFragment.split( '.' );
-	parts.shift();
-	const suffix = parts.join( '.' );
+	const suffix = parts.slice( 1 ).join( '.' );
 
 	return parseDomainAgainstTldList( suffix, tldList );
 }

--- a/client/lib/domains/utils/parse-domain-against-tld-list.js
+++ b/client/lib/domains/utils/parse-domain-against-tld-list.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { drop, join, split } from 'lodash';
-
 export function parseDomainAgainstTldList( domainFragment, tldList ) {
 	if ( ! domainFragment ) {
 		return '';
@@ -12,8 +7,9 @@ export function parseDomainAgainstTldList( domainFragment, tldList ) {
 		return domainFragment;
 	}
 
-	const parts = split( domainFragment, '.' );
-	const suffix = join( drop( parts ), '.' );
+	const parts = domainFragment.split( '.' );
+	parts.shift();
+	const suffix = parts.join( '.' );
 
 	return parseDomainAgainstTldList( suffix, tldList );
 }

--- a/client/lib/domains/utils/test/parse-domain-against-tld-list.js
+++ b/client/lib/domains/utils/test/parse-domain-against-tld-list.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { parseDomainAgainstTldList } from '../';
+
+describe( 'parseDomainAgainstTldList', () => {
+	const tldList = {
+		'co.in': 1,
+		'co.uk': 1,
+	};
+
+	test( 'should return an empty string if domain fragment is missing', () => {
+		expect( parseDomainAgainstTldList( '', tldList ) ).toEqual( '' );
+	} );
+
+	test( 'should return an empty string if the tld is not a known one', () => {
+		expect( parseDomainAgainstTldList( 'example.co.yz', tldList ) ).toEqual( '' );
+	} );
+
+	test( 'should return domain fragment if it exists in the list of known tlds', () => {
+		expect( parseDomainAgainstTldList( 'co.uk', tldList ) ).toEqual( 'co.uk' );
+	} );
+
+	test( 'should return the right multi-level tld with a subdomain', () => {
+		expect( parseDomainAgainstTldList( 'example.co.uk', tldList ) ).toEqual( 'co.uk' );
+	} );
+
+	test( 'should return the right multi-level tld with a sub-subdomain', () => {
+		expect( parseDomainAgainstTldList( 'test.example.co.uk', tldList ) ).toEqual( 'co.uk' );
+	} );
+} );


### PR DESCRIPTION
Lodash's `drop` is used in a single location in the entire codebase, and that usage is simple enough to allow removal by slightly refactoring the logic and using native `String` and `Array` methods. That's what this PR does. It also adds tests to ensure we're not breaking anything.

Also, it removes a couple of Lodash `split` and `join` usages - those are used infrequently, too, and will be easy to replace with their native JS alternatives soon as well.

#### Changes proposed in this Pull Request

* Add tests for `parseDomainAgainstTldList()`.
* Domains: Remove `drop` usage in utils.

#### Testing instructions

* Verify all tests still pass: `yarn run test-client client/lib/domains/utils/test`
* cc @Automattic/cobalt - could you please test and confirm we're not breaking anything? 😉 