### PR TITLE
CRO i.2: Jetpack search card - align Info Popover

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
@@ -170,11 +170,13 @@ const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 											<InfoPopover
 												className="jetpack-product-card-alt-2__search-price-popover"
 												position="right"
+												iconSize={ 24 }
 											>
 												{ searchRecordsDetails }
 											</InfoPopover>
 										) }
 									</span>
+
 									{ renderBillingTimeFrame( parsedExpiryDate, billingTimeFrame ) }
 								</>
 							) : (

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
@@ -189,12 +189,13 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 }
 
 .jetpack-product-card-alt-2__raw-price {
-	display: flex;
-	justify-content: center;
-	align-items: flex-end;
+	position: relative;
 
-	:last-child {
-		margin-right: 0;
+	.jetpack-product-card-alt-2__search-price-popover {
+		position: absolute;
+		top: 8px;
+		right: -27px;
+		padding: 5px;
 	}
 }
 
@@ -253,9 +254,6 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 }
 
 .jetpack-product-card-alt-2__search-price-popover {
-	margin-bottom: 40px;
-	margin-left: 24px;
-
 	.gridicon {
 		color: var( --studio-gray-20 );
 	}

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
@@ -253,7 +253,7 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 	color: var( --studio-gray-70 );
 }
 
-.jetpack-product-card-alt-2__search-price-popover {
+.info-popover.jetpack-product-card-alt-2__search-price-popover {
 	.gridicon {
 		color: var( --studio-gray-20 );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR aligns the InfoPopover to the right of the product Price (**allowing the Price to be center aligned**) in the Jetpack Search Card.

### Additional Notes:
I don't think the Jetpack Scan Price ($4.14) is correct. I think it should be a flat **$4** and will be handled in a different PR.  So therefore, disregard the price amount in testing this PR as well as any other copy differences, etc.  We are only testing to make sure the **price is now centered and the info pop-over is aligned to the right of the price**.

### Testing instructions

1. Checkout this PR
2. Start Calypso visit the Plans page
3.  In the jetpackConversionRateOptimization A/B test, select `v2 - slide outs` 
4. Scroll down to the Jetpack Search product card and verify that:
    1. The product price is centered.
    2. The info pop-over is aligned to the right of the price (See screenshot).
    3. The info Icon is slightly larger (24px), matching figma design.
    4. The info pop-over behaves as expected.

### Screenshots

**BEFORE:**

![Markup 2020-10-26 at 15 40 23](https://user-images.githubusercontent.com/11078128/97236507-792c0180-17a2-11eb-905b-78fbce3bc0d2.png)

**AFTER:**

![Markup 2020-10-26 at 16 04 03](https://user-images.githubusercontent.com/11078128/97237713-ee003b00-17a4-11eb-8b1c-2dfbbac10bb0.png)

**FIGMA DESIGN MOCKUP:**

![Screenshot on 2020-10-26 at 15-43-37](https://user-images.githubusercontent.com/11078128/97236529-83e69680-17a2-11eb-8896-89eaaa30f0b8.png)


Fixes: 1196341175636977-as-1198920526622500/f