### PR TITLE
Explat: Add schema so state is saved in cache

### DIFF
--- a/client/state/experiments/reducer.ts
+++ b/client/state/experiments/reducer.ts
@@ -9,6 +9,8 @@ import { Action, Reducer } from 'redux';
 import { EXPERIMENT_FETCH, EXPERIMENT_ASSIGN } from 'calypso/state/action-types';
 import { ExperimentState, ExperimentAssign } from 'calypso/state/experiments/types';
 import { tracksAnonymousUserId } from 'calypso/lib/analytics/ad-tracking';
+import { withSchemaValidation } from 'calypso/state/utils';
+import { schema } from 'calypso/state/experiments/schema';
 
 /**
  * Attempt to get the anon id for the user, if set
@@ -64,4 +66,4 @@ const reducer: Reducer< ExperimentState, HandledActions > = (
 	}
 };
 
-export default reducer;
+export default withSchemaValidation( schema, reducer );

--- a/client/state/experiments/schema.js
+++ b/client/state/experiments/schema.js
@@ -1,6 +1,6 @@
 export const schema = {
 	type: 'object',
-	additionalProperties: true,
+	additionalProperties: false,
 	properties: {
 		anonId: {
 			oneOf: [
@@ -12,12 +12,27 @@ export const schema = {
 				},
 			],
 		},
+		isLoading: {
+			type: 'boolean',
+		},
 		nextRefresh: {
 			type: 'number',
 		},
 		variations: {
 			type: 'object',
-			additionalProperties: true,
+			additionalProperties: false,
+			patternProperties: {
+				'^[a-z0-9_]+$': {
+					oneOf: [
+						{
+							type: 'string',
+						},
+						{
+							type: 'null',
+						},
+					],
+				},
+			},
 		},
 	},
 };

--- a/client/state/experiments/schema.js
+++ b/client/state/experiments/schema.js
@@ -1,0 +1,23 @@
+export const schema = {
+	type: 'object',
+	additionalProperties: true,
+	properties: {
+		anonId: {
+			oneOf: [
+				{
+					type: 'string',
+				},
+				{
+					type: 'null',
+				},
+			],
+		},
+		nextRefresh: {
+			type: 'number',
+		},
+		variations: {
+			type: 'object',
+			additionalProperties: true,
+		},
+	},
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a schema so experiment state will be persisted.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to a page with a running experiment
- Verify you have assignments by looking in `state.experiments` on your console
- Refresh the page
- `nextRefresh` should not update.
