### PR TITLE
Update copy of pricing page i2

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
@@ -170,7 +170,9 @@ const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 								<>
 									<span className="jetpack-product-card-alt-2__raw-price">
 										<PlanPrice
-											rawPrice={ isDiscounted ? discountedPrice : originalPrice }
+											rawPrice={ Math.floor(
+												( isDiscounted ? discountedPrice : originalPrice ) as number
+											) }
 											discounted
 											currencyCode={ currencyCode }
 										/>

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -374,19 +374,37 @@ const getPlanBusinessDetails = () => ( {
 const getPlanJetpackSecurityDailyDetails = () => ( {
 	group: constants.GROUP_JETPACK,
 	type: constants.TYPE_SECURITY_DAILY,
-	getTitle: () => translate( 'Security {{em}}Daily{{/em}}', { components: { em: <em /> } } ),
+	getTitle: () =>
+		getJetpackCROActiveVersion() === 'v2'
+			? translate( 'Jetpack Security {{em}}Daily{{/em}}', { components: { em: <em /> } } )
+			: translate( 'Security {{em}}Daily{{/em}}', { components: { em: <em /> } } ),
+	getButtonLabel: () =>
+		getJetpackCROActiveVersion() === 'v2'
+			? translate( 'Get Security {{em}}Daily{{/em}}', { components: { em: <em /> } } )
+			: undefined,
 	getAudience: () => translate(),
 	availableFor: ( plan ) =>
 		[ constants.PLAN_JETPACK_FREE, ...constants.JETPACK_LEGACY_PLANS ].includes( plan ),
 	getDescription: () =>
-		translate(
-			'Enjoy the peace of mind of complete site protection. ' +
-				'Great for brochure sites, restaurants, blogs, and resume sites.'
-		),
-	getTagline: () =>
-		getJetpackCROActiveVersion() === 'v1'
-			? translate( 'Backup, Scan, and Anti-spam in one package' )
-			: translate( 'Best for sites with occasional updates' ),
+		getJetpackCROActiveVersion() === 'v2'
+			? translate(
+					'All of the essential Jetpack Security features in one package including Backup, Scan, Anti-spam and more.'
+			  )
+			: translate(
+					'Enjoy the peace of mind of complete site protection. ' +
+						'Great for brochure sites, restaurants, blogs, and resume sites.'
+			  ),
+	getTagline: () => {
+		if ( getJetpackCROActiveVersion() === 'v1' ) {
+			return translate( 'Backup, Scan, and Anti-spam in one package' );
+		}
+
+		if ( getJetpackCROActiveVersion() === 'v2' ) {
+			return translate( 'Essential WordPress protection' );
+		}
+
+		return translate( 'Best for sites with occasional updates' );
+	},
 	getPlanCompareFeatures: () => [],
 	getPlanCardFeatures: () =>
 		getJetpackCROActiveVersion() === 'v2'
@@ -438,7 +456,14 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 const getPlanJetpackSecurityRealtimeDetails = () => ( {
 	group: constants.GROUP_JETPACK,
 	type: constants.TYPE_SECURITY_REALTIME,
-	getTitle: () => translate( 'Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } ),
+	getTitle: () =>
+		getJetpackCROActiveVersion() === 'v2'
+			? translate( 'Jetpack Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } )
+			: translate( 'Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } ),
+	getButtonLabel: () =>
+		getJetpackCROActiveVersion() === 'v2'
+			? translate( 'Get Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } )
+			: undefined,
 	getAudience: () => translate(),
 	availableFor: ( plan ) =>
 		[
@@ -448,11 +473,18 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 			...constants.JETPACK_LEGACY_PLANS,
 		].includes( plan ),
 	getDescription: () =>
-		translate(
-			'Additional security for sites with 24/7 activity. ' +
-				'Recommended for eCommerce stores, news organizations, and online forums.'
-		),
-	getTagline: () => translate( 'Best for sites with frequent updates' ),
+		getJetpackCROActiveVersion() === 'v2'
+			? translate(
+					'Get next level protection. Includes all essential security tools, but with on-demand scan, real time backup & more.'
+			  )
+			: translate(
+					'Additional security for sites with 24/7 activity. ' +
+						'Recommended for eCommerce stores, news organizations, and online forums.'
+			  ),
+	getTagline: () =>
+		getJetpackCROActiveVersion() === 'v2'
+			? translate( 'Always on protection, backs up as you edit' )
+			: translate( 'Best for sites with frequent updates' ),
 	getPlanCompareFeatures: () => [],
 	getPlanCardFeatures: () =>
 		getJetpackCROActiveVersion() === 'v2'

--- a/client/lib/plans/types.ts
+++ b/client/lib/plans/types.ts
@@ -40,6 +40,7 @@ export type Plan = {
 	getTitle: () => TranslateResult;
 	getDescription: () => TranslateResult;
 	getTagline?: ( features?: string[] ) => TranslateResult;
+	getButtonLabel?: () => TranslateResult;
 	getAnnualSlug?: () => JetpackPlanSlugs | string;
 	getMonthlySlug?: () => JetpackPlanSlugs | string;
 	getAudience?: () => TranslateResult;

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -55,25 +55,39 @@ export const getJetpackProductsShortNames = () => {
 };
 
 export const getJetpackProductsDisplayNames = () => {
+	const currentCROvariant = getJetpackCROActiveVersion();
 	const backupDaily = (
 		<>
-			{ translate( 'Backup {{em}}Daily{{/em}}', {
-				components: {
-					em: <em />,
-				},
-			} ) }
+			{ currentCROvariant === 'v2'
+				? translate( 'Jetpack Backup {{em}}Daily{{/em}}', {
+						components: {
+							em: <em />,
+						},
+				  } )
+				: translate( 'Backup {{em}}Daily{{/em}}', {
+						components: {
+							em: <em />,
+						},
+				  } ) }
 		</>
 	);
 	const backupRealtime = (
 		<>
-			{ translate( 'Backup {{em}}Real-Time{{/em}}', {
-				components: {
-					em: <em />,
-				},
-			} ) }
+			{ currentCROvariant === 'v2'
+				? translate( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+						components: {
+							em: <em />,
+						},
+				  } )
+				: translate( 'Backup {{em}}Real-Time{{/em}}', {
+						components: {
+							em: <em />,
+						},
+				  } ) }
 		</>
 	);
-	const search = translate( 'Jetpack Search' );
+	const search =
+		currentCROvariant === 'v2' ? translate( 'Jetpack Site Search' ) : translate( 'Jetpack Search' );
 	const scan = translate( 'Jetpack Scan' );
 	const antiSpam = <>{ translate( 'Jetpack Anti-spam' ) }</>;
 
@@ -144,13 +158,17 @@ export const getJetpackProductsTaglines = () => {
 			: translate( 'Best for sites with occasional updates' );
 	const backupRealtimeTagline = translate( 'Best for sites with frequent updates' );
 	const backupOwnedTagline = translate( 'Your site is actively being backed up' );
-
-	const searchTagline = [ 'v1', 'v2' ].includes( currentCROvariant )
-		? translate( 'Great for sites with a lot of content' )
-		: translate( 'Recommended for sites with lots of products or content' );
+	const searchTagline =
+		{
+			v1: translate( 'Great for sites with a lot of content' ),
+			v2: translate( 'Recommended for sites with lots of content' ),
+		}[ currentCROvariant ] || translate( 'Recommended for sites with lots of products or content' );
 	const scanTagline = translate( 'Protect your site' );
 	const scanOwnedTagline = translate( 'Your site is actively being scanned for malicious threats' );
-	const antiSpamTagline = translate( 'Block spam automatically' );
+	const antiSpamTagline =
+		currentCROvariant === 'v2'
+			? translate( 'Powered By Akismet' )
+			: translate( 'Block spam automatically' );
 
 	return {
 		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_DAILY ]: {

--- a/client/my-sites/plans-v2/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar/index.tsx
@@ -96,7 +96,7 @@ const PlansFilterBar = ( {
 			) }
 			{ showDiscountMessage && (
 				<span className="plans-filter-bar__discount-message">
-					{ translate( 'You save %(discount)s by paying yearly', {
+					{ translate( 'Save %(discount)s by paying yearly', {
 						args: { discount: '20%' },
 					} ) }
 				</span>

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -387,6 +387,7 @@ export function itemToSelectorProduct(
 			// Using the same slug for any duration helps prevent unnecessary DOM updates
 			iconSlug: ( yearlyProductSlug || productSlug ) + iconAppend,
 			displayName: item.getTitle(),
+			buttonLabel: item.getButtonLabel?.(),
 			type,
 			subtypes: [],
 			shortName: item.getTitle(),


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR  updates the copy in the last pricing page according to the mockups.

Fixes 1196341175636977-as-1198514641268292

### Implementation notes

- Versions checks are not scalable. We'll need to find a proper way of handling versioning.
- The Jetpack CRM card will be handled in a separate PR.

### Testing instructions

- Download the PR
- Run Calypso
- Make sure the variant `v2 - slide outs` is selected in the `jetpackConversionRateOptimization` A/B test
- Visit the plans page
- Check the copy against the mockups (see board)
- Make sure there's no error in the copy
- Switch back to the v1 variant and check that the page looks like production