### PR TITLE
Send all unhandled rejections and uncaught exceptions to the error log

### DIFF
--- a/client/server/index.js
+++ b/client/server/index.js
@@ -73,8 +73,11 @@ function createServer() {
 
 const server = createServer();
 
-// The desktop app runs Calypso in a fork. Let non-forks listen on any host.
+process.on( 'uncaughtExceptionMonitor', ( err ) => {
+	logger.error( err );
+} );
 
+// The desktop app runs Calypso in a fork. Let non-forks listen on any host.
 server.listen( { port, host: process.env.CALYPSO_IS_FORK ? host : null }, function () {
 	// Tell the parent process that Calypso has booted.
 	sendBootStatus( 'ready' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Uses https://nodejs.org/api/process.html#process_event_uncaughtexceptionmonitor to log all unhandled rejections and uncaught exceptions.

#### Testing instructions

Checkout the branch and add an error, for example add `setTimeout( () => fake(), 5000 );` to `client/server/index.js`

Then start the server with `yarn start`. You should see something like
```
09:47:31.146Z ERROR calypso: fake is not defined
    ReferenceError: fake is not defined
        at Timeout._onTimeout (/Users/sergio/src/automattic/wp-calypso/build/webpack:/client/server/index.js:83:2)
        at listOnTimeout (internal/timers.js:549:17)
        at processTimers (internal/timers.js:492:7)
```
(the timestamp and the string `ERROR calypso:` implies it comes from bunyan's error logger)

