### PR TITLE
Framework: Remove unnecessary Logger credentials

### DIFF
--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -5,11 +5,6 @@ import TraceKit from 'tracekit';
 import debug from 'debug';
 
 /**
- * Internal dependencies
- */
-import config from 'calypso/config';
-
-/**
  * Module variables
  */
 
@@ -125,8 +120,6 @@ export default class ErrorLogger {
 
 	sendToApi( error ) {
 		const params = new URLSearchParams( {
-			client_id: config( 'wpcom_signup_id' ),
-			client_secret: config( 'wpcom_signup_key' ),
 			error: JSON.stringify( error ),
 		} );
 

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -118,16 +118,16 @@ export default class ErrorLogger {
 		} catch ( e ) {}
 	}
 
-	async sendToApi( error ) {
+	sendToApi( error ) {
 		const body = new window.FormData();
 		body.append( 'error', JSON.stringify( error ) );
 
-		const response = await window.fetch( 'https://public-api.wordpress.com/rest/v1.1/js-error', {
-			method: 'POST',
-			body,
-		} );
-
-		if ( ! response.ok ) {
+		try {
+			window.fetch( 'https://public-api.wordpress.com/rest/v1.1/js-error', {
+				method: 'POST',
+				body,
+			} );
+		} catch {
 			// eslint-disable-next-line no-console
 			console.error( 'Error: Unable to record the error in Logstash.' );
 		}

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -119,13 +119,12 @@ export default class ErrorLogger {
 	}
 
 	sendToApi( error ) {
-		const params = new URLSearchParams( {
-			error: JSON.stringify( error ),
-		} );
+		const body = new window.FormData();
+		body.append( 'error', JSON.stringify( error ) );
 
-		const xhr = new window.XMLHttpRequest();
-		xhr.open( 'POST', 'https://public-api.wordpress.com/rest/v1.1/js-error?http_envelope=1', true );
-		xhr.setRequestHeader( 'Content-type', 'application/x-www-form-urlencoded' );
-		xhr.send( params.toString() );
+		window.fetch( 'https://public-api.wordpress.com/rest/v1.1/js-error?http_envelope=1', {
+			method: 'POST',
+			body,
+		} );
 	}
 }

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -1,9 +1,13 @@
 /**
  * External dependencies
  */
-
 import TraceKit from 'tracekit';
 import debug from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import config from 'calypso/config';
 
 /**
  * Module variables
@@ -120,12 +124,15 @@ export default class ErrorLogger {
 	}
 
 	sendToApi( error ) {
-		const xhr = new XMLHttpRequest();
+		const params = new URLSearchParams( {
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
+			error: JSON.stringify( error ),
+		} );
+
+		const xhr = new window.XMLHttpRequest();
 		xhr.open( 'POST', 'https://public-api.wordpress.com/rest/v1.1/js-error?http_envelope=1', true );
 		xhr.setRequestHeader( 'Content-type', 'application/x-www-form-urlencoded' );
-		let params =
-			'client_id=39911&client_secret=cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8&error=';
-		params += encodeURIComponent( JSON.stringify( error ) );
-		xhr.send( params );
+		xhr.send( params.toString() );
 	}
 }

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -118,13 +118,18 @@ export default class ErrorLogger {
 		} catch ( e ) {}
 	}
 
-	sendToApi( error ) {
+	async sendToApi( error ) {
 		const body = new window.FormData();
 		body.append( 'error', JSON.stringify( error ) );
 
-		window.fetch( 'https://public-api.wordpress.com/rest/v1.1/js-error', {
+		const response = await window.fetch( 'https://public-api.wordpress.com/rest/v1.1/js-error', {
 			method: 'POST',
 			body,
 		} );
+
+		if ( ! response.ok ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Error: Unable to record the error in Logstash.' );
+		}
 	}
 }

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -122,7 +122,7 @@ export default class ErrorLogger {
 		const body = new window.FormData();
 		body.append( 'error', JSON.stringify( error ) );
 
-		window.fetch( 'https://public-api.wordpress.com/rest/v1.1/js-error?http_envelope=1', {
+		window.fetch( 'https://public-api.wordpress.com/rest/v1.1/js-error', {
 			method: 'POST',
 			body,
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Framework: Remove unnecessary Logger credentials

#### Testing instructions

* Checkout the branch locally, you'll need to do changes to test this.
* Add `throw new Error ( 'this is an error' );` in the beginning of the `FollowingStream` component ([here](https://github.com/Automattic/wp-calypso/blob/update/error-logger-use-config-wpcom/client/reader/following/main.jsx#L46)).
* Go to http://calypso.localhost:3000/read?flags=catch-js-errors
* Inspect the network requests.
* Verify the request to `/js-error` still responds with `{ ok: true}`.
