### PR TITLE
Reader Lists: add new tab for list deletion

### DIFF
--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -37,6 +37,7 @@ import ReaderExportButton from 'calypso/blocks/reader-export-button';
 import { READER_EXPORT_TYPE_LIST } from 'calypso/blocks/reader-export-button/constants';
 import ListItem from './list-item';
 import Missing from 'calypso/reader/list-stream/missing';
+import ListDelete from './list-delete';
 
 /**
  * Style dependencies
@@ -255,11 +256,18 @@ function ReaderListEdit( props ) {
 								>
 									{ translate( 'Export' ) }
 								</NavItem>
+								<NavItem
+									selected={ selectedSection === 'delete' }
+									path={ `/read/list/${ props.owner }/${ props.slug }/delete` }
+								>
+									{ translate( 'Delete' ) }
+								</NavItem>
 							</NavTabs>
 						</SectionNav>
 						{ selectedSection === 'details' && <Details { ...sectionProps } /> }
 						{ selectedSection === 'items' && <Items { ...sectionProps } /> }
 						{ selectedSection === 'export' && <Export { ...sectionProps } /> }
+						{ selectedSection === 'delete' && <ListDelete { ...sectionProps } /> }
 					</>
 				) }
 			</Main>

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -8,7 +8,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { Button, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
 import {
 	getListByOwnerAndSlug,
 	getListItems,
@@ -22,7 +22,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormRadio from 'calypso/components/forms/form-radio';
-import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
@@ -130,22 +129,6 @@ function ListForm( { isCreateForm, isSubmissionDisabled, list, onChange, onSubmi
 				</FormButton>
 			</FormButtonsBar>
 		</Card>
-	);
-}
-
-function Details( { list } ) {
-	const translate = useTranslate();
-	return (
-		<>
-			<ListForm list={ list } />
-
-			<Card>
-				<FormSectionHeading>{ translate( 'DANGER!!' ) }</FormSectionHeading>
-				<Button scary primary>
-					{ translate( 'DELETE LIST FOREVER' ) }
-				</Button>
-			</Card>
-		</>
 	);
 }
 
@@ -264,7 +247,7 @@ function ReaderListEdit( props ) {
 								</NavItem>
 							</NavTabs>
 						</SectionNav>
-						{ selectedSection === 'details' && <Details { ...sectionProps } /> }
+						{ selectedSection === 'details' && <ListForm { ...sectionProps } /> }
 						{ selectedSection === 'items' && <Items { ...sectionProps } /> }
 						{ selectedSection === 'export' && <Export { ...sectionProps } /> }
 						{ selectedSection === 'delete' && <ListDelete { ...sectionProps } /> }

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -210,7 +210,7 @@ function ReaderListEdit( props ) {
 			<Main>
 				<FormattedHeader
 					headerText={ translate( 'Manage %(listName)s', {
-						args: { listName: list?.title || props.slug },
+						args: { listName: list?.title || decodeURIComponent( props.slug ) },
 					} ) }
 				/>
 				{ ! list && ! isMissing && <Card>{ translate( 'Loading…' ) }</Card> }

--- a/client/reader/list-manage/list-delete.jsx
+++ b/client/reader/list-manage/list-delete.jsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+
+function ListDelete() {
+	const translate = useTranslate();
+	return (
+		<Card>
+			<p>{ translate( 'Delete the list forever. Be careful - this is not reversible.' ) }</p>
+		</Card>
+	);
+}
+
+export default ListDelete;

--- a/client/reader/list-manage/list-delete.jsx
+++ b/client/reader/list-manage/list-delete.jsx
@@ -3,18 +3,52 @@
  */
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
+import { Button, Card, Dialog } from '@automattic/components';
+import { deleteReaderList } from 'calypso/state/reader/lists/actions';
 
-function ListDelete() {
+function ListDelete( { list } ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const [ deleteState, setDeleteState ] = React.useState( '' );
+
 	return (
-		<Card>
-			<p>{ translate( 'Delete the list forever. Be careful - this is not reversible.' ) }</p>
-		</Card>
+		<>
+			{ deleteState === '' && (
+				<Card>
+					<p>{ translate( 'Delete the list forever. Be careful - this is not reversible.' ) }</p>
+					<Button scary primary onClick={ () => setDeleteState( 'confirming' ) }>
+						{ translate( 'Delete list' ) }
+					</Button>
+				</Card>
+			) }
+			{ deleteState === 'confirming' && (
+				<Dialog
+					isVisible={ true }
+					buttons={ [
+						{ action: 'cancel', label: translate( 'Keep it!' ) },
+						{ action: 'delete', label: translate( 'Delete list' ), isPrimary: true },
+					] }
+					onClose={ ( action ) => {
+						if ( action === 'delete' ) {
+							return [
+								dispatch( deleteReaderList( list.ID, list.owner, list.slug ) ),
+								setDeleteState( 'deleted' ),
+							];
+						}
+
+						setDeleteState( '' );
+					} }
+				>
+					<h1>{ translate( 'Are you sure you want to delete this list?' ) }</h1>
+					<p>{ translate( 'This action cannot be undone.' ) }</p>
+				</Dialog>
+			) }
+		</>
 	);
 }
 

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -133,3 +133,26 @@ export const exportList = ( context, next ) => {
 	);
 	next();
 };
+
+export const deleteList = ( context, next ) => {
+	const basePath = '/read/list/:owner/:slug/delete';
+	const fullAnalyticsPageTitle = `${ analyticsPageTitle } > List > ${ context.params.user } - ${ context.params.list } > Edit > Delete`;
+	const mcKey = 'list';
+
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+	recordTrack( 'calypso_reader_list_delete_loaded', {
+		list_owner: context.params.user,
+		list_slug: context.params.list,
+	} );
+
+	context.primary = (
+		<AsyncLoad
+			require="calypso/reader/list-manage"
+			key="list-manage"
+			owner={ encodeURIComponent( context.params.user ) }
+			slug={ encodeURIComponent( context.params.list ) }
+			selectedSection={ 'delete' }
+		/>
+	);
+	next();
+};

--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -6,7 +6,14 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { createList, editList, editListItems, exportList, listListing } from './controller';
+import {
+	createList,
+	deleteList,
+	editList,
+	editListItems,
+	exportList,
+	listListing,
+} from './controller';
 import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 
@@ -35,6 +42,15 @@ export default function () {
 		updateLastRoute,
 		sidebar,
 		exportList,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/read/list/:user/:list/delete',
+		updateLastRoute,
+		sidebar,
+		deleteList,
 		makeLayout,
 		clientRender
 	);

--- a/client/state/data-layer/wpcom/read/lists/delete/index.js
+++ b/client/state/data-layer/wpcom/read/lists/delete/index.js
@@ -2,16 +2,17 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { READER_LIST_DELETE } from 'calypso/state/reader/action-types';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+import { navigate } from 'calypso/state/ui/actions';
+import { DEFAULT_NOTICE_DURATION } from 'calypso/state/notices/constants';
 
 registerHandlers( 'state/data-layer/wpcom/read/lists/delete/index.js', {
 	[ READER_LIST_DELETE ]: [
@@ -26,8 +27,15 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/delete/index.js', {
 					},
 					action
 				),
-			onSuccess: noop,
-			onError: () => errorNotice( translate( 'Unable to remove list' ) ),
+			onSuccess: () => {
+				return [
+					navigate( `/read` ),
+					successNotice( translate( 'List deleted successfully.' ), {
+						duration: DEFAULT_NOTICE_DURATION,
+					} ),
+				];
+			},
+			onError: () => errorNotice( translate( 'There was a problem deleting the list.' ) ),
 		} ),
 	],
 } );

--- a/client/state/notices/constants.js
+++ b/client/state/notices/constants.js
@@ -1,0 +1,2 @@
+// Set a sensible default for notice duration rather than inventing a new value each time
+export const DEFAULT_NOTICE_DURATION = 5000; // ms


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Create a new tab in List Management for deleting an existing list.

New tab:

<img width="821" alt="Screen Shot 2020-11-03 at 15 00 57" src="https://user-images.githubusercontent.com/17325/97938193-a8b3bd00-1de5-11eb-84dd-c6ffddd98bcd.png">

Confirmation dialog:

<img width="700" alt="Screen Shot 2020-11-03 at 15 01 02" src="https://user-images.githubusercontent.com/17325/97938205-b23d2500-1de5-11eb-814c-3a001b885b10.png">

...and it's gone!

<img width="1249" alt="Screen Shot 2020-11-03 at 15 01 14" src="https://user-images.githubusercontent.com/17325/97938213-b8330600-1de5-11eb-8607-dc1cf3a5a941.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
On an existing Reader list that you own and are happy to delete, press the 'cog' icon at the top right, then navigate to the 'Delete' tab.

Press the 'delete' button. If you choose 'keep it', you should return to the delete tab without any changes made.

Press the 'delete' button again, and this time, go through with the deletion. The list should be deleted and you should be navigated to /read with a success notice displayed.
