### PR TITLE
Components: Remove unused className prop from FormToggle

### DIFF
--- a/client/components/forms/form-toggle/README.md
+++ b/client/components/forms/form-toggle/README.md
@@ -15,7 +15,6 @@ export default function MyComponent() {
 				disabled={ this.props.disabled }
 				onChange={ this.props.onChange }
 				onKeyDown={ this.props.onKeyDown }
-				className={ this.props.className }
 				aria-label={ this.props[ 'aria-label' ] }
 				id="you-rock-uniquely"
 			>
@@ -32,6 +31,5 @@ export default function MyComponent() {
 - `disabled`: (bool) whether the toggle should be in the disabled state.
 - `onChange`: (callback) what should be executed once the user clicks the toggle.
 - `onKeyDown`: (callback) what should be executed once the user presses a key while the toggle is selected.
-- `className`: (string) a class name that should be added to the toggle `input` control.
 - `aria-label`: (string) a label that should be added to the control for accessibility purposes.
 - `id`: (string) the id of the checkbox and the for attribute of the label, should be unique.

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -28,8 +28,7 @@ export default class FormToggle extends PureComponent {
 		checked: PropTypes.bool,
 		disabled: PropTypes.bool,
 		id: PropTypes.string,
-		className: PropTypes.string,
-		toggling: PropTypes.bool,
+		wrapperClassName: PropTypes.string,
 		'aria-label': PropTypes.string,
 	};
 

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -85,13 +85,12 @@ export default class FormToggle extends PureComponent {
 		const wrapperClasses = classNames( 'form-toggle__wrapper', {
 			'is-disabled': this.props.disabled,
 		} );
-		const toggleClasses = classNames( 'form-toggle', this.props.className );
 
 		return (
 			<span className={ wrapperClasses }>
 				<FormInputCheckbox
 					id={ id }
-					className={ toggleClasses }
+					className="form-toggle"
 					checked={ this.props.checked }
 					readOnly={ true }
 					disabled={ this.props.disabled }


### PR DESCRIPTION
Currently, the `className` of the `FormToggle` component is not used at all. And this makes sense because the `className` is passed to the checkbox, which is actually hidden 😉 

So I'm suggesting to remove this prop for now, as this will make the migration to `@wordpress/components` easier. We can later add it, of course, and it would make sense for that `className` to be passed to the wrapper element, and not to a child inside the component.

#### Changes proposed in this Pull Request

* Components: Remove unused `className` prop from `FormToggle`

#### Testing instructions

* Do a manual scan in Calypso and verify there are no `<FormToggle />` instances that receive a `className` prop.
* This shouldn't affect any usage of `<FormToggle />`, as none use the `className`.
