### PR TITLE
Editor Toolkit: update slide copy in NUX

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -108,9 +108,9 @@ function getWpcomNuxPages( isGutenboarding ) {
 			alignBottom: true,
 		},
 		{
-			heading: __( 'Coming Soon', 'full-site-editing' ),
+			heading: __( 'Hidden until you’re ready', 'full-site-editing' ),
 			description: __(
-				'Your site will remain visible only to you until you’re ready to launch and share it with the world.',
+				'Your site will remain hidden until launched. Click “Launch” in the toolbar to share it with the world.',
 				'full-site-editing'
 			),
 			imgSrc: privateImage,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -108,9 +108,9 @@ function getWpcomNuxPages( isGutenboarding ) {
 			alignBottom: true,
 		},
 		{
-			heading: __( 'Private until you’re ready', 'full-site-editing' ),
+			heading: __( 'Coming Soon', 'full-site-editing' ),
 			description: __(
-				'Your site will remain private as you make changes until you’re ready to launch and share with the world.',
+				'Your site will remain visible only to you until you’re ready to launch and share it with the world.',
 				'full-site-editing'
 			),
 			imgSrc: privateImage,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -73,13 +73,11 @@ function WpcomNux() {
 }
 
 /**
- * This function returns a filtered collection of NUX slide data
- * Function arguments can be extended to customize the slides for specific environments, e.g., Gutenboarding
+ * This function returns a collection of NUX slide data
  *
- * @param   { boolean } isGutenboarding Whether the flow is Gutenboarding or not
- * @returns { Array }                   a collection of <NuxPage /> props filtered by whether the flow is Gutenboarding or not
+ * @returns { Array } a collection of <NuxPage /> props
  */
-function getWpcomNuxPages( isGutenboarding ) {
+function getWpcomNuxPages() {
 	return [
 		{
 			heading: __( 'Welcome to your website', 'full-site-editing' ),
@@ -114,11 +112,9 @@ function getWpcomNuxPages( isGutenboarding ) {
 				'full-site-editing'
 			),
 			imgSrc: privateImage,
-			// @TODO: hide for sites that are already public
-			shouldHide: ! isGutenboarding,
 			alignBottom: true,
 		},
-	].filter( ( nuxPage ) => ! nuxPage.shouldHide );
+	];
 }
 
 function NuxPage( { alignBottom = false, heading, description, imgSrc } ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updating copy to emphasis the hidden nature of new sites rather than the private by default aspect, which we'll be rolling back with coming soon v2 (by default new sites will be in coming soon mode, but public (not indexable)

We're also showing all steps now that the Launch button is persisting in p9Jlb4-1SN-p2 and https://github.com/Automattic/wp-calypso/pull/46817

<img width="915" alt="Screen Shot 2020-10-23 at 11 19 17 am" src="https://user-images.githubusercontent.com/6458278/96942782-ca798e00-1521-11eb-9517-22267cba81c3.png">


Context p1603330128417000-slack-C9EJ7KSGH

#### Testing instructions

The quick and dirty way of checking the changes is to comment out the following lines in [wpcom-nux.js](https://github.com/Automattic/wp-calypso/blob/205c3bd/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js#L52)

```
/*	
       if ( ! isWpcomNuxEnabled || isSPTOpen ) {
		return null;
	}
*/
```

Run `yarn dev --sync` from `apps/editing-toolkit`

Create a new site via `/new`

Sandbox that site

Navigate through the NUX modal to the last panel

Check that the copy reflect the changes in this PR

Also check that we're dislaying **all** the Nux Pages we return in [getWpcomNuxPages()](https://github.com/Automattic/wp-calypso/pull/46674/files#diff-45f05f01ccd04ef444c0e47c1bd985150897e6404f26f0186b96bd9c80db4705R80)

