### PR TITLE
Nav Unification performance - optimize unified item nav components

### DIFF
--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -16,17 +16,17 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import CurrentSite from 'my-sites/current-site';
+import CurrentSite from 'calypso/my-sites/current-site';
 import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
 import useSiteMenuItems from './use-site-menu-items';
 import useDomainsViewStatus from './use-domains-view-status';
-import { getIsRequestingAdminMenu } from 'state/admin-menu/selectors';
-import Sidebar from 'layout/sidebar';
-import SidebarSeparator from 'layout/sidebar/separator';
-import 'layout/sidebar-unified/style.scss';
-import 'state/admin-menu/init';
-import Spinner from 'components/spinner';
+import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
+import Sidebar from 'calypso/layout/sidebar';
+import SidebarSeparator from 'calypso/layout/sidebar/separator';
+import 'calypso/layout/sidebar-unified/style.scss';
+import 'calypso/state/admin-menu/init';
+import Spinner from 'calypso/components/spinner';
 import { itemLinkMatches } from '../sidebar/utils';
 import './style.scss';
 
@@ -67,14 +67,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 					);
 				}
 
-				return (
-					<MySitesSidebarUnifiedItem
-						key={ item.slug }
-						path={ path }
-						selected={ isSelected }
-						{ ...item }
-					/>
-				);
+				return <MySitesSidebarUnifiedItem key={ item.slug } selected={ isSelected } { ...item } />;
 			} ) }
 		</Sidebar>
 	);

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -8,18 +8,17 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React, { memo } from 'react';
+import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
-import StatsSparkline from 'calypso/blocks/stats-sparkline';
+import MySitesSidebarUnifiedStatsSparkline from './sparkline';
 import { collapseAllMySitesSidebarSections } from 'calypso/state/my-sites/sidebar/actions';
 
 export const MySitesSidebarUnifiedItem = ( {
@@ -30,15 +29,7 @@ export const MySitesSidebarUnifiedItem = ( {
 	selected = false,
 	isSubItem = false,
 } ) => {
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const reduxDispatch = useDispatch();
-	let children = null;
-
-	// "Stats" item has sparkline inside of it
-	const isStats = typeof slug === 'string' && slug.includes( '-comstats' );
-	if ( isStats && selectedSiteId ) {
-		children = <StatsSparkline className="sidebar-unified__sparkline" siteId={ selectedSiteId } />;
-	}
+    const reduxDispatch = useDispatch();
 
 	return (
 		<SidebarItem
@@ -50,16 +41,15 @@ export const MySitesSidebarUnifiedItem = ( {
 			forceInternalLink
 			className={ isSubItem ? 'sidebar__menu-item--child' : 'sidebar__menu-item-parent' }
 		>
-			{ children }
+			<MySitesSidebarUnifiedStatsSparkline slug={ slug } />
 		</SidebarItem>
 	);
 };
 
 MySitesSidebarUnifiedItem.propTypes = {
-	path: PropTypes.string,
 	title: PropTypes.string,
 	icon: PropTypes.string,
 	url: PropTypes.string,
 };
 
-export default MySitesSidebarUnifiedItem;
+export default memo( MySitesSidebarUnifiedItem );

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -29,7 +29,7 @@ export const MySitesSidebarUnifiedItem = ( {
 	selected = false,
 	isSubItem = false,
 } ) => {
-    const reduxDispatch = useDispatch();
+	const reduxDispatch = useDispatch();
 
 	return (
 		<SidebarItem

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -82,7 +82,6 @@ export const MySitesSidebarUnifiedMenu = ( {
 				return (
 					<MySitesSidebarUnifiedItem
 						key={ item.slug }
-						path={ path }
 						{ ...item }
 						selected={ isSelected }
 						isSubItem={ true }

--- a/client/my-sites/sidebar-unified/sparkline.js
+++ b/client/my-sites/sidebar-unified/sparkline.js
@@ -1,0 +1,31 @@
+/**
+ * MySitesSidebarUnifiedItem
+ *
+ * Renders a sidebar menu item with no child items.
+ * This could be a top level item, or a child item nested under a top level menu.
+ * These two cases might be to be split up?
+ */
+/**
+ * External dependencies
+ */
+import React, { memo } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import StatsSparkline from 'calypso/blocks/stats-sparkline';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export const MySitesSidebarUnifiedStatsSparkline = ( { slug } ) => {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const isStats = typeof slug === 'string' && slug.includes( '-comstats' );
+
+	if ( ! isStats || ! selectedSiteId ) {
+		return null;
+	}
+
+	return <StatsSparkline className="sidebar-unified__sparkline" siteId={ selectedSiteId } />;
+};
+
+export default memo( MySitesSidebarUnifiedStatsSparkline );


### PR DESCRIPTION
Initial pass at optimising some of the rendering of the component tree for the unified nav. Specifically this focuses on the `MySitesSidebarUnifiedItem` component and friends.

This is part of breaking up this PR https://github.com/Automattic/wp-calypso/pull/46448.

Address part of https://github.com/Automattic/wp-calypso/issues/46091

## Changes proposed in this Pull Request

* Optimize `MySitesSidebarUnifiedItem` to avoid unnecessary renders - important as it will render many items in the tree.
* Optimize Stats Sparkline so only re-renders where necessary. Move out of `MySitesSidebarUnifiedItem` to stop hook change (ie: `useSelector( getSelectedSiteId );`) causing that component to re-render.
* Allow expanded state of items to be determined by Redux state.

## Testing instructions

#### On Master

* `yarn && yarn start`. Wait for Calypso to boot.
* Goto `http://calypso.localhost:3000/home/` and select your test site.
* Add `?flags=nav-unification` to the end of the URL. Hit `Enter` to reload the page.
* Open React DevTools and go to the Profiler tab.
* Click the record button and start profiling.
* Click on `Pages` - wait for load, then click on `Posts`.
* Stop profiling.
* Analyse the flame chart and look for the `MySitesSidebarUnified` component - click to focus.
* Now use the timeline to move through the events that you profiled. 
* Observe how the `MySitesSidebarUnifiedItem` re-renders often and repeatedly. This cascades down the tree on each render cycle.

<img width="1398" alt="Screen Shot 2020-10-21 at 11 04 35" src="https://user-images.githubusercontent.com/444434/96706657-c406dd00-138e-11eb-84c9-fc4028cc37ae.png">

#### On this PR

* Checkout this PR.
* Repeat the steps above.
* This time observe how the `MySitesSidebarUnifiedItem` _seldom_ re-renders - it only happens where it is _absolutely_ necessary.

<img width="1680" alt="Screen Shot 2020-10-21 at 11 06 45" src="https://user-images.githubusercontent.com/444434/96706789-f1ec2180-138e-11eb-9f55-2f0a3e5c50da.png">


* Also check for any other regressions as a result - for example does the Stats Sparkline still render correctly? Can you toggle nav items?
