### PR TITLE
Add showRecaptcha for wpcc and crowdsignal flows

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -7,8 +7,8 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
-import { addQueryArgs } from 'lib/route';
+import { isEnabled } from 'calypso/config';
+import { addQueryArgs } from 'calypso/lib/route';
 
 export function generateFlows( {
 	getSiteDestination = noop,
@@ -252,6 +252,7 @@ export function generateFlows( {
 			description: 'WordPress.com Connect signup flow',
 			lastModified: '2017-08-24',
 			disallowResume: true, // don't allow resume so we don't clear query params when we go back in the history
+			showRecaptcha: true,
 		};
 	}
 
@@ -361,6 +362,7 @@ export function generateFlows( {
 		lastModified: '2018-11-14',
 		disallowResume: true,
 		autoContinue: true,
+		showRecaptcha: true,
 	};
 
 	flows[ 'plan-no-domain' ] = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A follow up to Automattic/wp-calypso#44786, enabling recaptcha for the wpcc and crowdsignal flows.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check `wpcc` flow:
* Go to gravatar.com and click "Create your own gravatar" button.
* In the signup page, replace wordpress.com in the address bar with `http://calypso.localhost:3000/` or the hash URL if you are using calypso.live. 
* Verify that you can see the recaptcha logo in the bottom right screen, and that you can complete signup.

Check `crowdsignal` flow:
* Go to crowdisgnal.com and click on "Get started". 
* In the signup page, replace wordpress.com in the address bar with `http://calypso.localhost:3000/` or the hash URL if you are using calypso.live. 
* Verify that you see the recaptcha logo in the bottom right screen.
* Verify that you can complete signup.


Fixes # 590-gh-martech
