### PR TITLE
Nav Unification - implement conditionals for static fallback nav data

### DIFF
--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -9,10 +9,10 @@ export default function buildFallbackResponse( {
 	shouldShowTestimonials = false,
 	shouldShowPortfolio = false,
 	shouldShowWooCommerce = false,
+	shouldShowThemes = false,
 	shouldShowApperanceHeaderAndBackground = false,
 	shouldShowAdControl = false,
 	shouldShowAMP = false,
-	shouldShowThemeOptions = false,
 } = {} ) {
 	const fallbackResponse = [
 		{
@@ -283,47 +283,47 @@ export default function buildFallbackResponse( {
 		{
 			type: 'separator',
 		},
-		{
-			icon: 'dashicons-admin-appearance',
-			slug: 'themes-php',
-			title: translate( 'Appearance' ),
-			type: 'menu-item',
-			url: `/themes/${ siteDomain }`,
-			children: [
-				{
-					parent: 'themes.php',
-					slug: 'themes-php',
-					title: translate( 'Themes' ),
-					type: 'submenu-item',
-					url: `/themes/${ siteDomain }`,
-				},
-				{
-					parent: 'themes.php',
-					slug: 'themes-customize',
-					title: translate( 'Customize' ),
-					type: 'submenu-item',
-					url: `/customize/${ siteDomain }`,
-				},
-				...( shouldShowApperanceHeaderAndBackground
-					? [
+		...( shouldShowThemes
+			? [
+					{
+						icon: 'dashicons-admin-appearance',
+						slug: 'themes-php',
+						title: translate( 'Appearance' ),
+						type: 'menu-item',
+						url: `/themes/${ siteDomain }`,
+						children: [
 							{
 								parent: 'themes.php',
-								slug: 'themes-header',
-								title: translate( 'Header' ),
+								slug: 'themes-php',
+								title: translate( 'Themes' ),
 								type: 'submenu-item',
-								url: `https://${ siteDomain }/wp-admin/customize.php?return=%2Fwp-admin%2F&autofocus%5Bcontrol%5D=header_image`,
+								url: `/themes/${ siteDomain }`,
 							},
 							{
 								parent: 'themes.php',
-								slug: 'themes-background',
-								title: translate( 'Background' ),
+								slug: 'themes-customize',
+								title: translate( 'Customize' ),
 								type: 'submenu-item',
-								url: `https://${ siteDomain }/wp-admin/customize.php?return=%2Fwp-admin%2F&autofocus%5Bcontrol%5D=background_image`,
+								url: `/customize/${ siteDomain }`,
 							},
-					  ]
-					: [] ),
-				...( shouldShowThemeOptions
-					? [
+							...( shouldShowApperanceHeaderAndBackground
+								? [
+										{
+											parent: 'themes.php',
+											slug: 'themes-header',
+											title: translate( 'Header' ),
+											type: 'submenu-item',
+											url: `https://${ siteDomain }/wp-admin/customize.php?return=%2Fwp-admin%2F&autofocus%5Bcontrol%5D=header_image`,
+										},
+										{
+											parent: 'themes.php',
+											slug: 'themes-background',
+											title: translate( 'Background' ),
+											type: 'submenu-item',
+											url: `https://${ siteDomain }/wp-admin/customize.php?return=%2Fwp-admin%2F&autofocus%5Bcontrol%5D=background_image`,
+										},
+								  ]
+								: [] ),
 							{
 								parent: 'themes.php',
 								slug: 'themes-options',
@@ -331,24 +331,24 @@ export default function buildFallbackResponse( {
 								type: 'submenu-item',
 								url: `https://${ siteDomain }/wp-admin/`,
 							},
-					  ]
-					: [] ),
-				{
-					parent: 'themes.php',
-					slug: 'themes-widgets',
-					title: translate( 'Widgets' ),
-					type: 'submenu-item',
-					url: `/customize/${ siteDomain }?autofocus[panel]=widgets`,
-				},
-				{
-					parent: 'themes.php',
-					slug: 'themes-menus',
-					title: translate( 'Menus' ),
-					type: 'submenu-item',
-					url: `/customize/${ siteDomain }?autofocus[panel]=nav_menus`,
-				},
-			],
-		},
+							{
+								parent: 'themes.php',
+								slug: 'themes-widgets',
+								title: translate( 'Widgets' ),
+								type: 'submenu-item',
+								url: `/customize/${ siteDomain }?autofocus[panel]=widgets`,
+							},
+							{
+								parent: 'themes.php',
+								slug: 'themes-menus',
+								title: translate( 'Menus' ),
+								type: 'submenu-item',
+								url: `/customize/${ siteDomain }?autofocus[panel]=nav_menus`,
+							},
+						],
+					},
+			  ]
+			: [] ),
 		{
 			icon: 'dashicons-admin-plugins',
 			slug: 'plugins',

--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -61,6 +61,29 @@ export default function buildFallbackResponse( {
 			title: translate( 'Upgrades' ),
 			type: 'menu-item',
 			url: `/plans/${ siteDomain }`,
+			children: [
+				{
+					parent: 'upgrades',
+					slug: 'upgrades',
+					title: translate( 'Plans' ),
+					type: 'submenu-item',
+					url: `/plans/${ siteDomain }`,
+				},
+				{
+					parent: 'upgrades',
+					slug: 'upgrades',
+					title: translate( 'Purchases' ),
+					type: 'submenu-item',
+					url: `/purchases/subscriptions/${ siteDomain }`,
+				},
+				{
+					parent: 'upgrades',
+					slug: 'upgrades',
+					title: translate( 'Domains' ),
+					type: 'submenu-item',
+					url: `/domains/manage/${ siteDomain }`,
+				},
+			],
 		},
 		{
 			icon: 'dashicons-admin-post',

--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -26,6 +26,8 @@ import { translate } from 'i18n-calypso';
  */
 /* eslint-enable jsdoc/require-param */
 
+const JETPACK_ICON = `data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 32 32" %3E%3Cpath fill="%23a0a5aa" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"%3E%3C/path%3E%3Cpolygon fill="%23fff" points="15,19 7,19 15,3 "%3E%3C/polygon%3E%3Cpolygon fill="%23fff" points="17,29 17,13 25,13 "%3E%3C/polygon%3E%3C/svg%3E`;
+
 export default function buildFallbackResponse( {
 	siteDomain = '',
 	shouldShowLinks = false,
@@ -270,7 +272,7 @@ export default function buildFallbackResponse( {
 			type: 'separator',
 		},
 		{
-			icon: 'dashicons-jetpack',
+			icon: JETPACK_ICON,
 			slug: 'jetpack',
 			title: translate( 'Jetpack' ),
 			type: 'menu-item',

--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -279,10 +279,20 @@ export default function buildFallbackResponse( {
 			type: 'separator',
 		},
 		// Add WooCommerce here
-		...( shouldShowWooCommerce ? [] : [] ),
-		{
-			type: 'separator',
-		},
+		...( shouldShowWooCommerce
+			? [
+					{
+						icon: 'dashicons-admin-generic',
+						slug: 'woo-php',
+						title: translate( 'WooCommerce' ),
+						type: 'menu-item',
+						url: `https://${ siteDomain }/wp-admin/admin.php?page=wc-admin`,
+					},
+					{
+						type: 'separator',
+					},
+			  ]
+			: [] ),
 		...( shouldShowThemes
 			? [
 					{

--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -383,13 +383,6 @@ export default function buildFallbackResponse( {
 								: [] ),
 							{
 								parent: 'themes.php',
-								slug: 'themes-options',
-								title: translate( 'Theme Options' ),
-								type: 'submenu-item',
-								url: `https://${ siteDomain }/wp-admin/`,
-							},
-							{
-								parent: 'themes.php',
 								slug: 'themes-widgets',
 								title: translate( 'Widgets' ),
 								type: 'submenu-item',

--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -315,13 +315,6 @@ export default function buildFallbackResponse( {
 					type: 'submenu-item',
 					url: `/backup/${ siteDomain }`,
 				},
-				{
-					parent: 'jetpack',
-					slug: 'jetpack-scan',
-					title: translate( 'Scan' ),
-					type: 'submenu-item',
-					url: `/scan/${ siteDomain }`,
-				},
 			],
 		},
 		{

--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -32,10 +32,10 @@ export default function buildFallbackResponse( {
 		},
 		{
 			icon: 'dashicons-cart',
-			slug: 'purchases',
-			title: translate( 'Purchases' ),
+			slug: 'upgrades',
+			title: translate( 'Upgrades' ),
 			type: 'menu-item',
-			url: `/purchases/${ siteDomain }`,
+			url: `/plans/${ siteDomain }`,
 		},
 		{
 			icon: 'dashicons-admin-post',

--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -3,6 +3,29 @@
  */
 import { translate } from 'i18n-calypso';
 
+/* eslint-disable jsdoc/require-param */
+/**
+ * Fallback nav menu items.
+ *
+ * These are used as a fallback to ensure that if the API response for menu items
+ * fails, the user always sees some menu items. They are required only in the
+ * following circumstances:
+ *
+ * 1. The user has loaded the site for the first time and the Menus API response
+ * has yet to be returned or cached in the Browser Storage APIs.
+ *
+ * 2. The Menu API REST API response fails and there is no response cached in the
+ * Browser Storage.
+ *
+ * As a result of these conditions being an edge case, in most cases the user will
+ * not see these menus items. They are a safe guard in case of error.
+ *
+ * As a rule the menu items are intended to be as close to the anticipated Menus API
+ * response as possible but we should not take this too far. We need only show the bear
+ * minimum required to navigate in the case that the API response fails.
+ */
+/* eslint-enable jsdoc/require-param */
+
 export default function buildFallbackResponse( {
 	siteDomain = '',
 	shouldShowLinks = false,

--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -3,16 +3,17 @@
  */
 import { translate } from 'i18n-calypso';
 
-const shouldShowLinks = true;
-const shouldShowTestimonials = true;
-const shouldShowPortfolio = true;
-const shouldShowWooCommerce = true;
-const shouldShowApperanceHeaderAndBackground = true;
-const shouldShowAdControl = true;
-const shouldShowAMP = true;
-const shouldShowThemeOptions = true;
-
-export default function buildFallbackResponse( { siteDomain = '' } = {} ) {
+export default function buildFallbackResponse( {
+	siteDomain = '',
+	shouldShowLinks = false,
+	shouldShowTestimonials = false,
+	shouldShowPortfolio = false,
+	shouldShowWooCommerce = false,
+	shouldShowApperanceHeaderAndBackground = false,
+	shouldShowAdControl = false,
+	shouldShowAMP = false,
+	shouldShowThemeOptions = false,
+} = {} ) {
 	const fallbackResponse = [
 		{
 			icon: 'dashicons-admin-home',

--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -10,7 +10,8 @@ export default function buildFallbackResponse( {
 	shouldShowPortfolio = false,
 	shouldShowWooCommerce = false,
 	shouldShowThemes = false,
-	shouldShowApperanceHeaderAndBackground = false,
+	shouldShowApperanceHeader = false,
+	shouldShowApperanceBackground = false,
 	shouldShowAdControl = false,
 	shouldShowAMP = false,
 } = {} ) {
@@ -316,7 +317,8 @@ export default function buildFallbackResponse( {
 								type: 'submenu-item',
 								url: `/customize/${ siteDomain }`,
 							},
-							...( shouldShowApperanceHeaderAndBackground
+
+							...( shouldShowApperanceHeader
 								? [
 										{
 											parent: 'themes.php',
@@ -325,6 +327,10 @@ export default function buildFallbackResponse( {
 											type: 'submenu-item',
 											url: `https://${ siteDomain }/wp-admin/customize.php?return=%2Fwp-admin%2F&autofocus%5Bcontrol%5D=header_image`,
 										},
+								  ]
+								: [] ),
+							...( shouldShowApperanceBackground
+								? [
 										{
 											parent: 'themes.php',
 											slug: 'themes-background',

--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -10,7 +10,7 @@ const shouldShowWooCommerce = true;
 const shouldShowApperanceHeaderAndBackground = true;
 const shouldShowAdControl = true;
 const shouldShowAMP = true;
-const showShowThemeOptions = true;
+const shouldShowThemeOptions = true;
 
 export default function buildFallbackResponse( { siteDomain = '' } = {} ) {
 	const fallbackResponse = [
@@ -321,7 +321,7 @@ export default function buildFallbackResponse( { siteDomain = '' } = {} ) {
 							},
 					  ]
 					: [] ),
-				...( showShowThemeOptions
+				...( shouldShowThemeOptions
 					? [
 							{
 								parent: 'themes.php',

--- a/client/my-sites/sidebar-unified/fallback-data.js
+++ b/client/my-sites/sidebar-unified/fallback-data.js
@@ -79,38 +79,40 @@ export default function buildFallbackResponse( { siteDomain = '' } = {} ) {
 			type: 'menu-item',
 			url: `/media/${ siteDomain }`,
 		},
-		...( shouldShowLinks && [
-			{
-				icon: 'dashicons-admin-links',
-				slug: 'link-manager-php',
-				title: translate( 'Links' ),
-				type: 'menu-item',
-				url: `https://${ siteDomain }/wp-admin/link-manager.php`,
-				children: [
+		...( shouldShowLinks
+			? [
 					{
-						parent: 'link-manager.php',
+						icon: 'dashicons-admin-links',
 						slug: 'link-manager-php',
-						title: translate( 'All Links' ),
-						type: 'submenu-item',
+						title: translate( 'Links' ),
+						type: 'menu-item',
 						url: `https://${ siteDomain }/wp-admin/link-manager.php`,
+						children: [
+							{
+								parent: 'link-manager.php',
+								slug: 'link-manager-php',
+								title: translate( 'All Links' ),
+								type: 'submenu-item',
+								url: `https://${ siteDomain }/wp-admin/link-manager.php`,
+							},
+							{
+								parent: 'link-manager.php',
+								slug: 'link-add-php',
+								title: translate( 'Add New' ),
+								type: 'submenu-item',
+								url: `https://${ siteDomain }/wp-admin/link-add.php`,
+							},
+							{
+								parent: 'link-manager.php',
+								slug: 'edit-tags-phptaxonomylink_category',
+								title: translate( 'Link Categories' ),
+								type: 'submenu-item',
+								url: `https://${ siteDomain }/wp-admin/edit-tags.php?taxonomy=link_category`,
+							},
+						],
 					},
-					{
-						parent: 'link-manager.php',
-						slug: 'link-add-php',
-						title: translate( 'Add New' ),
-						type: 'submenu-item',
-						url: `https://${ siteDomain }/wp-admin/link-add.php`,
-					},
-					{
-						parent: 'link-manager.php',
-						slug: 'edit-tags-phptaxonomylink_category',
-						title: translate( 'Link Categories' ),
-						type: 'submenu-item',
-						url: `https://${ siteDomain }/wp-admin/edit-tags.php?taxonomy=link_category`,
-					},
-				],
-			},
-		] ),
+			  ]
+			: [] ),
 		{
 			icon: 'dashicons-admin-page',
 			slug: 'edit-phppost_typepage',
@@ -134,70 +136,74 @@ export default function buildFallbackResponse( { siteDomain = '' } = {} ) {
 				},
 			],
 		},
-		...( shouldShowTestimonials && [
-			{
-				icon: 'dashicons-admin-links',
-				slug: 'testimonials',
-				title: translate( 'Testimonials' ),
-				type: 'menu-item',
-				url: `/types/jetpack-testimonial/${ siteDomain }`,
-				children: [
+		...( shouldShowTestimonials
+			? [
 					{
-						parent: 'testimonials',
+						icon: 'dashicons-admin-links',
 						slug: 'testimonials',
-						title: translate( 'All Testimonials' ),
-						type: 'submenu-item',
+						title: translate( 'Testimonials' ),
+						type: 'menu-item',
 						url: `/types/jetpack-testimonial/${ siteDomain }`,
+						children: [
+							{
+								parent: 'testimonials',
+								slug: 'testimonials',
+								title: translate( 'All Testimonials' ),
+								type: 'submenu-item',
+								url: `/types/jetpack-testimonial/${ siteDomain }`,
+							},
+							{
+								parent: 'testimonials',
+								slug: 'testimonials-add',
+								title: translate( 'Add New' ),
+								type: 'submenu-item',
+								url: `/edit/jetpack-testimonial/${ siteDomain }`,
+							},
+						],
 					},
+			  ]
+			: [] ),
+		...( shouldShowPortfolio
+			? [
 					{
-						parent: 'testimonials',
-						slug: 'testimonials-add',
-						title: translate( 'Add New' ),
-						type: 'submenu-item',
-						url: `/edit/jetpack-testimonial/${ siteDomain }`,
-					},
-				],
-			},
-		] ),
-		...( shouldShowPortfolio && [
-			{
-				icon: 'dashicons-admin-links',
-				slug: 'portfolio',
-				title: translate( 'Portfolio' ),
-				type: 'menu-item',
-				url: `/types/jetpack-portfolio/${ siteDomain }`,
-				children: [
-					{
-						parent: 'portfolio',
+						icon: 'dashicons-admin-links',
 						slug: 'portfolio',
-						title: translate( 'All Projects' ),
-						type: 'submenu-item',
+						title: translate( 'Portfolio' ),
+						type: 'menu-item',
 						url: `/types/jetpack-portfolio/${ siteDomain }`,
+						children: [
+							{
+								parent: 'portfolio',
+								slug: 'portfolio',
+								title: translate( 'All Projects' ),
+								type: 'submenu-item',
+								url: `/types/jetpack-portfolio/${ siteDomain }`,
+							},
+							{
+								parent: 'portfolio',
+								slug: 'portfolio-add',
+								title: translate( 'Add New' ),
+								type: 'submenu-item',
+								url: `/edit/jetpack-portfolio/${ siteDomain }`,
+							},
+							{
+								parent: 'portfolio',
+								slug: 'portfolio-types',
+								title: translate( 'Project Types' ),
+								type: 'submenu-item',
+								url: `https://${ siteDomain }/wp-admin/edit-tags.php?taxonomy=jetpack-portfolio-type&post_type=jetpack-portfolio`,
+							},
+							{
+								parent: 'portfolio',
+								slug: 'portfolio-tags',
+								title: translate( 'Project Tags' ),
+								type: 'submenu-item',
+								url: `https://${ siteDomain }/wp-admin/edit-tags.php?taxonomy=jetpack-portfolio-tag&post_type=jetpack-portfolio`,
+							},
+						],
 					},
-					{
-						parent: 'portfolio',
-						slug: 'portfolio-add',
-						title: translate( 'Add New' ),
-						type: 'submenu-item',
-						url: `/edit/jetpack-portfolio/${ siteDomain }`,
-					},
-					{
-						parent: 'portfolio',
-						slug: 'portfolio-types',
-						title: translate( 'Project Types' ),
-						type: 'submenu-item',
-						url: `https://${ siteDomain }/wp-admin/edit-tags.php?taxonomy=jetpack-portfolio-type&post_type=jetpack-portfolio`,
-					},
-					{
-						parent: 'portfolio',
-						slug: 'portfolio-tags',
-						title: translate( 'Project Tags' ),
-						type: 'submenu-item',
-						url: `https://${ siteDomain }/wp-admin/edit-tags.php?taxonomy=jetpack-portfolio-tag&post_type=jetpack-portfolio`,
-					},
-				],
-			},
-		] ),
+			  ]
+			: [] ),
 		{
 			icon: 'dashicons-admin-comments',
 			slug: 'edit-comments-php',
@@ -272,7 +278,7 @@ export default function buildFallbackResponse( { siteDomain = '' } = {} ) {
 			type: 'separator',
 		},
 		// Add WooCommerce here
-		...( shouldShowWooCommerce && [] ),
+		...( shouldShowWooCommerce ? [] : [] ),
 		{
 			type: 'separator',
 		},
@@ -297,31 +303,35 @@ export default function buildFallbackResponse( { siteDomain = '' } = {} ) {
 					type: 'submenu-item',
 					url: `/customize/${ siteDomain }`,
 				},
-				...( shouldShowApperanceHeaderAndBackground && [
-					{
-						parent: 'themes.php',
-						slug: 'themes-header',
-						title: translate( 'Header' ),
-						type: 'submenu-item',
-						url: `https://${ siteDomain }/wp-admin/customize.php?return=%2Fwp-admin%2F&autofocus%5Bcontrol%5D=header_image`,
-					},
-					{
-						parent: 'themes.php',
-						slug: 'themes-background',
-						title: translate( 'Background' ),
-						type: 'submenu-item',
-						url: `https://${ siteDomain }/wp-admin/customize.php?return=%2Fwp-admin%2F&autofocus%5Bcontrol%5D=background_image`,
-					},
-				] ),
-				...( showShowThemeOptions && [
-					{
-						parent: 'themes.php',
-						slug: 'themes-options',
-						title: translate( 'Theme Options' ),
-						type: 'submenu-item',
-						url: `https://${ siteDomain }/wp-admin/`,
-					},
-				] ),
+				...( shouldShowApperanceHeaderAndBackground
+					? [
+							{
+								parent: 'themes.php',
+								slug: 'themes-header',
+								title: translate( 'Header' ),
+								type: 'submenu-item',
+								url: `https://${ siteDomain }/wp-admin/customize.php?return=%2Fwp-admin%2F&autofocus%5Bcontrol%5D=header_image`,
+							},
+							{
+								parent: 'themes.php',
+								slug: 'themes-background',
+								title: translate( 'Background' ),
+								type: 'submenu-item',
+								url: `https://${ siteDomain }/wp-admin/customize.php?return=%2Fwp-admin%2F&autofocus%5Bcontrol%5D=background_image`,
+							},
+					  ]
+					: [] ),
+				...( showShowThemeOptions
+					? [
+							{
+								parent: 'themes.php',
+								slug: 'themes-options',
+								title: translate( 'Theme Options' ),
+								type: 'submenu-item',
+								url: `https://${ siteDomain }/wp-admin/`,
+							},
+					  ]
+					: [] ),
 				{
 					parent: 'themes.php',
 					slug: 'themes-widgets',
@@ -482,25 +492,29 @@ export default function buildFallbackResponse( { siteDomain = '' } = {} ) {
 					type: 'submenu-item',
 					url: `https://${ siteDomain }/wp-admin/options-general.php?page=ratings&action=options`,
 				},
-				...( shouldShowAdControl && [
-					{
-						parent: 'options-general.php',
-						slug: 'options-ad-control',
-						title: translate( 'AdControl' ),
-						type: 'submenu-item',
-						url: `https://${ siteDomain }/wp-admin/options-general.php?page=adcontrol`,
-					},
-				] ),
+				...( shouldShowAdControl
+					? [
+							{
+								parent: 'options-general.php',
+								slug: 'options-ad-control',
+								title: translate( 'AdControl' ),
+								type: 'submenu-item',
+								url: `https://${ siteDomain }/wp-admin/options-general.php?page=adcontrol`,
+							},
+					  ]
+					: [] ),
 			],
 		},
-		...( shouldShowAMP && [
-			{
-				slug: 'amp',
-				title: translate( 'AMP' ),
-				type: 'menu-item',
-				url: `https://${ siteDomain }/wp-admin/admin.php?page=amp-options`,
-			},
-		] ),
+		...( shouldShowAMP
+			? [
+					{
+						slug: 'amp',
+						title: translate( 'AMP' ),
+						type: 'menu-item',
+						url: `https://${ siteDomain }/wp-admin/admin.php?page=amp-options`,
+					},
+			  ]
+			: [] ),
 	];
 
 	return fallbackResponse;

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -31,12 +31,15 @@ const useSiteMenuItems = () => {
 		}
 	}, [ dispatch, selectedSiteId ] );
 
-	const shouldShowTestimonials = useSelector( ( state ) =>
-		get( state.siteSettings.items, [ selectedSiteId, 'jetpack_testimonial' ], false )
-	);
-	const shouldShowPortfolio = useSelector( ( state ) =>
-		get( state.siteSettings.items, [ selectedSiteId, 'jetpack_portfolio' ], false )
-	);
+	/**
+	 * As a general rule we allow fallback data to remain as static as possible.
+	 * Therefore we should avoid relying on API responses to determine what is/isn't
+	 * shown in the fallback data as then we have a situatoin where we are waiting on
+	 * network requests to display fallback data when it should be possible to display
+	 * without this. There are a couple of exceptions to this below where the menu items
+	 * are sufficiently important to the UX that it is worth attempting the API request
+	 * to determine whether or not the menu item should show in the fallback data.
+	 */
 	const shouldShowWooCommerce = useSelector(
 		( state ) => !! getPluginOnSite( state, selectedSiteId, 'woocommerce' )?.active
 	);
@@ -44,15 +47,18 @@ const useSiteMenuItems = () => {
 		canCurrentUser( state, selectedSiteId, 'edit_theme_options' )
 	);
 
-	const fallbackOptions = {
+	/**
+	 * Overides for the static fallback data which will be displayed if/when there are
+	 * no menu items in the API response or the API response has yet to be cached in
+	 * browser storage APIs.
+	 */
+	const fallbackDataOverides = {
 		siteDomain,
-		shouldShowTestimonials,
-		shouldShowPortfolio,
 		shouldShowWooCommerce,
 		shouldShowThemes,
 	};
 
-	return menuItems ?? buildFallbackResponse( fallbackOptions );
+	return menuItems ?? buildFallbackResponse( fallbackDataOverides );
 };
 
 export default useSiteMenuItems;

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -13,6 +13,7 @@ import { requestAdminMenu } from '../../state/admin-menu/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
 
 const useSiteMenuItems = () => {
 	const dispatch = useDispatch();
@@ -33,6 +34,7 @@ const useSiteMenuItems = () => {
 	 * avoids a situation where the user might be left with an
 	 * empty menu.
 	 */
+
 	const shouldShowLinks = true;
 	const shouldShowTestimonials = useSelector( ( state ) =>
 		get( state.siteSettings.items, [ selectedSiteId, 'jetpack_testimonial' ], false )
@@ -41,20 +43,29 @@ const useSiteMenuItems = () => {
 		get( state.siteSettings.items, [ selectedSiteId, 'jetpack_portfolio' ], false )
 	);
 	const shouldShowWooCommerce = true;
+	/*
+	 * Header controlled by: current_theme_supports( 'custom-header' ) && current_user_can( 'customize' )
+	 * Background controlled by: current_theme_supports( 'custom-background' ) && current_user_can( 'customize' )
+	 * "What the theme supports" doesn't seem to be available in calypso most of the time?
+	 * Example theme w/ these options: "Dara"
+	 */
+	const shouldShowThemes = useSelector( ( state ) =>
+		canCurrentUser( state, selectedSiteId, 'edit_theme_options' )
+	);
 	const shouldShowApperanceHeaderAndBackground = true;
+
 	const shouldShowAdControl = false;
 	const shouldShowAMP = false;
-	const shouldShowThemeOptions = true;
 	const fallbackOptions = {
 		siteDomain,
 		shouldShowLinks,
 		shouldShowTestimonials,
 		shouldShowPortfolio,
 		shouldShowWooCommerce,
+		shouldShowThemes,
 		shouldShowApperanceHeaderAndBackground,
 		shouldShowAdControl,
 		shouldShowAMP,
-		shouldShowThemeOptions,
 	};
 
 	return menuItems ?? buildFallbackResponse( fallbackOptions );

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -31,15 +31,6 @@ const useSiteMenuItems = () => {
 		}
 	}, [ dispatch, selectedSiteId ] );
 
-	/**
-	 * To ensure that a menu is always available in the UI even
-	 * if the network fails on an uncached request we provide a
-	 * set of static fallback data to render a basic menu. This
-	 * avoids a situation where the user might be left with an
-	 * empty menu.
-	 */
-
-	const shouldShowLinks = true;
 	const shouldShowTestimonials = useSelector( ( state ) =>
 		get( state.siteSettings.items, [ selectedSiteId, 'jetpack_testimonial' ], false )
 	);
@@ -49,30 +40,18 @@ const useSiteMenuItems = () => {
 	const shouldShowWooCommerce = useSelector(
 		( state ) => !! getPluginOnSite( state, selectedSiteId, 'woocommerce' )?.active
 	);
-	/*
-	 * Header controlled by: current_theme_supports( 'custom-header' ) && current_user_can( 'customize' )
-	 * Background controlled by: current_theme_supports( 'custom-background' ) && current_user_can( 'customize' )
-	 * "What the theme supports" doesn't seem to be available in calypso most of the time?
-	 * Example theme w/ these options: "Dara"
-	 */
 	const shouldShowThemes = useSelector( ( state ) =>
 		canCurrentUser( state, selectedSiteId, 'edit_theme_options' )
 	);
-	const shouldShowApperanceHeaderAndBackground = true;
 
-	const shouldShowAdControl = false;
-	const shouldShowAMP = false;
 	const fallbackOptions = {
 		siteDomain,
-		shouldShowLinks,
 		shouldShowTestimonials,
 		shouldShowPortfolio,
 		shouldShowWooCommerce,
 		shouldShowThemes,
-		shouldShowApperanceHeaderAndBackground,
-		shouldShowAdControl,
-		shouldShowAMP,
 	};
+
 	return menuItems ?? buildFallbackResponse( fallbackOptions );
 };
 

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -4,6 +4,7 @@
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import buildFallbackResponse from './fallback-data.js';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,8 +34,12 @@ const useSiteMenuItems = () => {
 	 * empty menu.
 	 */
 	const shouldShowLinks = true;
-	const shouldShowTestimonials = true;
-	const shouldShowPortfolio = true;
+	const shouldShowTestimonials = useSelector( ( state ) =>
+		get( state.siteSettings.items, [ selectedSiteId, 'jetpack_testimonial' ], false )
+	);
+	const shouldShowPortfolio = useSelector( ( state ) =>
+		get( state.siteSettings.items, [ selectedSiteId, 'jetpack_portfolio' ], false )
+	);
 	const shouldShowWooCommerce = true;
 	const shouldShowApperanceHeaderAndBackground = true;
 	const shouldShowAdControl = true;

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -32,12 +32,27 @@ const useSiteMenuItems = () => {
 	 * avoids a situation where the user might be left with an
 	 * empty menu.
 	 */
-	return (
-		menuItems ??
-		buildFallbackResponse( {
-			siteDomain,
-		} )
-	);
+	const shouldShowLinks = true;
+	const shouldShowTestimonials = true;
+	const shouldShowPortfolio = true;
+	const shouldShowWooCommerce = true;
+	const shouldShowApperanceHeaderAndBackground = true;
+	const shouldShowAdControl = true;
+	const shouldShowAMP = true;
+	const shouldShowThemeOptions = true;
+	const fallbackOptions = {
+		siteDomain,
+		shouldShowLinks,
+		shouldShowTestimonials,
+		shouldShowPortfolio,
+		shouldShowWooCommerce,
+		shouldShowApperanceHeaderAndBackground,
+		shouldShowAdControl,
+		shouldShowAMP,
+		shouldShowThemeOptions,
+	};
+
+	return menuItems ?? buildFallbackResponse( fallbackOptions );
 };
 
 export default useSiteMenuItems;

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -4,7 +4,6 @@
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import buildFallbackResponse from './fallback-data.js';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -15,6 +15,9 @@ import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 
+import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
+import { fetchPlugins } from 'calypso/state/plugins/installed/actions';
+
 const useSiteMenuItems = () => {
 	const dispatch = useDispatch();
 	const selectedSiteId = useSelector( getSelectedSiteId );
@@ -24,6 +27,7 @@ const useSiteMenuItems = () => {
 	useEffect( () => {
 		if ( selectedSiteId !== null ) {
 			dispatch( requestAdminMenu( selectedSiteId ) );
+			dispatch( fetchPlugins( [ selectedSiteId ] ) );
 		}
 	}, [ dispatch, selectedSiteId ] );
 
@@ -42,7 +46,9 @@ const useSiteMenuItems = () => {
 	const shouldShowPortfolio = useSelector( ( state ) =>
 		get( state.siteSettings.items, [ selectedSiteId, 'jetpack_portfolio' ], false )
 	);
-	const shouldShowWooCommerce = true;
+	const shouldShowWooCommerce = useSelector(
+		( state ) => !! getPluginOnSite( state, selectedSiteId, 'woocommerce' )?.active
+	);
 	/*
 	 * Header controlled by: current_theme_supports( 'custom-header' ) && current_user_can( 'customize' )
 	 * Background controlled by: current_theme_supports( 'custom-background' ) && current_user_can( 'customize' )
@@ -67,7 +73,6 @@ const useSiteMenuItems = () => {
 		shouldShowAdControl,
 		shouldShowAMP,
 	};
-
 	return menuItems ?? buildFallbackResponse( fallbackOptions );
 };
 

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -42,8 +42,8 @@ const useSiteMenuItems = () => {
 	);
 	const shouldShowWooCommerce = true;
 	const shouldShowApperanceHeaderAndBackground = true;
-	const shouldShowAdControl = true;
-	const shouldShowAMP = true;
+	const shouldShowAdControl = false;
+	const shouldShowAMP = false;
 	const shouldShowThemeOptions = true;
 	const fallbackOptions = {
 		siteDomain,


### PR DESCRIPTION
This improves the fallback data response to more closely resemble what is returned by the API endpoint. Note however that we aren't trying to guarantee a 1:1 between the dynamic API items and these static fallback. These fallback are very much that - fallback! We just need to aim for "good enough". To this end I've decided to avoid adding too many conditionals, interogating state or relying on API requests to decided what should/shouldn't be shown.

The aim is to make the fallback acceptable enough so that on the few occasions the user does see it, they don't notice a huge difference. 

Closes #45910

## Demo

📺 https://d.pr/v/ph2Fpx/cyvkiVr3sC - for an example in action take a look at the screencapture I recorded. Slow down to 0.5x to see the transition between fallback and the response from the API.



## Changes proposed in this Pull Request

* (Already existing) Nav Unification implements a left sidebar menu that's rendered with data pulled from an AJAX request to wpcom.
* (Already existing) That sidebar is rendered from static data in calypso if the menu items ajax request fails.
* (In this PR) We attempt to add/remove some items from the fallback data depending on other information we can find in state. In general however we opt for static data and avoid over complicating things.

## Feedback Requested

**Note:** The following feedback has been updated by @getdave in response to changes in this PR:

* Does this make sense to do?
  * ~If data could not be loaded from AJAX, we are making decisions with other data loaded from different AJAX.  It seems like a niche failure case we're addressing (one ajax request fails while other ajax requests work).~ @getdave - Great point. After considering, yes I believe it does but _only in limited circumstances_. I've now dramatically cut back on where we're making API requests to determine what is/isn't shown in the fallback. We need to strike a happy medium here. In general we should aim for completely static data and this is what I have documented in the code comments.
  * ~Data isn't always available.  For example, I found testimonials and portfolio in `state.siteSettings.items`, but that isn't always filled out.  It's requested by `<QuerySiteSettings>` only on some pages.  It seems like a waste to add that request though, as this is only rarely needed.~ @getdave - I agree. Some data isn't available (eg: `state.siteSettings` until you navigate to a particular portion of the admin. Therefore we should avoid relying on such data and just accept we don't need to be complete 1:1 with the actual menu API response. Otherwise we're going to be rewriting the Menu API! 

* Note: This isn't complete.
  * ~`shouldShowTestimonials`, `shouldShowPortfolio`: Found these in `state.siteSettings`.~ Defaulted these to `true` and removed any attempt to determine dynamically.
  * ~`shouldShowLinks`: Couldn't find a case when links don't show.  Does anyone know them?~ Defaulted these to `true` and removed any attempt to determine dynamically.
  * ~`shouldShowWooCommerce`, `shouldShowApperanceHeaderAndBackground`, `shouldShowAdControl`, `shouldShowAMP`, `shouldShowThemeOptions`: Wanted to get some feedback before spending time on these.  I did default ad control and AMP to off, though, since it seems like that's the default case for these.~ I have defaulted most of these to `false` with the expectation of WooCommerce where I am checking whether the Plugin is active. I think this is important enough to be worth the trade off of an additional API request.

* Note: The PR might be easier to follow if you look at the individual commits.

## Testing instructions

* Have at least one blog with testimonials turned on. To turn on testimonials, switch to the twentytwenty theme, then in regular calypso, visit Sidebar -> Manage -> Settings -> Main Area "Writing" Tab -> Turn testimonials on.
* Check out this branch.
* Open Dev tools and under `Application` delete the IndexDB to clear it out.
* Visit calypso with Nav Unification active.
* Observe the menu items on the left. You should see a set of fallback menu items load and then be replaced by the items from the menu API response. 
* If you're not sure you are seeing the fallback items, you should try editing some of the titles of the items in `client/my-sites/sidebar-unified/fallback-data.js` and then repeating the test procedure (being sure to clear IndexDB between each run else you'll get the cache!).
* Also try the test procedure above with an eCommerce site active. WooCommerce should show up in the fallback menu data if it is active.

#### Alternative - force use fallback data

If you wish to for the fallback data for testing purposes you can manually edit `client/my-sites/sidebar-unified/use-site-menu-items.js` as follows:

```diff
+      return buildFallbackResponse( fallbackDataOverides );
-       return menuItems ?? buildFallbackResponse( fallbackDataOverides );
 }; 
```

