### PR TITLE
Premium Content Block: Remove the intermediate block UI.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/index.js
@@ -13,6 +13,7 @@ import { select } from '@wordpress/data';
 import edit from './edit';
 import save from './save';
 import { getCategoryWithFallbacks } from '../../../block-helpers';
+import icon from '../icon.js';
 
 const name = 'premium-content/container';
 const category = getCategoryWithFallbacks( 'earn', 'common' );
@@ -88,21 +89,7 @@ const settings = {
 	 * An icon property should be specified to make it easier to identify a block.
 	 * These can be any of WordPress’ Dashicons, or a custom svg element.
 	 */
-	icon: (
-		<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-			<path
-				d="M12.7439 14.4271L8.64053 13.165L8.51431 13.8718L8.09208 20.7415C8.06165 21.2365 8.61087 21.5526 9.02363 21.2776L12.7439 18.799L16.7475 21.304C17.1687 21.5676 17.7094 21.2343 17.6631 20.7396L17.0212 13.8718L17.0212 13.165L12.7439 14.4271Z"
-				fill="black"
-			/>
-			<circle cx="12.7439" cy="8.69796" r="5.94466" stroke="black" strokeWidth="1.5" fill="none" />
-			<path
-				d="M9.71023 8.12461L11.9543 10.3687L15.7776 6.54533"
-				stroke="black"
-				strokeWidth="1.5"
-				fill="none"
-			/>
-		</svg>
-	),
+	icon,
 
 	/**
 	 * Optional block extended support features.

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/icon.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/icon.js
@@ -1,0 +1,15 @@
+export default (
+	<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			d="M12.7439 14.4271L8.64053 13.165L8.51431 13.8718L8.09208 20.7415C8.06165 21.2365 8.61087 21.5526 9.02363 21.2776L12.7439 18.799L16.7475 21.304C17.1687 21.5676 17.7094 21.2343 17.6631 20.7396L17.0212 13.8718L17.0212 13.165L12.7439 14.4271Z"
+			fill="black"
+		/>
+		<circle cx="12.7439" cy="8.69796" r="5.94466" stroke="black" strokeWidth="1.5" fill="none" />
+		<path
+			d="M9.71023 8.12461L11.9543 10.3687L15.7776 6.54533"
+			stroke="black"
+			strokeWidth="1.5"
+			fill="none"
+		/>
+	</svg>
+);

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/edit.js
@@ -3,44 +3,64 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { useDispatch, withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Context from '../container/context';
 
-/**
- * Block edit function
- */
-const Edit = () => (
-	<Context.Consumer>
-		{ ( { selectedTab, stripeNudge } ) => (
-			/** @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md#case-the-event-handler-is-only-being-used-to-capture-bubbled-events */
-			// eslint-disable-next-line
-			<div hidden={ selectedTab.id === 'premium' } className={ selectedTab.className }>
-				{ stripeNudge }
-				<InnerBlocks
-					templateLock={ false }
-					template={ [
-						[
-							'core/heading',
-							{ content: __( 'Subscribe to get access', 'full-site-editing' ), level: 3 },
-						],
-						[
-							'core/paragraph',
-							{
-								content: __(
-									'Read more of this content when you subscribe today.',
-									'full-site-editing'
-								),
-							},
-						],
-						[ 'premium-content/buttons' ],
-					] }
-				/>
-			</div>
-		) }
-	</Context.Consumer>
-);
+function Edit( { parentClientId, isSelected } ) {
+	const { selectBlock } = useDispatch( 'core/block-editor' );
 
-export default Edit;
+	useEffect( () => {
+		if ( isSelected ) {
+			selectBlock( parentClientId );
+		}
+	} );
+
+	return (
+		<Context.Consumer>
+			{ ( { selectedTab, stripeNudge } ) => (
+				/** @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md#case-the-event-handler-is-only-being-used-to-capture-bubbled-events */
+				// eslint-disable-next-line
+				<div hidden={ selectedTab.id === 'premium' } className={ selectedTab.className }>
+					{ stripeNudge }
+					<InnerBlocks
+						templateLock={ false }
+						template={ [
+							[
+								'core/heading',
+								{ content: __( 'Subscribe to get access', 'full-site-editing' ), level: 3 },
+							],
+							[
+								'core/paragraph',
+								{
+									content: __(
+										'Read more of this content when you subscribe today.',
+										'full-site-editing'
+									),
+								},
+							],
+							[ 'premium-content/buttons' ],
+						] }
+					/>
+				</div>
+			) }
+		</Context.Consumer>
+	);
+}
+
+export default compose(
+	withSelect( ( select ) => {
+		const { getSelectedBlockClientId, getBlockHierarchyRootClientId } = select(
+			'core/block-editor'
+		);
+		const selectedBlockClientId = getSelectedBlockClientId();
+		return {
+			parentClientId: getBlockHierarchyRootClientId( selectedBlockClientId ),
+		};
+	} )
+)( Edit );

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/edit.js
@@ -19,7 +19,7 @@ function Edit( { parentClientId, isSelected } ) {
 		if ( isSelected ) {
 			selectBlock( parentClientId );
 		}
-	} );
+	}, [ selectBlock, isSelected, parentClientId ] );
 
 	return (
 		<Context.Consumer>

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/index.js
@@ -5,6 +5,7 @@ import edit from './edit';
 import save from './save';
 import deprecated from './deprecated';
 import { getCategoryWithFallbacks } from '../../../block-helpers';
+import icon from '../icon.js';
 
 /**
  * WordPress dependencies
@@ -38,6 +39,7 @@ const settings = {
 	},
 	edit,
 	save,
+	icon,
 	deprecated,
 };
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/edit.js
@@ -19,7 +19,7 @@ function Edit( { hasInnerBlocks, parentClientId, isSelected } ) {
 		if ( isSelected ) {
 			selectBlock( parentClientId );
 		}
-	} );
+	}, [ selectBlock, isSelected, parentClientId ] );
 
 	return (
 		<Context.Consumer>

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/edit.js
@@ -3,53 +3,60 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { useDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Context from '../container/context';
 
-/**
- * Block edit function
- *
- * @typedef { object } Props
- * @property { string } clientId
- * @property { boolean } hasInnerBlocks
- *
- * @param { Props } props Properties
- */
-const Edit = ( props ) => (
-	<Context.Consumer>
-		{ ( { selectedTab, stripeNudge } ) => (
-			/** @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md#case-the-event-handler-is-only-being-used-to-capture-bubbled-events */
-			// eslint-disable-next-line
-			<div hidden={ selectedTab.id === 'wall' } className={ selectedTab.className }>
-				{ stripeNudge }
-				<InnerBlocks
-					renderAppender={ ! props.hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
-					templateLock={ false }
-					template={ [
-						[
-							'core/paragraph',
-							{
-								placeholder: __(
-									'Insert the piece of content you want your visitors to see after they subscribe.',
-									'full-site-editing'
-								),
-							},
-						],
-					] }
-				/>
-			</div>
-		) }
-	</Context.Consumer>
-);
+function Edit( { hasInnerBlocks, parentClientId, isSelected } ) {
+	const { selectBlock } = useDispatch( 'core/block-editor' );
+
+	useEffect( () => {
+		if ( isSelected ) {
+			selectBlock( parentClientId );
+		}
+	} );
+
+	return (
+		<Context.Consumer>
+			{ ( { selectedTab, stripeNudge } ) => (
+				/** @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md#case-the-event-handler-is-only-being-used-to-capture-bubbled-events */
+				// eslint-disable-next-line
+				<div hidden={ selectedTab.id === 'wall' } className={ selectedTab.className }>
+					{ stripeNudge }
+					<InnerBlocks
+						renderAppender={ ! hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
+						templateLock={ false }
+						template={ [
+							[
+								'core/paragraph',
+								{
+									placeholder: __(
+										'Insert the piece of content you want your visitors to see after they subscribe.',
+										'full-site-editing'
+									),
+								},
+							],
+						] }
+					/>
+				</div>
+			) }
+		</Context.Consumer>
+	);
+}
 
 export default compose( [
 	withSelect( ( select, props ) => {
+		const { getSelectedBlockClientId, getBlockHierarchyRootClientId } = select(
+			'core/block-editor'
+		);
+		const selectedBlockClientId = getSelectedBlockClientId();
 		return {
+			parentClientId: getBlockHierarchyRootClientId( selectedBlockClientId ),
 			// @ts-ignore difficult to type with JSDoc
 			hasInnerBlocks: !! select( 'core/block-editor' ).getBlocksByClientId( props.clientId )[ 0 ]
 				.innerBlocks.length,

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/index.js
@@ -4,6 +4,7 @@
 import edit from './edit';
 import save from './save';
 import { getCategoryWithFallbacks } from '../../../block-helpers';
+import icon from '../icon.js';
 
 /**
  * WordPress dependencies
@@ -28,6 +29,7 @@ const settings = {
 		html: false,
 	},
 	edit,
+	icon,
 	save,
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the intermediate UI when trying to select the parent of a child block.

| Before        | After           |
| ------------- |:-------------:|
| There is an intermediate container block UI when selecting the parent block. This is confusing. | There is no intermediate container block UI, selecting the parent goes straight to the root premium content block. |
| ![2020-10-20 14 14 25](https://user-images.githubusercontent.com/1464705/96644925-a4b07700-12de-11eb-936c-be4b0641de9a.gif) | ![2020-10-20 14 13 23](https://user-images.githubusercontent.com/1464705/96644930-a7ab6780-12de-11eb-969e-f1b7f49e24f1.gif) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch locally
* Sync this branch to your sandbox using `yarn dev --sync`
* Add a premium content block on a sandboxed site
* Confirm that selecting the parent block of a child block in either of the two different views selects the room premium block.

Fixes https://github.com/Automattic/view-design/issues/93
