### PR TITLE
Root redirect: check the logged in/out state when handling the / route, not when installing it

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -7,40 +7,35 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'calypso/config';
-import userFactory from 'calypso/lib/user';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { requestSite } from 'calypso/state/sites/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { canCurrentUserUseCustomerHome, getSite, getSiteSlug } from 'calypso/state/sites/selectors';
 
 export default function () {
-	const user = userFactory();
-	const isLoggedOut = ! user.get();
-	if ( isLoggedOut ) {
-		setupLoggedOut();
-	} else {
-		setupLoggedIn();
-	}
+	page( '/', ( context ) => {
+		const isLoggedIn = isUserLoggedIn( context.store.getState() );
+		if ( isLoggedIn ) {
+			handleLoggedIn( context );
+		} else {
+			handleLoggedOut( context );
+		}
+	} );
 }
 
-function setupLoggedOut() {
+function handleLoggedOut() {
 	if ( config.isEnabled( 'desktop' ) ) {
-		page( '/', () => {
-			if ( config.isEnabled( 'oauth' ) ) {
-				page.redirect( '/oauth-login' );
-			} else {
-				page.redirect( '/log-in' );
-			}
-		} );
+		if ( config.isEnabled( 'oauth' ) ) {
+			page.redirect( '/oauth-login' );
+		} else {
+			page.redirect( '/log-in' );
+		}
 	} else if ( config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) ) {
-		page( '/', () => {
-			page.redirect( '/devdocs/start' );
-		} );
+		page.redirect( '/devdocs/start' );
 	} else if ( config.isEnabled( 'jetpack-cloud' ) ) {
-		page( '/', () => {
-			if ( config.isEnabled( 'oauth' ) ) {
-				page.redirect( '/connect' );
-			}
-		} );
+		if ( config.isEnabled( 'oauth' ) ) {
+			page.redirect( '/connect' );
+		}
 	}
 }
 
@@ -59,32 +54,30 @@ const waitForSite = ( siteId ) => async ( dispatch, getState ) => {
 	}
 };
 
-function setupLoggedIn() {
-	page( '/', async ( context ) => {
-		// determine the primary site ID (it's a property of "current user" object) and then
-		// ensure that the primary site info is loaded into Redux before proceeding.
-		const primarySiteId = getPrimarySiteId( context.store.getState() );
-		await context.store.dispatch( waitForSite( primarySiteId ) );
+async function handleLoggedIn( context ) {
+	// determine the primary site ID (it's a property of "current user" object) and then
+	// ensure that the primary site info is loaded into Redux before proceeding.
+	const primarySiteId = getPrimarySiteId( context.store.getState() );
+	await context.store.dispatch( waitForSite( primarySiteId ) );
 
-		const state = context.store.getState();
-		const siteSlug = getSiteSlug( state, primarySiteId );
-		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, primarySiteId );
+	const state = context.store.getState();
+	const siteSlug = getSiteSlug( state, primarySiteId );
+	const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, primarySiteId );
 
-		let redirectPath;
+	let redirectPath;
 
-		if ( ! siteSlug ) {
-			// there is no primary site or the site info couldn't be fetched. Redirect to Reader.
-			redirectPath = '/read';
-		} else if ( isCustomerHomeEnabled ) {
-			redirectPath = `/home/${ siteSlug }`;
-		} else {
-			redirectPath = `/stats/${ siteSlug }`;
-		}
+	if ( ! siteSlug ) {
+		// there is no primary site or the site info couldn't be fetched. Redirect to Reader.
+		redirectPath = '/read';
+	} else if ( isCustomerHomeEnabled ) {
+		redirectPath = `/home/${ siteSlug }`;
+	} else {
+		redirectPath = `/stats/${ siteSlug }`;
+	}
 
-		if ( context.querystring ) {
-			redirectPath += `?${ context.querystring }`;
-		}
+	if ( context.querystring ) {
+		redirectPath += `?${ context.querystring }`;
+	}
 
-		page.redirect( redirectPath );
-	} );
+	page.redirect( redirectPath );
 }

--- a/client/root.js
+++ b/client/root.js
@@ -26,7 +26,7 @@ export default function () {
 function handleLoggedOut() {
 	if ( config.isEnabled( 'desktop' ) ) {
 		if ( config.isEnabled( 'oauth' ) ) {
-			page.redirect( '/oauth-login' );
+			page.redirect( config( 'login_url' ) );
 		} else {
 			page.redirect( '/log-in' );
 		}

--- a/client/root.js
+++ b/client/root.js
@@ -8,10 +8,9 @@ import page from 'page';
  */
 import config from 'calypso/config';
 import userFactory from 'calypso/lib/user';
-import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
+import { requestSite } from 'calypso/state/sites/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { canCurrentUserUseCustomerHome, getSite, getSiteSlug } from 'calypso/state/sites/selectors';
 
 export default function () {
 	const user = userFactory();
@@ -45,15 +44,40 @@ function setupLoggedOut() {
 	}
 }
 
-function setupLoggedIn() {
-	page( '/', ( context ) => {
-		const state = context.store.getState();
-		const primarySiteId = getPrimarySiteId( state );
-		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, primarySiteId );
-		const siteSlug = getSiteSlug( state, primarySiteId );
-		let redirectPath = siteSlug && isCustomerHomeEnabled ? `/home/${ siteSlug }` : '/read';
+// Helper thunk that ensures that the requested site info is fetched into Redux state before we
+// continue working with it.
+// The `siteSelection` handler in `my-sites/controller` contains similar code.
+const waitForSite = ( siteId ) => async ( dispatch, getState ) => {
+	if ( getSite( getState(), siteId ) ) {
+		return;
+	}
 
-		if ( isJetpackSite( state, primarySiteId ) && ! isAtomicSite( state, primarySiteId ) ) {
+	try {
+		await dispatch( requestSite( siteId ) );
+	} catch {
+		// if the fetching of site info fails, return gracefully and proceed to redirect to Reader
+	}
+};
+
+function setupLoggedIn() {
+	page( '/', async ( context ) => {
+		// determine the primary site ID (it's a property of "current user" object) and then
+		// ensure that the primary site info is loaded into Redux before proceeding.
+		const primarySiteId = getPrimarySiteId( context.store.getState() );
+		await context.store.dispatch( waitForSite( primarySiteId ) );
+
+		const state = context.store.getState();
+		const siteSlug = getSiteSlug( state, primarySiteId );
+		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, primarySiteId );
+
+		let redirectPath;
+
+		if ( ! siteSlug ) {
+			// there is no primary site or the site info couldn't be fetched. Redirect to Reader.
+			redirectPath = '/read';
+		} else if ( isCustomerHomeEnabled ) {
+			redirectPath = `/home/${ siteSlug }`;
+		} else {
 			redirectPath = `/stats/${ siteSlug }`;
 		}
 

--- a/desktop/e2e/tests/e2e.js
+++ b/desktop/e2e/tests/e2e.js
@@ -6,7 +6,7 @@ const chrome = require( 'selenium-webdriver/chrome' );
 const LoginPage = require( './lib/pages/login-page' );
 const NavBarComponent = require( './lib/components/nav-bar-component' );
 const ProfilePage = require( './lib/pages/profile-page' );
-const ReaderPage = require( './lib/pages/reader-page' );
+const CustomerHomePage = require( './lib/pages/customer-home-page' );
 const PostPreviewComponent = require( './lib/components/post-preview-component' );
 const GutenbergEditorComponent = require( './lib/components/gutenberg-editor-component' );
 
@@ -50,8 +50,8 @@ describe( 'User Can log in', function () {
 		return await loginPage.login( process.env.E2EGUTENBERGUSER, process.env.E2EPASSWORD );
 	} );
 
-	step( 'Can see Reader Page after logging in', async function () {
-		await ReaderPage.Expect( driver );
+	step( 'Can see Customer Home Page after logging in', async function () {
+		await CustomerHomePage.Expect( driver );
 		return ( loggedInUrl = await driver.getCurrentUrl() );
 	} );
 } );
@@ -108,7 +108,7 @@ describe( 'Publish a New Post', function () {
 		);
 	} );
 
-	step( 'Can return to reader', async function () {
+	step( 'Can return to customer home', async function () {
 		return await driver.get( loggedInUrl );
 	} );
 } );

--- a/desktop/e2e/tests/lib/pages/customer-home-page.js
+++ b/desktop/e2e/tests/lib/pages/customer-home-page.js
@@ -1,0 +1,10 @@
+const { By } = require( 'selenium-webdriver' );
+const AsyncBaseContainer = require( '../async-base-container' );
+
+class CustomerHomePage extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.is-section-home' ) );
+	}
+}
+
+module.exports = CustomerHomePage;


### PR DESCRIPTION
Should fix `wp-desktop` test failures that are related to login and logout.

If the user was logged in at the time when the `/` route handler was installed, then the `/` route won't be handled well right after the user logs out. And vice versa during the logged-out to logged-in transition.

The fix moves the logged in/out check inside the route handler, to be executed every time.

The Desktop app doesn't reboot/reload during these transitions, unlike the Web app, that's why the transitions fail.

Fixes a `wp-desktop` regression introduced in #46561.
