### PR TITLE
Wrap up the remove username A/B test

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1065,28 +1065,15 @@ function TrackRender( { children, eventName } ) {
 }
 
 export default connect(
-	( state, ownProps ) => {
-		const isDisplayUsernamePropSet = ownProps.hasOwnProperty( 'displayUsernameInput' );
-		const eligibleFlowsForRemoveUsernameTest = [ 'personal', 'premium', 'business', 'ecommerce' ];
-		let displayUsernameInput = true;
-
-		if ( eligibleFlowsForRemoveUsernameTest.includes( ownProps.flowName ) ) {
-			displayUsernameInput = 'control' === abtest( 'removeUsernameInSignup' );
-		} else if ( isDisplayUsernamePropSet ) {
-			displayUsernameInput = ownProps.displayUsernameInput;
-		}
-
-		return {
-			oauth2Client: getCurrentOAuth2Client( state ),
-			sectionName: getSectionName( state ),
-			isJetpackWooCommerceFlow:
-				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
-			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
-			from: get( getCurrentQueryArguments( state ), 'from' ),
-			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
-			displayUsernameInput,
-		};
-	},
+	( state ) => ( {
+		oauth2Client: getCurrentOAuth2Client( state ),
+		sectionName: getSectionName( state ),
+		isJetpackWooCommerceFlow:
+			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
+		isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
+		from: get( getCurrentQueryArguments( state ), 'from' ),
+		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
+	} ),
 	{
 		trackLoginMidFlow: () => recordTracksEventWithClientId( 'calypso_signup_login_midflow' ),
 		createSocialUserFailed,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -210,15 +210,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: [ 'en' ],
 	},
-	removeUsernameInSignup: {
-		datestamp: '20201002',
-		variations: {
-			variantRemoveUsername: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: false,
-	},
 	oneClickUpsell: {
 		datestamp: '20200922',
 		variations: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The remove username field test was initiated in https://github.com/Automattic/wp-calypso/pull/45609, and then re-launched for the plan-specific flows in https://github.com/Automattic/wp-calypso/pull/46038.
* We are wrapping up the test and retaining control experience for all users. Check pbxNRc-rq-p2 for context.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Depends on D51547-code**

* Apply D51547-code.
* Visit signup at /start/personal and verify that you are not assigned to the test. For this, `localStorage.ABTests` in your browser console should not return `removeUsernameInSignup`. Also verify this in the other plan-specific flows - /start/premium, /start/business, /start/ecommerce.
* Verify that signup works correctly.
