### PR TITLE
Components: Remove unused FormToggle onKeyDown prop

### DIFF
--- a/client/components/forms/form-toggle/README.md
+++ b/client/components/forms/form-toggle/README.md
@@ -14,7 +14,6 @@ export default function MyComponent() {
 				checked={ this.props.checked }
 				disabled={ this.props.disabled }
 				onChange={ this.props.onChange }
-				onKeyDown={ this.props.onKeyDown }
 				aria-label={ this.props[ 'aria-label' ] }
 				id="you-rock-uniquely"
 			>
@@ -30,6 +29,5 @@ export default function MyComponent() {
 - `checked`: (bool) the current status of the toggle.
 - `disabled`: (bool) whether the toggle should be in the disabled state.
 - `onChange`: (callback) what should be executed once the user clicks the toggle.
-- `onKeyDown`: (callback) what should be executed once the user presses a key while the toggle is selected.
 - `aria-label`: (string) a label that should be added to the control for accessibility purposes.
 - `id`: (string) the id of the checkbox and the for attribute of the label, should be unique.

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -24,7 +24,6 @@ import './style.scss';
 export default class FormToggle extends PureComponent {
 	static propTypes = {
 		onChange: PropTypes.func,
-		onKeyDown: PropTypes.func,
 		checked: PropTypes.bool,
 		disabled: PropTypes.bool,
 		id: PropTypes.string,
@@ -35,7 +34,6 @@ export default class FormToggle extends PureComponent {
 	static defaultProps = {
 		checked: false,
 		disabled: false,
-		onKeyDown: noop,
 		onChange: noop,
 	};
 
@@ -54,8 +52,6 @@ export default class FormToggle extends PureComponent {
 			event.preventDefault();
 			this.props.onChange( ! this.props.checked );
 		}
-
-		this.props.onKeyDown( event );
 	};
 
 	onClick = ( event ) => {


### PR DESCRIPTION
Currently, we accept an `onKeyDown` prop in the `FormToggle` component. However it's not used anywhere, so this PR removes it. It also won't be necessary when we migrate to `@wordpress/components`.

#### Changes proposed in this Pull Request

* Components: Remove unused `FormToggle` `onKeyDown` prop.

#### Testing instructions

* Verify there are no instances where we pass `onKeyDown` to a `<FormToggle />` component.
* Since this removes unused functionality, there should be no visual or functional changes.
