### PR TITLE
Make text of Premium Content's Subscribe button editable

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
@@ -24,20 +24,23 @@ const alignmentHooksSetting = {
 	isEmbedButton: true,
 };
 
-function ButtonsEdit( {
-	context,
-	subscribeButton,
-	setSubscribeButtonPlan,
-} ) {
+function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 	const planId = context ? context[ 'premium-content/planId' ] : null;
 
 	const template = [
 		[
 			'jetpack/recurring-payments',
-			{
-				planId,
-				submitButtonText: __( 'Subscribe', 'full-site-editing' ),
-			},
+			{ planId },
+			[
+				[
+					'jetpack/button',
+					{
+						element: 'a',
+						uniqueId: 'recurring-payments-id',
+						text: __( 'Subscribe', 'full-site-editing' ),
+					},
+				],
+			],
 		],
 		[ 'premium-content/login-button' ],
 	];
@@ -52,7 +55,7 @@ function ButtonsEdit( {
 		if ( subscribeButton.attributes.planId !== planId ) {
 			setSubscribeButtonPlan( planId );
 		}
-	}, [ planId, subscribeButton ] );
+	}, [ planId, subscribeButton, setSubscribeButtonPlan ] );
 
 	// Hides the inspector controls of the Recurring Payments inner block acting as a subscribe button so users can only
 	// switch plans using the plan selector of the Premium Content block.

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
@@ -26,9 +26,7 @@ const alignmentHooksSetting = {
 
 function ButtonsEdit( {
 	context,
-	jetpackButton,
 	subscribeButton,
-	setSubscribeButtonText,
 	setSubscribeButtonPlan,
 } ) {
 	const planId = context ? context[ 'premium-content/planId' ] : null;
@@ -74,14 +72,6 @@ function ButtonsEdit( {
 		);
 	}, [ subscribeButton ] );
 
-	// Updates the subscribe button text.
-	useEffect( () => {
-		if ( ! jetpackButton ) {
-			return;
-		}
-		setSubscribeButtonText( __( 'Subscribe', 'full-site-editing' ) );
-	}, [ jetpackButton, setSubscribeButtonText ] );
-
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Block.div className="wp-block-buttons">
@@ -105,13 +95,7 @@ export default compose( [
 			.getBlock( props.clientId )
 			.innerBlocks.find( ( block ) => block.name === 'jetpack/recurring-payments' );
 
-		const jetpackButton = select( 'core/block-editor' )
-			.getBlock( subscribeButton.clientId )
-			.innerBlocks.find( ( block ) => block.name === 'jetpack/button' );
-		return {
-			subscribeButton,
-			jetpackButton,
-		};
+		return subscribeButton;
 	} ),
 	withDispatch( ( dispatch, props ) => ( {
 		/**
@@ -122,16 +106,6 @@ export default compose( [
 		setSubscribeButtonPlan( planId ) {
 			dispatch( 'core/block-editor' ).updateBlockAttributes( props.subscribeButton.clientId, {
 				planId,
-			} );
-		},
-		/**
-		 * Updates the button text on the Recurring Payments block acting as a subscribe button.
-		 *
-		 * @param text {string} Button text.
-		 */
-		setSubscribeButtonText( text ) {
-			dispatch( 'core/block-editor' ).updateBlockAttributes( props.jetpackButton.clientId, {
-				text,
 			} );
 		},
 	} ) ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Premium Content block's 'Subscribe' button text could not be edited; it reverts instantly back to 'Subscribe'. There was a hook configured to reset the text each time the component was updated. This PR removes that. There is also an update to the block to correctly initialize the button text to 'Subscribe' the _first_ time it is added.

#### Testing instructions

1. Create a new post
2. Add the Premium Content Block. By default you should have a "Subscribe" and "Log In" button.
3. Click into the "Subscribe" button and edit the text to say something else.
4. Your edit should persist when you click out of the button.
5. Save the post and verify that your edited button text displays correctly on the frontend.

*

Fixes #46347
