### PR TITLE
Logs stale requests

### DIFF
--- a/client/server/index.js
+++ b/client/server/index.js
@@ -72,6 +72,7 @@ function createServer() {
 }
 
 const server = createServer();
+server.timeout = 50 * 1000; //50 seconds, in ms
 
 process.on( 'uncaughtExceptionMonitor', ( err ) => {
 	logger.error( err );

--- a/client/server/index.js
+++ b/client/server/index.js
@@ -72,7 +72,9 @@ function createServer() {
 }
 
 const server = createServer();
-server.timeout = 50 * 1000; //50 seconds, in ms
+if ( process.env.NODE_ENV !== 'development' ) {
+	server.timeout = 50 * 1000; //50 seconds, in ms;
+}
 
 process.on( 'uncaughtExceptionMonitor', ( err ) => {
 	logger.error( err );

--- a/client/server/middleware/logger.js
+++ b/client/server/middleware/logger.js
@@ -24,6 +24,8 @@ const parseUA = ( rawUA ) => {
 const logRequest = ( req, res, options ) => {
 	const { requestStart, env, version } = options;
 
+	const message = res.finished ? 'request finished' : 'request closed';
+
 	const fields = {
 		method: req.method,
 		status: res.statusCode,
@@ -41,7 +43,7 @@ const logRequest = ( req, res, options ) => {
 		referrer: req.get( 'referer' ),
 	};
 
-	req.logger.info( fields );
+	req.logger.info( fields, message );
 };
 
 export default () => {
@@ -54,7 +56,7 @@ export default () => {
 			reqId: uuidv4(),
 		} );
 		const requestStart = process.hrtime.bigint();
-		res.on( 'finish', () => logRequest( req, res, { requestStart, env, version } ) );
+		res.on( 'close', () => logRequest( req, res, { requestStart, env, version } ) );
 		next();
 	};
 };

--- a/client/server/middleware/test/logger.js
+++ b/client/server/middleware/test/logger.js
@@ -9,12 +9,14 @@ import EventEmitter from 'events';
 import loggerMiddleware from '../logger';
 import config from 'calypso/config';
 
-const mockLogger = {
+const requestLogger = {
 	info: jest.fn(),
-	child: jest.fn( () => mockLogger ),
+};
+const mockRootLogger = {
+	child: jest.fn( () => requestLogger ),
 };
 jest.mock( 'server/lib/logger', () => ( {
-	getLogger: () => mockLogger,
+	getLogger: () => mockRootLogger,
 } ) );
 jest.mock( 'config', () => jest.fn() );
 jest.mock( 'uuid', () => ( {
@@ -82,8 +84,8 @@ it( 'Adds a `logger` property to the request with the request id', () => {
 		res: fakeResponse(),
 	} );
 
-	expect( req.logger ).toBe( mockLogger );
-	expect( req.logger.child ).toHaveBeenCalledWith( {
+	expect( req.logger ).toBe( requestLogger );
+	expect( mockRootLogger.child ).toHaveBeenCalledWith( {
 		reqId: '00000000-0000-0000-0000-000000000000',
 	} );
 } );
@@ -112,7 +114,7 @@ it( 'Logs info about the request', () => {
 		delay: 100,
 	} );
 
-	expect( mockLogger.info ).toHaveBeenCalledWith(
+	expect( requestLogger.info ).toHaveBeenCalledWith(
 		{
 			length: 123,
 			duration: 100,
@@ -138,7 +140,7 @@ it( 'Logs closed requests', () => {
 		finished: false,
 	} );
 
-	expect( mockLogger.info ).toHaveBeenCalledWith( expect.anything(), 'request closed' );
+	expect( requestLogger.info ).toHaveBeenCalledWith( expect.anything(), 'request closed' );
 } );
 
 it( "Logs raw UserAgent if it can't be parsed", () => {
@@ -151,7 +153,7 @@ it( "Logs raw UserAgent if it can't be parsed", () => {
 		res: fakeResponse(),
 	} );
 
-	expect( mockLogger.info ).toHaveBeenCalledWith(
+	expect( requestLogger.info ).toHaveBeenCalledWith(
 		expect.objectContaining( {
 			userAgent: 'A random browser',
 		} ),
@@ -167,7 +169,7 @@ it( 'Adds the COMMIT_SHA as version', () => {
 		res: fakeResponse(),
 	} );
 
-	expect( mockLogger.info ).toHaveBeenCalledWith(
+	expect( requestLogger.info ).toHaveBeenCalledWith(
 		expect.objectContaining( {
 			appVersion: 'abcd1234',
 		} ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sets a timeout for all requests of 50 seconds
* Logs all closed requests (finished or not)

Relevant docs:
- https://nodejs.org/docs/latest-v12.x/api/http.html#http_server_timeout

#### Testing instructions

* Checkout this branch, start the server with `yarn start` and nagivate to `http://calypso.localhost:3000/`. Verify you see `"msg":"request finished"` in the logs
* Now open `client/server/pages/index.js` and comment out the call to `next()` in the function `setupDefaultContext`. Restart the server. After 30 seconds you should see `"msg":"request closed"` and a `duration` of about 30000 ms.

![image](https://user-images.githubusercontent.com/975703/97661532-e5458880-1a74-11eb-872f-2d43f7306571.png)
