### PR TITLE
Adds notice for users who are visiting from a different timezone

### DIFF
--- a/client/blocks/time-mismatch-warning/README.md
+++ b/client/blocks/time-mismatch-warning/README.md
@@ -7,11 +7,11 @@ Nothing will appear if we don't detect a discrepancy.
 ## How to use
 
 ```jsx
-import TimeMismatchWarning from 'blocks/time-mismatch-warning';
+import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 
 const Test = () => (
 	<>
-		<TimeMismatchWarning />
+		<TimeMismatchWarning siteId={ 1234 } />
 		<ListWithTimes />
 	</>
 );
@@ -19,4 +19,6 @@ const Test = () => (
 
 ## Props
 
-There is only one prop: `status`. This is optional, and allows overriding the notice status. See the `Notice` component for allowed values.
+There are two props:
+- `siteId`: Site ID to check.
+- `status`: This is optional, and allows overriding the notice status. See the `Notice` component for allowed values.

--- a/client/blocks/time-mismatch-warning/index.tsx
+++ b/client/blocks/time-mismatch-warning/index.tsx
@@ -34,9 +34,9 @@ export const TimeMismatchWarning: FC< ExternalProps > = ( {
 	return (
 		<Notice status={ status }>
 			{ translate(
-				'Looks like your computer time and site time don’t match! ' +
-					'We’re going to show you times based on your site. ' +
-					'If that doesn’t look right, you can {{SiteSettings}}go here to update it{{/SiteSettings}}.',
+				'This page reflects the time zone set on your site. ' +
+					'It looks like that does not match your current time zone. ' +
+					'{{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.',
 				{
 					components: {
 						SiteSettings: <a href={ settingsUrl } />,

--- a/client/blocks/time-mismatch-warning/index.tsx
+++ b/client/blocks/time-mismatch-warning/index.tsx
@@ -24,7 +24,7 @@ export const TimeMismatchWarning: FC< ExternalProps > = ( {
 	const translate = useTranslate();
 	const siteSlug = useSelector( ( state ) => siteId && getSiteSlug( state, siteId ) );
 	const settingsUrl = siteSlug ? `/settings/general/${ siteSlug }` : '#';
-	const userOffset = new Date().getTimezoneOffset() / 60;
+	const userOffset = new Date().getTimezoneOffset() / -60; // Negative as function returns minutes *behind* UTC.
 	const siteOffset = useSelector( ( state ) => siteId && getSiteGmtOffset( state, siteId ) );
 
 	if ( ! siteId || siteOffset === null || userOffset === siteOffset ) {

--- a/client/blocks/time-mismatch-warning/index.tsx
+++ b/client/blocks/time-mismatch-warning/index.tsx
@@ -9,34 +9,25 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import Notice from 'calypso/components/notice';
-import { withApplySiteOffset, applySiteOffsetType } from 'calypso/components/site-offset';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
-
-/**
- * Type dependencies
- */
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-
-interface ConnectedProps {
-	applySiteOffset: applySiteOffsetType;
-}
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
 
 interface ExternalProps {
 	status?: string;
+	siteId?: number;
 }
 
-export const TimeMismatchWarning: FC< ExternalProps & ConnectedProps > = ( {
-	applySiteOffset,
+export const TimeMismatchWarning: FC< ExternalProps > = ( {
 	status = 'is-warning',
-}: ExternalProps & ConnectedProps ) => {
+	siteId,
+}: ExternalProps ) => {
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
-	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteSlug = useSelector( ( state ) => siteId && getSiteSlug( state, siteId ) );
 	const settingsUrl = siteSlug ? `/settings/general/${ siteSlug }` : '#';
-	const now = moment();
-	const siteOffset = applySiteOffset( now );
+	const userOffset = new Date().getTimezoneOffset() / 60;
+	const siteOffset = useSelector( ( state ) => siteId && getSiteGmtOffset( state, siteId ) );
 
-	if ( ! siteOffset || now.isSame( siteOffset ) ) {
+	if ( ! siteId || siteOffset === null || userOffset === siteOffset ) {
 		return null;
 	}
 
@@ -56,4 +47,4 @@ export const TimeMismatchWarning: FC< ExternalProps & ConnectedProps > = ( {
 	);
 };
 
-export default withApplySiteOffset( TimeMismatchWarning );
+export default TimeMismatchWarning;

--- a/client/blocks/time-mismatch-warning/index.tsx
+++ b/client/blocks/time-mismatch-warning/index.tsx
@@ -11,6 +11,7 @@ import { useTranslate } from 'i18n-calypso';
 import Notice from 'calypso/components/notice';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
+import { preventWidows } from 'calypso/lib/formatting';
 
 interface ExternalProps {
 	status?: string;
@@ -33,15 +34,17 @@ export const TimeMismatchWarning: FC< ExternalProps > = ( {
 
 	return (
 		<Notice status={ status }>
-			{ translate(
-				'This page reflects the time zone set on your site. ' +
-					'It looks like that does not match your current time zone. ' +
-					'{{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.',
-				{
-					components: {
-						SiteSettings: <a href={ settingsUrl } />,
-					},
-				}
+			{ preventWidows(
+				translate(
+					'This page reflects the time zone set on your site. ' +
+						'It looks like that does not match your current time zone. ' +
+						'{{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.',
+					{
+						components: {
+							SiteSettings: <a href={ settingsUrl } />,
+						},
+					}
+				)
 			) }
 		</Notice>
 	);

--- a/client/blocks/time-mismatch-warning/test/index.jsx
+++ b/client/blocks/time-mismatch-warning/test/index.jsx
@@ -47,7 +47,7 @@ describe( 'TimeMismatchWarning', () => {
 		<Localized(Notice)
 		  status="is-warning"
 		>
-		  Looks like your computer time and site time don’t match! We’re going to show you times based on your site. If that doesn’t look right, you can {{SiteSettings}}go here to update it{{/SiteSettings}}.
+		  This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.
 		</Localized(Notice)>
 	` );
 	} );

--- a/client/blocks/time-mismatch-warning/test/index.jsx
+++ b/client/blocks/time-mismatch-warning/test/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-irregular-whitespace */
 /**
  * External dependencies
  */
@@ -47,7 +48,7 @@ describe( 'TimeMismatchWarning', () => {
 		<Localized(Notice)
 		  status="is-warning"
 		>
-		  This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.
+		  This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.
 		</Localized(Notice)>
 	` );
 	} );

--- a/client/blocks/time-mismatch-warning/test/index.jsx
+++ b/client/blocks/time-mismatch-warning/test/index.jsx
@@ -18,12 +18,12 @@ jest.mock( 'i18n-calypso', () => ( {
 	...jest.requireActual( 'i18n-calypso' ),
 	useTranslate: jest.fn( () => ( text ) => text ),
 } ) );
-jest.mock( 'calypso/state/selectors/get-site-gmt-offset', () => jest.fn( () => 0 ) );
+jest.mock( 'calypso/state/selectors/get-site-gmt-offset', () => jest.fn( () => -4 ) );
 jest.mock( 'calypso/state/sites/selectors/get-site-slug', () => jest.fn( () => 'wordpress.test' ) );
 
 describe( 'TimeMismatchWarning', () => {
 	beforeAll( () => {
-		jest.spyOn( global, 'Date' ).mockImplementation( () => ( { getTimezoneOffset: () => 0 } ) );
+		jest.spyOn( global, 'Date' ).mockImplementation( () => ( { getTimezoneOffset: () => 240 } ) );
 	} );
 
 	afterAll( () => {

--- a/client/blocks/time-mismatch-warning/test/index.jsx
+++ b/client/blocks/time-mismatch-warning/test/index.jsx
@@ -3,32 +3,46 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
-import moment from 'moment';
 
 /**
  * Internal dependencies
  */
 import { TimeMismatchWarning } from '../index';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 
 jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
-	useSelector: jest.fn(),
+	useSelector: jest.fn( ( func ) => func() ),
 } ) );
 jest.mock( 'i18n-calypso', () => ( {
 	...jest.requireActual( 'i18n-calypso' ),
 	useTranslate: jest.fn( () => ( text ) => text ),
 } ) );
+jest.mock( 'calypso/state/selectors/get-site-gmt-offset', () => jest.fn( () => 0 ) );
+jest.mock( 'calypso/state/sites/selectors/get-site-slug', () => jest.fn( () => 'wordpress.test' ) );
 
 describe( 'TimeMismatchWarning', () => {
-	test( 'to render nothing if times match', () => {
-		const wrapper = shallow( <TimeMismatchWarning applySiteOffset={ noop } /> );
+	beforeAll( () => {
+		jest.spyOn( global, 'Date' ).mockImplementation( () => ( { getTimezoneOffset: () => 0 } ) );
+	} );
+
+	afterAll( () => {
+		jest.spyOn( global, 'Date' ).mockRestore();
+	} );
+
+	test( 'to render nothing if no site ID is provided', () => {
+		const wrapper = shallow( <TimeMismatchWarning /> );
 		expect( wrapper.isEmptyRender() ).toBeTruthy();
 	} );
 
-	test( 'to render if time does not match', () => {
-		const applySiteOffset = () => moment().add( 1, 'hour' );
-		const wrapper = shallow( <TimeMismatchWarning applySiteOffset={ applySiteOffset } /> );
+	test( 'to render nothing if times match', () => {
+		const wrapper = shallow( <TimeMismatchWarning siteId={ 1 } /> );
+		expect( wrapper.isEmptyRender() ).toBeTruthy();
+	} );
+
+	test( 'to render if GMT offsets do not match', () => {
+		getSiteGmtOffset.mockReturnValueOnce( 10 );
+		const wrapper = shallow( <TimeMismatchWarning siteId={ 1 } /> );
 		expect( wrapper ).toMatchInlineSnapshot( `
 		<Localized(Notice)
 		  status="is-warning"

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -29,6 +29,7 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 
 /**
  * Style dependencies
@@ -95,6 +96,7 @@ const ActivityLogV2: FunctionComponent = () => {
 			<DocumentHead title={ translate( 'Activity log' ) } />
 			<SidebarNavigation />
 			<PageViewTracker path="/activity-log/:site" title="Activity log" />
+			<TimeMismatchWarning siteId={ siteId } />
 			{ isJetpackCloud() ? (
 				jetpackCloudHeader
 			) : (

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -75,6 +75,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 
 /**
  * Style dependencies
@@ -550,6 +551,7 @@ class ActivityLog extends Component {
 				<DocumentHead title={ translate( 'Activity' ) } />
 				{ siteId && <QueryRewindState siteId={ siteId } /> }
 				{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
+				{ siteId && <TimeMismatchWarning siteId={ siteId } /> }
 				{ '' !== rewindNoThanks && rewindIsNotReady
 					? siteId && <ActivityLogSwitch siteId={ siteId } redirect={ rewindNoThanks } />
 					: this.getActivityLog() }

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -57,6 +57,7 @@ import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabiliti
 import { emptyFilter } from 'calypso/state/activity-log/reducer';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import BackupCard from 'calypso/components/jetpack/backup-card';
+import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 
 /**
  * Style dependencies
@@ -364,6 +365,7 @@ class BackupsPage extends Component {
 					} ) }
 				>
 					<SidebarNavigation />
+					<TimeMismatchWarning siteId={ this.props.siteId } />
 					{ ! isJetpackCloud() && (
 						<FormattedHeader headerText="Jetpack Backup" align="left" brandFont />
 					) }

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -38,6 +38,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { triggerScanRun } from 'calypso/lib/jetpack/trigger-scan-run';
 import { withApplySiteOffset, applySiteOffsetType } from 'calypso/components/site-offset';
 import ScanNavigation from './navigation';
+import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 
 /**
  * Type dependencies
@@ -280,6 +281,7 @@ class ScanPage extends Component< Props > {
 				<DocumentHead title="Scan" />
 				<SidebarNavigation />
 				<PageViewTracker path="/scan/:site" title="Scanner" />
+				<TimeMismatchWarning siteId={ siteId } />
 				{ ! isJetpackPlatform && (
 					<FormattedHeader headerText={ 'Jetpack Scan' } align="left" brandFont />
 				) }

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -40,6 +40,11 @@ import { withApplySiteOffset, applySiteOffsetType } from 'calypso/components/sit
 import ScanNavigation from './navigation';
 
 /**
+ * Type dependencies
+ */
+import type { utc } from 'moment';
+
+/**
  * Style dependencies
  */
 import './style.scss';
@@ -56,11 +61,11 @@ interface Props {
 	timezone: string | null;
 	gmtOffset: number | null;
 	moment: {
-		utc: Function;
+		utc: typeof utc;
 	};
 	applySiteOffset: applySiteOffsetType;
-	dispatchRecordTracksEvent: Function;
-	dispatchScanRun: Function;
+	dispatchRecordTracksEvent: ( arg0: string, arg1: Record< string, unknown > ) => null;
+	dispatchScanRun: ( arg0: number ) => null;
 	isAdmin: boolean;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Implements `TimeMismatchNotice` block to Activity Log, Scan, and Backup pages in both Calypso and Jetpack sites.
This notice appears when a person's browser clock is different from the timezone set for the site. It notifies people about the discrepancy so they are aware when a time appears "in the future".

Note the link in the screenshot goes to the site settings page to set the timezone.

#### Screenshots
<img width="1083" alt="Screen Shot 2020-10-22 at 1 07 36 PM" src="https://user-images.githubusercontent.com/1760168/96909869-9db76f00-146c-11eb-9f80-c8f3cf7eb433.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Connect to a Jetpack site and set the timezone to one not your own.
* Visit the Activity Log, Scan, and Backup pages (purchasing plans if needed) to verify notice appears.
* Verify link is correct.

Fixes 1164141197617539-as-1185886809463829.
