### PR TITLE
Notifications: Render figure elements

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -96,6 +96,7 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 		case 'h4':
 		case 'h5':
 		case 'h6':
+		case 'figure':
 			switch ( range_info_type ) {
 				case 'list':
 					range_info_type = 'span';
@@ -224,6 +225,12 @@ function build_chunks( sub_text, sub_ranges, range_data, container, options ) {
 			// [ { id: [index of range in range_data], len: [span of range indices] }, { id: x, len: y }, ..., { id: n, len: m } ]
 			remove_r_id = null;
 			for ( r_id in sub_ranges[ i ].index ) {
+				// Give priority to empty ranges so they are not rendered inside sibling ranges sharing the same
+				// start position.
+				if ( sub_ranges[ i ].index[ r_id ].len === 0 ) {
+					remove_r_id = r_id;
+					break;
+				}
 				if (
 					null === remove_r_id ||
 					sub_ranges[ i ].index[ r_id ].len > sub_ranges[ i ].index[ remove_r_id ].len


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds support for `figure` elements so blocks using them (like the Media & Text block) are rendered correctly in the notifications.

It also fixes an issue in the logic that decides which range should be the next to enter so empty ranges (like the ones used by images) have higher priority in order to render them in the correct DOM level.

Frontend | Notification (before) | Notification (after)
--- | --- | ---
<img width="836" alt="Screen Shot 2020-10-28 at 13 07 27" src="https://user-images.githubusercontent.com/1233880/97470727-2b50fe00-1948-11eb-824e-fe291f256bbb.png"> | <img width="400" alt="Screen Shot 2020-10-28 at 13 08 27" src="https://user-images.githubusercontent.com/1233880/97469294-871a8780-1946-11eb-9bd2-b641e630fdf0.png"> | <img width="403" alt="Screen Shot 2020-10-28 at 17 47 37" src="https://user-images.githubusercontent.com/1233880/97469305-8a157800-1946-11eb-8781-2d11db236306.png">


#### Testing instructions

* Apply D51931-code and sandbox the API.
* Add `define( 'BLOCK_FALLBACKS_DEBUG', true );` to your `/wp-content/mu-plugins/0-sandbox.php` file.
* Publish a post that contains Media & Text blocks.
* Check the post in the masterbar notifications.
* Make sure the Media & Text blocks are rendered correctly.
* Make sure there are no regressions in other notifications.
