### PR TITLE
Checks credentials for empty object

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -131,13 +131,14 @@ export class RewindCredentialsForm extends Component {
 		const { credentials, siteSlug } = nextProps;
 
 		const nextForm = Object.assign( {}, this.state.form );
+		const hasCredentials = isEmpty( nextForm.host ) && ! isEmpty( credentials );
 
 		// Populate the fields with data from state if credentials are already saved
-		nextForm.protocol = credentials ? credentials.protocol : nextForm.protocol;
-		nextForm.host = isEmpty( nextForm.host ) && credentials ? credentials.host : nextForm.host;
-		nextForm.port = isEmpty( nextForm.port ) && credentials ? credentials.port : nextForm.port;
-		nextForm.user = isEmpty( nextForm.user ) && credentials ? credentials.user : nextForm.user;
-		nextForm.path = isEmpty( nextForm.path ) && credentials ? credentials.abspath : nextForm.path;
+		nextForm.protocol = ! isEmpty( credentials ) ? credentials.protocol : nextForm.protocol;
+		nextForm.host = hasCredentials ? credentials.host : nextForm.host;
+		nextForm.port = hasCredentials ? credentials.port : nextForm.port;
+		nextForm.user = hasCredentials ? credentials.user : nextForm.user;
+		nextForm.path = hasCredentials ? credentials.abspath : nextForm.path;
 
 		// Populate the host field with the site slug if needed
 		nextForm.host =

--- a/client/jetpack-cloud/sections/settings/main.jsx
+++ b/client/jetpack-cloud/sections/settings/main.jsx
@@ -4,6 +4,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { localize, useTranslate } from 'i18n-calypso';
+import { isEmpty } from 'lodash';
 import { Card } from '@automattic/components';
 
 /**
@@ -15,8 +16,10 @@ import ServerCredentialsForm from 'calypso/components/jetpack/server-credentials
 import FoldableCard from 'calypso/components/foldable-card';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import getSiteScanState from 'calypso/state/selectors/get-site-scan-state';
+import getSiteCredentials from 'calypso/state/selectors/get-jetpack-credentials';
 import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import QuerySiteCredentials from 'calypso/components/data/query-site-credentials';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -117,10 +120,11 @@ const SettingsPage = () => {
 
 	const scanState = useSelector( ( state ) => getSiteScanState( state, siteId ) );
 	const backupState = useSelector( ( state ) => getRewindState( state, siteId ) );
+	const credentials = useSelector( ( state ) => getSiteCredentials( state, siteId, 'main' ) );
 
 	const isInitialized =
 		backupState.state !== 'uninitialized' || scanState?.state !== 'provisioning';
-	const isConnected = backupState.state === 'active' || scanState?.credentials.length !== 0;
+	const isConnected = ! isEmpty( credentials );
 
 	const hasBackup = backupState?.state !== 'unavailable';
 	const hasScan = scanState?.state !== 'unavailable';
@@ -140,6 +144,7 @@ const SettingsPage = () => {
 			<SidebarNavigation />
 			<QueryRewindState siteId={ siteId } />
 			<QueryJetpackScan siteId={ siteId } />
+			<QuerySiteCredentials siteId={ siteId } />
 			<PageViewTracker path="/settings/:site" title="Settings" />
 
 			<div className="settings__title">

--- a/client/my-sites/site-settings/jetpack-credentials/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/index.jsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -44,7 +45,7 @@ class JetpackCredentials extends Component {
 			this.isSectionHighlighted() && 'is-highlighted'
 		);
 		const hasAuthorized = rewindState === 'provisioning' || rewindState === 'active';
-		const hasCredentials = !! credentials;
+		const hasCredentials = ! isEmpty( credentials );
 
 		return (
 			<div className={ classes }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a regression with #46501 where the API was returning an empty object and Javascript treats that as true.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a Jetpack site and purchase Backup.
2. In Calypso, view the Settings -> Jetpack page and verify form shows the site as needing credentials.
3. Fill out credentials and save.
4. Verify credentials now appear and backend reports them present.
5. Delete credentials from system and do 2-4 in Jetpack Cloud.
6. Reset or create new site and verify with Jetpack Scan.