### PR TITLE
handleScroll() doesn't run at all if waiting on requestAnimationFrame

### DIFF
--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -22,9 +22,11 @@ let pinnedSidebarBottom = false;
 let ticking = false; // Used for Scroll event throttling.
 
 export const handleScroll = ( event: any ): void => {
+	// Do not run until next requestAnimationFrame
 	if ( ticking ) {
 		return;
 	}
+
 	const secondaryEl = document.getElementById( 'secondary' );
 	const windowHeight = window?.innerHeight;
 	const secondaryElHeight = secondaryEl?.scrollHeight;
@@ -37,7 +39,6 @@ export const handleScroll = ( event: any ): void => {
 		secondaryElHeight !== undefined &&
 		masterbarHeight !== undefined &&
 		window.innerWidth > 660 && // Do not run when sidebar is fullscreen
-		! ticking && // Do not run until next requestAnimationFrame
 		( secondaryElHeight + masterbarHeight > windowHeight || 'resize' === event.type ) // Only run when sidebar & masterbar are taller than window height OR we have a resize event
 	) {
 		// Throttle scroll event

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -22,6 +22,9 @@ let pinnedSidebarBottom = false;
 let ticking = false; // Used for Scroll event throttling.
 
 export const handleScroll = ( event: any ): void => {
+	if ( ticking ) {
+		return;
+	}
 	const secondaryEl = document.getElementById( 'secondary' );
 	const windowHeight = window?.innerHeight;
 	const secondaryElHeight = secondaryEl?.scrollHeight;


### PR DESCRIPTION
- reading scrollHeight is potentially slow
https://stackoverflow.com/questions/45960181/what-is-the-fastest-way-to-get-height-width-of-unstyled-element-in-javascript
- So stop before scrollHeight is read if currently ticking

This is more of a theoretical optimization than anything, I couldn't find a situation where it makes a difference on my computer, but maybe on slower computers?

#### Testing instructions

* Same as #46689