### PR TITLE
desktop ci: use css-loader cache only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ references:
     name: Save Calypso build cache
     key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
-      - .cache
+      - .cache/evergreen/css-loader
   desktop-notify-github-success: &desktop-notify-github-success
     name: Notify Github Success
     when: on_success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,13 +218,13 @@ references:
   desktop-restore-calypso-build-cache: &desktop-restore-calypso-build-cache
     name: Restore Calypso build cache
     keys:
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-trunk
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-trunk
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
   desktop-save-calypso-build-cache: &desktop-save-calypso-build-cache
     name: Save Calypso build cache
-    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - .cache/evergreen/css-loader
   desktop-notify-github-success: &desktop-notify-github-success


### PR DESCRIPTION
### Description

Limit cache to `.cache/evergreen/css-loader`.

|   | Cache Restore Time  | Cache Save Time   | Source Build Time | Total Build Time  | link |
|---|---|---|---|---|---|
| All .cache (1.6 GB)  | 3m 37s  | 7m 11s   | 4m 2s | 19m 17s | [example](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/79063/workflows/29ae8b4a-c061-4d04-b411-4eb8d994963f/jobs/939010) |
| css-loader only (1.1 mb)  |  0s | 1s ([link](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/79066/workflows/c0b75af6-ee97-490a-8aff-d0496232c60d/jobs/939027))   | 7m 31s  |  11m 40s | [example](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/79066/workflows/e64e5f3c-3dcd-4dc9-8621-59ac9adda3b4/jobs/939040) | 

Looks like the `.cache` folder has become rather bloated (1.6 GB!), to the extent that it eats up a significant chunk of CI runtime for the Desktop app (see above) because of the significant cache restoration and save times. By limiting the cache to `css-loader` only, looks like we can bring down build times by ~50%. (in the ballpark of where they were initially).