### PR TITLE
Jetpack Backup: Center align restore button on mobile.

### DIFF
--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -65,9 +65,7 @@ const RestoreButton = ( { disabled, rewindId } ) => {
 			disabled={ ! canRestore }
 			onClick={ onRestore }
 		>
-			<div className="daily-backup-status__restore-button-icon">
-				<div>{ translate( 'Restore to this point' ) }</div>
-			</div>
+			{ translate( 'Restore to this point' ) }
 		</Button>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/style.scss
+++ b/client/components/jetpack/daily-backup-status/style.scss
@@ -13,18 +13,6 @@
 	margin-left: 0;
 }
 
-.form-button.daily-backup-status__restore-button img {
-	width: 22px;
-	height: 22px;
-	filter: grayscale( 100% ) contrast( 70% );
-}
-
-.daily-backup-status__restore-button-icon {
-	display: flex;
-	justify-content: flex-start;
-	align-items: center;
-}
-
 .daily-backup-status__download-button {
 	margin: 24px 0 1rem;
 	color: var( --studio-jetpack-green-60 );
@@ -215,15 +203,10 @@
 		padding-right: 2rem;
 	}
 
-	.form-button.daily-backup-status__restore-button img {
-		margin-right: 1rem;
-	}
-
 	.daily-backup-status__credentials-warning {
 		padding: 0;
 	}
 }
-
 
 /* Jetpack Cloud-specific rules */
 .is_jetpackcom .daily-backup-status {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR center aligns the "Restore to this point" button on mobile screens.

**BEFORE: (Restore button is left aligned)**
![Markup 2020-10-22 at 09 40 49](https://user-images.githubusercontent.com/11078128/96905065-cdef1580-144c-11eb-8046-e125e18b9b8e.png)

![Markup 2020-10-22 at 09 37 55](https://user-images.githubusercontent.com/11078128/96905120-e3fcd600-144c-11eb-9e7e-58b7dc429f6c.png)

#### AFTER: Restore button is centered
![Screenshot on 2020-10-22 at 09-39-24](https://user-images.githubusercontent.com/11078128/96905407-42c24f80-144d-11eb-8c1b-3407d812456c.png)
![Screenshot on 2020-10-22 at 09-38-53](https://user-images.githubusercontent.com/11078128/96905423-4655d680-144d-11eb-96fb-c6c7038797d9.png)

### Testing instructions
1. Run this PR (Calypso Blue and Calypso Green builds)
2. Go to jetpack.cloud.localhost:3001/backup/:site
3. Trigger mobile view in developer tools and verify that the "Restore to this point" button text is center aligned.
4. Repeat the same check in Calypso blue.