### PR TITLE
Don't show placeholder when loading JITM UI

### DIFF
--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -28,15 +28,32 @@ import './style.scss';
 const debug = debugFactory( 'calypso:jitm' );
 
 function renderTemplate( template, props ) {
-	if ( template === 'notice' ) {
-		return <AsyncLoad { ...props } require="calypso/blocks/jitm/templates/notice" />;
+	switch ( template ) {
+		case 'notice':
+			return (
+				<AsyncLoad
+					{ ...props }
+					require="calypso/blocks/jitm/templates/notice"
+					placeholder={ null }
+				/>
+			);
+		case 'sidebar-banner':
+			return (
+				<AsyncLoad
+					{ ...props }
+					require="calypso/blocks/jitm/templates/sidebar-banner"
+					placeholder={ null }
+				/>
+			);
+		default:
+			return (
+				<AsyncLoad
+					{ ...props }
+					require="calypso/blocks/jitm/templates/default"
+					placeholder={ null }
+				/>
+			);
 	}
-
-	if ( template === 'sidebar-banner' ) {
-		return <AsyncLoad { ...props } require="calypso/blocks/jitm/templates/sidebar-banner" />;
-	}
-
-	return <AsyncLoad { ...props } require="calypso/blocks/jitm/templates/default" />;
 }
 
 function getEventHandlers( props, dispatch ) {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -345,7 +345,11 @@ class ThemeSheet extends React.Component {
 		return (
 			<div className="theme__sheet-content">
 				{ config.isEnabled( 'jitms' ) && this.props.siteSlug && (
-					<AsyncLoad require="calypso/blocks/jitm" messagePathSuffix={ 'admin_notices' } />
+					<AsyncLoad
+						require="calypso/blocks/jitm"
+						placeholder={ null }
+						messagePathSuffix="admin_notices"
+					/>
 				) }
 				{ this.renderSectionNav( section ) }
 				{ activeSection }


### PR DESCRIPTION
Fixes a little bug where the sidebar shows a placeholder while the `blocks/jitm` component is async-loading:

![Screen Capture on 2020-10-26 at 15-01-49](https://user-images.githubusercontent.com/664258/97185307-310bdf80-17a0-11eb-92a4-198792f646d9.gif)

Notice the horizontal bar that looks like a scrollbar that appears for a moment.

This PR removes that by setting `placeholder={ null }`. There's one more similar instance in Themes.