### PR TITLE
Analytics: Use new analytics JS client: w2.js

### DIFF
--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -35,13 +35,13 @@ const EVENT_NAME_EXCEPTIONS = [
 	'wcadmin_storeprofiler_connect_store',
 	'wcadmin_storeprofiler_login_jetpack_account',
 	'wcadmin_storeprofiler_payment_login',
-	'wcadmin_storeprofiler_payment_create_account',
+	'wcadmin_storeprofiler_payment_create_account'
 ];
 let _superProps: any; // Added to all Tracks events.
 let _loadTracksResult = Promise.resolve(); // default value for non-BOM environments.
 
 if ( typeof document !== 'undefined' ) {
-	_loadTracksResult = loadScript( '//stats.wp.com/w.js?61' );
+	_loadTracksResult = loadScript( '//stats.wp.com/w2.js?1' );
 }
 
 function createRandomId( randomBytesLength = 9 ): string {
@@ -238,7 +238,7 @@ export function recordTracksPageView( urlPath: string, params: any ) {
 
 	let eventProperties = {
 		do_not_track: getDoNotTrack() ? 1 : 0,
-		path: urlPath,
+		path: urlPath
 	};
 
 	// Add calypso build timestamp if set

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -35,7 +35,7 @@ const EVENT_NAME_EXCEPTIONS = [
 	'wcadmin_storeprofiler_connect_store',
 	'wcadmin_storeprofiler_login_jetpack_account',
 	'wcadmin_storeprofiler_payment_login',
-	'wcadmin_storeprofiler_payment_create_account'
+	'wcadmin_storeprofiler_payment_create_account',
 ];
 let _superProps: any; // Added to all Tracks events.
 let _loadTracksResult = Promise.resolve(); // default value for non-BOM environments.
@@ -238,7 +238,7 @@ export function recordTracksPageView( urlPath: string, params: any ) {
 
 	let eventProperties = {
 		do_not_track: getDoNotTrack() ? 1 : 0,
-		path: urlPath
+		path: urlPath,
 	};
 
 	// Add calypso build timestamp if set


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Instead of loading `w.js` which is an outdated untested JS client for Tracks, loads `w2.js` which has been throughly tested enabling us:
- to offer beacon support in the near future, hopefully improving the reliability of our 1st party analytics data while limiting browser blocking for analytics resources and thus browser responsiveness.
- to create an anonymous mode where all Tracks identifiers are never persisted to disk: events that would opt into it would never be tied to the logged-in user or a locally stored anonymous ID: a page reload would serve as a privacy boundary.
- to potentially "bundle" the JS client within Calypso instead of loading yet-another external file?
- to open source the client ( 50-gh-analytics for the internal issue tracking this effort )

For more details about those changes, see p4qSXL-3BD-p2

#### Testing instructions

* Checkout `update/w2js` and start Calypso locally
* Make sure `w2.js` is loaded ( instead of `w.js` ), click around and double-check that `t.gif` pixels are being requested with all the usual parameters ( `_en` for the event name, `_ui` for the user ID, `_ts` for the event timestamp ... )

For now, `w2.js` has only been tested on recent browsers ( up to IE11 ), further testing on older browsers needs to be done, but this should not impact Calypso tracking since it already has [stricter browser requirements](https://github.com/Automattic/wp-calypso#browser-support).
