### PR TITLE
Re-enable monthly pricing test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -213,7 +213,7 @@ export default {
 		countryCodeTargets: [ 'US' ],
 	},
 	monthlyPricing: {
-		datestamp: '20501030',
+		datestamp: '20201031',
 		variations: {
 			control: 90,
 			treatment: 10,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Re-enable monthly pricing test.
* Set to start at midnight tonite, UTC time. 🎃

#### Testing Instructions

- Open in incognito window: https://calypso.live/start?branch=update/monthly-pricing-test
- Register, make your way to the plans page, and add yourself to the monthly pricing test.
- When you arrive at checkout, add paid credits to the test account and complete checkout w/ a monthly plan.

Repeat the test in both `control` and `treatment` groups. Just a spot-check is OK. This has already been looked at by many in the previous release of this test.