### PR TITLE
Try: Record Editor NuxPage usage

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -11,6 +11,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 
 /**
  * Internal dependencies
@@ -57,7 +58,7 @@ function WpcomNux() {
 
 	/* @TODO: the copy, images, and slides will eventually be the same for all sites. `isGutenboarding` is only needed right now to show the Privacy slide */
 	const isGutenboarding = !! window.calypsoifyGutenberg?.isGutenboarding;
-
+	const pages = getWpcomNuxPages( isGutenboarding );
 	return (
 		<Guide
 			className="wpcom-block-editor-nux"
@@ -65,8 +66,13 @@ function WpcomNux() {
 			finishButtonText={ __( 'Get started', 'full-site-editing' ) }
 			onFinish={ dismissWpcomNux }
 		>
-			{ getWpcomNuxPages( isGutenboarding ).map( ( nuxPage ) => (
-				<NuxPage key={ nuxPage.heading } { ...nuxPage } />
+			{ pages.map( ( nuxPage, index ) => (
+				<NuxPage
+					key={ nuxPage.heading }
+					pageNumber={ index + 1 }
+					isLastPage={ index === pages.length - 1 }
+					{ ...nuxPage }
+				/>
 			) ) }
 		</Guide>
 	);
@@ -121,7 +127,13 @@ function getWpcomNuxPages( isGutenboarding ) {
 	].filter( ( nuxPage ) => ! nuxPage.shouldHide );
 }
 
-function NuxPage( { alignBottom = false, heading, description, imgSrc } ) {
+function NuxPage( { pageNumber, isLastPage, alignBottom = false, heading, description, imgSrc } ) {
+	useEffect( () => {
+		recordTracksEvent( 'calypso_newsite_wpcomnux_slide_view', {
+			slide_number: pageNumber,
+			is_last_slide: isLastPage,
+		} );
+	}, [] );
 	return (
 		<GuidePage className="wpcom-block-editor-nux__page">
 			<div className="wpcom-block-editor-nux__text">


### PR DESCRIPTION
Record an event for each `NuxPage` mount with `slide_number` and `is_last_slide` props.

Fixes part of https://github.com/Automattic/wp-calypso/issues/46705
