### PR TITLE
Jetpack Connect: carry over query parameters to the checkout page

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -9,9 +9,9 @@ import { get, some, dropRight } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { recordPageView } from 'lib/analytics/page-view';
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import config from 'config';
+import { recordPageView } from 'calypso/lib/analytics/page-view';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import config from 'calypso/config';
 import InstallInstructions from './install-instructions';
 import JetpackAuthorize from './authorize';
 import JetpackConnect from './main';
@@ -24,11 +24,11 @@ import PlansLanding from './plans-landing';
 import SearchPurchase from './search';
 import StoreHeader from './store-header';
 import StoreFooter from './store-footer';
-import { addQueryArgs, sectionify } from 'lib/route';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { getLocaleFromPath, removeLocaleFromPath, getPathParts } from 'lib/i18n-utils';
-import switchLocale from 'lib/i18n-utils/switch-locale';
-import { hideMasterbar, showMasterbar } from 'state/ui/actions';
+import { addQueryArgs, sectionify } from 'calypso/lib/route';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getLocaleFromPath, removeLocaleFromPath, getPathParts } from 'calypso/lib/i18n-utils';
+import switchLocale from 'calypso/lib/i18n-utils/switch-locale';
+import { hideMasterbar, showMasterbar } from 'calypso/state/ui/actions';
 import { OFFER_RESET_FLOW_TYPES } from './flow-types';
 import {
 	ALLOWED_MOBILE_APP_REDIRECT_URL_LIST,
@@ -37,7 +37,7 @@ import {
 	JETPACK_ADMIN_PATH,
 	JPC_PATH_PLANS,
 } from './constants';
-import { login } from 'lib/paths';
+import { login } from 'calypso/lib/paths';
 import { parseAuthorizationQuery } from './utils';
 import {
 	isCalypsoStartedConnection,
@@ -45,11 +45,11 @@ import {
 	retrieveMobileRedirect,
 	storePlan,
 } from './persistence-utils';
-import { startAuthorizeStep } from 'state/jetpack-connect/actions';
-import canCurrentUser from 'state/selectors/can-current-user';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import { getSelectedSite } from 'state/ui/selectors';
-import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
+import { startAuthorizeStep } from 'calypso/state/jetpack-connect/actions';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { isCurrentPlanPaid, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
@@ -57,7 +57,7 @@ import {
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_PREMIUM_MONTHLY,
-} from 'lib/plans/constants';
+} from 'calypso/lib/plans/constants';
 
 import {
 	JETPACK_SEARCH_PRODUCTS,
@@ -71,10 +71,10 @@ import {
 	PRODUCT_JETPACK_SCAN_MONTHLY,
 	PRODUCT_JETPACK_ANTI_SPAM,
 	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
-} from 'lib/products-values/constants';
-import { getProductFromSlug } from 'lib/products-values/get-product-from-slug';
-import { getJetpackProductDisplayName } from 'lib/products-values/get-jetpack-product-display-name';
-import { externalRedirect } from 'lib/route/path';
+} from 'calypso/lib/products-values/constants';
+import { getProductFromSlug } from 'calypso/lib/products-values/get-product-from-slug';
+import { getJetpackProductDisplayName } from 'calypso/lib/products-values/get-jetpack-product-display-name';
+import { externalRedirect } from 'calypso/lib/route/path';
 
 /**
  * Module variables
@@ -273,6 +273,7 @@ export function connect( context, next ) {
 				path={ path }
 				type={ type }
 				url={ query.url }
+				queryArgs={ query }
 				forceRemoteInstall={ query.forceInstall }
 			/>
 		);

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import debugModule from 'debug';
-import config from 'config';
 import React, { Component } from 'react';
+import page from 'page';
 import { connect } from 'react-redux';
 import { flowRight, get, includes, omit } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -11,20 +11,19 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'calypso/config';
+import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
+import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
+import versionCompare from 'calypso/lib/version-compare';
+import { addQueryArgs, externalRedirect } from 'calypso/lib/route';
+import { checkUrl, dismissUrl } from 'calypso/state/jetpack-connect/actions';
+import { getConnectingSite, getJetpackSiteByUrl } from 'calypso/state/jetpack-connect/selectors';
+import { isRequestingSites } from 'calypso/state/sites/selectors';
+import { clearPlan, retrieveMobileRedirect, retrievePlan } from './persistence-utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import HelpButton from './help-button';
 import JetpackConnectNotices from './jetpack-connect-notices';
-import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
-import LoggedOutFormLinks from 'components/logged-out-form/links';
-import page from 'page';
-import versionCompare from 'lib/version-compare';
 import { redirect } from './utils';
-import { addQueryArgs, externalRedirect } from 'lib/route';
-import { checkUrl, dismissUrl } from 'state/jetpack-connect/actions';
-import { getConnectingSite, getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
-import { isRequestingSites } from 'state/sites/selectors';
-import { clearPlan, retrieveMobileRedirect, retrievePlan } from './persistence-utils';
-import { recordTracksEvent } from 'state/analytics/actions';
-
 import { IS_DOT_COM_GET_SEARCH, MINIMUM_JETPACK_VERSION } from './constants';
 import {
 	ALREADY_CONNECTED,
@@ -67,7 +66,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 		goBack = () => page.back();
 
 		processJpSite = ( url ) => {
-			const { isMobileAppFlow, skipRemoteInstall, forceRemoteInstall } = this.props;
+			const { forceRemoteInstall, isMobileAppFlow, queryArgs, skipRemoteInstall } = this.props;
 
 			const status = this.getStatus( url );
 
@@ -86,7 +85,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 				const currentPlan = retrievePlan();
 				clearPlan();
 				if ( currentPlan ) {
-					this.redirect( 'checkout', url, currentPlan );
+					this.redirect( 'checkout', url, currentPlan, queryArgs );
 				} else {
 					this.redirect( 'plans_selection', url );
 				}
@@ -121,11 +120,11 @@ const jetpackConnection = ( WrappedComponent ) => {
 			} );
 		};
 
-		redirect = ( type, url, product ) => {
+		redirect = ( type, url, product, queryArgs ) => {
 			if ( ! this.state.redirecting ) {
 				this.setState( { redirecting: true } );
 
-				redirect( type, url, product );
+				redirect( type, url, product, queryArgs );
 			}
 		};
 

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -1,24 +1,24 @@
 /**
  * External dependencies
  */
-import config, { isCalypsoLive } from 'config';
-import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import PropTypes from 'prop-types';
-import { authorizeQueryDataSchema } from './schema';
 import { head, includes, isEmpty, split } from 'lodash';
 import page from 'page';
-import { urlToSlug } from 'lib/url';
 
 /**
  * Internal dependencies
  */
-import { addQueryArgs, externalRedirect, untrailingslashit } from 'lib/route';
+import config, { isCalypsoLive } from 'calypso/config';
+import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
+import { addQueryArgs, externalRedirect, untrailingslashit } from 'calypso/lib/route';
+import { urlToSlug } from 'calypso/lib/url';
 import {
 	JPC_PATH_PLANS,
 	JPC_PATH_REMOTE_INSTALL,
 	REMOTE_PATH_AUTH,
 	JPC_PATH_CHECKOUT,
 } from './constants';
+import { authorizeQueryDataSchema } from './schema';
 
 export function authQueryTransformer( queryObject ) {
 	return {
@@ -141,9 +141,10 @@ export function parseAuthorizationQuery( query ) {
  * @param  {string}     type Redirect type
  * @param  {string}     url Site url
  * @param  {?string}    product Product slug
+ * @param  {?object}    queryArgs Query parameters
  * @returns {string}        Redirect url
  */
-export function redirect( type, url, product = null ) {
+export function redirect( type, url, product = null, queryArgs = {} ) {
 	let urlRedirect = '';
 	const instr = '/jetpack/connect/instructions';
 
@@ -169,7 +170,7 @@ export function redirect( type, url, product = null ) {
 
 	if ( type === 'checkout' ) {
 		urlRedirect = `${ JPC_PATH_CHECKOUT }/${ urlToSlug( url ) }/${ product }`;
-		page.redirect( urlRedirect );
+		page.redirect( addQueryArgs( queryArgs, urlRedirect ) );
 	}
 
 	return urlRedirect;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The goal is to carry over query parameters throughout the whole flow til the checkout step. This is necessary if we want to include discount coupons on our marketing emails are not linked to a specific site (no site URL is present in links).

#### Notes

* 90% of the changes are related to making `eslint` checks pass.

#### Testing instructions

* Run this PR (horizon works fine).
* Visit `http://calypso.localhost:3000/jetpack/connect/jetpack_security_daily?coupon=<COUPON_CODE>` (see ticket to get a valid coupon code).
* Enter a valid site URL.
* Verify that you are redirected to `http://calypso.localhost:3000/checkout/:site/jetpack_security_daily?coupon=<COUPON_CODE>` and that the coupon code was applied to your cart.

Fixes 1164141197617539-as-1198936119067523

#### Demo
![image](https://user-images.githubusercontent.com/3418513/97327189-7e955480-1853-11eb-871e-d691addb0507.png)
