### PR TITLE
Checkout: update credits pay button for mobile screens

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -64,7 +64,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
-		return sprintf( __( 'Pay %s with WordPress.com Credits' ), total.amount.displayValue );
+		return sprintf( __( 'Pay %s with credits' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the copy of the credits pay button to work better on smaller screens.

**Before**
![image](https://user-images.githubusercontent.com/6981253/97584739-ba085e00-19ce-11eb-96b1-a3b6a489ff3e.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/97584674-a6f58e00-19ce-11eb-93e9-4940400eedb9.png)


#### Testing instructions

* Make sure you have credits on your account and visit checkout. 
