### PR TITLE
Premium Content: Fix margins on child blocks in Varia based themes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/save.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/save.js
@@ -8,7 +8,7 @@ import { InnerBlocks } from '@wordpress/block-editor';
  */
 export default function Save() {
 	return (
-		<div className="wp-block-premium-content-logged-out-view">
+		<div className="wp-block-premium-content-logged-out-view entry-content">
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/save.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/save.js
@@ -8,7 +8,7 @@ import { InnerBlocks } from '@wordpress/block-editor';
  */
 export default function Save() {
 	return (
-		<div className="wp-block-premium-content-subscriber-view">
+		<div className="wp-block-premium-content-subscriber-view entry-content">
 			<InnerBlocks.Content />
 		</div>
 	);


### PR DESCRIPTION
Fixes: https://github.com/Automattic/themes/issues/2281

**Before:**

<img width="729" alt="Screen Shot 2020-10-19 at 2 54 05 PM" src="https://user-images.githubusercontent.com/1464705/96515884-f2fc4200-121a-11eb-922c-0437065f0113.png">

**After:**

<img width="781" alt="Screen Shot 2020-10-19 at 2 53 03 PM" src="https://user-images.githubusercontent.com/1464705/96515907-fb547d00-121a-11eb-9ba9-4d3ae67e21fd.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Activate Maywood as your theme 
* Insert a premium content block, save the post
* Confirm the margins look like the after picture not the before picture.
