### PR TITLE
Fix sidebar menu item image icon states (for icons which are images)

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -141,6 +141,10 @@ $font-size: rem( 14px );
 			margin-right: 8px;
 		}
 
+		img.sidebar__menu-icon {
+			opacity: 0.6;
+		}
+
 		.sidebar__menu-item-parent {
 			&.selected {
 				.sidebar__menu-link {
@@ -149,6 +153,10 @@ $font-size: rem( 14px );
 
 					.sidebar__menu-icon {
 						color: white;
+					}
+
+					img.sidebar__menu-icon {
+						opacity: 1;
 					}
 
 					&::after {
@@ -164,6 +172,9 @@ $font-size: rem( 14px );
 			&:hover {
 				.sidebar__menu-icon {
 					color: var( --color-sidebar-menu-hover );
+				}
+				img.sidebar__menu-icon {
+					opacity: 1;
 				}
 			}
 		}
@@ -192,10 +203,16 @@ $font-size: rem( 14px );
 					.sidebar__menu-icon {
 						color: var( --color-sidebar-menu-hover );
 					}
+					img.sidebar__menu-icon {
+						opacity: 1;
+					}
 				}
 
 				.sidebar__menu-icon {
 					color: #fff;
+				}
+				img.sidebar__menu-icon {
+					opacity: 1;
 				}
 			}
 			// Is toggled open and selected
@@ -205,6 +222,9 @@ $font-size: rem( 14px );
 
 				.sidebar__menu-icon {
 					color: #fff;
+				}
+				img.sidebar__menu-icon {
+					opacity: 1;
 				}
 			}
 		}
@@ -387,6 +407,9 @@ $font-size: rem( 14px );
 
 				.sidebar__menu-icon {
 					color: #fff;
+				}
+				img.sidebar__menu-icon {
+					opacity: 1;
 				}
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the state (not-active / active) of the icons that are rendered as images

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* add `?flags=nav-unification`
* check that Jetpack icon behaves the same as in `wp-admin`

Before | After
-------|------
![SS 2020-10-30 at 11 09 59](https://user-images.githubusercontent.com/12430020/97681313-83027d00-1aa0-11eb-9233-6893cee34b22.gif) | ![SS 2020-10-30 at 11 08 44](https://user-images.githubusercontent.com/12430020/97681053-577f9280-1aa0-11eb-9460-771ee839edc3.gif)
