### PR TITLE
desktop e2e: "no such session" error

### DIFF
--- a/desktop/e2e/mocha.opts
+++ b/desktop/e2e/mocha.opts
@@ -1,2 +1,1 @@
 --require mocha-steps
-test/tests/lib/mocha-hooks.js

--- a/desktop/e2e/run.js
+++ b/desktop/e2e/run.js
@@ -132,7 +132,7 @@ async function run() {
 		);
 
 		const tests = path.join( E2E_DIR, 'tests', 'e2e.js' );
-		execSync( `npx mocha ${ tests } --timeout 20000`, {
+		execSync( `npx mocha ${ tests } --timeout 20000 --exit`, {
 			stdio: 'inherit',
 		} );
 	} catch ( err ) {


### PR DESCRIPTION
### Description

Try to fix mocha "No such session error", which has only recently appeared and been occurring relatively frequently, recently.

### Context

- Despite all tests passing, an e2e error is reported when mocha fails with a "no such session" message
- Attempting to address this by ensuring mocha exits with the `--exit` flag:

  > By default, Mocha will no longer force the process to exit once all tests complete. This means any test code (or code under test) which would normally prevent node from exiting will do so when run in Mocha. Supply the --exit flag to revert to pre-v4.0.0 behavior

### Testing

- Ran the Mac job 10 times and did not encounter this failure. (There was 1 failure, but this was due to an intermittent failure with the logout test, which is unrelated).

Hopefully this works! 🤞 