### PR TITLE
Checkout: Convert getPlanFeatures to TypeScript

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -44,11 +44,11 @@ import isPresalesChatAvailable from 'calypso/state/happychat/selectors/is-presal
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
 import isSupportVariationDetermined from 'calypso/state/selectors/is-support-variation-determined';
-import { isEnabled } from 'calypso/config';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import Gridicon from 'calypso/components/gridicon';
 import { getABTestVariation } from 'calypso/lib/abtest';
+import getPlanFeatures from '../lib/get-plan-features';
 
 export default function WPCheckoutOrderSummary( {
 	onChangePlanLength,
@@ -279,7 +279,7 @@ function CheckoutSummaryPlanFeatures( { isMonthlyPricingTest } ) {
 
 	return (
 		<>
-			{ planFeatures.filter( Boolean ).map( ( feature ) => {
+			{ planFeatures.map( ( feature ) => {
 				const isSupported = ! feature.startsWith( '~~' );
 				if ( ! isSupported ) {
 					feature = feature.substr( 2 );
@@ -294,122 +294,6 @@ function CheckoutSummaryPlanFeatures( { isMonthlyPricingTest } ) {
 			} ) }
 		</>
 	);
-}
-
-function getPlanFeatures(
-	plan,
-	translate,
-	hasDomainsInCart,
-	hasRenewalInCart,
-	isMonthlyPricingTest
-) {
-	const showFreeDomainFeature = ! hasDomainsInCart && ! hasRenewalInCart;
-	const productSlug = plan.wpcom_meta?.product_slug;
-
-	if ( ! productSlug ) {
-		return [];
-	}
-
-	const isMonthlyPlan = isMonthly( productSlug );
-	const liveChatSupport = translate( 'Live chat support' );
-	const freeOneYearDomain = showFreeDomainFeature && translate( 'Free domain for one year' );
-	const googleAnalytics = translate( 'Track your stats with Google Analytics' );
-	const annualPlanOnly = ( feature ) => {
-		if ( ! feature ) {
-			return null;
-		}
-
-		const label = translate( '(annual plans only)', {
-			comment: 'Label attached to a feature',
-		} );
-
-		return `~~${ feature } ${ label }`;
-	};
-
-	if ( isWpComPersonalPlan( productSlug ) ) {
-		if ( isMonthlyPricingTest ) {
-			return [
-				isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
-				translate( 'Email support' ),
-				translate( 'Dozens of Free Themes' ),
-			];
-		}
-
-		return [
-			freeOneYearDomain,
-			translate( 'Remove WordPress.com ads' ),
-			translate( 'Limit your content to paying subscribers.' ),
-		];
-	}
-
-	if ( isWpComPremiumPlan( productSlug ) ) {
-		if ( isMonthlyPricingTest ) {
-			return [
-				isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
-				isMonthlyPlan ? annualPlanOnly( liveChatSupport ) : liveChatSupport,
-				translate( 'Unlimited access to our library of Premium Themes' ),
-				isEnabled( 'earn/pay-with-paypal' )
-					? translate( 'Subscriber-only content and Pay with PayPal buttons' )
-					: translate( 'Subscriber-only content and payment buttons' ),
-				googleAnalytics,
-			];
-		}
-
-		return [
-			freeOneYearDomain,
-			translate( 'Unlimited access to our library of Premium Themes' ),
-			isEnabled( 'earn/pay-with-paypal' )
-				? translate( 'Subscriber-only content and Pay with PayPal buttons' )
-				: translate( 'Subscriber-only content and payment buttons' ),
-			googleAnalytics,
-		];
-	}
-
-	if ( isWpComBusinessPlan( productSlug ) ) {
-		if ( isMonthlyPricingTest ) {
-			return [
-				isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
-				isMonthlyPlan ? annualPlanOnly( liveChatSupport ) : liveChatSupport,
-				translate( 'Install custom plugins and themes' ),
-				translate( 'Drive traffic to your site with our advanced SEO tools' ),
-				translate( 'Track your stats with Google Analytics' ),
-				translate( 'Real-time backups and activity logs' ),
-			];
-		}
-
-		return [
-			freeOneYearDomain,
-			translate( 'Install custom plugins and themes' ),
-			translate( 'Drive traffic to your site with our advanced SEO tools' ),
-			translate( 'Track your stats with Google Analytics' ),
-			translate( 'Real-time backups and activity logs' ),
-		];
-	}
-
-	if ( isWpComEcommercePlan( productSlug ) ) {
-		if ( isMonthlyPricingTest ) {
-			return [
-				isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
-				isMonthlyPlan ? annualPlanOnly( liveChatSupport ) : liveChatSupport,
-				translate( 'Install custom plugins and themes' ),
-				translate( 'Accept payments in 60+ countries' ),
-				translate( 'Integrations with top shipping carriers' ),
-				translate( 'Unlimited products or services for your online store' ),
-				translate( 'eCommerce marketing tools for emails and social networks' ),
-			];
-		}
-
-		return [
-			freeOneYearDomain,
-			translate( 'Install custom plugins and themes' ),
-			translate( 'Accept payments in 60+ countries' ),
-			translate( 'Integrations with top shipping carriers' ),
-			translate( 'Unlimited products or services for your online store' ),
-			translate( 'eCommerce marketing tools for emails and social networks' ),
-		];
-	}
-
-	return [];
 }
 
 function getHighestWpComPlanLabel( plans ) {

--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -14,7 +14,7 @@ import {
 	isWpComPersonalPlan,
 	isWpComPremiumPlan,
 } from 'calypso/lib/plans';
-import { WPCOMCartItem } from '../types/checkout-cart';
+import type { WPCOMCartItem } from '../types/checkout-cart';
 
 export default function getPlanFeatures(
 	plan: WPCOMCartItem | undefined,

--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -1,0 +1,139 @@
+/**
+ * External dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { isEnabled } from 'calypso/config';
+import { isMonthly } from 'calypso/lib/plans/constants';
+import {
+	isWpComBusinessPlan,
+	isWpComEcommercePlan,
+	isWpComPersonalPlan,
+	isWpComPremiumPlan,
+} from 'calypso/lib/plans';
+import { WPCOMCartItem } from '../types/checkout-cart';
+
+export default function getPlanFeatures(
+	plan: WPCOMCartItem | undefined,
+	translate: ReturnType< typeof useTranslate >,
+	hasDomainsInCart: boolean,
+	hasRenewalInCart: boolean,
+	isMonthlyPricingTest: boolean
+): string[] {
+	const showFreeDomainFeature = ! hasDomainsInCart && ! hasRenewalInCart;
+	const productSlug = plan?.wpcom_meta?.product_slug;
+
+	if ( ! productSlug ) {
+		return [];
+	}
+
+	const isMonthlyPlan = isMonthly( productSlug );
+	const liveChatSupport = String( translate( 'Live chat support' ) );
+	const freeOneYearDomain = showFreeDomainFeature
+		? String( translate( 'Free domain for one year' ) )
+		: undefined;
+	const googleAnalytics = String( translate( 'Track your stats with Google Analytics' ) );
+	const annualPlanOnly = ( feature: string | undefined ): string | null => {
+		if ( ! feature ) {
+			return null;
+		}
+
+		const label = translate( '(annual plans only)', {
+			comment: 'Label attached to a feature',
+		} );
+
+		return `~~${ feature } ${ label }`;
+	};
+
+	if ( isWpComPersonalPlan( productSlug ) ) {
+		if ( isMonthlyPricingTest ) {
+			return [
+				isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
+				String( translate( 'Email support' ) ),
+				String( translate( 'Dozens of Free Themes' ) ),
+			].filter( doesValueExist );
+		}
+
+		return [
+			freeOneYearDomain,
+			String( translate( 'Remove WordPress.com ads' ) ),
+			String( translate( 'Limit your content to paying subscribers.' ) ),
+		].filter( doesValueExist );
+	}
+
+	if ( isWpComPremiumPlan( productSlug ) ) {
+		if ( isMonthlyPricingTest ) {
+			return [
+				isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
+				isMonthlyPlan ? annualPlanOnly( liveChatSupport ) : liveChatSupport,
+				String( translate( 'Unlimited access to our library of Premium Themes' ) ),
+				isEnabled( 'earn/pay-with-paypal' )
+					? String( translate( 'Subscriber-only content and Pay with PayPal buttons' ) )
+					: String( translate( 'Subscriber-only content and payment buttons' ) ),
+				googleAnalytics,
+			].filter( doesValueExist );
+		}
+
+		return [
+			freeOneYearDomain,
+			String( translate( 'Unlimited access to our library of Premium Themes' ) ),
+			isEnabled( 'earn/pay-with-paypal' )
+				? String( translate( 'Subscriber-only content and Pay with PayPal buttons' ) )
+				: String( translate( 'Subscriber-only content and payment buttons' ) ),
+			googleAnalytics,
+		].filter( doesValueExist );
+	}
+
+	if ( isWpComBusinessPlan( productSlug ) ) {
+		if ( isMonthlyPricingTest ) {
+			return [
+				isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
+				isMonthlyPlan ? annualPlanOnly( liveChatSupport ) : liveChatSupport,
+				String( translate( 'Install custom plugins and themes' ) ),
+				String( translate( 'Drive traffic to your site with our advanced SEO tools' ) ),
+				String( translate( 'Track your stats with Google Analytics' ) ),
+				String( translate( 'Real-time backups and activity logs' ) ),
+			].filter( doesValueExist );
+		}
+
+		return [
+			freeOneYearDomain,
+			String( translate( 'Install custom plugins and themes' ) ),
+			String( translate( 'Drive traffic to your site with our advanced SEO tools' ) ),
+			String( translate( 'Track your stats with Google Analytics' ) ),
+			String( translate( 'Real-time backups and activity logs' ) ),
+		].filter( doesValueExist );
+	}
+
+	if ( isWpComEcommercePlan( productSlug ) ) {
+		if ( isMonthlyPricingTest ) {
+			return [
+				isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
+				isMonthlyPlan ? annualPlanOnly( liveChatSupport ) : liveChatSupport,
+				String( translate( 'Install custom plugins and themes' ) ),
+				String( translate( 'Accept payments in 60+ countries' ) ),
+				String( translate( 'Integrations with top shipping carriers' ) ),
+				String( translate( 'Unlimited products or services for your online store' ) ),
+				String( translate( 'eCommerce marketing tools for emails and social networks' ) ),
+			].filter( doesValueExist );
+		}
+
+		return [
+			freeOneYearDomain,
+			String( translate( 'Install custom plugins and themes' ) ),
+			String( translate( 'Accept payments in 60+ countries' ) ),
+			String( translate( 'Integrations with top shipping carriers' ) ),
+			String( translate( 'Unlimited products or services for your online store' ) ),
+			String( translate( 'eCommerce marketing tools for emails and social networks' ) ),
+		].filter( doesValueExist );
+	}
+
+	return [];
+}
+
+function doesValueExist< T >( value: T | null | undefined ): value is T {
+	return !! value;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For reasons I don't fully understand, [this line](https://github.com/Automattic/wp-calypso/blob/1fd266531b3ff3ed8d34ab2d2a92f1901a192a2f/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js#L283) (added in https://github.com/Automattic/wp-calypso/pull/46466) seems to be throwing a fatal error for some people of the form `e.startsWith is not a function. (In 'e.startsWith(\"~~\")', 'e.startsWith' is undefined)`. This seems to me like it shouldn't happen since that the value passed to that function [passes through `Boolean()`](https://github.com/Automattic/wp-calypso/blob/1fd266531b3ff3ed8d34ab2d2a92f1901a192a2f/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js#L282), but the fatal errors are still there. It may be that somehow the function is receiving a non-falsy object that is not a string; possibly something returned by `translate()`, which can return React elements?

This PR modifies the function that generates the array of strings used by the line in question, `getPlanFeatures`, changing it to TypeScript and making it so that it will only return strings. In theory that should prevent any case where the line could throw an error. If any of the calls to `translate()` are indeed returning a React element, this will likely transform the component into the string `[object Object]`, which is not ideal, but as none of these calls _should_ be returning a non-string, this should be safe.

An example of how this should look with a normal Business plan:

<img width="349" alt="Screen Shot 2020-11-01 at 12 52 34 PM" src="https://user-images.githubusercontent.com/2036909/97810362-3c985400-1c41-11eb-870b-e1e3b103196c.png">

And here's how it should look with a Monthly Business plan:

<img width="340" alt="Screen Shot 2020-11-01 at 1 54 07 PM" src="https://user-images.githubusercontent.com/2036909/97811617-c9471000-1c49-11eb-8c63-0d0635114ae1.png">

#### Testing instructions

- Visit checkout with a plan in your cart.
- Verify that you see a list of features in the sidebar (will be at the top of checkout instead at small widths).
- Try adding yourself to the `treatment` group of the `monthlyPricing` AB Test using the dev menu.
- Click to edit the first step in checkout (the order), and select the "Monthly" plan variation.
- Verify that you see a list of features in the sidebar as above, but that some of the features are crossed-out.

If anyone has any ideas how this error could be occurring in the first place, it would be great to be able to test that behavior.