### PR TITLE
Configure experiment for pricing page i2

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -196,8 +196,8 @@ export default {
 		datestamp: '20201102',
 		variations: {
 			'v0 - Offer Reset': 0, // Offer Reset
-			'v1 - 3 cols layout': 50, // first Offer Reset iteration (3 layout columns + simpler cards)
-			'v2 - slide outs': 50, // second Offer Reset iteration (reorder & slide outs)
+			'v1 - 3 cols layout': 0, // first Offer Reset iteration (3 layout columns + simpler cards)
+			'v2 - slide outs': 100, // second Offer Reset iteration (reorder & slide outs)
 		},
 		defaultVariation: 'v2 - slide outs',
 		allowExistingUsers: true,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -193,13 +193,13 @@ export default {
 		localeTargets: [ 'en' ],
 	},
 	jetpackConversionRateOptimization: {
-		datestamp: '20201020',
+		datestamp: '20201102',
 		variations: {
 			'v0 - Offer Reset': 0, // Offer Reset
-			'v1 - 3 cols layout': 100, // first Offer Reset iteration (3 layout columns + simpler cards)
-			'v2 - slide outs': 0, // second Offer Reset iteration (reorder & slide outs)
+			'v1 - 3 cols layout': 50, // first Offer Reset iteration (3 layout columns + simpler cards)
+			'v2 - slide outs': 50, // second Offer Reset iteration (reorder & slide outs)
 		},
-		defaultVariation: 'v1 - 3 cols layout',
+		defaultVariation: 'v2 - slide outs',
 		allowExistingUsers: true,
 	},
 	secureYourBrand: {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR configures the a/b test experiment for pricing page i2. Though the implementation is technically an a/b test, i2 will be shipped to everyone.

### Implementation notes

Once deployed, users who are not eligible to participate in the test ([see docs](https://github.com/Automattic/wp-calypso/blob/ba85297f6f21d08cd2c693040b8c2c3b2ac03185/client/lib/abtest/README.md)) will see i2. All eligible users will see i2 as well.

### Testing instructions

- Code review
- Test once deployed
