### PR TITLE
Jetpack Plans: Fix discount message overlapping term filter in some languages 

### DIFF
--- a/client/my-sites/plans-v2/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useRef } from 'react';
 import { useSelector } from 'react-redux';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import classNames from 'classnames';
 
 /**
@@ -49,6 +49,7 @@ const PlansFilterBar = ( {
 	onDurationChange,
 	onProductTypeChange,
 }: Props ) => {
+	const translate = useTranslate();
 	const isCloud = isJetpackCloud();
 	const masterbarSelector = isCloud ? '.jpcom-masterbar' : '.masterbar';
 	const masterbarDefaultHeight = isCloud ? CLOUD_MASTERBAR_HEIGHT : CALYPSO_MASTERBAR_HEIGHT;

--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -73,10 +73,9 @@
 	}
 
 	.segmented-control {
-		width: 100%;
-		max-width: 180px;
 		margin-left: 8px;
 		margin-right: 16px;
+		flex: 0 0 170px;
 
 		.segmented-control__item {
 			flex: 1 1 50%;

--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -80,6 +80,10 @@
 		.segmented-control__item {
 			flex: 1 1 50%;
 		}
+
+		.segmented-control__link {
+			padding: 8px 20px;
+		}
 	}
 }
 

--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -75,7 +75,7 @@
 	.segmented-control {
 		margin-left: 8px;
 		margin-right: 16px;
-		flex: 0 0 170px;
+		flex: 0 0 200px;
 
 		.segmented-control__item {
 			flex: 1 1 50%;

--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -73,7 +73,7 @@
 	}
 
 	.segmented-control {
-		margin-left: 8px;
+		margin-left: 15px;
 		margin-right: 16px;
 		flex: 0 0 200px;
 
@@ -89,6 +89,7 @@
 
 .plans-filter-bar__discount-message {
 	display: none;
+	padding-right: 15px;
 
 	color: var( --color-primary );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
Fixes discount message overlapping term filter in some languages:
![Markup 2020-10-23 at 13 57 51](https://user-images.githubusercontent.com/11078128/97053846-85ad2180-1538-11eb-9d5c-d7142002104c.png)

### Testing instructions
1. First do a regression test by going to wordpress.com (not localhost) and set your Calypso interface language to French.
    - Go to [https://wordpress.com/me/account](https://wordpress.com/me/account), and change the **Interface Language** to `Français du Canada` (_Français du Canada_ is a good testing example) and be sure to click "Save Account Settings" button.
    - Next go to https://wordpress.com/plans/:site and verify you can see the discount message overlapping problem (Like in the screenshot above)
2. Next run this PR (both Calypso blue and Cloud green)
4. Go to calypso.localhost:3000/plans/:site (Calypso interface should still be set to _Français du Canada_) and verify that the discount message overlapping problem is no longer present and the plans filter bar looks and behaves as expected.
5. Also check [jetpack.cloud.localhost:3001/fr/pricing](http://jetpack.cloud.localhost:3001/fr/pricing) (notice the `/fr` in the url, the page should be showing _French_ language), to verify that the discount message overlapping problem is no longer present.
6. Go back to [https://wordpress.com/me/account](https://wordpress.com/me/account), and change the **Interface Language** back to `English` (if that's you're preferred language).

Should look like the screenshots below:
![Screenshot on 2020-10-23 at 14-47-54](https://user-images.githubusercontent.com/11078128/97056987-20a8fa00-153f-11eb-8e80-404aa8b197bc.png)
![Screenshot on 2020-10-23 at 14-50-03](https://user-images.githubusercontent.com/11078128/97057003-27d00800-153f-11eb-87a2-83070bf8ef39.png)


Fixes: 1196341175636977-as-1198209888368925/f