### PR TITLE
Gutenboarding and nav sidebar use translations from translate.wordpres.org

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.php
@@ -33,6 +33,8 @@ function enqueue_script_and_style() {
 		true
 	);
 
+	wp_set_script_translations( 'a8c-fse-editor-gutenboarding-launch-script', 'full-site-editing' );
+
 	wp_enqueue_style(
 		'a8c-fse-editor-gutenboarding-launch-style',
 		plugins_url( 'dist/editor-gutenboarding-launch.css', __FILE__ ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
@@ -53,6 +53,8 @@ class WPCOM_Block_Editor_Nav_Sidebar {
 			true
 		);
 
+		wp_set_script_translations( 'wpcom-block-editor-nav-sidebar-script', 'full-site-editing' );
+
 		wp_localize_script(
 			'wpcom-block-editor-nav-sidebar-script',
 			'wpcomBlockEditorNavSidebarAssetsUrl',


### PR DESCRIPTION
So turns out we were missing something simple to get the low-hanging fruit of l10n going.

Plugins are supposed to call `wp_set_script_translations` when enqueueing internationised scripts:
https://developer.wordpress.org/apis/handbook/internationalization/#internationalizing-javascript

When you call `wp_set_script_translations` it will (by default) grab the translations from `translate.wordpress.org`, which has already translated the ETK: https://translate.wordpress.org/locale/es/default/wp-plugins/full-site-editing/

I then realised I hadn't included a to `wp_set_script_translations` when enqueueing the editor sidebar either, so I added that too.

If you look at other scripts that are enqueued by ETK they're already doing this. So it was just us that had forgotten :D

#### Changes proposed in this Pull Request

* Call `wp_set_script_translations` after enqueueing gutenboarding JS
* Call `wp_set_script_translations` after enqueueing nav sidebar JS

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch, `yarn dev --sync`, and sandbox and unlaunched gutenboarding site
* Switch user to a non-english langage
* Open a page in the editor
* The "Complete Setup" button in top right of the editor should now be translated
* Some missing sidebar copy should now be translated too e.g. the tooltip for the (W) button is now translated.

