### PR TITLE
Fix editor checkout modal layout on small devices

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -4,10 +4,9 @@
 import React, { useMemo } from 'react';
 import { connect } from 'react-redux';
 import wp from 'calypso/lib/wp';
-import classnames from 'classnames';
-import { Button } from '@wordpress/components';
-import { Icon, close, wordpress } from '@wordpress/icons';
+import { Icon, wordpress } from '@wordpress/icons';
 import { ShoppingCartProvider, RequestCart } from '@automattic/shopping-cart';
+import { Modal } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -65,15 +64,13 @@ const EditorCheckoutModal = ( props: Props ) => {
 	const commaSeparatedProductSlugs = productSlugs?.join( ',' ) || null;
 
 	return hasEmptyCart ? null : (
-		<div className={ classnames( 'editor-checkout-modal', isOpen ? 'is-open' : '' ) }>
-			<div className="editor-checkout-modal__header">
-				<div className="editor-checkout-modal__wp-logo">
-					<Icon icon={ wordpress } size={ 36 } />
-				</div>
-				<Button isLink className="editor-checkout-modal__close-button" onClick={ onClose }>
-					<Icon icon={ close } size={ 24 } />
-				</Button>
-			</div>
+		<Modal
+			open={ isOpen }
+			overlayClassName="editor-checkout-modal"
+			onRequestClose={ onClose }
+			title=""
+			icon={ <Icon icon={ wordpress } size={ 36 } /> }
+		>
 			<ShoppingCartProvider cartKey={ cartKey } getCart={ wpcomGetCart } setCart={ wpcomSetCart }>
 				<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>
 					<CompositeCheckout
@@ -84,7 +81,7 @@ const EditorCheckoutModal = ( props: Props ) => {
 					/>
 				</StripeHookProvider>
 			</ShoppingCartProvider>
-		</div>
+		</Modal>
 	);
 };
 

--- a/client/blocks/editor-checkout-modal/style.scss
+++ b/client/blocks/editor-checkout-modal/style.scss
@@ -1,5 +1,9 @@
 
 @import '~@automattic/typography/styles/variables';
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
+$editor-checkout-modal-header-height: 60px;
 
 .editor-checkout-modal {
 	position: fixed;
@@ -9,9 +13,14 @@
 	z-index: z-index( 'root', '.main.calypsoify.is-iframe' );
 	height: 100%;
 	overflow: auto;
-	padding: 80px 30px 30px;
-	background: white;
-	transition: all 0.5s ease-in-out;
+	padding: $editor-checkout-modal-header-height 0 0;
+	background: var( --studio-white );
+	transition: right 0.5s ease-in-out;
+	box-sizing: border-box;
+
+	@include break-medium {
+		padding: $editor-checkout-modal-header-height 30px 30px;
+	}
 
 	&.is-open {
 		right: 0;
@@ -24,16 +33,21 @@
 	left: 0;
 	z-index: z-index( 'root', '.main.calypsoify.is-iframe' );
 	width: 100%;
-	height: 0;
-	overflow: visible;
+	overflow: hidden;
+	background: var( --studio-white );
+	
+	@include break-medium {
+		overflow: visible;
+		background: transparent;
+	}
 }
 
 .editor-checkout-modal__wp-logo {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 60px;
-	height: 60px;
+	width: $editor-checkout-modal-header-height;
+	height: $editor-checkout-modal-header-height;
 }
 
 .editor-checkout-modal__close-button.components-button.is-link {
@@ -41,8 +55,8 @@
 	top: 0;
 	right: 0;
 	z-index: 9999;
-	width: 60px;
-	height: 60px;
+	width: $editor-checkout-modal-header-height;
+	height: $editor-checkout-modal-header-height;
 	justify-content: center;
 	color: var( --studio-gray-50 );
 

--- a/client/blocks/editor-checkout-modal/style.scss
+++ b/client/blocks/editor-checkout-modal/style.scss
@@ -2,8 +2,6 @@
 @import '~@wordpress/base-styles/breakpoints';
 @import '~@wordpress/base-styles/mixins';
 
-$editor-checkout-modal-header-height: 60px;
-
 .editor-checkout-modal {
 	.components-modal__frame {
 		top: auto;

--- a/client/blocks/editor-checkout-modal/style.scss
+++ b/client/blocks/editor-checkout-modal/style.scss
@@ -1,4 +1,3 @@
-
 @import '~@automattic/typography/styles/variables';
 @import '~@wordpress/base-styles/breakpoints';
 @import '~@wordpress/base-styles/mixins';
@@ -6,61 +5,23 @@
 $editor-checkout-modal-header-height: 60px;
 
 .editor-checkout-modal {
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: -100%;
-	z-index: z-index( 'root', '.main.calypsoify.is-iframe' );
-	height: 100%;
-	overflow: auto;
-	padding: $editor-checkout-modal-header-height 0 0;
-	background: var( --studio-white );
-	transition: right 0.5s ease-in-out;
-	box-sizing: border-box;
-
-	@include break-medium {
-		padding: $editor-checkout-modal-header-height 30px 30px;
+	.components-modal__frame {
+		top: auto;
+		right: auto;
+		bottom: auto;
+		left: auto;
+		min-width: auto;
+		min-height: auto;
+		max-height: none;
+		max-width: none;
+		transform: none;
+		width: 100%;
+		height: 100%;
 	}
-
-	&.is-open {
-		right: 0;
-	}
-}
-
-.editor-checkout-modal__header {
-	position: fixed;
-	top: 0;
-	left: 0;
-	z-index: z-index( 'root', '.main.calypsoify.is-iframe' );
-	width: 100%;
-	overflow: hidden;
-	background: var( --studio-white );
-	
-	@include break-medium {
-		overflow: visible;
-		background: transparent;
-	}
-}
-
-.editor-checkout-modal__wp-logo {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: $editor-checkout-modal-header-height;
-	height: $editor-checkout-modal-header-height;
-}
-
-.editor-checkout-modal__close-button.components-button.is-link {
-	position: absolute;
-	top: 0;
-	right: 0;
-	z-index: 9999;
-	width: $editor-checkout-modal-header-height;
-	height: $editor-checkout-modal-header-height;
-	justify-content: center;
-	color: var( --studio-gray-50 );
-
-	&:hover {
-		color: var( --studio-gray-40 );
+	.components-modal__header {
+		// hide border on desktop
+		@include break-medium {
+			border: none;
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use Modal component so it looks less cramped and does not hide important information such as the total price.
* This also takes care of existing accessibility issues for this feature.

Before:
![checkout-modal-before](https://user-images.githubusercontent.com/8639742/97694427-7418cc00-1a9a-11eb-8703-b8ab2d33b196.gif)

After:
![checkout-layout-after](https://user-images.githubusercontent.com/8639742/97694432-77ac5300-1a9a-11eb-816e-34e4a3774fdc.gif)

#### Testing instructions

* Go to a website with a free plan.
* Add a premium block in the editor for one of the posts/pages. (e.g. `/premium content`) whilst ensuring you are on a mobile device.
* Click the "Upgrade" button to reveal the modal and ensure that it's not cramped, or similar to `/checkout`

Fixes https://github.com/Automattic/wp-calypso/issues/46904
Fixes https://github.com/Automattic/wp-calypso/issues/46487
Fixes https://github.com/Automattic/wp-calypso/issues/46486