### PR TITLE
Marketing: Add support for GA4 measurement IDs

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -36,7 +36,8 @@ import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { OPTIONS_JETPACK_SECURITY } from 'calypso/my-sites/plans-v2/constants';
 import { getPathToDetails } from 'calypso/my-sites/plans-v2/utils';
 
-const validateGoogleAnalyticsCode = ( code ) => ! code || code.match( /^UA-\d+-\d+$/i );
+const validateGoogleAnalyticsCode = ( code ) =>
+	! code || code.match( /^(UA-\d+-\d+)|(G-[A-Z0-9]+)$/i );
 
 export class GoogleAnalyticsForm extends Component {
 	state = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Marketing: Add support for GA4 measurement IDs

#### Testing instructions

* Go to `/marketing/traffic/:site` where `:site` is the slug of a site with a premium or business plan.
* Enable Google Analytics if it's not enabled.
* Try adding en example Google Analytics measurement ID in both formats and verify they are accepted and work well:
  * Legacy: `UA-12345678-12`
  * GA4: `G-ABC123XYZ`

Fixes #46664
