### PR TITLE
Billing: set `async-payments` flag to false in all environments

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -16,7 +16,7 @@
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
 	"readerFollowingSource": "desktop",
 	"features": {
-		"async-payments": true,
+		"async-payments": false,
 		"ad-tracking": true,
 		"always_use_logout_url": true,
 		"automated-transfer": true,

--- a/config/development.json
+++ b/config/development.json
@@ -28,7 +28,7 @@
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"async-payments": true,
+		"async-payments": false,
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"blogger-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -15,7 +15,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"async-payments": true,
+		"async-payments": false,
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"blogger-plan": false,

--- a/config/test.json
+++ b/config/test.json
@@ -25,7 +25,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"async-payments": true,
+		"async-payments": false,
 		"ad-tracking": false,
 		"blogger-plan": false,
 		"calypsoify/plugins": true,


### PR DESCRIPTION
The `aync-payments` flag (i.e. "Pending Payments") is currently set to false in all non-development environments. Since there aren't any enabled async payment methods on the backend, this PR sets the flag to false in development and staging environments, essentially removing "Pending Payments" from the account-level billing management screens. It leaves the flag, route, and components in place in case we need to test, refund, troubleshoot any async payment methods (e.g. Sofort).

Fixes: #46414

**Before:**
<img width="752" alt="Screen Shot 2020-10-17 at 12 09 02 AM" src="https://user-images.githubusercontent.com/942359/96328124-b6a7c680-100d-11eb-9fb9-48c3ef05ad8d.png">

**After:**
<img width="756" alt="Screen Shot 2020-10-17 at 12 08 38 AM" src="https://user-images.githubusercontent.com/942359/96328132-bc051100-100d-11eb-8d5c-9e92f4141b7f.png">

**To test:**
- navigate to _Me > Manage Purchases_
- verify that "Pending Payments" has been removed from the section nav
- try to navigate directly to calypso.localhost:3000/me/purchases/pending
- verify that the route isn't available
- try to navigate directly to calypso.localhost:3000/me/purchases/pending?flags=async-payments
- verify that the route is available with the flag