### PR TITLE
Backup: Updates logic to show last successful backup instead of any last

### DIFF
--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -23,6 +23,7 @@ import {
 	// getMetaDiffForDailyBackup,
 	isActivityBackup,
 	isSuccessfulRealtimeBackup,
+	isSuccessfulDailyBackup,
 	INDEX_FORMAT,
 } from 'calypso/lib/jetpack/backup-utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -193,7 +194,7 @@ class BackupsPage extends Component {
 			logs,
 			moment,
 			siteSlug,
-			lastDateAvailable,
+			lastSuccessDateAvailable,
 			timezone,
 			gmtOffset,
 		} = this.props;
@@ -215,7 +216,7 @@ class BackupsPage extends Component {
 					<DailyBackupStatus
 						{ ...{
 							selectedDate: this.getSelectedDate(),
-							lastBackupDate: lastDateAvailable,
+							lastBackupDate: lastSuccessDateAvailable,
 							backup: lastBackup,
 							deltas,
 							// metaDiff, todo: commented because the non-english account issue
@@ -245,7 +246,7 @@ class BackupsPage extends Component {
 			siteCapabilities,
 			logs,
 			moment,
-			lastDateAvailable,
+			lastSuccessDateAvailable,
 			doesRewindNeedCredentials,
 		} = this.props;
 
@@ -265,7 +266,7 @@ class BackupsPage extends Component {
 						<DailyBackupStatusAlternate
 							{ ...{
 								selectedDate: this.getSelectedDate(),
-								lastBackupDate: lastDateAvailable,
+								lastBackupDate: lastSuccessDateAvailable,
 								backup,
 								isLatestBackup:
 									latestBackup && backup && latestBackup.activityId === backup.activityId,
@@ -388,6 +389,7 @@ const createIndexedLog = ( logs, timezone, gmtOffset ) => {
 		gmtOffset,
 	} );
 	let lastDateAvailable = null;
+	let lastSuccessDateAvailable = null;
 
 	if ( 'success' === logs.state ) {
 		logs.data.forEach( ( log ) => {
@@ -413,6 +415,9 @@ const createIndexedLog = ( logs, timezone, gmtOffset ) => {
 				if ( backupDate > lastDateAvailable ) {
 					lastDateAvailable = backupDate;
 				}
+				if ( backupDate > lastSuccessDateAvailable && isSuccessfulDailyBackup( log ) ) {
+					lastSuccessDateAvailable = backupDate;
+				}
 			}
 
 			indexedLog[ index ].push( log );
@@ -423,6 +428,7 @@ const createIndexedLog = ( logs, timezone, gmtOffset ) => {
 		indexedLog,
 		oldestDateAvailable,
 		lastDateAvailable,
+		lastSuccessDateAvailable,
 	};
 };
 
@@ -453,7 +459,7 @@ const mapStateToProps = ( state ) => {
 	const allowRestore =
 		'active' === rewind.state && ! ( 'queued' === restoreStatus || 'running' === restoreStatus );
 
-	const { indexedLog, oldestDateAvailable, lastDateAvailable } = createIndexedLog(
+	const { indexedLog, oldestDateAvailable, lastSuccessDateAvailable } = createIndexedLog(
 		logs,
 		timezone,
 		gmtOffset
@@ -477,7 +483,7 @@ const mapStateToProps = ( state ) => {
 		gmtOffset,
 		indexedLog,
 		oldestDateAvailable,
-		lastDateAvailable,
+		lastSuccessDateAvailable,
 		isLoadingBackups,
 	};
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates backup page to link to last successful backup.

<img width="761" alt="Screen Shot 2020-10-28 at 3 37 41 PM" src="https://user-images.githubusercontent.com/1760168/97487916-ea4eee80-1933-11eb-9b86-e4a22f943136.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Backups screen on a site with a failed backup yesterday and a scheduled one today.
2. Verify date shown is the last date before the failed backup.
3. Click link and verify it takes you to the correct backup date.

Note: creating this state is possible with altering Activity Log API response via proxy rewrite or similar.

Fixes 1164141197617539-as-1189970976408145