### PR TITLE
Update pricing page slide-out margins in Jetpack cloud

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
@@ -57,7 +57,7 @@ $jetpack-product-card-alt-2-icon-size: 55px;
 		margin-bottom: 0;
 	}
 
-	.foldable-card {
+	.card.foldable-card {
 		width: 100%;
 		margin-bottom: 0;
 		padding: 0 10px;
@@ -461,10 +461,5 @@ button.components-button.jetpack-product-card-alt-2__slideout-button {
 .is-section-jetpack-cloud-pricing {
 	.jetpack-product-card-alt-2 {
 		background-color: #f6f7f7;
-	}
-
-	.jetpack-product-card-alt-2__slide-out-product.expanded {
-		margin-left: -16px;
-		margin-right: -16px;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes a CSS issue occurring in the new pricing page in production. See capture below.

### Implementation notes

I noticed this bug in production, but not in staging. It seems that some CSS are not loaded in the same order depending on the environment. This PR fixes this by increasing the specificity of the CSS rule.

### Testing instructions

- In Jetpack cloud, visit the pricing page
- In one of the plan cards, open a product slide-out by clicking "Learn more"
- Notice that the slide-out is the same width as the card

### Screenshots

Before
<img width="369" alt="Screen Shot 2020-11-02 at 4 06 34 PM" src="https://user-images.githubusercontent.com/1620183/97919494-de916c80-1d25-11eb-93a2-106e2a939ec3.png">

After
<img width="369" alt="Screen Shot 2020-11-02 at 4 11 43 PM" src="https://user-images.githubusercontent.com/1620183/97919637-1ef0ea80-1d26-11eb-881c-293d1910772f.png">

