### PR TITLE
Remove deprecated use of Node URL in Site Notices

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import url from 'url';
+
 import moment from 'moment';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -13,6 +13,7 @@ import { get, reject, transform } from 'lodash';
 /**
  * Internal dependencies
  */
+import { getUrlParts } from 'calypso/lib/url/url-parts';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import getActiveDiscount from 'calypso/state/selectors/get-active-discount';
@@ -61,7 +62,7 @@ export class SiteNotice extends React.Component {
 		if ( ! ( site.options && site.options.is_redirect ) ) {
 			return null;
 		}
-		const { hostname } = url.parse( site.URL );
+		const { hostname } = getUrlParts( site.URL );
 		const { translate } = this.props;
 
 		return (


### PR DESCRIPTION
This is a minor PR to reduce the size of other PRs which are working on [the `SiteNotice` component](https://github.com/Automattic/wp-calypso/blob/691522b1bbbe64eb0d9bd28937f73a3a18d3a1c5/client/my-sites/current-site/notice.jsx).

<img width="453" alt="Screen Shot 2020-10-22 at 09 43 46" src="https://user-images.githubusercontent.com/444434/96847813-87e58200-144b-11eb-9a67-1a1398af1932.png">


#### Changes proposed in this Pull Request

* Replaces deprecated `url` usage with recommended lib alternative.

#### Testing instructions

* Checkout PR.
* `yarn && yarn start` - waiting and open calypso in browser.
* Set up a fresh test site at `https://wordpress.com/start`. Use a free plan and choose a free `wordpress.com` domain name.
* [Set up a new redirect for your new site](https://wordpress.com/support/site-redirect/) - https://wordpress.com/domains/add/site-redirect/
* Verify redirect works.
* In your **_local_** Calypso (http://calypso.localhost:3000/) go to the Calypso my home for your new site.
* You should see a Notice showing with the redirect notice.
* Check that the site URL shows up correctly in the resulting notice.
* Check no errors in browser console.


