### PR TITLE
Reader: Remove HTML Tag Stripping and Creating Better Excerpt

### DIFF
--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -11,7 +11,6 @@ import DISPLAY_TYPES from './display-types';
 /**
  * Rules
  */
-import createBetterExcerpt from 'lib/post-normalizer/rule-create-better-excerpt';
 import detectMedia from 'lib/post-normalizer/rule-content-detect-media';
 import detectPolls from 'lib/post-normalizer/rule-content-detect-polls';
 import detectSurveys from 'lib/post-normalizer/rule-content-detect-surveys';
@@ -28,7 +27,6 @@ import makeSiteIdSafeForApi from 'lib/post-normalizer/rule-make-site-id-safe-for
 import pickPrimaryTag from 'lib/post-normalizer/rule-pick-primary-tag';
 import preventWidows from 'lib/post-normalizer/rule-prevent-widows';
 import safeImageProperties from 'lib/post-normalizer/rule-safe-image-properties';
-import stripHtml from 'lib/post-normalizer/rule-strip-html';
 import withContentDom from 'lib/post-normalizer/rule-with-content-dom';
 import keepValidImages from 'lib/post-normalizer/rule-keep-valid-images';
 import waitForImagesToLoad from 'lib/post-normalizer/rule-wait-for-images-to-load';
@@ -99,7 +97,6 @@ export function classifyPost( post ) {
 
 const fastPostNormalizationRules = flow( [
 	decodeEntities,
-	stripHtml,
 	preventWidows,
 	makeSiteIdSafeForApi,
 	pickPrimaryTag,
@@ -118,7 +115,6 @@ const fastPostNormalizationRules = flow( [
 		detectSurveys,
 		linkJetpackCarousels,
 	] ),
-	createBetterExcerpt,
 	pickCanonicalImage,
 	pickCanonicalMedia,
 	classifyPost,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, Button blocks created in a post, and subsequently rendered in the reader renders as text. To enhance the user experience, this change makes it so that the button block is rendered to look like a button, aligning with the styles from the original post.
* Along the way while solving this problem, HTML tags were being stripped, and a "better excerpt" was created out of the actual post content that contained no HTML. Reader content now contains the appropriate HTML tags from a post, so the side-effect of this PR is that it should actually fix other content as well. For example, tables (see below screenshot)

#### Testing instructions

1. Apply this diff D51353-code and ensure you are sandboxed
2. See the"Block Rendering Development" "Testing" section in the README at https://github.com/Automattic/wp-calypso/client/reader/README.md
3. Use the "Follow" button that appears in the bottom right corner of a blog to add it to your Reader subscriptions:
4. Create a post for the blog you're following with a button block, with multiple buttons.
5. Go to https://wordpress.com/read and use the Inspector Tools to view that the buttons contain the same element nesting relationship, classes, and styles as in a post. The actual style and class properties should be addressed once D50508-code lands.

Before | After
--- | ---
<img width="762" alt="Screen Shot 2020-10-17 at 12 30 31 AM" src="https://user-images.githubusercontent.com/66652282/96329019-f9ba6780-1016-11eb-941f-0895242305f2.png"> | <img width="818" alt="Screen Shot 2020-10-17 at 12 21 47 AM" src="https://user-images.githubusercontent.com/66652282/96329023-017a0c00-1017-11eb-9a1c-5771f45b4f35.png">             

Fixes #46293