### PR TITLE
Revert "Update EDT to version 2.8.2"

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.2
+ * Version: 2.8.1
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.2' );
+define( 'PLUGIN_VERSION', '2.8.1' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.2
+Stable tag: 2.8.1
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -40,11 +40,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 == Changelog ==
 
-= 2.8.2 =
-* Gutenberg: Support new line height setting (https://github.com/Automattic/wp-calypso/pull/46792)
-* Gutenberg: Make line-height setting more robust. (https://github.com/Automattic/wp-calypso/pull/46873)
-
-= 2.8.1 =
+= 2.8.1 = 
 * Launch: Added persistent launch button. (https://github.com/Automattic/wp-calypso/pull/46558)
 
 = 2.8 =

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.2",
+	"version": "2.8.1",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#46887 - the build failed after deploy.