### PR TITLE
Support: Holiday closure notices for Chat and Quick Start

### DIFF
--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -7,6 +7,7 @@ import React, { Component, Fragment } from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
+import ClosureNotice from '../shared/closure-notice';
 import FormattedHeader from 'calypso/components/formatted-header';
 import ExternalLink from 'calypso/components/external-link';
 import { localize } from 'i18n-calypso';
@@ -18,6 +19,18 @@ class PrimaryHeader extends Component {
 
 		return (
 			<Fragment>
+				<ClosureNotice
+					displayAt="2020-12-17 00:00Z"
+					closesAt="2020-12-24 00:00Z"
+					reopensAt="2020-12-26 07:00Z"
+					holidayName="Christmas"
+				/>
+				<ClosureNotice
+					displayAt="2020-12-26 07:00Z"
+					closesAt="2020-12-31 00:00Z"
+					reopensAt="2021-01-02 07:00Z"
+					holidayName="New Year's Day"
+				/>
 				<Card>
 					<img
 						className="shared__info-illustration"

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -22,7 +22,7 @@ import HelpContactConfirmation from 'calypso/me/help/help-contact-confirmation';
 import HeaderCake from 'calypso/components/header-cake';
 import wpcomLib from 'calypso/lib/wp';
 import notices from 'calypso/notices';
-import ChatCovidLimitedAvailabilityNotice from 'calypso/me/help/contact-form-notice/chat-covid-limited-availability';
+import ChatHolidayClosureNotice from 'calypso/me/help/contact-form-notice/chat-holiday-closure';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import getHappychatUserInfo from 'calypso/state/happychat/selectors/get-happychat-userinfo';
 import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
@@ -52,10 +52,7 @@ import {
 } from 'calypso/state/help/directly/actions';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import getLocalizedLanguageNames from 'calypso/state/selectors/get-localized-language-names';
-import getSupportLevel, {
-	SUPPORT_LEVEL_PERSONAL,
-	SUPPORT_LEVEL_PERSONAL_WITH_LEGACY_CHAT,
-} from 'calypso/state/selectors/get-support-level';
+import getSupportLevel from 'calypso/state/selectors/get-support-level';
 import hasUserAskedADirectlyQuestion from 'calypso/state/selectors/has-user-asked-a-directly-question';
 import isDirectlyReady from 'calypso/state/selectors/is-directly-ready';
 import isDirectlyUninitialized from 'calypso/state/selectors/is-directly-uninitialized';
@@ -539,7 +536,7 @@ class HelpContact extends React.Component {
 	 */
 	getView = () => {
 		const { confirmation } = this.state;
-		const { activeSupportTickets, compact, supportLevel, supportVariation, translate } = this.props;
+		const { activeSupportTickets, compact, supportVariation, translate } = this.props;
 
 		debug( { supportVariation } );
 
@@ -601,15 +598,24 @@ class HelpContact extends React.Component {
 					<ActiveTicketsNotice count={ activeTicketCount } compact={ compact } />
 				) }
 
-				{ isUserAffectedByLiveChatClosure &&
-					( supportLevel === SUPPORT_LEVEL_PERSONAL ||
-						supportLevel === SUPPORT_LEVEL_PERSONAL_WITH_LEGACY_CHAT ) && (
-						<ChatCovidLimitedAvailabilityNotice
-							showAt="2020-08-24"
-							hideAt="2020-10-05"
+				{ isUserAffectedByLiveChatClosure && (
+					<>
+						<ChatHolidayClosureNotice
+							holidayName="Christmas"
 							compact={ compact }
+							displayAt="2020-12-17 00:00Z"
+							closesAt="2020-12-24 00:00Z"
+							reopensAt="2020-12-26 07:00Z"
 						/>
-					) }
+						<ChatHolidayClosureNotice
+							holidayName="New Year's Day"
+							compact={ compact }
+							displayAt="2020-12-26 07:00Z"
+							closesAt="2020-12-31 00:00Z"
+							reopensAt="2021-01-02 07:00Z"
+						/>
+					</>
+				) }
 
 				{ this.shouldShowTicketRequestErrorNotice( supportVariation ) && (
 					<Notice


### PR DESCRIPTION
Adds closure notices for Christmas and New Year's Day to the contact form and Quick Start signup form.

### To test

Open both http://calypso.localhost:3000/me/concierge and http://calypso.localhost:3000/help/contact. Adjust your system clock to the following dates and refresh both pages to ensure the results match up:

- **2020-12-16 23:00 UTC** — No notices appear
- **2020-12-17 0:00 UTC** — "____ will be closed for Christmas"
- **2020-12-24 0:00 UTC** — "____ closed for Christmas"
- **2020-12-26 7:00 UTC** — "____ will be closed for New Year's Eve"
- **2020-12-31 0:00 UTC** — "____ closed for New Year's Eve"
- **2021-01-02 7:00 UTC** — No notices appear
