### PR TITLE
Login: Fix logged in redirect

### DIFF
--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -7,13 +7,13 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { isUserLoggedIn } from 'state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 export function redirectLoggedIn( context, next ) {
 	const userLoggedIn = isUserLoggedIn( context.store.getState() );
 
 	if ( userLoggedIn ) {
-		page.redirect( '/' );
+		page( '/' );
 		return;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Login: Fix redirect for logged in users

#### Testing instructions

* As a logged-in user, go to `/log-in/link`
* Verify you're redirected to WP.com and you can see the customer home or the reader (whatever it is for your primary site). Previously, the route would change, but the app would still render the `/log-in/link` layout.
