### PR TITLE
Extensions: Remove invokeMap usage from WCS order fulfilment

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/unverified.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/unverified.js
@@ -5,14 +5,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import url from 'url';
-import { invokeMap } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
-import FormButton from 'components/forms/form-button';
-import Notice from 'components/notice';
+import ExternalLink from 'calypso/components/external-link';
+import FormButton from 'calypso/components/forms/form-button';
+import Notice from 'calypso/components/notice';
 import AddressSummary from './summary';
 import { ACCEPTED_USPS_ORIGIN_COUNTRIES } from 'woocommerce/woocommerce-services/state/shipping-label/constants';
 
@@ -79,10 +78,13 @@ const UnverifiedAddress = ( {
 		  } )
 		: null;
 
-	const googleMapsAddressString = invokeMap(
-		[ values.address + ' ' + values.address_2, values.city, values.state + ' ' + values.postcode ],
-		'trim'
-	).join( ', ' );
+	const googleMapsAddressString = [
+		values.address + ' ' + values.address_2,
+		values.city,
+		values.state + ' ' + values.postcode,
+	]
+		.map( ( addressLine ) => addressLine.trim() )
+		.join( ', ' );
 
 	const googleMapsUrlProperties = {
 		scheme: 'https',


### PR DESCRIPTION
We'll likely all agree that we're using `lodash` far more than we should. Especially, there are cases that can completely be replaced with their native alternatives. One of them is `_.invokeMap()` - it can often be replaced with `.map()` without any additional cost. 

This PR removes the only usage of `invokeMap`.

By removing `invokeMap` lodash usage it will also be removed from all the relevant chunks, making them slightly smaller. Going further with this approach, we might be able to completely remove lodash one day!

#### Changes proposed in this Pull Request

* Remove lodash `invokeMap` in favor of `Array.prototype.map`

#### Testing instructions

* Open a site with WooCommerce and WooCommerce Services (AKA WooCommerce Shipping & Tax) installed, and United States selected as the store country.
* Make sure shipping labels are enabled and configured.
* Make an order.
* Go to the Orders and start fulfilling the order.
* In the "Create shipping labels" modal, input a wrong address that can't be auto verified.
* Try the link to Google Maps and verify it still works the same way as it did before.

cc @timmyc and @c-shultz as I assume they have the best context to test this change.
