### PR TITLE
Adds `(Host)` and `(Points to)` to the CNAME DNS editor

### DIFF
--- a/client/my-sites/domains/domain-management/dns/cname-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/cname-record.jsx
@@ -49,7 +49,7 @@ class CnameRecord extends React.Component {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel>{ translate( 'Alias Of (Points to)' ) }</FormLabel>
+					<FormLabel>{ translate( 'Alias Of (Points To)' ) }</FormLabel>
 					<FormTextInput
 						name="data"
 						isError={ ! isDataValid }

--- a/client/my-sites/domains/domain-management/dns/cname-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/cname-record.jsx
@@ -33,7 +33,7 @@ class CnameRecord extends React.Component {
 		return (
 			<div className={ classes }>
 				<FormFieldset>
-					<FormLabel>{ translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
+					<FormLabel>{ translate( 'Name (Host)', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
 						placeholder={ translate( 'Enter subdomain (required)', {
@@ -49,7 +49,7 @@ class CnameRecord extends React.Component {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel>{ translate( 'Alias Of' ) }</FormLabel>
+					<FormLabel>{ translate( 'Alias Of (Points to)' ) }</FormLabel>
 					<FormTextInput
 						name="data"
 						isError={ ! isDataValid }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Improves the DNS editor when editing/creating CNAME records by adding `(Host)` after the `Name` label and `(Points to)` after `Alias of` label. This makes it easier for users that are already used to these descriptions at other providers.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch
- Navigate to the DNS editor for a domain
- Confirm the before and after images.

| Before | After |
| -------|--------|
| <img width="355" alt="Screenshot 2020-10-30 at 5 05 16 PM" src="https://user-images.githubusercontent.com/277661/97728785-418ac580-1ad2-11eb-8d89-4aba3951cd7e.png"> | <img width="347" alt="Screenshot 2020-10-30 at 5 04 35 PM" src="https://user-images.githubusercontent.com/277661/97728748-3768c700-1ad2-11eb-815f-4d18397508ce.png"> |
