### PR TITLE
Apply autofix for rule `wpcalypso/no-package-relative-imports` in `./client/reader`

### DIFF
--- a/client/reader/a8c/main.jsx
+++ b/client/reader/a8c/main.jsx
@@ -4,18 +4,18 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect, useDispatch } from 'react-redux';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies
  */
-import Stream from 'reader/stream';
+import Stream from 'calypso/reader/stream';
 import { Button } from '@automattic/components';
-import SectionHeader from 'components/section-header';
-import { requestMarkAllAsSeen } from 'state/reader/seen-posts/actions';
-import { SECTION_A8C_FOLLOWING } from 'state/reader/seen-posts/constants';
-import { AUTOMATTIC_ORG_ID } from 'state/reader/organizations/constants';
-import { getReaderOrganizationFeedsInfo } from 'state/reader/organizations/selectors';
+import SectionHeader from 'calypso/components/section-header';
+import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
+import { SECTION_A8C_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
+import { AUTOMATTIC_ORG_ID } from 'calypso/state/reader/organizations/constants';
+import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizations/selectors';
 
 const A8CFollowing = ( props ) => {
 	const { translate } = props;

--- a/client/reader/components/favicon/index.js
+++ b/client/reader/components/favicon/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 function Favicon( props ) {
 	const { site, className, size } = props;

--- a/client/reader/components/reader-infinite-stream/index.jsx
+++ b/client/reader/components/reader-infinite-stream/index.jsx
@@ -16,7 +16,7 @@ import { debounce, noop, get, pickBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { recordTracksRailcarRender } from 'reader/stats';
+import { recordTracksRailcarRender } from 'calypso/reader/stats';
 
 /**
  * Style dependencies

--- a/client/reader/components/reader-infinite-stream/row-renderers.js
+++ b/client/reader/components/reader-infinite-stream/row-renderers.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
 /**
  * Internal Dependencies
  */
-import ConnectedSubscriptionListItem from 'blocks/reader-subscription-list-item/connected';
+import ConnectedSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 
 export const siteRowRenderer = ( {
 	items,

--- a/client/reader/components/reader-main/index.jsx
+++ b/client/reader/components/reader-main/index.jsx
@@ -6,8 +6,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
-import SyncReaderFollows from 'components/data/sync-reader-follows';
+import Main from 'calypso/components/main';
+import SyncReaderFollows from 'calypso/components/data/sync-reader-follows';
 
 /**
  * Style dependencies

--- a/client/reader/components/reader-popover/index.jsx
+++ b/client/reader/components/reader-popover/index.jsx
@@ -8,7 +8,7 @@ import { omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import Popover from 'components/popover';
+import Popover from 'calypso/components/popover';
 
 /**
  * Style dependencies

--- a/client/reader/components/reader-popover/menu.jsx
+++ b/client/reader/components/reader-popover/menu.jsx
@@ -7,8 +7,8 @@ import { omit } from 'lodash';
 /**
  * Internal Dependencies
  */
-import ReaderPopover from 'reader/components/reader-popover';
-import PopoverMenu from 'components/popover/menu';
+import ReaderPopover from 'calypso/reader/components/reader-popover';
+import PopoverMenu from 'calypso/components/popover/menu';
 
 const ReaderPopoverMenu = ( props ) => {
 	const popoverProps = omit( props, 'popoverComponent' );

--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -7,11 +7,11 @@ import moment from 'moment';
 /**
  * Internal Dependencies
  */
-import { recordPageView } from 'lib/analytics/page-view';
-import { gaRecordEvent } from 'lib/analytics/ga';
-import { bumpStat } from 'lib/analytics/mc';
-import { recordTrack } from 'reader/stats';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import { recordPageView } from 'calypso/lib/analytics/page-view';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import { bumpStat } from 'calypso/lib/analytics/mc';
+import { recordTrack } from 'calypso/reader/stats';
+import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 
 export function trackPageLoad( path, title, readerView ) {
 	recordPageView( path, title );

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -8,8 +8,8 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
-import { sectionify } from 'lib/route';
+import { abtest } from 'calypso/lib/abtest';
+import { sectionify } from 'calypso/lib/route';
 import {
 	trackPageLoad,
 	trackUpdatesLoaded,
@@ -17,19 +17,19 @@ import {
 	setPageTitle,
 	getStartDate,
 } from './controller-helper';
-import FeedError from 'reader/feed-error';
-import StreamComponent from 'reader/following/main';
-import { getPrettyFeedUrl, getPrettySiteUrl } from 'reader/route';
-import { recordTrack } from 'reader/stats';
-import { requestFeedDiscovery } from 'state/data-getters';
-import { waitForHttpData } from 'state/data-layer/http-data';
-import AsyncLoad from 'components/async-load';
-import { isFollowingOpen } from 'state/reader-ui/sidebar/selectors';
-import { toggleReaderSidebarFollowing } from 'state/reader-ui/sidebar/actions';
-import { getLastPath } from 'state/reader-ui/selectors';
-import { getSection } from 'state/ui/selectors';
-import { isAutomatticTeamMember } from 'reader/lib/teams';
-import { getReaderTeams } from 'state/reader/teams/selectors';
+import FeedError from 'calypso/reader/feed-error';
+import StreamComponent from 'calypso/reader/following/main';
+import { getPrettyFeedUrl, getPrettySiteUrl } from 'calypso/reader/route';
+import { recordTrack } from 'calypso/reader/stats';
+import { requestFeedDiscovery } from 'calypso/state/data-getters';
+import { waitForHttpData } from 'calypso/state/data-layer/http-data';
+import AsyncLoad from 'calypso/components/async-load';
+import { isFollowingOpen } from 'calypso/state/reader-ui/sidebar/selectors';
+import { toggleReaderSidebarFollowing } from 'calypso/state/reader-ui/sidebar/actions';
+import { getLastPath } from 'calypso/state/reader-ui/selectors';
+import { getSection } from 'calypso/state/ui/selectors';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
 
 const analyticsPageTitle = 'Reader';
 
@@ -117,7 +117,7 @@ const exported = {
 
 	sidebar( context, next ) {
 		context.secondary = (
-			<AsyncLoad require="reader/sidebar" path={ context.path } placeholder={ null } />
+			<AsyncLoad require="calypso/reader/sidebar" path={ context.path } placeholder={ null } />
 		);
 
 		next();
@@ -206,7 +206,7 @@ const exported = {
 
 		context.primary = (
 			<AsyncLoad
-				require="reader/feed-stream"
+				require="calypso/reader/feed-stream"
 				key={ 'feed-' + feedId }
 				streamKey={ 'feed:' + feedId }
 				feedId={ +feedId }
@@ -241,7 +241,7 @@ const exported = {
 
 		context.primary = (
 			<AsyncLoad
-				require="reader/site-stream"
+				require="calypso/reader/site-stream"
 				key={ 'site-' + blogId }
 				streamKey={ streamKey }
 				siteId={ +blogId }
@@ -276,7 +276,7 @@ const exported = {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		context.primary = (
 			<AsyncLoad
-				require="reader/a8c/main"
+				require="calypso/reader/a8c/main"
 				key="read-a8c"
 				className="is-a8c"
 				listName="Automattic"

--- a/client/reader/conversations/controller.js
+++ b/client/reader/conversations/controller.js
@@ -6,10 +6,10 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { sectionify } from 'lib/route';
-import { recordTrack } from 'reader/stats';
-import AsyncLoad from 'components/async-load';
-import { trackPageLoad, trackScrollPage } from 'reader/controller-helper';
+import { sectionify } from 'calypso/lib/route';
+import { recordTrack } from 'calypso/reader/stats';
+import AsyncLoad from 'calypso/components/async-load';
+import { trackPageLoad, trackScrollPage } from 'calypso/reader/controller-helper';
 
 export function conversations( context, next ) {
 	const basePath = sectionify( context.path );
@@ -24,7 +24,7 @@ export function conversations( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
-			require="reader/conversations/stream"
+			require="calypso/reader/conversations/stream"
 			key={ 'conversations' }
 			title="Conversations"
 			streamKey={ streamKey }
@@ -54,7 +54,7 @@ export function conversationsA8c( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
-			require="reader/conversations/stream"
+			require="calypso/reader/conversations/stream"
 			key={ 'conversations' }
 			title="Conversations @ Automattic"
 			streamKey={ streamKey }

--- a/client/reader/conversations/index.js
+++ b/client/reader/conversations/index.js
@@ -7,8 +7,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { conversations, conversationsA8c } from './controller';
-import { initAbTests, sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { initAbTests, sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	page(

--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -4,21 +4,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import QueryPreferences from 'components/data/query-preferences';
-import { savePreference } from 'state/preferences/actions';
-import { getPreference } from 'state/preferences/selectors';
-import { recordTrack } from 'reader/stats';
+import QueryPreferences from 'calypso/components/data/query-preferences';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { recordTrack } from 'calypso/reader/stats';
 
 /**
  * Image dependencies
  */
-import charactersImage from 'assets/images/reader/reader-conversations-characters.svg';
+import charactersImage from 'calypso/assets/images/reader/reader-conversations-characters.svg';
 
 /**
  * Style dependencies

--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -7,10 +7,10 @@ import { get } from 'lodash';
 /**
  * Internal Dependencies
  */
-import Stream from 'reader/stream';
-import DocumentHead from 'components/data/document-head';
+import Stream from 'calypso/reader/stream';
+import DocumentHead from 'calypso/components/data/document-head';
 import ConversationsIntro from './intro';
-import ConversationsEmptyContent from 'blocks/conversations/empty';
+import ConversationsEmptyContent from 'calypso/blocks/conversations/empty';
 
 /**
  * Style dependencies

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -6,11 +6,15 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import { sectionify } from 'lib/route';
-import { recordTrack } from 'reader/stats';
-import { trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
-import AsyncLoad from 'components/async-load';
+import config from 'calypso/config';
+import { sectionify } from 'calypso/lib/route';
+import { recordTrack } from 'calypso/reader/stats';
+import {
+	trackPageLoad,
+	trackUpdatesLoaded,
+	trackScrollPage,
+} from 'calypso/reader/controller-helper';
+import AsyncLoad from 'calypso/components/async-load';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
 
@@ -29,7 +33,7 @@ const exported = {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		context.primary = (
 			<AsyncLoad
-				require="reader/site-stream"
+				require="calypso/reader/site-stream"
 				key={ 'site-' + blogId }
 				streamKey={ streamKey }
 				siteId={ +blogId }

--- a/client/reader/discover/follow-button.jsx
+++ b/client/reader/discover/follow-button.jsx
@@ -8,9 +8,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import FollowButton from 'reader/follow-button';
+import FollowButton from 'calypso/reader/follow-button';
 import { recordFollowToggle } from './stats';
-import { DISCOVER_POST } from 'reader/follow-sources';
+import { DISCOVER_POST } from 'calypso/reader/follow-sources';
 
 class DiscoverFollowButton extends React.Component {
 	static propTypes = {

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -2,16 +2,16 @@
  * External dependencies
  */
 import { find, get } from 'lodash';
-import config from 'config';
+import config from 'calypso/config';
 import Debug from 'debug';
 
 const debug = Debug( 'calypso:reader:discover' ); // eslint-disable-line
 /**
  * Internal Dependencies
  */
-import userUtils from 'lib/user/utils';
-import { getSiteUrl as readerRouteGetSiteUrl } from 'reader/route';
-import { getUrlParts } from 'lib/url';
+import userUtils from 'calypso/lib/user/utils';
+import { getSiteUrl as readerRouteGetSiteUrl } from 'calypso/reader/route';
+import { getUrlParts } from 'calypso/lib/url';
 
 function hasDiscoverSlug( post, searchSlug ) {
 	const metaData = get( post, 'discover_metadata.discover_fp_post_formats' );

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -7,8 +7,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { discover } from './controller';
-import { initAbTests, sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { initAbTests, sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	page( '/discover', updateLastRoute, initAbTests, sidebar, discover, makeLayout, clientRender );

--- a/client/reader/discover/stats.js
+++ b/client/reader/discover/stats.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
 
 export function recordAuthorClick( author ) {
 	recordGaEvent( 'Clicked Discover Card Attribution Author' );

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -8,10 +8,10 @@ import i18n, { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import ReaderMain from 'reader/components/reader-main';
-import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
-import EmptyContent from 'components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
+import EmptyContent from 'calypso/components/empty-content';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
 
 class FeedError extends React.Component {
 	static defaultProps = {

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -7,8 +7,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import EmptyContent from 'components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import EmptyContent from 'calypso/components/empty-content';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
 
 class FeedEmptyContent extends React.PureComponent {
 	recordAction = () => {

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -10,17 +10,17 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import EmptyContent from './empty';
-import DocumentHead from 'components/data/document-head';
-import Stream from 'reader/stream';
-import FeedError from 'reader/feed-error';
-import ReaderFeedHeader from 'blocks/reader-feed-header';
-import QueryReaderSite from 'components/data/query-reader-site';
-import QueryReaderFeed from 'components/data/query-reader-feed';
-import { getSite } from 'state/reader/sites/selectors';
-import { getFeed } from 'state/reader/feeds/selectors';
-import { getSiteName } from 'reader/get-helpers';
-import { isSiteBlocked } from 'state/reader/site-blocks/selectors';
-import SiteBlocked from 'reader/site-blocked';
+import DocumentHead from 'calypso/components/data/document-head';
+import Stream from 'calypso/reader/stream';
+import FeedError from 'calypso/reader/feed-error';
+import ReaderFeedHeader from 'calypso/blocks/reader-feed-header';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import { getSite } from 'calypso/state/reader/sites/selectors';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import { getSiteName } from 'calypso/reader/get-helpers';
+import { isSiteBlocked } from 'calypso/state/reader/site-blocks/selectors';
+import SiteBlocked from 'calypso/reader/site-blocked';
 
 // If the blog_ID of a reader feed is 0, that means no site exists for it.
 const getReaderSiteId = ( feed ) => ( feed && feed.blog_ID === 0 ? null : feed && feed.blog_ID );

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -7,12 +7,12 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FollowButtonContainer from 'blocks/follow-button';
-import FollowButton from 'blocks/follow-button/button';
+import FollowButtonContainer from 'calypso/blocks/follow-button';
+import FollowButton from 'calypso/blocks/follow-button/button';
 import {
 	recordFollow as recordFollowTracks,
 	recordUnfollow as recordUnfollowTracks,
-} from 'reader/stats';
+} from 'calypso/reader/stats';
 
 function ReaderFollowButton( props ) {
 	const { onFollowToggle, railcar, followSource, isButtonOnly, siteUrl } = props;

--- a/client/reader/following-manage/empty.jsx
+++ b/client/reader/following-manage/empty.jsx
@@ -7,8 +7,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import EmptyContent from 'components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import EmptyContent from 'calypso/components/empty-content';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
 
 class FollowingManageEmptyContent extends React.Component {
 	componentDidMount() {

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -6,18 +6,18 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { take, times } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-list-item/placeholder';
-import { READER_FOLLOWING_MANAGE_SEARCH_RESULT } from 'reader/follow-sources';
-import InfiniteStream from 'reader/components/reader-infinite-stream';
-import { siteRowRenderer } from 'reader/components/reader-infinite-stream/row-renderers';
-import { requestFeedSearch } from 'state/reader/feed-searches/actions';
+import ReaderSubscriptionListItemPlaceholder from 'calypso/blocks/reader-subscription-list-item/placeholder';
+import { READER_FOLLOWING_MANAGE_SEARCH_RESULT } from 'calypso/reader/follow-sources';
+import InfiniteStream from 'calypso/reader/components/reader-infinite-stream';
+import { siteRowRenderer } from 'calypso/reader/components/reader-infinite-stream/row-renderers';
+import { requestFeedSearch } from 'calypso/state/reader/feed-searches/actions';
 
 class FollowingManageSearchFeedsResults extends React.Component {
 	static propTypes = {

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -13,38 +13,38 @@ import { stringify } from 'qs';
  * Internal Dependencies
  */
 import { CompactCard } from '@automattic/components';
-import DocumentHead from 'components/data/document-head';
-import SearchInput from 'components/search';
-import HeaderCake from 'components/header-cake';
-import ReaderMain from 'reader/components/reader-main';
-import { getBlockedSites } from 'state/reader/site-blocks/selectors';
-import { getDismissedSites } from 'state/reader/site-dismissals/selectors';
+import DocumentHead from 'calypso/components/data/document-head';
+import SearchInput from 'calypso/components/search';
+import HeaderCake from 'calypso/components/header-cake';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import { getBlockedSites } from 'calypso/state/reader/site-blocks/selectors';
+import { getDismissedSites } from 'calypso/state/reader/site-dismissals/selectors';
 import {
 	getReaderFeedsCountForQuery,
 	getReaderFeedsForQuery,
-} from 'state/reader/feed-searches/selectors';
+} from 'calypso/state/reader/feed-searches/selectors';
 import {
 	getReaderAliasedFollowFeedUrl,
 	getReaderFollowsCount,
-} from 'state/reader/follows/selectors';
+} from 'calypso/state/reader/follows/selectors';
 import {
 	getReaderRecommendedSites,
 	getReaderRecommendedSitesPagingOffset,
-} from 'state/reader/recommended-sites/selectors';
-import QueryReaderFeedsSearch from 'components/data/query-reader-feeds-search';
-import QueryReaderRecommendedSites from 'components/data/query-reader-recommended-sites';
-import RecommendedSites from 'blocks/reader-recommended-sites';
+} from 'calypso/state/reader/recommended-sites/selectors';
+import QueryReaderFeedsSearch from 'calypso/components/data/query-reader-feeds-search';
+import QueryReaderRecommendedSites from 'calypso/components/data/query-reader-recommended-sites';
+import RecommendedSites from 'calypso/blocks/reader-recommended-sites';
 import FollowingManageSubscriptions from './subscriptions';
 import FollowingManageSearchFeedsResults from './feed-search-results';
 import FollowingManageEmptyContent from './empty';
-import FollowButton from 'reader/follow-button';
+import FollowButton from 'calypso/reader/follow-button';
 import {
 	READER_FOLLOWING_MANAGE_URL_INPUT,
 	READER_FOLLOWING_MANAGE_RECOMMENDATION,
-} from 'reader/follow-sources';
-import { resemblesUrl, withoutHttp, addSchemeIfMissing, addQueryArgs } from 'lib/url';
-import { recordTrack, recordAction } from 'reader/stats';
-import { SORT_BY_RELEVANCE } from 'state/reader/feed-searches/actions';
+} from 'calypso/reader/follow-sources';
+import { resemblesUrl, withoutHttp, addSchemeIfMissing, addQueryArgs } from 'calypso/lib/url';
+import { recordTrack, recordAction } from 'calypso/reader/stats';
+import { SORT_BY_RELEVANCE } from 'calypso/state/reader/feed-searches/actions';
 
 /**
  * Style dependencies

--- a/client/reader/following-manage/search-followed.jsx
+++ b/client/reader/following-manage/search-followed.jsx
@@ -9,7 +9,7 @@ import { noop } from 'lodash';
 /**
  * Internal Dependencies
  */
-import SearchCard from 'components/search-card';
+import SearchCard from 'calypso/components/search-card';
 
 class FollowingManageSearchFollowed extends Component {
 	static propTypes = {

--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import FormSelect from 'components/forms/form-select';
+import FormSelect from 'calypso/components/forms/form-select';
 
 class FollowingManageSortControls extends React.Component {
 	static propTypes = {

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -12,22 +12,27 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import ReaderImportButton from 'blocks/reader-import-button';
-import ReaderExportButton from 'blocks/reader-export-button';
-import InfiniteStream from 'reader/components/reader-infinite-stream';
-import { siteRowRenderer } from 'reader/components/reader-infinite-stream/row-renderers';
-import SyncReaderFollows from 'components/data/sync-reader-follows';
+import ReaderImportButton from 'calypso/blocks/reader-import-button';
+import ReaderExportButton from 'calypso/blocks/reader-export-button';
+import InfiniteStream from 'calypso/reader/components/reader-infinite-stream';
+import { siteRowRenderer } from 'calypso/reader/components/reader-infinite-stream/row-renderers';
+import SyncReaderFollows from 'calypso/components/data/sync-reader-follows';
 import FollowingManageSearchFollowed from './search-followed';
 import FollowingManageSortControls from './sort-controls';
-import { getReaderFollows, getReaderFollowsCount } from 'state/reader/follows/selectors';
-import UrlSearch from 'lib/url-search';
-import { getSiteName, getSiteUrl, getSiteDescription, getSiteAuthorName } from 'reader/get-helpers';
-import EllipsisMenu from 'components/ellipsis-menu';
-import PopoverMenuItem from 'components/popover/menu-item';
-import { formatUrlForDisplay, getFeedTitle } from 'reader/lib/feed-display-helper';
-import { addQueryArgs } from 'lib/url';
-import { READER_SUBSCRIPTIONS } from 'reader/follow-sources';
-import { READER_EXPORT_TYPE_SUBSCRIPTIONS } from 'blocks/reader-export-button/constants';
+import { getReaderFollows, getReaderFollowsCount } from 'calypso/state/reader/follows/selectors';
+import UrlSearch from 'calypso/lib/url-search';
+import {
+	getSiteName,
+	getSiteUrl,
+	getSiteDescription,
+	getSiteAuthorName,
+} from 'calypso/reader/get-helpers';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import { formatUrlForDisplay, getFeedTitle } from 'calypso/reader/lib/feed-display-helper';
+import { addQueryArgs } from 'calypso/lib/url';
+import { READER_SUBSCRIPTIONS } from 'calypso/reader/follow-sources';
+import { READER_EXPORT_TYPE_SUBSCRIPTIONS } from 'calypso/blocks/reader-export-button/constants';
 
 class FollowingManageSubscriptions extends Component {
 	static propTypes = {

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -7,9 +7,9 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { sectionify } from 'lib/route';
-import { trackPageLoad, setPageTitle } from 'reader/controller-helper';
-import AsyncLoad from 'components/async-load';
+import { sectionify } from 'calypso/lib/route';
+import { trackPageLoad, setPageTitle } from 'calypso/reader/controller-helper';
+import AsyncLoad from 'calypso/components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
@@ -26,7 +26,7 @@ const exported = {
 
 		context.primary = (
 			<AsyncLoad
-				require="reader/following-manage"
+				require="calypso/reader/following-manage"
 				key="following-manage"
 				initialFollowUrl={ context.query.follow }
 				sitesQuery={ sitesQuery }

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -7,8 +7,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { followingManage } from './controller';
-import { initAbTests, updateLastRoute, sidebar } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { initAbTests, updateLastRoute, sidebar } from 'calypso/reader/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	page( '/following/*', initAbTests );

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -3,25 +3,25 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
  */
-import QueryPreferences from 'components/data/query-preferences';
-import { savePreference } from 'state/preferences/actions';
-import { getPreference } from 'state/preferences/selectors';
-import { recordTrack } from 'reader/stats';
-import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'state/guided-tours/contexts';
-import cssSafeUrl from 'lib/css-safe-url';
+import QueryPreferences from 'calypso/components/data/query-preferences';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { recordTrack } from 'calypso/reader/stats';
+import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
+import cssSafeUrl from 'calypso/lib/css-safe-url';
 
 /**
  * Image dependencies
  */
-import readerImage from 'assets/images/reader/reader-intro-character.svg';
-import readerBackground from 'assets/images/reader/reader-intro-background.svg';
+import readerImage from 'calypso/assets/images/reader/reader-intro-character.svg';
+import readerBackground from 'calypso/assets/images/reader/reader-intro-background.svg';
 
 class FollowingIntro extends React.Component {
 	componentDidMount() {

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -8,8 +8,8 @@ import { defer } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { trackPageLoad } from 'reader/controller-helper';
-import AsyncLoad from 'components/async-load';
+import { trackPageLoad } from 'calypso/reader/controller-helper';
+import AsyncLoad from 'calypso/components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
@@ -34,7 +34,7 @@ export function blogPost( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
-			require="blocks/reader-full-post"
+			require="calypso/blocks/reader-full-post"
 			blogId={ blogId }
 			postId={ postId }
 			referral={ referral }
@@ -62,7 +62,7 @@ export function feedPost( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
-			require="blocks/reader-full-post"
+			require="calypso/blocks/reader-full-post"
 			feedId={ feedId }
 			postId={ postId }
 			onClose={ closer }

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -7,8 +7,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { blogPost, feedPost } from './controller';
-import { updateLastRoute, unmountSidebar } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { updateLastRoute, unmountSidebar } from 'calypso/reader/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	// Feed full post

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -7,9 +7,9 @@ import { trim } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { decodeEntities } from 'lib/formatting';
-import { isSiteDescriptionBlocked } from 'reader/lib/site-description-blocklist';
-import { getUrlParts } from 'lib/url';
+import { decodeEntities } from 'calypso/lib/formatting';
+import { isSiteDescriptionBlocked } from 'calypso/reader/lib/site-description-blocklist';
+import { getUrlParts } from 'calypso/lib/url';
 
 /**
  * Given a feed, site, or post: return the site url. return false if one could not be found.

--- a/client/reader/header-back/index.jsx
+++ b/client/reader/header-back/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import HeaderCake from 'components/header-cake';
+import HeaderCake from 'calypso/components/header-cake';
 
 function goBack() {
 	if ( typeof window !== 'undefined' ) {

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -19,8 +19,8 @@ import {
 	sidebar,
 	updateLastRoute,
 } from './controller';
-import config from 'config';
-import { makeLayout, render as clientRender } from 'controller';
+import config from 'calypso/config';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 import { addMiddleware } from 'redux-dynamic-middlewares';
 
 /**
@@ -37,7 +37,7 @@ export async function lazyLoadDependencies() {
 	const isBrowser = typeof window === 'object';
 	if ( isBrowser && config.isEnabled( 'lasagna' ) && config.isEnabled( 'reader' ) ) {
 		const lasagnaMiddleware = await import(
-			/* webpackChunkName: "lasagnaMiddleware" */ 'state/lasagna/middleware.js'
+			/* webpackChunkName: "lasagnaMiddleware" */ 'calypso/state/lasagna/middleware.js'
 		);
 		addMiddleware( lasagnaMiddleware.default );
 	}

--- a/client/reader/lib/feed-display-helper/index.js
+++ b/client/reader/lib/feed-display-helper/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getSiteUrl as getSiteUrlFromRoute, getFeedUrl } from 'reader/route';
+import { getSiteUrl as getSiteUrlFromRoute, getFeedUrl } from 'calypso/reader/route';
 
 const exported = {
 	/**

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -7,15 +7,15 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { reduxGetState } from 'lib/redux-bridge';
-import LikeButtonContainer from 'blocks/like-button';
-import PostLikesPopover from 'blocks/post-likes/popover';
-import { markPostSeen } from 'state/reader/posts/actions';
-import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
-import { getPostByKey } from 'state/reader/posts/selectors';
-import QueryPostLikes from 'components/data/query-post-likes';
-import { getPostLikeCount } from 'state/posts/selectors/get-post-like-count';
-import { isLikedPost } from 'state/posts/selectors/is-liked-post';
+import { reduxGetState } from 'calypso/lib/redux-bridge';
+import LikeButtonContainer from 'calypso/blocks/like-button';
+import PostLikesPopover from 'calypso/blocks/post-likes/popover';
+import { markPostSeen } from 'calypso/state/reader/posts/actions';
+import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import QueryPostLikes from 'calypso/components/data/query-post-likes';
+import { getPostLikeCount } from 'calypso/state/posts/selectors/get-post-like-count';
+import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
 
 /**
  * Style dependencies

--- a/client/reader/like-helper.jsx
+++ b/client/reader/like-helper.jsx
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { isDiscoverPost, isInternalDiscoverPost, isDiscoverSitePick } from 'reader/discover/helper';
+import {
+	isDiscoverPost,
+	isInternalDiscoverPost,
+	isDiscoverSitePick,
+} from 'calypso/reader/discover/helper';
 
 export function shouldShowLikes( post ) {
 	let showLikes = false;

--- a/client/reader/liked-stream/controller.js
+++ b/client/reader/liked-stream/controller.js
@@ -6,9 +6,13 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { sectionify } from 'lib/route';
-import { trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
-import LikedPostsStream from 'reader/liked-stream/main';
+import { sectionify } from 'calypso/lib/route';
+import {
+	trackPageLoad,
+	trackUpdatesLoaded,
+	trackScrollPage,
+} from 'calypso/reader/controller-helper';
+import LikedPostsStream from 'calypso/reader/liked-stream/main';
 
 const analyticsPageTitle = 'Reader';
 

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -7,10 +7,10 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import EmptyContent from 'components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import { isDiscoverEnabled } from 'reader/discover/helper';
-import { withPerformanceTrackerStop } from 'lib/performance-tracking';
+import EmptyContent from 'calypso/components/empty-content';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
+import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 
 class TagEmptyContent extends React.Component {
 	shouldComponentUpdate() {

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -7,8 +7,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { likes } from './controller';
-import { initAbTests, updateLastRoute, sidebar } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { initAbTests, updateLastRoute, sidebar } from 'calypso/reader/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	page(

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -7,9 +7,9 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Stream from 'reader/stream';
+import Stream from 'calypso/reader/stream';
 import EmptyContent from './empty';
-import DocumentHead from 'components/data/document-head';
+import DocumentHead from 'calypso/components/data/document-head';
 
 const title = translate( 'My Likes' );
 const documentTitle = translate( '%s ‹ Reader', {

--- a/client/reader/list-gap/index.jsx
+++ b/client/reader/list-gap/index.jsx
@@ -10,8 +10,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import { fillGap } from 'state/reader/streams/actions';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import { fillGap } from 'calypso/state/reader/streams/actions';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
 
 /**
  * Style dependencies

--- a/client/reader/list-manage/feed-item.tsx
+++ b/client/reader/list-manage/feed-item.tsx
@@ -8,12 +8,12 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { Button } from '@automattic/components';
-import SitePlaceholder from 'blocks/site/placeholder';
+import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import { Item, Feed, FeedError } from './types';
-import { getFeed } from 'state/reader/feeds/selectors';
-import QueryReaderFeed from 'components/data/query-reader-feed';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
 
 function isFeedError( feed: Feed | FeedError ): feed is FeedError {
 	return 'errors' in feed;

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -14,28 +14,28 @@ import {
 	getListItems,
 	isCreatingList as isCreatingListSelector,
 	isUpdatingList as isUpdatingListSelector,
-} from 'state/reader/lists/selectors';
-import FormattedHeader from 'components/formatted-header';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormTextInput from 'components/forms/form-text-input';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import FormButton from 'components/forms/form-button';
-import QueryReaderList from 'components/data/query-reader-list';
-import QueryReaderListItems from 'components/data/query-reader-list-items';
-import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavItem from 'components/section-nav/item';
-import Main from 'components/main';
+} from 'calypso/state/reader/lists/selectors';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormButton from 'calypso/components/forms/form-button';
+import QueryReaderList from 'calypso/components/data/query-reader-list';
+import QueryReaderListItems from 'calypso/components/data/query-reader-list-items';
+import SectionNav from 'calypso/components/section-nav';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import NavItem from 'calypso/components/section-nav/item';
+import Main from 'calypso/components/main';
 import {
 	addReaderListFeedByUrl,
 	createReaderList,
 	updateReaderList,
-} from 'state/reader/lists/actions';
-import ReaderExportButton from 'blocks/reader-export-button';
-import { READER_EXPORT_TYPE_LIST } from 'blocks/reader-export-button/constants';
+} from 'calypso/state/reader/lists/actions';
+import ReaderExportButton from 'calypso/blocks/reader-export-button';
+import { READER_EXPORT_TYPE_LIST } from 'calypso/blocks/reader-export-button/constants';
 import ListItem from './list-item';
 import ListForm from './list-form';
 

--- a/client/reader/list-manage/list-form.jsx
+++ b/client/reader/list-manage/list-form.jsx
@@ -8,15 +8,15 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import FormButton from 'components/forms/form-button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormLegend from 'components/forms/form-legend';
-import FormRadio from 'components/forms/form-radio';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormTextInput from 'components/forms/form-text-input';
-import FormTextarea from 'components/forms/form-textarea';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormLegend from 'calypso/components/forms/form-legend';
+import FormRadio from 'calypso/components/forms/form-radio';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextarea from 'calypso/components/forms/form-textarea';
 
 const INITIAL_UPDATE_FORM_STATE = {
 	description: '',

--- a/client/reader/list-manage/list-item.tsx
+++ b/client/reader/list-manage/list-item.tsx
@@ -16,7 +16,7 @@ import {
 	deleteReaderListFeed,
 	deleteReaderListSite,
 	deleteReaderListTag,
-} from 'state/reader/lists/actions';
+} from 'calypso/state/reader/lists/actions';
 
 export default function ListItem( props: { item: Item; owner: string; list: any } ) {
 	const { item, owner, list } = props;

--- a/client/reader/list-manage/site-item.tsx
+++ b/client/reader/list-manage/site-item.tsx
@@ -8,8 +8,8 @@ import React from 'react';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import SitePlaceholder from 'blocks/site/placeholder';
-import Gridicon from 'components/gridicon';
+import SitePlaceholder from 'calypso/blocks/site/placeholder';
+import Gridicon from 'calypso/components/gridicon';
 import { Item, Site, SiteError } from './types';
 
 function isSiteError( site: Site | SiteError ): site is SiteError {

--- a/client/reader/list-manage/tag-item.tsx
+++ b/client/reader/list-manage/tag-item.tsx
@@ -6,9 +6,9 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { Button } from '@automattic/components';
-import SitePlaceholder from 'blocks/site/placeholder';
+import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import { Item, Tag } from './types';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -7,9 +7,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import EmptyContent from 'components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import { isDiscoverEnabled } from 'reader/discover/helper';
+import EmptyContent from 'calypso/components/empty-content';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
 
 class ListEmptyContent extends React.Component {
 	shouldComponentUpdate() {

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -5,14 +5,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import { isExternal } from 'lib/url';
-import FollowButton from 'blocks/follow-button/button';
+import { isExternal } from 'calypso/lib/url';
+import FollowButton from 'calypso/blocks/follow-button/button';
 
 const ListStreamHeader = ( {
 	isPlaceholder,

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -9,20 +9,20 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import Stream from 'reader/stream';
+import config from 'calypso/config';
+import Stream from 'calypso/reader/stream';
 import EmptyContent from './empty';
-import DocumentHead from 'components/data/document-head';
+import DocumentHead from 'calypso/components/data/document-head';
 import ListMissing from './missing';
 import ListStreamHeader from './header';
-import { followList, unfollowList } from 'state/reader/lists/actions';
+import { followList, unfollowList } from 'calypso/state/reader/lists/actions';
 import {
 	getListByOwnerAndSlug,
 	isSubscribedByOwnerAndSlug,
 	isMissingByOwnerAndSlug,
-} from 'state/reader/lists/selectors';
-import QueryReaderList from 'components/data/query-reader-list';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+} from 'calypso/state/reader/lists/selectors';
+import QueryReaderList from 'calypso/components/data/query-reader-list';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
 
 /**
  * Style dependencies

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -8,10 +8,10 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import EmptyContent from 'components/empty-content';
-import { isDiscoverEnabled } from 'reader/discover/helper';
-import QueryReaderList from 'components/data/query-reader-list';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import EmptyContent from 'calypso/components/empty-content';
+import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
+import QueryReaderList from 'calypso/components/data/query-reader-list';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
 
 class ListMissing extends React.Component {
 	static propTypes = {

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -6,9 +6,13 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { recordTrack } from 'reader/stats';
-import { trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
-import AsyncLoad from 'components/async-load';
+import { recordTrack } from 'calypso/reader/stats';
+import {
+	trackPageLoad,
+	trackUpdatesLoaded,
+	trackScrollPage,
+} from 'calypso/reader/controller-helper';
+import AsyncLoad from 'calypso/components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
@@ -20,7 +24,9 @@ export const createList = ( context, next ) => {
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 	recordTrack( 'calypso_reader_list_create_loaded' );
 
-	context.primary = <AsyncLoad require="reader/list-manage" key="list-manage" isCreateForm />;
+	context.primary = (
+		<AsyncLoad require="calypso/reader/list-manage" key="list-manage" isCreateForm />
+	);
 	next();
 };
 
@@ -40,7 +46,7 @@ export const listListing = ( context, next ) => {
 
 	context.primary = (
 		<AsyncLoad
-			require="reader/list-stream"
+			require="calypso/reader/list-stream"
 			key={ 'tag-' + context.params.user + '-' + context.params.list }
 			streamKey={ streamKey }
 			owner={ encodeURIComponent( context.params.user ) }
@@ -72,7 +78,7 @@ export const editList = ( context, next ) => {
 
 	context.primary = (
 		<AsyncLoad
-			require="reader/list-manage"
+			require="calypso/reader/list-manage"
 			key="list-manage"
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
@@ -95,7 +101,7 @@ export const editListItems = ( context, next ) => {
 
 	context.primary = (
 		<AsyncLoad
-			require="reader/list-manage"
+			require="calypso/reader/list-manage"
 			key="list-manage"
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
@@ -118,7 +124,7 @@ export const exportList = ( context, next ) => {
 
 	context.primary = (
 		<AsyncLoad
-			require="reader/list-manage"
+			require="calypso/reader/list-manage"
 			key="list-manage"
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }

--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -7,8 +7,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { createList, editList, editListItems, exportList, listListing } from './controller';
-import { sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	page(

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { recordPermalinkClick } from 'reader/stats';
+import { recordPermalinkClick } from 'calypso/reader/stats';
 
 /**
  * Style dependencies

--- a/client/reader/route/index.js
+++ b/client/reader/route/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import config from 'config';
+import config from 'calypso/config';
 
 const FEED_URL_BASE = '/read/feeds/';
 const SITE_URL_BASE = '/read/blogs/';

--- a/client/reader/route/test/index.js
+++ b/client/reader/route/test/index.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import * as route from '../';
-import config from 'config';
+import config from 'calypso/config';
 
 describe( 'index', () => {
 	describe( 'getStreamUrlFromPost', () => {

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -8,10 +8,10 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import EmptyContent from 'components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import { isDiscoverEnabled } from 'reader/discover/helper';
-import { withPerformanceTrackerStop } from 'lib/performance-tracking';
+import EmptyContent from 'calypso/components/empty-content';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
+import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 
 class SearchEmptyContent extends React.Component {
 	static propTypes = {

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -12,26 +12,29 @@ import classnames from 'classnames';
 /**
  * Internal Dependencies
  */
-import BlankSuggestions from 'reader/components/reader-blank-suggestions';
-import SegmentedControl from 'components/segmented-control';
+import BlankSuggestions from 'calypso/reader/components/reader-blank-suggestions';
+import SegmentedControl from 'calypso/components/segmented-control';
 import { CompactCard } from '@automattic/components';
-import DocumentHead from 'components/data/document-head';
-import SearchInput from 'components/search';
-import { recordAction, recordTrack } from 'reader/stats';
+import DocumentHead from 'calypso/components/data/document-head';
+import SearchInput from 'calypso/components/search';
+import { recordAction, recordTrack } from 'calypso/reader/stats';
 import SiteResults from './site-results';
 import PostResults from './post-results';
-import ReaderMain from 'reader/components/reader-main';
-import { addQueryArgs, resemblesUrl, withoutHttp, addSchemeIfMissing } from 'lib/url';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import { addQueryArgs, resemblesUrl, withoutHttp, addSchemeIfMissing } from 'calypso/lib/url';
 import SearchStreamHeader, { SEARCH_TYPES } from './search-stream-header';
-import { SORT_BY_RELEVANCE, SORT_BY_LAST_UPDATED } from 'state/reader/feed-searches/actions';
-import withDimensions from 'lib/with-dimensions';
+import {
+	SORT_BY_RELEVANCE,
+	SORT_BY_LAST_UPDATED,
+} from 'calypso/state/reader/feed-searches/actions';
+import withDimensions from 'calypso/lib/with-dimensions';
 import SuggestionProvider from './suggestion-provider';
 import Suggestion from './suggestion';
-import { getReaderAliasedFollowFeedUrl } from 'state/reader/follows/selectors';
-import { SEARCH_RESULTS_URL_INPUT } from 'reader/follow-sources';
-import FollowButton from 'reader/follow-button';
-import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
-import { getSearchPlaceholderText } from 'reader/search/utils';
+import { getReaderAliasedFollowFeedUrl } from 'calypso/state/reader/follows/selectors';
+import { SEARCH_RESULTS_URL_INPUT } from 'calypso/reader/follow-sources';
+import FollowButton from 'calypso/reader/follow-button';
+import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
+import { getSearchPlaceholderText } from 'calypso/reader/search/utils';
 
 /**
  * Style dependencies

--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -9,12 +9,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import Stream from 'reader/stream';
+import Stream from 'calypso/reader/stream';
 import EmptyContent from './empty';
-import HeaderBack from 'reader/header-back';
-import { RelatedPostCard } from 'blocks/reader-related-card';
-import { SEARCH_RESULTS } from 'reader/follow-sources';
-import PostPlaceholder from 'reader/stream/post-placeholder';
+import HeaderBack from 'calypso/reader/header-back';
+import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
+import { SEARCH_RESULTS } from 'calypso/reader/follow-sources';
+import PostPlaceholder from 'calypso/reader/stream/post-placeholder';
 
 class PostResults extends Component {
 	static propTypes = {

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -9,9 +9,9 @@ import { noop, values } from 'lodash';
 /**
  * Internal Dependencies
  */
-import NavTabs from 'components/section-nav/tabs';
-import SectionNav from 'components/section-nav';
-import NavItem from 'components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
 
 export const SEARCH_TYPES = { POSTS: 'posts', SITES: 'sites' };
 

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -12,17 +12,17 @@ import { connect } from 'react-redux';
 import {
 	getReaderFeedsForQuery,
 	getReaderFeedsCountForQuery,
-} from 'state/reader/feed-searches/selectors';
-import QueryReaderFeedsSearch from 'components/data/query-reader-feeds-search';
-import ReaderInfiniteStream from 'reader/components/reader-infinite-stream';
+} from 'calypso/state/reader/feed-searches/selectors';
+import QueryReaderFeedsSearch from 'calypso/components/data/query-reader-feeds-search';
+import ReaderInfiniteStream from 'calypso/reader/components/reader-infinite-stream';
 import {
 	requestFeedSearch,
 	SORT_BY_RELEVANCE,
 	SORT_BY_LAST_UPDATED,
-} from 'state/reader/feed-searches/actions';
-import { SEARCH_RESULTS_SITES } from 'reader/follow-sources';
-import { siteRowRenderer } from 'reader/components/reader-infinite-stream/row-renderers';
-import withDimensions from 'lib/with-dimensions';
+} from 'calypso/state/reader/feed-searches/actions';
+import { SEARCH_RESULTS_SITES } from 'calypso/reader/follow-sources';
+import { siteRowRenderer } from 'calypso/reader/components/reader-infinite-stream/row-renderers';
+import withDimensions from 'calypso/lib/with-dimensions';
 
 class SiteResults extends React.Component {
 	static propTypes = {

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -8,9 +8,9 @@ import { map, sampleSize, times } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { getLocaleSlug } from 'lib/i18n-utils';
-import { suggestions } from 'reader/search-stream/suggestions';
-import { getReaderFollowedTags } from 'state/reader/tags/selectors';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
+import { suggestions } from 'calypso/reader/search-stream/suggestions';
+import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 
 function createRandomId( randomBytesLength = 9 ) {
 	// 9 * 4/3 = 12

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -8,8 +8,8 @@ import { stringify } from 'qs';
 /**
  * Internal Dependencies
  */
-import { recordTrack, recordTracksRailcarInteract } from 'reader/stats';
-import { recordTracksEvent } from 'lib/analytics/tracks';
+import { recordTrack, recordTracksRailcarInteract } from 'calypso/reader/stats';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 export class Suggestion extends Component {
 	static propTypes = {

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -8,10 +8,14 @@ import { stringify } from 'qs';
 /**
  * Internal dependencies
  */
-import { recordTrack } from 'reader/stats';
-import { trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
-import AsyncLoad from 'components/async-load';
-import { SEARCH_TYPES } from 'reader/search-stream/search-stream-header';
+import { recordTrack } from 'calypso/reader/stats';
+import {
+	trackPageLoad,
+	trackUpdatesLoaded,
+	trackScrollPage,
+} from 'calypso/reader/controller-helper';
+import AsyncLoad from 'calypso/components/async-load';
+import { SEARCH_TYPES } from 'calypso/reader/search-stream/search-stream-header';
 
 const analyticsPageTitle = 'Reader';
 
@@ -64,7 +68,7 @@ const exported = {
 
 		context.primary = (
 			<AsyncLoad
-				require="reader/search-stream"
+				require="calypso/reader/search-stream"
 				key="search"
 				streamKey={ streamKey }
 				isSuggestion={ isQuerySuggestion }

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -7,8 +7,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { search } from './controller';
-import { sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	// Old recommendations page

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -16,28 +16,31 @@ import ReaderSidebarLists from './reader-sidebar-lists';
 import ReaderSidebarTags from './reader-sidebar-tags';
 import ReaderSidebarOrganizations from './reader-sidebar-organizations';
 import ReaderSidebarNudges from './reader-sidebar-nudges';
-import QueryReaderLists from 'components/data/query-reader-lists';
-import QueryReaderTeams from 'components/data/query-reader-teams';
-import Sidebar from 'layout/sidebar';
-import SidebarFooter from 'layout/sidebar/footer';
-import SidebarHeading from 'layout/sidebar/heading';
-import SidebarItem from 'layout/sidebar/item';
-import SidebarMenu from 'layout/sidebar/menu';
-import SidebarRegion from 'layout/sidebar/region';
-import { isDiscoverEnabled } from 'reader/discover/helper';
-import { isAutomatticTeamMember } from 'reader/lib/teams';
-import { getTagStreamUrl } from 'reader/route';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import { getSubscribedLists } from 'state/reader/lists/selectors';
-import { getReaderTeams } from 'state/reader/teams/selectors';
-import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
-import { toggleReaderSidebarLists, toggleReaderSidebarTags } from 'state/reader-ui/sidebar/actions';
-import { isListsOpen, isTagsOpen } from 'state/reader-ui/sidebar/selectors';
+import QueryReaderLists from 'calypso/components/data/query-reader-lists';
+import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
+import Sidebar from 'calypso/layout/sidebar';
+import SidebarFooter from 'calypso/layout/sidebar/footer';
+import SidebarHeading from 'calypso/layout/sidebar/heading';
+import SidebarItem from 'calypso/layout/sidebar/item';
+import SidebarMenu from 'calypso/layout/sidebar/menu';
+import SidebarRegion from 'calypso/layout/sidebar/region';
+import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import { getTagStreamUrl } from 'calypso/reader/route';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { getSubscribedLists } from 'calypso/state/reader/lists/selectors';
+import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
+import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import {
+	toggleReaderSidebarLists,
+	toggleReaderSidebarTags,
+} from 'calypso/state/reader-ui/sidebar/actions';
+import { isListsOpen, isTagsOpen } from 'calypso/state/reader-ui/sidebar/selectors';
 import ReaderSidebarPromo from './promo';
-import QueryReaderOrganizations from 'components/data/query-reader-organizations';
-import { getReaderOrganizations } from 'state/reader/organizations/selectors';
-import ReaderSidebarFollowedSites from 'reader/sidebar/reader-sidebar-followed-sites';
-import SidebarSeparator from 'layout/sidebar/separator';
+import QueryReaderOrganizations from 'calypso/components/data/query-reader-organizations';
+import { getReaderOrganizations } from 'calypso/state/reader/organizations/selectors';
+import ReaderSidebarFollowedSites from 'calypso/reader/sidebar/reader-sidebar-followed-sites';
+import SidebarSeparator from 'calypso/layout/sidebar/separator';
 
 /**
  * Style dependencies

--- a/client/reader/sidebar/promo.jsx
+++ b/client/reader/sidebar/promo.jsx
@@ -10,11 +10,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import AsyncLoad from 'components/async-load';
-import { getCurrentUserLocale } from 'state/current-user/selectors';
-import QueryUserSettings from 'components/data/query-user-settings';
-import config from 'config';
-import getUserSetting from 'state/selectors/get-user-setting';
+import AsyncLoad from 'calypso/components/async-load';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import config from 'calypso/config';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
 
 export const ReaderSidebarPromo = ( { currentUserLocale, shouldRenderAppPromo } ) => {
 	return (
@@ -24,7 +24,7 @@ export const ReaderSidebarPromo = ( { currentUserLocale, shouldRenderAppPromo } 
 			{ shouldRenderAppPromo && (
 				<div className="sidebar__app-promo">
 					<AsyncLoad
-						require="blocks/app-promo"
+						require="calypso/blocks/app-promo"
 						placeholder={ null }
 						location="reader"
 						locale={ currentUserLocale }

--- a/client/reader/sidebar/reader-sidebar-followed-sites/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-followed-sites/index.jsx
@@ -10,15 +10,15 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import ReaderSidebarFollowingItem from './item';
-import { toggleReaderSidebarFollowing } from 'state/reader-ui/sidebar/actions';
-import { isFollowingOpen } from 'state/reader-ui/sidebar/selectors';
-import getReaderFollowedSites from 'state/reader/follows/selectors/get-reader-followed-sites';
-import ReaderSidebarHelper from 'reader/sidebar/helper';
-import SidebarItem from 'layout/sidebar/item';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import Count from 'components/count';
+import { toggleReaderSidebarFollowing } from 'calypso/state/reader-ui/sidebar/actions';
+import { isFollowingOpen } from 'calypso/state/reader-ui/sidebar/selectors';
+import getReaderFollowedSites from 'calypso/state/reader/follows/selectors/get-reader-followed-sites';
+import ReaderSidebarHelper from 'calypso/reader/sidebar/helper';
+import SidebarItem from 'calypso/layout/sidebar/item';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import Count from 'calypso/components/count';
 
 /**
  * Styles

--- a/client/reader/sidebar/reader-sidebar-followed-sites/item.jsx
+++ b/client/reader/sidebar/reader-sidebar-followed-sites/item.jsx
@@ -8,15 +8,15 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import ReaderSidebarHelper from '../helper';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import Count from 'components/count';
-import { formatUrlForDisplay } from 'reader/lib/feed-display-helper';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import Count from 'calypso/components/count';
+import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
 
 /**
  * Styles
  */
 import '../style.scss';
-import Favicon from 'reader/components/favicon';
+import Favicon from 'calypso/reader/components/favicon';
 
 export class ReaderSidebarFollowingItem extends Component {
 	static propTypes = {

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import ReaderSidebarListsList from './list';
 
 export class ReaderSidebarLists extends Component {

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -12,7 +12,7 @@ import ReactDom from 'react-dom';
  * Internal dependencies
  */
 import ReaderSidebarHelper from '../helper';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
 
 export class ReaderSidebarListsListItem extends Component {
 	static propTypes = {

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -9,16 +9,16 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import QuerySitePlans from 'components/data/query-site-plans';
-import isDomainOnlySite from 'state/selectors/is-domain-only-site';
-import { getCurrentUserCountryCode } from 'state/current-user/selectors';
-import isEligibleForFreeToPaidUpsell from 'state/selectors/is-eligible-for-free-to-paid-upsell';
-import { isJetpackSite } from 'state/sites/selectors';
-import getSites from 'state/selectors/get-sites';
-import getPrimarySiteId from 'state/selectors/get-primary-site-id';
-import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
-import { clickUpgradeNudge } from 'state/marketing/actions';
-import UpsellNudge from 'blocks/upsell-nudge';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
+import isEligibleForFreeToPaidUpsell from 'calypso/state/selectors/is-eligible-for-free-to-paid-upsell';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import getSites from 'calypso/state/selectors/get-sites';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
+import { clickUpgradeNudge } from 'calypso/state/marketing/actions';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 const debug = debugFactory( 'calypso:reader:sidebar-nudges' );
 

--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -8,14 +8,14 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import ReaderSidebarHelper from '../helper';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import Count from 'components/count';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import Count from 'calypso/components/count';
 
 /**
  * Styles
  */
 import '../style.scss';
-import Favicon from 'reader/components/favicon';
+import Favicon from 'calypso/reader/components/favicon';
 
 export class ReaderSidebarOrganizationsListItem extends Component {
 	static propTypes = {

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -10,23 +10,23 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import ReaderSidebarOrganizationsListItem from './list-item';
-import getOrganizationSites from 'state/reader/follows/selectors/get-reader-follows-organization';
-import { toggleReaderSidebarOrganization } from 'state/reader-ui/sidebar/actions';
-import { isOrganizationOpen } from 'state/reader-ui/sidebar/selectors';
-import { AUTOMATTIC_ORG_ID } from 'state/reader/organizations/constants';
-import ReaderSidebarHelper from 'reader/sidebar/helper';
-import SidebarItem from 'layout/sidebar/item';
-import Count from 'components/count';
+import getOrganizationSites from 'calypso/state/reader/follows/selectors/get-reader-follows-organization';
+import { toggleReaderSidebarOrganization } from 'calypso/state/reader-ui/sidebar/actions';
+import { isOrganizationOpen } from 'calypso/state/reader-ui/sidebar/selectors';
+import { AUTOMATTIC_ORG_ID } from 'calypso/state/reader/organizations/constants';
+import ReaderSidebarHelper from 'calypso/reader/sidebar/helper';
+import SidebarItem from 'calypso/layout/sidebar/item';
+import Count from 'calypso/components/count';
 
 /**
  * Styles
  */
 import '../style.scss';
-import SVGIcon from 'components/svg-icon';
-import AutomatticLogo from 'assets/images/icons/a8c-logo.svg';
-import P2Logo from 'assets/images/icons/p2-logo.svg';
+import SVGIcon from 'calypso/components/svg-icon';
+import AutomatticLogo from 'calypso/assets/images/icons/a8c-logo.svg';
+import P2Logo from 'calypso/assets/images/icons/p2-logo.svg';
 
 export class ReaderSidebarOrganizationsList extends Component {
 	static propTypes = {

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -10,13 +10,13 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import ReaderSidebarTagsList from './list';
-import QueryReaderFollowedTags from 'components/data/query-reader-followed-tags';
-import FormTextInputWithAction from 'components/forms/form-text-input-with-action';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import { requestFollowTag } from 'state/reader/tags/items/actions';
-import { getReaderFollowedTags } from 'state/reader/tags/selectors';
+import QueryReaderFollowedTags from 'calypso/components/data/query-reader-followed-tags';
+import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { requestFollowTag } from 'calypso/state/reader/tags/items/actions';
+import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 
 export class ReaderSidebarTags extends Component {
 	static propTypes = {

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -11,7 +11,7 @@ import '../style.scss';
  * Internal dependencies
  */
 import ReaderSidebarHelper from '../helper';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
 
 export class ReaderSidebarTagsListItem extends Component {
 	static propTypes = {

--- a/client/reader/site-blocked/index.jsx
+++ b/client/reader/site-blocked/index.jsx
@@ -9,12 +9,12 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import ReaderMain from 'reader/components/reader-main';
-import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
-import EmptyContent from 'components/empty-content';
-import { recordTrack as recordReaderTrack } from 'reader/stats';
-import { bumpStat, recordGoogleEvent } from 'state/analytics/actions';
-import { unblockSite } from 'state/reader/site-blocks/actions';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
+import EmptyContent from 'calypso/components/empty-content';
+import { recordTrack as recordReaderTrack } from 'calypso/reader/stats';
+import { bumpStat, recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { unblockSite } from 'calypso/state/reader/site-blocks/actions';
 
 class SiteBlocked extends React.Component {
 	static propTypes = {

--- a/client/reader/site-stream/empty.jsx
+++ b/client/reader/site-stream/empty.jsx
@@ -7,9 +7,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import EmptyContent from 'components/empty-content';
-import { recordAction as statRecordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import { isDiscoverEnabled } from 'reader/discover/helper';
+import EmptyContent from 'calypso/components/empty-content';
+import { recordAction as statRecordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
 
 const SiteEmptyContent = ( { translate } ) => {
 	const recordAction = () => {

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -10,17 +10,17 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import DocumentHead from 'components/data/document-head';
-import ReaderFeedHeader from 'blocks/reader-feed-header';
+import DocumentHead from 'calypso/components/data/document-head';
+import ReaderFeedHeader from 'calypso/blocks/reader-feed-header';
 import EmptyContent from './empty';
-import Stream from 'reader/stream';
-import FeedError from 'reader/feed-error';
-import { getSite } from 'state/reader/sites/selectors';
-import { getFeed } from 'state/reader/feeds/selectors';
-import { isSiteBlocked } from 'state/reader/site-blocks/selectors';
-import SiteBlocked from 'reader/site-blocked';
-import QueryReaderSite from 'components/data/query-reader-site';
-import QueryReaderFeed from 'components/data/query-reader-feed';
+import Stream from 'calypso/reader/stream';
+import FeedError from 'calypso/reader/feed-error';
+import { getSite } from 'calypso/state/reader/sites/selectors';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import { isSiteBlocked } from 'calypso/state/reader/site-blocks/selectors';
+import SiteBlocked from 'calypso/reader/site-blocked';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
 
 class SiteStream extends React.Component {
 	static propTypes = {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -7,9 +7,9 @@ import debugFactory from 'debug';
 /**
  * Internal Dependencies
  */
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import { gaRecordEvent } from 'lib/analytics/ga';
-import { bumpStat, bumpStatWithPageView } from 'lib/analytics/mc';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import { bumpStat, bumpStatWithPageView } from 'calypso/lib/analytics/mc';
 
 const debug = debugFactory( 'calypso:reader:stats' );
 

--- a/client/reader/stream/empty-search-recommended-post.jsx
+++ b/client/reader/stream/empty-search-recommended-post.jsx
@@ -6,9 +6,9 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { RelatedPostCard } from 'blocks/reader-related-card';
-import { recordTrackForPost, recordAction } from 'reader/stats';
-import { EMPTY_SEARCH_RECOMMENDATIONS } from 'reader/follow-sources';
+import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
+import { recordTrackForPost, recordAction } from 'calypso/reader/stats';
+import { EMPTY_SEARCH_RECOMMENDATIONS } from 'calypso/reader/follow-sources';
 
 export default function EmptySearchRecommendedPost( { post } ) {
 	function handlePostClick() {

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -7,14 +7,14 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import EmptyContent from 'components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import { withPerformanceTrackerStop } from 'lib/performance-tracking';
+import EmptyContent from 'calypso/components/empty-content';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 
 /**
  * Image dependencies
  */
-import welcomeImage from 'assets/images/reader/reader-welcome-illustration.svg';
+import welcomeImage from 'calypso/assets/images/reader/reader-welcome-illustration.svg';
 
 class FollowingEmptyContent extends React.Component {
 	shouldComponentUpdate() {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import ReaderMain from 'reader/components/reader-main';
+import ReaderMain from 'calypso/reader/components/reader-main';
 import EmptyContent from './empty';
 import {
 	requestPage,
@@ -20,35 +20,35 @@ import {
 	selectNextItem,
 	selectPrevItem,
 	showUpdates,
-} from 'state/reader/streams/actions';
+} from 'calypso/state/reader/streams/actions';
 import {
 	getStream,
 	getTransformedStreamItems,
 	shouldRequestRecs,
-} from 'state/reader/streams/selectors';
+} from 'calypso/state/reader/streams/selectors';
 
-import { shouldShowLikes } from 'reader/like-helper';
-import { like as likePost, unlike as unlikePost } from 'state/posts/likes/actions';
-import { isLikedPost } from 'state/posts/selectors/is-liked-post';
-import ListEnd from 'components/list-end';
-import InfiniteList from 'components/infinite-list';
-import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
+import { shouldShowLikes } from 'calypso/reader/like-helper';
+import { like as likePost, unlike as unlikePost } from 'calypso/state/posts/likes/actions';
+import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
+import ListEnd from 'calypso/components/list-end';
+import InfiniteList from 'calypso/components/infinite-list';
+import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
 import PostPlaceholder from './post-placeholder';
-import UpdateNotice from 'reader/update-notice';
-import KeyboardShortcuts from 'lib/keyboard-shortcuts';
-import scrollTo from 'lib/scroll-to';
-import XPostHelper from 'reader/xpost-helper';
+import UpdateNotice from 'calypso/reader/update-notice';
+import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
+import scrollTo from 'calypso/lib/scroll-to';
+import XPostHelper from 'calypso/reader/xpost-helper';
 import PostLifecycle from './post-lifecycle';
-import { showSelectedPost, getStreamType } from 'reader/utils';
-import { getBlockedSites } from 'state/reader/site-blocks/selectors';
-import { keysAreEqual, keyToString, keyForPost } from 'reader/post-key';
-import { resetCardExpansions } from 'state/reader-ui/card-expansions/actions';
-import { reduxGetState } from 'lib/redux-bridge';
-import { getPostByKey } from 'state/reader/posts/selectors';
-import { viewStream } from 'state/reader/watermarks/actions';
-import { Interval, EVERY_MINUTE } from 'lib/interval';
-import { PER_FETCH, INITIAL_FETCH } from 'state/data-layer/wpcom/read/streams';
-import { PerformanceTrackerStop } from 'lib/performance-tracking';
+import { showSelectedPost, getStreamType } from 'calypso/reader/utils';
+import { getBlockedSites } from 'calypso/state/reader/site-blocks/selectors';
+import { keysAreEqual, keyToString, keyForPost } from 'calypso/reader/post-key';
+import { resetCardExpansions } from 'calypso/state/reader-ui/card-expansions/actions';
+import { reduxGetState } from 'calypso/lib/redux-bridge';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import { viewStream } from 'calypso/state/reader/watermarks/actions';
+import { Interval, EVERY_MINUTE } from 'calypso/lib/interval';
+import { PER_FETCH, INITIAL_FETCH } from 'calypso/state/data-layer/wpcom/read/streams';
+import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 
 /**
  * Style dependencies

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -11,18 +11,18 @@ import { omit, includes } from 'lodash';
  */
 import PostPlaceholder from './post-placeholder';
 import PostUnavailable from './post-unavailable';
-import ListGap from 'reader/list-gap';
+import ListGap from 'calypso/reader/list-gap';
 import CrossPost from './x-post';
 import RecommendedPosts from './recommended-posts';
-import XPostHelper, { isXPost } from 'reader/xpost-helper';
-import PostBlocked from 'blocks/reader-post-card/blocked';
+import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
+import PostBlocked from 'calypso/blocks/reader-post-card/blocked';
 import Post from './post';
-import { IN_STREAM_RECOMMENDATION } from 'reader/follow-sources';
-import CombinedCard from 'blocks/reader-combined-card';
+import { IN_STREAM_RECOMMENDATION } from 'calypso/reader/follow-sources';
+import CombinedCard from 'calypso/blocks/reader-combined-card';
 import EmptySearchRecommendedPost from './empty-search-recommended-post';
-import { getPostByKey } from 'state/reader/posts/selectors';
-import QueryReaderPost from 'components/data/query-reader-post';
-import compareProps from 'lib/compare-props';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import QueryReaderPost from 'calypso/components/data/query-reader-post';
+import compareProps from 'calypso/lib/compare-props';
 
 class PostLifecycle extends React.Component {
 	static propTypes = {

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -8,15 +8,18 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import ReaderPostCard from 'blocks/reader-post-card';
-import { getSite } from 'state/reader/sites/selectors';
-import { getFeed } from 'state/reader/feeds/selectors';
-import QueryReaderSite from 'components/data/query-reader-site';
-import QueryReaderFeed from 'components/data/query-reader-feed';
-import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
-import { getSourceData as getDiscoverSourceData, discoverBlogId } from 'reader/discover/helper';
-import { getPostByKey } from 'state/reader/posts/selectors';
-import QueryReaderPost from 'components/data/query-reader-post';
+import ReaderPostCard from 'calypso/blocks/reader-post-card';
+import { getSite } from 'calypso/state/reader/sites/selectors';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
+import {
+	getSourceData as getDiscoverSourceData,
+	discoverBlogId,
+} from 'calypso/reader/discover/helper';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import QueryReaderPost from 'calypso/components/data/query-reader-post';
 
 class ReaderPostCardAdapter extends React.Component {
 	static displayName = 'ReaderPostCardAdapter';

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -6,18 +6,18 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { map, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal Dependencies
  */
-import { RelatedPostCard } from 'blocks/reader-related-card';
-import { recordAction, recordTrackForPost } from 'reader/stats';
+import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
+import { recordAction, recordTrackForPost } from 'calypso/reader/stats';
 import { Button } from '@automattic/components';
-import { dismissPost } from 'state/reader/site-dismissals/actions';
-import { keyForPost } from 'reader/post-key';
-import QueryReaderPost from 'components/data/query-reader-post';
-import { getPostsByKeys } from 'state/reader/posts/selectors';
+import { dismissPost } from 'calypso/state/reader/site-dismissals/actions';
+import { keyForPost } from 'calypso/reader/post-key';
+import QueryReaderPost from 'calypso/components/data/query-reader-post';
+import { getPostsByKeys } from 'calypso/state/reader/posts/selectors';
 
 function dismissPostAnalytics( uiIndex, storeId, post ) {
 	recordTrackForPost( 'calypso_reader_recommended_post_dismissed', post, {

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -7,7 +7,7 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
-import { isDiscoverBlog, isDiscoverFeed } from 'reader/discover/helper';
+import { isDiscoverBlog, isDiscoverFeed } from 'calypso/reader/discover/helper';
 
 export function isDiscoverPostKey( postKey ) {
 	return isDiscoverBlog( postKey.blogId ) || isDiscoverFeed( postKey.feedId );

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -14,14 +14,14 @@ import { connect } from 'react-redux';
  * Internal Dependencies
  */
 import { Card } from '@automattic/components';
-import ReaderAvatar from 'blocks/reader-avatar';
-import { getSite } from 'state/reader/sites/selectors';
-import { getFeed } from 'state/reader/feeds/selectors';
-import QueryReaderSite from 'components/data/query-reader-site';
-import QueryReaderFeed from 'components/data/query-reader-feed';
-import Emojify from 'components/emojify';
-import { getUrlParts } from 'lib/url';
-import config from 'config';
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
+import { getSite } from 'calypso/state/reader/sites/selectors';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import Emojify from 'calypso/components/emojify';
+import { getUrlParts } from 'calypso/lib/url';
+import config from 'calypso/config';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 class CrossPost extends PureComponent {

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -7,15 +7,15 @@ import { trim } from 'lodash';
 /**
  * Internal dependencies
  */
-import { recordTrack } from 'reader/stats';
+import { recordTrack } from 'calypso/reader/stats';
 import {
 	trackPageLoad,
 	trackUpdatesLoaded,
 	trackScrollPage,
 	getStartDate,
-} from 'reader/controller-helper';
-import AsyncLoad from 'components/async-load';
-import { TAG_PAGE } from 'reader/follow-sources';
+} from 'calypso/reader/controller-helper';
+import AsyncLoad from 'calypso/components/async-load';
+import { TAG_PAGE } from 'calypso/reader/follow-sources';
 
 const analyticsPageTitle = 'Reader';
 
@@ -38,7 +38,7 @@ export const tagListing = ( context, next ) => {
 
 	context.primary = (
 		<AsyncLoad
-			require="reader/tag-stream/main"
+			require="calypso/reader/tag-stream/main"
 			key={ 'tag-' + encodedTag }
 			streamKey={ streamKey }
 			encodedTagSlug={ encodedTag }

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -8,10 +8,10 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import EmptyContent from 'components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import { isDiscoverEnabled } from 'reader/discover/helper';
-import { withPerformanceTrackerStop } from 'lib/performance-tracking';
+import EmptyContent from 'calypso/components/empty-content';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
+import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 
 class TagEmptyContent extends React.Component {
 	static propTypes = {

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -7,17 +7,17 @@ import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { sample } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-import FollowButton from 'blocks/follow-button/button';
-import QueryReaderTagImages from 'components/data/query-reader-tag-images';
-import { getTagImages } from 'state/reader/tags/images/selectors';
-import resizeImageUrl from 'lib/resize-image-url';
-import cssSafeUrl from 'lib/css-safe-url';
-import { decodeEntities } from 'lib/formatting';
+import FollowButton from 'calypso/blocks/follow-button/button';
+import QueryReaderTagImages from 'calypso/components/data/query-reader-tag-images';
+import { getTagImages } from 'calypso/state/reader/tags/images/selectors';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
+import cssSafeUrl from 'calypso/lib/css-safe-url';
+import { decodeEntities } from 'calypso/lib/formatting';
 
 const TAG_HEADER_WIDTH = 800;
 const TAG_HEADER_HEIGHT = 140;

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -8,8 +8,8 @@ import { startsWith } from 'lodash';
  * Internal dependencies
  */
 import { tagListing } from './controller';
-import { initAbTests, sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { initAbTests, sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 
 const redirectHashtaggedTags = ( context, next ) => {
 	if ( context.hashstring && startsWith( context.pathname, '/tag/#' ) ) {

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -10,17 +10,17 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import Stream from 'reader/stream';
-import DocumentHead from 'components/data/document-head';
+import Stream from 'calypso/reader/stream';
+import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from './empty';
 import TagStreamHeader from './header';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import HeaderBack from 'reader/header-back';
-import { getReaderTags, getReaderFollowedTags } from 'state/reader/tags/selectors';
-import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
-import QueryReaderFollowedTags from 'components/data/query-reader-followed-tags';
-import QueryReaderTag from 'components/data/query-reader-tag';
-import ReaderMain from 'reader/components/reader-main';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import HeaderBack from 'calypso/reader/header-back';
+import { getReaderTags, getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
+import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
+import QueryReaderFollowedTags from 'calypso/components/data/query-reader-followed-tags';
+import QueryReaderTag from 'calypso/components/data/query-reader-tag';
+import ReaderMain from 'calypso/reader/components/reader-main';
 
 /**
  * Style dependencies

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -7,15 +7,15 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { noop, filter, get, flatMap } from 'lodash';
 import classnames from 'classnames';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-import DocumentHead from 'components/data/document-head';
-import { getDocumentHeadCappedUnreadCount } from 'state/document-head/selectors/get-document-head-capped-unread-count';
-import { getCommentById } from 'state/comments/selectors';
-import { getStream } from 'state/reader/streams/selectors';
+import DocumentHead from 'calypso/components/data/document-head';
+import { getDocumentHeadCappedUnreadCount } from 'calypso/state/document-head/selectors/get-document-head-capped-unread-count';
+import { getCommentById } from 'calypso/state/comments/selectors';
+import { getStream } from 'calypso/state/reader/streams/selectors';
 
 /**
  * Style dependencies

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -6,9 +6,9 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
-import XPostHelper, { isXPost } from 'reader/xpost-helper';
-import { reduxGetState } from 'lib/redux-bridge';
-import { getPostByKey } from 'state/reader/posts/selectors';
+import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
+import { reduxGetState } from 'calypso/lib/redux-bridge';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 
 export function isSpecialClick( event ) {
 	return event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey;

--- a/client/reader/xpost-helper.js
+++ b/client/reader/xpost-helper.js
@@ -6,8 +6,8 @@ import { has } from 'lodash';
 /**
  * Internal dependencies
  */
-import displayTypes from 'state/reader/posts/display-types';
-import { getUrlParts } from 'lib/url';
+import displayTypes from 'calypso/state/reader/posts/display-types';
+import { getUrlParts } from 'calypso/lib/url';
 
 const { X_POST } = displayTypes;
 


### PR DESCRIPTION
### Background

See #44602

### Changes

Automatically apply fix for eslint rule `wpcalypso/no-package-relative-imports` in `./client/reader`

Fix applied with `./node_modules/.bin/eslint-nibble --ext .js,.jsx,.ts,.tsx,.md.js,.md.javascript,.md.jsx client/reader`

### Testing instructions

* Check all tests passes (ignore lint errors, there will be a ton).
* Do a smoke test on the live branch
* Verify there are no huge changes in package size in ICFY report.

