### PR TITLE
Premium Content: Remove double banners

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
@@ -90,6 +90,7 @@ function ButtonsEdit( {
 					allowedBlocks={ ALLOWED_BLOCKS }
 					template={ template }
 					__experimentalMoverDirection="horizontal"
+					templateInsertUpdatesSelection={ false }
 				/>
 			</AlignmentHookSettingsProvider>
 		</Block.div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/blocks.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/blocks.js
@@ -13,6 +13,7 @@ export default function Blocks() {
 					[ 'premium-content/subscriber-view' ],
 					[ 'premium-content/logged-out-view' ],
 				] }
+				__experimentalCaptureToolbars={ true }
 			/>
 		</div>
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/blocks.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/blocks.js
@@ -14,6 +14,7 @@ export default function Blocks() {
 					[ 'premium-content/logged-out-view' ],
 				] }
 				__experimentalCaptureToolbars={ true }
+				templateInsertUpdatesSelection={ false }
 			/>
 		</div>
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
@@ -2,12 +2,22 @@
  * WordPress dependencies
  */
 import { useEffect, useState, useRef } from '@wordpress/element';
-import { Placeholder, Button, ExternalLink, withNotices, Spinner } from '@wordpress/components';
+import {
+	Placeholder,
+	Button,
+	ExternalLink,
+	withNotices,
+	Spinner,
+	ToolbarGroup,
+	ToolbarButton,
+} from '@wordpress/components';
+import { BlockControls } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, isURL } from '@wordpress/url';
 import formatCurrency from '@automattic/format-currency';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -16,9 +26,8 @@ import Tabs from './tabs';
 import Blocks from './blocks';
 import Controls from './controls';
 import Inspector from './inspector';
-import StripeNudge from './stripe-nudge';
 import Context from './context';
-import apiFetch from '@wordpress/api-fetch';
+import { flashIcon } from './icons';
 import { isPriceValid, minimumTransactionAmountForCurrency } from '.';
 
 /**
@@ -330,41 +339,78 @@ function Edit( props ) {
 		);
 	}
 
-	let stripeNudge = null;
+	const shouldShowConnectButton = () => {
+		//const stripeConnectUrl = getConnectUrl( props, connectURL );
 
-	if ( ! shouldUpgrade && apiState !== API_STATE_CONNECTED && connectURL ) {
-		const stripeConnectUrl = getConnectUrl( props, connectURL );
+		if ( ! shouldUpgrade && apiState !== API_STATE_CONNECTED && connectURL ) {
+			return true;
+		}
 
-		stripeNudge = <StripeNudge { ...props } stripeConnectUrl={ stripeConnectUrl } />;
-	}
+		return false;
+	};
 
 	return (
-		<div className={ className } ref={ wrapperRef }>
-			{ props.noticeUI }
-			{ ( isSelected || selectedInnerBlock ) && apiState === API_STATE_CONNECTED && (
-				<Controls
-					{ ...props }
-					plans={ products }
-					selectedPlanId={ props.attributes.selectedPlanId }
-					onSelected={ selectPlan }
-					getPlanDescription={ getPlanDescription }
-				/>
-			) }
-			{ ( isSelected || selectedInnerBlock ) && apiState === API_STATE_CONNECTED && (
-				<Inspector { ...props } savePlan={ savePlan } siteSlug={ siteSlug } />
-			) }
-			{ ( isSelected || selectedInnerBlock ) && (
-				<Tabs { ...props } tabs={ tabs } selectedTab={ selectedTab } onSelected={ selectTab } />
-			) }
-			<Context.Provider
-				value={ {
-					selectedTab,
-					stripeNudge,
-				} }
-			>
-				<Blocks />
-			</Context.Provider>
-		</div>
+		<>
+			<BlockControls>
+				{ shouldShowConnectButton && (
+					<ToolbarGroup>
+						<ToolbarButton
+							icon={ flashIcon }
+							onClick={ ( e ) => {
+								props.autosaveAndRedirect( e, getConnectUrl( props, connectURL ) );
+							} }
+							className="components-tab-button"
+						>
+							{ __( 'Connect', 'full-site-editing' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+				) }
+
+				<ToolbarGroup>
+					<ToolbarButton
+						onClick={ () => {
+							selectTab( tabs[ 1 ] );
+						} }
+						className="components-tab-button"
+						isPressed={ selectedTab.className === 'wp-premium-content-logged-out-view' }
+					>
+						<span>{ __( 'Visitor View', 'full-site-editing' ) }</span>
+					</ToolbarButton>
+					<ToolbarButton
+						onClick={ () => {
+							selectTab( tabs[ 0 ] );
+						} }
+						className="components-tab-button"
+						isPressed={ selectedTab.className !== 'wp-premium-content-logged-out-view' }
+					>
+						<span>{ __( 'Subscriber View', 'full-site-editing' ) }</span>
+					</ToolbarButton>
+				</ToolbarGroup>
+			</BlockControls>
+
+			<div className={ className } ref={ wrapperRef }>
+				{ props.noticeUI }
+				{ ( isSelected || selectedInnerBlock ) && apiState === API_STATE_CONNECTED && (
+					<Controls
+						{ ...props }
+						plans={ products }
+						selectedPlanId={ props.attributes.selectedPlanId }
+						onSelected={ selectPlan }
+						getPlanDescription={ getPlanDescription }
+					/>
+				) }
+				{ ( isSelected || selectedInnerBlock ) && apiState === API_STATE_CONNECTED && (
+					<Inspector { ...props } savePlan={ savePlan } siteSlug={ siteSlug } />
+				) }
+				<Context.Provider
+					value={ {
+						selectedTab
+					} }
+				>
+					<Blocks />
+				</Context.Provider>
+			</div>
+		</>
 	);
 }
 
@@ -473,6 +519,12 @@ export default compose( [
 			selectBlock() {
 				// @ts-ignore difficult to type via JSDoc
 				blockEditor.selectBlock( ownProps.clientId );
+			},
+			autosaveAndRedirect: async ( event, stripeConnectUrl ) => {
+				event.preventDefault(); // Don't follow the href before autosaving
+				await dispatch( 'core/editor' ).savePost();
+				// Using window.top to escape from the editor iframe on WordPress.com
+				window.top.location.href = stripeConnectUrl;
 			},
 		};
 	} ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
@@ -388,6 +388,7 @@ function Edit( props ) {
 
 			<div className={ className } ref={ wrapperRef }>
 				{ props.noticeUI }
+
 				{ ( isSelected || selectedInnerBlock ) && apiState === API_STATE_CONNECTED && (
 					<Controls
 						{ ...props }

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
@@ -340,8 +340,6 @@ function Edit( props ) {
 	}
 
 	const shouldShowConnectButton = () => {
-		//const stripeConnectUrl = getConnectUrl( props, connectURL );
-
 		if ( ! shouldUpgrade && apiState !== API_STATE_CONNECTED && connectURL ) {
 			return true;
 		}
@@ -352,16 +350,16 @@ function Edit( props ) {
 	return (
 		<>
 			<BlockControls>
-				{ shouldShowConnectButton && (
+				{ shouldShowConnectButton() && (
 					<ToolbarGroup>
 						<ToolbarButton
 							icon={ flashIcon }
 							onClick={ ( e ) => {
 								props.autosaveAndRedirect( e, getConnectUrl( props, connectURL ) );
 							} }
-							className="components-tab-button"
+							className="connect-stripe components-tab-button"
 						>
-							{ __( 'Connect', 'full-site-editing' ) }
+							{ __( 'Connect Stripe', 'full-site-editing' ) }
 						</ToolbarButton>
 					</ToolbarGroup>
 				) }
@@ -404,7 +402,7 @@ function Edit( props ) {
 				) }
 				<Context.Provider
 					value={ {
-						selectedTab
+						selectedTab,
 					} }
 				>
 					<Blocks />

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/icons.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/icons.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/components';
+
+export const flashIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M7 2v11h3v9l7-12h-4l4-8z" fill="currentColor" />
+	</SVG>
+);

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/stripe-nudge.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/stripe-nudge.js
@@ -39,11 +39,11 @@ export const StripeNudge = ( { autosaveAndRedirect, stripeConnectUrl } ) => (
 			{ <Dashicon icon="star-filled" /> }
 			<span className="premium-content-block-nudge__text-container">
 				<span className="premium-content-block-nudge__title">
-					{ __( 'Connect to Stripe to use this block on your site', 'full-site-editing' ) }
+					{ __( 'Connect to Stripe to add premium content to your site.', 'full-site-editing' ) }
 				</span>
 				<span className="premium-content-block-nudge__message">
 					{ __(
-						'This block will be hidden from your visitors until you connect to Stripe.',
+						'Premium content will be hidden from your visitors until you connect to Stripe.',
 						'full-site-editing'
 					) }
 				</span>
@@ -64,6 +64,8 @@ export default compose( [
 		 * Complicated to define the valid type with JSDoc
 		 *
 		 * @param dispatch
+		 * @param root0
+		 * @param root0.stripeConnectUrl
 		 */
 		// @ts-ignore
 		( dispatch, { stripeConnectUrl } ) => ( {

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/edit.js
@@ -30,6 +30,7 @@ function Edit( { parentClientId, isSelected } ) {
 					{ stripeNudge }
 					<InnerBlocks
 						templateLock={ false }
+						templateInsertUpdatesSelection={ false }
 						template={ [
 							[
 								'core/heading',

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/edit.js
@@ -31,6 +31,7 @@ function Edit( { hasInnerBlocks, parentClientId, isSelected } ) {
 					<InnerBlocks
 						renderAppender={ ! hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
 						templateLock={ false }
+						templateInsertUpdatesSelection={ false }
 						template={ [
 							[
 								'core/paragraph',

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/editor.css
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/editor.css
@@ -123,6 +123,13 @@
 	border-width: 4px;
 }
 
+.connect-stripe.has-icon.has-text svg {
+	margin-right: 0;
+}
+.connect-stripe.has-icon.has-text {
+	font-weight: normal;
+}
+
 /* Subscribe/Login buttons */
 
 .wp-block-buttons .wp-block[data-type='jetpack/recurring-payments'] {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the premium content block to remove the Stripe connect banner, and the subscriber/non subscriber banner. Doing this means there is no persistent block UI in the canvas, improving the design experience for patterns using this block. These two banners have been merged into the block toolbar for the block.

| Before        | After           |
| ------------- |:-------------:|
| Multiple "banners" when selecting the block. | Options from the old banners merged into the block toolbar. |
|  <img width="842" alt="Screen Shot 2020-10-21 at 1 10 53 PM" src="https://user-images.githubusercontent.com/1464705/96777356-1a7c1780-139f-11eb-9698-9d8a2be0163e.png"> | <img width="833" alt="Screen Shot 2020-10-21 at 1 11 47 PM" src="https://user-images.githubusercontent.com/1464705/96777419-29fb6080-139f-11eb-869d-b6dd381a3d53.png"> |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch locally and run `yarn dev --sync` in the `wp-calypso/apps/editing-toolkit` directory
* Open up a site on your sandbox and insert the premium content block.
* Confirm that you see the "After" UI above.
* Confirm that you can connect stripe and the "Connect Stripe" button disappears.
* Confirm that you can switch back and forth between the Visitor, and Subscriber views.
* Confirm that you can edit blocks in both views.

Fixes https://github.com/Automattic/view-design/issues/84
cc @ianstewart 