### PR TITLE
Billing: Add account-level payment methods tab

### DIFF
--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -32,7 +32,7 @@ export function BillingHistoryList( { siteId = null, getReceiptUrlFor = billingH
 }
 
 const BillingHistory = ( { translate } ) => (
-	<Main className="billing-history">
+	<Main className="billing-history is-wide-layout">
 		<DocumentHead title={ translate( 'Billing History' ) } />
 		<PageViewTracker path="/me/purchases/billing" title="Me > Billing History" />
 		<MeSidebarNavigation />

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -7,10 +7,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { addCreditCard, billingHistoryReceipt } from 'calypso/me/purchases/paths';
+import { billingHistoryReceipt } from 'calypso/me/purchases/paths';
 import { Card } from '@automattic/components';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import CreditCards from 'calypso/me/purchases/credit-cards';
 import PurchasesHeader from '../purchases/purchases-list/header';
 import BillingHistoryTable from './billing-history-table';
 import Main from 'calypso/components/main';
@@ -39,7 +38,6 @@ const BillingHistory = ( { translate } ) => (
 		<QueryBillingTransactions />
 		<PurchasesHeader section={ 'billing' } />
 		<BillingHistoryList />
-		<CreditCards addPaymentMethodUrl={ addCreditCard } />
 	</Main>
 );
 

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -63,7 +63,7 @@ class BillingReceipt extends React.Component {
 		const { transaction, transactionId, translate } = this.props;
 
 		return (
-			<Main>
+			<Main className="receipt is-wide-layout">
 				<DocumentHead title={ translate( 'Billing History' ) } />
 				<PageViewTracker
 					path="/me/purchases/billing/:receipt"

--- a/client/me/billing-history/upcoming-charges.jsx
+++ b/client/me/billing-history/upcoming-charges.jsx
@@ -22,7 +22,7 @@ import QueryBillingTransactions from 'calypso/components/data/query-billing-tran
 import './style.scss';
 
 const UpcomingCharges = ( { translate } ) => (
-	<Main>
+	<Main className="upcoming-charges is-wide-layout">
 		<DocumentHead title={ translate( 'Upcoming Charges' ) } />
 		<PageViewTracker path="/me/purchases/upcoming" title="Me > Upcoming Charges" />
 		<MeSidebarNavigation />

--- a/client/me/memberships/main.jsx
+++ b/client/me/memberships/main.jsx
@@ -110,7 +110,7 @@ const MembershipsHistory = ( { translate, subscriptions, moment } ) => {
 	}
 
 	return (
-		<Main className="memberships">
+		<Main className="memberships is-wide-layout">
 			<DocumentHead title={ translate( 'Other Sites' ) } />
 			<PageViewTracker path="/me/purchases/other" title="Me > Other Sites" />
 			<MeSidebarNavigation />

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -39,7 +39,7 @@ class Subscription extends React.Component {
 		const { translate, subscription, moment, stoppingStatus } = this.props;
 
 		return (
-			<Main className="memberships__subscription">
+			<Main className="memberships__subscription is-wide-layout">
 				<DocumentHead title={ translate( 'Other Sites' ) } />
 				<MeSidebarNavigation />
 				<QueryMembershipsSubscriptions />

--- a/client/me/payment-methods/README.md
+++ b/client/me/payment-methods/README.md
@@ -1,0 +1,9 @@
+# Payment Methods
+
+This is the `PaymentMethods` component that renders the `/me/purchases/payment-methods/` route.
+
+Supported routes:
+
+```
+/me/purchases/payment-methods/
+```

--- a/client/me/payment-methods/controller.js
+++ b/client/me/payment-methods/controller.js
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PaymentMethodsComponent from './main';
+
+export function paymentMethods( context, next ) {
+	context.primary = React.createElement( PaymentMethodsComponent );
+	next();
+}

--- a/client/me/payment-methods/main.tsx
+++ b/client/me/payment-methods/main.tsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { addCreditCard } from 'calypso/me/purchases/paths';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import CreditCards from 'calypso/me/purchases/credit-cards';
+import PurchasesHeader from '../purchases/purchases-list/header';
+import Main from 'calypso/components/main';
+import DocumentHead from 'calypso/components/data/document-head';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+export function PaymentMethods(): JSX.Element {
+	const translate = useTranslate();
+
+	return (
+		<Main className="payment-methods">
+			<DocumentHead title={ translate( 'Payment Methods' ) } />
+			<PageViewTracker path="/me/purchases/payment-methods" title="Me > Payment Methods" />
+			<MeSidebarNavigation />
+			<PurchasesHeader section={ 'payment-methods' } />
+
+			<CreditCards addPaymentMethodUrl={ addCreditCard } />
+		</Main>
+	);
+}

--- a/client/me/payment-methods/main.tsx
+++ b/client/me/payment-methods/main.tsx
@@ -15,7 +15,7 @@ import Main from 'calypso/components/main';
 import DocumentHead from 'calypso/components/data/document-head';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
-export function PaymentMethods(): JSX.Element {
+export default function PaymentMethods(): JSX.Element {
 	const translate = useTranslate();
 
 	return (

--- a/client/me/payment-methods/main.tsx
+++ b/client/me/payment-methods/main.tsx
@@ -19,7 +19,7 @@ export default function PaymentMethods(): JSX.Element {
 	const translate = useTranslate();
 
 	return (
-		<Main className="payment-methods">
+		<Main className="payment-methods is-wide-layout">
 			<DocumentHead title={ translate( 'Payment Methods' ) } />
 			<PageViewTracker path="/me/purchases/payment-methods" title="Me > Payment Methods" />
 			<MeSidebarNavigation />

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -111,7 +111,7 @@ export class PendingPayments extends Component {
 		}
 
 		return (
-			<Main className="pending-payments">
+			<Main className="pending-payments is-wide-layout">
 				<PageViewTracker path="/me/purchases/pending" title="Pending Payments" />
 				<MeSidebarNavigation />
 				<PurchasesHeader section="pending" />

--- a/client/me/purchases/add-credit-card/index.jsx
+++ b/client/me/purchases/add-credit-card/index.jsx
@@ -28,7 +28,7 @@ function AddCreditCard( props ) {
 	const recordFormSubmitEvent = () => recordTracksEvent( 'calypso_add_credit_card_form_submit' );
 
 	return (
-		<Main>
+		<Main className="add-credit-card is-wide-layout">
 			<PageViewTracker path="/me/purchases/add-credit-card" title="Purchases > Add Credit Card" />
 			<DocumentHead title={ concatTitle( titles.purchases, titles.addCreditCard ) } />
 

--- a/client/me/purchases/add-credit-card/index.jsx
+++ b/client/me/purchases/add-credit-card/index.jsx
@@ -18,13 +18,13 @@ import DocumentHead from 'calypso/components/data/document-head';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import titles from 'calypso/me/purchases/titles';
-import { billingHistory } from 'calypso/me/purchases/paths';
+import { paymentMethods } from 'calypso/me/purchases/paths';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { StripeHookProvider } from 'calypso/lib/stripe';
 
 function AddCreditCard( props ) {
 	const createAddCardToken = ( ...args ) => createCardToken( 'card_add', ...args );
-	const goToBillingHistory = () => page( billingHistory );
+	const goToPaymentMethods = () => page( paymentMethods );
 	const recordFormSubmitEvent = () => recordTracksEvent( 'calypso_add_credit_card_form_submit' );
 
 	return (
@@ -32,13 +32,13 @@ function AddCreditCard( props ) {
 			<PageViewTracker path="/me/purchases/add-credit-card" title="Purchases > Add Credit Card" />
 			<DocumentHead title={ concatTitle( titles.purchases, titles.addCreditCard ) } />
 
-			<HeaderCake onClick={ goToBillingHistory }>{ titles.addCreditCard }</HeaderCake>
+			<HeaderCake onClick={ goToPaymentMethods }>{ titles.addCreditCard }</HeaderCake>
 			<StripeHookProvider configurationArgs={ { needs_intent: true } }>
 				<CreditCardForm
 					createCardToken={ createAddCardToken }
 					recordFormSubmitEvent={ recordFormSubmitEvent }
 					saveStoredCard={ props.addStoredCard }
-					successCallback={ goToBillingHistory }
+					successCallback={ goToPaymentMethods }
 					showUsedForExistingPurchasesInfo={ true }
 				/>
 			</StripeHookProvider>

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -35,7 +35,7 @@ const userHasNoSites = ( state ) => getCurrentUserSiteCount( state ) <= 0;
 function noSites( context, analyticsPath ) {
 	setTitle( context );
 	context.primary = (
-		<Main>
+		<Main className="purchases__no-site is-wide-layout">
 			<PageViewTracker path={ analyticsPath } title="Purchases > No Sites" />
 			<PurchasesHeader section={ 'purchases' } />
 			<NoSitesMessage />
@@ -55,13 +55,13 @@ export function addCardDetails( context, next ) {
 	setTitle( context, titles.addCardDetails );
 
 	context.primary = (
-		<Main>
+		<Main className="purchases__add-cart-details is-wide-layout">
 			<AddCardDetails
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 				siteSlug={ context.params.site }
 				getManagePurchaseUrlFor={ managePurchaseUrl }
 				purchaseListUrl={ purchasesRoot }
-				isFullWidth={ false }
+				isFullWidth={ true }
 			/>
 		</Main>
 	);
@@ -140,7 +140,7 @@ export function list( context, next ) {
 
 export function managePurchase( context, next ) {
 	setTitle( context, titles.managePurchase );
-	const classes = 'manage-purchase';
+	const classes = 'manage-purchase is-wide-layout';
 
 	context.primary = (
 		<Main className={ classes }>

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -7,6 +7,7 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
+import * as paymentMethodsController from 'calypso/me/payment-methods/controller';
 import * as billingController from 'calypso/me/billing-history/controller';
 import * as pendingController from 'calypso/me/pending-payments/controller';
 import * as membershipsController from 'calypso/me/memberships/controller';
@@ -18,6 +19,13 @@ import { siteSelection } from 'calypso/my-sites/controller';
 
 export default ( router ) => {
 	if ( config.isEnabled( 'manage/payment-methods' ) ) {
+		router(
+			paths.paymentMethods,
+			sidebar,
+			paymentMethodsController.paymentMethods,
+			makeLayout,
+			clientRender
+		);
 		router( paths.addCreditCard, sidebar, controller.addCreditCard, makeLayout, clientRender );
 
 		// redirect legacy urls

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -4,6 +4,8 @@ export const addCreditCard = purchasesRoot + '/add-credit-card';
 
 export const billingHistory = purchasesRoot + '/billing';
 
+export const paymentMethods = purchasesRoot + '/payment-methods';
+
 export const upcomingCharges = purchasesRoot + '/upcoming';
 
 export const pendingPayments = purchasesRoot + '/pending';

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -14,6 +14,7 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import {
 	billingHistory,
+	paymentMethods,
 	upcomingCharges,
 	pendingPayments,
 	myMemberships,
@@ -34,6 +35,8 @@ const PurchasesHeader = ( { section, translate } ) => {
 		text = translate( 'Pending Payments' );
 	} else if ( section === 'memberships' ) {
 		text = translate( 'Other Sites' );
+	} else if ( section === 'payment-methods' ) {
+		text = translate( 'Payment Methods' );
 	}
 
 	return (
@@ -45,6 +48,10 @@ const PurchasesHeader = ( { section, translate } ) => {
 
 				<NavItem path={ billingHistory } selected={ section === 'billing' }>
 					{ translate( 'Billing History' ) }
+				</NavItem>
+
+				<NavItem path={ paymentMethods } selected={ section === 'payment-methods' }>
+					{ translate( 'Payment Methods' ) }
 				</NavItem>
 
 				<NavItem path={ upcomingCharges } selected={ section === 'upcoming' }>

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -145,7 +145,7 @@ class PurchasesList extends Component {
 		}
 
 		return (
-			<Main className="purchases-list">
+			<Main className="purchases-list is-wide-layout">
 				<QueryUserPurchases userId={ this.props.userId } />
 				<PageViewTracker path="/me/purchases" title="Purchases" />
 				<MeSidebarNavigation />


### PR DESCRIPTION
In #46300, we moved the payment methods from the site-level billing history to its own tab. This PR does the same for the account-level view. It additionally makes all of the account-level purchase screens full-width, to both accommodate the number of items in the nav and match the site-level views. If we need to, we can break the width changes into their own PR @fditrapani.

Fixes: #46324 

<img width="1499" alt="payment-methods" src="https://user-images.githubusercontent.com/942359/96327748-20be6c80-100a-11eb-85a9-f023294cb858.png">

<img width="1499" alt="add-card" src="https://user-images.githubusercontent.com/942359/96327757-2d42c500-100a-11eb-968e-47d8b79bc518.png">

**To test:**
- visit `/me/purchases`
- verify that the different screens in this section are all full-width
- verify that "payment methods" exist as a section nav item
- visit "billing history"
- verify that the payment methods are no longer shown below the billing history table
- visit "payment methods"
- verify that your payment methods are shown
- click "add credit card"
- verify that you're taken to the add credit card screen
- verify that clicking back returns you to the payment methods screen
- verify that you can add a new card
- verify that you're returned to the payment methods screen after adding a new card
- verify that the new card shows up in the payment methods screen
- verify that cards can be deleted from the payment methods screen
