### PR TITLE
Reader: Keep inline styles in post content

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -10,7 +10,7 @@
 	margin: 0;
 	padding-top: 16px;
 	position: relative;
-	font-size: 17px;
+	font-size: 1rem;
 	line-height: 1.7;
 	overflow-wrap: break-word;
 	word-wrap: break-word;
@@ -196,7 +196,7 @@
 		position: relative;
 		margin-bottom: 24px;
 		padding: 11px 24px;
-		border-radius: 1px;
+		border-radius: 2px;
 		background: var( --color-neutral-0 );
 		box-sizing: border-box;
 		font-size: $font-body-small;
@@ -213,7 +213,7 @@
 	sub {
 		vertical-align: baseline;
 		position: relative;
-		font-size: 0.83em;
+		font-size: 0.875rem;
 	}
 
 	sup {
@@ -248,28 +248,17 @@
 		margin: auto;
 	}
 
-	.wp-block-buttons {
-		margin: 0;
-	}
-
-	.wp-block-button {
-		border-style: solid;
+	.wp-block-button__link {
+		// Styles forced with !important in order to override the inline styles present in the post content.
+		border: 1px solid var( --color-neutral-10 ) !important;
+		background-color: inherit !important;
+		color: inherit !important;
+		border-radius: 2px !important;
+		padding: 8px 14px !important;
+		font-size: 0.875rem !important;
 		font-family: $sans;
-		border-width: 1px;
-		cursor: pointer;
-		display: inline-block;
-		margin: 0;
-		margin-right: 0.25em;
-		margin-bottom: 0.6em;
-		outline: 0;
-		overflow: hidden;
-		vertical-align: top;
-		font-size: 14px;
 		font-weight: 600;
 		line-height: 22px;
-		border-radius: 2px;
-		padding: 8px 14px;
-		border-color: var( --color-neutral-10 );
 	}
 
 	.wp-block-table table {
@@ -279,18 +268,13 @@
 	.wp-block-table td,
 	.wp-block-table th {
 		border: 1px solid var( --color-neutral-10 );
-		font-size: 1em;
+		font-size: 1rem;
 		line-height: 1.8;
 	}
 
 	.wp-block-table th {
 		font-weight: bold;
 		background: var( --color-neutral-0 );
-	}
-
-	.wp-block-button__link,
-	.wp-block-button__link:hover {
-		color: inherit;
 	}
 
 	// Import Gutenberg gallery styles
@@ -321,7 +305,7 @@
 		&:first-child::first-letter {
 			float: left;
 			margin: 10px 12px 0 0;
-			font-size: 66px;
+			font-size: 66px; /* stylelint-disable-line scales/font-size */
 			font-weight: 400;
 			line-height: 0.7;
 		}
@@ -493,7 +477,7 @@
     display: block;
     width: 36px;
     height: 36px;
-    border-radius: 36px;
+    border-radius: 36px; /* stylelint-disable-line scales/radii */
     margin-right: 8px;
     transition: transform 0.1s ease;
 }

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -16,7 +16,6 @@ import detectMedia from 'calypso/lib/post-normalizer/rule-content-detect-media';
 import detectPolls from 'calypso/lib/post-normalizer/rule-content-detect-polls';
 import detectSurveys from 'calypso/lib/post-normalizer/rule-content-detect-surveys';
 import makeEmbedsSafe from 'calypso/lib/post-normalizer/rule-content-make-embeds-safe';
-import removeStyles from 'calypso/lib/post-normalizer/rule-content-remove-styles';
 import makeImagesSafe from 'calypso/lib/post-normalizer/rule-content-make-images-safe';
 import {
 	disableAutoPlayOnMedia,
@@ -106,7 +105,6 @@ const fastPostNormalizationRules = flow( [
 	safeImageProperties( READER_CONTENT_WIDTH ),
 	makeLinksSafe,
 	withContentDom( [
-		removeStyles,
 		removeElementsBySelector,
 		makeImagesSafe(),
 		makeEmbedsSafe,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/44992.
Helps with https://github.com/Automattic/wp-calypso/issues/43595.

#### Changes proposed in this Pull Request

The reader API endpoints return posts with content that might include inline styles provided by the Gutenberg blocks fallbacks plugin (D50508-code). However, Calypso was stripping out those styles as part of a normalization process. This PR removes the piece of logic that was removing the inline styles so they are kept in the post content rendered in the reader.

Before | After
--- | ---
<img width="748" alt="Screen Shot 2020-10-23 at 15 03 13" src="https://user-images.githubusercontent.com/1233880/97007327-88f8db00-1541-11eb-944c-c4350322cc51.png"> | <img width="754" alt="Screen Shot 2020-10-23 at 15 03 18" src="https://user-images.githubusercontent.com/1233880/97007339-8dbd8f00-1541-11eb-85c9-39b28209aae4.png"> Requires D51569-code
<img width="753" alt="Screen Shot 2020-10-23 at 15 00 25" src="https://user-images.githubusercontent.com/1233880/97007438-b0e83e80-1541-11eb-8453-ad3c68597139.png"> | <img width="736" alt="Screen Shot 2020-10-23 at 15 20 21" src="https://user-images.githubusercontent.com/1233880/97008606-56e87880-1543-11eb-8278-8b49d239521a.png"> They look the same, but we use less code now given that most styles are coming from Gutenberg.
<img width="751" alt="Screen Shot 2020-10-23 at 15 35 33" src="https://user-images.githubusercontent.com/1233880/97010261-741e4680-1545-11eb-8130-74a3eb7d3b65.png"> | <img width="749" alt="Screen Shot 2020-10-23 at 15 35 42" src="https://user-images.githubusercontent.com/1233880/97010268-77193700-1545-11eb-9df0-036d94cec38d.png">

#### Testing instructions

* Apply D51569-code and sandbox the API.
* Make sure the block fallbacks cache is turned off by adding `define( 'BLOCK_FALLBACKS_DEBUG', true );` to your `/wp-content/mu-plugins/0-sandbox.php` file.
* Go to Reader and check different post.
* Make sure the block styles are applied to what's rendered.
