### PR TITLE
Localise the launch sidebar and final launch step

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
@@ -33,6 +33,8 @@ function enqueue_script_and_style() {
 		true
 	);
 
+	wp_set_script_translations( 'a8c-fse-editor-site-launch-script', 'full-site-editing' );
+
 	wp_enqueue_style(
 		'a8c-fse-editor-site-launch-style',
 		plugins_url( 'dist/editor-site-launch.css', __FILE__ ),


### PR DESCRIPTION
Just like #46552, we were missing something simple to get the low-hanging fruit of l10n going for the launch modal.

Plugins are supposed to call `wp_set_script_translations` when enqueueing internationised scripts:
https://developer.wordpress.org/apis/handbook/internationalization/#internationalizing-javascript

When you call `wp_set_script_translations` it will (by default) grab the translations from `translate.wordpress.org`, which has already translated the ETK: https://translate.wordpress.org/locale/es/default/wp-plugins/full-site-editing/

If you look at other scripts that are enqueued by ETK they're already doing this. So it was just us that had forgotten :D

#### Changes proposed in this Pull Request

* Call `wp_set_script_translations` after enqueueing the launch JS

#### Testing instructions

* Checkout branch, yarn dev --sync, and sandbox an unlaunched gutenboarding site
* Switch user to a non-english langage
* Open a page in the editor
* Click the "Complete Setup" button in the top right of the editor, which should open the modal launch flow (not the one that redirects to another page)
  * The launch sidebar on the right should be translated
  * The final step in the launch flow should be translated

The domain picker and plan picker won't be translated. They come from a shared package that isn't using the `full-site-editing` text domain, which we still need to figure out.