### PR TITLE
CSS fixes for Jetpack credentials form

### DIFF
--- a/client/components/step-progress/style.scss
+++ b/client/components/step-progress/style.scss
@@ -45,7 +45,7 @@
 
 .step-progress__element-button {
 	border-radius: 50%;
-	font-size: 0.875rem;
+	font-size: 0.8rem;
 	font-weight: 700;
 	height: 24px;
 	width: 24px;

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
@@ -475,7 +475,9 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 
 			{ formMode === FormMode.Password ? renderPasswordForm() : renderPrivateKeyForm() }
 
-			<FormFieldset className="credentials-form__buttons">{ children }</FormFieldset>
+			<FormFieldset className="credentials-form__buttons">
+				<div class="credentials-form__buttons_flex">{ children }</div>
+			</FormFieldset>
 		</div>
 	);
 };

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/style.scss
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/style.scss
@@ -29,7 +29,7 @@
 		}
 	}
 
-	&__buttons {
+	&__buttons .credentials-form__buttons_flex {
 		display: flex;
 		flex-direction: row;
 		align-items: center;

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/style.scss
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/style.scss
@@ -51,6 +51,9 @@
 .advanced-credentials__connected {
 	display: flex;
 	align-items: center;
+	text-align: left;
+	font-weight: normal;
+
 	.gridicon {
 		flex-shrink: 0;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**Improve stepper component number size**

Before:
![Screenshot 2020-10-28 at 12 33 52](https://user-images.githubusercontent.com/411945/97430935-dd250600-1919-11eb-8a5e-c9862c086abf.png)

After:
![Screenshot 2020-10-28 at 11 43 29](https://user-images.githubusercontent.com/411945/97430597-67b93580-1919-11eb-93c8-102918997129.png)

**Fix button alignment in older versions of Chrome**

Before:
![Screenshot 2020-10-28 at 12 34 53](https://user-images.githubusercontent.com/411945/97431024-ff1e8880-1919-11eb-922a-ad7f2a83e660.png)

After:
![Screenshot 2020-10-28 at 12 24 08](https://user-images.githubusercontent.com/411945/97431052-08a7f080-191a-11eb-9fe9-e143dc549c44.png)

**Fix text on OK state**

Before:
![Screenshot 2020-10-28 at 12 36 36](https://user-images.githubusercontent.com/411945/97431225-3e4cd980-191a-11eb-87d0-d5b743beaef6.png)

After:
![Screenshot 2020-10-28 at 11 02 02](https://user-images.githubusercontent.com/411945/97431245-486ed800-191a-11eb-820d-5f069b9b6070.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull this branch
* Use the `http://jetpack.cloud.localhost:3000/` entry point
* Check for CSS regressions
