### PR TITLE
Fix notice height when sidebar is collapsed

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -214,6 +214,7 @@ $font-size: rem( 14px );
 			&.is-compact {
 				margin: 0;
 				align-items: center;
+				min-height: 34px;
 			}
 
 			.notice__icon-wrapper {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- set `min-height` of notice so that it has the same height as the rest of the menu items when collapsed

Before | After
-------|------
![](https://cln.sh/MgJdN4+) | ![](https://cln.sh/7s3hVy+)

