### PR TITLE
Align "See all features" links in pricing page i2

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/features.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/features.tsx
@@ -88,23 +88,25 @@ const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
 			onOpen={ onOpen }
 			onClose={ onClose }
 		>
-			<ul className="jetpack-product-card-alt-2__features-list">
-				{ ( items as ProductCardFeaturesItem[] ).map( ( item, i ) => (
-					<FeaturesItem
-						key={ i }
-						item={ item }
-						billingTerm={ billingTerm }
-						onProductClick={ onButtonClick }
-					/>
-				) ) }
-			</ul>
-			{ more && (
-				<div className="jetpack-product-card-alt-2__feature-more">
-					<ExternalLink icon={ true } href={ more.url }>
-						{ more.label }
-					</ExternalLink>
-				</div>
-			) }
+			<div>
+				<ul className="jetpack-product-card-alt-2__features-list">
+					{ ( items as ProductCardFeaturesItem[] ).map( ( item, i ) => (
+						<FeaturesItem
+							key={ i }
+							item={ item }
+							billingTerm={ billingTerm }
+							onProductClick={ onButtonClick }
+						/>
+					) ) }
+				</ul>
+				{ more && (
+					<div className="jetpack-product-card-alt-2__feature-more">
+						<ExternalLink icon={ true } href={ more.url }>
+							{ more.label }
+						</ExternalLink>
+					</div>
+				) }
+			</div>
 			<div className="jetpack-product-card-alt-2__feature-cta">{ ctaElt }</div>
 		</FoldableCard>
 	);

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
@@ -325,6 +325,9 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 	border-bottom: solid 1px var( --color-border-subtle );
 
 	&:last-of-type {
+		margin-bottom: 0;
+		padding-bottom: 0;
+
 		border-bottom: none;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR aligns "See all features" links in pricing page.

Fixes 1196341175636977-as-1198950642531518

### Testing instructions

- Download the PR
- Run Calypso
- Make sure the variant `v2 - slide outs` is selected in the `jetpackConversionRateOptimization` A/B test
- Visit the plans page with the 3 plan cards in a single row
- Check that "See all features" links are positioned just below the features lists (see captures)

### Screenshots

_Before_
![Markup 2020-10-28 at 12 34 38](https://user-images.githubusercontent.com/1620183/97614587-850d0300-19f0-11eb-89dc-9d4c713b1c2e.png)


_After_
<img width="1073" alt="Screen Shot 2020-10-29 at 2 06 36 PM" src="https://user-images.githubusercontent.com/1620183/97614577-80484f00-19f0-11eb-99c1-6ae7f3ccb25c.png">