### PR TITLE
Email: Fix back button on email management page

### DIFF
--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -69,7 +69,7 @@ export function domainManagementRoot() {
 }
 
 export function domainManagementList( siteName, relativeTo = null ) {
-	if ( isUnderDomainManagementAll( relativeTo ) ) {
+	if ( isUnderDomainManagementAll( relativeTo ) || isUnderEmailManagementAll( relativeTo ) ) {
 		return domainManagementRoot();
 	}
 	return domainManagementRoot() + '/' + siteName;

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -3,7 +3,7 @@
  */
 import { filter } from 'lodash';
 import { stringify } from 'qs';
-import { isUnderEmailManagementAll } from 'my-sites/email/paths';
+import { isUnderEmailManagementAll } from 'calypso/my-sites/email/paths';
 
 function resolveRootPath( relativeTo = null ) {
 	if ( relativeTo ) {
@@ -47,7 +47,7 @@ function domainManagementTransferBase(
 }
 
 export function isUnderDomainManagementAll( path ) {
-	return path?.startsWith( domainManagementAllRoot() + '/' );
+	return path?.startsWith( domainManagementAllRoot() + '/' ) || path === domainManagementRoot();
 }
 
 export function domainAddNew( siteName, searchTerm ) {

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -267,7 +267,7 @@ class EmailManagement extends React.Component {
 		if ( selectedDomainName && previousRoute.startsWith( domainPath ) ) {
 			page( domainPath );
 		} else {
-			page( domainManagementList( selectedSiteSlug, previousRoute ) );
+			page( domainManagementList( selectedSiteSlug, currentRoute ) );
 		}
 	};
 }

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -46,6 +46,7 @@ import QueryGSuiteUsers from 'calypso/components/data/query-gsuite-users';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import EmailProvidersComparison from '../email-providers-comparison';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
@@ -260,12 +261,13 @@ class EmailManagement extends React.Component {
 	}
 
 	goToEditOrList = () => {
-		const { selectedDomainName, selectedSiteSlug, currentRoute } = this.props;
+		const { selectedDomainName, selectedSiteSlug, currentRoute, previousRoute } = this.props;
+		const domainPath = domainManagementEdit( selectedSiteSlug, selectedDomainName, currentRoute );
 
-		if ( selectedDomainName ) {
-			page( domainManagementEdit( selectedSiteSlug, selectedDomainName, currentRoute ) );
+		if ( selectedDomainName && previousRoute.startsWith( domainPath ) ) {
+			page( domainPath );
 		} else {
-			page( domainManagementList( selectedSiteSlug ) );
+			page( domainManagementList( selectedSiteSlug, previousRoute ) );
 		}
 	};
 }
@@ -280,6 +282,7 @@ export default connect(
 			gsuiteUsers: getGSuiteUsers( state, selectedSiteId ),
 			hasGSuiteUsersLoaded: hasLoadedGSuiteUsers( state, selectedSiteId ),
 			hasSiteDomainsLoaded: hasLoadedSiteDomains( state, selectedSiteId ),
+			previousRoute: getPreviousRoute( state ),
 			selectedSiteId,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the back button under the email management page, to send the user to the page they were visiting before, when applicable.

#### Testing instructions

There are 4 scenarios you need to test:
 - Clicking the "Setup your email"/"Manage your email" button from the domain enhanced navigation
 - Same as above, but from the all domains context (i.e. `/email/all/<DOMAIN>/manage/<SITE>`)
 - Clicking the "Add" email button from site domains list
 - Clicking the "Add" email button from all domains list

In all those cases, then clicking the back button should send you back to where you were before, after applying the changes.
