### PR TITLE
Launch Jetpack Cloud Host-Specific Credentials Project

### DIFF
--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -23,7 +23,7 @@
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
-		"jetpack/server-credentials-advanced-flow": false,
+		"jetpack/server-credentials-advanced-flow": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -20,7 +20,7 @@
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
-		"jetpack/server-credentials-advanced-flow": false,
+		"jetpack/server-credentials-advanced-flow": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -22,7 +22,7 @@
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
-		"jetpack/server-credentials-advanced-flow": false,
+		"jetpack/server-credentials-advanced-flow": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -21,7 +21,7 @@
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
-		"jetpack/server-credentials-advanced-flow": false,
+		"jetpack/server-credentials-advanced-flow": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Toggle `jetpack/server-credentials-advanced-flow` in all jetpack cloud configs

#### Testing instructions

1. navigate to `/settings/:siteSlug`
2. verify new host-specific site flow is visible
