### PR TITLE
Atomic: Don't use front page editor for Atomic sites yet

### DIFF
--- a/client/state/selectors/get-customize-or-edit-front-page-url.js
+++ b/client/state/selectors/get-customize-or-edit-front-page-url.js
@@ -5,6 +5,8 @@ import { getThemeCustomizeUrl, isThemeActive } from 'calypso/state/themes/select
 import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
 import getFrontPageEditorUrl from 'calypso/state/selectors/get-front-page-editor-url';
 import shouldCustomizeHomepageWithGutenberg from 'calypso/state/selectors/should-customize-homepage-with-gutenberg';
+import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+
 /**
  * Returns the URL for opening customizing the given site in either the block editor with
  * Full Site Editing, or the Customizer for unsupported sites. Can be used wherever
@@ -22,9 +24,10 @@ export default function getCustomizeOrEditFrontPageUrl( state, themeId, siteId )
 	const shouldUseGutenberg =
 		shouldCustomizeHomepageWithGutenberg( state, siteId ) ||
 		isSiteUsingFullSiteEditing( state, siteId );
+	const isAtomic = isSiteAtomic( state, siteId );
 
 	// If the theme is not active, use the other function to preview customization with the theme.
-	if ( shouldUseGutenberg && isThemeActive( state, themeId, siteId ) ) {
+	if ( ! isAtomic && shouldUseGutenberg && isThemeActive( state, themeId, siteId ) ) {
 		return getFrontPageEditorUrl( state, siteId );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Don't use front page editor for Atomic sites yet

#### Testing instructions

- Create an atomic site with `brompton` theme
- Visit `/themes/tooloom.jp`

Before:
- Errors in console.

After:
- No errors in console, and page is shown

Reference: p9F6qB-63w-p2