### PR TITLE
Add recordTracksEvent for Editor NUX modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -63,7 +63,12 @@ function WpcomNux() {
 		return null;
 	}
 
-	const dismissWpcomNux = () => setWpcomNuxStatus( { isNuxEnabled: false } );
+	const dismissWpcomNux = () => {
+		recordTracksEvent( 'calypso_editor_wpcom_nux_dismiss', {
+			is_gutenboarding: window.calypsoifyGutenberg?.isGutenboarding,
+		} );
+		setWpcomNuxStatus( { isNuxEnabled: false } );
+	};
 
 	/* @TODO: the copy, images, and slides will eventually be the same for all sites. `isGutenboarding` is only needed right now to show the Privacy slide */
 	const isGutenboarding = !! window.calypsoifyGutenberg?.isGutenboarding;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -50,12 +50,18 @@ function WpcomNux() {
 		isWpcomNuxEnabled && closeGeneralSidebar();
 	}, [ closeGeneralSidebar, isWpcomNuxEnabled ] );
 
+	// Track opening of the NUX Guide
+	useEffect( () => {
+		if ( isWpcomNuxEnabled && ! isSPTOpen ) {
+			recordTracksEvent( 'calypso_editor_wpcom_nux_open', {
+				is_gutenboarding: window.calypsoifyGutenberg?.isGutenboarding,
+			} );
+		}
+	}, [ isWpcomNuxEnabled, isSPTOpen ] );
+
 	if ( ! isWpcomNuxEnabled || isSPTOpen ) {
 		return null;
 	}
-	recordTracksEvent( 'calypso_newsite_wpcomnux_view', {
-		is_new_flow: isGutenboarding,
-	} );
 
 	const dismissWpcomNux = () => setWpcomNuxStatus( { isNuxEnabled: false } );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -72,7 +72,7 @@ function WpcomNux() {
 
 	/* @TODO: the copy, images, and slides will eventually be the same for all sites. `isGutenboarding` is only needed right now to show the Privacy slide */
 	const isGutenboarding = !! window.calypsoifyGutenberg?.isGutenboarding;
-
+	const pages = getWpcomNuxPages( isGutenboarding );
 	return (
 		<Guide
 			className="wpcom-block-editor-nux"
@@ -80,8 +80,13 @@ function WpcomNux() {
 			finishButtonText={ __( 'Get started', 'full-site-editing' ) }
 			onFinish={ dismissWpcomNux }
 		>
-			{ getWpcomNuxPages( isGutenboarding ).map( ( nuxPage ) => (
-				<NuxPage key={ nuxPage.heading } { ...nuxPage } />
+			{ pages.map( ( nuxPage, index ) => (
+				<NuxPage
+					key={ nuxPage.heading }
+					pageNumber={ index + 1 }
+					isLastPage={ index === pages.length - 1 }
+					{ ...nuxPage }
+				/>
 			) ) }
 		</Guide>
 	);
@@ -136,7 +141,13 @@ function getWpcomNuxPages( isGutenboarding ) {
 	].filter( ( nuxPage ) => ! nuxPage.shouldHide );
 }
 
-function NuxPage( { alignBottom = false, heading, description, imgSrc } ) {
+function NuxPage( { pageNumber, isLastPage, alignBottom = false, heading, description, imgSrc } ) {
+	useEffect( () => {
+		recordTracksEvent( 'calypso_newsite_wpcomnux_slide_view', {
+			slide_number: pageNumber,
+			is_last_slide: isLastPage,
+		} );
+	}, [] );
 	return (
 		<GuidePage className="wpcom-block-editor-nux__page">
 			<div className="wpcom-block-editor-nux__text">

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -146,6 +146,7 @@ function NuxPage( { pageNumber, isLastPage, alignBottom = false, heading, descri
 		recordTracksEvent( 'calypso_editor_wpcom_nux_slide_view', {
 			slide_number: pageNumber,
 			is_last_slide: isLastPage,
+			is_gutenboarding: window.calypsoifyGutenberg?.isGutenboarding,
 		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -11,6 +11,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 
 /**
  * Internal dependencies
@@ -52,6 +53,9 @@ function WpcomNux() {
 	if ( ! isWpcomNuxEnabled || isSPTOpen ) {
 		return null;
 	}
+	recordTracksEvent( 'calypso_newsite_wpcomnux_view', {
+		is_new_flow: isGutenboarding,
+	} );
 
 	const dismissWpcomNux = () => setWpcomNuxStatus( { isNuxEnabled: false } );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -72,7 +72,7 @@ function WpcomNux() {
 
 	/* @TODO: the copy, images, and slides will eventually be the same for all sites. `isGutenboarding` is only needed right now to show the Privacy slide */
 	const isGutenboarding = !! window.calypsoifyGutenberg?.isGutenboarding;
-	const pages = getWpcomNuxPages( isGutenboarding );
+	const nuxPages = getWpcomNuxPages( isGutenboarding );
 	return (
 		<Guide
 			className="wpcom-block-editor-nux"
@@ -80,11 +80,11 @@ function WpcomNux() {
 			finishButtonText={ __( 'Get started', 'full-site-editing' ) }
 			onFinish={ dismissWpcomNux }
 		>
-			{ pages.map( ( nuxPage, index ) => (
+			{ nuxPages.map( ( nuxPage, index ) => (
 				<NuxPage
 					key={ nuxPage.heading }
 					pageNumber={ index + 1 }
-					isLastPage={ index === pages.length - 1 }
+					isLastPage={ index === nuxPages.length - 1 }
 					{ ...nuxPage }
 				/>
 			) ) }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -143,10 +143,11 @@ function getWpcomNuxPages( isGutenboarding ) {
 
 function NuxPage( { pageNumber, isLastPage, alignBottom = false, heading, description, imgSrc } ) {
 	useEffect( () => {
-		recordTracksEvent( 'calypso_newsite_wpcomnux_slide_view', {
+		recordTracksEvent( 'calypso_editor_wpcom_nux_slide_view', {
 			slide_number: pageNumber,
 			is_last_slide: isLastPage,
 		} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 	return (
 		<GuidePage className="wpcom-block-editor-nux__page">


### PR DESCRIPTION
# Changes proposed in this Pull Request

* track NUX modal opening: `calypso_editor_wpcom_nux_open`
* track NUX modal dismiss: `calypso_editor_wpcom_nux_dismiss`
* track each NUX modal screen the user sees: `calypso_editor_wpcom_nux_slide_view`
* track `is_last_slide`



# Testing instructions

* sync Editing Toolkit to your sandbox
* create new user & new site -or- see below for instructions to reset nux status for exisiting user

* View NUX model opening in the Editor 
* Verify tracking network request (see screenshot) for each of the 3 tracking events. The last event will fire for each of the 4 slides with data to track slide number.
  * `calypso_editor_wpcom_nux_open`
  * `calypso_editor_wpcom_nux_dismiss`
  * `calypso_editor_wpcom_nux_slide_view` (fired on each slide)
		- note the data passed for each slide: `slide_number` `is_last_slide`. 


Hover over the network request to show the full tracking event label
![Screen Shot 2020-10-30 at 16 14 33](https://user-images.githubusercontent.com/5665959/97662473-50ba4500-1acb-11eb-8389-7fd408a48d01.png)


####  🚧  This didn't work reliably every time for me. To try reset your nux status to `enabled` so that NUX dialog shows on existing account:
* reset nux status in your sandbox 
  > `wpsh`
  > `update_user_attribute( your_user_id, 'wpcom-block-editor-preferences', [ 'nux-status' => 'enabled' ] );`
  >`update_user_meta( your_user_id, 'wpcom_block_editor_nux_status', 'enabled' )`

* clear local storage: both WP_DATA_USER AND WP_LAUNCH as shown in screenshot
![Screen Shot 2020-10-30 at 16 26 21](https://user-images.githubusercontent.com/5665959/97663054-ac390280-1acc-11eb-9616-aa5ec16713f2.png)


Fixed #47257
