### PR TITLE
Components: Remove toggling prop from FormToggle

### DIFF
--- a/client/components/forms/form-toggle/README.md
+++ b/client/components/forms/form-toggle/README.md
@@ -12,7 +12,6 @@ export default function MyComponent() {
 		<div className="you-rock">
 			<FormToggle
 				checked={ this.props.checked }
-				toggling={ this.props.toggling }
 				disabled={ this.props.disabled }
 				onChange={ this.props.onChange }
 				onKeyDown={ this.props.onKeyDown }
@@ -31,7 +30,6 @@ export default function MyComponent() {
 ## Props
 
 - `checked`: (bool) the current status of the toggle.
-- `toggling`: (bool) whether the toggle is in the middle of being performed.
 - `disabled`: (bool) whether the toggle should be in the disabled state.
 - `onChange`: (callback) what should be executed once the user clicks the toggle.
 - `onKeyDown`: (callback) what should be executed once the user presses a key while the toggle is selected.

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -30,7 +30,6 @@ export default class FormToggle extends PureComponent {
 		id: PropTypes.string,
 		className: PropTypes.string,
 		wrapperClassName: PropTypes.string,
-		toggling: PropTypes.bool,
 		'aria-label': PropTypes.string,
 	};
 
@@ -87,9 +86,7 @@ export default class FormToggle extends PureComponent {
 		const wrapperClasses = classNames( 'form-toggle__wrapper', this.props.wrapperClassName, {
 			'is-disabled': this.props.disabled,
 		} );
-		const toggleClasses = classNames( 'form-toggle', this.props.className, {
-			'is-toggling': this.props.toggling,
-		} );
+		const toggleClasses = classNames( 'form-toggle', this.props.className );
 
 		return (
 			<span className={ wrapperClasses }>

--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -98,27 +98,4 @@
 			cursor: default;
 		}
 	}
-
-	&.is-toggling {
-		+ .form-toggle__label.form-label {
-			color: var( --color-neutral );
-			animation: loading-fade 1.6s ease-in-out infinite;
-		}
-		+ .form-toggle__label.form-label .form-toggle__switch {
-			background: var( --color-primary );
-			animation: loading-fade 1.6s ease-in-out infinite;
-			&::after {
-				left: 8px;
-			}
-		}
-		&:checked {
-			+ .form-toggle__label.form-label .form-toggle__switch {
-				background: var( --color-neutral-10 );
-				animation: loading-fade 1.6s ease-in-out infinite;
-				&::after {
-					left: 0;
-				}
-			}
-		}
-	}
 }

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -223,7 +223,6 @@ class AutoRenewToggle extends Component {
 				<FormToggle
 					checked={ this.getToggleUiStatus() }
 					disabled={ this.isUpdatingAutoRenew() }
-					toggling={ this.isUpdatingAutoRenew() }
 					onChange={ this.onToggleAutoRenew }
 				>
 					{ withTextStatus && this.renderTextStatus() }

--- a/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
@@ -73,7 +73,6 @@ class ContactsPrivacyCard extends React.Component {
 					<FormToggle
 						wrapperClassName="edit__privacy-protection-toggle"
 						checked={ privateDomain }
-						toggling={ isUpdatingPrivacy }
 						disabled={ isUpdatingPrivacy || ! privacyAvailable }
 						onChange={ this.togglePrivacy }
 					>
@@ -117,7 +116,6 @@ class ContactsPrivacyCard extends React.Component {
 					<FormToggle
 						wrapperClassName="edit__disclose-contact-information"
 						checked={ contactInfoDisclosed }
-						toggling={ isUpdatingPrivacy }
 						disabled={ isUpdatingPrivacy || isPendingIcannVerification }
 						onChange={ this.toggleContactInfo }
 					>

--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -74,8 +74,7 @@ class PluginAction extends React.Component {
 			<FormToggle
 				onChange={ this.props.action }
 				checked={ this.props.status }
-				toggling={ this.props.inProgress }
-				disabled={ this.props.disabled || !! this.props.disabledInfo }
+				disabled={ this.props.inProgress || this.props.disabled || !! this.props.disabledInfo }
 				id={ this.props.htmlFor }
 			>
 				{ this.renderLabel() }

--- a/client/my-sites/site-settings/jetpack-module-toggle.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle.jsx
@@ -72,9 +72,8 @@ class JetpackModuleToggle extends Component {
 				<FormToggle
 					id={ `${ this.props.siteId }-${ this.props.moduleSlug }-toggle` }
 					checked={ this.props.checked || false }
-					toggling={ this.props.toggling }
 					onChange={ this.handleChange }
-					disabled={ this.props.disabled || this.props.toggleDisabled }
+					disabled={ this.props.disabled || this.props.toggleDisabled || this.props.toggling }
 				>
 					{ this.props.label }
 				</FormToggle>


### PR DESCRIPTION
Currently, we have 2 ways of marking a toggle in "loading" state:

* `toggling` - since #40522 it makes the toggle blink, but keeps the toggle available for interaction.
* `disabled` - disables the toggle visually and prevents any interaction.

Sometimes they're used together (which makes sense), and sometimes not. 

In favor of our current migration to `@wordpress/components`, this PR is removing the `toggling` prop, in favor of the `disabled` one. The main reason for that is that there's no `toggling` support in the `@wordpress/components` version, and we'd like to be consistent with the design patterns. This is the main purpose of the unification, after all.

That doesn't mean we can't implement `toggling` functionality in the `@wordpress/components` form toggle component in the future. But this is related to work and decisions that span beyond Calypso - it has to be discussed and addressed in the Gutenberg repo. That way we'll be able to benefit from it in Calypso, and it will also be beneficial for the rest of the community.

What we're doing here is making a decision to remove a non-widespread option. This is consistent with the WordPress philosophy: [Decisions, not options](https://wordpress.org/about/philosophy/#decisions).

#### Changes proposed in this Pull Request

* Replace all usages of the `toggling` prop to `disabled` (if that's not done yet)
* Remove the `toggling` prop completely from `<FormToggle />`.

#### Testing instructions

* In all of the instances below, verify the toggles are still working correctly and are disabled while loading:
  * Go to `/me/purchases`, select one of your purchases and try toggling the auto-renewal toggle.
  * Go to `/domains/manage/:siteSlug/contacts-privacy/:domain` where `:siteSlug` is the slug of a site that has a custom domain on WP.com, and `:domain` is that domain, try toggling the "Privacy Protection" toggle.
  * Go to `/plugins/manage/:site` where `:site` is the slug of a Jetpack site, try toggling the "Active" toggle.
  * Go to `/settings/security/:site` where `:site` is the slug of a Jetpack site, try toggling the "Allow users to log in to this site using WordPress.com accounts" toggle.
* Go to `/devdocs/design/form-fields` and verify form toggles work well.
* Verify all tests pass.

#### Notes

ESLint warnings are unrelated and expected.