### PR TITLE
Jetpack Backup: Correctly display backup status and navigation for sites with lots of activities

### DIFF
--- a/client/components/jetpack/backup-date-picker/index.jsx
+++ b/client/components/jetpack/backup-date-picker/index.jsx
@@ -26,7 +26,7 @@ class BackupDatePicker extends Component {
 		siteId: PropTypes.number.isRequired,
 		selectedDate: PropTypes.object.isRequired,
 		onDateChange: PropTypes.func.isRequired,
-		oldestDateAvailable: PropTypes.object.isRequired,
+		oldestDateAvailable: PropTypes.object,
 	};
 
 	getDisplayDate = ( date, showTodayYesterday = true ) => {

--- a/client/components/jetpack/backup-placeholder/index.jsx
+++ b/client/components/jetpack/backup-placeholder/index.jsx
@@ -8,10 +8,10 @@ import React from 'react';
  */
 import './style.scss';
 
-export default function BackupPlaceholder() {
+export default function BackupPlaceholder( { showDatePicker = true } ) {
 	return (
 		<div className="backup-placeholder">
-			<div className="backup-placeholder__backup-date-picker" />
+			{ showDatePicker && <div className="backup-placeholder__backup-date-picker" /> }
 			<div className="backup-placeholder__daily-backup-status" />
 		</div>
 	);

--- a/client/components/jetpack/daily-backup-status/backup-changes.jsx
+++ b/client/components/jetpack/daily-backup-status/backup-changes.jsx
@@ -54,7 +54,7 @@ const BackupChanges = ( { deltas } ) => {
 	const mediaCountDisplay = `${ mediaOperator }${ mediaCount }`;
 
 	const deletedElement = [
-		<div className="daily-backup-status__media-image">
+		<div className="daily-backup-status__media-image" key="media-deleted">
 			<img alt="" src={ mediaImage } />
 			<div className="daily-backup-status__deleted-count-bubble">
 				-{ deltas.mediaDeleted.length }

--- a/client/components/jetpack/daily-backup-status/backup-changes.jsx
+++ b/client/components/jetpack/daily-backup-status/backup-changes.jsx
@@ -136,14 +136,23 @@ const BackupChanges = ( { deltas } ) => {
 		);
 	} );
 
+	const users = deltas.users.map( ( item ) => {
+		return (
+			<div key={ item.activityId } className="daily-backup-status__extension-block-installed">
+				<Gridicon icon="plus" className="daily-backup-status__extension-block-installed" />
+				<div className="daily-backup-status__extension-block-text">
+					{ item.activityDescription[ 0 ].children[ 0 ] }
+				</div>
+			</div>
+		);
+	} );
+
 	const hasChanges = !! (
-		(
-			deltas.mediaCreated.length ||
-			deltas.posts.length ||
-			deltas.plugins.length ||
-			deltas.themes.length
-		)
-		//|| !! metaDiff.filter( ( diff ) => 0 !== diff.num ).length
+		deltas.mediaCreated.length ||
+		deltas.posts.length ||
+		deltas.plugins.length ||
+		deltas.themes.length ||
+		deltas.users.length
 	);
 
 	return (
@@ -188,7 +197,12 @@ const BackupChanges = ( { deltas } ) => {
 					<div className="daily-backup-status__section-plugins">{ themes }</div>
 				</>
 			) }
-			{ /*{ renderMetaDiff( metaDiff ) }*/ }
+			{ !! deltas.users.length && (
+				<>
+					<div className="daily-backup-status__section-header">{ translate( 'Users' ) }</div>
+					<div className="daily-backup-status__section-plugins">{ users }</div>
+				</>
+			) }
 		</div>
 	);
 };

--- a/client/lib/jetpack/backup-utils.js
+++ b/client/lib/jetpack/backup-utils.js
@@ -106,46 +106,56 @@ export const getMetaDiffForDailyBackup = ( logs, date ) => {
 	];
 };
 
-export const getDailyBackupDeltas = ( logs, date ) => {
-	const changes = getEventsInDailyBackup( logs, date );
+export const getDeltaActivities = ( logs ) => {
+	const DELTA_ACTIVITIES = [
+		'attachment__uploaded',
+		// 'attachment__updated',
+		'attachment__deleted',
+		'post__published',
+		'post__trashed',
+		'post__published',
+		// 'post__updated',
+		'post__trashed',
+		'plugin__installed',
+		'plugin__deleted',
+		'theme__installed',
+		'theme__deleted',
+		'user__invite_accepted',
+	];
 
+	return logs.filter( ( { activityName } ) => DELTA_ACTIVITIES.includes( activityName ) );
+};
+
+export const getDeltaActivitiesByType = ( logs ) => {
 	return {
-		mediaCreated: changes.filter( ( event ) => 'attachment__uploaded' === event.activityName ),
-		mediaDeleted: changes.filter( ( event ) => 'attachment__deleted' === event.activityName ),
-		posts: changes.filter(
+		mediaCreated: logs.filter( ( event ) => 'attachment__uploaded' === event.activityName ),
+		mediaDeleted: logs.filter( ( event ) => 'attachment__deleted' === event.activityName ),
+		posts: logs.filter(
 			( event ) =>
 				'post__published' === event.activityName || 'post__trashed' === event.activityName
 		),
-		postsCreated: changes.filter( ( event ) => 'post__published' === event.activityName ),
-		postsDeleted: changes.filter( ( event ) => 'post__trashed' === event.activityName ),
-		plugins: changes.filter(
+		postsCreated: logs.filter( ( event ) => 'post__published' === event.activityName ),
+		postsDeleted: logs.filter( ( event ) => 'post__trashed' === event.activityName ),
+		plugins: logs.filter(
 			( event ) =>
 				'plugin__installed' === event.activityName || 'plugin__deleted' === event.activityName
 		),
-		themes: changes.filter(
+		themes: logs.filter(
 			( event ) =>
 				'theme__installed' === event.activityName || 'theme__deleted' === event.activityName
 		),
+		users: logs.filter( ( event ) => 'user__invite_accepted' === event.activityName ),
 	};
 };
 
+export const getDailyBackupDeltas = ( logs, date ) => {
+	const changes = getEventsInDailyBackup( logs, date );
+	return getDeltaActivitiesByType( changes );
+};
+
 export const getRawDailyBackupDeltas = ( logs, date ) => {
-	return getEventsInDailyBackup( logs, date ).filter( ( { activityName } ) =>
-		[
-			'attachment__uploaded',
-			// 'attachment__updated',
-			'attachment__deleted',
-			'post__published',
-			'post__trashed',
-			'post__published',
-			// 'post__updated',
-			'post__trashed',
-			'plugin__installed',
-			'plugin__deleted',
-			'theme__installed',
-			'theme__deleted',
-		].includes( activityName )
-	);
+	const events = getEventsInDailyBackup( logs, date );
+	return getDeltaActivities( events );
 };
 
 /**

--- a/client/lib/jetpack/backup-utils.js
+++ b/client/lib/jetpack/backup-utils.js
@@ -106,23 +106,21 @@ export const getMetaDiffForDailyBackup = ( logs, date ) => {
 	];
 };
 
-export const getDeltaActivities = ( logs ) => {
-	const DELTA_ACTIVITIES = [
-		'attachment__uploaded',
-		// 'attachment__updated',
-		'attachment__deleted',
-		'post__published',
-		'post__trashed',
-		'post__published',
-		// 'post__updated',
-		'post__trashed',
-		'plugin__installed',
-		'plugin__deleted',
-		'theme__installed',
-		'theme__deleted',
-		'user__invite_accepted',
-	];
+export const DELTA_ACTIVITIES = [
+	'attachment__uploaded',
+	// 'attachment__updated',
+	'attachment__deleted',
+	'post__published',
+	'post__trashed',
+	// 'post__updated',
+	'plugin__installed',
+	'plugin__deleted',
+	'theme__installed',
+	'theme__deleted',
+	'user__invite_accepted',
+];
 
+export const getDeltaActivities = ( logs ) => {
 	return logs.filter( ( { activityName } ) => DELTA_ACTIVITIES.includes( activityName ) );
 };
 

--- a/client/lib/jetpack/test/backup-utils.js
+++ b/client/lib/jetpack/test/backup-utils.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getBackupAttemptsForDate } from 'calypso/lib/jetpack/backup-utils';
+import { getBackupAttemptsForDate } from '../backup-utils';
 
 describe( 'getBackupAttemptsForDate', () => {
 	test( 'should filter out rewind complete items not on date in utc', () => {

--- a/client/my-sites/backup/date-picker.jsx
+++ b/client/my-sites/backup/date-picker.jsx
@@ -31,12 +31,12 @@ const DatePicker = ( { onSelectDate, selectedDate } ) => {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const firstKnownBackupAttempt = useFirstKnownBackupAttempt( siteId );
-	const oldestDateAvailable = firstKnownBackupAttempt.isLoading
+	const oldestDateAvailable = ! firstKnownBackupAttempt.backupAttempt
 		? undefined
 		: applySiteOffset?.( firstKnownBackupAttempt.backupAttempt.activityTs );
 
 	if ( ! applySiteOffset ) {
-		return;
+		return null;
 	}
 
 	return (

--- a/client/my-sites/backup/date-picker.jsx
+++ b/client/my-sites/backup/date-picker.jsx
@@ -8,11 +8,10 @@ import { useDispatch, useSelector } from 'react-redux';
  * Internal dependencies
  */
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { useApplySiteOffset } from 'calypso/components/site-offset';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import BackupDatePicker from 'calypso/components/jetpack/backup-date-picker';
-import { useFirstMatchingBackupAttempt } from './hooks';
+import { useDateWithOffset, useFirstMatchingBackupAttempt } from './hooks';
 
 const useFirstKnownBackupAttempt = ( siteId ) => {
 	return useFirstMatchingBackupAttempt( siteId, { sortOrder: 'asc' } );
@@ -22,22 +21,18 @@ const DatePicker = ( { onSelectDate, selectedDate } ) => {
 	const dispatch = useDispatch();
 	const dispatchRecordTracksEvent = ( name ) => dispatch( recordTracksEvent( name ) );
 
-	const applySiteOffset = useApplySiteOffset();
 	const moment = useLocalizedMoment();
 
-	const today = applySiteOffset?.( moment() );
+	const today = useDateWithOffset( moment() );
 
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const firstKnownBackupAttempt = useFirstKnownBackupAttempt( siteId );
-	const oldestDateAvailable = ! firstKnownBackupAttempt.backupAttempt
-		? undefined
-		: applySiteOffset?.( firstKnownBackupAttempt.backupAttempt.activityTs );
-
-	if ( ! applySiteOffset ) {
-		return null;
-	}
+	const oldestDateAvailable = useDateWithOffset(
+		firstKnownBackupAttempt.backupAttempt?.activityTs,
+		!! firstKnownBackupAttempt.backupAttempt
+	);
 
 	return (
 		<BackupDatePicker

--- a/client/my-sites/backup/date-picker.jsx
+++ b/client/my-sites/backup/date-picker.jsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useApplySiteOffset } from 'calypso/components/site-offset';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import BackupDatePicker from 'calypso/components/jetpack/backup-date-picker';
+import { useFirstMatchingBackupAttempt } from './hooks';
+
+const useFirstKnownBackupAttempt = ( siteId ) => {
+	return useFirstMatchingBackupAttempt( siteId, { sortOrder: 'asc' } );
+};
+
+const DatePicker = ( { onSelectDate, selectedDate } ) => {
+	const dispatch = useDispatch();
+	const dispatchRecordTracksEvent = ( name ) => dispatch( recordTracksEvent( name ) );
+
+	const applySiteOffset = useApplySiteOffset();
+	const moment = useLocalizedMoment();
+
+	const today = applySiteOffset?.( moment() );
+
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const firstKnownBackupAttempt = useFirstKnownBackupAttempt( siteId );
+	const oldestDateAvailable = firstKnownBackupAttempt.isLoading
+		? undefined
+		: applySiteOffset?.( firstKnownBackupAttempt.backupAttempt.activityTs );
+
+	if ( ! applySiteOffset ) {
+		return;
+	}
+
+	return (
+		<BackupDatePicker
+			siteId={ siteId }
+			siteSlug={ siteSlug }
+			today={ today }
+			selectedDate={ selectedDate }
+			oldestDateAvailable={ oldestDateAvailable }
+			onDateChange={ onSelectDate }
+			dispatchRecordTracksEvent={ dispatchRecordTracksEvent }
+		/>
+	);
+};
+
+export default DatePicker;

--- a/client/my-sites/backup/hooks.js
+++ b/client/my-sites/backup/hooks.js
@@ -33,18 +33,6 @@ export const BACKUP_ATTEMPT_ACTIVITIES = [
 	'rewind__backup_error',
 ];
 
-export const DELTA_ACTIVITIES = [
-	'attachment__uploaded',
-	'attachment__deleted',
-	'post__published',
-	'post__trashed',
-	'plugin__installed',
-	'plugin__deleted',
-	'theme__installed',
-	'theme__deleted',
-	'user__invite_accepted',
-];
-
 const useMemoizeFilter = ( filter ) => {
 	const filterRef = useRef();
 

--- a/client/my-sites/backup/hooks.js
+++ b/client/my-sites/backup/hooks.js
@@ -68,7 +68,7 @@ export const useActivityLogs = ( siteId, filter, shouldExecute = true ) => {
 	] );
 
 	return {
-		isLoadingActivityLogs: shouldExecute && isLoading( response ),
+		isLoadingActivityLogs: !! ( shouldExecute && isLoading( response ) ),
 		activityLogs: ( response?.data || [] ).sort( byActivityTsDescending ),
 	};
 };
@@ -113,7 +113,11 @@ export const useFirstMatchingBackupAttempt = (
 		? getRealtimeAttemptFilter( { before, after, sortOrder } )
 		: getDailyAttemptFilter( { before, after, successOnly, sortOrder } );
 
-	const { activityLogs, isLoadingActivityLogs } = useActivityLogs( siteId, filter, shouldExecute );
+	const { activityLogs, isLoadingActivityLogs } = useActivityLogs(
+		siteId,
+		filter,
+		!! shouldExecute
+	);
 
 	if ( ! shouldExecute ) {
 		return {

--- a/client/my-sites/backup/hooks.js
+++ b/client/my-sites/backup/hooks.js
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import { isArray } from 'lodash';
+import { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getHttpData } from 'calypso/state/data-layer/http-data';
+import { getRequestActivityLogsId, requestActivityLogs } from 'calypso/state/data-getters';
+import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
+
+const isLoading = ( response ) => [ 'uninitialized', 'pending' ].includes( response.state );
+
+const byActivityTsDescending = ( a, b ) => ( a.activityTs > b.activityTs ? -1 : 1 );
+
+export const SUCCESSFUL_BACKUP_ACTIVITIES = [
+	'rewind__backup_complete_full',
+	'rewind__backup_complete_initial',
+	'rewind__backup_only_complete_full',
+	'rewind__backup_only_complete_initial',
+];
+
+export const BACKUP_ATTEMPT_ACTIVITIES = [
+	...SUCCESSFUL_BACKUP_ACTIVITIES,
+	'rewind__backup_error',
+];
+
+export const DELTA_ACTIVITIES = [
+	'attachment__uploaded',
+	'attachment__deleted',
+	'post__published',
+	'post__trashed',
+	'plugin__installed',
+	'plugin__deleted',
+	'theme__installed',
+	'theme__deleted',
+	'user__invite_accepted',
+];
+
+const useMemoizeFilter = ( filter ) => {
+	const filterRef = useRef();
+
+	const refRequestId = filterRef.current && getRequestActivityLogsId( null, filterRef.current );
+	const inputRequestId = filter && getRequestActivityLogsId( null, filter );
+
+	if ( inputRequestId !== refRequestId ) {
+		filterRef.current = filter;
+	}
+
+	return filterRef.current;
+};
+
+export const useActivityLogs = ( siteId, filter, shouldExecute = true ) => {
+	const memoizedFilter = useMemoizeFilter( filter );
+
+	useEffect( () => {
+		shouldExecute && requestActivityLogs( siteId, memoizedFilter );
+	}, [ shouldExecute, siteId, memoizedFilter ] );
+
+	const requestId = getRequestActivityLogsId( siteId, memoizedFilter );
+	const response = useSelector( () => shouldExecute && getHttpData( requestId ), [
+		shouldExecute,
+		requestId,
+	] );
+
+	return {
+		isLoadingActivityLogs: shouldExecute && isLoading( response ),
+		activityLogs: ( response?.data || [] ).sort( byActivityTsDescending ),
+	};
+};
+
+export const useFirstMatchingBackupAttempt = (
+	siteId,
+	{ before, after, successOnly, sortOrder } = {},
+	shouldExecute = true
+) => {
+	const rewindCapabilities = useSelector( ( state ) => getRewindCapabilities( state, siteId ) );
+	const hasRealtimeBackups =
+		isArray( rewindCapabilities ) && rewindCapabilities.includes( 'backup-realtime' );
+
+	const backupAttemptActivities = [
+		...( hasRealtimeBackups ? DELTA_ACTIVITIES : [] ),
+		...( successOnly ? SUCCESSFUL_BACKUP_ACTIVITIES : BACKUP_ATTEMPT_ACTIVITIES ),
+	];
+
+	const filter = {
+		name: backupAttemptActivities,
+		before: before ? before.toISOString() : undefined,
+		after: after ? after.toISOString() : undefined,
+		aggregate: false,
+		number: 1,
+		sortOrder,
+	};
+
+	const { activityLogs, isLoadingActivityLogs } = useActivityLogs( siteId, filter, shouldExecute );
+	return {
+		isLoading: isLoadingActivityLogs,
+		backupAttempt: activityLogs[ 0 ] || undefined,
+	};
+};

--- a/client/my-sites/backup/hooks.js
+++ b/client/my-sites/backup/hooks.js
@@ -101,7 +101,9 @@ export const useFirstMatchingBackupAttempt = (
 	{ before, after, successOnly, sortOrder } = {},
 	shouldExecute = true
 ) => {
-	useEffect( () => requestRewindCapabilities( siteId ), [ siteId ] );
+	useEffect( () => {
+		requestRewindCapabilities( siteId );
+	}, [ siteId ] );
 
 	const rewindCapabilities = useSelector( ( state ) => getRewindCapabilities( state, siteId ) );
 	const hasRealtimeBackups =

--- a/client/my-sites/backup/hooks.js
+++ b/client/my-sites/backup/hooks.js
@@ -11,6 +11,7 @@ import { useSelector } from 'react-redux';
 import { getHttpData } from 'calypso/state/data-layer/http-data';
 import { getRequestActivityLogsId, requestActivityLogs } from 'calypso/state/data-getters';
 import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
+import { requestRewindCapabilities } from 'calypso/state/rewind/capabilities/actions';
 
 const isLoading = ( response ) => [ 'uninitialized', 'pending' ].includes( response.state );
 
@@ -77,6 +78,8 @@ export const useFirstMatchingBackupAttempt = (
 	{ before, after, successOnly, sortOrder } = {},
 	shouldExecute = true
 ) => {
+	useEffect( () => requestRewindCapabilities( siteId ), [ siteId ] );
+
 	const rewindCapabilities = useSelector( ( state ) => getRewindCapabilities( state, siteId ) );
 	const hasRealtimeBackups =
 		isArray( rewindCapabilities ) && rewindCapabilities.includes( 'backup-realtime' );

--- a/client/my-sites/backup/hooks.js
+++ b/client/my-sites/backup/hooks.js
@@ -2,16 +2,20 @@
  * External dependencies
  */
 import { isArray } from 'lodash';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import { applySiteOffset } from 'calypso/lib/site/timezone';
 import { getHttpData } from 'calypso/state/data-layer/http-data';
 import { getRequestActivityLogsId, requestActivityLogs } from 'calypso/state/data-getters';
-import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
 import { requestRewindCapabilities } from 'calypso/state/rewind/capabilities/actions';
+import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
 const isLoading = ( response ) => [ 'uninitialized', 'pending' ].includes( response.state );
 
@@ -157,4 +161,22 @@ export const useFirstMatchingBackupAttempt = (
 		isLoading: isLoadingActivityLogs,
 		backupAttempt: matchingAttempt || undefined,
 	};
+};
+
+// Tolerates null settings values, unlike the implementation in `calypso/components/site-offset`;
+// I don't want to disturb existing behavior, but we may want to come back later
+// and DRY up this bit of code.
+export const useDateWithOffset = ( date, shouldExecute = true ) => {
+	const siteId = useSelector( getSelectedSiteId );
+
+	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
+	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
+
+	const dateWithOffset = useMemo( () => applySiteOffset( date, { timezone, gmtOffset } ), [
+		date,
+		timezone,
+		gmtOffset,
+	] );
+
+	return shouldExecute ? dateWithOffset : undefined;
 };

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -1,507 +1,177 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
-import React, { Component } from 'react';
-import momentDate from 'moment';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import page from 'page';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
+import { useTranslate } from 'i18n-calypso';
+import { isArray } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import EnableRestoresBanner from './enable-restores-banner';
-import { backupMainPath } from './paths';
 import { isEnabled } from 'calypso/config';
-import DocumentHead from 'calypso/components/data/document-head';
-import { updateFilter, setFilter } from 'calypso/state/activity-log/actions';
-import {
-	getRawDailyBackupDeltas,
-	getDailyBackupDeltas,
-	// getMetaDiffForDailyBackup,
-	isActivityBackup,
-	isSuccessfulRealtimeBackup,
-	isSuccessfulDailyBackup,
-	INDEX_FORMAT,
-} from 'calypso/lib/jetpack/backup-utils';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useApplySiteOffset } from 'calypso/components/site-offset';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { requestActivityLogs } from 'calypso/state/data-getters';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
+import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
+import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import DocumentHead from 'calypso/components/data/document-head';
+import QueryRewindCapabilities from 'calypso/components/data/query-rewind-capabilities';
+import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
-import BackupDelta from 'calypso/components/jetpack/backup-delta';
-import DailyBackupStatus from 'calypso/components/jetpack/daily-backup-status';
-import DailyBackupStatusAlternate from 'calypso/components/jetpack/daily-backup-status/index-alternate';
-import BackupDatePicker from 'calypso/components/jetpack/backup-date-picker';
-import getRewindState from 'calypso/state/selectors/get-rewind-state';
-import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import QueryRewindState from 'calypso/components/data/query-rewind-state';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import QueryRewindCapabilities from 'calypso/components/data/query-rewind-capabilities';
 import Main from 'calypso/components/main';
-import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
-import ActivityCardList from 'calypso/components/activity-card-list';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
-import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
-import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
-import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials.js';
-import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
-import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
-import { applySiteOffset } from 'calypso/lib/site/timezone';
-import QuerySiteSettings from 'calypso/components/data/query-site-settings'; // Required to get site time offset
-import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
-import { emptyFilter } from 'calypso/state/activity-log/reducer';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import BackupCard from 'calypso/components/jetpack/backup-card';
-import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import { backupMainPath } from './paths';
+import DatePicker from './date-picker';
+import EnableRestoresBanner from './enable-restores-banner';
+import SearchResults from './search-results';
+import { DailyStatus, RealtimeStatus } from './status';
+import {
+	DailyStatus as DailyStatusSimplifiedI4,
+	RealtimeStatus as RealtimeStatusSimplifiedI4,
+} from './status/simplified-i4';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-class BackupsPage extends Component {
-	componentDidMount() {
-		const { queryDate, moment, clearFilter, siteId } = this.props;
+const isCurrentUserAdmin = ( state, siteId ) => canCurrentUser( state, siteId, 'manage_options' );
 
-		// filters in the global state are modified by other pages, we want to enter this page with the filter empty
-		clearFilter( siteId );
+const BackupPage = ( { queryDate } ) => {
+	const translate = useTranslate();
 
-		// On first load, check if we have a selected date from the URL
-		if ( queryDate ) {
-			this.onDateChange( moment( queryDate, INDEX_FORMAT ) );
-		}
+	const siteId = useSelector( getSelectedSiteId );
+	const isAdmin = useSelector( ( state ) => isCurrentUserAdmin( state, siteId ) );
+
+	const applySiteOffset = useApplySiteOffset();
+	const moment = useLocalizedMoment();
+	const selectedDate = applySiteOffset?.(
+		queryDate ? moment( queryDate, INDEX_FORMAT ) : moment()
+	);
+
+	if ( ! selectedDate ) {
+		return null;
 	}
 
-	onDateChange = ( date ) => {
-		const { siteSlug, moment, timezone, gmtOffset } = this.props;
-
-		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
-
-		if ( date && date.isValid() && date <= today ) {
-			// Valid dates
-			page(
-				backupMainPath( siteSlug, {
-					date: date.format( INDEX_FORMAT ),
-				} )
-			);
-		} else {
-			// No query for invalid dates
-			page( backupMainPath( siteSlug ) );
-		}
-	};
-
-	getSelectedDate() {
-		const { timezone, gmtOffset, moment, queryDate } = this.props;
-
-		const today = applySiteOffset( moment(), {
-			timezone: timezone,
-			gmtOffset: gmtOffset,
-		} );
-
-		const selectedDate = moment( queryDate, INDEX_FORMAT );
-
-		return ( selectedDate.isValid() && selectedDate ) || today;
-	}
-
-	/**
-	 *  Return an object with the last backup and the rest of the activities from the selected date
-	 */
-	backupsFromSelectedDate = () => {
-		const { moment, siteCapabilities } = this.props;
-
-		const date = this.getSelectedDate();
-		const index = moment( date ).format( INDEX_FORMAT );
-		const hasRealtimeBackups = includes( siteCapabilities, 'backup-realtime' );
-
-		const backupsOnSelectedDate = {
-			lastBackup: null,
-			rewindableActivities: [],
-		};
-
-		if ( index in this.props.indexedLog && this.props.indexedLog[ index ].length > 0 ) {
-			this.props.indexedLog[ index ].forEach( ( log ) => {
-				// Discard log if it's not activity rewindable, failed backup or with streams
-				if (
-					( ! hasRealtimeBackups && ! isActivityBackup( log ) ) ||
-					( ! isActivityBackup( log ) && ! isSuccessfulRealtimeBackup( log ) )
-				) {
-					return;
-				}
-
-				// Looking for the last backup on the date (any activity rewindable)
-				if ( ! backupsOnSelectedDate.lastBackup ) {
-					backupsOnSelectedDate.lastBackup = log;
-				} else if ( log ) {
-					backupsOnSelectedDate.rewindableActivities.push( log );
-				}
-			} );
-		}
-
-		return backupsOnSelectedDate;
-	};
-
-	getLatestBackup() {
-		const { logs, moment, siteCapabilities } = this.props;
-
-		const filteredLogs = includes( siteCapabilities, 'backup-realtime' )
-			? logs.filter( isSuccessfulRealtimeBackup )
-			: logs.filter( ( log ) => log.activityIsRewindable );
-
-		if ( filteredLogs.length > 0 ) {
-			return filteredLogs.sort( ( l1, l2 ) =>
-				moment( l1.activityDate ).isBefore( l2.activityDate )
-			)[ 0 ];
-		}
-	}
-
-	renderMain() {
-		const { siteId, isLoadingBackups, translate } = this.props;
-
-		return (
-			<>
-				<DocumentHead title={ translate( 'Latest backups' ) } />
-				<PageViewTracker path="/backup/:site" title="Backups" />
-
-				<QueryRewindState siteId={ siteId } />
-				<QuerySitePurchases siteId={ siteId } />
-				<QuerySiteSettings siteId={ siteId } />
-				<QueryRewindCapabilities siteId={ siteId } />
-
-				{ isLoadingBackups ? (
-					<BackupPlaceholder />
-				) : (
-					<div className="backup__main-wrap">
-						{ isEnabled( 'jetpack/backup-simplified-screens-i4' )
-							? this.renderAlternateWrap()
-							: this.renderWrap() }
-					</div>
-				) }
-			</>
-		);
-	}
-
-	renderWrap() {
-		const {
-			allowRestore,
-			doesRewindNeedCredentials,
-			siteCapabilities,
-			logs,
-			moment,
-			siteSlug,
-			lastSuccessDateAvailable,
-			timezone,
-			gmtOffset,
-		} = this.props;
-
-		const { lastBackup, rewindableActivities: realtimeBackups } = this.backupsFromSelectedDate();
-		const selectedDateString = moment.parseZone( this.getSelectedDate() ).toISOString( true );
-		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
-		const deltas = getDailyBackupDeltas( logs, selectedDateString );
-		// todo: commented as a quick fix before Jetpack Cloud launch. All the non-english account break here.
-		// See: 1169345694087188-as-1176670093007897
-		// const metaDiff = getMetaDiffForDailyBackup( logs, selectedDateString );
-
-		return (
-			<>
-				<div className="backup__last-backup-status">
-					{ doesRewindNeedCredentials && <EnableRestoresBanner /> }
-					{ this.renderDatePicker() }
-
-					<DailyBackupStatus
-						{ ...{
-							selectedDate: this.getSelectedDate(),
-							lastBackupDate: lastSuccessDateAvailable,
-							backup: lastBackup,
-							deltas,
-							// metaDiff, todo: commented because the non-english account issue
-						} }
-					/>
-				</div>
-
-				{ includes( siteCapabilities, 'backup-realtime' ) && lastBackup && (
-					<BackupDelta
-						{ ...{
-							deltas,
-							realtimeBackups,
-							doesRewindNeedCredentials,
-							allowRestore,
-							moment,
-							siteSlug,
-							isToday: today.isSame( this.getSelectedDate(), 'day' ),
-						} }
-					/>
-				) }
-			</>
-		);
-	}
-
-	renderAlternateWrap() {
-		const {
-			siteCapabilities,
-			logs,
-			moment,
-			lastSuccessDateAvailable,
-			doesRewindNeedCredentials,
-		} = this.props;
-
-		const {
-			lastBackup: backup,
-			rewindableActivities: realtimeBackups,
-		} = this.backupsFromSelectedDate();
-		const selectedDateString = moment.parseZone( this.getSelectedDate() ).toISOString( true );
-		const latestBackup = this.getLatestBackup();
-
-		return (
-			<>
-				{ doesRewindNeedCredentials && <EnableRestoresBanner /> }
-				{ this.renderDatePicker() }
-				<ul className="backup__card-list">
-					<li key="daily-backup-status">
-						<DailyBackupStatusAlternate
-							{ ...{
-								selectedDate: this.getSelectedDate(),
-								lastBackupDate: lastSuccessDateAvailable,
-								backup,
-								isLatestBackup:
-									latestBackup && backup && latestBackup.activityId === backup.activityId,
-								dailyDeltas: getRawDailyBackupDeltas( logs, selectedDateString ),
-							} }
-						/>
-					</li>
-					{ includes( siteCapabilities, 'backup-realtime' ) && backup && (
-						<>
-							{ realtimeBackups.map( ( activity ) => (
-								<li key={ activity.activityId }>
-									<BackupCard activity={ activity } />
-								</li>
-							) ) }
-						</>
-					) }
-				</ul>
-			</>
-		);
-	}
-
-	renderDatePicker() {
-		const {
-			dispatchRecordTracksEvent,
-			moment,
-			siteId,
-			siteSlug,
-			oldestDateAvailable,
-			timezone,
-			gmtOffset,
-		} = this.props;
-		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
-
-		return (
-			<BackupDatePicker
-				{ ...{
-					onDateChange: this.onDateChange,
-					selectedDate: this.getSelectedDate(),
-					siteId,
-					oldestDateAvailable,
-					today,
-					siteSlug,
-					dispatchRecordTracksEvent,
-				} }
-			/>
-		);
-	}
-
-	renderBackupSearch() {
-		const { logs, siteSlug, translate } = this.props;
-
-		// Filter out anything that is not restorable
-		const restorablePoints = logs.filter( ( event ) => !! event.activityIsRewindable );
-
-		return (
-			<div className="backup__search">
-				<div className="backup__search-header">
-					{ translate( 'Find a backup or restore point' ) }
-				</div>
-				<div className="backup__search-description">
-					{ translate(
-						'This is the complete event history for your site. Filter by date range and/ or activity type.'
-					) }
-				</div>
-				<ActivityCardList logs={ restorablePoints } pageSize={ 10 } siteSlug={ siteSlug } />
-			</div>
-		);
-	}
-
-	renderContent() {
-		const { isAdmin, isEmptyFilter, translate } = this.props;
-
-		if ( ! isAdmin ) {
-			return (
-				<EmptyContent
-					illustration="/calypso/images/illustrations/illustration-404.svg"
-					title={ translate( 'You are not authorized to view this page' ) }
-				/>
-			);
-		}
-
-		return isEmptyFilter ? this.renderMain() : this.renderBackupSearch();
-	}
-
-	render() {
-		return (
-			<div
-				className={ classNames( 'backup__page', {
-					wordpressdotcom: ! isJetpackCloud(),
+	return (
+		<div
+			className={ classNames( 'backup__page', {
+				wordpressdotcom: ! isJetpackCloud(),
+			} ) }
+		>
+			<Main
+				className={ classNames( {
+					is_jetpackcom: isJetpackCloud(),
 				} ) }
 			>
-				<Main
-					className={ classNames( {
-						is_jetpackcom: isJetpackCloud(),
-					} ) }
-				>
-					<SidebarNavigation />
-					<TimeMismatchWarning
-						siteId={ this.props.siteId }
-						settingsUrl={ this.props.settingsUrl }
+				<SidebarNavigation />
+				<TimeMismatchWarning siteId={ siteId } />
+				{ ! isJetpackCloud() && (
+					<FormattedHeader headerText="Jetpack Backup" align="left" brandFont />
+				) }
+
+				{ isAdmin ? (
+					<AdminContent selectedDate={ selectedDate } />
+				) : (
+					<EmptyContent
+						illustration="/calypso/images/illustrations/illustration-404.svg"
+						title={ translate( 'You are not authorized to view this page' ) }
 					/>
-					{ ! isJetpackCloud() && (
-						<FormattedHeader headerText="Jetpack Backup" align="left" brandFont />
-					) }
-					{ this.renderContent() }
-				</Main>
-			</div>
-		);
-	}
-}
-
-/**
- * Create an indexed log of backups based on the date of the backup and in the site time zone
- *
- * @param {Array} logs The activity logs retrieved from the store
- * @param {string} timezone The site time zone
- * @param {number} gmtOffset The site offset from the GMT
- */
-const createIndexedLog = ( logs, timezone, gmtOffset ) => {
-	const indexedLog = {};
-	let oldestDateAvailable = applySiteOffset( momentDate(), {
-		timezone,
-		gmtOffset,
-	} );
-	let lastDateAvailable = null;
-	let lastSuccessDateAvailable = null;
-
-	if ( 'success' === logs.state ) {
-		logs.data.forEach( ( log ) => {
-			//Move the backup date to the site timezone
-			const backupDate = applySiteOffset( momentDate( log.activityTs ), {
-				timezone,
-				gmtOffset,
-			} );
-
-			//Get the index for this backup, index format: YYYYMMDD
-			const index = backupDate.format( INDEX_FORMAT );
-
-			if ( ! ( index in indexedLog ) ) {
-				//The first time we create the index for this date
-				indexedLog[ index ] = [];
-			}
-
-			// Check for the oldest and the last backup dates
-			if ( isActivityBackup( log ) || log.activityIsRewindable ) {
-				if ( backupDate < oldestDateAvailable ) {
-					oldestDateAvailable = backupDate;
-				}
-				if ( backupDate > lastDateAvailable ) {
-					lastDateAvailable = backupDate;
-				}
-				if ( backupDate > lastSuccessDateAvailable && isSuccessfulDailyBackup( log ) ) {
-					lastSuccessDateAvailable = backupDate;
-				}
-			}
-
-			indexedLog[ index ].push( log );
-		} );
-	}
-
-	return {
-		indexedLog,
-		oldestDateAvailable,
-		lastDateAvailable,
-		lastSuccessDateAvailable,
-	};
+				) }
+			</Main>
+		</div>
+	);
 };
 
-const getIsEmptyFilter = ( filter ) => {
+const isFilterEmpty = ( filter ) => {
 	if ( ! filter ) {
 		return true;
 	}
+
 	if ( filter.group || filter.on || filter.before || filter.after ) {
 		return false;
 	}
+
 	if ( filter.page !== 1 ) {
 		return false;
 	}
+
 	return true;
 };
 
-const mapStateToProps = ( state ) => {
-	const siteId = getSelectedSiteId( state );
-	const filter = getActivityLogFilter( state, siteId );
-	const logs = requestActivityLogs( siteId, filter );
-	const gmtOffset = getSiteGmtOffset( state, siteId );
-	const timezone = getSiteTimezoneValue( state, siteId );
-	const rewind = getRewindState( state, siteId );
-	const restoreStatus = rewind.rewind && rewind.rewind.status;
-	const doesRewindNeedCredentials = getDoesRewindNeedCredentials( state, siteId );
-	const siteCapabilities = getRewindCapabilities( state, siteId );
+const AdminContent = ( { selectedDate } ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
 
-	const allowRestore =
-		'active' === rewind.state && ! ( 'queued' === restoreStatus || 'running' === restoreStatus );
+	const activityLogFilter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
+	const isFiltering = ! isFilterEmpty( activityLogFilter );
 
-	const { indexedLog, oldestDateAvailable, lastSuccessDateAvailable } = createIndexedLog(
-		logs,
-		timezone,
-		gmtOffset
+	const needCredentials = useSelector( ( state ) => getDoesRewindNeedCredentials( state, siteId ) );
+
+	const onSelectDate = ( date ) =>
+		page( backupMainPath( siteSlug, { date: date.format( INDEX_FORMAT ) } ) );
+
+	return (
+		<>
+			<QueryRewindCapabilities siteId={ siteId } />
+			<QueryRewindState siteId={ siteId } />
+
+			{ isFiltering && <SearchResults /> }
+
+			{ ! isFiltering && (
+				<>
+					<DocumentHead title={ translate( 'Latest backups' ) } />
+					<PageViewTracker path="/backup/:site" title="Backups" />
+
+					<div className="backup__main-wrap">
+						<div className="backup__last-backup-status">
+							{ needCredentials && <EnableRestoresBanner /> }
+
+							<DatePicker onSelectDate={ onSelectDate } selectedDate={ selectedDate } />
+							<BackupStatus selectedDate={ selectedDate } />
+						</div>
+					</div>
+				</>
+			) }
+		</>
 	);
-
-	const isLoadingBackups = ! ( logs.state === 'success' );
-
-	return {
-		allowRestore,
-		doesRewindNeedCredentials,
-		filter,
-		isAdmin: canCurrentUser( state, siteId, 'manage_options' ),
-		isEmptyFilter: getIsEmptyFilter( filter ),
-		siteCapabilities,
-		logs: logs?.data ?? [],
-		rewind,
-		siteId,
-		siteUrl: getSiteUrl( state, siteId ),
-		siteSlug: getSelectedSiteSlug( state ),
-		settingsUrl: getSettingsUrl( state, siteId, 'general' ),
-		timezone,
-		gmtOffset,
-		indexedLog,
-		oldestDateAvailable,
-		lastSuccessDateAvailable,
-		isLoadingBackups,
-	};
 };
 
-const mapDispatchToProps = ( dispatch ) => ( {
-	selectPage: ( siteId, pageNumber ) => dispatch( updateFilter( siteId, { page: pageNumber } ) ),
-	clearFilter: ( siteId ) =>
-		// skipUrlUpdate prevents this action from trigger a redirect back to backups/activity in state/navigation/middleware.js
-		dispatch( { ...setFilter( siteId, emptyFilter ), meta: { skipUrlUpdate: true } } ),
-	dispatchRecordTracksEvent: recordTracksEvent,
-} );
+const BackupStatus = ( { selectedDate } ) => {
+	const siteId = useSelector( getSelectedSiteId );
+	const rewindCapabilities = useSelector( ( state ) => getRewindCapabilities( state, siteId ) );
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( localize( withLocalizedMoment( BackupsPage ) ) );
+	if ( ! isArray( rewindCapabilities ) ) {
+		return <BackupPlaceholder showDatePicker={ false } />;
+	}
+
+	const hasRealtimeBackups = rewindCapabilities.includes( 'backup-realtime' );
+
+	if ( isEnabled( 'jetpack/backup-simplified-screens-i4' ) ) {
+		return hasRealtimeBackups ? (
+			<RealtimeStatusSimplifiedI4 selectedDate={ selectedDate } />
+		) : (
+			<DailyStatusSimplifiedI4 selectedDate={ selectedDate } />
+		);
+	}
+
+	return hasRealtimeBackups ? (
+		<RealtimeStatus selectedDate={ selectedDate } />
+	) : (
+		<DailyStatus selectedDate={ selectedDate } />
+	);
+};
+
+export default BackupPage;

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -13,7 +13,6 @@ import { isArray } from 'lodash';
  */
 import { isEnabled } from 'calypso/config';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { useApplySiteOffset } from 'calypso/components/site-offset';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
@@ -31,6 +30,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import { useDateWithOffset } from './hooks';
 import { backupMainPath } from './paths';
 import DatePicker from './date-picker';
 import EnableRestoresBanner from './enable-restores-banner';
@@ -54,15 +54,9 @@ const BackupPage = ( { queryDate } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const isAdmin = useSelector( ( state ) => isCurrentUserAdmin( state, siteId ) );
 
-	const applySiteOffset = useApplySiteOffset();
 	const moment = useLocalizedMoment();
-	const selectedDate = applySiteOffset?.(
-		queryDate ? moment( queryDate, INDEX_FORMAT ) : moment()
-	);
-
-	if ( ! selectedDate ) {
-		return null;
-	}
+	const parsedQueryDate = queryDate ? moment( queryDate, INDEX_FORMAT ) : moment();
+	const selectedDate = useDateWithOffset( parsedQueryDate );
 
 	return (
 		<div

--- a/client/my-sites/backup/search-results.jsx
+++ b/client/my-sites/backup/search-results.jsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
+import ActivityCardList from 'calypso/components/activity-card-list';
+
+const SearchResults = () => {
+	const translate = useTranslate();
+
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const rewindableEvents = []; // TODO
+
+	return (
+		<div className="backup__search">
+			<div className="backup__search-header">{ translate( 'Find a backup or restore point' ) }</div>
+			<div className="backup__search-description">
+				{ translate(
+					'This is the complete event history for your site. Filter by date range and/ or activity type.'
+				) }
+			</div>
+			<ActivityCardList logs={ rewindableEvents } pageSize={ 10 } siteSlug={ siteSlug } />
+		</div>
+	);
+};
+
+export default SearchResults;

--- a/client/my-sites/backup/search-results.jsx
+++ b/client/my-sites/backup/search-results.jsx
@@ -21,6 +21,7 @@ const SearchResults = () => {
 
 	const filter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
 	const { activityLogs } = useActivityLogs( siteId, filter );
+	const rewindableEvents = activityLogs && activityLogs.filter( ( a ) => a.activityIsRewindable );
 
 	return (
 		<div className="backup__search">
@@ -30,7 +31,7 @@ const SearchResults = () => {
 					'This is the complete event history for your site. Filter by date range and/ or activity type.'
 				) }
 			</div>
-			<ActivityCardList logs={ activityLogs } pageSize={ 10 } siteSlug={ siteSlug } />
+			<ActivityCardList logs={ rewindableEvents } pageSize={ 10 } siteSlug={ siteSlug } />
 		</div>
 	);
 };

--- a/client/my-sites/backup/search-results.jsx
+++ b/client/my-sites/backup/search-results.jsx
@@ -8,14 +8,19 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import ActivityCardList from 'calypso/components/activity-card-list';
+import { useActivityLogs } from './hooks';
 
 const SearchResults = () => {
 	const translate = useTranslate();
 
+	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
-	const rewindableEvents = []; // TODO
+
+	const filter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
+	const { activityLogs } = useActivityLogs( siteId, filter );
 
 	return (
 		<div className="backup__search">
@@ -25,7 +30,7 @@ const SearchResults = () => {
 					'This is the complete event history for your site. Filter by date range and/ or activity type.'
 				) }
 			</div>
-			<ActivityCardList logs={ rewindableEvents } pageSize={ 10 } siteSlug={ siteSlug } />
+			<ActivityCardList logs={ activityLogs } pageSize={ 10 } siteSlug={ siteSlug } />
 		</div>
 	);
 };

--- a/client/my-sites/backup/status/hooks.js
+++ b/client/my-sites/backup/status/hooks.js
@@ -3,12 +3,13 @@
  */
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import {
+	DELTA_ACTIVITIES,
 	getDeltaActivities,
 	getDeltaActivitiesByType,
 	isActivityBackup,
 	isSuccessfulRealtimeBackup,
 } from 'calypso/lib/jetpack/backup-utils';
-import { DELTA_ACTIVITIES, useActivityLogs, useFirstMatchingBackupAttempt } from '../hooks';
+import { useActivityLogs, useFirstMatchingBackupAttempt } from '../hooks';
 
 const useLatestBackupAttempt = ( siteId, { before, after, successOnly = false } = {} ) => {
 	return useFirstMatchingBackupAttempt( siteId, {

--- a/client/my-sites/backup/status/hooks.js
+++ b/client/my-sites/backup/status/hooks.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { useApplySiteOffset } from 'calypso/components/site-offset';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	getDeltaActivities,
@@ -122,7 +121,6 @@ export const useDailyBackupStatus = ( siteId, selectedDate ) => {
 };
 
 export const useRealtimeBackupStatus = ( siteId, selectedDate ) => {
-	const applySiteOffset = useApplySiteOffset();
 	const moment = useLocalizedMoment();
 
 	const mostRecentBackupEver = useLatestBackupAttempt( siteId, {
@@ -151,8 +149,8 @@ export const useRealtimeBackupStatus = ( siteId, selectedDate ) => {
 	const rawDeltas = useRawBackupDeltas(
 		siteId,
 		{
-			before: applySiteOffset( lastBackupAttemptOnDate?.activityTs ),
-			after: applySiteOffset( lastBackupBeforeDate.backupAttempt?.activityTs ),
+			before: moment( lastBackupAttemptOnDate?.activityTs ),
+			after: moment( lastBackupBeforeDate.backupAttempt?.activityTs ),
 		},
 		!! ( hasPreviousBackup && successfulLastAttempt )
 	);

--- a/client/my-sites/backup/status/hooks.js
+++ b/client/my-sites/backup/status/hooks.js
@@ -1,0 +1,162 @@
+/**
+ * Internal dependencies
+ */
+import { useApplySiteOffset } from 'calypso/components/site-offset';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import {
+	getDeltaActivities,
+	getDeltaActivitiesByType,
+	isActivityBackup,
+	isSuccessfulRealtimeBackup,
+} from 'calypso/lib/jetpack/backup-utils';
+import { DELTA_ACTIVITIES, useActivityLogs, useFirstMatchingBackupAttempt } from '../hooks';
+
+const byActivityTsDescending = ( a, b ) => ( a.activityTs > b.activityTs ? -1 : 1 );
+
+const useLatestBackupAttempt = ( siteId, { before, after, successOnly = false } = {} ) => {
+	return useFirstMatchingBackupAttempt( siteId, {
+		before,
+		after,
+		successOnly,
+		sortOrder: 'desc',
+	} );
+};
+
+const useBackupDeltas = ( siteId, { before, after, number = 1000 } = {} ) => {
+	const filter = {
+		name: DELTA_ACTIVITIES,
+		before: before ? before.toISOString() : undefined,
+		after: after ? after.toISOString() : undefined,
+		number,
+	};
+
+	const isValidRequest = filter.before && filter.after;
+
+	const { isLoadingActivityLogs, activityLogs } = useActivityLogs( siteId, filter, isValidRequest );
+
+	return {
+		isLoadingDeltas: isLoadingActivityLogs,
+		deltas: getDeltaActivitiesByType( activityLogs ),
+	};
+};
+
+const useRawBackupDeltas = ( siteId, { before, after, number = 1000 } = {} ) => {
+	const filter = {
+		name: DELTA_ACTIVITIES,
+		before: before ? before.toISOString() : undefined,
+		after: after ? after.toISOString() : undefined,
+		number,
+	};
+
+	const isValidRequest = filter.before && filter.after;
+
+	const { isLoadingActivityLogs, activityLogs } = useActivityLogs( siteId, filter, isValidRequest );
+
+	return {
+		isLoadingDeltas: isLoadingActivityLogs,
+		deltas: getDeltaActivities( activityLogs ).sort( byActivityTsDescending ),
+	};
+};
+
+export const useDailyBackupStatus = ( siteId, selectedDate ) => {
+	const moment = useLocalizedMoment();
+
+	const lastBackupBeforeDate = useLatestBackupAttempt( siteId, {
+		before: moment( selectedDate ).startOf( 'day' ),
+		successOnly: true,
+	} );
+	const lastAttemptOnDate = useLatestBackupAttempt( siteId, {
+		after: moment( selectedDate ).startOf( 'day' ),
+		before: moment( selectedDate ).endOf( 'day' ),
+	} );
+
+	const mostRecentBackupEver = useLatestBackupAttempt( siteId, {
+		successOnly: true,
+	} );
+
+	const hasPreviousBackup = ! lastBackupBeforeDate.isLoading && lastBackupBeforeDate.backupAttempt;
+	const successfulLastAttempt =
+		! lastAttemptOnDate.isLoading && lastAttemptOnDate.backupAttempt?.activityIsRewindable;
+
+	const backupDeltas = useBackupDeltas(
+		siteId,
+		hasPreviousBackup &&
+			successfulLastAttempt && {
+				before: moment( lastAttemptOnDate.backupAttempt.activityTs ),
+				after: moment( lastBackupBeforeDate.backupAttempt.activityTs ),
+			}
+	);
+
+	const rawBackupDeltas = useRawBackupDeltas(
+		siteId,
+		hasPreviousBackup &&
+			successfulLastAttempt && {
+				after: moment( lastBackupBeforeDate.backupAttempt.activityTs ),
+				before: moment( lastAttemptOnDate.backupAttempt.activityTs ),
+			}
+	);
+
+	return {
+		isLoading:
+			mostRecentBackupEver.isLoading ||
+			lastBackupBeforeDate.isLoading ||
+			lastAttemptOnDate.isLoading ||
+			backupDeltas.isLoading ||
+			rawBackupDeltas.isLoading,
+		mostRecentBackupEver: mostRecentBackupEver.backupAttempt,
+		lastBackupBeforeDate: lastBackupBeforeDate.backupAttempt,
+		lastBackupAttemptOnDate: lastAttemptOnDate.backupAttempt,
+		deltas: backupDeltas.deltas,
+		rawDeltas: rawBackupDeltas.deltas,
+	};
+};
+
+export const useRealtimeBackupStatus = ( siteId, selectedDate ) => {
+	const applySiteOffset = useApplySiteOffset();
+	const moment = useLocalizedMoment();
+
+	const mostRecentBackupEver = useLatestBackupAttempt( siteId, {
+		successOnly: true,
+	} );
+
+	const lastBackupBeforeDate = useLatestBackupAttempt( siteId, {
+		before: moment( selectedDate ).startOf( 'day' ),
+		successOnly: true,
+	} );
+
+	const { activityLogs, isLoadingActivityLogs } = useActivityLogs( siteId, {
+		before: moment( selectedDate ).endOf( 'day' ).toISOString(),
+		after: moment( selectedDate ).startOf( 'day' ).toISOString(),
+	} );
+
+	const backupAttemptsOnDate = activityLogs.filter(
+		( activity ) => isActivityBackup( activity ) || isSuccessfulRealtimeBackup( activity )
+	);
+	const lastBackupAttemptOnDate = backupAttemptsOnDate[ 0 ];
+
+	const hasPreviousBackup = ! lastBackupBeforeDate.isLoading && lastBackupBeforeDate.backupAttempt;
+	const successfulLastAttempt =
+		lastBackupAttemptOnDate && isSuccessfulRealtimeBackup( lastBackupAttemptOnDate );
+
+	const rawDeltas = useRawBackupDeltas(
+		siteId,
+		hasPreviousBackup &&
+			successfulLastAttempt && {
+				before: applySiteOffset( lastBackupAttemptOnDate.activityTs ),
+				after: applySiteOffset( lastBackupBeforeDate.backupAttempt.activityTs ),
+			}
+	);
+
+	return {
+		isLoading:
+			mostRecentBackupEver.isLoading ||
+			lastBackupBeforeDate.isLoading ||
+			isLoadingActivityLogs ||
+			rawDeltas.isLoading,
+		mostRecentBackupEver: mostRecentBackupEver.backupAttempt,
+		lastBackupBeforeDate: lastBackupBeforeDate.backupAttempt,
+		lastBackupAttemptOnDate: backupAttemptsOnDate[ 0 ],
+		earlierBackupAttemptsOnDate: backupAttemptsOnDate?.slice?.( 1 ) || [],
+		rawDeltas: rawDeltas.deltas,
+	};
+};

--- a/client/my-sites/backup/status/index.jsx
+++ b/client/my-sites/backup/status/index.jsx
@@ -7,12 +7,12 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { useApplySiteOffset } from 'calypso/components/site-offset';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import BackupDelta from 'calypso/components/jetpack/backup-delta';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import MostRecentStatus from 'calypso/components/jetpack/daily-backup-status';
+import { useDateWithOffset } from '../hooks';
 import { useDailyBackupStatus, useRealtimeBackupStatus } from './hooks';
 
 /**
@@ -23,7 +23,6 @@ import './style.scss';
 export const DailyStatus = ( { selectedDate } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 
-	const applySiteOffset = useApplySiteOffset();
 	const moment = useLocalizedMoment();
 
 	const { isLoading, lastBackupBeforeDate, lastBackupAttemptOnDate, deltas } = useDailyBackupStatus(
@@ -35,6 +34,11 @@ export const DailyStatus = ( { selectedDate } ) => {
 	useDailyBackupStatus( siteId, moment( selectedDate ).subtract( 1, 'day' ) );
 	useDailyBackupStatus( siteId, moment( selectedDate ).add( 1, 'day' ) );
 
+	const lastBackupDate = useDateWithOffset(
+		lastBackupBeforeDate?.activityTs,
+		!! lastBackupBeforeDate
+	);
+
 	if ( isLoading ) {
 		return <BackupPlaceholder showDatePicker={ false } />;
 	}
@@ -43,7 +47,7 @@ export const DailyStatus = ( { selectedDate } ) => {
 		<MostRecentStatus
 			{ ...{
 				selectedDate,
-				lastBackupDate: lastBackupBeforeDate && applySiteOffset( lastBackupBeforeDate.activityTs ),
+				lastBackupDate,
 				backup: lastBackupAttemptOnDate,
 				deltas,
 			} }
@@ -54,7 +58,6 @@ export const DailyStatus = ( { selectedDate } ) => {
 export const RealtimeStatus = ( { selectedDate } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 
-	const applySiteOffset = useApplySiteOffset();
 	const moment = useLocalizedMoment();
 
 	const {
@@ -68,6 +71,11 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 	useRealtimeBackupStatus( siteId, moment( selectedDate ).subtract( 1, 'day' ) );
 	useRealtimeBackupStatus( siteId, moment( selectedDate ).add( 1, 'day' ) );
 
+	const lastBackupDate = useDateWithOffset(
+		lastBackupBeforeDate?.activityTs,
+		!! lastBackupBeforeDate
+	);
+
 	if ( isLoading ) {
 		return <BackupPlaceholder showDatePicker={ false } />;
 	}
@@ -77,8 +85,7 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 			<MostRecentStatus
 				{ ...{
 					selectedDate,
-					lastBackupDate:
-						lastBackupBeforeDate && applySiteOffset( lastBackupBeforeDate.activityTs ),
+					lastBackupDate,
 					backup: lastBackupAttemptOnDate,
 				} }
 			/>

--- a/client/my-sites/backup/status/index.jsx
+++ b/client/my-sites/backup/status/index.jsx
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { useApplySiteOffset } from 'calypso/components/site-offset';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import BackupDelta from 'calypso/components/jetpack/backup-delta';
+import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
+import MostRecentStatus from 'calypso/components/jetpack/daily-backup-status';
+import { useDailyBackupStatus, useRealtimeBackupStatus } from './hooks';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export const DailyStatus = ( { selectedDate } ) => {
+	const siteId = useSelector( getSelectedSiteId );
+
+	const applySiteOffset = useApplySiteOffset();
+	const moment = useLocalizedMoment();
+
+	const { isLoading, lastBackupBeforeDate, lastBackupAttemptOnDate, deltas } = useDailyBackupStatus(
+		siteId,
+		selectedDate
+	);
+
+	// Eagerly cache requests for the days before and after our selected date, to make navigation smoother
+	useDailyBackupStatus( siteId, moment( selectedDate ).subtract( 1, 'day' ) );
+	useDailyBackupStatus( siteId, moment( selectedDate ).add( 1, 'day' ) );
+
+	if ( isLoading ) {
+		return <BackupPlaceholder showDatePicker={ false } />;
+	}
+
+	return (
+		<MostRecentStatus
+			{ ...{
+				selectedDate,
+				lastBackupDate: lastBackupBeforeDate && applySiteOffset( lastBackupBeforeDate.activityTs ),
+				backup: lastBackupAttemptOnDate,
+				deltas,
+			} }
+		/>
+	);
+};
+
+export const RealtimeStatus = ( { selectedDate } ) => {
+	const siteId = useSelector( getSelectedSiteId );
+
+	const applySiteOffset = useApplySiteOffset();
+	const moment = useLocalizedMoment();
+
+	const {
+		isLoading,
+		lastBackupBeforeDate,
+		lastBackupAttemptOnDate,
+		earlierBackupAttemptsOnDate,
+	} = useRealtimeBackupStatus( siteId, selectedDate );
+
+	// Eagerly cache requests for the days before and after our selected date, to make navigation smoother
+	useRealtimeBackupStatus( siteId, moment( selectedDate ).subtract( 1, 'day' ) );
+	useRealtimeBackupStatus( siteId, moment( selectedDate ).add( 1, 'day' ) );
+
+	if ( isLoading ) {
+		return <BackupPlaceholder showDatePicker={ false } />;
+	}
+
+	return (
+		<>
+			<MostRecentStatus
+				{ ...{
+					selectedDate,
+					lastBackupDate:
+						lastBackupBeforeDate && applySiteOffset( lastBackupBeforeDate.activityTs ),
+					backup: lastBackupAttemptOnDate,
+				} }
+			/>
+
+			{ lastBackupAttemptOnDate && (
+				<BackupDelta
+					{ ...{
+						realtimeBackups: earlierBackupAttemptsOnDate,
+						isToday: moment().isSame( selectedDate, 'day' ),
+					} }
+				/>
+			) }
+		</>
+	);
+};

--- a/client/my-sites/backup/status/simplified-i4.jsx
+++ b/client/my-sites/backup/status/simplified-i4.jsx
@@ -7,7 +7,7 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getDeltaActivities } from 'calypso/lib/jetpack/backup-utils';
+import { getDeltaActivities, isSuccessfulDailyBackup } from 'calypso/lib/jetpack/backup-utils';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useApplySiteOffset } from 'calypso/components/site-offset';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
@@ -78,6 +78,7 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 		lastBackupBeforeDate,
 		lastBackupAttemptOnDate,
 		earlierBackupAttemptsOnDate,
+		rawDeltas,
 	} = useRealtimeBackupStatus( siteId, selectedDate );
 
 	// Eagerly cache requests for the days before and after our selected date, to make navigation smoother
@@ -93,7 +94,13 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 		lastBackupAttemptOnDate &&
 		mostRecentBackupEver.activityId === lastBackupAttemptOnDate.activityId;
 
-	const dailyDeltas = getDeltaActivities( [ lastBackupAttemptOnDate ].filter( ( i ) => i ) );
+	// If the latest backup for this date is a full backup,
+	// show details about what it contains
+	const dailyDeltas = getDeltaActivities(
+		isSuccessfulDailyBackup( lastBackupAttemptOnDate )
+			? rawDeltas
+			: [ lastBackupAttemptOnDate ].filter( ( i ) => i )
+	);
 
 	return (
 		<ul className="status__card-list">

--- a/client/my-sites/backup/status/simplified-i4.jsx
+++ b/client/my-sites/backup/status/simplified-i4.jsx
@@ -97,7 +97,7 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 	// If the latest backup for this date is a full backup,
 	// show details about what it contains
 	const dailyDeltas = getDeltaActivities(
-		isSuccessfulDailyBackup( lastBackupAttemptOnDate )
+		lastBackupAttemptOnDate && isSuccessfulDailyBackup( lastBackupAttemptOnDate )
 			? rawDeltas
 			: [ lastBackupAttemptOnDate ].filter( ( i ) => i )
 	);

--- a/client/my-sites/backup/status/simplified-i4.jsx
+++ b/client/my-sites/backup/status/simplified-i4.jsx
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getDeltaActivities } from 'calypso/lib/jetpack/backup-utils';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useApplySiteOffset } from 'calypso/components/site-offset';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import BackupCard from 'calypso/components/jetpack/backup-card';
+import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
+import MostRecentStatus from 'calypso/components/jetpack/daily-backup-status/index-alternate';
+import { useDailyBackupStatus, useRealtimeBackupStatus } from './hooks';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export const DailyStatus = ( { selectedDate } ) => {
+	const siteId = useSelector( getSelectedSiteId );
+
+	const applySiteOffset = useApplySiteOffset();
+	const moment = useLocalizedMoment();
+
+	const {
+		isLoading,
+		mostRecentBackupEver,
+		lastBackupBeforeDate,
+		lastBackupAttemptOnDate,
+		rawDeltas,
+	} = useDailyBackupStatus( siteId, selectedDate );
+
+	// Eagerly cache requests for the days before and after our selected date, to make navigation smoother
+	useDailyBackupStatus( siteId, moment( selectedDate ).subtract( 1, 'day' ) );
+	useDailyBackupStatus( siteId, moment( selectedDate ).add( 1, 'day' ) );
+
+	if ( isLoading ) {
+		return <BackupPlaceholder showDatePicker={ false } />;
+	}
+
+	const isLatestBackup =
+		lastBackupAttemptOnDate &&
+		mostRecentBackupEver &&
+		lastBackupAttemptOnDate.activityId === mostRecentBackupEver.activityId;
+
+	return (
+		<ul className="status__card-list">
+			<li key="daily-backup-status">
+				<MostRecentStatus
+					{ ...{
+						selectedDate,
+						lastBackupDate:
+							lastBackupBeforeDate && applySiteOffset( lastBackupBeforeDate.activityTs ),
+						backup: lastBackupAttemptOnDate,
+						isLatestBackup,
+						dailyDeltas: rawDeltas,
+					} }
+				/>
+			</li>
+		</ul>
+	);
+};
+
+export const RealtimeStatus = ( { selectedDate } ) => {
+	const siteId = useSelector( getSelectedSiteId );
+
+	const applySiteOffset = useApplySiteOffset();
+	const moment = useLocalizedMoment();
+
+	const {
+		isLoading,
+		mostRecentBackupEver,
+		lastBackupBeforeDate,
+		lastBackupAttemptOnDate,
+		earlierBackupAttemptsOnDate,
+	} = useRealtimeBackupStatus( siteId, selectedDate );
+
+	// Eagerly cache requests for the days before and after our selected date, to make navigation smoother
+	useRealtimeBackupStatus( siteId, moment( selectedDate ).subtract( 1, 'day' ) );
+	useRealtimeBackupStatus( siteId, moment( selectedDate ).add( 1, 'day' ) );
+
+	if ( isLoading ) {
+		return <BackupPlaceholder showDatePicker={ false } />;
+	}
+
+	const isLatestBackup =
+		mostRecentBackupEver &&
+		lastBackupAttemptOnDate &&
+		mostRecentBackupEver.activityId === lastBackupAttemptOnDate.activityId;
+
+	const dailyDeltas = getDeltaActivities( [ lastBackupAttemptOnDate ].filter( ( i ) => i ) );
+
+	return (
+		<ul className="status__card-list">
+			<li key="daily-backup-status">
+				<MostRecentStatus
+					{ ...{
+						selectedDate,
+						lastBackupDate:
+							lastBackupBeforeDate && applySiteOffset( lastBackupBeforeDate.activityTs ),
+						backup: lastBackupAttemptOnDate,
+						isLatestBackup,
+						dailyDeltas,
+					} }
+				/>
+			</li>
+
+			{ earlierBackupAttemptsOnDate.map( ( activity ) => (
+				<li key={ activity.activityId }>
+					<BackupCard activity={ activity } />
+				</li>
+			) ) }
+		</ul>
+	);
+};

--- a/client/my-sites/backup/status/style.scss
+++ b/client/my-sites/backup/status/style.scss
@@ -1,0 +1,18 @@
+.status__card-list {
+	margin: 0;
+	padding: 0;
+
+	list-style-type: none;
+
+	> li {
+		margin: 44px 0;
+
+		&:first-child {
+			margin-top: 0;
+		}
+	}
+}
+
+.is_jetpackcom .status__card-list {
+	margin-top: 32px;
+}

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -46,21 +46,6 @@
 	}
 }
 
-.backup__card-list {
-	margin: 0;
-	padding: 0;
-
-	list-style-type: none;
-
-	> li {
-		margin: 44px 0;
-
-		&:first-child {
-			margin-top: 0;
-		}
-	}
-}
-
 .backup__search {
 	padding: 0 1rem;
 }
@@ -172,9 +157,5 @@
 		&.banner.card {
 			@include banner-color( var( --color-primary-40 ) );
 		}
-	}
-
-	.backup__card-list {
-		margin-top: 32px;
 	}
 }

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -19,7 +19,8 @@ export const filterStateToApiQuery = ( filter ) => {
 		filter.group && { group: filter.group },
 		filter.notGroup && { not_group: filter.notGroup },
 		filter.name && { name: filter.name },
-		{ number: 1000 }
+		{ number: filter.number > 0 ? filter.number : 1000 },
+		filter.sortOrder && { sort_order: filter.sortOrder }
 	);
 };
 

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { omit, sortBy } from 'lodash';
+import { omit, isArray, isUndefined, sortBy } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -64,14 +64,35 @@ export const requestActivityActionTypeCounts = (
 };
 
 export const getRequestActivityLogsId = ( siteId, filter ) => {
-	const group =
-		filter && filter.group && filter.group.length ? sortBy( filter.group ).join( ',' ) : '';
-	const before = filter && filter.before ? filter.before : '';
-	const after = filter && filter.after ? filter.after : '';
-	const on = filter && filter.on ? filter.on : '';
-	const aggregate = filter && filter.aggregate ? filter.aggregate : '';
+	const knownFilterOptions = [
+		'action',
+		'after',
+		'aggregate',
+		'before',
+		'by',
+		'dateRange',
+		'group',
+		'name',
+		'notGroup',
+		'number',
+		'on',
+		'sortOrder',
+	];
+	const filterCacheKey = knownFilterOptions
+		.map( ( opt ) => {
+			const optionValue = filter[ opt ];
+			if ( isUndefined( optionValue ) ) {
+				return undefined;
+			}
 
-	return `activity-log-${ siteId }-${ group }-${ after }-${ before }-${ on }-${ aggregate }`;
+			const cacheKeyValue = String( isArray( optionValue ) ? sortBy( optionValue ) : optionValue );
+
+			return `${ opt }=${ cacheKeyValue }`;
+		} )
+		.filter( ( pair ) => pair )
+		.join( '-' );
+
+	return `activity-log-${ siteId }-${ filterCacheKey }`;
 };
 
 export const requestActivityLogs = ( siteId, filter, { freshness = 5 * 60 * 1000 } = {} ) => {


### PR DESCRIPTION
Fixes `1164141197617539-as-1186890594349665`, `1184358343400545-as-1190849472047377`.

#### Changes proposed in this Pull Request

* Split the Backup page into several discrete components, like `DatePicker`, `BackupStatus`, and `SearchResults`.
* Create separate status components for daily and real-time backups, because the information they display is fairly diverged.
* Preserve feature flag behavior for `jetpack/backup-simplified-screens-i4`, but move it under `backup/status/simplified-screens-i4.jsx`.
* Create new custom hooks `useDailyBackupStatus` and `useRealtimeBackupStatus`, to simplify the process of getting the information to display the backup status for a particular site on a given date.
* Try to make all the logic -- and there's so much of it -- more self-contained and easy to reason about.
* Move a couple styles to get rid of linting errors as a result of all the above changes.
* Make `requestActivityLogs` respect and use the `number` param to control how many results come back.

#### Implementation notes

* You may notice some brief flickering as activity log information loads. I'm not a fan of this, and I tried to mitigate it by eagerly fetching data for 1 day before/after the selected date. This solution works, mostly, but I feel like it's a bit quick-n-dirty.

#### Testing instructions

**NOTE:** This pull request touches pretty much every part of the Backup page and its `simplified-screens-i4` variant! Be extra thorough; keep an eagle eye out for issues with styling and behavior; and importantly, remember to test both Calypso and Jetpack Cloud on both mobile and desktop layouts.

Most of these instructions are for targeted testing against known possible regressions, but we have one scenario we're trying to fix with this PR: **sites that have many Activity Log events** should be able to see their backups and navigate forward/backward through time without difficulty. We should be showing details of their changes on the page, just like sites with fewer activities (though we're limiting to only the 1000 latest per day at the moment).

If you need to gain access to a site with lots of activities in its Activity Log, message me privately and I can set you up. I recommend testing this PR side-by-side with production, because other than the bug-fix case described in the last paragraph, everything should behave the same as it does today.

For sites with either Backup Daily or Real-time:
* If today's backup failed but a successful one exists in the past, a link is displayed to that successful backup (see #46886).
* The date picker should be unrestricted, allowing navigation to any calendar date, **especially** for sites with lots of activities.
* All dates are correct for the site's time zone, and all "deltas" display appropriately with respect to the state of the `jetpack/backup-simplified-screens-i4` feature flag.

For sites with Backup Daily, verify that:
* The daily backup status correctly displays the status of the daily backup attempt that happened (or didn't happen) on the selected date.

For sites with Backup Real-time, verify that:
* The daily backup status correctly displays the most recent rewindable activity as the backup for the selected date. If no activities are available on the selected date, behavior should be similar to sites with Backup Daily re: success, failure, etc.

#### Screenshots

<img width="742" alt="Screen Shot 2020-10-29 at 14 55 59" src="https://user-images.githubusercontent.com/670067/97625727-e20bb780-19f6-11eb-9fc9-c884f0021524.png">
<img width="744" alt="Screen Shot 2020-10-29 at 15 08 47" src="https://user-images.githubusercontent.com/670067/97626981-b25daf00-19f8-11eb-9878-1958372c4f2e.png">