### PR TITLE
wpcom-proxy-request: Improve safeguard for onmessage

### DIFF
--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -351,9 +351,15 @@ function onload() {
 function onmessage( e ) {
 	debug( 'onmessage' );
 
-	// Filter out messages from iframes not equal to the iframe variable, different origins
-	if ( e.origin !== proxyOrigin || e.source !== iframe.contentWindow ) {
+	// Filter out messages from different origins
+	if ( e.origin !== proxyOrigin ) {
 		debug( 'ignoring message... %o !== %o', e.origin, proxyOrigin );
+		return;
+	}
+
+	// Filter out messages from different iframes
+	if ( e.source !== iframe.contentWindow ) {
+		debug( 'ignoring message... iframe elements do not match' );
 		return;
 	}
 

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -351,8 +351,8 @@ function onload() {
 function onmessage( e ) {
 	debug( 'onmessage' );
 
-	// safeguard...
-	if ( e.origin !== proxyOrigin ) {
+	// Filter out messages from iframes not equal to the iframe variable, different origins
+	if ( e.origin !== proxyOrigin || e.source !== iframe.contentWindow ) {
 		debug( 'ignoring message... %o !== %o', e.origin, proxyOrigin );
 		return;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a race condition that can occur when multiple instances of `wpcom-proxy-request` are initialized on a single window. This causes the iframe initialization to fail. This was causing https://github.com/Automattic/jetpack/issues/17269.

* This fix is already in use in the Jetpack Search bundle.

#### Testing instructions

* Package wpcom-proxy-request into two bundles (e.g. `a.js` and `b.js`).
* Load both `a.js` and `b.js` into a single document.
* Queue up an API request in each bundle.
* Ensure that the requests execute as expected.

Try repeating these steps without this fix to reproduce the race condition bug.