### PR TITLE
Jetpack CRO: add AB test to switch between different variant of the Plans page

### DIFF
--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -7,9 +7,9 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'calypso/config';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { preventWidows } from 'calypso/lib/formatting';
+import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
 import JetpackComMasterbar from '../jpcom-masterbar';
 
 /**
@@ -18,7 +18,8 @@ import JetpackComMasterbar from '../jpcom-masterbar';
 import './style.scss';
 
 const Header = () => {
-	const isAlternateSelector = isEnabled( 'plans/alternate-selector' );
+	const isAlternateSelector =
+		getJetpackCROActiveVersion() === 'v1' || getJetpackCROActiveVersion() === 'v2';
 	const header = isAlternateSelector
 		? translate( 'Security, performance, and growth tools for WordPress' )
 		: translate( 'Security, performance, and marketing tools for WordPress' );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -172,15 +172,6 @@ export default {
 			'ZA',
 		],
 	},
-	offerResetFlow: {
-		datestamp: '20200916',
-		variations: {
-			showOfferResetFlow: 100,
-			control: 0,
-		},
-		defaultVariation: 'showOfferResetFlow',
-		allowExistingUsers: true,
-	},
 	userlessCheckout: {
 		datestamp: '20210806',
 		variations: {
@@ -226,6 +217,16 @@ export default {
 			control: 50,
 		},
 		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
+	jetpackConversionRateOptimization: {
+		datestamp: '20201020',
+		variations: {
+			'v0 - Offer Reset': 0, // Offer Reset
+			'v1 - 3 cols layout': 100, // first Offer Reset iteration (3 layout columns + simpler cards)
+			'v2 - slide outs': 0, // second Offer Reset iteration (reorder & slide outs)
+		},
+		defaultVariation: 'v1 - 3 cols layout',
 		allowExistingUsers: true,
 	},
 };

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -9,6 +9,7 @@ import i18n, { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { isEnabled } from 'calypso/config';
+import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
 import * as constants from './constants';
 
 const WPComGetBillingTimeframe = () => i18n.translate( 'per month, billed annually' );
@@ -384,7 +385,7 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 				'Great for brochure sites, restaurants, blogs, and resume sites.'
 		),
 	getTagline: () =>
-		isEnabled( 'plans/alternate-selector' )
+		getJetpackCROActiveVersion() === 'v1'
 			? translate( 'Backup, Scan, and Anti-spam in one package' )
 			: translate( 'Best for sites with occasional updates' ),
 	getPlanCompareFeatures: () => [],

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -9,6 +9,7 @@ import { numberFormat, translate } from 'i18n-calypso';
  */
 import { isEnabled } from 'calypso/config';
 import { shouldShowOfferResetFlow } from 'calypso/lib/plans/config';
+import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
 import * as CONSTANTS from './constants.js';
 
 // Translatable strings
@@ -93,6 +94,7 @@ export const getJetpackProductsDisplayNames = () => {
 };
 
 export const getJetpackProductsCallToAction = () => {
+	const currentCROvariant = getJetpackCROActiveVersion();
 	const backupDaily = (
 		<>
 			{ translate( 'Get Backup {{em}}Daily{{/em}}', {
@@ -111,15 +113,14 @@ export const getJetpackProductsCallToAction = () => {
 			} ) }
 		</>
 	);
-	const search = isEnabled( 'plans/alternate-selector' )
-		? translate( 'Get Jetpack Search' )
-		: translate( 'Get Search' );
-	const scan = isEnabled( 'plans/alternate-selector' )
-		? translate( 'Get Jetpack Scan' )
-		: translate( 'Get Scan' );
-	const antiSpam = isEnabled( 'plans/alternate-selector' )
-		? translate( 'Get Jetpack Anti-spam' )
-		: translate( 'Get Anti-spam' );
+	const search =
+		currentCROvariant === 'v1' ? translate( 'Get Jetpack Search' ) : translate( 'Get Search' );
+	const scan =
+		currentCROvariant === 'v1' ? translate( 'Get Jetpack Scan' ) : translate( 'Get Scan' );
+	const antiSpam =
+		currentCROvariant === 'v1'
+			? translate( 'Get Jetpack Anti-spam' )
+			: translate( 'Get Anti-spam' );
 
 	return {
 		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_DAILY ]: backupDaily,
@@ -136,15 +137,18 @@ export const getJetpackProductsCallToAction = () => {
 };
 
 export const getJetpackProductsTaglines = () => {
-	const backupDailyTagline = isEnabled( 'plans/alternate-selector' )
-		? translate( 'Automated backups with one-click restores' )
-		: translate( 'Best for sites with occasional updates' );
+	const currentCROvariant = getJetpackCROActiveVersion();
+	const backupDailyTagline =
+		currentCROvariant === 'v1'
+			? translate( 'Automated backups with one-click restores' )
+			: translate( 'Best for sites with occasional updates' );
 	const backupRealtimeTagline = translate( 'Best for sites with frequent updates' );
 	const backupOwnedTagline = translate( 'Your site is actively being backed up' );
 
-	const searchTagline = isEnabled( 'plans/alternate-selector' )
-		? translate( 'Great for sites with a lot of content' )
-		: translate( 'Recommended for sites with lots of products or content' );
+	const searchTagline =
+		currentCROvariant === 'v1'
+			? translate( 'Great for sites with a lot of content' )
+			: translate( 'Recommended for sites with lots of products or content' );
 	const scanTagline = translate( 'Protect your site' );
 	const scanOwnedTagline = translate( 'Your site is actively being scanned for malicious threats' );
 	const antiSpamTagline = translate( 'Block spam automatically' );

--- a/client/my-sites/plans-v2/abtest.ts
+++ b/client/my-sites/plans-v2/abtest.ts
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'calypso/lib/abtest';
+
+/**
+ * Returns the name of the Conversion Rate Optimization test that is currently active.
+ *
+ * @returns {string}  The name of the active test.
+ */
+export const getJetpackCROActiveVersion = (): string => {
+	const currentVariant = abtest( 'jetpackConversionRateOptimization' );
+
+	switch ( currentVariant ) {
+		case 'v0 - Offer Reset':
+			return 'v0';
+		case 'v1 - 3 cols layout':
+			return 'v1';
+		case 'v2 - slide outs':
+			return 'v2';
+	}
+
+	return 'v1';
+};

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -6,7 +6,6 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'calypso/config';
 import {
 	JETPACK_SCAN_PRODUCTS,
 	JETPACK_ANTI_SPAM_PRODUCTS,
@@ -50,6 +49,7 @@ import {
 	FEATURE_CRM_NO_CONTACT_LIMITS,
 	FEATURE_CRM_PRIORITY_SUPPORT,
 } from 'calypso/lib/plans/constants';
+import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
 import { buildCardFeaturesFromItem } from './utils';
 
 /**
@@ -286,7 +286,9 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 	subtypes: [],
 	costProductSlug: PRODUCT_JETPACK_CRM,
 	monthlyProductSlug: PRODUCT_JETPACK_CRM,
-	iconSlug: 'jetpack_crm',
+	iconSlug: [ 'v1', 'v2' ].includes( getJetpackCROActiveVersion() )
+		? 'jetpack_crm_dark'
+		: 'jetpack_crm',
 	displayName: translate( 'Jetpack CRM' ),
 	shortName: translate( 'CRM', {
 		comment: 'Short name of the Jetpack CRM',
@@ -295,9 +297,8 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 	description: translate(
 		'The most simple and powerful WordPress CRM. Improve customer relationships and increase profits.'
 	),
-	buttonLabel: isEnabled( 'plans/alternate-selector' )
-		? translate( 'Get Jetpack CRM' )
-		: translate( 'Get CRM' ),
+	buttonLabel:
+		getJetpackCROActiveVersion() === 'v1' ? translate( 'Get Jetpack CRM' ) : translate( 'Get CRM' ),
 	features: {
 		items: buildCardFeaturesFromItem(
 			[

--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -6,12 +6,12 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'calypso/config';
 import SelectorPage from './selector';
 import SelectorPageAlt from './selector-alt';
 import DetailsPage from './details';
 import UpsellPage from './upsell';
 import { stringToDuration } from './utils';
+import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
 import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { TERM_ANNUALLY } from 'calypso/lib/plans/constants';
@@ -30,10 +30,22 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 		( TERM_ANNUALLY as Duration );
 	const urlQueryArgs: QueryArgs = context.query;
 
-	if ( isEnabled( 'plans/alternate-selector' ) ) {
-		// TODO: Implement new product selector page;
-		// right now we're showing exactly the same page
-		// as when the flag is disabled
+	const currentCROvariant = getJetpackCROActiveVersion();
+
+	if ( currentCROvariant === 'v1' ) {
+		context.primary = (
+			<SelectorPageAlt
+				defaultDuration={ duration }
+				rootUrl={ rootUrl }
+				siteSlug={ context.params.site || context.query.site }
+				urlQueryArgs={ urlQueryArgs }
+				header={ context.header }
+				footer={ context.footer }
+			/>
+		);
+	} else if ( currentCROvariant === 'v2' ) {
+		// TODO: render the new iteration. It's possible that we won't need a new
+		// Selector page for this. In that case, we should delete this if branch.
 		context.primary = (
 			<SelectorPageAlt
 				defaultDuration={ duration }

--- a/client/my-sites/plans-v2/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans-v2/use-get-plans-grid-products.ts
@@ -6,8 +6,6 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'calypso/config';
-import { slugToSelectorProduct } from './utils';
 import { getPlan } from 'calypso/lib/plans';
 import {
 	JETPACK_ANTI_SPAM_PRODUCTS,
@@ -20,12 +18,14 @@ import {
 	PRODUCT_JETPACK_CRM,
 	PRODUCT_JETPACK_CRM_MONTHLY,
 } from 'calypso/lib/products-values/constants';
+import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
 import {
 	OPTIONS_JETPACK_BACKUP,
 	OPTIONS_JETPACK_BACKUP_MONTHLY,
 } from 'calypso/my-sites/plans-v2/constants';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
+import { slugToSelectorProduct } from './utils';
 
 const useSelectorPageProducts = ( siteId: number | null ) => {
 	let availableProducts: string[] = [];
@@ -67,9 +67,25 @@ const useSelectorPageProducts = ( siteId: number | null ) => {
 		! ownedProducts.some( ( ownedProduct ) => JETPACK_BACKUP_PRODUCTS.includes( ownedProduct ) )
 	) {
 		// The Alternative Selector page include Jetpack Backup Daily rather than the option card.
-		const backupProductsToShow = isEnabled( 'plans/alternate-selector' )
-			? [ PRODUCT_JETPACK_BACKUP_DAILY, PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]
-			: [ OPTIONS_JETPACK_BACKUP, OPTIONS_JETPACK_BACKUP_MONTHLY ];
+		const backupProductsToShow = [];
+		switch ( getJetpackCROActiveVersion() ) {
+			case 'v0':
+				backupProductsToShow.push( OPTIONS_JETPACK_BACKUP, OPTIONS_JETPACK_BACKUP_MONTHLY );
+				break;
+			case 'v1':
+				backupProductsToShow.push(
+					PRODUCT_JETPACK_BACKUP_DAILY,
+					PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY
+				);
+				break;
+			case 'v2':
+				// TODO: add Backup Real-time
+				backupProductsToShow.push(
+					PRODUCT_JETPACK_BACKUP_DAILY,
+					PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY
+				);
+				break;
+		}
 		availableProducts = [ ...availableProducts, ...backupProductsToShow ];
 	}
 

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -64,6 +64,7 @@ import { getJetpackProductTagline } from 'calypso/lib/products-values/get-jetpac
 import { getJetpackProductCallToAction } from 'calypso/lib/products-values/get-jetpack-product-call-to-action';
 import { getJetpackProductDescription } from 'calypso/lib/products-values/get-jetpack-product-description';
 import { getJetpackProductShortName } from 'calypso/lib/products-values/get-jetpack-product-short-name';
+import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
 import { MORE_FEATURES_LINK } from 'calypso/my-sites/plans-v2/constants';
 import { addQueryArgs } from 'calypso/lib/route';
 
@@ -337,10 +338,16 @@ export function itemToSelectorProduct(
 		} else if ( item.term === TERM_MONTHLY ) {
 			yearlyProductSlug = PRODUCTS_LIST[ item.product_slug as JetpackProductSlug ].type;
 		}
+
+		const currentCROvariant = getJetpackCROActiveVersion();
+		const iconSlug = [ 'v1', 'v2' ].includes( currentCROvariant )
+			? `${ yearlyProductSlug || item.product_slug }_v2_dark`
+			: `${ yearlyProductSlug || item.product_slug }_v2`;
+
 		return {
 			productSlug: item.product_slug,
 			// Using the same slug for any duration helps prevent unnecessary DOM updates
-			iconSlug: `${ yearlyProductSlug || item.product_slug }_v2`,
+			iconSlug,
 			displayName: getJetpackProductDisplayName( item ),
 			type: ITEM_TYPE_PRODUCT,
 			subtypes: [],

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -104,7 +104,6 @@
 		"p2/p2-plus": true,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -77,7 +77,6 @@
 		"nav-unification": false,
 		"oauth": true,
 		"persist-redux": true,
-		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,

--- a/config/development.json
+++ b/config/development.json
@@ -143,7 +143,6 @@
 		"page/export": true,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,
 		"post-editor/launch-overlay": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -98,7 +98,6 @@
 		"network-connection": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -30,7 +30,6 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"plans/alternate-selector": true,
 		"oauth": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -27,7 +27,6 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"plans/alternate-selector": true,
 		"oauth": false,
 		"site-indicator": false,
 		"support-user": true

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -29,7 +29,6 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"plans/alternate-selector": true,
 		"oauth": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -28,7 +28,6 @@
 		"layout/nps-survey-notice": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"plans/alternate-selector": true,
 		"oauth": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/production.json
+++ b/config/production.json
@@ -104,7 +104,6 @@
 		"nps-survey/dev-trigger": false,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -112,7 +112,6 @@
 		"page/export": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/test.json
+++ b/config/test.json
@@ -82,7 +82,6 @@
 		"network-connection": true,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/image-editor": true,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -117,7 +117,6 @@
 		"nps-survey/dev-trigger": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/alternate-selector": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,
 		"post-editor/html-toolbar": true,

--- a/packages/components/src/product-icon/config.js
+++ b/packages/components/src/product-icon/config.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'calypso/config';
 import jetpackBackup from './images/jetpack-backup.svg';
 import jetpackBackupV2 from './images/jetpack-backup-v2.svg';
 import jetpackBackupV2Darkblue from './images/jetpack-backup-v2-darkblue.svg';
@@ -31,29 +30,26 @@ import wpcomPremium from './images/wpcom-premium.svg';
 
 export const paths = {
 	'jetpack-scan': jetpackScan,
-	'jetpack-scan-v2': isEnabled( 'plans/alternate-selector' )
-		? jetpackScanV2Darkblue
-		: jetpackScanV2,
+	'jetpack-scan-v2': jetpackScanV2,
+	'jetpack-scan-v2-dark': jetpackScanV2Darkblue,
 	'jetpack-backup-daily': jetpackBackup,
 	'jetpack-backup-realtime': jetpackBackup,
-	'jetpack-backup-v2': isEnabled( 'plans/alternate-selector' )
-		? jetpackBackupV2Darkblue
-		: jetpackBackupV2,
+	'jetpack-backup-v2': jetpackBackupV2,
+	'jetpack-backup-v2-dark': jetpackBackupV2Darkblue,
 	'jetpack-free': jetpackFree,
 	'jetpack-personal': jetpackPersonal,
 	'jetpack-premium': jetpackPremium,
 	'jetpack-professional': jetpackProfessional,
 	'jetpack-complete-v2': jetpackCompleteV2,
-	'jetpack-crm-v2': isEnabled( 'plans/alternate-selector' ) ? jetpackCrmV2Darkblue : jetpackCrmV2,
+	'jetpack-crm-v2': jetpackCrmV2,
+	'jetpack-crm-v2-dark': jetpackCrmV2Darkblue,
 	'jetpack-search': jetpackSearch,
-	'jetpack-search-v2': isEnabled( 'plans/alternate-selector' )
-		? jetpackSearchV2Darkblue
-		: jetpackSearchV2,
+	'jetpack-search-v2': jetpackSearchV2,
+	'jetpack-search-v2-dark': jetpackSearchV2Darkblue,
 	'jetpack-security-v2': jetpackSecurityV2,
 	'jetpack-anti-spam': jetpackAntiSpam,
-	'jetpack-anti-spam-v2': isEnabled( 'plans/alternate-selector' )
-		? jetpackAntiSpamV2Darkblue
-		: jetpackAntiSpamV2,
+	'jetpack-anti-spam-v2': jetpackAntiSpamV2,
+	'jetpack-anti-spam-v2-dark': jetpackAntiSpamV2Darkblue,
 	'wpcom-blogger': wpcomBlogger,
 	'wpcom-business': wpcomBusiness,
 	'wpcom-ecommerce': wpcomEcommerce,
@@ -81,7 +77,8 @@ export const iconToProductSlugMap = {
 		'jetpack_complete_v2',
 		'jetpack_complete_monthly_v2',
 	],
-	'jetpack-crm-v2': [ 'jetpack_crm' ],
+	'jetpack-crm-v2': [ 'jetpack_crm', 'jetpack_crm_monthly' ],
+	'jetpack-crm-v2-dark': [ 'jetpack_crm_dark', 'jetpack_crm_monthly_dark' ],
 	'jetpack-backup-daily': [ 'jetpack_backup_daily', 'jetpack_backup_daily_monthly' ],
 	'jetpack-backup-realtime': [ 'jetpack_backup_realtime', 'jetpack_backup_realtime_monthly' ],
 	'jetpack-backup-v2': [
@@ -90,6 +87,13 @@ export const iconToProductSlugMap = {
 		'jetpack_backup_daily_monthly_v2',
 		'jetpack_backup_realtime_v2',
 		'jetpack_backup_realtime_monthly_v2',
+	],
+	'jetpack-backup-v2-dark': [
+		'jetpack_backup_v2_dark',
+		'jetpack_backup_daily_v2_dark',
+		'jetpack_backup_daily_monthly_v2_dark',
+		'jetpack_backup_realtime_v2_dark',
+		'jetpack_backup_realtime_monthly_v2_dark',
 	],
 	'jetpack-scan': [ 'jetpack_scan', 'jetpack_scan_monthly' ],
 	'jetpack-scan-v2': [
@@ -100,6 +104,14 @@ export const iconToProductSlugMap = {
 		'jetpack_scan_realtime_v2',
 		'jetpack_scan_realtime_monthly_v2',
 	],
+	'jetpack-scan-v2-dark': [
+		'jetpack_scan_v2_dark',
+		'jetpack_scan_monthly_v2_dark',
+		'jetpack_scan_daily_v2_dark',
+		'jetpack_scan_daily_monthly_v2_dark',
+		'jetpack_scan_realtime_v2_dark',
+		'jetpack_scan_realtime_monthly_v2_dark',
+	],
 	'jetpack-search': [
 		'jetpack_search',
 		'jetpack_search_monthly',
@@ -107,8 +119,10 @@ export const iconToProductSlugMap = {
 		'wpcom_search_monthly',
 	],
 	'jetpack-search-v2': [ 'jetpack_search_v2', 'jetpack_search_monthly_v2' ],
+	'jetpack-search-v2-dark': [ 'jetpack_search_v2_dark', 'jetpack_search_monthly_v2_dark' ],
 	'jetpack-anti-spam': [ 'jetpack_anti_spam', 'jetpack_anti_spam_monthly' ],
 	'jetpack-anti-spam-v2': [ 'jetpack_anti_spam_v2', 'jetpack_anti_spam_monthly_v2' ],
+	'jetpack-anti-spam-v2-dark': [ 'jetpack_anti_spam_v2_dark', 'jetpack_anti_spam_monthly_v2_dark' ],
 	'jetpack-security-v2': [
 		'jetpack_security_v2',
 		'jetpack_security_monthly_v2',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace the `plans/alternate-selector` feature flag with an AB test experiment. We need this because we might have to maintain multiple variants of the page at the same time.

#### Implementation notes

* I introduced three variants: `v0 - Offer Reset`, `v1 - 3 cols layout`, and `v2 - slide outs`. The first one corresponds to the plain new Offer Reset Plans page. The second one is the current version of the page. The latter corresponds to next iteration with slide outs cards.
* Removed from the `ProductIcon` component all traces of the feature flag and moved the logic that decides which icon to use back to Calypso. I did this mainly because I believe this package might be used externally where feature flags don't exist.
* I tried to give variants a name that explain what is behind each one of them (for internal non-dev users). However, our code should use the `getJetpackCROActiveVersion` util which returns an abbreviated name. Those names are `v1`, `v2`, and `v3`, for now.
* Depending on whether we have to support two or three versions of something (say a piece of copy), we might have to use a `switch` or an if to manage the cases (this PR have some examples of this).

#### Testing instructions

* Run this PR (Calypso Blue and Green).
* Open Calypso Blue and select the `v1 - 3 cols layout` variant of the `jetpackConversionRateOptimization` AB test (this is the current one – the same UI we had behind the `plans/alternate-selector` feature flag).
* Visit the Plans page.
* Make sure that the page looks the same as in production.
* Change the variant to `v0 - Offer Reset`.
* Make sure that it looks like the first version of the Offer Reset project.
* Change the variant to `v2 - slide outs`.
* Make sure that the page looks the same as in production (we haven't changed anything yet).

**Make sure that from a code perspective, the AB test configuration is the right one, meaning that we won't expose anything different to the users unless we re-start the test with a new configuration. Is this configuration safe to work behind the scenes?** 

Fixes 1196341175636977-as-1198561816278773

#### Demo
![Kapture 2020-10-20 at 13 41 15](https://user-images.githubusercontent.com/3418513/96617434-ff939f80-12d9-11eb-8033-238e7350fb97.gif)

