### PR TITLE
State: Fix default membership products state

### DIFF
--- a/client/state/memberships/product-list/selectors.js
+++ b/client/state/memberships/product-list/selectors.js
@@ -3,6 +3,8 @@
  */
 import 'calypso/state/memberships/init';
 
+const EMPTY_LIST = [];
+
 export function getProductsForSiteId( state, siteId ) {
-	return state.memberships?.productList.items[ siteId ] ?? [];
+	return state.memberships?.productList.items[ siteId ] ?? EMPTY_LIST;
 }

--- a/client/state/memberships/product-list/selectors.js
+++ b/client/state/memberships/product-list/selectors.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import 'calypso/state/memberships/init';
 
 export function getProductsForSiteId( state, siteId ) {
-	return get( state, [ 'memberships', 'productList', 'items', siteId ] );
+	return state.memberships?.productList.items[ siteId ] ?? [];
 }


### PR DESCRIPTION
Currently, there's a bug when changing the site on the Earn > Payment Plans page - the app crashes:

* Go to `/earn/payments-plans/:site` where `:site` is a site with one or more Memberships payment plans created.
* Switch site to a site without any payment plans created.
* You witness a crash.

Or the easiest way is to just navigate to `/earn/payments-plans/:site` where `:site` is a site with no payment plans created.

This happens because we're attempting to `map()` on the `products` from the `getProductsForSiteId` selector, but if it's empty, it will return `undefined` instead of an empty array. `undefined.map()` triggers an error.

#### Changes proposed in this Pull Request

* State: Fix default membership products state

#### Testing instructions

* Go to `/earn/payments-plans/:site` where `:site` is a site with no payment plans created.

#### Notes

In addition to defaulting to an empty array if there are no products:

* We're taking the opportunity to refactor away from lodash's `get()`. Ideally, we wouldn't be using `lodash` at all.
* We're conditionally chaining the `.memberships` reducer tree because it's loaded asynchronously and may not always exist.
