### PR TITLE
Fix Upgrade to Business Nudge for Monthly Plans

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -54,6 +54,7 @@ import {
 	isUnlimitedThemes,
 	isVideoPress,
 	isConciergeSession,
+	isMonthly,
 } from 'calypso/lib/products-values';
 import sortProducts from 'calypso/lib/products-values/sort';
 import { getTld } from 'calypso/lib/domains';
@@ -363,6 +364,10 @@ export function hasBusinessPlan( cart ) {
 
 export function hasDomainCredit( cart ) {
 	return cart.has_bundle_credit || hasPlan( cart );
+}
+
+export function hasMonthlyCartItem( cart ) {
+	return some( getAllCartItems( cart ), isMonthly );
 }
 
 /**

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -23,6 +23,7 @@ import {
 	hasPremiumPlan,
 	hasBusinessPlan,
 	hasEcommercePlan,
+	hasMonthlyCartItem,
 } from 'calypso/lib/cart-values/cart-items';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
@@ -291,7 +292,8 @@ function maybeShowPlanBumpOffer( {
 		return;
 	}
 	if ( hasPremiumPlan( cart ) && ! isTransactionResultEmpty && ! didPurchaseFail ) {
-		return `/checkout/${ siteSlug }/offer-plan-upgrade/business/${ pendingOrReceiptId }`;
+		const upgradeItem = hasMonthlyCartItem( cart ) ? 'business-monthly' : 'business';
+		return `/checkout/${ siteSlug }/offer-plan-upgrade/${ upgradeItem }/${ pendingOrReceiptId }`;
 	}
 	return;
 }

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -562,6 +562,7 @@ describe( 'getThankYouPageUrl', () => {
 			products: [
 				{
 					product_slug: 'value_bundle',
+					bill_period: 365,
 				},
 			],
 		};
@@ -572,6 +573,25 @@ describe( 'getThankYouPageUrl', () => {
 			receiptId: '1234abcd',
 		} );
 		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/business/1234abcd' );
+	} );
+
+	it( 'redirects to business monthly upgrade nudge if concierge and jetpack are not in the cart, and premium monthly is in the cart', () => {
+		isEnabled.mockImplementation( ( flag ) => flag === 'upsell/concierge-session' );
+		const cart = {
+			products: [
+				{
+					product_slug: 'value_bundle_monthly',
+					bill_period: 31,
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+			receiptId: '1234abcd',
+		} );
+		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/business-monthly/1234abcd' );
 	} );
 
 	it( 'redirects to the thank-you pending page with an order id when the business upgrade nudge would normally be included', () => {

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -40,6 +40,7 @@ import getUpgradePlanSlugFromPath from 'calypso/state/selectors/get-upgrade-plan
 import { PurchaseModal } from './purchase-modal';
 import { replaceCartWithItems } from 'calypso/lib/cart/actions';
 import Gridicon from 'calypso/components/gridicon';
+import { isMonthly } from 'calypso/lib/plans/constants';
 
 /**
  * Style dependencies
@@ -129,6 +130,7 @@ export class UpsellNudge extends React.Component {
 			upsellType,
 			translate,
 			siteSlug,
+			hasSevenDayRefundPeriod,
 		} = this.props;
 
 		switch ( upsellType ) {
@@ -172,6 +174,7 @@ export class UpsellNudge extends React.Component {
 						translate={ translate }
 						handleClickAccept={ this.handleClickAccept }
 						handleClickDecline={ this.handleClickDecline }
+						hasSevenDayRefundPeriod={ hasSevenDayRefundPeriod }
 					/>
 				);
 		}
@@ -292,6 +295,7 @@ export default connect(
 			isLoggedIn: isUserLoggedIn( state ),
 			siteSlug,
 			selectedSiteId,
+			hasSevenDayRefundPeriod: isMonthly( planSlug ),
 		};
 	},
 	{

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
@@ -61,7 +61,13 @@ export class PlanUpgradeUpsell extends PureComponent {
 	}
 
 	body() {
-		const { translate, planRawPrice, planDiscountedRawPrice, currencyCode } = this.props;
+		const {
+			translate,
+			planRawPrice,
+			planDiscountedRawPrice,
+			currencyCode,
+			hasSevenDayRefundPeriod,
+		} = this.props;
 		return (
 			<>
 				<h2 className="plan-upgrade-upsell__header">
@@ -184,29 +190,56 @@ export class PlanUpgradeUpsell extends PureComponent {
 							) }
 						</p>
 						<p>
-							{ translate(
-								'The good news is that you can upgrade your plan today and try the Business plan risk-free thanks to our {{b}}30-day money-back guarantee{{/b}}.',
-								{
-									components: { b: <b /> },
-								}
-							) }
+							{ hasSevenDayRefundPeriod && // @todo - Remove the duplicate translations once the new string is translated
+								translate(
+									'The good news is that you can upgrade your plan today and try the Business plan risk-free thanks to our {{b}}%(days)d-day money-back guarantee{{/b}}.',
+									{
+										args: { days: 7 },
+										components: { b: <b /> },
+									}
+								) }
+							{ ! hasSevenDayRefundPeriod &&
+								translate(
+									'The good news is that you can upgrade your plan today and try the Business plan risk-free thanks to our {{b}}30-day money-back guarantee{{/b}}.',
+									{
+										components: { b: <b /> },
+									}
+								) }
 						</p>
 						<p>
-							{ translate(
-								'Simply click the link below and select the Business plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have 30 days to evaluate the plan and decide if it’s right for you.',
-								{
-									components: {
-										del: <del />,
-										b: <b />,
-									},
-									args: {
-										fullPrice: formatCurrency( planRawPrice, currencyCode, { stripZeros: true } ),
-										discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
-											stripZeros: true,
-										} ),
-									},
-								}
-							) }
+							{ hasSevenDayRefundPeriod &&
+								translate(
+									'Simply click the link below and select the Business plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have %(days)d days to evaluate the plan and decide if it’s right for you.',
+									{
+										components: {
+											del: <del />,
+											b: <b />,
+										},
+										args: {
+											days: 7,
+											fullPrice: formatCurrency( planRawPrice, currencyCode, { stripZeros: true } ),
+											discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
+												stripZeros: true,
+											} ),
+										},
+									}
+								) }
+							{ ! hasSevenDayRefundPeriod &&
+								translate(
+									'Simply click the link below and select the Business plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have 30 days to evaluate the plan and decide if it’s right for you.',
+									{
+										components: {
+											del: <del />,
+											b: <b />,
+										},
+										args: {
+											fullPrice: formatCurrency( planRawPrice, currencyCode, { stripZeros: true } ),
+											discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
+												stripZeros: true,
+											} ),
+										},
+									}
+								) }
 						</p>
 						<p>{ translate( 'So are you ready to explore our most powerful plan ever?' ) }</p>
 					</div>


### PR DESCRIPTION
<img width="1041" alt="Screenshot 2020-10-28 at 11 52 51" src="https://user-images.githubusercontent.com/82778/97420654-443fbc00-1914-11eb-9641-1aa67ebc3d1f.png">


#### Testing instructions

0. Make sure you're in `treatment` group for the a/b test
1. Apply D51830-code and D51847-code
2. Buy Monthly Premium and make sure the refund period and the prices are fine
3. Continue to checkout and make sure Business Monthly is there
4. Cancel the subscriptions
5. Buy the annual plan

Note: This is technically broken for 2-year plans. However, despite being broken, it works quite smoothly as it offers a transition from 2-year Premium to 1-year Business for just $120. I don't want to fix such a bug that can be a feature.
