### PR TITLE
Components: Remove lodash mean() from LineChart

### DIFF
--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -93,7 +93,7 @@ class LineChart extends Component {
 			.filter( ( e ) => e !== null );
 		const meanTickRefs = matchingTicks.length
 			? matchingTicks.reduce( ( total, current ) => total + current, 0 ) / matchingTicks.length
-			: 0;
+			: NaN;
 		// this can only be figured out here, because D3 will decide how many ticks there should be
 		const isFirstMonthTick = index === Math.round( meanTickRefs );
 

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -8,7 +8,7 @@ import { line as d3Line, area as d3Area, curveMonotoneX as d3MonotoneXCurve } fr
 import { scaleLinear as d3ScaleLinear, scaleTime as d3TimeScale } from 'd3-scale';
 import { axisBottom as d3AxisBottom, axisRight as d3AxisRight } from 'd3-axis';
 import { select as d3Select, mouse as d3Mouse } from 'd3-selection';
-import { concat, first, last, mean, throttle, uniq } from 'lodash';
+import { concat, first, last, throttle, uniq } from 'lodash';
 
 /**
  * Internal dependencies
@@ -86,18 +86,17 @@ class LineChart extends Component {
 
 	dateFormatFunction = ( displayMonthTicksOnly ) => ( date, index, tickRefs ) => {
 		const everyOtherTickOnly = ! displayMonthTicksOnly && tickRefs.length > X_AXIS_TICKS_MAX;
+		const matchingTicks = tickRefs
+			.map( ( tickRef, tickRefIndex ) =>
+				tickRef.__data__.getMonth() === date.getMonth() ? tickRefIndex : null
+			)
+			.filter( ( e ) => e !== null );
+		const meanTickRefs = matchingTicks.length
+			? matchingTicks.reduce( ( total, current ) => total + current, 0 ) / matchingTicks.length
+			: 0;
 		// this can only be figured out here, because D3 will decide how many ticks there should be
-		const isFirstMonthTick =
-			index ===
-			Math.round(
-				mean(
-					tickRefs
-						.map( ( tickRef, tickRefIndex ) =>
-							tickRef.__data__.getMonth() === date.getMonth() ? tickRefIndex : null
-						)
-						.filter( ( e ) => e !== null )
-				)
-			);
+		const isFirstMonthTick = index === Math.round( meanTickRefs );
+
 		return ( ! everyOtherTickOnly && ! displayMonthTicksOnly ) ||
 			( everyOtherTickOnly && index % 2 === 0 ) ||
 			( displayMonthTicksOnly && isFirstMonthTick )


### PR DESCRIPTION
This PR rewrites `LineChart` to not use `mean()` and just use pure maths to calculate it. Since this is the only usage of this lodash function, we're effectively removing it from any chunks it's being used in.

#### Changes proposed in this Pull Request

* Components: Remove lodash `mean()` from `LineChart`

#### Testing instructions

* Go to `/devdocs/design/line-chart`
* Click the "Show Data Controls" button.
* Play around with "Series Length" and verify the component still works well with any number you test with.
* Increase the "Series Length" to 30, 31, 32, and observe the x-axis and format of the date.
* Verify in each step of "Series Length" from above the result is the same as in production.