### PR TITLE
Pause Secure Your Brand

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -205,8 +205,8 @@ export default {
 	secureYourBrand: {
 		datestamp: '20201026',
 		variations: {
-			test: 50,
-			control: 50,
+			test: 0,
+			control: 100,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change will pause the Secure Your Brand test for the duration of the Monthly price 

#### Testing instructions

1. Set country_code cookie to US
2. Sign up with a new user and make sure the user is assigned to `control` with secureYourBrand