### PR TITLE
Blocks: Remove needless bind() from UserMentionsSuggestionList

### DIFF
--- a/client/blocks/user-mentions/suggestion-list.jsx
+++ b/client/blocks/user-mentions/suggestion-list.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { bind } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,7 +41,7 @@ const UserMentionsSuggestionList = ( {
 				className="user-mentions__suggestion"
 				key={ suggestion.ID }
 				isSelected={ suggestion.ID === selectedSuggestionId }
-				onClick={ bind( onClick, null, suggestion ) }
+				onClick={ () => onClick( suggestion ) }
 			>
 				<UserMentionsSuggestion
 					avatarUrl={ suggestion.image_URL }


### PR DESCRIPTION
This PR removes the one and only usage of lodash's `bind()`.

In this instance, removing it is particularly easy, because when binding, we don't even bind `this`. So we can just replace the `bind()` call with a simple arrow function that calls the bound function with a specified argument.

#### Changes proposed in this Pull Request

* Blocks: Remove needless `bind()` from `UserMentionsSuggestionList`

#### Testing instructions

* Go to a post with comments in the reader.
* In the field for comment content, try pinging someone by typing `@` followed by some characters.
* Click on a username from the suggestions.
* Verify that username gets populated in the comment field.
* Try the same steps in `/devdocs/blocks/user-mentions`.
