### PR TITLE
desktop: Bump version to 6.3.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "6.2.0",
+	"version": "6.3.0-beta1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "6.3.0-beta1",
+	"version": "6.3.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bumps the desktop app version to 6.3.0-beta1

#### Testing instructions

* Given this is just a version change, green CI should be enough. In fact, the whole reason to open this PR in the first place is to have the tests run in CI