### PR TITLE
Purchases: fix duplicated manage purchases title

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -190,7 +190,10 @@ class CancelPurchase extends React.Component {
 					eventName="calypso_cancel_purchase_purchase_view"
 					purchaseId={ this.props.purchaseId }
 				/>
-				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+
+				{ this.props.showTitle && (
+					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+				) }
 
 				<HeaderCake
 					backHref={ this.props.getManagePurchaseUrlFor(

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -38,7 +38,6 @@ import ProductLink from 'calypso/me/purchases/product-link';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -190,10 +189,6 @@ class CancelPurchase extends React.Component {
 					eventName="calypso_cancel_purchase_purchase_view"
 					purchaseId={ this.props.purchaseId }
 				/>
-
-				{ this.props.showTitle && (
-					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-				) }
 
 				<HeaderCake
 					backHref={ this.props.getManagePurchaseUrlFor(

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -102,6 +102,7 @@ export function confirmCancelDomain( context, next ) {
 
 	context.primary = (
 		<Main className={ classes }>
+			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 			<ConfirmCancelDomain
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 				siteSlug={ context.params.site }

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -81,6 +81,7 @@ export function cancelPurchase( context, next ) {
 			<CancelPurchase
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 				siteSlug={ context.params.site }
+				showTitle={ true }
 			/>
 		</Main>
 	);
@@ -126,6 +127,7 @@ export function editCardDetails( context, next ) {
 				getManagePurchaseUrlFor={ managePurchaseUrl }
 				purchaseListUrl={ purchasesRoot }
 				isFullWidth={ true }
+				showTitle={ true }
 			/>
 		</Main>
 	);

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -24,6 +24,7 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { managePurchase as managePurchaseUrl, purchasesRoot } from 'calypso/me/purchases/paths';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 function setTitle( context, ...title ) {
@@ -56,6 +57,7 @@ export function addCardDetails( context, next ) {
 
 	context.primary = (
 		<Main className="purchases__add-cart-details is-wide-layout">
+			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 			<AddCardDetails
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 				siteSlug={ context.params.site }
@@ -78,10 +80,10 @@ export function cancelPurchase( context, next ) {
 
 	context.primary = (
 		<Main className="purchases__cancel is-wide-layout">
+			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 			<CancelPurchase
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 				siteSlug={ context.params.site }
-				showTitle={ true }
 			/>
 		</Main>
 	);
@@ -120,6 +122,7 @@ export function editCardDetails( context, next ) {
 
 	context.primary = (
 		<Main className="purchases__change is-wide-layout">
+			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 			<EditCardDetails
 				cardId={ context.params.cardId }
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
@@ -127,7 +130,6 @@ export function editCardDetails( context, next ) {
 				getManagePurchaseUrlFor={ managePurchaseUrl }
 				purchaseListUrl={ purchasesRoot }
 				isFullWidth={ true }
-				showTitle={ true }
 			/>
 		</Main>
 	);
@@ -147,6 +149,7 @@ export function managePurchase( context, next ) {
 
 	context.primary = (
 		<Main className={ classes }>
+			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 			<PageViewTracker path="/me/purchases/:site/:purchaseId" title="Purchases > Manage Purchase" />
 			<ManagePurchase
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -625,6 +625,7 @@ class ManagePurchase extends Component {
 			getAddPaymentMethodUrlFor,
 			getEditPaymentMethodUrlFor,
 			isProductOwner,
+			showHeader,
 		} = this.props;
 
 		let editCardDetailsPath = false;
@@ -654,7 +655,9 @@ class ManagePurchase extends Component {
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 				{ isPurchaseTheme && <QueryCanonicalTheme siteId={ siteId } themeId={ purchase.meta } /> }
 
-				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+				{ showHeader && (
+					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+				) }
 
 				<HeaderCake backHref={ this.props.purchaseListUrl }>{ this.props.cardTitle }</HeaderCake>
 				{ showExpiryNotice ? (

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -96,7 +96,6 @@ import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/co
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
-import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -625,7 +624,6 @@ class ManagePurchase extends Component {
 			getAddPaymentMethodUrlFor,
 			getEditPaymentMethodUrlFor,
 			isProductOwner,
-			showHeader,
 		} = this.props;
 
 		let editCardDetailsPath = false;
@@ -654,10 +652,6 @@ class ManagePurchase extends Component {
 				<QueryUserPurchases userId={ this.props.userId } />
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 				{ isPurchaseTheme && <QueryCanonicalTheme siteId={ siteId } themeId={ purchase.meta } /> }
-
-				{ showHeader && (
-					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-				) }
 
 				<HeaderCake backHref={ this.props.purchaseListUrl }>{ this.props.cardTitle }</HeaderCake>
 				{ showExpiryNotice ? (

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -27,7 +27,6 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { StripeHookProvider } from 'calypso/lib/stripe';
-import FormattedHeader from 'calypso/components/formatted-header';
 
 function AddCardDetails( props ) {
 	const createCardUpdateToken = ( ...args ) => createCardToken( 'card_update', ...args );
@@ -73,7 +72,6 @@ function AddCardDetails( props ) {
 				path="/me/purchases/:site/:purchaseId/payment/add"
 				title="Purchases > Add Card Details"
 			/>
-			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 
 			<HeaderCake backHref={ props.getManagePurchaseUrlFor( props.siteSlug, props.purchaseId ) }>
 				{ titles.addCardDetails }

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -50,6 +50,10 @@ function EditCardDetails( props ) {
 
 				<QueryUserPurchases userId={ props.userId } />
 
+				{ props.showTitle && (
+					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+				) }
+
 				<CreditCardFormLoadingPlaceholder
 					title={ titles.editCardDetails }
 					isFullWidth={ props.isFullWidth }
@@ -81,7 +85,10 @@ function EditCardDetails( props ) {
 				path="/me/purchases/:site/:purchaseId/payment/edit/:cardId"
 				title="Purchases > Edit Card Details"
 			/>
-			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+
+			{ props.showTitle && (
+				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+			) }
 
 			<HeaderCake backHref={ props.getManagePurchaseUrlFor( props.siteSlug, props.purchaseId ) }>
 				{ titles.editCardDetails }

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -32,7 +32,6 @@ import {
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { StripeHookProvider } from 'calypso/lib/stripe';
-import FormattedHeader from 'calypso/components/formatted-header';
 
 function EditCardDetails( props ) {
 	const isDataLoading = ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;
@@ -49,10 +48,6 @@ function EditCardDetails( props ) {
 				<QueryStoredCards />
 
 				<QueryUserPurchases userId={ props.userId } />
-
-				{ props.showTitle && (
-					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-				) }
 
 				<CreditCardFormLoadingPlaceholder
 					title={ titles.editCardDetails }
@@ -85,10 +80,6 @@ function EditCardDetails( props ) {
 				path="/me/purchases/:site/:purchaseId/payment/edit/:cardId"
 				title="Purchases > Edit Card Details"
 			/>
-
-			{ props.showTitle && (
-				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-			) }
 
 			<HeaderCake backHref={ props.getManagePurchaseUrlFor( props.siteSlug, props.purchaseId ) }>
 				{ titles.editCardDetails }

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -104,7 +104,7 @@ export function PurchaseCancel( {
 			<FormattedHeader
 				brandFont
 				className="purchases__page-heading"
-				headerText={ translate( 'Cancel purchase' ) }
+				headerText={ translate( 'Billing' ) }
 				align="left"
 			/>
 
@@ -114,7 +114,6 @@ export function PurchaseCancel( {
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 				getConfirmCancelDomainUrlFor={ getConfirmCancelDomainUrlFor }
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
-				showTitle={ false }
 			/>
 		</Main>
 	);
@@ -178,7 +177,6 @@ export function PurchaseEditPaymentMethod( {
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 				isFullWidth={ true }
-				showTitle={ false }
 			/>
 		</Main>
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -114,6 +114,7 @@ export function PurchaseCancel( {
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 				getConfirmCancelDomainUrlFor={ getConfirmCancelDomainUrlFor }
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
+				showTitle={ false }
 			/>
 		</Main>
 	);
@@ -177,6 +178,7 @@ export function PurchaseEditPaymentMethod( {
 				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 				isFullWidth={ true }
+				showTitle={ false }
 			/>
 		</Main>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

https://github.com/Automattic/wp-calypso/pull/46602 introduced a bug on our site-level billing screens where we now see a duplicated title. This PR cleans that up. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/96732281-260f1480-1386-11eb-902d-be607ad29934.png)

![image](https://user-images.githubusercontent.com/6981253/96732316-31624000-1386-11eb-955e-9d73e28777f8.png)

![image](https://user-images.githubusercontent.com/6981253/96732360-3e7f2f00-1386-11eb-8c1d-6f80dcbc8813.png)

![image](https://user-images.githubusercontent.com/6981253/96733803-ddf0f180-1387-11eb-8d64-df3534a1a4a8.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/96732124-ff50de00-1385-11eb-8fa7-908693c89dfe.png)

![image](https://user-images.githubusercontent.com/6981253/96732173-0a0b7300-1386-11eb-8226-5f7d508c9e77.png)

![image](https://user-images.githubusercontent.com/6981253/96734365-77b89e80-1388-11eb-8970-9b80dccd9a13.png)

![image](https://user-images.githubusercontent.com/6981253/96733935-01b43780-1388-11eb-9dbe-51a0e87fcb14.png)


#### Testing instructions
Needs to be tested locally

* Visit the subscription screen at the site and account level and confirm you only see a single title for the following screens:
 * Subscription settings
 * Change payment method
 * Add payment method (from subscription screen)
 * Cancel purchase 


