### PR TITLE
Components: Introduce a Disableable component

### DIFF
--- a/client/components/disableable/README.md
+++ b/client/components/disableable/README.md
@@ -1,0 +1,24 @@
+# Disableable
+
+This component is used as a wrapper of form elements that can potentially be disabled.
+
+Whether they'll be disabled or not is specified by simply providing a boolean prop to the component.
+
+## How to use
+
+```js
+import { Disableable } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+
+function render() {
+	return (
+		<Disableable disabled={ this.props.isDisabled }>
+			<ToggleControl label="An example here" />
+		</Disableable>
+	);
+}
+```
+
+## Props
+
+- `disabled`: whether the form fields nested inside the component should be disabled (required).

--- a/client/components/disableable/docs/example.jsx
+++ b/client/components/disableable/docs/example.jsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { ToggleControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import Disableable from 'calypso/components/disableable';
+
+const DisableableExample = () => {
+	const [ firstToggle, setFirstToggle ] = useState( true );
+	const [ secondToggle, setSecondToggle ] = useState( true );
+
+	return (
+		<React.Fragment>
+			<p>Form control, wrapped with a disabled Disableable component</p>
+			<Disableable disabled>
+				<ToggleControl
+					label="Click me"
+					onChange={ () => setFirstToggle( ! firstToggle ) }
+					checked={ firstToggle }
+				/>
+			</Disableable>
+
+			<p>Form control, wrapped with a non-disabled Disableable component</p>
+			<Disableable disabled={ false }>
+				<ToggleControl
+					label="Click me"
+					onChange={ () => setSecondToggle( ! secondToggle ) }
+					checked={ secondToggle }
+				/>
+			</Disableable>
+		</React.Fragment>
+	);
+};
+
+DisableableExample.displayName = 'Disableable';
+
+export default DisableableExample;

--- a/client/components/disableable/index.tsx
+++ b/client/components/disableable/index.tsx
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { Disabled } from '@wordpress/components';
+
+const Disableable: React.FC = ( { children, disabled } ) => {
+	const DisabledComponent = disabled ? Disabled : React.Fragment;
+	return <DisabledComponent>{ children }</DisabledComponent>;
+};
+
+export default Disableable;

--- a/client/components/disableable/test/index.js
+++ b/client/components/disableable/test/index.js
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { Disabled } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import Disableable from '..';
+
+describe( 'Disableable', () => {
+	test( 'should contain a Disabled component', () => {
+		const disableable = shallow( <Disableable disabled /> );
+		expect( disableable.find( Disabled ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should not contain a Disabled component', () => {
+		const disableable = shallow( <Disableable disabled={ false } /> );
+		expect( disableable.find( Disabled ) ).toHaveLength( 0 );
+	} );
+} );

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -44,6 +44,7 @@ import CreditCard from 'calypso/components/credit-card/docs/example';
 import DatePicker from 'calypso/components/date-picker/docs/example';
 import DateRange from 'calypso/components/date-range/docs/example';
 import DiffViewerExample from 'calypso/components/diff-viewer/docs/example';
+import Disableable from 'calypso/components/disableable/docs/example';
 import DotPager from 'calypso/components/dot-pager/docs/example';
 import DropZones from 'calypso/components/drop-zone/docs/example';
 import EllipsisMenu from 'calypso/components/ellipsis-menu/docs/example';
@@ -206,6 +207,7 @@ export default class DesignAssets extends React.Component {
 					<DatePicker readmeFilePath="date-picker" />
 					<DateRange readmeFilePath="date-range" />
 					<DiffViewerExample readmeFilePath="diff-viewer" />
+					<Disableable readmeFilePath="disableable" />
 					<DotPager readmeFilePath="dot-pager" />
 					<DropZones searchKeywords="drag" readmeFilePath="drop-zone" />
 					<EllipsisMenu readmeFilePath="ellipsis-menu" />


### PR DESCRIPTION
As part of the migration to `@wordpress/components`, we're looking at how the form field disabled states are handled there. While in Calypso it's common for a form field component to expect a `disabled` prop, in `@wordpress/components` we wrap the form field components with a special `Disabled` component, also part of `@wordpress/components`. It's pretty neat because that means one less prop needs to be passed down to form components.

However, the `Disabled` component doesn't offer any props or way to add logic. We either wrap a form field in a `Disabled` component, or not. 

Since in Calypso we often have the "disabled" information as a prop from above, we could use a component that could receive the `disabled` as a prop, and determine whether to wrap the contents in a `<Disabled />` or not. 

This PR introduces this very simple component.

#### Changes proposed in this Pull Request

* Components: Introduce a Disableable component

#### Testing instructions

* Go to `/devdocs/design/disableable`
* Verify the toggle in the first example is disabled, and the second one can be interacted with.
* Verify tests pass: `yarn run test-client client/components/disableable`
