### PR TITLE
i18n: Refactor translation chunks setup

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import { get } from 'lodash';
-import debugFactory from 'debug';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,16 +12,9 @@ import {
 	isDefaultLocale,
 	isTranslatedIncompletely,
 } from 'calypso/lib/i18n-utils';
-import {
-	loadUserUndeployedTranslations,
-	getLanguageManifestFile,
-	getTranslationChunkFile,
-} from 'calypso/lib/i18n-utils/switch-locale';
-import { getUrlParts } from 'calypso/lib/url/url-parts';
+import { loadUserUndeployedTranslations } from 'calypso/lib/i18n-utils/switch-locale';
 import { setLocale, setLocaleRawData } from 'calypso/state/ui/language/actions';
 import { initLanguageEmpathyMode } from 'calypso/lib/i18n-utils/empathy-mode';
-
-const debug = debugFactory( 'calypso:i18n' );
 
 function getLocaleFromPathname() {
 	const pathname = window.location.pathname.replace( /\/$/, '' );
@@ -35,68 +26,7 @@ function getLocaleFromPathname() {
 	return pathLocaleSlug;
 }
 
-const setupTranslationChunks = async ( localeSlug, reduxStore ) => {
-	const { translatedChunks, locale } = await getLanguageManifestFile(
-		localeSlug,
-		window.BUILD_TARGET
-	).catch( () => {
-		debug( `Failed to get language manifest for ${ localeSlug }.` );
-
-		return {};
-	} );
-
-	if ( ! locale || ! translatedChunks ) {
-		debug(
-			`Encountered an error setting up translation chunks for ${ localeSlug }. Falling back to English.`
-		);
-
-		return;
-	}
-
-	reduxStore.dispatch( setLocaleRawData( locale ) );
-
-	let userTranslations;
-	const loadedTranslationChunks = {};
-	const loadTranslationForChunkIfNeeded = ( chunkId ) => {
-		if ( ! translatedChunks.includes( chunkId ) || loadedTranslationChunks[ chunkId ] ) {
-			return;
-		}
-
-		return getTranslationChunkFile( chunkId, i18n.getLocaleSlug(), window.BUILD_TARGET ).then(
-			( translations ) => {
-				i18n.addTranslations( { ...translations, ...userTranslations } );
-				loadedTranslationChunks[ chunkId ] = true;
-			}
-		);
-	};
-	const installedChunks = new Set(
-		( window.installedChunks || [] ).concat( window.__requireChunkCallback__.getInstalledChunks() )
-	);
-
-	installedChunks.forEach( ( chunkId ) => {
-		loadTranslationForChunkIfNeeded( chunkId );
-	} );
-
-	window.__requireChunkCallback__.add( ( { publicPath, scriptSrc }, promises ) => {
-		const chunkId = scriptSrc.replace( publicPath, '' ).replace( /\.js$/, '' );
-
-		promises.push( loadTranslationForChunkIfNeeded( chunkId ) );
-	} );
-
-	const userTranslationsPromise = loadUserUndeployedTranslations( localeSlug );
-
-	if ( userTranslationsPromise ) {
-		userTranslationsPromise.then( ( translations ) => {
-			userTranslations = translations;
-		} );
-	}
-};
-
 export const setupLocale = ( currentUser, reduxStore ) => {
-	const useTranslationChunks =
-		config.isEnabled( 'use-translation-chunks' ) ||
-		getUrlParts( document.location.href ).searchParams.has( 'useTranslationChunks' );
-
 	if ( config.isEnabled( 'i18n/empathy-mode' ) && currentUser.i18n_empathy_mode ) {
 		initLanguageEmpathyMode();
 	}
@@ -108,14 +38,6 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 
 	if ( shouldUseFallbackLocale ) {
 		userLocaleSlug = config( 'i18n_default_locale_slug' );
-	}
-
-	if ( useTranslationChunks && '__requireChunkCallback__' in window ) {
-		const localeSlug = userLocaleSlug || getLocaleFromPathname();
-
-		if ( localeSlug && ! isDefaultLocale( localeSlug ) ) {
-			setupTranslationChunks( localeSlug, reduxStore );
-		}
 	}
 
 	if ( window.i18nLocaleStrings ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Move require chunk listener setup for translation chunks in `client/lib/i18n-utils/switch-locale.js`
- Remove duplicated code in `client/boot/locale.js` related to translation chunks setup

#### Testing instructions

- Boot Calypso locally with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks yarn start` or use calypso.live build. For calypso.live, you'll need to enable translation chunks by adding `?useTranslationChunks`  flag to the URL
- Change UI language to a Mag-16 one.
- Add Navigate through Calypso screens and confirm translations display properly.
- Additionally, inspect the Network tab in DevTools to confirm translation chunks are being fetched. Translation chunk JSON file names should be prefixed with the selected locale slug, e.g. `de-{chunkId}.json`.
- Go to `/start/{localeSlug}`, e.g. `/start/de`, in an incognito tab and confirm translations are being loaded for the sign up screen.
- Additionally, set your browser primary language to any of the Mag-16, and go to `/start` (w/o the locale slug) in an incognito tab and confirm translations are loaded and displayed properly.

Fixes 171-gh-i18n-issues
