### PR TITLE
Apply autofix for rule `wpcalypso/no-package-relative-imports` in Markdown files

### DIFF
--- a/client/blocks/all-sites/README.md
+++ b/client/blocks/all-sites/README.md
@@ -5,7 +5,7 @@ This component displays the All Sites item. It's used in the Sidebar as the curr
 ## How to use
 
 ```js
-import AllSites from 'blocks/all-sites';
+import AllSites from 'calypso/blocks/all-sites';
 
 function render() {
 	return <AllSites sites={ sitesArray } />;

--- a/client/blocks/app-promo/README.md
+++ b/client/blocks/app-promo/README.md
@@ -5,7 +5,7 @@ This component is used to suggest the desktop app to users.
 ## How to use
 
 ```js
-import AppPromo from 'components/app-promo';
+import AppPromo from 'calypso/components/app-promo';
 
 function render() {
 	return <AppPromo />;

--- a/client/blocks/calendar-button/README.md
+++ b/client/blocks/calendar-button/README.md
@@ -5,7 +5,7 @@ This component is used to display a calendar button. When it pressed, it shows a
 ## Usage
 
 ```jsx
-import CalendarButton from 'blocks/calendar-button';
+import CalendarButton from 'calypso/blocks/calendar-button';
 
 function render() {
 	return <CalendarButton />;
@@ -78,7 +78,7 @@ This property defines to this component as a `button`. You shouldn't change this
 ### As much simple as possible
 
 ```jsx
-import CalendarButton from 'blocks/calendar-button';
+import CalendarButton from 'calypso/blocks/calendar-button';
 
 function render() {
 	const tomorrow = new Date( new Date().getTime() + 24 * 60 * 60 * 1000 );
@@ -90,7 +90,7 @@ function render() {
 ### Custom calendar icon
 
 ```jsx
-import CalendarButton from 'blocks/calendar-button';
+import CalendarButton from 'calypso/blocks/calendar-button';
 
 function render() {
 	return <CalendarButton icon="thumbs-up" />;
@@ -100,7 +100,7 @@ function render() {
 ### Render using children property
 
 ```jsx
-import CalendarButton from 'blocks/calendar-button';
+import CalendarButton from 'calypso/blocks/calendar-button';
 
 function render() {
 	return (

--- a/client/blocks/calendar-popover/README.md
+++ b/client/blocks/calendar-popover/README.md
@@ -8,7 +8,7 @@ Beyond combining Popover and PostSchedule, this component connects with the stat
 
 ```jsx
 import { Button } from '@automattic/components';
-import CalendarPopover from 'blocks/calendar-popover';
+import CalendarPopover from 'calypso/blocks/calendar-popover';
 
 const toggle = () => this.setState( { show: ! this.state.show } );
 const buttonRef = React.createRef();

--- a/client/blocks/color-scheme-picker/README.md
+++ b/client/blocks/color-scheme-picker/README.md
@@ -8,7 +8,7 @@ When the props `temporarySelection` and `onSelection` are provided, a selection 
 ## Usage
 
 ```jsx
-import ColorSchemePicker from 'blocks/color-scheme-picker';
+import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
 
 handleColorSchemeSelection = ( event ) => {
 	console.log( event.currentTarget.value );

--- a/client/blocks/comment-button/README.md
+++ b/client/blocks/comment-button/README.md
@@ -5,7 +5,7 @@ This component is used to display a button with an embedded number indicator.
 ## How to use
 
 ```js
-import CommentButton from 'blocks/comment-button';
+import CommentButton from 'calypso/blocks/comment-button';
 
 function render() {
 	return <CommentButton commentCount={ 123 } />;

--- a/client/blocks/conversation-caterpillar/README.md
+++ b/client/blocks/conversation-caterpillar/README.md
@@ -5,7 +5,7 @@ This component is used to show who's involved in a conversation, and how many co
 ## How to use
 
 ```js
-import ConversationCaterpillar from 'blocks/conversation-caterpillar';
+import ConversationCaterpillar from 'calypso/blocks/conversation-caterpillar';
 
 function render() {
 	return <ConversationCaterpillar blogId={ blogId } postId={ postId } />;

--- a/client/blocks/credit-card-form/README.md
+++ b/client/blocks/credit-card-form/README.md
@@ -5,7 +5,7 @@ This component is used to display a credit card form.
 ## How to use
 
 ```js
-import CreditCardForm from 'blocks/credit-card-form';
+import CreditCardForm from 'calypso/blocks/credit-card-form';
 
 function render() {
 	return (

--- a/client/blocks/dismissible-card/README.md
+++ b/client/blocks/dismissible-card/README.md
@@ -6,7 +6,7 @@ via user preference.
 ## How to use
 
 ```js
-import DismissibleCard from 'blocks/dismissible-card';
+import DismissibleCard from 'calypso/blocks/dismissible-card';
 
 function render() {
 	return (

--- a/client/blocks/domain-to-plan-nudge/README.md
+++ b/client/blocks/domain-to-plan-nudge/README.md
@@ -6,7 +6,7 @@ and a paid domain.
 ## How to use
 
 ```js
-import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
+import DomainToPlanNudge from 'calypso/blocks/domain-to-plan-nudge';
 
 function render() {
 	return (

--- a/client/blocks/follow-button/README.md
+++ b/client/blocks/follow-button/README.md
@@ -7,7 +7,7 @@ For most uses, the container is the easiest route.
 ## How to use the container
 
 ```js
-import FollowButtonContainer from 'blocks/follow-button';
+import FollowButtonContainer from 'calypso/blocks/follow-button';
 
 function render() {
 	return (
@@ -25,7 +25,7 @@ function render() {
 ## How to use the button directly
 
 ```js
-import FollowButton from 'blocks/follow-button/button';
+import FollowButton from 'calypso/blocks/follow-button/button';
 
 function render() {
 	return (

--- a/client/blocks/followers-count/README.md
+++ b/client/blocks/followers-count/README.md
@@ -5,7 +5,7 @@
 ## Example
 
 ```js
-import FollowersCount from 'blocks/followers-count';
+import FollowersCount from 'calypso/blocks/followers-count';
 
 function render() {
 	return <FollowersCount />;

--- a/client/blocks/global-notice/README.md
+++ b/client/blocks/global-notice/README.md
@@ -6,7 +6,7 @@ They allow you to use a component for your notice instead of calling the notices
 ## How to use the container
 
 ```js
-import { InfoNotice } from 'blocks/global-notice';
+import { InfoNotice } from 'calypso/blocks/global-notice';
 
 function render() {
 	return (

--- a/client/blocks/image-editor/README.md
+++ b/client/blocks/image-editor/README.md
@@ -126,7 +126,7 @@ Already-translated string which will be used on the 'Done' button. If not used, 
 ## Example
 
 ```js
-import ImageEditor from 'blocks/image-editor';
+import ImageEditor from 'calypso/blocks/image-editor';
 
 function render() {
 	return <ImageEditor siteId={ siteId } media={ { URL: 'http://example.com/image.jpg' } } />;

--- a/client/blocks/image-selector/README.md
+++ b/client/blocks/image-selector/README.md
@@ -9,7 +9,7 @@ Pass an array of image IDs that will be shown in the preview and preselected in 
 Changes to the selection of images will be passed back in various props for setting images, dropping images, and removing images. See the example.jsx file for a more complete example.
 
 ```jsx
-import ImageSelector from 'blocks/image-selector';
+import ImageSelector from 'calypso/blocks/image-selector';
 
 export default function MyFeaturedImages() {
 	return <ImageSelector imageIds={ [ 34, 105 ] } multiple />;

--- a/client/blocks/like-button/README.md
+++ b/client/blocks/like-button/README.md
@@ -7,7 +7,7 @@ For most usage, the container is the easiest route.
 ## How to use the container
 
 ```js
-import LikeButtonContainer from 'blocks/like-button';
+import LikeButtonContainer from 'calypso/blocks/like-button';
 
 function render() {
 	return (
@@ -26,7 +26,7 @@ function render() {
 ## How to use the button directly
 
 ```js
-import LikeButton from 'blocks/like-button/button';
+import LikeButton from 'calypso/blocks/like-button/button';
 
 function render() {
 	return (

--- a/client/blocks/location-search/README.md
+++ b/client/blocks/location-search/README.md
@@ -5,8 +5,8 @@ A search component for searching locations via the [Google Places API](https://c
 ## Usage
 
 ```jsx
-import LocationSearch from 'blocks/location-search';
-import { createNotice } from 'state/notices/actions';
+import LocationSearch from 'calypso/blocks/location-search';
+import { createNotice } from 'calypso/state/notices/actions';
 
 class LocationSearchExample extends Component {
 	static propTypes = {

--- a/client/blocks/plan-storage/README.md
+++ b/client/blocks/plan-storage/README.md
@@ -20,9 +20,9 @@ media storage limits are fetched.
 ## Usage
 
 ```javascript
-import PlanStorageBar from 'blocks/plan-storage/bar';
-import QueryMediaStorage from 'components/data/query-media-storage';
-import { getMediaStorage } from 'state/sites/media-storage/selectors';
+import PlanStorageBar from 'calypso/blocks/plan-storage/bar';
+import QueryMediaStorage from 'calypso/components/data/query-media-storage';
+import { getMediaStorage } from 'calypso/state/sites/media-storage/selectors';
 
 function render() {
 	const planName = this.props.site.plan.product_name_short;

--- a/client/blocks/post-likes/README.md
+++ b/client/blocks/post-likes/README.md
@@ -52,7 +52,7 @@ show/hide logic for this popover must be managed externally: if the popover is
 rendered with a valid `context` prop, it will be shown.
 
 ```js
-import PostLikesPopover from 'blocks/post-likes/popover';
+import PostLikesPopover from 'calypso/blocks/post-likes/popover';
 
 export default function SomeComponent() {
 	return (

--- a/client/blocks/post-share/README.md
+++ b/client/blocks/post-share/README.md
@@ -5,7 +5,7 @@ Component/Block to share posts to social-media accounts
 ## Example
 
 ```jsx
-import PostShare from 'blocks/post-share';
+import PostShare from 'calypso/blocks/post-share';
 
 <PostShare post={ post } siteId={ siteId } />;
 ```

--- a/client/blocks/product-plan-overlap-notices/README.md
+++ b/client/blocks/product-plan-overlap-notices/README.md
@@ -8,9 +8,9 @@ Those notices will appear when there is a feature overlap between the current pl
 
 ```jsx
 import React from 'react';
-import ProductPlanOverlapNotices from 'blocks/product-plan-overlap-notices';
-import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
-import { JETPACK_PLANS } from 'lib/plans/constants';
+import ProductPlanOverlapNotices from 'calypso/blocks/product-plan-overlap-notices';
+import { JETPACK_PRODUCTS_LIST } from 'calypso/lib/products-values/constants';
+import { JETPACK_PLANS } from 'calypso/lib/plans/constants';
 
 export default class extends React.Component {
 	render() {

--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -8,7 +8,7 @@ It's used on the plans page near the bundle plans grid and is intended to provid
 
 ```jsx
 import React from 'react';
-import ProductSelector from 'blocks/product-selector';
+import ProductSelector from 'calypso/blocks/product-selector';
 
 const products = [
 	{

--- a/client/blocks/shortcode/README.md
+++ b/client/blocks/shortcode/README.md
@@ -10,7 +10,7 @@ Simply pass a site ID and a shortcode string child. The component will automatic
 
 ```jsx
 import React from 'react';
-import Shortcode from 'blocks/shortcode';
+import Shortcode from 'calypso/blocks/shortcode';
 
 export default class extends React.Component {
 	static displayName = 'MyComponent';

--- a/client/blocks/signup-form/README.md
+++ b/client/blocks/signup-form/README.md
@@ -11,7 +11,7 @@ disabled={ this.isDisabled() }
 submitting={ this.isSubmitting() }
 
 ```js
-import SignupForm from 'blocks/signup-form';
+import SignupForm from 'calypso/blocks/signup-form';
 
 function render() {
 	return (

--- a/client/blocks/site-icon/README.md
+++ b/client/blocks/site-icon/README.md
@@ -5,7 +5,7 @@ This component is used to display the icon for a site. It takes a Site object as
 ## How to use
 
 ```js
-import SiteIcon from 'blocks/site-icon';
+import SiteIcon from 'calypso/blocks/site-icon';
 
 function render() {
 	return <SiteIcon site={ site } />;

--- a/client/blocks/site/README.md
+++ b/client/blocks/site/README.md
@@ -5,7 +5,7 @@ This component displays a Site item using site data retrieved from Redux store. 
 ## How to use
 
 ```js
-import Site from 'blocks/site';
+import Site from 'calypso/blocks/site';
 
 function render() {
 	return <Site siteId={ siteId } indicator={ true } />;

--- a/client/blocks/stats-sparkline/README.md
+++ b/client/blocks/stats-sparkline/README.md
@@ -5,7 +5,7 @@ The `StatsSparkline` block renders an image of a chart representing hourly views
 ## Usage
 
 ```jsx
-import StatsSparkline from 'blocks/stats-sparkline';
+import StatsSparkline from 'calypso/blocks/stats-sparkline';
 
 <StatsSparkline className="my-awesome-component__sparkline" siteId="777" />;
 ```

--- a/client/blocks/support-article-dialog/README.md
+++ b/client/blocks/support-article-dialog/README.md
@@ -9,7 +9,7 @@ The component is rendered from our main `<Layout />` component and so is availab
 To launch a support article call the corresponding redux action, like so:
 
 ```jsx
-import { openSupportArticleDialog } from 'state/inline-support-article/actions';
+import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
 
 function onSupportLinkClick() {
 	const { postId, postUrl } = this.props;

--- a/client/blocks/term-form-dialog/README.md
+++ b/client/blocks/term-form-dialog/README.md
@@ -5,7 +5,7 @@ The `TermFormDialog` component renders a dialog that allows to create/edit Terms
 ## Usage
 
 ```jsx
-import TermFormDialog from 'blocks/term-form-dialog';
+import TermFormDialog from 'calypso/blocks/term-form-dialog';
 
 <TermFormDialog showDialog={ true } taxonomy="category" onClose={ callback } postType="post" />;
 ```

--- a/client/blocks/term-tree-selector/README.md
+++ b/client/blocks/term-tree-selector/README.md
@@ -7,7 +7,7 @@ Under the hood, it uses [`<QueryTerms />`](../../components/data/query-terms) to
 ## Usage
 
 ```jsx
-import TermSelector from 'blocks/term-tree-selector';
+import TermSelector from 'calypso/blocks/term-tree-selector';
 
 <TermTreeSelector taxonomy="category" />;
 ```

--- a/client/blocks/time-mismatch-warning/README.md
+++ b/client/blocks/time-mismatch-warning/README.md
@@ -7,7 +7,7 @@ Nothing will appear if we don't detect a discrepancy.
 ## How to use
 
 ```jsx
-import TimeMismatchWarning from 'blocks/time-mismatch-warning';
+import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 
 const Test = () => (
 	<>

--- a/client/blocks/upsell-nudge/README.md
+++ b/client/blocks/upsell-nudge/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```js
-import UpsellNudge from 'blocks/upsell-nudge';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 function myUpsell() {
 	return (

--- a/client/blocks/user-mentions/README.md
+++ b/client/blocks/user-mentions/README.md
@@ -8,8 +8,8 @@ It also provides the components `UserMentionsSuggestionList` and `UserMentionsSu
 ## How to use
 
 ```js
-import FormTextarea from 'components/forms/form-textarea';
-import withUserMentions from 'blocks/user-mentions';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import withUserMentions from 'calypso/blocks/user-mentions';
 
 const ExampleInput = React.forwardRef( ( props, ref ) => (
 	<FormTextarea forwardedRef={ ref } onKeyUp={ props.onKeyUp } onKeyDown={ props.onKeyDown } />

--- a/client/blocks/video-editor/README.md
+++ b/client/blocks/video-editor/README.md
@@ -57,7 +57,7 @@ It receives one argument:
 ## Example
 
 ```js
-import VideoEditor from 'blocks/video-editor';
+import VideoEditor from 'calypso/blocks/video-editor';
 
 function render() {
 	return <VideoEditor media={ { videopress_guid: 'kUJmAcSf' } } />;

--- a/client/components/accordion/README.md
+++ b/client/components/accordion/README.md
@@ -7,7 +7,7 @@ Accordion is a React component to display collapsible content panels.
 At a minimum, you must provide a `title` for your Accordion, and a child or set of children to be shown in the expanded panel.
 
 ```jsx
-import Accordion from 'components/accordion';
+import Accordion from 'calypso/components/accordion';
 
 export default function MyComponent() {
 	return (

--- a/client/components/action-card/README.md
+++ b/client/components/action-card/README.md
@@ -5,7 +5,7 @@ This is a [`Card` component](../../components/card) that has a call-to-action bu
 ## Usage
 
 ```jsx
-import ActionCard from 'components/action-card';
+import ActionCard from 'calypso/components/action-card';
 
 function render() {
 	return (

--- a/client/components/action-panel/README.md
+++ b/client/components/action-panel/README.md
@@ -5,12 +5,12 @@ This is a larger [`Card` component](../../components/card) that has a title, des
 ## Usage
 
 ```jsx
-import ActionPanel from 'components/action-panel';
-import ActionPanelTitle from 'components/action-panel/title';
-import ActionPanelBody from 'components/action-panel/body';
-import ActionPanelFigure from 'components/action-panel/figure';
-import ActionPanelCta from 'components/action-panel/cta';
-import ActionPanelFooter from 'components/action-panel/footer';
+import ActionPanel from 'calypso/components/action-panel';
+import ActionPanelTitle from 'calypso/components/action-panel/title';
+import ActionPanelBody from 'calypso/components/action-panel/body';
+import ActionPanelFigure from 'calypso/components/action-panel/figure';
+import ActionPanelCta from 'calypso/components/action-panel/cta';
+import ActionPanelFooter from 'calypso/components/action-panel/footer';
 import { Button } from '@automattic/components';
 
 const ActionPanelExample = ( { translate } ) => {

--- a/client/components/animate/README.md
+++ b/client/components/animate/README.md
@@ -5,7 +5,7 @@ Simple interface to introduce animations to components on initial render. Used a
 ## How to use
 
 ```jsx
-import Animate from 'components/animate';
+import Animate from 'calypso/components/animate';
 
 function render() {
 	return <Animate type="appear">Will animate</Animate>;

--- a/client/components/async-load/README.md
+++ b/client/components/async-load/README.md
@@ -7,7 +7,7 @@
 Pass with a `require` string for the module path to be loaded:
 
 ```jsx
-<AsyncLoad require="components/async-load" />;
+<AsyncLoad require="calypso/components/async-load" />;
 ```
 
 Depending on the environment configuration, this will be transformed automatically into either a `require` or `require.ensure` call.

--- a/client/components/async-loader/README.md
+++ b/client/components/async-loader/README.md
@@ -16,7 +16,7 @@ We're going to use the dynamic `import()` syntax to load our components and then
 In the absence of the loading component the async loader will render `null`.
 
 ```js
-import { asyncLoader } from 'components/async-loader';
+import { asyncLoader } from 'calypso/components/async-loader';
 
 export default ( { siteId, currentSearch } ) =>
 	React.createElement(
@@ -49,7 +49,7 @@ Usually it looks like `if ( null == someData ) { return null; }`.
 We can use the `asyncLoader` to separate the concern of waiting for data from the concern of rendering that data.
 
 ```js
-import { asyncLoader } from 'components/async-loader';
+import { asyncLoader } from 'calypso/components/async-loader';
 
 export default ( props ) =>
 	React.createElement(
@@ -79,7 +79,7 @@ We don't use the data returned by the promise in this case because the framework
 Thus we're not passing any data to the success component.
 
 ```js
-import { asyncLoader } from 'components/async-loader';
+import { asyncLoader } from 'calypso/components/async-loader';
 
 const getTranslations = ( slug ) =>
 	waitForHttpData( () => ( {

--- a/client/components/back-button/README.md
+++ b/client/components/back-button/README.md
@@ -5,7 +5,7 @@ Simple back button, usually used in a HeaderCake to go back to the previous scre
 ## Usage
 
 ```jsx
-import BackButton from 'components/back-button';
+import BackButton from 'calypso/components/back-button';
 
 function render() {
 	return <BackButton onClick={ myClickHandler } />;

--- a/client/components/badge/README.md
+++ b/client/components/badge/README.md
@@ -7,7 +7,7 @@ should stand out from the rest.
 
 ```jsx
 import React from 'react';
-import Badge from 'components/badge';
+import Badge from 'calypso/components/badge';
 
 class MyComponent extends React.Component {
 	render() {

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -7,8 +7,8 @@ This component renders a customizable banner.
 ## Usage
 
 ```jsx
-import { PLAN_BUSINESS, FEATURE_ADVANCED_SEO } from 'lib/plans/constants';
-import Banner from 'components/banner';
+import { PLAN_BUSINESS, FEATURE_ADVANCED_SEO } from 'calypso/lib/plans/constants';
+import Banner from 'calypso/components/banner';
 
 function render() {
 	return (

--- a/client/components/bulk-select/README.md
+++ b/client/components/bulk-select/README.md
@@ -5,7 +5,7 @@ This component is used to implement a checkbox which you can use to bulk select 
 ## How to use
 
 ```jsx
-import BulkSelect from 'components/bulk-select';
+import BulkSelect from 'calypso/components/bulk-select';
 
 function render() {
 	return <BulkSelect selectedElements={ 3 } totalElements={ 6 } onToggle={ callback } />;

--- a/client/components/button-group/README.md
+++ b/client/components/button-group/README.md
@@ -5,7 +5,7 @@ Button group displays multiple related actions in a row to help with the display
 ## Usage
 
 ```jsx
-import ButtonGroup from 'components/button-group';
+import ButtonGroup from 'calypso/components/button-group';
 import { Button } from '@automattic/components';
 
 function render() {

--- a/client/components/card-heading/README.md
+++ b/client/components/card-heading/README.md
@@ -5,7 +5,7 @@ This component displays a heading for a `<Card>`
 ## How to use
 
 ```js
-import CardHeading from 'components/card-heading';
+import CardHeading from 'calypso/components/card-heading';
 
 function render() {
 	return (

--- a/client/components/chart/README.md
+++ b/client/components/chart/README.md
@@ -6,7 +6,7 @@ This module renders a dataset as an HTML-based chart representing the data.
 
 ```jsx
 // import the component
-import ElementChart from 'my-sites/chart';
+import ElementChart from 'calypso/my-sites/chart';
 
 // And use it inline inside the render method of another component
 function render() {

--- a/client/components/clipboard-button-input/README.md
+++ b/client/components/clipboard-button-input/README.md
@@ -8,7 +8,7 @@ In most cases, the component can be treated much like any other text input eleme
 
 ```jsx
 import React from 'react';
-import ClipboardButtonInput from 'components/clipboard-button-input';
+import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 
 export default function MyComponent() {
 	return <ClipboardButtonInput value="https://example.wordpress.com/" />;

--- a/client/components/close-on-escape/README.md
+++ b/client/components/close-on-escape/README.md
@@ -9,7 +9,7 @@ This is useful for components such as `<Dialog />` and `<Popover />`, particular
 To use this component, either nest it inside of an existing component or as a sibling, passing it a function as `onEscape` to be called when <kbd>esc</kbd> is pressed.
 
 ```jsx
-import CloseOnEscape from 'components/close-on-escape';
+import CloseOnEscape from 'calypso/components/close-on-escape';
 
 function closeDialog() {
 	// Take care of closing this component

--- a/client/components/credit-card-form-fields/README.md
+++ b/client/components/credit-card-form-fields/README.md
@@ -21,7 +21,7 @@ Brazil requires that users provide additional details when making payments. When
 
 ```jsx
 import React, { Component } from 'react';
-import CreditCardFormFields from 'components/credit-card-form-fields';
+import CreditCardFormFields from 'calypso/components/credit-card-form-fields';
 
 class YourComponent extends Component {
 	render() {

--- a/client/components/credit-card/README.md
+++ b/client/components/credit-card/README.md
@@ -9,7 +9,7 @@ The `CreditCard` component serves as a container for a selectable credit card li
 Example credit card selection list:
 
 ```jsx
-import CreditCard from 'components/credit-card';
+import CreditCard from 'calypso/components/credit-card';
 
 export default ( { cards, selectedId, onSelectCard } ) => {
 	return cards.map( ( card ) => (
@@ -41,7 +41,7 @@ The `StoredCard` component is a representation of a single credit card, used int
 Example usage within `<CreditCard>`:
 
 ```jsx
-import StoredCard from 'components/stored-card';
+import StoredCard from 'calypso/components/stored-card';
 
 export default ( cardData, onRemoveCard ) => {
 	return (

--- a/client/components/data/cart/README.md
+++ b/client/components/data/cart/README.md
@@ -8,7 +8,7 @@ Wrap a child component with `<CartData />`. [As a controller-view](https://faceb
 
 ```jsx
 import React from 'react';
-import CartData from 'components/data/cart-data';
+import CartData from 'calypso/components/data/cart-data';
 import MyChildComponent from './my-child-component';
 
 export default class extends React.Component {

--- a/client/components/data/checkout/README.md
+++ b/client/components/data/checkout/README.md
@@ -8,7 +8,7 @@ Wrap a child component with `<CheckoutData />`. [As a controller-view](https://f
 
 ```jsx
 import React from 'react';
-import CheckoutData from 'components/data/checkout';
+import CheckoutData from 'calypso/components/data/checkout';
 import MyChildComponent from './my-child-component';
 
 export default class extends React.component {

--- a/client/components/data/document-head/README.md
+++ b/client/components/data/document-head/README.md
@@ -8,7 +8,7 @@ Render the component, passing `title`, `skipTitleFormatting`, `unreadCount`, `li
 
 ```jsx
 import React from 'react';
-import DocumentHead from 'components/data/document-head';
+import DocumentHead from 'calypso/components/data/document-head';
 
 export default function HomeSection() {
 	const count = 123;

--- a/client/components/data/domain-management/README.md
+++ b/client/components/data/domain-management/README.md
@@ -9,8 +9,8 @@ It will handle the data itself thus helping us to decouple concerns: i.e. fetchi
 
 ```js
 import React from 'react';
-import DomainManagementData from 'components/data/domain-management';
-import MyChildComponent from 'components/my-child-component';
+import DomainManagementData from 'calypso/components/data/domain-management';
+import MyChildComponent from 'calypso/components/my-child-component';
 
 // initialize rest of the variables
 

--- a/client/components/data/media-list-data/README.md
+++ b/client/components/data/media-list-data/README.md
@@ -8,7 +8,7 @@ Wrap a child component with `<MediaListData />`, passing a `siteId` and optional
 
 ```jsx
 import React from 'react';
-import MediaListData from 'components/data/media-list-data';
+import MediaListData from 'calypso/components/data/media-list-data';
 import MyChildComponent from './my-child-component';
 
 export default class extends React.Component {

--- a/client/components/data/query-active-theme/README.md
+++ b/client/components/data/query-active-theme/README.md
@@ -9,8 +9,8 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 ```jsx
 import React from 'react';
 import { connect } from 'react-redux';
-import QueryActiveTheme from 'components/data/query-active-theme';
-import { getActiveTheme } from 'state/themes/selectors';
+import QueryActiveTheme from 'calypso/components/data/query-active-theme';
+import { getActiveTheme } from 'calypso/state/themes/selectors';
 
 function MyActiveTheme( { activeTheme } ) {
 	return (

--- a/client/components/data/query-all-domains/README.md
+++ b/client/components/data/query-all-domains/README.md
@@ -7,7 +7,7 @@
 Render the component. It does not accept any properties and/or children, nor does it render any elements to the page.
 
 ```jsx
-import QueryAllDomains from 'components/data/query-all-domains';
+import QueryAllDomains from 'calypso/components/data/query-all-domains';
 
 export default function listAllDomains( { domains } ) {
 	return (

--- a/client/components/data/query-application-passwords/README.md
+++ b/client/components/data/query-application-passwords/README.md
@@ -7,7 +7,7 @@
 Render the component without props. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
-import QueryApplicationPasswords from 'components/data/query-application-passwords';
+import QueryApplicationPasswords from 'calypso/components/data/query-application-passwords';
 
 export default () => (
 	<div>

--- a/client/components/data/query-atat-eligibility/README.md
+++ b/client/components/data/query-atat-eligibility/README.md
@@ -10,7 +10,7 @@ You can use it adjacent to other sibling components which make use of the fetche
 ```js
 import React from 'react';
 import { connect } from 'react-redux';
-import QueryEligibility from 'components/data/query-atat-eligibility';
+import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 
 export function MyTransferView( { eligibility, siteId } ) {
 	return (

--- a/client/components/data/query-billing-transaction/README.md
+++ b/client/components/data/query-billing-transaction/README.md
@@ -8,7 +8,7 @@ Render the component and pass `transactionId` as a prop. It does not accept any 
 
 ```jsx
 import React from 'react';
-import QueryBillingTransaction from 'components/data/query-billing-transaction';
+import QueryBillingTransaction from 'calypso/components/data/query-billing-transaction';
 import Receipt from './receipt';
 
 export default function MyBillingTransaction( { transactionId, transaction } ) {

--- a/client/components/data/query-billing-transactions/README.md
+++ b/client/components/data/query-billing-transactions/README.md
@@ -8,7 +8,7 @@ Render the component as a child in any component. It does not accept any childre
 
 ```jsx
 import React from 'react';
-import QueryBillingTransactions from 'components/data/query-billing-transactions';
+import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
 import MyBillingTransactionsList from './list';
 
 export default function MyBillingTransactions( { billingTransactions } ) {

--- a/client/components/data/query-canonical-theme/README.md
+++ b/client/components/data/query-canonical-theme/README.md
@@ -9,9 +9,9 @@ Render the component, passing `siteId` and `themeId`. It does not accept any chi
 ```jsx
 import React from 'react';
 import { connect } from 'react-redux';
-import QueryCanonicalTheme from 'components/data/query-canonical-theme';
-import Theme from 'components/theme';
-import { getCanonicalTheme } from 'state/themes/selectors';
+import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
+import Theme from 'calypso/components/theme';
+import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 
 function MyTheme( { theme } ) {
 	return (

--- a/client/components/data/query-comment/README.md
+++ b/client/components/data/query-comment/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```js
-import QueryComment from 'components/query-comment';
+import QueryComment from 'calypso/components/query-comment';
 
 const CommentDetail = ( { comment, commentId, siteId } ) => (
 	<div>

--- a/client/components/data/query-connected-applications/README.md
+++ b/client/components/data/query-connected-applications/README.md
@@ -8,7 +8,7 @@ Render the component without props. It does not accept any children, nor does it
 
 ```jsx
 import React, { Fragment } from 'react';
-import QueryConnectedApplications from 'components/data/query-connected-applications';
+import QueryConnectedApplications from 'calypso/components/data/query-connected-applications';
 
 export default () => (
 	<Fragment>

--- a/client/components/data/query-countries/README.md
+++ b/client/components/data/query-countries/README.md
@@ -8,7 +8,7 @@ Render the component without props. It does not accept any children, nor does it
 
 ```jsx
 import React from 'react';
-import QueryDomainCountries from 'components/data/query-countries/domains';
+import QueryDomainCountries from 'calypso/components/data/query-countries/domains';
 
 export default function CountriesList( { countries } ) {
 	return (

--- a/client/components/data/query-country-states/README.md
+++ b/client/components/data/query-country-states/README.md
@@ -8,7 +8,7 @@ Render the component, passing `countryCode`. It does not accept any children, no
 
 ```jsx
 import React from 'react';
-import QueryCountryStates from 'components/data/query-country-states';
+import QueryCountryStates from 'calypso/components/data/query-country-states';
 
 export default function MyStatesList( { countryStates } ) {
 	return (

--- a/client/components/data/query-domains-suggestions/README.md
+++ b/client/components/data/query-domains-suggestions/README.md
@@ -7,7 +7,7 @@
 Render the component, passing in the properties below. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
-import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
+import QueryDomainsSuggestions from 'calypso/components/data/query-domains-suggestions';
 
 export default function defaultSuggestions() {
 	return (

--- a/client/components/data/query-email-accounts/README.md
+++ b/client/components/data/query-email-accounts/README.md
@@ -7,7 +7,7 @@
 Render the component, passing in the properties below. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
-import QueryEmailAccounts from 'components/data/query-email-accounts';
+import QueryEmailAccounts from 'calypso/components/data/query-email-accounts';
 
 export default function listEmailAccounts( { emailAccounts } ) {
 	return (

--- a/client/components/data/query-email-forwards/README.md
+++ b/client/components/data/query-email-forwards/README.md
@@ -7,7 +7,7 @@
 Render the component, passing in the properties below. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
-import QueryEmailForwards from 'components/data/query-email-forwards';
+import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 
 export default function listEmailForwards( { emailForwards } ) {
 	return (

--- a/client/components/data/query-embed/README.md
+++ b/client/components/data/query-embed/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `url`. It does not accept any childre
 
 ```jsx
 import React from 'react';
-import QueryEmbed from 'components/data/query-embed';
+import QueryEmbed from 'calypso/components/data/query-embed';
 
 export default function MyEmbed( { embed } ) {
 	return (

--- a/client/components/data/query-experiments/readme.md
+++ b/client/components/data/query-experiments/readme.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```jsx
-import QueryExperiments from 'components/data/query-experiments';
+import QueryExperiments from 'calypso/components/data/query-experiments';
 export default function listExperiments() {
 	return (
 		<div>

--- a/client/components/data/query-gsuite-users/README.md
+++ b/client/components/data/query-gsuite-users/README.md
@@ -7,7 +7,7 @@
 Render the component, passing in the properties below. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
-import QueryGSuiteUsers from 'components/data/query-gsuite-users';
+import QueryGSuiteUsers from 'calypso/components/data/query-gsuite-users';
 
 export default function listGSuiteUsers( { gsuiteUsers } ) {
 	return (

--- a/client/components/data/query-help-links/README.md
+++ b/client/components/data/query-help-links/README.md
@@ -8,7 +8,7 @@ Render the component, passing `query`. It does not accept any children, nor does
 
 ```jsx
 import React from 'react';
-import QueryHelpLinks from 'components/data/query-help-links';
+import QueryHelpLinks from 'calypso/components/data/query-help-links';
 
 export default function MyHelpLinksSection( { links } ) {
 	return (

--- a/client/components/data/query-jetpack-connection/README.md
+++ b/client/components/data/query-jetpack-connection/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QueryJetpackConnection from 'components/data/query-jetpack-connection';
+import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connection';
 import MyJetpackConnectionStatusBlock from './status-block';
 
 export default function MyJetpackConnectionStatus( { jetpackConnection } ) {

--- a/client/components/data/query-jetpack-modules/README.md
+++ b/client/components/data/query-jetpack-modules/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QueryJetpackModules from 'components/data/query-jetpack-modules';
+import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import MyJetpackModulesListItem from './list-item';
 
 export default function MyJetpackModulesList( { jetpackModules } ) {

--- a/client/components/data/query-jetpack-scan-history/README.md
+++ b/client/components/data/query-jetpack-scan-history/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QueryJetpackScanHistory from 'components/data/query-jetpack-scan-history';
+import QueryJetpackScanHistory from 'calypso/components/data/query-jetpack-scan-history';
 import Scan from './scan';
 
 export default function MyJetpackScanHistory( { jetpackScanHistory } ) {

--- a/client/components/data/query-jetpack-scan/README.md
+++ b/client/components/data/query-jetpack-scan/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QueryJetpackScan from 'components/data/query-jetpack-scan';
+import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
 import Scan from './scan';
 
 export default function MyJetpackScanStatus( { jetpackScanStatus } ) {

--- a/client/components/data/query-jetpack-settings/README.md
+++ b/client/components/data/query-jetpack-settings/README.md
@@ -11,8 +11,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { map } from 'lodash';
 
-import getJetpackSettings from 'state/selectors/get-jetpack-settings';
-import QueryJetpackSettings from 'components/data/query-jetpack-settings';
+import getJetpackSettings from 'calypso/state/selectors/get-jetpack-settings';
+import QueryJetpackSettings from 'calypso/components/data/query-jetpack-settings';
 
 function MyJetpackSettings( { settings, siteId } ) {
 	const query = {

--- a/client/components/data/query-jetpack-user-connection/README.md
+++ b/client/components/data/query-jetpack-user-connection/README.md
@@ -9,9 +9,9 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 ```jsx
 import React from 'react';
 import { connect } from 'react-redux';
-import QueryJetpackUserConnection from 'components/data/query-jetpack-user-connection';
+import QueryJetpackUserConnection from 'calypso/components/data/query-jetpack-user-connection';
 import MyJetpackConnectionDataBlock from './data-block';
-import getJetpackUserConnection from 'state/selectors/get-jetpack-user-connection';
+import getJetpackUserConnection from 'calypso/state/selectors/get-jetpack-user-connection';
 
 function MyJetpackConnectionData( { jetpackConnection } ) {
 	return (

--- a/client/components/data/query-keyring-connections/README.md
+++ b/client/components/data/query-keyring-connections/README.md
@@ -8,7 +8,7 @@ Render the component without props. It does not accept any children, nor does it
 
 ```jsx
 import React from 'react';
-import QueryKeyringConnections from 'components/data/query-keyring-connections';
+import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 
 export default function MyConnectionsList( { connections } ) {
 	return (

--- a/client/components/data/query-keyring-services/README.md
+++ b/client/components/data/query-keyring-services/README.md
@@ -8,7 +8,7 @@ Render the component without props. It does not accept any children, nor does it
 
 ```jsx
 import React from 'react';
-import QueryKeyringServices from 'components/data/query-keyring-services';
+import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 
 export default function MyServicesList( { services } ) {
 	return (

--- a/client/components/data/query-language-names/README.md
+++ b/client/components/data/query-language-names/README.md
@@ -7,7 +7,7 @@
 Render the component without props. It does not accept any children or render any elements to the page.
 
 ```jsx
-import QueryLanguageNames from 'components/data/query-language-names';
+import QueryLanguageNames from 'calypso/components/data/query-language-names';
 
 export default function () {
 	return (

--- a/client/components/data/query-locale-suggestions/README.md
+++ b/client/components/data/query-locale-suggestions/README.md
@@ -7,7 +7,7 @@
 Render the component without props. It does not accept any children or render any elements to the page.
 
 ```jsx
-import QueryLocaleSuggestions from 'components/data/query-locale-suggestions';
+import QueryLocaleSuggestions from 'calypso/components/data/query-locale-suggestions';
 
 export default function () {
 	return (

--- a/client/components/data/query-media/README.md
+++ b/client/components/data/query-media/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `query` or a `siteId` and `mediaId`. 
 
 ```jsx
 import React from 'react';
-import QueryMedia from 'components/data/query-media';
+import QueryMedia from 'calypso/components/data/query-media';
 import MyMediaListItem from './list-item';
 
 export default function MyMediaList( { media } ) {

--- a/client/components/data/query-page-templates/README.md
+++ b/client/components/data/query-page-templates/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QueryPageTemplates from 'components/data/query-page-templates';
+import QueryPageTemplates from 'calypso/components/data/query-page-templates';
 
 export default function MyPostTypesList( { pageTemplates } ) {
 	return (

--- a/client/components/data/query-post-counts/README.md
+++ b/client/components/data/query-post-counts/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `type`. It does not accept any childr
 
 ```jsx
 import React from 'react';
-import QueryPostCounts from 'components/data/query-post-counts';
+import QueryPostCounts from 'calypso/components/data/query-post-counts';
 
 export default function PostCount( { count } ) {
 	return (

--- a/client/components/data/query-post-formats/README.md
+++ b/client/components/data/query-post-formats/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QueryPostFormats from 'components/data/query-post-formats';
+import QueryPostFormats from 'calypso/components/data/query-post-formats';
 import MyPostFormatsListItem from './list-item';
 
 export default function MyPostFormatsList( { postFormats } ) {

--- a/client/components/data/query-post-likes/README.md
+++ b/client/components/data/query-post-likes/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `postId`. It does not accept any chil
 
 ```jsx
 import React from 'react';
-import QueryPostLikes from 'components/data/query-post-likes';
+import QueryPostLikes from 'calypso/components/data/query-post-likes';
 import MyPostLikesListItem from './list-item';
 
 export default function Component( { likes } ) {

--- a/client/components/data/query-post-revision-authors/README.md
+++ b/client/components/data/query-post-revision-authors/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `userIds`. It does not accept any chi
 
 ```jsx
 import React from 'react';
-import QueryUsers from 'components/data/query-users';
+import QueryUsers from 'calypso/components/data/query-users';
 
 export default function PostRevisionAuthors( { authors } ) {
 	return (

--- a/client/components/data/query-post-revisions/README.md
+++ b/client/components/data/query-post-revisions/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `postId`. It does not accept any chil
 
 ```jsx
 import React from 'react';
-import QueryPostRevisions from 'components/data/query-post-revisions';
+import QueryPostRevisions from 'calypso/components/data/query-post-revisions';
 
 export default function PostRevisions( { revisions } ) {
 	return (

--- a/client/components/data/query-post-stats/README.md
+++ b/client/components/data/query-post-stats/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`, `postId` and `fields`. It does not accep
 
 ```jsx
 import React from 'react';
-import QueryPostStats from 'components/data/query-post-stats';
+import QueryPostStats from 'calypso/components/data/query-post-stats';
 
 export default function Component( { statValue } ) {
 	return (

--- a/client/components/data/query-post-types/README.md
+++ b/client/components/data/query-post-types/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QueryPostTypes from 'components/data/query-post-types';
+import QueryPostTypes from 'calypso/components/data/query-post-types';
 import MyPostTypesListItem from './list-item';
 
 export default function MyPostTypesList( { postTypes } ) {

--- a/client/components/data/query-posts/README.md
+++ b/client/components/data/query-posts/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `query`. It does not accept any child
 
 ```jsx
 import React from 'react';
-import QueryPosts from 'components/data/query-posts';
+import QueryPosts from 'calypso/components/data/query-posts';
 import MyPostsListItem from './list-item';
 
 export default function MyPostsList( { posts } ) {

--- a/client/components/data/query-profile-links/README.md
+++ b/client/components/data/query-profile-links/README.md
@@ -7,7 +7,7 @@
 Render the component without props. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
-import QueryProfileLinks from 'components/data/query-profile-links';
+import QueryProfileLinks from 'calypso/components/data/query-profile-links';
 
 export default () => (
 	<div>

--- a/client/components/data/query-publicize-connections/README.md
+++ b/client/components/data/query-publicize-connections/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` or the boolean attribute `selectedSite`. 
 
 ```jsx
 import React from 'react';
-import QueryPublicizeConnections from 'components/data/query-publicize-connetions';
+import QueryPublicizeConnections from 'calypso/components/data/query-publicize-connetions';
 import MyConnectionsListItem from './list-item';
 
 export default function MyConnectionsList( { connections } ) {

--- a/client/components/data/query-reader-list/README.md
+++ b/client/components/data/query-reader-list/README.md
@@ -8,7 +8,7 @@ Render the component. It does not accept any children, nor does it render any el
 
 ```jsx
 import React from 'react';
-import QueryReaderList from 'components/data/query-reader-list';
+import QueryReaderList from 'calypso/components/data/query-reader-list';
 import MyListItem from './list-item';
 
 export default function MyReaderList( { list } ) {

--- a/client/components/data/query-reader-lists/README.md
+++ b/client/components/data/query-reader-lists/README.md
@@ -8,7 +8,7 @@ Render the component. It does not accept any children, nor does it render any el
 
 ```jsx
 import React from 'react';
-import QueryReaderLists from 'components/data/query-reader-lists';
+import QueryReaderLists from 'calypso/components/data/query-reader-lists';
 import MyListItem from './list-item';
 
 export default function MyReaderLists( { subscribedLists } ) {

--- a/client/components/data/query-reader-tag-images/README.md
+++ b/client/components/data/query-reader-tag-images/README.md
@@ -8,7 +8,7 @@ Render the component. It does not accept any children, nor does it render any el
 
 ```jsx
 import React from 'react';
-import QueryReaderTagImages from 'components/data/query-reader-tag-images';
+import QueryReaderTagImages from 'calypso/components/data/query-reader-tag-images';
 import MyListItem from './list-item';
 
 export default function MyReaderTagImages( { images } ) {

--- a/client/components/data/query-reader-thumbnails/README.md
+++ b/client/components/data/query-reader-thumbnails/README.md
@@ -8,8 +8,8 @@ Render the component. It does not accept any children, nor does it render any el
 
 ```jsx
 import React from 'react';
-import QueryReaderThumbnails from 'components/data/query-reader-thumbnail';
-import { getThumbnailForIframe } from 'state/reader/thumbnails/selectors';
+import QueryReaderThumbnails from 'calypso/components/data/query-reader-thumbnail';
+import { getThumbnailForIframe } from 'calypso/state/reader/thumbnails/selectors';
 
 function MyFeaturedAsset( { embedUrl, thumbnailUrl } ) {
 	return (

--- a/client/components/data/query-rewind-backup-status/README.md
+++ b/client/components/data/query-rewind-backup-status/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `backupId`. It does not accept any ch
 
 ```jsx
 import React from 'react';
-import QueryBackupRestoreStatus from 'components/data/query-backup-backup-status';
+import QueryBackupRestoreStatus from 'calypso/components/data/query-backup-backup-status';
 
 export default function MyComponent( props ) {
 	return (

--- a/client/components/data/query-rewind-backups/README.md
+++ b/client/components/data/query-rewind-backups/README.md
@@ -9,8 +9,8 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 ```jsx
 import React from 'react';
 import { useSelector } from 'react-redux';
-import getRewindBackups from 'state/selectors/get-rewind-backups';
-import QueryRewindBackups from 'components/data/query-rewind-backups';
+import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';
+import QueryRewindBackups from 'calypso/components/data/query-rewind-backups';
 
 export default function MyComponent( { siteId } ) {
 	const rewindBackups = useSelector( getRewindBackups( siteId ) );

--- a/client/components/data/query-rewind-restore-status/README.md
+++ b/client/components/data/query-rewind-restore-status/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `restoreId`. It does not accept any c
 
 ```jsx
 import React from 'react';
-import QueryRewindRestoreStatus from 'components/data/query-rewind-restore-status';
+import QueryRewindRestoreStatus from 'calypso/components/data/query-rewind-restore-status';
 
 export default function MyComponent( props ) {
 	return (

--- a/client/components/data/query-segments/README.md
+++ b/client/components/data/query-segments/README.md
@@ -9,8 +9,8 @@ Because it's static data from the server, it will only fire if there are no segm
 Render the component. It accepts neither props or children, nor does it render any elements to the page.
 
 ```js
-import QuerySegments from 'components/data/query-segments';
-import { getSegments } from 'state/signup/segments/selectors';
+import QuerySegments from 'calypso/components/data/query-segments';
+import { getSegments } from 'calypso/state/signup/segments/selectors';
 
 class MyComponent extends React.Component {
 	render() {

--- a/client/components/data/query-sharing-buttons/README.md
+++ b/client/components/data/query-sharing-buttons/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QuerySharingButtons from 'components/data/query-sharing-buttons';
+import QuerySharingButtons from 'calypso/components/data/query-sharing-buttons';
 
 export default function MySettingsPage( { buttons } ) {
 	return (

--- a/client/components/data/query-shortcode/README.md
+++ b/client/components/data/query-shortcode/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `shortcode`. It does not accept any c
 
 ```jsx
 import React from 'react';
-import QueryShortcode from 'components/data/query-shortcode';
+import QueryShortcode from 'calypso/components/data/query-shortcode';
 import MySiteShortcodeItemDetail from './item-detail';
 
 export default function MySiteShortcodeItem( { shortcode } ) {

--- a/client/components/data/query-site-comments-list/README.md
+++ b/client/components/data/query-site-comments-list/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```js
-import QuerySiteCommentsList from 'components/data/query-site-comments-list';
+import QuerySiteCommentsList from 'calypso/components/data/query-site-comments-list';
 
 const CommentList = ( { comments, siteId } ) => (
 	<div>

--- a/client/components/data/query-site-comments-tree/README.md
+++ b/client/components/data/query-site-comments-tree/README.md
@@ -12,7 +12,7 @@ There is planned support for additional features not yet implemented:
 - Pinghub connection
 
 ```js
-import QuerySiteCommentsTree from 'components/data/query-site-comments-tree';
+import QuerySiteCommentsTree from 'calypso/components/data/query-site-comments-tree';
 
 const CommentList = ( { comments, siteId } ) => (
 	<div>

--- a/client/components/data/query-site-connection-status/README.md
+++ b/client/components/data/query-site-connection-status/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QuerySiteConnectionStatus from 'components/data/query-site-connection-status';
+import QuerySiteConnectionStatus from 'calypso/components/data/query-site-connection-status';
 
 export default function ExampleSiteComponent( { siteConnectionStatus, translate } ) {
 	return (

--- a/client/components/data/query-site-domains/README.md
+++ b/client/components/data/query-site-domains/README.md
@@ -7,7 +7,7 @@
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
-import QuerySiteDomains from 'components/data/query-site-domains';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 
 class MyComponent extends React.Component {
 	render() {

--- a/client/components/data/query-site-invites/README.md
+++ b/client/components/data/query-site-invites/README.md
@@ -13,7 +13,7 @@ the global application state.
 ```jsx
 import React from 'react';
 import { connect } from 'react-redux';
-import QuerySiteInvites from 'components/data/query-site-invites';
+import QuerySiteInvites from 'calypso/components/data/query-site-invites';
 
 const SITE_ID = 3584907;
 

--- a/client/components/data/query-site-keyrings/README.md
+++ b/client/components/data/query-site-keyrings/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QuerySiteKeyrings from 'components/data/query-site-keyrings';
+import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
 
 export default function MyKeyringsPage( { keyrings } ) {
 	return (

--- a/client/components/data/query-site-monitor-settings/README.md
+++ b/client/components/data/query-site-monitor-settings/README.md
@@ -10,8 +10,8 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import QuerySiteMonitorSettings from 'components/data/query-site-monitor-settings';
-import getSiteMonitorSettings from 'state/selectors/get-site-monitor-settings';
+import QuerySiteMonitorSettings from 'calypso/components/data/query-site-monitor-settings';
+import getSiteMonitorSettings from 'calypso/state/selectors/get-site-monitor-settings';
 
 function ExampleSiteComponent( { siteMonitorSettings, translate } ) {
 	return (

--- a/client/components/data/query-site-roles/README.md
+++ b/client/components/data/query-site-roles/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QuerySiteRoles from 'components/data/query-site-roles';
+import QuerySiteRoles from 'calypso/components/data/query-site-roles';
 import MySiteRolesListItem from './list-item';
 
 export default function MySiteRolesList( { siteRoles } ) {

--- a/client/components/data/query-site-settings/README.md
+++ b/client/components/data/query-site-settings/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QuerySiteSettings from 'components/data/query-site-settings';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 
 export default function MySettingsPage( { settings } ) {
 	return (

--- a/client/components/data/query-site-stats/README.md
+++ b/client/components/data/query-site-stats/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `statType`. It does not accept any ch
 
 ```jsx
 import React from 'react';
-import QuerySiteStats from 'components/data/query-site-stats';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
 
 export default function AmazingVisualizationOfStats( { stats } ) {
 	return (

--- a/client/components/data/query-stats-recent-post-views/README.md
+++ b/client/components/data/query-stats-recent-post-views/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `postIds`. It does not accept any chi
 
 ```jsx
 import React from 'react';
-import QueryRecentPostViews from 'components/data/query-stats-recent-post-views';
+import QueryRecentPostViews from 'calypso/components/data/query-stats-recent-post-views';
 
 export default function ViewCount( { viewCount } ) {
 	return (

--- a/client/components/data/query-taxonomies/README.md
+++ b/client/components/data/query-taxonomies/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `postType`. It does not accept any ch
 
 ```jsx
 import React from 'react';
-import QueryTaxonomies from 'components/data/query-taxonomies';
+import QueryTaxonomies from 'calypso/components/data/query-taxonomies';
 
 export default function MyTaxonomiesList( { taxonomies } ) {
 	return (

--- a/client/components/data/query-terms/README.md
+++ b/client/components/data/query-terms/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId` and `taxonomy`. It does not accept any ch
 
 ```jsx
 import React from 'react';
-import QueryTerms from 'components/data/query-terms';
+import QueryTerms from 'calypso/components/data/query-terms';
 
 export default function AmazingListOfTerms( { terms } ) {
 	return (

--- a/client/components/data/query-theme/README.md
+++ b/client/components/data/query-theme/README.md
@@ -9,9 +9,9 @@ Render the component, passing `siteId` and `themeId`. It does not accept any chi
 ```jsx
 import React from 'react';
 import { connect } from 'react-redux';
-import QueryTheme from 'components/data/query-theme';
-import Theme from 'components/theme';
-import { getTheme } from 'state/themes/selectors';
+import QueryTheme from 'calypso/components/data/query-theme';
+import Theme from 'calypso/components/theme';
+import { getTheme } from 'calypso/state/themes/selectors';
 
 function MyTheme( { theme } ) {
 	return (

--- a/client/components/data/query-themes/README.md
+++ b/client/components/data/query-themes/README.md
@@ -9,9 +9,9 @@ Render the component, passing `siteId` and `query`. It does not accept any child
 ```jsx
 import React from 'react';
 import { connect } from 'react-redux';
-import QueryThemes from 'components/data/query-themes';
-import Theme from 'components/theme';
-import { getThemesForQueryIgnoringPage } from 'state/themes/selectors';
+import QueryThemes from 'calypso/components/data/query-themes';
+import Theme from 'calypso/components/theme';
+import { getThemesForQueryIgnoringPage } from 'calypso/state/themes/selectors';
 
 function MyThemesList( { themes } ) {
 	return (

--- a/client/components/data/query-wordads-settings/README.md
+++ b/client/components/data/query-wordads-settings/README.md
@@ -8,7 +8,7 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 
 ```jsx
 import React from 'react';
-import QueryWordadsSettings from 'components/data/query-wordads-settings';
+import QueryWordadsSettings from 'calypso/components/data/query-wordads-settings';
 
 export default function MySettings( { settings } ) {
 	return (

--- a/client/components/date-picker/README.md
+++ b/client/components/date-picker/README.md
@@ -8,7 +8,7 @@ React component used to display a Date Picker.
 
 ```js
 import React from 'react';
-import DatePicker from 'components/date-picker';
+import DatePicker from 'calypso/components/date-picker';
 
 export default class extends React.Component {
 	// ...

--- a/client/components/date-range/README.md
+++ b/client/components/date-range/README.md
@@ -7,7 +7,7 @@ A DateRange component for displaying and selecting a range of dates using a pick
 First, display a `jsx` code block to show an example of usage, including import statements and a React component.
 
 ```jsx
-import DateRange from 'components/date-range';
+import DateRange from 'calypso/components/date-range';
 
 export default class extends React.Component {
 	render() {

--- a/client/components/diff-viewer/README.md
+++ b/client/components/diff-viewer/README.md
@@ -6,7 +6,7 @@ visual format recognizable by someone who works with `diff` and comparing files.
 ## Usage
 
 ```jsx
-import DiffViewer from 'components/diff-viewer';
+import DiffViewer from 'calypso/components/diff-viewer';
 
 export const CommitView = ( { commitHash, description, diff } ) => (
 	<div>

--- a/client/components/dot-pager/README.md
+++ b/client/components/dot-pager/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```js
-import DotPager from 'blocks/dot-pager';
+import DotPager from 'calypso/blocks/dot-pager';
 
 function myDotPager() {
 	return (

--- a/client/components/drop-zone/README.md
+++ b/client/components/drop-zone/README.md
@@ -10,7 +10,7 @@ Render the component in the context of a parent element which is assigned a `rel
 
 ```jsx
 import React, { Component } from 'react';
-import DropZone from 'components/drop-zone';
+import DropZone from 'calypso/components/drop-zone';
 
 class MyComponent extends Component {
 	onFilesDrop( files ) {

--- a/client/components/ellipsis-menu/README.md
+++ b/client/components/ellipsis-menu/README.md
@@ -7,8 +7,8 @@ A React component for displaying a toggle menu. By default, only an ellipsis but
 Render `<EllipsisMenu />` in a similar fashion as you would [the `<PopoverMenu />` component](../popover-menu), as it is effectively a convenience wrapper for this component with a few additional options. Specifically, you'll still need to render `<PopoverMenuItem />` as children of the `<EllipsisMenu />`.
 
 ```jsx
-import EllipsisMenu from 'components/ellipsis-menu';
-import PopoverMenuItem from 'components/popover/menu-item';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
 
 export default function MyComponent( { onMenuItemClick } ) {
 	return (

--- a/client/components/email-verification/README.md
+++ b/client/components/email-verification/README.md
@@ -10,7 +10,7 @@ when it does.
 ### Usage
 
 ```js
-import emailVerification from 'components/email-verification';
+import emailVerification from 'calypso/components/email-verification';
 
 page( '*', emailVerification );
 ```
@@ -24,7 +24,7 @@ to resend the email.
 ### Usage
 
 ```jsx
-import VerifyEmailDialog from 'components/email-verification/email-verification-dialog';
+import VerifyEmailDialog from 'calypso/components/email-verification/email-verification-dialog';
 
 function UI( { showDialog, closeDialog } ) {
 	return (
@@ -44,7 +44,7 @@ The wrapped content will be disabled: grayed out and won't react to input events
 ### Usage
 
 ```jsx
-import EmailVerificationGate from 'components/email-verification/email-verification-gate';
+import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 
 function GatedUI() {
 	return (

--- a/client/components/emojify/README.md
+++ b/client/components/emojify/README.md
@@ -8,7 +8,7 @@ This is desirable since implementations are inconsistent or non-existant.
 
 ```js
 // require the module
-import Emojify from 'components/emojify';
+import Emojify from 'calypso/components/emojify';
 
 const textToEmojify = 'This will be converted 🙈🙉🙊';
 

--- a/client/components/empty-content/README.md
+++ b/client/components/empty-content/README.md
@@ -8,7 +8,7 @@ EmptyContent is used when a customer has no data to show. This is an opportunity
 
 ```jsx
 // import the component
-import EmptyContentComponent from 'components/empty-content';
+import EmptyContentComponent from 'calypso/components/empty-content';
 
 // Render the component
 function show( context, next ) {
@@ -20,7 +20,7 @@ function show( context, next ) {
 ### As an inline component
 
 ```jsx
-import EmptyContent from 'components/empty-content';
+import EmptyContent from 'calypso/components/empty-content';
 
 // Use it inline inside the render method of another component
 function render() {

--- a/client/components/environment-badge/README.md
+++ b/client/components/environment-badge/README.md
@@ -11,7 +11,7 @@ The component already provides a few helpers which are used for Calypso e.g. _Pr
 ## Usage
 
 ```jsx
-import EnvironmentBadge, { PreferencesHelper } from 'components/environment-badge';
+import EnvironmentBadge, { PreferencesHelper } from 'calypso/components/environment-badge';
 
 <EnvironmentBadge badge="development" feedbackURL="http://feedback">
 	<PreferencesHelper />

--- a/client/components/external-link/README.md
+++ b/client/components/external-link/README.md
@@ -8,7 +8,7 @@ External Link is a React component for rendering an external link.
 
 ```jsx
 import React from 'react';
-import ExternalLink from 'components/external-link';
+import ExternalLink from 'calypso/components/external-link';
 
 class MyComponent extends React.Component {
 	render() {
@@ -43,7 +43,7 @@ and is capable of recording Tracks events.
 
 ```jsx
 import React from 'react';
-import ExternalLinkWithTracking from 'components/external-link/with-tracking';
+import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 
 class MyComponent extends React.Component {
 	render() {

--- a/client/components/faq/README.md
+++ b/client/components/faq/README.md
@@ -11,8 +11,8 @@ The FAQ component is made of two parts:
 - FAQItem child component(s) which has a `question` and an `answer` props
 
 ```jsx
-import FAQ from 'components/faq';
-import FAQItem from 'components/faq/faq-item';
+import FAQ from 'calypso/components/faq';
+import FAQItem from 'calypso/components/faq/faq-item';
 import i18n from 'i18n-calypso';
 
 export default class MyFaq extends React.Component {

--- a/client/components/feature-example/README.md
+++ b/client/components/feature-example/README.md
@@ -6,8 +6,8 @@ Feature Example is a component used to render an mocked example of any feature. 
 
 ```jsx
 import React from 'react';
-import FeatureExample from 'components/feature-example';
-import EmptyContent from 'components/empty-content';
+import FeatureExample from 'calypso/components/feature-example';
+import EmptyContent from 'calypso/components/empty-content';
 
 class MyComponent extends React.Component {
 	render() {

--- a/client/components/file-picker/README.md
+++ b/client/components/file-picker/README.md
@@ -7,7 +7,7 @@ It is a very thin wrapper around
 ## How to use
 
 ```js
-import FilePicker from 'components/file-picker';
+import FilePicker from 'calypso/components/file-picker';
 
 function render() {
 	return (

--- a/client/components/focusable/README.md
+++ b/client/components/focusable/README.md
@@ -14,7 +14,7 @@ If you want to add an action to a larger element, for example the Language Picke
 ## How to use
 
 ```jsx
-import Focusable from 'components/focusable';
+import Focusable from 'calypso/components/focusable';
 
 export default function InteractiveItem() {
 	return (

--- a/client/components/foldable-card/README.md
+++ b/client/components/foldable-card/README.md
@@ -5,7 +5,7 @@ This component is used to display a box that can be clicked to expand a hidden s
 ## Usage
 
 ```js
-import FoldableCard from 'components/foldable-card';
+import FoldableCard from 'calypso/components/foldable-card';
 
 function render() {
 	return (

--- a/client/components/formatted-header/README.md
+++ b/client/components/formatted-header/README.md
@@ -7,7 +7,7 @@ When the `compactOnMobile` flag is set, the header renders in a compact way on s
 ## How to use
 
 ```js
-import FormattedHeader from 'components/formatted-header';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 function render() {
 	return <FormattedHeader headerText="A main title" subHeaderText="A main title" />;

--- a/client/components/forms/clipboard-button/README.md
+++ b/client/components/forms/clipboard-button/README.md
@@ -6,7 +6,7 @@ Clipboard Button is a React component to facilitate creating a "click-to-copy" b
 
 ```jsx
 import React, { Component } from 'react';
-import ClipboardButton from 'components/forms/clipboard-button';
+import ClipboardButton from 'calypso/components/forms/clipboard-button';
 
 const MyComponent = () => <ClipboardButton text="Text to copy">Button Text</ClipboardButton>;
 ```

--- a/client/components/forms/counted-textarea/README.md
+++ b/client/components/forms/counted-textarea/README.md
@@ -10,7 +10,7 @@ Counted Textarea is a React form component which renders a `<textarea />` accomp
 
 ```jsx
 import React from 'react';
-import CountedTextarea from 'components/forms/counted-textarea';
+import CountedTextarea from 'calypso/components/forms/counted-textarea';
 
 class MyComponent extends Component {
 	state = {

--- a/client/components/forms/form-toggle/README.md
+++ b/client/components/forms/form-toggle/README.md
@@ -5,7 +5,7 @@ This component is used to implement toggle switches.
 ## How to use
 
 ```js
-import FormToggle from 'components/forms/form-toggle';
+import FormToggle from 'calypso/components/forms/form-toggle';
 
 export default function MyComponent() {
 	return (

--- a/client/components/forms/sortable-list/README.md
+++ b/client/components/forms/sortable-list/README.md
@@ -25,7 +25,7 @@ In traditional React fashion, a SortableList does not track its own state, but i
 
 ```jsx
 import React, { Component } from 'react';
-import SortableList from 'components/forms/sortable-list';
+import SortableList from 'calypso/components/forms/sortable-list';
 
 class MyComponent extends Component {
 	state = {

--- a/client/components/gallery-shortcode/README.md
+++ b/client/components/gallery-shortcode/README.md
@@ -8,7 +8,7 @@ Simply pass a site ID and an array of media items.
 
 ```jsx
 import React from 'react';
-import GalleryShortcode from 'components/gallery-shortcode';
+import GalleryShortcode from 'calypso/components/gallery-shortcode';
 
 export default class extends React.Component {
 	static displayName = 'MyComponent';

--- a/client/components/gauge/README.md
+++ b/client/components/gauge/README.md
@@ -5,7 +5,7 @@ This component renders a simple gauge to show a percentage visually.
 ## How to use
 
 ```js
-import Gauge from 'components/gauge';
+import Gauge from 'calypso/components/gauge';
 
 function render() {
 	return <Gauge percentage={ 40 } metric={ 'Visits' } />;

--- a/client/components/global-notices/README.md
+++ b/client/components/global-notices/README.md
@@ -11,7 +11,7 @@ Notices should be added by dispatching a notice action. See [notice actions](../
 Dispatching a notice from a component might look like this:
 
 ```js
-import { successNotices } from 'state/notices/actions';
+import { successNotices } from 'calypso/state/notices/actions';
 
 function MyComponent() {
 	return <button onClick={ this.props.successNotice( 'Objective achieved!' ) }>Click me!</button>;
@@ -27,7 +27,7 @@ It's unlikely you'll need to render GlobalNotices, because that will be handled 
 Rendering GlobalNotices is straightforward:
 
 ```js
-import GlobalNotices from 'components/global-notices';
+import GlobalNotices from 'calypso/components/global-notices';
 
 function Layout() {
 	return (

--- a/client/components/gravatar-caterpillar/README.md
+++ b/client/components/gravatar-caterpillar/README.md
@@ -7,7 +7,7 @@ On smaller screens (<660px wide), the component will display half the maximum nu
 ## How to use
 
 ```js
-import GravatarCaterpillar from 'components/gravatar-caterpillar';
+import GravatarCaterpillar from 'calypso/components/gravatar-caterpillar';
 
 function render() {
 	return <GravatarCaterpillar users={ users } />;

--- a/client/components/gravatar/README.md
+++ b/client/components/gravatar/README.md
@@ -9,7 +9,7 @@ The images size is set at 96px, used at smaller sizes for retina display. Using 
 ## How to use
 
 ```js
-import Gravatar from 'components/gravatar';
+import Gravatar from 'calypso/components/gravatar';
 
 function render() {
 	return <Gravatar user={ post.author } />;

--- a/client/components/happiness-engineers-tray/README.md
+++ b/client/components/happiness-engineers-tray/README.md
@@ -5,7 +5,7 @@ Renders a row of Happiness Engineers' Gravatars.
 ## How to use
 
 ```jsx
-import HappinessEngineersTray from 'components/happiness-engineers-tray';
+import HappinessEngineersTray from 'calypso/components/happiness-engineers-tray';
 
 function render() {
 	return <HappinessEngineersTray />;

--- a/client/components/happiness-support/README.md
+++ b/client/components/happiness-support/README.md
@@ -6,7 +6,7 @@ This component renders a card presenting our support resources, including links 
 
 ```js
 import React from 'react';
-import HappinessSupport from 'components/happiness-support';
+import HappinessSupport from 'calypso/components/happiness-support';
 
 export default () => {
 	return (

--- a/client/components/head/README.md
+++ b/client/components/head/README.md
@@ -5,7 +5,7 @@ Provides an HTML `<head>` prefilled with boilerplate (such as `meta`s and `links
 ## Usage
 
 ```jsx
-import Head from 'components/head';
+import Head from 'calypso/components/head';
 
 <Head title="Calypso">
 	<meta property="myCustomMeta" content="foobar" />

--- a/client/components/header-button/README.md
+++ b/client/components/header-button/README.md
@@ -9,7 +9,7 @@ implement this one.
 ## How to use
 
 ```js
-import HeaderButton from 'components/header-button';
+import HeaderButton from 'calypso/components/header-button';
 
 function MyHeader() {
 	return (

--- a/client/components/header-cake/README.md
+++ b/client/components/header-cake/README.md
@@ -5,7 +5,7 @@ The "header cake" component should be used at the top of an item's detail page. 
 ## Usage
 
 ```js
-import HeaderCake from 'components/header-cake';
+import HeaderCake from 'calypso/components/header-cake';
 
 <HeaderCake onClick={ callback }>Item Details</HeaderCake>;
 ```

--- a/client/components/hr-with-text/README.md
+++ b/client/components/hr-with-text/README.md
@@ -7,7 +7,7 @@ An [hr-like](https://developer.mozilla.org/en/docs/Web/HTML/Element/hr) line wit
 ## Usage
 
 ```js
-import HrWithText from 'components/hr-with-text';
+import HrWithText from 'calypso/components/hr-with-text';
 
 <HrWithText>This is some text</HrWithText>;
 ```

--- a/client/components/image-preloader/README.md
+++ b/client/components/image-preloader/README.md
@@ -8,7 +8,7 @@ Image Preloader is a React component to display a placeholder element until the 
 
 ```jsx
 import React from 'react';
-import ImagePreloader from 'components/image-preloader';
+import ImagePreloader from 'calypso/components/image-preloader';
 
 export default class extends React.Component {
 	render() {

--- a/client/components/image/README.md
+++ b/client/components/image/README.md
@@ -7,7 +7,7 @@ to the image element if the image fails to load.
 
 ```jsx
 import React from 'react';
-import Image from 'components/image';
+import Image from 'calypso/components/image';
 
 const MyComponent = () => <Image src="http://example.com/fails" className="my-image" />;
 ```

--- a/client/components/infinite-scroll/README.md
+++ b/client/components/infinite-scroll/README.md
@@ -9,7 +9,7 @@ There is an alternative implementation called [InfiniteList](../infinite-list), 
 First, require the component with
 
 ```js
-import InfiniteScroll from 'components/infinite-scroll';
+import InfiniteScroll from 'calypso/components/infinite-scroll';
 ```
 
 and in your component's `render` method, render it, passing a name of method that fetches next page. Be sure to place it at the bottom of your content list, so that it can serve as an anchor point for a new load.

--- a/client/components/info-popover/README.md
+++ b/client/components/info-popover/README.md
@@ -39,7 +39,7 @@ Also reqires the `gaEventCategory` attribute.
 Turns into this even when opened:
 
 ```js
-import { gaRecordEvent } from 'lib/analytics/ga';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 
 gaRecordEvent( gaEventCategory, 'InfoPopover: ' + popoverName + 'Opened' );
 ```

--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -7,7 +7,7 @@ The component's `children` prop will be used for the link text; if none is suppl
 ## Example Usage
 
 ```js
-import InlineSupportLink from 'components/inline-support-link';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 function render() {
 	const inlineSupportProps = {

--- a/client/components/input-chrono/README.md
+++ b/client/components/input-chrono/README.md
@@ -5,7 +5,7 @@ React component that creates a Date object from a user-entered textual date desc
 ## Example Usage
 
 ```js
-import InputChrono from 'components/input-chrono';
+import InputChrono from 'calypso/components/input-chrono';
 
 export default class extends React.Component {
 	// ...

--- a/client/components/jetpack-colophon/README.md
+++ b/client/components/jetpack-colophon/README.md
@@ -7,7 +7,7 @@ This component is used to display a "Powered by Jetpack" colophon, usually on th
 ## How to use
 
 ```js
-import JetpackColophon from 'components/jetpack-colophon';
+import JetpackColophon from 'calypso/components/jetpack-colophon';
 
 function MyFooter() {
 	return (

--- a/client/components/jetpack-logo/README.md
+++ b/client/components/jetpack-logo/README.md
@@ -7,7 +7,7 @@ This component is used to display a Jetpack logo
 ## How to use
 
 ```js
-import JetpackLogo from 'components/jetpack-logo';
+import JetpackLogo from 'calypso/components/jetpack-logo';
 
 export default function JetpackLogoExample() {
 	return (

--- a/client/components/jetpack-plus-wpcom-logo/README.md
+++ b/client/components/jetpack-plus-wpcom-logo/README.md
@@ -7,7 +7,7 @@ This component is used to display the Jetpack Plus WPCOM logo (a Jetpack logo, a
 ## How to use
 
 ```js
-import JetpackPlusWpComLogo from 'components/jetpack-plus-wpcom-logo';
+import JetpackPlusWpComLogo from 'calypso/components/jetpack-plus-wpcom-logo';
 
 export default function JetpackPlusWpComLogoExample() {
 	return (

--- a/client/components/jetpack/card/jetpack-bundle-card/README.md
+++ b/client/components/jetpack/card/jetpack-bundle-card/README.md
@@ -7,7 +7,7 @@ This component is used to display a Jetpack bundle card.
 ## How to use
 
 ```js
-import JetpackBundleCard from 'components/jetpack/card/jetpack-bundle-card';
+import JetpackBundleCard from 'calypso/components/jetpack/card/jetpack-bundle-card';
 
 export default function JetpackBundleCardExample() {
 	return (

--- a/client/components/jetpack/card/jetpack-plan-card/README.md
+++ b/client/components/jetpack/card/jetpack-plan-card/README.md
@@ -7,7 +7,7 @@ This component is used to display a Jetpack plan card.
 ## How to use
 
 ```js
-import JetpackPlanCard from 'components/jetpack/card/jetpack-plan-card';
+import JetpackPlanCard from 'calypso/components/jetpack/card/jetpack-plan-card';
 
 export default function JetpackPlanCardExample() {
 	return (

--- a/client/components/jetpack/card/jetpack-product-card/README.md
+++ b/client/components/jetpack/card/jetpack-product-card/README.md
@@ -7,7 +7,7 @@ This component is used to display a Jetpack product card.
 ## How to use
 
 ```js
-import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
+import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
 
 export default function JetpackProductCardExample() {
 	return (

--- a/client/components/jetpack/security-icon/README.md
+++ b/client/components/jetpack/security-icon/README.md
@@ -5,7 +5,7 @@ This is a component that is used for security icons to indicate state in Jetpack
 ## Usage
 
 ```jsx
-import SecurityIcon from 'components/jetpack/security-icon';
+import SecurityIcon from 'calypso/components/jetpack/security-icon';
 
 const SecurityIconExample = () => (
 	<div>

--- a/client/components/language-picker/README.md
+++ b/client/components/language-picker/README.md
@@ -9,9 +9,9 @@ React component used to display a Language Picker.
 ```js
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import LanguagePicker from 'components/language-picker';
-import getUserSetting from 'state/selectors/get-user-setting';
-import { saveUserSettings } from 'state/user-settings/actions';
+import LanguagePicker from 'calypso/components/language-picker';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { saveUserSettings } from 'calypso/state/user-settings/actions';
 
 const languages = [
 	{

--- a/client/components/list-end/README.md
+++ b/client/components/list-end/README.md
@@ -7,7 +7,7 @@ This component is used to display a WordPress logo in the centre of a line. It s
 ## How to use
 
 ```js
-import ListEnd from 'components/list-end';
+import ListEnd from 'calypso/components/list-end';
 
 export default function ListEndExample() {
 	return <ListEnd />;

--- a/client/components/localized-moment/README.md
+++ b/client/components/localized-moment/README.md
@@ -13,7 +13,7 @@ Is a higher-order component (HOC) that provides two props to the wrapped child:
 
 ```jsx
 import React from 'react';
-import { withLocalizedMoment } from 'components/localized-moment';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 
 class Label extends React.Component {
 	render() {
@@ -39,7 +39,7 @@ in `withLocalizedMoment`. It's just a different implementation of the same conce
 
 ```jsx
 import React from 'react';
-import { useLocalizedMoment } from 'components/localized-moment';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 export default function Label( { date } ) {
 	const moment = useLocalizedMoment();
@@ -64,7 +64,7 @@ locale slug.
 ```jsx
 import React from 'react';
 import ReactDom from 'react-dom';
-import MomentProvider from 'components/localized-moment/provider';
+import MomentProvider from 'calypso/components/localized-moment/provider';
 
 ReactDom.render(
 	<MomentProvider currentLocale="cs">

--- a/client/components/logged-out-form/README.md
+++ b/client/components/logged-out-form/README.md
@@ -5,13 +5,13 @@ This component is meant to be used when creating form for logged out users. You 
 ## Usage
 
 ```js
-import LoggedOutForm from 'components/logged-out-form';
-import LoggedOutFormFooter from 'components/logged-out-form-footer';
-import LoggedOutFormLinks from 'components/logged-out-form/links';
-import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
-import config from 'config';
+import LoggedOutForm from 'calypso/components/logged-out-form';
+import LoggedOutFormFooter from 'calypso/components/logged-out-form-footer';
+import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
+import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
+import config from 'calypso/config';
 import { Button } from '@automattic/components';
-import FormTextInput from 'components/forms/form-text-input';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 
 class MyLoggedOutForm extends React.Component {
 	handleSubmit = ( event ) => {

--- a/client/components/main/README.md
+++ b/client/components/main/README.md
@@ -5,7 +5,7 @@ Component used to declare the main area of any given section —- it's the main 
 ## How to use
 
 ```jsx
-import Main from 'components/main';
+import Main from 'calypso/components/main';
 
 function render() {
 	return <Main className="your-component">Your section content...</Main>;

--- a/client/components/marked-lines/README.md
+++ b/client/components/marked-lines/README.md
@@ -6,7 +6,7 @@ optional highlighting or marks to point out specific parts of one or more lines.
 ## Usage
 
 ```jsx
-import MarkedLines from 'components/marked-lines';
+import MarkedLines from 'calypso/components/marked-lines';
 
 return (
 	<MarkedLines

--- a/client/components/multiple-choice-question/README.md
+++ b/client/components/multiple-choice-question/README.md
@@ -5,7 +5,7 @@ This is a component for presenting a question and a list of answers to a user. T
 ## Usage
 
 ```jsx
-import MultipleChoiceQuestion from 'components/multiple-choice-question';
+import MultipleChoiceQuestion from 'calypso/components/multiple-choice-question';
 
 function MultipleChoiceQuestionExamples( { translate } ) {
 	const [ selectedAnswer, setSelectedAnswer ] = useState( null );

--- a/client/components/notice/README.md
+++ b/client/components/notice/README.md
@@ -7,7 +7,7 @@ This component is used to display inline notices, rather than Global ones
 ### Usage
 
 ```js
-import Notice from 'components/notice';
+import Notice from 'calypso/components/notice';
 
 function MyNotice() {
 	return (
@@ -39,7 +39,7 @@ This component is used to display an action inside a notice
 ### Usage
 
 ```js
-import NoticeAction from 'components/notice/notice-action';
+import NoticeAction from 'calypso/components/notice/notice-action';
 
 function MyNotice() {
 	return (

--- a/client/components/pagination/README.md
+++ b/client/components/pagination/README.md
@@ -5,7 +5,7 @@ Use pagination to allow navigation between pages that represent an ordered colle
 ## Usage
 
 ```js
-import Pagination from 'components/pagination';
+import Pagination from 'calypso/components/pagination';
 
 function render() {
 	return <Pagination />;

--- a/client/components/payment-logo/README.md
+++ b/client/components/payment-logo/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import PaymentLogo from 'components/payment-logo';
+import PaymentLogo from 'calypso/components/payment-logo';
 
 <>
 	<p>Empty Placeholder</p>

--- a/client/components/pie-chart/README.md
+++ b/client/components/pie-chart/README.md
@@ -23,8 +23,8 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PieChart from 'components/pie-chart';
-import PieChartLegend from 'components/pie-chart/legend';
+import PieChart from 'calypso/components/pie-chart';
+import PieChartLegend from 'calypso/components/pie-chart/legend';
 
 const titleFunc = ( translateFn, dataTotal ) => {
 	return translateFn( '%(dataTotal)d Total Searches', {

--- a/client/components/plans/plans-skip-button/README.md
+++ b/client/components/plans/plans-skip-button/README.md
@@ -17,7 +17,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import PlansSkipButton from 'components/plans/plans-skip-button';
+import PlansSkipButton from 'calypso/components/plans/plans-skip-button';
 
 class PlansSkipButtonExample extends PureComponent {
 	static displayName = 'PlansSkipButton';

--- a/client/components/podcast-indicator/README.md
+++ b/client/components/podcast-indicator/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import PodcastIndicator from 'components/podcast-indicator';
+import PodcastIndicator from 'calypso/components/podcast-indicator';
 
 <PodcastIndicator size={ 24 } />;
 ```

--- a/client/components/post-schedule/README.md
+++ b/client/components/post-schedule/README.md
@@ -7,7 +7,7 @@ This React component implements a small calendar (shown by month) which allows u
 ## Example Usage
 
 ```js
-import PostSchedule from 'components/post-schedule';
+import PostSchedule from 'calypso/components/post-schedule';
 
 export default class extends React.Component {
 	// ...

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -23,7 +23,7 @@ See p1HpG7-7ET-p2 for more details.
 
 ```jsx
 import React, { Fragment } from 'react';
-import ProductCard from 'components/product-card';
+import ProductCard from 'calypso/components/product-card';
 
 export default class extends React.Component {
 	render() {
@@ -80,8 +80,8 @@ Product Card Promo Nudge is a Product Card's sub-component for rendering a promo
 
 ```jsx
 import React, { Fragment } from 'react';
-import ProductCard from 'components/product-card';
-import ProductCardPromoNudge from 'components/product-card/promo-nudge';
+import ProductCard from 'calypso/components/product-card';
+import ProductCardPromoNudge from 'calypso/components/product-card/promo-nudge';
 
 export default class extends React.Component {
 	render() {
@@ -122,8 +122,8 @@ be passed to the Product Card as a child component.
 
 ```jsx
 import React, { useState } from 'react';
-import ProductCard from 'components/product-card';
-import ProductCardOptions from 'components/product-card/options';
+import ProductCard from 'calypso/components/product-card';
+import ProductCardOptions from 'calypso/components/product-card/options';
 
 export default function () {
 	const [ selectedProductOption, selectProductOption ] = useState(
@@ -194,8 +194,8 @@ text (optional) and a button.
 
 ```jsx
 import React from 'react';
-import ProductCard from 'components/product-card';
-import ProductCardAction from 'components/product-card/action';
+import ProductCard from 'calypso/components/product-card';
+import ProductCardAction from 'calypso/components/product-card/action';
 
 export default class extends React.Component {
 	render() {

--- a/client/components/promo-section/README.md
+++ b/client/components/promo-section/README.md
@@ -5,7 +5,7 @@ A compontent to layout [`PromoCard` components](../../components/promo-section/p
 ## Usage
 
 ```jsx
-import PromoCard from 'my-sites/promo-section/promo-card';
+import PromoCard from 'calypso/my-sites/promo-section/promo-card';
 
 const PromoCardExample = () => {
 	return (

--- a/client/components/promo-section/promo-card/README.md
+++ b/client/components/promo-section/promo-card/README.md
@@ -5,8 +5,8 @@ A [`Card` component](../../components/card) based on [`ActionPanel'](../../compo
 ## Usage
 
 ```jsx
-import PromoCard from 'my-sites/promo-section/promo-card';
-import referralImage from 'assets/images/earn/referral.svg';
+import PromoCard from 'calypso/my-sites/promo-section/promo-card';
+import referralImage from 'calypso/assets/images/earn/referral.svg';
 
 const PromoCardExample = () => {
 	const img = {

--- a/client/components/purchase-detail/README.md
+++ b/client/components/purchase-detail/README.md
@@ -7,7 +7,7 @@ This component renders a box with a title, description, button, and icon, based 
 ```js
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import PurchaseDetail from 'components/purchase-detail';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 const MyComponent = ( { translate } ) => (
 	<PurchaseDetail

--- a/client/components/rating/README.md
+++ b/client/components/rating/README.md
@@ -6,7 +6,7 @@ that represents a rating in a scale between 0 and 5.
 ## How to use
 
 ```js
-import Rating from 'components/rating';
+import Rating from 'calypso/components/rating';
 
 function render() {
 	return <Rating rating={ 65 } size={ 48 } />;

--- a/client/components/redirect-when-logged-in/README.md
+++ b/client/components/redirect-when-logged-in/README.md
@@ -10,7 +10,7 @@ If a user is not detected, it subscribes to the `storage` event and listens for 
 ## Usage
 
 ```javascript
-import RedirectWhenLoggedIn from 'components/redirect-when-logged-in';
+import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
 
 class YourComponent extends React.Component {
 	// ...

--- a/client/components/section-header/README.md
+++ b/client/components/section-header/README.md
@@ -9,7 +9,7 @@ and optional actions buttons.
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
-import SectionHeader from 'components/section-header';
+import SectionHeader from 'calypso/components/section-header';
 import { Button } from '@automattic/components';
 
 const MyHeader = ( { translate } ) => (

--- a/client/components/section-nav/README.md
+++ b/client/components/section-nav/README.md
@@ -9,11 +9,11 @@ React component used to display a particular section's navigation bar. Or more t
 ## Example Usage
 
 ```js
-import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavSegmented from 'components/section-nav/segmented';
-import NavItem from 'components/section-nav/item';
-import Search from 'components/search';
+import SectionNav from 'calypso/components/section-nav';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import NavSegmented from 'calypso/components/section-nav/segmented';
+import NavItem from 'calypso/components/section-nav/item';
+import Search from 'calypso/components/search';
 
 export default class extends React.Component {
 	// ...

--- a/client/components/segmented-control/README.md
+++ b/client/components/segmented-control/README.md
@@ -14,7 +14,7 @@ A good example for this case is navigation. Sometimes the option that is selecte
 
 ```jsx
 import React from 'react';
-import SegmentedControl from 'components/segmented-control';
+import SegmentedControl from 'calypso/components/segmented-control';
 
 export default class extends React.Component {
 	// ...
@@ -104,7 +104,7 @@ A good example for this case is a form element. You don't want to have to write 
 
 ```jsx
 import React from 'react';
-import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
+import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 
 const options = [
 	{ value: 'all', label: 'All' },

--- a/client/components/select-dropdown/README.md
+++ b/client/components/select-dropdown/README.md
@@ -14,7 +14,7 @@ A good example for this case is navigation. Sometimes the option that is selecte
 
 ```js
 import React from 'react';
-import SelectDropdown from 'components/select-dropdown';
+import SelectDropdown from 'calypso/components/select-dropdown';
 
 export default class extends React.Component {
 	// ...
@@ -107,7 +107,7 @@ As a sibling to `SelectDropdown.Item`, an item "separator" or horizontal line ca
 ![separator example screenshot](https://cldup.com/CWEH2K9PUf.png)
 
 ```js
-import SelectDropdown from 'components/select-dropdown';
+import SelectDropdown from 'calypso/components/select-dropdown';
 
 export default class extends React.Component {
 	// ...
@@ -142,7 +142,7 @@ A good example for this case is a form element. You don't want to have to write 
 > **NOTE** - there is still more work here in order to be fully functional as a form element, not recommended use case... yet.
 
 ```js
-import SelectDropdown from 'components/select-dropdown';
+import SelectDropdown from 'calypso/components/select-dropdown';
 
 const options = [
 	{ label: 'Post status', isLabel: true },

--- a/client/components/share-button/README.md
+++ b/client/components/share-button/README.md
@@ -7,7 +7,7 @@ ShareButton is a component which allows you to open a popup window to share cont
 ## How to use
 
 ```js
-import ShareButton from 'components/share-button';
+import ShareButton from 'calypso/components/share-button';
 
 function MyButton() {
 	const service = {

--- a/client/components/sidebar-navigation/README.md
+++ b/client/components/sidebar-navigation/README.md
@@ -7,8 +7,8 @@ This component is used to display the mobile sidebar navigation header at the to
 Put the component in your `Main` component, and wrap it around any components you want it to display as its children. It relies on the [`document-head`](/client/state/document-head) Redux subtree, whose fields you can set through the [`DocumentHead`](/client/components/data/document-head) component. It handles detecting the selected site.
 
 ```js
-import SidebarNavigation from 'components/sidebar-navigation';
-import Gridicon from 'components/gridicons';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import Gridicon from 'calypso/components/gridicons';
 
 function render() {
 	return (

--- a/client/components/site-offset/README.md
+++ b/client/components/site-offset/README.md
@@ -12,7 +12,7 @@ Is a higher-order component (HOC) that provides one prop to the wrapped child:
 
 ```jsx
 import React from 'react';
-import { withApplySiteOffset } from 'components/site-offset';
+import { withApplySiteOffset } from 'calypso/components/site-offset';
 
 class Label extends React.Component {
 	render() {
@@ -39,7 +39,7 @@ in `withApplySiteOffset`. It's just a different implementation of the same conce
 
 ```jsx
 import React from 'react';
-import { useApplySiteOffset } from 'components/localized-moment';
+import { useApplySiteOffset } from 'calypso/components/localized-moment';
 
 export default function Label( { date } ) {
 	const applySiteOffset = useApplySiteOffset();
@@ -64,7 +64,7 @@ The `SiteOffsetProvider` component takes one prop: `site`. It is a string that i
 ```jsx
 import React from 'react';
 import ReactDom from 'react-dom';
-import { SiteOffsetProvider } from 'components/site-offset/context';
+import { SiteOffsetProvider } from 'calypso/components/site-offset/context';
 
 ReactDom.render(
 	<SiteOffsetProvider siteId={ siteId }>

--- a/client/components/site-verticals-suggestion-search/README.md
+++ b/client/components/site-verticals-suggestion-search/README.md
@@ -5,7 +5,7 @@ As a wrapper for `<SuggestionSearch />`, SiteVerticalsSuggestionSearch fetches s
 ## Usage
 
 ```jsx
-import SiteVerticalsSuggestionSearch from 'components/site-verticals-suggestion-search';
+import SiteVerticalsSuggestionSearch from 'calypso/components/site-verticals-suggestion-search';
 
 function onChange( { vertical_name, vertical_slug, vertical_id } ) {
 	console.log( 'New vertical values: ', vertical_name, vertical_slug, vertical_id );

--- a/client/components/sites-dropdown/README.md
+++ b/client/components/sites-dropdown/README.md
@@ -7,7 +7,7 @@ It supports searching if you have many sites, handles sites with empty titles, s
 ## How to use
 
 ```js
-import SitesDropdown from 'components/sites-dropdown';
+import SitesDropdown from 'calypso/components/sites-dropdown';
 
 function render() {
 	return <SitesDropdown />;

--- a/client/components/spinner-button/README.md
+++ b/client/components/spinner-button/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```jsx
-import SpinnerButton from 'components/spinner-button';
+import SpinnerButton from 'calypso/components/spinner-button';
 
 export default function MyComponent() {
 	return <SpinnerButton />;

--- a/client/components/spinner-line/README.md
+++ b/client/components/spinner-line/README.md
@@ -9,7 +9,7 @@
 ## Usage
 
 ```jsx
-import SpinnerLine from 'components/spinner-line';
+import SpinnerLine from 'calypso/components/spinner-line';
 
 export default function MyComponent() {
 	return <SpinnerLine />;

--- a/client/components/spinner/README.md
+++ b/client/components/spinner/README.md
@@ -8,7 +8,7 @@ Spinner is a React component for rendering a loading indicator.
 
 ```jsx
 import React from 'react';
-import Spinner from 'components/spinner';
+import Spinner from 'calypso/components/spinner';
 
 export default class extends React.Component {
 	render() {

--- a/client/components/split-button/README.md
+++ b/client/components/split-button/README.md
@@ -7,8 +7,8 @@ A React component for displaying a button with a labeled main action plus a seco
 Render `<SplitButton />` in a similar fashion as you would [the `<PopoverMenu />` component](../popover-menu), as it is effectively a convenience wrapper for this component with a few additional options. Specifically, you'll still need to render `<PopoverMenuItem />` as children of the `<SplitButton />`.
 
 ```jsx
-import SplitButton from 'components/split-button';
-import PopoverMenuItem from 'components/popover/menu-item';
+import SplitButton from 'calypso/components/split-button';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
 
 export default function MyComponent( { onMenuItemClick } ) {
 	return (

--- a/client/components/sub-masterbar-nav/README.md
+++ b/client/components/sub-masterbar-nav/README.md
@@ -12,7 +12,7 @@ In case no option is selected, the `fallback` value will be shown in the dropdow
 If no `icon` is provided, `star` will be used by default.
 
 ```js
-import SubMasterbarNav from 'components/sub-masterbar-nav';
+import SubMasterbarNav from 'calypso/components/sub-masterbar-nav';
 
 const options = [
 	{

--- a/client/components/suggestion-search/README.md
+++ b/client/components/suggestion-search/README.md
@@ -5,7 +5,7 @@ SuggestionSearch is a bundled component of FormTextInput and Suggestions which e
 ## Usage
 
 ```jsx
-import SuggestionSearch from 'components/suggestion-search';
+import SuggestionSearch from 'calypso/components/suggestion-search';
 
 function onChange( newValue, isNavigating ) {
 	console.log( 'New value: ', newValue, 'isNavigating:', isNavigating );

--- a/client/components/support-info/README.md
+++ b/client/components/support-info/README.md
@@ -5,7 +5,7 @@ This component is used to display a support info icon. When clicked, it displays
 ## Example Usage
 
 ```js
-import SupportInfo from 'components/support-info';
+import SupportInfo from 'calypso/components/support-info';
 
 function render() {
 	const support = {

--- a/client/components/text-diff/README.md
+++ b/client/components/text-diff/README.md
@@ -8,7 +8,7 @@ TextDiff should be passed an array of 'operations'. These operations might be ad
 In the following example the operations array represents a title rename by including the deletion of the old title and addition of a new title:
 
 ```jsx
-import TextDiff from 'components/text-diff';
+import TextDiff from 'calypso/components/text-diff';
 
 export default function RenamedTitle() {
 	const operations = [

--- a/client/components/textarea-autosize/README.md
+++ b/client/components/textarea-autosize/README.md
@@ -7,7 +7,7 @@
 Since it is a drop-in replacement, use as you would a regular `<textarea />` element.
 
 ```jsx
-import TextareaAutosize from 'components/textarea-autosize';
+import TextareaAutosize from 'calypso/components/textarea-autosize';
 
 export default function MyForm( { onTextareaChange } ) {
 	return <TextareaAutosize onChange={ onTextareaChange } rows="1" />;

--- a/client/components/tile-grid/README.md
+++ b/client/components/tile-grid/README.md
@@ -30,8 +30,8 @@ Component used to display a clickable tile with an image, call to action, and de
 ### How to use
 
 ```js
-import Tile from 'components/tile-grid/tile';
-import TileGrid from 'components/tile-grid';
+import Tile from 'calypso/components/tile-grid/tile';
+import TileGrid from 'calypso/components/tile-grid';
 
 class MyExampleComponent extends PureComponent {
 	render() {

--- a/client/components/timeline/README.md
+++ b/client/components/timeline/README.md
@@ -59,8 +59,8 @@ The function to call when the action button is clicked.
 ---
 
 ```jsx
-import Timeline from 'components/timeline';
-import TimelineEvent from 'components/timeline/timeline-item';
+import Timeline from 'calypso/components/timeline';
+import TimelineEvent from 'calypso/components/timeline/timeline-item';
 
 export default class extends React.Component {
 	// ...

--- a/client/components/timezone/README.md
+++ b/client/components/timezone/README.md
@@ -5,7 +5,7 @@ Select timezone react component.
 ---
 
 ```jsx
-import Timezone from 'components/timezone';
+import Timezone from 'calypso/components/timezone';
 
 export default class extends React.Component {
 	// ...

--- a/client/components/tinymce/plugins/embed/README.md
+++ b/client/components/tinymce/plugins/embed/README.md
@@ -14,7 +14,7 @@ Component used to show an embedded URL in a dialog
 ## How to use
 
 ```js
-import EmbedDialog from 'components/tinymce/plugins/embed';
+import EmbedDialog from 'calypso/components/tinymce/plugins/embed';
 
 function render() {
 	return (

--- a/client/components/upgrades/credit-card-number-input/README.md
+++ b/client/components/upgrades/credit-card-number-input/README.md
@@ -6,7 +6,7 @@
 
 ```jsx
 import React from 'react';
-import CreditCardNumberInput from 'components/upgrades/credit-card-number-input';
+import CreditCardNumberInput from 'calypso/components/upgrades/credit-card-number-input';
 
 class MyComponent extends React.Component {
 	render() {

--- a/client/components/upgrades/gsuite/README.md
+++ b/client/components/upgrades/gsuite/README.md
@@ -6,9 +6,9 @@ GSuiteUpgrade is a React component used to add G Suite email addresses to domain
 
 ```jsx
 import React from 'react';
-import CartData from 'components/data/cart';
-import GSuiteUpgrade from 'components/upgrades/gsuite';
-import productsListFactory from 'lib/products-list';
+import CartData from 'calypso/components/data/cart';
+import GSuiteUpgrade from 'calypso/components/upgrades/gsuite';
+import productsListFactory from 'calypso/lib/products-list';
 
 const productsList = productsListFactory();
 

--- a/client/components/version/README.md
+++ b/client/components/version/README.md
@@ -6,7 +6,7 @@ Version is a React component for rendering a version number
 
 ```jsx
 import React from 'react';
-import Version from 'components/version';
+import Version from 'calypso/components/version';
 
 class MyComponent extends React.Component {
 	render() {

--- a/client/components/vertical-menu/README.md
+++ b/client/components/vertical-menu/README.md
@@ -11,8 +11,8 @@ The following predefined item types exist:
 ## Usage
 
 ```js
-import VerticalMenu from 'components/vertical-menu';
-import { SocialItem } from 'components/vertical-menu/items';
+import VerticalMenu from 'calypso/components/vertical-menu';
+import { SocialItem } from 'calypso/components/vertical-menu/items';
 
 const announceIt = ( service ) => console.log( `Clicked on ${ service }` );
 

--- a/client/components/wizard-progress-bar/README.md
+++ b/client/components/wizard-progress-bar/README.md
@@ -8,7 +8,7 @@ A Progress Bar for use with a custom wizard. It has buttons to go backward and f
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import WizardProgressBar from 'components/wizard-progress-bar';
+import WizardProgressBar from 'calypso/components/wizard-progress-bar';
 
 export default class WizardProgressBarExample extends Component {
 	static defaultProps = {

--- a/client/components/wpcom-colophon/README.md
+++ b/client/components/wpcom-colophon/README.md
@@ -7,7 +7,7 @@ This component is used to display a "In partnership with WordPress.com" colophon
 ## How to use
 
 ```js
-import WpcomColophon from 'components/wpcom-colophon';
+import WpcomColophon from 'calypso/components/wpcom-colophon';
 
 function MyFooter() {
 	return (

--- a/client/config/README.md
+++ b/client/config/README.md
@@ -18,7 +18,7 @@ in-progress features without launching them to production.
 Is a feature enabled?
 
 ```js
-import config from 'config';
+import config from 'calypso/config';
 
 if ( config.isEnabled( 'myFeature' ) ) {
 	// do something only when myFeature is enabled
@@ -57,7 +57,7 @@ testing environment. The `config` module exports a helper function `isCalypsoLiv
 `true` if Calypso is running on the `*.calypso.live` origin.
 
 ```js
-import { isCalypsoLive } from 'config';
+import { isCalypsoLive } from 'calypso/config';
 
 if ( isCalypsoLive() ) {
 	/* ... */

--- a/client/devdocs/docs-example/README.md
+++ b/client/devdocs/docs-example/README.md
@@ -5,7 +5,7 @@ This component is used to implement a skeleton for components examples which are
 ## How to use
 
 ```jsx
-import DocsExample from 'devdocs/design/docs-example';
+import DocsExample from 'calypso/devdocs/design/docs-example';
 
 function render() {
 	return (

--- a/client/extensions/README.md
+++ b/client/extensions/README.md
@@ -41,8 +41,8 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { makeLayout, render as clientRender } from 'controller';
-import { navigation, siteSelection } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { navigation, siteSelection } from 'calypso/my-sites/controller';
 import { helloWorld } from './controller';
 
 export default () => {

--- a/client/extensions/woocommerce/components/form-location-select/README.md
+++ b/client/extensions/woocommerce/components/form-location-select/README.md
@@ -43,7 +43,7 @@ The source site for the countries list request. Defaults to the currently-select
 ### How to use
 
 ```jsx
-import FormFieldSet from 'components/forms/form-fieldset';
+import FormFieldSet from 'calypso/components/forms/form-fieldset';
 import FormCountrySelectFromApi from 'woocommerce/components/form-location-select/countries';
 import FormStateSelectFromApi from 'woocommerce/components/form-location-select/states';
 

--- a/client/extensions/woocommerce/lib/formatted-variation-name/README.md
+++ b/client/extensions/woocommerce/lib/formatted-variation-name/README.md
@@ -7,7 +7,7 @@ This method will return a formatted variation name based on the attribute option
 ## Example (1 Attribute)
 
 ```javascript
-import formattedVariationName from 'lib/formatted-variation-name';
+import formattedVariationName from 'calypso/lib/formatted-variation-name';
 
 // Provide a WooCommerce Variation Object (from state or server)
 const variation = {
@@ -29,7 +29,7 @@ Returns `Red`.
 ## Example (Multiple Attributes)
 
 ```javascript
-import formattedVariationName from 'lib/formatted-variation-name';
+import formattedVariationName from 'calypso/lib/formatted-variation-name';
 
 // Provide a WooCommerce Variation Object (from state or server)
 const variation = {
@@ -55,7 +55,7 @@ Returns `Red - Small`.
 ## Example (Fallback)
 
 ```javascript
-import formattedVariationName from 'lib/formatted-variation-name';
+import formattedVariationName from 'calypso/lib/formatted-variation-name';
 
 // Provide a WooCommerce Variation Object (from state or server)
 // This is a variation that provides fallback settings for the other variations.

--- a/client/extensions/woocommerce/lib/generate-variations/README.md
+++ b/client/extensions/woocommerce/lib/generate-variations/README.md
@@ -5,7 +5,7 @@ Given a WooCommerce product object, this library will generate new WooCommerce v
 ## Example
 
 ```javascript
-import generateVariations from 'lib/generate-variations';
+import generateVariations from 'calypso/lib/generate-variations';
 
 // Provide a WooCommerce Product Object (from state or server)
 const product = {

--- a/client/layout/guided-tours/docs/TUTORIAL.md
+++ b/client/layout/guided-tours/docs/TUTORIAL.md
@@ -61,7 +61,7 @@ First we'll need to create a directory tour, under `tours`. In there, we create 
 /**
  * Internal dependencies
  */
-import { and } from 'layout/guided-tours/utils';
+import { and } from 'calypso/layout/guided-tours/utils';
 
 export default {};
 ```
@@ -85,8 +85,12 @@ import {
 	ButtonRow,
 	Quit,
 	Continue,
-} from 'layout/guided-tours/config-elements';
-import { isNewUser, isEnabled, isSelectedSitePreviewable } from 'state/guided-tours/contexts';
+} from 'calypso/layout/guided-tours/config-elements';
+import {
+	isNewUser,
+	isEnabled,
+	isSelectedSitePreviewable,
+} from 'calypso/state/guided-tours/contexts';
 
 export const TutorialSitePreviewTour = makeTour();
 ```

--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -41,7 +41,7 @@ There are also several optional configuration settings available:
 Next, in your code, import the `abtest` method from the `abtest` module:
 
 ```js
-import { abtest } from 'lib/abtest';
+import { abtest } from 'calypso/lib/abtest';
 ```
 
 The exported `abtest` method takes a test name (and optional country code) and returns one of the variations you defined in the config file.
@@ -87,7 +87,7 @@ if ( abtest( 'freeTrialButtonWordingForIndia', userCountryCode ) === 'startFreeT
 If you want to determine whether the user is a participant in a specific A/B test, you can import the `abtest` module's `getABTestVariation` method:
 
 ```js
-import { getABTestVariation } from 'lib/abtest';
+import { getABTestVariation } from 'calypso/lib/abtest';
 
 // ...
 

--- a/client/lib/accept/README.md
+++ b/client/lib/accept/README.md
@@ -21,7 +21,7 @@ Accept is a stylized substitute to the browser `confirm` dialog.
 While `confirm` returns a value synchronously, Accept must be performed asynchronously. In addition to your message, you must pass a function which will be executed upon a user's selection with the result of the confirmation.
 
 ```js
-import accept from 'lib/accept';
+import accept from 'calypso/lib/accept';
 
 accept( 'Are you sure you want to perform this action?', function ( accepted ) {
 	if ( accepted ) {
@@ -35,7 +35,7 @@ accept( 'Are you sure you want to perform this action?', function ( accepted ) {
 This will make the confirmation button look scary:
 
 ```js
-import accept from 'lib/accept';
+import accept from 'calypso/lib/accept';
 
 accept(
 	'Are you sure you want to perform this action?',

--- a/client/lib/analytics/docs/google-analytics.md
+++ b/client/lib/analytics/docs/google-analytics.md
@@ -13,7 +13,7 @@ In most situations, it is best to use the [Analytics Middleware](https://github.
 ### `recordGoogleEvent( category, action [, label, value ] )`
 
 ```js
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 dispatch( recordGoogleEvent( 'Reader', 'Loaded Next Page', 'page', 2 ) );
 ```
@@ -25,7 +25,7 @@ _Note: Unless you have a strong reason to call `analytics.ga` directly, you shou
 Record an event:
 
 ```js
-import { gaRecordEvent } from 'lib/analytics/ga';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 
 gaRecordEvent( 'Reader', 'Clicked Like' );
 gaRecordEvent( 'Reader', 'Loaded Next Page', 'page', 2 );
@@ -40,7 +40,7 @@ _Note: Unless you have a strong reason to directly record a page view to Google 
 Record a virtual page view:
 
 ```js
-import { gaRecordPageView } from 'lib/analytics/ga';
+import { gaRecordPageView } from 'calypso/lib/analytics/ga';
 
 gaRecordPageView( '/posts/draft', 'Posts > Drafts' );
 ```

--- a/client/lib/analytics/docs/mc.md
+++ b/client/lib/analytics/docs/mc.md
@@ -9,7 +9,7 @@ Automatticians may refer to internal documentation for more information about MC
 Bump a single WP.com stat:
 
 ```js
-import { bumpStat } from 'lib/analytics/mc';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 
 bumpStat( 'newdash_visits', 'sites' );
 ```
@@ -19,7 +19,7 @@ bumpStat( 'newdash_visits', 'sites' );
 Bump multiple WP.com stats:
 
 ```js
-import { bumpStat } from 'lib/analytics/mc';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 
 bumpStat( {
 	stat_name1: 'stat_value1',

--- a/client/lib/analytics/docs/page-views.md
+++ b/client/lib/analytics/docs/page-views.md
@@ -9,7 +9,7 @@ These tools will automatically record page views to both Google Analytics and Tr
 ### `PageViewTracker`
 
 ```js
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 function render() {
 	return (
@@ -30,7 +30,7 @@ For more information about `PageViewTracker`, refer to [its own documentation](h
 _Note: Unless you have a strong reason to record a page view with Redux, you should use the `PageViewTracker` component instead._
 
 ```js
-import { recordPageView } from 'state/analytics/actions';
+import { recordPageView } from 'calypso/state/analytics/actions';
 
 dispatch( recordPageView( '/section/page', 'My Cool Section > My Cool Page' ) );
 ```
@@ -40,7 +40,7 @@ dispatch( recordPageView( '/section/page', 'My Cool Section > My Cool Page' ) );
 _Note: Unless you have a strong reason to directly record a page view, you should use the `PageViewTracker` component instead._
 
 ```js
-import { recordPageView } from 'lib/analytics/page-view';
+import { recordPageView } from 'calypso/lib/analytics/page-view';
 
 recordPageView( '/section/page', 'My Cool Section > My Cool Page' );
 ```

--- a/client/lib/analytics/page-view-tracker/README.md
+++ b/client/lib/analytics/page-view-tracker/README.md
@@ -18,7 +18,7 @@ This component is aware of the selected site and, if the current URL contains a 
 ### Immediate Page View Tracking
 
 ```js
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 function render() {
 	return (

--- a/client/lib/analytics/with-tracking-tool/README.md
+++ b/client/lib/analytics/with-tracking-tool/README.md
@@ -11,7 +11,7 @@ The return is a wrapper function that takes your component and loads the specifi
 When directly wrapping a component:
 
 ```js
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
+import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 
 class MyComponent {
 	render() {
@@ -25,7 +25,7 @@ export default withTrackingTool( 'HotJar' )( MyComponent );
 When combined with other wrappers (like `localize()`):
 
 ```js
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
+import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 

--- a/client/lib/browser-storage/README.md
+++ b/client/lib/browser-storage/README.md
@@ -6,7 +6,7 @@ back to `localStorage` otherwise.
 ## Usage
 
 ```js
-import { getStoredItem, setStoredItem, clearStorage } from 'lib/browser-storage';
+import { getStoredItem, setStoredItem, clearStorage } from 'calypso/lib/browser-storage';
 
 setStoredItem( 'my-stored-key', { complex: value } ).then( () => doSomething() );
 getStoredItem( 'my-stored-key' ).then( ( val ) => doSomethingWithVal( val ) );
@@ -22,7 +22,7 @@ a volatile memory store instead. The `bypassPersistentStorage` method exists to 
 on and off.
 
 ```js
-import { setStoredItem, bypassPersistentStorage } from 'lib/browser-storage';
+import { setStoredItem, bypassPersistentStorage } from 'calypso/lib/browser-storage';
 
 async function demo() {
 	// Use persistent storage.

--- a/client/lib/catch-js-errors/README.md
+++ b/client/lib/catch-js-errors/README.md
@@ -13,7 +13,7 @@ For hard-to-debug cases, `log` function is being exported to log unusual events.
 ### Example
 
 ```javascript
-import log from 'lib/catch-js-errors/log';
+import log from 'calypso/lib/catch-js-errors/log';
 
 // Something unusual happened
 log( 'This is unexpected', { additionalData: 'data' } );

--- a/client/lib/data-poller/README.md
+++ b/client/lib/data-poller/README.md
@@ -29,8 +29,8 @@ Add a new poller that fetches updates
 ## Example
 
 ```js
-import PollerPool from 'lib/data-poller';
-import SitesList from 'lib/sites-list/list';
+import PollerPool from 'calypso/lib/data-poller';
+import SitesList from 'calypso/lib/sites-list/list';
 
 const sites = new SitesList();
 

--- a/client/lib/email-followers/README.md
+++ b/client/lib/email-followers/README.md
@@ -37,8 +37,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import EmailFollowersStore from 'lib/followers/wpcom-followers-store';
-import EmailFollowersActions from 'lib/followers/actions';
+import EmailFollowersStore from 'calypso/lib/followers/wpcom-followers-store';
+import EmailFollowersActions from 'calypso/lib/followers/actions';
 
 export default class extends React.Component {
 	static displayName = 'yourComponent';

--- a/client/lib/embed-frame-markup/README.md
+++ b/client/lib/embed-frame-markup/README.md
@@ -7,7 +7,7 @@ Exports a single default function which, when invoked with an object containing 
 ## Usage
 
 ```js
-import generateEmbedFrameMarkup from 'lib/embed-frame-markup';
+import generateEmbedFrameMarkup from 'calypso/lib/embed-frame-markup';
 
 const markup = generateEmbedFrameMarkup( {
 	body: 'Hello World',

--- a/client/lib/feature-detection/README.md
+++ b/client/lib/feature-detection/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```javascript
-import { supportsFeatureToDetect } from 'lib/feature-detection';
+import { supportsFeatureToDetect } from 'calypso/lib/feature-detection';
 
 if ( supportsFeatureToDetect() ) {
 	doSomething();

--- a/client/lib/followers/README.md
+++ b/client/lib/followers/README.md
@@ -37,8 +37,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FollowersStore from 'lib/followers/wpcom-followers-store';
-import FollowersActions from 'lib/followers/actions';
+import FollowersStore from 'calypso/lib/followers/wpcom-followers-store';
+import FollowersActions from 'calypso/lib/followers/actions';
 
 export default class extends React.Component {
 	static displayName = 'yourComponent';

--- a/client/lib/format-number-compact/README.md
+++ b/client/lib/format-number-compact/README.md
@@ -5,7 +5,7 @@ Given a language code, this library will take in a number and display it in a co
 ## Usage
 
 ```javascript
-import formatNumberCompact from 'lib/format-number-compact';
+import formatNumberCompact from 'calypso/lib/format-number-compact';
 
 const noChange = formatNumberCompact( 999, 'en' ); // '999'
 const shortEn = formatNumberCompact( 1234, 'en' ); // '1.2K'

--- a/client/lib/geocoding/README.md
+++ b/client/lib/geocoding/README.md
@@ -9,7 +9,7 @@ Geocoding exports two functions: `geocode` and `reverseGeocode`.
 `geocode` accepts a single `address` argument and returns a Promise instance. The promise resolver should expect to receive an array of [geocoding results](https://developers.google.com/maps/documentation/geocoding/intro#Results), or an error if the request could not be made.
 
 ```jsx
-import { geocode } from 'lib/geocoding';
+import { geocode } from 'calypso/lib/geocoding';
 
 geocode( '1600 Amphitheatre Parkway, Mountain View, CA' )
 	.then( ( results ) => console.log( results ) )
@@ -19,7 +19,7 @@ geocode( '1600 Amphitheatre Parkway, Mountain View, CA' )
 `reverseGeocode` accepts a `latitude` and a `longitude` argument and returns a Promise instance. The promise resolver should expect to receive an array of [geocoding results](https://developers.google.com/maps/documentation/geocoding/intro#Results), or an error if the request could not be made.
 
 ```jsx
-import { reverseGeocode } from 'lib/geocoding';
+import { reverseGeocode } from 'calypso/lib/geocoding';
 
 geocode( '41.878114', '-87.629798' )
 	.then( ( results ) => console.log( results ) )

--- a/client/lib/gsuite/README.md
+++ b/client/lib/gsuite/README.md
@@ -9,7 +9,7 @@ G Suite is a helper library to help interact with G Suite components and APIs
 The `GSuiteNewUserList` depends on its parent managing the state of the new users. For this purpose `lib/gsuite/new-users` provides a collection of helper functions
 
 ```jsx
-import { newUsers } from 'lib/gsuite/new-users';
+import { newUsers } from 'calypso/lib/gsuite/new-users';
 
 const GSuiteExample = () => {
 	const [ users, setUsers ] = useState( newUsers( 'test.com' ) );

--- a/client/lib/i18n-utils/README.md
+++ b/client/lib/i18n-utils/README.md
@@ -5,7 +5,7 @@ I18n-related utilities, for use both client- and server-side.
 ## Usage
 
 ```js
-import i18nUtils from 'lib/i18n-utils';
+import i18nUtils from 'calypso/lib/i18n-utils';
 ```
 
 ### Loading Waiting User Translations

--- a/client/lib/impure-lodash/README.md
+++ b/client/lib/impure-lodash/README.md
@@ -17,7 +17,7 @@ In this new module we export a single object instead of separate named exports.
 When importing this works the same way…
 
 ```js
-import impureLodash from 'lib/impure-lodash';
+import impureLodash from 'calypso/lib/impure-lodash';
 const { uniqueId } = impureLodash;
 ```
 

--- a/client/lib/keyboard-shortcuts/README.md
+++ b/client/lib/keyboard-shortcuts/README.md
@@ -7,7 +7,7 @@ This module emits an event when a keyboard shortcut is used, indicating the keyb
 This module can be used outside of React, but this is a typical use within React:
 
 ```js
-import KeyboardShortcuts from 'lib/keyboard-shortcuts';
+import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
 
 class MyComponent extends React.Component {
 	componentWillMount() {

--- a/client/lib/local-storage-polyfill/README.md
+++ b/client/lib/local-storage-polyfill/README.md
@@ -13,5 +13,5 @@ localStorage.length;
 Just require and call this once into the page (prior to any calls to these methods) and it will either create or augment the `window.localStorage` object as necessary.
 
 ```js
-import localStorePolyfill from 'lib/local-storage-polyfill';
+import localStorePolyfill from 'calypso/lib/local-storage-polyfill';
 ```

--- a/client/lib/media/README.md
+++ b/client/lib/media/README.md
@@ -15,7 +15,7 @@ This is the single source of truth for media data. As data flows through the Flu
 The stores are singleton objects, which offer `get` and `getAll` methods to retrieve data.
 
 ```js
-import MediaStoreFactory from 'lib/media/store';
+import MediaStoreFactory from 'calypso/lib/media/store';
 const MediaStore = MediaStoreFactory();
 
 const allMedia = MediaStore.getAll( siteId );
@@ -25,7 +25,7 @@ const singleMedia = MediaStore.get( siteId, postId );
 To interact with the store, use the actions made available in `actions.js`.
 
 ```js
-import MediaActions from 'lib/media/actions';
+import MediaActions from 'calypso/lib/media/actions';
 
 MediaActions.fetchNextPage( siteId );
 ```
@@ -33,7 +33,7 @@ MediaActions.fetchNextPage( siteId );
 You should monitor the store for changes in case another module interacts with the store:
 
 ```js
-import MediaStore from 'lib/media/store';
+import MediaStore from 'calypso/lib/media/store';
 let mediaScale = MediaStore.get( 'media-scale' );
 
 MediaStore.on( 'change', function () {

--- a/client/lib/mixins/data-observe/README.md
+++ b/client/lib/mixins/data-observe/README.md
@@ -8,7 +8,7 @@ A React mixin that makes it easy to trigger re-rendering of a component when a `
 
 ```js
 /* eslint-disable react/prefer-es6-class */
-import observe from 'lib/mixins/data-observe';
+import observe from 'calypso/lib/mixins/data-observe';
 import createReactClass from 'create-react-class';
 
 const Component = createReactClass( {

--- a/client/lib/mobile-app/README.md
+++ b/client/lib/mobile-app/README.md
@@ -7,7 +7,7 @@ This module contains a function to identify whether requests are coming from the
 Simple usage:
 
 ```js
-import { isWpMobileApp } from 'lib/mobile-app';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
 
 if ( isWpMobileApp() ) {
 	// Perform a mobile app-specific logic.

--- a/client/lib/network-connection/README.md
+++ b/client/lib/network-connection/README.md
@@ -7,7 +7,7 @@
 Public API can be used through main file:
 
 ```js
-import NetworkConnectionApp from 'lib/network-connection';
+import NetworkConnectionApp from 'calypso/lib/network-connection';
 ```
 
 To init default handler which shows/hides error notice when connection lost/restored simply call:

--- a/client/lib/payment-gateway-loader/README.md
+++ b/client/lib/payment-gateway-loader/README.md
@@ -7,7 +7,7 @@ This class, `PaymentGatewayLoader`, takes care of the details of loading the rem
 You can access the `Paygate` class from within the callback of `PaygateLoader.ready` like so:
 
 ```js
-import paymentGatewayLoader from 'lib/payment-gateway-loader';
+import paymentGatewayLoader from 'calypso/lib/payment-gateway-loader';
 
 function onSuccess( token ) {
 	// Do something with the Paygate token

--- a/client/lib/perfmon/README.md
+++ b/client/lib/perfmon/README.md
@@ -31,7 +31,7 @@ To enable monitoring for a page, import and run `recordPlaceholdersTiming` as
 part of its load:
 
 ```js
-import { recordPlaceholdersTiming } from 'lib/perfmon';
+import { recordPlaceholdersTiming } from 'calypso/lib/perfmon';
 
 recordPlaceholdersTiming();
 ```

--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -87,7 +87,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import PluginsStore from 'lib/plugins/store';
+import PluginsStore from 'calypso/lib/plugins/store';
 
 export default class extends React.Component {
 	static displayName = 'yourComponent';
@@ -181,7 +181,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import PluginsActions from 'lib/plugins/actions';
+import PluginsActions from 'calypso/lib/plugins/actions';
 
 export default class extends React.Component {
 	static displayName = 'yourComponent';

--- a/client/lib/plugins/wporg-data/README.md
+++ b/client/lib/plugins/wporg-data/README.md
@@ -58,7 +58,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import PluginsDataStore from 'lib/plugins/wporg-data/store';
+import PluginsDataStore from 'calypso/lib/plugins/wporg-data/store';
 
 export class YourComponent extends Component {
 	constructor( props ) {
@@ -113,7 +113,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import PluginsDataActions from 'lib/plugins/wporg-data/actions';
+import PluginsDataActions from 'calypso/lib/plugins/wporg-data/actions';
 
 export class YourComponent extends Component {
 	updatePlugin() {

--- a/client/lib/post-metadata/README.md
+++ b/client/lib/post-metadata/README.md
@@ -7,7 +7,7 @@ Post Metadata is a set of helper functions to assist in extracting metadata from
 Each function in the module expects to receive a post object, and will return either the value, or `undefined` if the value could be not be determined from the object.
 
 ```js
-import PostMetadata from 'lib/post-metadata';
+import PostMetadata from 'calypso/lib/post-metadata';
 
 const geoCoordinate = PostMetadata.geoCoordinate( post );
 ```

--- a/client/lib/products-list/README.md
+++ b/client/lib/products-list/README.md
@@ -3,7 +3,7 @@
 `products-list` is a collection of all the products users can have on WordPress.com, as returned from the `/products` REST API endpoint. It can be required into a file like:
 
 ```js
-import productsListFactory from 'lib/products-list';
+import productsListFactory from 'calypso/lib/products-list';
 const productsList = productsListFactory();
 ```
 

--- a/client/lib/protect-form/README.md
+++ b/client/lib/protect-form/README.md
@@ -12,7 +12,7 @@ has an API that is more suitable for integration with Redux state.
 ## Usage (HOC)
 
 ```js
-import { protectForm } from 'lib/protect-form';
+import { protectForm } from 'calypso/lib/protect-form';
 ```
 
 ... and then later in your component definition like so:
@@ -41,7 +41,7 @@ handleSubmit = ( event ) => {
 ## Usage (declarative)
 
 ```js
-import { ProtectFormGuard } from 'lib/protect-form';
+import { ProtectFormGuard } from 'calypso/lib/protect-form';
 ```
 
 ... and then render the `ProtectFormGuard` inside your form to protect it, while changing

--- a/client/lib/react-pass-to-children/README.md
+++ b/client/lib/react-pass-to-children/README.md
@@ -8,7 +8,7 @@ The exposed method expects to receive the current react element instance, and an
 
 ```js
 import React from 'react';
-import passToChildren from 'lib/react-pass-to-children';
+import passToChildren from 'calypso/lib/react-pass-to-children';
 
 export default class extends React.Component {
 	render() {

--- a/client/lib/reader-connect-site/README.md
+++ b/client/lib/reader-connect-site/README.md
@@ -6,7 +6,7 @@ The output component expects to be handed either a feedId or a siteId. It will o
 ## Example
 
 ```js
-import connectSite from 'lib/reader-connect-site';
+import connectSite from 'calypso/lib/reader-connect-site';
 
 const SiteInfo = () => {
 	if ( ! this.props.site ) {

--- a/client/lib/route/README.md
+++ b/client/lib/route/README.md
@@ -9,14 +9,14 @@ as middleware to redirect any pathname ending in `/` to the same path minus the 
 For instance, to redirect `/foo/` to `/foo`:
 
 ```js
-import { normalize } from 'lib/route';
+import { normalize } from 'calypso/lib/route';
 page( '/foo/?', normalize, displayFoo );
 ```
 
 Alternatively, to normalize all routes:
 
 ```js
-import { normalize } from 'lib/route';
+import { normalize } from 'calypso/lib/route';
 page( '*', normalize );
 ```
 
@@ -35,7 +35,7 @@ This module is meant to simplify the work of adding query arguments to a URL.
 ### Example
 
 ```js
-import { addQueryArgs } from 'lib/route';
+import { addQueryArgs } from 'calypso/lib/route';
 
 addQueryArgs( { foo: 'bar' }, 'https://wordpress.com' ); // https://wordpress.com?foo=bar
 addQueryArgs( { foo: 'bar' }, 'https://wordpress.com?search=test' ); // https://wordpress.com/?search=test&foo=bar

--- a/client/lib/safe-image-url/README.md
+++ b/client/lib/safe-image-url/README.md
@@ -8,7 +8,7 @@ If it is not on an Automattic-controlled CDN, the URL is routed through photon.
 ## Example
 
 ```js
-import safeImageUrl from 'lib/safe-image-url';
+import safeImageUrl from 'calypso/lib/safe-image-url';
 
 safeImageUrl( '//example.com/foo.png' );
 // "https://i1.wp.com/example.com/foo.png"

--- a/client/lib/scroll-to/README.md
+++ b/client/lib/scroll-to/README.md
@@ -5,7 +5,7 @@ A utility module to smoothly scroll to a window position.
 ## Usage
 
 ```js
-import scrollTo from 'lib/scroll-to';
+import scrollTo from 'calypso/lib/scroll-to';
 
 scrollTo( {
 	x: 400,

--- a/client/lib/service-worker/README.md
+++ b/client/lib/service-worker/README.md
@@ -3,7 +3,7 @@
 ## How to use
 
 ```js
-import { isServiceWorkerSupported, registerServerWorker } from 'lib/service-worker';
+import { isServiceWorkerSupported, registerServerWorker } from 'calypso/lib/service-worker';
 
 if ( isServiceWorkerSupported() ) {
 	registerServerWorker();

--- a/client/lib/shortcode/README.md
+++ b/client/lib/shortcode/README.md
@@ -5,7 +5,7 @@ Utility functions for working with WordPress shortcodes. These functions largely
 ## Usage
 
 ```js
-import { parse, stringify } from 'lib/shortcode';
+import { parse, stringify } from 'calypso/lib/shortcode';
 
 const value = stringify( {
 	tag: 'foo',

--- a/client/lib/signup/README.md
+++ b/client/lib/signup/README.md
@@ -47,8 +47,8 @@ If `errors` has a non-zero length, it will be attached to the step and the step'
 Actions which provide a `providedDependencies` object will have this information added to the dependency store.
 
 ```js
-import SignupDependencyStore from 'lib/signup/dependency-store';
-import SignupActions from 'lib/signup/actions';
+import SignupDependencyStore from 'calypso/lib/signup/dependency-store';
+import SignupActions from 'calypso/lib/signup/actions';
 
 SignupActions.completeSignupStep( { stepName: 'example' }, [], { userId: 1337 } );
 
@@ -64,7 +64,7 @@ SignupDependencyStore.get(); // => { userId: 1337 }
 `SignupFlowController` accepts an object with a `flowName` property and begins the signup flow with the given name.
 
 ```js
-import SignupFlowController from 'lib/signup/flow-controller';
+import SignupFlowController from 'calypso/lib/signup/flow-controller';
 
 // this is the component that renders the signup flow
 class SignupComponent extends React.Component {

--- a/client/lib/two-step-authorization/README.md
+++ b/client/lib/two-step-authorization/README.md
@@ -3,5 +3,5 @@
 This component is meant to be used with `client/me/reauth-required`, and is used to display a dialog that allows a user to reauthorize without logging out and back in.
 
 ```js
-import TwoStepAuthorization from 'lib/two-step-authorization';
+import TwoStepAuthorization from 'calypso/lib/two-step-authorization';
 ```

--- a/client/lib/url-search/README.md
+++ b/client/lib/url-search/README.md
@@ -28,7 +28,7 @@ Then in the component file, enhance with `urlSearch`:
 /**
  * Internal dependencies
  */
-import urlSearch from 'lib/url-search';
+import urlSearch from 'calypso/lib/url-search';
 
 class SomeComponentWithSearch extends Component {
 	/*...*/

--- a/client/lib/user/README.md
+++ b/client/lib/user/README.md
@@ -5,7 +5,7 @@ This component is a wrapper module for interacting with the wpcom.js `/me` endpo
 ## User
 
 ```js
-import user from 'lib/user';
+import user from 'calypso/lib/user';
 
 function clearUser() {
 	user().clear();
@@ -31,7 +31,7 @@ Clears user stored data and handles relevant redirects based on type of authenti
 ## UserUtilities
 
 ```js
-import user from 'lib/user/utilities';
+import user from 'calypso/lib/user/utilities';
 ```
 
 ### `UserUtilities#logout()`

--- a/client/lib/users/README.md
+++ b/client/lib/users/README.md
@@ -49,7 +49,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import UsersStore from 'lib/users/store';
+import UsersStore from 'calypso/lib/users/store';
 
 export default class extends React.Component {
 	static displayName = 'yourComponent';

--- a/client/lib/wp/localization/README.md
+++ b/client/lib/wp/localization/README.md
@@ -7,7 +7,7 @@ This module enables the extension of a `wpcom.js` instance to automatically mark
 The helper is already bound for the global instance of `wpcom.js` used in Calypso and should work automatically:
 
 ```js
-import wpcom from 'lib/wp';
+import wpcom from 'calypso/lib/wp';
 
 wpcom
 	.site( siteId )

--- a/client/lib/wpcom-undocumented/README.md
+++ b/client/lib/wpcom-undocumented/README.md
@@ -5,7 +5,7 @@
 These undocumented endpoints are automatically added to your `wpcom.js` instance when you use the `wp` constructor.
 
 ```javascript
-import wpcom from 'lib/wp';
+import wpcom from 'calypso/lib/wp';
 
 wpcom.undocumented().readLists( function ( err, data ) {
 	debug( 'Posts:', data );

--- a/client/me/purchases/components/loading-placeholder/README.md
+++ b/client/me/purchases/components/loading-placeholder/README.md
@@ -7,7 +7,7 @@ import React from 'react';
 import { localize } from 'i18n-calypso';
 
 import { Card } from '@automattic/components';
-import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
+import LoadingPlaceholder from 'calypso/me/purchases/components/loading-placeholder';
 
 const MyComponentLoadingPlaceholder = ( { translate } ) => (
 	<LoadingPlaceholder title={ translate( 'Header title' ) }>

--- a/client/my-sites/current-site/README.md
+++ b/client/my-sites/current-site/README.md
@@ -6,7 +6,7 @@ Redux state and the component receives no props. It's used in the My Sites Sideb
 ## How to use
 
 ```js
-import CurrentSite from 'my-sites/current-site';
+import CurrentSite from 'calypso/my-sites/current-site';
 
 function render() {
 	return <CurrentSite />;

--- a/client/my-sites/jetpack-manage-error-page/README.md
+++ b/client/my-sites/jetpack-manage-error-page/README.md
@@ -16,7 +16,7 @@ You'll need to declare `site` which is simply the current site object.
 You can optionally declare `version` to display what version is necessary (defaults to 3.4).
 
 ```jsx
-import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import JetpackManageErrorPage from 'calypso/my-sites/jetpack-manage-error-page';
 
 <JetpackManageErrorPage template="updateJetpack" siteId={ jetpackSiteId } version="3.4" />;
 ```
@@ -30,7 +30,7 @@ As stated above, this component renders an `emptyContent` component by default. 
 If you initialize the component with a property `featureExample` containing jsx, it will be added in the bottom of the Jetpack Manage Error Page as an example of what the user could be viewing if there weren't any access errors.
 
 ```jsx
-import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import JetpackManageErrorPage from 'calypso/my-sites/jetpack-manage-error-page';
 
 // create the component using properties accepted by EmptyContent
 <JetpackManageErrorPage

--- a/client/my-sites/plan-compare-card/README.md
+++ b/client/my-sites/plan-compare-card/README.md
@@ -11,7 +11,7 @@ This component is used to display a current or next plan, highlighting the featu
 	<PlanCompareCardItem unavailable={ true }>No Ads</PlanCompareCardItem>
 	<PlanCompareCardItem unavailable={ true }>Custom Design</PlanCompareCardItem>
 	<PlanCompareCardItem unavailable={ true }>VideoPress</PlanCompareCardItem>
-</PlanCompareCard>
+</PlanCompareCard>;
 ```
 
 ## Props

--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -11,7 +11,7 @@ If you pass an array of two numbers in the `rawPrice` prop, a range of prices wi
 ## Usage
 
 ```jsx
-import PlanPrice from 'my-sites/plan-price';
+import PlanPrice from 'calypso/my-sites/plan-price';
 
 export default class extends React.Component {
 	static displayName = 'MyPlanPrice';

--- a/client/my-sites/plans/current-plan/my-plan-card/README.md
+++ b/client/my-sites/plans/current-plan/my-plan-card/README.md
@@ -11,7 +11,7 @@ See p1HpG7-7ET-p2 for more details.
 
 ```jsx
 import React from 'react';
-import MyPlanCard from 'components/my-plan-card';
+import MyPlanCard from 'calypso/components/my-plan-card';
 import { Button } from '@automattic/components';
 
 export default class extends React.Component {

--- a/client/my-sites/plugins/plugin-action/README.md
+++ b/client/my-sites/plugins/plugin-action/README.md
@@ -7,7 +7,7 @@ This component is used to display a plugin action in the form of a toggle or a d
 By default, the PluginAction component will attempt to render a FormToggle.
 
 ```js
-import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
+import PluginAction from 'calypso/my-sites/plugins/plugin-action/plugin-action';
 
 function render() {
 	return (
@@ -27,7 +27,7 @@ function render() {
 This behavior can be overridden by passing a child to the PluginAction component.
 
 ```js
-import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
+import PluginAction from 'calypso/my-sites/plugins/plugin-action/plugin-action';
 import { Button } from '@automattic/components';
 
 function render() {

--- a/client/my-sites/plugins/plugin-activate-toggle/README.md
+++ b/client/my-sites/plugins/plugin-activate-toggle/README.md
@@ -5,7 +5,7 @@ This component is used to display a plugin activation toggle.
 ## How to use
 
 ```js
-import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
+import PluginActivateToggle from 'calypso/my-sites/plugins/plugin-activate-toggle';
 
 function render() {
 	return (

--- a/client/my-sites/plugins/plugin-automated-transfer/README.md
+++ b/client/my-sites/plugins/plugin-automated-transfer/README.md
@@ -3,7 +3,7 @@ This component is used to display an install bar for automated transfers.
 #### How to use
 
 ```js
-import PluginAutomatedTransfer from 'my-sites/plugins/plugin-automated-transfer';
+import PluginAutomatedTransfer from 'calypso/my-sites/plugins/plugin-automated-transfer';
 
 function render() {
 	return (

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/README.md
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/README.md
@@ -5,7 +5,7 @@ This component is used to display a plugin autupdate toggle.
 ## How to use
 
 ```js
-import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
+import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 
 function render() {
 	return (

--- a/client/my-sites/plugins/plugin-icon/README.md
+++ b/client/my-sites/plugins/plugin-icon/README.md
@@ -5,7 +5,7 @@ This component is used to display the icon for a plugin. It takes a plugin image
 ## How to use
 
 ```js
-import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
+import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 
 function render() {
 	return (

--- a/client/my-sites/plugins/plugin-install-button/README.md
+++ b/client/my-sites/plugins/plugin-install-button/README.md
@@ -5,7 +5,7 @@ This component is used to display a button that launch a install action when cli
 ## How to use
 
 ```js
-import PluginInstallButton from 'my-sites/plugins/plugin-install-button';
+import PluginInstallButton from 'calypso/my-sites/plugins/plugin-install-button';
 
 function render() {
 	return (

--- a/client/my-sites/plugins/plugin-item/README.md
+++ b/client/my-sites/plugins/plugin-item/README.md
@@ -5,7 +5,7 @@ This component is used to display a plugin card in a list of plugins.
 ## How to use
 
 ```js
-import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
+import PluginItem from 'calypso/my-sites/plugins/plugin-item/plugin-item';
 
 function render() {
 	return (

--- a/client/my-sites/plugins/plugin-meta/README.md
+++ b/client/my-sites/plugins/plugin-meta/README.md
@@ -5,7 +5,7 @@ This component is used to display the meta information of a single plugin. Inclu
 ## How to use
 
 ```js
-import PluginMeta from 'my-sites/plugins/plugin-meta';
+import PluginMeta from 'calypso/my-sites/plugins/plugin-meta';
 
 function render() {
 	return <PluginMeta plugin={ plugin } />;

--- a/client/my-sites/plugins/plugin-ratings/README.md
+++ b/client/my-sites/plugins/plugin-ratings/README.md
@@ -5,7 +5,7 @@ This component is used to display the detail of how the ratings of a plugin are 
 ## How to use
 
 ```js
-import PluginRatings from 'my-sites/plugins/plugin-ratings';
+import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings';
 
 function render() {
 	return <PluginRatings plugin={ this.props.plugin } barWidth={ 100 } />;

--- a/client/my-sites/plugins/plugin-remove-button/README.md
+++ b/client/my-sites/plugins/plugin-remove-button/README.md
@@ -5,7 +5,7 @@ This component is used to display a button that launch a remove action when clic
 ## How to use
 
 ```js
-import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
+import PluginRemoveButton from 'calypso/my-sites/plugins/plugin-remove-button';
 
 function render() {
 	return <PluginRemoveButton plugin={ plugin } site={ site } notices={ notices } />;

--- a/client/my-sites/plugins/plugin-sections/README.md
+++ b/client/my-sites/plugins/plugin-sections/README.md
@@ -5,7 +5,7 @@ This component is used to display the sections for a plugin as returned from the
 ## How to use
 
 ```js
-import PluginSections from 'my-sites/plugins/plugin-sections';
+import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
 
 function render() {
 	return <PluginSections plugin={ plugin } />;

--- a/client/my-sites/plugins/plugin-site-jetpack/README.md
+++ b/client/my-sites/plugins/plugin-site-jetpack/README.md
@@ -5,7 +5,7 @@ This component is used to display a single instance of a plugin within a jetpack
 ## How to use
 
 ```js
-import PluginSiteJetpack from 'my-sites/plugins/plugin-site/plugin-site-jetpack';
+import PluginSiteJetpack from 'calypso/my-sites/plugins/plugin-site/plugin-site-jetpack';
 
 function render() {
 	return <PluginSiteJetpack site={ site } plugin={ plugin } notices={ notices } />;

--- a/client/my-sites/plugins/plugin-site-list/README.md
+++ b/client/my-sites/plugins/plugin-site-list/README.md
@@ -5,7 +5,7 @@ This component is used to represent a list of `Plugin-Site`, with a `Section-Hea
 ## How to use
 
 ```jsx
-import PluginSiteList from 'my-sites/plugins/plugin-site-list';
+import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
 
 return (
 	<PluginSiteList

--- a/client/my-sites/plugins/plugin-site-network/README.md
+++ b/client/my-sites/plugins/plugin-site-network/README.md
@@ -5,7 +5,7 @@ This component is used to display a single instance of a plugin within a multisi
 ## How to use
 
 ```js
-import PluginSiteNetwork from 'my-sites/plugins/plugin-site/plugin-site-network';
+import PluginSiteNetwork from 'calypso/my-sites/plugins/plugin-site/plugin-site-network';
 
 function render() {
 	return (

--- a/client/my-sites/plugins/plugin-site-update-indicator/README.md
+++ b/client/my-sites/plugins/plugin-site-update-indicator/README.md
@@ -5,7 +5,7 @@ This component is used to display a update indicator which can be turned into a 
 ## How to use
 
 ```js
-import PluginSiteUpdateIndicator from 'my-sites/plugins/plugin-site-update-indicator';
+import PluginSiteUpdateIndicator from 'calypso/my-sites/plugins/plugin-site-update-indicator';
 
 function render() {
 	return (

--- a/client/my-sites/plugins/plugin-site/README.md
+++ b/client/my-sites/plugins/plugin-site/README.md
@@ -5,7 +5,7 @@ This component is used to represent the state of a single instance of a plugin i
 ## How to use
 
 ```js
-import PluginSite from 'my-sites/plugins/plugin-site/plugin-site';
+import PluginSite from 'calypso/my-sites/plugins/plugin-site/plugin-site';
 
 function render() {
 	return (

--- a/client/my-sites/plugins/plugins-browser-item/README.md
+++ b/client/my-sites/plugins/plugins-browser-item/README.md
@@ -5,7 +5,7 @@ This component is used to display small infobox with the data of a plugin.
 ## How to use
 
 ```js
-import PluginListItem from 'my-sites/plugins-browser-item';
+import PluginListItem from 'calypso/my-sites/plugins-browser-item';
 
 function render() {
 	return (

--- a/client/my-sites/plugins/plugins-browser-list/README.md
+++ b/client/my-sites/plugins/plugins-browser-list/README.md
@@ -8,7 +8,7 @@ This component is used to display a list with the a parametrizable number of plu
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
-import PluginsList from 'my-sites/plugins/plugins-browser-list';
+import PluginsList from 'calypso/my-sites/plugins/plugins-browser-list';
 
 const MyPluginsList = ( { pluginsData, translate } ) => (
 	<div>

--- a/client/my-sites/plugins/plugins-browser/README.md
+++ b/client/my-sites/plugins/plugins-browser/README.md
@@ -5,7 +5,7 @@ This component renders the main plugins browser page.
 ## How to use
 
 ```js
-import BrowserMainView from 'my-sites/plugins/plugins-browser';
+import BrowserMainView from 'calypso/my-sites/plugins/plugins-browser';
 
 function render() {
 	return (

--- a/client/my-sites/plugins/plugins-list/README.md
+++ b/client/my-sites/plugins/plugins-list/README.md
@@ -5,7 +5,7 @@ This component is used to represent a list `PluginItem`s, with a `PluginsListHea
 ## How to use
 
 ```jsx
-import PluginsList from 'my-sites/plugins/plugins-list';
+import PluginsList from 'calypso/my-sites/plugins/plugins-list';
 
 return (
 	<PluginsList

--- a/client/my-sites/post-selector/README.md
+++ b/client/my-sites/post-selector/README.md
@@ -7,7 +7,7 @@ Under the hood, it uses [`<QueryPosts />`](../../components/data/query-posts) to
 ## Usage
 
 ```jsx
-import PostSelector from 'my-sites/post-selector';
+import PostSelector from 'calypso/my-sites/post-selector';
 
 <PostSelector siteId={ this.props.siteId } />;
 ```

--- a/client/my-sites/post-type-list/README.md
+++ b/client/my-sites/post-type-list/README.md
@@ -10,7 +10,7 @@ Render the component, passing props to describe your query.
 
 ```jsx
 import React from 'react';
-import PostTypeList from 'my-sites/post-type-list';
+import PostTypeList from 'calypso/my-sites/post-type-list';
 
 export default function MyComponent() {
 	return <PostTypeList type="jetpack-portfolio" />;

--- a/client/my-sites/sidebar-navigation/README.md
+++ b/client/my-sites/sidebar-navigation/README.md
@@ -7,7 +7,7 @@ This component is used to display the mobile sidebar navigation header at the to
 Put the component in your `Main` component. It handles detecting the selected site.
 
 ```js
-import SidebarNavigation from 'my-sites/sidebar-navigation';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 
 function render() {
 	return (

--- a/client/my-sites/site-indicator/README.md
+++ b/client/my-sites/site-indicator/README.md
@@ -5,7 +5,7 @@ This component is used to display a round badge next to a site with information 
 ## How to use
 
 ```js
-import SiteIndicator from 'my-sites/site-indicator';
+import SiteIndicator from 'calypso/my-sites/site-indicator';
 
 function render() {
 	return <SiteIndicator site={ siteObject } />;

--- a/client/my-sites/site-settings/redirect-non-jetpack/README.md
+++ b/client/my-sites/site-settings/redirect-non-jetpack/README.md
@@ -24,7 +24,7 @@ The following code redirects to the `Plans` site for non-Jetpack and Atomic
 sites:
 
 ```js
-import redirectNonJetpack from 'my-sites/site-settings/redirect-non-jetpack';
+import redirectNonJetpack from 'calypso/my-sites/site-settings/redirect-non-jetpack';
 
 export default flowRight( localize, redirectNonJetpack( '/plans/' ) )( WrappedComponent );
 ```

--- a/client/my-sites/stats/geochart/README.md
+++ b/client/my-sites/stats/geochart/README.md
@@ -5,7 +5,7 @@ This component creates the geochart used in the Countries module. It utilizes th
 ## How to use
 
 ```js
-import GeoChart from 'my-sites/stats/geochart';
+import GeoChart from 'calypso/my-sites/stats/geochart';
 
 const MyComponent = () => {
 	return <GeoChart query={ query /*object*/ } />;

--- a/client/my-sites/stats/post-performance/README.md
+++ b/client/my-sites/stats/post-performance/README.md
@@ -5,7 +5,7 @@ This component creates an insights card that displays stats about the last post 
 ## How to use
 
 ```js
-import PostPerformance from 'my-sites/stats/post-performance';
+import PostPerformance from 'calypso/my-sites/stats/post-performance';
 
 function render() {
 	return <PostPerformance site={ site /*object*/ } />;

--- a/client/my-sites/stats/post-trends/README.md
+++ b/client/my-sites/stats/post-trends/README.md
@@ -5,7 +5,7 @@ This module provides a React component to visualize frequency of posting in a Gi
 ## How to use
 
 ```js
-import PostTrends from 'my-sites/stats/post-trends';
+import PostTrends from 'calypso/my-sites/stats/post-trends';
 
 const MyComponent = () => {
 	return <PostTrends />;

--- a/client/my-sites/stats/stats-download-csv/README.md
+++ b/client/my-sites/stats/stats-download-csv/README.md
@@ -5,7 +5,7 @@ The download csv component creates a download link that allows a stats-list to b
 ## How to use
 
 ```js
-import DownloadCsv from 'my-sites/stats/stats-download-csv';
+import DownloadCsv from 'calypso/my-sites/stats/stats-download-csv';
 
 const MyComponent = () => {
 	return (

--- a/client/my-sites/stats/stats-site-overview/README.md
+++ b/client/my-sites/stats/stats-site-overview/README.md
@@ -5,7 +5,7 @@ This component creates Stats Overview which is what renders each site section on
 ## How to use
 
 ```js
-import StatsOverview from 'my-sites/stats/overview';
+import StatsOverview from 'calypso/my-sites/stats/overview';
 
 const MyComponent = () => {
 	return <StatsOverview site={ site /*object*/ } path={ path /*string*/ } />;

--- a/client/notices/README.md
+++ b/client/notices/README.md
@@ -7,7 +7,7 @@ Provides some helper functions to render a notice on the UI. Types of notices ar
 Once you require the component you have access to .
 
 ```javascript
-import notices from 'notices';
+import notices from 'calypso/notices';
 
 // Success notice when saving settings
 notices.success( 'Settings saved successfully!', { overlay: true } );

--- a/client/post-editor/editor-fieldset/README.md
+++ b/client/post-editor/editor-fieldset/README.md
@@ -8,9 +8,9 @@ The `<EditorFieldset />` component accepts a single `legend` prop to specify the
 
 ```jsx
 import React from 'react';
-import EditorFieldset from 'post-editor/editor-fieldset';
-import FormInputCheckbox from 'components/forms/form-checkbox';
-import FormLabel from 'components/forms/form-label';
+import EditorFieldset from 'calypso/post-editor/editor-fieldset';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
 
 class MyComponent extends React.Component {
 	render() {

--- a/client/reader/update-notice/README.md
+++ b/client/reader/update-notice/README.md
@@ -5,7 +5,7 @@ A little pill that is used to notify the user when new posts are available.
 ## Usage
 
 ```jsx
-import UpdateNotice from 'reader/update-notice';
+import UpdateNotice from 'calypso/reader/update-notice';
 
 class MyComponent extends React.Component {
 	constructor() {

--- a/client/server/bundler/README.md
+++ b/client/server/bundler/README.md
@@ -31,7 +31,7 @@ const sections = [
 	{
 		name: 'me',
 		paths: [ '/me' ],
-		module: 'me',
+		module: 'calypso/me',
 	},
 ];
 ```
@@ -51,7 +51,7 @@ page( /^\/me(\/.*)?$/, function ( context, next ) {
 			return;
 		}
 		if ( ! _loadedSections.me ) {
-			require( 'me' )();
+			require( 'calypso/me' )();
 			_loadedSections.me = true;
 		}
 

--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -52,7 +52,7 @@ The React component for a step should be implemented in `/signup/steps/`, in its
 Steps must use the `SignupActions` module, by requiring it as an internal dependency:
 
 ```javascript
-import SignupActions from 'lib/signup/actions';
+import SignupActions from 'calypso/lib/signup/actions';
 ```
 
 `SignupActions` allows the Modular Framework to handle the data collected by a step. This means your step must include a UI element that allows users to move to the next step in the flow, and that the function handling this element must use the method `submitSignupStep` from `SignupActions`.
@@ -182,7 +182,7 @@ function render() {
 Make sure to require `SignupActions`:
 
 ```javascript
-import SignupActions from 'lib/signup/actions';
+import SignupActions from 'calypso/lib/signup/actions';
 ```
 
 ... and to create a function to handle what happens when the form is submitted:

--- a/client/state/README.md
+++ b/client/state/README.md
@@ -11,7 +11,7 @@ Calypso started off with a monolithic state approach, following the guidelines o
 As such, Calypso now implements a modularized state approach, where reducers can be registered on demand. Each modularized portion of state has an `init` file that takes care of registration through a side effect. For example, for `reader`:
 
 ```js
-import { registerReducer } from 'state/redux-store';
+import { registerReducer } from 'calypso/state/redux-store';
 import reducer from './reducer';
 
 registerReducer( [ 'reader' ], reducer );
@@ -20,7 +20,7 @@ registerReducer( [ 'reader' ], reducer );
 This `init` file is then imported on every selector and action creator module that makes use of `reader` state:
 
 ```js
-import 'state/reader/init';
+import 'calypso/state/reader/init';
 
 function getStream( state, streamKey ) {
 	return state.reader.streams[ streamKey ] || emptyStream;
@@ -36,7 +36,7 @@ There is currently an ongoing migration effort in modularizing all of Calypso st
 ## Usage
 
 ```js
-import { createReduxStore } from 'state';
+import { createReduxStore } from 'calypso/state';
 
 const store = createReduxStore();
 ```

--- a/client/state/active-promotions/README.md
+++ b/client/state/active-promotions/README.md
@@ -24,7 +24,7 @@ import {
 	activePromotionsRequestSuccessAction,
 	activePromotionsRequestFailureAction,
 	requestActivePromotions,
-} from 'state/activePromotions/actions';
+} from 'calypso/state/activePromotions/actions';
 
 dispatch( requestActivePromotions() );
 

--- a/client/state/analytics/README.md
+++ b/client/state/analytics/README.md
@@ -27,7 +27,7 @@ import {
 	recordGoogleEvent,
 	recordTracksEvent,
 	recordPageView,
-} from 'state/analytics/actions';
+} from 'calypso/state/analytics/actions';
 
 // track a page-view
 dispatch( recordPageView( '/path/to/page', 'Page Title' ) );

--- a/client/state/current-user/README.md
+++ b/client/state/current-user/README.md
@@ -11,7 +11,7 @@ Used in combination with the Redux store instance `dispatch` function, actions c
 Sets the current user by user ID.
 
 ```js
-import { setCurrentUser } from 'state/current-user/actions';
+import { setCurrentUser } from 'calypso/state/current-user/actions';
 
 dispatch( setCurrentUser( { ID: 73705554 } ) );
 ```
@@ -33,7 +33,7 @@ Selectors are intended to assist in extracting data from the global state tree f
 Returns the current user object.
 
 ```js
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 const selectedSite = getCurrentUser( store.getState() );
 ```

--- a/client/state/data-layer/README.md
+++ b/client/state/data-layer/README.md
@@ -119,10 +119,10 @@ Let's look at a full example:
 /**
  * Internal dependencies
  */
-import { addSplines } from 'state/splines/actions';
-import { errorNotice } from 'state/notices/actions';
-import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { addSplines } from 'calypso/state/splines/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 
 /**
  * Transform the API response into consumble data

--- a/client/state/data-layer/wpcom-http/README.md
+++ b/client/state/data-layer/wpcom-http/README.md
@@ -88,7 +88,7 @@ Inside of this model we can build a simple interface for issuing and responding 
 Use the `http` function to create a Redux action describing an HTTP request.
 
 ```js
-import { http } from 'state/data-layer/wpcom-http/actions';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 
 // announce presence - requires no response inside of Calypso
 dispatch(
@@ -145,7 +145,7 @@ We can be as creative or dull as we want to be in the request lifecycle.
 Because the information from the request response extends the action through meta, we can actually re-use the originating action and handle it based on that meta.
 
 ```js
-import { getProgress } from 'state/data-layer/wpcom-http/utils';
+import { getProgress } from 'calypso/state/data-layer/wpcom-http/utils';
 
 const packageMiddleware = ( store, action ) => {
 	if ( CREATE_PACKAGE !== action.type ) {
@@ -197,7 +197,7 @@ If given, the action passed as the second and optional parameter will take the p
 Because we have a very common pattern when issuing requests there is a built-in helper to hand each action off to the right function based on the (possibly) attached metadata.
 
 ```js
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 
 // create request when no meta present, add on success, alert on failure
 dispatchRequest( { fetch: fetchMenu, onSuccess: addMenuItems, onError: alertFailure } );
@@ -234,9 +234,9 @@ Its inclusion here is meant merely to illustrate how the pieces can fit together
 
 ```js
 // API Middleware, Post Like
-import { LIKE_POST, LIKE_POST_PROGRESS, UNLIKE_POST } from 'state/action-types';
-import { http } from 'state/data-layer/wpcom-http/actions';
-import { QUEUE_REQUEST } from 'state/data-layer/wpcom-http/constants';
+import { LIKE_POST, LIKE_POST_PROGRESS, UNLIKE_POST } from 'calypso/state/action-types';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { QUEUE_REQUEST } from 'calypso/state/data-layer/wpcom-http/constants';
 
 /**
  * @see https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/posts/%24post_ID/likes/new/ API description

--- a/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/README.md
+++ b/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/README.md
@@ -43,7 +43,7 @@ These are added with the `retryPolicy` override in the HTTP request description.
 import {
 	noRetry,
 	exponentialBackoff,
-} from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
+} from 'calypso/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 
 dispatch(
 	http(

--- a/client/state/http/README.md
+++ b/client/state/http/README.md
@@ -9,9 +9,9 @@ It follows the same API as `wpcom-http`, the only difference from the user's per
 So, let's say you would like to do a `POST` request to <https://api.example.com> when the action `GET_EXAMPLE_DATA` is dispatched, later continuing with `EXAMPLE_DATA_ADD` for the data or `NOTICE_CREATE` for the error. You'll be able to do that with the following code (that could be located under `third-party`):
 
 ```js
-import { GET_EXAMPLE_DATA, EXAMPLE_DATA_ADD, NOTICE_CREATE } from 'state/action-types';
-import { dispatchRequest } from 'state/wpcom-http/utils';
-import { http } from 'state/http/actions';
+import { GET_EXAMPLE_DATA, EXAMPLE_DATA_ADD, NOTICE_CREATE } from 'calypso/state/action-types';
+import { dispatchRequest } from 'calypso/state/wpcom-http/utils';
+import { http } from 'calypso/state/http/actions';
 import { get } from 'lodash';
 
 const requestExampleData = ( action ) =>

--- a/client/state/lib/README.md
+++ b/client/state/lib/README.md
@@ -36,7 +36,7 @@ And in this middleware, we can create a handler:
 
 ```jsx
 /* eslint-disable no-case-declarations */
-import library from 'lib/example';
+import library from 'calypso/lib/example';
 
 switch ( action ) {
 	case MY_EXAMPLE_LIBRARY_ACTION:
@@ -63,7 +63,7 @@ Then add a handler in this middleware:
 
 ```jsx
 /* eslint-disable no-case-declarations */
-import library from 'lib/example';
+import library from 'calypso/lib/example';
 
 switch ( action ) {
 	//All relevant site update events

--- a/client/state/navigation/README.md
+++ b/client/state/navigation/README.md
@@ -7,7 +7,7 @@ In its current state, the middleware allows for triggering redirects within the 
 Dispatching a `NAVIGATE` action and providing a `path` will trigger a redirect, just like calling `page()`.
 
 ```js
-import { navigate } from 'state/ui/actions';
+import { navigate } from 'calypso/state/ui/actions';
 
 dispatch( navigate( '/your/path/here' ) );
 ```

--- a/client/state/notices/README.md
+++ b/client/state/notices/README.md
@@ -11,7 +11,7 @@ First, the component that wants to send notices must be connected to Redux.
 
 ```javascript
 import { connect } from 'react-redux';
-import { successNotice, errorNotice } from 'state/notices/actions';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 
 export default connect( null, { successNotice, errorNotice } )( Component );
 ```

--- a/client/state/plans/README.md
+++ b/client/state/plans/README.md
@@ -32,7 +32,7 @@ import {
 	plansRequestSuccessAction,
 	plansRequestFailureAction,
 	requestPlans,
-} from 'state/plans/actions';
+} from 'calypso/state/plans/actions';
 
 dispatch( requestPlans() );
 

--- a/client/state/plugins/premium/README.md
+++ b/client/state/plugins/premium/README.md
@@ -11,7 +11,7 @@ Used in combination with the Redux store instance `dispatch` function, actions c
 Get a list of plugins to auto-install for a given site. Plugin information returned includes the registration keys.
 
 ```js
-import { fetchInstallInstructions } from 'state/plugins/premium/actions';
+import { fetchInstallInstructions } from 'calypso/state/plugins/premium/actions';
 
 fetchInstallInstructions( 106093271 );
 ```
@@ -21,7 +21,7 @@ fetchInstallInstructions( 106093271 );
 Start the install process for a plugin. Plugin object should be pulled from the [PluginsStore](https://github.com/Automattic/wp-calypso/tree/HEAD/client/lib/plugins).
 
 ```js
-import { installPlugin } from 'state/plugins/premium/actions';
+import { installPlugin } from 'calypso/state/plugins/premium/actions';
 
 const plugin = PluginsStore.getSitePlugin( site, 'vaultpress' );
 installPlugin( plugin, site );

--- a/client/state/plugins/wporg/README.md
+++ b/client/state/plugins/wporg/README.md
@@ -11,7 +11,7 @@ Used in combination with the Redux store instance `dispatch` function, actions c
 Fetches the info of a plugin from .org plugins API.
 
 ```js
-import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
+import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 
 dispatch( fetchPluginData( 'akismet' ) );
 ```

--- a/client/state/post-formats/README.md
+++ b/client/state/post-formats/README.md
@@ -11,7 +11,7 @@ Used in combination with the Redux store instance `dispatch` function, actions c
 Get a list of supported post formats for a given site.
 
 ```js
-import { requestPostFormats } from 'state/post-formats/actions';
+import { requestPostFormats } from 'calypso/state/post-formats/actions';
 
 requestPostFormats( 12345678 );
 ```
@@ -45,7 +45,7 @@ state.postFormats = {
 Returns true if post formats are currently fetching for the given site ID.
 
 ```js
-import { isRequestingPostFormats } from 'state/post-formats/selectors';
+import { isRequestingPostFormats } from 'calypso/state/post-formats/selectors';
 
 const isRequesting = isRequestingPostFormats( state, 12345678 );
 ```
@@ -55,7 +55,7 @@ const isRequesting = isRequestingPostFormats( state, 12345678 );
 Returns an array of all supported site formats for the given site ID.
 
 ```js
-import { getPostFormats } from 'state/post-formats/selectors';
+import { getPostFormats } from 'calypso/state/post-formats/selectors';
 
 const postFormats = getPostFormats( state, 12345678 );
 ```

--- a/client/state/selectors/README.md
+++ b/client/state/selectors/README.md
@@ -13,5 +13,5 @@ When adding a new selector to this directory, make note of the following details
 To import specific selectors, use the exact path, which leverages the Babel "transform-imports" plugin to transform the import to its individual file:
 
 ```javascript
-import getSite from 'state/selectors/get-site';
+import getSite from 'calypso/state/selectors/get-site';
 ```

--- a/client/state/sharing/README.md
+++ b/client/state/sharing/README.md
@@ -15,7 +15,7 @@ Used in combination with the Redux store instance `dispatch` function, actions c
 Triggers a network request to retrieve Publicize connections for the specified site ID from the WordPress.com REST API.
 
 ```js
-import { fetchConnections } from 'state/sharing/publicize/actions';
+import { fetchConnections } from 'calypso/state/sharing/publicize/actions';
 
 dispatch( fetchConnections( 2916284 ) );
 ```
@@ -41,7 +41,7 @@ Selectors are intended to assist in extracting data from the global state tree f
 Returns an array of known connections for the given site ID.
 
 ```js
-import { getConnectionsBySiteId } from 'state/sharing/publicize/selectors';
+import { getConnectionsBySiteId } from 'calypso/state/sharing/publicize/selectors';
 
 const connections = getConnectionsBySiteId( store.getState(), 2916284 );
 ```
@@ -51,7 +51,7 @@ const connections = getConnectionsBySiteId( store.getState(), 2916284 );
 Returns true if connections have been fetched for the given site ID.
 
 ```js
-import { hasFetchedConnections } from 'state/sharing/publicize/selectors';
+import { hasFetchedConnections } from 'calypso/state/sharing/publicize/selectors';
 
 const connections = hasFetchedConnections( store.getState(), 2916284 );
 ```
@@ -61,7 +61,7 @@ const connections = hasFetchedConnections( store.getState(), 2916284 );
 Returns true if connections are currently fetching for the given site ID.
 
 ```js
-import { isFetchingConnections } from 'state/sharing/publicize/selectors';
+import { isFetchingConnections } from 'calypso/state/sharing/publicize/selectors';
 
 const connections = isFetchingConnections( store.getState(), 2916284 );
 ```

--- a/client/state/sharing/keyring/README.md
+++ b/client/state/sharing/keyring/README.md
@@ -12,8 +12,8 @@ Get a list of keyring connections.
 
 ```js
 import { connect } from 'react-redux';
-import { isKeyringConnectionsFetching } from 'state/sharing/keyring/selectors';
-import { requestKeyringConnections } from 'state/sharing/keyring/actions';
+import { isKeyringConnectionsFetching } from 'calypso/state/sharing/keyring/selectors';
+import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
 
 class QueryKeyringConnections extends Component {
 	componentWillMount() {
@@ -57,7 +57,7 @@ Selectors are intended to assist in extracting data from the global state tree f
 Returns an array of keyring connection objects.
 
 ```js
-import { getKeyringConnections } from 'state/sharing/keyring/selectors';
+import { getKeyringConnections } from 'calypso/state/sharing/keyring/selectors';
 
 const connections = getKeyringConnections( state );
 ```
@@ -67,7 +67,7 @@ const connections = getKeyringConnections( state );
 Returns a keyring connection object with a specified ID.
 
 ```js
-import { getKeyringConnectionById } from 'state/sharing/keyring/selectors';
+import { getKeyringConnectionById } from 'calypso/state/sharing/keyring/selectors';
 
 const connection = getKeyringConnectionById( state, 23353 );
 ```
@@ -77,7 +77,7 @@ const connection = getKeyringConnectionById( state, 23353 );
 Returns an array of keyring connection objects for a specified service.
 
 ```js
-import { getKeyringConnectionsByName } from 'state/sharing/keyring/selectors';
+import { getKeyringConnectionsByName } from 'calypso/state/sharing/keyring/selectors';
 
 const twitterConnections = getKeyringConnectionsByName( state, 'twitter' );
 ```
@@ -87,7 +87,7 @@ const twitterConnections = getKeyringConnectionsByName( state, 'twitter' );
 Returns an array of keyring connection objects for a specific user.
 
 ```js
-import { getUserConnections } from 'state/sharing/keyring/selectors';
+import { getUserConnections } from 'calypso/state/sharing/keyring/selectors';
 
 const userConnections = getUserConnections( state, 344325 );
 ```
@@ -97,7 +97,7 @@ const userConnections = getUserConnections( state, 344325 );
 Returns true if keyring connections are currently being requested.
 
 ```js
-import { isKeyringConnectionsFetching } from 'state/sharing/keyring/selectors';
+import { isKeyringConnectionsFetching } from 'calypso/state/sharing/keyring/selectors';
 
 const isRequesting = isKeyringConnectionsFetching( state );
 ```

--- a/client/state/sharing/services/README.md
+++ b/client/state/sharing/services/README.md
@@ -12,8 +12,8 @@ Get a list of keyring services.
 
 ```js
 import { connect } from 'react-redux';
-import { isKeyringServicesFetching } from 'state/sharing/services/selectors';
-import { requestKeyringServices } from 'state/sharing/services/actions';
+import { isKeyringServicesFetching } from 'calypso/state/sharing/services/selectors';
+import { requestKeyringServices } from 'calypso/state/sharing/services/actions';
 
 class QueryKeyringServices extends Component {
 	componentWillMount() {
@@ -60,7 +60,7 @@ Selectors are intended to assist in extracting data from the global state tree f
 Returns an array of keyring services.
 
 ```js
-import { getKeyringServices } from 'state/sharing/services/selectors';
+import { getKeyringServices } from 'calypso/state/sharing/services/selectors';
 
 const services = getKeyringServices( state );
 ```
@@ -70,7 +70,7 @@ const services = getKeyringServices( state );
 Returns an array of keyring services with the specified type.
 
 ```js
-import { getKeyringServicesByType } from 'state/sharing/services/selectors';
+import { getKeyringServicesByType } from 'calypso/state/sharing/services/selectors';
 
 const publiciseServices = getKeyringServicesByType( state, 'publicize' );
 ```
@@ -86,8 +86,8 @@ A service is eligible for a given site if
 3. the current user can publish posts in case of all publicize services.
 
 ```js
-import { getEligibleKeyringServices } from 'state/sharing/services/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEligibleKeyringServices } from 'calypso/state/sharing/services/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const eligibleServices = getEligibleKeyringServices(
 	state,
@@ -101,7 +101,7 @@ const eligibleServices = getEligibleKeyringServices(
 Returns true if keyring services are currently being requested.
 
 ```js
-import { isKeyringServicesFetching } from 'state/sharing/services/selectors';
+import { isKeyringServicesFetching } from 'calypso/state/sharing/services/selectors';
 
 const isRequesting = isKeyringServicesFetching( state );
 ```

--- a/client/state/site-roles/README.md
+++ b/client/state/site-roles/README.md
@@ -11,7 +11,7 @@ Used in combination with the Redux store instance `dispatch` function, actions c
 Get a list of supported user roles for a given site.
 
 ```js
-import { requestSiteRoles } from 'state/site-roles/actions';
+import { requestSiteRoles } from 'calypso/state/site-roles/actions';
 
 requestSiteRoles( 12345678 );
 ```
@@ -58,7 +58,7 @@ Selectors are intended to assist in extracting data from the global state tree f
 Returns true if user roles are currently fetching for the given site ID.
 
 ```js
-import { isRequestingSiteRoles } from 'state/site-roles/selectors';
+import { isRequestingSiteRoles } from 'calypso/state/site-roles/selectors';
 
 const isRequesting = isRequestingSiteRoles( state, 12345678 );
 ```
@@ -68,7 +68,7 @@ const isRequesting = isRequestingSiteRoles( state, 12345678 );
 Returns an array of all supported user roles for the given site ID.
 
 ```js
-import { getSiteRoles } from 'state/site-roles/selectors';
+import { getSiteRoles } from 'calypso/state/site-roles/selectors';
 
 const siteRoles = getSiteRoles( state, 12345678 );
 ```

--- a/client/state/sites/README.md
+++ b/client/state/sites/README.md
@@ -11,7 +11,7 @@ Used in combination with the Redux store instance `dispatch` function, actions c
 Adds a site object to the set of known sites.
 
 ```js
-import { receiveSite } from 'state/sites/actions';
+import { receiveSite } from 'calypso/state/sites/actions';
 
 dispatch( receiveSite( { ID: 2916284, name: 'WordPress.com Example Blog' } ) );
 ```

--- a/client/state/sites/domains/README.md
+++ b/client/state/sites/domains/README.md
@@ -32,7 +32,7 @@ import {
 	domainsRequestAction,
 	domainsRequestSuccessAction,
 	domainsRequestFailureAction,
-} from 'state/sites/domains/actions';
+} from 'calypso/state/sites/domains/actions';
 
 const siteId = 2916284;
 

--- a/client/state/sites/plans/README.md
+++ b/client/state/sites/plans/README.md
@@ -15,7 +15,7 @@ Fetches plans for the site with the given site ID.
 Adds the plans fetched from the API to the set of plans for the given site ID.
 
 ```js
-import { fetchSitePlans, fetchSitePlansCompleted } from 'state/sites/plans/actions';
+import { fetchSitePlans, fetchSitePlansCompleted } from 'calypso/state/sites/plans/actions';
 
 dispatch( fetchSitePlans( 555555555 ) );
 dispatch(

--- a/client/state/sites/products/README.md
+++ b/client/state/sites/products/README.md
@@ -15,7 +15,10 @@ Fetches products for the site with the given site ID.
 Adds the products fetched from the API to the set of products for the given site ID.
 
 ```js
-import { fetchSiteProducts, fetchSiteProductsCompleted } from 'state/sites/products/actions';
+import {
+	fetchSiteProducts,
+	fetchSiteProductsCompleted,
+} from 'calypso/state/sites/products/actions';
 
 dispatch( fetchSiteProducts( 555555555 ) );
 dispatch(

--- a/client/state/sites/vouchers/README.md
+++ b/client/state/sites/vouchers/README.md
@@ -40,7 +40,7 @@ import {
 	vouchersRequestAction,
 	vouchersRequestSuccessAction,
 	vouchersRequestFailureAction,
-} from 'state/sites/vouchers/actions';
+} from 'calypso/state/sites/vouchers/actions';
 
 const siteId = 2916284;
 

--- a/client/state/ui/README.md
+++ b/client/state/ui/README.md
@@ -11,7 +11,7 @@ Used in combination with the Redux store instance `dispatch` function, actions c
 Sets the currently selected site by site ID.
 
 ```js
-import { setSelectedSiteId } from 'state/ui/actions';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 
 dispatch( setSelectedSiteId( 2916284 ) );
 ```
@@ -33,7 +33,7 @@ Selectors are intended to assist in extracting data from the global state tree f
 Returns the currently selected site object.
 
 ```js
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const selectedSite = getSelectedSite( store.getState() );
 ```
@@ -43,7 +43,7 @@ const selectedSite = getSelectedSite( store.getState() );
 Returns the currently selected site slug.
 
 ```js
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const selectedSiteSlug = getSelectedSiteSlug( store.getState() );
 ```

--- a/client/test-helpers/use-nock/README.md
+++ b/client/test-helpers/use-nock/README.md
@@ -11,7 +11,7 @@ Because it's possible to allow `nock` interceptions and modifiers to persist bey
 ## Usage
 
 ```js
-import useNock, { nock } from 'test-helpers/use-nock';
+import useNock, { nock } from 'calypso/test-helpers/use-nock';
 
 /*
 //or

--- a/client/test-helpers/use-sinon/README.md
+++ b/client/test-helpers/use-sinon/README.md
@@ -7,7 +7,7 @@ A set of helpers for folks using sinon to fake, mock, spy and bend time.
 ### Full sandbox
 
 ```js
-import { useSandbox } from 'test-helpers/use-sinon';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'my tests that use a sandbox and arrow functions', function () {
 	let sandbox = null;
@@ -26,7 +26,7 @@ describe( 'my tests that use a sandbox and arrow functions', function () {
 ### Fake Clock
 
 ```js
-import { useFakeTimers } from 'test-helpers/use-sinon';
+import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
 
 describe( 'my time dependent test', function () {
 	let clock;


### PR DESCRIPTION
### Background

See #44602

### Changes

Automatically apply fix for eslint rule `wpcalypso/no-package-relative-imports` in Markdown files

Fix applied with `./node_modules/.bin/eslint-nibble --ext .md,.md.js,.md.javascript,.md.jsx client`

### Testing instructions

N/A
