### PR TITLE
My Plan: fix broken Jetpack Security product name

### DIFF
--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -116,7 +116,11 @@ class PurchasesListing extends Component {
 		if ( currentPlan ) {
 			const planObject = getPlan( currentPlan.productSlug );
 			if ( planObject.term === TERM_MONTHLY ) {
-				return `${ planObject.getTitle() } ${ translate( 'monthly' ) }`;
+				return (
+					<>
+						{ planObject.getTitle() } { translate( 'monthly' ) }
+					</>
+				);
 			}
 			return planObject.getTitle();
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, monthly versions of Jetpack Security are being displayed with an unintelligible name. This is because the name of these products are composed of React components and we are trying to print them as they were strings.

#### Testing instructions

* Run this PR (horizon is enough since we only care about Calypso Blue).
* Visit `/plans/my-plan/:site` with a Jetpack Site that has the monthly version of Jetpack Security Daily.
* Make sure that the name of the plan looks correct and that there is no trace of `[Object object]`.
* Visit `/plans/my-plan/:site` with a Jetpack Site that has the monthly version of Jetpack Security Real-time.
* Make sure that the name of the plan looks correct and that there is no trace of `[Object object]`.

Fixes 1164141197617539-as-1198981849134413

#### Demo
##### Before

> ##### Jetpack Security Daily
> ![image](https://user-images.githubusercontent.com/3418513/97873467-6cedfa00-1cf6-11eb-901f-bc8795780cc7.png)
> ##### Jetpack Security Real-time
> ![image](https://user-images.githubusercontent.com/3418513/97873535-8bec8c00-1cf6-11eb-86b6-f47fb5c7d214.png)


##### After

> ##### Jetpack Security Daily
> ![image](https://user-images.githubusercontent.com/3418513/97873456-68294600-1cf6-11eb-9b7c-5a1a03a4e429.png)
> ##### Jetpack Security Real-time
> ![image](https://user-images.githubusercontent.com/3418513/97873482-737c7180-1cf6-11eb-8f0b-38b9376e88fd.png)


##### Other plans and products that were not affected

> ##### Jetpack Complete
> ![image](https://user-images.githubusercontent.com/3418513/97873810-e71e7e80-1cf6-11eb-8149-9a75c1143f05.png)
> 
> ##### Jetpack Backup, Jetpack Scan, Jetpack Search, and Jetpack Anti-spam
> ![image](https://user-images.githubusercontent.com/3418513/97873834-ec7bc900-1cf6-11eb-934b-a501ae9a0eaf.png)
> 
