### PR TITLE
Search: i18nify the component

### DIFF
--- a/packages/search/.storybook/preview.js
+++ b/packages/search/.storybook/preview.js
@@ -1,2 +1,4 @@
 import '@automattic/calypso-color-schemes';
 import '@wordpress/components/build-style/style.css';
+
+window.__i18n_text_domain__ = 'default';

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -29,9 +29,9 @@
 	],
 	"types": "dist/types",
 	"dependencies": {
+		"@automattic/react-i18n": "^1.0.0-alpha.0",
 		"@babel/runtime": "^7.12.5",
 		"@wordpress/components": "^10.0.5",
-		"@wordpress/i18n": "^3.14.0",
 		"@wordpress/icons": "^2.4.0",
 		"classnames": "^2.2.6",
 		"lodash": "^4.17.15",

--- a/packages/search/src/search.stories.jsx
+++ b/packages/search/src/search.stories.jsx
@@ -7,10 +7,10 @@ import { Search } from './search';
 
 export default { title: 'Search', component: Search };
 
-const BoxedSearch = ( props: any ) => (
+const BoxedSearch = ( props ) => (
 	<div style={ { position: 'relative', width: '270px', height: '50px' } }>
 		<Search
-			__={ ( str: string ) => str }
+			__={ ( str ) => str }
 			placeholder="Search..."
 			fitsContainer
 			onSearch={ ( search ) => console.log( 'Searched: ', search ) } // eslint-disable-line no-console
@@ -44,7 +44,7 @@ export const Compact = () => <BoxedSearch compact />;
 export const CompactPinned = () => <BoxedSearch pinned compact fitsContainer />;
 
 export const WithOverlayStyling = () => {
-	const overlayStyling = ( input: string ) => {
+	const overlayStyling = ( input ) => {
 		const tokens = input.split( /(\s+)/ );
 
 		return tokens

--- a/packages/search/src/search.stories.tsx
+++ b/packages/search/src/search.stories.tsx
@@ -3,13 +3,14 @@
  */
 import React from 'react';
 
-import Search from '.';
+import { Search } from './search';
 
 export default { title: 'Search', component: Search };
 
 const BoxedSearch = ( props: any ) => (
 	<div style={ { position: 'relative', width: '270px', height: '50px' } }>
 		<Search
+			__={ ( str: string ) => str }
 			placeholder="Search..."
 			fitsContainer
 			onSearch={ ( search ) => console.log( 'Searched: ', search ) } // eslint-disable-line no-console

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+
+import { withI18n, I18nReact } from '@automattic/react-i18n';
 import classNames from 'classnames';
 import React, { ChangeEvent, FocusEvent, FormEvent, KeyboardEvent, MouseEvent } from 'react';
 import { debounce } from 'lodash';
@@ -10,7 +12,6 @@ import { debounce } from 'lodash';
  * WordPress dependencies
  */
 import { Button, Spinner } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { close, search, Icon } from '@wordpress/icons';
 
 /**
@@ -41,6 +42,7 @@ const keyListener = (
 };
 
 type Props = {
+	__: I18nReact[ '__' ];
 	autoFocus: boolean;
 	className?: string;
 	compact: boolean;
@@ -321,7 +323,7 @@ class Search extends React.Component< Props, State > {
 
 	render(): JSX.Element {
 		const searchValue = this.state.keyword;
-		const placeholder = this.props.placeholder || __( 'Search…' );
+		const placeholder = this.props.placeholder || this.props.__( 'Search…', __i18n_text_domain__ );
 		const inputLabel = this.props.inputLabel;
 		const isOpenUnpinnedOrQueried = this.state.isOpen || ! this.props.pinned || searchValue;
 
@@ -355,7 +357,7 @@ class Search extends React.Component< Props, State > {
 						id={ 'search-component-' + this.instanceId }
 						autoFocus={ this.props.autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 						aria-describedby={ this.props.describedBy }
-						aria-label={ inputLabel ? inputLabel : __( 'Search' ) }
+						aria-label={ inputLabel ? inputLabel : this.props.__( 'Search', __i18n_text_domain__ ) }
 						aria-hidden={ ! isOpenUnpinnedOrQueried }
 						className={ inputClass }
 						placeholder={ placeholder }
@@ -393,7 +395,7 @@ class Search extends React.Component< Props, State > {
 				tabIndex={ enableOpenIcon ? 0 : undefined }
 				onKeyDown={ enableOpenIcon ? this.openListener : undefined }
 				aria-controls={ 'search-component-' + this.instanceId }
-				aria-label={ __( 'Open Search' ) }
+				aria-label={ this.props.__( 'Open Search', __i18n_text_domain__ ) }
 			>
 				{ ! this.props.hideOpenIcon && (
 					/* @ts-ignore */
@@ -423,7 +425,7 @@ class Search extends React.Component< Props, State > {
 					tabIndex={ 0 }
 					onKeyDown={ this.closeListener }
 					aria-controls={ 'search-component-' + this.instanceId }
-					aria-label={ __( 'Close Search' ) }
+					aria-label={ this.props.__( 'Close Search', __i18n_text_domain__ ) }
 				>
 					{ /* @ts-ignore */ }
 					<Icon icon={ close } className="search-component__close-icon" />
@@ -435,4 +437,4 @@ class Search extends React.Component< Props, State > {
 	}
 }
 
-export default Search;
+export default withI18n( Search );

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -89,7 +89,7 @@ type State = {
 	hasFocus: boolean;
 };
 
-class Search extends React.Component< Props, State > {
+export class Search extends React.Component< Props, State > {
 	static defaultProps = {
 		autoFocus: false,
 		compact: false,

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -43,20 +43,20 @@ const keyListener = (
 
 type Props = {
 	__: I18nReact[ '__' ];
-	autoFocus: boolean;
+	autoFocus?: boolean;
 	className?: string;
-	compact: boolean;
-	defaultIsOpen: boolean;
+	compact?: boolean;
+	defaultIsOpen?: boolean;
 	defaultValue?: string;
-	delaySearch: boolean;
-	delayTimeout: number;
+	delaySearch?: boolean;
+	delayTimeout?: number;
 	describedBy?: string;
 	dir?: 'ltr' | 'rtl';
-	disableAutocorrect: boolean;
-	disabled: boolean;
-	fitsContainer: boolean;
-	hideClose: boolean;
-	hideOpenIcon: boolean;
+	disableAutocorrect?: boolean;
+	disabled?: boolean;
+	fitsContainer?: boolean;
+	hideClose?: boolean;
+	hideOpenIcon?: boolean;
 	inputLabel?: string;
 	openIconSide?: 'left' | 'right';
 	maxLength?: number;
@@ -65,21 +65,21 @@ type Props = {
 	onClick?: () => void;
 	onKeyDown?: ( event: KeyboardEvent< HTMLInputElement > ) => void;
 	onSearch: ( search: string ) => void;
-	onSearchChange: ( search: string ) => void;
-	onSearchOpen: (
+	onSearchChange?: ( search: string ) => void;
+	onSearchOpen?: (
 		event?:
 			| MouseEvent< HTMLButtonElement | HTMLInputElement >
 			| KeyboardEvent< HTMLButtonElement | HTMLInputElement >
 	) => void;
-	onSearchClose: (
+	onSearchClose?: (
 		event:
 			| MouseEvent< HTMLButtonElement | HTMLInputElement >
 			| KeyboardEvent< HTMLButtonElement | HTMLInputElement >
 	) => void;
 	overlayStyling?: ( search: string ) => React.ReactNode;
 	placeholder?: string;
-	pinned: boolean;
-	searching: boolean;
+	pinned?: boolean;
+	searching?: boolean;
 	value?: string;
 };
 
@@ -95,7 +95,7 @@ export class Search extends React.Component< Props, State > {
 		compact: false,
 		delaySearch: false,
 		delayTimeout: SEARCH_DEBOUNCE_MS,
-		describedBy: null,
+		describedBy: undefined,
 		dir: undefined,
 		disableAutocorrect: false,
 		disabled: false,
@@ -108,7 +108,7 @@ export class Search extends React.Component< Props, State > {
 		onSearchChange: noop,
 		onSearchOpen: noop,
 		onSearchClose: noop,
-		openIconSide: 'left',
+		openIconSide: 'left' as const,
 		//undefined value for overlayStyling is an optimization that will
 		//disable overlay scrolling calculation when no overlay is provided.
 		overlayStyling: undefined,
@@ -133,8 +133,8 @@ export class Search extends React.Component< Props, State > {
 
 	state = {
 		keyword: this.props.defaultValue ?? '',
-		isOpen: this.props.defaultIsOpen,
-		hasFocus: this.props.autoFocus,
+		isOpen: this.props.defaultIsOpen ?? false,
+		hasFocus: this.props.autoFocus ?? false,
 	};
 
 	openSearch = (
@@ -147,7 +147,7 @@ export class Search extends React.Component< Props, State > {
 			keyword: '',
 			isOpen: true,
 		} );
-		this.props.onSearchOpen( event );
+		this.props.onSearchOpen?.( event );
 		// prevent outlines around the open icon after being clicked
 		this.openIcon.current?.blur();
 	};
@@ -179,7 +179,7 @@ export class Search extends React.Component< Props, State > {
 			this.searchInput.current?.focus();
 		}
 
-		this.props.onSearchClose( event );
+		this.props.onSearchClose?.( event );
 	};
 
 	closeListener = keyListener( this.closeSearch );
@@ -209,7 +209,7 @@ export class Search extends React.Component< Props, State > {
 			this.props.onSearch( this.state.keyword );
 		}
 
-		this.props.onSearchChange( this.state.keyword );
+		this.props.onSearchChange?.( this.state.keyword );
 	}
 
 	scrollOverlay = (): void => {
@@ -302,7 +302,7 @@ export class Search extends React.Component< Props, State > {
 	// with `initialValue` set.
 	onFocus = (): void => {
 		this.setState( { hasFocus: true } );
-		this.props.onSearchOpen();
+		this.props.onSearchOpen?.();
 
 		if ( ! this.searchInput.current ) {
 			return;

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -1,0 +1,1 @@
+declare const __i18n_text_domain__: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `withI18n` rather than using `wp/i18n` directly. Aligns with how we're doing things in the LanguagePicker component.

#### Testing instructions

* Run the storybook and ensure the component still renders and works correctly
* Use the language picker in Calypso at `/me/account` and ensure search still behaves as expected on desktop and mobile

Fixes #
