### PR TITLE
Purchases: Fix jumping of action card illustration

### DIFF
--- a/client/components/action-card/style.scss
+++ b/client/components/action-card/style.scss
@@ -16,6 +16,10 @@
 	@include breakpoint-deprecated( '<960px' ) {
 		display: none;
 	}
+
+	@include breakpoint-deprecated( '>960px' ) {
+		width: 200px;
+	}
 }
 
 .action-card__button-container {


### PR DESCRIPTION
Currently, on the purchases page, when viewing on a > 960px width of window, when the user loads the illustration for the first time, there is a brief jump of the content. This PR fixes that.

#### Changes proposed in this Pull Request

* Purchases: Fix jumping of action card illustration

Before:
![](https://cldup.com/ZMf8KJnS9V.png)

After:
![](https://cldup.com/eQWO6rNe0b.png)

#### Testing instructions

* Checkout this branch
* Open the network tab and ensure browser caching is disabled.
* Go to `/me/purchases` on a desktop resolution
* Verify that you can no longer see the jumping on a > 960px screen width and illustration still loads correctly.
* Verify that <960px screen width looks unchanged.

#### Notes

* This is using a deprecated breakpoint, but it's what the component already uses.
* This is the only instance where we use `ActionCard` with an illustration, so we are safe.
* This isn't an ideal solution in the long run but will resolve the UX defect with minimal refactoring.