### PR TITLE
desktop: fix mistaken init removal

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -380,6 +380,10 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 		setupGlobalKeyboardShortcuts();
 	}
 
+	if ( config.isEnabled( 'desktop' ) ) {
+		require( 'calypso/lib/desktop' ).default.init();
+	}
+
 	if (
 		config.isEnabled( 'dev/test-helper' ) &&
 		document.querySelector( '.environment.is-tests' )


### PR DESCRIPTION
### Description

Whoops. In an earlier PR I erroneously deleted the desktop renderer `init` method as I was refactoring ([link](https://github.com/Automattic/wp-calypso/pull/46621/files#diff-a63ee371c7bc2ee8a7642920f46f27318abb705b367cd6fd5512739a832388ecL383-L386)). 🤦 Putting it back.

To emphasize: the intent of the original PR wasn't even to delete that piece of code - I was moving things around and totally spaced out on deleting this in its entirety.