### PR TITLE
Jetpack Scan: fix API's response transform function

### DIFF
--- a/client/components/jetpack/threat-item-subheader/index.tsx
+++ b/client/components/jetpack/threat-item-subheader/index.tsx
@@ -11,7 +11,10 @@ import moment from 'moment';
  */
 import Badge from 'calypso/components/badge';
 import { Threat } from 'calypso/components/jetpack/threat-item/types';
-import { getThreatType, getThreatVulnerability } from 'calypso/components/jetpack/threat-item/utils';
+import {
+	getThreatType,
+	getThreatVulnerability,
+} from 'calypso/components/jetpack/threat-item/utils';
 
 /**
  * Style dependencies

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -28,10 +28,8 @@ export const formatScanThreat = ( threat ) => ( {
 	signature: threat.signature,
 	description: threat.description,
 	status: threat.status,
-	firstDetected: Number.isFinite( threat.first_detected )
-		? new Date( threat.first_detected )
-		: undefined,
-	fixedOn: Number.isFinite( threat.fixed_on ) ? new Date( threat.fixed_on ) : undefined,
+	firstDetected: threat.first_detected ? new Date( threat.first_detected ) : undefined,
+	fixedOn: threat.fixed_on ? new Date( threat.fixed_on ) : undefined,
 	fixable: threat.fixable,
 	fixerStatus: threat.fixer_status,
 	filename: threat.filename,
@@ -46,6 +44,10 @@ export const formatScanThreat = ( threat ) => ( {
  * dates represented as string to Date object.
  *
  * @param {object} scanState Raw Scan state object from Scan endpoint
+ * @param {string} scanState.state State of the scan. E.g. "idle"
+ * @param {object[]} scanState.threats Array of active threats
+ * @param {object} scanState.most_recent Info about the most recent scan
+ * @param {object} scanState.current Info about the current scan
  * @returns {object} Processed Scan state
  */
 const formatScanStateRawResponse = ( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `Number.isFinite` check since dates come as strings and `Number.isFinite` always returns false on string inputs. This is making the `firstDetected` field undefined regardless of what comes from the API.

#### Notes

* This won't fix wrong dates in the History section immediately since there is still a bug on the backend side that is preventing us from showing the right ones.

#### Testing instructions

* Run this PR (Calypso Blue works fine).
* Select a Jetpack site that has active threats.
* Visit the Jetpack > Scan section.
* Open the Components (React) panel in Developer Tools, search for a `ThreatItem` component, and make sure that threats have a valid `firstDetected` date property (see capture below).

Fixes 1164141197617539-as-1198954012346061

#### Demo
##### Before
![image](https://user-images.githubusercontent.com/3418513/97482533-0a32e200-1935-11eb-8749-d06849964061.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/97482119-7b25ca00-1934-11eb-9906-9dc538c38d97.png)