### PR TITLE
G Suite: Enable password fields for G Suite users

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -9,7 +9,6 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import config from 'calypso/config';
 import GSuiteDomainsSelect from './domains-select';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
@@ -169,27 +168,25 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 						{ hasMailBoxError && <FormInputValidation text={ mailBoxError } isError /> }
 					</div>
 
-					{ config.isEnabled( 'gsuite/passwords' ) && (
-						<div className="gsuite-new-user-list__new-user-password-container">
-							<FormPasswordInput
-								autoCapitalize="off"
-								autoCorrect="off"
-								placeholder={ translate( 'Password' ) }
-								value={ password }
-								maxLength={ 100 }
-								isError={ hasPasswordError }
-								onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
-									onUserValueChange( 'password', event.target.value );
-								} }
-								onBlur={ () => {
-									setPasswordFieldTouched( wasValidated );
-								} }
-								onKeyUp={ onReturnKeyPress }
-							/>
+					<div className="gsuite-new-user-list__new-user-password-container">
+						<FormPasswordInput
+							autoCapitalize="off"
+							autoCorrect="off"
+							placeholder={ translate( 'Password' ) }
+							value={ password }
+							maxLength={ 100 }
+							isError={ hasPasswordError }
+							onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
+								onUserValueChange( 'password', event.target.value );
+							} }
+							onBlur={ () => {
+								setPasswordFieldTouched( wasValidated );
+							} }
+							onKeyUp={ onReturnKeyPress }
+						/>
 
-							{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
-						</div>
-					) }
+						{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
+					</div>
 				</div>
 			</FormFieldset>
 		</div>

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import config from 'calypso/config';
 import emailValidator from 'email-validator';
 import { translate, TranslateResult } from 'i18n-calypso';
 import { countBy, find, includes, groupBy, map, mapValues } from 'lodash';
@@ -44,7 +43,6 @@ export interface GSuiteProductUser {
 const getFields = ( user: GSuiteNewUser ): GSuiteNewUserField[] =>
 	Object.keys( user )
 		.filter( ( key ) => 'uuid' !== key )
-		.filter( ( key ) => config.isEnabled( 'gsuite/passwords' ) || 'password' !== key )
 		.map( ( key ) => user[ key ] );
 
 /**
@@ -56,10 +54,6 @@ const getFields = ( user: GSuiteNewUser ): GSuiteNewUserField[] =>
 const mapFieldValues = ( user: GSuiteNewUser, callback ): GSuiteNewUser =>
 	mapValues( user, ( fieldValue, fieldName ) => {
 		if ( 'uuid' === fieldName ) {
-			return fieldValue;
-		}
-
-		if ( 'password' === fieldName && ! config.isEnabled( 'gsuite/passwords' ) ) {
 			return fieldValue;
 		}
 
@@ -225,6 +219,7 @@ const validatePasswordField = ( { value, error }: GSuiteNewUserField ): GSuiteNe
 			value,
 			error: translate( "This field can't accept '%s' as character.", {
 				args: firstForbiddenCharacter,
+				comment: '%s denotes a single character that is not allowed in this field',
 			} ),
 		};
 	}
@@ -253,7 +248,7 @@ const validateUser = ( user: GSuiteNewUser ): GSuiteNewUser => {
 		mailBox: validateOverallEmail( validEmailCharacterField( mailBox ), domain ),
 		firstName: sixtyCharacterField( firstName ),
 		lastName: sixtyCharacterField( lastName ),
-		password: config.isEnabled( 'gsuite/passwords' ) ? validatePasswordField( password ) : password,
+		password: validatePasswordField( password ),
 	};
 };
 


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/46204 which enables the `Password` input field on the `Add G Suite` page.

#### Testing instructions

1. Run `git checkout enable/gsuite-passwords` and start your server, or open a [live branch](https://calypso.live/?branch=enable/gsuite-passwords)
2. Open the [`Email` page](http://calypso.localhost:3000/email)
3. Proceed to the `Add G Suite` page
4. Assert that a `Password` field is displayed for every G Suite user
5. Purchase G Suite
6. Assert that you are able to log into the accounts of the G Suite users