### PR TITLE
Don't show placeholder when loading JITM UI part 2

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -186,6 +186,7 @@ class Layout extends Component {
 					{ config.isEnabled( 'jitms' ) && this.props.isEligibleForJITM && (
 						<AsyncLoad
 							require="calypso/blocks/jitm"
+							placeholder={ null }
 							messagePath={ `calypso:${ this.props.sectionJitmPath }:admin_notices` }
 						/>
 					) }

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -275,6 +275,7 @@ export class SiteNotice extends React.Component {
 				{ showJitms && (
 					<AsyncLoad
 						require="calypso/blocks/jitm"
+						placeholder={ null }
 						messagePath="calypso:sites:sidebar_notice"
 						template="sidebar-banner"
 					/>


### PR DESCRIPTION
Followup to #46770 -- there's still one unwanted placeholder 🙂 
