### PR TITLE
Fix Broken Admin Stats Graphic on Desktop App Boot

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -427,13 +427,27 @@ const boot = ( currentUser, registerRoutes ) => {
 			registerRoutes();
 		}
 
+		const isDesktop = config.isEnabled( 'desktop' );
+
 		// Render initial `<Layout>` for non-isomorphic sections.
 		// Isomorphic sections will take care of rendering their `<Layout>` themselves.
-		if ( ! document.getElementById( 'primary' ) ) {
+		if ( ! isDesktop && ! document.getElementById( 'primary' ) ) {
 			renderLayout( reduxStore );
+
+			page.start( { decodeURLComponents: false } );
 		}
 
-		page.start( { decodeURLComponents: false } );
+		if ( isDesktop ) {
+			const ipc = require( 'electron' ).ipcRenderer;
+
+			ipc.on( 'cookie-auth-complete', function () {
+				debug( 'Cookies set, rendering layout...' );
+
+				renderLayout( reduxStore );
+
+				page.start( { decodeURLComponents: false } );
+			} );
+		}
 	} );
 };
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -438,20 +438,24 @@ const boot = ( currentUser, registerRoutes ) => {
 
 		// Render initial `<Layout>` for non-isomorphic sections.
 		// Isomorphic sections will take care of rendering their `<Layout>` themselves.
-		if ( ! isDesktop && ! document.getElementById( 'primary' ) ) {
-			render();
-		}
-
-		if ( isDesktop && loggedIn ) {
-			const ipc = require( 'electron' ).ipcRenderer;
-
-			ipc.on( 'cookie-auth-complete', function () {
-				debug( 'Desktop cookies set, rendering main layout...' );
+		if ( ! document.getElementById( 'primary' ) ) {
+			if ( ! isDesktop ) {
+				// If we're not in a WP-Desktop context, render.
 				render();
-			} );
-		} else {
-			debug( 'Desktop user logged out, rendering main layout...' );
-			render();
+			} else if ( loggedIn ) {
+				// WP-Desktop: logged in
+				// Wait on cookie-authentication
+				const ipc = require( 'electron' ).ipcRenderer;
+
+				ipc.on( 'cookie-auth-complete', function () {
+					debug( 'Desktop cookies set, rendering main layout...' );
+					render();
+				} );
+			} else {
+				// WP-Desktop: logged out
+				debug( 'Desktop user logged out, rendering main layout...' );
+				render();
+			}
 		}
 	} );
 };

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -13,49 +13,49 @@ import store from 'store';
  * Internal dependencies
  */
 import { setupLocale } from './locale';
-import config from 'config';
-import { ProviderWrappedLayout } from 'controller';
-import notices from 'notices';
-import { getToken } from 'lib/oauth-token';
-import emailVerification from 'components/email-verification';
-import { getSavedVariations } from 'lib/abtest'; // used by error logger
-import accessibleFocus from 'lib/accessible-focus';
-import Logger from 'lib/catch-js-errors';
-import { bindState as bindWpLocaleState } from 'lib/wp/localization';
-import { hasTouch } from 'lib/touch-detect';
-import { installPerfmonPageHandlers } from 'lib/perfmon';
-import { setupRoutes } from 'sections-middleware';
-import { checkFormHandler } from 'lib/protect-form';
-import { setReduxStore as setReduxBridgeReduxStore } from 'lib/redux-bridge';
-import { init as pushNotificationsInit } from 'state/push-notifications/actions';
-import { setSupportSessionReduxStore } from 'lib/user/support-user-interop';
-import { tracksEvents } from 'lib/analytics/tracks';
-import { initializeAnalytics } from 'lib/analytics/init';
-import { bumpStat } from 'lib/analytics/mc';
-import getSuperProps from 'lib/analytics/super-props';
-import { getSiteFragment, normalize } from 'lib/route';
-import { isLegacyRoute } from 'lib/route/legacy-routes';
-import { setCurrentUser } from 'state/current-user/actions';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { initConnection as initHappychatConnection } from 'state/happychat/connection/actions';
-import { requestHappychatEligibility } from 'state/happychat/user/actions';
-import { getHappychatAuth } from 'state/happychat/utils';
-import wasHappychatRecentlyActive from 'state/happychat/selectors/was-happychat-recently-active';
-import { setRoute } from 'state/route/actions';
-import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
-import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
-import setupGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
-import { createReduxStore } from 'state';
-import initialReducer from 'state/reducer';
-import { getInitialState, persistOnChange, loadAllState } from 'state/initial-state';
-import detectHistoryNavigation from 'lib/detect-history-navigation';
-import userFactory from 'lib/user';
-import { getUrlParts, isOutsideCalypso } from 'lib/url';
-import { setStore } from 'state/redux-store';
-import { requestUnseenStatus } from 'state/reader-ui/seen-posts/actions';
-import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
-import { inJetpackCloudOAuthOverride } from 'lib/jetpack/oauth-override';
-import { getLanguageSlugs } from 'lib/i18n-utils/utils';
+import config from 'calypso/config';
+import { ProviderWrappedLayout } from 'calypso/controller';
+import notices from 'calypso/notices';
+import { getToken } from 'calypso/lib/oauth-token';
+import emailVerification from 'calypso/components/email-verification';
+import { getSavedVariations } from 'calypso/lib/abtest'; // used by error logger
+import accessibleFocus from 'calypso/lib/accessible-focus';
+import Logger from 'calypso/lib/catch-js-errors';
+import { bindState as bindWpLocaleState } from 'calypso/lib/wp/localization';
+import { hasTouch } from 'calypso/lib/touch-detect';
+import { installPerfmonPageHandlers } from 'calypso/lib/perfmon';
+import { setupRoutes } from 'calypso/sections-middleware';
+import { checkFormHandler } from 'calypso/lib/protect-form';
+import { setReduxStore as setReduxBridgeReduxStore } from 'calypso/lib/redux-bridge';
+import { init as pushNotificationsInit } from 'calypso/state/push-notifications/actions';
+import { setSupportSessionReduxStore } from 'calypso/lib/user/support-user-interop';
+import { tracksEvents } from 'calypso/lib/analytics/tracks';
+import { initializeAnalytics } from 'calypso/lib/analytics/init';
+import { bumpStat } from 'calypso/lib/analytics/mc';
+import getSuperProps from 'calypso/lib/analytics/super-props';
+import { getSiteFragment, normalize } from 'calypso/lib/route';
+import { isLegacyRoute } from 'calypso/lib/route/legacy-routes';
+import { setCurrentUser } from 'calypso/state/current-user/actions';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { initConnection as initHappychatConnection } from 'calypso/state/happychat/connection/actions';
+import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
+import { getHappychatAuth } from 'calypso/state/happychat/utils';
+import wasHappychatRecentlyActive from 'calypso/state/happychat/selectors/was-happychat-recently-active';
+import { setRoute } from 'calypso/state/route/actions';
+import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
+import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import setupGlobalKeyboardShortcuts from 'calypso/lib/keyboard-shortcuts/global';
+import { createReduxStore } from 'calypso/state';
+import initialReducer from 'calypso/state/reducer';
+import { getInitialState, persistOnChange, loadAllState } from 'calypso/state/initial-state';
+import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
+import userFactory from 'calypso/lib/user';
+import { getUrlParts, isOutsideCalypso } from 'calypso/lib/url';
+import { setStore } from 'calypso/state/redux-store';
+import { requestUnseenStatus } from 'calypso/state/reader-ui/seen-posts/actions';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { inJetpackCloudOAuthOverride } from 'calypso/lib/jetpack/oauth-override';
+import { getLanguageSlugs } from 'calypso/lib/i18n-utils/utils';
 
 const debug = debugFactory( 'calypso' );
 
@@ -245,7 +245,7 @@ function setupErrorLogger( reduxStore ) {
 	const errorLogger = new Logger();
 
 	// Save errorLogger to a singleton for use in arbitrary logging.
-	require( 'lib/catch-js-errors/log' ).registerLogger( errorLogger );
+	require( 'calypso/lib/catch-js-errors/log' ).registerLogger( errorLogger );
 
 	// Save data to JS error logger
 	errorLogger.saveDiagnosticData( {

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -430,28 +430,28 @@ const boot = ( currentUser, registerRoutes ) => {
 		const isDesktop = config.isEnabled( 'desktop' );
 		const loggedIn = currentUser.get() !== false;
 
-		// Render initial `<Layout>` for non-isomorphic sections.
-		// Isomorphic sections will take care of rendering their `<Layout>` themselves.
-		if ( ! isDesktop && ! document.getElementById( 'primary' ) ) {
+		const render = () => {
 			renderLayout( reduxStore );
 
 			page.start( { decodeURLComponents: false } );
+		};
+
+		// Render initial `<Layout>` for non-isomorphic sections.
+		// Isomorphic sections will take care of rendering their `<Layout>` themselves.
+		if ( ! isDesktop && ! document.getElementById( 'primary' ) ) {
+			render();
 		}
 
 		if ( isDesktop && loggedIn ) {
 			const ipc = require( 'electron' ).ipcRenderer;
 
 			ipc.on( 'cookie-auth-complete', function () {
-				debug( 'Cookies set, rendering layout...' );
-
-				renderLayout( reduxStore );
-
-				page.start( { decodeURLComponents: false } );
+				debug( 'Desktop cookies set, rendering main layout...' );
+				render();
 			} );
 		} else {
-			renderLayout( reduxStore );
-
-			page.start( { decodeURLComponents: false } );
+			debug( 'Desktop user logged out, rendering main layout...' );
+			render();
 		}
 	} );
 };

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -428,6 +428,7 @@ const boot = ( currentUser, registerRoutes ) => {
 		}
 
 		const isDesktop = config.isEnabled( 'desktop' );
+		const loggedIn = currentUser.get() !== false;
 
 		// Render initial `<Layout>` for non-isomorphic sections.
 		// Isomorphic sections will take care of rendering their `<Layout>` themselves.
@@ -437,7 +438,7 @@ const boot = ( currentUser, registerRoutes ) => {
 			page.start( { decodeURLComponents: false } );
 		}
 
-		if ( isDesktop ) {
+		if ( isDesktop && loggedIn ) {
 			const ipc = require( 'electron' ).ipcRenderer;
 
 			ipc.on( 'cookie-auth-complete', function () {
@@ -447,6 +448,10 @@ const boot = ( currentUser, registerRoutes ) => {
 
 				page.start( { decodeURLComponents: false } );
 			} );
+		} else {
+			renderLayout( reduxStore );
+
+			page.start( { decodeURLComponents: false } );
 		}
 	} );
 };

--- a/client/desktop/lib/cookie-auth/index.js
+++ b/client/desktop/lib/cookie-auth/index.js
@@ -4,7 +4,11 @@
 const { ipcMain: ipc } = require( 'electron' );
 const https = require( 'https' ); // eslint-disable-line import/no-nodejs-modules
 const url = require( 'url' );
-const events = require( 'events' );
+
+/**
+ * Internal Dependencies
+ */
+const log = require( 'calypso/desktop/lib/logger' )( 'cookie-auth' );
 
 /**
  * Module variables
@@ -12,34 +16,27 @@ const events = require( 'events' );
 const noop = function () {};
 
 function authorize( username, token ) {
-	const responder = new events.EventEmitter();
 	const body = 'log=' + username;
-	const options = url.parse( 'https://wordpress.com/wp-login.php' );
-
-	responder.username = username;
-
-	options.method = 'POST';
-	options.headers = {
+	const params = url.parse( 'https://wordpress.com/wp-login.php' );
+	params.method = 'POST';
+	params.headers = {
 		Authorization: 'Bearer ' + token,
 		'Content-Type': 'application/x-www-form-urlencoded',
 		'Content-Length': body.length,
 	};
 
-	const req = https.request( options, function ( res ) {
-		let responseBody = '';
-
-		responder.emit( 'response', res );
-
-		res.on( 'data', function ( data ) {
-			responseBody += data;
+	return new Promise( ( resolve, reject ) => {
+		const req = https.request( params, ( res ) => {
+			if ( res.statusCode < 200 ) {
+				return reject( new Error( `Status Code: ${ res.statusCode }` ) );
+			}
+			return resolve( res );
 		} );
 
-		res.on( 'end', function () {
-			responder.emit( 'body', responseBody );
-		} );
+		req.on( 'error', reject );
+
+		req.end( body );
 	} );
-	req.end( body );
-	return responder;
 }
 
 function parseCookie( cookieStr ) {
@@ -70,9 +67,9 @@ function parseCookie( cookieStr ) {
 	}, cookie );
 }
 
-function setSessionCookies( window, onComplete ) {
-	return function ( response ) {
-		let cookieHeaders = response.headers[ 'set-cookie' ];
+function setSessionCookies( window, authorizeResponse ) {
+	return new Promise( ( resolve ) => {
+		let cookieHeaders = authorizeResponse.headers[ 'set-cookie' ];
 		let count = 0;
 		if ( ! Array.isArray( cookieHeaders ) ) {
 			cookieHeaders = [ cookieHeaders ];
@@ -80,40 +77,44 @@ function setSessionCookies( window, onComplete ) {
 
 		count = cookieHeaders.length;
 
+		if ( count === 0 ) {
+			return resolve( true );
+		}
+
 		cookieHeaders.map( parseCookie ).forEach( function ( cookie ) {
 			cookie.url = 'https://wordpress.com/';
-			if ( cookie.httponly ) {
+			if ( cookie.HttpOnly ) {
 				cookie.session = true;
 			}
-			window.webContents.session.cookies.set( cookie, function () {
-				count--;
-				if ( count === 0 ) {
-					if ( onComplete ) onComplete();
-				}
-			} );
+			window.webContents.session.cookies.set( cookie );
+			count--;
+			if ( count === 0 ) {
+				return resolve( true );
+			}
 		} );
-	};
+	} );
 }
 
 function auth( window, onAuthorized ) {
-	let currentRequest;
+	ipc.handleOnce( 'user-auth', async function ( event, user, token ) {
+		log.info( `Handling 'user-auth' IPC event, setting session cookies...` );
 
-	ipc.on( 'user-auth', function ( event, user, token ) {
 		if ( user && user.data ) {
 			const userData = user.data;
-			if ( currentRequest && currentRequest.username === userData.username ) {
-				// already authing
-				return;
+			const response = await authorize( userData.username, token );
+			if ( response ) {
+				await setSessionCookies( window, response );
+
+				onAuthorized();
+
+				return 'session-cookies-set';
 			}
-			currentRequest = authorize( userData.username, token ).on(
-				'response',
-				setSessionCookies( window, onAuthorized )
-			);
 		} else {
-			// retrieve all cookies
+			log.info( 'No user data, clearing session cookies...' );
+
 			window.webContents.session.cookies.get( {}, function ( e, cookies ) {
 				if ( e ) {
-					return;
+					return 'session-cookies-none';
 				}
 
 				cookies.forEach( function ( cookie ) {
@@ -123,6 +124,8 @@ function auth( window, onAuthorized ) {
 
 					window.webContents.session.cookies.remove( cookieUrl, cookie.name, noop );
 				} );
+
+				return 'session-cookies-cleared';
 			} );
 		}
 	} );

--- a/client/desktop/lib/cookie-auth/index.js
+++ b/client/desktop/lib/cookie-auth/index.js
@@ -83,7 +83,7 @@ function setSessionCookies( window, authorizeResponse ) {
 
 		cookieHeaders.map( parseCookie ).forEach( function ( cookie ) {
 			cookie.url = 'https://wordpress.com/';
-			if ( cookie.HttpOnly ) {
+			if ( cookie.HttpOnly || cookie.httpOnly || cookie.httponly ) {
 				cookie.session = true;
 			}
 			window.webContents.session.cookies.set( cookie );

--- a/client/desktop/lib/cookie-auth/index.js
+++ b/client/desktop/lib/cookie-auth/index.js
@@ -81,12 +81,12 @@ function setSessionCookies( window, authorizeResponse ) {
 			return resolve( true );
 		}
 
-		cookieHeaders.map( parseCookie ).forEach( async function ( cookie ) {
+		cookieHeaders.map( parseCookie ).forEach( function ( cookie ) {
 			cookie.url = 'https://wordpress.com/';
 			if ( cookie.HttpOnly || cookie.httpOnly || cookie.httponly ) {
 				cookie.session = true;
 			}
-			await window.webContents.session.cookies.set( cookie );
+			window.webContents.session.cookies.set( cookie );
 			count--;
 			if ( count === 0 ) {
 				return resolve( true );

--- a/client/desktop/lib/cookie-auth/index.js
+++ b/client/desktop/lib/cookie-auth/index.js
@@ -81,12 +81,12 @@ function setSessionCookies( window, authorizeResponse ) {
 			return resolve( true );
 		}
 
-		cookieHeaders.map( parseCookie ).forEach( function ( cookie ) {
+		cookieHeaders.map( parseCookie ).forEach( async function ( cookie ) {
 			cookie.url = 'https://wordpress.com/';
 			if ( cookie.HttpOnly || cookie.httpOnly || cookie.httponly ) {
 				cookie.session = true;
 			}
-			window.webContents.session.cookies.set( cookie );
+			await window.webContents.session.cookies.set( cookie );
 			count--;
 			if ( count === 0 ) {
 				return resolve( true );

--- a/client/desktop/lib/cookie-auth/index.js
+++ b/client/desktop/lib/cookie-auth/index.js
@@ -103,11 +103,17 @@ function auth( window, onAuthorized ) {
 			const userData = user.data;
 			const response = await authorize( userData.username, token );
 			if ( response ) {
-				await setSessionCookies( window, response );
+				try {
+					await setSessionCookies( window, response );
 
-				onAuthorized();
+					onAuthorized();
 
-				return 'session-cookies-set';
+					return 'session-cookies-set';
+				} catch ( e ) {
+					log.error( 'Failed to set session cookies: ', e );
+
+					return 'session-cookies-error';
+				}
 			}
 		} else {
 			log.info( 'No user data, clearing session cookies...' );

--- a/client/desktop/lib/cookie-auth/index.js
+++ b/client/desktop/lib/cookie-auth/index.js
@@ -96,7 +96,7 @@ function setSessionCookies( window, authorizeResponse ) {
 }
 
 function auth( window, onAuthorized ) {
-	ipc.handleOnce( 'user-auth', async function ( event, user, token ) {
+	ipc.handle( 'user-auth', async function ( _, user, token ) {
 		log.info( `Handling 'user-auth' IPC event, setting session cookies...` );
 
 		if ( user && user.data ) {

--- a/client/desktop/lib/cookie-auth/index.js
+++ b/client/desktop/lib/cookie-auth/index.js
@@ -81,12 +81,18 @@ function setSessionCookies( window, authorizeResponse ) {
 			return resolve( true );
 		}
 
-		cookieHeaders.map( parseCookie ).forEach( function ( cookie ) {
+		cookieHeaders.forEach( async function ( cookieStr ) {
+			const cookie = parseCookie( cookieStr );
 			cookie.url = 'https://wordpress.com/';
 			if ( cookie.HttpOnly || cookie.httpOnly || cookie.httponly ) {
 				cookie.session = true;
 			}
-			window.webContents.session.cookies.set( cookie );
+			try {
+				await window.webContents.session.cookies.set( cookie );
+			} catch ( e ) {
+				const { value, ...logCookie } = cookie; // don't log sensitive "value" field
+				log.error( `Failed to set session cookie (${ e.message }): `, logCookie );
+			}
 			count--;
 			if ( count === 0 ) {
 				return resolve( true );

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -83,8 +83,7 @@ const Desktop = {
 
 		// Send some events immediately - this sets the app state
 		this.sendNotificationUnseenCount();
-		const userAuthorized = await this.sendUserLoginStatus();
-		debug( 'Cookies set: ', userAuthorized );
+		this.sendUserLoginStatus();
 	},
 
 	selectedSite: null,
@@ -205,7 +204,7 @@ const Desktop = {
 		debug( 'Sending logged-in = ' + status );
 
 		ipc.send( 'user-login-status', status );
-		return ipc.invoke( 'user-auth', user(), oAuthToken.getToken() );
+		ipc.send( 'user-auth', user(), oAuthToken.getToken() );
 	},
 
 	onToggleNotifications: function () {

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -10,7 +10,6 @@ import { newPost } from 'calypso/lib/paths';
 import store from 'store';
 import user from 'calypso/lib/user';
 import { ipcRenderer as ipc } from 'electron';
-import * as oAuthToken from 'calypso/lib/oauth-token';
 import userUtilities from 'calypso/lib/user/utils';
 import { getStatsPathForTab } from 'calypso/lib/route';
 import { getReduxStore } from 'calypso/lib/redux-bridge';
@@ -204,7 +203,6 @@ const Desktop = {
 		debug( 'Sending logged-in = ' + status );
 
 		ipc.send( 'user-login-status', status );
-		ipc.send( 'user-auth', user(), oAuthToken.getToken() );
 	},
 
 	onToggleNotifications: function () {

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -83,7 +83,8 @@ const Desktop = {
 
 		// Send some events immediately - this sets the app state
 		this.sendNotificationUnseenCount();
-		this.sendUserLoginStatus();
+		const userAuthorized = await this.sendUserLoginStatus();
+		debug( 'Cookies set: ', userAuthorized );
 	},
 
 	selectedSite: null,
@@ -204,7 +205,7 @@ const Desktop = {
 		debug( 'Sending logged-in = ' + status );
 
 		ipc.send( 'user-login-status', status );
-		ipc.send( 'user-auth', user(), oAuthToken.getToken() );
+		return ipc.invoke( 'user-auth', user(), oAuthToken.getToken() );
 	},
 
 	onToggleNotifications: function () {


### PR DESCRIPTION
### Description

Attempting to fix the broken admin bar stats graphic of the "Stats" menu item on the main Calypso landing page.

### Context

- At application boot, the graphic is displayed as a broken link due to a forbidden URL request:

<p align="center">
<img width="275" alt="admin-bar-broken" src="https://user-images.githubusercontent.com/8979548/96647820-5f02a700-12fc-11eb-9b95-644d0b07ff72.png">
</p>

Console error: `status 403 (forbidden): https://<site_name>.wordpress.com/wp-includes/charts/admin-bar-hours-scale-2x.php?masterbar=1&s=<site_id>`

On a refresh triggered through the console, the graphic displays correctly.

<p align="center">
<img width="275" alt="admin-bar-not-broken" src="https://user-images.githubusercontent.com/8979548/96647960-9bce9e00-12fc-11eb-838c-275fba0b1e15.png">
</p>

Closer inspection of headers sent with the bad/good requests indicate that the bad request is missing the `wordpress_logged_in` cookie in the `Cookie` header. TL;DR: it appears the `wordpress_logged_in` cookie has not yet been parsed and set in Electron by the time the request for the `admin-bar-hours` graphic is made. (However, the cookie _is_ present when the renderer is refreshed with `CMD + R` from the Developer Console.

At present, cookies from Calypso/renderer process are relayed via a `user-auth` IPC event ([link](https://github.com/Automattic/wp-calypso/blob/3a779a0ca38129848941bc4bbe6f4d38486214e3/client/desktop/lib/cookie-auth/index.js#L101-L126)). However, triggering this IPC event isn't conditional on Calypso having completely finished its boot sequence (where things like user bootstrapping take place). Ideally the sequence-of-events here should be deterministic and Calypso should be fully booted after the environment is set and Electron's main process has completed the user authentication step (i.e. writing cookies to the user's window's `webSession`). 

### Fix

Ensure that Calypso rendering takes place after Electron main process cookie-handling is complete.

### To Test

Download and run the build artifacts associated for this PR. Boot the application and note that the graphic for the `Stats` menu item is displayed on first boot.

<p align="center">
<img width="275" alt="Screen Shot 2020-10-27 at 11 19 43 AM" src="https://user-images.githubusercontent.com/8979548/97322590-53f0cf00-1846-11eb-821e-1f8ff16c6b1c.png">
</p>