### PR TITLE
fix/unified-sidebar-items-positioning

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -85,7 +85,12 @@ class CurrentSite extends Component {
 					{ this.props.siteCount > 1 && (
 						<span className="current-site__switch-sites">
 							<Button borderless onClick={ this.switchSites }>
-								<Gridicon icon="chevron-left" />
+								{ isEnabled( 'nav-unification' ) ? (
+									// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+									<span className="gridicon dashicons-before dashicons-arrow-left-alt2"></span>
+								) : (
+									<Gridicon icon="chevron-left" />
+								) }
 								<span className="current-site__switch-sites-label">
 									{ translate( 'Switch Site' ) }
 								</span>

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -234,6 +234,10 @@ $font-size: rem( 14px );
 	}
 
 	// client/my-sites/current-site/style.scss
+	.current-site__switch-sites:hover .button.is-borderless:hover {
+		background-color: var( --color-sidebar-menu-hover-heading-background );
+	}
+
 	.current-site__switch-sites .button.is-borderless {
 		color: var( --color-sidebar-text-alternative );
 		padding: 6px 8px 6px 36px;
@@ -244,6 +248,12 @@ $font-size: rem( 14px );
 		width: 20px;
 		top: 9px;
 		left: 8px;
+	}
+
+	// client/blocks/site/style.scss
+	.site__content,
+	.all-sites .all-sites__content {
+		padding: 10px 0 10px 8px;
 	}
 
 	.is-sidebar-collapsed & {

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -120,6 +120,7 @@ $font-size: rem( 14px );
 
 		.sidebar__menu-icon {
 			color: var( --color-sidebar-gridicon-fill );
+			margin-right: 8px;
 		}
 
 		.sidebar__menu-item-parent {
@@ -235,14 +236,14 @@ $font-size: rem( 14px );
 	// client/my-sites/current-site/style.scss
 	.current-site__switch-sites .button.is-borderless {
 		color: var( --color-sidebar-text-alternative );
-		padding: 6px 8px 6px 38px;
+		padding: 6px 8px 6px 36px;
 	}
 
 	.current-site__switch-sites .button.is-borderless .gridicon {
 		height: 20px;
 		width: 20px;
 		top: 9px;
-		left: 9px;
+		left: 8px;
 	}
 
 	.is-sidebar-collapsed & {
@@ -328,12 +329,21 @@ $font-size: rem( 14px );
 		}
 	}
 
-	.collapse-sidebar__toggle .sidebar__menu-link {
-		cursor: pointer;
+	.collapse-sidebar__toggle {
+		.sidebar__menu-link {
+			cursor: pointer;
+			color: var( --color-sidebar-text-alternative );
+			/* stylelint-disable-next-line scales/font-size */
+			font-size: rem( 13px );
 
-		&:hover,
-		&:focus {
-			background-color: transparent;
+			&:hover,
+			&:focus {
+				background-color: transparent;
+			}
+		}
+
+		.sidebar__menu-icon {
+			margin-top: 1px;
 		}
 	}
 
@@ -347,7 +357,8 @@ $font-size: rem( 14px );
 
 	.sidebar-unified__sparkline {
 		width: 80px;
-		height: 24px;
+		height: 21px;
+		margin-right: 8px;
 	}
 
 	/*


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* refines item positioning
* changes site switcher icon to dashicon

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply D51839-code in your sandbox
- Add `nav-unification` sticker in your site (eg `wp blog-stickers add --sticker=nav-unification --who=<username> --blog_id=<blog_id>`)
- Boot the sandboxed site in calypso with `?flags=nav-unification`
- Open the sandboxed site wp-admin
- Compare the interfaces

In the after gif, I captured the masterbar also to distinguish the interfaces (wp-admin doesn't show the unread in Reader)
Before | After
-------|------
![SS 2020-10-27 at 12 21 36](https://user-images.githubusercontent.com/12430020/97295528-1301b600-1858-11eb-8a00-5d90ff640919.gif) | ![SS 2020-10-27 at 13 25 11](https://user-images.githubusercontent.com/12430020/97295548-1dbc4b00-1858-11eb-83fb-1116f2ba61be.gif)


Fixes #46797