### PR TITLE
Update Editing Toolkit plugin to version 2.8

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.7.2
+ * Version: 2.8
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.7.2' );
+define( 'PLUGIN_VERSION', '2.8' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.7.2
+Stable tag: 2.8
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,10 +39,13 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+= 2.8 =
+* Added new block patterns to the block editor.
+
 = 2.7.2 =
 * Enable Coming Soon v2 for a12s
 
-= 2.7.1 = 
+= 2.7.1 =
 * Coming Soon v2: adding links to default page (https://github.com/Automattic/wp-calypso/pull/46441)
 * Remove "gutenboarding/new-launch" feature flag and checks. (https://github.com/Automattic/wp-calypso/pull/46453)
 * Fixes Global Styles plugin translation (https://github.com/Automattic/wp-calypso/pull/46421)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -40,7 +40,16 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 == Changelog ==
 = 2.8 =
-* Added new block patterns to the block editor.
+* Editing Toolkit: Load patterns from the rest API endpoint v3 (https://github.com/Automattic/wp-calypso/pull/46463)
+* Contextual-tips: remove /block-editor from URL (https://github.com/Automattic/wp-calypso/pull/46592)
+* Premium Content: Fix margins on child blocks in Varia based themes (https://github.com/Automattic/wp-calypso/pull/46579)
+* Premium Content Block: Remove the intermediate block UI. (https://github.com/Automattic/wp-calypso/pull/46619)
+* ET/FSE: Remove the "Showcase New Blocks" module (https://github.com/Automattic/wp-calypso/pull/46663)
+* Add text domain to copy in domain-picker and plans-grid packages (https://github.com/Automattic/wp-calypso/pull/46557)
+* Gutenboarding: stop HotJar capturing input fields in gutenboarding (https://github.com/Automattic/wp-calypso/pull/46620)
+* Launch: Move launch store to package/data-stores. (https://github.com/Automattic/wp-calypso/pull/46570)
+* Launch: Hide inline help button when launch modal opens. (https://github.com/Automattic/wp-calypso/pull/46768)
+* Localise the launch sidebar and final launch step (https://github.com/Automattic/wp-calypso/pull/46555)
 
 = 2.7.2 =
 * Enable Coming Soon v2 for a12s

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.7.2",
+	"version": "2.8.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Version bump and changelog

### Changes to Editing Toolkit since 2.7.2:

I've requested a review from everyone who merged their PRs since the last release. Please apply the diff (D51800-code) on your sandbox and test your changes work correctly. ✔️ == tested and confirmed working.

* ✔️ Editing Toolkit: Load patterns from the rest API endpoint v3 #46463
* ✔️ Contextual-tips: remove `/block-editor` from URL #46592
* ✔️ Premium Content: Fix margins on child blocks in Varia based themes #46579
* ✔️ Premium Content Block: Remove the intermediate block UI. #46619
* ✔️ ET/FSE: Remove the "Showcase New Blocks" module #46663
* ✔️ Add text domain to copy in domain-picker and plans-grid packages #46557
* ✔️ Gutenboarding: stop HotJar capturing input fields in gutenboarding #46620 
* ✔️ Launch: Move launch store to package/data-stores. #46570
* ✔️ Launch: Hide inline help button when launch modal opens. #46768
* ✔️ Localise the launch sidebar and final launch step #46555
* ✔️ Updated webpack dependencies #46718

### Testing instructions
* Load the diff on your sandbox D51800-code and confirm above changes work correctly.
* Make sure that you do not see the new block patterns loaded by default (because there is no filter set). See https://github.com/Automattic/wp-calypso/pull/46463
