### PR TITLE
Billing: add membership subscriptions to purchase data

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -87,6 +87,7 @@ function getSubscriptionsBySite( subscriptions ) {
 					{
 						id: currentValue.site_id,
 						name: currentValue.site_title,
+						domain: currentValue.site_url,
 						subscriptions: [ currentValue ],
 					},
 				];

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -27,6 +27,7 @@ import {
 	isConciergeSession,
 } from 'calypso/lib/products-values';
 import { getJetpackProductsDisplayNames } from 'calypso/lib/products-values/translations';
+import { MembershipSubscription, MembershipSubscriptionsSite } from 'calypso/lib/purchases/types';
 
 const debug = debugFactory( 'calypso:purchases' );
 
@@ -72,17 +73,15 @@ function getPurchasesBySite( purchases, sites ) {
 /**
  * Returns an array of sites objects, each of which contains an array of subscriptions.
  *
- * @param {Array} subscriptions An array of subscription objects.
- * @returns {Array} An array of sites with subscriptions attached.
+ * @param {MembershipSubscription[]} subscriptions An array of subscription objects.
+ * @returns {MembershipSubscriptionsSite[]} An array of sites with subscriptions attached.
  */
 function getSubscriptionsBySite( subscriptions ) {
 	return subscriptions
 		.reduce( ( result, currentValue ) => {
-			const site = find( result, { id: currentValue.site_id } );
-			if ( site ) {
-				site.subscriptions = [ ...site.subscriptions, currentValue ];
-			} else {
-				result = [
+			const site = result.find( ( subscription ) => subscription.id === currentValue.site_id );
+			if ( ! site ) {
+				return [
 					...result,
 					{
 						id: currentValue.site_id,
@@ -93,6 +92,7 @@ function getSubscriptionsBySite( subscriptions ) {
 				];
 			}
 
+			site.subscriptions = [ ...site.subscriptions, currentValue ];
 			return result;
 		}, [] )
 		.sort( ( a, b ) => ( a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1 ) );

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -10,11 +10,11 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import notices from 'notices';
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import { getRenewalItemFromProduct } from 'lib/cart-values/cart-items';
-import { getPlan } from 'lib/plans';
-import { isMonthly as isMonthlyPlan } from 'lib/plans/constants';
+import notices from 'calypso/notices';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getRenewalItemFromProduct } from 'calypso/lib/cart-values/cart-items';
+import { getPlan } from 'calypso/lib/plans';
+import { isMonthly as isMonthlyPlan } from 'calypso/lib/plans/constants';
 import {
 	getProductFromSlug,
 	isDomainMapping,
@@ -25,8 +25,8 @@ import {
 	isPlan,
 	isTheme,
 	isConciergeSession,
-} from 'lib/products-values';
-import { getJetpackProductsDisplayNames } from 'lib/products-values/translations';
+} from 'calypso/lib/products-values';
+import { getJetpackProductsDisplayNames } from 'calypso/lib/products-values/translations';
 
 const debug = debugFactory( 'calypso:purchases' );
 
@@ -67,6 +67,34 @@ function getPurchasesBySite( purchases, sites ) {
 			return result;
 		}, [] )
 		.sort( ( a, b ) => ( a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1 ) );
+}
+
+/**
+ * Returns an array of sites objects, each of which contains an array of subscriptions.
+ *
+ * @param {Array} subscriptions An array of subscription objects.
+ * @returns {Array} An array of sites with subscriptions attached.
+ */
+function getSubscriptionsBySite( subscriptions ) {
+	return subscriptions
+		.reduce( ( result, currentValue ) => {
+			const site = find( result, { id: currentValue.site_id } );
+			if ( site ) {
+				site.subscriptions = [ ...site.subscriptions, currentValue ];
+			} else {
+				result = [
+					...result,
+					{
+						id: currentValue.site_id,
+						name: currentValue.site_title,
+						subscriptions: [ currentValue ],
+					},
+				];
+			}
+
+			return result;
+		}, [] )
+		.sort( ( a, b ) => ( a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1 ) );
 }
 
 function getName( purchase ) {
@@ -669,6 +697,7 @@ export {
 	getPurchasesBySite,
 	getRenewalPrice,
 	getSubscriptionEndDate,
+	getSubscriptionsBySite,
 	handleRenewMultiplePurchasesClick,
 	handleRenewNowClick,
 	hasAmountAvailableToRefund,

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -29,3 +29,10 @@ export interface MembershipSubscription {
 	status: string;
 	title: string;
 }
+
+export interface MembershipSubscriptionsSite {
+	id: string;
+	name: string;
+	domain: string;
+	subscriptions: MembershipSubscription[];
+}

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -14,3 +14,18 @@ export interface Purchase {
 	siteId: number;
 	subscribedDate: string;
 }
+
+export interface MembershipSubscription {
+	ID: string;
+	currency: string;
+	end_date?: string;
+	product_id: string;
+	renew_interval?: null;
+	renewal_price: string;
+	site_id: string;
+	site_title: string;
+	site_url: string;
+	start_date: string;
+	status: string;
+	title: string;
+}

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -18,9 +18,9 @@ export interface Purchase {
 export interface MembershipSubscription {
 	ID: string;
 	currency: string;
-	end_date?: string;
+	end_date: string | null;
 	product_id: string;
-	renew_interval?: null;
+	renew_interval: string | null;
 	renewal_price: string;
 	site_id: string;
 	site_title: string;

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -41,12 +41,11 @@ class Subscription extends React.Component {
 
 		return (
 			<Main className="memberships__subscription is-wide-layout">
-				<DocumentHead title={ translate( 'Other Sites' ) } />
+				<DocumentHead title={ translate( 'Subscription Details' ) } />
 				<MeSidebarNavigation />
 				<QueryMembershipsSubscriptions />
 				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-
-				<HeaderCake backHref={ purchasesRoot + '/other' }>
+				<HeaderCake backHref={ purchasesRoot }>
 					{ subscription ? subscription.title : translate( 'All subscriptions' ) }
 				</HeaderCake>
 				{ stoppingStatus === 'start' && (

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { useTranslate, LocalizeProps } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
 
 /**
@@ -24,8 +24,8 @@ const getMembershipTerms = ( {
 	moment,
 }: {
 	subscription: MembershipSubscription;
-	translate: LocalizeProps[ 'translate' ];
-	moment: any;
+	translate: ReturnType< typeof useTranslate >;
+	moment: ReturnType< typeof useLocalizedMoment >;
 } ) => {
 	/* $5 - never expires. */
 	if ( subscription.end_date === null ) {

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -18,43 +18,50 @@ import { MembershipSubscription } from 'calypso/lib/purchases/types';
  */
 import './style.scss';
 
-const getMembershipTerms = ( {
-	subscription,
-	translate,
-	moment,
-}: {
-	subscription: MembershipSubscription;
-	translate: ReturnType< typeof useTranslate >;
-	moment: ReturnType< typeof useLocalizedMoment >;
-} ) => {
+const MembershipTerms = ( { subscription }: { subscription: MembershipSubscription } ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
 	/* $5 - never expires. */
 	if ( subscription.end_date === null ) {
-		return translate( '%(amount)s - never expires.', {
-			args: {
-				amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
-			},
-		} );
+		return (
+			<div className="membership-item__term-label">
+				{ translate( '%(amount)s - never expires.', {
+					args: {
+						amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
+					},
+				} ) }
+			</div>
+		);
 	}
 
 	/* Renews every month for $5. Next renewal on November 22, 2020. */
 	if ( subscription.renew_interval ) {
-		return translate( 'Renews every %(interval)s for %(amount)s. Next renewal on %(date)s.', {
-			args: {
-				interval: subscription.renew_interval,
-				amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
-				date: moment( subscription.end_date ).format( 'LL' ),
-			},
-		} );
+		return (
+			<div className="membership-item__term-label">
+				{ translate( 'Renews every %(interval)s for %(amount)s. Next renewal on %(date)s.', {
+					args: {
+						interval: subscription.renew_interval,
+						amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
+						date: moment( subscription.end_date ).format( 'LL' ),
+					},
+				} ) }
+			</div>
+		);
 	}
 
 	/* Renews at $5 on November 22, 2020. */
 	/* I'm not sure we can have a renewal without an interval, so this might not get called. */
-	return translate( 'Renews at %(amount)s on %(date)s.', {
-		args: {
-			amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
-			date: moment( subscription.end_date ).format( 'LL' ),
-		},
-	} );
+	return (
+		<div className="membership-item__term-label">
+			{ translate( 'Renews at %(amount)s on %(date)s.', {
+				args: {
+					amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
+					date: moment( subscription.end_date ).format( 'LL' ),
+				},
+			} ) }
+		</div>
+	);
 };
 
 export default function MembershipItem( {
@@ -63,7 +70,6 @@ export default function MembershipItem( {
 	subscription: MembershipSubscription;
 } ): JSX.Element {
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 
 	return (
 		<CompactCard
@@ -80,9 +86,7 @@ export default function MembershipItem( {
 					<div className="membership-item__site">
 						{ translate( 'On %s', { args: subscription.site_title } ) }
 					</div>
-					<div className="membership-item__term-label">
-						{ getMembershipTerms( { subscription, translate, moment } ) }
-					</div>
+					<MembershipTerms subscription={ subscription } />
 				</div>
 			</span>
 		</CompactCard>

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+import formatCurrency from '@automattic/format-currency';
+
+/**
+ * Internal dependencies
+ */
+import { CompactCard } from '@automattic/components';
+import Gridicon from 'calypso/components/gridicon';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const getMembershipTerms = ( {
+	subscription,
+	translate,
+	moment,
+}: {
+	subscription: any;
+	translate: any;
+	moment: any;
+} ) => {
+	/* $5 - never expires. */
+	if ( subscription.end_date === null ) {
+		return translate( '%(amount)s - never expires.', {
+			args: {
+				amount: formatCurrency( subscription.renewal_price, subscription.currency ),
+			},
+		} );
+	}
+
+	/* Renews every month for $5. Next renewal on November 22, 2020. */
+	if ( subscription.renewal_interval ) {
+		return translate( 'Renews every %(interval)s for %(amount)s. Next renewal on %(date)s.', {
+			args: {
+				interval: subscription.renewal_interval,
+				amount: formatCurrency( subscription.renewal_price, subscription.currency ),
+				date: moment( subscription.endDate ).format( 'LL' ),
+			},
+		} );
+	}
+
+	/* Renews at $5 on November 22, 2020. */
+	/* I'm not sure we can have a renewal without an interval, so this might not get called. */
+	return translate( 'Renews at %(amount)s on %(date)s.', {
+		args: {
+			amount: formatCurrency( subscription.renewal_price, subscription.currency ),
+			date: moment( subscription.endDate ).format( 'LL' ),
+		},
+	} );
+};
+
+export default function MembershipItem( { subscription }: { subscription: any } ): JSX.Element {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
+	return (
+		<CompactCard
+			className="membership-item"
+			key={ subscription.ID }
+			href={ '/me/purchases/other/' + subscription.ID }
+		>
+			<span className="membership-item__wrapper">
+				<div className="membership-item__icon">
+					<Gridicon icon="credit-card" size={ 24 } />
+				</div>
+				<div className="membership-item__details">
+					<div className="membership-item__title">{ subscription.title }</div>
+					<div className="membership-item__site">
+						{ translate( 'On %s', { args: subscription.site_title } ) }
+					</div>
+					<div className="membership-item__term-label">
+						{ getMembershipTerms( { subscription, translate, moment } ) }
+					</div>
+				</div>
+			</span>
+		</CompactCard>
+	);
+}

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, LocalizeProps } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
 
 /**
@@ -11,6 +11,7 @@ import formatCurrency from '@automattic/format-currency';
 import { CompactCard } from '@automattic/components';
 import Gridicon from 'calypso/components/gridicon';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { MembershipSubscription } from 'calypso/lib/purchases/types';
 
 /**
  * Style dependencies
@@ -22,26 +23,26 @@ const getMembershipTerms = ( {
 	translate,
 	moment,
 }: {
-	subscription: any;
-	translate: any;
+	subscription: MembershipSubscription;
+	translate: LocalizeProps[ 'translate' ];
 	moment: any;
 } ) => {
 	/* $5 - never expires. */
 	if ( subscription.end_date === null ) {
 		return translate( '%(amount)s - never expires.', {
 			args: {
-				amount: formatCurrency( subscription.renewal_price, subscription.currency ),
+				amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
 			},
 		} );
 	}
 
 	/* Renews every month for $5. Next renewal on November 22, 2020. */
-	if ( subscription.renewal_interval ) {
+	if ( subscription.renew_interval ) {
 		return translate( 'Renews every %(interval)s for %(amount)s. Next renewal on %(date)s.', {
 			args: {
-				interval: subscription.renewal_interval,
-				amount: formatCurrency( subscription.renewal_price, subscription.currency ),
-				date: moment( subscription.endDate ).format( 'LL' ),
+				interval: subscription.renew_interval,
+				amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
+				date: moment( subscription.end_date ).format( 'LL' ),
 			},
 		} );
 	}
@@ -50,13 +51,17 @@ const getMembershipTerms = ( {
 	/* I'm not sure we can have a renewal without an interval, so this might not get called. */
 	return translate( 'Renews at %(amount)s on %(date)s.', {
 		args: {
-			amount: formatCurrency( subscription.renewal_price, subscription.currency ),
-			date: moment( subscription.endDate ).format( 'LL' ),
+			amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
+			date: moment( subscription.end_date ).format( 'LL' ),
 		},
 	} );
 };
 
-export default function MembershipItem( { subscription }: { subscription: any } ): JSX.Element {
+export default function MembershipItem( {
+	subscription,
+}: {
+	subscription: MembershipSubscription;
+} ): JSX.Element {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 

--- a/client/me/purchases/membership-item/style.scss
+++ b/client/me/purchases/membership-item/style.scss
@@ -1,0 +1,66 @@
+.membership-item.card {
+	&.is-expired {
+		.membership-item__plan-icon,
+		.membership-item__title,
+		.membership-item__site {
+			opacity: 0.7;
+		}
+	}
+
+	.membership-item__wrapper {
+		display: flex;
+	}
+
+	.membership-item__details,
+	.membership-item__icon {
+		flex: 1;
+	}
+}
+
+.membership-item__icon {
+	margin: 0 8px 0 0;
+	max-width: 32px;
+	width: 32px;
+
+	.gridicon {
+		padding: 4px;
+		border-radius: 50%;
+		background: var( --color-neutral );
+		fill: var( --color-text-inverted );
+	}
+}
+
+.membership-item__term-label,
+.membership-item__site {
+	line-height: 14px;
+	margin-top: 2px;
+}
+
+.membership-item__title {
+	color: var( --color-text );
+	display: block;
+	font-size: $font-body-small;
+	line-height: 1.2em;
+	margin: 4px 20px 4px 0;
+	overflow: hidden;
+	position: relative;
+	white-space: nowrap;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		font-size: $font-title-small;
+		max-width: none;
+	}
+}
+
+.membership-item__site {
+	color: var( --color-text-subtle );
+	font-size: $font-body-extra-small;
+	margin: 0 0 4px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.membership-item__term-label {
+	color: var( --color-neutral-70 );
+	font-size: $font-body-extra-small;
+}

--- a/client/me/purchases/membership-site/header.tsx
+++ b/client/me/purchases/membership-site/header.tsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { CompactCard } from '@automattic/components';
+import Gridicon from 'calypso/components/gridicon';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default function MembershipSiteHeader( {
+	name,
+	domain,
+}: {
+	name: string;
+	domain: string;
+} ): JSX.Element {
+	return (
+		<CompactCard className="membership-site__header">
+			<div className="membership-site__icon">
+				<Gridicon icon="globe" />
+			</div>
+			<div className="membership-site__info">
+				<div className="membership-site__title">{ name }</div>
+				<div className="membership-site__domain">{ domain }</div>
+			</div>
+		</CompactCard>
+	);
+}

--- a/client/me/purchases/membership-site/index.tsx
+++ b/client/me/purchases/membership-site/index.tsx
@@ -8,9 +8,13 @@ import React from 'react';
  */
 import MembershipSiteHeader from './header';
 import MembershipItem from '../membership-item';
-import { MembershipSubscription } from 'calypso/lib/purchases/types';
+import { MembershipSubscriptionsSite, MembershipSubscription } from 'calypso/lib/purchases/types';
 
-export default function MembershipSite( { site }: { site: any } ): JSX.Element {
+export default function MembershipSite( {
+	site,
+}: {
+	site: MembershipSubscriptionsSite;
+} ): JSX.Element {
 	return (
 		<div className="membership-site">
 			<MembershipSiteHeader name={ site.name } domain={ site.domain } />

--- a/client/me/purchases/membership-site/index.tsx
+++ b/client/me/purchases/membership-site/index.tsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import MembershipSiteHeader from './header';
+import MembershipItem from '../membership-item';
+import { MembershipSubscription } from 'calypso/lib/purchases/types';
+
+export default function MembershipSite( { site }: { site: any } ): JSX.Element {
+	return (
+		<div className="membership-site">
+			<MembershipSiteHeader name={ site.name } domain={ site.domain } />
+
+			{ site.subscriptions.map( ( subscription: MembershipSubscription ) => (
+				<MembershipItem subscription={ subscription } key={ subscription.ID } />
+			) ) }
+		</div>
+	);
+}

--- a/client/me/purchases/membership-site/style.scss
+++ b/client/me/purchases/membership-site/style.scss
@@ -1,8 +1,8 @@
-.purchases-list__site-header {
+.membership-site__header {
 	padding: 11px 24px;
 	display: flex;
 
-	.purchases-list__site-icon {
+	.membership-site__icon {
 		background: var( --color-neutral-10 );
 		display: inline-block;
 		height: 32px;
@@ -22,18 +22,18 @@
 		}
 	}
 
-	.purchases-list__site-info {
+	.membership-site__info {
 		width: 0;
 		flex: 1 0 auto;
 	}
 
-	.purchases-list__site-title,
-	.purchases-list__site-domain {
+	.membership-site__title,
+	.membership-site__domain {
 		overflow: hidden;
 		white-space: nowrap;
 	}
 
-	.purchases-list__site-title {
+	.membership-site__title {
 		color: var( --color-text );
 		display: block;
 		font-size: 0.875rem;
@@ -41,7 +41,7 @@
 		line-height: 1.3;
 	}
 
-	.purchases-list__site-domain {
+	.membership-site__domain {
 		color: var( --color-text-subtle );
 		display: block;
 		max-width: 95%;

--- a/client/me/purchases/membership-site/style.scss
+++ b/client/me/purchases/membership-site/style.scss
@@ -1,3 +1,7 @@
+.membership-site {
+	margin-bottom: 24px;
+}
+
 .membership-site__header {
 	padding: 11px 24px;
 	display: flex;

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -18,9 +18,12 @@ import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PurchasesHeader from './header';
 import PurchasesSite from '../purchases-site';
+import MembershipItem from '../membership-item';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getPurchasesBySite } from 'calypso/lib/purchases';
+import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
+import { getAllSubscriptions } from 'calypso/state/memberships/subscriptions/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import {
 	getUserPurchases,
@@ -90,6 +93,18 @@ class PurchasesList extends Component {
 		);
 	}
 
+	renderMembershipSubscriptions() {
+		const { subscriptions } = this.props;
+
+		if ( ! subscriptions.length ) {
+			return null;
+		}
+
+		return subscriptions.map( ( subscription ) => (
+			<MembershipItem subscription={ subscription } key={ subscription.ID } />
+		) );
+	}
+
 	render() {
 		let content;
 
@@ -99,7 +114,7 @@ class PurchasesList extends Component {
 
 		if ( this.props.hasLoadedUserPurchasesFromServer && this.props.purchases.length ) {
 			content = (
-				<div>
+				<>
 					{ this.renderConciergeBanner() }
 
 					{ getPurchasesBySite( this.props.purchases, this.props.sites ).map( ( site ) => (
@@ -112,7 +127,7 @@ class PurchasesList extends Component {
 							purchases={ site.purchases }
 						/>
 					) ) }
-				</div>
+				</>
 			);
 		}
 
@@ -150,12 +165,14 @@ class PurchasesList extends Component {
 		return (
 			<Main className="purchases-list is-wide-layout">
 				<QueryUserPurchases userId={ this.props.userId } />
+				<QueryMembershipsSubscriptions />
 				<PageViewTracker path="/me/purchases" title="Purchases" />
 				<MeSidebarNavigation />
 
 				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 				<PurchasesHeader section="purchases" />
 				{ content }
+				{ this.renderMembershipSubscriptions() }
 				<QueryConciergeInitial />
 			</Main>
 		);
@@ -166,6 +183,7 @@ PurchasesList.propTypes = {
 	isBusinessPlanUser: PropTypes.bool.isRequired,
 	noticeType: PropTypes.string,
 	purchases: PropTypes.oneOfType( [ PropTypes.array, PropTypes.bool ] ),
+	subscriptions: PropTypes.array,
 	sites: PropTypes.array.isRequired,
 	userId: PropTypes.number.isRequired,
 };
@@ -178,6 +196,7 @@ export default connect(
 			isBusinessPlanUser: isBusinessPlanUser( state ),
 			isFetchingUserPurchases: isFetchingUserPurchases( state ),
 			purchases: getUserPurchases( state, userId ),
+			subscriptions: getAllSubscriptions( state ),
 			sites: getSites( state ),
 			nextAppointment: getConciergeNextAppointment( state ),
 			scheduleId: getConciergeScheduleId( state ),

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -21,7 +21,7 @@ import PurchasesSite from '../purchases-site';
 import MembershipItem from '../membership-item';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { getPurchasesBySite } from 'calypso/lib/purchases';
+import { getPurchasesBySite, getSubscriptionsBySite } from 'calypso/lib/purchases';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
 import { getAllSubscriptions } from 'calypso/state/memberships/subscriptions/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -100,9 +100,17 @@ class PurchasesList extends Component {
 			return null;
 		}
 
-		return subscriptions.map( ( subscription ) => (
-			<MembershipItem subscription={ subscription } key={ subscription.ID } />
-		) );
+		return getSubscriptionsBySite( subscriptions ).map( ( site ) => {
+			return (
+				<div key={ site.id }>
+					<CompactCard>{ site.name }</CompactCard>
+
+					{ site.subscriptions.map( ( subscription ) => (
+						<MembershipItem subscription={ subscription } key={ subscription.ID } />
+					) ) }
+				</div>
+			);
+		} );
 	}
 
 	render() {

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal Dependencies
@@ -19,7 +18,7 @@ import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PurchasesHeader from './header';
 import PurchasesSite from '../purchases-site';
-import MembershipItem from '../membership-item';
+import MembershipSite from '../membership-site';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getPurchasesBySite, getSubscriptionsBySite } from 'calypso/lib/purchases';
@@ -46,11 +45,6 @@ import {
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import FormattedHeader from 'calypso/components/formatted-header';
 import titles from 'calypso/me/purchases/titles';
-
-/**
- * Style dependencies
- */
-import './style.scss';
 
 class PurchasesList extends Component {
 	isDataLoading() {
@@ -106,25 +100,9 @@ class PurchasesList extends Component {
 			return null;
 		}
 
-		return getSubscriptionsBySite( subscriptions ).map( ( site ) => {
-			return (
-				<div key={ site.id }>
-					<CompactCard className="purchases-list__site-header">
-						<div className="purchases-list__site-icon">
-							<Gridicon icon="globe" />
-						</div>
-						<div className="purchases-list__site-info">
-							<div className="purchases-list__site-title">{ site.name }</div>
-							<div className="purchases-list__site-domain">{ site.domain }</div>
-						</div>
-					</CompactCard>
-
-					{ site.subscriptions.map( ( subscription ) => (
-						<MembershipItem subscription={ subscription } key={ subscription.ID } />
-					) ) }
-				</div>
-			);
-		} );
+		return getSubscriptionsBySite( subscriptions ).map( ( site ) => (
+			<MembershipSite site={ site } key={ site.id } />
+		) );
 	}
 
 	render() {

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal Dependencies
@@ -45,6 +46,11 @@ import {
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import FormattedHeader from 'calypso/components/formatted-header';
 import titles from 'calypso/me/purchases/titles';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class PurchasesList extends Component {
 	isDataLoading() {
@@ -103,7 +109,15 @@ class PurchasesList extends Component {
 		return getSubscriptionsBySite( subscriptions ).map( ( site ) => {
 			return (
 				<div key={ site.id }>
-					<CompactCard>{ site.name }</CompactCard>
+					<CompactCard className="purchases-list__site-header">
+						<div className="purchases-list__site-icon">
+							<Gridicon icon="globe" />
+						</div>
+						<div className="purchases-list__site-info">
+							<div className="purchases-list__site-title">{ site.name }</div>
+							<div className="purchases-list__site-domain">{ site.domain }</div>
+						</div>
+					</CompactCard>
 
 					{ site.subscriptions.map( ( subscription ) => (
 						<MembershipItem subscription={ subscription } key={ subscription.ID } />

--- a/client/me/purchases/purchases-list/style.scss
+++ b/client/me/purchases/purchases-list/style.scss
@@ -1,0 +1,52 @@
+.purchases-list__site-header {
+	padding: 11px 24px;
+	display: flex;
+
+	.purchases-list__site-icon {
+		background: var( --color-neutral-10 );
+		display: inline-block;
+		height: 32px;
+		width: 32px;
+		line-height: 32px;
+		font-size: 2rem;
+		margin-right: 12px;
+		text-align: center;
+		vertical-align: middle;
+		position: relative;
+		overflow: hidden;
+		align-self: flex-start;
+		flex: 0 0 auto;
+
+		.gridicon {
+			color: var( --color-surface );
+		}
+	}
+
+	.purchases-list__site-info {
+		width: 0;
+		flex: 1 0 auto;
+	}
+
+	.purchases-list__site-title,
+	.purchases-list__site-domain {
+		overflow: hidden;
+		white-space: nowrap;
+	}
+
+	.purchases-list__site-title {
+		color: var( --color-text );
+		display: block;
+		font-size: 0.875rem;
+		font-weight: 400;
+		line-height: 1.3;
+	}
+
+	.purchases-list__site-domain {
+		color: var( --color-text-subtle );
+		display: block;
+		max-width: 95%;
+		font-size: 0.75rem;
+		line-height: 1.4;
+		margin-top: 2px;
+	}
+}

--- a/client/state/memberships/subscriptions/selectors.js
+++ b/client/state/memberships/subscriptions/selectors.js
@@ -1,27 +1,18 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import 'calypso/state/memberships/init';
 
 export function getAllSubscriptions( state ) {
-	return get( state, [ 'memberships', 'subscriptions', 'items' ] );
+	return state.memberships?.subscriptions?.items || [];
 }
 
 export function getSubscription( state, subscriptionId ) {
-	return ( getAllSubscriptions( state ) ?? [] )
+	return getAllSubscriptions( state )
 		.filter( ( sub ) => sub.ID === subscriptionId )
 		.pop();
 }
 
 export function getStoppingStatus( state, subscriptionId ) {
-	return get(
-		state,
-		[ 'memberships', 'subscriptions', 'stoppingSubscription', subscriptionId ],
-		false
-	);
+	return state?.memberships?.subscriptions?.stoppingSubscription[ subscriptionId ] || false;
 }


### PR DESCRIPTION
This adds membership subscriptions to the purchase list under `/me/purchases`.

Fixes #46604

<img width="652" alt="Screen Shot 2020-10-22 at 1 47 40 PM" src="https://user-images.githubusercontent.com/942359/96921914-29d19280-147d-11eb-8d79-b5be866e5e37.png">

**To do:**
- [x] Add subscription site header with site icon (update: using a fallback icon for now and will address site icons in another PR)
- [x] Update back button on membership detail page
- [x] Update types

**To test:**
- On a site with membership subscriptions (ping me if you need one):
- Visit _Me > Manage Purchase_
- Verify that membership subscriptions are shown on the same screen (at the bottom) as your own site's purchases
- Click on a membership subscription
- Verify that the subscription details page is unchanged
- Click "back"
- Verify that you're taken back to `/me/purchases` (I'm not making this conditional, since we'll be removing Other Sites as part of the next PR)