### PR TITLE
Stop creating a social login if the account does not exist

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -14,7 +14,11 @@ import { localize } from 'i18n-calypso';
  */
 import config from 'calypso/config';
 import { Card } from '@automattic/components';
-import { loginSocialUser, createSocialUser, createSocialUserFailed } from 'calypso/state/login/actions';
+import {
+	loginSocialUser,
+	createSocialUser,
+	createSocialUserFailed,
+} from 'calypso/state/login/actions';
 import {
 	getCreatedSocialAccountUsername,
 	getCreatedSocialAccountBearerToken,
@@ -90,16 +94,7 @@ class SocialLoginForm extends Component {
 				onSuccess();
 			},
 			( error ) => {
-				if ( error.code === 'unknown_user' ) {
-					return this.props.createSocialUser( socialInfo, 'login' ).then(
-						() => this.recordEvent( 'calypso_login_social_signup_success', 'google' ),
-						( createAccountError ) =>
-							this.recordEvent( 'calypso_login_social_signup_failure', 'google', {
-								error_code: createAccountError.code,
-								error_message: createAccountError.message,
-							} )
-					);
-				} else if ( error.code === 'user_exists' ) {
+				if ( error.code === 'user_exists' ) {
 					this.props.createSocialUserFailed( socialInfo, error );
 				}
 
@@ -142,16 +137,7 @@ class SocialLoginForm extends Component {
 				onSuccess();
 			},
 			( error ) => {
-				if ( error.code === 'unknown_user' ) {
-					return this.props.createSocialUser( socialInfo, 'login' ).then(
-						() => this.recordEvent( 'calypso_login_social_signup_success', 'apple' ),
-						( createAccountError ) =>
-							this.recordEvent( 'calypso_login_social_signup_failure', 'apple', {
-								error_code: createAccountError.code,
-								error_message: createAccountError.message,
-							} )
-					);
-				} else if ( error.code === 'user_exists' ) {
+				if ( error.code === 'user_exists' ) {
 					this.props.createSocialUserFailed( socialInfo, error );
 				}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
If you visit the login page and do a social login, we currently brute force the creation of your account, even though you were simply trying to login. Practically, this means that you might end up with multiple WordPress.com accounts just because you forgot that you used a password login previously.

I think this approach is a little _too_ smart, as evidenced by all the reports over here: #21921. We already show a warning if your email + password doesn't match an existing account, so why not keep it consistent? If you want to create an account, you can just click the "create account" button.

This change simply removes the code which creates an account, which actually allows an existing error message to display without any extra work. This error message comes from the backend API, which I have updated here: D51538-code. (The string was about passwords, not social login, so this makes it more clear.)


### Testing instructions
1. Checkout this branch locally and run it in calypso.localhost
2. In an incognito/private window, visit calypso.localhost:3000/log-in
3. Try using the "continue with google" flow.
4. When prompted, either create a new account, OR use a google account which is not related to a wpcom account.
5. You should see an error message.

<img width="1796" alt="Screen Shot 2020-10-20 at 3 57 19 PM" src="https://user-images.githubusercontent.com/6265975/96653984-1bee0700-12ef-11eb-8719-e018df10ef5b.png">


Fixes #21921