### PR TITLE
Adds a field reqId with an unique request id

### DIFF
--- a/client/server/middleware/logger.js
+++ b/client/server/middleware/logger.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import uaParser from 'ua-parser-js';
+import { v4 as uuidv4 } from 'uuid';
 
 /**
  * Internal dependencies
  */
-import { getLogger } from 'server/lib/logger';
-import config from 'config';
+import { getLogger } from 'calypso/server/lib/logger';
+import config from 'calypso/config';
 
 const NS_TO_MS = 1e-6;
 
@@ -49,7 +50,9 @@ export default () => {
 	const version = process.env.COMMIT_SHA;
 
 	return ( req, res, next ) => {
-		req.logger = logger;
+		req.logger = logger.child( {
+			reqId: uuidv4(),
+		} );
 		const requestStart = process.hrtime.bigint();
 		res.on( 'finish', () => logRequest( req, res, { requestStart, env, version } ) );
 		next();

--- a/client/server/middleware/test/logger.js
+++ b/client/server/middleware/test/logger.js
@@ -7,15 +7,19 @@ import EventEmitter from 'events';
  * Internal dependencies
  */
 import loggerMiddleware from '../logger';
-import config from 'config';
+import config from 'calypso/config';
 
 const mockLogger = {
 	info: jest.fn(),
+	child: jest.fn( () => mockLogger ),
 };
 jest.mock( 'server/lib/logger', () => ( {
 	getLogger: () => mockLogger,
 } ) );
 jest.mock( 'config', () => jest.fn() );
+jest.mock( 'uuid', () => ( {
+	v4: jest.fn( () => '00000000-0000-0000-0000-000000000000' ),
+} ) );
 
 const fakeRequest = ( { method, url, ip, httpVersion, headers = {} } = {} ) => {
 	const req = new EventEmitter();
@@ -66,10 +70,10 @@ beforeEach( () => {
 
 afterEach( () => {
 	jest.useRealTimers();
-	jest.resetAllMocks();
+	jest.clearAllMocks();
 } );
 
-it( 'Adds a `logger` property to the request', () => {
+it( 'Adds a `logger` property to the request with the request id', () => {
 	const req = fakeRequest();
 
 	simulateRequest( {
@@ -78,6 +82,9 @@ it( 'Adds a `logger` property to the request', () => {
 	} );
 
 	expect( req.logger ).toBe( mockLogger );
+	expect( req.logger.child ).toHaveBeenCalledWith( {
+		reqId: '00000000-0000-0000-0000-000000000000',
+	} );
 } );
 
 it( 'It logs info about the request', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new field `reqId` with an unique identifier for each request. Useful to correlate requests with errors or other log lines.

#### Testing instructions

* Run `yarn start` and navigate to http://calypso.localhost:3000/. Verify you see a `reqId` in the console
