### PR TITLE
Register required data stores in Domain Picker and Plans Grid packages

### DIFF
--- a/packages/domain-picker/src/constants.ts
+++ b/packages/domain-picker/src/constants.ts
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { DomainSuggestions } from '@automattic/data-stores';
+
 export const PAID_DOMAINS_TO_SHOW = 5;
 export const PAID_DOMAINS_TO_SHOW_EXPANDED = 10;
 
@@ -11,6 +16,10 @@ export const PAID_DOMAINS_TO_SHOW_EXPANDED = 10;
  */
 export const DOMAIN_SEARCH_DEBOUNCE_INTERVAL = 300;
 
-export const DOMAIN_SUGGESTIONS_STORE = 'automattic/domains/suggestions';
+// TODO: Check domain suggestions store registration discrepancies
+// (see https://github.com/Automattic/wp-calypso/issues/46869)
+export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register( {
+	vendor: 'variation2_front',
+} );
 
 export const domainIsAvailableStatus = [ 'available', 'available_premium' ];

--- a/packages/plans-grid/src/constants.ts
+++ b/packages/plans-grid/src/constants.ts
@@ -1,2 +1,7 @@
-export const PLANS_STORE = 'automattic/onboard/plans';
-export const WPCOM_FEATURES_STORE = 'automattic/wpcom-features';
+/**
+ * External dependencies
+ */
+import { Plans, WPCOMFeatures } from '@automattic/data-stores';
+
+export const PLANS_STORE = Plans.register();
+export const WPCOM_FEATURES_STORE = WPCOMFeatures.register();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Instead of hardcoding the store keys, those packages now also try to register the store
* This fixes a bug where the `@automattic/domain-picker` and the `@automattic/plans-grid` packages would not be able to correctly use the required data-stores, if those stores were not already registered somewhere else in the code
* This change ultimately makes these packages more independent 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site with `/new`
* Domain picker and Plans grid should work as usual

Fixes #46870
