### PR TITLE
Remove `jetpack/backup-simplified-screens` feature flag

### DIFF
--- a/client/components/activity-card/activity-actor.tsx
+++ b/client/components/activity-card/activity-actor.tsx
@@ -54,8 +54,7 @@ const ActivityActor: FunctionComponent< Props > = ( {
 	if ( actorName === 'Jetpack' && actorType === 'Application' ) {
 		return (
 			<div className="activity-card__actor">
-				{ ( ! isEnabled( 'jetpack/backup-simplified-screens' ) ||
-					isEnabled( 'jetpack/backup-simplified-screens-i4' ) ) && <JetpackLogo size={ size } /> }
+				{ isEnabled( 'jetpack/backup-simplified-screens-i4' ) && <JetpackLogo size={ size } /> }
 				{ ! withoutInfo && (
 					<div className="activity-card__actor-info">
 						<div className="activity-card__actor-name">Jetpack</div>
@@ -68,8 +67,7 @@ const ActivityActor: FunctionComponent< Props > = ( {
 	if ( actorName === 'Happiness Engineer' && actorType === 'Happiness Engineer' ) {
 		return (
 			<div className="activity-card__actor">
-				{ ( ! isEnabled( 'jetpack/backup-simplified-screens' ) ||
-					isEnabled( 'jetpack/backup-simplified-screens-i4' ) ) && <JetpackLogo size={ size } /> }
+				{ isEnabled( 'jetpack/backup-simplified-screens-i4' ) && <JetpackLogo size={ size } /> }
 				{ ! withoutInfo && (
 					<div className="activity-card__actor-info">
 						<div className="activity-card__actor-name">Happiness Engineer</div>

--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -9,10 +9,7 @@ import { useDispatch, useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'calypso/config';
-import ExternalLink from 'calypso/components/external-link';
 import Button from 'calypso/components/forms/form-button';
-import { settingsPath } from 'calypso/lib/jetpack/paths';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
@@ -22,7 +19,6 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
  * Style dependencies
  */
 import './style.scss';
-import missingCredentialsIcon from './missing-credentials.svg';
 
 const DownloadButton = ( { disabled, rewindId } ) => {
 	const translate = useTranslate();
@@ -70,76 +66,18 @@ const RestoreButton = ( { disabled, rewindId } ) => {
 			onClick={ onRestore }
 		>
 			<div className="daily-backup-status__restore-button-icon">
-				{ needsCredentials && ! isEnabled( 'jetpack/backup-simplified-screens' ) && (
-					<img src={ missingCredentialsIcon } alt="" role="presentation" />
-				) }
 				<div>{ translate( 'Restore to this point' ) }</div>
 			</div>
 		</Button>
 	);
 };
 
-const MissingCredentials = () => {
-	const translate = useTranslate();
-	const dispatch = useDispatch();
-	const siteSlug = useSelector( getSelectedSiteSlug );
-
-	const onActivateRestores = () =>
-		dispatch( recordTracksEvent( 'calypso_jetpack_backup_activate_click' ) );
-
-	return (
-		<div className="daily-backup-status__credentials-warning">
-			<div className="daily-backup-status__credentials-warning-top">
-				<img src={ missingCredentialsIcon } alt="" role="presentation" />
-				<div>{ translate( 'Restore points have not been enabled for your account' ) }</div>
-			</div>
-
-			<div className="daily-backup-status__credentials-warning-bottom">
-				<div className="daily-backup-status__credentials-warning-text">
-					{ translate(
-						'A backup of your data has been made, but you must enter your server credentials to enable one-click restores. {{a}}Find your server credentials{{/a}}',
-						{
-							components: {
-								a: (
-									<ExternalLink
-										icon
-										href="https://jetpack.com/support/ssh-sftp-and-ftp-credentials/"
-										onClick={ () => {} }
-									/>
-								),
-							},
-						}
-					) }
-				</div>
-				<Button
-					isPrimary={ false }
-					className="daily-backup-status__activate-restores-button"
-					href={ settingsPath( siteSlug ) }
-					onClick={ onActivateRestores }
-				>
-					{ translate( 'Activate restores' ) }
-				</Button>
-			</div>
-		</div>
-	);
-};
-
-const ActionButtons = ( { rewindId, disabled } ) => {
-	const siteId = useSelector( getSelectedSiteId );
-	const hasCredentials = useSelector(
-		( state ) => ! getDoesRewindNeedCredentials( state, siteId )
-	);
-
-	return (
-		<>
-			<DownloadButton disabled={ disabled || ! rewindId } rewindId={ rewindId } />
-			<RestoreButton disabled={ disabled || ! rewindId } rewindId={ rewindId } />
-			{ ! hasCredentials && ! isEnabled( 'jetpack/backup-simplified-screens' ) && (
-				<MissingCredentials />
-			) }
-		</>
-	);
-};
+const ActionButtons = ( { rewindId, disabled } ) => (
+	<>
+		<DownloadButton disabled={ disabled || ! rewindId } rewindId={ rewindId } />
+		<RestoreButton disabled={ disabled || ! rewindId } rewindId={ rewindId } />
+	</>
+);
 
 ActionButtons.propTypes = {
 	rewindId: PropTypes.string,

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { get, isArray } from 'lodash';
 import React from 'react';
@@ -10,7 +9,6 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'calypso/config';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -75,11 +73,7 @@ const BackupSuccessful = ( { backup, deltas, selectedDate } ) => {
 			<div className="status-card__meta">{ meta }</div>
 			<ActionButtons rewindId={ backup.rewindId } />
 			{ showBackupDetails && (
-				<div
-					className={ classNames( 'status-card__realtime-details', {
-						'is-simplified': isEnabled( 'jetpack/backup-simplified-screens' ),
-					} ) }
-				>
+				<div className="status-card__realtime-details">
 					<div className="status-card__realtime-details-card">
 						<ActivityCard activity={ backup } summarize />
 					</div>

--- a/client/components/jetpack/daily-backup-status/status-card/no-backups-yet.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/no-backups-yet.jsx
@@ -8,10 +8,7 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'calypso/config';
 import ExternalLink from 'calypso/components/external-link';
-import Button from 'calypso/components/forms/form-button';
-import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
@@ -23,7 +20,6 @@ import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
  */
 import './style.scss';
 import cloudPendingIcon from './icons/cloud-pending.svg';
-import cloudWarningIcon from './icons/cloud-warning.svg';
 
 const NoBackupsYet = () => {
 	const translate = useTranslate();
@@ -32,76 +28,50 @@ const NoBackupsYet = () => {
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 	const siteName = useSelector( ( state ) => getRawSite( state, siteId ) )?.name;
 
-	if ( isEnabled( 'jetpack/backup-simplified-screens' ) ) {
-		return (
-			<>
-				<div className="status-card__message-head">
-					<img src={ cloudPendingIcon } alt="" role="presentation" />
-					<div>
-						{ translate( 'We are preparing to backup %s', {
-							args: siteName,
-							comment: '%s is the name of the site',
-						} ) }
-					</div>
-				</div>
-				<h2 className="status-card__title">
-					{ translate( 'Your first backup will be ready soon' ) }
-				</h2>
-				<div className="status-card__label">
-					{ isJetpackCloud()
-						? translate(
-								'Your first backup will appear here {{strong}}within 24 hours{{/strong}} and you will receive a {{wpcomLink/}} notification once the backup has been completed.',
-								{
-									components: {
-										strong: <strong />,
-										wpcomLink: (
-											<ExternalLink href="https://wordpress.com">WordPress.com</ExternalLink>
-										),
-									},
-								}
-						  )
-						: translate(
-								'Your first backup will appear here {{strong}}within 24 hours{{/strong}} and you will receive a notification once the backup has been completed.',
-								{
-									components: {
-										strong: <strong />,
-									},
-								}
-						  ) }
-				</div>
-				<ul className="status-card__link-list">
-					<li>
-						<ExternalLink href={ siteUrl }>{ translate( 'Visit your website' ) }</ExternalLink>
-					</li>
-					<li>
-						<ExternalLink href={ adminUrl }>{ translate( 'Manage your website' ) }</ExternalLink>
-					</li>
-				</ul>
-			</>
-		);
-	}
-
 	return (
 		<>
 			<div className="status-card__message-head">
-				<img src={ cloudWarningIcon } alt="" role="presentation" />
-				<div>{ translate( 'No backups are available yet' ) }</div>
+				<img src={ cloudPendingIcon } alt="" role="presentation" />
+				<div>
+					{ translate( 'We are preparing to backup %s', {
+						args: siteName,
+						comment: '%s is the name of the site',
+					} ) }
+				</div>
 			</div>
+			<h2 className="status-card__title">
+				{ translate( 'Your first backup will be ready soon' ) }
+			</h2>
 			<div className="status-card__label">
-				{ translate(
-					'But don’t worry, one should become available in the next 24 hours. Contact support if you still need help.'
-				) }
+				{ isJetpackCloud()
+					? translate(
+							'Your first backup will appear here {{strong}}within 24 hours{{/strong}} and you will receive a {{wpcomLink/}} notification once the backup has been completed.',
+							{
+								components: {
+									strong: <strong />,
+									wpcomLink: (
+										<ExternalLink href="https://wordpress.com">WordPress.com</ExternalLink>
+									),
+								},
+							}
+					  )
+					: translate(
+							'Your first backup will appear here {{strong}}within 24 hours{{/strong}} and you will receive a notification once the backup has been completed.',
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+					  ) }
 			</div>
-
-			<Button
-				className="status-card__support-button"
-				href={ contactSupportUrl( siteUrl ) }
-				target="_blank"
-				rel="noopener noreferrer"
-				isPrimary={ false }
-			>
-				{ translate( 'Contact support' ) }
-			</Button>
+			<ul className="status-card__link-list">
+				<li>
+					<ExternalLink href={ siteUrl }>{ translate( 'Visit your website' ) }</ExternalLink>
+				</li>
+				<li>
+					<ExternalLink href={ adminUrl }>{ translate( 'Manage your website' ) }</ExternalLink>
+				</li>
+			</ul>
 		</>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -76,12 +76,8 @@
 
 /* Details for real-time backups */
 .status-card__realtime-details {
-	margin-top: 24px;
+	margin-top: 48px;
 	text-align: left;
-
-	&.is-simplified {
-		margin-top: 48px;
-	}
 }
 
 .status-card__realtime-details-card .activity-card .card {

--- a/client/components/jetpack/daily-backup-status/test/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/test/action-buttons.jsx
@@ -90,18 +90,6 @@ describe( 'ActionButtons', () => {
 		expect( restoreButton.prop( 'disabled' ) ).toEqual( true );
 	} );
 
-	test( "shows 'Activate restores' prompt when credentials are needed", () => {
-		getDoesRewindNeedCredentials.mockImplementation( () => true );
-
-		const wrapper = render( <ActionButtons rewindId="test" /> );
-		const activateButton = wrapper
-			.find( '.daily-backup-status__activate-restores-button' )
-			.hostNodes();
-
-		expect( activateButton.prop( 'href' ) ).toBeTruthy();
-		expect( activateButton.prop( 'disabled' ) ).toBeFalsy();
-	} );
-
 	test( 'emits a Tracks event when the download button is enabled and clicked', () => {
 		const rewindId = 'test';
 		const wrapper = render( <ActionButtons rewindId={ rewindId } /> );
@@ -125,17 +113,5 @@ describe( 'ActionButtons', () => {
 		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_jetpack_backup_restore', {
 			rewind_id: rewindId,
 		} );
-	} );
-
-	test( "emits a Tracks event when the 'Activate restores' button is clicked", () => {
-		getDoesRewindNeedCredentials.mockImplementation( () => true );
-		const wrapper = render( <ActionButtons rewindId="test" /> );
-
-		const activateButton = wrapper
-			.find( '.daily-backup-status__activate-restores-button' )
-			.hostNodes();
-		activateButton.simulate( 'click' );
-
-		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_jetpack_backup_activate_click' );
 	} );
 } );

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -208,7 +208,7 @@ class BackupsPage extends Component {
 		return (
 			<>
 				<div className="backup__last-backup-status">
-					{ this.maybeRenderBanner() }
+					{ doesRewindNeedCredentials && <EnableRestoresBanner /> }
 					{ this.renderDatePicker() }
 
 					<DailyBackupStatus

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -240,7 +240,13 @@ class BackupsPage extends Component {
 	}
 
 	renderAlternateWrap() {
-		const { siteCapabilities, logs, moment, lastDateAvailable } = this.props;
+		const {
+			siteCapabilities,
+			logs,
+			moment,
+			lastDateAvailable,
+			doesRewindNeedCredentials,
+		} = this.props;
 
 		const {
 			lastBackup: backup,
@@ -251,7 +257,7 @@ class BackupsPage extends Component {
 
 		return (
 			<>
-				{ this.maybeRenderBanner() }
+				{ doesRewindNeedCredentials && <EnableRestoresBanner /> }
 				{ this.renderDatePicker() }
 				<ul className="backup__card-list">
 					<li key="daily-backup-status">
@@ -276,15 +282,6 @@ class BackupsPage extends Component {
 					) }
 				</ul>
 			</>
-		);
-	}
-
-	maybeRenderBanner() {
-		const { doesRewindNeedCredentials } = this.props;
-
-		return (
-			isEnabled( 'jetpack/backup-simplified-screens' ) &&
-			doesRewindNeedCredentials && <EnableRestoresBanner />
 		);
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -92,7 +92,6 @@
 		"jetpack/scan-product": true,
 		"jetpack/anti-spam-product": true,
 		"jetpack/backups-restore": true,
-		"jetpack/backup-simplified-screens": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/personal-plan": false,
 		"jitms": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -57,7 +57,6 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/search-product": true,
 		"jetpack/backups-restore": true,
-		"jetpack/backup-simplified-screens": true,
 		"jetpack/anti-spam-product": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/personal-plan": false,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -21,7 +21,6 @@
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
-		"jetpack/backup-simplified-screens": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -18,7 +18,6 @@
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
-		"jetpack/backup-simplified-screens": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -20,7 +20,6 @@
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
-		"jetpack/backup-simplified-screens": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -19,7 +19,6 @@
 		"jetpack-cloud": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/backups-restore": true,
-		"jetpack/backup-simplified-screens": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": false,

--- a/config/production.json
+++ b/config/production.json
@@ -47,7 +47,6 @@
 		"i18n/translation-scanner": true,
 		"ive/use-external-assignment": true,
 		"jetpack/api-cache": false,
-		"jetpack/backup-simplified-screens": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -52,7 +52,6 @@
 		"i18n/empathy-mode": true,
 		"ive/use-external-assignment": true,
 		"jetpack/api-cache": true,
-		"jetpack/backup-simplified-screens": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request

The flag was implemented for development/deployment purpose. This PR removes it since it's not necessary anymore, and make the code less readable.

### Testing instructions

- Run the PR
- Create a new self-hosted Jetpack site that has Backup Daily, and server credentials **not** set up
- Check that the _Backup_ section looks and behaves like production
- Wait for or force a backup, then check again
- Check again with server credentials set up
- Repeat these steps with Backup Real-time