### PR TITLE
Jetpack Checklist: Update copy for Downtime Monitor on Jetpack checklist

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -278,7 +278,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 						completedButtonText={ translate( 'Change', { context: 'verb' } ) }
 						completedTitle={ translate( 'You turned on Downtime Monitoring.' ) }
 						description={ translate(
-							"Monitor your site's uptime and alert you the moment downtime is detected with instant notifications."
+							'Jetpack will continuously watch your site, and alert you the moment that downtime is detected with instant notifications.'
 						) }
 						duration={ this.getDuration( 3 ) }
 						href={ `/settings/security/${ siteSlug }` }

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -278,7 +278,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 						completedButtonText={ translate( 'Change', { context: 'verb' } ) }
 						completedTitle={ translate( 'You turned on Downtime Monitoring.' ) }
 						description={ translate(
-							'Jetpack will continuously watch your site, and alert you the moment that downtime is detected with instant notifications.'
+							'Jetpack will continuously watch your site, and alert you with instant notifications if downtime is detected.'
 						) }
 						duration={ this.getDuration( 3 ) }
 						href={ `/settings/security/${ siteSlug }` }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update copy for Downtime Monitor on Jetpack checklist.

#### Testing instructions

* Fire up with PR, possibly creating a [new JN site in the process](https://jurassic.ninja/create/).
* Connect your site, purchase a plan, wait to get redirected to the checklist.
* Alternatively, connect your site and head directly to http://calypso.localhost:3000/plans/my-plan/SITE_URL

#### Screenshots

Before

![image](https://user-images.githubusercontent.com/390760/97879266-ad11a480-1d17-11eb-9489-204ed7409601.png)


After

![image](https://user-images.githubusercontent.com/390760/97883226-7c803980-1d1c-11eb-9ecb-ede59e16371e.png)
