### PR TITLE
State: Do not mutate likes reducer when state is the same

### DIFF
--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -76,11 +76,6 @@ export const itemReducer = withSchemaValidation(
 				const { likeCount, liker } = action;
 				const hasLiker = some( state.likes, ( like ) => like.ID === liker.ID );
 
-				if ( state.likeCount === likeCount && hasLiker ) {
-					// if the like count matches and we already have this liker, bail
-					return state;
-				}
-
 				let likes = state.likes;
 				if ( ! hasLiker ) {
 					likes = [ liker, ...( state.likes || [] ) ];
@@ -96,11 +91,6 @@ export const itemReducer = withSchemaValidation(
 			case POST_LIKES_REMOVE_LIKER: {
 				const { likeCount, liker } = action;
 				const hasLiker = some( state.likes, ( like ) => like.ID === liker.ID );
-
-				if ( state.likeCount === likeCount && ! hasLiker ) {
-					// if the like count matches and we don't have this liker, bail
-					return state;
-				}
 
 				let likes = state.likes;
 				if ( hasLiker ) {

--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -76,6 +76,11 @@ export const itemReducer = withSchemaValidation(
 				const { likeCount, liker } = action;
 				const hasLiker = some( state.likes, ( like ) => like.ID === liker.ID );
 
+				if ( state.found === likeCount && hasLiker ) {
+					// if the like count matches and we already have this liker, bail
+					return state;
+				}
+
 				let likes = state.likes;
 				if ( ! hasLiker ) {
 					likes = [ liker, ...( state.likes || [] ) ];
@@ -91,6 +96,11 @@ export const itemReducer = withSchemaValidation(
 			case POST_LIKES_REMOVE_LIKER: {
 				const { likeCount, liker } = action;
 				const hasLiker = some( state.likes, ( like ) => like.ID === liker.ID );
+
+				if ( state.found === likeCount && ! hasLiker ) {
+					// if the like count matches and we don't have this liker, bail
+					return state;
+				}
 
 				let likes = state.likes;
 				if ( hasLiker ) {

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -426,6 +426,21 @@ describe( 'reducer', () => {
 				} );
 				expect( state.likes ).toBe( initialState.likes );
 			} );
+
+			test( 'should return previous state if liker is already present and like count is the same', () => {
+				const initialState = deepFreeze( {
+					likes: [ { ID: 2 }, liker ],
+					found: 5,
+					iLike: false,
+				} );
+				const state = itemReducer(
+					initialState,
+					// same liker, same count!
+					addLiker( 1, 1, 5, liker )
+				);
+
+				expect( state ).toEqual( initialState );
+			} );
 		} );
 
 		describe( 'a POST_LIKES_REMOVE_LIKER action', () => {
@@ -493,6 +508,22 @@ describe( 'reducer', () => {
 					iLike: false,
 				} );
 				expect( state.likes ).toBe( initialState.likes );
+			} );
+
+			test( 'should return previous state if liker is not present and like count is the same', () => {
+				const initialState = deepFreeze( {
+					likes: [ { ID: 2 } ],
+					found: 5,
+					iLike: false,
+					lastUpdated: undefined,
+				} );
+				const state = itemReducer(
+					initialState,
+					// same liker, same count!
+					removeLiker( 1, 1, 5, liker )
+				);
+
+				expect( state ).toEqual( initialState );
 			} );
 		} );
 	} );

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -439,7 +439,7 @@ describe( 'reducer', () => {
 					addLiker( 1, 1, 5, liker )
 				);
 
-				expect( state ).toEqual( initialState );
+				expect( state ).toBe( initialState );
 			} );
 		} );
 
@@ -523,7 +523,7 @@ describe( 'reducer', () => {
 					removeLiker( 1, 1, 5, liker )
 				);
 
-				expect( state ).toEqual( initialState );
+				expect( state ).toBe( initialState );
 			} );
 		} );
 	} );


### PR DESCRIPTION
This PR fixes the post likes reducer to not mutate state in the instance where we're adding a like or removing one, and the likes count is the same. Previously, we were creating a new instance with the same state, which would result in unnecessary re-renders.

This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/46526#discussion_r506894235, cc @jsnajdr

I've added some tests to verify the new behavior is working correctly.

#### Changes proposed in this Pull Request

* Add posts reducer tests for adding and removing a liker. 

#### Testing instructions

* Verify liking and unliking a post works the same way as it did before.
* Verify tests pass.
