### PR TITLE
Fix broken Checkout's cancel button when coming from Jetpack's Plans page

### DIFF
--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -597,13 +597,19 @@ export function checkout(
 	urlQueryArgs: QueryArgs
 ): void {
 	const productsArray = isArray( products ) ? products : [ products ];
+	const productsString = productsArray.join( ',' );
 
-	// There is not siteSlug, we need to redirect the user to the site selection
+	// If there is not siteSlug, we need to redirect the user to the site selection
 	// step of the flow. Since purchases of multiple products are allowed, we need
 	// to pass all products separated by comma in the URL.
-	const path = siteSlug
-		? `/checkout/${ siteSlug }/${ isJetpackCloud() ? productsArray.join( ',' ) : '' }`
-		: `/jetpack/connect/${ productsArray.join( ',' ) }`;
+	let path;
+	if ( ! siteSlug ) {
+		path = `/jetpack/connect/${ productsString }`;
+	} else {
+		path = isJetpackCloud()
+			? `/checkout/${ siteSlug }/${ productsString }`
+			: `/checkout/${ siteSlug }`;
+	}
 
 	if ( isJetpackCloud() ) {
 		window.location.href = addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a bug that only affects users visiting the Checkout page that came from the Jetpack's Plans page.

* Fix the behavior of the Checkout's cancel button to redirect users back to where they came from. The problem is that we were redirecting users to `/checkout/:site/` instead of to `/checkout/:site` (notice the `/` at the end of the path). That `/` at the end of the path made the app do a double redirect to the Checkout page, which overrode the stored previous path.

#### Testing instructions

* Run this PR (horizon is fine).
* Visit the Plans page with a Jetpack site.
* Select any plan or product.
* Once in the Checkout page, click on the cancel button located at the upper-left corner of the screen.
* Make sure you are redirected back to the Plans page.
* Repeat the process in production to make sure you understand what the problem is (you should get stuck in the Checkout page).

Fixes 1164141197617539-as-1198902726378856

#### Demo

##### Before
![Kapture 2020-10-26 at 17 39 42](https://user-images.githubusercontent.com/3418513/97226696-1b53e580-17b3-11eb-8a37-7a382ee8ae0b.gif)

##### After
![Kapture 2020-10-26 at 17 38 58](https://user-images.githubusercontent.com/3418513/97226692-1a22b880-17b3-11eb-8364-ad1e7e1d8407.gif)
