### PR TITLE
Support new line height setting

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -140,7 +140,13 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_script_and_
  * @return array Gutenberg editor settings with line-height setting always enabled.
  **/
 function wpcom_gutenberg_enable_custom_line_height( $settings ) {
-	$settings['enableCustomLineHeight'] = true;
+	if ( isset( $settings['__experimentalFeatures']['global']['typography'] ) ) {
+		// Update the global styles settings to always enable line height.
+		$settings['__experimentalFeatures']['global']['typography']['customLineHeight'] = true;
+	} else {
+		// This approach is deprecated, but we should still support it as a fallback just in case.
+		$settings['enableCustomLineHeight'] = true;
+	}
 	return $settings;
 }
 add_filter( 'block_editor_settings', __NAMESPACE__ . '\wpcom_gutenberg_enable_custom_line_height', 11 );


### PR DESCRIPTION
### Changes proposed in this Pull Request
In https://github.com/WordPress/gutenberg/pull/25738, Gutenberg moved the lineHeight setting to a new place in the settings object. It also introduced a (sort of?) bug where even though it has a mechanism to use the deprecated location for the setting, it is never used because the default value is returned instead.

This simply updates our existing filter to enable line height in the new location if the new location exists. I left the old setting in place as well, just in case we still need to support older gutenberg versions. 

### To test:
1. Sandbox a site on wordpress.com
2. Sync these changes with `yarn dev --sync`
3. Open the post editor.
4. Select a paragraph block
5. Verify that line height is an option in the settings. 

<img width="1410" alt="Screen Shot 2020-10-26 at 6 07 47 PM" src="https://user-images.githubusercontent.com/6265975/97244523-31af7080-17b6-11eb-997b-ac0e2891f5e5.png">

