### PR TITLE
Fix integration tests by using calypso/config import path and updating the alias

### DIFF
--- a/client/server/api/index.js
+++ b/client/server/api/index.js
@@ -7,7 +7,7 @@ import express from 'express';
  * Internal dependencies
  */
 import { version } from '../../package.json';
-import config from 'config';
+import config from 'calypso/config';
 import oauth from './oauth';
 import signInWithApple from './sign-in-with-apple';
 

--- a/client/server/api/integration/index.js
+++ b/client/server/api/integration/index.js
@@ -5,12 +5,12 @@
  */
 import request from 'superagent';
 import supertest from 'supertest';
-import unmodifiedConfig from 'config';
+import unmodifiedConfig from 'calypso/config';
 
 /**
  * Internal dependencies
  */
-import { useSandbox } from 'test-helpers/use-sinon';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'api', () => {
 	let app, config, localRequest, sandbox;
@@ -18,7 +18,7 @@ describe( 'api', () => {
 	useSandbox( ( newSandbox ) => ( sandbox = newSandbox ) );
 
 	beforeAll( () => {
-		config = require( 'config' );
+		config = require( 'calypso/config' );
 		sandbox.stub( config, 'isEnabled' ).withArgs( 'oauth' ).returns( true );
 		app = require( '../' )();
 		localRequest = supertest( app );

--- a/client/server/api/oauth.js
+++ b/client/server/api/oauth.js
@@ -7,7 +7,7 @@ import bodyParser from 'body-parser';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import config from 'calypso/config';
 
 function oauth() {
 	return {

--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -7,8 +7,8 @@ import qs from 'qs';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import wpcom from 'lib/wp';
+import config from 'calypso/config';
+import wpcom from 'calypso/lib/wp';
 
 function loginEndpointData() {
 	return {

--- a/test/integration/jest.config.js
+++ b/test/integration/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
 	moduleNameMapper: {
-		'^config$': '<rootDir>/client/server/config/index.js',
+		'^calypso/config$': '<rootDir>/client/server/config/index.js',
 	},
 	modulePaths: [ '<rootDir>/test', '<rootDir>/client', '<rootDir>/client/extensions' ],
 	rootDir: '../..',


### PR DESCRIPTION
The `test-integration` CI job we run nightly on `master` has been failing recently, like here: https://app.circleci.com/pipelines/github/Automattic/wp-calypso/78586/workflows/ac645fbe-5f0a-4891-8901-54919252facd/jobs/935506

It's caused by the ambiguous `import 'config'` and `import 'calypso/config'` statements. Some modules that are imported by the integration tests were using the old import, some the new one. But the `integration/jest.config.js` was defining only an alias for the old `config` import. That leads to importing the client version of the `config` module rather than the server one.

This patch solves that by defining the `calypso/config` alias in Jest config, and making all the imports in involved modules consistent.

**How to test:**
Run `yarn run test-integration` and verify that this patch makes it green.