### PR TITLE
Billing: fix "Manage Purchase" page tracking

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -144,6 +144,7 @@ export function managePurchase( context, next ) {
 
 	context.primary = (
 		<Main className={ classes }>
+			<PageViewTracker path="/me/purchases/:site/:purchaseId" title="Purchases > Manage Purchase" />
 			<ManagePurchase
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 				siteSlug={ context.params.site }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -84,7 +84,6 @@ import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { cancelPurchase, managePurchase, purchasesRoot } from '../paths';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import titles from 'calypso/me/purchases/titles';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import PlanRenewalMessage from 'calypso/my-sites/plans-v2/plan-renewal-message';
 import {
@@ -105,21 +104,21 @@ import './style.scss';
 
 class ManagePurchase extends Component {
 	static propTypes = {
-		showHeader: PropTypes.bool,
-		purchaseListUrl: PropTypes.string,
-		getCancelPurchaseUrlFor: PropTypes.func,
+		cardTitle: PropTypes.string,
 		getAddPaymentMethodUrlFor: PropTypes.func,
+		getCancelPurchaseUrlFor: PropTypes.func,
 		getEditPaymentMethodUrlFor: PropTypes.func,
 		getManagePurchaseUrlFor: PropTypes.func,
-		cardTitle: PropTypes.string,
 		hasLoadedDomains: PropTypes.bool,
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		hasNonPrimaryDomainsFlag: PropTypes.bool,
 		isAtomicSite: PropTypes.bool,
+		renewableSitePurchases: PropTypes.arrayOf( PropTypes.object ),
 		purchase: PropTypes.object,
 		purchaseAttachedTo: PropTypes.object,
-		renewableSitePurchases: PropTypes.arrayOf( PropTypes.object ),
+		purchaseListUrl: PropTypes.string,
+		showHeader: PropTypes.bool,
 		site: PropTypes.object,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string.isRequired,
@@ -649,10 +648,6 @@ class ManagePurchase extends Component {
 				<TrackPurchasePageView
 					eventName="calypso_manage_purchase_view"
 					purchaseId={ this.props.purchaseId }
-				/>
-				<PageViewTracker
-					path="/me/purchases/:site/:purchaseId"
-					title="Purchases > Manage Purchase"
 				/>
 				<QueryUserPurchases userId={ this.props.userId } />
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Main from 'calypso/components/main';
 import Subscriptions from './subscriptions';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import ManagePurchase from 'calypso/me/purchases/manage-purchase';
@@ -56,7 +57,7 @@ export function PurchaseDetails( {
 }: {
 	purchaseId: number;
 	siteSlug: string;
-} ) {
+} ): JSX.Element {
 	const translate = useTranslate();
 
 	return (
@@ -67,6 +68,10 @@ export function PurchaseDetails( {
 				className="purchases__page-heading"
 				headerText={ translate( 'Billing' ) }
 				align="left"
+			/>
+			<PageViewTracker
+				path="/purchases/subscriptions/:site/:purchaseId"
+				title="Purchases > Manage Purchase"
 			/>
 
 			<ManagePurchase


### PR DESCRIPTION
This updates where the page view tracking is called for the Subscription Setting page, now that site-level billing management is available.

**To test:**
- debug the analytics component with `localStorage.setItem('debug', 'calypso:analytics:*');`
- on a site with purchases
- visit the site-level settings page for a subscription: _Plans > Billing > Click on a purchase_
- verify that the page tracking for the page has the `/purchases/subscriptions/:site/:purchaseId` path
- visit the account-level settings page for a subscription: _Me > Manage Purchases > Click on a purchase_
- verify that the page tracking for the page has the `/me/purchases/:site/:purchaseId` path