### PR TITLE
Some a11y improvements to Reader cards

### DIFF
--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -31,11 +31,11 @@ const CompactPost = ( { post, postByline, children, isDiscover, onClick } ) => {
 					position="bottom"
 				/>
 				<AutoDirection>
-					<h1 className="reader-post-card__title">
+					<h2 className="reader-post-card__title">
 						<a className="reader-post-card__title-link" href={ post.URL }>
 							<Emojify>{ post.title }</Emojify>
 						</a>
-					</h1>
+					</h2>
 				</AutoDirection>
 				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
 				{ children }

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -56,11 +56,11 @@ const PostGallery = ( { post, children, isDiscover } ) => {
 			<ul className="reader-post-card__gallery">{ listItems }</ul>
 			<div className="reader-post-card__post-details">
 				<AutoDirection>
-					<h1 className="reader-post-card__title">
+					<h2 className="reader-post-card__title">
 						<a className="reader-post-card__title-link" href={ post.URL }>
 							<Emojify>{ post.title }</Emojify>
 						</a>
-					</h1>
+					</h2>
 				</AutoDirection>
 				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
 				{ children }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -262,7 +262,6 @@ class ReaderPostCard extends React.Component {
 		const onClick = ! isPhotoPost && ! compact ? this.handleCardClick : noop;
 		return (
 			<Card className={ classes } onClick={ onClick }>
-				{ ! compact && postByline }
 				{ showPrimaryFollowButton && followUrl && (
 					<FollowButton
 						siteUrl={ followUrl }
@@ -271,6 +270,7 @@ class ReaderPostCard extends React.Component {
 					/>
 				) }
 				{ readerPostCard }
+				{ ! compact && postByline }
 				{ this.props.children }
 			</Card>
 		);

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -262,6 +262,7 @@ class ReaderPostCard extends React.Component {
 		const onClick = ! isPhotoPost && ! compact ? this.handleCardClick : noop;
 		return (
 			<Card className={ classes } onClick={ onClick } tagName="article">
+				{ ! compact && postByline }
 				{ showPrimaryFollowButton && followUrl && (
 					<FollowButton
 						siteUrl={ followUrl }
@@ -270,7 +271,6 @@ class ReaderPostCard extends React.Component {
 					/>
 				) }
 				{ readerPostCard }
-				{ ! compact && postByline }
 				{ this.props.children }
 			</Card>
 		);

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -261,7 +261,7 @@ class ReaderPostCard extends React.Component {
 		const followUrl = feed ? feed.feed_URL : post.site_URL;
 		const onClick = ! isPhotoPost && ! compact ? this.handleCardClick : noop;
 		return (
-			<Card className={ classes } onClick={ onClick }>
+			<Card className={ classes } onClick={ onClick } tagName="article">
 				{ showPrimaryFollowButton && followUrl && (
 					<FollowButton
 						siteUrl={ followUrl }

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -114,7 +114,7 @@ class PostPhoto extends React.Component {
 					<div ref={ this.handleWidthDivLoaded } style={ { width: '100%' } } />
 				</a>
 				<AutoDirection>
-					<h1 className="reader-post-card__title">
+					<h2 className="reader-post-card__title">
 						<a
 							className="reader-post-card__title-link"
 							href={ post.URL }
@@ -122,7 +122,7 @@ class PostPhoto extends React.Component {
 						>
 							<Emojify>{ linkTitle }</Emojify>
 						</a>
-					</h1>
+					</h2>
 				</AutoDirection>
 			</div>
 		);
@@ -130,7 +130,7 @@ class PostPhoto extends React.Component {
 
 	render() {
 		const { post, children } = this.props;
-		const featuredImage = !! post.canonical_media.src ? this.renderFeaturedImage() : null;
+		const featuredImage = post.canonical_media.src ? this.renderFeaturedImage() : null;
 
 		return (
 			<div className="reader-post-card__post">

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -28,11 +28,11 @@ const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpa
 			/>
 			<div className="reader-post-card__post-details">
 				<AutoDirection>
-					<h1 className="reader-post-card__title">
+					<h2 className="reader-post-card__title">
 						<a className="reader-post-card__title-link" href={ post.URL }>
 							<Emojify>{ post.title }</Emojify>
 						</a>
-					</h1>
+					</h2>
 				</AutoDirection>
 				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
 				{ children }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -9,8 +9,6 @@
 	margin: 0 15px;
 	padding: 18px 0 20px;
 	position: relative;
-	display: flex;
-	flex-direction: column;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		margin: 0;
@@ -255,7 +253,6 @@
 }
 
 .reader-post-card__byline {
-	order: 1;
 	display: flex;
 	font-size: $font-body-small;
 }
@@ -400,7 +397,6 @@
 }
 
 .reader-post-card__post {
-	order: 2;
 	clear: both;
 	display: flex;
 	flex-direction: row;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -9,6 +9,8 @@
 	margin: 0 15px;
 	padding: 18px 0 20px;
 	position: relative;
+	display: flex;
+	flex-direction: column;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		margin: 0;
@@ -253,6 +255,7 @@
 }
 
 .reader-post-card__byline {
+	order: 1;
 	display: flex;
 	font-size: $font-body-small;
 }
@@ -397,6 +400,7 @@
 }
 
 .reader-post-card__post {
+	order: 2;
 	clear: both;
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change to `h2` elements for card titles. Only one `h1` should be on the page at a time.
* Push the byline lower so a11y software associates it with the correct card

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See #46648 

Fixes #46648 

relevant slack convo p1603290552059600-slack-C029GN3KD