### PR TITLE
Payments: Update titles for purchases

### DIFF
--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -10,7 +10,7 @@ export default {
 	confirmCancelDomain: i18n.translate( 'Cancel Domain' ),
 	editCardDetails: i18n.translate( 'Change Credit Card', { comment: 'Credit card' } ),
 	addCardDetails: i18n.translate( 'Add Credit Card', { comment: 'Credit card' } ),
-	managePurchase: i18n.translate( 'Manage Purchase' ),
+	managePurchase: i18n.translate( 'Purchase Settings' ),
 	sectionTitle: i18n.translate( 'Manage Purchases' ),
 	purchases: i18n.translate( 'Purchases' ),
 };

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -111,7 +111,7 @@ export function PurchaseDetails( {
 				onError={ logPurchasesError }
 			>
 				<ManagePurchase
-					cardTitle={ translate( 'Subscription settings' ) }
+					cardTitle={ translate( 'Purchase Settings' ) }
 					purchaseId={ purchaseId }
 					siteSlug={ siteSlug }
 					showHeader={ false }

--- a/client/my-sites/purchases/subscriptions/account-level-purchase-links.tsx
+++ b/client/my-sites/purchases/subscriptions/account-level-purchase-links.tsx
@@ -13,7 +13,7 @@ export default function AccountLevelPurchaseLinks() {
 	const translate = useTranslate();
 	return (
 		<>
-			<CompactCard href="/me/purchases">{ translate( 'View all subscriptions' ) }</CompactCard>
+			<CompactCard href="/me/purchases">{ translate( 'View all purchases' ) }</CompactCard>
 		</>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the titles for the purchase settings screens and standardizes the terminology.

**Before**

![image](https://user-images.githubusercontent.com/6981253/96591691-86825100-12b5-11eb-8310-056c9eff554a.png)

![image](https://user-images.githubusercontent.com/6981253/96591343-29869b00-12b5-11eb-90bb-e2ed544cf328.png)

![image](https://user-images.githubusercontent.com/6981253/96591630-75d1db00-12b5-11eb-8bf4-3847dfd96f5f.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/96591747-95690380-12b5-11eb-93a8-87b37c85a0f4.png)


![image](https://user-images.githubusercontent.com/6981253/96591436-3efbc500-12b5-11eb-90cb-23f65f82e51b.png)

![image](https://user-images.githubusercontent.com/6981253/96591592-681c5580-12b5-11eb-920d-11b939e8310c.png)



#### Testing instructions
Review the screenshots or: 
* Visit the billing screen at the site level and confirm the "View all subscriptions" button has been changed to "View all purchases".
* Click on a purchase and confirm the title in the header cake is "Purchase Settings" instead of "Subscription Settings".
* Visit the account level manage purchases screen and visit a purchase. Confirm the header cake says "Purchase Settings" instead of "Manage Purchase".

Fixes https://github.com/Automattic/wp-calypso/issues/46239
