### PR TITLE
WIP: Uses the promise version of user fetch

### DIFF
--- a/client/lib/signup/step-actions/fetch-sites-and-user.js
+++ b/client/lib/signup/step-actions/fetch-sites-and-user.js
@@ -36,9 +36,6 @@ function fetchSitesUntilSiteAppears( siteSlug, reduxStore, callback ) {
 export function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {
 	Promise.all( [
 		promisify( fetchSitesUntilSiteAppears )( siteSlug, reduxStore ),
-		new Promise( ( resolve ) => {
-			user().once( 'change', resolve );
-			user().fetch();
-		} ),
+		user().fetch(),
 	] ).then( onComplete );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#### Testing Instructions

Without this PR, test in production first:
https://wordpress.com/start

- Enter signup flow in an incognito window.
- Register new account and make your way to the plans page.
- Reload the page.
- Choose a plan.

Do you get stuck on this page?

<img width="500" alt="Screen Shot 2020-10-30 at 12 55 12" src="https://user-images.githubusercontent.com/1563559/97734406-83eedb00-1aaf-11eb-9b52-2011b90f8cac.png">

**Now test with this PR. Still an issue?**
https://calypso.live/start?branch=try/fetch-site-user-fix

---

## Why is this a fix?

@jaswrks writes...

This resolves the issue for me. I don't understand why, though. It's definitely cleaner this way, but the promise chain in `user.fetch()` was already triggering `user.handleFetchSuccess()`, which was emitting the change event every time. Why does this fix it? https://github.com/Automattic/wp-calypso/blob/d682d34136b055b7c392ab3586f94c77de6a6411/client/lib/user/user.js#L134

@taggon writes...

> There’s a kind of race condition. So an event handler at the previous line user.once( 'change', ...)  is triggered and cleared at an unexpected moment for some reason, which causes the endless pending promise.

This corrects the issue for me, so I'm good with it! Would love to dig deeper into this afterward, though. Mainly curious to know if this has had a impact previously, and for how long. Race conditions are super tricky.