### PR TITLE
Notifications: Ensure all links opening with target=_blank have a rel attribute as well

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -133,6 +133,7 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 				} else {
 					// Other links should link into a new window/tab
 					new_container.setAttribute( 'target', '_blank' );
+					new_container.setAttribute( 'rel', 'noopener noreferrer' );
 				}
 
 				if ( 'post' === range_info.type ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates handling of links opening in a new window to include `rel="noopener noreferrer"` as well. (https://web.dev/external-anchors-use-rel-noopener/)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure you have the API sandboxed.
* Open a Calypso web notification containing a link that opens in a new window.
* Verify that in the HTML for the notification, the link has the attribute `rel="noopener noreferrer"` applied to it.
