### PR TITLE
Declare param run_full_eslint

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -57,6 +57,7 @@ project {
 		param("teamcity.git.fetchAllHeads", "true")
 		text("env.CHILD_CONCURRENCY", "15", label = "Yarn child concurrency", description = "How many packages yarn builds in parallel", allowEmpty = true)
 		text("docker_image", "registry.a8c.com/calypso/ci:latest", label = "Docker image", description = "Docker image to use for the run", allowEmpty = true)
+		text("calypso.run_full_eslint", "false", label = "Run full eslint", description = "True will lint all files, empty/false will lint only changed files", allowEmpty = true)
 	}
 
 	features {
@@ -601,3 +602,4 @@ object WpCalypso : GitVcsRoot({
 		uploadedKey = "Sergio TeamCity"
 	}
 })
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enables the global setting `calypso.run_full_eslint` with value "false". Otherwise TeamCity expect that to be defined on each agent, and it will refuse to start the Code Style build if it is not.

It is used in https://github.com/Automattic/wp-calypso/blob/master/.teamcity/settings.kts#L529 to lint all files in branches (as opposed to only lint changed files)

#### Testing instructions

Check the Code Style job is running for this branch
