### PR TITLE
Update slide-outs styles in pricing page i2

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
@@ -387,6 +387,11 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 	}
 }
 
+.jetpack-product-card-alt-2__slide-out-product.expanded {
+	margin-left: -26px;
+	margin-right: -26px;
+}
+
 button.components-button.jetpack-product-card-alt-2__slideout-button {
 	color: var( --studio-gray-50 );
 	height: auto;

--- a/client/components/jetpack/card/jetpack-product-slide-out-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-slide-out-card/index.tsx
@@ -51,7 +51,7 @@ const JetpackProductSlideOutCard: FC< Props > = ( {
 			<header className="jetpack-product-slide-out-card__header">
 				<h3 className="jetpack-product-slide-out-card__product-name">
 					<ProductIcon className="jetpack-product-slide-out-card__icon" slug={ iconSlug } />
-					{ preventWidows( productName ) }
+					<div>{ preventWidows( productName ) }</div>
 				</h3>
 
 				<div className="jetpack-product-slide-out-card__price">

--- a/client/components/jetpack/card/jetpack-product-slide-out-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-slide-out-card/style.scss
@@ -2,16 +2,17 @@ $jetpack-product-slide-out-card-color: var( --studio-wordpress-blue-30 );
 
 .jetpack-product-slide-out-card {
 	box-sizing: border-box;
+	margin: 12px 0 -14px;
+	padding: 24px 24px 16px;
 
-	background: var( --color-surface );
-	border: 1px solid var( --color-border-subtle );
+	background: #f6f7f7;
+	border-top: 1px solid var( --color-border-subtle );
+	border-bottom: 1px solid var( --color-border-subtle );
 	box-shadow: inset 0 4px 8px rgba( 0, 0, 0, 0.06 );
 }
 
 .jetpack-product-slide-out-card__header {
 	position: relative;
-
-	padding: 24px 16px 12px;
 
 	text-align: center;
 }
@@ -26,13 +27,12 @@ $jetpack-product-slide-out-card-color: var( --studio-wordpress-blue-30 );
 
 .jetpack-product-slide-out-card__product-name {
 	display: flex;
-	align-items: center;
-
-	margin-bottom: 6px;
+	align-items: flex-start;
 
 	font-size: $font-title-medium;
 	font-weight: 600;
 	line-height: rem( 30px ) / $font-title-medium;
+	text-align: left;
 }
 
 .jetpack-product-slide-out-card__price {
@@ -41,7 +41,7 @@ $jetpack-product-slide-out-card-color: var( --studio-wordpress-blue-30 );
 	justify-content: center;
 	align-items: center;
 
-	margin: 24px 0 12px;
+	margin: 16px 0 24px;
 }
 
 .jetpack-product-slide-out-card__billing-time-frame {
@@ -85,18 +85,20 @@ $jetpack-product-slide-out-card-color: var( --studio-wordpress-blue-30 );
 	}
 }
 
-.jetpack-product-slide-out-card .plan-price__integer {
-	font-size: $font-title-medium;
+.jetpack-product-slide-out-card .plan-price .plan-price__integer {
+	font-size: 1.5rem;
 	font-weight: 600;
 }
 
-.jetpack-product-slide-out-card__body {
-	padding: 0 16px;
+.jetpack-product-slide-out-card .plan-price .plan-price__currency-symbol {
+	margin: 4px 2px 0 0;
+
+	font-size: 0.75rem;
 }
 
 .jetpack-product-slide-out-card .button {
 	width: 100%;
-	margin-bottom: 30px;
+	margin-bottom: 8px;
 
 	font-size: $font-body;
 
@@ -112,15 +114,12 @@ $jetpack-product-slide-out-card-color: var( --studio-wordpress-blue-30 );
 
 .jetpack-product-slide-out-card__description {
 	margin-bottom: 24px;
-	padding: 0 4px;
 }
 
 .jetpack-product-slide-out-card__badge {
 	display: block;
 
-	margin: -20px 0 24px;
-
-	min-height: 12px;
+	color: var( --studio-gray-50 );
 
 	font-size: $font-body-extra-small;
 	font-style: italic;
@@ -146,4 +145,11 @@ $jetpack-product-slide-out-card-color: var( --studio-wordpress-blue-30 );
 
 	width: 100px;
 	height: 12px;
+}
+
+/* Jetpack cloud specific styles */
+.is-section-jetpack-cloud-pricing {
+	.jetpack-product-slide-out-card {
+		background-color: var( --color-surface );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the slide-outs styles in the new pricing page to match the mockups.

Fixes 1196341175636977-as-1198950642531501

### Testing instructions

- Download the PR
- Run Calypso and cloud concurrently
- Make sure the variant `v2 - slide outs` is selected in the `jetpackConversionRateOptimization` A/B test
- Visit the plans page in both Calypso and cloud
- Check that the slide-outs match the mockups

### Screenshots

#### Mockups
<img width="369" alt="Screen Shot 2020-10-29 at 3 56 26 PM" src="https://user-images.githubusercontent.com/1620183/97628508-2e5cf480-1a03-11eb-917b-0112e824fcf1.png">

#### Implementation
  
<img width="368" alt="Screen Shot 2020-10-29 at 4 15 40 PM" src="https://user-images.githubusercontent.com/1620183/97628539-37e65c80-1a03-11eb-96c4-01caf40bdaac.png">