### PR TITLE
Earn: Replace images with Gridicons

### DIFF
--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -30,6 +30,7 @@ const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 	isPrimary,
 	title,
 	image,
+	icon,
 	body,
 	badge,
 	actions,
@@ -37,7 +38,13 @@ const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 	const cta = get( actions, 'cta', null );
 	const learnMoreLink = get( actions, 'learnMoreLink', null );
 	return (
-		<PromoCard isPrimary={ !! isPrimary } title={ title } image={ image } badge={ badge }>
+		<PromoCard
+			isPrimary={ !! isPrimary }
+			title={ title }
+			image={ image }
+			badge={ badge }
+			icon={ icon }
+		>
 			<p>{ body }</p>
 			{ cta && ( cta.component || <PromoCardCta cta={ cta } learnMoreLink={ learnMoreLink } /> ) }
 		</PromoCard>

--- a/client/components/promo-section/promo-card/index.tsx
+++ b/client/components/promo-section/promo-card/index.tsx
@@ -14,6 +14,7 @@ import ActionPanelBody from 'calypso/components/action-panel/body';
 import PromoCardCta from './cta';
 import classNames from 'classnames';
 import Badge from 'calypso/components/badge';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Style dependencies
@@ -27,6 +28,7 @@ export interface Image {
 }
 
 export interface Props {
+	icon: string;
 	image?: Image | ReactElement;
 	title: string | TranslateResult;
 	isPrimary?: boolean;
@@ -38,6 +40,7 @@ const isImage = ( image: Image | ReactElement ): image is Image => image.hasOwnP
 
 const PromoCard: FunctionComponent< Props > = ( {
 	title,
+	icon,
 	image,
 	isPrimary,
 	children,
@@ -56,6 +59,11 @@ const PromoCard: FunctionComponent< Props > = ( {
 			{ image && (
 				<ActionPanelFigure inlineBodyText={ false } align={ image?.align || 'left' }>
 					{ isImage( image ) ? <img src={ image.path } alt={ image.alt } /> : image }
+				</ActionPanelFigure>
+			) }
+			{ icon && (
+				<ActionPanelFigure inlineBodyText={ false } align="left">
+					<Gridicon icon={ icon } size="32" />
 				</ActionPanelFigure>
 			) }
 			<ActionPanelBody>

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -50,13 +50,6 @@ import {
  * Image dependencies
  */
 import earnSectionImage from 'calypso/assets/images/earn/earn-section.svg';
-import adsImage from 'calypso/assets/images/earn/ads.svg';
-import recurringImage from 'calypso/assets/images/earn/recurring.svg';
-import donationsImage from 'calypso/assets/images/earn/donations.svg';
-import referralImage from 'calypso/assets/images/earn/referral.svg';
-import simplePaymentsImage from 'calypso/assets/images/earn/simple-payments.svg';
-import premiumContentImage from 'calypso/assets/images/earn/premium-content.svg';
-import paidNewsletterImage from 'calypso/assets/images/earn/newsletters.svg';
 
 /**
  * Style dependencies
@@ -171,9 +164,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		return {
 			title,
 			body,
-			image: {
-				path: simplePaymentsImage,
-			},
+			icon: 'credit-card',
 			actions: {
 				cta,
 				learnMoreLink,
@@ -229,9 +220,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			title,
 			body,
 			badge: translate( 'New' ),
-			image: {
-				path: recurringImage,
-			},
+			icon: 'money',
 			actions: {
 				cta,
 				learnMoreLink,
@@ -280,9 +269,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			title,
 			body,
 			badge: translate( 'New' ),
-			image: {
-				path: donationsImage,
-			},
+			icon: 'heart-outline',
 			actions: {
 				cta,
 				learnMoreLink,
@@ -347,9 +334,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			title,
 			body,
 			badge: translate( 'New' ),
-			image: {
-				path: premiumContentImage,
-			},
+			icon: 'bookmark-outline',
 			actions: {
 				cta,
 				learnMoreLink,
@@ -399,9 +384,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			title,
 			body,
 			badge: translate( 'New' ),
-			image: {
-				path: paidNewsletterImage,
-			},
+			icon: 'mail',
 			actions: {
 				cta,
 			},
@@ -450,9 +433,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 							},
 						}
 				  ),
-			image: {
-				path: referralImage,
-			},
+			icon: 'user-add',
 			actions: {
 				cta,
 			},
@@ -505,9 +486,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		return {
 			title,
 			body,
-			image: {
-				path: adsImage,
-			},
+			icon: 'speaker',
 			actions: {
 				cta,
 				learnMoreLink,

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -18,3 +18,9 @@
 		}
 	}
 }
+
+.earn .promo-section__promos .gridicon {
+    fill: var( --studio-blue-10 );
+    position: relative;
+    top: -5px;
+}

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -22,5 +22,12 @@
 .earn .promo-section__promos .gridicon {
     fill: var( --studio-blue-10 );
     position: relative;
-    top: -5px;
+    top: -8px;
+}
+
+@include break-wide {
+	.earn .promo-card.is-primary {
+		padding-left: 72px;
+		padding-right: 72px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add support for Gridicons in the `PromoSection PromoCard` component.
* Replace images with Gridicons on the `/earn` screen for a cleaner, more flexible look.
* We don't have exact matches for the custom images in our icon set; feel free to dispute my alternatives with [something else from Gridicons](https://github.com/Automattic/gridicons).
* The color in the old PNGs was also different, so I used a close approximation from Color Studio.

**Before**

![screencapture-wordpress-earn-calobeetesting87-wordpress-com-2020-10-20-13_59_19](https://user-images.githubusercontent.com/2124984/96626726-dbd25880-12dd-11eb-9205-13840a155291.png)

**After**

![screencapture-calypso-localhost-3000-earn-calobeetesting87-wpcomstaging-com-2020-10-27-15_40_04](https://user-images.githubusercontent.com/2124984/97353754-cffd0e00-186a-11eb-8438-86b713a9bc33.png)


#### Testing instructions

* Switch to this PR and navigate to `/earn` on your site
* Note the icon changes
* Make sure this screen for different types of sites (Business, Premium, Free, Jetpack) appears as expected
* Make sure other instances of the `PromoSection PromoCard` component outside the `/earn` screen are unaffected (these include but are not limited to Jetpack Scan, Jetpack Backup, and Email sections across Calypso). Tagging Jetpack Design for a second look there in case I've missed something!

Fixes #45275
