### PR TITLE
Privacy: Add title

### DIFF
--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -30,6 +30,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { requestHttpData, getHttpData } from 'calypso/state/data-layer/http-data';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -97,11 +98,13 @@ const Privacy = createReactClass( {
 		);
 
 		return (
-			<Main className="privacy">
+			<Main className="privacy is-wide-layout">
 				<PageViewTracker path="/me/privacy" title="Me > Privacy" />
 				<DocumentHead title={ translate( 'Privacy Settings' ) } />
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				<FormattedHeader brandFont headerText={ translate( 'Privacy' ) } align="left" />
+
 				<SectionHeader label={ translate( 'Usage information' ) } />
 				<Card className="privacy__settings">
 					<form onChange={ markChanged } onSubmit={ this.submitForm }>

--- a/client/me/privacy/style.scss
+++ b/client/me/privacy/style.scss
@@ -6,6 +6,7 @@
 
     .form-toggle__label {
         display: flex;
+        align-items: center;
     }
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a page title and makes the screen full width to match the updates we're making on the Payments Methods screens.


**Before**
![image](https://user-images.githubusercontent.com/6981253/96622268-ba6e6e00-12d7-11eb-8bba-d2fe4aab44a3.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/96622232-ae82ac00-12d7-11eb-9595-e20e6e8915ba.png)


#### Testing instructions

* Visit the Privacy screens in `/me` and confirm the title and width match the screenshots.