### PR TITLE
Fix menu-item active state

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -74,17 +74,17 @@ $font-size: rem( 14px );
 			}
 
 			&::after {
-				display: none;
-				right: 0;
-				border: solid 8px transparent;
 				content: ' ';
-				height: 0;
-				width: 0;
+				display: none;
 				position: absolute;
-				pointer-events: none;
-				border-right-color: #f1f1f1;
 				top: 50%;
+				right: 0;
+				width: 0;
+				height: 0;
 				margin-top: -8px;
+				border: solid 8px transparent;
+				border-right-color: #f1f1f1;
+				pointer-events: none;
 			}
 		}
 

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -72,6 +72,20 @@ $font-size: rem( 14px );
 				background-color: var( --color-sidebar-menu-hover-heading-background );
 				color: var( --color-sidebar-menu-hover );
 			}
+
+			&::after {
+				display: none;
+				right: 0;
+				border: solid 8px transparent;
+				content: ' ';
+				height: 0;
+				width: 0;
+				position: absolute;
+				pointer-events: none;
+				border-right-color: #f1f1f1;
+				top: 50%;
+				margin-top: -8px;
+			}
 		}
 
 		.sidebar__expandable-title,
@@ -132,6 +146,10 @@ $font-size: rem( 14px );
 					.sidebar__menu-icon {
 						color: white;
 					}
+
+					&::after {
+						display: block;
+					}
 				}
 			}
 		}
@@ -151,20 +169,6 @@ $font-size: rem( 14px );
 			.sidebar__heading {
 				padding: 0 0 0 8px;
 				font-weight: 400;
-
-				&::after {
-					display: none;
-					right: 0;
-					border: solid 8px transparent;
-					content: ' ';
-					height: 0;
-					width: 0;
-					position: absolute;
-					pointer-events: none;
-					border-right-color: #f1f1f1;
-					top: 50%;
-					margin-top: -8px;
-				}
 			}
 		}
 

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -172,6 +172,13 @@ $font-size: rem( 14px );
 			}
 		}
 
+		// Is togglable but selected
+		.sidebar__menu.sidebar__menu--selected .sidebar__heading {
+			&::after {
+				display: block;
+			}
+		}
+
 		// Is toggled open
 		.sidebar__menu.is-toggle-open {
 			.sidebar__heading {
@@ -181,10 +188,6 @@ $font-size: rem( 14px );
 					.sidebar__menu-icon {
 						color: var( --color-sidebar-menu-hover );
 					}
-				}
-
-				&::after {
-					display: block;
 				}
 
 				.sidebar__menu-icon {
@@ -316,6 +319,11 @@ $font-size: rem( 14px );
 		.sidebar__menu-link,
 		.sidebar__menu.is-togglable .sidebar__heading {
 			overflow: hidden;
+
+			&::after {
+				border-width: 4px;
+				margin-top: -4px;
+			}
 		}
 
 		// Is toggled open
@@ -327,12 +335,6 @@ $font-size: rem( 14px );
 
 				.sidebar__menu-icon {
 					color: #fff;
-				}
-
-				&::after {
-					display: block;
-					border-width: 4px;
-					margin-top: -4px;
 				}
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The arrow was missing from active menu items that were not menus

Before | After
-------|------
![](https://cln.sh/3vAiyR+) | ![](https://cln.sh/VAKLOW+)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* add `?flags=nav-unification`
* test that menu items that don't have a submenu show the arrow on the right
* test that menu items with submenus continue showing the arrow on the right
* repeat the above for collapsed state

Relates to #45435
