### PR TITLE
Jetpack scan: Update copy on scan screen regarding contacting support.

### DIFF
--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -176,7 +176,7 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 				) }
 				<br />
 				{ translate(
-					'Please review them below and take action. We are {{a}}here to help{{/a}} if you need us.',
+					'Please review them below and take action. If you have any questions, we are {{a}}here to help{{/a}}.',
 					{
 						components: {
 							a: (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As proposed in a [JPOP issue](https://github.com/Automattic/jpop-issues/issues/6085), the wording of on the Jetpack Scan screen might not line up with our [new scope of support](https://jpophappy.wordpress.com/2020/10/15/scans-scope-of-support/), so after a conversation in Slack this PR tweaks the copy to clarify that support can answer questions rather than suggesting we could help resolve threats. It changes the wording on the page from:

> Please review them below and take action. We are here to help if you need us.
![image](https://user-images.githubusercontent.com/2012803/97628612-50567700-1a03-11eb-9175-b62eeb7064df.png)

To instead:

> Please review them below and take action. If you have any questions, we are here to help.
![image](https://user-images.githubusercontent.com/2012803/97628561-3f0d6a80-1a03-11eb-8a3a-753a9de3d3ee.png)


#### Testing instructions

Testing requires a WordPress site with a Jetpack plan that includes Scanning.
- Use [jurassic.ninja](https://jurassic.ninja/create/?shortlived) to create a temporary Jetpack site
- Install our [jetpack-threat-tester plugin](https://github.com/Automattic/jetpack-threat-tester) to generate fake "threats" on your site.

* Test Calypso Blue by going to https://calypso.live/scan/{test-site}?branch=update/scan-screen-copy and confirm that the copy is updated.
* Test Calypso Green by:
  * Ensure this repo is cloned/installed locally and checkout this branch.
  * Ensure `jetpack.cloud.localhost` is pointing to `127.0.0.1` in your hosts file.
  * In the repository folder, run `yarn start start-jetpack-cloud` to start the local dev server
  * Navigate to http://jetpack.cloud.localhost:3000/scan/{test-site} to confirm that the copy is updated.
