### PR TITLE
Marketing Connections: Make the UI aware of the refresh-failed status

### DIFF
--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -64,7 +64,7 @@ const SharingServiceAction = ( {
 		if ( 'must-disconnect' === status ) {
 			warning = true;
 		}
-	} else if ( 'reconnect' === status ) {
+	} else if ( 'reconnect' === status || 'refresh-failed' === status ) {
 		label = translate( 'Reconnect', {
 			context: 'Sharing: Publicize reconnect pending button label',
 		} );

--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -182,20 +182,21 @@ class SharingServiceDescription extends Component {
 		} else if ( 'refresh-failed' === this.props.status ) {
 			if ( this.props.expires ) {
 				description = this.props.translate(
-					'We are unable to refresh your %(service)s token. Please reconnect before %(expiryDate)s',
+					'Your %(service)s connection has expired. This happens sometimes. Click the "Reconnect" button to fix it before %(expiryDate)s',
 					{
 						args: {
 							service: this.props.service.label,
 							expiryDate: this.props.moment( this.props.expires * 1000 ).format( 'll' ),
 						},
-						context: 'Sharing: Publicize',
 					}
 				);
 			} else {
-				description = this.props.translate( 'We are unable to refresh your %(service)s token.', {
-					args: { service: this.props.service.label },
-					context: 'Sharing: Publicize',
-				} );
+				description = this.props.translate(
+					'Your %(service)s connection has expired. This happens sometimes. Click the "Reconnect" button to fix it.',
+					{
+						args: { service: this.props.service.label },
+					}
+				);
 			}
 		} else if (
 			'function' === typeof this.props.descriptions[ this.props.service.ID.replace( /-/g, '_' ) ]

--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -180,7 +180,8 @@ class SharingServiceDescription extends Component {
 				context: 'Sharing: Publicize',
 			} );
 		} else if ( 'refresh-failed' === this.props.status ) {
-			if ( this.props.expires ) {
+			const nowInSeconds = Math.floor( Date.now() / 1000 );
+			if ( this.props.expires && this.props.expires > nowInSeconds ) {
 				description = this.props.translate(
 					'Please reconnect to %(service)s before your connection expires on %(expiryDate)s.',
 					{

--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -182,7 +182,7 @@ class SharingServiceDescription extends Component {
 		} else if ( 'refresh-failed' === this.props.status ) {
 			if ( this.props.expires ) {
 				description = this.props.translate(
-					'Your %(service)s connection has expired. This happens sometimes. Click the "Reconnect" button to fix it before %(expiryDate)s',
+					'Please reconnect to %(service)s before your connection expires on %(expiryDate)s.',
 					{
 						args: {
 							service: this.props.service.label,
@@ -192,7 +192,7 @@ class SharingServiceDescription extends Component {
 				);
 			} else {
 				description = this.props.translate(
-					'Your %(service)s connection has expired. This happens sometimes. Click the "Reconnect" button to fix it.',
+					'Your connection has expired. Please reconnect to %(service)s.',
 					{
 						args: { service: this.props.service.label },
 					}

--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -6,13 +6,19 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 
 class SharingServiceDescription extends Component {
 	static propTypes = {
 		descriptions: PropTypes.object,
 		numberOfConnections: PropTypes.number,
 		translate: PropTypes.func,
+		moment: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -173,6 +179,24 @@ class SharingServiceDescription extends Component {
 				args: { service: this.props.service.label },
 				context: 'Sharing: Publicize',
 			} );
+		} else if ( 'refresh-failed' === this.props.status ) {
+			if ( this.props.expires ) {
+				description = this.props.translate(
+					'We are unable to refresh your %(service)s token. Please reconnect before %(expiryDate)s',
+					{
+						args: {
+							service: this.props.service.label,
+							expiryDate: this.props.moment( this.props.expires * 1000 ).format( 'll' ),
+						},
+						context: 'Sharing: Publicize',
+					}
+				);
+			} else {
+				description = this.props.translate( 'We are unable to refresh your %(service)s token.', {
+					args: { service: this.props.service.label },
+					context: 'Sharing: Publicize',
+				} );
+			}
 		} else if (
 			'function' === typeof this.props.descriptions[ this.props.service.ID.replace( /-/g, '_' ) ]
 		) {
@@ -191,4 +215,4 @@ class SharingServiceDescription extends Component {
 	}
 }
 
-export default localize( SharingServiceDescription );
+export default localize( withLocalizedMoment( SharingServiceDescription ) );

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -27,7 +27,7 @@ import { getAvailableExternalAccounts, isServiceExpanded } from 'calypso/state/s
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import {
 	getKeyringConnectionsByName,
-	getBrokenKeyringConnectionsByName,
+	getRefreshableKeyringConnections,
 } from 'calypso/state/sharing/keyring/selectors';
 import {
 	getBrokenSiteUserConnectionsForService,
@@ -634,10 +634,10 @@ export function connectFor( sharingService, mapStateToProps, mapDispatchToProps 
 				userId,
 				service.ID
 			);
-			const brokenKeyringConnections = getBrokenKeyringConnectionsByName( state, service.ID );
+			const refreshableConnections = getRefreshableKeyringConnections( state, service.ID );
 			const props = {
 				availableExternalAccounts: getAvailableExternalAccounts( state, service.ID ),
-				brokenConnections: brokenPublicizeConnections.concat( brokenKeyringConnections ),
+				brokenConnections: brokenPublicizeConnections.concat( refreshableConnections ),
 				isFetching: isFetchingConnections( state, siteId ),
 				keyringConnections: getKeyringConnectionsByName( state, service.ID ),
 				removableConnections: getRemovableConnections( state, service.ID ),

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -4,6 +4,7 @@
 	}
 
 	.sharing-service__logo {
+		/* Flex is used here so if the description wraps it stays aligned */
 		flex: 0 0 auto;
 		margin-right: 8px;
 	}

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -1,6 +1,10 @@
 .foldable-card.sharing-service {
+	.foldable-card__main > div {
+		display: flex;
+	}
+
 	.sharing-service__logo {
-		float: left;
+		flex: 0 0 auto;
 		margin-right: 8px;
 	}
 

--- a/client/state/sharing/keyring/schema.js
+++ b/client/state/sharing/keyring/schema.js
@@ -8,7 +8,7 @@ export const itemSchema = {
 			properties: {
 				ID: { type: 'integer' },
 				additional_external_users: { type: 'array' },
-				expires: { type: 'string' },
+				expires: { type: [ 'number', 'boolean' ] },
 				external_ID: { type: [ 'string', 'null' ] },
 				external_display: { type: [ 'string', 'null' ] },
 				external_name: { type: [ 'string', 'null' ] },

--- a/client/state/sharing/keyring/selectors.js
+++ b/client/state/sharing/keyring/selectors.js
@@ -57,6 +57,21 @@ export function getBrokenKeyringConnectionsByName( state, service ) {
 }
 
 /**
+ * Returns an array of keyring connection objects for a specified service that
+ * need to be manually refreshed/reconnected.
+ *
+ * @param  {object} state   Global state tree
+ * @param  {string} service Service slug.
+ * @returns {Array}         Keyring connections, if any.
+ */
+export function getRefreshableKeyringConnections( state, service ) {
+	return filter(
+		getKeyringConnectionsByName( state, service ),
+		( conn ) => 'broken' === conn.status || 'refresh-failed' === conn.status
+	);
+}
+
+/**
  * Returns an array of keyring connection objects for a specific user.
  *
  * @param  {object} state  Global state tree


### PR DESCRIPTION
Instagram, Facebook and possibly other, tokens need to be refreshed on a
regular basis. If we aren't able to, we should indicate that the
connection will break after the token expiry date.

#### Changes proposed in this Pull Request

This is the front end changes to D52030-code, which sets adds the
`refresh-failed` status to the API endpoint. As such this PR should be
merged before the backend changes.

If the connection is returned as having the `refresh-failed` status then
we treat it like a broken connection, displaying the 'Reconnect' button,
and a message about when the connection is due to expire.

#### Testing instructions

* Apply D52030-code to your sandbox, and follow the instructions there to place your Instagram connection in the required state.
* Using this branch, check the display of the connection in `/marketing/connections`. It should look similar to this:

<img width="1051" alt="image" src="https://user-images.githubusercontent.com/96462/98747995-9a9b0900-23b0-11eb-9e01-810bd53fe508.png">

* Check that you can go through the reconnection flow and return to a standard connected state

