### PR TITLE
Billing Management: Add error boundary to site-level purchase routes

### DIFF
--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -90,6 +90,7 @@ export function PurchaseDetails( {
 	siteSlug: string;
 } ): JSX.Element {
 	const translate = useTranslate();
+	const logPurchasesError = useLogPurchasesError( 'site level purchase details load error' );
 
 	return (
 		<Main className="purchases is-wide-layout">
@@ -105,17 +106,22 @@ export function PurchaseDetails( {
 				title="Purchases > Manage Purchase"
 			/>
 
-			<ManagePurchase
-				cardTitle={ translate( 'Subscription settings' ) }
-				purchaseId={ purchaseId }
-				siteSlug={ siteSlug }
-				showHeader={ false }
-				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
-				getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
-				getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
-				getEditPaymentMethodUrlFor={ getEditOrAddPaymentMethodUrlFor }
-				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
-			/>
+			<SiteLevelPurchasesErrorBoundary
+				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
+				onError={ logPurchasesError }
+			>
+				<ManagePurchase
+					cardTitle={ translate( 'Subscription settings' ) }
+					purchaseId={ purchaseId }
+					siteSlug={ siteSlug }
+					showHeader={ false }
+					purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
+					getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
+					getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
+					getEditPaymentMethodUrlFor={ getEditOrAddPaymentMethodUrlFor }
+					getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+				/>
+			</SiteLevelPurchasesErrorBoundary>
 		</Main>
 	);
 }
@@ -128,6 +134,7 @@ export function PurchaseCancel( {
 	siteSlug: string;
 } ) {
 	const translate = useTranslate();
+	const logPurchasesError = useLogPurchasesError( 'site level purchase cancel load error' );
 
 	return (
 		<Main className="purchases is-wide-layout">
@@ -139,13 +146,18 @@ export function PurchaseCancel( {
 				align="left"
 			/>
 
-			<CancelPurchase
-				purchaseId={ purchaseId }
-				siteSlug={ siteSlug }
-				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
-				getConfirmCancelDomainUrlFor={ getConfirmCancelDomainUrlFor }
-				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
-			/>
+			<SiteLevelPurchasesErrorBoundary
+				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
+				onError={ logPurchasesError }
+			>
+				<CancelPurchase
+					purchaseId={ purchaseId }
+					siteSlug={ siteSlug }
+					getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+					getConfirmCancelDomainUrlFor={ getConfirmCancelDomainUrlFor }
+					purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
+				/>
+			</SiteLevelPurchasesErrorBoundary>
 		</Main>
 	);
 }
@@ -158,6 +170,9 @@ export function PurchaseAddPaymentMethod( {
 	siteSlug: string;
 } ) {
 	const translate = useTranslate();
+	const logPurchasesError = useLogPurchasesError(
+		'site level purchase add payment method load error'
+	);
 
 	return (
 		<Main className="purchases is-wide-layout">
@@ -169,13 +184,18 @@ export function PurchaseAddPaymentMethod( {
 				align="left"
 			/>
 
-			<AddCardDetails
-				purchaseId={ purchaseId }
-				siteSlug={ siteSlug }
-				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
-				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
-				isFullWidth={ true }
-			/>
+			<SiteLevelPurchasesErrorBoundary
+				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
+				onError={ logPurchasesError }
+			>
+				<AddCardDetails
+					purchaseId={ purchaseId }
+					siteSlug={ siteSlug }
+					getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+					purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
+					isFullWidth={ true }
+				/>
+			</SiteLevelPurchasesErrorBoundary>
 		</Main>
 	);
 }
@@ -190,6 +210,9 @@ export function PurchaseEditPaymentMethod( {
 	cardId: string;
 } ) {
 	const translate = useTranslate();
+	const logPurchasesError = useLogPurchasesError(
+		'site level purchase edit payment method load error'
+	);
 
 	return (
 		<Main className="purchases is-wide-layout">
@@ -201,14 +224,19 @@ export function PurchaseEditPaymentMethod( {
 				align="left"
 			/>
 
-			<EditCardDetails
-				cardId={ cardId }
-				purchaseId={ purchaseId }
-				siteSlug={ siteSlug }
-				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
-				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
-				isFullWidth={ true }
-			/>
+			<SiteLevelPurchasesErrorBoundary
+				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
+				onError={ logPurchasesError }
+			>
+				<EditCardDetails
+					cardId={ cardId }
+					purchaseId={ purchaseId }
+					siteSlug={ siteSlug }
+					getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+					purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
+					isFullWidth={ true }
+				/>
+			</SiteLevelPurchasesErrorBoundary>
 		</Main>
 	);
 }
@@ -221,6 +249,7 @@ export function PurchaseCancelDomain( {
 	siteSlug: string;
 } ) {
 	const translate = useTranslate();
+	const logPurchasesError = useLogPurchasesError( 'site level purchase cancel domain load error' );
 
 	return (
 		<Main className="purchases is-wide-layout">
@@ -232,12 +261,17 @@ export function PurchaseCancelDomain( {
 				align="left"
 			/>
 
-			<ConfirmCancelDomain
-				purchaseId={ purchaseId }
-				siteSlug={ siteSlug }
-				getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
-				purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
-			/>
+			<SiteLevelPurchasesErrorBoundary
+				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
+				onError={ logPurchasesError }
+			>
+				<ConfirmCancelDomain
+					purchaseId={ purchaseId }
+					siteSlug={ siteSlug }
+					getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
+					purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
+				/>
+			</SiteLevelPurchasesErrorBoundary>
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -33,17 +33,15 @@ import SiteLevelPurchasesErrorBoundary from 'calypso/my-sites/purchases/site-lev
 import { logToLogstash } from 'calypso/state/logstash/actions';
 import config from 'calypso/config';
 
-export function Purchases() {
+function useLogPurchasesError( message: string ) {
 	const reduxDispatch = useDispatch();
-	const translate = useTranslate();
-	const siteSlug = useSelector( getSelectedSiteSlug );
 
-	const logPurchasesError = useCallback(
+	return useCallback(
 		( error ) => {
 			reduxDispatch(
 				logToLogstash( {
 					feature: 'calypso_client',
-					message: 'site level purchases load error',
+					message,
 					severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
 					extra: {
 						env: config( 'env_id' ),
@@ -55,6 +53,12 @@ export function Purchases() {
 		},
 		[ reduxDispatch ]
 	);
+}
+
+export function Purchases() {
+	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const logPurchasesError = useLogPurchasesError( 'site level purchases load error' );
 
 	return (
 		<Main className="purchases is-wide-layout">

--- a/client/my-sites/purchases/site-level-purchases-error-boundary.tsx
+++ b/client/my-sites/purchases/site-level-purchases-error-boundary.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React, { ErrorInfo } from 'react';
+import debugFactory from 'debug';
+import styled from '@emotion/styled';
+
+const debug = debugFactory( 'calypso:site-level-purchases-error-boundary' );
+
+export default class SiteLevelPurchasesErrorBoundary extends React.Component<
+	SiteLevelPurchasesErrorBoundaryProps
+> {
+	constructor( props: SiteLevelPurchasesErrorBoundaryProps ) {
+		super( props );
+	}
+
+	public state = { hasError: false, currentError: null };
+
+	static getDerivedStateFromError( error: string ) {
+		return { currentError: error, hasError: true };
+	}
+
+	componentDidCatch( error: Error, errorInfo: ErrorInfo ) {
+		if ( this.props.onError ) {
+			const errorMessage = `${ error.message }; Stack: ${ error.stack }; Component Stack: ${ errorInfo.componentStack }`;
+			debug( 'reporting the error', errorMessage );
+			this.props.onError( errorMessage );
+		}
+	}
+
+	render() {
+		if ( this.state.hasError ) {
+			return <ErrorFallback errorMessage={ this.props.errorMessage } />;
+		}
+		return this.props.children;
+	}
+}
+
+interface SiteLevelPurchasesErrorBoundaryProps {
+	errorMessage: React.ReactNode;
+	onError?: ( message: string ) => void;
+}
+
+const ErrorContainer = styled.div`
+	margin: 2em;
+	text-align: center;
+`;
+
+function ErrorFallback( { errorMessage }: { errorMessage: React.ReactNode } ) {
+	return <ErrorContainer>{ errorMessage }</ErrorContainer>;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an error boundary around purchase management routes so we can surface errors here in our usual reporting channels. Touches routes under `/purchases`, `/purchases/billing-history`, and `/purchases/payment-methods`.

#### Testing instructions

* Throw an error right before the render function of some component under `Purchases`. For example, [SubscriptionsContent](https://github.com/Automattic/wp-calypso/blob/d43a26ff471af93cae27882580aca2eb2584d084/client/my-sites/purchases/subscriptions/subscriptions-content.tsx#L24).
* Use `localStorage.setItem('debug', 'calypso:site-level-purchases-error-boundary:*')` in your console to see these errors.
* Load the component where the error is thrown and verify that you see it in the console.

![Screen Shot 2020-10-21 at 6 30 46 PM](https://user-images.githubusercontent.com/9310939/96801163-9c366a00-13cc-11eb-9a32-7f0b4705777c.png)

Fixes #46432
