### PR TITLE
Checkout: Do not create Apple Pay stripe.paymentRequest if there is no currency set

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -173,7 +173,7 @@ function useStripePaymentRequest( { paymentRequestOptions, onSubmit, stripe } ) 
 
 	useEffect( () => {
 		let isSubscribed = true;
-		if ( ! stripe ) {
+		if ( ! stripe || ! paymentRequestOptions ) {
 			return;
 		}
 		const request = stripe.paymentRequest( paymentRequestOptions );

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -136,21 +136,23 @@ const PAYMENT_REQUEST_OPTIONS = {
 
 function usePaymentRequestOptions( stripeConfiguration ) {
 	const [ items, total ] = useLineItems();
-	const countryCode = getProcessorCountryFromStripeConfiguration( stripeConfiguration );
+	const country = getProcessorCountryFromStripeConfiguration( stripeConfiguration );
 	const currency = items.reduce(
 		( firstCurrency, item ) => firstCurrency || item.amount.currency,
 		null
 	);
-	const paymentRequestOptions = useMemo(
-		() => ( {
-			country: countryCode,
-			currency: currency && currency.toLowerCase(),
-			displayItems: getDisplayItemsForLineItems( items ),
+	const paymentRequestOptions = useMemo( () => {
+		if ( ! currency || ! total.amount.value ) {
+			return null;
+		}
+		return {
+			country,
+			currency: currency?.toLowerCase(),
 			total: getPaymentRequestTotalFromTotal( total ),
+			displayItems: getDisplayItemsForLineItems( items ),
 			...PAYMENT_REQUEST_OPTIONS,
-		} ),
-		[ countryCode, currency, items, total ]
-	);
+		};
+	}, [ country, currency, items, total ] );
 	return paymentRequestOptions;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When checkout loads the Apple Pay payment method, it's possible (although I'm still not sure how, exactly) for there to be no currency in the shopping cart's line items; this may be because the shopping cart's item list is empty (unlikely since checkout does not load the payment methods until the shopping cart is loaded), or because the items have no `currency` set (unlikely since the currency is required and validated by the composite-checkout package). It _might_ happen if the cart key changes after checkout has already loaded (the issues we are seeing started with #46532 so it's likely that something happened there).

In any case, the code already allows for an empty currency, but it sends that empty currency to Stripe's `stripe.paymentRequest()` function, causing that function to throw an error like `Invalid value for paymentRequest(): currency should be one of the following strings`.

In this PR, we prevent attempting to call `stripe.paymentRequest()` if either its currency or total are not set. This will have the effect that the Apple Pay button will still appear to be loading if the customer chooses it as a payment method. Since it's likely that this issue only occurs while the cart is still loading, that shouldn't be an issue.

Fixes https://github.com/Automattic/wp-calypso/issues/46753 although not the way I had planned.

#### Testing instructions

Test an Apple Pay purchase. Verify that you get the apple pay dialog. Testing the actual purchase is less important.

<img width="606" alt="Screen Shot 2020-10-26 at 11 22 01 AM" src="https://user-images.githubusercontent.com/2036909/97191764-94d0e100-177d-11eb-8eec-c35fecc0d801.png">

