### PR TITLE
Coming Soon v2: add site badge and ensure we show the correct launch message on the settings page

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -18,6 +18,7 @@ import SiteIcon from 'calypso/blocks/site-icon';
 import SiteIndicator from 'calypso/my-sites/site-indicator';
 import { getSite, getSiteSlug, isSitePreviewable } from 'calypso/state/sites/selectors';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
+import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 
 /**
  * Style dependencies
@@ -116,6 +117,11 @@ class Site extends React.Component {
 			'is-compact': this.props.compact,
 		} );
 
+		const isPublicComingSoon =
+			isEnabled( 'coming-soon-v2' ) &&
+			! this.props.site.is_private &&
+			this.props.site.is_coming_soon;
+
 		return (
 			<div className={ siteClass }>
 				<a
@@ -155,11 +161,16 @@ class Site extends React.Component {
 								: site.domain }
 						</div>
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-						{ this.props.site.is_private && (
+						{ this.props.site.is_private && ( // Coming Soon v1
 							<span className="site__badge site__badge-private">
 								{ this.props.site.is_coming_soon
 									? translate( 'Coming Soon' )
 									: translate( 'Private' ) }
+							</span>
+						) }
+						{ isPublicComingSoon && ( // Coming Soon v2
+							<span className="site__badge site__badge-coming-soon">
+								{ translate( 'Coming Soon' ) }
 							</span>
 						) }
 						{ site.options && site.options.is_redirect && (
@@ -193,6 +204,7 @@ function mapStateToProps( state, ownProps ) {
 		site,
 		isPreviewable: isSitePreviewable( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
+		isComingSoon: isSiteComingSoon( state, siteId ),
 	};
 }
 

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -18,7 +18,6 @@ import SiteIcon from 'calypso/blocks/site-icon';
 import SiteIndicator from 'calypso/my-sites/site-indicator';
 import { getSite, getSiteSlug, isSitePreviewable } from 'calypso/state/sites/selectors';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
-import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 
 /**
  * Style dependencies
@@ -117,10 +116,7 @@ class Site extends React.Component {
 			'is-compact': this.props.compact,
 		} );
 
-		const isPublicComingSoon =
-			isEnabled( 'coming-soon-v2' ) &&
-			! this.props.site.is_private &&
-			this.props.site.is_coming_soon;
+		const isPublicComingSoon = isEnabled( 'coming-soon-v2' ) && this.props.site.is_coming_soon;
 
 		return (
 			<div className={ siteClass }>
@@ -204,7 +200,6 @@ function mapStateToProps( state, ownProps ) {
 		site,
 		isPreviewable: isSitePreviewable( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
-		isComingSoon: isSiteComingSoon( state, siteId ),
 	};
 }
 

--- a/client/state/selectors/is-site-coming-soon.js
+++ b/client/state/selectors/is-site-coming-soon.js
@@ -4,7 +4,6 @@
 
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import { getSiteSettings } from 'calypso/state/site-settings/selectors';
-import isPrivateSite from 'calypso/state/selectors/is-private-site';
 
 /**
  * Returns true if the site is coming_soon
@@ -14,10 +13,6 @@ import isPrivateSite from 'calypso/state/selectors/is-private-site';
  * @returns {boolean} True if site is coming_soon
  */
 export default function isSiteComingSoon( state, siteId ) {
-	if ( ! isPrivateSite( state, siteId ) ) {
-		return false;
-	}
-
 	const site = getRawSite( state, siteId );
 
 	if ( site ) {

--- a/client/state/selectors/test/is-site-coming-soon.js
+++ b/client/state/selectors/test/is-site-coming-soon.js
@@ -55,32 +55,6 @@ describe( 'isSiteComingSoon()', () => {
 		expect( isComingSoon ).toBe( true );
 	} );
 
-	test( 'should always return false for non-private sites', () => {
-		const isComingSoon = isSiteComingSoon(
-			{
-				sites: {
-					items: {
-						2916284: {
-							ID: 2916284,
-							is_coming_soon: true,
-							is_private: false,
-						},
-					},
-				},
-				siteSettings: {
-					items: {
-						2916284: {
-							wpcom_coming_soon: 1,
-						},
-					},
-				},
-			},
-			2916284
-		);
-
-		expect( isComingSoon ).toBe( false );
-	} );
-
 	test( 'should fall back to settings state', () => {
 		const isComingSoon = isSiteComingSoon(
 			{
@@ -100,31 +74,6 @@ describe( 'isSiteComingSoon()', () => {
 		);
 
 		expect( isComingSoon ).toBe( true );
-	} );
-
-	test( 'should return false for public sites', () => {
-		const isComingSoon = isSiteComingSoon(
-			{
-				sites: {
-					items: {
-						2916284: {
-							ID: 2916284,
-							is_coming_soon: false,
-						},
-					},
-				},
-				siteSettings: {
-					items: {
-						2916284: {
-							blog_public: 1,
-						},
-					},
-				},
-			},
-			2916284
-		);
-
-		expect( isComingSoon ).toBe( false );
 	} );
 
 	test( 'should return true for coming soon sites', () => {


### PR DESCRIPTION
## Changes proposed in this Pull Request

This commit adds a Coming Soon badge to the site in the sidebar when coming soon v2 is enabled.

<img width="392" alt="Screen Shot 2020-10-22 at 2 37 30 pm" src="https://user-images.githubusercontent.com/6458278/96821712-31406e00-1474-11eb-9ba6-a06d100a0161.png">

We're also checking if coming soon v2 is enabled in the is-coming-soon selector so we can return the correct value. 

⚠️ This only works on Simple Sites :)

## Testing instructions

Apply D51626-code (this ensures that `is_coming_soon` is `true` for coming soon v2 in the `me/sites` response)

Create a site at `/new?flags=coming-soon-v2`

Check that the new site has the correct badge in the sidebar (Coming Soon)

To test that the selector is returning the correct value, head over to `/settings/general/{your_new_site}?flags=coming-soon-v2`

You should see the following:

<img width="776" alt="Screen Shot 2020-10-22 at 2 34 01 pm" src="https://user-images.githubusercontent.com/6458278/96821846-795f9080-1474-11eb-91fc-d2ddc2505934.png">

If you remove ?flags=coming-soon-v2 from the URL, you'll see the v1 message (private ) 

<img width="798" alt="Screen Shot 2020-10-22 at 2 31 52 pm" src="https://user-images.githubusercontent.com/6458278/96821912-998f4f80-1474-11eb-92fb-4e6193d2ae9e.png">

Fixes #46628
