### PR TITLE
Fix pexels attribution placement for long languages

### DIFF
--- a/client/my-sites/media-library/content.scss
+++ b/client/my-sites/media-library/content.scss
@@ -56,7 +56,6 @@
 	.media__main-section .media-library__pexels-attribution {
 		order: 2;
 		margin-right: 0;
-		text-align: right;
 		width: calc( 88% - 220px );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Always place the pexels attribution on the left of the space available for it. This allows it to work for "long" languages (the current placement only works for English, it seems).

Before:
<img width="1291" alt="Captura de Tela 2020-10-19 às 09 32 49" src="https://user-images.githubusercontent.com/24264157/96479980-77849b80-11ee-11eb-94aa-be7d4f681fe5.png">

After:
<img width="1174" alt="Captura de Tela 2020-10-19 às 09 32 29" src="https://user-images.githubusercontent.com/24264157/96479987-7bb0b900-11ee-11eb-9a3e-d0cbaf7622c0.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open up production and observe the bug using a "long" language like Spanish or German.
* Next, open up the calypso.live for this branch using the same interface language and note that the bug is fixed.

Fixes #
