### PR TITLE
Gutenboarding Header: make (W) icon link back to root path  /  

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -67,7 +67,7 @@ const Header: React.FunctionComponent = () => {
 			tabIndex={ -1 }
 		>
 			<section className="gutenboarding__header-section">
-				<div className="gutenboarding__header-section-item">
+				<div className="gutenboarding__header-section-item gutenboarding__header-section-item--wp-logo">
 					<Button href={ 'https://wordpress.com' }>
 						<div className="gutenboarding__header-wp-logo">
 							<Icon icon={ wordpress } size={ 28 } />

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -43,6 +43,8 @@ const Header: React.FunctionComponent = () => {
 	// CreateSite step clears state before redirecting, don't show the default text in this case
 	const siteTitleDefault = 'CreateSite' === currentStep ? '' : __( 'Start your website' );
 
+	const homeLink = '/';
+
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 	const changeLocaleButton = () => {
@@ -68,7 +70,7 @@ const Header: React.FunctionComponent = () => {
 		>
 			<section className="gutenboarding__header-section">
 				<div className="gutenboarding__header-section-item gutenboarding__header-section-item--wp-logo">
-					<Button href={ 'https://wordpress.com' }>
+					<Button href={ homeLink }>
 						<div className="gutenboarding__header-wp-logo">
 							<Icon icon={ wordpress } size={ 28 } />
 						</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import { Icon, wordpress } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -67,9 +68,11 @@ const Header: React.FunctionComponent = () => {
 		>
 			<section className="gutenboarding__header-section">
 				<div className="gutenboarding__header-section-item">
-					<div className="gutenboarding__header-wp-logo">
-						<Icon icon={ wordpress } size={ 28 } />
-					</div>
+					<Button href={ 'https://wordpress.com' }>
+						<div className="gutenboarding__header-wp-logo">
+							<Icon icon={ wordpress } size={ 28 } />
+						</div>
+					</Button>
 				</div>
 				<div className="gutenboarding__header-section-item gutenboarding__header-site-title-section">
 					<div className="gutenboarding__header-site-title">

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -54,6 +54,12 @@ $padding--gutenboarding__header: $grid-unit-10;
 	}
 }
 
+.gutenboarding__header-section-item--wp-logo {
+	.components-button {
+		padding: 0;
+	}
+}
+
 .gutenboarding__header-wp-logo {
 	margin-left: 24px - $padding--gutenboarding__header -
 		$margin-left--gutenboarding__header-section-item; // we want 24px exact on spec: ( 24 - header padding - own margin )


### PR DESCRIPTION
WIP: see CSS issue
https://d.pr/i/XC3MIo

#### Changes proposed in this Pull Request

* In Gutenboarding head Make (W) logo clickable and send user to wordpress.com ("home")

#### Testing instructions

* Go to /new
* Click on (W) in header:
	- in logged-in state check user is routed to thier primary site: e.g.  `/home/myprimarysite.wordpress.com`
   - in logged-out state, user is simply routed back to `/`

Fixes https://github.com/Automattic/wp-calypso/issues/41065
