### PR TITLE
Reader: add vote banner for US election 2020

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -20,14 +20,12 @@ import Suggestion from 'calypso/reader/search-stream/suggestion';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import FollowingIntro from './intro';
 import { getSearchPlaceholderText } from 'calypso/reader/search/utils';
-import Banner from 'calypso/components/banner';
-import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
 import SectionHeader from 'calypso/components/section-header';
 import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
 import { SECTION_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
 import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizations/selectors';
 import { NO_ORG_ID } from 'calypso/state/reader/organizations/constants';
-
+import FollowingVoteBanner from './vote-banner';
 /**
  * Style dependencies
  */
@@ -43,8 +41,6 @@ function handleSearch( query ) {
 	}
 }
 
-const hideVoteBannerDate = new Date( '2020-10-17T19:00:00' );
-
 const FollowingStream = ( props ) => {
 	const suggestionList =
 		props.suggestions &&
@@ -55,11 +51,9 @@ const FollowingStream = ( props ) => {
 			] )
 		);
 	const placeholderText = getSearchPlaceholderText();
-	const now = new Date();
-	const showRegistrationMsg = props.userInNZ && now < hideVoteBannerDate;
 	const { translate } = props;
 	const dispatch = useDispatch();
-
+	const voteBanner = <FollowingVoteBanner />;
 	const markAllAsSeen = ( feedsInfo ) => {
 		const { feedIds, feedUrls } = feedsInfo;
 		dispatch( requestMarkAllAsSeen( { identifier: SECTION_FOLLOWING, feedIds, feedUrls } ) );
@@ -68,20 +62,7 @@ const FollowingStream = ( props ) => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<Stream { ...props }>
-			{ ! showRegistrationMsg && <FollowingIntro /> }
-			{ showRegistrationMsg && (
-				<Banner
-					className="following__reader-vote"
-					title="NZ Election Day: Saturday 17 October"
-					callToAction="How to vote"
-					description="You can vote from 3 October to election day, 17 October."
-					event="reader-vote-prompt"
-					href="https://vote.nz/"
-					icon="star"
-					horizontal
-					target="_blank"
-				/>
-			) }
+			{ voteBanner ? voteBanner : <FollowingIntro /> }
 			<CompactCard className="following__search">
 				<SearchInput
 					onSearch={ handleSearch }
@@ -111,6 +92,5 @@ const FollowingStream = ( props ) => {
 };
 
 export default connect( ( state ) => ( {
-	userInNZ: getCurrentUserCountryCode( state ) === 'NZ',
 	feedsInfo: getReaderOrganizationFeedsInfo( state, NO_ORG_ID ),
 } ) )( SuggestionProvider( localize( FollowingStream ) ) );

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -26,6 +26,7 @@ import { SECTION_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
 import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizations/selectors';
 import { NO_ORG_ID } from 'calypso/state/reader/organizations/constants';
 import FollowingVoteBanner from './vote-banner';
+
 /**
  * Style dependencies
  */

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -149,7 +149,3 @@
 		background-color: var( --color-surface );
 	}
 }
-
-div.following__reader-vote {
-	border-left-color: #d94f4f !important;
-}

--- a/client/reader/following/vote-banner.jsx
+++ b/client/reader/following/vote-banner.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { sample } from 'lodash';
-import { translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,24 +14,26 @@ import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors'
 
 const electionDayStart = new Date( '2020-11-03T00:00:00' );
 const electionDayEnd = new Date( '2020-11-03T23:59:59' );
-const earlyVotingMessage = translate( 'Early voting is open now in most states.' );
-const electionDayMessages = [
-	translate( 'Remember to vote.' ),
-	translate( "Don't forget to vote." ),
-	translate( 'Make your voice heard!' ),
-	translate( 'Your vote is important.' ),
-	translate( 'Your participation is important.' ),
-	translate( 'Make a plan to vote.' ),
-	translate( 'Do you have a plan to vote?' ),
-];
 
 const FollowingVoteBanner = ( props ) => {
+	const { translate, userInUS } = props;
 	const now = new Date();
-	const showRegistrationMsg = props.userInUS && now < electionDayEnd;
+	const showRegistrationMsg = userInUS && now < electionDayEnd;
 
 	if ( ! showRegistrationMsg ) {
 		return null;
 	}
+
+	const earlyVotingMessage = translate( 'Early voting is open now in most states.' );
+	const electionDayMessages = [
+		translate( 'Remember to vote.' ),
+		translate( "Don't forget to vote." ),
+		translate( 'Make your voice heard!' ),
+		translate( 'Your vote is important.' ),
+		translate( 'Your participation is important.' ),
+		translate( 'Make a plan to vote.' ),
+		translate( 'Do you have a plan to vote?' ),
+	];
 
 	// Show the early voting message if it's not election day yet
 	const electionDayMessage = sample( electionDayMessages );
@@ -56,4 +58,4 @@ const FollowingVoteBanner = ( props ) => {
 
 export default connect( ( state ) => ( {
 	userInUS: getCurrentUserCountryCode( state ) === 'US',
-} ) )( FollowingVoteBanner );
+} ) )( localize( FollowingVoteBanner ) );

--- a/client/reader/following/vote-banner.jsx
+++ b/client/reader/following/vote-banner.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { sample } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,26 +11,41 @@ import { connect } from 'react-redux';
 import Banner from 'calypso/components/banner';
 import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
 
-const hideVoteBannerDate = new Date( '2020-11-03T23:59:59' );
+const electionDayStart = new Date( '2020-11-03T00:00:00' );
+const electionDayEnd = new Date( '2020-11-03T23:59:59' );
+const earlyVotingMessage = 'Early voting is open now in most states.';
+const electionDayMessages = [
+	'Remember to vote.',
+	"Don't forget to vote.",
+	'Make your voice heard!',
+	'Your vote is important.',
+	'Your participation is important.',
+	'Make a plan to vote.',
+	'Do you have a plan to vote?',
+];
 
 const FollowingVoteBanner = ( props ) => {
 	const now = new Date();
-	const showRegistrationMsg = props.userInUS && now < hideVoteBannerDate;
+	const showRegistrationMsg = props.userInUS && now < electionDayEnd;
 
 	if ( ! showRegistrationMsg ) {
 		return null;
 	}
 
+	// Show the early voting message if it's not election day yet
+	const electionDayMessage = sample( electionDayMessages );
+	const description = now < electionDayStart ? earlyVotingMessage : electionDayMessage;
+
 	return (
 		<Banner
 			className="following__reader-vote"
-			title="Election Day: Tuesday 3rd November"
+			title="Election Day: Tuesday, November 3"
 			callToAction="How to vote"
-			description="Remember to vote."
+			description={ description }
 			event="reader-vote-prompt"
 			tracksImpressionName="calypso_reader_vote_banner_impression"
 			tracksClickName="calypso_reader_vote_banner_click"
-			href="https://www.usa.gov/how-to-vote"
+			href="https://www.vote.org"
 			icon="star"
 			horizontal
 			target="_blank"

--- a/client/reader/following/vote-banner.jsx
+++ b/client/reader/following/vote-banner.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Banner from 'calypso/components/banner';
+import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
+
+const hideVoteBannerDate = new Date( '2020-11-03T23:59:59' );
+
+const FollowingVoteBanner = ( props ) => {
+	const now = new Date();
+	const showRegistrationMsg = props.userInUS && now < hideVoteBannerDate;
+
+	if ( ! showRegistrationMsg ) {
+		return null;
+	}
+
+	return (
+		<Banner
+			className="following__reader-vote"
+			title="Election Day: Tuesday 3rd November"
+			callToAction="How to vote"
+			description="Remember to vote."
+			event="reader-vote-prompt"
+			tracksImpressionName="calypso_reader_vote_banner_impression"
+			tracksClickName="calypso_reader_vote_banner_click"
+			href="https://www.usa.gov/how-to-vote"
+			icon="star"
+			horizontal
+			target="_blank"
+		/>
+	);
+};
+
+export default connect( ( state ) => ( {
+	userInUS: getCurrentUserCountryCode( state ) === 'US',
+} ) )( FollowingVoteBanner );

--- a/client/reader/following/vote-banner.jsx
+++ b/client/reader/following/vote-banner.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { sample } from 'lodash';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,15 +14,15 @@ import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors'
 
 const electionDayStart = new Date( '2020-11-03T00:00:00' );
 const electionDayEnd = new Date( '2020-11-03T23:59:59' );
-const earlyVotingMessage = 'Early voting is open now in most states.';
+const earlyVotingMessage = translate( 'Early voting is open now in most states.' );
 const electionDayMessages = [
-	'Remember to vote.',
-	"Don't forget to vote.",
-	'Make your voice heard!',
-	'Your vote is important.',
-	'Your participation is important.',
-	'Make a plan to vote.',
-	'Do you have a plan to vote?',
+	translate( 'Remember to vote.' ),
+	translate( "Don't forget to vote." ),
+	translate( 'Make your voice heard!' ),
+	translate( 'Your vote is important.' ),
+	translate( 'Your participation is important.' ),
+	translate( 'Make a plan to vote.' ),
+	translate( 'Do you have a plan to vote?' ),
 ];
 
 const FollowingVoteBanner = ( props ) => {
@@ -40,7 +41,7 @@ const FollowingVoteBanner = ( props ) => {
 		<Banner
 			className="following__reader-vote"
 			title="Election Day: Tuesday, November 3"
-			callToAction="How to vote"
+			callToAction={ translate( 'How to vote' ) }
 			description={ description }
 			event="reader-vote-prompt"
 			tracksImpressionName="calypso_reader_vote_banner_impression"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following on from the recent banner for the NZ election (https://github.com/Automattic/wp-calypso/pull/46377), this PR adds a vote banner at the top of Reader's Following stream for the US election on 3rd Nov, 2020.

<img width="870" alt="Screen Shot 2020-10-20 at 15 10 40" src="https://user-images.githubusercontent.com/17325/96532023-7aaf8280-12e7-11eb-837d-3debe3e8bce8.png">

It also refactors the vote banner into its own component.

#### Testing instructions

As a user in the US, ensure that the vote banner appears at the top of your Following feed: http://calypso.localhost:3000/read.

As a user outside the US, ensure you do not see the banner at all.