### PR TITLE
Capture user country code for RUM

### DIFF
--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -13,6 +13,7 @@ import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import {
 	getCurrentUserSiteCount,
 	getCurrentUserVisibleSiteCount,
+	getCurrentUserCountryCode,
 } from 'calypso/state/current-user/selectors';
 
 /**
@@ -28,6 +29,7 @@ const buildDefaultCollector = ( state ) => {
 	const siteIsAtomic = isSiteWpcomAtomic( state, siteId );
 	const sitesCount = getCurrentUserSiteCount( state );
 	const sitesVisibleCount = getCurrentUserVisibleSiteCount( state );
+	const countryCode = getCurrentUserCountryCode( state );
 
 	return ( report ) => {
 		report.data.set( 'siteId', siteId );
@@ -36,6 +38,7 @@ const buildDefaultCollector = ( state ) => {
 		report.data.set( 'siteIsAtomic', siteIsAtomic );
 		report.data.set( 'sitesCount', sitesCount );
 		report.data.set( 'sitesVisibleCount', sitesVisibleCount );
+		report.data.set( 'country', countryCode );
 	};
 };
 

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -29,7 +29,7 @@ const buildDefaultCollector = ( state ) => {
 	const siteIsAtomic = isSiteWpcomAtomic( state, siteId );
 	const sitesCount = getCurrentUserSiteCount( state );
 	const sitesVisibleCount = getCurrentUserVisibleSiteCount( state );
-	const countryCode = getCurrentUserCountryCode( state );
+	const userCountryCode = getCurrentUserCountryCode( state );
 
 	return ( report ) => {
 		report.data.set( 'siteId', siteId );
@@ -38,7 +38,7 @@ const buildDefaultCollector = ( state ) => {
 		report.data.set( 'siteIsAtomic', siteIsAtomic );
 		report.data.set( 'sitesCount', sitesCount );
 		report.data.set( 'sitesVisibleCount', sitesVisibleCount );
-		report.data.set( 'country', countryCode );
+		report.data.set( 'userCountryCode', userCountryCode );
 	};
 };
 

--- a/client/lib/performance-tracking/test/lib.js
+++ b/client/lib/performance-tracking/test/lib.js
@@ -155,7 +155,7 @@ describe( 'stopPerformanceTracking', () => {
 		expect( report.data.get( 'siteIsAtomic' ) ).toBe( false );
 		expect( report.data.get( 'sitesCount' ) ).toBe( 2 );
 		expect( report.data.get( 'sitesVisibleCount' ) ).toBe( 1 );
-		expect( report.data.get( 'country' ) ).toBe( 'es' );
+		expect( report.data.get( 'userCountryCode' ) ).toBe( 'es' );
 	} );
 
 	it( 'uses metdata to generate a collector', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Capture user's country code and add it to RUM report

#### Testing instructions

* Go to the Reader in calypso.live
* Open the network tab and search for a request to `/logstash`
* Examine the payload of the request, it should contain `country:<your-country>`
