### PR TITLE
Fix notices styles in unified sidebar

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -204,7 +204,6 @@ $font-size: rem( 14px );
 
 			&.is-compact {
 				margin: 0;
-				height: 56px;
 				align-items: center;
 			}
 
@@ -227,13 +226,14 @@ $font-size: rem( 14px );
 			}
 
 			.notice__content {
-				padding-left: 4px;
+				padding: 10px 10px 10px 4px;
 				overflow-wrap: anywhere;
 			}
 
 			.notice__action {
 				color: #fff;
 				font-weight: 600;
+				padding-right: 12px;
 			}
 		}
 	}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -19,6 +19,7 @@
 	--color-sidebar-text: #eee;
 	--color-sidebar-text-alternative: #a2aab2;
 	--color-sidebar-gridicon-fill: #a2aab2;
+	--color-sidebar-notice-background: #3c434a;
 
 	.is-sidebar-collapsed:not( .is-section-reader ):not( .is-section-me ) & {
 		--sidebar-width-max: 36px;
@@ -198,7 +199,7 @@ $font-size: rem( 14px );
 		}
 
 		.notice {
-			background-color: #3c434a;
+			background-color: var( --color-sidebar-notice-background );
 			/* stylelint-disable-next-line scales/font-weight */
 			font-weight: 300;
 
@@ -217,12 +218,12 @@ $font-size: rem( 14px );
 					width: 18px;
 					height: 18px;
 					border-radius: 50%;
-					background: #a7aaad;
+					background: var( --color-sidebar-gridicon-fill );
 				}
 			}
 
 			.gridicon {
-				fill: #3c434a;
+				fill: var( --color-sidebar-notice-background );
 			}
 
 			.notice__content {

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -196,6 +196,46 @@ $font-size: rem( 14px );
 				}
 			}
 		}
+
+		.notice {
+			background-color: #3c434a;
+			/* stylelint-disable-next-line scales/font-weight */
+			font-weight: 300;
+
+			&.is-compact {
+				margin: 0;
+				height: 56px;
+				align-items: center;
+			}
+
+			.notice__icon-wrapper {
+				background-color: transparent;
+				width: 35px;
+
+				.notice__icon-wrapper-drop {
+					top: calc( 50% - 9px );
+					left: calc( 50% - 9px );
+					width: 18px;
+					height: 18px;
+					border-radius: 50%;
+					background: #a7aaad;
+				}
+			}
+
+			.gridicon {
+				fill: #3c434a;
+			}
+
+			.notice__content {
+				padding-left: 4px;
+				overflow-wrap: anywhere;
+			}
+
+			.notice__action {
+				color: #fff;
+				font-weight: 600;
+			}
+		}
 	}
 
 	//client/components/site-selector/style.scss
@@ -301,6 +341,13 @@ $font-size: rem( 14px );
 		.sidebar__menu-link,
 		.sidebar__menu.is-togglable .sidebar__heading {
 			overflow: hidden;
+		}
+
+		.sidebar .notice {
+			.notice__content,
+			.notice__action {
+				display: none;
+			}
 		}
 
 		// Is toggled open


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Themes notices according to figma designs https://www.figma.com/file/9cy0DIowQkPAu0rodb9jsL/WP-Admin-for-Dotcom?node-id=325%3A2792&viewport=2516%2C-103%2C5.115475654602051
* Allow text-content to wrap if it is too long

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before | After
-------|------
![](https://cln.sh/gpleCR+) | ![](https://cln.sh/DMD3UV+)

Text wrapping
Before | After
-------|------
![image](https://user-images.githubusercontent.com/12430020/97343527-42ccb000-1890-11eb-8e63-debad46166a9.png) | ![](https://cln.sh/xeBqZO+)

- add `?flags=nav-unification` 
- Go to a site with domain warning or edit `client/my-sites/domains/components/domain-warnings/index.jsx` to force show some 

Fixes #46732
