### PR TITLE
Editing Toolkit: Add a workaround to prevent slider blocks breaking the editor at full width

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -61,6 +61,27 @@ function is_homepage_title_hidden() {
 }
 
 /**
+ * Detects if the site is using Gutenberg 9.2 or above, which contains a bug in the
+ * interface package, causing some "slider" blocks (such as Jetpack's Slideshow) to
+ * incorrectly calculate their width as 33554400px when set at full width.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/26552
+ *
+ * @return bool True if the site needs a temporary fix for the incorrect slider width.
+ */
+function needs_slider_width_workaround() {
+	$gutenberg_path = ABSPATH . 'wp-content/plugins/gutenberg/gutenberg.php';
+	if ( ! file_exists( $gutenberg_path ) ) {
+		return false;
+	}
+	$gutenberg_data = get_plugin_data( $gutenberg_path );
+	if ( version_compare( $gutenberg_data['Version'], '9.2', '>=' ) ) {
+		return true;
+	}
+	return false;
+}
+
+/**
  * Detects if assets for the common module should be loaded.
  *
  * It should return true if any of the features added to the common module need
@@ -72,7 +93,7 @@ function is_homepage_title_hidden() {
  * @return bool True if the common module assets should be loaded.
  */
 function should_load_assets() {
-	return (bool) is_homepage_title_hidden();
+	return (bool) is_homepage_title_hidden() || needs_slider_width_workaround();
 }
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -70,12 +70,10 @@ function is_homepage_title_hidden() {
  * @return bool True if the site needs a temporary fix for the incorrect slider width.
  */
 function needs_slider_width_workaround() {
-	$gutenberg_path = ABSPATH . 'wp-content/plugins/gutenberg/gutenberg.php';
-	if ( ! file_exists( $gutenberg_path ) ) {
-		return false;
-	}
-	$gutenberg_data = get_plugin_data( $gutenberg_path );
-	if ( version_compare( $gutenberg_data['Version'], '9.2', '>=' ) ) {
+	if (
+		( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE ) ||
+		( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '9.2', '>=' ) )
+	) {
 		return true;
 	}
 	return false;

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
@@ -9,3 +9,7 @@ body.hide-homepage-title {
 		margin-top: 64px;
 	}
 }
+
+.interface-interface-skeleton__editor {
+	max-width: 100%;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a 100% max width to `.interface-interface-skeleton__editor` to prevent some "slider" blocks to incorrectly calculate their width to 33554400px when aligned at full width.

This is a workaround derived from https://github.com/WordPress/gutenberg/pull/26552, and already included in Jetpack (https://github.com/Automattic/jetpack/pull/17645, to be released on 2020-01-10).

The reason to add it to the Editing Toolkit is to be able to immediately release it to Atomic sites.

#### Testing instructions

Note: this is already fixed on Simple sites, so please test it on Atomic or local WordPress installs with Jetpack and/or CoBlocks installed.

- Before applying this change, open the editor.
- Add a Jetpack Slideshow block or a CoBlocks Post Carousel block.
- Set it to full width, and notice how it "breaks" the editor width.
- Apply this change, and reload the editor.
- Notice that the block, at full width, doesn't break the editor anymore, and is only as wide as the available space.
- You can also double-check the page code, by searching for the `interface-interface-skeleton__editor` element, and make sure it has `max-width: 100%`.

Fixes p9N30q-2GL-p2