### PR TITLE
Checkout: Add CheckoutErrorBoundary around CheckoutSummaryArea

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -21,6 +21,7 @@ import {
 	usePaymentMethod,
 	useSelect,
 	useTotal,
+	CheckoutErrorBoundary,
 } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
 
@@ -277,26 +278,46 @@ export default function WPCheckout( {
 		[ onEvent ]
 	);
 
+	const onSummaryError = useCallback(
+		( error ) =>
+			onEvent( {
+				type: 'STEP_LOAD_ERROR',
+				payload: {
+					message: error,
+					stepId: 'summary',
+				},
+			} ),
+		[ onEvent ]
+	);
+
 	return (
 		<Checkout>
 			<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
-				<CheckoutSummaryTitleLink onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }>
-					<CheckoutSummaryTitle>
-						<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
-						{ translate( 'Purchase Details' ) }
-						<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" />
-					</CheckoutSummaryTitle>
-					<CheckoutSummaryTitlePrice className="wp-checkout__total-price">
-						{ total.amount.displayValue }
-					</CheckoutSummaryTitlePrice>
-				</CheckoutSummaryTitleLink>
-				<CheckoutSummaryBody>
-					<WPCheckoutOrderSummary
-						onChangePlanLength={ changePlanLength }
-						nextDomainIsFree={ responseCart?.next_domain_is_free }
-					/>
-					<SecondaryCartPromotions responseCart={ responseCart } addItemToCart={ addItemToCart } />
-				</CheckoutSummaryBody>
+				<CheckoutErrorBoundary
+					errorMessage={ translate( 'Sorry, there was an error loading this information.' ) }
+					onError={ onSummaryError }
+				>
+					<CheckoutSummaryTitleLink onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }>
+						<CheckoutSummaryTitle>
+							<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
+							{ translate( 'Purchase Details' ) }
+							<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" />
+						</CheckoutSummaryTitle>
+						<CheckoutSummaryTitlePrice className="wp-checkout__total-price">
+							{ total.amount.displayValue }
+						</CheckoutSummaryTitlePrice>
+					</CheckoutSummaryTitleLink>
+					<CheckoutSummaryBody>
+						<WPCheckoutOrderSummary
+							onChangePlanLength={ changePlanLength }
+							nextDomainIsFree={ responseCart?.next_domain_is_free }
+						/>
+						<SecondaryCartPromotions
+							responseCart={ responseCart }
+							addItemToCart={ addItemToCart }
+						/>
+					</CheckoutSummaryBody>
+				</CheckoutErrorBoundary>
 			</CheckoutSummaryArea>
 			<CheckoutStepArea
 				submitButtonHeader={ <SubmitButtonHeader /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a React error boundary around the contents of the `CheckoutSummaryArea` (the information sidebar) in new checkout. This will catch any fatal errors thrown inside the sidebar and prevent them from breaking the rest of checkout.

Fixes https://github.com/Automattic/wp-calypso/issues/47020

Without an error:

![without-error](https://user-images.githubusercontent.com/2036909/97916189-a76c8c80-1d20-11eb-856d-e168e73de751.png)

With an error:

![with-error](https://user-images.githubusercontent.com/2036909/97916201-ab001380-1d20-11eb-9335-8a28411ebaaa.png)


#### Testing instructions

First, visit checkout and be sure that you see the sidebar (which is collapsed to the top of the main column at small widths) and that it includes some information on the purchase you're making.

Next, modify the code in `WPCheckoutOrderSummary` to throw an Error. Load checkout and verify that you see the error boundary in the sidebar (`Sorry, there was an error loading this information.`) but that the rest of checkout is unaffected.