### PR TITLE
Fix Oauth Client ID Resolution

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -27,7 +27,7 @@ function setupLoggedOut() {
 	if ( config.isEnabled( 'desktop' ) ) {
 		page( '/', () => {
 			if ( config.isEnabled( 'oauth' ) ) {
-				page.redirect( '/authorize' );
+				page.redirect( '/oauth-login' );
 			} else {
 				page.redirect( '/log-in' );
 			}

--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -73,6 +73,8 @@ module.exports = function ( configPath, defaultOpts ) {
 		const oauthTokenEndpoint = secrets.desktop_oauth_token_endpoint;
 
 		data.oauth_client_id = oauthClientId !== undefined ? oauthClientId : false;
+
+		data.desktop_oauth_client_id = oauthClientId !== undefined ? oauthClientId : false;
 		data.desktop_oauth_client_secret = oauthSecret !== undefined ? oauthSecret : false;
 		data.desktop_oauth_token_endpoint =
 			oauthTokenEndpoint !== undefined ? oauthTokenEndpoint : false;

--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -66,7 +66,19 @@ module.exports = function ( configPath, defaultOpts ) {
 		data.features[ 'wpcom-user-bootstrap' ] = false;
 	}
 
-	const serverData = assign( {}, data, getDataFromFile( secretsPath ) );
+	const secrets = getDataFromFile( secretsPath );
+	if ( opts.env === 'desktop' && secretsPath === realSecretsPath ) {
+		const oauthClientId = secrets.desktop_oauth_client_id;
+		const oauthSecret = secrets.desktop_oauth_client_secret;
+		const oauthTokenEndpoint = secrets.desktop_oauth_token_endpoint;
+
+		data.oauth_client_id = oauthClientId !== undefined ? oauthClientId : false;
+		data.desktop_oauth_client_secret = oauthSecret !== undefined ? oauthSecret : false;
+		data.desktop_oauth_token_endpoint =
+			oauthTokenEndpoint !== undefined ? oauthTokenEndpoint : false;
+	}
+
+	const serverData = assign( {}, data, secrets );
 	const clientData = assign( {}, data );
 
 	return { serverData, clientData };

--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -66,21 +66,7 @@ module.exports = function ( configPath, defaultOpts ) {
 		data.features[ 'wpcom-user-bootstrap' ] = false;
 	}
 
-	const secrets = getDataFromFile( secretsPath );
-	if ( opts.env === 'desktop' && secretsPath === realSecretsPath ) {
-		const oauthClientId = secrets.desktop_oauth_client_id;
-		const oauthSecret = secrets.desktop_oauth_client_secret;
-		const oauthTokenEndpoint = secrets.desktop_oauth_token_endpoint;
-
-		data.oauth_client_id = oauthClientId !== undefined ? oauthClientId : false;
-
-		data.desktop_oauth_client_id = oauthClientId !== undefined ? oauthClientId : false;
-		data.desktop_oauth_client_secret = oauthSecret !== undefined ? oauthSecret : false;
-		data.desktop_oauth_token_endpoint =
-			oauthTokenEndpoint !== undefined ? oauthTokenEndpoint : false;
-	}
-
-	const serverData = assign( {}, data, secrets );
+	const serverData = assign( {}, data, getDataFromFile( secretsPath ) );
 	const clientData = assign( {}, data );
 
 	return { serverData, clientData };


### PR DESCRIPTION
### Description

This patch addresses a bug reported by several Desktop users where the error message `"You need to set `oauth_client_id` in your config file"` is displayed on the login page. (At least - it's been very hard to repro and I hope it fixes the root cause! 🤞).  

<p align="center">
<img width="500" alt="Screen Shot 2020-10-26 at 10 21 07 PM" src="https://user-images.githubusercontent.com/8979548/97355966-0ab47580-186e-11eb-9136-419d25c88f51.png">
</p>

### Context

At runtime, various config files are parsed (see [here](https://github.com/Automattic/wp-calypso/blob/f025fdec6e95e9a61625f47164adcc08231600c9/client/server/config/parser.js#L27)) and ultimately made available in the Desktop app via the `window.configData` object (see [here](https://github.com/Automattic/wp-calypso/blob/f025fdec6e95e9a61625f47164adcc08231600c9/client/document/desktop.jsx#L70) and [here](https://github.com/Automattic/wp-calypso/blob/f025fdec6e95e9a61625f47164adcc08231600c9/client/config/index.js#L23)).

This error is displayed by the `connect.jsx` component, which tries to resolve the `oauth_client_id` value (see [here](https://github.com/Automattic/wp-calypso/blob/f025fdec6e95e9a61625f47164adcc08231600c9/client/auth/connect.jsx#L30)). **Problem**: when we try to log `window.configData.oauth_client_id` in the Desktop app, we see that it returns `false`:

<p align="center">
<img width="350" alt="desktop_oauth_client_id_false" src="https://user-images.githubusercontent.com/8979548/97357287-e5c10200-186f-11eb-83dc-8191c73c0379.png">
</p>

Examination of the `secrets.json` file confirms that the expected client id is actually named `desktop_oauth_client_id`, not `oauth_client_id`. However, this `desktop_oauth_client_id` is also not set to the `window.configData` object (i.e. `window.configData.desktop_oauth_client_id` is `undefined`. 

Strangely enough, the only references to `desktop_oauth_client_id` exist in `client/server/api/oauth.js`, and as far as i can tell these references would be invalid as well (unless I'm missing something) - see [here](https://github.com/Automattic/wp-calypso/blob/f025fdec6e95e9a61625f47164adcc08231600c9/client/server/api/oauth.js#L14-L15).

This patch updates the logic in `client/server/config/parser.js` to ensure that the `oauth_client_id` and `desktop_`-prefixed oauth values are copied over to the global `config` object.

<p align="center">
<img width="350" alt="desktop_oauth_client_id_ok" src="https://user-images.githubusercontent.com/8979548/97358969-6e40a200-1872-11eb-8ab9-3cbbdc555317.png">
</p>

I'm not sure if there's a better/cleaner way to do this - all feedback is appreciated.

### To Verify

~~Build and run the desktop app. (Make sure to export `CONFIG_ENV=release`). Log `window.configData` in Developer Console to verify the `oauth_client_id` and `desktop_oauth_client-` attributes before + after this patch.~~

Update: see comments below. This patch addresses the symptom of the problem, i.e. that users were being redirected to the wrong login route on the Desktop app. The root cause is still TBD (i.e. why they are being "logged out" to begin with), but at the very least this provides a user-facing escape hatch for when this does occur.

Fixes Automattic/wp-desktop#700