### PR TITLE
Framework: Remove lodash entries() in favor of Object.entries()

### DIFF
--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { entries } from 'lodash';
 import { CURRENCIES } from '@automattic/format-currency';
 
 /**
@@ -40,8 +39,8 @@ import getCountries from 'calypso/state/selectors/get-countries';
 import PhoneInput from 'calypso/components/phone-input';
 import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
 
-const currencyList = entries( CURRENCIES ).map( ( [ code ] ) => ( { code } ) );
-const visualCurrencyList = entries( CURRENCIES ).map( ( [ code, { symbol } ] ) => ( {
+const currencyList = Object.entries( CURRENCIES ).map( ( [ code ] ) => ( { code } ) );
+const visualCurrencyList = Object.entries( CURRENCIES ).map( ( [ code, { symbol } ] ) => ( {
 	code,
 	label: `${ code } ${ symbol }`,
 } ) );

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { entries, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 import store from 'store';
 import debugFactory from 'debug';
 import config from 'calypso/config';
@@ -250,7 +250,7 @@ User.prototype.sendVerificationEmail = function ( fn ) {
 User.prototype.set = function ( attributes ) {
 	let changed = false;
 
-	for ( const [ attrName, attrValue ] of entries( attributes ) ) {
+	for ( const [ attrName, attrValue ] of Object.entries( attributes ) ) {
 		if ( ! isEqual( attrValue, this.data[ attrName ] ) ) {
 			this.data[ attrName ] = attrValue;
 			changed = true;


### PR DESCRIPTION
This PR removes the last 2 remaining instances of lodash's `entries()` in favor of `Object.entries()`. Ideally, we'd like to get rid of Lodash completely, but we need to do it one step at a time.

#### Changes proposed in this Pull Request

* Framework: Remove lodash `entries()` in favor of `Object.entries()`

#### Testing instructions

* Checkout this branch.
* Verify deleting a site successfully decreases the number of total sites in your site switcher.
* Verify currency fields on `/devdocs/design/form-fields` still work and look the same way.