### PR TITLE
Jetpack: Update plan/product discount percentage from 17% to 20%

### DIFF
--- a/client/my-sites/plans-v2/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar/index.tsx
@@ -96,7 +96,7 @@ const PlansFilterBar = ( {
 			{ showDiscountMessage && (
 				<span className="plans-filter-bar__discount-message">
 					{ translate( 'You save %(discount)s by paying yearly', {
-						args: { discount: '17%' },
+						args: { discount: '20%' },
 					} ) }
 				</span>
 			) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the advertised discount percentage from 17% to 20%.

#### Testing instructions

* Ensure the discount percent text has been updated in the Yearly/Monthly filterbar in both Calypso Green & Calypso Blue.