### PR TITLE
Purchases: fix jetpack descriptions

### DIFF
--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -233,8 +233,7 @@ const getPlanPremiumDetails = () => ( {
 	getStoreAudience: () => i18n.translate( 'Best for freelancers' ),
 	getDescription: () =>
 		i18n.translate(
-			'{{strong}}Best for freelancers:{{/strong}}' +
-				' Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
+			'{{strong}}Best for freelancers:{{/strong}} Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
 				' Google Analytics support,' +
 				' and the ability to monetize your site with ads.',
 			plansDescriptionHeadingComponent
@@ -904,8 +903,7 @@ export const PLANS_LIST = {
 		getPathSlug: () => 'premium',
 		getDescription: () =>
 			i18n.translate(
-				'{{strong}}Best for small businesses:{{/strong}}' +
-					'Comprehensive, automated scanning for security vulnerabilities, ' +
+				'{{strong}}Best for small businesses:{{/strong}} Comprehensive, automated scanning for security vulnerabilities, ' +
 					'fast video hosting, and marketing automation.',
 				plansDescriptionHeadingComponent
 			),
@@ -982,8 +980,7 @@ export const PLANS_LIST = {
 			),
 		getDescription: () =>
 			i18n.translate(
-				'{{strong}}Best for small businesses:{{/strong}}' +
-					'Comprehensive, automated scanning for security vulnerabilities, ' +
+				'{{strong}}Best for small businesses:{{/strong}} Comprehensive, automated scanning for security vulnerabilities, ' +
 					'fast video hosting, and marketing automation.',
 				plansDescriptionHeadingComponent
 			),
@@ -1053,8 +1050,7 @@ export const PLANS_LIST = {
 		getPathSlug: () => 'jetpack-personal',
 		getDescription: () =>
 			i18n.translate(
-				'{{strong}}Best for personal use:{{/strong}}' +
-					'Security essentials for your WordPress site, including ' +
+				'{{strong}}Best for personal use:{{/strong}} Security essentials for your WordPress site, including ' +
 					'automated backups and priority support.',
 				plansDescriptionHeadingComponent
 			),
@@ -1102,8 +1098,7 @@ export const PLANS_LIST = {
 		availableFor: ( plan ) => includes( [ constants.PLAN_JETPACK_FREE ], plan ),
 		getDescription: () =>
 			i18n.translate(
-				'{{strong}}Best for personal use:{{/strong}}' +
-					'Security essentials for your WordPress site, including ' +
+				'{{strong}}Best for personal use:{{/strong}} Security essentials for your WordPress site, including ' +
 					'automated backups and priority support.',
 				plansDescriptionHeadingComponent
 			),
@@ -1162,8 +1157,7 @@ export const PLANS_LIST = {
 		getPathSlug: () => 'professional',
 		getDescription: () =>
 			i18n.translate(
-				'{{strong}}Best for organizations:{{/strong}}' +
-					'The most powerful WordPress sites: real-time backups ' +
+				'{{strong}}Best for organizations:{{/strong}} The most powerful WordPress sites: real-time backups ' +
 					'and unlimited premium themes.',
 				plansDescriptionHeadingComponent
 			),
@@ -1235,8 +1229,7 @@ export const PLANS_LIST = {
 			),
 		getDescription: () =>
 			i18n.translate(
-				'{{strong}}Best for organizations:{{/strong}}' +
-					'The most powerful WordPress sites: real-time backups ' +
+				'{{strong}}Best for organizations:{{/strong}} The most powerful WordPress sites: real-time backups ' +
 					'and unlimited premium themes.',
 				plansDescriptionHeadingComponent
 			),

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -192,7 +192,7 @@ class PurchaseItem extends Component {
 		const { purchase, translate } = this.props;
 
 		if ( purchase && isPartnerPurchase( purchase ) ) {
-			return translate( 'This plan is managed by %(partnerName)s', {
+			return translate( 'This plan is managed by %(partnerName)s.', {
 				args: {
 					partnerName: getPartnerName( purchase ),
 				},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a missing space in the Jetpack product descriptions.

**Before**
![image](https://user-images.githubusercontent.com/6981253/96597196-88e7a980-12bb-11eb-8308-e366a3d32415.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/96597228-943ad500-12bb-11eb-9c77-fd615656285c.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since we don't offer these Jetpack plans any longer, you'll need to go into Store Admin and add any of the old Jetpack plans to a Jetpack site and check the subscriptions settings screen to confirm a space has been added in the description.

Fixes https://github.com/Automattic/wp-calypso/issues/46240