### PR TITLE
Use Node.js version of redirectLoggedIn on server

### DIFF
--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -47,13 +47,3 @@ const ProviderWrappedLoggedOutLayout = ( {
  * `context.primary` and `context.secondary` to populate it.
  */
 export const makeLayout = makeLayoutMiddleware( ProviderWrappedLoggedOutLayout );
-
-export function redirectLoggedIn( { isLoggedIn, res }, next ) {
-	// TODO: Make it work also for development env
-	if ( isLoggedIn ) {
-		res.redirect( '/' );
-		return;
-	}
-
-	next();
-}

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -27,7 +27,7 @@ import { hydrate } from './web-util.js';
  * Re-export
  */
 export { setSectionMiddleware, setLocaleMiddleware } from './shared.js';
-export { render, hydrate, redirectLoggedIn } from './web-util.js';
+export { render, hydrate } from './web-util.js';
 
 export const ProviderWrappedLayout = ( {
 	store,

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -2,23 +2,6 @@
  * External dependencies
  */
 import ReactDom from 'react-dom';
-import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-
-export function redirectLoggedIn( context, next ) {
-	const userLoggedIn = isUserLoggedIn( context.store.getState() );
-
-	if ( userLoggedIn ) {
-		page( '/' );
-		return;
-	}
-
-	next();
-}
 
 export function render( context ) {
 	ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );

--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -1,10 +1,11 @@
 /**
  * Internal dependencies
  */
-import config from 'config';
+import config from 'calypso/config';
 import webRouter from './index.web';
-import { makeLayout, redirectLoggedIn, setLocaleMiddleware } from 'controller';
-import { getLanguageRouteParam } from 'lib/i18n-utils';
+import { makeLayout, setLocaleMiddleware } from 'calypso/controller';
+import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
+import redirectLoggedIn from './redirect-logged-in';
 
 /**
  * Re-exports

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -21,7 +21,7 @@ import {
 	setSectionMiddleware,
 	makeLayoutMiddleware,
 } from 'calypso/controller/shared';
-import { redirectLoggedIn } from 'calypso/controller/web-util';
+import { redirectLoggedIn } from 'calypso/controller';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 import { RouteProvider } from 'calypso/components/route';

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -21,10 +21,10 @@ import {
 	setSectionMiddleware,
 	makeLayoutMiddleware,
 } from 'calypso/controller/shared';
-import { redirectLoggedIn } from 'calypso/controller';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 import { RouteProvider } from 'calypso/components/route';
+import redirectLoggedIn from './redirect-logged-in';
 
 export const LOGIN_SECTION_DEFINITION = {
 	name: 'login',

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -64,18 +64,18 @@ export default ( router ) => {
 	if ( config.isEnabled( 'login/magic-login' ) ) {
 		router(
 			`/log-in/link/use/${ lang }`,
+			redirectLoggedIn,
 			setLocaleMiddleware,
 			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
-			redirectLoggedIn,
 			magicLoginUse,
 			makeLoggedOutLayout
 		);
 
 		router(
 			[ `/log-in/link/${ lang }`, `/log-in/jetpack/link/${ lang }`, `/log-in/new/link/${ lang }` ],
+			redirectLoggedIn,
 			setLocaleMiddleware,
 			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
-			redirectLoggedIn,
 			magicLogin,
 			makeLoggedOutLayout
 		);

--- a/client/login/redirect-logged-in/index.node.js
+++ b/client/login/redirect-logged-in/index.node.js
@@ -1,0 +1,8 @@
+export default function redirectLoggedIn( { isLoggedIn, res }, next ) {
+	if ( isLoggedIn ) {
+		res.redirect( '/' );
+		return;
+	}
+
+	next();
+}

--- a/client/login/redirect-logged-in/index.web.js
+++ b/client/login/redirect-logged-in/index.web.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import page from 'page';
-
-/**
  * Internal dependencies
  */
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -12,7 +7,8 @@ export default function redirectLoggedIn( context, next ) {
 	const userLoggedIn = isUserLoggedIn( context.store.getState() );
 
 	if ( userLoggedIn ) {
-		page( '/' );
+		// force full page reload to avoid SSR hydration issues.
+		window.location = '/';
 		return;
 	}
 

--- a/client/login/redirect-logged-in/index.web.js
+++ b/client/login/redirect-logged-in/index.web.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+
+export default function redirectLoggedIn( context, next ) {
+	const userLoggedIn = isUserLoggedIn( context.store.getState() );
+
+	if ( userLoggedIn ) {
+		page( '/' );
+		return;
+	}
+
+	next();
+}

--- a/client/login/redirect-logged-in/package.json
+++ b/client/login/redirect-logged-in/package.json
@@ -1,0 +1,4 @@
+{
+	"main": "index.node.js",
+	"browser": "index.web.js"
+}


### PR DESCRIPTION
When redirecting `/log-in/link` to `/` in a logged-in session, use the Node.js/Express.js handler to do that.

The handler in `web-util` uses `page.js` to do the redirect, probably crashing the server. It can't ever work. The `page.js` router works with `window.history` etc.

**How to test:**
Unfortunately testable only with user bootstrapping. Check that `/log-in/link` in logged-in session is redirected by server.

Fixes #46652