### PR TITLE
Launch: Hide inline help button when launch modal opens.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
+import { doAction, hasAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -30,6 +31,13 @@ registerPlugin( 'a8c-editor-site-launch', {
 			// @automattic/viewport doesn't have a breakpoint for medium (782px)
 			window.innerWidth < 782 ? setSidebarFullscreen() : unsetSidebarFullscreen();
 		}, [ isSidebarOpen, setSidebarFullscreen, unsetSidebarFullscreen ] );
+
+		React.useEffect( () => {
+			const TOGGLE_INLINE_HELP_BUTTON_ACTION = 'a8c.wpcom-block-editor.toggleInlineHelpButton';
+			if ( hasAction( TOGGLE_INLINE_HELP_BUTTON_ACTION ) ) {
+				doAction( TOGGLE_INLINE_HELP_BUTTON_ACTION, { hidden: isSidebarOpen } );
+			}
+		}, [ isSidebarOpen ] );
 
 		if ( ! isSidebarOpen ) {
 			return null;

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -947,6 +947,20 @@ function handleCheckoutModal( calypsoPort ) {
 	};
 }
 
+function handleInlineHelpButton( calypsoPort ) {
+	addAction(
+		'a8c.wpcom-block-editor.toggleInlineHelpButton',
+		'a8c/wpcom-block-editor/toggleInlineHelpButton',
+		/** @type {({ hidden: boolean }) => void} */
+		( data ) => {
+			calypsoPort.postMessage( {
+				action: 'toggleInlineHelpButton',
+				payload: data,
+			} );
+		}
+	);
+}
+
 function initPort( message ) {
 	if ( 'initPort' !== message.data.action ) {
 		return;
@@ -1051,6 +1065,8 @@ function initPort( message ) {
 		handleEditorLoaded( calypsoPort );
 
 		handleCheckoutModal( calypsoPort );
+
+		handleInlineHelpButton( calypsoPort );
 	}
 
 	window.removeEventListener( 'message', initPort, false );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -121,7 +121,7 @@ enum EditorActions {
 	GetCloseButtonUrl = 'getCloseButtonUrl',
 	LogError = 'logError',
 	GetGutenboardingStatus = 'getGutenboardingStatus',
-	ToggleInlineHelp = 'toggleInlineHelp',
+	ToggleInlineHelpButton = 'toggleInlineHelpButton',
 	GetNavSidebarLabels = 'getNavSidebarLabels',
 	GetCalypsoUrlInfo = 'getCalypsoUrlInfo',
 	TrackPerformance = 'trackPerformance',
@@ -385,10 +385,12 @@ class CalypsoifyIframe extends Component<
 			} );
 		}
 
-		if ( EditorActions.ToggleInlineHelp === action ) {
+		if ( EditorActions.ToggleInlineHelpButton === action ) {
 			const inlineHelp = window.top.document.querySelector( '#wpcom > .layout > .inline-help' );
-			const { hidden } = payload;
-			inlineHelp.hidden = hidden;
+
+			if ( inlineHelp ) {
+				inlineHelp.hidden = payload.hidden;
+			}
 		}
 
 		if ( EditorActions.GetNavSidebarLabels === action ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide inline help button when launch modal opens using WP actions.
* `toggleInlineHelp` renamed to `toggleInlineHelpButton` to prevent confusion with existing function `toggleInlineHelp` in `client/blocks/inline-help`.

#### Testing instructions

* `yarn start` on root calypso.
* `yarn dev --sync` on `apps/editing-toolkit`.
* `yarn dev --sync` on `apps/wpcom-block-editor`.
* sandbox `widgets.wp.com`.
* create and sandbox an unlaunched site.
* test on the block editor via the local calypso url with the `gutenboarding/new-launch-mobile` feature flag, e.g. `http://calypso.localhost:3000/post/YOUR_UNLAUNCHED_SITE.wordpress.com/home?flags=gutenboarding/new-launch-mobile`
* opening launch modal, the inline help button should be hidden.
* close the launch modal, the inline help button should be visible.

#### Screenshot

![image](https://user-images.githubusercontent.com/1287077/97175126-4cbcb900-1793-11eb-9e74-a3d42c77645a.png)

![image](https://user-images.githubusercontent.com/1287077/97175138-50e8d680-1793-11eb-9005-e32fe7d8005a.png)


Fixes https://github.com/Automattic/wp-calypso/pull/46475
