### PR TITLE
Fix FormPasswordInput bug

### DIFF
--- a/client/components/forms/form-password-input/index.jsx
+++ b/client/components/forms/form-password-input/index.jsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import { isMobile } from '@automattic/viewport';
-import React from 'react';
-import Gridicon from 'calypso/components/gridicon';
-import classNames from 'classnames';
 import { omit } from 'lodash';
+import { withMobileBreakpoint } from '@automattic/viewport-react';
+import classNames from 'classnames';
+import Gridicon from 'calypso/components/gridicon';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
  */
 import './style.scss';
 
-export default class extends React.Component {
+class FormPasswordInput extends React.Component {
 	static displayName = 'FormPasswordInput';
 
 	state = {
@@ -26,13 +26,9 @@ export default class extends React.Component {
 
 	textFieldRef = React.createRef();
 
-	componentDidMount() {
-		if ( isMobile() ) {
-			this.state = { hidePassword: false };
-			return;
-		}
-		this.state = { hidePassword: true };
-		return;
+	constructor( props ) {
+		super( props );
+		this.state = { hidePassword: ! props.isBreakpointActive };
 	}
 
 	togglePasswordVisibility = () => {
@@ -60,7 +56,7 @@ export default class extends React.Component {
 		return (
 			<div className="form-password-input">
 				<FormTextInput
-					{ ...omit( this.props, 'hideToggle', 'submitting' ) }
+					{ ...omit( this.props, 'hideToggle', 'submitting', 'isBreakpointActive' ) }
 					autoComplete="off"
 					ref={ this.textFieldRef }
 					type={ this.hidden() ? 'password' : 'text' }
@@ -73,3 +69,5 @@ export default class extends React.Component {
 		);
 	}
 }
+
+export default withMobileBreakpoint( FormPasswordInput );

--- a/client/components/forms/form-password-input/index.jsx
+++ b/client/components/forms/form-password-input/index.jsx
@@ -20,10 +20,6 @@ import './style.scss';
 class FormPasswordInput extends React.Component {
 	static displayName = 'FormPasswordInput';
 
-	state = {
-		hidePassword: true,
-	};
-
 	textFieldRef = React.createRef();
 
 	constructor( props ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* setting the React state directly in the `componentDidMount` is consider worthy of a console warning. This refactor moves the logic to the constructor and uses the `withMobileBreakpoint` component to correctly render there.

#### Testing instructions

1. Navigate to a a screen with `FormPasswordInput`, such as `/devdocs/design/form-fields`, on a development branch
2. Confirm the following error does not appear in the console
<img width="782" alt="Screen Shot 2020-10-16 at 2 09 30 PM" src="https://user-images.githubusercontent.com/2810519/96309023-5129ea80-0fb9-11eb-8c7a-f767dff6da40.png">
3. Verify starting the page at a mobile width ( <=660px ) the password form starts visible, and at wide widths it starts hidden.

