### PR TITLE
Marketing: roll out one-click upsell to 100% users.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -201,15 +201,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: [ 'en' ],
 	},
-	oneClickUpsell: {
-		datestamp: '20200922',
-		variations: {
-			test: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	jetpackConversionRateOptimization: {
 		datestamp: '20201020',
 		variations: {

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -38,7 +38,6 @@ import { ConciergeSupportSession } from './concierge-support-session';
 import { PlanUpgradeUpsell } from './plan-upgrade-upsell';
 import getUpgradePlanSlugFromPath from 'calypso/state/selectors/get-upgrade-plan-slug-from-path';
 import { PurchaseModal } from './purchase-modal';
-import { abtest } from 'calypso/lib/abtest';
 import { replaceCartWithItems } from 'calypso/lib/cart/actions';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -192,7 +191,7 @@ export class UpsellNudge extends React.Component {
 			`calypso_${ upsellType.replace( /-/g, '_' ) }_${ buttonAction }_button_click`
 		);
 
-		if ( this.isEligibleForOneClickUpsellABTest( buttonAction ) ) {
+		if ( this.isEligibleForOneClickUpsell( buttonAction ) ) {
 			this.setState( {
 				showPurchaseModal: true,
 				cartLastServerResponseDate: this.getCartUpdatedTime(),
@@ -206,7 +205,7 @@ export class UpsellNudge extends React.Component {
 			: page( `/checkout/${ upgradeItem }` );
 	};
 
-	isEligibleForOneClickUpsellABTest = ( buttonAction ) => {
+	isEligibleForOneClickUpsell = ( buttonAction ) => {
 		const { cards, siteSlug, upsellType } = this.props;
 
 		if ( 'accept' !== buttonAction || 'concierge-quickstart-session' !== upsellType ) {
@@ -222,7 +221,7 @@ export class UpsellNudge extends React.Component {
 			return false;
 		}
 
-		return 'test' === abtest( 'oneClickUpsell' );
+		return true;
 	};
 
 	handleOneClickUpsellComplete = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As the variant wins, we're going to roll out to the one-click upsell to 100% users. See  pcbrnV-aX-p2 for more details on the preceding test.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase Personal or Premium dotcom plan for your website.
* You may need to remember the receipt ID.
* Visit `/checkout/offer-quickstart-session/RECEIPT_ID/YOUR_SITE_SLUG`. Please replace RECEIPT_ID and YOUR_SITE_SLUG with your owns. It would look like `/checkout/offer-quickstart-session/1234567/testblog.woordpress.com`.
* Ensure you have one or more stored credit cards.
* Click the "Yes, I want a WordPress Expert by my side!" button.
* You should be able to see a modal dialog as below:
  <img width="788" alt="Checkout_‹_Quick_Start_Session_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/94092862-c9880a80-fe56-11ea-9e7d-1260138bee12.png">
* Click on the Pay button and the transaction of purchasing Concierge Session is going to be _automatically_ processed.
* When everything goes okay, a sucess notification appears. Otherwise, an error notification shows up.
  <img width="961" alt="My_Home_‹_Site_Title_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/93323074-17958080-f84f-11ea-9d65-54925c3ad644.png">

Related: #45350
