### PR TITLE
Gutenboarding: stop HotJar capturing input fields in gutenboarding

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -332,10 +332,6 @@ module.exports = {
 					'comment_whitelist',
 					'blacklist_keys',
 
-					// For HotJar compatibility. HJ will reach out to @saramarcondes once a new
-					// and inclusive attribute name exists to be used: https://github.com/Automattic/wp-calypso/pull/43348#discussion_r442015229
-					'data-hj-whitelist',
-
 					// Depends on https://github.com/Automattic/jetpack/blob/3dae8f80e5020338e84bfc20bb41786f056a2eec/json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php#L38
 					'option_name_not_in_whitelist',
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
@@ -50,7 +50,6 @@ const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 						autoComplete="off"
 						placeholder={ __( 'Enter site name', 'full-site-editing' ) }
 						autoCorrect="off"
-						data-hj-whitelist
 					/>
 					<div className="nux-launch-step__input-hint">
 						<Tip size={ 18 } />

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/index.tsx
@@ -80,7 +80,6 @@ const AcquireIntentTextInput: React.FunctionComponent< Props > = ( {
 				autoComplete="off"
 				autoCorrect="off"
 				onChange={ handleChange }
-				data-hj-whitelist
 				spellCheck={ false }
 				value={ value }
 				onFocus={ onFocus }

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -197,8 +197,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					<Icon icon={ search } />
 				</div>
 				<TextControl
-					// Unable to remove this instance due to it being a HotJar term: https://github.com/Automattic/wp-calypso/pull/43348#discussion_r442015229
-					data-hj-whitelist
 					hideLabelFromVision
 					label={ label }
 					placeholder={ label }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Stop HotJar capturing input fields in gutenboarding
* Remove exception for HotJar from our list of allowed terms as [they now use `data-hj-allow`](https://help.hotjar.com/hc/en-us/articles/115015563287-How-to-Whitelist-Elements-and-Keystrokes)

Discussion: pbAok1-1CF-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run through the gutenboarding flow and see that the "site name" and "domain" fields still work as usual
* To test that the name and domain fields in the launch modal no longer have the `data-hj-whitelist` attribute you will need to apply D51533-code and test a sandboxed, unlaunched site, that was created with gutenboarding.

HotJar isn't currently recording so unfortunately you can't look at any sessions to verify that the fields are now obfuscated.