### PR TITLE
Notifications: Fix orphan text nodes

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -352,7 +352,7 @@ function recurse_convert( text, ranges, options ) {
 			for ( let i = ranges[ id ].indices[ 0 ]; i < ranges[ id ].indices[ 1 ]; i++ ) {
 				t[ i ].index.push( { id: id, len: range_len } );
 			}
-		} else if ( typeof t[ ranges[ id ].indices[ 0 ] ] !== 'undefined' ) {
+		} else {
 			t[ ranges[ id ].indices[ 0 ] ].index.push( { id: id, len: range_len } );
 		}
 		// Clear out the currently-selected range so that it won't

--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -232,13 +232,10 @@ function build_chunks( sub_text, sub_ranges, range_data, container, options ) {
 				}
 			}
 
-			// Since we've picked a range we'll record some information for future reference
-			const range_info = range_data[ range.id ]; // the origin range data
-			const new_sub_text = sub_text.substring( i, i + range.len ); // the text we will be recursing with
-			const new_sub_range = sub_ranges.slice( i, i + ( range.len > 0 ? range.len : 1 ) ); // the new ranges we'll be recursing with
-
-			// Remove empty ranges processed on this iteration so they are not picked on next iteration.
-			ranges[ i ].index = ranges[ i ].index.filter( ( sub_range ) => sub_range.len > 0 );
+			// Since we've picked a range we'll record some information for future reference.
+			const range_info = range_data[ range.id ]; // The origin range data.
+			const new_sub_text = sub_text.substring( i, i + range.len ); // The text we will be recursing with.
+			const new_sub_range = sub_ranges.slice( i, i + ( range.len > 0 ? range.len : 1 ) ); // The new ranges we'll be recursing with.
 
 			for ( let j = 0; j < new_sub_range.length; j++ ) {
 				new_sub_range[ j ].index = new_sub_range[ j ].index.filter( ( new_range ) => {
@@ -253,11 +250,6 @@ function build_chunks( sub_text, sub_ranges, range_data, container, options ) {
 						return false;
 					}
 
-					// Remove empty ranges if we've picked a non-empty range.
-					if ( range.len > 0 && new_range.len === 0 ) {
-						return false;
-					}
-
 					return true;
 				} );
 			}
@@ -266,7 +258,12 @@ function build_chunks( sub_text, sub_ranges, range_data, container, options ) {
 				render_range( new_sub_text, new_sub_range, range_info, range_data, options )
 			);
 
-			i += range.len - 1; // the position we will be jumping to after recursing
+			// Remove empty ranges from the current position so they are not picked again during the
+			// next iteration if the position doesn't change (only possible if the picked range for
+			// the current iteration is empty).
+			ranges[ i ].index = ranges[ i ].index.filter( ( sub_range ) => sub_range.len > 0 );
+
+			i += range.len - 1; // The position we will be jumping to after recursing.
 		}
 	}
 	if ( text_start != null ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Refactors how the empty ranges are handled by notifications in order to properly display the text nodes.

Before | After
--- | ---
<img width="400" alt="Screen Shot 2020-11-09 at 16 29 25" src="https://user-images.githubusercontent.com/1233880/98562583-84a32080-22aa-11eb-8e9b-55b1d51b3457.png"> | <img width="398" alt="Screen Shot 2020-11-09 at 16 29 33" src="https://user-images.githubusercontent.com/1233880/98562597-8836a780-22aa-11eb-8d50-e1402432c0cd.png">
<img width="392" alt="Screen Shot 2020-11-09 at 16 30 13" src="https://user-images.githubusercontent.com/1233880/98562620-8e2c8880-22aa-11eb-8365-f5549dd2e686.png"> | <img width="405" alt="Screen Shot 2020-11-09 at 16 30 33" src="https://user-images.githubusercontent.com/1233880/98562644-91277900-22aa-11eb-9836-a147ec1d6922.png">
<img width="400" alt="Screen Shot 2020-11-09 at 16 31 14" src="https://user-images.githubusercontent.com/1233880/98562663-95ec2d00-22aa-11eb-8ca7-023df42280ed.png"> | <img width="399" alt="Screen Shot 2020-11-09 at 16 31 32" src="https://user-images.githubusercontent.com/1233880/98562681-997fb400-22aa-11eb-80f2-d70db23506cb.png">
<img width="397" alt="Screen Shot 2020-11-09 at 16 31 57" src="https://user-images.githubusercontent.com/1233880/98562722-a4d2df80-22aa-11eb-85c6-2eb59d55daf1.png"> | <img width="400" alt="Screen Shot 2020-11-09 at 16 32 13" src="https://user-images.githubusercontent.com/1233880/98562750-adc3b100-22aa-11eb-8a81-17081c619021.png">
<img width="399" alt="Screen Shot 2020-11-09 at 16 32 38" src="https://user-images.githubusercontent.com/1233880/98562773-b320fb80-22aa-11eb-9895-6d3976d66597.png"> | <img width="398" alt="Screen Shot 2020-11-09 at 16 32 53" src="https://user-images.githubusercontent.com/1233880/98562791-b916dc80-22aa-11eb-953c-feaaefa6d506.png">


#### Testing instructions

- Sandbox the API and apply D52453-code and D52422-code.
- Create a variety of posts containing blocks affected by the issues noted in https://github.com/Automattic/wp-calypso/issues/46961:
  - File block.
  - Blocks with `figcaption` elements (e.g. Gallery block).
  - Separator block.
  - HTML block.
  - Posts without title.
- Make sure they are displayed correctly.

Fixes https://github.com/Automattic/wp-calypso/issues/46961