### PR TITLE
Reader: drop authuser=0 from image URLs before passing to Photon

### DIFF
--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -75,6 +75,11 @@ export default function safeImageUrl( url ) {
 		// If it's just size parameters, let's remove them
 		SIZE_PARAMS.forEach( ( param ) => parsedUrl.searchParams.delete( param ) );
 
+		// Ditch authuser=0 if we find it - we see this on googleusercontent.com URLs and it doesn't affect the image output
+		if ( parsedUrl.searchParams.get( 'authuser' ) === '0' ) {
+			parsedUrl.searchParams.delete( 'authuser' );
+		}
+
 		// There are still parameters left, since they might be needed to retrieve the image, bail out
 		if ( parsedUrl.searchParams.length ) {
 			return null;

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -123,6 +123,12 @@ describe( 'safeImageUrl()', () => {
 			);
 		} );
 
+		test( 'should ignore authuser=0 param in an image URL', () => {
+			expect( safeImageUrl( 'https://example.com/foo.jpg?authuser=0' ) ).toEqual(
+				'https://i0.wp.com/example.com/foo.jpg?ssl=1'
+			);
+		} );
+
 		test( 'should return null for SVG images', () => {
 			expect( safeImageUrl( 'https://example.com/foo.svg' ) ).toBeNull();
 			expect( safeImageUrl( 'https://example.com/foo.svg?ssl=1' ) ).toBeNull();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Photon, our image resizing service, will not process images with a query string. We only serve Photon-processed images on the Reader post card.

A user contacted us wanting to know why their post isn't shown as a gallery card, when there are several large images in the post:

<img width="828" alt="Screen Shot 2020-10-30 at 14 52 05" src="https://user-images.githubusercontent.com/17325/97651383-bd7c1200-1ac0-11eb-9602-2139e20a149a.png">

Several images in the post were hosted on googleusercontent.com (Google Photos) and had a query string of `authuser=0`. Since this parameter seems make no difference to the rendering of the image, this PR adds stripping of authuser when the value is 0. This allows Photon to process the image and the result is:

<img width="857" alt="Screen Shot 2020-10-30 at 14 51 30" src="https://user-images.githubusercontent.com/17325/97651436-e4d2df00-1ac0-11eb-8804-dc57b849e8b5.png">

P2 reference: p5PDj3-4Up-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit https://wordpress.com/read/blogs/146448168. Scroll down to 18th May 2020. Note that it only displays one image on the post card.

Apply the PR and visit http://calypso.localhost:3000/read/blogs/146448168. Scroll down to 18th May 2020. Note that the post in question now has 4 images (gallery card).

