### PR TITLE
Launch: Add persistent launch flow button in the block editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -63,7 +63,8 @@ function updateEditor() {
 		}
 		clearInterval( awaitSettingsBar );
 
-		const isMobileViewport = window.innerWidth < 782;
+		const BREAK_MEDIUM = 782;
+		const isMobileViewport = window.innerWidth < BREAK_MEDIUM;
 		const isNewLaunchMobile = window?.calypsoifyGutenberg?.isNewLaunchMobile;
 		const isExperimental = window?.calypsoifyGutenberg?.isExperimental;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -55,7 +55,7 @@ function updateEditor() {
 		}
 		clearInterval( awaitSettingsBar );
 
-		const isMobile = window.innerWidth < 782;
+		const isMobileViewport = window.innerWidth < 782;
 		const isNewLaunchMobile = window?.calypsoifyGutenberg?.isNewLaunchMobile;
 		const isExperimental = window?.calypsoifyGutenberg?.isExperimental;
 
@@ -63,7 +63,7 @@ function updateEditor() {
 		const launchHref = window?.calypsoifyGutenberg?.launchUrl as string;
 
 		// On mobile there is not enough space to display "Complete setup" label.
-		const launchLabel = isMobile
+		const launchLabel = isMobileViewport
 			? __( 'Launch', 'full-site-editing' )
 			: __( 'Complete setup', 'full-site-editing' );
 
@@ -77,7 +77,7 @@ function updateEditor() {
 			// Disable href navigation
 			e.preventDefault();
 
-			const shouldOpenNewFlow = ! isMobile || ( isMobile && isNewLaunchMobile );
+			const shouldOpenNewFlow = ! isMobileViewport || ( isMobileViewport && isNewLaunchMobile );
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click', {
 				is_new_flow: shouldOpenNewFlow,

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -18,7 +18,7 @@ import './index.scss';
 
 interface CalypsoifyWindow extends Window {
 	calypsoifyGutenberg?: {
-		frankenflowUrl?: string;
+		launchUrl?: string;
 		isGutenboarding?: boolean;
 		[ key: string ]: unknown;
 	};
@@ -36,7 +36,7 @@ function updateEditor() {
 	if (
 		handled ||
 		! window?.calypsoifyGutenberg?.isGutenboarding ||
-		! window?.calypsoifyGutenberg?.frankenflowUrl
+		! window?.calypsoifyGutenberg?.launchUrl
 	) {
 		return;
 	}
@@ -55,7 +55,7 @@ function updateEditor() {
 		const isExperimental = window?.calypsoifyGutenberg?.isExperimental;
 
 		// Assert reason: We have an early return above with optional and falsy values. This should be a string.
-		const launchHref = window?.calypsoifyGutenberg?.frankenflowUrl as string;
+		const launchHref = window?.calypsoifyGutenberg?.launchUrl as string;
 
 		// On mobile there is not enough space to display "Complete setup" label.
 		const launchLabel = isMobile
@@ -104,7 +104,7 @@ function updateEditor() {
 		// leaving it in there until we can decide on the UX for this component
 		//saveButton && ( saveButton.innerText = __( 'Save' ) );
 
-		// Wrap 'Launch' button link to frankenflow.
+		// Wrap 'Launch' button link to control launch flow.
 		const launchLink = document.createElement( 'a' );
 
 		launchLink.href = launchHref;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -20,6 +20,7 @@ interface CalypsoifyWindow extends Window {
 	calypsoifyGutenberg?: {
 		launchUrl?: string;
 		isGutenboarding?: boolean;
+		isSiteUnlaunched?: boolean;
 		[ key: string ]: unknown;
 	};
 }
@@ -36,6 +37,7 @@ function updateEditor() {
 	if (
 		handled ||
 		! window?.calypsoifyGutenberg?.isGutenboarding ||
+		! window?.calypsoifyGutenberg?.isSiteUnlaunched ||
 		! window?.calypsoifyGutenberg?.launchUrl
 	) {
 		return;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -71,11 +71,6 @@ function updateEditor() {
 		// Assert reason: We have an early return above with optional and falsy values. This should be a string.
 		const launchHref = window?.calypsoifyGutenberg?.launchUrl as string;
 
-		// On mobile there is not enough space to display "Complete setup" label.
-		const launchLabel = isMobileViewport
-			? __( 'Launch', 'full-site-editing' )
-			: __( 'Complete setup', 'full-site-editing' );
-
 		const saveAndNavigate = async () => {
 			await dispatch( 'core/editor' ).savePost();
 			// Using window.top to escape from the editor iframe on WordPress.com
@@ -138,7 +133,7 @@ function updateEditor() {
 		launchLink.target = '_top';
 		launchLink.className = 'editor-gutenberg-launch__launch-button components-button is-primary';
 
-		const textContent = document.createTextNode( launchLabel );
+		const textContent = document.createTextNode( __( 'Launch', 'full-site-editing' ) );
 		launchLink.appendChild( textContent );
 
 		launchLink.addEventListener( 'click', handleLaunch );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -117,6 +117,10 @@ function updateEditor() {
 		};
 
 		const body = document.querySelector( 'body' );
+		if ( ! body ) {
+			return;
+		}
+
 		body.classList.add( 'editor-gutenberg-launch__fse-overrides' );
 
 		// 'Update'/'Publish' primary button to become 'Save' tertiary button.

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -96,7 +96,8 @@ function updateEditor() {
 				isGutenboarding && ( ! isMobileViewport || ( isMobileViewport && isNewLaunchMobile ) );
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click', {
-				is_new_flow: shouldOpenNewFlow,
+				// TODO: 'is_new_flow' flag — is it still relevant?
+				is_new_flow: shouldOpenNewFlowModal,
 				is_experimental: isExperimental,
 			} );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -21,6 +21,9 @@ interface CalypsoifyWindow extends Window {
 		launchUrl?: string;
 		isGutenboarding?: boolean;
 		isSiteUnlaunched?: boolean;
+		isNewLaunchMobile?: boolean;
+		isExperimental?: boolean;
+		isPersistentLaunchButton?: boolean;
 		[ key: string ]: unknown;
 	};
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -92,7 +92,6 @@ function updateEditor() {
 				isGutenboarding && ( ! isMobileViewport || ( isMobileViewport && isNewLaunchMobile ) );
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click', {
-				// TODO: 'is_new_flow' flag — is it still relevant?
 				is_new_flow: shouldOpenNewFlowModal,
 				is_experimental: isExperimental,
 			} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8
+ * Version: 2.8.1
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8' );
+define( 'PLUGIN_VERSION', '2.8.1' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8
+Stable tag: 2.8.1
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.1 = 
+* Launch: Added persistent launch button. (https://github.com/Automattic/wp-calypso/pull/46558)
+
 = 2.8 =
 * Editing Toolkit: Load patterns from the rest API endpoint v3 (https://github.com/Automattic/wp-calypso/pull/46463)
 * Contextual-tips: remove /block-editor from URL (https://github.com/Automattic/wp-calypso/pull/46592)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.0",
+	"version": "2.8.1",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -756,12 +756,14 @@ function getGutenboardingStatus( calypsoPort ) {
 	port1.onmessage = ( { data } ) => {
 		const {
 			isGutenboarding,
+			isSiteUnlaunched,
 			launchUrl,
 			isNewLaunchMobile,
 			isExperimental,
 			isPersistentLaunchButton,
 		} = data;
 		calypsoifyGutenberg.isGutenboarding = isGutenboarding;
+		calypsoifyGutenberg.isSiteUnlaunched = isSiteUnlaunched;
 		calypsoifyGutenberg.launchUrl = launchUrl;
 		calypsoifyGutenberg.isNewLaunchMobile = isNewLaunchMobile;
 		calypsoifyGutenberg.isExperimental = isExperimental;

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -756,13 +756,13 @@ function getGutenboardingStatus( calypsoPort ) {
 	port1.onmessage = ( { data } ) => {
 		const {
 			isGutenboarding,
-			frankenflowUrl,
+			launchUrl,
 			isNewLaunchMobile,
 			isExperimental,
 			isPersistentLaunchButton,
 		} = data;
 		calypsoifyGutenberg.isGutenboarding = isGutenboarding;
-		calypsoifyGutenberg.frankenflowUrl = frankenflowUrl;
+		calypsoifyGutenberg.launchUrl = launchUrl;
 		calypsoifyGutenberg.isNewLaunchMobile = isNewLaunchMobile;
 		calypsoifyGutenberg.isExperimental = isExperimental;
 		calypsoifyGutenberg.isPersistentLaunchButton = isPersistentLaunchButton;

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -369,8 +369,8 @@ class CalypsoifyIframe extends Component<
 		}
 
 		if ( EditorActions.GetGutenboardingStatus === action ) {
-			const isGutenboarding =
-				this.props.siteCreationFlow === 'gutenboarding' && this.props.isSiteUnlaunched;
+			const isGutenboarding = this.props.siteCreationFlow === 'gutenboarding';
+			const isSiteUnlaunched = this.props.isSiteUnlaunched;
 			const launchUrl = `${ window.location.origin }/start/launch-site?siteSlug=${ this.props.siteSlug }`;
 			const isNewLaunchMobile = config.isEnabled( 'gutenboarding/new-launch-mobile' );
 			const isExperimental = config.isEnabled( 'gutenboarding/feature-picker' );
@@ -378,6 +378,7 @@ class CalypsoifyIframe extends Component<
 
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
+				isSiteUnlaunched,
 				launchUrl,
 				isNewLaunchMobile,
 				isExperimental,

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -371,14 +371,14 @@ class CalypsoifyIframe extends Component<
 		if ( EditorActions.GetGutenboardingStatus === action ) {
 			const isGutenboarding =
 				this.props.siteCreationFlow === 'gutenboarding' && this.props.isSiteUnlaunched;
-			const frankenflowUrl = `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteSlug }&source=editor`;
+			const launchUrl = `${ window.location.origin }/start/launch-site?siteSlug=${ this.props.siteSlug }`;
 			const isNewLaunchMobile = config.isEnabled( 'gutenboarding/new-launch-mobile' );
 			const isExperimental = config.isEnabled( 'gutenboarding/feature-picker' );
 			const isPersistentLaunchButton = config.isEnabled( 'gutenboarding/persistent-launch-button' );
 
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
-				frankenflowUrl,
+				launchUrl,
 				isNewLaunchMobile,
 				isExperimental,
 				isPersistentLaunchButton,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -52,6 +52,7 @@
 		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
+		"gutenboarding/persistent-launch-button": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
## Changes proposed in this Pull Request

- Adds persistent launch button (as spec'd in pbAok1-1y7-p2 and p9Jlb4-1SN-p2)
- All un-launched sites should now see this button — when clicked, users will be taken to one of two possible launch flows:
   - "Complete setup" if the site was created through Gutenboarding (this flow opens a modal on top of the editor)
   - "Control launch flow" otherwise (this flow redirects the user to a new page)


Related phab patches:
- FSE plugin: D51379-code
- WBE widget: D51381-code



## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply FSE and WBE phab patches to the sandbox (see above for phab patches links)

2. **First flow: a site created via the _control_ flow should display the launch button behind a flag**
   * Create a new site via `/start`
   * Add the newly created site to the sandbox
   * Edit homepage in the calypso block editor — persistent launch button should not appear
   * Add the query param `flags=gutenboarding/persistent-launch-button` to the URL, refresh the editor page
   * "Launch" button should appear
   * Clicking on the launch button should redirect to `/start/launch-site`

3. **Second flow: a site created with the _gutenboarding_ flow should always display the launch button**
   * Create a new site via `/new`
   * Add the newly created site to the sandbox
   * Resize the viewport to a desktop size
   * Edit homepage in the calypso block editor
   * "Launch" button should appear
   * Clicking on the launch button should open the new launch flow in a modal (without redirect)