### PR TITLE
Payments: update payment methods display when auto-renew is disabled

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -202,15 +202,18 @@ class PurchaseMeta extends Component {
 			return translate( 'Included with plan' );
 		}
 
-		if ( ( isExpired( purchase ) || isExpiring( purchase ) ) && ! isPaidWithCredits( purchase ) ) {
-			return '—';
-		}
-
 		if ( hasPaymentMethod( purchase ) ) {
 			let paymentInfo = null;
 
 			if ( isPaidWithCredits( purchase ) ) {
 				return translate( 'Credits' );
+			}
+
+			if (
+				( isExpired( purchase ) || isExpiring( purchase ) ) &&
+				! isPaidWithCredits( purchase )
+			) {
+				return '—';
 			}
 
 			if ( isPaidWithCreditCard( purchase ) ) {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -213,7 +213,7 @@ class PurchaseMeta extends Component {
 				( isExpired( purchase ) || isExpiring( purchase ) ) &&
 				! isPaidWithCredits( purchase )
 			) {
-				return '—';
+				return translate( 'None' );
 			}
 
 			if ( isPaidWithCreditCard( purchase ) ) {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -202,6 +202,10 @@ class PurchaseMeta extends Component {
 			return translate( 'Included with plan' );
 		}
 
+		if ( ( isExpired( purchase ) || isExpiring( purchase ) ) && ! isPaidWithCredits( purchase ) ) {
+			return '—';
+		}
+
 		if ( hasPaymentMethod( purchase ) ) {
 			let paymentInfo = null;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

During a support rotation, I saw people getting confused with the payment method still showing when auto-renew has been disabled. In this PR, I hide the payment method when auto-renew is disabled.

**Before**
![image](https://user-images.githubusercontent.com/6981253/96650813-80b25d00-1301-11eb-839c-6738a1878bb2.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/96652009-0800d000-1304-11eb-997b-ceacd82aed14.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a subscription that has a payment method attached. 
* Turn off auto-renew and confirm that there is no payment method.
* Visit a subscription that was purchased with credits to make sure it says "Credits" under payment method.
* Add a payment method and confirm the payment method displays
* Disable auto-renew once again to confirm that the payment method isn't showing anymore.
