### PR TITLE
Purchases: add title to add manage purchases screen

### DIFF
--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -16,6 +16,8 @@ import Main from 'calypso/components/main';
 import DocumentHead from 'calypso/components/data/document-head';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
+import titles from 'calypso/me/purchases/titles';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -35,6 +37,8 @@ const BillingHistory = ( { translate } ) => (
 		<DocumentHead title={ translate( 'Billing History' ) } />
 		<PageViewTracker path="/me/purchases/billing" title="Me > Billing History" />
 		<MeSidebarNavigation />
+
+		<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 		<QueryBillingTransactions />
 		<PurchasesHeader section={ 'billing' } />
 		<BillingHistoryList />

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -29,6 +29,8 @@ import {
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getPlanTermLabel } from 'calypso/lib/plans';
 import { PARTNER_PAYPAL_EXPRESS } from 'calypso/lib/checkout/payment-methods';
+import titles from 'calypso/me/purchases/titles';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 class BillingReceipt extends React.Component {
 	componentDidMount() {
@@ -69,6 +71,8 @@ class BillingReceipt extends React.Component {
 					path="/me/purchases/billing/:receipt"
 					title="Me > Billing History > Receipt"
 				/>
+
+				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 				<QueryBillingTransaction transactionId={ transactionId } />
 
 				<ReceiptTitle backHref={ billingHistory } />
@@ -308,7 +312,7 @@ function ReceiptLabels() {
 
 export function ReceiptTitle( { backHref } ) {
 	const translate = useTranslate();
-	return <HeaderCake backHref={ backHref }>{ translate( 'Billing History' ) }</HeaderCake>;
+	return <HeaderCake backHref={ backHref }>{ translate( 'Receipt' ) }</HeaderCake>;
 }
 
 export default connect(

--- a/client/me/billing-history/upcoming-charges.jsx
+++ b/client/me/billing-history/upcoming-charges.jsx
@@ -15,6 +15,8 @@ import Main from 'calypso/components/main';
 import DocumentHead from 'calypso/components/data/document-head';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
+import titles from 'calypso/me/purchases/titles';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -25,6 +27,8 @@ const UpcomingCharges = ( { translate } ) => (
 	<Main className="upcoming-charges is-wide-layout">
 		<DocumentHead title={ translate( 'Upcoming Charges' ) } />
 		<PageViewTracker path="/me/purchases/upcoming" title="Me > Upcoming Charges" />
+		<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+
 		<MeSidebarNavigation />
 		<QueryBillingTransactions />
 		<PurchasesHeader section={ 'upcoming' } />

--- a/client/me/memberships/main.jsx
+++ b/client/me/memberships/main.jsx
@@ -20,6 +20,8 @@ import { CompactCard } from '@automattic/components';
 import EmptyContent from 'calypso/components/empty-content';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { getAllSubscriptions } from 'calypso/state/memberships/subscriptions/selectors';
+import titles from 'calypso/me/purchases/titles';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -113,6 +115,7 @@ const MembershipsHistory = ( { translate, subscriptions, moment } ) => {
 		<Main className="memberships is-wide-layout">
 			<DocumentHead title={ translate( 'Other Sites' ) } />
 			<PageViewTracker path="/me/purchases/other" title="Me > Other Sites" />
+			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 			<MeSidebarNavigation />
 			<QueryMembershipsSubscriptions />
 			<PurchasesHeader section={ 'memberships' } />

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -11,7 +11,6 @@ import formatCurrency from '@automattic/format-currency';
  */
 import { Card, CompactCard } from '@automattic/components';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import PurchasesHeader from '../purchases/purchases-list/header';
 import Main from 'calypso/components/main';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
@@ -26,6 +25,8 @@ import {
 	getSubscription,
 	getStoppingStatus,
 } from 'calypso/state/memberships/subscriptions/selectors';
+import titles from 'calypso/me/purchases/titles';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -43,7 +44,8 @@ class Subscription extends React.Component {
 				<DocumentHead title={ translate( 'Other Sites' ) } />
 				<MeSidebarNavigation />
 				<QueryMembershipsSubscriptions />
-				<PurchasesHeader section={ 'memberships' } />
+				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+
 				<HeaderCake backHref={ purchasesRoot + '/other' }>
 					{ subscription ? subscription.title : translate( 'All subscriptions' ) }
 				</HeaderCake>

--- a/client/me/payment-methods/main.tsx
+++ b/client/me/payment-methods/main.tsx
@@ -14,6 +14,8 @@ import PurchasesHeader from '../purchases/purchases-list/header';
 import Main from 'calypso/components/main';
 import DocumentHead from 'calypso/components/data/document-head';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import titles from 'calypso/me/purchases/titles';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 export default function PaymentMethods(): JSX.Element {
 	const translate = useTranslate();
@@ -23,8 +25,8 @@ export default function PaymentMethods(): JSX.Element {
 			<DocumentHead title={ translate( 'Payment Methods' ) } />
 			<PageViewTracker path="/me/purchases/payment-methods" title="Me > Payment Methods" />
 			<MeSidebarNavigation />
+			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 			<PurchasesHeader section={ 'payment-methods' } />
-
 			<CreditCards addPaymentMethodUrl={ addCreditCard } />
 		</Main>
 	);

--- a/client/me/purchases/add-credit-card/index.jsx
+++ b/client/me/purchases/add-credit-card/index.jsx
@@ -15,6 +15,7 @@ import { concatTitle } from 'calypso/lib/react-helpers';
 import { createCardToken } from 'calypso/lib/store-transactions';
 import CreditCardForm from 'calypso/blocks/credit-card-form';
 import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import titles from 'calypso/me/purchases/titles';
@@ -32,6 +33,7 @@ function AddCreditCard( props ) {
 			<PageViewTracker path="/me/purchases/add-credit-card" title="Purchases > Add Credit Card" />
 			<DocumentHead title={ concatTitle( titles.purchases, titles.addCreditCard ) } />
 
+			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 			<HeaderCake onClick={ goToPaymentMethods }>{ titles.addCreditCard }</HeaderCake>
 			<StripeHookProvider configurationArgs={ { needs_intent: true } }>
 				<CreditCardForm

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -38,6 +38,7 @@ import ProductLink from 'calypso/me/purchases/product-link';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -189,6 +190,8 @@ class CancelPurchase extends React.Component {
 					eventName="calypso_cancel_purchase_purchase_view"
 					purchaseId={ this.props.purchaseId }
 				/>
+				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+
 				<HeaderCake
 					backHref={ this.props.getManagePurchaseUrlFor(
 						this.props.siteSlug,

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -43,6 +43,7 @@ import titles from 'calypso/me/purchases/titles';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -282,6 +283,7 @@ class ConfirmCancelDomain extends React.Component {
 					path="/me/purchases/:site/:purchaseId/confirm-cancel-domain"
 					title="Purchases > Confirm Cancel Domain"
 				/>
+				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 				<HeaderCake
 					backHref={ this.props.getCancelPurchaseUrlFor(
 						this.props.siteSlug,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -96,6 +96,7 @@ import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/co
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -652,6 +653,9 @@ class ManagePurchase extends Component {
 				<QueryUserPurchases userId={ this.props.userId } />
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 				{ isPurchaseTheme && <QueryCanonicalTheme siteId={ siteId } themeId={ purchase.meta } /> }
+
+				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+
 				<HeaderCake backHref={ this.props.purchaseListUrl }>{ this.props.cardTitle }</HeaderCake>
 				{ showExpiryNotice ? (
 					<Notice status="is-info" text={ <PlanRenewalMessage /> } showDismiss={ false }>

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -27,6 +27,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { StripeHookProvider } from 'calypso/lib/stripe';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 function AddCardDetails( props ) {
 	const createCardUpdateToken = ( ...args ) => createCardToken( 'card_update', ...args );
@@ -72,6 +73,8 @@ function AddCardDetails( props ) {
 				path="/me/purchases/:site/:purchaseId/payment/add"
 				title="Purchases > Add Card Details"
 			/>
+			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+
 			<HeaderCake backHref={ props.getManagePurchaseUrlFor( props.siteSlug, props.purchaseId ) }>
 				{ titles.addCardDetails }
 			</HeaderCake>

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -32,6 +32,7 @@ import {
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { StripeHookProvider } from 'calypso/lib/stripe';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 function EditCardDetails( props ) {
 	const isDataLoading = ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;
@@ -80,6 +81,8 @@ function EditCardDetails( props ) {
 				path="/me/purchases/:site/:purchaseId/payment/edit/:cardId"
 				title="Purchases > Edit Card Details"
 			/>
+			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+
 			<HeaderCake backHref={ props.getManagePurchaseUrlFor( props.siteSlug, props.purchaseId ) }>
 				{ titles.editCardDetails }
 			</HeaderCake>

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -40,6 +40,8 @@ import {
 	CONCIERGE_WPCOM_SESSION_PRODUCT_ID,
 } from 'calypso/me/concierge/constants';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
+import FormattedHeader from 'calypso/components/formatted-header';
+import titles from 'calypso/me/purchases/titles';
 
 class PurchasesList extends Component {
 	isDataLoading() {
@@ -119,6 +121,7 @@ class PurchasesList extends Component {
 				return (
 					<Main>
 						<PageViewTracker path="/me/purchases" title="Purchases > No Sites" />
+						<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 						<PurchasesHeader section="purchases" />
 						<NoSitesMessage />
 					</Main>
@@ -149,6 +152,8 @@ class PurchasesList extends Component {
 				<QueryUserPurchases userId={ this.props.userId } />
 				<PageViewTracker path="/me/purchases" title="Purchases" />
 				<MeSidebarNavigation />
+
+				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 				<PurchasesHeader section="purchases" />
 				{ content }
 				<QueryConciergeInitial />

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -11,5 +11,6 @@ export default {
 	editCardDetails: i18n.translate( 'Change Credit Card', { comment: 'Credit card' } ),
 	addCardDetails: i18n.translate( 'Add Credit Card', { comment: 'Credit card' } ),
 	managePurchase: i18n.translate( 'Manage Purchase' ),
+	sectionTitle: i18n.translate( 'Manage Purchases' ),
 	purchases: i18n.translate( 'Purchases' ),
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the Manage Purchases page title to all the manage purchases screens. The title has been centralized as a string in a central location so that when we update it, it can be updated in one place. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/96605148-db2cc880-12c3-11eb-817a-387153d81805.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/96605187-e41d9a00-12c3-11eb-93a3-554deaec7aec.png)

#### Testing instructions

* Visit the Managed Purchases section in `/me` and confirm the title appears on all the tabs and sub pages.
* Visit the site level billing section and confirm there are no unintended artifacts.
