### PR TITLE
Add "Upgrade to Yearly" functionality to slide-out products.

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/features-product-slide-out.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/features-product-slide-out.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -20,6 +20,7 @@ import { durationToText, productBadgeLabelAlt } from 'calypso/my-sites/plans-v2/
 import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
+import { TERM_ANNUALLY } from 'calypso/lib/plans/constants';
 
 /**
  * Type dependencies
@@ -77,24 +78,38 @@ const FeaturesProductSlideOut: FunctionComponent< Props > = ( {
 			slug === productSlug ||
 			JETPACK_PRODUCTS_LIST[ slug as JetpackProductSlug ]?.type === productSlug
 	);
+
 	const isItemPlanFeature = !! ( sitePlan && planHasFeature( sitePlan.product_slug, productSlug ) );
 	const isOwned = isItemPlanFeature || isItemPurchased;
+	const isUpgradeableToYearly =
+		( isOwned &&
+			productBillingTerm === TERM_ANNUALLY &&
+			monthlyProductSlug &&
+			purchases.some( ( { productSlug } ) => productSlug === monthlyProductSlug ) ) ||
+		false;
 	const purchase = isItemPlanFeature
 		? getPurchaseByProductSlug( purchases, sitePlan?.product_slug || '' )
 		: getPurchaseByProductSlug( purchases, productSlug ) ||
 		  ( monthlyProductSlug
 				? getPurchaseByProductSlug( purchases, monthlyProductSlug )
 				: undefined );
-	const slideOutButtonLabel = isOwned
-		? translate( 'Manage Subscription' )
-		: translate( 'Get {{name/}} %(price)s', {
-				args: {
-					price: formattedPrice,
-				},
-				components: {
-					name: <>{ shortName }</>,
-				},
-		  } );
+
+	const slideOutButtonLabel = useCallback( () => {
+		if ( isOwned ) {
+			if ( isUpgradeableToYearly ) {
+				return translate( 'Upgrade to Yearly' );
+			}
+			return translate( 'Manage Subscription' );
+		}
+		return translate( 'Get {{name/}} %(price)s', {
+			args: {
+				price: formattedPrice,
+			},
+			components: {
+				name: <>{ shortName }</>,
+			},
+		} );
+	}, [ isOwned, isUpgradeableToYearly, formattedPrice, shortName ] );
 
 	return (
 		<div
@@ -110,7 +125,7 @@ const FeaturesProductSlideOut: FunctionComponent< Props > = ( {
 					price={ Math.floor( ( displayPrice || price ) as number ) }
 					billingTimeFrame={ durationToText( displayTerm || productBillingTerm ) }
 					description={ description }
-					buttonLabel={ slideOutButtonLabel }
+					buttonLabel={ slideOutButtonLabel() }
 					onButtonClick={ () => onProductClick( product, false, purchase ) }
 					buttonPrimary={ ! isOwned }
 					isOwned={ isOwned }

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/features-product-slide-out.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/features-product-slide-out.tsx
@@ -126,7 +126,7 @@ const FeaturesProductSlideOut: FunctionComponent< Props > = ( {
 					billingTimeFrame={ durationToText( displayTerm || productBillingTerm ) }
 					description={ description }
 					buttonLabel={ slideOutButtonLabel() }
-					onButtonClick={ () => onProductClick( product, false, purchase ) }
+					onButtonClick={ () => onProductClick( product, isUpgradeableToYearly, purchase ) }
 					buttonPrimary={ ! isOwned }
 					isOwned={ isOwned }
 					badgeLabel={ productBadgeLabelAlt( product, isItemPurchased, sitePlan ) }

--- a/client/components/jetpack/card/jetpack-product-card-alt-2/features-product-slide-out.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/features-product-slide-out.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent, useCallback } from 'react';
+import React, { FunctionComponent, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -94,7 +94,7 @@ const FeaturesProductSlideOut: FunctionComponent< Props > = ( {
 				? getPurchaseByProductSlug( purchases, monthlyProductSlug )
 				: undefined );
 
-	const slideOutButtonLabel = useCallback( () => {
+	const slideOutButtonLabel = useMemo( () => {
 		if ( isOwned ) {
 			if ( isUpgradeableToYearly ) {
 				return translate( 'Upgrade to Yearly' );
@@ -108,6 +108,8 @@ const FeaturesProductSlideOut: FunctionComponent< Props > = ( {
 			components: {
 				name: <>{ shortName }</>,
 			},
+			comment:
+				'{name}: is the jetpack product name, ie- Backup Daily, Backup Real-time, Scan, Anti-spam, Search, Jetpack CRM',
 		} );
 	}, [ isOwned, isUpgradeableToYearly, formattedPrice, shortName ] );
 
@@ -125,7 +127,7 @@ const FeaturesProductSlideOut: FunctionComponent< Props > = ( {
 					price={ Math.floor( ( displayPrice || price ) as number ) }
 					billingTimeFrame={ durationToText( displayTerm || productBillingTerm ) }
 					description={ description }
-					buttonLabel={ slideOutButtonLabel() }
+					buttonLabel={ slideOutButtonLabel }
 					onButtonClick={ () => onProductClick( product, isUpgradeableToYearly, purchase ) }
 					buttonPrimary={ ! isOwned }
 					isOwned={ isOwned }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds "Upgrade to Yearly" functionality to the product 'slide-outs' if the product is upgradable (owned as an individual product with a monthly billing-term).

![chrome-capture (9)](https://user-images.githubusercontent.com/11078128/97918662-4f775b00-1d0b-11eb-9303-3da1648870e3.gif)

### Testing instructions

1. Checkout this PR, visit the Plans page.
2. First test with any site that has individual products owned on a 'Monthly' billing-term basis. Open/expand the owned product slide-out:
    - Verify that the "Upgrade to Yearly" button label appears when it should. (only on owned _monthly-billing_ products, when the "Yearly" billing-term filter is selected.
    - Verify that clicking "Upgrade to Yearly" button takes you to checkout with the _Yearly_ variant of the product in the cart.
3. Verify that the other button states ("Manage Subscription", "Get _Product_Name_") in the product slide-outs have not been affected by this change and are still working as expected.


Fixes # 1196341175636977-as-1198997553586645/f