### PR TITLE
Fix: Domain bundle upsell not shown bug

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -236,5 +236,6 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: false,
+		countryCodeTargets: [ 'US' ],
 	},
 };

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -867,22 +867,22 @@ export function isSecureYourBrandFulfilled( stepName, defaultDependencies, nextP
 	const domainItem = get( nextProps, 'signupDependencies.domainItem', false );
 	const skipSecureYourBrand = get( nextProps, 'skipSecureYourBrand', false );
 	const isNotRegistration = hasDomainItemInDependencyStore && ! isDomainRegistration( domainItem );
+	console.log( 'isNotRegistration: ' + isNotRegistration );
+	console.log( 'skipSecureYourBrand: ' + skipSecureYourBrand + ' stepName: ' + stepName );
+	console.log( 'flows.excludedSteps' );
+	console.log( flows.excludedSteps );
 
 	if ( isNotRegistration || skipSecureYourBrand ) {
-		const domainUpsellItems = null;
-		submitSignupStep( { stepName, domainUpsellItems, wasSkipped: true }, { domainUpsellItems } );
-		flows.excludeStep( stepName );
-		return;
-	}
+		if ( includes( flows.excludedSteps, stepName ) ) {
+			return;
+		}
 
-	const hasDomainUpsellItems = has( nextProps, 'signupDependencies.domainUpsellItems' );
-	const existingDomainUpsellItems = get( nextProps, 'signupDependencies.domainUpsellItems', false );
-	if (
-		hasDomainUpsellItems &&
-		isEmpty( existingDomainUpsellItems ) &&
-		isDomainRegistration( domainItem )
-	) {
+		const domainUpsellItems = null;
+		submitSignupStep( { stepName, domainUpsellItems, wasSkipped: true }, {} );
+		flows.excludeStep( stepName );
+	} else if ( includes( flows.excludedSteps, stepName ) ) {
+		console.log( 'resetting' );
 		flows.resetExcludedStep( stepName );
-		// submitSignupStep( { stepName, wasSkipped: false }, {} );
+		nextProps.removeStep( { stepName } );
 	}
 }

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -7,7 +7,6 @@ import {
 	defer,
 	difference,
 	get,
-	has,
 	includes,
 	isEmpty,
 	isNull,
@@ -33,7 +32,6 @@ import {
 	supportsPrivacyProtectionPurchase,
 	planItem as getCartItemForPlan,
 } from 'calypso/lib/cart-values/cart-items';
-import { isDomainRegistration } from 'calypso/lib/products-values';
 import { getUrlParts } from 'calypso/lib/url';
 
 // State actions and selectors
@@ -858,31 +856,5 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 
 	if ( shouldExcludeStep( stepName, fulfilledDependencies ) ) {
 		flows.excludeStep( stepName );
-	}
-}
-
-export function isSecureYourBrandFulfilled( stepName, defaultDependencies, nextProps ) {
-	const { submitSignupStep } = nextProps;
-	const hasDomainItemInDependencyStore = has( nextProps, 'signupDependencies.domainItem' );
-	const domainItem = get( nextProps, 'signupDependencies.domainItem', false );
-	const skipSecureYourBrand = get( nextProps, 'skipSecureYourBrand', false );
-	const isNotRegistration = hasDomainItemInDependencyStore && ! isDomainRegistration( domainItem );
-	console.log( 'isNotRegistration: ' + isNotRegistration );
-	console.log( 'skipSecureYourBrand: ' + skipSecureYourBrand + ' stepName: ' + stepName );
-	console.log( 'flows.excludedSteps' );
-	console.log( flows.excludedSteps );
-
-	if ( isNotRegistration || skipSecureYourBrand ) {
-		if ( includes( flows.excludedSteps, stepName ) ) {
-			return;
-		}
-
-		const domainUpsellItems = null;
-		submitSignupStep( { stepName, domainUpsellItems, wasSkipped: true }, {} );
-		flows.excludeStep( stepName );
-	} else if ( includes( flows.excludedSteps, stepName ) ) {
-		console.log( 'resetting' );
-		flows.resetExcludedStep( stepName );
-		nextProps.removeStep( { stepName } );
 	}
 }

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -10,7 +10,6 @@ import {
 	isPlanFulfilled,
 	isSiteTopicFulfilled,
 	isSiteTypeFulfilled,
-	isSecureYourBrandFulfilled,
 } from '../step-actions';
 import { useNock } from 'calypso/test-helpers/use-nock';
 import flows from 'calypso/signup/config/flows';
@@ -511,69 +510,5 @@ describe( 'isSiteTopicFulfilled()', () => {
 		isSiteTopicFulfilled( stepName, undefined, nextProps );
 
 		expect( flows.excludeStep ).toHaveBeenCalledWith( 'site-topic-with-optional-survey-question' );
-	} );
-} );
-
-describe( 'isSecureYourBrandFulfilled()', () => {
-	const submitSignupStep = jest.fn();
-
-	beforeEach( () => {
-		flows.excludeStep.mockClear();
-		submitSignupStep.mockClear();
-	} );
-
-	test( 'should remove the step if the domainItem is free', () => {
-		const stepName = 'secure-your-brand';
-		const nextProps = {
-			signupDependencies: { domainItem: false },
-			sitePlanSlug: 'sitePlanSlug',
-			submitSignupStep,
-		};
-
-		expect( flows.excludeStep ).not.toHaveBeenCalled();
-		expect( submitSignupStep ).not.toHaveBeenCalled();
-
-		isSecureYourBrandFulfilled( stepName, undefined, nextProps );
-
-		expect( submitSignupStep ).toHaveBeenCalledWith(
-			{ stepName, domainUpsellItems: null, wasSkipped: true },
-			{ domainUpsellItems: null }
-		);
-		expect( flows.excludeStep ).toHaveBeenCalledWith( stepName );
-	} );
-
-	test( 'should remove the step if skipSecureYourBrand is true', () => {
-		const stepName = 'secure-your-brand';
-		const nextProps = {
-			signupDependencies: { domainItem: { domain: 'test' } },
-			skipSecureYourBrand: true,
-			submitSignupStep,
-		};
-
-		expect( flows.excludeStep ).not.toHaveBeenCalled();
-		expect( submitSignupStep ).not.toHaveBeenCalled();
-
-		isSecureYourBrandFulfilled( stepName, undefined, nextProps );
-
-		expect( submitSignupStep ).toHaveBeenCalledWith(
-			{ stepName, domainUpsellItems: null, wasSkipped: true },
-			{ domainUpsellItems: null }
-		);
-		expect( flows.excludeStep ).toHaveBeenCalledWith( stepName );
-	} );
-
-	test( 'should not remove unfulfilled step', () => {
-		const stepName = 'secure-your-brand';
-		const nextProps = {
-			submitSignupStep,
-		};
-
-		expect( flows.excludeStep ).not.toHaveBeenCalled();
-		expect( submitSignupStep ).not.toHaveBeenCalled();
-
-		isSecureYourBrandFulfilled( stepName, undefined, nextProps );
-
-		expect( flows.excludeStep ).not.toHaveBeenCalled();
-		expect( submitSignupStep ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -36,7 +36,6 @@ export function generateSteps( {
 	isSiteTypeFulfilled = noop,
 	isSiteTopicFulfilled = noop,
 	maybeRemoveStepForUserlessCheckout = noop,
-	isSecureYourBrandFulfilled = noop,
 } = {} ) {
 	return {
 		survey: {
@@ -329,7 +328,6 @@ export function generateSteps( {
 			stepName: 'secure-your-brand',
 			dependencies: [ 'domainItem', 'siteSlug' ],
 			providesDependencies: [ 'domainUpsellItems' ],
-			fulfilledStepCallback: isSecureYourBrandFulfilled,
 		},
 
 		'domains-store': {

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -22,7 +22,6 @@ import {
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
 	maybeRemoveStepForUserlessCheckout,
-	isSecureYourBrandFulfilled,
 } from 'calypso/lib/signup/step-actions';
 import { abtest } from 'calypso/lib/abtest';
 import { generateSteps } from './steps-pure';
@@ -43,7 +42,6 @@ export default generateSteps( {
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
 	maybeRemoveStepForUserlessCheckout,
-	isSecureYourBrandFulfilled,
 } );
 
 export function isDomainStepSkippable( flowName ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -42,7 +42,6 @@ import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors'
 import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
 import { getSiteGoals } from 'calypso/state/signup/steps/site-goals/selectors';
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
-import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
 import { getDomainProductSlug } from 'calypso/lib/domains';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
@@ -801,7 +800,6 @@ export default connect(
 			isSitePreviewVisible: isSitePreviewVisible( state ),
 			sites: getSitesItems( state ),
 			isReskinned,
-			countryCode: getCurrentUserCountryCode( state ),
 		};
 	},
 	{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { defer, get, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import classNames from 'classnames';
+import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -41,6 +42,7 @@ import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors'
 import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
 import { getSiteGoals } from 'calypso/state/signup/steps/site-goals/selectors';
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
+import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
 import { getDomainProductSlug } from 'calypso/lib/domains';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
@@ -166,11 +168,18 @@ class DomainsStep extends React.Component {
 		return this.showTestCopy;
 	}
 
+	getGeoLocationFromCookie() {
+		const cookies = cookie.parse( document.cookie );
+
+		return cookies.country_code;
+	}
+
 	isEligibleForSecureYourBrandTest( isPurchasingItem ) {
 		return (
 			includes( [ 'onboarding', 'onboarding-secure-your-brand' ], this.props.flowName ) &&
 			isPurchasingItem &&
-			'test' === abtest( 'secureYourBrand' )
+			! this.props.skipSecureYourBrand &&
+			'test' === abtest( 'secureYourBrand', this.getGeoLocationFromCookie() )
 		);
 	}
 
@@ -792,6 +801,7 @@ export default connect(
 			isSitePreviewVisible: isSitePreviewVisible( state ),
 			sites: getSitesItems( state ),
 			isReskinned,
+			countryCode: getCurrentUserCountryCode( state ),
 		};
 	},
 	{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -166,6 +166,14 @@ class DomainsStep extends React.Component {
 		return this.showTestCopy;
 	}
 
+	isEligibleForSecureYourBrandTest( isPurchasingItem ) {
+		return (
+			includes( [ 'onboarding', 'onboarding-secure-your-brand' ], this.props.flowName ) &&
+			isPurchasingItem &&
+			'test' === abtest( 'secureYourBrand' )
+		);
+	}
+
 	getMapDomainUrl = () => {
 		return getStepUrl( this.props.flowName, this.props.stepName, 'mapping', this.props.locale );
 	};
@@ -301,7 +309,12 @@ class DomainsStep extends React.Component {
 		);
 
 		this.props.setDesignType( this.getDesignType() );
-		this.props.goToNextStep();
+
+		if ( this.isEligibleForSecureYourBrandTest( isPurchasingItem ) ) {
+			this.props.goToNextStep( 'onboarding-secure-your-brand' );
+		} else {
+			this.props.goToNextStep();
+		}
 
 		// Start the username suggestion process.
 		siteUrl && this.props.fetchUsernameSuggestion( siteUrl.split( '.' )[ 0 ] );

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -10,14 +10,10 @@ import { translate } from 'i18n-calypso';
 import steps from 'calypso/signup/config/steps-pure';
 import flows from 'calypso/signup/config/flows';
 import user from 'calypso/lib/user';
-import { abtest } from 'calypso/lib/abtest';
 
 const { defaultFlowName } = flows;
 
 function getDefaultFlowName() {
-	if ( ! user().get() && 'test' === abtest( 'secureYourBrand' ) ) {
-		return 'onboarding-secure-your-brand';
-	}
 	return defaultFlowName;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switches flow to the secure-your-brand onboarding flow if a custom domain is selected.
* Assigns to the A/B test only if a custom domain is selected
* Fixes the issue described in [this comment](https://github.com/Automattic/wp-calypso/pull/46078#pullrequestreview-511510074) that caused the domain bundle upsell to not show in the following sequence: 
select a free *.wordpress.com subdomain -> go back from the plans step -> select a custom domain -> No upsell offer
* Restricts A/B test to EN-US

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the testing instructions in https://github.com/Automattic/wp-calypso/pull/46078
