### PR TITLE
Update free domain checkout wording

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -521,7 +521,7 @@ function DomainDiscountCallout( { item } ) {
 
 	const isFreeBundledDomainRegistration = item.wpcom_meta?.is_bundled && item.amount.value === 0;
 	if ( isFreeBundledDomainRegistration ) {
-		return <DiscountCallout>{ translate( 'First year free' ) }</DiscountCallout>;
+		return <DiscountCallout>{ translate( 'Discount for first year' ) }</DiscountCallout>;
 	}
 
 	const isFreeDomainMapping =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update wording for free domain in cart checkout to mitigate confusion.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*BEFORE*

[![Screenshot](https://d.pr/i/a5CwD6+)](https://d.pr/i/a5CwD6)

*AFTER*

[![Screenshot](https://d.pr/i/fEf3iX+)](https://d.pr/i/fEf3iX)

Fixes #46769 
