### PR TITLE
Docs: Update path for link to the bundler documentation in routing.md

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -63,7 +63,7 @@ This wraps up the more introductory part; if you're interested in more details, 
 
 ## Section Definitions
 
-More formally, sections are defined in [`client/sections.js`](../client/sections.js). While that file's format should be intuitive enough to understand, we use quite a bit of magic to turn it into actual routing and code-splitting code. Most of it is documented in [`server/bundler/README.md`](../server/bundler/README.md).
+More formally, sections are defined in [`client/sections.js`](../client/sections.js). While that file's format should be intuitive enough to understand, we use quite a bit of magic to turn it into actual routing and code-splitting code. Most of it is documented in [`client/server/bundler/README.md`](../client/server/bundler/README.md).
 
 ## Site-specific URLs
 


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/38190 the `server` directory was moved into the `client` directory. This tiny PR updates a link to a document to point to the correct place (it currently 404s because it was still pointing to the old location).

#### Changes proposed in this Pull Request

* Update the link to bundler/README.md

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just make sure that I've linked to the correct location, please!

Fixes #
