### PR TITLE
Notifications - adding support for classic block formatting

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -84,6 +84,7 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 		case 'em':
 		case 'sub':
 		case 'sup':
+		case 'del':
 		case 's':
 		case 'ol':
 		case 'ul':


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR, along with D51415-code, updates web notifications to properly render formatting available in the "Classic block".
* (Note that some of the bugs described in the issue have been addressed by previous recent notifications fixes; this PR/diff combo only actively fixes strikethrough formatting and a bug that was preventing style attributes on paragraphs from being applied. But all bugs mentioned in the issue are included here for testing purposes.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D51415-code in your sandbox and make sure the API is sandboxed.
* Apply this change to calypso, navigate to your Calypso dashboard and open a notification for a post with a classic block as part of its content. Make sure the classic block includes the following:
    * Some bulleted text with a nested bullet.
    * Indented text
    * Centered text
    * Right justified text
    * Text set to a different color (for example, blue)
    * A hyperlink
    * Strikethrough text
* Verify that the notification displays all mentioned formatting correctly.

<img width="800" alt="classic block" src="https://user-images.githubusercontent.com/13437011/96481278-f1be1b80-1200-11eb-8af5-13cb1fdf0a7c.png">


Fixes #45142
