### PR TITLE
Checkout: Convert smaller composite checkout dependencies to TypeScript

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -448,7 +448,7 @@ export default function CompositeCheckout( {
 
 	const { storedCards, isLoading: isLoadingStoredCards, error: storedCardsError } = useStoredCards(
 		getStoredCards || wpcomGetStoredCards,
-		isLoggedOutCart
+		Boolean( isLoggedOutCart )
 	);
 
 	useActOnceOnStrings( [ storedCardsError ].filter( doesValueExist ), ( messages ) => {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -91,6 +91,7 @@ import {
 	applyContactDetailsRequiredMask,
 	domainRequiredContactDetails,
 	taxRequiredContactDetails,
+	ManagedContactDetails,
 } from './types/wpcom-store-state';
 import { StoredCard } from './types/stored-cards';
 import { CheckoutPaymentMethodSlug } from './types/checkout-payment-method-slug';
@@ -485,10 +486,14 @@ export default function CompositeCheckout( {
 			? onlyLoadPaymentMethods.includes( 'apple-pay' ) && isApplePayLoading
 			: isApplePayLoading );
 
+	const contactInfo: ManagedContactDetails | undefined = select( 'wpcom' )?.getContactInfo();
+	const countryCode: string = contactInfo?.countryCode?.value ?? '';
+
 	const paymentMethods = arePaymentMethodsLoading
 		? []
 		: filterAppropriatePaymentMethods( {
 				paymentMethodObjects,
+				countryCode,
 				total,
 				credits,
 				subtotal,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -55,11 +55,8 @@ import {
 } from 'calypso/signup/storageUtils';
 import CartMessages from 'calypso/my-sites/checkout/cart/cart-messages';
 import CheckoutTerms from 'calypso/my-sites/checkout/checkout/checkout-terms.jsx';
-import {
-	useStoredCards,
-	useIsApplePayAvailable,
-	filterAppropriatePaymentMethods,
-} from './payment-method-helpers';
+import { useIsApplePayAvailable, filterAppropriatePaymentMethods } from './payment-method-helpers';
+import useStoredCards from './hooks/use-stored-cards';
 import usePrepareProductsForCart from './hooks/use-prepare-products-for-cart';
 import useCreatePaymentMethods from './use-create-payment-methods';
 import {
@@ -447,11 +444,16 @@ export default function CompositeCheckout( {
 		createUserAndSiteBeforeTransaction
 	);
 
-	const { storedCards, isLoading: isLoadingStoredCards } = useStoredCards(
+	const { storedCards, isLoading: isLoadingStoredCards, error: storedCardsError } = useStoredCards(
 		getStoredCards || wpcomGetStoredCards,
-		recordEvent,
 		isLoggedOutCart
 	);
+
+	useActOnceOnStrings( [ storedCardsError ].filter( doesValueExist ), ( messages ) => {
+		messages.forEach( ( message ) =>
+			recordEvent( { type: 'STORED_CARD_ERROR', payload: message } )
+		);
+	} );
 
 	const {
 		canMakePayment: isApplePayAvailable,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -55,7 +55,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import CartMessages from 'calypso/my-sites/checkout/cart/cart-messages';
 import CheckoutTerms from 'calypso/my-sites/checkout/checkout/checkout-terms.jsx';
-import { useIsApplePayAvailable } from './payment-method-helpers';
+import useIsApplePayAvailable from './hooks/use-is-apple-pay-available';
 import filterAppropriatePaymentMethods from './lib/filter-appropriate-payment-methods';
 import useStoredCards from './hooks/use-stored-cards';
 import usePrepareProductsForCart from './hooks/use-prepare-products-for-cart';

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -55,7 +55,8 @@ import {
 } from 'calypso/signup/storageUtils';
 import CartMessages from 'calypso/my-sites/checkout/cart/cart-messages';
 import CheckoutTerms from 'calypso/my-sites/checkout/checkout/checkout-terms.jsx';
-import { useIsApplePayAvailable, filterAppropriatePaymentMethods } from './payment-method-helpers';
+import { useIsApplePayAvailable } from './payment-method-helpers';
+import filterAppropriatePaymentMethods from './lib/filter-appropriate-payment-methods';
 import useStoredCards from './hooks/use-stored-cards';
 import usePrepareProductsForCart from './hooks/use-prepare-products-for-cart';
 import useCreatePaymentMethods from './use-create-payment-methods';
@@ -497,8 +498,7 @@ export default function CompositeCheckout( {
 				total,
 				credits,
 				subtotal,
-				allowedPaymentMethods,
-				serverAllowedPaymentMethods,
+				allowedPaymentMethods: allowedPaymentMethods || serverAllowedPaymentMethods,
 		  } );
 	debug( 'filtered payment method objects', paymentMethods );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -4,6 +4,7 @@
 import { useEffect, useRef } from 'react';
 import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
 import { defaultRegistry } from '@automattic/composite-checkout';
+import type { UpdateTaxLocationInCart } from '@automattic/shopping-cart';
 import debugFactory from 'debug';
 
 /**
@@ -11,12 +12,15 @@ import debugFactory from 'debug';
  */
 import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
+import type { PossiblyCompleteDomainContactDetails } from '../types/backend/domain-contact-details-components';
 
 const { dispatch } = defaultRegistry;
 
 const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contact-details' );
 
-export default function useCachedDomainContactDetails( updateCartLocation ) {
+export default function useCachedDomainContactDetails(
+	updateCartLocation: UpdateTaxLocationInCart
+): void {
 	const reduxDispatch = useReduxDispatch();
 	const haveRequestedCachedDetails = useRef( false );
 
@@ -28,7 +32,9 @@ export default function useCachedDomainContactDetails( updateCartLocation ) {
 		}
 	}, [ reduxDispatch ] );
 
-	const cachedContactDetails = useSelector( getContactDetailsCache );
+	const cachedContactDetails: PossiblyCompleteDomainContactDetails | null = useSelector(
+		getContactDetailsCache
+	);
 	useEffect( () => {
 		if ( cachedContactDetails ) {
 			debug( 'using fetched cached domain contact details', cachedContactDetails );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -12,7 +12,6 @@ import debugFactory from 'debug';
  */
 import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
-import type { PossiblyCompleteDomainContactDetails } from '../types/backend/domain-contact-details-components';
 
 const { dispatch } = defaultRegistry;
 
@@ -32,9 +31,7 @@ export default function useCachedDomainContactDetails(
 		}
 	}, [ reduxDispatch ] );
 
-	const cachedContactDetails: PossiblyCompleteDomainContactDetails | null = useSelector(
-		getContactDetailsCache
-	);
+	const cachedContactDetails = useSelector( getContactDetailsCache );
 	useEffect( () => {
 		if ( cachedContactDetails ) {
 			debug( 'using fetched cached domain contact details', cachedContactDetails );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-country-list.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-country-list.ts
@@ -10,20 +10,23 @@ import { useSelector, useDispatch } from 'react-redux';
  */
 import getCountries from 'calypso/state/selectors/get-countries';
 import { fetchPaymentCountries } from 'calypso/state/countries/actions';
+import type { CountryListItem } from '../types/country-list-item';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-country-list' );
 
-export default function useCountryList( overrideCountryList ) {
+export default function useCountryList(
+	overrideCountryList: CountryListItem[]
+): CountryListItem[] {
 	// Should we fetch the country list from global state?
 	const shouldFetchList = overrideCountryList?.length <= 0;
 
 	const [ countriesList, setCountriesList ] = useState( overrideCountryList );
 
 	const reduxDispatch = useDispatch();
-	const globalCountryList = useSelector( ( state ) => getCountries( state, 'payments' ) );
+	const globalCountryList = useSelector( ( state ) => getCountries( state, 'payments' ) ) || [];
 
 	// Has the global list been populated?
-	const isListFetched = globalCountryList?.length > 0;
+	const isListFetched = globalCountryList.length > 0;
 
 	useEffect( () => {
 		if ( shouldFetchList ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
@@ -28,8 +28,8 @@ interface CanMakePaymentState {
 }
 
 export default function useIsApplePayAvailable(
-	stripe: Stripe,
-	stripeConfiguration: StripeConfiguration,
+	stripe: Stripe | null,
+	stripeConfiguration: StripeConfiguration | null,
 	isStripeError: boolean,
 	items: LineItem[]
 ): CanMakePaymentState {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
@@ -24,7 +24,7 @@ interface ApplePaySessionInterface {
 
 interface CanMakePaymentState {
 	isLoading: boolean;
-	value: boolean;
+	canMakePayment: boolean;
 }
 
 export default function useIsApplePayAvailable(
@@ -35,7 +35,7 @@ export default function useIsApplePayAvailable(
 ): CanMakePaymentState {
 	const [ canMakePayment, setCanMakePayment ] = useState< CanMakePaymentState >( {
 		isLoading: true,
-		value: false,
+		canMakePayment: false,
 	} );
 
 	useEffect( () => {
@@ -52,7 +52,7 @@ export default function useIsApplePayAvailable(
 		// If stripe did not load, we will never load
 		if ( isStripeError ) {
 			debug( 'isApplePayAvailable giving up due to stripe error' );
-			setCanMakePayment( { isLoading: false, value: false } );
+			setCanMakePayment( { isLoading: false, canMakePayment: false } );
 			return unsubscribe;
 		}
 
@@ -66,7 +66,7 @@ export default function useIsApplePayAvailable(
 		// check that first.
 		if ( ! window.PaymentRequest ) {
 			debug( 'isApplePayAvailable giving up because there is no paymentRequest API' );
-			setCanMakePayment( { isLoading: false, value: false } );
+			setCanMakePayment( { isLoading: false, canMakePayment: false } );
 			return unsubscribe;
 		}
 
@@ -77,12 +77,12 @@ export default function useIsApplePayAvailable(
 			const browserResponse = !! window.ApplePaySession?.canMakePayments();
 			if ( ! browserResponse ) {
 				debug( 'isApplePayAvailable giving up because apple pay is not available in browser' );
-				setCanMakePayment( { isLoading: false, value: false } );
+				setCanMakePayment( { isLoading: false, canMakePayment: false } );
 				return unsubscribe;
 			}
 		} catch ( error ) {
 			debug( 'isApplePayAvailable giving up because apple pay is not available in browser' );
-			setCanMakePayment( { isLoading: false, value: false } );
+			setCanMakePayment( { isLoading: false, canMakePayment: false } );
 			return unsubscribe;
 		}
 
@@ -115,7 +115,7 @@ export default function useIsApplePayAvailable(
 				return;
 			}
 			debug( 'isApplePayAvailable setting result from Stripe', !! result?.applePay );
-			setCanMakePayment( { isLoading: false, value: !! result?.applePay } );
+			setCanMakePayment( { isLoading: false, canMakePayment: !! result?.applePay } );
 		} );
 
 		return unsubscribe;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from 'react';
+import { LineItem } from '@automattic/composite-checkout';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import { Stripe, StripeConfiguration } from 'calypso/lib/stripe';
+
+const debug = debugFactory( 'calypso:composite-checkout:use-is-apple-pay-available' );
+
+declare global {
+	interface Window {
+		ApplePaySession: ApplePaySessionInterface | undefined;
+	}
+}
+
+interface ApplePaySessionInterface {
+	canMakePayments: () => boolean;
+}
+
+interface CanMakePaymentState {
+	isLoading: boolean;
+	value: boolean;
+}
+
+export default function useIsApplePayAvailable(
+	stripe: Stripe,
+	stripeConfiguration: StripeConfiguration,
+	isStripeError: boolean,
+	items: LineItem[]
+): CanMakePaymentState {
+	const [ canMakePayment, setCanMakePayment ] = useState< CanMakePaymentState >( {
+		isLoading: true,
+		value: false,
+	} );
+
+	useEffect( () => {
+		let isSubscribed = true;
+		const unsubscribe = () => {
+			isSubscribed = false;
+		};
+
+		// Only calculate this once
+		if ( ! canMakePayment.isLoading ) {
+			return unsubscribe;
+		}
+
+		// If stripe did not load, we will never load
+		if ( isStripeError ) {
+			debug( 'isApplePayAvailable giving up due to stripe error' );
+			setCanMakePayment( { isLoading: false, value: false } );
+			return unsubscribe;
+		}
+
+		// We'll need the Stripe library so wait until it is loaded
+		if ( ! stripe || ! stripeConfiguration ) {
+			debug( 'isApplePayAvailable waiting on stripe' );
+			return unsubscribe;
+		}
+
+		// Our Apple Pay implementation uses the Payment Request API, so
+		// check that first.
+		if ( ! window.PaymentRequest ) {
+			debug( 'isApplePayAvailable giving up because there is no paymentRequest API' );
+			setCanMakePayment( { isLoading: false, value: false } );
+			return unsubscribe;
+		}
+
+		// Ask the browser if apple pay can be used. This can be very
+		// expensive on certain Safari versions due to a bug
+		// (https://trac.webkit.org/changeset/243447/webkit)
+		try {
+			const browserResponse = !! window.ApplePaySession?.canMakePayments();
+			if ( ! browserResponse ) {
+				debug( 'isApplePayAvailable giving up because apple pay is not available in browser' );
+				setCanMakePayment( { isLoading: false, value: false } );
+				return unsubscribe;
+			}
+		} catch ( error ) {
+			debug( 'isApplePayAvailable giving up because apple pay is not available in browser' );
+			setCanMakePayment( { isLoading: false, value: false } );
+			return unsubscribe;
+		}
+
+		// Ask Stripe if apple pay can be used. This is async.
+		const countryCode =
+			stripeConfiguration && stripeConfiguration.processor_id === 'stripe_ie' ? 'IE' : 'US';
+		const currency = items.reduce(
+			( firstCurrency, item ) => firstCurrency || item.amount.currency,
+			'usd'
+		);
+		const paymentRequestOptions = {
+			requestPayerName: true,
+			requestPayerPhone: false,
+			requestPayerEmail: false,
+			requestShipping: false,
+			country: countryCode,
+			currency: currency.toLowerCase(),
+			// This is just used here to determine if apple pay is available, not for the actual payment, so we leave this blank
+			displayItems: [],
+			total: {
+				label: 'Total',
+				amount: 0,
+			},
+		};
+		const request = stripe.paymentRequest( paymentRequestOptions );
+		request.canMakePayment().then( ( result ) => {
+			debug( 'applePay canMakePayment returned', result );
+			if ( ! isSubscribed ) {
+				debug( 'useIsApplePayAvailable not subscribed; not updating' );
+				return;
+			}
+			debug( 'isApplePayAvailable setting result from Stripe', !! result?.applePay );
+			setCanMakePayment( { isLoading: false, value: !! result?.applePay } );
+		} );
+
+		return unsubscribe;
+	}, [ canMakePayment, stripe, items, stripeConfiguration, isStripeError ] );
+
+	debug( 'useIsApplePayAvailable', canMakePayment );
+	return canMakePayment;
+}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
@@ -18,7 +18,7 @@ interface ApplePaySessionInterface {
 	canMakePayments: () => boolean;
 }
 
-interface CanMakePaymentState {
+export interface CanMakePaymentState {
 	isLoading: boolean;
 	canMakePayment: boolean;
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
@@ -10,7 +10,7 @@ const debug = debugFactory( 'calypso:composite-checkout:use-is-apple-pay-availab
 
 declare global {
 	interface Window {
-		ApplePaySession: ApplePaySessionInterface | undefined;
+		ApplePaySession?: ApplePaySessionInterface;
 	}
 }
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
@@ -2,13 +2,9 @@
  * External dependencies
  */
 import { useEffect, useState } from 'react';
-import { LineItem } from '@automattic/composite-checkout';
+import type { LineItem } from '@automattic/composite-checkout';
+import type { Stripe, StripeConfiguration } from '@automattic/calypso-stripe';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import { Stripe, StripeConfiguration } from 'calypso/lib/stripe';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-is-apple-pay-available' );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
@@ -87,7 +87,7 @@ export default function useIsApplePayAvailable(
 			stripeConfiguration && stripeConfiguration.processor_id === 'stripe_ie' ? 'IE' : 'US';
 		const currency = items.reduce(
 			( firstCurrency, item ) => firstCurrency || item.amount.currency,
-			'usd'
+			null
 		);
 		const paymentRequestOptions = {
 			requestPayerName: true,
@@ -95,7 +95,7 @@ export default function useIsApplePayAvailable(
 			requestPayerEmail: false,
 			requestShipping: false,
 			country: countryCode,
-			currency: currency.toLowerCase(),
+			currency: currency ? currency.toLowerCase() : 'usd',
 			// This is just used here to determine if apple pay is available, not for the actual payment, so we leave this blank
 			displayItems: [],
 			total: {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -200,9 +200,12 @@ function useAddRenewalItems( {
 					dispatch( {
 						type: 'PRODUCTS_ADD_ERROR',
 						message: String(
-							translate( "Could not find renewal product matching '%(productSlug)s'", {
-								args: { productSlug },
-							} )
+							translate(
+								"I tried and failed to create a renewal product matching the identifier '%(productSlug)s'",
+								{
+									args: { productSlug },
+								}
+							)
 						),
 					} );
 					return null;
@@ -221,9 +224,12 @@ function useAddRenewalItems( {
 			dispatch( {
 				type: 'PRODUCTS_ADD_ERROR',
 				message: String(
-					translate( "Creating renewal products failed for '%(productAlias)s'", {
-						args: { productAlias },
-					} )
+					translate(
+						"I tried and failed to create products matching the identifier '%(productAlias)s'",
+						{
+							args: { productAlias },
+						}
+					)
 				),
 			} );
 			return;
@@ -315,9 +321,12 @@ function useAddProductFromSlug( {
 			dispatch( {
 				type: 'PRODUCTS_ADD_ERROR',
 				message: String(
-					translate( "Creating products failed for '%(productAliasFromUrl)s'", {
-						args: { productAliasFromUrl },
-					} )
+					translate(
+						"I tried and failed to create products matching the identifier '%(productAlias)s'",
+						{
+							args: { productAlias: productAliasFromUrl },
+						}
+					)
 				),
 			} );
 			return;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-stored-cards.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-stored-cards.ts
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { useReducer, useEffect } from 'react';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import type { StoredCard } from '../types/stored-cards';
+
+const debug = debugFactory( 'calypso:composite-checkout:use-stored-cards' );
+
+export interface StoredCardState {
+	storedCards: StoredCard[];
+	isLoading: boolean;
+	error: string | null;
+}
+
+type StoredCardAction =
+	| { type: 'FETCH_END'; payload: StoredCard[] }
+	| { type: 'FETCH_ERROR'; payload: string };
+
+export default function useStoredCards(
+	getStoredCards: () => StoredCard[],
+	isLoggedOutCart: boolean
+): StoredCardState {
+	const [ state, dispatch ] = useReducer( storedCardsReducer, {
+		storedCards: [],
+		isLoading: true,
+		error: null,
+	} );
+
+	useEffect( () => {
+		if ( isLoggedOutCart ) {
+			return;
+		}
+		let isSubscribed = true;
+		async function fetchStoredCards() {
+			debug( 'fetching stored cards' );
+			return getStoredCards();
+		}
+
+		fetchStoredCards()
+			.then( ( cards ) => {
+				debug( 'stored cards fetched', cards );
+				isSubscribed && dispatch( { type: 'FETCH_END', payload: cards } );
+			} )
+			.catch( ( error ) => {
+				debug( 'stored cards failed to load', error );
+				isSubscribed && dispatch( { type: 'FETCH_ERROR', payload: error.message } );
+			} );
+
+		return () => {
+			isSubscribed = false;
+		};
+	}, [ getStoredCards, isLoggedOutCart ] );
+
+	if ( isLoggedOutCart ) {
+		return { ...state, isLoading: false };
+	}
+
+	return state;
+}
+
+function storedCardsReducer( state: StoredCardState, action: StoredCardAction ) {
+	switch ( action.type ) {
+		case 'FETCH_END':
+			return { ...state, storedCards: action.payload, isLoading: false };
+		case 'FETCH_ERROR':
+			return { ...state, storedCards: [], error: action.payload, isLoading: false };
+		default:
+			return state;
+	}
+}

--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import type { PaymentMethod, LineItem } from '@automattic/composite-checkout';
+
+/**
+ * Internal dependencies
+ */
+import { CheckoutCartItem } from '../types/checkout-cart';
+import { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
+
+const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
+
+export default function filterAppropriatePaymentMethods( {
+	paymentMethodObjects,
+	countryCode,
+	total,
+	credits,
+	subtotal,
+	allowedPaymentMethods,
+}: {
+	paymentMethodObjects: PaymentMethod[];
+	countryCode: string;
+	total: LineItem;
+	credits: CheckoutCartItem | null;
+	subtotal: CheckoutCartItem;
+	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
+} ): PaymentMethod[] {
+	const isPurchaseFree = total.amount.value === 0;
+	const isFullCredits =
+		! isPurchaseFree &&
+		credits &&
+		credits.amount.value > 0 &&
+		credits.amount.value >= subtotal.amount.value;
+	debug( 'filtering payment methods with this input', {
+		total,
+		credits,
+		subtotal,
+		allowedPaymentMethods,
+		isPurchaseFree,
+		isFullCredits,
+		countryCode,
+	} );
+
+	return paymentMethodObjects
+		.filter( ( methodObject ) => {
+			// If the purchase is free, only display the free-purchase method
+			if ( methodObject.id === 'free-purchase' ) {
+				return isPurchaseFree ? true : false;
+			}
+			return isPurchaseFree ? false : true;
+		} )
+		.filter( ( methodObject ) => {
+			// If the purchase is full-credits, only display the full-credits method
+			if ( methodObject.id === 'full-credits' ) {
+				return isFullCredits ? true : false;
+			}
+			return isFullCredits ? false : true;
+		} )
+		.filter( ( methodObject ) => {
+			// Some country-specific payment methods should only be available if that
+			// country is selected in the contact information.
+			if ( methodObject.id === 'netbanking' && countryCode !== 'IN' ) {
+				return false;
+			}
+			if ( methodObject.id === 'ebanx-tef' && countryCode !== 'BR' ) {
+				return false;
+			}
+			return true;
+		} )
+		.filter( ( methodObject ) => {
+			if ( methodObject.id.startsWith( 'existingCard-' ) ) {
+				return isPaymentMethodEnabled( 'card', allowedPaymentMethods );
+			}
+			if ( methodObject.id === 'full-credits' ) {
+				// If the full-credits payment method still exists here (see above filter), it's enabled
+				return true;
+			}
+			if ( methodObject.id === 'free-purchase' ) {
+				// If the free payment method still exists here (see above filter), it's enabled
+				return true;
+			}
+			return isPaymentMethodEnabled(
+				methodObject.id as CheckoutPaymentMethodSlug,
+				allowedPaymentMethods
+			);
+		} )
+		.filter(
+			( methodObject ) =>
+				! isPaymentMethodLegallyRestricted( methodObject.id as CheckoutPaymentMethodSlug )
+		);
+}
+
+function isPaymentMethodLegallyRestricted( paymentMethodId: CheckoutPaymentMethodSlug ): boolean {
+	// Add the names of any legally-restricted payment methods to this list.
+	const restrictedPaymentMethods: CheckoutPaymentMethodSlug[] = [];
+
+	return restrictedPaymentMethods.includes( paymentMethodId );
+}
+
+function isPaymentMethodEnabled(
+	method: CheckoutPaymentMethodSlug,
+	allowedPaymentMethods: null | CheckoutPaymentMethodSlug[]
+): boolean {
+	// By default, allow all payment methods
+	if ( ! allowedPaymentMethods?.length ) {
+		return true;
+	}
+	return allowedPaymentMethods.includes( method );
+}

--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -81,15 +81,9 @@ export default function filterAppropriatePaymentMethods( {
 				// If the free payment method still exists here (see above filter), it's enabled
 				return true;
 			}
-			return isPaymentMethodEnabled(
-				methodObject.id as CheckoutPaymentMethodSlug,
-				allowedPaymentMethods
-			);
+			return isPaymentMethodEnabled( methodObject.id, allowedPaymentMethods );
 		} )
-		.filter(
-			( methodObject ) =>
-				! isPaymentMethodLegallyRestricted( methodObject.id as CheckoutPaymentMethodSlug )
-		);
+		.filter( ( methodObject ) => ! isPaymentMethodLegallyRestricted( methodObject.id ) );
 }
 
 function isPaymentMethodLegallyRestricted( paymentMethodId: CheckoutPaymentMethodSlug ): boolean {

--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -10,7 +10,7 @@ import type { PaymentMethod, LineItem } from '@automattic/composite-checkout';
 import { CheckoutCartItem } from '../types/checkout-cart';
 import { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
 
-const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
+const debug = debugFactory( 'calypso:composite-checkout:filter-appropriate-payment-methods' );
 
 export default function filterAppropriatePaymentMethods( {
 	paymentMethodObjects,

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useReducer, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import debugFactory from 'debug';
 import styled from '@emotion/styled';
 import i18n, { useTranslate } from 'i18n-calypso';
@@ -29,52 +29,6 @@ import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
 const { select } = defaultRegistry;
-
-export function useStoredCards( getStoredCards, onEvent, isLoggedOutCart ) {
-	const [ state, dispatch ] = useReducer( storedCardsReducer, {
-		storedCards: [],
-		isLoading: true,
-	} );
-
-	useEffect( () => {
-		if ( isLoggedOutCart ) {
-			return;
-		}
-		let isSubscribed = true;
-		async function fetchStoredCards() {
-			debug( 'fetching stored cards' );
-			return getStoredCards();
-		}
-
-		fetchStoredCards()
-			.then( ( cards ) => {
-				debug( 'stored cards fetched', cards );
-				isSubscribed && dispatch( { type: 'FETCH_END', payload: cards } );
-			} )
-			.catch( ( error ) => {
-				debug( 'stored cards failed to load', error );
-				onEvent( { type: 'STORED_CARD_ERROR', payload: error.message } );
-				isSubscribed && dispatch( { type: 'FETCH_END', payload: [] } );
-			} );
-
-		return () => ( isSubscribed = false );
-	}, [ getStoredCards, onEvent, isLoggedOutCart ] );
-
-	if ( isLoggedOutCart ) {
-		return { ...state, isLoading: false };
-	}
-
-	return state;
-}
-
-function storedCardsReducer( state, action ) {
-	switch ( action.type ) {
-		case 'FETCH_END':
-			return { ...state, storedCards: action.payload, isLoading: false };
-		default:
-			return state;
-	}
-}
 
 export async function submitExistingCardPayment( transactionData, submit, transactionOptions ) {
 	debug( 'formatting existing card transaction', transactionData );

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import debugFactory from 'debug';
 import styled from '@emotion/styled';
 import i18n, { useTranslate } from 'i18n-calypso';
@@ -331,96 +331,6 @@ export async function wpcomPayPalExpress( payload, transactionOptions ) {
 	}
 
 	return wp.undocumented().paypalExpressUrl( payload );
-}
-
-export function useIsApplePayAvailable( stripe, stripeConfiguration, isStripeError, items ) {
-	const [ canMakePayment, setCanMakePayment ] = useState( { isLoading: true, value: false } );
-
-	useEffect( () => {
-		let isSubscribed = true;
-		const unsubscribe = () => {
-			isSubscribed = false;
-		};
-
-		// Only calculate this once
-		if ( ! canMakePayment.isLoading ) {
-			return unsubscribe;
-		}
-
-		// If stripe did not load, we will never load
-		if ( isStripeError ) {
-			debug( 'isApplePayAvailable giving up due to stripe error' );
-			setCanMakePayment( { isLoading: false, value: false } );
-			return unsubscribe;
-		}
-
-		// We'll need the Stripe library so wait until it is loaded
-		if ( ! stripe || ! stripeConfiguration ) {
-			debug( 'isApplePayAvailable waiting on stripe' );
-			return unsubscribe;
-		}
-
-		// Our Apple Pay implementation uses the Payment Request API, so
-		// check that first.
-		if ( ! window.PaymentRequest ) {
-			debug( 'isApplePayAvailable giving up because there is no paymentRequest API' );
-			setCanMakePayment( { isLoading: false, value: false } );
-			return unsubscribe;
-		}
-
-		// Ask the browser if apple pay can be used. This can be very
-		// expensive on certain Safari versions due to a bug
-		// (https://trac.webkit.org/changeset/243447/webkit)
-		try {
-			const browserResponse = !! window.ApplePaySession?.canMakePayments();
-			if ( ! browserResponse ) {
-				debug( 'isApplePayAvailable giving up because apple pay is not available in browser' );
-				setCanMakePayment( { isLoading: false, value: false } );
-				return unsubscribe;
-			}
-		} catch ( error ) {
-			debug( 'isApplePayAvailable giving up because apple pay is not available in browser' );
-			setCanMakePayment( { isLoading: false, value: false } );
-			return unsubscribe;
-		}
-
-		// Ask Stripe if apple pay can be used. This is async.
-		const countryCode =
-			stripeConfiguration && stripeConfiguration.processor_id === 'stripe_ie' ? 'IE' : 'US';
-		const currency = items.reduce(
-			( firstCurrency, item ) => firstCurrency || item.amount.currency,
-			'usd'
-		);
-		const paymentRequestOptions = {
-			requestPayerName: true,
-			requestPayerPhone: false,
-			requestPayerEmail: false,
-			requestShipping: false,
-			country: countryCode,
-			currency: currency.toLowerCase(),
-			// This is just used here to determine if apple pay is available, not for the actual payment, so we leave this blank
-			displayItems: [],
-			total: {
-				label: 'Total',
-				amount: 0,
-			},
-		};
-		const request = stripe.paymentRequest( paymentRequestOptions );
-		request.canMakePayment().then( ( result ) => {
-			debug( 'applePay canMakePayment returned', result );
-			if ( ! isSubscribed ) {
-				debug( 'useIsApplePayAvailable not subscribed; not updating' );
-				return;
-			}
-			debug( 'isApplePayAvailable setting result from Stripe', !! result?.applePay );
-			setCanMakePayment( { isLoading: false, value: !! result?.applePay } );
-		} );
-
-		return unsubscribe;
-	}, [ canMakePayment, stripe, items, stripeConfiguration, isStripeError ] );
-
-	debug( 'useIsApplePayAvailable', canMakePayment );
-	return { canMakePayment: canMakePayment.value, isLoading: canMakePayment.isLoading };
 }
 
 export function needsDomainDetails( cart ) {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -145,7 +145,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_stored_card_error', {
 							error_type: action.payload.type,
-							error_message: String( action.payload.message ),
+							error_message: String( action.payload ),
 						} )
 					);
 				case 'CART_ERROR':

--- a/client/state/selectors/get-contact-details-cache.js
+++ b/client/state/selectors/get-contact-details-cache.js
@@ -9,10 +9,14 @@ import { get } from 'lodash';
 import 'calypso/state/domains/init';
 
 /**
+ * @typedef {import('calypso/my-sites/checkout/composite-checkout/types/backend/domain-contact-details-components').PossiblyCompleteDomainContactDetails} PossiblyCompleteDomainContactDetails
+ */
+
+/**
  * Returns cached domain contact details if we've successfully requested them.
  *
  * @param  {object}  state       Global state tree
- * @returns {object}              Contact details
+ * @returns {null|PossiblyCompleteDomainContactDetails}              Contact details
  */
 export default function getContactDetailsCache( state ) {
 	return get( state, 'domains.management.items._contactDetailsCache', null );

--- a/client/state/selectors/get-countries.js
+++ b/client/state/selectors/get-countries.js
@@ -13,7 +13,7 @@ import 'calypso/state/countries/init';
  *
  * @param {object} state - global state tree
  * @param {string} type - type of list ('domains, 'payments', or 'sms)
- * @returns {Array?} the list of countries
+ * @returns {null|({code: string, name: string})[]} the list of countries
  */
 export default function getCountries( state, type ) {
 	return get( state, [ 'countries', type ], null );

--- a/client/state/selectors/get-countries.js
+++ b/client/state/selectors/get-countries.js
@@ -9,11 +9,15 @@ import { get } from 'lodash';
 import 'calypso/state/countries/init';
 
 /**
+ * @typedef {import('calypso/my-sites/checkout/composite-checkout/types/country-list-item').CountryListItem} CountryListItem
+ */
+
+/**
  * Retrieves the list of countries from the specified type.
  *
  * @param {object} state - global state tree
  * @param {string} type - type of list ('domains, 'payments', or 'sms)
- * @returns {null|({code: string, name: string})[]} the list of countries
+ * @returns {null|CountryListItem[]} the list of countries
  */
 export default function getCountries( state, type ) {
 	return get( state, [ 'countries', type ], null );

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -82,7 +82,7 @@ import {
 	makeRedirectResponse,
 } from './lib/payment-processors';
 import checkoutTheme from './lib/theme';
-import { FormStatus, TransactionStatus, PaymentProcessorResponseType } from './types';
+export * from './types';
 
 // Re-export the public API
 export {
@@ -103,14 +103,11 @@ export {
 	CheckoutSteps,
 	CheckoutSummaryArea,
 	CheckoutSummaryCard,
-	FormStatus,
 	MainContentWrapper,
 	OrderReviewLineItems,
 	OrderReviewSection,
 	OrderReviewTotal,
-	PaymentProcessorResponseType,
 	SubmitButtonWrapper,
-	TransactionStatus,
 	checkoutTheme,
 	createAlipayMethod,
 	createAlipayPaymentMethodStore,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/46758 which converts the main `CompositeCheckout` component to TypeScript.

In this PR we convert some of the smaller dependencies of `CompositeCheckout` to TypeScript as well, specifically:

- useIsApplePayAvailable
- filterAppropriatePaymentMethods
- useStoredCards
- useCachedDomainContactDetails
- useCountryList

#### Testing instructions

- Make sure Apple Pay loads when it should (testing instructions are beyond the scope of this PR).
- Make sure you see the payment methods you expect when paying with or without full credits.
- Make sure that stored cards are listed as payment methods.
- Make sure that cached contact details load as expected.
- Make sure that all the counties you'd expect are listed in the contact details form.
