### PR TITLE
Contextual Tips: remove `/block-editor` from URL

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips/tip-link.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips/tip-link.js
@@ -18,9 +18,7 @@ export default function ( { section, children, subsection } ) {
 	const returnLink =
 		isEditorIFramed && ! isSimpleSite
 			? '&' +
-			  encodeURIComponent(
-					`return=https://wordpress.com/block-editor/${ postType }/${ hostname }/${ postId }`
-			  )
+			  encodeURIComponent( `return=https://wordpress.com/${ postType }/${ hostname }/${ postId }` )
 			: '';
 	const autofocus = `autofocus[section]=${ subsection }`;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `/block-editor` string from the contextual tips.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

A visual check should be enough, but in case you want to test completely

* Apply this patch
* Test with the editor sandboxed and Not Simple site
* Open the block inserter
* Type a string that raises up a tip, for instance, `CSS` (1)
* Confirm the return value in the URL (2) shouldn't contain the `/block-editor` string.

<img width="363" alt="Screen Shot 2020-10-20 at 8 47 47 AM" src="https://user-images.githubusercontent.com/77539/96582147-402af300-12b1-11eb-9eb3-8ac9e09ef4da.png">

Fixes #
