### PR TITLE
Notifications - fix formatting for code blocks

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -79,6 +79,7 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 		case 'br':
 		case 'div':
 		case 'code':
+		case 'pre':
 		case 'span':
 		case 'strong':
 		case 'em':


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR, along with D51523-code, fixes formatting for code blocks when displayed in Calypso notifications.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D51415-code in your sandbox and make sure the API is sandboxed.
* Apply this change to calypso, navigate to your Calypso dashboard and open a notification for a post with a code block as part of its content. 
* Verify that the code block is styled as a block rather than inline, and maintains whitespace formatting.

Before:
![image](https://user-images.githubusercontent.com/13437011/96640555-f65dff00-12e8-11eb-9e1b-7035cd3115fa.png)

After:
![image](https://user-images.githubusercontent.com/13437011/96640580-0249c100-12e9-11eb-8946-184766e64c0f.png)


Fixes #45126
