### PR TITLE
Focused Launch: Typography and Mobile Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
 		"@types/wordpress__api-fetch": "^3.2.2",
 		"@types/wordpress__block-editor": "^2.2.8",
 		"@types/wordpress__block-library": "^2.6.0",
-		"@types/wordpress__components": "^9.8.0",
+		"@types/wordpress__components": "^9.8.4",
 		"@types/wordpress__compose": "^3.4.2",
 		"@types/wordpress__data": "^4.6.7",
 		"@types/wordpress__data-controls": "^1.0.3",

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -4,12 +4,19 @@
 import { Title } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { TextControl } from '@wordpress/components';
+import { TextControl, SVG, Path } from '@wordpress/components';
 import * as React from 'react';
 import DomainPicker from '@automattic/domain-picker';
 import { useSite, useDomainSearch } from '../hooks';
+import { Icon, check } from '@wordpress/icons';
 
 import './styles.scss';
+
+const bulb = (
+	<SVG viewBox="0 0 24 24">
+		<Path d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8 6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z" />
+	</SVG>
+);
 
 function noop( ...args: unknown[] ) {
 	return args;
@@ -41,7 +48,11 @@ const FocusedLaunch: React.FunctionComponent = () => {
 					<div className="focused-launch__section">
 						<TextControl
 							className="focused-launch__input"
-							label={ __( '1. Name your site', 'launch' ) }
+							label={
+								<label className="focused-launch__label">
+									{ __( '1. Name your site', 'launch' ) }
+								</label>
+							}
 							value={ siteTitle }
 							onChange={ ( value ) => setSiteTitle( value ) }
 							// eslint-disable-next-line jsx-a11y/no-autofocus
@@ -51,9 +62,14 @@ const FocusedLaunch: React.FunctionComponent = () => {
 					<div className="focused-launch__section">
 						<DomainPicker
 							header={
-								<label className="focused-launch__label">
-									{ __( '2. Confirm your domain', 'launch' ) }
-								</label>
+								<>
+									<label className="focused-launch__label">
+										{ __( '2. Confirm your domain', 'launch' ) }
+									</label>
+									<p className="focused-launch__mobile-commentary focused-launch__mobile-only">
+										<Icon icon={ bulb } /> 46.9% of globally registered domains are .com
+									</p>
+								</>
 							}
 							existingSubdomain={ siteDomainName }
 							currentDomain={ siteDomainName }
@@ -64,25 +80,53 @@ const FocusedLaunch: React.FunctionComponent = () => {
 							analyticsUiAlgo="focused_launch_domain_picker"
 							onDomainSearchBlur={ () => noop( 'TODO: on domain search blur' ) }
 							onSetDomainSearch={ () => noop( 'TODO: on set domain search' ) }
+							quantity={ 3 }
 						/>
 					</div>
 				</div>
-				<div className="focused-launch__commentary">
-					<div>
+				<div className="focused-launch__side-commentary">
+					<p className="focused-launch__side-commentary-title">
 						<strong>46.9%</strong> of globally registered domains are <strong>.com</strong>
-					</div>
+					</p>
+					<ul className="focused-launch__side-commentary-list">
+						<li className="focused-launch__side-commentary-list-item">
+							<Icon icon={ check } /> Stand out with a unique domain
+						</li>
+						<li className="focused-launch__side-commentary-list-item">
+							<Icon icon={ check } /> Easy to remember and easy to share
+						</li>
+						<li className="focused-launch__side-commentary-list-item">
+							<Icon icon={ check } /> Builds brand recognition and trust
+						</li>
+					</ul>
 				</div>
 			</div>
 			<div className="focused-launch__step">
 				<div className="focused-launch__data-input">
-					<label className="focused-launch__label">
-						{ __( '3. Confirm your plan', 'launch' ) }
-					</label>
-				</div>
-				<div className="focused-launch__commentary">
-					<div>
-						<strong>Some</strong> other interesting info
+					<div className="focused-launch__section">
+						<label className="focused-launch__label">
+							{ __( '3. Confirm your plan', 'launch' ) }
+						</label>
+						<p className="focused-launch__mobile-commentary focused-launch__mobile-only">
+							<Icon icon={ bulb } /> Monetize your site with <strong>WordPress Premium</strong>
+						</p>
 					</div>
+				</div>
+				<div className="focused-launch__side-commentary">
+					<p className="focused-launch__side-commentary-title">
+						Monetize your site with <strong>WordPress Premium</strong>
+					</p>
+					<ul className="focused-launch__side-commentary-list">
+						<li className="focused-launch__side-commentary-list-item">
+							<Icon icon={ check } /> Advanced tools and customization
+						</li>
+						<li className="focused-launch__side-commentary-list-item">
+							<Icon icon={ check } /> Unlimited premium themes
+						</li>
+						<li className="focused-launch__side-commentary-list-item">
+							<Icon icon={ check } /> Accept payments
+						</li>
+					</ul>
 				</div>
 			</div>
 		</div>

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -43,6 +43,7 @@ const FocusedLaunch: React.FunctionComponent = () => {
 					) }
 				</p>
 			</div>
+
 			<div className="focused-launch__step">
 				<div className="focused-launch__data-input">
 					<div className="focused-launch__section">
@@ -59,6 +60,12 @@ const FocusedLaunch: React.FunctionComponent = () => {
 							autoFocus={ true }
 						/>
 					</div>
+				</div>
+				<div className="focused-launch__side-commentary"></div>
+			</div>
+
+			<div className="focused-launch__step">
+				<div className="focused-launch__data-input">
 					<div className="focused-launch__section">
 						<DomainPicker
 							header={

--- a/packages/launch/src/focused-launch/styles.scss
+++ b/packages/launch/src/focused-launch/styles.scss
@@ -84,10 +84,16 @@
 	display: none;
 
 	@include break-medium {
+		// add a vertical gap before plan commentary to align
+		// with the input (not the step title).
+		&::before {
+			content: '';
+			display: block;
+			height: 18px;
+		}
 		margin-left: 10px;
 		border-left: 1px solid #eee;
 		display: flex;
-		justify-content: center;
 		flex-direction: column;
 		flex: 0.4;
 		padding: 0 42.5px;

--- a/packages/launch/src/focused-launch/styles.scss
+++ b/packages/launch/src/focused-launch/styles.scss
@@ -7,34 +7,67 @@
 @import '~@automattic/onboarding/styles/mixins';
 
 .focused-launch__input {
-	.components-base-control__label {
-		font-weight: bold;
+	.components-text-control__input {
+		font-size: 1rem;
+		padding: 10px 16px;
+
+		.components-base-control__label {
+			margin: 0;
+		}
+	}
+}
+
+.focused-launch__mobile-only {
+	@include break-medium {
+		display: none;
+	}
+}
+
+.focused-launch__mobile-commentary {
+	font-size: 0.875rem;
+	color: var( --studio-gray-60 );
+	svg {
+		vertical-align: bottom;
 	}
 }
 
 .focused-launch__label {
-	font-weight: bold;
 	margin-bottom: 8px;
 	display: block;
+	font-size: 1.25rem;
+	color: var( --studio-gray-90 );
+	line-height: 24px;
 }
 
 .focused-launch__section {
-	margin: 20px 0;
+	margin: 0 20px 40px;
+
+	@include break-medium {
+		margin: 0 10px 40px;
+	}
 }
 
 .focused-launch__caption {
-	margin: 0;
+	margin: 12px 0;
+	font-size: 1rem;
+	color: #50575e;
 }
 
 .focused-launch__step {
 	display: flex;
-	justify-content: center;
-	gap: 10%;
 	opacity: 0.5;
 	transition: opacity 0.5s ease-in-out;
+
+	@include break-medium {
+		gap: 50px;
+	}
+
+	@include break-large {
+		gap: 100px;
+	}
 }
 
-// default highlighting the all steps when nothing is in focus
+// by default: highlight all steps when nothing is in focus
 .focused-launch__container:not( :focus-within ) {
 	.focused-launch__step {
 		opacity: 1;
@@ -46,15 +79,56 @@
 	opacity: 1;
 }
 
-.focused-launch__commentary {
-	margin-left: 10px;
-	border-left: 1px solid #eee;
-	display: flex;
-	align-items: center;
-	flex: 0.4;
-	padding: 0 5%;
+.focused-launch__side-commentary {
+	display: none;
+
+	@include break-medium {
+		margin-left: 10px;
+		border-left: 1px solid #eee;
+		display: flex;
+		justify-content: center;
+		flex-direction: column;
+		flex: 0.4;
+		padding: 0 42.5px;
+		max-width: 350px;
+
+		&-title {
+			font-size: 1.25rem;
+			line-height: 26px;
+			margin: 12px 0;
+		}
+
+		&-list {
+			list-style: none;
+		}
+
+		&-list-item {
+			font-size: 0.875rem;
+			margin: 4px 0;
+			display: flex;
+		}
+
+		&-list-item svg {
+			vertical-align: bottom;
+			width: 18px;
+			height: 18px;
+			margin-right: 12px;
+		}
+	}
 }
 
 .focused-launch__data-input {
-	flex: 0.6;
+	flex: 1;
+
+	@include break-medium {
+		flex: 0.6;
+	}
+}
+
+.onboarding-title {
+	@include onboarding-font-recoleta;
+
+	font-size: 2.25rem;
+	line-height: 40px;
+	color: #101517;
 }

--- a/packages/launch/src/focused-launch/styles.scss
+++ b/packages/launch/src/focused-launch/styles.scss
@@ -40,6 +40,7 @@
 }
 
 .focused-launch__section {
+	// maybe use @include onboarding-block-margin;
 	margin: 0 20px 40px;
 
 	@include break-medium {

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -3,8 +3,8 @@
  */
 import * as React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Modal, Button } from '@wordpress/components';
-import { Icon, wordpress, close } from '@wordpress/icons';
+import { Modal } from '@wordpress/components';
+import { Icon, wordpress } from '@wordpress/icons';
 import FocusedLaunch from '../focused-launch';
 
 import './styles.scss';
@@ -21,26 +21,16 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( { onClose } ) => 
 			overlayClassName="launch__focused-modal-overlay"
 			bodyOpenClassName="has-focused-launch-modal"
 			onRequestClose={ onClose }
-			title=""
+			title={ __( 'Complete setup' ) }
+			// remove the wrong type when https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49156 is merged
+			icon={
+				( ( <Icon icon={ wordpress } size={ 36 } /> ) as unknown ) as React.FunctionComponent<
+					unknown
+				>
+			}
 		>
 			<>
 				<div className="launch__focused-modal-wrapper ">
-					<div className="launch__focused-modal-header">
-						<div className="launch__focused-modal-header-wp-logo">
-							<Icon icon={ wordpress } size={ 36 } />
-						</div>
-						<Button
-							isLink
-							className="launch__focused-modal-close-button"
-							onClick={ onClose }
-							aria-label={ __( 'Close dialog', 'launch' ) }
-							disabled={ ! onClose }
-						>
-							<span>
-								<Icon icon={ close } size={ 24 } />
-							</span>
-						</Button>
-					</div>
 					<div className="launch__focused-modal-body">
 						<FocusedLaunch />
 					</div>

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -22,12 +22,7 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( { onClose } ) => 
 			bodyOpenClassName="has-focused-launch-modal"
 			onRequestClose={ onClose }
 			title={ __( 'Complete setup' ) }
-			// remove the wrong type when https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49156 is merged
-			icon={
-				( ( <Icon icon={ wordpress } size={ 36 } /> ) as unknown ) as React.FunctionComponent<
-					unknown
-				>
-			}
+			icon={ <Icon icon={ wordpress } size={ 36 } /> }
 		>
 			<>
 				<div className="launch__focused-modal-wrapper ">

--- a/packages/launch/src/launch/styles.scss
+++ b/packages/launch/src/launch/styles.scss
@@ -16,7 +16,20 @@ body.has-focused-launch-modal {
 	}
 
 	.components-modal__header {
-		display: none;
+		margin: 0 0 20px;
+
+		.components-modal__icon-container {
+			margin-right: 12px;
+		}
+
+		@include break-medium {
+			border-bottom: none;
+
+			.components-modal__icon-container,
+			.components-modal__header-heading {
+				display: none;
+			}
+		}
 	}
 
 	.components-modal__content {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4186,16 +4186,17 @@
     "@types/wordpress__rich-text" "*"
     re-resizable "^4.7.1"
 
-"@types/wordpress__components@^9.8.0":
-  version "9.8.0"
-  resolved "https://registry.yarnpkg.com/@types/wordpress__components/-/wordpress__components-9.8.0.tgz#25b9799178b777910304aec35e6453b6faec3fb2"
-  integrity sha512-pt0FxWz9Spbqk7xF7YVDUosW5YMTHkfCzkG7lWESm6OuEXc6HmHN3JSmC82FS+NQjht3qTGjbdULYLxXrxzTvQ==
+"@types/wordpress__components@^9.8.4":
+  version "9.8.4"
+  resolved "https://registry.yarnpkg.com/@types/wordpress__components/-/wordpress__components-9.8.4.tgz#f6155df7223199667fff0aee0e3e8b6bd6704af2"
+  integrity sha512-8K+WlCPh30XCjkCN9WIlfDMYTrPxcxwmtG1vLhDW7Nonjisr3e4Bfajtx0pWmtNsE6Cb4s06KOXAXFj5rxyglQ==
   dependencies:
     "@types/react" "*"
     "@types/wordpress__components" "*"
     "@types/wordpress__notices" "*"
     "@types/wordpress__rich-text" "*"
     "@wordpress/element" "^2.14.0"
+    downshift "^4.0.5"
     re-resizable "^4.7.1"
 
 "@types/wordpress__compose@^3.4.2":


### PR DESCRIPTION
💡  Merges into https://github.com/Automattic/wp-calypso/pull/46686

### Changes proposed in this Pull Request

#### Typography 
* ~~This PR adds Recoleta font weight 500 (MediumBold) to our font mixins. This is to stick with the Figma spec.~~
* ~~Then modifies stylelint rules to allow weight 500~~.
* It makes numerous UI changes to make sure every typography in the focused launch is ready for all the upcoming changes. 

#### Layout 
* Implements mobile layout. Now mobile layout is ready. 
* Makes all the gaps and spaces exactly like the spec.

#### Testing instructions

1. Sandbox a site (say `MY_SITE.wordpress.com`). The site needs to be:
   - unlaunched
   - created via Gutenboarding (`/new`)
2. Run `yarn start` in the repo root. At the same time, in a different terminal window, go inside `apps/editing-toolkit` and run `yarn dev --sync`
3. Edit the home page in the block editor
4. Click on the "Complete setup" button to open the Focused Launch Flow modal

Closes #46840
Partially tackles #46844

