### PR TITLE
Display app banner when no site is selected

### DIFF
--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -12,5 +12,5 @@ export function getShouldShowAppBanner( site: any ): boolean {
 
 		return olderThanAWeek && isLaunched;
 	}
-	return false;
+	return true;
 }


### PR DESCRIPTION
The change in #42164 appears to have resulted in a larger-than-expected drop in the number of mobile app banner impressions. It seems that while the original intent of that change was to delay banner display until a user was able to complete onboarding. That change however blocked the loading of the banner anywhere that not site is selected for all users.

#### Changes proposed in this Pull Request

* Show the App install banner when no site is selected. This could occur when you are in the Reader, Settings, etc.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site using /new
* The app banner shouldn't appear.
* Go to reader
* Banner should appear
