### PR TITLE
Launch: Enable launch flow mobile.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -65,7 +65,7 @@
 		"google-drive": true,
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/feature-picker": true,
-		"gutenboarding/new-launch-mobile": false,
+		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/persistent-launch-button": true,
 		"gutenboarding/show-vertical-input": false,
 		"help": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -41,6 +41,7 @@
 		"google-my-business": false,
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/feature-picker": true,
+		"gutenboarding/new-launch-mobile": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -39,6 +39,7 @@
 		"gdpr-banner": true,
 		"google-my-business": true,
 		"gutenboarding/feature-picker": true,
+		"gutenboarding/new-launch-mobile": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -44,6 +44,7 @@
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,
+		"gutenboarding/new-launch-mobile": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/test.json
+++ b/config/test.json
@@ -39,6 +39,7 @@
 		"gdpr-banner": false,
 		"google-my-business": false,
 		"gutenboarding/feature-picker": true,
+		"gutenboarding/new-launch-mobile": true,
 		"help": true,
 		"inline-help": true,
 		"ive/use-external-assignment": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -51,6 +51,7 @@
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/language-picker": false,
 		"gutenboarding/feature-picker": true,
+		"gutenboarding/new-launch-mobile": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This sets the `gutenboarding/new-launch-mobile` feature flag to true on all WP environments.

#### Testing instructions

* Launch flow should be testable without flags on calypso.live and other places as we deploy.

