### PR TITLE
Internationalise the text in <DomainNameExplanationImage>

### DIFF
--- a/packages/domain-picker/src/domain-name-explanation/index.tsx
+++ b/packages/domain-picker/src/domain-name-explanation/index.tsx
@@ -2,8 +2,11 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
+import { useI18n } from '@automattic/react-i18n';
 
 export const DomainNameExplanationImage: FunctionComponent = () => {
+	const { __ } = useI18n();
+
 	return (
 		<svg
 			version="1.1"
@@ -23,7 +26,10 @@ export const DomainNameExplanationImage: FunctionComponent = () => {
 				https://
 			</text>
 			<text x="133" y="26" fill="#515151">
-				example.com
+				{
+					/* translators: An example domain name. Used to describe what a domain name is. */
+					__( 'example.com' )
+				}
 			</text>
 		</svg>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Small PR that wraps the text in `<DomainNameExplanationImage>` in a `__()`.

More work needs to be done to support RTL languages because the image is oriented to assume LTR. But we're prioritising LTR at the moment (see pbxlJb-ry-p2).

* Wrap `'example.com'`, like `__( 'example.com' )`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new/domains` or `/new/domains/ro`
* Ensure the search field is empty
* The `https://example.com` example should appear like it used to, but now it'll be queued for translation.

Like this:
![Screen Shot on 2020-10-20 at 10:13:36](https://user-images.githubusercontent.com/1500769/96512414-f0eabf80-12bc-11eb-8f6d-de3eb9af9fa8.png)
