### PR TITLE
Use admin URL for time mismatch warning in Jetpack env

### DIFF
--- a/client/blocks/time-mismatch-warning/README.md
+++ b/client/blocks/time-mismatch-warning/README.md
@@ -21,4 +21,5 @@ const Test = () => (
 
 There are two props:
 - `siteId`: Site ID to check.
+- `settingsUrl`: Site settings URL. If unset defaults to current page.
 - `status`: This is optional, and allows overriding the notice status. See the `Notice` component for allowed values.

--- a/client/blocks/time-mismatch-warning/index.tsx
+++ b/client/blocks/time-mismatch-warning/index.tsx
@@ -14,7 +14,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 
 interface ExternalProps {
 	status?: string;
-	siteId?: number;
+	siteId: number | null;
 	settingsUrl?: string;
 }
 

--- a/client/blocks/time-mismatch-warning/index.tsx
+++ b/client/blocks/time-mismatch-warning/index.tsx
@@ -10,21 +10,20 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Notice from 'calypso/components/notice';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
-import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
 import { preventWidows } from 'calypso/lib/formatting';
 
 interface ExternalProps {
 	status?: string;
 	siteId?: number;
+	settingsUrl?: string;
 }
 
 export const TimeMismatchWarning: FC< ExternalProps > = ( {
 	status = 'is-warning',
 	siteId,
+	settingsUrl = '#',
 }: ExternalProps ) => {
 	const translate = useTranslate();
-	const siteSlug = useSelector( ( state ) => siteId && getSiteSlug( state, siteId ) );
-	const settingsUrl = siteSlug ? `/settings/general/${ siteSlug }` : '#';
 	const userOffset = new Date().getTimezoneOffset() / -60; // Negative as function returns minutes *behind* UTC.
 	const siteOffset = useSelector( ( state ) => siteId && getSiteGmtOffset( state, siteId ) );
 

--- a/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
+++ b/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TimeMismatchWarning to render if GMT offsets do not match 1`] = `
+<Localized(Notice)
+  status="is-warning"
+>
+  This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.
+</Localized(Notice)>
+`;
+
+exports[`TimeMismatchWarning to render the passed site settings URL 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.",
+      Object {
+        "components": Object {
+          "SiteSettings": <a
+            href="https://example.com"
+          />,
+        },
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": "This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.",
+    },
+  ],
+}
+`;

--- a/client/blocks/time-mismatch-warning/test/index.jsx
+++ b/client/blocks/time-mismatch-warning/test/index.jsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -44,12 +45,14 @@ describe( 'TimeMismatchWarning', () => {
 	test( 'to render if GMT offsets do not match', () => {
 		getSiteGmtOffset.mockReturnValueOnce( 10 );
 		const wrapper = shallow( <TimeMismatchWarning siteId={ 1 } /> );
-		expect( wrapper ).toMatchInlineSnapshot( `
-		<Localized(Notice)
-		  status="is-warning"
-		>
-		  This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.
-		</Localized(Notice)>
-	` );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	test( 'to render the passed site settings URL', () => {
+		const translate = jest.fn( ( text ) => text );
+		getSiteGmtOffset.mockReturnValueOnce( 10 );
+		useTranslate.mockImplementationOnce( () => translate );
+		shallow( <TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" /> );
+		expect( translate ).toMatchSnapshot();
 	} );
 } );

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -67,6 +67,7 @@ import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { requestActivityLogs } from 'calypso/state/data-getters';
@@ -537,7 +538,7 @@ class ActivityLog extends Component {
 			);
 		}
 
-		const { context, rewindState } = this.props;
+		const { context, rewindState, siteSettingsUrl } = this.props;
 
 		const rewindNoThanks = get( context, 'query.rewind-redirect', '' );
 		const rewindIsNotReady =
@@ -551,7 +552,7 @@ class ActivityLog extends Component {
 				<DocumentHead title={ translate( 'Activity' ) } />
 				{ siteId && <QueryRewindState siteId={ siteId } /> }
 				{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
-				{ siteId && <TimeMismatchWarning siteId={ siteId } /> }
+				{ siteId && <TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } /> }
 				{ '' !== rewindNoThanks && rewindIsNotReady
 					? siteId && <ActivityLogSwitch siteId={ siteId } redirect={ rewindNoThanks } />
 					: this.getActivityLog() }
@@ -602,6 +603,7 @@ export default connect(
 			rewindState,
 			siteId,
 			siteTitle: getSiteTitle( state, siteId ),
+			siteSettingsUrl: getSettingsUrl( state, siteId, 'general' ),
 			slug: getSiteSlug( state, siteId ),
 			timezone,
 			siteHasNoLog,

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -48,6 +48,7 @@ import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filte
 import ActivityCardList from 'calypso/components/activity-card-list';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
+import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials.js';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
@@ -363,7 +364,10 @@ class BackupsPage extends Component {
 					} ) }
 				>
 					<SidebarNavigation />
-					<TimeMismatchWarning siteId={ this.props.siteId } />
+					<TimeMismatchWarning
+						siteId={ this.props.siteId }
+						settingsUrl={ this.props.settingsUrl }
+					/>
 					{ ! isJetpackCloud() && (
 						<FormattedHeader headerText="Jetpack Backup" align="left" brandFont />
 					) }
@@ -473,6 +477,7 @@ const mapStateToProps = ( state ) => {
 		siteId,
 		siteUrl: getSiteUrl( state, siteId ),
 		siteSlug: getSelectedSiteSlug( state ),
+		settingsUrl: getSettingsUrl( state, siteId, 'general' ),
 		timezone,
 		gmtOffset,
 		indexedLog,

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -150,7 +150,11 @@ class ScanPage extends Component< Props > {
 					) }
 				</p>
 				{ isEnabled( 'jetpack/on-demand-scan' ) && (
-					<Button primary className="scan__button" onClick={ () => dispatchScanRun( siteId ) }>
+					<Button
+						primary
+						className="scan__button"
+						onClick={ () => siteId && dispatchScanRun( siteId ) }
+					>
 						{ translate( 'Scan now' ) }
 					</Button>
 				) }
@@ -205,7 +209,7 @@ class ScanPage extends Component< Props > {
 				{ isEnabled( 'jetpack/on-demand-scan' ) && (
 					<Button
 						className="scan__button scan__retry-bottom"
-						onClick={ () => dispatchScanRun( siteId ) }
+						onClick={ () => siteId && dispatchScanRun( siteId ) }
 					>
 						{ translate( 'Retry scan' ) }
 					</Button>

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -30,6 +30,7 @@ import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
 import getSiteScanProgress from 'calypso/state/selectors/get-site-scan-progress';
 import getSiteScanIsInitial from 'calypso/state/selectors/get-site-scan-is-initial';
 import getSiteScanState from 'calypso/state/selectors/get-site-scan-state';
+import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
 import isRequestingJetpackScan from 'calypso/state/selectors/is-requesting-jetpack-scan';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
@@ -68,6 +69,7 @@ interface Props {
 	dispatchRecordTracksEvent: ( arg0: string, arg1: Record< string, unknown > ) => null;
 	dispatchScanRun: ( arg0: number ) => null;
 	isAdmin: boolean;
+	siteSettingsUrl: string;
 }
 
 class ScanPage extends Component< Props > {
@@ -269,7 +271,7 @@ class ScanPage extends Component< Props > {
 	}
 
 	render() {
-		const { isAdmin, siteId } = this.props;
+		const { isAdmin, siteId, siteSettingsUrl } = this.props;
 		const isJetpackPlatform = isJetpackCloud();
 
 		if ( ! siteId ) {
@@ -285,7 +287,7 @@ class ScanPage extends Component< Props > {
 				<DocumentHead title="Scan" />
 				<SidebarNavigation />
 				<PageViewTracker path="/scan/:site" title="Scanner" />
-				<TimeMismatchWarning siteId={ siteId } />
+				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
 				{ ! isJetpackPlatform && (
 					<FormattedHeader headerText={ 'Jetpack Scan' } align="left" brandFont />
 				) }
@@ -320,6 +322,7 @@ export default connect(
 			};
 		}
 		const siteUrl = getSiteUrl( state, siteId ) ?? undefined;
+		const siteSettingsUrl = getSettingsUrl( state, siteId, 'general' );
 		const scanState = ( getSiteScanState( state, siteId ) as Scan ) ?? undefined;
 		const scanProgress = getSiteScanProgress( state, siteId ) ?? undefined;
 		const isRequestingScan = isRequestingJetpackScan( state, siteId );
@@ -333,6 +336,7 @@ export default connect(
 			scanState,
 			scanProgress,
 			isInitialScan,
+			siteSettingsUrl,
 			isRequestingScan,
 			isAdmin,
 		};

--- a/client/state/selectors/get-settings-url.ts
+++ b/client/state/selectors/get-settings-url.ts
@@ -3,7 +3,6 @@
  */
 import { getSiteSlug, getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import isSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 
 /**
  * Type dependencies
@@ -22,15 +21,12 @@ function getSettingsUrl(
 	}
 	const siteSlug = getSiteSlug( state, siteId );
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
-	const siteIsWPCOM = isSiteWPCOM( state, siteId );
-	if ( isJetpackCloud() && ! siteIsWPCOM ) {
+	if ( isJetpackCloud() ) {
 		if ( section === 'general' ) {
 			return `${ siteAdminUrl }options-general.php`;
 		}
-	} else if ( siteIsWPCOM ) {
-		if ( section === 'general' ) {
-			return `/settings/general/${ siteSlug }`;
-		}
+	} else if ( section === 'general' ) {
+		return `/settings/general/${ siteSlug }`;
 	}
 
 	return null;

--- a/client/state/selectors/get-settings-url.ts
+++ b/client/state/selectors/get-settings-url.ts
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import { getSiteSlug, getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import isSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+
+/**
+ * Type dependencies
+ */
+import type { AppState } from 'calypso/types';
+
+type Sections = 'general';
+
+function getSettingsUrl(
+	state: AppState,
+	siteId: number | null,
+	section: Sections
+): string | null {
+	if ( ! siteId ) {
+		return null;
+	}
+	const siteSlug = getSiteSlug( state, siteId );
+	const siteAdminUrl = getSiteAdminUrl( state, siteId );
+	const siteIsWPCOM = isSiteWPCOM( state, siteId );
+	if ( isJetpackCloud() && ! siteIsWPCOM ) {
+		if ( section === 'general' ) {
+			return `${ siteAdminUrl }options-general.php`;
+		}
+	} else if ( siteIsWPCOM ) {
+		if ( section === 'general' ) {
+			return `/settings/general/${ siteSlug }`;
+		}
+	}
+
+	return null;
+}
+
+export default getSettingsUrl;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Creates a new selector, `getSettingsUrl`, which returns either a Calypso or wp-admin path based on environment.
* Wires up selector to `TimeMismatchWarning` component to send users to correct path in all envs.

Note: right now the selector only handles the general settings, as there's no map between wp-admin and Calypso settings paths that I could leverage.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set up a JP site with a timezone not in yours.
2. Check activity log, backup, and scan pages in Calypso environment.
3. Verify notice appears and link takes you to the Calypso settings page.
4. Check again, this time with Jetpack environment.
5. Verify notice appears and link takes you to the wp-admin settings page. 
