### PR TITLE
Create product card for i2 version of pricing page

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/assets/ribbon.svg
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/assets/ribbon.svg
@@ -1,0 +1,18 @@
+<svg width="103" height="85" viewBox="0 0 103 85" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M96 2H99L100 4H96V2Z" fill="#007117"/>
+<path d="M4 77H6V80L4 79V77Z" fill="#007117"/>
+<g filter="url(#filter0_d)">
+<path d="M72.3791 2L4 57.4615V79L99 2H72.3791Z" fill="#069E08"/>
+</g>
+<defs>
+<filter id="filter0_d" x="0" y="0" width="103" height="85" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/features-item.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/features-item.tsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { isObject } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'calypso/components/gridicon';
+import InfoPopover from 'calypso/components/info-popover';
+import { preventWidows } from 'calypso/lib/formatting';
+
+/**
+ * Type dependencies
+ */
+import type { ProductCardFeaturesItem } from './types';
+
+export type Props = {
+	item: ProductCardFeaturesItem;
+};
+
+type IconComponent = FunctionComponent< { icon: string; className?: string } >;
+
+const DEFAULT_ICON = 'checkmark';
+
+const JetpackProductCardFeaturesItem: FunctionComponent< Props > = ( { item } ) => {
+	const { icon, text, description, subitems } = item;
+	const iconName = ( isObject( icon ) ? icon?.icon : icon ) || DEFAULT_ICON;
+	const Icon = ( ( isObject( icon ) && icon?.component ) || Gridicon ) as IconComponent;
+
+	return (
+		<li className="jetpack-product-card-alt-2__features-item">
+			<div className="jetpack-product-card-alt-2__features-main">
+				<div className="jetpack-product-card-alt-2__features-summary">
+					<Icon className="jetpack-product-card-alt-2__features-icon" icon={ iconName } />
+					<p className="jetpack-product-card-alt-2__features-text">{ preventWidows( text ) }</p>
+				</div>
+				{ description && <InfoPopover>{ preventWidows( description ) }</InfoPopover> }
+			</div>
+			{ subitems && subitems?.length > 0 && (
+				<ul className="jetpack-product-card-alt-2__features-subitems">
+					{ subitems.map( ( subitem, index ) => (
+						<JetpackProductCardFeaturesItem key={ index } item={ subitem } />
+					) ) }
+				</ul>
+			) }
+		</li>
+	);
+};
+
+export default JetpackProductCardFeaturesItem;

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/features.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/features.tsx
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import React, { useState, useCallback, FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'calypso/components/external-link';
+import FoldableCard from 'calypso/components/foldable-card';
+import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import FeaturesItem from './features-item';
+
+/**
+ * Type dependencies
+ */
+import type {
+	ProductCardFeatures,
+	ProductCardFeaturesSection,
+	ProductCardFeaturesItem,
+} from './types';
+
+export type Props = {
+	className?: string;
+	features: ProductCardFeatures;
+	isExpanded?: boolean;
+	productSlug?: string;
+};
+
+const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
+	className,
+	features,
+	isExpanded: isExpandedByDefault,
+	productSlug,
+} ) => {
+	const trackProps = productSlug ? { product_slug: productSlug } : {};
+	const trackShowFeatures = useTrackCallback(
+		undefined,
+		'calypso_product_features_open',
+		trackProps
+	);
+	const trackHideFeatures = useTrackCallback(
+		undefined,
+		'calypso_product_features_close',
+		trackProps
+	);
+	const [ isExpanded, setExpanded ] = useState( !! isExpandedByDefault );
+	const onOpen = useCallback( () => {
+		setExpanded( true );
+		trackShowFeatures();
+	}, [ setExpanded, trackShowFeatures ] );
+	const onClose = useCallback( () => {
+		setExpanded( false );
+		trackHideFeatures();
+	}, [ setExpanded, trackHideFeatures ] );
+	const translate = useTranslate();
+
+	const { items, more } = features;
+
+	return (
+		<FoldableCard
+			className={ className }
+			header={ isExpanded ? translate( 'Hide features' ) : translate( 'Show features' ) }
+			clickableHeader
+			expanded={ isExpanded }
+			onOpen={ onOpen }
+			onClose={ onClose }
+		>
+			<ul className="jetpack-product-card-alt-2__features-list">
+				{ ( items as ( ProductCardFeaturesItem | ProductCardFeaturesSection )[] ).map(
+					( item, i ) => {
+						if ( 'heading' in item && 'list' in item ) {
+							return (
+								<li key={ i }>
+									<p className="jetpack-product-card-alt-2__features-category">{ item.heading }</p>
+									<ul className="jetpack-product-card-alt-2__features-list">
+										{ item.list.map( ( subitem, j ) => (
+											<FeaturesItem key={ j } item={ subitem } />
+										) ) }
+									</ul>
+								</li>
+							);
+						}
+
+						return <FeaturesItem key={ i } item={ item } />;
+					}
+				) }
+			</ul>
+			{ more && (
+				<div className="jetpack-product-card-alt-2__feature-more">
+					<ExternalLink icon={ true } href={ more.url }>
+						{ more.label }
+					</ExternalLink>
+				</div>
+			) }
+		</FoldableCard>
+	);
+};
+
+export default JetpackProductCardFeatures;

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/features.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/features.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useTranslate } from 'i18n-calypso';
-import React, { useState, useCallback, FunctionComponent } from 'react';
+import React, { useState, useCallback, FunctionComponent, ReactNode } from 'react';
 
 /**
  * Internal dependencies
@@ -26,6 +26,7 @@ export type Props = {
 	features: ProductCardFeatures;
 	isExpanded?: boolean;
 	productSlug?: string;
+	ctaElt: ReactNode;
 };
 
 const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
@@ -33,6 +34,7 @@ const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
 	features,
 	isExpanded: isExpandedByDefault,
 	productSlug,
+	ctaElt,
 } ) => {
 	const trackProps = productSlug ? { product_slug: productSlug } : {};
 	const trackShowFeatures = useTrackCallback(
@@ -94,6 +96,7 @@ const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
 					</ExternalLink>
 				</div>
 			) }
+			<div className="jetpack-product-card-alt-2__feature-cta">{ ctaElt }</div>
 		</FoldableCard>
 	);
 };

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
@@ -1,0 +1,219 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { isFinite, isNumber } from 'lodash';
+import React, { createElement, ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Button, ProductIcon } from '@automattic/components';
+import InfoPopover from 'calypso/components/info-popover';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { preventWidows } from 'calypso/lib/formatting';
+import PlanPrice from 'calypso/my-sites/plan-price';
+import PlanPriceFree from 'calypso/my-sites/plan-price-free';
+import JetpackProductCardFeatures, { Props as FeaturesProps } from './features';
+
+/**
+ * Type dependencies
+ */
+import type { Moment } from 'moment';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+type OwnProps = {
+	className?: string;
+	iconSlug: string;
+	productName: TranslateResult;
+	productType?: string;
+	headingLevel?: number;
+	subheadline?: TranslateResult;
+	description?: ReactNode;
+	currencyCode: string | null;
+	originalPrice: number;
+	discountedPrice?: number;
+	withStartingPrice?: boolean;
+	billingTimeFrame: TranslateResult;
+	buttonLabel: TranslateResult;
+	buttonPrimary: boolean;
+	badgeLabel?: TranslateResult;
+	onButtonClick: () => void;
+	cancelLabel?: TranslateResult;
+	onCancelClick?: () => void;
+	searchRecordsDetails?: ReactNode;
+	isHighlighted?: boolean;
+	isOwned?: boolean;
+	isDeprecated?: boolean;
+	expiryDate?: Moment;
+	isFree?: boolean;
+};
+
+export type Props = OwnProps & Partial< FeaturesProps >;
+
+const JetpackProductCardAlt2 = ( {
+	className,
+	iconSlug,
+	productName,
+	productType,
+	headingLevel,
+	subheadline,
+	description,
+	currencyCode,
+	originalPrice,
+	discountedPrice,
+	withStartingPrice,
+	billingTimeFrame,
+	buttonLabel,
+	buttonPrimary,
+	badgeLabel,
+	onButtonClick,
+	cancelLabel,
+	onCancelClick,
+	searchRecordsDetails,
+	isHighlighted,
+	isOwned,
+	isDeprecated,
+	expiryDate,
+	features,
+	isExpanded,
+	isFree,
+	productSlug,
+}: Props ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
+	const isDiscounted = isFinite( discountedPrice );
+	const parsedHeadingLevel = isNumber( headingLevel )
+		? Math.min( Math.max( Math.floor( headingLevel ), 1 ), 6 )
+		: 2;
+	const parsedExpiryDate =
+		moment.isMoment( expiryDate ) && expiryDate.isValid() ? expiryDate : null;
+
+	const renderBillingTimeFrame = (
+		productExpiryDate: Moment | null,
+		billingTerm: TranslateResult
+	) => {
+		return productExpiryDate ? (
+			<time
+				className="jetpack-product-card-alt-2__expiration-date"
+				dateTime={ productExpiryDate.format( 'YYYY-DD-YY' ) }
+			>
+				{ translate( 'expires %(date)s', {
+					args: {
+						date: productExpiryDate.format( 'L' ),
+					},
+				} ) }
+			</time>
+		) : (
+			<span className="jetpack-product-card-alt-2__billing-time-frame">{ billingTerm }</span>
+		);
+	};
+
+	return (
+		<div
+			className={ classNames( className, 'jetpack-product-card-alt-2', {
+				'is-owned': isOwned,
+				'is-deprecated': isDeprecated,
+				'is-featured': isHighlighted,
+			} ) }
+			data-e2e-product-slug={ productSlug }
+		>
+			<div className="jetpack-product-card-alt-2__summary">
+				<header className="jetpack-product-card-alt-2__header">
+					<ProductIcon className="jetpack-product-card-alt-2__icon" slug={ iconSlug } />
+					{ createElement(
+						`h${ parsedHeadingLevel }`,
+						{ className: 'jetpack-product-card-alt-2__product-name' },
+						<>
+							{ preventWidows( productName ) }
+							{ productType && (
+								<span className="jetpack-product-card-alt-2__product-type">
+									{ ' ' }
+									{ preventWidows( productType ) }
+								</span>
+							) }
+						</>
+					) }
+
+					{ subheadline && (
+						<p className="jetpack-product-card-alt-2__subheadline">
+							{ preventWidows( subheadline ) }
+						</p>
+					) }
+
+					{ isFree ? (
+						<PlanPriceFree productSlug={ productSlug } />
+					) : (
+						<div className="jetpack-product-card-alt-2__price">
+							{ currencyCode && originalPrice ? (
+								<>
+									<span className="jetpack-product-card-alt-2__raw-price">
+										{ withStartingPrice && (
+											<span className="jetpack-product-card-alt-2__from">
+												{ translate( 'from' ) }
+											</span>
+										) }
+
+										<PlanPrice
+											rawPrice={ isDiscounted ? discountedPrice : originalPrice }
+											discounted
+											currencyCode={ currencyCode }
+										/>
+
+										{ searchRecordsDetails && (
+											<InfoPopover
+												className="jetpack-product-card-alt-2__search-price-popover"
+												position="right"
+											>
+												{ searchRecordsDetails }
+											</InfoPopover>
+										) }
+									</span>
+									{ renderBillingTimeFrame( parsedExpiryDate, billingTimeFrame ) }
+								</>
+							) : (
+								<>
+									<div className="jetpack-product-card-alt-2__price-placeholder" />
+									<div className="jetpack-product-card-alt-2__time-frame-placeholder" />
+								</>
+							) }
+						</div>
+					) }
+				</header>
+				<div className="jetpack-product-card-alt-2__body">
+					<span className="jetpack-product-card-alt-2__badge">{ badgeLabel }</span>
+					<Button
+						primary={ buttonPrimary }
+						className="jetpack-product-card-alt-2__button"
+						onClick={ onButtonClick }
+					>
+						{ buttonLabel }
+					</Button>
+					{ cancelLabel && (
+						<Button className="jetpack-product-card-alt-2__cancel" onClick={ onCancelClick }>
+							{ cancelLabel }
+						</Button>
+					) }
+					{ description && (
+						<p className="jetpack-product-card-alt-2__description">{ description }</p>
+					) }
+				</div>
+			</div>
+			{ features && features.items.length > 0 && (
+				<JetpackProductCardFeatures
+					features={ features }
+					productSlug={ productSlug }
+					isExpanded={ isExpanded }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default JetpackProductCardAlt2;

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
@@ -108,6 +108,16 @@ const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 		);
 	};
 
+	const buttonElt = (
+		<Button
+			primary={ buttonPrimary }
+			className="jetpack-product-card-alt-2__button"
+			onClick={ onButtonClick }
+		>
+			{ buttonLabel }
+		</Button>
+	);
+
 	return (
 		<div
 			className={ classNames( className, 'jetpack-product-card-alt-2', {
@@ -177,13 +187,7 @@ const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 					) }
 				</header>
 				<div className="jetpack-product-card-alt-2__body">
-					<Button
-						primary={ buttonPrimary }
-						className="jetpack-product-card-alt-2__button"
-						onClick={ onButtonClick }
-					>
-						{ buttonLabel }
-					</Button>
+					{ buttonElt }
 					{ description && (
 						<p className="jetpack-product-card-alt-2__description">{ description }</p>
 					) }
@@ -194,6 +198,7 @@ const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 					features={ features }
 					productSlug={ productSlug }
 					isExpanded={ isExpanded }
+					ctaElt={ buttonElt }
 				/>
 			) }
 		</div>

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
@@ -4,7 +4,7 @@
 import classNames from 'classnames';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { isFinite, isNumber } from 'lodash';
-import React, { createElement, ReactNode } from 'react';
+import React, { createElement, ReactNode, FunctionComponent } from 'react';
 
 /**
  * Internal dependencies
@@ -26,6 +26,7 @@ import type { Moment } from 'moment';
  * Style dependencies
  */
 import './style.scss';
+import ribbonSvg from './assets/ribbon.svg';
 
 type OwnProps = {
 	className?: string;
@@ -38,14 +39,10 @@ type OwnProps = {
 	currencyCode: string | null;
 	originalPrice: number;
 	discountedPrice?: number;
-	withStartingPrice?: boolean;
 	billingTimeFrame: TranslateResult;
 	buttonLabel: TranslateResult;
 	buttonPrimary: boolean;
-	badgeLabel?: TranslateResult;
 	onButtonClick: () => void;
-	cancelLabel?: TranslateResult;
-	onCancelClick?: () => void;
 	searchRecordsDetails?: ReactNode;
 	isHighlighted?: boolean;
 	isOwned?: boolean;
@@ -56,7 +53,7 @@ type OwnProps = {
 
 export type Props = OwnProps & Partial< FeaturesProps >;
 
-const JetpackProductCardAlt2 = ( {
+const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 	className,
 	iconSlug,
 	productName,
@@ -67,14 +64,10 @@ const JetpackProductCardAlt2 = ( {
 	currencyCode,
 	originalPrice,
 	discountedPrice,
-	withStartingPrice,
 	billingTimeFrame,
 	buttonLabel,
 	buttonPrimary,
-	badgeLabel,
 	onButtonClick,
-	cancelLabel,
-	onCancelClick,
 	searchRecordsDetails,
 	isHighlighted,
 	isOwned,
@@ -124,6 +117,10 @@ const JetpackProductCardAlt2 = ( {
 			} ) }
 			data-e2e-product-slug={ productSlug }
 		>
+			<div className="jetpack-product-card-alt-2__ribbon">
+				<span className="jetpack-product-card-alt-2__ribbon-text">{ translate( 'Bundle' ) }</span>
+				<img className="jetpack-product-card-alt-2__ribbon-img" src={ ribbonSvg } alt="" />
+			</div>
 			<div className="jetpack-product-card-alt-2__summary">
 				<header className="jetpack-product-card-alt-2__header">
 					<ProductIcon className="jetpack-product-card-alt-2__icon" slug={ iconSlug } />
@@ -154,18 +151,11 @@ const JetpackProductCardAlt2 = ( {
 							{ currencyCode && originalPrice ? (
 								<>
 									<span className="jetpack-product-card-alt-2__raw-price">
-										{ withStartingPrice && (
-											<span className="jetpack-product-card-alt-2__from">
-												{ translate( 'from' ) }
-											</span>
-										) }
-
 										<PlanPrice
 											rawPrice={ isDiscounted ? discountedPrice : originalPrice }
 											discounted
 											currencyCode={ currencyCode }
 										/>
-
 										{ searchRecordsDetails && (
 											<InfoPopover
 												className="jetpack-product-card-alt-2__search-price-popover"
@@ -187,7 +177,6 @@ const JetpackProductCardAlt2 = ( {
 					) }
 				</header>
 				<div className="jetpack-product-card-alt-2__body">
-					<span className="jetpack-product-card-alt-2__badge">{ badgeLabel }</span>
 					<Button
 						primary={ buttonPrimary }
 						className="jetpack-product-card-alt-2__button"
@@ -195,11 +184,6 @@ const JetpackProductCardAlt2 = ( {
 					>
 						{ buttonLabel }
 					</Button>
-					{ cancelLabel && (
-						<Button className="jetpack-product-card-alt-2__cancel" onClick={ onCancelClick }>
-							{ cancelLabel }
-						</Button>
-					) }
 					{ description && (
 						<p className="jetpack-product-card-alt-2__description">{ description }</p>
 					) }

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
@@ -78,18 +78,45 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 	}
 }
 
+.jetpack-product-card-alt-2__ribbon {
+	position: absolute;
+	top: -4px;
+	left: -6px;
+}
+
+.jetpack-product-card-alt-2__ribbon-text {
+	position: absolute;
+	// Position text to left edge of the ribbon
+	bottom: 13px;
+	left: 4px;
+
+	width: 100%;
+
+	color: var( --color-text-inverted );
+
+	line-height: 20px; // Ribbon height
+	font-size: 0.75rem;
+	font-weight: 700;
+	text-align: center;
+	text-transform: uppercase;
+
+	transform-origin: 0 0;
+	// Then rotate it, and apply some offset to nail centering
+	transform: rotate( -39deg ) translate( -2px, -2px );
+}
+
 .jetpack-product-card-alt-2__summary {
 	min-height: unset;
 
 	@media ( min-width: 600px ) {
-		min-height: 435px;
+		min-height: 350px;
 	}
 }
 
 .jetpack-product-card-alt-2__header {
 	position: relative;
 
-	padding: 42px 16px 12px;
+	padding: 64px 16px 12px;
 
 	text-align: center;
 }
@@ -104,7 +131,7 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 }
 
 .jetpack-product-card-alt-2__product-name {
-	margin-bottom: 6px;
+	margin-bottom: 2px;
 
 	font-size: $font-title-medium;
 	font-weight: 600;
@@ -117,7 +144,7 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 }
 
 .jetpack-product-card-alt-2__subheadline {
-	margin-bottom: 16px;
+	margin-bottom: 0;
 
 	color: var( --color-neutral-50 );
 
@@ -135,13 +162,15 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 	justify-content: center;
 	align-items: center;
 
-	margin-bottom: 20px;
+	margin-bottom: 12px;
 }
 
 .jetpack-product-card-alt-2__from,
 .jetpack-product-card-alt-2__billing-time-frame,
 .jetpack-product-card-alt-2__expiration-date {
 	display: block;
+
+	margin-top: -8px;
 
 	color: var( --color-text-subtle );
 
@@ -158,15 +187,10 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 	text-align: right;
 }
 
-.jetpack-product-card-alt-2__from {
-	margin: 0 8px 8px 0;
-}
-
 .jetpack-product-card-alt-2__raw-price {
 	display: flex;
 	justify-content: center;
 	align-items: flex-end;
-	margin-bottom: 4px;
 
 	:last-child {
 		margin-right: 0;
@@ -213,29 +237,6 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 	padding: 0 16px;
 }
 
-.jetpack-product-card-alt-2__discount-message {
-	margin: -20px 0 16px;
-
-	color: var( --color-success-40 );
-
-	font-style: italic;
-}
-
-.jetpack-product-card-alt-2__badge {
-	display: block;
-
-	margin: -10px 0 10px;
-
-	min-height: 12px;
-
-	color: var( --color-primary );
-
-	font-size: $font-body-extra-small;
-	font-style: italic;
-	line-height: 1;
-	text-align: center;
-}
-
 .jetpack-product-card-alt-2 .button {
 	width: 100%;
 	margin-bottom: 30px;
@@ -244,8 +245,10 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 }
 
 .jetpack-product-card-alt-2__description {
-	margin-bottom: 10px;
+	margin-bottom: 0;
 	padding: 0 4px;
+
+	color: var( --studio-gray-70 );
 }
 
 .jetpack-product-card-alt-2__search-price-popover {
@@ -345,8 +348,9 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 	@include placeholder( --color-neutral-10 );
 
 	width: 100px;
-	min-height: 72px;
+	height: 50px;
 	margin-bottom: 4px;
+	margin-top: 12px;
 }
 
 .jetpack-product-card-alt-2__time-frame-placeholder {

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
@@ -1,0 +1,357 @@
+$jetpack-product-card-alt-2-color: var( --studio-wordpress-blue-30 );
+$jetpack-product-card-alt-2-circle-size: 65px;
+$jetpack-product-card-alt-2-icon-size: 55px;
+
+.jetpack-product-card-alt-2 {
+	position: relative;
+
+	box-sizing: border-box;
+	margin: calc( 24px + #{$jetpack-product-card-alt-2-circle-size/2} ) 0 24px;
+
+	background: var( --color-surface );
+	border: 1px solid var( --color-border-subtle );
+	border-left: none;
+	border-right: none;
+
+	// Top circle
+	&::before {
+		content: '';
+
+		position: absolute;
+		top: -$jetpack-product-card-alt-2-circle-size/2;
+		left: calc( 50% - #{$jetpack-product-card-alt-2-circle-size/2} );
+
+		display: block;
+		box-sizing: border-box;
+		width: $jetpack-product-card-alt-2-circle-size;
+		height: $jetpack-product-card-alt-2-circle-size;
+
+		background: inherit;
+		border: 1px solid var( --color-border-subtle );
+		border-radius: 50%;
+	}
+
+	// Mask for the bottom half of the circle
+	&::after {
+		content: '';
+
+		position: absolute;
+		top: 0;
+		left: calc( 50% - #{$jetpack-product-card-alt-2-circle-size/2} );
+
+		display: block;
+		width: $jetpack-product-card-alt-2-circle-size;
+		height: $jetpack-product-card-alt-2-circle-size/2;
+
+		background: inherit;
+	}
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+
+	.foldable-card {
+		margin-bottom: 0;
+
+		font-size: $font-body;
+
+		background: var( --color-gray-0 );
+
+		box-shadow: none;
+		&.card.is-expanded {
+			margin-top: 0;
+		}
+	}
+
+	@media ( min-width: 660px ) {
+		border-left: 1px solid var( --color-border-subtle );
+		border-right: 1px solid var( --color-border-subtle );
+
+		&:not( .with-nudge ) .foldable-card {
+			border-bottom-left-radius: 2px;
+			border-bottom-right-radius: 2px;
+		}
+
+		.foldable-card--square-border {
+			border-radius: 0;
+		}
+	}
+}
+
+.jetpack-product-card-alt-2__summary {
+	min-height: unset;
+
+	@media ( min-width: 600px ) {
+		min-height: 435px;
+	}
+}
+
+.jetpack-product-card-alt-2__header {
+	position: relative;
+
+	padding: 42px 16px 12px;
+
+	text-align: center;
+}
+
+.jetpack-product-card-alt-2 .product-icon {
+	position: absolute;
+	top: -$jetpack-product-card-alt-2-icon-size/2;
+	left: calc( 50% - #{$jetpack-product-card-alt-2-icon-size/2} );
+	z-index: 1;
+
+	width: $jetpack-product-card-alt-2-icon-size;
+}
+
+.jetpack-product-card-alt-2__product-name {
+	margin-bottom: 6px;
+
+	font-size: $font-title-medium;
+	font-weight: 600;
+	line-height: rem( 30px ) / $font-title-medium;
+}
+
+.jetpack-product-card-alt-2__product-type {
+	font-style: italic;
+	font-weight: 400;
+}
+
+.jetpack-product-card-alt-2__subheadline {
+	margin-bottom: 16px;
+
+	color: var( --color-neutral-50 );
+
+	font-size: $font-body-extra-small;
+	line-height: rem( 16px ) / $font-body-extra-small;
+
+	@media ( min-width: 660px ) {
+		font-size: $font-body-small;
+	}
+}
+
+.jetpack-product-card-alt-2__price {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+
+	margin-bottom: 20px;
+}
+
+.jetpack-product-card-alt-2__from,
+.jetpack-product-card-alt-2__billing-time-frame,
+.jetpack-product-card-alt-2__expiration-date {
+	display: block;
+
+	color: var( --color-text-subtle );
+
+	font-size: $font-body-extra-small;
+	font-style: italic;
+	line-height: 1;
+}
+
+.jetpack-product-card-alt-2__expiration-date {
+	margin-top: 10px;
+
+	color: var( --studio-pink-50 );
+
+	text-align: right;
+}
+
+.jetpack-product-card-alt-2__from {
+	margin: 0 8px 8px 0;
+}
+
+.jetpack-product-card-alt-2__raw-price {
+	display: flex;
+	justify-content: center;
+	align-items: flex-end;
+	margin-bottom: 4px;
+
+	:last-child {
+		margin-right: 0;
+	}
+}
+
+.jetpack-product-card-alt-2 .plan-price {
+	display: flex;
+
+	border-color: $jetpack-product-card-alt-2-color;
+
+	sup {
+		margin-top: 13px;
+		top: 13px;
+
+		font-size: $font-title-small;
+		font-weight: 400;
+	}
+
+	sup.plan-price__currency-symbol {
+		left: -13px;
+	}
+
+	&.is-original::before {
+		// Enable the overwrite of the border color by setting it to .plan-price
+		border-color: inherit;
+	}
+
+	&.is-discounted {
+		color: var( --color-text );
+
+		.plan-price__currency-symbol {
+			color: inherit;
+		}
+	}
+}
+
+.jetpack-product-card-alt-2 .plan-price__integer {
+	font-size: $font-headline-medium;
+	font-weight: 600;
+}
+
+.jetpack-product-card-alt-2__body {
+	padding: 0 16px;
+}
+
+.jetpack-product-card-alt-2__discount-message {
+	margin: -20px 0 16px;
+
+	color: var( --color-success-40 );
+
+	font-style: italic;
+}
+
+.jetpack-product-card-alt-2__badge {
+	display: block;
+
+	margin: -10px 0 10px;
+
+	min-height: 12px;
+
+	color: var( --color-primary );
+
+	font-size: $font-body-extra-small;
+	font-style: italic;
+	line-height: 1;
+	text-align: center;
+}
+
+.jetpack-product-card-alt-2 .button {
+	width: 100%;
+	margin-bottom: 30px;
+
+	font-size: $font-body;
+}
+
+.jetpack-product-card-alt-2__description {
+	margin-bottom: 10px;
+	padding: 0 4px;
+}
+
+.jetpack-product-card-alt-2__search-price-popover {
+	margin-bottom: 40px;
+	margin-left: 24px;
+
+	.gridicon {
+		color: var( --studio-gray-20 );
+	}
+}
+
+.jetpack-product-card-alt-2 .foldable-card.is-expanded {
+	margin-bottom: 0;
+}
+
+.jetpack-product-card-alt-2 .foldable-card.is-expanded .foldable-card__content {
+	padding: 0 16px 16px;
+
+	border-top: none;
+}
+
+.jetpack-product-card-alt-2 .foldable-card .foldable-card__header {
+	color: var( --studio-gray-50 );
+
+	.gridicon {
+		fill: var( --studio-gray-50 );
+	}
+}
+
+.jetpack-product-card-alt-2__features-category {
+	margin: 8px 0 12px;
+	padding-bottom: 6px;
+
+	border-bottom: solid 1px var( --color-border-subtle );
+	color: var( --studio-gray-70 );
+
+	font-weight: 600;
+}
+
+.jetpack-product-card-alt-2__features-list {
+	margin: 0;
+
+	list-style-type: none;
+}
+
+.jetpack-product-card-alt-2__features-main {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 12px 0;
+}
+
+.jetpack-product-card-alt-2__features-subitems {
+	margin-left: 36px;
+
+	list-style-type: none;
+}
+
+.jetpack-product-card-alt-2__features-summary {
+	display: flex;
+	align-items: flex-start;
+}
+
+.jetpack-product-card-alt-2__features-text {
+	flex: 1;
+	margin: 0 16px 0 0;
+}
+
+.jetpack-product-card-alt-2__features-icon {
+	margin-right: 14px;
+	fill: var( --studio-gray-50 );
+	&.gridicons-lock,
+	&.gridicons-cloud-upload,
+	&.material-icon-security,
+	&.gridicons-bug {
+		background: var( --studio-blue );
+		fill: var( --studio-white );
+		border-radius: 50%;
+		padding: 5px;
+		width: 15px;
+		height: 15px;
+	}
+	&.gridicons-lock {
+		background: var( --studio-purple-50 );
+	}
+	&.gridicons-checkmark {
+		fill: $jetpack-product-card-alt-2-color;
+	}
+}
+
+.jetpack-product-card-alt-2__feature-more {
+	padding-top: 16px;
+}
+
+/* Prices Loading state */
+.jetpack-product-card-alt-2__price-placeholder {
+	@include placeholder( --color-neutral-10 );
+
+	width: 100px;
+	min-height: 72px;
+	margin-bottom: 4px;
+}
+
+.jetpack-product-card-alt-2__time-frame-placeholder {
+	@include placeholder( --color-neutral-10 );
+
+	width: 100px;
+	height: 12px;
+}

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
@@ -52,14 +52,16 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 
 	.foldable-card {
 		margin-bottom: 0;
+		padding: 0 10px;
 
-		font-size: $font-body;
+		font-size: 1rem;
 
 		background: var( --color-gray-0 );
-
 		box-shadow: none;
+
 		&.card.is-expanded {
 			margin-top: 0;
+			margin-bottom: 0;
 		}
 	}
 
@@ -165,7 +167,6 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 	margin-bottom: 12px;
 }
 
-.jetpack-product-card-alt-2__from,
 .jetpack-product-card-alt-2__billing-time-frame,
 .jetpack-product-card-alt-2__expiration-date {
 	display: block;
@@ -234,17 +235,17 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 }
 
 .jetpack-product-card-alt-2__body {
-	padding: 0 16px;
+	padding: 0 24px;
 }
 
 .jetpack-product-card-alt-2 .button {
 	width: 100%;
-	margin-bottom: 30px;
 
 	font-size: $font-body;
 }
 
 .jetpack-product-card-alt-2__description {
+	margin-top: 30px;
 	margin-bottom: 0;
 	padding: 0 4px;
 
@@ -260,12 +261,8 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 	}
 }
 
-.jetpack-product-card-alt-2 .foldable-card.is-expanded {
-	margin-bottom: 0;
-}
-
 .jetpack-product-card-alt-2 .foldable-card.is-expanded .foldable-card__content {
-	padding: 0 16px 16px;
+	padding: 0 16px;
 
 	border-top: none;
 }
@@ -341,6 +338,17 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 
 .jetpack-product-card-alt-2__feature-more {
 	padding-top: 16px;
+
+	a {
+		color: var( --studio-jetpack-green-40 );
+	}
+}
+
+.jetpack-product-card-alt-2__feature-cta {
+	margin: 32px -24px 0;
+	padding: 24px 28px;
+
+	border-top: solid 1px var( --color-border-subtle );
 }
 
 /* Prices Loading state */
@@ -358,4 +366,11 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 
 	width: 100px;
 	height: 12px;
+}
+
+/* Jetpack.com-only changes */
+.is-section-jetpack-cloud-pricing {
+	.jetpack-product-card-alt-2 {
+		background-color: #f6f7f7;
+	}
 }

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/types.ts
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Type dependencies
+ */
+import type {
+	SelectorProductFeaturesItem,
+	SelectorProductFeaturesSection,
+	SelectorProductFeatures,
+} from 'calypso/my-sites/plans-v2/types';
+
+export type ProductCardFeaturesItem = SelectorProductFeaturesItem;
+export type ProductCardFeaturesSection = SelectorProductFeaturesSection;
+export type ProductCardFeatures = SelectorProductFeatures;

--- a/client/my-sites/plans-v2/product-card-alt-2/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt-2/index.tsx
@@ -1,0 +1,154 @@
+/**
+ * External dependencies
+ */
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	durationToText,
+	getProductWithOptionDisplayName,
+	productBadgeLabelAlt,
+	productButtonLabel,
+	productButtonLabelAlt,
+	slugIsFeaturedProduct,
+} from '../utils';
+import PlanRenewalMessage from '../plan-renewal-message';
+import RecordsDetailsAlt from '../records-details-alt';
+import useItemPrice from '../use-item-price';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
+import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
+import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import JetpackProductCardAlt2 from 'calypso/components/jetpack/card/jetpack-product-card-alt-2';
+import { planHasFeature } from 'calypso/lib/plans';
+import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
+import { JETPACK_SEARCH_PRODUCTS } from 'calypso/lib/products-values/constants';
+import { isCloseToExpiration } from 'calypso/lib/purchases';
+import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
+
+/**
+ * Type dependencies
+ */
+import type { Duration, PurchaseCallback, SelectorProduct } from '../types';
+
+interface ProductCardProps {
+	item: SelectorProduct;
+	onClick: PurchaseCallback;
+	siteId: number | null;
+	currencyCode: string | null;
+	className?: string;
+	highlight?: boolean;
+	selectedTerm?: Duration;
+}
+
+const ProductCardAltWrapper = ( {
+	item,
+	onClick,
+	siteId,
+	currencyCode,
+	className,
+	highlight = false,
+	selectedTerm,
+}: ProductCardProps ) => {
+	// Determine whether product is owned.
+	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
+	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
+	const isOwned = useMemo( () => {
+		if ( sitePlan && sitePlan.product_slug === item.productSlug ) {
+			return true;
+		} else if ( siteProducts ) {
+			return siteProducts
+				.filter( ( product ) => ! product.expired )
+				.map( ( product ) => product.productSlug )
+				.includes( item.productSlug );
+		}
+		return false;
+	}, [ item.productSlug, sitePlan, siteProducts ] );
+
+	// Calculate the product price.
+	const { originalPrice, discountedPrice } = useItemPrice(
+		siteId,
+		item,
+		item?.monthlyProductSlug || ''
+	);
+
+	const isFree = originalPrice === -1 && discountedPrice === -1;
+
+	// Handles expiry.
+	const moment = useLocalizedMoment();
+	const purchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+
+	// If item is a plan feature, use the plan purchase object.
+	const isItemPlanFeature = sitePlan && planHasFeature( sitePlan.product_slug, item.productSlug );
+	const purchase = isItemPlanFeature
+		? getPurchaseByProductSlug( purchases, sitePlan?.product_slug || '' )
+		: getPurchaseByProductSlug( purchases, item.productSlug );
+
+	const isExpiring = purchase && isCloseToExpiration( purchase );
+	const showExpiryNotice = item.legacy && isExpiring;
+
+	// Is highlighted?
+	const isMobile: boolean = useMobileBreakpoint();
+	const isHighlighted = highlight && ! isOwned && slugIsFeaturedProduct( item.productSlug );
+
+	const isUpgradeableToYearly =
+		isOwned && selectedTerm === TERM_ANNUALLY && item.term === TERM_MONTHLY;
+
+	const description = showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description;
+	const showRecordsDetails = JETPACK_SEARCH_PRODUCTS.includes( item.productSlug ) && siteId;
+
+	// In v1, we use the name of the option instead of the name of the product. In v2 we
+	// honor the name of the product.
+	// E.g. In v1, Jetpack Security Daily is featured as Jetpack Security.
+	const currentCROvariant = getJetpackCROActiveVersion();
+	const productName =
+		currentCROvariant === 'v1'
+			? getProductWithOptionDisplayName( item, isOwned, isItemPlanFeature )
+			: item.displayName;
+
+	const buttonLabel =
+		currentCROvariant === 'v1'
+			? productButtonLabelAlt( item, isOwned, isItemPlanFeature, isUpgradeableToYearly, sitePlan )
+			: productButtonLabel( item, isOwned, isUpgradeableToYearly, sitePlan );
+
+	return (
+		<JetpackProductCardAlt2
+			headingLevel={ 3 }
+			iconSlug={ item.iconSlug }
+			productName={ productName }
+			subheadline={ item.tagline }
+			description={ description }
+			currencyCode={ currencyCode }
+			billingTimeFrame={ durationToText( item.term ) }
+			buttonLabel={ buttonLabel }
+			buttonPrimary={ ! ( isOwned || isItemPlanFeature ) }
+			badgeLabel={ productBadgeLabelAlt( item, isOwned, sitePlan ) }
+			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
+			features={ item.features }
+			searchRecordsDetails={
+				showRecordsDetails && <RecordsDetailsAlt productSlug={ item.productSlug } />
+			}
+			originalPrice={ originalPrice }
+			discountedPrice={ discountedPrice }
+			withStartingPrice={
+				// Search has several pricing tiers
+				item.subtypes.length > 0 || JETPACK_SEARCH_PRODUCTS.includes( item.productSlug )
+			}
+			isFree={ isFree }
+			isOwned={ isOwned }
+			isDeprecated={ item.legacy }
+			className={ className }
+			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
+			isHighlighted={ isHighlighted }
+			isExpanded={ isHighlighted && ! isMobile }
+			productSlug={ item.productSlug }
+		/>
+	);
+};
+
+export default ProductCardAltWrapper;

--- a/client/my-sites/plans-v2/product-card-alt-2/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt-2/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useMemo } from 'react';
+import React, { useMemo, FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 
@@ -11,7 +11,6 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 import {
 	durationToText,
 	getProductWithOptionDisplayName,
-	productBadgeLabelAlt,
 	productButtonLabel,
 	productButtonLabelAlt,
 	slugIsFeaturedProduct,
@@ -46,7 +45,7 @@ interface ProductCardProps {
 	selectedTerm?: Duration;
 }
 
-const ProductCardAltWrapper = ( {
+const ProductCardAltWrapper: FunctionComponent< ProductCardProps > = ( {
 	item,
 	onClick,
 	siteId,
@@ -84,7 +83,9 @@ const ProductCardAltWrapper = ( {
 	const purchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
 
 	// If item is a plan feature, use the plan purchase object.
-	const isItemPlanFeature = sitePlan && planHasFeature( sitePlan.product_slug, item.productSlug );
+	const isItemPlanFeature = !! (
+		sitePlan && planHasFeature( sitePlan.product_slug, item.productSlug )
+	);
 	const purchase = isItemPlanFeature
 		? getPurchaseByProductSlug( purchases, sitePlan?.product_slug || '' )
 		: getPurchaseByProductSlug( purchases, item.productSlug );
@@ -127,7 +128,6 @@ const ProductCardAltWrapper = ( {
 			billingTimeFrame={ durationToText( item.term ) }
 			buttonLabel={ buttonLabel }
 			buttonPrimary={ ! ( isOwned || isItemPlanFeature ) }
-			badgeLabel={ productBadgeLabelAlt( item, isOwned, sitePlan ) }
 			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
 			features={ item.features }
 			searchRecordsDetails={
@@ -135,10 +135,6 @@ const ProductCardAltWrapper = ( {
 			}
 			originalPrice={ originalPrice }
 			discountedPrice={ discountedPrice }
-			withStartingPrice={
-				// Search has several pricing tiers
-				item.subtypes.length > 0 || JETPACK_SEARCH_PRODUCTS.includes( item.productSlug )
-			}
 			isFree={ isFree }
 			isOwned={ isOwned }
 			isDeprecated={ item.legacy }

--- a/client/my-sites/plans-v2/products-grid-alt/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-alt/index.tsx
@@ -25,6 +25,7 @@ import { getJetpackDescriptionWithOptions, slugToSelectorProduct } from '../util
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
 import { getProductPosition } from './products-order';
 import ProductCardAlt from '../product-card-alt';
+import ProductCardAlt2 from '../product-card-alt-2';
 
 /**
  * Type dependencies
@@ -117,6 +118,8 @@ const ProductsGridAlt = ( {
 	onSelectProduct: PurchaseCallback;
 	urlQueryArgs: QueryArgs;
 } ): ReactElement => {
+	const croVersion = getJetpackCROActiveVersion();
+
 	const siteId = useSelector( getSelectedSiteId );
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
@@ -141,6 +144,10 @@ const ProductsGridAlt = ( {
 			} ),
 		[ duration, availableProducts, includedInPlanProducts, purchasedProducts ]
 	);
+	const ProductCardComponent = useMemo(
+		() => ( croVersion === 'v2' ? ProductCardAlt2 : ProductCardAlt ),
+		[ croVersion ]
+	);
 
 	const sortedGridItems = useMemo(
 		() =>
@@ -161,7 +168,7 @@ const ProductsGridAlt = ( {
 	return (
 		<div className="products-grid-alt">
 			{ hasLegacyPlan && (
-				<ProductCardAlt
+				<ProductCardComponent
 					// iconSlug has the same value for all durations.
 					// Using this value as a key prevents unnecessary DOM updates.
 					key={ currentPlanSlug }
@@ -174,7 +181,7 @@ const ProductsGridAlt = ( {
 			) }
 
 			{ sortedGridItems.map( ( product ) => (
-				<ProductCardAlt
+				<ProductCardComponent
 					// iconSlug has the same value for all durations.
 					// Using this value as a key prevents unnecessary DOM updates.
 					key={ product.iconSlug }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR implements the new product card for the last iteration of the pricing page. See board for details and mockups.

Fixes 1196341175636977-as-1198514641268269

### Implementation notes

- I created a new chain of components (card + features section) altogether, similarly to the other versions.
- Text in the ribbon is dynamic to support internationalization and copy updates.
- The features section will be tackled in a separate PR.

### Testing instructions

- Download the PR locally
- Run Calypso and cloud concurrently
- Make sure the variant `v2 - slide outs` is selected in the `jetpackConversionRateOptimization` A/B test
- Visit the plans page in both Calypso and cloud, and compare it to the mockups (or screenshots below)

### Screenshots

#### Calypso
_Mockups_
<img width="290" alt="Screen Shot 2020-10-26 at 10 38 14 AM" src="https://user-images.githubusercontent.com/1620183/97190797-92ba5280-177c-11eb-8b35-285a39a29a1c.png">

_Implementation_
<img width="358" alt="Screen Shot 2020-10-26 at 11 07 16 AM" src="https://user-images.githubusercontent.com/1620183/97190852-a2399b80-177c-11eb-9875-e2a639b884a4.png">
<img width="358" alt="Screen Shot 2020-10-26 at 11 07 22 AM" src="https://user-images.githubusercontent.com/1620183/97190849-a2399b80-177c-11eb-84ac-ee4a8c45d0eb.png">


#### Cloud
_Mockups_
<img width="289" alt="Screen Shot 2020-10-26 at 10 37 57 AM" src="https://user-images.githubusercontent.com/1620183/97190775-8930ea80-177c-11eb-9d1a-78b91bdb91fe.png">

_Implementation_
<img width="355" alt="Screen Shot 2020-10-26 at 11 06 20 AM" src="https://user-images.githubusercontent.com/1620183/97190826-9a79f700-177c-11eb-80d2-18cd30824bb5.png">
<img width="359" alt="Screen Shot 2020-10-26 at 11 06 26 AM" src="https://user-images.githubusercontent.com/1620183/97190824-99e16080-177c-11eb-9301-185fa25f6879.png">

