### PR TITLE
Backup card: fix restore button tooltip target area

### DIFF
--- a/client/components/jetpack/backup-card/style.scss
+++ b/client/components/jetpack/backup-card/style.scss
@@ -98,7 +98,10 @@ $cloud-icon-height: 24px;
 	list-style-type: none;
 
 	> li {
+		position: relative;
+
 		margin-bottom: 20px;
+
 		.button {
 			width: 100%;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

The tooltip that describes the _Restore to this point_ button in the new backup card is made visible when hovering the whole card instead of the button. This PR fixes this.

### Implementation notes

A CSS rule was unfortunately removed.

### Testing instructions

- Select a self-hosted Jetpack site that has Backup, and no server credentials set up
- Visit `/backup/:site?flags=jetpack/backup-simplified-screens-i4`
- Hover a backup card and check that you don't see any tooltip
- Hover the restore button and notice the tooltip

### Screenshots

_Before_
<img width="770" alt="Screen Shot 2020-10-22 at 10 33 21 AM" src="https://user-images.githubusercontent.com/1620183/96887594-bca90780-1452-11eb-9aec-7e1d181a3a2a.png">

_After_
<img width="759" alt="Screen Shot 2020-10-22 at 10 33 51 AM" src="https://user-images.githubusercontent.com/1620183/96887612-c0d52500-1452-11eb-916e-a919cf58192f.png">
