### PR TITLE
Disable rule `wpcalypso/no-package-relative-imports` in test/e2e

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,7 +89,8 @@ module.exports = {
 			rules: {
 				'import/no-nodejs-modules': 'off',
 				'no-console': 'off',
-
+				// test/e2e doesn't support package-relative imports
+				'wpcalypso/no-package-relative-imports': 'off',
 				// Disable all rules from "plugin:jest/recommended", as e2e tests use mocha
 				...Object.keys( require( 'eslint-plugin-jest' ).configs.recommended.rules ).reduce(
 					( disabledRules, key ) => ( { ...disabledRules, [ key ]: 'off' } ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Disable the rule `wpcalypso/no-package-relative-imports` in `test/e2e`, as they doesn't support package-relative imports anyway. When they do `import config from 'config'` they actually mean `node_modules/config`, not `client/config`

#### Testing instructions

N/A
