### PR TITLE
Purchases: Add upgrade button

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -56,6 +56,7 @@ import {
 	isPersonal,
 	isPremium,
 	isBusiness,
+	isEcommerce,
 	isPlan,
 	isDomainProduct,
 	isDomainRegistration,
@@ -237,6 +238,37 @@ class ManagePurchase extends Component {
 		);
 	}
 
+	handleUpgradeClick = () => {
+		const { purchase } = this.props;
+
+		recordTracksEvent( 'calypso_purchases_upgrade_plan', {
+			status: isExpired( purchase ) ? 'expired' : 'active',
+			plan: purchase.productName,
+		} );
+	};
+
+	renderUpgradeNavItem() {
+		const { purchase, translate, siteId } = this.props;
+		const buttonText = isExpired( purchase )
+			? translate( 'Pick another plan' )
+			: translate( 'Upgrade plan' );
+
+		if ( ! isPlan( purchase ) || isEcommerce( purchase ) ) {
+			return null;
+		}
+
+		return (
+			<CompactCard
+				tagName="button"
+				displayAsLink
+				href={ `/plans/${ siteId }/` }
+				onClick={ this.handleUpgradeClick }
+			>
+				{ buttonText }
+			</CompactCard>
+		);
+	}
+
 	renderSelectNewNavItem() {
 		const { translate, siteId } = this.props;
 
@@ -246,6 +278,10 @@ class ManagePurchase extends Component {
 			</CompactCard>
 		);
 	}
+
+	handleEditPaymentMethodNavItem = () => {
+		recordTracksEvent( 'calypso_purchases_edit_payment_method' );
+	};
 
 	renderEditPaymentMethodNavItem() {
 		const { purchase, translate, siteSlug, getEditPaymentMethodUrlFor } = this.props;
@@ -267,7 +303,7 @@ class ManagePurchase extends Component {
 			}
 
 			return (
-				<CompactCard href={ path }>
+				<CompactCard href={ path } onClick={ this.handleEditPaymentMethodNavItem }>
 					{ hasPaymentMethod( purchase )
 						? translate( 'Change Payment Method' )
 						: translate( 'Add Credit Card' ) }
@@ -600,6 +636,7 @@ class ManagePurchase extends Component {
 
 				{ isProductOwner && preventRenewal && this.renderSelectNewNavItem() }
 				{ isProductOwner && ! preventRenewal && this.renderRenewNowNavItem() }
+				{ isProductOwner && ! preventRenewal && this.renderUpgradeNavItem() }
 				{ isProductOwner && this.renderEditPaymentMethodNavItem() }
 				{ isProductOwner && this.renderCancelPurchaseNavItem() }
 				{ isProductOwner && this.renderRemovePurchaseNavItem() }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -250,8 +250,8 @@ class ManagePurchase extends Component {
 	renderUpgradeNavItem() {
 		const { purchase, translate, siteId } = this.props;
 		const buttonText = isExpired( purchase )
-			? translate( 'Pick another plan' )
-			: translate( 'Upgrade plan' );
+			? translate( 'Pick Another Plan' )
+			: translate( 'Upgrade Plan' );
 
 		if ( ! isPlan( purchase ) || isEcommerce( purchase ) ) {
 			return null;

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -55,6 +55,7 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { canEditPaymentDetails, isDataLoading } from '../utils';
 import { TERM_BIENNIALLY, TERM_MONTHLY, JETPACK_LEGACY_PLANS } from 'calypso/lib/plans/constants';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 class PurchaseMeta extends Component {
 	static propTypes = {
@@ -237,6 +238,10 @@ class PurchaseMeta extends Component {
 		return translate( 'None' );
 	}
 
+	handleEditPaymentMethodClick = () => {
+		recordTracksEvent( 'calypso_purchases_edit_payment_method' );
+	};
+
 	renderPaymentDetails() {
 		const { purchase, translate, getEditPaymentMethodUrlFor, siteSlug } = this.props;
 
@@ -262,7 +267,12 @@ class PurchaseMeta extends Component {
 
 		return (
 			<li>
-				<a href={ getEditPaymentMethodUrlFor( siteSlug, purchase ) }>{ paymentDetails }</a>
+				<a
+					href={ getEditPaymentMethodUrlFor( siteSlug, purchase ) }
+					onClick={ this.handleEditPaymentMethodClick }
+				>
+					{ paymentDetails }
+				</a>
 			</li>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds an upgrade button, and some tracking events, to the plan settings screen.

**Before**
![image](https://user-images.githubusercontent.com/6981253/97727657-0a52ef00-1aa7-11eb-9fad-f91e6b3191f4.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/97727600-fc04d300-1aa6-11eb-8f11-787ee473fff9.png)


#### Testing instructions

- Pick a plan and manage your subscription. Confirm there is an upgrade button and that it takes you to the plans, and fires an event, when you click on it.
- Manage a subscription for an eCommerce plan and confirm there is no upgrade button.
- Pick a domain or any non-plan product and confirm that there's no upgrade button.
