### PR TITLE
bump editing toolkit version to 2.7.2

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.7.1
+ * Version: 2.7.2
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.7.1' );
+define( 'PLUGIN_VERSION', '2.7.2' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.7.1
+Stable tag: 2.7.2
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,8 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+= 2.7.2 =
+* Enable Coming Soon v2 for a12s
 
 = 2.7.1 = 
 * Coming Soon v2: adding links to default page (https://github.com/Automattic/wp-calypso/pull/46441)
@@ -46,7 +48,6 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Fixes Global Styles plugin translation (https://github.com/Automattic/wp-calypso/pull/46421)
 
 = 2.7 =
-* Added coming soon page. (https://github.com/Automattic/wp-calypso/pull/45950)
 * Added launch flow mobile layout (https://github.com/Automattic/wp-calypso/pull/45714).
 * Added vertical space above the first content block when the page title is hidden. (https://github.com/Automattic/wp-calypso/pull/46003)
 * Removed the Premium Content block from the "New" category, and add it to the "Earn" category. (https://github.com/Automattic/wp-calypso/pull/45978)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.7.1",
+	"version": "2.7.2",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
 		"@automattic/webpack-inline-constant-exports-plugin": "^0.0.1",
 		"@automattic/wp-babel-makepot": "^1.0.0",
 		"@automattic/wpcom-block-editor": "^1.0.0-alpha.0",
-		"@automattic/wpcom-editing-toolkit": "^2.7.1",
+		"@automattic/wpcom-editing-toolkit": "^2.7.2",
 		"@babel/cli": "^7.10.5",
 		"@babel/core": "^7.11.1",
 		"@babel/register": "^7.10.5",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This just releases one change which will allow us to activate coming soon v2 for a12s (#46434)

https://github.com/Automattic/wp-calypso/commits/master/apps/editing-toolkit