### PR TITLE
Draft: Add focused launch to WP Admin

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.ts
@@ -3,3 +3,4 @@
  */
 import './src/stores';
 import './src/attach-launch-sidebar';
+import './src/attach-focused-launch';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import FocusedLaunchModal from './focused-launch-modal';
+import { useOnLaunch } from './hooks';
+import { LAUNCH_STORE } from './stores';
+
+const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	originalRegisterPlugin( name, settings as any );
+
+registerPlugin( 'a8c-editor-editor-focused-launch', {
+	render: function LaunchSidebar() {
+		const { isFocusedLaunchOpen } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+		const { closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
+
+		// handle redirects to checkout / my home after launch
+		useOnLaunch();
+
+		if ( ! isFocusedLaunchOpen ) {
+			return null;
+		}
+
+		return <FocusedLaunchModal onClose={ closeFocusedLaunch } />;
+	},
+} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/focused-launch-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/focused-launch-modal/index.tsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Modal, Button } from '@wordpress/components';
+import { Icon, wordpress, close } from '@wordpress/icons';
+import FocusedLaunch from '../focused-launch';
+
+import './styles.scss';
+
+interface Props {
+	onClose: () => void;
+}
+
+const FocusedLaunchModal: React.FunctionComponent< Props > = ( { onClose } ) => {
+	return (
+		<Modal
+			open={ true }
+			className="focused-launch-modal"
+			overlayClassName="focused-launch-modal-overlay"
+			bodyOpenClassName="has-focused-launch-modal"
+			onRequestClose={ onClose }
+			title=""
+		>
+			<>
+				<div className="focused-launch-modal-body">
+					<div className="focused-launch-modal-header">
+						<div className="focused-launch-modal-header__wp-logo">
+							<Icon icon={ wordpress } size={ 36 } />
+						</div>
+						<Button
+							isLink
+							className="focused-launch-modal__close-button"
+							onClick={ onClose }
+							aria-label={ __( 'Close dialog', 'full-site-editing' ) }
+							disabled={ ! onClose }
+						>
+							<span>
+								<Icon icon={ close } size={ 24 } />
+							</span>
+						</Button>
+					</div>
+					<div className="focused-launch-body">
+						<div className="focused-launch-inputs">
+							<FocusedLaunch />
+						</div>
+						<div className="focused-launch-modal-aside">
+							<div>
+								<strong>46.9%</strong> of globally registered domains are <strong>.com</strong>
+							</div>
+						</div>
+					</div>
+				</div>
+			</>
+		</Modal>
+	);
+};
+
+export default FocusedLaunchModal;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/focused-launch-modal/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/focused-launch-modal/styles.scss
@@ -1,0 +1,146 @@
+@import '~@wordpress/base-styles/mixins';
+@import '~@wordpress/base-styles/variables';
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/z-index';
+@import '~@automattic/typography/styles/variables';
+@import '~@automattic/onboarding/styles/variables';
+@import '~@automattic/onboarding/styles/mixins';
+
+body.has-focused-launch-modal {
+	overflow: hidden;
+}
+
+.focused-launch-modal {
+	&.components-modal__frame {
+		transform: none;
+	}
+
+	.components-modal__header {
+		display: none;
+	}
+
+	.components-modal__content {
+		position: fixed;
+		top: 0;
+		left: 0;
+		background: var( --studio-white );
+		width: 100%;
+		height: 100%;
+		padding: 0;
+		// Using overflow-y: scroll for consistent viewport width has an unintended
+		// consequence where if the content height is shorter than the viewport height
+		// the modal header overlaps the scrollbar on Chrome.
+		overflow: auto;
+	}
+}
+
+.focused-launch-modal-header {
+	justify-content: space-between;
+	display: flex;
+}
+
+.focused-launch-body {
+	display: flex;
+	width: 100%;
+	margin: 0 auto;
+	justify-content: center;
+}
+
+.focused-launch-modal-header__wp-logo {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 60px;
+	height: 60px;
+}
+
+.focused-launch-modal-body {
+	position: relative;
+	flex-grow: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+}
+
+.focused-launch-modal-aside {
+	// Instead of display: none, the sidebar hides off-screen
+	// on mobile view, this is to prevents "Get Started" button
+	// from disappearing when clicked, causing the modal to blur
+	// itself out and abruptly closes the modal.
+	position: absolute;
+	top: 0;
+	left: -200%;
+	width: 100%;
+	height: 100%;
+	background: var( --studio-white );
+	z-index: z-index( '.components-modal__header' ) + 2;
+
+	@media ( max-width: $break-medium ) {
+		// This brings the sidebar that is hiding offscreen into view.
+		.is-sidebar-fullscreen & {
+			left: 0;
+		}
+	}
+
+	@include break-medium {
+		// Use sticky or relative positioning because fixed or absolute
+		// positioning causes the vertical scrollbar from the parent element
+		// to overlap the content on the sidebar.
+		position: sticky;
+		top: 0;
+		left: auto;
+		width: $sidebar-width;
+		min-width: $sidebar-width;
+		max-width: $sidebar-width;
+		border-left: 1px solid var( --studio-gray-5 );
+	}
+}
+
+.focused-launch-modal__close-button.components-button.is-link {
+	// This keeps the button on the top right corner even when scrolled down
+	position: sticky;
+	top: 0;
+	z-index: z-index( '.components-modal__header' ) + 3;
+
+	// Give it no dimension so it doesn't take any flex space
+	// but overflow it so the close button is visible
+	width: 0;
+	height: 0;
+	overflow: visible;
+
+	// Anchor the inline content to the top right (instead of middle).
+	display: flex;
+	align-items: flex-start;
+
+	// Close button icon color
+	color: var( --studio-gray-50 );
+	&:hover {
+		color: var( --studio-gray-40 );
+	}
+
+	> span {
+		// Push the icon back out from the right side
+		position: relative;
+		right: $onboarding-header-height;
+
+		// Use padding to create width
+		// (18px left padding + 24px icon width + 18px right padding = 60px width)
+		padding: 0 #{( $onboarding-header-height - 24px ) / 2};
+		height: $onboarding-header-height;
+
+		// Vertically align icon
+		display: flex;
+		align-items: center;
+	}
+}
+
+.focused-launch-modal-aside {
+	height: 100%;
+    flex: 0.5;
+    padding: 1%;
+}
+.focused-launch-inputs {
+    flex: 0.5;
+    padding: 1%;
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/focused-launch/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/focused-launch/index.tsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { Title } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { TextControl } from '@wordpress/components';
+import * as React from 'react';
+import DomainPicker from '@automattic/domain-picker';
+import { useSite, useDomainSearch } from '../hooks';
+
+import './styles.scss';
+
+const FocusedLaunch: React.FunctionComponent = () => {
+	const { getSite } = useSelect( ( select ) => select( 'core' ) ) as any;
+	const title = getSite()?.title;
+
+	const site = useSite();
+
+	const [ siteTitle, setSiteTitle ] = React.useState( title );
+	const [ siteDomainName ] = React.useState( site.currentDomainName );
+	const domainSearch = useDomainSearch();
+
+	return (
+		<>
+			<div className="focused-launch-section">
+				<Title>{ __( "You're almost there", 'full-site-editing' ) }</Title>
+				<p className="focused-launch-caption">
+					{ __(
+						'Prepare for launch! Confirm a few final things before you take it live.',
+						'full-site-editing'
+					) }
+				</p>
+			</div>
+			<div className="focused-launch-section">
+				<TextControl
+					className="focused-launch-input"
+					label={ __( '1. Name your site', 'full-site-editing' ) }
+					value={ siteTitle }
+					onChange={ ( value ) => setSiteTitle( value ) }
+				/>
+			</div>
+			<div className="focused-launch-section">
+				<DomainPicker
+					header={
+						<label className="focused-launch-label">
+							{ __( '2. Confirm your domain', 'full-site-editing' ) }
+						</label>
+					}
+					existingSubdomain={ siteDomainName }
+					currentDomain={ siteDomainName }
+					onDomainSelect={ setSiteTitle }
+					initialDomainSearch={ domainSearch }
+					showSearchField={ false }
+					analyticsFlowId="focused-launch"
+					analyticsUiAlgo="focused_launch_domain_picker"
+				/>
+			</div>
+			<div className="focused-launch-section">
+				<label className="focused-launch-label">
+					{ __( '3. Confirm your plan', 'full-site-editing' ) }
+				</label>
+			</div>
+		</>
+	);
+};
+
+export default FocusedLaunch;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/focused-launch/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/focused-launch/styles.scss
@@ -1,0 +1,27 @@
+@import '~@wordpress/base-styles/mixins';
+@import '~@wordpress/base-styles/variables';
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/z-index';
+@import '~@automattic/typography/styles/variables';
+@import '~@automattic/onboarding/styles/variables';
+@import '~@automattic/onboarding/styles/mixins';
+
+.focused-launch-input {
+	.components-base-control__label {
+		font-weight: bold;
+	}
+}
+
+.focused-launch-label {
+	font-weight: bold;
+	margin-bottom: 8px;
+	display: block;
+}
+
+.focused-launch-section {
+	margin: 20px 0;
+}
+
+.focused-launch-caption {
+	margin: 0;
+}

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -76,6 +76,16 @@ export function* launchSite() {
 	}
 }
 
+export const openFocusedLaunch = () =>
+	( {
+		type: 'OPEN_FOCUSED_LAUNCH',
+	} as const );
+
+export const closeFocusedLaunch = () =>
+	( {
+		type: 'CLOSE_FOCUSED_LAUNCH',
+	} as const );
+
 export const openSidebar = () =>
 	( {
 		type: 'OPEN_SIDEBAR',
@@ -101,6 +111,8 @@ export type LaunchAction = ReturnType<
 	| typeof unsetPlan
 	| typeof openSidebar
 	| typeof closeSidebar
+	| typeof openFocusedLaunch
+	| typeof closeFocusedLaunch
 	| typeof enableExperimental
 	| typeof setSidebarFullscreen
 	| typeof unsetSidebarFullscreen

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -68,6 +68,17 @@ const isSidebarOpen: Reducer< boolean, LaunchAction > = ( state = false, action 
 	return state;
 };
 
+const isFocusedLaunchOpen: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
+	if ( action.type === 'OPEN_FOCUSED_LAUNCH' ) {
+		return true;
+	}
+
+	if ( action.type === 'CLOSE_FOCUSED_LAUNCH' ) {
+		return false;
+	}
+	return state;
+};
+
 const isSidebarFullscreen: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
 	if ( action.type === 'SET_SIDEBAR_FULLSCREEN' ) {
 		return true;
@@ -95,6 +106,7 @@ const reducer = combineReducers( {
 	isSidebarOpen,
 	isSidebarFullscreen,
 	isExperimental,
+	isFocusedLaunchOpen,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -86,6 +86,9 @@ export interface Props {
 
 	/** Weather to segregate free and paid domains from each other */
 	segregateFreeAndPaid?: boolean;
+
+	/** Weather to show search field or not. Defaults to true */
+	showSearchField?: boolean;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {
@@ -104,6 +107,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	isCheckingDomainAvailability,
 	existingSubdomain,
 	segregateFreeAndPaid = false,
+	showSearchField = true,
 } ) => {
 	const { __ } = useI18n();
 	const label = __( 'Search for a domain' );
@@ -192,21 +196,23 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	return (
 		<div className="domain-picker">
 			{ header && header }
-			<div className="domain-picker__search">
-				<div className="domain-picker__search-icon">
-					<Icon icon={ search } />
+			{ showSearchField && (
+				<div className="domain-picker__search">
+					<div className="domain-picker__search-icon">
+						<Icon icon={ search } />
+					</div>
+					<TextControl
+						// Unable to remove this instance due to it being a HotJar term: https://github.com/Automattic/wp-calypso/pull/43348#discussion_r442015229
+						data-hj-whitelist
+						hideLabelFromVision
+						label={ label }
+						placeholder={ label }
+						onChange={ handleInputChange }
+						onBlur={ onDomainSearchBlurValue }
+						value={ domainSearch }
+					/>
 				</div>
-				<TextControl
-					// Unable to remove this instance due to it being a HotJar term: https://github.com/Automattic/wp-calypso/pull/43348#discussion_r442015229
-					data-hj-whitelist
-					hideLabelFromVision
-					label={ label }
-					placeholder={ label }
-					onChange={ handleInputChange }
-					onBlur={ onDomainSearchBlurValue }
-					value={ domainSearch }
-				/>
-			</div>
+			) }
 			{ showErrorMessage && (
 				<div className="domain-picker__error">
 					<p className="domain-picker__error-message">


### PR DESCRIPTION
#### Running this code

1. Sandbox a site, say MY_SITE.wordpress.com.
2. Go inside `apps/editing-toolkit` and run `yarn dev --sync`.
3. Edit the home page (http://calypso.localhost:3000/page/MY_SITE.wordpress.com/2).
4. In Chrome DevTools console, select `post.php`, then type `wp.data.dispatch('automattic/launch' ).openFocusedLaunch()`.

