### PR TITLE
Components: Fix search input direction

### DIFF
--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -12,8 +12,7 @@
 
 		input[type='url']#{&},
 		input[type='password']#{&},
-		input[type='email']#{&},
-		input[type='search']#{&} {
+		input[type='email']#{&} {
 			/*!rtl:ignore*/
 			direction: ltr;
 		}


### PR DESCRIPTION
The `direction` property introduced in https://github.com/Automattic/wp-calypso/pull/45358 for search type inputs is causing Search component alignment problems with RTL languages.

#### Changes proposed in this Pull Request

* Remove `input[type='search']`selector from rule-set that forces direction for certain input types in FormTextInput's styles. 

**Before:**
![image](https://user-images.githubusercontent.com/2722412/96561681-8fc8e900-12c8-11eb-9eac-9ce4fa17d121.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/96561702-93f50680-12c8-11eb-8228-98aa3abd7a7b.png)

#### Testing instructions

* Change your UI to RTL language (e.g. Hebrew)
* Test different sections and confirm search input inherits the direction from the page, e.g. `/read`, `/pages`, `/media/`, `/devdocs`, etc.
* Test domain search component at `/domains/add` and confirm it's using the `dir` attribute to render in LTR all languages.

Fixes 164-gh-i18n-issues
