### PR TITLE
e2e tests: Always scrollIntoView in enterTestCreditCardDetails

### DIFF
--- a/desktop/e2e/tests/lib/driver-helper.js
+++ b/desktop/e2e/tests/lib/driver-helper.js
@@ -16,9 +16,15 @@ exports.highlightElement = async function ( driver, element, color = 'gold' ) {
 	}
 };
 
-exports.clickWhenClickable = async function ( driver, selector, waitOverride ) {
+exports.clickWhenClickable = async function (
+	driver,
+	selector,
+	waitOverride = null,
+	extraErrorString = null
+) {
 	const self = this;
 	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
+	const extraErrorStringAppend = extraErrorString ? ' ' + extraErrorString : '';
 
 	return driver.wait(
 		function () {
@@ -36,7 +42,7 @@ exports.clickWhenClickable = async function ( driver, selector, waitOverride ) {
 			);
 		},
 		timeoutWait,
-		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be clickable`
+		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be clickable${ extraErrorStringAppend }`
 	);
 };
 
@@ -291,7 +297,7 @@ exports.selectElementByText = async function ( driver, selector, text ) {
 			async ( e ) => ( await e.getText() ) === text
 		);
 	};
-	return await this.clickWhenClickable( driver, element );
+	return await this.clickWhenClickable( driver, element, `while looking for '${ text }'` );
 };
 
 exports.clearTextArea = async function ( driver, selector ) {

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -79,9 +79,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		await this.completeTaxDetailsForCreditCard( { cardPostCode, cardCountryCode } );
 
 		const creditCardHandleSelector = By.css( 'label[for="card"]' );
-		if ( currentScreenSize() === 'mobile' ) {
-			await driverHelper.scrollIntoView( this.driver, creditCardHandleSelector );
-		}
+		await driverHelper.scrollIntoView( this.driver, creditCardHandleSelector );
 
 		// Sometimes the credit card form will be closed and it will require a click to be opened.
 		// This can happen when users have a credit card already associated with their account.

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -24,8 +24,14 @@ export async function highlightElement( driver, element ) {
 	}
 }
 
-export function clickWhenClickable( driver, selector, waitOverride ) {
+export function clickWhenClickable(
+	driver,
+	selector,
+	waitOverride = null,
+	extraErrorString = null
+) {
 	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
+	const extraErrorStringAppend = extraErrorString ? ' ' + extraErrorString : '';
 
 	return driver.wait(
 		function () {
@@ -55,7 +61,7 @@ export function clickWhenClickable( driver, selector, waitOverride ) {
 			);
 		},
 		timeoutWait,
-		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be clickable`
+		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be clickable${ extraErrorStringAppend }`
 	);
 }
 
@@ -524,7 +530,7 @@ export async function selectElementByText( driver, selector, text ) {
 		const allElements = await driver.findElements( selector );
 		return await webdriver.promise.filter( allElements, getInnerTextMatcherFunction( text ) );
 	};
-	return await this.clickWhenClickable( driver, element );
+	return await this.clickWhenClickable( driver, element, null, `while looking for '${ text }'` );
 }
 
 export async function verifyTextPresent( driver, selector, text ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some e2e tests are failing (with the cryptic error `TimeoutError: Timed out waiting for element with undefined of 'undefined' to be clickable`) which is thrown by `clickWhenClickable` [if the selector does not exist](https://github.com/Automattic/wp-calypso/blob/08a46585106b1a4981b166217372b68b99358d88/desktop/e2e/tests/lib/driver-helper.js#L39). This is because the checkout cardholder name field is slightly too high on the page and cannot be selected. The test code in `enterTestCreditCardDetails` already accounts for this on mobile by scrolling, but on desktop it did not. This PR changes that behavior so it is always scrolled into view.

#### Testing instructions

If you're set up for running e2e tests, then do:

`env BROWSERSIZE=desktop ./node_modules/.bin/mocha --grep "Sign up for a domain only purchase coming in from wordpress.com/domains in EUR currency" specs/wp-signup-spec.js`

You'll still see the tests fail, but they'll fail because of [the sidebar missing](https://github.com/Automattic/wp-calypso/issues/46684) after the purchase completes (fixed in [a separate PR](https://github.com/Automattic/wp-calypso/pull/46711)), not before the purchase.
