### PR TITLE
CRO i2: Add tracking events to plans slide-out products.

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/features-item.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/features-item.tsx
@@ -10,8 +10,6 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import Gridicon from 'calypso/components/gridicon';
 import FeaturesProductSlideOut from './features-product-slide-out';
 import InfoPopover from 'calypso/components/info-popover';

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/features-item.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/features-item.tsx
@@ -4,7 +4,6 @@
 import classNames from 'classnames';
 import { isObject } from 'lodash';
 import React, { FunctionComponent, useState, useCallback, useEffect, useRef } from 'react';
-
 import { useTranslate } from 'i18n-calypso';
 import { Button } from '@wordpress/components';
 
@@ -45,11 +44,10 @@ const JetpackProductCardFeaturesItem: FunctionComponent< Props > = ( {
 	billingTerm,
 	onProductClick,
 } ) => {
-	const translate = useTranslate();
-
 	const { icon, text, description, isHighlighted, slug } = item;
 	const iconName = ( isObject( icon ) ? icon?.icon : icon ) || DEFAULT_ICON;
 	const Icon = ( ( isObject( icon ) && icon?.component ) || Gridicon ) as IconComponent;
+	const translate = useTranslate();
 
 	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/features-product-slide-out.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/features-product-slide-out.tsx
@@ -4,6 +4,7 @@
 import React, { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
+import classNames from 'classnames';
 import formatCurrency from '@automattic/format-currency';
 
 /**
@@ -29,12 +30,14 @@ import type { Duration, PurchaseCallback, SelectorProduct } from 'calypso/my-sit
 type Props = {
 	product: SelectorProduct;
 	productBillingTerm: Duration;
+	isOpen: boolean;
 	onProductClick: PurchaseCallback;
 };
 
 const FeaturesProductSlideOut: FunctionComponent< Props > = ( {
 	product,
 	productBillingTerm,
+	isOpen,
 	onProductClick,
 } ) => {
 	const {
@@ -93,21 +96,29 @@ const FeaturesProductSlideOut: FunctionComponent< Props > = ( {
 				},
 		  } );
 
-	return product ? (
-		<JetpackProductSlideOutCard
-			iconSlug={ iconSlug }
-			productName={ displayName }
-			currencyCode={ currencyCode }
-			price={ Math.floor( ( displayPrice || price ) as number ) }
-			billingTimeFrame={ durationToText( displayTerm || productBillingTerm ) }
-			description={ description }
-			buttonLabel={ slideOutButtonLabel }
-			onButtonClick={ () => onProductClick( product, false, purchase ) }
-			buttonPrimary={ ! isOwned }
-			isOwned={ isOwned }
-			badgeLabel={ productBadgeLabelAlt( product, isItemPurchased, sitePlan ) }
-		/>
-	) : null;
+	return (
+		<div
+			className={ classNames( 'jetpack-product-card-alt-2__slide-out-product', {
+				expanded: isOpen,
+			} ) }
+		>
+			{ isOpen && (
+				<JetpackProductSlideOutCard
+					iconSlug={ iconSlug }
+					productName={ displayName }
+					currencyCode={ currencyCode }
+					price={ Math.floor( ( displayPrice || price ) as number ) }
+					billingTimeFrame={ durationToText( displayTerm || productBillingTerm ) }
+					description={ description }
+					buttonLabel={ slideOutButtonLabel }
+					onButtonClick={ () => onProductClick( product, false, purchase ) }
+					buttonPrimary={ ! isOwned }
+					isOwned={ isOwned }
+					badgeLabel={ productBadgeLabelAlt( product, isItemPurchased, sitePlan ) }
+				/>
+			) }
+		</div>
+	);
 };
 
 export default FeaturesProductSlideOut;

--- a/client/components/jetpack/card/jetpack-product-card-alt/features.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt/features.tsx
@@ -19,7 +19,7 @@ import type {
 	ProductCardFeatures,
 	ProductCardFeaturesSection,
 	ProductCardFeaturesItem,
-} from './types';
+} from 'calypso/components/jetpack/card/jetpack-product-card-alt-2/types';
 
 export type Props = {
 	className?: string;


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds Tracks tracking events to the "Learn more"(open) and "Close" actions of the product slide-outs in the features-list of all plans. 

- Add the `calypso_product_slideout_open` Tracks event to fire when product slide-outs are opened and `calypso_product_slideout_close` when they are closed, with parameters for the current site ID and the specific product_slug that was opened.

#### Additional changes:
- Refactored & cleaned up code a little bit`:
    - Added `useOpenClose()` custom hook in `features-item.tsx`
    - Moved the slide-out open/close functionality into `FeaturesProductSlideOut` component by adding an `isOpen` prop.

### Testing instructions

- Checkout this branch, yarn start Calypso and jetpack.cloud concurrently.
- make sure `v2` is selected from the `jetpackConversionRateOptimization` A/B test.

Open and close all the slide-out products.

A Tracks event should fire for each time a slide-out product is opened and closed, with the following parameters:
* `name`: `calypso_product_slideout_open` when opened, and `calypso_product_slideout_closed` when closed.
* `site_id`: the current site ID
* `product_slug`: a slug that corresponds to the slide-out product you opened/closed.

Test in Calypso, Jetpack Cloud, and Jetpack Connect,

**TIP:** You can enable debugging to examine Tracks events by running `localStorage.debug = 'calypso:analytics'` in your browser's console.

![slide-outs (1)](https://user-images.githubusercontent.com/11078128/97753651-5572ff00-1ab3-11eb-99c0-934ca5082008.gif)


Fixes # 1196341175636977-as-1198514641268296/f