### PR TITLE
Editor close button should deal with situation where experimental GB feature is unavailable

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -15,51 +15,53 @@ import ToggleSidebarButton from './components/toggle-sidebar-button';
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
 	originalRegisterPlugin( name, settings as any );
 
-registerPlugin( 'a8c-full-site-editing-nav-sidebar', {
-	render: function NavSidebar() {
-		const { addEntities } = useDispatch( 'core' );
+if ( typeof MainDashboardButton !== 'undefined' ) {
+	registerPlugin( 'a8c-full-site-editing-nav-sidebar', {
+		render: function NavSidebar() {
+			const { addEntities } = useDispatch( 'core' );
 
-		useEffect( () => {
-			// Teach core data about the status entity so we can use selectors like `getEntityRecords()`
-			addEntities( [
-				{
-					baseURL: '/wp/v2/statuses',
-					key: 'slug',
-					kind: 'root',
-					name: 'status',
-					plural: 'statuses',
-				},
-			] );
+			useEffect( () => {
+				// Teach core data about the status entity so we can use selectors like `getEntityRecords()`
+				addEntities( [
+					{
+						baseURL: '/wp/v2/statuses',
+						key: 'slug',
+						kind: 'root',
+						name: 'status',
+						plural: 'statuses',
+					},
+				] );
 
-			// Only register entity once
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [] );
+				// Only register entity once
+				// eslint-disable-next-line react-hooks/exhaustive-deps
+			}, [] );
 
-		const [ clickGuardRoot ] = useState( () => document.createElement( 'div' ) );
-		useEffect( () => {
-			document.body.appendChild( clickGuardRoot );
-			return () => {
-				document.body.removeChild( clickGuardRoot );
-			};
-		} );
+			const [ clickGuardRoot ] = useState( () => document.createElement( 'div' ) );
+			useEffect( () => {
+				document.body.appendChild( clickGuardRoot );
+				return () => {
+					document.body.removeChild( clickGuardRoot );
+				};
+			} );
 
-		// Uses presence of data store to detect whether this is the experimental site editor.
-		const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ) );
+			// Uses presence of data store to detect whether this is the experimental site editor.
+			const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ) );
 
-		// Disable sidebar nav if the editor is not in fullscreen mode
-		const isFullscreenActive = useSelect( ( select ) =>
-			select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' )
-		);
+			// Disable sidebar nav if the editor is not in fullscreen mode
+			const isFullscreenActive = useSelect( ( select ) =>
+				select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' )
+			);
 
-		if ( isSiteEditor || ! isFullscreenActive ) {
-			return null;
-		}
+			if ( isSiteEditor || ! isFullscreenActive ) {
+				return null;
+			}
 
-		return (
-			<MainDashboardButton>
-				<ToggleSidebarButton />
-				{ createPortal( <WpcomBlockEditorNavSidebar />, clickGuardRoot ) }
-			</MainDashboardButton>
-		);
-	},
-} );
+			return (
+				<MainDashboardButton>
+					<ToggleSidebarButton />
+					{ createPortal( <WpcomBlockEditorNavSidebar />, clickGuardRoot ) }
+				</MainDashboardButton>
+			);
+		},
+	} );
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/test/attach-sidebar.test.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/test/attach-sidebar.test.ts
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { __experimentalMainDashboardButton } from '@wordpress/interface';
+
+test( '__experimentalMainDashboardButton should be available', () => {
+	expect( typeof __experimentalMainDashboardButton ).not.toBe( 'undefined' );
+} );

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -549,6 +549,10 @@ function handleCloseEditor( calypsoPort ) {
 
 	handleCloseInLegacyEditors( dispatchAction );
 
+	if ( typeof MainDashboardButton !== 'undefined' ) {
+		return;
+	}
+
 	if ( isNavSidebarPresent() ) {
 		return;
 	}

--- a/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
@@ -51,6 +51,16 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 		const wpGlobalName = _.camelCase( packageName.substr( '@wordpress/'.length ) );
 
 		describe( packageName, () => {
+			step(
+				`"${ wpGlobalName }" package should be available in the global window object`,
+				async () => {
+					const typeofPackage = await driver.executeScript(
+						`typeof window.wp['${ wpGlobalName }']`
+					);
+					assert.notStrictEqual( typeofPackage, 'undefined'`${ wpGlobalName } is undefined` );
+				}
+			);
+
 			for ( const feature of features ) {
 				step( `${ feature } should be available in ${ packageName }`, async () => {
 					const typeofExperimentalFeature = await driver.executeScript(

--- a/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
@@ -3,7 +3,6 @@
  */
 import assert from 'assert';
 import config from 'config';
-import _ from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,6 +30,19 @@ const EXPERIMENTAL_FEATURES = {
 	],
 };
 
+/**
+ * Given a string, returns a new string with dash separators converted to
+ * camelCase equivalent. This is not as aggressive as `_.camelCase` in
+ * converting to uppercase, where Lodash will also capitalize letters
+ * following numbers.
+ *
+ * @param {string} string Input dash-delimited string.
+ * @returns {string} Camel-cased string.
+ */
+function camelCaseDash( string ) {
+	return string.replace( /-([a-z])/g, ( _, letter ) => letter.toUpperCase() );
+}
+
 let driver;
 
 before( async function () {
@@ -47,8 +59,9 @@ describe( `[${ host }] Experimental features we depend on are available (${ scre
 	} );
 
 	for ( const [ packageName, features ] of Object.entries( EXPERIMENTAL_FEATURES ) ) {
-		// Remove the `@wordpress/` prefix and hyphens from package name
-		const wpGlobalName = _.camelCase( packageName.substr( '@wordpress/'.length ) );
+		// Removes the `@wordpress/` prefix and hyphens from package name
+		// The algorithm WP uses to convert package names to variable names is here: https://github.com/WordPress/gutenberg/blob/a03ea51e11a36d0abeecb4ce4e4cea5ffebdffc5/packages/dependency-extraction-webpack-plugin/lib/util.js#L40-L45
+		const wpGlobalName = camelCaseDash( packageName.substr( '@wordpress/'.length ) );
 
 		describe( packageName, () => {
 			step(

--- a/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import assert from 'assert';
+import config from 'config';
+import _ from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import LoginFlow from '../lib/flows/login-flow.js';
+import * as driverManager from '../lib/driver-manager';
+import * as dataHelper from '../lib/data-helper';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+const gutenbergUser =
+	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
+
+// Experimental Gutenberg features that we depend on in Calypso (and other projects)
+// Tests will fail if an experimental feature is no longer being exported from one
+// of the @wordpress/* packages. The purpose of these tests is to give us an early
+// warning if an experimental feature has been removed or renamed.
+const EXPERIMENTAL_FEATURES = {
+	'@wordpress/block-editor': [
+		// Used in the premium content block in the Editing Toolkit plugin
+		'__experimentalAlignmentHookSettingsProvider',
+		'__experimentalBlock',
+	],
+};
+
+let driver;
+
+before( async function () {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+} );
+
+describe( `[${ host }] Experimental features we depend on are available (${ screenSize })`, function () {
+	this.timeout( mochaTimeOut );
+
+	step( 'Can log in', async function () {
+		this.loginFlow = new LoginFlow( driver, gutenbergUser );
+		return await this.loginFlow.loginAndStartNewPost( null, true );
+	} );
+
+	for ( const [ packageName, features ] of Object.entries( EXPERIMENTAL_FEATURES ) ) {
+		// Remove the `@wordpress/` prefix and hyphens from package name
+		const wpGlobalName = _.camelCase( packageName.substr( '@wordpress/'.length ) );
+
+		describe( packageName, () => {
+			for ( const feature of features ) {
+				step( `${ feature } should be available in ${ packageName }`, async () => {
+					const typeofExperimentalFeature = await driver.executeScript(
+						`typeof window.wp['${ wpGlobalName }']['${ feature }']`
+					);
+					assert.notStrictEqual(
+						typeofExperimentalFeature,
+						'undefined',
+						`${ feature } is undefined`
+					);
+				} );
+			}
+		} );
+	}
+
+	after( async () => {
+		return await driver.switchTo().defaultContent();
+	} );
+} );


### PR DESCRIPTION
Context: pc9Uba-96-p2

#### Changes proposed in this Pull Request

* Don't attach block editor nav sidebar if `__experimentalMainDashboardButton` is unavailable
* If `__experimentalMainDashboardButton` is unavailable then `wpcom-block-editor` will revert to the legacy way of overriding the (W) button to take the user back to Calypso.
* Add a unit test that fails if `__experimentalMainDashboardButton` is unavailable

If the nav sidebar isn't attached then the (W) button in the top-left will do what it used to do: clicking it will return the user to Calypso.

From pc9Uba-96-p2, the unit test is so that it forces us to have a conversation about what to do if this export disappears in a GB update.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Clone branch
* Sandbox a test site and `widgets.wp.com`
* Build Editing Toolkit plugin and sync to sandbox PCYsg-ly5-p2
* Build wpcom-block-editor and sync to sandbox PCYsg-l4k-p2
* Open the editor on your test site, click the (W) icon, see the nav sidebar still opens
* Check that new e2e test spec is running in CI

Fixes #46524 and part of #46494
