### PR TITLE
Show discounted yearly price in pricing page i2

### DIFF
--- a/client/my-sites/plans-v2/product-card-alt-2/index.tsx
+++ b/client/my-sites/plans-v2/product-card-alt-2/index.tsx
@@ -65,7 +65,11 @@ const ProductCardAltWrapper: FunctionComponent< ProductCardProps > = ( {
 	}, [ item.productSlug, sitePlan, siteProducts ] );
 
 	// Calculate the product price.
-	const { originalPrice } = useItemPrice( siteId, item, item?.monthlyProductSlug || '' );
+	const { originalPrice, discountedPrice } = useItemPrice(
+		siteId,
+		item,
+		item?.monthlyProductSlug || ''
+	);
 
 	// Handles expiry.
 	const moment = useLocalizedMoment();
@@ -106,6 +110,7 @@ const ProductCardAltWrapper: FunctionComponent< ProductCardProps > = ( {
 				showRecordsDetails && <RecordsDetailsAlt productSlug={ item.productSlug } />
 			}
 			originalPrice={ originalPrice }
+			discountedPrice={ discountedPrice }
 			isOwned={ isOwned }
 			isDeprecated={ item.legacy }
 			className={ className }

--- a/client/my-sites/plans-v2/use-item-price.ts
+++ b/client/my-sites/plans-v2/use-item-price.ts
@@ -111,7 +111,7 @@ const useItemPrice = (
 
 	// Jetpack CRM price won't come from the API, so we need to hard-code it for now.
 	if ( item && [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes( item.productSlug ) ) {
-		discountedPrice = -1;
+		discountedPrice = item.displayPrice || -1;
 		originalPrice = item.displayPrice || -1;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes a bug that displayed monthly prices when the yearly option was selected.

### Testing instructions

- Download the PR
- Run Calypso and cloud concurrently
- Make sure the variant `v2 - slide outs` is selected in the `jetpackConversionRateOptimization` A/B test
- Visit the plans page
- Check that yearly prices are lower than monthly prices (except for Jetpack CRM Entrepreneur)