### PR TITLE
DomainPicker: Add select button.

### DIFF
--- a/client/landing/gutenboarding/gutenberg-types-patch.ts
+++ b/client/landing/gutenboarding/gutenberg-types-patch.ts
@@ -1,7 +1,0 @@
-declare module '@wordpress/compose' {
-	type breakpoint = 'huge' | 'wide' | 'large' | 'medium' | 'small' | 'mobile';
-	type operator = '>=' | '<';
-	export function useViewportMatch( viewport: breakpoint, operator?: operator ): boolean;
-}
-
-export {};

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -32,9 +32,6 @@ import type { Design } from './stores/onboard/types';
 import 'calypso/assets/stylesheets/gutenboarding.scss';
 import 'calypso/components/environment-badge/style.scss';
 
-// TODO: remove when all needed core types are available
-/*#__PURE__*/ import './gutenberg-types-patch';
-
 function generateGetSuperProps() {
 	return () => ( {
 		environment: process.env.NODE_ENV,

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -27,6 +27,8 @@ import {
 	domainIsAvailableStatus,
 } from '../constants';
 import { DomainNameExplanationImage } from '../domain-name-explanation/';
+import type { SUGGESTION_ITEM_TYPE } from './suggestion-item';
+import { ITEM_TYPE_RADIO } from './suggestion-item';
 
 /**
  * Style dependencies
@@ -90,6 +92,9 @@ export interface Props {
 
 	/** Whether to show search field or not. Defaults to true */
 	showSearchField?: boolean;
+
+	/** Whether to show radio button or select button. Defaults to radio button */
+	itemType?: SUGGESTION_ITEM_TYPE;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {
@@ -109,6 +114,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	existingSubdomain,
 	segregateFreeAndPaid = false,
 	showSearchField = true,
+	itemType = ITEM_TYPE_RADIO,
 } ) => {
 	const label = __( 'Search for a domain', __i18n_text_domain__ );
 
@@ -259,6 +265,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 										onSelect={ () => {
 											onExistingSubdomainSelect?.( existingSubdomain );
 										} }
+										type={ itemType }
 									/>
 								) }
 							</ItemGrouper>
@@ -302,6 +309,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 												onDomainSelect( suggestion );
 											} }
 											selected={ currentDomain === suggestion.domain_name }
+											type={ itemType }
 										/>
 									);
 								} ) ?? times( quantity, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -95,13 +95,13 @@
 	}
 
 	&:first-of-type {
-		border-top-left-radius: 5px;
-		border-top-right-radius: 5px;
+		border-top-left-radius: 5px; /* stylelint-disable-line scales/radii */
+		border-top-right-radius: 5px; /* stylelint-disable-line scales/radii */
 	}
 
 	&:last-of-type {
-		border-bottom-left-radius: 5px;
-		border-bottom-right-radius: 5px;
+		border-bottom-left-radius: 5px; /* stylelint-disable-line scales/radii */
+		border-bottom-right-radius: 5px; /* stylelint-disable-line scales/radii */
 	}
 
 	+ .domain-picker__suggestion-item {
@@ -185,22 +185,16 @@
 }
 
 .domain-picker__suggestion-item-name {
-	flex-grow: 1;
+	flex-grow: 2;
+	flex-basis: 2px;
 	letter-spacing: 0.4px;
+	margin-right: 24px;
 
 	.domain-picker__suggestion-item-name-inner {
 		// vertically align elements within, needed for items showing information icon.
 		display: flex;
 		align-items: center;
 		flex-wrap: wrap;
-	}
-
-	.domain-picker__suggestion-item:not( .is-free ) & {
-		margin-right: 0;
-
-		@include break-mobile {
-			margin-right: 24px;
-		}
 	}
 
 	.domain-picker__domain-name {
@@ -216,7 +210,6 @@
 
 .domain-picker__domain-tld {
 	color: var( --studio-blue-40 );
-
 
 	&.with-margin {
 		// margin for recommended badge. this margin shouldn't
@@ -257,14 +250,20 @@
 	color: var( --studio-gray-40 );
 	text-align: right;
 	flex-basis: 0;
+	flex-grow: 1;
 	transition: opacity 200ms ease-in-out;
 	// Don't show free text on mobile view
 	&:not( .is-paid ) {
 		display: none;
 	}
 
+	// When select button is visible
+	&:not( :last-child ) {
+		text-align: left;
+	}
+
 	@include break-small {
-		flex-basis: auto;
+		flex-basis: 1px;
 
 		&:not( .is-paid ) {
 			display: inline;
@@ -324,5 +323,20 @@
 
 	#{&}-retry-btn {
 		margin-top: 16px;
+	}
+}
+
+.domain-picker__suggestion-select-button.components-button.is-secondary {
+	min-width: 140px;
+	justify-content: center;
+
+	&:not( :hover ):not( .is-selected ) {
+		box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
+		color: var( --mainColor );
+	}
+
+	&.is-selected {
+		box-shadow: inset 0 0 0 1px var( --wp-admin-theme-color-darker-10 );
+		color: var( --wp-admin-theme-color-darker-10 );
 	}
 }

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 import { sprintf } from '@wordpress/i18n';
 import { v4 as uuid } from 'uuid';
 import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,6 +18,10 @@ import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
 import InfoTooltip from '../info-tooltip';
 // TODO: remove when all needed core types are available
 /*#__PURE__*/ import '../types-patch';
+
+export const ITEM_TYPE_RADIO = 'radio';
+export const ITEM_TYPE_BUTTON = 'button';
+export type SUGGESTION_ITEM_TYPE = typeof ITEM_TYPE_RADIO | typeof ITEM_TYPE_BUTTON;
 
 interface Props {
 	isUnavailable?: boolean;
@@ -31,6 +36,7 @@ interface Props {
 	onRender: () => void;
 	onSelect: ( domain: string ) => void;
 	selected?: boolean;
+	type?: SUGGESTION_ITEM_TYPE;
 }
 
 const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
@@ -46,6 +52,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	onSelect,
 	onRender,
 	selected,
+	type = ITEM_TYPE_RADIO,
 } ) => {
 	const isMobile = useViewportMatch( 'small', '<' );
 
@@ -81,25 +88,30 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 
 	return (
 		<label
-			className={ classnames( 'domain-picker__suggestion-item', {
-				'is-free': isFree,
-				'is-selected': selected,
-				'is-unavailable': isUnavailable,
-			} ) }
-		>
-			{ isLoading ? (
-				<Spinner />
-			) : (
-				<input
-					aria-labelledby={ labelId }
-					className="domain-picker__suggestion-radio-button"
-					type="radio"
-					disabled={ isUnavailable }
-					name="domain-picker-suggestion-option"
-					onChange={ onDomainSelect }
-					checked={ selected && ! isUnavailable }
-				/>
+			className={ classnames(
+				'domain-picker__suggestion-item',
+				{
+					'is-free': isFree,
+					'is-selected': selected,
+					'is-unavailable': isUnavailable,
+				},
+				`type-{ type }`
 			) }
+		>
+			{ type === ITEM_TYPE_RADIO &&
+				( isLoading ? (
+					<Spinner />
+				) : (
+					<input
+						aria-labelledby={ labelId }
+						className="domain-picker__suggestion-radio-button"
+						type="radio"
+						disabled={ isUnavailable }
+						name="domain-picker-suggestion-option"
+						onChange={ onDomainSelect }
+						checked={ selected && ! isUnavailable }
+					/>
+				) ) }
 			<div className="domain-picker__suggestion-item-name">
 				<div className="domain-picker__suggestion-item-name-inner">
 					<span className="domain-picker__domain-name">{ domainName }</span>
@@ -171,6 +183,26 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					</>
 				) }
 			</div>
+			{ type === ITEM_TYPE_BUTTON &&
+				( isLoading ? (
+					<Spinner />
+				) : (
+					<div className="domain-picker__action">
+						<Button
+							isSecondary
+							aria-labelledby={ labelId }
+							className={ classnames( 'domain-picker__suggestion-select-button', {
+								'is-selected': selected && ! isUnavailable,
+							} ) }
+							disabled={ isUnavailable }
+							onClick={ onDomainSelect }
+						>
+							{ selected && ! isUnavailable
+								? __( 'Selected', __i18n_text_domain__ )
+								: __( 'Select', __i18n_text_domain__ ) }
+						</Button>
+					</div>
+				) ) }
 		</label>
 	);
 };

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -16,8 +16,6 @@ import { Button } from '@wordpress/components';
  * Internal dependencies
  */
 import InfoTooltip from '../info-tooltip';
-// TODO: remove when all needed core types are available
-/*#__PURE__*/ import '../types-patch';
 
 export const ITEM_TYPE_RADIO = 'radio';
 export const ITEM_TYPE_BUTTON = 'button';

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -16,6 +16,8 @@ import { Button } from '@wordpress/components';
  * Internal dependencies
  */
 import InfoTooltip from '../info-tooltip';
+// TODO: remove when all needed core types are available
+/*#__PURE__*/ import '../types-patch';
 
 export const ITEM_TYPE_RADIO = 'radio';
 export const ITEM_TYPE_BUTTON = 'button';

--- a/packages/domain-picker/src/index.tsx
+++ b/packages/domain-picker/src/index.tsx
@@ -2,3 +2,5 @@
  * Internal dependencies
  */
 export { default, Props } from './domain-picker';
+export { ITEM_TYPE_RADIO, ITEM_TYPE_BUTTON } from './domain-picker/suggestion-item';
+export type { SUGGESTION_ITEM_TYPE } from './domain-picker/suggestion-item';

--- a/packages/domain-picker/src/types-patch.ts
+++ b/packages/domain-picker/src/types-patch.ts
@@ -1,7 +1,0 @@
-declare module '@wordpress/compose' {
-	type breakpoint = 'huge' | 'wide' | 'large' | 'medium' | 'small' | 'mobile';
-	type operator = '>=' | '<';
-	export function useViewportMatch( viewport: breakpoint, operator?: operator ): boolean;
-}
-
-export {};

--- a/packages/domain-picker/src/types-patch.ts
+++ b/packages/domain-picker/src/types-patch.ts
@@ -1,0 +1,7 @@
+declare module '@wordpress/compose' {
+	type breakpoint = 'huge' | 'wide' | 'large' | 'medium' | 'small' | 'mobile';
+	type operator = '>=' | '<';
+	export function useViewportMatch( viewport: breakpoint, operator?: operator ): boolean;
+}
+
+export {};


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Add select button to domain picker.
* Make domain price aligned in the middle (2:1 ratio between domain name and domain price).

**Selected Label**

Currently the select button behaves like radio button because it is the role of the implementor to decide what to do once a domain is selected by listening to the `onSelect` event, e.g. go back to the main focused launch page.

So for now, when select button is clicked, the button label turns from "Select" to "Selected". This is not part of the design but is necessary.

**Mobile**

There is no mobile version implemented for this one as this is only intended for desktop. We will decide how to switch between Select button and tapping the entire row for mobile in another PR.

**Usage**

The usage would look like this when integrated with focused launch.

```js
import DomainPicker, { ITEM_TYPE_BUTTON } from '@automattic/domain-picker';

function handleSelect = () => {
    // go back to focused launch main page
}
<DomainPicker itemType={ ITEM_TYPE_BUTTON } onSelect={ handleSelect } />
<!-- or -->
<DomainPicker itemType="button" onSelect={ handleSelect } />
```

## Testing instructions

* Modify `ITEM_TYPE_RADIO` to `ITEM_TYPE_BUTTON` in `packages/domain-picker/src/domain-picker/index.tsx`.
* Go to `/new/domains`.
* Select button should appear. Radio button should not be present.
* No regression should be introduced to `/new/domain` without any modification and step-by-step launch flow. Editing Toolkit build and sync would be needed to test the latter.

## Screenshot

![image](https://user-images.githubusercontent.com/1287077/97701660-0bd3e580-1aae-11eb-96a7-0b8a3d0f533c.png)


Fixes part of #46866
