### PR TITLE
Shopping Cart: Remove TempResponseCartProduct

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -2,11 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import {
-	ResponseCart,
-	ResponseCartProduct,
-	TempResponseCartProduct,
-} from '@automattic/shopping-cart';
+import { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -151,7 +147,7 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 
 type ExcludesNull = < T >( x: T | null ) => x is T;
 
-function isRealProduct( serverCartItem: ResponseCartProduct | TempResponseCartProduct ): boolean {
+function isRealProduct( serverCartItem: ResponseCartProduct ): boolean {
 	// Credits are displayed separately, so we do not need to include the pseudo-product in the line items.
 	if ( serverCartItem.product_slug === 'wordpress-com-credits' ) {
 		return false;
@@ -161,7 +157,7 @@ function isRealProduct( serverCartItem: ResponseCartProduct | TempResponseCartPr
 
 // Convert a backend cart item to a checkout cart item
 function translateReponseCartProductToWPCOMCartItem(
-	serverCartItem: ResponseCartProduct | TempResponseCartProduct
+	serverCartItem: ResponseCartProduct
 ): WPCOMCartItem {
 	const {
 		product_id,

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -65,7 +65,7 @@ export function convertTempResponseCartToResponseCart( cart: TempResponseCart ):
 function isValidResponseCartProduct(
 	product: RequestCartProduct | ResponseCartProduct
 ): product is ResponseCartProduct {
-	return 'product_cost_integer' in product;
+	return 'uuid' in product;
 }
 
 export function removeItemFromResponseCart(

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -1,20 +1,20 @@
 /**
  * Internal dependencies
  */
-import { emptyResponseCart } from './shopping-cart-endpoint';
+import { emptyResponseCart } from './empty-carts';
+import { TempResponseCart } from './shopping-cart-endpoint';
 import type {
 	CartLocation,
 	RequestCart,
 	RequestCartProduct,
 	ResponseCart,
 	ResponseCartProduct,
-	TempResponseCartProduct,
 } from './types';
 
 let lastUUID = 100;
 
 function convertResponseCartProductToRequestCartProduct(
-	product: ResponseCartProduct | TempResponseCartProduct
+	product: ResponseCartProduct | RequestCartProduct
 ): RequestCartProduct {
 	const { product_slug, meta, product_id, extra } = product;
 	return {
@@ -32,7 +32,7 @@ export function convertResponseCartToRequestCart( {
 	coupon,
 	is_coupon_applied,
 	tax,
-}: ResponseCart ): RequestCart {
+}: TempResponseCart ): RequestCart {
 	let requestCartTax = null;
 	if ( tax.location.country_code || tax.location.postal_code || tax.location.subdivision_code ) {
 		requestCartTax = {
@@ -55,19 +55,35 @@ export function convertResponseCartToRequestCart( {
 	};
 }
 
+export function convertTempResponseCartToResponseCart( cart: TempResponseCart ): ResponseCart {
+	return {
+		...cart,
+		products: cart.products.filter( isValidResponseCartProduct ),
+	};
+}
+
+function isValidResponseCartProduct(
+	product: RequestCartProduct | ResponseCartProduct
+): product is ResponseCartProduct {
+	return 'product_cost_integer' in product;
+}
+
 export function removeItemFromResponseCart(
-	cart: ResponseCart,
+	cart: TempResponseCart,
 	uuidToRemove: string
-): ResponseCart {
+): TempResponseCart {
 	return {
 		...cart,
 		products: cart.products.filter( ( product ) => {
-			return product.uuid !== uuidToRemove;
+			return isValidResponseCartProduct( product ) ? product.uuid !== uuidToRemove : true;
 		} ),
 	};
 }
 
-export function addCouponToResponseCart( cart: ResponseCart, couponToAdd: string ): ResponseCart {
+export function addCouponToResponseCart(
+	cart: TempResponseCart,
+	couponToAdd: string
+): TempResponseCart {
 	return {
 		...cart,
 		coupon: couponToAdd,
@@ -75,7 +91,7 @@ export function addCouponToResponseCart( cart: ResponseCart, couponToAdd: string
 	};
 }
 
-export function removeCouponFromResponseCart( cart: ResponseCart ): ResponseCart {
+export function removeCouponFromResponseCart( cart: TempResponseCart ): TempResponseCart {
 	return {
 		...cart,
 		coupon: '',
@@ -84,9 +100,9 @@ export function removeCouponFromResponseCart( cart: ResponseCart ): ResponseCart
 }
 
 export function addLocationToResponseCart(
-	cart: ResponseCart,
+	cart: TempResponseCart,
 	location: CartLocation
-): ResponseCart {
+): TempResponseCart {
 	return {
 		...cart,
 		tax: {
@@ -101,7 +117,7 @@ export function addLocationToResponseCart(
 }
 
 export function doesCartLocationDifferFromResponseCartLocation(
-	cart: ResponseCart,
+	cart: TempResponseCart,
 	location: CartLocation
 ): boolean {
 	const { countryCode, postalCode, subdivisionCode } = location;
@@ -154,40 +170,34 @@ export function convertRawResponseCartToResponseCart(
 }
 
 export function addItemsToResponseCart(
-	responseCart: ResponseCart,
+	responseCart: TempResponseCart,
 	products: RequestCartProduct[]
-): ResponseCart {
-	const responseCartProducts: TempResponseCartProduct[] = products.map(
-		convertRequestCartProductToResponseCartProduct
-	);
+): TempResponseCart {
 	return {
 		...responseCart,
-		products: [ ...responseCart.products, ...responseCartProducts ],
+		products: [ ...responseCart.products, ...products ],
 	};
 }
 
 export function replaceAllItemsInResponseCart(
-	responseCart: ResponseCart,
+	responseCart: TempResponseCart,
 	products: RequestCartProduct[]
-): ResponseCart {
-	const responseCartProducts: TempResponseCartProduct[] = products.map(
-		convertRequestCartProductToResponseCartProduct
-	);
+): TempResponseCart {
 	return {
 		...responseCart,
-		products: [ ...responseCartProducts ],
+		products: [ ...products ],
 	};
 }
 
 export function replaceItemInResponseCart(
-	cart: ResponseCart,
+	cart: TempResponseCart,
 	uuidToReplace: string,
 	productPropertiesToChange: Partial< RequestCartProduct >
-): ResponseCart {
+): TempResponseCart {
 	return {
 		...cart,
 		products: cart.products.map( ( item ) => {
-			if ( item.uuid === uuidToReplace ) {
+			if ( isValidResponseCartProduct( item ) && item.uuid === uuidToReplace ) {
 				return { ...item, ...productPropertiesToChange };
 			}
 			return item;
@@ -195,38 +205,17 @@ export function replaceItemInResponseCart(
 	};
 }
 
-function convertRequestCartProductToResponseCartProduct(
-	product: RequestCartProduct
-): TempResponseCartProduct {
-	const { product_slug, product_id, meta, extra } = product;
-	return {
-		product_name: '',
-		product_slug,
-		product_id,
-		currency: null,
-		item_original_cost_display: null,
-		item_original_cost_integer: null,
-		item_subtotal_monthly_cost_display: null,
-		item_subtotal_monthly_cost_integer: null,
-		item_original_subtotal_display: null,
-		item_original_subtotal_integer: null,
-		product_cost_integer: null,
-		product_cost_display: null,
-		item_subtotal_integer: null,
-		item_subtotal_display: null,
-		is_domain_registration: null,
-		is_bundled: null,
-		months_per_bill_period: null,
-		meta,
-		volume: 1,
-		extra,
-		uuid: 'calypso-shopping-cart-endpoint-uuid-' + lastUUID++,
-		cost: null,
-		price: null,
-		product_type: null,
-		included_domain_purchase_amount: null,
-		is_renewal: undefined,
-		is_sale_coupon_applied: false,
-		subscription_id: undefined,
-	};
+export function doesResponseCartContainProductMatching(
+	responseCart: TempResponseCart,
+	productProperties: Partial< ResponseCartProduct >
+): boolean {
+	return responseCart.products.some( ( product ) => {
+		return (
+			isValidResponseCartProduct( product ) &&
+			Object.keys( productProperties ).every( ( key ) => {
+				const typedKey = key as keyof ResponseCartProduct;
+				return product[ typedKey ] === productProperties[ typedKey ];
+			} )
+		);
+	} );
 }

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import type { ResponseCart } from './shopping-cart-endpoint';
+
+export const emptyResponseCart: ResponseCart = {
+	blog_id: '',
+	create_new_blog: false,
+	cart_generated_at_timestamp: 0,
+	cart_key: '',
+	products: [],
+	total_tax_integer: 0,
+	total_tax_display: '0',
+	total_cost: 0,
+	total_cost_integer: 0,
+	total_cost_display: '0',
+	coupon_savings_total_integer: 0,
+	coupon_savings_total_display: '0',
+	savings_total_integer: 0,
+	savings_total_display: '0',
+	sub_total_integer: 0,
+	sub_total_display: '0',
+	currency: 'USD',
+	credits_integer: 0,
+	credits_display: '0',
+	allowed_payment_methods: [],
+	coupon: '',
+	is_coupon_applied: false,
+	coupon_discounts_integer: [],
+	locale: 'en-us',
+	tax: { location: {}, display_taxes: false },
+	is_signup: false,
+};

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -53,7 +53,49 @@ export interface ResponseCart {
 	blog_id: number | string;
 	create_new_blog: boolean;
 	cart_key: string;
-	products: ( TempResponseCartProduct | ResponseCartProduct )[];
+	products: ResponseCartProduct[];
+	total_tax_integer: number;
+	total_tax_display: string;
+	total_cost: number; // Please try not to use this
+	total_cost_integer: number;
+	total_cost_display: string;
+	coupon_savings_total_integer: number;
+	coupon_savings_total_display: string;
+	savings_total_integer: number;
+	savings_total_display: string;
+	sub_total_integer: number;
+	sub_total_display: string;
+	currency: string;
+	credits_integer: number;
+	credits_display: string;
+	allowed_payment_methods: string[];
+	coupon: string;
+	is_coupon_applied: boolean;
+	coupon_discounts_integer: number[];
+	locale: string;
+	is_signup: boolean;
+	messages?: ResponseCartMessages;
+	cart_generated_at_timestamp: number;
+	tax: {
+		location: {
+			country_code?: string;
+			postal_code?: string;
+			subdivision_code?: string;
+		};
+		display_taxes: boolean;
+	};
+}
+
+/**
+ * Local schema for response cart that can contain incomplete products. This
+ * schema is only used inside the reducer and will only differ from a
+ * ResponseCart if the cacheStatus is invalid.
+ */
+export interface TempResponseCart {
+	blog_id: number | string;
+	create_new_blog: boolean;
+	cart_key: string;
+	products: ( RequestCartProduct | ResponseCartProduct )[];
 	total_tax_integer: number;
 	total_tax_display: string;
 	total_cost: number; // Please try not to use this
@@ -157,44 +199,6 @@ export interface ResponseCartProduct {
 	included_domain_purchase_amount: number;
 	is_renewal?: boolean;
 	subscription_id?: string;
-
-	// Temporary optional properties for the monthly pricing test
-	related_monthly_plan_cost_display?: string;
-	related_monthly_plan_cost_integer?: number;
-}
-
-/**
- * A way to add an item to the response cart with incomplete data while the data is loading.
- */
-export interface TempResponseCartProduct {
-	product_name: string | null;
-	product_slug: string;
-	product_id: number;
-	currency: string | null;
-	product_cost_integer: null;
-	product_cost_display: null;
-	item_subtotal_integer: null;
-	item_subtotal_display: null;
-	item_subtotal_monthly_cost_display: null;
-	item_subtotal_monthly_cost_integer: null;
-	item_original_cost_display: null;
-	item_original_cost_integer: null;
-	item_original_subtotal_display: null;
-	item_original_subtotal_integer: null;
-	is_domain_registration: boolean | null;
-	is_bundled: boolean | null;
-	is_sale_coupon_applied: boolean | null;
-	months_per_bill_period: number | null;
-	meta: string;
-	volume: number;
-	extra: ResponseCartProductExtra;
-	uuid: string;
-	cost: null;
-	price: null;
-	product_type: null;
-	included_domain_purchase_amount: null;
-	is_renewal: undefined;
-	subscription_id: undefined;
 
 	// Temporary optional properties for the monthly pricing test
 	related_monthly_plan_cost_display?: string;

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -49,11 +49,11 @@ export interface RequestCartProduct {
 /**
  * Response schema for the shopping cart endpoint
  */
-export interface ResponseCart {
+export interface ResponseCart< P = ResponseCartProduct > {
 	blog_id: number | string;
 	create_new_blog: boolean;
 	cart_key: string;
-	products: ResponseCartProduct[];
+	products: P[];
 	total_tax_integer: number;
 	total_tax_display: string;
 	total_cost: number; // Please try not to use this
@@ -91,42 +91,7 @@ export interface ResponseCart {
  * schema is only used inside the reducer and will only differ from a
  * ResponseCart if the cacheStatus is invalid.
  */
-export interface TempResponseCart {
-	blog_id: number | string;
-	create_new_blog: boolean;
-	cart_key: string;
-	products: ( RequestCartProduct | ResponseCartProduct )[];
-	total_tax_integer: number;
-	total_tax_display: string;
-	total_cost: number; // Please try not to use this
-	total_cost_integer: number;
-	total_cost_display: string;
-	coupon_savings_total_integer: number;
-	coupon_savings_total_display: string;
-	savings_total_integer: number;
-	savings_total_display: string;
-	sub_total_integer: number;
-	sub_total_display: string;
-	currency: string;
-	credits_integer: number;
-	credits_display: string;
-	allowed_payment_methods: string[];
-	coupon: string;
-	is_coupon_applied: boolean;
-	coupon_discounts_integer: number[];
-	locale: string;
-	is_signup: boolean;
-	messages?: ResponseCartMessages;
-	cart_generated_at_timestamp: number;
-	tax: {
-		location: {
-			country_code?: string;
-			postal_code?: string;
-			subdivision_code?: string;
-		};
-		display_taxes: boolean;
-	};
-}
+export type TempResponseCart = ResponseCart< RequestCartProduct >;
 
 export interface ResponseCartMessages {
 	errors?: ResponseCartMessage[];

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -138,35 +138,6 @@ export interface ResponseCartMessage {
 	message: string;
 }
 
-export const emptyResponseCart: ResponseCart = {
-	blog_id: '',
-	create_new_blog: false,
-	cart_generated_at_timestamp: 0,
-	cart_key: '',
-	products: [],
-	total_tax_integer: 0,
-	total_tax_display: '0',
-	total_cost: 0,
-	total_cost_integer: 0,
-	total_cost_display: '0',
-	coupon_savings_total_integer: 0,
-	coupon_savings_total_display: '0',
-	savings_total_integer: 0,
-	savings_total_display: '0',
-	sub_total_integer: 0,
-	sub_total_display: '0',
-	currency: 'USD',
-	credits_integer: 0,
-	credits_display: '0',
-	allowed_payment_methods: [],
-	coupon: '',
-	is_coupon_applied: false,
-	coupon_discounts_integer: [],
-	locale: 'en-us',
-	tax: { location: {}, display_taxes: false },
-	is_signup: false,
-};
-
 /**
  * Product item schema for the shopping cart endpoint (response)
  */

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import {
+	TempResponseCart,
 	ResponseCart,
 	RequestCart,
 	RequestCartProduct,
@@ -98,20 +99,8 @@ export type ShoppingCartAction =
 
 export type ShoppingCartError = 'GET_SERVER_CART_ERROR' | 'SET_SERVER_CART_ERROR';
 
-/**
- *     * responseCart
- *         Stored shopping cart endpoint response. We manipulate this
- *         directly and pass it back to the endpoint on update events.
- *     * couponStatus
- *         Used to determine whether to render coupon input fields and
- *         coupon-related error messages.
- *     * cacheStatus
- *         Used to determine whether we need to re-validate the cart on
- *         the backend. We can't use responseCart directly to decide this
- *         in e.g. useEffect because this causes an infinite loop.
- */
 export type ShoppingCartState = {
-	responseCart: ResponseCart;
+	responseCart: TempResponseCart;
 	couponStatus: CouponStatus;
 	cacheStatus: CacheStatus;
 	loadingError?: string;

--- a/packages/shopping-cart/src/use-cart-update-and-revalidate.ts
+++ b/packages/shopping-cart/src/use-cart-update-and-revalidate.ts
@@ -11,17 +11,23 @@ import {
 	convertResponseCartToRequestCart,
 	convertRawResponseCartToResponseCart,
 } from './cart-functions';
-import { ResponseCart, RequestCart, CacheStatus, ShoppingCartAction } from './types';
+import {
+	TempResponseCart,
+	RequestCart,
+	ResponseCart,
+	CacheStatus,
+	ShoppingCartAction,
+} from './types';
 
 const debug = debugFactory( 'shopping-cart:use-cart-update-and-revalidate' );
 
 export default function useCartUpdateAndRevalidate(
 	cacheStatus: CacheStatus,
-	responseCart: ResponseCart,
+	responseCart: TempResponseCart,
 	setServerCart: ( arg0: RequestCart ) => Promise< ResponseCart >,
 	hookDispatch: ( arg0: ShoppingCartAction ) => void
 ): void {
-	const pendingResponseCart = useRef< ResponseCart >( responseCart );
+	const pendingResponseCart = useRef< TempResponseCart >( responseCart );
 
 	useEffect( () => {
 		if ( cacheStatus !== 'invalid' ) {

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -8,7 +8,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import {
-	ResponseCart,
+	TempResponseCart,
 	RequestCartProduct,
 	CartLocation,
 	ShoppingCartManager,
@@ -18,6 +18,7 @@ import {
 	ShoppingCartError,
 	ReplaceProductInCart,
 } from './types';
+import { convertTempResponseCartToResponseCart } from './cart-functions';
 import useShoppingCartReducer from './use-shopping-cart-reducer';
 import useInitializeCartFromServer from './use-initialize-cart-from-server';
 import useCartUpdateAndRevalidate from './use-cart-update-and-revalidate';
@@ -37,7 +38,7 @@ export default function useShoppingCartManager( {
 
 	const [ hookState, hookDispatch ] = useShoppingCartReducer();
 
-	const responseCart: ResponseCart = hookState.responseCart;
+	const responseCart: TempResponseCart = hookState.responseCart;
 	const couponStatus: CouponStatus = hookState.couponStatus;
 	const cacheStatus: CacheStatus = hookState.cacheStatus;
 	const loadingError: string | undefined = hookState.loadingError;
@@ -117,7 +118,7 @@ export default function useShoppingCartManager( {
 			replaceProductInCart,
 			replaceProductsInCart,
 			reloadFromServer,
-			responseCart,
+			responseCart: convertTempResponseCartToResponseCart( responseCart ),
 		} ),
 		[
 			isLoading,

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -102,6 +102,10 @@ export default function useShoppingCartManager( {
 	const isLoading = cacheStatus === 'fresh' || cacheStatus === 'fresh-pending' || ! cartKey;
 	const loadingErrorForManager = cacheStatus === 'error' ? loadingError : null;
 	const isPendingUpdate = cacheStatus !== 'valid' || ! cartKey;
+	const responseCartWithoutTempProducts = useMemo(
+		() => convertTempResponseCartToResponseCart( responseCart ),
+		[ responseCart ]
+	);
 
 	const shoppingCartManager = useMemo(
 		() => ( {
@@ -118,9 +122,10 @@ export default function useShoppingCartManager( {
 			replaceProductInCart,
 			replaceProductsInCart,
 			reloadFromServer,
-			responseCart: convertTempResponseCartToResponseCart( responseCart ),
+			responseCart: responseCartWithoutTempProducts,
 		} ),
 		[
+			responseCartWithoutTempProducts,
 			isLoading,
 			isPendingUpdate,
 			loadingErrorForManager,
@@ -134,7 +139,6 @@ export default function useShoppingCartManager( {
 			replaceProductInCart,
 			replaceProductsInCart,
 			reloadFromServer,
-			responseCart,
 		]
 	);
 

--- a/packages/shopping-cart/src/use-shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-reducer.ts
@@ -16,16 +16,10 @@ import {
 	removeCouponFromResponseCart,
 	addLocationToResponseCart,
 	doesCartLocationDifferFromResponseCartLocation,
+	doesResponseCartContainProductMatching,
 } from './cart-functions';
-import {
-	emptyResponseCart,
-	ResponseCart,
-	ResponseCartProduct,
-	TempResponseCartProduct,
-	ShoppingCartState,
-	ShoppingCartAction,
-	CouponStatus,
-} from './types';
+import { ResponseCart, ShoppingCartState, ShoppingCartAction, CouponStatus } from './types';
+import { emptyResponseCart } from './empty-carts';
 
 const debug = debugFactory( 'shopping-cart:use-shopping-cart-reducer' );
 
@@ -283,16 +277,4 @@ function getUpdatedCouponStatus( currentCouponStatus: CouponStatus, responseCart
 		default:
 			return currentCouponStatus;
 	}
-}
-
-function doesResponseCartContainProductMatching(
-	responseCart: ResponseCart,
-	productProperties: Partial< ResponseCartProduct >
-): boolean {
-	return responseCart.products.some( ( product: ResponseCartProduct | TempResponseCartProduct ) => {
-		return Object.keys( productProperties ).every( ( key ) => {
-			const typedKey = key as keyof ResponseCartProduct;
-			return product[ typedKey ] === productProperties[ typedKey ];
-		} );
-	} );
 }

--- a/packages/shopping-cart/src/use-shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-reducer.ts
@@ -81,11 +81,14 @@ function shoppingCartReducer(
 	switch ( action.type ) {
 		case 'FETCH_INITIAL_RESPONSE_CART':
 			return { ...state, cacheStatus: 'fresh-pending' };
+
 		case 'CART_RELOAD':
 			debug( 'reloading cart from server' );
 			return getInitialShoppingCartState();
+
 		case 'CLEAR_QUEUED_ACTIONS':
 			return { ...state, queuedActions: [] };
+
 		case 'REMOVE_CART_ITEM': {
 			const uuidToRemove = action.uuidToRemove;
 			debug( 'removing item from cart with uuid', uuidToRemove );
@@ -95,22 +98,23 @@ function shoppingCartReducer(
 				cacheStatus: 'invalid',
 			};
 		}
-		case 'CART_PRODUCTS_ADD': {
+
+		case 'CART_PRODUCTS_ADD':
 			debug( 'adding items to cart', action.products );
 			return {
 				...state,
 				responseCart: addItemsToResponseCart( state.responseCart, action.products ),
 				cacheStatus: 'invalid',
 			};
-		}
-		case 'CART_PRODUCTS_REPLACE_ALL': {
+
+		case 'CART_PRODUCTS_REPLACE_ALL':
 			debug( 'replacing items in cart with', action.products );
 			return {
 				...state,
 				responseCart: replaceAllItemsInResponseCart( state.responseCart, action.products ),
 				cacheStatus: 'invalid',
 			};
-		}
+
 		case 'CART_PRODUCT_REPLACE': {
 			const uuidToReplace = action.uuidToReplace;
 			if (
@@ -123,7 +127,6 @@ function shoppingCartReducer(
 				return state;
 			}
 			debug( `replacing item with uuid ${ uuidToReplace } with`, action.productPropertiesToChange );
-
 			return {
 				...state,
 				responseCart: replaceItemInResponseCart(
@@ -134,31 +137,27 @@ function shoppingCartReducer(
 				cacheStatus: 'invalid',
 			};
 		}
-		case 'REMOVE_COUPON': {
+
+		case 'REMOVE_COUPON':
 			if ( couponStatus !== 'applied' ) {
 				debug( `coupon status is '${ couponStatus }'; not removing` );
 				return state;
 			}
-
 			debug( 'removing coupon' );
-
 			return {
 				...state,
 				responseCart: removeCouponFromResponseCart( state.responseCart ),
 				couponStatus: 'fresh',
 				cacheStatus: 'invalid',
 			};
-		}
+
 		case 'ADD_COUPON': {
 			const newCoupon = action.couponToAdd;
-
 			if ( couponStatus === 'applied' || couponStatus === 'pending' ) {
 				debug( `coupon status is '${ couponStatus }'; not submitting again` );
 				return state;
 			}
-
 			debug( 'adding coupon', newCoupon );
-
 			return {
 				...state,
 				responseCart: addCouponToResponseCart( state.responseCart, newCoupon ),
@@ -166,6 +165,7 @@ function shoppingCartReducer(
 				cacheStatus: 'invalid',
 			};
 		}
+
 		case 'RECEIVE_INITIAL_RESPONSE_CART': {
 			const response = action.initialResponseCart;
 			return {
@@ -175,21 +175,21 @@ function shoppingCartReducer(
 				cacheStatus: 'valid',
 			};
 		}
+
 		case 'REQUEST_UPDATED_RESPONSE_CART':
 			return {
 				...state,
 				cacheStatus: 'pending',
 			};
+
 		case 'RECEIVE_UPDATED_RESPONSE_CART': {
 			const response = action.updatedResponseCart;
 			const newCouponStatus = getUpdatedCouponStatus( couponStatus, response );
 			const cartKey = response.cart_key;
 			const productSlugsInCart = response.products.map( ( product ) => product.product_slug );
-
 			if ( cartKey === 'no-user' ) {
 				removeItemFromLocalStorage( productSlugsInCart );
 			}
-
 			return {
 				...state,
 				responseCart: response,
@@ -197,6 +197,7 @@ function shoppingCartReducer(
 				cacheStatus: 'valid',
 			};
 		}
+
 		case 'RAISE_ERROR':
 			switch ( action.error ) {
 				case 'GET_SERVER_CART_ERROR':
@@ -210,6 +211,7 @@ function shoppingCartReducer(
 				default:
 					return state;
 			}
+
 		case 'SET_LOCATION':
 			if ( doesCartLocationDifferFromResponseCartLocation( state.responseCart, action.location ) ) {
 				debug( 'setting location on cart', action.location );
@@ -221,6 +223,7 @@ function shoppingCartReducer(
 			}
 			debug( 'cart location is the same; not updating' );
 			return state;
+
 		default:
 			return state;
 	}

--- a/packages/shopping-cart/test/shopping-cart-endpoint.js
+++ b/packages/shopping-cart/test/shopping-cart-endpoint.js
@@ -48,7 +48,7 @@ const product3 = {
 };
 
 describe( 'replaceItemInResponseCart', function () {
-	it( 'replaces an item in the  with a matching uuid', function () {
+	it( 'replaces an item in the cart with a matching uuid', function () {
 		const product1B = { ...product3, uuid: product1.uuid };
 		const result = replaceItemInResponseCart(
 			{ ...cart, products: [ product1, product2 ] },
@@ -68,39 +68,11 @@ describe( 'replaceItemInResponseCart', function () {
 } );
 
 describe( 'addItemsToResponseCart', function () {
-	it( 'adds the requested item to the product list with placeholder properties', function () {
+	it( 'adds the requested item to the product list', function () {
 		const result = addItemsToResponseCart( { ...cart, products: [ product1, product2 ] }, [
 			product3,
 		] );
-		const product3B = {
-			...product3,
-			cost: null,
-			currency: null,
-			extra: undefined,
-			included_domain_purchase_amount: null,
-			is_bundled: null,
-			is_domain_registration: null,
-			is_sale_coupon_applied: false,
-			is_renewal: undefined,
-			item_subtotal_display: null,
-			item_subtotal_integer: null,
-			item_subtotal_monthly_cost_display: null,
-			item_subtotal_monthly_cost_integer: null,
-			months_per_bill_period: null,
-			meta: undefined,
-			price: null,
-			item_original_cost_display: null,
-			item_original_cost_integer: null,
-			item_original_subtotal_display: null,
-			item_original_subtotal_integer: null,
-			product_cost_display: null,
-			product_cost_integer: null,
-			product_name: '',
-			product_type: null,
-			subscription_id: undefined,
-			uuid: 'calypso-shopping-cart-endpoint-uuid-100',
-			volume: 1,
-		};
+		const product3B = { ...product3 }; // Make a copy
 		expect( result.products[ 0 ] ).toEqual( product1 );
 		expect( result.products[ 1 ] ).toEqual( product2 );
 		expect( result.products[ 2 ] ).toEqual( product3B );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new type inside the shopping-cart package, `ResponseCart<RequestCartProduct>`. This type is used internally within the package and allows us to remove the `TempResponseCartProduct` type that was previously required outside the package, as it was a leaky abstraction.

Previously `TempResponseCartProduct` was used as a way to add new products, missing important properties like their price, to the local cache of the cart so that they could be stored with the other products retrieved from the server until the updated cart could be sent to the server, at which point the updated cart (probably) will return the full version of those products. However, this presented a lot of challenges for consumers of the package that want to safely manipulate the data of the products in the cart because they might be using a real product or a temporary one and had to account for both.

This new type will be used instead of `ResponseCart` to internally keep the cart state. It is identical to `ResponseCart` except that it can contain products that have only the data required to request an update from the server (a type we already support, `RequestCartProduct`). These products are filtered out before returning the cart for use, so the API of the package remains the same.

This allows us to clearly define what type of cart we're working with in any given location, and removes the ambiguity of the `TempResponseCartProduct` that previously had to be dealt with everywhere.  Now we can guarantee that the products in a `ResponseCart` will always have the data returned by the server. Any new products added that have not yet made the round-trip to the server will be hidden from consumers until the server sends them back. In the meantime, consumers should respect the `isLoading` and `isPendingUpdate` flags that indicate that the cart data is currently not up-to-date.

The only potential downside of this that I can think of is that it removes the possibility for optimistic updates of the shopping cart (at least, without some additional mechanism). However, since products added to the cart only include their slug and ID and neither name nor price, optimistic updates are not really very feasible anyway. If that ever becomes something desirable, and we have a means to retrieve data for not-yet-saved items, the feature can be added later.

#### Testing instructions

Try the following operations and verify that the behavior in checkout remains the same as it was previously:

- Add a product to the cart. Expect that the cart will display a loading state, then will update with the new product added.
- Remove a product from the cart. Expect that the cart will display a loading state, then will update with the product having been removed.
- Replace a product in the cart. This can be done by using the plan variant selector displayed in the review step when you press "Edit" on that step. Expect that the cart will display a loading state, then will update with the new product in place of the old one.
- Replace all the products in the cart. This can be done by first having new products in the cart and then adding a renewal product. Expect that the cart will display a loading state, then will update with the new product added and the other products removed.
