### PR TITLE
Earn: show title of subscriber plans

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -406,10 +406,11 @@ class MembershipsSection extends Component {
 			} );
 		} else if ( subscriber.plan.renew_interval === '1 year' ) {
 			return this.props.translate(
-				'Paying %(amount)s/year since %(formattedDate)s. Total of %(total)s.',
+				'Paying %(amount)s/year%(title)ssince %(formattedDate)s. Total of %(total)s.',
 				{
 					args: {
 						amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
+						title: subscriber.plan.title ? ` (${ subscriber.plan.title }) ` : '',
 						formattedDate: this.props.moment( subscriber.start_date ).format( 'll' ),
 						total: formatCurrency( subscriber.all_time_total, subscriber.plan.currency ),
 					},
@@ -417,10 +418,11 @@ class MembershipsSection extends Component {
 			);
 		} else if ( subscriber.plan.renew_interval === '1 month' ) {
 			return this.props.translate(
-				'Paying %(amount)s/month since %(formattedDate)s. Total of %(total)s.',
+				'Paying %(amount)s/month%(title)ssince %(formattedDate)s. Total of %(total)s.',
 				{
 					args: {
 						amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
+						title: subscriber.plan.title ? ` (${ subscriber.plan.title }) ` : '',
 						formattedDate: this.props.moment( subscriber.start_date ).format( 'll' ),
 						total: formatCurrency( subscriber.all_time_total, subscriber.plan.currency ),
 					},

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -397,34 +397,50 @@ class MembershipsSection extends Component {
 	}
 
 	renderSubscriberSubscriptionSummary( subscriber ) {
+		const title = subscriber.plan.title ? ` (${ subscriber.plan.title }) ` : ' ';
 		if ( subscriber.plan.renew_interval === 'one-time' ) {
-			return this.props.translate( 'Paid %(amount)s once on %(formattedDate)s', {
+			/* translators: Information about a one-time payment made by a subscriber to a site owner.
+				%(amount)s - the amount paid,
+				%(formattedDate) - the date it was paid
+				%(title) - description of the payment plan, or a blank space if no description available. */
+			return this.props.translate( 'Paid %(amount)s once on %(formattedDate)s%(title)s', {
 				args: {
 					amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
 					formattedDate: this.props.moment( subscriber.start_date ).format( 'll' ),
+					title,
 				},
 			} );
 		} else if ( subscriber.plan.renew_interval === '1 year' ) {
+			/* translators: Information about a recurring yearly payment made by a subscriber to a site owner.
+				%(amount)s - the amount paid,
+				%(formattedDate)s - the date it was first paid
+				%(title)s - description of the payment plan, or a blank space if no description available
+				%(total)s - the total amount subscriber has paid thus far */
 			return this.props.translate(
 				'Paying %(amount)s/year%(title)ssince %(formattedDate)s. Total of %(total)s.',
 				{
 					args: {
 						amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
-						title: subscriber.plan.title ? ` (${ subscriber.plan.title }) ` : '',
 						formattedDate: this.props.moment( subscriber.start_date ).format( 'll' ),
 						total: formatCurrency( subscriber.all_time_total, subscriber.plan.currency ),
+						title,
 					},
 				}
 			);
 		} else if ( subscriber.plan.renew_interval === '1 month' ) {
+			/* translators: Information about a recurring monthly payment made by a subscriber to a site owner.
+				%(amount)s - the amount paid,
+				%(formattedDate)s - the date it was first paid
+				%(title)s - description of the payment plan, or a blank space if no description available
+				%(total)s - the total amount subscriber has paid thus far */
 			return this.props.translate(
 				'Paying %(amount)s/month%(title)ssince %(formattedDate)s. Total of %(total)s.',
 				{
 					args: {
 						amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
-						title: subscriber.plan.title ? ` (${ subscriber.plan.title }) ` : '',
 						formattedDate: this.props.moment( subscriber.start_date ).format( 'll' ),
 						total: formatCurrency( subscriber.all_time_total, subscriber.plan.currency ),
+						title,
 					},
 				}
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds extra text to a user's list of active subscribers, indicating which subscription plan the subscription applies to. This makes it easier to distinguish between subscribers of different plans with the same price.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the store and connect your account to Stripe via the steps described in PCYsg-lW4-p2, "Sandbox method"
* Navigate to `/earn/payments-plans/{siteId}` and add two new monthly payment plans with the same price but different descriptions.
* Create a post with two Premium Content blocks, each associated with one of the new payment plans.
* From another account, visit the post and subscribe to both payment plans.
    * Use one of the test credit card numbers from the above FG page.
* On your original account, navigate to `/earn/payments/{siteId}`. You should see both of your new subscriptions with the description attached to each, indicating which is which.
* Repeat the above with yearly instead of monthly payment plans.

Before:

![image](https://user-images.githubusercontent.com/13437011/96920710-1c170f80-1473-11eb-96aa-caf409d61855.png)

After:

![image](https://user-images.githubusercontent.com/13437011/96920730-276a3b00-1473-11eb-9897-22db1ee9aed3.png)

Fixes #46157
