### PR TITLE
Sidebar: Nudge the comment count down 1px for better alignment

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -149,7 +149,7 @@
 		line-height: 0;
 		padding: 8px 6px;
 		position: absolute;
-		top: 9px;
+		top: 10px;
 	}
 
 	.badge {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix vertical alignment of the sidebar's comment count. Fixes #45097

**Before**
<img width="309" alt="Screen Shot 2020-10-20 at 1 01 30 PM" src="https://user-images.githubusercontent.com/2124984/96620712-ceb16b80-12d5-11eb-86e1-a04abb80eb77.png">

**After**
<img width="304" alt="Screen Shot 2020-10-20 at 1 11 58 PM" src="https://user-images.githubusercontent.com/2124984/96620749-d83ad380-12d5-11eb-9c48-fbd709c2c773.png">


#### Testing instructions

* Switch to this PR
* Navigate to a site that has unmoderated comments
* Check out the comment count bubble in the sidebar
* Make sure other instances of the count are not negatively affected (I think the only other instance is in the Reader but I'll do another sweep to double check)