### PR TITLE
Make slide-outs buttons functional in pricing page i2

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
@@ -45,6 +45,7 @@ type OwnProps = {
 	buttonLabel: TranslateResult;
 	buttonPrimary: boolean;
 	onButtonClick: PurchaseCallback;
+	onSlideOutClick: PurchaseCallback;
 	searchRecordsDetails?: ReactNode;
 	isHighlighted?: boolean;
 	isOwned?: boolean;
@@ -72,6 +73,7 @@ const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 	buttonLabel,
 	buttonPrimary,
 	onButtonClick,
+	onSlideOutClick,
 	searchRecordsDetails,
 	isHighlighted,
 	isOwned,
@@ -213,7 +215,7 @@ const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 					isExpanded={ isExpanded }
 					onFeaturesToggle={ onFeaturesToggle }
 					ctaElt={ buttonElt }
-					onButtonClick={ onButtonClick }
+					onButtonClick={ onSlideOutClick }
 				/>
 			) }
 		</div>

--- a/client/my-sites/plans-v2/product-card-alt-2/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt-2/index.tsx
@@ -106,6 +106,7 @@ const ProductCardAltWrapper: FunctionComponent< ProductCardProps > = ( {
 			buttonLabel={ buttonLabel }
 			buttonPrimary={ ! ( isOwned || isItemPlanFeature ) }
 			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
+			onSlideOutClick={ onClick }
 			features={ item.features }
 			searchRecordsDetails={
 				showRecordsDetails && <RecordsDetailsAlt productSlug={ item.productSlug } />


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR implements the correct behaviour of the slide-outs buttons in the new pricing page.

Fixes 1196341175636977-as-1198950642531510

### Testing instructions

- Download the PR
- Run Calypso
- Make sure the variant `v2 - slide outs` is selected in the `jetpackConversionRateOptimization` A/B test
- Visit the plans page
- Check that in each of the 6 slide-outs (see capture), clicking on the button redirects you to the checkout page with the corresponding product in the cart (except for CRM, which links to its own website)

### Screenshots

<img width="1083" alt="Screen Shot 2020-10-29 at 2 59 43 PM" src="https://user-images.githubusercontent.com/1620183/97620122-7aa23780-19f7-11eb-9861-3a60a311e0bd.png">