### PR TITLE
Update CRM cards in pricing page i2

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/features-product-slide-out.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/features-product-slide-out.tsx
@@ -5,6 +5,7 @@ import React, { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import { isFinite } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
+import formatCurrency from '@automattic/format-currency';
 
 /**
  * Internal dependencies
@@ -43,15 +44,23 @@ const FeaturesProductSlideOut: FunctionComponent< Props > = ( {
 	);
 	const isDiscounted = isFinite( discountedPrice );
 	const productPrice = isDiscounted ? discountedPrice : originalPrice;
+	const formattedPrice = formatCurrency(
+		( ( product && product.displayPrice ) || productPrice ) as number,
+		( ( product && product.displayCurrency ) || currencyCode ) as string,
+		{
+			precision: 0,
+		}
+	);
+	const billingTimeFrame = durationToText(
+		( product && product.displayTerm ) || productBillingTerm
+	);
 
-	const billingTimeFrame = durationToText( productBillingTerm );
-
-	const slideOutButtonLabel = translate( 'Get {{name/}} $%(price)s', {
+	const slideOutButtonLabel = translate( 'Get {{name/}} %(price)s', {
 		args: {
-			price: productPrice,
+			price: formattedPrice,
 		},
 		components: {
-			name: <>{ product?.displayName }</>,
+			name: <>{ product?.shortName }</>,
 		},
 	} );
 
@@ -60,7 +69,7 @@ const FeaturesProductSlideOut: FunctionComponent< Props > = ( {
 			iconSlug={ product.iconSlug }
 			productName={ product.displayName }
 			currencyCode={ currencyCode }
-			price={ productPrice }
+			price={ Math.floor( ( ( product && product.displayPrice ) || productPrice ) as number ) }
 			billingTimeFrame={ billingTimeFrame }
 			description={ product?.description }
 			buttonLabel={ slideOutButtonLabel }

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { createElement } from 'react';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -299,11 +300,26 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 	iconSlug: [ 'v1', 'v2' ].includes( getJetpackCROActiveVersion() )
 		? 'jetpack_crm_dark'
 		: 'jetpack_crm',
-	displayName: translate( 'Jetpack CRM' ),
-	shortName: translate( 'CRM', {
-		comment: 'Short name of the Jetpack CRM',
-	} ),
+	displayName:
+		getJetpackCROActiveVersion() === 'v2'
+			? translate( 'Jetpack CRM {{em}}Entrepreneur{{/em}}', {
+					components: {
+						em: createElement( 'em' ),
+					},
+			  } )
+			: translate( 'Jetpack CRM' ),
+	shortName:
+		getJetpackCROActiveVersion() === 'v2'
+			? translate( 'Jetpack CRM ' )
+			: translate( 'CRM', {
+					comment: 'Short name of the Jetpack CRM',
+			  } ),
 	tagline: translate( 'Manage contacts effortlessly' ),
+	// Jetpack CRM isn't considered as a product like others for the time being (and therefore not
+	// available via the API). Rather like a third-party product.
+	// See pricing in https://jetpackcrm.com/pricing/ (only available in USD)
+	displayPrice: getJetpackCROActiveVersion() === 'v2' ? 17 : undefined,
+	displayCurrency: getJetpackCROActiveVersion() === 'v2' ? 'USD' : undefined,
 	description: translate(
 		'The most simple and powerful WordPress CRM. Improve customer relationships and increase profits.'
 	),
@@ -329,6 +345,7 @@ export const EXTERNAL_PRODUCT_CRM_MONTHLY: SelectorProduct = {
 	...EXTERNAL_PRODUCT_CRM,
 	productSlug: PRODUCT_JETPACK_CRM_MONTHLY,
 	term: TERM_MONTHLY,
+	displayTerm: getJetpackCROActiveVersion() === 'v2' ? TERM_ANNUALLY : undefined,
 	subtypes: [],
 	costProductSlug: PRODUCT_JETPACK_CRM_MONTHLY,
 };

--- a/client/my-sites/plans-v2/product-card-alt-2/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt-2/index.tsx
@@ -65,13 +65,7 @@ const ProductCardAltWrapper: FunctionComponent< ProductCardProps > = ( {
 	}, [ item.productSlug, sitePlan, siteProducts ] );
 
 	// Calculate the product price.
-	const { originalPrice, discountedPrice } = useItemPrice(
-		siteId,
-		item,
-		item?.monthlyProductSlug || ''
-	);
-
-	const isFree = originalPrice === -1 && discountedPrice === -1;
+	const { originalPrice } = useItemPrice( siteId, item, item?.monthlyProductSlug || '' );
 
 	// Handles expiry.
 	const moment = useLocalizedMoment();
@@ -101,8 +95,8 @@ const ProductCardAltWrapper: FunctionComponent< ProductCardProps > = ( {
 			productName={ productName }
 			subheadline={ item.tagline }
 			description={ description }
-			currencyCode={ currencyCode }
-			billingTerm={ item.term }
+			currencyCode={ item.displayCurrency || currencyCode }
+			billingTerm={ item.displayTerm || item.term }
 			buttonLabel={ buttonLabel }
 			buttonPrimary={ ! ( isOwned || isItemPlanFeature ) }
 			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
@@ -111,8 +105,6 @@ const ProductCardAltWrapper: FunctionComponent< ProductCardProps > = ( {
 				showRecordsDetails && <RecordsDetailsAlt productSlug={ item.productSlug } />
 			}
 			originalPrice={ originalPrice }
-			discountedPrice={ discountedPrice }
-			isFree={ isFree }
 			isOwned={ isOwned }
 			isDeprecated={ item.legacy }
 			className={ className }

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -115,6 +115,9 @@ export interface SelectorProduct extends SelectorProductCost {
 	legacy?: boolean;
 	hidePrice?: boolean;
 	externalUrl?: string;
+	displayTerm?: Duration;
+	displayPrice?: number;
+	displayCurrency?: string;
 }
 
 export interface AvailableProductData {

--- a/client/my-sites/plans-v2/use-item-price.ts
+++ b/client/my-sites/plans-v2/use-item-price.ts
@@ -112,7 +112,7 @@ const useItemPrice = (
 	// Jetpack CRM price won't come from the API, so we need to hard-code it for now.
 	if ( item && [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes( item.productSlug ) ) {
 		discountedPrice = -1;
-		originalPrice = -1;
+		originalPrice = item.displayPrice || -1;
 	}
 
 	return {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the copy of the Jetpack CRM card and slide-out.

Fixes 1196341175636977-as-1198877504751357

### Implementation notes

- Slide-out doesn't look like the mockups. There's a separate PR for this.
- Time frame in slide-out says "per month, billed yearly", instead of "per month".
- CRM is not considered as a regular product and price must be harcoded for the time being.
- Price is only shown in USD for the time being.
- Added 3 news properties to `SelectorProduct` to handle this specific case: `displayTerm`, `displayPrice`, `displayCurrency`.

### Testing instructions

- Download the PR
- Run Calypso
- Make sure the variant `v2 - slide outs` is selected in the `jetpackConversionRateOptimization` A/B test
- Visit the plans page
- Check the CRM card and the CRM slide-out inside the Complete card against the mockups (see captures below)
- Check that price and billing time frame is the same when you switch from Monthly to Annually and vice-versa
- Change the currency (directly in the code or otherwise) and notice that the price of CRM is still in dollars
- Make sure there's no error in the copy
- Switch back to the v1 variant and check that the page looks like production

### Screenshots

#### Mockups
<img width="385" alt="Screen Shot 2020-10-21 at 9 34 49 AM" src="https://user-images.githubusercontent.com/1620183/97590974-88df5c00-19d5-11eb-92cb-403cb59c4d85.png">
<img width="497" alt="Screen Shot 2020-10-21 at 9 38 48 AM" src="https://user-images.githubusercontent.com/1620183/97590995-8d0b7980-19d5-11eb-9e17-2b999d6e399a.png">



#### Implementation
<img width="393" alt="Screen Shot 2020-10-29 at 10 19 06 AM" src="https://user-images.githubusercontent.com/1620183/97591017-91d02d80-19d5-11eb-93a3-eb534e07a0fc.png">
<img width="332" alt="Screen Shot 2020-10-29 at 10 19 34 AM" src="https://user-images.githubusercontent.com/1620183/97591032-94cb1e00-19d5-11eb-93f4-788cebbb4604.png">