### PR TITLE
P2: redirect to Home when trying to access Plans

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -61,6 +61,7 @@ import { makeLayout, render as clientRender, setSectionMiddleware } from 'calyps
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import EmptyContentComponent from 'calypso/components/empty-content';
 import DomainOnly from 'calypso/my-sites/domains/domain-management/list/domain-only';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -501,4 +502,21 @@ export function redirectWithoutSite( redirectPath ) {
 
 		return next();
 	};
+}
+
+export function wpForTeamsNotSupportedRedirect( context, next ) {
+	const store = context.store;
+	const selectedSite = getSelectedSite( store.getState() );
+
+	if (
+		! config.isEnabled( 'p2/p2-plus' ) &&
+		selectedSite &&
+		isSiteWPForTeams( store.getState(), selectedSite.ID )
+	) {
+		const siteSlug = getSiteSlug( store.getState(), selectedSite.ID );
+
+		return page.redirect( `/home/${ siteSlug }` );
+	}
+
+	next();
 }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -504,7 +504,17 @@ export function redirectWithoutSite( redirectPath ) {
 	};
 }
 
-export function wpForTeamsNotSupportedRedirect( context, next ) {
+/**
+ * Use this middleware to prevent navigation to pages which are not supported by the P2 project but only
+ * if the P2+ paid plan is disabled for the specific environment (ie development vs production).
+ *
+ * If you need to prevent navigation to pages for the P2 project in general,
+ * see `wpForTeamsP2PlusNotSupportedRedirect`.
+ *
+ * @param {object} context -- Middleware context
+ * @param {Function} next -- Call next middleware in chain
+ */
+export function wpForTeamsP2PlusNotSupportedRedirect( context, next ) {
 	const store = context.store;
 	const selectedSite = getSelectedSite( store.getState() );
 
@@ -513,6 +523,28 @@ export function wpForTeamsNotSupportedRedirect( context, next ) {
 		selectedSite &&
 		isSiteWPForTeams( store.getState(), selectedSite.ID )
 	) {
+		const siteSlug = getSiteSlug( store.getState(), selectedSite.ID );
+
+		return page.redirect( `/home/${ siteSlug }` );
+	}
+
+	next();
+}
+
+/**
+ * Use this middleware to prevent navigation to pages which are not supported by the P2 project in general.
+ *
+ * If you need to prevent navigation to pages based on whether the P2+ paid plan is enabled or disabled,
+ * see `wpForTeamsP2PlusNotSupportedRedirect`.
+ *
+ * @param {object} context -- Middleware context
+ * @param {Function} next -- Call next middleware in chain
+ */
+export function wpForTeamsGeneralNotSupportedRedirect( context, next ) {
+	const store = context.store;
+	const selectedSite = getSelectedSite( store.getState() );
+
+	if ( selectedSite && isSiteWPForTeams( store.getState(), selectedSite.ID ) ) {
 		const siteSlug = getSiteSlug( store.getState(), selectedSite.ID );
 
 		return page.redirect( `/home/${ siteSlug }` );

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -42,7 +42,6 @@ import { canUserPurchaseGSuite } from 'calypso/lib/gsuite';
 import { addItem } from 'calypso/lib/cart/actions';
 import { planItem } from 'calypso/lib/cart-values/cart-items';
 import { PLAN_PERSONAL } from 'calypso/lib/plans/constants';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 
 const domainsAddHeader = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () => {
@@ -275,23 +274,11 @@ const jetpackNoDomainsWarning = ( context, next ) => {
 	}
 };
 
-const wpForTeamsNoDomainsRedirect = ( context, next ) => {
-	const state = context.store.getState();
-	const selectedSite = getSelectedSite( state );
-
-	if ( selectedSite && isSiteWPForTeams( state, selectedSite.ID ) ) {
-		return page.redirect( '/' );
-	}
-
-	next();
-};
-
 export default {
 	domainsAddHeader,
 	domainsAddRedirectHeader,
 	domainSearch,
 	jetpackNoDomainsWarning,
-	wpForTeamsNoDomainsRedirect,
 	siteRedirect,
 	mapDomain,
 	googleAppsWithRegistration,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -6,7 +6,12 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import {
+	navigation,
+	siteSelection,
+	sites,
+	wpForTeamsGeneralNotSupportedRedirect,
+} from 'calypso/my-sites/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
 import SiftScience from 'calypso/lib/siftscience';
@@ -32,7 +37,7 @@ function getCommonHandlers( {
 	noSitePath = paths.domainManagementRoot(),
 	warnIfJetpack = true,
 } = {} ) {
-	const handlers = [ siteSelection, navigation, domainsController.wpForTeamsNoDomainsRedirect ];
+	const handlers = [ siteSelection, navigation, wpForTeamsGeneralNotSupportedRedirect ];
 
 	if ( noSitePath ) {
 		handlers.push( domainsController.redirectIfNoSite( noSitePath ) );

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -15,7 +15,12 @@ import {
 } from './controller';
 import { currentPlan } from './current-plan/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import {
+	navigation,
+	siteSelection,
+	sites,
+	wpForTeamsNotSupportedRedirect,
+} from 'calypso/my-sites/controller';
 import { shouldShowOfferResetFlow } from 'calypso/lib/plans/config';
 import plansV2 from 'calypso/my-sites/plans-v2';
 
@@ -24,19 +29,73 @@ const trackedPage = ( url, ...rest ) => {
 };
 
 export default function () {
-	trackedPage( '/plans', siteSelection, sites );
-	trackedPage( '/plans/compare', siteSelection, navigation, redirectToPlans );
-	trackedPage( '/plans/compare/:domain', siteSelection, navigation, redirectToPlans );
-	trackedPage( '/plans/features', siteSelection, navigation, redirectToPlans );
-	trackedPage( '/plans/features/:domain', siteSelection, navigation, redirectToPlans );
+	trackedPage( '/plans', siteSelection, wpForTeamsNotSupportedRedirect, sites );
+	trackedPage(
+		'/plans/compare',
+		siteSelection,
+		wpForTeamsNotSupportedRedirect,
+		navigation,
+		redirectToPlans
+	);
+	trackedPage(
+		'/plans/compare/:domain',
+		siteSelection,
+		wpForTeamsNotSupportedRedirect,
+		navigation,
+		redirectToPlans
+	);
+	trackedPage(
+		'/plans/features',
+		siteSelection,
+		wpForTeamsNotSupportedRedirect,
+		navigation,
+		redirectToPlans
+	);
+	trackedPage(
+		'/plans/features/:domain',
+		siteSelection,
+		wpForTeamsNotSupportedRedirect,
+		navigation,
+		redirectToPlans
+	);
 	trackedPage( '/plans/features/:feature/:domain', features );
-	trackedPage( '/plans/my-plan', siteSelection, sites, navigation, currentPlan );
-	trackedPage( '/plans/my-plan/:site', siteSelection, navigation, currentPlan );
-	trackedPage( '/plans/select/:plan/:domain', siteSelection, redirectToCheckout );
+	trackedPage(
+		'/plans/my-plan',
+		siteSelection,
+		wpForTeamsNotSupportedRedirect,
+		sites,
+		navigation,
+		currentPlan
+	);
+	trackedPage(
+		'/plans/my-plan/:site',
+		siteSelection,
+		wpForTeamsNotSupportedRedirect,
+		navigation,
+		currentPlan
+	);
+	trackedPage(
+		'/plans/select/:plan/:domain',
+		siteSelection,
+		wpForTeamsNotSupportedRedirect,
+		redirectToCheckout
+	);
 
 	// This route renders the plans page for both WPcom and Jetpack sites.
-	trackedPage( '/plans/:intervalType?/:site', siteSelection, navigation, plans );
+	trackedPage(
+		'/plans/:intervalType?/:site',
+		siteSelection,
+		wpForTeamsNotSupportedRedirect,
+		navigation,
+		plans
+	);
 	if ( shouldShowOfferResetFlow() ) {
-		plansV2( '/plans', siteSelection, redirectToPlansIfNotJetpack, navigation );
+		plansV2(
+			'/plans',
+			siteSelection,
+			wpForTeamsNotSupportedRedirect,
+			redirectToPlansIfNotJetpack,
+			navigation
+		);
 	}
 }

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -19,7 +19,7 @@ import {
 	navigation,
 	siteSelection,
 	sites,
-	wpForTeamsNotSupportedRedirect,
+	wpForTeamsP2PlusNotSupportedRedirect,
 } from 'calypso/my-sites/controller';
 import { shouldShowOfferResetFlow } from 'calypso/lib/plans/config';
 import plansV2 from 'calypso/my-sites/plans-v2';
@@ -29,32 +29,32 @@ const trackedPage = ( url, ...rest ) => {
 };
 
 export default function () {
-	trackedPage( '/plans', siteSelection, wpForTeamsNotSupportedRedirect, sites );
+	trackedPage( '/plans', siteSelection, wpForTeamsP2PlusNotSupportedRedirect, sites );
 	trackedPage(
 		'/plans/compare',
 		siteSelection,
-		wpForTeamsNotSupportedRedirect,
+		wpForTeamsP2PlusNotSupportedRedirect,
 		navigation,
 		redirectToPlans
 	);
 	trackedPage(
 		'/plans/compare/:domain',
 		siteSelection,
-		wpForTeamsNotSupportedRedirect,
+		wpForTeamsP2PlusNotSupportedRedirect,
 		navigation,
 		redirectToPlans
 	);
 	trackedPage(
 		'/plans/features',
 		siteSelection,
-		wpForTeamsNotSupportedRedirect,
+		wpForTeamsP2PlusNotSupportedRedirect,
 		navigation,
 		redirectToPlans
 	);
 	trackedPage(
 		'/plans/features/:domain',
 		siteSelection,
-		wpForTeamsNotSupportedRedirect,
+		wpForTeamsP2PlusNotSupportedRedirect,
 		navigation,
 		redirectToPlans
 	);
@@ -62,7 +62,7 @@ export default function () {
 	trackedPage(
 		'/plans/my-plan',
 		siteSelection,
-		wpForTeamsNotSupportedRedirect,
+		wpForTeamsP2PlusNotSupportedRedirect,
 		sites,
 		navigation,
 		currentPlan
@@ -70,14 +70,14 @@ export default function () {
 	trackedPage(
 		'/plans/my-plan/:site',
 		siteSelection,
-		wpForTeamsNotSupportedRedirect,
+		wpForTeamsP2PlusNotSupportedRedirect,
 		navigation,
 		currentPlan
 	);
 	trackedPage(
 		'/plans/select/:plan/:domain',
 		siteSelection,
-		wpForTeamsNotSupportedRedirect,
+		wpForTeamsP2PlusNotSupportedRedirect,
 		redirectToCheckout
 	);
 
@@ -85,7 +85,7 @@ export default function () {
 	trackedPage(
 		'/plans/:intervalType?/:site',
 		siteSelection,
-		wpForTeamsNotSupportedRedirect,
+		wpForTeamsP2PlusNotSupportedRedirect,
 		navigation,
 		plans
 	);
@@ -93,7 +93,7 @@ export default function () {
 		plansV2(
 			'/plans',
 			siteSelection,
-			wpForTeamsNotSupportedRedirect,
+			wpForTeamsP2PlusNotSupportedRedirect,
 			redirectToPlansIfNotJetpack,
 			navigation
 		);

--- a/client/my-sites/plans/test/index.js
+++ b/client/my-sites/plans/test/index.js
@@ -52,28 +52,78 @@ import plansV2 from 'calypso/my-sites/plans-v2';
 import router from '../index';
 
 const routes = {
-	'/plans': [ siteSelection, sites, makeLayout, clientRender ],
-	'/plans/compare': [ siteSelection, navigation, redirectToPlans, makeLayout, clientRender ],
-	'/plans/compare/:domain': [
+	'/plans': [
 		siteSelection,
+		wpForTeamsP2PlusNotSupportedRedirect,
+		sites,
+		makeLayout,
+		clientRender,
+	],
+	'/plans/compare': [
+		siteSelection,
+		wpForTeamsP2PlusNotSupportedRedirect,
 		navigation,
 		redirectToPlans,
 		makeLayout,
 		clientRender,
 	],
-	'/plans/features': [ siteSelection, navigation, redirectToPlans, makeLayout, clientRender ],
+	'/plans/compare/:domain': [
+		siteSelection,
+		wpForTeamsP2PlusNotSupportedRedirect,
+		navigation,
+		redirectToPlans,
+		makeLayout,
+		clientRender,
+	],
+	'/plans/features': [
+		siteSelection,
+		wpForTeamsP2PlusNotSupportedRedirect,
+		navigation,
+		redirectToPlans,
+		makeLayout,
+		clientRender,
+	],
 	'/plans/features/:domain': [
 		siteSelection,
+		wpForTeamsP2PlusNotSupportedRedirect,
 		navigation,
 		redirectToPlans,
 		makeLayout,
 		clientRender,
 	],
 	'/plans/features/:feature/:domain': [ features, makeLayout, clientRender ],
-	'/plans/my-plan': [ siteSelection, sites, navigation, currentPlan, makeLayout, clientRender ],
-	'/plans/my-plan/:site': [ siteSelection, navigation, currentPlan, makeLayout, clientRender ],
-	'/plans/select/:plan/:domain': [ siteSelection, redirectToCheckout, makeLayout, clientRender ],
-	'/plans/:intervalType?/:site': [ siteSelection, navigation, plans, makeLayout, clientRender ],
+	'/plans/my-plan': [
+		siteSelection,
+		wpForTeamsP2PlusNotSupportedRedirect,
+		sites,
+		navigation,
+		currentPlan,
+		makeLayout,
+		clientRender,
+	],
+	'/plans/my-plan/:site': [
+		siteSelection,
+		wpForTeamsP2PlusNotSupportedRedirect,
+		navigation,
+		currentPlan,
+		makeLayout,
+		clientRender,
+	],
+	'/plans/select/:plan/:domain': [
+		siteSelection,
+		wpForTeamsP2PlusNotSupportedRedirect,
+		redirectToCheckout,
+		makeLayout,
+		clientRender,
+	],
+	'/plans/:intervalType?/:site': [
+		siteSelection,
+		wpForTeamsP2PlusNotSupportedRedirect,
+		navigation,
+		plans,
+		makeLayout,
+		clientRender,
+	],
 };
 
 describe( 'Sets all routes', () => {

--- a/client/my-sites/plans/test/index.js
+++ b/client/my-sites/plans/test/index.js
@@ -40,7 +40,12 @@ import {
 } from '../controller';
 import { currentPlan } from '../current-plan/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import {
+	navigation,
+	siteSelection,
+	sites,
+	wpForTeamsP2PlusNotSupportedRedirect,
+} from 'calypso/my-sites/controller';
 import { shouldShowOfferResetFlow } from 'calypso/lib/plans/config';
 import plansV2 from 'calypso/my-sites/plans-v2';
 
@@ -92,6 +97,7 @@ describe( 'Loads Jetpack plan page', () => {
 		expect( plansV2 ).toHaveBeenCalledWith(
 			'/plans',
 			siteSelection,
+			wpForTeamsP2PlusNotSupportedRedirect,
 			redirectToPlansIfNotJetpack,
 			navigation
 		);


### PR DESCRIPTION
In this PR, we fix a bug with the P2 project in which we allow interacting with the Plans page when navigated to it directly.

We enable using the plans page if the P2+ (P2 paid plan) is enabled. So far it's enabled only on dev and staging so a12s will be able to use it.

We also fix a bug in which if you navigate to the Manage Domains page with a P2 site you are redirected to `/` instead of the site's home as it's very closely related.

## Testing

1. Locally, with the config flag `"p2/p2-plus"` set to whatever as it shouldn't affect this one: Navigate to a non-p2 site's Manage Domains page (under Manage in sidebar). Now, switch to a P2 site. You should be redirected to the site's Home page.
2. Locally, with the config flag `"p2/p2-plus"` set to `true`: Navigate to a non-p2 site's Plans page. Now, switch to a P2 site. You should stay on the Plans page and see the P2+ option.
3.  Locally, with the config flag `"p2/p2-plus"` set to `false`: Navigate to a non-p2 site's Plans page. Now, switch to a P2 site. You should be redirected to the site's Home page.
