### PR TITLE
Billing management: deprecate the "Other Sites" tab

### DIFF
--- a/client/me/memberships/controller.js
+++ b/client/me/memberships/controller.js
@@ -3,13 +3,7 @@
  */
 
 import React from 'react';
-import BillingHistoryComponent from './main';
 import Subscription from './subscription';
-
-export function myMemberships( context, next ) {
-	context.primary = React.createElement( BillingHistoryComponent );
-	next();
-}
 
 export function subscription( context, next ) {
 	const subscriptionId = context.params.subscriptionId;

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -52,7 +52,7 @@ export default ( router ) => {
 		);
 	}
 
-	router( paths.purchasesRoot + '/other', () => page.redirect( paths.purchasesRoot ) );
+	router( paths.deprecated.otherPurchases, () => page.redirect( paths.purchasesRoot ) );
 
 	router(
 		paths.purchasesRoot + '/other/:subscriptionId',

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -52,13 +52,8 @@ export default ( router ) => {
 		);
 	}
 
-	router(
-		paths.purchasesRoot + '/other',
-		sidebar,
-		membershipsController.myMemberships,
-		makeLayout,
-		clientRender
-	);
+	router( paths.purchasesRoot + '/other', () => page.redirect( paths.purchasesRoot ) );
+
 	router(
 		paths.purchasesRoot + '/other/:subscriptionId',
 		sidebar,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -40,8 +40,6 @@ export default ( router ) => {
 		clientRender
 	);
 
-	router( paths.deprecated.upcomingCharges, () => page.redirect( paths.purchasesRoot ) );
-
 	if ( config.isEnabled( 'async-payments' ) ) {
 		router(
 			paths.purchasesRoot + '/pending',
@@ -52,8 +50,6 @@ export default ( router ) => {
 		);
 	}
 
-	router( paths.deprecated.otherPurchases, () => page.redirect( paths.purchasesRoot ) );
-
 	router(
 		paths.purchasesRoot + '/other/:subscriptionId',
 		sidebar,
@@ -61,16 +57,20 @@ export default ( router ) => {
 		makeLayout,
 		clientRender
 	);
+
 	// Legacy:
+
+	router( paths.deprecated.upcomingCharges, () => page.redirect( paths.purchasesRoot ) );
+	router( paths.deprecated.otherPurchases, () => page.redirect( paths.purchasesRoot ) );
+
 	router(
 		paths.purchasesRoot + '/memberships/:subscriptionId',
 		( { params: { subscriptionId } } ) => {
 			page.redirect( paths.purchasesRoot + '/other/' + subscriptionId );
 		}
 	);
-	router( paths.purchasesRoot + '/memberships', () =>
-		page.redirect( paths.purchasesRoot + '/other' )
-	);
+
+	router( paths.purchasesRoot + '/memberships', () => page.redirect( paths.purchasesRoot ) );
 
 	router(
 		paths.billingHistoryReceipt( ':receiptId' ),

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -8,8 +8,6 @@ export const paymentMethods = purchasesRoot + '/payment-methods';
 
 export const pendingPayments = purchasesRoot + '/pending';
 
-export const myMemberships = purchasesRoot + '/other';
-
 export function billingHistoryReceipt( receiptId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof receiptId ) {
@@ -70,4 +68,5 @@ export function editCardDetails( siteName, purchaseId, cardId ) {
 
 export const deprecated = {
 	upcomingCharges: purchasesRoot + '/upcoming',
+	otherPurchases: purchasesRoot + '/other',
 };

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -12,13 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import {
-	billingHistory,
-	paymentMethods,
-	pendingPayments,
-	myMemberships,
-	purchasesRoot,
-} from '../../paths.js';
+import { billingHistory, paymentMethods, pendingPayments, purchasesRoot } from '../../paths.js';
 import SectionNav from 'calypso/components/section-nav';
 import config from 'calypso/config';
 import getPastBillingTransactions from 'calypso/state/selectors/get-past-billing-transactions';
@@ -30,8 +24,6 @@ const PurchasesHeader = ( { section, translate } ) => {
 		text = translate( 'Purchases' );
 	} else if ( section === 'pending' ) {
 		text = translate( 'Pending Payments' );
-	} else if ( section === 'memberships' ) {
-		text = translate( 'Other Sites' );
 	} else if ( section === 'payment-methods' ) {
 		text = translate( 'Payment Methods' );
 	}
@@ -56,10 +48,6 @@ const PurchasesHeader = ( { section, translate } ) => {
 						{ translate( 'Pending Payments' ) }
 					</NavItem>
 				) }
-
-				<NavItem path={ myMemberships } selected={ section === 'memberships' }>
-					{ translate( 'Other Sites' ) }
-				</NavItem>
 			</NavTabs>
 		</SectionNav>
 	);

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -16,7 +16,6 @@ import {
 	addCreditCard,
 	billingHistory,
 	pendingPayments,
-	myMemberships,
 	purchasesRoot,
 	deprecated as deprecatedPaths,
 } from 'calypso/me/purchases/paths';
@@ -92,7 +91,7 @@ class MeSidebar extends React.Component {
 			[ addCreditCard ]: 'purchases',
 			[ deprecatedPaths.upcomingCharges ]: 'purchases',
 			[ pendingPayments ]: 'purchases',
-			[ myMemberships ]: 'purchases',
+			[ deprecatedPaths.otherPurchases ]: 'purchases',
 			'/me/chat': 'happychat',
 			'/me/site-blocks': 'site-blocks',
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the Upcoming Charges tab from the account level billing management pages and delete any newly unused code.

#### Testing instructions

* Navigate to `/me/purchases` and verify that there is no "Other Sites" tab in the nav bar.
* Manually load `/me/purchases/upcoming` and verify that you are redirected to `/me/purchases`.

![Screen Shot 2020-10-22 at 4 11 17 PM](https://user-images.githubusercontent.com/9310939/96930404-41127f00-1481-11eb-92b6-1ac08472dea9.png)
