### PR TITLE
Update Gutenboarding style preview to use i18nLocale instead of path language param

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -4,13 +4,12 @@
 import * as React from 'react';
 import { addQueryArgs } from '@wordpress/url';
 import { useSelect } from '@wordpress/data';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
-import { useLangRouteParam } from '../../path';
-import { isEnabled } from 'config';
 import { fontPairings } from '../../constants';
 import type { Viewport } from './types';
 
@@ -56,13 +55,13 @@ interface Props {
 	viewport: Viewport;
 }
 const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
+	const { i18nLocale } = useI18n();
 	const [ previewHtml, setPreviewHtml ] = React.useState< string >();
-	const { selectedDesign, selectedFonts, siteVertical, siteTitle } = useSelect( ( select ) =>
+	const { selectedDesign, selectedFonts, siteTitle } = useSelect( ( select ) =>
 		select( STORE_KEY ).getState()
 	);
 
 	const iframe = React.useRef< HTMLIFrameElement >( null );
-	const language = useLangRouteParam();
 
 	React.useEffect(
 		() => {
@@ -73,19 +72,14 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 				const templateUrl = `https://public-api.wordpress.com/rest/v1/template/demo/${ encodeURIComponent(
 					selectedDesign.theme
 				) }/${ encodeURIComponent( selectedDesign.template ) }/`;
-				let url = addQueryArgs( templateUrl, {
-					language: language,
+				const url = addQueryArgs( templateUrl, {
+					language: i18nLocale,
 					site_title: siteTitle,
 					...( selectedFonts && {
 						font_headings: selectedFonts.headings,
 						font_base: selectedFonts.base,
 					} ),
 				} );
-				if ( isEnabled( 'gutenboarding/style-preview-verticals' ) ) {
-					url = addQueryArgs( url, {
-						vertical: siteVertical?.label,
-					} );
-				}
 
 				let resp;
 
@@ -111,7 +105,7 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 			eff();
 		},
 		// Disable reason: We'll handle font change elsewhere.
-		[ language, selectedDesign, siteVertical ] // eslint-disable-line react-hooks/exhaustive-deps
+		[ i18nLocale, selectedDesign ] // eslint-disable-line react-hooks/exhaustive-deps
 	);
 
 	React.useEffect( () => {

--- a/config/stage.json
+++ b/config/stage.json
@@ -42,7 +42,6 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"gutenboarding/mshot-preview": false,
-		"gutenboarding/style-preview-verticals": false,
 		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,
 		"happychat": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -48,7 +48,6 @@
 		"gdpr-banner": true,
 		"google-my-business": true,
 		"gutenboarding/mshot-preview": false,
-		"gutenboarding/style-preview-verticals": false,
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,


### PR DESCRIPTION
Prior to this PR, if you set your logged-in user locale to a non `en` language, the style preview in Gutenboarding would not use the locale for generating the url for the design preview as it depended on the path param value. This PR swaps out the `useLangRouteParam()` for `i18nLocale` from `useI18n` in `@automattic/react-i18n` to get the current locale.

#### Changes proposed in this Pull Request

* Change the Gutenboarding style preview step to use `i18nLocale` to grab the current locale for use in generating the preview url
* Remove the `'gutenboarding/style-preview-verticals'` config flag and conditional block in constructing the template/demo url since we are unlikely to implement verticals here any time soon and the endpoint doesn't currently support it.

#### Screenshot

![image](https://user-images.githubusercontent.com/14988353/97254873-7ba26000-1863-11eb-8854-72a846f340a6.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change your user's locale to a non-EN locale
* Go to `calypso.localhost:3000/new` without adding a locale to the URL and check that when you get to the style preview step, that the preview is translated
* Add a locale to the URL, e.g. `calypso.localhost:3000/new/ko` and when you get to the style preview, check that the preview renders with the language you used in the url
* Double-check that the removal of the `gutenboarding/style-preview-verticals` flag looks good (e.g. I haven't missed other areas where that flag was referenced)

Related to: #37665 
