### PR TITLE
Default to FTP for new Jetpack credentials form

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
@@ -342,8 +342,8 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 					onChange={ handleFormChange }
 					disabled={ disabled }
 				>
-					<option value="ssh">{ translate( 'SSH/SFTP' ) }</option>
 					<option value="ftp">{ translate( 'FTP' ) }</option>
+					<option value="ssh">{ translate( 'SSH/SFTP' ) }</option>
 				</FormSelect>
 			</FormFieldset>
 

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/form.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/form.ts
@@ -28,9 +28,9 @@ export interface FormState {
 }
 
 export const INITIAL_FORM_STATE: FormState = {
-	protocol: 'ssh',
+	protocol: 'ftp',
 	host: '',
-	port: 22,
+	port: 21,
 	user: '',
 	pass: '',
 	path: '',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Default to FTP as this is the most common on the new credentials form

![Screenshot 2020-10-26 at 10 33 53](https://user-images.githubusercontent.com/411945/97156443-fc376280-1776-11eb-8a72-79f2a39ab779.png)

#### Testing instructions

* Head to cloud.jetpack.com
* Use the flag ` ?flags=+jetpack/server-credentials-advanced-flow`
* Test the new credentials flow and ensure FTP is the default

