### PR TITLE
Root redirect: ensure that the primary site info is fetched before making decisions

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -6,12 +6,12 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import userFactory from 'lib/user';
-import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
-import getPrimarySiteId from 'state/selectors/get-primary-site-id';
-import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import config from 'calypso/config';
+import userFactory from 'calypso/lib/user';
+import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 
 export default function () {
 	const user = userFactory();

--- a/client/root.js
+++ b/client/root.js
@@ -8,10 +8,9 @@ import page from 'page';
  */
 import config from 'calypso/config';
 import userFactory from 'calypso/lib/user';
-import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
+import { requestSite } from 'calypso/state/sites/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { canCurrentUserUseCustomerHome, getSite, getSiteSlug } from 'calypso/state/sites/selectors';
 
 export default function () {
 	const user = userFactory();
@@ -45,15 +44,40 @@ function setupLoggedOut() {
 	}
 }
 
-function setupLoggedIn() {
-	page( '/', ( context ) => {
-		const state = context.store.getState();
-		const primarySiteId = getPrimarySiteId( state );
-		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, primarySiteId );
-		const siteSlug = getSiteSlug( state, primarySiteId );
-		let redirectPath = siteSlug && isCustomerHomeEnabled ? `/home/${ siteSlug }` : '/read';
+// Helper thunk that ensures that the requested site info is fetched into Redux state before we
+// continue working with it.
+// The `siteSelection` handler in `my-sites/controller` contains similar code.
+const waitForSite = ( siteId ) => async ( dispatch, getState ) => {
+	if ( getSite( getState(), siteId ) ) {
+		return;
+	}
 
-		if ( isJetpackSite( state, primarySiteId ) && ! isAtomicSite( state, primarySiteId ) ) {
+	try {
+		await dispatch( requestSite( siteId ) );
+	} catch {
+		// if the fetching of site info fails, return gracefully and proceed to redirect to Reader
+	}
+};
+
+function setupLoggedIn() {
+	page( '/', async ( context ) => {
+		// determine the primary site ID (it's a property of "current user" object) and then
+		// ensure that the primary site info is loaded into Redux before proceeding.
+		const primarySiteId = getPrimarySiteId( context.store.getState() );
+		await context.store.dispatch( waitForSite( primarySiteId ) );
+
+		const state = context.store.getState();
+		const siteSlug = getSiteSlug( state, primarySiteId );
+		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, primarySiteId );
+
+		let redirectPath;
+
+		if ( ! siteSlug ) {
+			// there is no primary site or the site info couldn't be fetched. Redirect to Reader.
+			redirectPath = '/read';
+		} else if ( isCustomerHomeEnabled ) {
+			redirectPath = `/home/${ siteSlug }`;
+		} else {
 			redirectPath = `/stats/${ siteSlug }`;
 		}
 


### PR DESCRIPTION
In the `page( '/' )` handler that decides where to redirect -- to Reader, Customer Home or Stats --- we need to ensure that the primary site info has been fetched and stored in Redux. Otherwise, the redirect is unreliable. It can redirect to Reader (thinking there is no primary site) even if it should really redirect to Home or Stats.

The redirect works reliably only when the site info was stored previously into IndexedDB by a previous session. In a clean session, it's buggy.

This patch also removes the check whether the site is Jetpack/Atomic. That check is already done by the `canCurrentUserUseCustomerHome` selector. It also checks for VIP sites and manage permission of the current user.

**How to test:**
With a clean local storage and IndexedDB, navigate to `/`. Before this patch, you would always be redirected to Reader. After this patch, you'll be redirected to `/home/your.site` or `/stats/your.site`, depending on whether your primary site is Jetpack etc.
