### PR TITLE
Fix: Domain step CTA should be "Select" instead of "Upgrade"

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -39,6 +39,7 @@ const NOTICE_GREEN = '#4ab866';
 class DomainRegistrationSuggestion extends React.Component {
 	static propTypes = {
 		isDomainOnly: PropTypes.bool,
+		isSignupStep: PropTypes.bool,
 		showStrikedOutPrice: PropTypes.bool,
 		isFeatured: PropTypes.bool,
 		buttonStyles: PropTypes.object,
@@ -123,7 +124,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		const {
 			cart,
 			domainsWithPlansOnly,
-			showStrikedOutPrice,
+			isSignupStep,
 			selectedSite,
 			suggestion,
 			translate,
@@ -145,7 +146,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			buttonStyles = { ...buttonStyles, primary: false };
 		} else {
 			buttonContent =
-				! showStrikedOutPrice &&
+				! isSignupStep &&
 				shouldBundleDomainWithPlan( domainsWithPlansOnly, selectedSite, cart, suggestion )
 					? translate( 'Upgrade', {
 							context: 'Domain mapping suggestion button with plan upgrade',

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -262,6 +262,7 @@ class DomainSearchResults extends React.Component {
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					isDomainOnly={ isDomainOnly }
 					fetchAlgo={ this.props.fetchAlgo }
+					isSignupStep={ this.props.isSignupStep }
 					showStrikedOutPrice={ showStrikedOutPrice }
 					key="featured"
 					onButtonClick={ this.props.onClickResult }
@@ -287,6 +288,7 @@ class DomainSearchResults extends React.Component {
 						suggestion={ suggestion }
 						key={ suggestion.domain_name }
 						cart={ this.props.cart }
+						isSignupStep={ this.props.isSignupStep }
 						showStrikedOutPrice={ this.props.showStrikedOutPrice }
 						selectedSite={ this.props.selectedSite }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -116,6 +116,7 @@ export class FeaturedDomainSuggestions extends Component {
 						suggestion={ primarySuggestion }
 						isFeatured
 						railcarId={ this.props.railcarId + '-0' }
+						isSignupStep={ this.props.isSignupStep }
 						uiPosition={ 0 }
 						premiumDomain={ this.props.premiumDomains[ primarySuggestion.domain_name ] }
 						fetchAlgo={ this.getFetchAlgorithm( primarySuggestion ) }
@@ -128,6 +129,7 @@ export class FeaturedDomainSuggestions extends Component {
 						suggestion={ secondarySuggestion }
 						isFeatured
 						railcarId={ this.props.railcarId + '-1' }
+						isSignupStep={ this.props.isSignupStep }
 						uiPosition={ 1 }
 						premiumDomain={ this.props.premiumDomains[ secondarySuggestion.domain_name ] }
 						fetchAlgo={ this.getFetchAlgorithm( secondarySuggestion ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* With the roll out of the domain step test variant to all users in https://github.com/Automattic/wp-calypso/pull/45618, the CTA on a domain changed to "Upgrade" in the domain only flow and site launch flow, as described in [this comment](https://github.com/Automattic/wp-calypso/pull/45618#pullrequestreview-515253379). This PR fixes the issue.

You should now the CTA as "Select" in the following cases:
* the domain search results in the domain only flow
* The initial suggestions in the launch site flow.
* the domain search results in the launch site flow

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the domain only flow at /start/domain and confirm that the CTA on each domain in the domain search results is "Select", check [screenshot](https://d.pr/i/IsqXMG). Verify the same for add-domain flow too.
* Go to the launch site flow and verify that the CTA is "Select" instead of "Upgrade" in the initial suggestions list and in the domain search results list, check [screenshot](https://d.pr/i/y6Udqb).
* Verify that the CTA is "Select" in the signup flows.

