### PR TITLE
Disable monthly pricing experiment while we research a bug.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -213,7 +213,7 @@ export default {
 		countryCodeTargets: [ 'US' ],
 	},
 	monthlyPricing: {
-		datestamp: '20201030',
+		datestamp: '20501030',
 		variations: {
 			control: 90,
 			treatment: 10,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This sets the start date for the monthly pricing experiment to a far-future date, which effectively disables the test for now, while we continue to research an issue with this test that's causing the final loading screen in the signup flow, just prior to checkout, to hang indefinitely.

#### Testing Instructions

- Open: https://calypso.live/start?branch=update/monthly-pricing-exp-date in an incognito window.
- Register, choose domain, select plan, and confirm that you're forwarded to checkout.

Repeat again for each plan, and confirm no issues with the redirection to checkout at the end of signup.
