### PR TITLE
Fix duplicate headers and layout widths

### DIFF
--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -43,7 +43,6 @@ import titles from 'calypso/me/purchases/titles';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -283,7 +282,6 @@ class ConfirmCancelDomain extends React.Component {
 					path="/me/purchases/:site/:purchaseId/confirm-cancel-domain"
 					title="Purchases > Confirm Cancel Domain"
 				/>
-				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 				<HeaderCake
 					backHref={ this.props.getCancelPurchaseUrlFor(
 						this.props.siteSlug,

--- a/client/me/purchases/confirm-cancel-domain/loading-placeholder.jsx
+++ b/client/me/purchases/confirm-cancel-domain/loading-placeholder.jsx
@@ -21,9 +21,9 @@ const ConfirmCancelDomainLoadingPlaceholder = ( { purchaseId, selectedSite } ) =
 	}
 
 	return (
-		<LoadingPlaceholder title={ titles.confirmCancelDomain } path={ path }>
+		<LoadingPlaceholder title={ titles.confirmCancelDomain } path={ path } isFullWidth={ true }>
 			<Card className="confirm-cancel-domain__loading-placeholder-card">
-				<h2 className="loading-placeholder__content confirm-cancel-domain__loading-placeholder-header" />
+				<div className="loading-placeholder__content confirm-cancel-domain__loading-placeholder-header" />
 				<div className="loading-placeholder__content confirm-cancel-domain__loading-placeholder-subheader" />
 				<div className="loading-placeholder__content confirm-cancel-domain__loading-placeholder-reason" />
 				<div className="loading-placeholder__content confirm-cancel-domain__loading-placeholder-reason" />

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -92,7 +92,6 @@ export function cancelPurchase( context, next ) {
 
 export function confirmCancelDomain( context, next ) {
 	const state = context.store.getState();
-	const classes = 'confirm-cancel-domain';
 
 	if ( userHasNoSites( state ) ) {
 		return noSites( context, '/me/purchases/:site/:purchaseId/confirm-cancel-domain' );
@@ -101,7 +100,7 @@ export function confirmCancelDomain( context, next ) {
 	setTitle( context, titles.confirmCancelDomain );
 
 	context.primary = (
-		<Main className={ classes }>
+		<Main className="purchases__cancel-domain confirm-cancel-domain is-wide-layout">
 			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 			<ConfirmCancelDomain
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a duplicate title for folks deleting domains purchased with a payment method.

**Before**
![image](https://user-images.githubusercontent.com/6981253/96889404-8e2c2c00-1454-11eb-94d8-e06545cf8c5f.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/96889367-87051e00-1454-11eb-9ae8-5ad263b0e768.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you don't have a domain purchased with a payment method, go ahead and buy one.
* Visit `me/purchases` and go try delete a domain. 
* Continue past the first step and confirm the screen is full width and there isn't a duplicate title. 
* Try the same steps from the site level by visiting `/purchases/subscriptions/:site`
