### PR TITLE
Account settings: Add title

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -58,6 +58,7 @@ import {
 	getCurrentUserName,
 	getCurrentUserVisibleSiteCount,
 } from 'calypso/state/current-user/selectors';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -811,10 +812,12 @@ const Account = createReactClass( {
 		const renderUsernameForm = userSettings.isSettingUnsaved( 'user_login' );
 
 		return (
-			<Main className="account">
+			<Main className="account is-wide-layout">
 				<PageViewTracker path="/me/account" title="Me > Account Settings" />
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				<FormattedHeader brandFont headerText={ translate( 'Account Settings' ) } align="left" />
+
 				<Card className="account__settings">
 					<form onChange={ markChanged } onSubmit={ this.submitForm }>
 						<FormFieldset>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a title to the Account setting screens and increases the screen width to match the changes in the Managed Purchases section.

**Before**
![image](https://user-images.githubusercontent.com/6981253/96617423-9b6cdd80-12d1-11eb-9f43-ca92edeb38c5.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/96617460-a58edc00-12d1-11eb-85bc-f275197bfa47.png)


#### Testing instructions

* Visit the Account Settings screen in `/me`
