### PR TITLE
Add instructions to Google login popover to enable third-party cookies

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -18,7 +18,7 @@ import Popover from 'calypso/components/popover';
 import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isFormDisabled } from 'calypso/state/login/selectors';
-import { localizeUrl } from 'lib/i18n-utils';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 let auth2InitDone = false;
 

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { loadScript } from '@automattic/load-script';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ import Popover from 'calypso/components/popover';
 import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isFormDisabled } from 'calypso/state/login/selectors';
+import { localizeUrl } from 'lib/i18n-utils';
 
 let auth2InitDone = false;
 
@@ -123,8 +125,19 @@ class GoogleLoginButton extends Component {
 				if ( 'idpiframe_initialization_failed' === error.error ) {
 					// This error is caused by 3rd party cookies being blocked.
 					this.setState( {
-						error: translate(
-							'Please enable "third-party cookies" to connect your Google account.'
+						error: createInterpolateElement(
+							translate(
+								'Please enable "third-party cookies" to connect your Google account. To find out how to do this <learn_more_link>learn more here</learn_more_link>.'
+							),
+							{
+								learn_more_link: (
+									<a
+										target="_blank"
+										rel="noreferrer"
+										href={ localizeUrl( 'https://wordpress.com/support/third-party-cookies/' ) }
+									/>
+								),
+							}
 						),
 					} );
 				}
@@ -213,7 +226,6 @@ class GoogleLoginButton extends Component {
 						className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
 						onMouseOver={ this.showError }
 						onFocus={ this.showError }
-						onMouseOut={ this.hideError }
 						onBlur={ this.hideError }
 						onClick={ this.handleClick }
 					>

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import { loadScript } from '@automattic/load-script';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -125,18 +124,18 @@ class GoogleLoginButton extends Component {
 				if ( 'idpiframe_initialization_failed' === error.error ) {
 					// This error is caused by 3rd party cookies being blocked.
 					this.setState( {
-						error: createInterpolateElement(
-							translate(
-								'Please enable "third-party cookies" to connect your Google account. To find out how to do this <learn_more_link>learn more here</learn_more_link>.'
-							),
+						error: translate(
+							'Please enable "third-party cookies" to connect your Google account. To learn how to do this, {{learnMoreLink}}click here{{/learnMoreLink}}.',
 							{
-								learn_more_link: (
-									<a
-										target="_blank"
-										rel="noreferrer"
-										href={ localizeUrl( 'https://wordpress.com/support/third-party-cookies/' ) }
-									/>
-								),
+								components: {
+									learnMoreLink: (
+										<a
+											target="_blank"
+											rel="noreferrer"
+											href={ localizeUrl( 'https://wordpress.com/support/third-party-cookies/' ) }
+										/>
+									),
+								},
 							}
 						),
 					} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add instructions to the disabled "Continue with Google" button on how to enable third-party cookies by directing them to the support page.
* Removed the "onMouseOut" call back to hide the error so users can hover over the pop over and click the link.

#### Testing instructions

* In Incognito mode go to [http://calypso.localhost:3000/log-in](http://calypso.localhost:3000/log-in).
* Hover over the disabled "Continue with Google" button and a popover should appear with a "learn more here" link in.
* Clicking the link should take you to [https://wordpress.com/support/third-party-cookies/](https://wordpress.com/support/third-party-cookies/).
* Clicking elsewhere on the `/log-in` page should make the popover disappear.

Fixes https://github.com/Automattic/wp-calypso/issues/39758
