### PR TITLE
Persistent Launch Button: add translators hint for button label

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -132,6 +132,11 @@ function updateEditor() {
 		launchLink.target = '_top';
 		launchLink.className = 'editor-gutenberg-launch__launch-button components-button is-primary';
 
+		/*
+		 * translators: "Launch" here refers to launching a whole site.
+		 * Please translate differently from "Publish", which intstead
+		 * refers to publishing a page.
+		 */
 		const textContent = document.createTextNode( __( 'Launch', 'full-site-editing' ) );
 		launchLink.appendChild( textContent );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a comment in the code to hint that the "Launch" button should have an explicit, different translation from the "Publish" button

#### Testing instructions

N/A