### PR TITLE
Checkout: Disable old checkout completely

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -12,7 +12,6 @@ import { ShoppingCartProvider } from '@automattic/shopping-cart';
  * Internal Dependencies
  */
 import wp from 'calypso/lib/wp';
-import CheckoutContainer from './checkout/checkout-container';
 import PrePurchaseNotices from './checkout/prepurchase-notices';
 import CompositeCheckout from './composite-checkout/composite-checkout';
 import { fetchStripeConfiguration } from './composite-checkout/payment-method-helpers';
@@ -30,7 +29,7 @@ const wpcom = wp.undocumented();
 const wpcomGetCart = ( ...args ) => wpcom.getCart( ...args );
 const wpcomSetCart = ( ...args ) => wpcom.setCart( ...args );
 
-// Decide if we should use CompositeCheckout or CheckoutContainer
+// Decide if we should use new or old checkout
 export default function CheckoutSystemDecider( {
 	productAliasFromUrl,
 	purchaseId,
@@ -54,8 +53,6 @@ export default function CheckoutSystemDecider( {
 	const translate = useTranslate();
 
 	const prepurchaseNotices = <PrePurchaseNotices />;
-
-	const checkoutVariant = getCheckoutVariant();
 
 	useEffect( () => {
 		if ( productAliasFromUrl ) {
@@ -104,80 +101,48 @@ export default function CheckoutSystemDecider( {
 	);
 	debug( 'cartKey is', cartKey );
 
-	if ( 'composite-checkout' === checkoutVariant ) {
-		let siteSlug = selectedSite?.slug;
+	let siteSlug = selectedSite?.slug;
 
-		if ( ! siteSlug ) {
-			siteSlug = 'no-site';
+	if ( ! siteSlug ) {
+		siteSlug = 'no-site';
 
-			if ( isLoggedOutCart || isNoSiteCart ) {
-				siteSlug = 'no-user';
-			}
+		if ( isLoggedOutCart || isNoSiteCart ) {
+			siteSlug = 'no-user';
 		}
-
-		const getCart =
-			isLoggedOutCart || isNoSiteCart ? () => Promise.resolve( otherCart ) : wpcomGetCart;
-		debug( 'getCart being controlled by', { isLoggedOutCart, isNoSiteCart, otherCart } );
-
-		return (
-			<>
-				<CheckoutErrorBoundary
-					errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
-					onError={ logCheckoutError }
-				>
-					<ShoppingCartProvider cartKey={ cartKey } getCart={ getCart } setCart={ wpcomSetCart }>
-						<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>
-							<CompositeCheckout
-								siteSlug={ siteSlug }
-								siteId={ selectedSite?.ID }
-								productAliasFromUrl={ productAliasFromUrl }
-								purchaseId={ purchaseId }
-								couponCode={ couponCode }
-								redirectTo={ redirectTo }
-								feature={ selectedFeature }
-								plan={ plan }
-								isComingFromUpsell={ isComingFromUpsell }
-								infoMessage={ prepurchaseNotices }
-								isLoggedOutCart={ isLoggedOutCart }
-								isNoSiteCart={ isNoSiteCart }
-							/>
-						</StripeHookProvider>
-					</ShoppingCartProvider>
-				</CheckoutErrorBoundary>
-				{ isLoggedOutCart && <Recaptcha badgePosition="bottomright" /> }
-			</>
-		);
 	}
+
+	const getCart =
+		isLoggedOutCart || isNoSiteCart ? () => Promise.resolve( otherCart ) : wpcomGetCart;
+	debug( 'getCart being controlled by', { isLoggedOutCart, isNoSiteCart, otherCart } );
 
 	return (
-		<CheckoutContainer
-			product={ productAliasFromUrl }
-			purchaseId={ purchaseId }
-			selectedFeature={ selectedFeature }
-			couponCode={ couponCode }
-			isComingFromSignup={ isComingFromSignup }
-			isComingFromGutenboarding={ isComingFromGutenboarding }
-			isGutenboardingCreate={ isGutenboardingCreate }
-			isComingFromUpsell={ isComingFromUpsell }
-			plan={ plan }
-			selectedSite={ selectedSite }
-			reduxStore={ reduxStore }
-			redirectTo={ redirectTo }
-			upgradeIntent={ upgradeIntent }
-			clearTransaction={ clearTransaction }
-			infoMessage={ prepurchaseNotices }
-		/>
+		<>
+			<CheckoutErrorBoundary
+				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
+				onError={ logCheckoutError }
+			>
+				<ShoppingCartProvider cartKey={ cartKey } getCart={ getCart } setCart={ wpcomSetCart }>
+					<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>
+						<CompositeCheckout
+							siteSlug={ siteSlug }
+							siteId={ selectedSite?.ID }
+							productAliasFromUrl={ productAliasFromUrl }
+							purchaseId={ purchaseId }
+							couponCode={ couponCode }
+							redirectTo={ redirectTo }
+							feature={ selectedFeature }
+							plan={ plan }
+							isComingFromUpsell={ isComingFromUpsell }
+							infoMessage={ prepurchaseNotices }
+							isLoggedOutCart={ isLoggedOutCart }
+							isNoSiteCart={ isNoSiteCart }
+						/>
+					</StripeHookProvider>
+				</ShoppingCartProvider>
+			</CheckoutErrorBoundary>
+			{ isLoggedOutCart && <Recaptcha badgePosition="bottomright" /> }
+		</>
 	);
-}
-
-function getCheckoutVariant() {
-	if ( config.isEnabled( 'old-checkout-force' ) ) {
-		debug( 'shouldShowCompositeCheckout false because old-checkout-force flag is set' );
-		return 'old-checkout';
-	}
-
-	debug( 'shouldShowCompositeCheckout true' );
-	return 'composite-checkout';
 }
 
 function fetchStripeConfigurationWpcom( args ) {

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -29,22 +29,15 @@ const wpcom = wp.undocumented();
 const wpcomGetCart = ( ...args ) => wpcom.getCart( ...args );
 const wpcomSetCart = ( ...args ) => wpcom.setCart( ...args );
 
-// Decide if we should use new or old checkout
 export default function CheckoutSystemDecider( {
 	productAliasFromUrl,
 	purchaseId,
 	selectedFeature,
 	couponCode,
-	isComingFromSignup,
-	isComingFromGutenboarding,
-	isGutenboardingCreate,
 	isComingFromUpsell,
 	plan,
 	selectedSite,
-	reduxStore,
 	redirectTo,
-	upgradeIntent,
-	clearTransaction,
 	isLoggedOutCart,
 	isNoSiteCart,
 	cart: otherCart,

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -93,16 +93,10 @@ export function checkout( context, next ) {
 				purchaseId={ purchaseId }
 				selectedFeature={ feature }
 				couponCode={ couponCode }
-				isComingFromSignup={ !! context.query.signup }
-				isComingFromGutenboarding={ !! context.query.preLaunch }
-				isGutenboardingCreate={ !! context.query.isGutenboardingCreate }
 				isComingFromUpsell={ !! context.query.upgrade }
 				plan={ plan }
 				selectedSite={ selectedSite }
-				reduxStore={ context.store }
 				redirectTo={ context.query.redirect_to }
-				upgradeIntent={ context.query.intent }
-				clearTransaction={ false }
 				isLoggedOutCart={ isLoggedOutCart }
 				isNoSiteCart={ isNoSiteCart }
 			/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the option to enter old checkout from the `CheckoutSystemDecider` (making the name of that component a little less semantic; it should probably later be changed to something like `CheckoutWrapper`).

This should have no effect since old checkout is already unused.

This also removes the major use of the `CheckoutContainer` component, although it is still in-use by the GSuite and plan upsell pages, so it cannot yet be removed completely.

#### Testing instructions

Visit checkout and be sure that it still shows up.