### PR TITLE
Data stores: add site title getter and setter

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -125,16 +125,26 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		return success;
 	}
 
-	function* setSiteTitle( title: string, siteId: number = window._currentSiteId ) {
-		yield wpcomRequest( {
+	/**
+	 * Updates site settings by posting to /sites/:site-id/settings
+	 *
+	 * @param siteId the site id
+	 * @param settings an object of {key: value} settings
+	 */
+	function* updateSiteSettings( siteId: number, settings: Record< string, unknown > ) {
+		return yield wpcomRequest( {
 			path: `/sites/${ encodeURIComponent( siteId ) }/settings`,
 			apiVersion: '1.4',
-			body: {
-				blogname: title,
-			},
+			body: settings,
 			method: 'POST',
 		} );
-		yield receiveSiteTitle( siteId, title );
+	}
+
+	function* setSiteTitle( siteId: number, title: string ) {
+		try {
+			yield updateSiteSettings( siteId, { blogname: title } );
+			yield receiveSiteTitle( siteId, title );
+		} catch ( e ) {}
 	}
 
 	return {

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -70,6 +70,12 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		response,
 	} );
 
+	const receiveSiteTitle = ( siteId: number, title: string ) => ( {
+		type: 'RECEIVE_SITE_TITLE' as const,
+		siteId,
+		title,
+	} );
+
 	const receiveSiteFailed = ( siteId: number, response: SiteError | undefined ) => ( {
 		type: 'RECEIVE_SITE_FAILED' as const,
 		siteId,
@@ -119,7 +125,21 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		return success;
 	}
 
+	function* setSiteTitle( title: string, siteId: number = window._currentSiteId ) {
+		yield wpcomRequest( {
+			path: `/sites/${ encodeURIComponent( siteId ) }/settings`,
+			apiVersion: '1.4',
+			body: {
+				blogname: title,
+			},
+			method: 'POST',
+		} );
+		yield receiveSiteTitle( siteId, title );
+	}
+
 	return {
+		setSiteTitle,
+		receiveSiteTitle,
 		fetchNewSite,
 		receiveNewSite,
 		receiveNewSiteFailed,
@@ -141,6 +161,7 @@ export type Action =
 	| ReturnType<
 			| ActionCreators[ 'fetchNewSite' ]
 			| ActionCreators[ 'receiveNewSite' ]
+			| ActionCreators[ 'receiveSiteTitle' ]
 			| ActionCreators[ 'receiveNewSiteFailed' ]
 			| ActionCreators[ 'receiveSite' ]
 			| ActionCreators[ 'receiveSiteFailed' ]

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -125,24 +125,15 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		return success;
 	}
 
-	/**
-	 * Updates site settings by posting to /sites/:site-id/settings
-	 *
-	 * @param siteId the site id
-	 * @param settings an object of {key: value} settings
-	 */
-	function* updateSiteSettings( siteId: number, settings: Record< string, unknown > ) {
-		return yield wpcomRequest( {
-			path: `/sites/${ encodeURIComponent( siteId ) }/settings`,
-			apiVersion: '1.4',
-			body: settings,
-			method: 'POST',
-		} );
-	}
-
 	function* setSiteTitle( siteId: number, title: string ) {
 		try {
-			yield updateSiteSettings( siteId, { blogname: title } );
+			// extract this into its own function as a generic settings setter
+			yield wpcomRequest( {
+				path: `/sites/${ encodeURIComponent( siteId ) }/settings`,
+				apiVersion: '1.4',
+				body: { blogname: title },
+				method: 'POST',
+			} );
 			yield receiveSiteTitle( siteId, title );
 		} catch ( e ) {}
 	}

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -68,6 +68,11 @@ export const sites: Reducer< { [ key: number ]: SiteDetails | undefined }, Actio
 		return { ...remainingState };
 	} else if ( action.type === 'RESET_SITE_STORE' ) {
 		return {};
+	} else if ( action.type === 'RECEIVE_SITE_TITLE' ) {
+		return {
+			...state,
+			[ action.siteId ]: { ...( state[ action.siteId ] as SiteDetails ), name: action.title },
+		};
 	}
 	return state;
 };

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -28,3 +28,8 @@ export function* getSite( siteId: number ) {
 		yield dispatch( STORE_KEY ).receiveSiteFailed( siteId, undefined );
 	}
 }
+
+export function* getSiteTitle( siteId: number = window._currentSiteId ) {
+	const site = yield getSite( siteId );
+	return site?.name;
+}

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -28,8 +28,3 @@ export function* getSite( siteId: number ) {
 		yield dispatch( STORE_KEY ).receiveSiteFailed( siteId, undefined );
 	}
 }
-
-export function* getSiteTitle( siteId: number = window._currentSiteId ) {
-	const site = yield getSite( siteId );
-	return site?.name;
-}

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -9,8 +9,6 @@ export const getNewSite = ( state: State ) => state.newSite.data;
 export const getNewSiteError = ( state: State ) => state.newSite.error;
 export const isFetchingSite = ( state: State ) => state.newSite.isFetching;
 export const isNewSite = ( state: State ) => !! state.newSite.data;
-export const getSiteTitle = ( state: State, siteId = window._currentSiteId ) =>
-	state.sites[ siteId ]?.name;
 
 /**
  * Get a site matched by id. This selector has a matching
@@ -23,6 +21,8 @@ export const getSiteTitle = ( state: State, siteId = window._currentSiteId ) =>
 export const getSite = ( state: State, siteId: number ) => {
 	return state.sites[ siteId ];
 };
+
+export const getSiteTitle = ( state: State, siteId: number ) => getSite( state, siteId )?.name;
 
 export const isLaunched = ( state: State, siteId: number ) => {
 	return state.launchStatus[ siteId ];

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -9,6 +9,8 @@ export const getNewSite = ( state: State ) => state.newSite.data;
 export const getNewSiteError = ( state: State ) => state.newSite.error;
 export const isFetchingSite = ( state: State ) => state.newSite.isFetching;
 export const isNewSite = ( state: State ) => !! state.newSite.data;
+export const getSiteTitle = ( state: State, siteId = window._currentSiteId ) =>
+	state.sites[ siteId ]?.name;
 
 /**
  * Get a site matched by id. This selector has a matching


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a clean isomorphic (Calypso & wp-admin friendly) way to get and set the site title. 

#### Usage

```js
wp.data.select('automattic/site').getSiteTitle()
wp.data.dispatch('automattic/site').setSiteTitle( 'new title' );
```

#### Testing instructions

#### Title

1. Sandbox testingfocusedflow.wordpress.com.
2. in `apps/editing-toolkit`, run `yarn dev --sync`.
3. Go to https://testingfocusedflow.wordpress.com/wp-admin/post-new.php.
4. In Chrome DevTools console, type 
```js
// get the title
wp.data.select('automattic/site').getSiteTitle(window._currentSiteId);

// set the title
wp.data.dispatch('automattic/site').setSiteTitle(window._currentSiteId, 'new title');

// get it again, refresh the page, and do this again, should get the same title
wp.data.select('automattic/site').getSiteTitle(window._currentSiteId);
```
Fixes #46872
