### PR TITLE
Update cards for owned products in pricing page i2

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
@@ -44,6 +44,7 @@ type OwnProps = {
 	billingTerm: Duration;
 	buttonLabel: TranslateResult;
 	buttonPrimary: boolean;
+	badgeLabel?: TranslateResult;
 	onButtonClick: PurchaseCallback;
 	searchRecordsDetails?: ReactNode;
 	isHighlighted?: boolean;
@@ -71,6 +72,7 @@ const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 	billingTerm,
 	buttonLabel,
 	buttonPrimary,
+	badgeLabel,
 	onButtonClick,
 	searchRecordsDetails,
 	isHighlighted,
@@ -198,6 +200,7 @@ const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 					) }
 				</header>
 				<div className="jetpack-product-card-alt-2__body">
+					{ badgeLabel && <p className="jetpack-product-card-alt-2__owned">{ badgeLabel }</p> }
 					{ buttonElt }
 					{ description && (
 						<p className="jetpack-product-card-alt-2__description">{ description }</p>

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
@@ -174,7 +174,7 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 	justify-content: center;
 	align-items: center;
 
-	margin-bottom: 12px;
+	margin-bottom: 24px;
 }
 
 .jetpack-product-card-alt-2__billing-time-frame,
@@ -246,7 +246,24 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 }
 
 .jetpack-product-card-alt-2__body {
+	position: relative;
+
 	padding: 0 24px;
+}
+
+.jetpack-product-card-alt-2__owned {
+	position: absolute;
+	left: 0;
+	bottom: 100%;
+
+	width: 100%;
+	margin-bottom: 4px;
+
+	color: var( --studio-green-40 );
+
+	font-size: 0.75rem;
+	font-style: italic;
+	text-align: center;
 }
 
 .jetpack-product-card-alt-2 .button {
@@ -264,6 +281,10 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 
 	@media ( min-width: 660px ) {
 		min-height: 100px;
+	}
+
+	.is-owned & {
+		margin-bottom: 32px;
 	}
 }
 

--- a/client/my-sites/plans-v2/product-card-alt-2/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt-2/index.tsx
@@ -7,7 +7,7 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { productButtonLabel } from '../utils';
+import { productButtonLabel, productBadgeLabelAlt } from '../utils';
 import PlanRenewalMessage from '../plan-renewal-message';
 import RecordsDetailsAlt from '../records-details-alt';
 import useItemPrice from '../use-item-price';
@@ -17,7 +17,7 @@ import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import JetpackProductCardAlt2 from 'calypso/components/jetpack/card/jetpack-product-card-alt-2';
 import { planHasFeature } from 'calypso/lib/plans';
-import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
+import { JETPACK_LEGACY_PLANS, TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
 import { isJetpackPlanSlug } from 'calypso/lib/products-values';
 import { JETPACK_SEARCH_PRODUCTS } from 'calypso/lib/products-values/constants';
 import { isCloseToExpiration } from 'calypso/lib/purchases';
@@ -105,6 +105,7 @@ const ProductCardAltWrapper: FunctionComponent< ProductCardProps > = ( {
 			billingTerm={ item.term }
 			buttonLabel={ buttonLabel }
 			buttonPrimary={ ! ( isOwned || isItemPlanFeature ) }
+			badgeLabel={ productBadgeLabelAlt( item, isOwned, sitePlan ) }
 			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
 			features={ item.features }
 			searchRecordsDetails={
@@ -118,7 +119,7 @@ const ProductCardAltWrapper: FunctionComponent< ProductCardProps > = ( {
 			className={ className }
 			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
 			isExpanded={ isPlan && shouldExpand }
-			withBundleRibbon={ isPlan }
+			withBundleRibbon={ isPlan && ! JETPACK_LEGACY_PLANS.includes( item.productSlug ) }
 			productSlug={ item.productSlug }
 			onFeaturesToggle={ isPlan ? onFeaturesToggle : undefined }
 		/>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the style of an owned product, for legacy and current plans.

### Implementation notes

- I made the "You own this" mention absolute, so that main buttons are still aligned (given the tagline is a oneliner)

### Testing instructions

- Download the PR
- Run Calypso
- Select a site that has a legacy Jetpack plan
- Make sure the variant `v2 - slide outs` is selected in the `jetpackConversionRateOptimization` A/B test
- Visit the plans page
- Make sure the legacy plan card has no ribbon, and padding at the bottom
- Check that plans and products owned or included in the plan are marked as such
- Switch back to the v1 variant and check that the page looks like production

### Screenshots

_Before_
<img width="1076" alt="Screen Shot 2020-10-29 at 11 42 02 AM" src="https://user-images.githubusercontent.com/1620183/97598678-97ca0c80-19dd-11eb-9d87-34324ec7a1aa.png">


_After_
<img width="1071" alt="Screen Shot 2020-10-29 at 11 46 45 AM" src="https://user-images.githubusercontent.com/1620183/97598701-9c8ec080-19dd-11eb-8ccf-c2932b7987ab.png">
