### PR TITLE
Adds correct settings link to Activity Log v2

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -259,9 +259,12 @@ const mapDispatchToProps = ( dispatch ) => ( {
 	selectPage: ( siteId, pageNumber ) => dispatch( updateFilter( siteId, { page: pageNumber } ) ),
 } );
 
-export default connect(
+/** @type {typeof ActivityCardList} */
+const connectedComponent = connect(
 	mapStateToProps,
 	mapDispatchToProps
 )(
 	withMobileBreakpoint( withApplySiteOffset( withLocalizedMoment( localize( ActivityCardList ) ) ) )
 );
+
+export default connectedComponent;

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -29,6 +29,7 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 
 /**
@@ -53,6 +54,7 @@ const ActivityLogV2: FunctionComponent = () => {
 	const siteHasBackupPurchase = useSelector(
 		( state ) => siteId && siteHasBackupProductPurchase( state, siteId )
 	);
+	const settingsUrl = useSelector( ( state ) => getSettingsUrl( state, siteId, 'general' ) );
 
 	const showUpgrade = siteIsOnFreePlan && ! siteHasBackupPurchase;
 	const showFilter = ! showUpgrade;
@@ -97,7 +99,7 @@ const ActivityLogV2: FunctionComponent = () => {
 			<DocumentHead title={ translate( 'Activity log' ) } />
 			<SidebarNavigation />
 			<PageViewTracker path="/activity-log/:site" title="Activity log" />
-			<TimeMismatchWarning siteId={ siteId } />
+			{ settingsUrl && <TimeMismatchWarning siteId={ siteId } settingsUrl={ settingsUrl } /> }
 			{ isJetpackCloud() ? (
 				jetpackCloudHeader
 			) : (

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -46,11 +46,12 @@ const ActivityLogV2: FunctionComponent = () => {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const siteIsOnFreePlan = useSelector(
 		( state ) =>
+			siteId &&
 			isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ) &&
 			! isVipSite( state, siteId )
 	);
-	const siteHasBackupPurchase = useSelector( ( state ) =>
-		siteHasBackupProductPurchase( state, siteId )
+	const siteHasBackupPurchase = useSelector(
+		( state ) => siteId && siteHasBackupProductPurchase( state, siteId )
 	);
 
 	const showUpgrade = siteIsOnFreePlan && ! siteHasBackupPurchase;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds link to settings page in Activity Log v2. Based off of #46874.
* Fixes a few TS issues.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a JP site with a timezone different from yours and a paid plan.
* Visit Jetpack Cloud -> Activity Log and verify link correctly goes to wp-admin settings page.
