### PR TITLE
Set an explicit timeout for teamcity

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -125,6 +125,10 @@ object BuildBaseImages : BuildType({
 		}
 	}
 
+	failureConditions {
+		executionTimeoutMin = 20
+	}
+
 	features {
 		perfmon {
 		}
@@ -348,6 +352,10 @@ object RunAllUnitTests : BuildType({
 		}
 	}
 
+	failureConditions {
+		executionTimeoutMin = 10
+	}
+
 	features {
 		feature {
 			type = "xml-report-plugin"
@@ -471,6 +479,10 @@ object CheckCodeStyle : BuildType({
 				-:pull*
 			""".trimIndent()
 		}
+	}
+
+	failureConditions {
+		executionTimeoutMin = 20
 	}
 
 	features {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sets a timeout for our builds. The time I picked is the usual run time + 5 minutes.

Related doc: https://www.jetbrains.com/help/teamcity/build-failure-conditions.html#Common+build+failure+conditions

#### Testing instructions

* Can't be tested on a branch.
* Sanity check: open the TC build and verify there are no errors applying the DSL.
