### PR TITLE
Change app banner delay from a week to an hour

### DIFF
--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -1,16 +1,16 @@
 const HOUR_IN_MS = 60 * 60 * 1000;
 
 /**
- * Returns false if the site is unlaunched or is younger than 1 week
+ * Returns false if the site is unlaunched or is younger than 1 hour
  *
  * @param site the site object
  */
 export function getShouldShowAppBanner( site: any ): boolean {
 	if ( site && site.options ) {
-		const olderThanAWeek = Date.now() - new Date( site.options.created_at ).getTime() > HOUR_IN_MS;
+		const olderThanAnHour = Date.now() - new Date( site.options.created_at ).getTime() > HOUR_IN_MS;
 		const isLaunched = site.launch_status !== 'unlaunched';
 
-		return olderThanAWeek && isLaunched;
+		return olderThanAnHour && isLaunched;
 	}
 	return false;
 }

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -1,4 +1,4 @@
-const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+const HOUR_IN_MS = 60 * 60 * 1000;
 
 /**
  * Returns false if the site is unlaunched or is younger than 1 week
@@ -7,7 +7,7 @@ const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
  */
 export function getShouldShowAppBanner( site: any ): boolean {
 	if ( site && site.options ) {
-		const olderThanAWeek = Date.now() - new Date( site.options.created_at ).getTime() > WEEK_IN_MS;
+		const olderThanAWeek = Date.now() - new Date( site.options.created_at ).getTime() > HOUR_IN_MS;
 		const isLaunched = site.launch_status !== 'unlaunched';
 
 		return olderThanAWeek && isLaunched;


### PR DESCRIPTION
The change in #42164 appears to have resulted in a larger-than-expected drop in the number of mobile app banner impressions. It seems that while the original intent of that change was to delay the banner display to 1 hour, the final implementation resulted in a delay of 1 week. This PR implements the 1-hour delay and makes a couple of other logical changes.

#### Changes proposed in this Pull Request

* Change the delay for showing the App install banner from one week to one hour

#### Testing instructions

* Create a site using /new
* The app banner shouldn't appear.
* Wait for one hour
* Banner should appear

