### PR TITLE
Jetpack Cloud: Update html meta for SEO purposes

### DIFF
--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -6,6 +6,7 @@ import { uniqWith, isEqual, isArray } from 'lodash';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import {
 	DOCUMENT_HEAD_LINK_SET,
@@ -19,7 +20,7 @@ import { titleSchema, unreadCountSchema, linkSchema, metaSchema } from './schema
 /**
  * Constants
  */
-export const DEFAULT_META_STATE = [ { property: 'og:site_name', content: 'WordPress.com' } ];
+export const DEFAULT_META_STATE = config( 'meta' );
 
 export const title = withSchemaValidation( titleSchema, ( state = '', action ) => {
 	switch ( action.type ) {

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -140,6 +140,12 @@
 	"site_filter": [],
 	"theme": "default",
 	"site_name": "WordPress.com",
+	"meta": [
+		{
+			"property": "og:site_name",
+			"content": "WordPress.com"
+		}
+	],
 	"restricted_me_access": true,
 	"theme_color": "#135e96"
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -10,7 +10,21 @@
 	"rtl": false,
 	"login_url": "/connect",
 	"logout_url": "https://jetpack.com",
-	"site_name": "Jetpack.com",
+	"site_name": "Jetpack: WordPress Security, Backups, Speed, & Growth",
+	"meta": [
+		{
+			"name": "description",
+			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+		},
+		{
+			"property": "og:description",
+			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+		},
+		{
+			"property": "og:image",
+			"content": "https://i1.wp.com/s0.wp.com/wp-content/themes/a8c/jetpackme-new/images-2019/jetpack-logo.png?ssl=1"
+		}
+	],
 	"oauth_client_id": 68663,
 	"features": {
 		"activity-log/v2": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -9,6 +9,20 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"site_name": "Jetpack.com",
+	"meta": [
+		{
+			"name": "description",
+			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+		},
+		{
+			"property": "og:description",
+			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+		},
+		{
+			"property": "og:image",
+			"content": "https://i1.wp.com/s0.wp.com/wp-content/themes/a8c/jetpackme-new/images-2019/jetpack-logo.png?ssl=1"
+		}
+	],
 	"features": {
 		"activity-log/v2": true,
 		"always_use_logout_url": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -9,6 +9,20 @@
 	"login_url": "/connect",
 	"logout_url": "https://jetpack.com",
 	"site_name": "Jetpack.com",
+	"meta": [
+		{
+			"name": "description",
+			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+		},
+		{
+			"property": "og:description",
+			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+		},
+		{
+			"property": "og:image",
+			"content": "https://i1.wp.com/s0.wp.com/wp-content/themes/a8c/jetpackme-new/images-2019/jetpack-logo.png?ssl=1"
+		}
+	],
 	"oauth_client_id": 69041,
 	"features": {
 		"activity-log/v2": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -9,6 +9,20 @@
 	"login_url": "/connect",
 	"logout_url": "https://jetpack.com",
 	"site_name": "Jetpack.com",
+	"meta": [
+		{
+			"name": "description",
+			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+		},
+		{
+			"property": "og:description",
+			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+		},
+		{
+			"property": "og:image",
+			"content": "https://i1.wp.com/s0.wp.com/wp-content/themes/a8c/jetpackme-new/images-2019/jetpack-logo.png?ssl=1"
+		}
+	],
 	"oauth_client_id": 69040,
 	"features": {
 		"activity-log/v2": true,


### PR DESCRIPTION
This is a part of the overall push to improve Jetpack.com metadata and search engine placement since cloud.jetpack.com/pricing is crawlable.
Context: pbNhbs-hL-p2

#### Changes proposed in this Pull Request

* Introduce a new `meta` property in config files which holds data that is rendered as `<meta>` tags.
* Add `description`, `og:description`, and `og:image` meta tags to Calypso Green in accordance with marketing needs.
* Update the meta title of Calypso Green in accordance with marketing needs.

#### Testing instructions

* Confirm Calypso Green meta title, description, og:description and og:image are rendered server side and contain the required messages as described in the doc linked in pbNhbs-hL-p2.
* Confirm the meta changes do not affect Calypso Blue.