### PR TITLE
Shopping Cart: Use 'fresh-pending' cacheStatus for initial loading

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -57,12 +57,13 @@ export type UpdateTaxLocationInCart = ( location: CartLocation ) => void;
  * cache status.
  *
  *   - 'fresh': Page has loaded and no requests have been sent.
+ *   - 'fresh-pending': Page has loaded and we are waiting for the initial request.
  *   - 'invalid': Local cart data has been edited.
  *   - 'valid': Local cart has been reloaded from the server.
  *   - 'pending': Request has been sent, awaiting response.
  *   - 'error': Something went wrong.
  */
-export type CacheStatus = 'fresh' | 'valid' | 'invalid' | 'pending' | 'error';
+export type CacheStatus = 'fresh' | 'fresh-pending' | 'valid' | 'invalid' | 'pending' | 'error';
 
 /**
  * Possible states re. coupon submission.

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -98,7 +98,7 @@ export default function useShoppingCartManager( {
 		hookDispatch( { type: 'CART_RELOAD' } );
 	}, [ hookDispatch ] );
 
-	const isLoading = cacheStatus === 'fresh' || ! cartKey;
+	const isLoading = cacheStatus === 'fresh' || cacheStatus === 'fresh-pending' || ! cartKey;
 	const loadingErrorForManager = cacheStatus === 'error' ? loadingError : null;
 	const isPendingUpdate = cacheStatus !== 'valid' || ! cartKey;
 

--- a/packages/shopping-cart/src/use-shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-reducer.ts
@@ -62,7 +62,9 @@ function shoppingCartReducer(
 	// queue any action that comes through during that time except for
 	// 'RECEIVE_INITIAL_RESPONSE_CART' or 'RAISE_ERROR'.
 	if (
-		( state.cacheStatus === 'fresh' || state.cacheStatus === 'pending' ) &&
+		( state.cacheStatus === 'fresh' ||
+			state.cacheStatus === 'pending' ||
+			state.cacheStatus === 'fresh-pending' ) &&
 		action.type !== 'RECEIVE_INITIAL_RESPONSE_CART' &&
 		action.type !== 'RECEIVE_UPDATED_RESPONSE_CART' &&
 		action.type !== 'FETCH_INITIAL_RESPONSE_CART' &&
@@ -78,7 +80,7 @@ function shoppingCartReducer(
 	debug( 'processing requested action', action );
 	switch ( action.type ) {
 		case 'FETCH_INITIAL_RESPONSE_CART':
-			return { ...state, cacheStatus: 'pending' };
+			return { ...state, cacheStatus: 'fresh-pending' };
 		case 'CART_RELOAD':
 			debug( 'reloading cart from server' );
 			return getInitialShoppingCartState();


### PR DESCRIPTION
This differentiates the `@automattic/shopping-cart` cache status of 'pending' (when a cart update is pending) versus a new status, 'fresh-pending', which is when the cart has not loaded at all, but has made a request. This allows the `isLoading` property of `useShoppingCart` to stay true while the cart has made a request but has not yet received it. This used to be the case but was accidentally changed by https://github.com/Automattic/wp-calypso/pull/46532/commits/b17921046062678f25120271e4b70fd835d51442 in https://github.com/Automattic/wp-calypso/pull/46532 (I believe this was the actual cause of the bug mentioned in https://github.com/Automattic/wp-calypso/issues/46753).

#### Testing instructions

- Visit checkout with a product in the URL and be sure that the loading animation displays.
- Verify that when the loading animation disappears, the cart has loaded (there's no jump in the UI where the cart contents change or the available payment methods change).