### PR TITLE
Update form button position everywhere

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -7,7 +7,7 @@ import { localize } from 'i18n-calypso';
 import { camelCase, values } from 'lodash';
 import { connect } from 'react-redux';
 import debugFactory from 'debug';
-import { Card, CompactCard } from '@automattic/components';
+import { Card } from '@automattic/components';
 
 /**
  * Internal dependencies
@@ -173,16 +173,15 @@ export function CreditCardForm( {
 					translate={ translate }
 					showUsedForExistingPurchasesInfo={ showUsedForExistingPurchasesInfo }
 				/>
-			</Card>
-			<CompactCard className="credit-card-form__footer">
-				<em>{ translate( 'All fields required' ) }</em>
+
+				<SaveButton translate={ translate } formSubmitting={ formSubmitting } />
+
 				{ onCancel && (
 					<FormButton type="button" isPrimary={ false } onClick={ onCancel }>
 						{ translate( 'Cancel' ) }
 					</FormButton>
 				) }
-				<SaveButton translate={ translate } formSubmitting={ formSubmitting } />
-			</CompactCard>
+			</Card>
 		</form>
 	);
 }

--- a/client/blocks/credit-card-form/style.scss
+++ b/client/blocks/credit-card-form/style.scss
@@ -15,7 +15,6 @@
 
 	p {
 		font-size: $font-body-extra-small;
-		margin: 0;
 
 		@include breakpoint-deprecated( '>660px' ) {
 			margin-left: 24px;
@@ -33,16 +32,10 @@
 
 .credit-card-form__footer {
 	align-items: center;
-	border-top-color: var( --color-neutral-0 );
 	display: flex;
-	justify-content: space-between;
 
 	em {
 		color: var( --color-text-subtle );
-	}
-
-	button:first-of-type {
-		margin-left: auto;
 	}
 
 	@include breakpoint-deprecated( '<660px' ) {

--- a/client/blocks/get-apps/mobile-download-card.jsx
+++ b/client/blocks/get-apps/mobile-download-card.jsx
@@ -225,8 +225,6 @@ class MobileDownloadCard extends React.Component {
 							) }
 						</div>
 						<div className="get-apps__sms-button-wrapper">
-							<p>{ translate( 'Standard SMS rates may apply' ) }</p>
-
 							<Button
 								className="get-apps__sms-button"
 								onClick={ this.onSubmit }
@@ -234,6 +232,8 @@ class MobileDownloadCard extends React.Component {
 							>
 								{ translate( 'Text me a link' ) }
 							</Button>
+
+							<p>{ translate( 'Standard SMS rates may apply' ) }</p>
 						</div>
 					</div>
 				) }
@@ -248,7 +248,7 @@ class MobileDownloadCard extends React.Component {
 							) }
 						</p>
 					</div>
-					<div className="get-apps__link-button-wrapper">
+					<div>
 						<Button className="get-apps__magic-link-button" onClick={ this.onSubmitLink }>
 							{ translate( 'Email me a log in link' ) }
 						</Button>

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -68,26 +68,7 @@
 	}
 
 	.get-apps__magic-link-subpanel {
-
 		margin-top: 64px;
-
-		.get-apps__link-button-wrapper {
-
-			@include breakpoint-deprecated('>480px') {
-				display: flex;
-				flex-direction: row;
-				justify-content: flex-end;
-				align-items: center;
-			}
-
-			@include breakpoint-deprecated('<480px') {
-
-				.get-apps__magic-link-button {
-					width: 100%;
-				}
-			}
-		}
-
 	}
 
 	.get-apps__sms-subpanel {
@@ -114,28 +95,13 @@
 		}
 
 		.get-apps__sms-button-wrapper {
-
-			@include breakpoint-deprecated('>480px') {
-				display: flex;
-				flex-direction: row;
-				justify-content: flex-end;
-				align-items: center;
-			}
-
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			
 			p {
 				margin: 0;
-				padding-right: 16px;
-			}
-
-			@include breakpoint-deprecated('<480px') {
-
-				p {
-					margin-bottom: 24px;
-				}
-
-				.get-apps__sms-button {
-					width: 100%;
-				}
+				padding-left: 16px;
 			}
 		}
 	}

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -366,13 +366,11 @@ export class ContactDetailsFormFields extends Component {
 	}
 
 	renderContactDetailsFields() {
-		const { translate, needsFax, hasCountryStates, labelTexts, children } = this.props;
+		const { translate, needsFax, hasCountryStates, labelTexts } = this.props;
 		const countryCode = this.getCountryCode();
-		const classes = ! children
-			? 'contact-details-form-fields__contact-extra-details'
-			: 'contact-details-form-fields__contact-details';
+
 		return (
-			<div className={ classes }>
+			<div className="contact-details-form-fields__contact-details">
 				<div className="contact-details-form-fields__row">
 					{ this.createField(
 						'organization',

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -366,11 +366,13 @@ export class ContactDetailsFormFields extends Component {
 	}
 
 	renderContactDetailsFields() {
-		const { translate, needsFax, hasCountryStates, labelTexts } = this.props;
+		const { translate, needsFax, hasCountryStates, labelTexts, children } = this.props;
 		const countryCode = this.getCountryCode();
-
+		const classes = ! children
+			? 'contact-details-form-fields__contact-extra-details'
+			: 'contact-details-form-fields__contact-details';
 		return (
-			<div className="contact-details-form-fields__contact-details">
+			<div className={ classes }>
 				<div className="contact-details-form-fields__row">
 					{ this.createField(
 						'organization',
@@ -536,7 +538,7 @@ export class ContactDetailsFormFields extends Component {
 					? this.renderGAppsFieldset()
 					: this.renderContactDetailsFields() }
 
-				{ ! React.Children.count( this.props.children ) && (
+				{ this.props.children && (
 					<div className="contact-details-form-fields__extra-fields">{ this.props.children }</div>
 				) }
 

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -26,7 +26,6 @@ import { localize } from 'i18n-calypso';
 import { getCountryStates } from 'calypso/state/country-states/selectors';
 import { CountrySelect, Input, HiddenInput } from 'calypso/my-sites/domains/components/form';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormFooter from 'calypso/my-sites/domains/domain-management/components/form-footer';
 import FormButton from 'calypso/components/forms/form-button';
 import FormPhoneMediaInput from 'calypso/components/forms/form-phone-media-input';
 import { countries } from 'calypso/components/phone-input/data';
@@ -537,10 +536,12 @@ export class ContactDetailsFormFields extends Component {
 					? this.renderGAppsFieldset()
 					: this.renderContactDetailsFields() }
 
-				<div className="contact-details-form-fields__extra-fields">{ this.props.children }</div>
+				{ ! React.Children.count( this.props.children ) && (
+					<div className="contact-details-form-fields__extra-fields">{ this.props.children }</div>
+				) }
 
 				{ isFooterVisible && (
-					<FormFooter>
+					<div>
 						{ this.props.onSubmit && (
 							<FormButton
 								className="contact-details-form-fields__submit-button"
@@ -560,7 +561,7 @@ export class ContactDetailsFormFields extends Component {
 								{ translate( 'Cancel' ) }
 							</FormButton>
 						) }
-					</FormFooter>
+					</div>
 				) }
 				<QueryDomainCountries />
 			</FormFieldset>

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -383,7 +383,9 @@ export class ManagedContactDetailsFormFields extends Component {
 					this.renderContactDetailsFields()
 				) }
 
-				<div className="contact-details-form-fields__extra-fields">{ this.props.children }</div>
+				{ this.props.children && (
+					<div className="contact-details-form-fields__extra-fields">{ this.props.children }</div>
+				) }
 
 				<QueryDomainCountries />
 			</FormFieldset>

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -96,7 +96,7 @@
 
 }
 
-.contact-details-form-fields__contact-details {
+.contact-details-form-fields__contact-extra-details {
 	margin-bottom: 1.5rem;
 }
 

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -96,12 +96,8 @@
 
 }
 
-.contact-details-form-fields__contact-extra-details {
+.contact-details-form-fields__contact-details {
 	margin-bottom: 1.5rem;
-}
-
-.contact-details-form-fields__extra-fields {
-	margin-top: 15px;
 }
 
 .form__hidden-input .form__hidden-input {

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -96,6 +96,10 @@
 
 }
 
+.contact-details-form-fields__contact-details {
+	margin-bottom: 1.5rem;
+}
+
 .contact-details-form-fields__extra-fields {
 	margin-top: 15px;
 }

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -151,7 +151,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
   <div
     className="contact-details-form-fields__extra-fields"
   />
-  <DomainManagementFormFooter>
+  <div>
     <FormButton
       className="contact-details-form-fields__submit-button"
       disabled={false}
@@ -162,7 +162,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
     >
       Submit
     </FormButton>
-  </DomainManagementFormFooter>
+  </div>
   <Connect(QueryCountries) />
 </FormFieldset>
 `;

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -148,9 +148,6 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       translate={[Function]}
     />
   </div>
-  <div
-    className="contact-details-form-fields__extra-fields"
-  />
   <div>
     <FormButton
       className="contact-details-form-fields__submit-button"

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -211,6 +211,7 @@ class FormFields extends React.PureComponent {
 					<FormToggle checked={ false } disabled />
 					<br />
 					<FormToggle checked={ true } disabled />
+					<br />
 
 					<FormButtonsBar>
 						<FormButton>Form Button</FormButton>

--- a/client/components/forms/form-button/style.scss
+++ b/client/components/forms/form-button/style.scss
@@ -1,4 +1,3 @@
 .form-button {
-	float: right;
-	margin-left: 10px;
+	margin-right: 10px;
 }

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -14,7 +14,6 @@ import { map } from 'lodash';
  */
 import HeaderCake from 'calypso/components/header-cake';
 import ActionPanel from 'calypso/components/action-panel';
-import ActionPanelTitle from 'calypso/components/action-panel/title';
 import ActionPanelBody from 'calypso/components/action-panel/body';
 import ActionPanelFigure from 'calypso/components/action-panel/figure';
 import ActionPanelFigureHeader from 'calypso/components/action-panel/figure-header';
@@ -34,6 +33,7 @@ import { hasLoadedUserPurchasesFromServer } from 'calypso/state/purchases/select
 import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
 import getUserPurchasedPremiumThemes from 'calypso/state/selectors/get-user-purchased-premium-themes';
 import userUtils from 'calypso/lib/user/utils';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 /**
  * Style dependencies
@@ -88,7 +88,7 @@ class AccountSettingsClose extends Component {
 			purchasedPremiumThemes,
 		} = this.props;
 		const isDeletePossible = ! isLoading && ! hasAtomicSites && ! hasCancelablePurchases;
-		const containerClasses = classnames( 'account-close', 'main', {
+		const containerClasses = classnames( 'account-close', 'main', 'is-wide-layout', {
 			'is-loading': isLoading,
 			'is-hiding-other-sites': this.state.showSiteDropdown,
 		} );
@@ -96,13 +96,12 @@ class AccountSettingsClose extends Component {
 		return (
 			<div className={ containerClasses } role="main">
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
+				<FormattedHeader brandFont headerText={ translate( 'Account Settings' ) } align="left" />
+
 				<HeaderCake onClick={ this.goBack }>
 					<h1>{ translate( 'Close account' ) }</h1>
 				</HeaderCake>
 				<ActionPanel>
-					<ActionPanelTitle className="account-close__heading">
-						{ translate( 'Close account' ) }
-					</ActionPanelTitle>
 					<ActionPanelBody>
 						{ isDeletePossible && (
 							<ActionPanelFigure>

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -136,12 +136,12 @@ export function ReceiptBody( { transaction, handlePrintLinkClick } ) {
 					) }
 				</ul>
 				<ReceiptLineItems transaction={ transaction } />
-			</Card>
 
-			<Card compact className="billing-history__receipt-links">
-				<Button primary onClick={ handlePrintLinkClick }>
-					{ translate( 'Print Receipt' ) }
-				</Button>
+				<div className="billing-history__receipt-links">
+					<Button primary onClick={ handlePrintLinkClick }>
+						{ translate( 'Print Receipt' ) }
+					</Button>
+				</div>
 			</Card>
 		</div>
 	);

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -344,14 +344,7 @@ textarea.billing-history__billing-details-editable {
 }
 
 .billing-history__receipt-links {
-	.button {
-		margin: 16px 0;
-
-		@include breakpoint-deprecated( '>480px' ) {
-			float: right;
-			margin: 0 1%;
-		}
-	}
+	padding: 0 40px 10px;
 }
 
 .billing-history__receipt-card.card.is-compact {

--- a/client/me/notification-settings/settings-form/actions.jsx
+++ b/client/me/notification-settings/settings-form/actions.jsx
@@ -28,6 +28,10 @@ class NotificationSettingsFormActions extends React.PureComponent {
 		return (
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<div className="notification-settings-form-actions">
+				<FormButton disabled={ this.props.disabled } onClick={ this.props.onSave }>
+					{ this.props.translate( 'Save settings' ) }
+				</FormButton>
+
 				{ this.props.isApplyAllVisible && (
 					<FormButton
 						className="notification-settings-form-actions__save-to-all"
@@ -38,9 +42,6 @@ class NotificationSettingsFormActions extends React.PureComponent {
 						{ this.props.translate( 'Save to all sites' ) }
 					</FormButton>
 				) }
-				<FormButton disabled={ this.props.disabled } onClick={ this.props.onSave }>
-					{ this.props.translate( 'Save settings' ) }
-				</FormButton>
 			</div>
 			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		);

--- a/client/me/notification-settings/settings-form/actions.scss
+++ b/client/me/notification-settings/settings-form/actions.scss
@@ -1,15 +1,12 @@
 .notification-settings-form-actions {
 	display: block;
-	border-top: solid 1px var( --color-neutral-0 );
 	padding: 15px 0;
-	text-align: right;
 
 	.form-fieldset {
 		margin-bottom: 10px;
 
 		@include breakpoint-deprecated( '>480px' ) {
 			margin: 10px 0 0;
-			float: left;
 		}
 	}
 

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -198,7 +198,7 @@ const Privacy = createReactClass( {
 							) }
 						</strong>
 					</p>
-					<Button primary className="privacy__dpa-request-button" onClick={ this.props.requestDpa }>
+					<Button className="privacy__dpa-request-button" onClick={ this.props.requestDpa }>
 						{ translate( 'Request a DPA', {
 							comment:
 								'A Data Processing Addendum (DPA) is a document to assure customers, vendors, and partners that their data handling complies with the law.',

--- a/client/me/privacy/style.scss
+++ b/client/me/privacy/style.scss
@@ -8,8 +8,3 @@
         align-items: center;
     }
 }
-
-.privacy__dpa-request-button {
-	display: block;
-	margin-left: auto;
-}

--- a/client/me/profile-links-add-other/index.jsx
+++ b/client/me/profile-links-add-other/index.jsx
@@ -105,7 +105,7 @@ class ProfileLinksAddOther extends React.Component {
 						'Please enter the URL and description of the site you want to add to your profile.'
 					) }
 				</p>
-				<FormFieldset>
+				<FormFieldset className="profile-links-add-other__fieldset">
 					<FormTextInput
 						className="profile-links-add-other__value"
 						placeholder={ this.props.translate( 'Enter a URL' ) }

--- a/client/me/profile-links-add-other/style.scss
+++ b/client/me/profile-links-add-other/style.scss
@@ -1,15 +1,15 @@
-input.form-text-input.profile-links-add-other__value {
-	margin: 0 0 10px;
-}
+.form-fieldset.profile-links-add-other__fieldset {
+	margin-bottom: 0;
 
-input.form-text-input.profile-links-add-other__title {
-	margin: 0 0 10px;
+	.profile-links-add-other__value {
+		margin: 0 0 10px;
+	}
+	
+	.profile-links-add-other__title {
+		margin-bottom: 1.5rem;
+	}
 }
 
 .profile-links-add-other .notice {
 	margin-bottom: 1.5em;
-}
-
-.profile-links-add-other__add {
-	margin-left: 10px;
 }

--- a/client/me/profile-links/style.scss
+++ b/client/me/profile-links/style.scss
@@ -7,6 +7,7 @@
 	display: block;
 	font-style: italic;
 	color: var( --color-neutral-light );
+	margin-bottom: 0;
 }
 
 .profile-links .notice {

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -78,6 +78,33 @@ const Profile = createReactClass( {
 
 				<SectionHeader label={ this.props.translate( 'Profile' ) } />
 				<Card className="profile__settings">
+					<p>
+						{ this.props.translate(
+							'This information will be displayed publicly on {{profilelink}}your profile{{/profilelink}} and in ' +
+								'{{hovercardslink}}Gravatar Hovercards{{/hovercardslink}}.',
+							{
+								components: {
+									profilelink: (
+										<a
+											onClick={ this.getClickHandler( 'My Profile Link' ) }
+											href={ gravatarProfileLink }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+									hovercardslink: (
+										<a
+											onClick={ this.getClickHandler( 'Gravatar Hovercards Link' ) }
+											href={ localizeUrl( 'https://wordpress.com/support/gravatar-hovercards/' ) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+						) }
+					</p>
+
 					<EditGravatar />
 
 					<form onSubmit={ this.submitForm } onChange={ this.props.markChanged }>
@@ -131,7 +158,7 @@ const Profile = createReactClass( {
 							/>
 						</FormFieldset>
 
-						<p>
+						<p className="profile__submit-button-wrapper">
 							<FormButton
 								disabled={
 									! this.props.userSettings.hasUnsavedSettings() || this.getDisabledState()
@@ -144,32 +171,6 @@ const Profile = createReactClass( {
 							</FormButton>
 						</p>
 					</form>
-					<p className="profile__info-text">
-						{ this.props.translate(
-							'This information will be displayed publicly on {{profilelink}}your profile{{/profilelink}} and in ' +
-								'{{hovercardslink}}Gravatar Hovercards{{/hovercardslink}}.',
-							{
-								components: {
-									profilelink: (
-										<a
-											onClick={ this.getClickHandler( 'My Profile Link' ) }
-											href={ gravatarProfileLink }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-									hovercardslink: (
-										<a
-											onClick={ this.getClickHandler( 'Gravatar Hovercards Link' ) }
-											href={ localizeUrl( 'https://wordpress.com/support/gravatar-hovercards/' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
-							}
-						) }
-					</p>
 				</Card>
 
 				<ProfileLinks />

--- a/client/me/profile/style.scss
+++ b/client/me/profile/style.scss
@@ -21,7 +21,7 @@
 	}
 }
 
-.profile__info-text {
+.profile__submit-button-wrapper {
 	margin-bottom: 0;
 }
 

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -16,7 +16,6 @@ import { flowRight as compose } from 'lodash';
  * Internal dependencies
  */
 import FormButton from 'calypso/components/forms/form-button';
-import FormButtonBar from 'calypso/components/forms/form-buttons-bar';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 import config from 'calypso/config';
@@ -274,7 +273,7 @@ class Security2faBackupCodesList extends React.Component {
 
 				{ this.possiblyRenderError() }
 
-				<FormButtonBar>
+				<div>
 					<FormLabel className="security-2fa-backup-codes-list__print-agreement">
 						<FormCheckbox
 							defaultChecked={ this.state.userAgrees }
@@ -296,7 +295,7 @@ class Security2faBackupCodesList extends React.Component {
 							context: 'The user presses the All Finished button at the end of Two-Step setup.',
 						} ) }
 					</FormButton>
-					<ButtonGroup className="security-2fa-backup-codes-list__btn-group">
+					<ButtonGroup>
 						<Button
 							className="security-2fa-backup-codes-list__copy"
 							disabled={ ! this.props.backupCodes.length }
@@ -348,7 +347,7 @@ class Security2faBackupCodesList extends React.Component {
 					>
 						{ this.props.translate( 'Download Codes' ) }
 					</Tooltip>
-				</FormButtonBar>
+				</div>
 			</div>
 		);
 	}

--- a/client/me/security-2fa-backup-codes-list/style.scss
+++ b/client/me/security-2fa-backup-codes-list/style.scss
@@ -3,20 +3,12 @@
 }
 
 .security-2fa-backup-codes-list__print-agreement {
-	display: inline-block;
-	float: left;
-	min-width: 50%;
-	position: relative;
-	top: 8px;
-
+	display: block;
+	margin-bottom: 1.5em;
+	
 	.form-label {
 		font-weight: normal;
-		margin-left: 8px;
 		display: inline-block;
-	}
-
-	@include breakpoint-deprecated( '<660px' ) {
-		margin-bottom: 24px;
 	}
 }
 
@@ -24,10 +16,6 @@
 	.security-2fa-backup-codes-list__btn-group .button {
 		display: inline-block;
 	}
-}
-
-.security-2fa-backup-codes-list__btn-group {
-	float: right;
 }
 
 .security-2fa-backup-codes-list__generate {

--- a/client/me/security-2fa-code-prompt/style.scss
+++ b/client/me/security-2fa-code-prompt/style.scss
@@ -8,10 +8,6 @@
 	}
 }
 
-.security-2fa-code-prompt__verify-code {
-	margin-left: 10px;
-}
-
 .security-2fa-code-prompt .security-2fa-code-prompt__send-code {
 	float: left;
 	margin-left: 0;

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -15,7 +15,6 @@ const debug = debugFactory( 'calypso:me:security:2fa-enable' );
  */
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import FormButton from 'calypso/components/forms/form-button';
-import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
@@ -176,7 +175,7 @@ class Security2faEnable extends React.Component {
 
 	getToggleLink = () => {
 		return (
-			<a
+			<button
 				className="security-2fa-enable__toggle"
 				onClick={ function ( event ) {
 					this.toggleMethod( event );
@@ -329,7 +328,6 @@ class Security2faEnable extends React.Component {
 				{ this.renderInputHelp() }
 
 				<FormVerificationCodeInput
-					autoFocus
 					disabled={ this.state.submittingForm }
 					name="verificationCode"
 					method={ this.state.method }
@@ -358,7 +356,7 @@ class Security2faEnable extends React.Component {
 
 	renderButtons = () => {
 		return (
-			<FormButtonsBar className="security-2fa-enable__buttons-bar">
+			<div className="security-2fa-enable__buttons-bar">
 				<FormButton
 					className="security-2fa-enable__verify"
 					disabled={ this.getFormDisabled() }
@@ -373,22 +371,6 @@ class Security2faEnable extends React.Component {
 						: this.props.translate( 'Enable', {
 								context: 'A button label used during Two-Step setup.',
 						  } ) }
-				</FormButton>
-
-				<FormButton
-					className="security-2fa-enable__cancel"
-					isPrimary={ false }
-					onClick={ function ( event ) {
-						gaRecordEvent(
-							'Me',
-							'Clicked On Step 2 Cancel 2fa Button',
-							'method',
-							this.state.method
-						);
-						this.props.onCancel( event );
-					}.bind( this ) }
-				>
-					{ this.props.translate( 'Cancel' ) }
 				</FormButton>
 
 				{ 'sms' === this.state.method ? (
@@ -417,7 +399,23 @@ class Security2faEnable extends React.Component {
 						} ) }
 					</FormButton>
 				) }
-			</FormButtonsBar>
+
+				<FormButton
+					className="security-2fa-enable__cancel"
+					isPrimary={ false }
+					onClick={ function ( event ) {
+						gaRecordEvent(
+							'Me',
+							'Clicked On Step 2 Cancel 2fa Button',
+							'method',
+							this.state.method
+						);
+						this.props.onCancel( event );
+					}.bind( this ) }
+				>
+					{ this.props.translate( 'Cancel' ) }
+				</FormButton>
+			</div>
 		);
 	};
 

--- a/client/me/security-2fa-enable/style.scss
+++ b/client/me/security-2fa-enable/style.scss
@@ -1,8 +1,3 @@
-.security-2fa-enable .security-2fa-enable__cancel {
-	float: left;
-	margin-left: 0;
-}
-
 .security-2fa-enable__code-block {
 	margin-bottom: 16px;
 }
@@ -32,6 +27,8 @@
 .security-2fa-enable__toggle {
 	cursor: pointer;
 	display: block;
+	color: var( --color-link );
+	font-size: 1rem;
 }
 
 .security-2fa-enable .notice {

--- a/client/me/security-2fa-key/name.jsx
+++ b/client/me/security-2fa-key/name.jsx
@@ -57,13 +57,13 @@ class Security2faKeyAddName extends React.Component {
 						value={ this.state.keyName }
 					/>
 				</FormFieldset>
-				<Button onClick={ this.props.onCancel }>{ this.props.translate( 'Cancel' ) }</Button>
 				<FormButton
 					className="security-2fa-key__register-key"
 					disabled={ 0 === this.state.keyName.length }
 				>
 					{ this.props.translate( 'Register key' ) }
 				</FormButton>
+				<Button onClick={ this.props.onCancel }>{ this.props.translate( 'Cancel' ) }</Button>
 			</form>
 		);
 	}

--- a/client/me/security-2fa-sms-settings/style.scss
+++ b/client/me/security-2fa-sms-settings/style.scss
@@ -31,11 +31,6 @@
 	margin-bottom: 5px;
 }
 
-.security-2fa-sms-settings__cancel-button.form-button {
-	float: left;
-	margin-left: 0;
-}
-
 .security-2fa-sms-settings__buttons {
 	margin-top: 10px;
 }

--- a/client/me/security-account-recovery/buttons.jsx
+++ b/client/me/security-account-recovery/buttons.jsx
@@ -9,7 +9,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import FormButton from 'calypso/components/forms/form-button';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -27,7 +26,7 @@ class SecurityAccountRecoveryManageContactButtons extends React.Component {
 
 	render() {
 		return (
-			<FormButtonsBar>
+			<div>
 				<FormButton disabled={ ! this.props.isSavable } onClick={ this.props.onSave }>
 					{ this.props.saveText ? this.props.saveText : this.props.translate( 'Save' ) }
 				</FormButton>
@@ -37,15 +36,12 @@ class SecurityAccountRecoveryManageContactButtons extends React.Component {
 				</FormButton>
 
 				{ this.props.isDeletable ? (
-					<button
-						className={ 'security-account-recovery-contact__remove' }
-						onClick={ this.props.onDelete }
-					>
+					<button className="security-account-recovery__remove" onClick={ this.props.onDelete }>
 						<Gridicon icon="trash" size={ 24 } />
 						<span>{ this.props.translate( 'Remove' ) }</span>
 					</button>
 				) : null }
-			</FormButtonsBar>
+			</div>
 		);
 	}
 }

--- a/client/me/security-account-recovery/style.scss
+++ b/client/me/security-account-recovery/style.scss
@@ -63,6 +63,10 @@
 	flex-direction: row;
 }
 
+.security-account-recovery-contact__header-action .form-button {
+	margin: 0;
+}
+
 .security-account-recovery-contact__header-info {
 	flex: 2;
 }
@@ -77,9 +81,9 @@
 	margin-top: 8px;
 }
 
-.security-account-recovery-contact__remove {
+.security-account-recovery__remove {
 	color: var( --color-text-subtle );
-	float: left;
+	float: right;
 	cursor: pointer;
 	padding: 9px 0;
 
@@ -90,19 +94,8 @@
 	.gridicon {
 		vertical-align: bottom;
 		margin-right: 2px;
-
-		@include breakpoint-deprecated( '>480px' ) {
-			width: 16px;
-			height: 16px;
-		}
-	}
-
-	span {
-		display: none;
-
-		@include breakpoint-deprecated( '>480px' ) {
-			display: inline;
-		}
+		width: 16px;
+		height: 16px;
 	}
 }
 

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -14,7 +14,6 @@ import ARecord from './a-record';
 import CnameRecord from './cname-record';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormFooter from 'calypso/my-sites/domains/domain-management/components/form-footer';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import MxRecord from './mx-record';
@@ -202,11 +201,11 @@ class DnsAddNew extends React.Component {
 					</FormSelect>
 				</FormFieldset>
 				{ this.recordFields() }
-				<FormFooter>
+				<div>
 					<FormButton disabled={ isSubmitDisabled } onClick={ this.onAddDnsRecord }>
 						{ translate( 'Add new DNS record' ) }
 					</FormButton>
-				</FormFooter>
+				</div>
 			</form>
 		);
 	}

--- a/client/my-sites/domains/domain-management/dns/email-provider.jsx
+++ b/client/my-sites/domains/domain-management/dns/email-provider.jsx
@@ -11,7 +11,6 @@ import { connect } from 'react-redux';
  */
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormFooter from 'calypso/my-sites/domains/domain-management/components/form-footer';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -92,7 +91,7 @@ class EmailProvider extends Component {
 						<FormInputValidation text={ translate( 'Invalid Token' ) } isError />
 					) }
 				</FormFieldset>
-				<FormFooter>
+				<div>
 					<FormButton disabled={ ! isDataValid || submitting } onClick={ this.onAddDnsRecords }>
 						{ translate( 'Set up %(providerName)s', {
 							args: { providerName: name },
@@ -101,7 +100,7 @@ class EmailProvider extends Component {
 								'provider that this template is used for, for example G Suite or Office 365',
 						} ) }
 					</FormButton>
-				</FormFooter>
+				</div>
 			</form>
 		);
 	}

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
  */
 import { Card } from '@automattic/components';
 import FormButton from 'calypso/components/forms/form-button';
-import FormFooter from 'calypso/my-sites/domains/domain-management/components/form-footer';
 import CustomNameserversRow from './custom-nameservers-row';
 import { change, remove } from 'calypso/lib/domains/nameservers';
 import { CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS } from 'calypso/lib/url/support';
@@ -118,7 +117,7 @@ class CustomNameserversForm extends React.PureComponent {
 					{ this.rows() }
 					{ this.popularHostsMessage() }
 
-					<FormFooter>
+					<div>
 						<FormButton
 							isPrimary
 							onClick={ this.handleSubmit }
@@ -130,7 +129,7 @@ class CustomNameserversForm extends React.PureComponent {
 						<FormButton type="button" isPrimary={ false } onClick={ this.handleReset }>
 							{ translate( 'Reset to defaults' ) }
 						</FormButton>
-					</FormFooter>
+					</div>
 				</form>
 			</Card>
 		);

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -58,7 +58,7 @@
 
 .name-servers__custom-nameservers-form-explanation {
 	display: block;
-	margin-top: 5px;
+	margin: 5px 0 1.5rem;
 	font-size: $font-body-small;
 	font-style: italic;
 	color: var( --color-text-subtle );

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -15,7 +15,6 @@ import { trim, trimEnd } from 'lodash';
 import Header from 'calypso/my-sites/domains/domain-management/components/header';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import div from 'calypso/my-sites/domains/domain-management/components/form-footer';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import Main from 'calypso/components/main';

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -15,7 +15,7 @@ import { trim, trimEnd } from 'lodash';
 import Header from 'calypso/my-sites/domains/domain-management/components/header';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormFooter from 'calypso/my-sites/domains/domain-management/components/form-footer';
+import div from 'calypso/my-sites/domains/domain-management/components/form-footer';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import Main from 'calypso/components/main';
@@ -166,7 +166,7 @@ class SiteRedirect extends React.Component {
 								</p>
 							</FormFieldset>
 
-							<FormFooter>
+							<div>
 								<FormButton disabled={ isFetching || isUpdating } onClick={ this.handleClick }>
 									{ translate( 'Update Site Redirect' ) }
 								</FormButton>
@@ -179,7 +179,7 @@ class SiteRedirect extends React.Component {
 								>
 									{ translate( 'Cancel' ) }
 								</FormButton>
-							</FormFooter>
+							</div>
 						</form>
 					</Card>
 				</Main>

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/style.scss
@@ -9,17 +9,17 @@
 }
 
 .transfer-out__action-button {
-	float: right;
 	margin-right: 10px;
-	&:first-of-type {
-		margin-right: 0;
-	}
 }
 
 .transfer-out__card {
 	p {
 		color: var( --color-neutral-50 );
 	}
+}
+
+.transfer-out__content {
+	margin-bottom: 1.5rem;
 }
 
 .dialog.card.transfer-out__select-ips-tag-dialog {

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
@@ -282,7 +282,7 @@ class Unlocked extends React.Component {
 		return (
 			<div>
 				<Card className="transfer-out__card">
-					<div>
+					<div className="transfer-out__content">
 						{ submitting && <p>{ translate( 'Sending request…' ) }</p> }
 						{ domainStateMessage && <p>{ domainStateMessage }</p> }
 						{ this.renderBody( domain ) }

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new.jsx
@@ -13,7 +13,6 @@ import EmailForwardingLimit from './email-forwarding-limit';
 import { validateAllFields } from 'calypso/lib/domains/email-forwarding';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormFooter from 'calypso/my-sites/domains/domain-management/components/form-footer';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
@@ -145,10 +144,10 @@ class EmailForwardingAddNew extends React.Component {
 
 	formFooter() {
 		return (
-			<FormFooter>
+			<div>
 				{ this.addButton() }
 				{ this.cancelButton() }
-			</FormFooter>
+			</div>
 		);
 	}
 

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -23,16 +23,8 @@
 	padding: 8px;
 }
 
-.export-card__export-button {
-	float: right;
-}
-
 .export-card__placeholder-select {
 	animation: loading-fade 1.6s ease-in-out infinite;
-}
-
-.export-card__advanced-settings {
-	padding-bottom: 50px;
 }
 
 .export-card__advanced-settings-title {
@@ -46,6 +38,8 @@
 }
 
 .export-card__advanced-settings-row {
+	margin-bottom: 1.5em;
+
 	@include breakpoint-deprecated( '>960px' ) {
 		display: flex;
 		flex-wrap: wrap;

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -171,10 +171,10 @@ class AuthorMappingPane extends React.PureComponent {
 					);
 				} ) }
 				<ImporterActionButtonContainer>
-					<ImporterCloseButton importerStatus={ importerStatus } site={ site } isEnabled />
 					<ImporterActionButton primary disabled={ ! canStartImport } onClick={ onStartImport }>
 						{ this.props.translate( 'Start import' ) }
 					</ImporterActionButton>
+					<ImporterCloseButton importerStatus={ importerStatus } site={ site } isEnabled />
 				</ImporterActionButtonContainer>
 			</div>
 		);

--- a/client/my-sites/importer/importer-action-buttons/action-button.scss
+++ b/client/my-sites/importer/importer-action-buttons/action-button.scss
@@ -1,23 +1,11 @@
 .importer-action-buttons__action-button {
-	width: 100%;
-	margin-bottom: 0.5em;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		width: auto;
-		margin-left: 0.75em;
-		margin-bottom: 0;
-	}
+	margin-right: 0.75em;
 }
 
 .importer-action-buttons__container {
 	clear: both;
 	display: flex;
-	flex-direction: column-reverse;
 	margin-top: 1.5em;
 	margin-bottom: 1em;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		flex-direction: row;
-		justify-content: flex-end;
-	}
+	flex-direction: row;
 }

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { includes, isEmpty, noop, flowRight, has, trim, sortBy, reverse } from 'lodash';
-import url from 'url';
+import url from 'url'; // eslint-disable-line no-restricted-imports
 import moment from 'moment';
 
 /**
@@ -270,11 +270,6 @@ class SiteImporterInputPane extends React.Component {
 				) }
 				{ importStage === 'idle' && (
 					<ImporterActionButtonContainer>
-						<ImporterCloseButton
-							importerStatus={ importerStatus }
-							site={ site }
-							isEnabled={ isEnabled }
-						/>
 						<ImporterActionButton
 							primary
 							disabled={ isLoading || isEmpty( this.state.siteURLInput ) }
@@ -283,6 +278,11 @@ class SiteImporterInputPane extends React.Component {
 						>
 							{ this.props.translate( 'Continue' ) }
 						</ImporterActionButton>
+						<ImporterCloseButton
+							importerStatus={ importerStatus }
+							site={ site }
+							isEnabled={ isEnabled }
+						/>
 					</ImporterActionButtonContainer>
 				) }
 			</div>

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -182,7 +182,7 @@
 
 	.connections__sharing-service-accounts-detail {
 		h2 {
-			font-size: 1.2em;
+			font-size: 1rem;
 		}
 
 		.new-account {
@@ -190,7 +190,7 @@
 			background: var( --color-surface );
 			// stylelint-disable-next-line selector-max-id
 			#content & {
-				font-size: 0.9em;
+				font-size: 0.875rem;
 			}
 		}
 	}
@@ -480,10 +480,6 @@
 			opacity: 0.3;
 		}
 	}
-}
-
-.sharing-buttons__submit {
-	float: right;
 }
 
 .sharing-buttons-tray__buttons {

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -257,7 +257,7 @@ export function PurchaseCancelDomain( {
 			<FormattedHeader
 				brandFont
 				className="purchases__page-heading"
-				headerText={ translate( 'Cancel domain' ) }
+				headerText={ translate( 'Billing' ) }
 				align="left"
 			/>
 

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -148,10 +148,6 @@
 		color: var( --color-neutral-20 );
 		border-color: var( --color-neutral-10 );
 	}
-
-	.podcasting-details__save-button {
-		float: right;
-	}
 }
 
 .podcasting-details__private-site,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is larger than I usually like to make them but it's because it's making a system wide update for the position of all in-page form buttons. It involves centrally updating the component but then also required some little touch ups across a number of screens. More details here: p9Jlb4-1Rl-p2

**Before**
![image](https://user-images.githubusercontent.com/6981253/97026908-057ec000-1528-11eb-9179-95ba4881541a.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/97026958-17606300-1528-11eb-8abe-c9ea597e37a9.png)

For RTL languages:
![image](https://user-images.githubusercontent.com/6981253/97026803-dec08980-1527-11eb-9744-f1fe2b38cd01.png)


#### Testing instructions
Browse around calypso and confirm that in-page form submission buttons appear on the left side and that there aren't any funky side effects like collapsed margins or text overlapping buttons. This is a list of screens I put together while testing:

- /me
- /me/account
- /me/purchases/:site/:receipt/payment/add
- /me/purchases/:site/:receipt/payment/edit
- /me/purchases/billing/:receipt
- /me/security
- /me/notifications
- /me/privacy
- /me/get-apps
- /import
- /export
- /marketing/sharing-buttons
- /domains/manage/:domain/name-servers/:site
- /domains/manage/:domain/edit-contact-info/:site
- /domains/manage/:domain/dns/:site
- /domains/manage/:domain/transfer/out/:site (for eligible domains)