### PR TITLE
Purchases: Fix screen width

### DIFF
--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -21,7 +21,7 @@ const CancelPurchaseLoadingPlaceholder = ( { purchaseId, siteSlug, getManagePurc
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace, jsx-a11y/heading-has-content */
 	return (
-		<LoadingPlaceholder title={ titles.cancelPurchase } path={ path }>
+		<LoadingPlaceholder title={ titles.cancelPurchase } path={ path } isFullWidth={ true }>
 			<Card className="cancel-purchase-loading-placeholder__card">
 				<h2 className="loading-placeholder__content cancel-purchase-loading-placeholder__header" />
 				<div className="loading-placeholder__content cancel-purchase-loading-placeholder__subheader" />

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -75,10 +75,9 @@ export function addCreditCard( context, next ) {
 
 export function cancelPurchase( context, next ) {
 	setTitle( context, titles.cancelPurchase );
-	const classes = 'cancel-purchase';
 
 	context.primary = (
-		<Main className={ classes }>
+		<Main className="purchases__cancel is-wide-layout">
 			<CancelPurchase
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 				siteSlug={ context.params.site }
@@ -119,14 +118,16 @@ export function editCardDetails( context, next ) {
 	setTitle( context, titles.editCardDetails );
 
 	context.primary = (
-		<EditCardDetails
-			cardId={ context.params.cardId }
-			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			siteSlug={ context.params.site }
-			getManagePurchaseUrlFor={ managePurchaseUrl }
-			purchaseListUrl={ purchasesRoot }
-			isFullWidth={ false }
-		/>
+		<Main className="purchases__change is-wide-layout">
+			<EditCardDetails
+				cardId={ context.params.cardId }
+				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+				siteSlug={ context.params.site }
+				getManagePurchaseUrlFor={ managePurchaseUrl }
+				purchaseListUrl={ purchasesRoot }
+				isFullWidth={ true }
+			/>
+		</Main>
 	);
 	next();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes some width issues in the Purchase management sections.

**Before**
![image](https://user-images.githubusercontent.com/6981253/96649609-78f1b900-12ff-11eb-97ef-39b439013dab.png)


![image](https://user-images.githubusercontent.com/6981253/96649511-421ba300-12ff-11eb-963f-4fd959806c19.png)

![image](https://user-images.githubusercontent.com/6981253/96649625-8149f400-12ff-11eb-9aea-b8efcae42fd2.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/96649733-ac344800-12ff-11eb-9b29-524fd0151cf1.png)


![image](https://user-images.githubusercontent.com/6981253/96649659-8d35b600-12ff-11eb-9fa4-024d003adda1.png)

![image](https://user-images.githubusercontent.com/6981253/96649751-b3f3ec80-12ff-11eb-8077-967b25dd0370.png)


#### Testing instructions
- Visit the account view for Manage Payments.
- View a subscription with an existing credit card associated with it.
- Click on "Change credit card".
- Confirm that the pre-loader and edit credit card forms are the same width as the previous screen.
- Return back to subscription screen and ensure you have a payment method attached to the subscription.
- Click Cancel subscription and confirm the cancel subscription screen is the same width as the previous screen.
