### PR TITLE
Reader Lists: Enable list creation

### DIFF
--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -12,6 +12,11 @@ import React, { Component } from 'react';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import ReaderSidebarListsList from './list';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class ReaderSidebarLists extends Component {
 	static propTypes = {
 		lists: PropTypes.array,

--- a/client/reader/sidebar/reader-sidebar-lists/list-item-create-link.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item-create-link.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'calypso/components/gridicon';
+import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import ReaderSidebarHelper from '../helper';
+
+export class ReaderSidebarListsListItemCreateLink extends Component {
+	handleListSidebarClick = () => {
+		recordAction( 'clicked_reader_sidebar_list_item_create_link' );
+		recordGaEvent( 'Clicked Reader Sidebar List Item Create Link' );
+		recordTrack( 'calypso_reader_sidebar_list_item_create_link_clicked' );
+	};
+
+	render() {
+		const relativePath = '/read/list/new';
+		const classes = classNames( 'sidebar__menu-item--create-reader-list-link', {
+			selected: ReaderSidebarHelper.pathStartsWithOneOf( [ relativePath ], this.props.path ),
+		} );
+
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		return (
+			<li className={ classes }>
+				<a
+					className="sidebar__menu-link"
+					href="/read/list/new"
+					onClick={ this.handleListSidebarClick }
+				>
+					<div className="sidebar__menu-item-title">
+						<Gridicon icon="add-outline" />{ ' ' }
+						<span className="sidebar__menu-item-title-text">
+							{ this.props.translate( 'Create new list' ) }
+						</span>
+					</div>
+				</a>
+			</li>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	}
+}
+
+export default localize( ReaderSidebarListsListItemCreateLink );

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -60,7 +60,7 @@ export class ReaderSidebarListsListItem extends Component {
 			this.props.path
 		);
 
-		const classes = classNames( {
+		const classes = classNames( 'sidebar__menu-item--reader-list', {
 			selected: isCurrentList || isActionButtonSelected,
 		} );
 
@@ -77,7 +77,7 @@ export class ReaderSidebarListsListItem extends Component {
 						},
 					} ) }
 				>
-					<div className="sidebar__menu-item-listname">{ list.title }</div>
+					<div className="sidebar__menu-item-title">{ list.title }</div>
 				</a>
 			</li>
 		);

--- a/client/reader/sidebar/reader-sidebar-lists/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list.jsx
@@ -9,7 +9,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderSidebarListsListItem from './list-item';
+import ListItem from './list-item';
+import ListItemCreateLink from './list-item-create-link';
 
 export class ReaderSidebarListsList extends React.Component {
 	static propTypes = {
@@ -28,7 +29,7 @@ export class ReaderSidebarListsList extends React.Component {
 		const { currentListOwner, currentListSlug, path } = this.props;
 		return map( this.props.lists, function ( list ) {
 			return (
-				<ReaderSidebarListsListItem
+				<ListItem
 					key={ list.ID }
 					list={ list }
 					path={ path }
@@ -50,7 +51,12 @@ export class ReaderSidebarListsList extends React.Component {
 			);
 		}
 
-		return <ul className="sidebar__menu-list">{ this.renderItems() }</ul>;
+		return (
+			<ul className="sidebar__menu-list">
+				{ this.renderItems() }
+				<ListItemCreateLink key="create-item-link" path={ this.props.path } />
+			</ul>
+		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }

--- a/client/reader/sidebar/reader-sidebar-lists/style.scss
+++ b/client/reader/sidebar/reader-sidebar-lists/style.scss
@@ -1,0 +1,6 @@
+.sidebar__menu-item--create-reader-list-link {
+	.gridicon,
+	.sidebar__menu-item-title-text {
+		vertical-align: middle;
+	}
+}

--- a/client/state/data-layer/wpcom/read/lists/index.js
+++ b/client/state/data-layer/wpcom/read/lists/index.js
@@ -36,10 +36,17 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 					},
 					action
 				),
-			onSuccess: ( action, response ) => [
-				receiveReaderList( { list: response } ),
-				navigate( `/read/list/${ response.owner }/${ response.slug }/edit` ),
-			],
+			onSuccess: ( action, { list } ) => {
+				if ( list?.owner && list?.slug ) {
+					return [
+						receiveReaderList( { list } ),
+						navigate( `/read/list/${ list.owner }/${ list.slug }/edit` ),
+						successNotice( translate( 'List created successfully!' ) ),
+					];
+				}
+				// NOTE: Add better handling for unexpected response format here.
+				errorNotice( translate( 'List could not be created, please try again later.' ) );
+			},
 			onError: ( action, error ) => [
 				errorNotice( String( error ) ),
 				handleReaderListRequestFailure( error ),

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -128,6 +128,11 @@ export const subscribedLists = withSchemaValidation(
 				return filter( state, ( listId ) => {
 					return listId !== action.listId;
 				} );
+			case READER_LIST_REQUEST_SUCCESS:
+				if ( ! state.includes( action.data.list.ID ) ) {
+					return [ ...state, action.data.list.ID ];
+				}
+				return state;
 		}
 		return state;
 	}

--- a/client/state/reader/lists/test/reducer.js
+++ b/client/state/reader/lists/test/reducer.js
@@ -273,6 +273,7 @@ describe( 'reducer', () => {
 					listId: 1,
 				} )
 			).toEqual( [ 2 ] );
+		} );
 		test( 'should add a list on creation', () => {
 			const initial = deepFreeze( [ 1 ] );
 			expect(

--- a/client/state/reader/lists/test/reducer.js
+++ b/client/state/reader/lists/test/reducer.js
@@ -242,7 +242,7 @@ describe( 'reducer', () => {
 			).toEqual( expect.arrayContaining( [ 1, 3 ] ) );
 		} );
 
-		test( 'should add an item on follow', () => {
+		test( 'should add a list on follow', () => {
 			const initial = deepFreeze( [ 1, 2 ] );
 			expect(
 				subscribedLists( initial, {
@@ -254,7 +254,7 @@ describe( 'reducer', () => {
 			).toEqual( expect.arrayContaining( [ 1, 2, 5 ] ) );
 		} );
 
-		test( 'should remove an item on unfollow', () => {
+		test( 'should remove a list on unfollow', () => {
 			const initial = deepFreeze( [ 1, 2 ] );
 			expect(
 				subscribedLists( initial, {
@@ -265,7 +265,6 @@ describe( 'reducer', () => {
 				} )
 			).toEqual( [ 2 ] );
 		} );
-
 		test( 'should remove a list on delete', () => {
 			const initial = deepFreeze( [ 1, 2 ] );
 			expect(
@@ -274,6 +273,16 @@ describe( 'reducer', () => {
 					listId: 1,
 				} )
 			).toEqual( [ 2 ] );
+		test( 'should add a list on creation', () => {
+			const initial = deepFreeze( [ 1 ] );
+			expect(
+				subscribedLists( initial, {
+					type: READER_LIST_REQUEST_SUCCESS,
+					data: {
+						list: { ID: 2 },
+					},
+				} )
+			).toEqual( [ 1, 2 ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a `Create new list` link in the sidebar.
> <img width="269" alt="Screen Shot 2020-11-02 at 3 40 00 PM" src="https://user-images.githubusercontent.com/4044428/97927226-d33c4200-1d21-11eb-9abb-7f2ba426945c.png">

* Tweaks data-layer and state handling to work properly with our ListForm.

#### Testing instructions

* Spin this up locally or enable the `reader/list-management` feature flag in the environment of your choice.
* Ensure that you can see the new `Create new list` link in the Reader sidebar. It should be within the Lists dropdown folder.
* Ensure that clicking the link takes you to a working create form.
* Ensure that creating a list takes you directly to the list edit page (`/read/list/:user/:listSlug/edit`).
