### PR TITLE
data-layer: simplify media handlers

### DIFF
--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -56,10 +56,10 @@ export function updateMedia( action ) {
 	];
 }
 
-export const updateMediaSuccess = ( { siteId }, mediaItem ) => ( dispatch ) => {
-	dispatch( receiveMedia( siteId, mediaItem ) );
-	dispatch( gutenframeUpdateImageBlocks( mediaItem, 'updated' ) );
-};
+export const updateMediaSuccess = ( { siteId }, mediaItem ) => [
+	receiveMedia( siteId, mediaItem ),
+	gutenframeUpdateImageBlocks( mediaItem, 'updated' ),
+];
 
 export const updateMediaError = ( { siteId, originalMediaItem } ) => [
 	receiveMedia( siteId, originalMediaItem ),
@@ -123,9 +123,7 @@ export const requestMediaSuccess = ( { siteId, query }, data ) => ( dispatch, ge
 	dispatch( setNextPageHandle( siteId, data.meta ) );
 };
 
-export const requestMediaError = ( { siteId, query } ) => ( dispatch ) => {
-	dispatch( failMediaRequest( siteId, query ) );
-};
+export const requestMediaError = ( { siteId, query } ) => [ failMediaRequest( siteId, query ) ];
 
 export function requestMediaItem( action ) {
 	const { mediaId, query, siteId } = action;
@@ -145,14 +143,14 @@ export function requestMediaItem( action ) {
 	];
 }
 
-export const receiveMediaItem = ( { mediaId, siteId }, media ) => ( dispatch ) => {
-	dispatch( receiveMedia( siteId, media ) );
-	dispatch( successMediaItemRequest( siteId, mediaId ) );
-};
+export const receiveMediaItem = ( { mediaId, siteId }, media ) => [
+	receiveMedia( siteId, media ),
+	successMediaItemRequest( siteId, mediaId ),
+];
 
-export const receiveMediaItemError = ( { mediaId, siteId } ) => ( dispatch ) => {
-	dispatch( failMediaItemRequest( siteId, mediaId ) );
-};
+export const receiveMediaItemError = ( { mediaId, siteId } ) => [
+	failMediaItemRequest( siteId, mediaId ),
+];
 
 export const requestDeleteMedia = ( action ) => {
 	const { siteId, mediaId } = action;
@@ -170,11 +168,11 @@ export const requestDeleteMedia = ( action ) => {
 	];
 };
 
-export const deleteMediaSuccess = ( { siteId }, mediaItem ) => ( dispatch ) => {
-	dispatch( deleteMedia( siteId, mediaItem.ID ) );
-	dispatch( requestMediaStorage( siteId ) );
-	dispatch( gutenframeUpdateImageBlocks( mediaItem, 'deleted' ) );
-};
+export const deleteMediaSuccess = ( { siteId }, mediaItem ) => [
+	deleteMedia( siteId, mediaItem.ID ),
+	requestMediaStorage( siteId ),
+	gutenframeUpdateImageBlocks( mediaItem, 'deleted' ),
+];
 
 export const deleteMediaError = ( { mediaId } ) => [
 	errorNotice( translate( 'We were unable to delete this media item.' ), {

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -123,7 +123,7 @@ export const requestMediaSuccess = ( { siteId, query }, data ) => ( dispatch, ge
 	dispatch( setNextPageHandle( siteId, data.meta ) );
 };
 
-export const requestMediaError = ( { siteId, query } ) => [ failMediaRequest( siteId, query ) ];
+export const requestMediaError = ( { siteId, query } ) => failMediaRequest( siteId, query );
 
 export function requestMediaItem( action ) {
 	const { mediaId, query, siteId } = action;
@@ -148,9 +148,8 @@ export const receiveMediaItem = ( { mediaId, siteId }, media ) => [
 	successMediaItemRequest( siteId, mediaId ),
 ];
 
-export const receiveMediaItemError = ( { mediaId, siteId } ) => [
-	failMediaItemRequest( siteId, mediaId ),
-];
+export const receiveMediaItemError = ( { mediaId, siteId } ) =>
+	failMediaItemRequest( siteId, mediaId );
 
 export const requestDeleteMedia = ( action ) => {
 	const { siteId, mediaId } = action;

--- a/client/state/data-layer/wpcom/sites/media/test/index.js
+++ b/client/state/data-layer/wpcom/sites/media/test/index.js
@@ -52,11 +52,9 @@ describe( 'media request', () => {
 	} );
 
 	test( 'should dispatch FAILURE action when request fails', () => {
-		const dispatch = jest.fn();
+		const result = requestMediaError( { siteId: 2916284, query: 'a=b' } );
 
-		requestMediaError( { siteId: 2916284, query: 'a=b' } )( dispatch );
-
-		expect( dispatch ).toHaveBeenCalledWith( failMediaRequest( 2916284, 'a=b' ) );
+		expect( result ).toEqual( [ failMediaRequest( 2916284, 'a=b' ) ] );
 	} );
 
 	test( 'should dispatch http request', () => {
@@ -111,17 +109,17 @@ describe( 'receiveMediaItem', () => {
 		};
 		const media = { ID: 91827364 };
 
-		const dispatch = jest.fn();
+		const result = receiveMediaItem( action, media );
 
-		receiveMediaItem( action, media )( dispatch );
-
-		expect( dispatch ).toHaveBeenNthCalledWith( 1, receiveMedia( siteId, media ) );
-		expect( dispatch ).toHaveBeenNthCalledWith( 2, successMediaItemRequest( siteId, mediaId ) );
+		expect( result ).toEqual( [
+			receiveMedia( siteId, media ),
+			successMediaItemRequest( siteId, mediaId ),
+		] );
 	} );
 } );
 
 describe( 'receiveMediaItemError', () => {
-	test( 'should dispatch failure', () => {
+	test( 'should return a failure action', () => {
 		const siteId = 12345;
 		const mediaId = 67890;
 		const action = {
@@ -130,10 +128,8 @@ describe( 'receiveMediaItemError', () => {
 			siteId,
 		};
 
-		const dispatch = jest.fn();
+		const result = receiveMediaItemError( action );
 
-		receiveMediaItemError( action )( dispatch );
-
-		expect( dispatch ).toHaveBeenCalledWith( failMediaItemRequest( siteId, mediaId ) );
+		expect( result ).toEqual( [ failMediaItemRequest( siteId, mediaId ) ] );
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/media/test/index.js
+++ b/client/state/data-layer/wpcom/sites/media/test/index.js
@@ -54,7 +54,7 @@ describe( 'media request', () => {
 	test( 'should dispatch FAILURE action when request fails', () => {
 		const result = requestMediaError( { siteId: 2916284, query: 'a=b' } );
 
-		expect( result ).toEqual( [ failMediaRequest( 2916284, 'a=b' ) ] );
+		expect( result ).toEqual( failMediaRequest( 2916284, 'a=b' ) );
 	} );
 
 	test( 'should dispatch http request', () => {
@@ -130,6 +130,6 @@ describe( 'receiveMediaItemError', () => {
 
 		const result = receiveMediaItemError( action );
 
-		expect( result ).toEqual( [ failMediaItemRequest( siteId, mediaId ) ] );
+		expect( result ).toEqual( failMediaItemRequest( siteId, mediaId ) );
 	} );
 } );


### PR DESCRIPTION
Note: This PR is intended to be merged into #46781 

#### Changes proposed in this Pull Request

* Simplify a few media data layer handlers where we don't need the additional thunk-style syntax anymore

#### Testing instructions

* Open the media library and make sure you're able update media data (e.g. description or caption) and deleting items
