### PR TITLE
Billing: update membership subscription detail design

### DIFF
--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
@@ -16,7 +16,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
 import HeaderCake from 'calypso/components/header-cake';
 import { purchasesRoot } from '../purchases/paths';
-import Site from 'calypso/blocks/site';
+import MembershipSiteHeader from '../purchases/membership-site/header';
 import Gridicon from 'calypso/components/gridicon';
 import { requestSubscriptionStop } from 'calypso/state/memberships/subscriptions/actions';
 import Notice from 'calypso/components/notice';
@@ -45,9 +45,7 @@ class Subscription extends React.Component {
 				<MeSidebarNavigation />
 				<QueryMembershipsSubscriptions />
 				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-				<HeaderCake backHref={ purchasesRoot }>
-					{ subscription ? subscription.title : translate( 'All subscriptions' ) }
-				</HeaderCake>
+				<HeaderCake backHref={ purchasesRoot }>{ translate( 'Subscription Details' ) }</HeaderCake>
 				{ stoppingStatus === 'start' && (
 					<Notice
 						status="is-info"
@@ -69,48 +67,46 @@ class Subscription extends React.Component {
 				) }
 
 				{ subscription && (
-					<div>
+					<>
 						<Card className="memberships__subscription-meta">
-							<Site siteId={ parseInt( subscription.site_id ) } href={ subscription.site_url } />
-							<div className="memberships__subscription-title">{ subscription.title }</div>
-							<Fragment>
-								<ul className="memberships__subscription-inner-meta">
-									<li>
-										<em className="memberships__subscription-inner-detail-label">
-											{ translate( 'Price' ) }
-										</em>
-										<span className="memberships__subscription-inner-detail">
-											{ formatCurrency( subscription.renewal_price, subscription.currency ) }
-										</span>
-									</li>
-									<li>
-										<em className="memberships__subscription-inner-detail-label">
-											{ translate( 'Renew interval' ) }
-										</em>
-										<span className="memberships__subscription-inner-detail">
-											{ subscription.renew_interval || '-' }
-										</span>
-									</li>
-									<li>
-										<em className="memberships__subscription-inner-detail-label">
-											{ translate( 'Subscribed On' ) }
-										</em>
-										<span className="memberships__subscription-inner-detail">
-											{ moment( subscription.start_date ).format( 'll' ) }
-										</span>
-									</li>
-									<li>
-										<em className="memberships__subscription-inner-detail-label">
-											{ translate( 'Renews on' ) }
-										</em>
-										<span className="memberships__subscription-inner-detail">
-											{ subscription.end_date
-												? moment( subscription.end_date ).format( 'll' )
-												: translate( 'Never Expires' ) }
-										</span>
-									</li>
-								</ul>
-							</Fragment>
+							<MembershipSiteHeader
+								name={ subscription.site_title }
+								domain={ subscription.site_url }
+							/>
+							<div className="memberships__subscription-header">
+								<div className="memberships__subscription-title">{ subscription.title }</div>
+								<div className="memberships__subscription-price">
+									{ formatCurrency( subscription.renewal_price, subscription.currency ) }
+								</div>
+							</div>
+							<ul className="memberships__subscription-inner-meta">
+								<li>
+									<em className="memberships__subscription-inner-detail-label">
+										{ translate( 'Renew interval' ) }
+									</em>
+									<span className="memberships__subscription-inner-detail">
+										{ subscription.renew_interval || '-' }
+									</span>
+								</li>
+								<li>
+									<em className="memberships__subscription-inner-detail-label">
+										{ translate( 'Subscribed On' ) }
+									</em>
+									<span className="memberships__subscription-inner-detail">
+										{ moment( subscription.start_date ).format( 'll' ) }
+									</span>
+								</li>
+								<li>
+									<em className="memberships__subscription-inner-detail-label">
+										{ translate( 'Renews on' ) }
+									</em>
+									<span className="memberships__subscription-inner-detail">
+										{ subscription.end_date
+											? moment( subscription.end_date ).format( 'll' )
+											: translate( 'Never Expires' ) }
+									</span>
+								</li>
+							</ul>
 						</Card>
 						<CompactCard
 							tagName="button"
@@ -120,7 +116,7 @@ class Subscription extends React.Component {
 							<Gridicon icon="trash" />
 							{ translate( 'Stop %s subscription.', { args: subscription.title } ) }
 						</CompactCard>
-					</div>
+					</>
 				) }
 			</Main>
 		);

--- a/client/me/memberships/subscription.scss
+++ b/client/me/memberships/subscription.scss
@@ -91,14 +91,29 @@
 	}
 }
 
+.memberships__subscription-header {
+	padding: 16px 24px;
+}
+
 .memberships__subscription-title {
-	color: var( --color-primary );
-	display: block;
-	font-size: $font-title-small;
-	line-height: 1.2em;
-	padding: 20px;
-	white-space: nowrap;
-	text-align: center;
+	color: var( --color-text );
+    display: block;
+    font-size: 1.25rem;
+    font-weight: 400;
+	clear: none;
+}
+
+.memberships__subscription-price {
+	margin: 0;
+    font-size: 1.5rem;
+    line-height: 1.5;
+	color: var( --color-neutral-70 );
+
+	&::first-letter {
+		color: var( --color-text-subtle );
+		vertical-align: super;
+		font-size: 0.75rem;
+	}
 }
 
 .memberships__subscription-remove {


### PR DESCRIPTION
This PR updates the detail view of individual membership subscription details to look more like the detail pages for other purchases. In #46683, we're combining the two into a single screen.

This includes the changes from #46683 (they'll be rebased out after it merges). The changes specific to this PR are all in 8611ab1.

Fixes #46723

**Before:**
<img width="899" alt="Screen Shot 2020-10-22 at 4 15 05 PM" src="https://user-images.githubusercontent.com/942359/96925687-897e6c80-1482-11eb-8954-fed4d9507746.png">

**After:**
<img width="899" alt="Screen Shot 2020-10-22 at 4 14 36 PM" src="https://user-images.githubusercontent.com/942359/96925703-900ce400-1482-11eb-9947-2badd54ef809.png">

**To test:**
- On a site with membership subscriptions (ping me if you need one):
- Visit _Me > Manage Purchases_
- Click on membership subscription
- Verify that the details page matches the screenshot above (depending on the type of subscription)
