### PR TITLE
Jetpack Search: Remove race condition from purchase process

### DIFF
--- a/client/my-sites/purchase-product/search.jsx
+++ b/client/my-sites/purchase-product/search.jsx
@@ -125,11 +125,8 @@ export class SearchPurchase extends Component {
 		// Track that connection was started by button-click, so we can auto-approve at auth step.
 		persistSession( this.state.currentUrl );
 
-		if ( this.props.isRequestingSites ) {
-			this.setState( { waitingForSites: true } );
-		} else {
-			this.checkUrl( this.state.currentUrl, true );
-		}
+		// TODO: Look into fixing waitingForSites state handling.
+		this.checkUrl( this.state.currentUrl, true );
 	};
 
 	handleOnClickTos = () => this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes #46702, a bug where the user gets stuck unable to submit a site URL.

#### Testing instructions

* Spin up this PR.
* Navigate to `/purchase-product/jetpack_search/monthly` while having the browser's network console open.
* While the `https://public-api.wordpress.com/rest/v1.2/me/sites` request is still in transit, enter a site URL into the input and submit the form.
* Ensure that you are redirected to the checkout page (`/checkout/<siteSlug>/jetpack_search_monthly`).