### PR TITLE
Components: Remove wrapperClassName prop from FormToggle

### DIFF
--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -157,7 +157,6 @@ class ReaderSiteNotificationSettings extends Component {
 						<FormToggle
 							onChange={ this.toggleNewPostNotification }
 							checked={ sendNewPostsByNotification }
-							wrapperClassName="reader-site-notification-settings__popout-form-toggle"
 							id="reader-site-notification-settings__notifications"
 						>
 							{ translate( 'Notify me of new posts' ) }

--- a/client/components/forms/form-toggle/README.md
+++ b/client/components/forms/form-toggle/README.md
@@ -16,7 +16,6 @@ export default function MyComponent() {
 				onChange={ this.props.onChange }
 				onKeyDown={ this.props.onKeyDown }
 				className={ this.props.className }
-				wrapperClassName={ this.props.wrapperClassName }
 				aria-label={ this.props[ 'aria-label' ] }
 				id="you-rock-uniquely"
 			>
@@ -34,6 +33,5 @@ export default function MyComponent() {
 - `onChange`: (callback) what should be executed once the user clicks the toggle.
 - `onKeyDown`: (callback) what should be executed once the user presses a key while the toggle is selected.
 - `className`: (string) a class name that should be added to the toggle `input` control.
-- `wrapperClassName`: (string) a class name that should be added to the `div` wrapping the component.
 - `aria-label`: (string) a label that should be added to the control for accessibility purposes.
 - `id`: (string) the id of the checkbox and the for attribute of the label, should be unique.

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -29,7 +29,7 @@ export default class FormToggle extends PureComponent {
 		disabled: PropTypes.bool,
 		id: PropTypes.string,
 		className: PropTypes.string,
-		wrapperClassName: PropTypes.string,
+		toggling: PropTypes.bool,
 		'aria-label': PropTypes.string,
 	};
 
@@ -83,7 +83,7 @@ export default class FormToggle extends PureComponent {
 
 	render() {
 		const id = this.props.id || 'toggle-' + this.id;
-		const wrapperClasses = classNames( 'form-toggle__wrapper', this.props.wrapperClassName, {
+		const wrapperClasses = classNames( 'form-toggle__wrapper', {
 			'is-disabled': this.props.disabled,
 		} );
 		const toggleClasses = classNames( 'form-toggle', this.props.className );

--- a/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
@@ -71,7 +71,6 @@ class ContactsPrivacyCard extends React.Component {
 			<React.Fragment>
 				<div className="contacts-privacy__settings">
 					<FormToggle
-						wrapperClassName="edit__privacy-protection-toggle"
 						checked={ privateDomain }
 						disabled={ isUpdatingPrivacy || ! privacyAvailable }
 						onChange={ this.togglePrivacy }
@@ -114,7 +113,6 @@ class ContactsPrivacyCard extends React.Component {
 			<React.Fragment>
 				<div className="contacts-privacy__settings">
 					<FormToggle
-						wrapperClassName="edit__disclose-contact-information"
 						checked={ contactInfoDisclosed }
 						disabled={ isUpdatingPrivacy || isPendingIcannVerification }
 						onChange={ this.toggleContactInfo }


### PR DESCRIPTION
Currently, we accept a `wrapperClassName` prop in the `FormToggle` component. However, because it's used in a couple of locations and there are no styles added to the classnames in these instances, it's unnecessary. So this PR removes it completely. It also won't be necessary when we migrate to `@wordpress/components`.

#### Changes proposed in this Pull Request

* Components: Remove unused `FormToggle` `wrapperClassName` prop.

#### Testing instructions

* Verify there are no instances where we pass `wrapperClassName` to a `<FormToggle />` component.
* Since this removes unused functionality, there should be no visual or functional changes.
