### PR TITLE
Make line-height setting more robust

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -128,25 +128,11 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_script_and_
  * users had been utilizing the feature. With the 8.6 release, though, line-height
  * was turned off by default unless the theme supported it. As a result, users
  * suddenly were no longer able to access the settings they previously had access
- * to. This filter turns the setting on for all wpcom users regardless of theme.
- *
- * Note: we use a priority of 11 so that this filter runs after the one which
- * turns off custom line height depending on theme support.
+ * to. This turns the setting on for all wpcom users regardless of theme.
  *
  * @see https://github.com/WordPress/gutenberg/pull/23904
- *
- * @param array $settings The associative array of Gutenberg editor settings with
- *                        line-height sometimes disabled based on theme support.
- * @return array Gutenberg editor settings with line-height setting always enabled.
  **/
-function wpcom_gutenberg_enable_custom_line_height( $settings ) {
-	if ( isset( $settings['__experimentalFeatures']['global']['typography'] ) ) {
-		// Update the global styles settings to always enable line height.
-		$settings['__experimentalFeatures']['global']['typography']['customLineHeight'] = true;
-	} else {
-		// This approach is deprecated, but we should still support it as a fallback just in case.
-		$settings['enableCustomLineHeight'] = true;
-	}
-	return $settings;
+function wpcom_gutenberg_enable_custom_line_height() {
+	add_theme_support( 'custom-line-height' );
 }
-add_filter( 'block_editor_settings', __NAMESPACE__ . '\wpcom_gutenberg_enable_custom_line_height', 11 );
+add_action( 'after_setup_theme', __NAMESPACE__ . '\wpcom_gutenberg_enable_custom_line_height' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following up on https://github.com/Automattic/wp-calypso/pull/46792#discussion_r513351893, this makes the setting more robust against changes in the experimental settings object shape.

#### Testing instructions

1. Sandbox a site on wordpress.com.
2. Sync these changes with `yarn dev --sync`. (You might need to run `yarn build` from the root as well if you get some `No such file` errors. See https://github.com/Automattic/wp-calypso/issues/46811#issuecomment-718034494 for more info).
3. Open the post editor.
4. Select a paragraph block.
5. Verify that the line-height is an option in the settings.