### PR TITLE
Lower z-index to checkout modal to reveal notice element

### DIFF
--- a/client/blocks/editor-checkout-modal/style.scss
+++ b/client/blocks/editor-checkout-modal/style.scss
@@ -6,7 +6,7 @@
 	top: 0;
 	left: 0;
 	right: -100%;
-	z-index: 9998;
+	z-index: z-index( 'root', '.main.calypsoify.is-iframe' );
 	height: 100%;
 	overflow: auto;
 	padding: 80px 30px 30px;
@@ -22,7 +22,7 @@
 	position: fixed;
 	top: 0;
 	left: 0;
-	z-index: 9998;
+	z-index: z-index( 'root', '.main.calypsoify.is-iframe' );
 	width: 100%;
 	height: 0;
 	overflow: visible;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a lower z-index to the checkout modal to avoid notices getting hidden behind it when the modal is open and an incorrect coupon code gets entered.

#### Testing instructions

* On a site that is on the free plan, open the editor and add a premium block.
* Click "Upgrade" which should display the checkout modal
* Once the modal successfully loads, click "Add a coupon code" to reveal the input field.
* Add a random set of characters and hit "Apply"
* Error notice should successfully appear over the checkout modal.
* It is also worth checking no other unwanted elements within the editor overlay the checkout modal when its open as we've lowered the `z-index`

Alternatively, [watch here](https://www.loom.com/share/62176fddf1394f61b8870e4fcf38a9ef) for testing steps.

Fixes https://github.com/Automattic/wp-calypso/issues/46906
