### PR TITLE
State: Refactor getPartnerIdFromQuery to use Number and optional chaining

### DIFF
--- a/client/state/selectors/get-partner-id-from-query.js
+++ b/client/state/selectors/get-partner-id-from-query.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import { get, toNumber, isInteger } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 
 /**
  * Returns the partner_id query param if present or null.
@@ -15,8 +10,9 @@ import getCurrentQueryArguments from 'state/selectors/get-current-query-argument
  * @returns {?number}       The partner ID as an integer or null
  */
 export const getPartnerIdFromQuery = function ( state ) {
-	const partnerId = toNumber( get( getCurrentQueryArguments( state ), 'partner_id' ) );
-	return isInteger( partnerId ) ? partnerId : null;
+	const queryArgs = getCurrentQueryArguments( state );
+	const partnerId = Number( queryArgs?.partner_id );
+	return Number.isInteger( partnerId ) ? partnerId : null;
 };
 
 export default getPartnerIdFromQuery;


### PR DESCRIPTION
Lodash's `toNumber()` is used in a single location in the entire codebase, and that usage is simple enough to allow removal by using `Number`. That's what this PR does. Additionally, it removes `get` and `isInteger` usage. `isInteger` isn't used too broadly in the codebase, so we should be able to remove it soon, as well.

#### Changes proposed in this Pull Request

* State: Refactor `getPartnerIdFromQuery` to use `Number` and optional chaining

#### Testing instructions

* Go to `/jetpack/connect?partner_id=49640`
* Verify you can see the Jetpack + Pressable logo.
* If you wish to test more logos, do it with some IDs from https://github.com/Automattic/wp-calypso/blob/master/client/state/selectors/get-partner-slug-from-query.js#L15
* Go to `/jetpack/connect`
* Verify you can see just the Jetpack logo.
* Verify all tests still pass: `yarn run test-client client/state/selectors/test/get-partner-id-from-query.js`