### PR TITLE
Shopping Cart: Remove lodash extend() from fillInSingleCartItemAttributes

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import url from 'url'; // eslint-disable-line no-restricted-imports
-import { extend, get, isArray, invert } from 'lodash';
+import { get, isArray, invert } from 'lodash';
 import update, { extend as extendImmutabilityHelper } from 'immutability-helper';
 import { translate } from 'i18n-calypso';
 
@@ -276,7 +276,7 @@ export function fillInSingleCartItemAttributes( cartItem, products ) {
 	const product = products[ cartItem.product_slug ];
 	const attributes = allowedProductAttributes( product );
 
-	return extend( {}, cartItem, attributes );
+	return { ...cartItem, ...attributes };
 }
 
 /**


### PR DESCRIPTION
This PR rewrites `fillInSingleCartItemAttributes()` to not use `extend()` and just use object spread instead. Since this is the only usage of this lodash function, we're effectively removing it from any chunks it's being used in.

#### Changes proposed in this Pull Request

* Shopping Cart: Remove lodash `extend()` from `fillInSingleCartItemAttributes()`

#### Testing instructions

* Go to `/domains/add/:site` where `:site` is a WP.com simple site.
* Pick a domain and add it to your cart.
* Verify it gets added correctly to the cart.
* Try removing it.
* Verify it gets removed correctly from the cart.
* Verify no errors are thrown in the meantime.