### PR TITLE
Login: Set the right autocomplete value on 2FA code field

### DIFF
--- a/client/components/forms/form-verification-code-input/index.jsx
+++ b/client/components/forms/form-verification-code-input/index.jsx
@@ -55,7 +55,7 @@ export default class FormVerificationCodeInput extends React.Component {
 
 		return (
 			<FormTextInput
-				autoComplete="off"
+				autoComplete="one-time-code"
 				className={ classes }
 				pattern="[0-9 ]*"
 				placeholder={ placeholder }


### PR DESCRIPTION
💡 [TIL](https://twitter.com/sulco/status/1320700982943223808) that you can hint to the browser to auto get the 2FA code from SMS. 


#### Changes proposed in this Pull Request

* This PR sets the right autocomplete value for 2FA input field to streamline entering the code at least for macOS and iOS users. 

#### Testing instructions (only works on iOS)

1. Create a new WP.com account using a non-automattic email (you can add `+testing` and use your personal email, eg `omar+testing@gmail.com`). 
2. Activate 2FA using SMS.
3. Using this [URL](https://hash-bb5fff59c660324a4382f14091b57ad9e5651bc4.calypso.live/log-in), Sign in using your phone.
4. The keyboard should suggest the code from the SMS.


I tested this on Chrome iOS and worked like a breeze.