### PR TITLE
Make sure that current section is always set in router context when changing it

### DIFF
--- a/client/layout/body-section-css-class.js
+++ b/client/layout/body-section-css-class.js
@@ -36,7 +36,14 @@ const addSectionClass = addBodyClass( ( s ) => `is-section-${ s }` );
 export default function BodySectionCssClass( { group, section, bodyClass } ) {
 	React.useEffect( addGroupClass( group ), [ group ] );
 	React.useEffect( addSectionClass( section ), [ section ] );
-	React.useEffect( () => bodyClass && document.body.classList.add( bodyClass ) );
+	React.useEffect( () => {
+		if ( ! bodyClass ) {
+			return;
+		}
+
+		document.body.classList.add( bodyClass );
+		return () => document.body.classList.remove( bodyClass );
+	}, [ bodyClass ] );
 
 	return null;
 }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -124,29 +124,25 @@ class Layout extends Component {
 	}
 
 	render() {
-		const sectionClass = classnames(
-			'layout',
-			`is-group-${ this.props.sectionGroup }`,
-			`is-section-${ this.props.sectionName }`,
-			`focus-${ this.props.currentLayoutFocus }`,
-			{
-				'is-support-session': this.props.isSupportSession,
-				'has-no-sidebar': ! this.props.secondary,
-				'has-chat': this.props.chatIsOpen,
-				'has-no-masterbar': this.props.masterbarIsHidden,
-				'is-jetpack-login': this.props.isJetpackLogin,
-				'is-jetpack-site': this.props.isJetpack,
-				'is-jetpack-mobile-flow': this.props.isJetpackMobileFlow,
-				'is-jetpack-woocommerce-flow':
-					config.isEnabled( 'jetpack/connect/woocommerce' ) && this.props.isJetpackWooCommerceFlow,
-				'is-jetpack-woo-dna-flow': this.props.isJetpackWooDnaFlow,
-				'is-wccom-oauth-flow':
-					config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-					isWooOAuth2Client( this.props.oauth2Client ) &&
-					this.props.wccomFrom,
-				'is-nav-unification': config.isEnabled( 'nav-unification' ),
-			}
-		);
+		const sectionClass = classnames( 'layout', `focus-${ this.props.currentLayoutFocus }`, {
+			[ 'is-group-' + this.props.sectionGroup ]: this.props.sectionGroup,
+			[ 'is-section-' + this.props.sectionName ]: this.props.sectionName,
+			'is-support-session': this.props.isSupportSession,
+			'has-no-sidebar': ! this.props.secondary,
+			'has-chat': this.props.chatIsOpen,
+			'has-no-masterbar': this.props.masterbarIsHidden,
+			'is-jetpack-login': this.props.isJetpackLogin,
+			'is-jetpack-site': this.props.isJetpack,
+			'is-jetpack-mobile-flow': this.props.isJetpackMobileFlow,
+			'is-jetpack-woocommerce-flow':
+				config.isEnabled( 'jetpack/connect/woocommerce' ) && this.props.isJetpackWooCommerceFlow,
+			'is-jetpack-woo-dna-flow': this.props.isJetpackWooDnaFlow,
+			'is-wccom-oauth-flow':
+				config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
+				isWooOAuth2Client( this.props.oauth2Client ) &&
+				this.props.wccomFrom,
+			'is-nav-unification': config.isEnabled( 'nav-unification' ),
+		} );
 
 		const optionalBodyProps = () => {
 			const optionalProps = {};
@@ -245,8 +241,8 @@ class Layout extends Component {
 export default compose(
 	withCurrentRoute,
 	connect( ( state, { currentSection, currentRoute, currentQuery } ) => {
-		const sectionGroup = currentSection?.group;
-		const sectionName = currentSection?.name;
+		const sectionGroup = currentSection?.group ?? null;
+		const sectionName = currentSection?.name ?? null;
 		const siteId = getSelectedSiteId( state );
 		const shouldShowAppBanner = getShouldShowAppBanner( getSelectedSite( state ) );
 		const sectionJitmPath = getMessagePathForJITM( currentRoute );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -11,44 +11,44 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import AsyncLoad from 'components/async-load';
-import MasterbarLoggedIn from 'layout/masterbar/logged-in';
-import JetpackCloudMasterbar from 'components/jetpack/masterbar';
-import HtmlIsIframeClassname from 'layout/html-is-iframe-classname';
-import notices from 'notices';
-import config from 'config';
-import OfflineStatus from 'layout/offline-status';
-import QueryPreferences from 'components/data/query-preferences';
-import QuerySites from 'components/data/query-sites';
-import QuerySiteSelectedEditor from 'components/data/query-site-selected-editor';
-import { isOffline } from 'state/application/selectors';
-import { getSelectedSiteId, masterbarIsVisible, getSelectedSite } from 'state/ui/selectors';
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
-import { isJetpackSite } from 'state/sites/selectors';
-import { isSupportSession } from 'state/support/selectors';
-import SitePreview from 'blocks/site-preview';
-import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
-import DocumentHead from 'components/data/document-head';
-import { getPreference } from 'state/preferences/selectors';
-import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
-import SupportUser from 'support/support-user';
-import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
-import { isE2ETest } from 'lib/e2e';
-import { getMessagePathForJITM } from 'lib/route';
+import AsyncLoad from 'calypso/components/async-load';
+import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
+import JetpackCloudMasterbar from 'calypso/components/jetpack/masterbar';
+import HtmlIsIframeClassname from 'calypso/layout/html-is-iframe-classname';
+import notices from 'calypso/notices';
+import config from 'calypso/config';
+import OfflineStatus from 'calypso/layout/offline-status';
+import QueryPreferences from 'calypso/components/data/query-preferences';
+import QuerySites from 'calypso/components/data/query-sites';
+import QuerySiteSelectedEditor from 'calypso/components/data/query-site-selected-editor';
+import { isOffline } from 'calypso/state/application/selectors';
+import { getSelectedSiteId, masterbarIsVisible, getSelectedSite } from 'calypso/state/ui/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isSupportSession } from 'calypso/state/support/selectors';
+import SitePreview from 'calypso/blocks/site-preview';
+import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
+import DocumentHead from 'calypso/components/data/document-head';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import KeyboardShortcutsMenu from 'calypso/lib/keyboard-shortcuts/menu';
+import SupportUser from 'calypso/support/support-user';
+import { isCommunityTranslatorEnabled } from 'calypso/components/community-translator/utils';
+import { isE2ETest } from 'calypso/lib/e2e';
+import { getMessagePathForJITM } from 'calypso/lib/route';
 import BodySectionCssClass from './body-section-css-class';
-import { retrieveMobileRedirect } from 'jetpack-connect/persistence-utils';
-import { isWooOAuth2Client } from 'lib/oauth2-clients';
-import { getCurrentOAuth2Client } from 'state/oauth2-clients/ui/selectors';
+import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-utils';
+import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import LayoutLoader from './loader';
-import wooDnaConfig from 'jetpack-connect/woo-dna-config';
-import { withCurrentRoute } from 'components/route';
+import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
+import { withCurrentRoute } from 'calypso/components/route';
 
 /**
  * Style dependencies
  */
 // goofy import for environment badge, which is SSR'd
-import 'components/environment-badge/style.scss';
+import 'calypso/components/environment-badge/style.scss';
 import './style.scss';
 import { getShouldShowAppBanner } from './utils';
 
@@ -172,10 +172,10 @@ class Layout extends Component {
 					<QuerySiteSelectedEditor siteId={ this.props.siteId } />
 				) }
 				{ config.isEnabled( 'layout/guided-tours' ) && (
-					<AsyncLoad require="layout/guided-tours" placeholder={ null } />
+					<AsyncLoad require="calypso/layout/guided-tours" placeholder={ null } />
 				) }
 				{ config.isEnabled( 'layout/nps-survey-notice' ) && ! isE2ETest() && (
-					<AsyncLoad require="layout/nps-survey-notice" placeholder={ null } />
+					<AsyncLoad require="calypso/layout/nps-survey-notice" placeholder={ null } />
 				) }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				{ this.renderMasterbar() }
@@ -185,14 +185,14 @@ class Layout extends Component {
 				<div id="content" className="layout__content">
 					{ config.isEnabled( 'jitms' ) && this.props.isEligibleForJITM && (
 						<AsyncLoad
-							require="blocks/jitm"
+							require="calypso/blocks/jitm"
 							placeholder={ null }
 							messagePath={ `calypso:${ this.props.sectionJitmPath }:admin_notices` }
 							sectionName={ this.props.sectionName }
 						/>
 					) }
 					<AsyncLoad
-						require="components/global-notices"
+						require="calypso/components/global-notices"
 						placeholder={ null }
 						id="notices"
 						notices={ notices.list }
@@ -206,32 +206,35 @@ class Layout extends Component {
 				</div>
 				{ config.isEnabled( 'i18n/community-translator' )
 					? isCommunityTranslatorEnabled() && (
-							<AsyncLoad require="components/community-translator" />
+							<AsyncLoad require="calypso/components/community-translator" />
 					  )
 					: config( 'restricted_me_access' ) && (
-							<AsyncLoad require="layout/community-translator/launcher" placeholder={ null } />
+							<AsyncLoad
+								require="calypso/layout/community-translator/launcher"
+								placeholder={ null }
+							/>
 					  ) }
 				{ this.props.sectionGroup === 'sites' && <SitePreview /> }
 				{ config.isEnabled( 'happychat' ) && this.props.chatIsOpen && (
-					<AsyncLoad require="components/happychat" />
+					<AsyncLoad require="calypso/components/happychat" />
 				) }
 				{ 'development' === process.env.NODE_ENV && (
-					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
+					<AsyncLoad require="calypso/components/webpack-build-monitor" placeholder={ null } />
 				) }
 				{ this.shouldLoadInlineHelp() && (
-					<AsyncLoad require="blocks/inline-help" placeholder={ null } />
+					<AsyncLoad require="calypso/blocks/inline-help" placeholder={ null } />
 				) }
 				{ config.isEnabled( 'layout/support-article-dialog' ) && (
-					<AsyncLoad require="blocks/support-article-dialog" placeholder={ null } />
+					<AsyncLoad require="calypso/blocks/support-article-dialog" placeholder={ null } />
 				) }
 				{ shouldShowAppBanner && config.isEnabled( 'layout/app-banner' ) && (
-					<AsyncLoad require="blocks/app-banner" placeholder={ null } />
+					<AsyncLoad require="calypso/blocks/app-banner" placeholder={ null } />
 				) }
 				{ config.isEnabled( 'gdpr-banner' ) && (
-					<AsyncLoad require="blocks/gdpr-banner" placeholder={ null } />
+					<AsyncLoad require="calypso/blocks/gdpr-banner" placeholder={ null } />
 				) }
 				{ config.isEnabled( 'legal-updates-banner' ) && (
-					<AsyncLoad require="blocks/legal-updates-banner" placeholder={ null } />
+					<AsyncLoad require="calypso/blocks/legal-updates-banner" placeholder={ null } />
 				) }
 			</div>
 		);

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -17,10 +17,9 @@ import notices from 'notices';
 import OauthClientMasterbar from 'layout/masterbar/oauth-client';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import { getCurrentOAuth2Client, showOAuth2Layout } from 'state/oauth2-clients/ui/selectors';
-import { getCurrentRoute } from 'state/selectors/get-current-route';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
-import { getSection, masterbarIsVisible } from 'state/ui/selectors';
+import { masterbarIsVisible } from 'state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
 import GdprBanner from 'blocks/gdpr-banner';
 import wooDnaConfig from 'jetpack-connect/woo-dna-config';
@@ -41,12 +40,12 @@ const LayoutLoggedOut = ( {
 	oauth2Client,
 	primary,
 	secondary,
-	section,
+	sectionGroup,
+	sectionName,
+	sectionTitle,
 	redirectUri,
 	useOAuth2Layout,
 } ) => {
-	const sectionGroup = get( section, 'group', null );
-	const sectionName = get( section, 'name', null );
 	const isCheckout = sectionName === 'checkout';
 
 	const classes = {
@@ -93,8 +92,8 @@ const LayoutLoggedOut = ( {
 	} else {
 		masterbar = (
 			<MasterbarLoggedOut
-				title={ section.title }
-				sectionName={ section.name }
+				title={ sectionTitle }
+				sectionName={ sectionName }
 				isCheckout={ isCheckout }
 				redirectUri={ redirectUri }
 			/>
@@ -137,15 +136,16 @@ LayoutLoggedOut.propTypes = {
 	showOAuth2Layout: PropTypes.bool,
 };
 
-export default connect( ( state ) => {
-	const section = getSection( state );
-	const currentRoute = getCurrentRoute( state );
+export default connect( ( state, { currentSection, currentRoute } ) => {
+	const sectionGroup = currentSection?.group ?? null;
+	const sectionName = currentSection?.name ?? null;
+	const sectionTitle = currentSection?.title ?? '';
 	const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
 	const isGutenboardingLogin = startsWith( currentRoute, '/log-in/new' );
 	const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
 	const noMasterbarForRoute = isJetpackLogin || isGutenboardingLogin || isJetpackWooDnaFlow;
 	const isPopup = '1' === get( getCurrentQueryArguments( state ), 'is_popup' );
-	const noMasterbarForSection = 'signup' === section.name || 'jetpack-connect' === section.name;
+	const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
 	const isJetpackWooCommerceFlow =
 		'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
@@ -160,7 +160,9 @@ export default connect( ( state ) => {
 		wccomFrom,
 		masterbarIsHidden:
 			! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,
-		section,
+		sectionGroup,
+		sectionName,
+		sectionTitle,
 		oauth2Client: getCurrentOAuth2Client( state ),
 		useOAuth2Layout: showOAuth2Layout( state ),
 	};

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -10,19 +10,22 @@ import { get, startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import AsyncLoad from 'components/async-load';
-import config from 'config';
-import MasterbarLoggedOut from 'layout/masterbar/logged-out';
-import notices from 'notices';
-import OauthClientMasterbar from 'layout/masterbar/oauth-client';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
-import { getCurrentOAuth2Client, showOAuth2Layout } from 'state/oauth2-clients/ui/selectors';
-import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
-import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
-import { masterbarIsVisible } from 'state/ui/selectors';
+import AsyncLoad from 'calypso/components/async-load';
+import config from 'calypso/config';
+import MasterbarLoggedOut from 'calypso/layout/masterbar/logged-out';
+import notices from 'calypso/notices';
+import OauthClientMasterbar from 'calypso/layout/masterbar/oauth-client';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	getCurrentOAuth2Client,
+	showOAuth2Layout,
+} from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import { masterbarIsVisible } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
-import GdprBanner from 'blocks/gdpr-banner';
-import wooDnaConfig from 'jetpack-connect/woo-dna-config';
+import GdprBanner from 'calypso/blocks/gdpr-banner';
+import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 
 /**
  * Style dependencies
@@ -106,12 +109,12 @@ const LayoutLoggedOut = ( {
 			{ masterbar }
 			<div id="content" className="layout__content">
 				<AsyncLoad
-					require="components/global-notices"
+					require="calypso/components/global-notices"
 					placeholder={ null }
 					id="notices"
 					notices={ notices.list }
 				/>
-				{ isCheckout && <AsyncLoad require="blocks/inline-help" placeholder={ null } /> }
+				{ isCheckout && <AsyncLoad require="calypso/blocks/inline-help" placeholder={ null } /> }
 				<div id="primary" className="layout__primary">
 					{ primary }
 				</div>

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get, startsWith } from 'lodash';
+import { get, startsWith, flowRight as compose } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,6 +26,7 @@ import { masterbarIsVisible } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
 import GdprBanner from 'calypso/blocks/gdpr-banner';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
+import { withCurrentRoute } from 'calypso/components/route';
 
 /**
  * Style dependencies
@@ -139,34 +140,37 @@ LayoutLoggedOut.propTypes = {
 	showOAuth2Layout: PropTypes.bool,
 };
 
-export default connect( ( state, { currentSection, currentRoute } ) => {
-	const sectionGroup = currentSection?.group ?? null;
-	const sectionName = currentSection?.name ?? null;
-	const sectionTitle = currentSection?.title ?? '';
-	const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
-	const isGutenboardingLogin = startsWith( currentRoute, '/log-in/new' );
-	const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
-	const noMasterbarForRoute = isJetpackLogin || isGutenboardingLogin || isJetpackWooDnaFlow;
-	const isPopup = '1' === get( getCurrentQueryArguments( state ), 'is_popup' );
-	const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
-	const isJetpackWooCommerceFlow =
-		'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
-	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
+export default compose(
+	withCurrentRoute,
+	connect( ( state, { currentSection, currentRoute } ) => {
+		const sectionGroup = currentSection?.group ?? null;
+		const sectionName = currentSection?.name ?? null;
+		const sectionTitle = currentSection?.title ?? '';
+		const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
+		const isGutenboardingLogin = startsWith( currentRoute, '/log-in/new' );
+		const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
+		const noMasterbarForRoute = isJetpackLogin || isGutenboardingLogin || isJetpackWooDnaFlow;
+		const isPopup = '1' === get( getCurrentQueryArguments( state ), 'is_popup' );
+		const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
+		const isJetpackWooCommerceFlow =
+			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
+		const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 
-	return {
-		currentRoute,
-		isJetpackLogin,
-		isGutenboardingLogin,
-		isPopup,
-		isJetpackWooCommerceFlow,
-		isJetpackWooDnaFlow,
-		wccomFrom,
-		masterbarIsHidden:
-			! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,
-		sectionGroup,
-		sectionName,
-		sectionTitle,
-		oauth2Client: getCurrentOAuth2Client( state ),
-		useOAuth2Layout: showOAuth2Layout( state ),
-	};
-} )( LayoutLoggedOut );
+		return {
+			currentRoute,
+			isJetpackLogin,
+			isGutenboardingLogin,
+			isPopup,
+			isJetpackWooCommerceFlow,
+			isJetpackWooDnaFlow,
+			wccomFrom,
+			masterbarIsHidden:
+				! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,
+			sectionGroup,
+			sectionName,
+			sectionTitle,
+			oauth2Client: getCurrentOAuth2Client( state ),
+			useOAuth2Layout: showOAuth2Layout( state ),
+		};
+	} )
+)( LayoutLoggedOut );

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -20,6 +20,7 @@ import { setLocaleMiddleware, setSectionMiddleware, makeLayoutMiddleware } from 
 import { redirectLoggedIn } from 'controller/web-util';
 import LayoutLoggedOut from 'layout/logged-out';
 import { getLanguageRouteParam } from 'lib/i18n-utils';
+import { RouteProvider } from 'calypso/components/route';
 
 export const LOGIN_SECTION_DEFINITION = {
 	name: 'login',
@@ -29,11 +30,25 @@ export const LOGIN_SECTION_DEFINITION = {
 	isomorphic: true,
 };
 
-const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } ) => {
+const ReduxWrappedLayout = ( {
+	store,
+	currentSection,
+	currentRoute,
+	currentQuery,
+	primary,
+	secondary,
+	redirectUri,
+} ) => {
 	return (
-		<ReduxProvider store={ store }>
-			<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
-		</ReduxProvider>
+		<RouteProvider
+			currentSection={ currentSection }
+			currentRoute={ currentRoute }
+			currentQuery={ currentQuery }
+		>
+			<ReduxProvider store={ store }>
+				<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
+			</ReduxProvider>
+		</RouteProvider>
 	);
 };
 

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -7,7 +7,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import config from 'calypso/config';
 import {
 	login,
 	magicLogin,
@@ -16,10 +16,14 @@ import {
 	redirectDefaultLocale,
 } from './controller';
 import { setShouldServerSideRenderLogin } from './ssr';
-import { setLocaleMiddleware, setSectionMiddleware, makeLayoutMiddleware } from 'controller/shared';
-import { redirectLoggedIn } from 'controller/web-util';
-import LayoutLoggedOut from 'layout/logged-out';
-import { getLanguageRouteParam } from 'lib/i18n-utils';
+import {
+	setLocaleMiddleware,
+	setSectionMiddleware,
+	makeLayoutMiddleware,
+} from 'calypso/controller/shared';
+import { redirectLoggedIn } from 'calypso/controller/web-util';
+import LayoutLoggedOut from 'calypso/layout/logged-out';
+import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 import { RouteProvider } from 'calypso/components/route';
 
 export const LOGIN_SECTION_DEFINITION = {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -10,7 +10,6 @@ import page from 'page';
  * Internal Dependencies
  */
 import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
-import { setSection } from 'calypso/state/ui/actions';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import GSuiteNudge from './gsuite-nudge';
@@ -21,6 +20,7 @@ import CheckoutThankYouComponent from './checkout-thank-you';
 import UpsellNudge from './upsell-nudge';
 import { canUserPurchaseGSuite } from 'calypso/lib/gsuite';
 import { getRememberedCoupon } from 'calypso/lib/cart/actions';
+import { setSectionMiddleware } from 'calypso/controller';
 import { sites } from 'calypso/my-sites/controller';
 import CartData from 'calypso/components/data/cart';
 import userFactory from 'calypso/lib/user';
@@ -63,7 +63,7 @@ export function checkout( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
 
-	context.store.dispatch( setSection( { name: 'checkout' } ) );
+	setSectionMiddleware( { name: 'checkout' } )( context );
 
 	// NOTE: `context.query.code` is deprecated in favor of `context.query.coupon`.
 	const couponCode = context.query.coupon || context.query.code || getRememberedCoupon();
@@ -116,7 +116,7 @@ export function checkoutPending( context, next ) {
 	const orderId = Number( context.params.orderId );
 	const siteSlug = context.params.site;
 
-	context.store.dispatch( setSection( { name: 'checkout-thank-you' } ) );
+	setSectionMiddleware( { name: 'checkout-thank-you' } )( context );
 
 	context.primary = (
 		<CheckoutPendingComponent
@@ -137,7 +137,7 @@ export function checkoutThankYou( context, next ) {
 	const selectedSite = getSelectedSite( state );
 	const displayMode = get( context, 'query.d' );
 
-	context.store.dispatch( setSection( { name: 'checkout-thank-you' } ) );
+	setSectionMiddleware( { name: 'checkout-thank-you' } )( context );
 
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Thank You' ) ) );
@@ -161,7 +161,7 @@ export function checkoutThankYou( context, next ) {
 
 export function gsuiteNudge( context, next ) {
 	const { domain, site, receiptId } = context.params;
-	context.store.dispatch( setSection( { name: 'gsuite-nudge' } ) );
+	setSectionMiddleware( { name: 'gsuite-nudge' } )( context );
 
 	const state = context.store.getState();
 	const selectedSite =
@@ -208,7 +208,7 @@ export function upsellNudge( context, next ) {
 		upgradeItem = context.params.upgradeItem;
 	}
 
-	context.store.dispatch( setSection( { name: upsellType } ) );
+	setSectionMiddleware( { name: upsellType } )( context );
 
 	context.primary = (
 		<CheckoutContainer

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -18,7 +18,7 @@ import {
 	isJetpackSite,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { setSelectedSiteId, setSection, setAllSitesSelected } from 'calypso/state/ui/actions';
+import { setSelectedSiteId, setAllSitesSelected } from 'calypso/state/ui/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { hasReceivedRemotePreferences, getPreference } from 'calypso/state/preferences/selectors';
 import NavigationComponent from 'calypso/my-sites/navigation';
@@ -57,7 +57,7 @@ import {
 } from 'calypso/my-sites/email/paths';
 import SitesComponent from 'calypso/my-sites/sites';
 import { warningNotice } from 'calypso/state/notices/actions';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender, setSectionMiddleware } from 'calypso/controller';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import EmptyContentComponent from 'calypso/components/empty-content';
 import DomainOnly from 'calypso/my-sites/domains/domain-management/list/domain-only';
@@ -99,7 +99,7 @@ function createNavigation( context ) {
 }
 
 function renderEmptySites( context ) {
-	context.store.dispatch( setSection( { group: 'sites' } ) );
+	setSectionMiddleware( { group: 'sites' } )( context );
 
 	context.primary = React.createElement( NoSitesMessage );
 
@@ -113,7 +113,7 @@ function renderNoVisibleSites( context ) {
 	const hiddenSites = currentUser && currentUser.site_count - currentUser.visible_site_count;
 	const signup_url = config( 'signup_url' );
 
-	context.store.dispatch( setSection( { group: 'sites' } ) );
+	setSectionMiddleware( { group: 'sites' } )( context );
 
 	context.primary = React.createElement( EmptyContentComponent, {
 		title: i18n.translate(
@@ -485,7 +485,7 @@ export function sites( context, next ) {
 	}
 
 	context.store.dispatch( setLayoutFocus( 'content' ) );
-	context.store.dispatch( setSection( { group: 'sites' } ) );
+	setSectionMiddleware( { group: 'sites' } )( context );
 
 	context.primary = createSitesComponent( context );
 	next();

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -7,7 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { setSection, setSectionLoading } from 'state/ui/actions';
+import { setSectionLoading } from 'state/ui/actions';
 import { activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { bumpStat } from 'state/analytics/actions';
 import * as LoadingError from 'layout/error';
@@ -22,8 +22,7 @@ import sections from './sections';
 receiveSections( sections );
 
 function activateSection( section, context ) {
-	context.section = section;
-	context.store.dispatch( setSection( section ) );
+	controller.setSectionMiddleware( section )( context );
 	context.store.dispatch( activateNextLayoutFocus() );
 }
 

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -1,22 +1,22 @@
 /**
  * External dependencies
  */
-import config from 'config';
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import { setSectionLoading } from 'state/ui/actions';
-import { activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
-import { bumpStat } from 'state/analytics/actions';
-import * as LoadingError from 'layout/error';
+import config from 'calypso/config';
+import { setSectionLoading } from 'calypso/state/ui/actions';
+import { activateNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import { bumpStat } from 'calypso/state/analytics/actions';
+import * as LoadingError from 'calypso/layout/error';
 import * as controller from './controller/index.web';
 import { pathToRegExp } from './utils';
 import { receiveSections, load } from './sections-helper';
 import isSectionEnabled from './sections-filter';
-import { addReducerToStore } from 'state/add-reducer';
-import { performanceTrackerStart } from 'lib/performance-tracking';
+import { addReducerToStore } from 'calypso/state/add-reducer';
+import { performanceTrackerStart } from 'calypso/lib/performance-tracking';
 
 import sections from './sections';
 receiveSections( sections );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/46684 (issue brought up by @sirbrillig in https://github.com/Automattic/wp-calypso/pull/46086#issuecomment-714634933)

Whenever some route handler sets a custom section name/group with `dispatch( setSection() )`, make sure that the new section value is also set in the `RouteContext`. This PR does that by using `setSectionMiddleware` for setting the section.

The suggestion by @tyxla in https://github.com/Automattic/wp-calypso/pull/46086#discussion_r510069167 became urgent much faster than I expected! 🙂 

It turns out that the work in #46086 wasn't really finished, so this PR contains some additional fixes like converting `LoggedOutLayout` to the route context, too.

Also fixes the `BodySectionCssClass` component to remove the `bodyClass` class from `<body>` when the component is unmounted or the `bodyClass` prop changed or removed.

**How to test:**
Go to `/checkout/thank-you/:site` and verify that the `is-section-checkout-thank-you` CSS class is present on `<body>`:
<img width="637" alt="Screenshot 2020-10-23 at 08 54 48" src="https://user-images.githubusercontent.com/664258/96974656-d2353480-1519-11eb-90b1-1b92f7ef759b.png">

Before this fix, the class wasn't there, there was just `is-section-checkout`:
<img width="637" alt="Screenshot 2020-10-23 at 08 54 48" src="https://user-images.githubusercontent.com/664258/96974707-e4af6e00-1519-11eb-9338-77748c9f4731.png">
