### PR TITLE
Profile: Add title to profile screen

### DIFF
--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -30,6 +30,7 @@ import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import { protectForm } from 'calypso/lib/protect-form';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -65,10 +66,16 @@ const Profile = createReactClass( {
 			'https://gravatar.com/' + this.props.userSettings.getSetting( 'user_login' );
 
 		return (
-			<Main className="profile">
+			<Main className="profile is-wide-layout">
 				<PageViewTracker path="/me" title="Me > My Profile" />
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				<FormattedHeader
+					brandFont
+					headerText={ this.props.translate( 'My Profile' ) }
+					align="left"
+				/>
+
 				<SectionHeader label={ this.props.translate( 'Profile' ) } />
 				<Card className="profile__settings">
 					<EditGravatar />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a title to the My Profile screen and makes it full width to match the upcoming changes in the Managed Purchases screen.

**Before**
![image](https://user-images.githubusercontent.com/6981253/96614458-28159c80-12ce-11eb-82de-889bb03a0af9.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/96614523-35328b80-12ce-11eb-85b4-f36f6440ebfc.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the My Profile screen in `/me`.
