### PR TITLE
Security: Add page title

### DIFF
--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -23,6 +23,7 @@ import QueryConnectedApplications from 'calypso/components/data/query-connected-
 import ReauthRequired from 'calypso/me/reauth-required';
 import SecuritySectionNav from 'calypso/me/security-section-nav';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -109,7 +110,7 @@ class ConnectedApplications extends PureComponent {
 		const { translate } = this.props;
 
 		return (
-			<Main className="security connected-applications">
+			<Main className="security connected-applications is-wide-layout">
 				<QueryConnectedApplications />
 
 				<PageViewTracker
@@ -118,6 +119,8 @@ class ConnectedApplications extends PureComponent {
 				/>
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<MeSidebarNavigation />
+
+				<FormattedHeader brandFont headerText={ translate( 'Security' ) } align="left" />
 
 				<DocumentHead title={ translate( 'Connected Applications' ) } />
 

--- a/client/me/security-account-recovery/index.jsx
+++ b/client/me/security-account-recovery/index.jsx
@@ -47,6 +47,7 @@ import {
 } from 'calypso/state/account-recovery/settings/selectors';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -54,11 +55,13 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import './style.scss';
 
 const SecurityAccountRecovery = ( props ) => (
-	<Main className="security security-account-recovery">
+	<Main className="security security-account-recovery is-wide-layout">
 		<PageViewTracker path="/me/security/account-recovery" title="Me > Account Recovery" />
 		<QueryAccountRecoverySettings />
 
 		<MeSidebarNavigation />
+
+		<FormattedHeader brandFont headerText={ props.translate( 'Security' ) } align="left" />
 
 		{ ! config.isEnabled( 'security/security-checkup' ) && (
 			<SecuritySectionNav path={ props.path } />

--- a/client/me/security-account-recovery/style.scss
+++ b/client/me/security-account-recovery/style.scss
@@ -15,7 +15,6 @@
 	padding-right: 0;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		flex: 1;
 		padding-right: 20px;
 		margin-bottom: 0;
 	}
@@ -68,14 +67,8 @@
 	flex: 2;
 }
 
-.security-account-recovery-contact__header-title {
-	font-size: 1em;
-	line-height: 1em;
-}
-
 .security-account-recovery-contact__header-subtitle {
 	display: block;
-	font-size: 1em;
 	font-style: italic;
 	color: var( --color-text-subtle );
 }

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -42,14 +42,14 @@ class SecurityCheckupComponent extends React.Component {
 		const { path, translate } = this.props;
 
 		return (
-			<Main className="security security-checkup">
+			<Main className="security security-checkup is-wide-layout">
 				<PageViewTracker path={ path } title="Me > Security Checkup" />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<MeSidebarNavigation />
 
 				<DocumentHead title={ translate( 'Security' ) } />
 
-				<FormattedHeader headerText={ translate( 'Security' ) } align="left" />
+				<FormattedHeader brandFont headerText={ translate( 'Security' ) } align="left" />
 
 				<SectionHeader label={ translate( 'Security Checklist' ) } />
 

--- a/client/me/security/main.jsx
+++ b/client/me/security/main.jsx
@@ -21,6 +21,7 @@ import ReauthRequired from 'calypso/me/reauth-required';
 import SecuritySectionNav from 'calypso/me/security-section-nav';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 const debug = debugFactory( 'calypso:me:security:password' );
 
@@ -49,10 +50,12 @@ class Security extends React.Component {
 		const useCheckupMenu = config.isEnabled( 'security/security-checkup' );
 
 		return (
-			<Main className="security">
+			<Main className="security is-wide-layout">
 				<PageViewTracker path={ path } title="Me > Password" />
 				<DocumentHead title={ translate( 'Password' ) } />
 				<MeSidebarNavigation />
+
+				<FormattedHeader brandFont headerText={ translate( 'Security' ) } align="left" />
 
 				{ ! useCheckupMenu && <SecuritySectionNav path={ path } /> }
 				{ useCheckupMenu && (

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -24,6 +24,7 @@ import ReauthRequired from 'calypso/me/reauth-required';
 import SecuritySectionNav from 'calypso/me/security-section-nav';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import SocialLoginService from './service';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -83,10 +84,12 @@ class SocialLogin extends Component {
 		const title = useCheckupMenu ? translate( 'Social Logins' ) : translate( 'Social Login' );
 
 		return (
-			<Main className="security social-login">
+			<Main className="security social-login is-wide-layout">
 				<PageViewTracker path="/me/security/social-login" title="Me > Social Login" />
 				<DocumentHead title={ title } />
 				<MeSidebarNavigation />
+
+				<FormattedHeader brandFont headerText={ translate( 'Security' ) } align="left" />
 
 				{ ! useCheckupMenu && <SecuritySectionNav path={ path } /> }
 				{ useCheckupMenu && (

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -25,6 +25,7 @@ import SecuritySectionNav from 'calypso/me/security-section-nav';
 import Security2faKey from 'calypso/me/security-2fa-key';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -167,13 +168,15 @@ class TwoStep extends Component {
 		const useCheckupMenu = config.isEnabled( 'security/security-checkup' );
 
 		return (
-			<Main className="security two-step">
+			<Main className="security two-step is-wide-layout">
 				<PageViewTracker path="/me/security/two-step" title="Me > Two-Step Authentication" />
 				<MeSidebarNavigation />
 
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
 				<DocumentHead title={ translate( 'Two-Step Authentication' ) } />
+
+				<FormattedHeader brandFont headerText={ translate( 'Security' ) } align="left" />
 
 				{ ! useCheckupMenu && <SecuritySectionNav path={ path } /> }
 				{ useCheckupMenu && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR updates Adds the page title to all the Security related screens and makes them full width to match the upcoming changes to the Manage Purchases screen.

**Before**
![image](https://user-images.githubusercontent.com/6981253/96621223-5d25ed00-12d6-11eb-86ca-2df04e1a2810.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/96621171-4ed7d100-12d6-11eb-8e33-abf25c1904f1.png)

#### Testing instructions

* Visit the Security screen in `/me` and navigate through all the child screens to confirm the title is there and the screens are all full width. 
