### PR TITLE
Notifications: Buttons and YouTube Preview Image Clickable

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -94,7 +94,6 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 		case 'h4':
 		case 'h5':
 		case 'h6':
-		case 'a':
 			switch ( range_info_type ) {
 				case 'list':
 					range_info_type = 'span';
@@ -123,11 +122,16 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 			new_classes.push( 'is-primary' );
 		default:
 			// Most range types fall here
-			if ( options.links && range_info.url ) {
+			if ( ( options.links && range_info.url ) || range_info_type === 'a' ) {
 				// We are a link of some sort...
 				new_container = document.createElement( 'a' );
-
 				new_container.setAttribute( 'href', range_info.url );
+				if ( range_info.hasOwnProperty( 'class' ) ) {
+					new_classes.push( range_info.class );
+				}
+				if ( range_info.hasOwnProperty( 'style' ) ) {
+					new_container.setAttribute( 'style', range_info.style );
+				}
 				if ( range_info_type === 'stat' ) {
 					// Stat links should change the whole window/tab
 					new_container.setAttribute( 'target', '_parent' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, Button blocks and YouTube embeds created in a post, and subsequently rendered in a notification in the master bar renders as a unclickable. This change makes it so that they redirect to the appropriate content.
* `a` tags are now rendered with the appropriate `href`.

#### Testing instructions

1. Use the Calypso live link, or checkout this branch
2. See the"Creating post notification" section in the README at https://github.com/Automattic/wp-calypso/blob/master/apps/notifications/src/doc/note-rendering.md
3. Use the "Follow" button that appears in the bottom right corner of the blog to add it to your Reader subscriptions:
4. Then navigate to https://wordpress.com/following/manage and enable "Notify me of new posts" for the blog. With this enabled, future posts on that blog will appear as notifications in your masterbar.
5. Create a post for the blog you're following with a button block with a link and a separate YouTube embed.
6. Go to your masterbar and select the notification that contains the buttons and YouTube embed. Confirm that when clicking on the button, or the YouTube preview image, it redirects you to the appropriate content. You can also confirm via the Chrome Inspector that the `a` tag contains an `href`
#### Screenshots and GIFs
Before | After
--- | ---
<img width="287" alt="Screen Shot 2020-10-20 at 1 14 56 AM" src="https://user-images.githubusercontent.com/66652282/96543149-bd367800-1271-11eb-825e-a2f0ce30ca82.png"> | <img width="292" alt="Screen Shot 2020-10-20 at 1 13 01 AM" src="https://user-images.githubusercontent.com/66652282/96543045-84969e80-1271-11eb-83a3-5d8a57a42fcd.png">
<img width="303" alt="Screen Shot 2020-10-20 at 1 15 09 AM" src="https://user-images.githubusercontent.com/66652282/96543170-c7f10d00-1271-11eb-812c-004f16fb057b.png"> | <img width="292" alt="Screen Shot 2020-10-20 at 1 13 16 AM" src="https://user-images.githubusercontent.com/66652282/96543050-87918f00-1271-11eb-9355-2381fe9421a7.png">



Fixes #46295 