### PR TITLE
Enable single product yearly upgrade from pricing page

### DIFF
--- a/client/lib/products-values/get-product-yearly-variant.ts
+++ b/client/lib/products-values/get-product-yearly-variant.ts
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { TERM_ANNUALLY } from 'calypso/lib/plans/constants';
+import { PRODUCTS_LIST } from 'calypso/lib/products-values/products-list';
+
+/**
+ * Type dependencies
+ */
+import type { ProductSlug } from './types';
+
+/**
+ * Return the yearly variant of a product
+ *
+ * @param {ProductSlug} productSlug Slug of the product to get the yearly variant from
+ * @returns {string} Slug of the yearly variant
+ */
+export function getProductYearlyVariant( productSlug: ProductSlug ): string | undefined {
+	const product = PRODUCTS_LIST[ productSlug ];
+
+	if ( product ) {
+		return Object.values( PRODUCTS_LIST )
+			.filter( ( { type } ) => type === product.type )
+			.find( ( { term } ) => TERM_ANNUALLY === term )?.product_slug;
+	}
+}

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -10,6 +10,7 @@ export { getJetpackProductShortName } from './get-jetpack-product-short-name';
 export { getJetpackProductTagline } from './get-jetpack-product-tagline';
 export { getProductClass } from './get-product-class';
 export { getProductTermVariants } from './get-product-term-variants';
+export { getProductYearlyVariant } from './get-product-yearly-variant';
 export { getProductFromSlug } from './get-product-from-slug';
 export { getProductsSlugs } from './get-products-slugs';
 export { includesProduct } from './includes-product';

--- a/client/my-sites/plans-v2/selector-alt.tsx
+++ b/client/my-sites/plans-v2/selector-alt.tsx
@@ -15,6 +15,7 @@ import { getPathToDetails, checkout } from './utils';
 import QueryProducts from './query-products';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getYearlyPlanByMonthly } from 'calypso/lib/plans';
+import { getProductYearlyVariant, isJetpackPlan } from 'calypso/lib/products-values';
 import { TERM_ANNUALLY } from 'calypso/lib/plans/constants';
 import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -30,6 +31,7 @@ import ProductsGridAlt2 from './products-grid-alt-2';
  * Type dependencies
  */
 import type { Duration, SelectorPageProps, SelectorProduct, PurchaseCallback } from './types';
+import type { ProductSlug } from 'calypso/lib/products-values/types';
 
 import './style.scss';
 
@@ -78,7 +80,15 @@ const SelectorPageAlt = ( {
 					duration: currentDuration,
 				} )
 			);
-			checkout( siteSlug, getYearlyPlanByMonthly( product.productSlug ), urlQueryArgs );
+
+			const { productSlug: slug } = product;
+			const yearlyItem = isJetpackPlan( slug )
+				? getYearlyPlanByMonthly( slug )
+				: getProductYearlyVariant( slug as ProductSlug );
+
+			if ( yearlyItem ) {
+				checkout( siteSlug, yearlyItem, urlQueryArgs );
+			}
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes a bug that prevented upgrading a single product to its yearly variant from the pricing page.

### Testing instructions

- The issue should occur in any variant of the pricing page
- Download the PR
- Select a self-hosted Jetpack site that has a paid monthly plan, and a monthly subscription to a single product
- Visit the pricing page with the Yearly term selected
- For both your plan and single product, check that the CTA in the card reads "Upgrade to Yearly"
- Verify that clicking on the button redirects you to the checkout page with the yearly variant in the cart, without errors

### Screenshots

_Product card with yearly upgrade CTA_
<img width="363" alt="Screen Shot 2020-11-02 at 10 50 16 AM" src="https://user-images.githubusercontent.com/1620183/97892366-e806de80-1cfd-11eb-9dea-c2db1204394e.png">


_Error seen before the fix_
<img width="487" alt="Screen Shot 2020-11-02 at 10 50 31 AM" src="https://user-images.githubusercontent.com/1620183/97892380-eb9a6580-1cfd-11eb-9000-806eb9ad38df.png">
