### PR TITLE
Coming Soon: updating the fallback page

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -82,7 +82,7 @@ function get_onboarding_url() {
 				/* No admin bar nor marketing bar on this page */
 				margin-top: 0 !important;
 			}
-			.body {
+			.wpcom-coming-soon-body {
 				background: #117ac9;
 				color: #fff;
 				display: grid;
@@ -93,7 +93,7 @@ function get_onboarding_url() {
 				padding-right: 24px;
 				padding-left: 24px;
 			}
-			.inner {
+			.wpcom-coming-soon-inner {
 				align-items: flex-end;
 				display: flex;
 				flex-wrap: wrap;
@@ -104,11 +104,11 @@ function get_onboarding_url() {
 				height: 100vh;
 				justify-content: space-between;
 			}
-			.main,
-			.marketing {
+			.wpcom-coming-soon-main,
+			.wpcom-coming-soon-marketing {
 				flex: 0 0 100%;
 			}
-			.name {
+			.wpcom-coming-soon-name {
 				color: #fff;
 				font-size: 19px;
 				line-height: 1.3;
@@ -116,34 +116,34 @@ function get_onboarding_url() {
 				padding: 0;
 				text-align: left;
 			}
-			.description {
+			.wpcom-coming-soon-description {
 				color: #fff;
 				font-size: 40px;
 				line-height: 1.15;
 				padding: 0;
 				text-align: left;
 			}
-			.description,
-			.copy {
+			.wpcom-coming-soon-description,
+			.wpcom-coming-soon-marketing-copy-text {
 				font-family: Georgia, "Times New Roman", Times, serif;
 			}
-			.marketing {
+			.wpcom-coming-soon-marketing {
 				padding-bottom: 8px;
 			}
-			.marketing-copy {
+			.wpcom-coming-soon-marketing-copy {
 				display: flex;
 				align-items: center;
+				margin-bottom: 20px;
 			}
-			.logo {
-				height: 32px;
+			.wpcom-coming-soon-wplogo {
 				margin-right: 16px;
-				width: 32px;
+				margin-bottom: 0;
 			}
-			.copy {
+			.wpcom-coming-soon-marketing-copy-text {
 				line-height: 1.4;
 				margin: 0;
 			}
-			.marketing-buttons .button {
+			.wpcom-coming-soon-marketing-buttons .button {
 				background: #fff;
 				border-radius: 2px;
 				border: 1px solid #fff;
@@ -161,46 +161,47 @@ function get_onboarding_url() {
 				white-space: nowrap;
 				width: 100%;
 			}
-			.marketing-buttons .button-secondary,
-			.marketing-buttons .button-secondary:hover,
-			.marketing-buttons .button-secondary:focus {
+			.wpcom-coming-soon-marketing-buttons .button-secondary,
+			.wpcom-coming-soon-marketing-buttons .button-secondary:hover,
+			.wpcom-coming-soon-marketing-buttons .button-secondary:focus {
 				background: transparent;
 				color: #fff;
 			}
-			.marketing-buttons .button:hover,
-			.marketing-buttons .button:focus {
+			.wpcom-coming-soon-marketing-buttons .button:hover,
+			.wpcom-coming-soon-marketing-buttons .button:focus {
 				opacity: .85;
 			}
 			@media screen and ( min-width: 660px ) {
-				.description,
-				.copy {
+				.wpcom-coming-soon-description,
+				.wpcom-coming-soon-marketing-copy-text {
 					font-family: Recoleta, Georgia, "Times New Roman", Times, serif;
 				}
-				.name {
+				.wpcom-coming-soon-name {
 					font-size: 23px;
 				}
-				.description {
+				.wpcom-coming-soon-description {
 					font-size: 69px;
 				}
-				.marketing {
+				.wpcom-coming-soon-marketing {
 					align-items: center;
 					display: flex;
 					justify-content: space-between;
 					padding-bottom: 24px;
 				}
-				.marketing-copy {
+				.wpcom-coming-soon-marketing-copy {
 					margin-right: 16px;
+					margin-bottom: 0;
 				}
-				.marketing-buttons {
+				.wpcom-coming-soon-marketing-buttons {
 					display: flex;
 				}
-				.marketing-buttons p {
+				.wpcom-coming-soon-marketing-buttons p {
 					margin: 0;
 				}
-				.marketing-buttons p:nth-child(2) {
+				.wpcom-coming-soon-marketing-buttons p:nth-child(2) {
 					margin-left: 8px;
 				}
-				.marketing-buttons .button {
+				.wpcom-coming-soon-marketing-buttons .button {
 					font-size: 13px;
 					padding: 7px 13px;
 					min-width: 145px;
@@ -213,48 +214,58 @@ function get_onboarding_url() {
 				}
 			}
 			@media screen and ( min-width: 960px ) {
-				.name {
+				.wpcom-coming-soon-name {
 					font-size: 28px;
 					margin-bottom: 16px;
 				}
-				.description {
+				.wpcom-coming-soon-description {
 					font-size: 99px;
 				}
-				.copy {
+				.wpcom-coming-soon-marketing-copy-text {
 					font-size: 19px;
 				}
 			}
 			@media screen and ( min-width: 1040px ) {
-				.body {
+				.wpcom-coming-soon-body {
 					-ms-grid-columns: (1fr)[12];
 					grid-template-columns: repeat(12, 1fr);
 				}
-				.inner {
+				.wpcom-coming-soon-inner {
 					-ms-grid-column: 2;
 					grid-column-start: 2;
 					-ms-grid-column-span: 10;
 					grid-column-end: span 10;
 				}
-				.marketing {
+				.wpcom-coming-soon-marketing {
 					padding-bottom: 32px;
 				}
 			}
 		</style>
 	</head>
-	<body class="body">
-		<div class="inner">
-			<div class="main">
-				<div class="name"><?php echo esc_html( get_bloginfo( 'name' ) ); ?></div>
-				<div class="description"><?php esc_html_e( 'Coming Soon', 'full-site-editing' ); ?></div>
-				<p>(v2 — remove this line when finished testing)</p>
+	<body class="wpcom-coming-soon-body">
+		<div class="wpcom-coming-soon-inner">
+			<div class="wpcom-coming-soon-main">
+				<div class="wpcom-coming-soon-name"><?php echo esc_html( get_bloginfo( 'name' ) ); ?></div>
+				<div class="wpcom-coming-soon-description"><?php esc_html_e( 'Coming Soon', 'full-site-editing' ); ?></div>
 			</div>
-			<div class="marketing">
+			<div class="wpcom-coming-soon-marketing">
 				<?php if ( ! is_user_logged_in() ) : ?>
-					<div class="marketing-copy">
-						<img src="/wp-content/themes/a8c/domain-landing-page/wpcom-wmark-white.svg" alt="WordPress.com" class="logo" />
-						<p class="copy"><?php esc_html_e( 'Build a website. Sell your stuff. Write a blog. And so much more.', 'full-site-editing' ); ?></p>
+					<div class="wpcom-coming-soon-marketing-copy">
+						<div class="wpcom-coming-soon-wplogo">
+							<a href="<?php echo esc_url( get_onboarding_url() ); ?>" title="WordPress.com">
+								<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+									<title>WordPress.com</title>
+									<g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+										<g transform="translate(-701.000000, -950.000000)" fill="#FFFFFF">
+											<path d="M730.04024,985.542 L735.53216,969.66248 C736.55848,967.09712 736.89992,965.046 736.89992,963.222 C736.89992,962.56 736.85632,961.94544 736.7788,961.3728 C738.18232,963.93376 738.9812,966.87296 738.9812,969.99976 C738.9812,976.63312 735.38624,982.42536 730.04024,985.542 L730.04024,985.542 Z M723.47808,961.56864 C724.56048,961.51192 725.53592,961.39784 725.53592,961.39784 C726.5048,961.28336 726.39072,959.8592 725.4216,959.91616 C725.4216,959.91616 722.50896,960.14464 720.6288,960.14464 C718.86176,960.14464 715.8928,959.91616 715.8928,959.91616 C714.92328,959.8592 714.80944,961.34048 715.77904,961.39784 C715.77904,961.39784 716.69616,961.51192 717.6648,961.56864 L720.466,969.2444 L716.53008,981.0464 L709.98288,961.56864 C711.06624,961.51192 712.04056,961.39784 712.04056,961.39784 C713.0092,961.28336 712.89464,959.8592 711.92552,959.91616 C711.92552,959.91616 709.01352,960.14464 707.13336,960.14464 C706.79616,960.14464 706.39824,960.13608 705.97552,960.12264 C709.19128,955.24152 714.7176,952.01808 720.99976,952.01808 C725.68112,952.01808 729.94352,953.80776 733.1424,956.7392 C733.06536,956.73408 732.98944,956.72448 732.90984,956.72448 C731.14328,956.72448 729.89008,958.26312 729.89008,959.91616 C729.89008,961.39784 730.74488,962.65128 731.6564,964.13336 C732.34008,965.33096 733.13872,966.86944 733.13872,969.09216 C733.13872,970.63208 732.68224,972.5684 731.77048,974.90568 L729.97656,980.89832 L723.47808,961.56864 Z M720.99976,987.98328 C719.23488,987.98328 717.53104,987.72376 715.92024,987.25072 L721.31592,971.57256 L726.84248,986.71584 C726.8788,986.80384 726.92336,986.88536 726.97136,986.96312 C725.1024,987.62072 723.09392,987.98328 720.99976,987.98328 L720.99976,987.98328 Z M703.01856,969.99976 C703.01856,967.3924 703.57776,964.91736 704.57576,962.68128 L713.1532,986.18272 C707.154,983.2684 703.01856,977.11744 703.01856,969.99976 L703.01856,969.99976 Z M720.99976,950 C709.97208,950 701,958.97184 701,969.99976 C701,981.02856 709.97208,990.00112 720.99976,990.00112 C732.02768,990.00112 741,981.02856 741,969.99976 C741,958.97184 732.02768,950 720.99976,950 L720.99976,950 Z" id="wpcom-wmark"></path>
+										</g>
+									</g>
+								</svg>
+							</a>
+						</div>
+						<p class="wpcom-coming-soon-marketing-copy-text"><?php esc_html_e( 'Build a website. Sell your stuff. Write a blog. And so much more.', 'full-site-editing' ); ?></p>
 					</div>
-					<div class="marketing-buttons">
+					<div class="wpcom-coming-soon-marketing-buttons">
 						<p><a class="button button-secondary" href="<?php echo esc_url( get_login_url() ); ?>"><?php esc_html_e( 'Log in', 'full-site-editing' ); ?></a></p>
 						<p><a class="button button-primary " href="<?php echo esc_url( get_onboarding_url() ); ?>"><?php esc_html_e( 'Start your website', 'full-site-editing' ); ?></a></p>
 					</div>

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -116,7 +116,9 @@ class Site extends React.Component {
 			'is-compact': this.props.compact,
 		} );
 
-		const isPublicComingSoon = isEnabled( 'coming-soon-v2' ) && this.props.site.is_coming_soon;
+		// To ensure two Coming Soon badges don't appear while we introduce public coming soon
+		const isPublicComingSoon =
+			isEnabled( 'coming-soon-v2' ) && ! site.is_private && this.props.site.is_coming_soon;
 
 		return (
 			<div className={ siteClass }>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR swaps the WP logo image with the relative path so it will display on all sites (think Atomic), and namespaces the class names.

We're also removing the test copy for v2. We can tell v2 from v1 by the class names in the source.

<img width="1011" alt="Screen Shot 2020-11-02 at 11 09 00 am" src="https://user-images.githubusercontent.com/6458278/97819712-78ddba00-1cfe-11eb-8767-4ec7e1511da0.png">

As an aside, I also noticed the appearance of two coming soon badges on the site bar. This will happen hopefully only during testing, when you're toggling coming soon v2 on an existing site, but I added a small safeguard to prevent that.

<img width="813" alt="Screen Shot 2020-11-02 at 10 35 56 am" src="https://user-images.githubusercontent.com/6458278/97819722-84c97c00-1cfe-11eb-8631-0bbfe24f3b2d.png">


### Testing instructions

While sandboxing, run `yarn dev --sync` in `apps/editing-toolkit`

Create a new site over at wordpress.com/new?flags=coming-soon-v2

Take a look at the new site in an incognito window. You should see the coming soon page (the class names should be prefixed with `wpcom-coming-soon-*` and the WordPress logo should be an SVG)

On an existing test site (or one created at wordpress.com/new), make sure you have coming soon enabled. The go to the settings page with the flag enabled, e.g., `http://calypso.localhost:3000/settings/general/your_test_site?flags=coming-soon-v2`. 

You should only see one badge.
