### PR TITLE
Notifications: Add title and increase width

### DIFF
--- a/client/me/notification-settings/comment-settings/index.jsx
+++ b/client/me/notification-settings/comment-settings/index.jsx
@@ -23,6 +23,7 @@ import {
 	getNotificationSettings,
 	hasUnsavedNotificationSettingsChanges,
 } from 'calypso/state/notification-settings/selectors';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -55,7 +56,7 @@ class NotificationCommentsSettings extends Component {
 		const { path, translate } = this.props;
 
 		return (
-			<Main>
+			<Main className="comment-settings__main is-wide-layout">
 				<PageViewTracker
 					path="/me/notifications/comments"
 					title="Me > Notifications > Comments on other sites"
@@ -63,6 +64,12 @@ class NotificationCommentsSettings extends Component {
 				<QueryUserDevices />
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+
+				<FormattedHeader
+					brandFont
+					headerText={ translate( 'Notification Settings' ) }
+					align="left"
+				/>
 
 				<Navigation path={ path } />
 

--- a/client/me/notification-settings/main.jsx
+++ b/client/me/notification-settings/main.jsx
@@ -23,6 +23,7 @@ import {
 	getNotificationSettings,
 	hasUnsavedNotificationSettingsChanges,
 } from 'calypso/state/notification-settings/selectors';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 class NotificationSettings extends Component {
 	componentDidMount() {
@@ -58,11 +59,17 @@ class NotificationSettings extends Component {
 			this.props.saveSettings( 'blogs', findSettingsForBlog( blogId ), true );
 
 		return (
-			<Main className="notification-settings">
+			<Main className="notification-settings is-wide-layout">
 				<PageViewTracker path="/me/notifications" title="Me > Notifications" />
 				<QueryUserDevices />
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				<FormattedHeader
+					brandFont
+					headerText={ this.props.translate( 'Notification Settings' ) }
+					align="left"
+				/>
+
 				<Navigation path={ this.props.path } />
 				<PushNotificationSettings pushNotifications={ this.props.pushNotifications } />
 				<BlogsSettings

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -30,6 +30,7 @@ import Main from 'calypso/components/main';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /* eslint-disable react/prefer-es6-class */
 const NotificationSubscriptions = createReactClass( {
@@ -70,13 +71,19 @@ const NotificationSubscriptions = createReactClass( {
 
 	render() {
 		return (
-			<Main className="reader-subscriptions__notifications-settings">
+			<Main className="reader-subscriptions__notifications-settings is-wide-layout">
 				<PageViewTracker
 					path="/me/notifications/subscriptions"
 					title="Me > Notifications > Subscriptions Delivery"
 				/>
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+
+				<FormattedHeader
+					brandFont
+					headerText={ this.props.translate( 'Notification Settings' ) }
+					align="left"
+				/>
 
 				<Navigation path={ this.props.path } />
 

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -29,6 +29,7 @@ import {
 import EmailCategory from './email-category';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -184,13 +185,18 @@ class WPCOMNotifications extends React.Component {
 
 	render() {
 		return (
-			<Main>
+			<Main className="wpcom-settings__main is-wide-layout">
 				<PageViewTracker
 					path="/me/notifications/updates"
 					title="Me > Notifications > Updates from WordPress.com"
 				/>
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				<FormattedHeader
+					brandFont
+					headerText={ this.props.translate( 'Notification Settings' ) }
+					align="left"
+				/>
 
 				<Navigation path={ this.props.path } />
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a page title and increases the layout width to match our updates to the Payments Management screens. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/96629775-15a55e00-12e2-11eb-8741-89d5ff4c8057.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/96629738-08886f00-12e2-11eb-9abc-fb37efdaaf94.png)


#### Testing instructions

* Visit the Notification Settings screen in `/me` and checkout all the child pages to confirm the title and layout width match the screenshot. 

