### PR TITLE
fix(media-library): add 'source' to media library list key

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -359,7 +359,7 @@ export class MediaLibraryContent extends React.Component {
 		}
 
 		const listKey = [
-			'list-',
+			'list',
 			this.props.site.ID,
 			this.props.search,
 			this.props.filter,

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -358,6 +358,14 @@ export class MediaLibraryContent extends React.Component {
 			return this.renderConnectExternalMedia();
 		}
 
+		const listKey = [
+			'list-',
+			this.props.site.ID,
+			this.props.search,
+			this.props.filter,
+			this.props.source,
+		].join( '-' );
+
 		return (
 			<MediaListData
 				siteId={ this.props.site.ID }
@@ -367,7 +375,7 @@ export class MediaLibraryContent extends React.Component {
 				source={ this.props.source }
 			>
 				<MediaLibraryList
-					key={ 'list-' + [ this.props.site.ID, this.props.search, this.props.filter ].join() }
+					key={ listKey }
 					site={ this.props.site }
 					filter={ this.props.filter }
 					filterRequiresUpgrade={ this.props.filterRequiresUpgrade }

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -12,33 +12,33 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import { gaRecordEvent } from 'lib/analytics/ga';
-import getMediaLibrarySelectedItems from 'state/selectors/get-media-library-selected-items';
-import TrackComponentView from 'lib/analytics/track-component-view';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import MediaListData from 'components/data/media-list-data';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import MediaListData from 'calypso/components/data/media-list-data';
 import {
 	ValidationErrors as MediaValidationErrors,
 	MEDIA_IMAGE_RESIZER,
 	MEDIA_IMAGE_THUMBNAIL,
-} from 'lib/media/constants';
-import canCurrentUser from 'state/selectors/can-current-user';
-import { getSiteSlug } from 'state/sites/selectors';
+} from 'calypso/lib/media/constants';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import MediaLibraryHeader from './header';
 import MediaLibraryExternalHeader from './external-media-header';
 import MediaLibraryList from './list';
-import InlineConnection from 'my-sites/marketing/connections/inline-connection';
+import InlineConnection from 'calypso/my-sites/marketing/connections/inline-connection';
 import {
 	isKeyringConnectionsFetching,
 	getKeyringConnectionsByName,
-} from 'state/sharing/keyring/selectors';
-import { pauseGuidedTour, resumeGuidedTour } from 'state/guided-tours/actions';
-import { deleteKeyringConnection } from 'state/sharing/keyring/actions';
-import { getGuidedTourState } from 'state/guided-tours/selectors';
-import { withoutNotice } from 'state/notices/actions';
-import { clearMediaErrors, changeMediaSource } from 'state/media/actions';
+} from 'calypso/state/sharing/keyring/selectors';
+import { pauseGuidedTour, resumeGuidedTour } from 'calypso/state/guided-tours/actions';
+import { deleteKeyringConnection } from 'calypso/state/sharing/keyring/actions';
+import { getGuidedTourState } from 'calypso/state/guided-tours/selectors';
+import { withoutNotice } from 'calypso/state/notices/actions';
+import { clearMediaErrors, changeMediaSource } from 'calypso/state/media/actions';
 
 /**
  * Style dependencies


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `source` param to the `<MediaLibraryList />` `key` prop

The above makes sure that we use a different component instance for different sources and reset any internal values which are stored by the `ScrollHelper` which is itself used by `<InfiniteList />` component.

During debugging I noticed, that certain scroll values didn't reset when the media source changed which is necessary to trigger a (re)fetch of media items. You can see a hint of this on the screenshot below, or follow the provided screen capture in #46380 and look closely at the scrollbar.

<img width="675" alt="Screenshot 2020-10-19 at 15 16 31" src="https://user-images.githubusercontent.com/9202899/96456854-5f794000-121f-11eb-9e31-a990cb4f33dc.png">

The list of media items was cleared when switching to Pexels. However, as the the list component didn't update and therefore the scroll values which indicate we should refetch items (e.g. when the size of the thumbnail changes) weren't updated the list of media library items is empty when we switch back to the media library.

#### Testing instructions

* (on [calypso.live](https://calypso.live/?branch=fix/media-library-list-key)) open a post using the block editor and insert an image block
* Hit _Select Image_ > _Media Library_
* Now choose the largest size for thumbnails on the top right
  * if you're on the largest size on load make sure to change it but then leave it at the largest size again
* Make sure all items are loaded
* Now switch to Pexels and make sure you get the correct _"emtpy"_ view
* Switch back to the media library and make sure items are loaded

Also follow the instructions mentioned in #46380

- This is how it should **NOT** look like: https://d.pr/v/fltO4x
- This is how it **should** look like: https://d.pr/v/iKRREJ

Fixes #46380
