### PR TITLE
Purchases: Add delete payment method event

### DIFF
--- a/client/me/purchases/credit-cards/credit-card-delete.tsx
+++ b/client/me/purchases/credit-cards/credit-card-delete.tsx
@@ -21,6 +21,7 @@ import {
 } from 'calypso/lib/checkout/payment-methods';
 import StoredCard from 'calypso/components/credit-card/stored-card';
 import PaymentMethodDeleteDialog from './payment-method-delete-dialog';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 /**
  * Style dependencies
@@ -49,6 +50,8 @@ const CreditCardDelete: FunctionComponent< Props > = ( { card } ) => {
 				} else {
 					reduxDispatch( successNotice( translate( 'Card deleted successfully' ) ) );
 				}
+
+				recordTracksEvent( 'calypso_purchases_delete_payment_method' );
 			} )
 			.catch( ( error: Error ) => {
 				reduxDispatch( errorNotice( error.message ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds an event for when someone removes a payment method.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the account-level or site-level billing section.
* Delete a payment method and confirm the `calypso_purchases_delete_payment_method` event fires. 

Fixes https://github.com/Automattic/wp-calypso/issues/46605
