### PR TITLE
Revert "Root redirect: ensure that the primary site info is fetched before making decisions"

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -6,11 +6,12 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'calypso/config';
-import userFactory from 'calypso/lib/user';
-import { requestSite } from 'calypso/state/sites/actions';
-import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-import { canCurrentUserUseCustomerHome, getSite, getSiteSlug } from 'calypso/state/sites/selectors';
+import config from 'config';
+import userFactory from 'lib/user';
+import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
+import getPrimarySiteId from 'state/selectors/get-primary-site-id';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 
 export default function () {
 	const user = userFactory();
@@ -44,40 +45,15 @@ function setupLoggedOut() {
 	}
 }
 
-// Helper thunk that ensures that the requested site info is fetched into Redux state before we
-// continue working with it.
-// The `siteSelection` handler in `my-sites/controller` contains similar code.
-const waitForSite = ( siteId ) => async ( dispatch, getState ) => {
-	if ( getSite( getState(), siteId ) ) {
-		return;
-	}
-
-	try {
-		await dispatch( requestSite( siteId ) );
-	} catch {
-		// if the fetching of site info fails, return gracefully and proceed to redirect to Reader
-	}
-};
-
 function setupLoggedIn() {
-	page( '/', async ( context ) => {
-		// determine the primary site ID (it's a property of "current user" object) and then
-		// ensure that the primary site info is loaded into Redux before proceeding.
-		const primarySiteId = getPrimarySiteId( context.store.getState() );
-		await context.store.dispatch( waitForSite( primarySiteId ) );
-
+	page( '/', ( context ) => {
 		const state = context.store.getState();
-		const siteSlug = getSiteSlug( state, primarySiteId );
+		const primarySiteId = getPrimarySiteId( state );
 		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, primarySiteId );
+		const siteSlug = getSiteSlug( state, primarySiteId );
+		let redirectPath = siteSlug && isCustomerHomeEnabled ? `/home/${ siteSlug }` : '/read';
 
-		let redirectPath;
-
-		if ( ! siteSlug ) {
-			// there is no primary site or the site info couldn't be fetched. Redirect to Reader.
-			redirectPath = '/read';
-		} else if ( isCustomerHomeEnabled ) {
-			redirectPath = `/home/${ siteSlug }`;
-		} else {
+		if ( isJetpackSite( state, primarySiteId ) && ! isAtomicSite( state, primarySiteId ) ) {
 			redirectPath = `/stats/${ siteSlug }`;
 		}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#46561 because it broke `wp-desktop` e2e tests and my attempt at fix in #46567 doesn't work.