### PR TITLE
Billing: make `/plans/` default route for the plans item

### DIFF
--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -63,14 +63,6 @@ class PlansNavigation extends React.Component {
 					onMobileNavPanelOpen={ this.onMobileNavPanelOpen }
 				>
 					<NavTabs label="Section" selectedText={ sectionTitle }>
-						{ shouldShowMyPlan && (
-							<NavItem
-								path={ `/plans/my-plan/${ site.slug }` }
-								selected={ path === '/plans/my-plan' }
-							>
-								{ translate( 'My Plan' ) }
-							</NavItem>
-						) }
 						<NavItem
 							path={ `/plans/${ site.slug }` }
 							selected={
@@ -79,6 +71,14 @@ class PlansNavigation extends React.Component {
 						>
 							{ translate( 'Plans' ) }
 						</NavItem>
+						{ shouldShowMyPlan && (
+							<NavItem
+								path={ `/plans/my-plan/${ site.slug }` }
+								selected={ path === '/plans/my-plan' }
+							>
+								{ translate( 'My Plan' ) }
+							</NavItem>
+						) }
 					</NavTabs>
 					{ cartToggleButton }
 				</SectionNav>

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -30,8 +30,6 @@ import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QueryScanState from 'calypso/components/data/query-jetpack-scan';
 import ToolsMenu from './tools-menu';
-import isCurrentPlanPaid from 'calypso/state/sites/selectors/is-current-plan-paid';
-import { siteHasJetpackProductPurchase } from 'calypso/state/purchases/selectors';
 import { isEcommerce } from 'calypso/lib/products-values';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import isJetpackSectionEnabledForSite from 'calypso/state/selectors/is-jetpack-section-enabled-for-site';
@@ -621,14 +619,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	plans() {
-		const {
-			canUserManageOptions,
-			hasPaidJetpackPlan,
-			hasPurchasedJetpackProduct,
-			path,
-			site,
-			translate,
-		} = this.props;
+		const { canUserManageOptions, path, site, translate } = this.props;
 
 		if ( ! site ) {
 			return null;
@@ -646,12 +637,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		let planLink = '/plans' + this.props.siteSuffix;
-
-		// Show plan details for upgraded sites
-		if ( hasPaidJetpackPlan || hasPurchasedJetpackProduct ) {
-			planLink = '/plans/my-plan' + this.props.siteSuffix;
-		}
+		const planLink = '/plans' + this.props.siteSuffix;
 
 		const linkClass = classNames( {
 			selected: itemLinkMatches( [ '/plans' ], path ),
@@ -1087,8 +1073,6 @@ function mapStateToProps( state ) {
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		forceAllSitesView: isAllDomainsView,
 		hasJetpackSites: hasJetpackSites( state ),
-		hasPaidJetpackPlan: isCurrentPlanPaid( state, siteId ),
-		hasPurchasedJetpackProduct: siteHasJetpackProductPurchase( state, siteId ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack,
 		shouldRenderJetpackSection: isJetpackSectionEnabledForSite( state, selectedSiteId ),

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -639,7 +639,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarItem
 				label={ translate( 'Plans', { context: 'noun' } ) }
-				tipTarget="plan"
+				tipTarget="plans"
 				selected={ itemLinkMatches( '/plans', path ) }
 				link={ '/plans' + siteSuffix }
 				onNavigate={ this.trackPlanClick }

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -619,7 +618,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	plans() {
-		const { canUserManageOptions, path, site, translate } = this.props;
+		const { canUserManageOptions, path, site, siteSuffix, translate } = this.props;
 
 		if ( ! site ) {
 			return null;
@@ -637,25 +636,18 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const planLink = '/plans' + this.props.siteSuffix;
-
-		const linkClass = classNames( {
-			selected: itemLinkMatches( [ '/plans' ], path ),
-		} );
-
-		const tipTarget = 'plan';
-
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<li className={ linkClass } data-tip-target={ tipTarget }>
-				<a className="sidebar__menu-link" onClick={ this.trackPlanClick } href={ planLink }>
-					<span className="menu-link-text" data-e2e-sidebar="Plan">
-						{ translate( 'Plans', { context: 'noun' } ) }
-					</span>
-				</a>
-			</li>
+			<SidebarItem
+				label={ translate( 'Plans', { context: 'noun' } ) }
+				tipTarget="plan"
+				selected={ itemLinkMatches( '/plans', path ) }
+				link={ '/plans' + siteSuffix }
+				onNavigate={ this.trackPlanClick }
+				preloadSectionName="plans"
+				forceInternalLink
+				expandSection={ this.expandPlanSection }
+			/>
 		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	trackStoreClick = () => {

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -63,9 +63,9 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		return await this._scrollToAndClickMenuItem( 'themes' );
 	}
 
-	async selectPlan() {
+	async selectPlans() {
 		await this.expandDrawerItem( /^Plan\b/ );
-		return await this._scrollToAndClickMenuItem( 'plan' );
+		return await this._scrollToAndClickMenuItem( 'plans' );
 	}
 
 	async selectMyHome() {

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -43,12 +43,11 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 
 		step( 'Can Select Plans', async function () {
 			const sideBarComponent = await SidebarComponent.Expect( driver );
-			return await sideBarComponent.selectPlan();
+			return await sideBarComponent.selectPlans();
 		} );
 
 		step( 'Can Compare Plans', async function () {
 			const plansPage = await PlansPage.Expect( driver );
-			await plansPage.openPlansTab();
 			return await plansPage.waitForComparison();
 		} );
 
@@ -91,12 +90,11 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 
 		step( 'Can Select Plans', async function () {
 			const sideBarComponent = await SidebarComponent.Expect( driver );
-			return await sideBarComponent.selectPlan();
+			return await sideBarComponent.selectPlans();
 		} );
 
-		step( 'Can Select Plans tab', async function () {
+		step( 'Can Compare Plans', async function () {
 			const plansPage = await PlansPage.Expect( driver );
-			await plansPage.openPlansTab();
 			if ( host === 'WPCOM' ) {
 				await plansPage.openAdvancedPlansSegment();
 			}
@@ -192,9 +190,8 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 
 		step( 'Can navigate to plans page and select business plan', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( driver );
-			await sidebarComponent.selectPlan();
+			await sidebarComponent.selectPlans();
 			const plansPage = await PlansPage.Expect( driver );
-			await plansPage.openPlansTab();
 			return await plansPage.selectBusinessPlan();
 		} );
 


### PR DESCRIPTION
As part of upcoming navigation and IA changes to the Plan/Purchases section, this PR makes the `/plans/:site` route the default for the "plans" item (previously, it was "My Plan" for sites with a purchase). It additionally cleans up some of the render logic and makes use of the `SidebarItem` component, instead of a custom list item and link.

ref: p1HpG7-asg-p2

**Before:**
<img width="675" alt="Screen Shot 2020-10-16 at 10 18 02 PM" src="https://user-images.githubusercontent.com/942359/96326330-ba335180-0ffd-11eb-9417-9553e8d386a1.png">

**After:**
<img width="675" alt="Screen Shot 2020-10-16 at 10 18 58 PM" src="https://user-images.githubusercontent.com/942359/96326338-c3bcb980-0ffd-11eb-834a-6b8c0dfa63ae.png">

**To test:**
- first off, apologies for the plan-splosion in these instructions
- visit a Jetpack or WPcom site with a purchase
- navigate to _Plan_ section in the sidebar
- verify that the _Plans_ link in the _Plan_ section is visually unchanged
- click the _Plans_ link
- verify that you are taken to the _Plans_ screen and that _My Plan_ is the secondary item in the tabbed navigation