### PR TITLE
Podcasting: make deprecated keywords field read-only

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -125,7 +125,7 @@ class PodcastingDetails extends Component {
 		);
 	}
 
-	renderTextField( { FormComponent = FormInput, key, label, explanation } ) {
+	renderTextField( { FormComponent = FormInput, key, label, explanation, isDisabled = false } ) {
 		const { fields, isRequestingSettings, onChangeField, isPodcastingEnabled } = this.props;
 
 		return (
@@ -137,7 +137,7 @@ class PodcastingDetails extends Component {
 					name={ key }
 					value={ decodeEntities( fields[ key ] ) || '' }
 					onChange={ onChangeField( key ) }
-					disabled={ isRequestingSettings || ! isPodcastingEnabled }
+					disabled={ isDisabled || isRequestingSettings || ! isPodcastingEnabled }
 				/>
 			</FormFieldset>
 		);
@@ -378,6 +378,7 @@ class PodcastingDetails extends Component {
 					explanation: translate(
 						'The keywords setting has been deprecated. This field is for reference only.'
 					),
+					isDisabled: true,
 				} ) }
 				{ isPodcastingEnabled && this.renderSaveButton( true ) }
 			</Fragment>


### PR DESCRIPTION
Apple has deprecated and dropped support for the `itunes:keyword` tag. In #46467, I quickly added a notice to the podcasting keywords field before we recorded a podcasting tutorial video. In D51182-code I removed the output from the podcasting feed, and per @nbloomf's request, this makes the field read-only.

ref: p1602699974038200-slack-podcasting-async-workshop-content

<img width="696" alt="Screen Shot 2020-10-16 at 4 38 30 PM" src="https://user-images.githubusercontent.com/942359/96307128-18950b80-0fcf-11eb-929c-bbe1ead92e25.png">

**To test:**
- on a site with podcasting enabled (ping me if you need a site/user)
- visit the podcast settings page, _Settings > Writing > Podcasting > Manage Details_
- verify that the keywords field is read-only