### PR TITLE
Update Host-Specific Credentials Flow with QuerySiteCredentials

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
@@ -319,7 +319,7 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 	return (
 		<div className="credentials-form">
 			<h3>{ translate( 'Provide your SSH, SFTP or FTP server credentials' ) }</h3>
-			<p class="credentials-form__intro-text">{ getSubHeaderText() }</p>
+			<p className="credentials-form__intro-text">{ getSubHeaderText() }</p>
 			{ renderCredentialLinks() }
 			<FormFieldset className="credentials-form__protocol-type">
 				<div className="credentials-form__support-info">

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/form.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/form.ts
@@ -10,11 +10,11 @@ export enum FormMode {
 }
 
 export interface Credentials {
-	type: 'ssh' | 'ftp';
+	protocol: 'ssh' | 'ftp';
 	host: string;
 	port: number | '';
 	user: string;
-	path: string;
+	abspath: string;
 }
 
 export interface FormState {

--- a/client/state/selectors/has-requested-site-credentials.ts
+++ b/client/state/selectors/has-requested-site-credentials.ts
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns true if we are currently performing a request to fetch the site credentials.
+ * False otherwise.
+ *
+ * @param  {object}  state       Global state tree
+ * @param  {number}  siteId      The ID of the site we're querying
+ * @returns {boolean}             Whether credentials are currently being requested for that site.
+ */
+export default function hasRequestedSiteCredentials( state: AppState, siteId: number ): boolean {
+	return !! get( state.jetpack.credentials.getRequestStatus, siteId, false );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switch from `QueryRewindState` to product-agnostic `QuerySiteCredentials`
* Update parts of flow control that depended on the rewindState
* Add new selector, `hasRequestedSiteCredentials`, to help with state of component
* bug fix `class` -> `className`

#### Testing instructions

1. boot branch and put side-by-side with production
2. test that the following has not changed
a. navigating to a site with credentials shows the "remote credentials for ... are present and correct" message ew/ out the 4 step progress tracker
b. deleting credentials routes back to the host selection page w the progress tracker
c. adding and saving credentials works as before
