### PR TITLE
Jetpack Backup: Center align restore button on mobile.

### DIFF
--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -69,12 +69,18 @@ const RestoreButton = ( { disabled, rewindId } ) => {
 			disabled={ ! canRestore }
 			onClick={ onRestore }
 		>
-			<div className="daily-backup-status__restore-button-icon">
-				{ needsCredentials && ! isEnabled( 'jetpack/backup-simplified-screens' ) && (
-					<img src={ missingCredentialsIcon } alt="" role="presentation" />
-				) }
-				<div>{ translate( 'Restore to this point' ) }</div>
-			</div>
+			{ needsCredentials && ! isEnabled( 'jetpack/backup-simplified-screens' ) ? (
+				<div className="daily-backup-status__restore-button-icon">
+					{ needsCredentials && ! isEnabled( 'jetpack/backup-simplified-screens' ) && (
+						<img src={ missingCredentialsIcon } alt="" role="presentation" />
+					) }
+					<div>{ translate( 'Restore to this point' ) }</div>
+				</div>
+			) : (
+				<div className="daily-backup-status__restore-button">
+					<div>{ translate( 'Restore to this point' ) }</div>
+				</div>
+			) }
 		</Button>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/style.scss
+++ b/client/components/jetpack/daily-backup-status/style.scss
@@ -14,6 +14,7 @@
 }
 
 .form-button.daily-backup-status__restore-button img {
+	display: none;
 	width: 22px;
 	height: 22px;
 	filter: grayscale( 100% ) contrast( 70% );
@@ -21,8 +22,9 @@
 
 .daily-backup-status__restore-button-icon {
 	display: flex;
-	justify-content: flex-start;
+	justify-content: center;
 	align-items: center;
+	padding-right: 10px;
 }
 
 .daily-backup-status__download-button {
@@ -215,7 +217,12 @@
 		padding-right: 2rem;
 	}
 
+	.daily-backup-status__restore-button-icon {
+		justify-content: flex-start;
+	}
+
 	.form-button.daily-backup-status__restore-button img {
+		display: inline-block;
 		margin-right: 1rem;
 	}
 
@@ -223,7 +230,6 @@
 		padding: 0;
 	}
 }
-
 
 /* Jetpack Cloud-specific rules */
 .is_jetpackcom .daily-backup-status {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR center aligns the "Restore to this point" button on mobile screens.

**BEFORE: (Restore button is left aligned)**
![Markup 2020-10-22 at 09 40 49](https://user-images.githubusercontent.com/11078128/96905065-cdef1580-144c-11eb-8046-e125e18b9b8e.png)

![Markup 2020-10-22 at 09 37 55](https://user-images.githubusercontent.com/11078128/96905120-e3fcd600-144c-11eb-9e7e-58b7dc429f6c.png)

#### AFTER: Restore button is centered
![Screenshot on 2020-10-22 at 09-39-24](https://user-images.githubusercontent.com/11078128/96905407-42c24f80-144d-11eb-8c1b-3407d812456c.png)
![Screenshot on 2020-10-22 at 09-38-53](https://user-images.githubusercontent.com/11078128/96905423-4655d680-144d-11eb-96fb-c6c7038797d9.png)

### Testing instructions
1. Run this PR (Calypso Blue and Calypso Green builds)
2. Go to jetpack.cloud.localhost:3001/backup/:site
3. Trigger mobile view in developer tools and verify that the "Restore to this point" button text is center aligned.
4. Repeat the same check in Calypso blue.

Also check previous feature flag iteration:
(The button was incorrectly left-aligned on mobile in the previous iteration too.)
 
1. Same checks above but with `?flags=-jetpack/backup-simplified-screens`   ( notice the minus sign(-) before the feature flag )  We're turning the flag OFF.

**BEFORE:**
![Markup 2020-10-22 at 09 36 10](https://user-images.githubusercontent.com/11078128/96906773-27f0da80-144f-11eb-8fc6-470fdb51b6ce.png)

**AFTER:**
![Markup 2020-10-22 at 09 35 41](https://user-images.githubusercontent.com/11078128/96906793-2e7f5200-144f-11eb-91dc-a8130e6ab828.png)
