### PR TITLE
Checkout: fix secure checkout title for small screens

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -618,6 +618,14 @@ a.masterbar__quick-language-switcher {
 	.masterbar__secure-checkout-text {
 		color: var( --color-primary-5 );
 		transform: translateY( 1px );
+		line-height: 1.2em;
+		font-size: 0.75rem;
+		margin-left: 5px;
+
+		@include breakpoint-deprecated( '>480px' ) {
+			font-size: 100%;
+			margin-left: 0;
+		}
 
 		.is-jetpack-site & {
 			color: var( --color-jetpack-masterbar-text );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the Secure checkout title on small screens.

**Before**
![image](https://user-images.githubusercontent.com/6981253/97204393-6c041800-178c-11eb-8d3e-b0d682192b1d.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/97204479-8211d880-178c-11eb-9174-5f9695d09315.png)


#### Testing instructions

* Add a product to your cart and go to checkout
* Confirm that the secure checkout title doesn't look busted on screens smaller than 400px wide.
* Then check on a wide screen to make sure it still looks good.

