### PR TITLE
Shopping cart: Fix tax location calculation

### DIFF
--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -142,10 +142,14 @@ export function convertRawResponseCartToResponseCart(
 	}
 
 	// If tax.location is an empty PHP associative array, it will be JSON serialized to [] but we need {}
-	const taxLocation =
-		rawResponseCart.tax?.location && Array.isArray( rawResponseCart.tax.location )
-			? rawResponseCart.tax.location
-			: {};
+	let taxLocation = {};
+	if ( rawResponseCart.tax?.location ) {
+		if ( Array.isArray( rawResponseCart.tax.location ) ) {
+			taxLocation = {};
+		} else {
+			taxLocation = rawResponseCart.tax.location;
+		}
+	}
 
 	const rawProducts =
 		rawResponseCart.products?.length && Array.isArray( rawResponseCart.products )

--- a/packages/shopping-cart/test/shopping-cart-endpoint.js
+++ b/packages/shopping-cart/test/shopping-cart-endpoint.js
@@ -9,6 +9,8 @@ import {
 	addItemsToResponseCart,
 	addLocationToResponseCart,
 	doesCartLocationDifferFromResponseCartLocation,
+	convertResponseCartToRequestCart,
+	convertRawResponseCartToResponseCart,
 } from '../src/cart-functions';
 
 const cart = {
@@ -315,5 +317,112 @@ describe( 'addCouponToResponseCart', function () {
 	} );
 	it( 'does not have the coupon applied', function () {
 		expect( result.is_coupon_applied ).toEqual( false );
+	} );
+} );
+
+describe( 'convertResponseCartToRequestCart', function () {
+	it( 'preserves the tax location', function () {
+		const responseCart = {
+			...cart,
+			products: [
+				{
+					product_name: 'WordPress.com Personal',
+					product_slug: 'wpcom_personal',
+					product_id: 0,
+					currency: 'USD',
+					item_subtotal_integer: 0,
+					item_subtotal_display: '$0',
+					is_domain_registration: false,
+					meta: '',
+					volume: 1,
+					extra: [],
+					uuid: '0',
+				},
+				{
+					product_name: 'DotLive Domain',
+					product_slug: 'dotlive_domain',
+					product_id: 0,
+					currency: 'USD',
+					item_subtotal_integer: 0,
+					item_subtotal_display: '$0',
+					is_domain_registration: true,
+					meta: '',
+					volume: 1,
+					extra: [],
+					uuid: '1',
+				},
+			],
+			tax: {
+				display_taxes: true,
+				location: {
+					country_code: 'US',
+					postal_code: 90210,
+				},
+			},
+		};
+
+		const requestCart = convertResponseCartToRequestCart( responseCart );
+
+		expect( requestCart.tax.location.country_code ).toEqual(
+			responseCart.tax.location.country_code
+		);
+		expect( requestCart.tax.location.postal_code ).toEqual( responseCart.tax.location.postal_code );
+	} );
+} );
+
+describe( 'convertRawResponseCartToResponseCart', function () {
+	const responseCart = {
+		...cart,
+		products: [
+			{
+				product_name: 'WordPress.com Personal',
+				product_slug: 'wpcom_personal',
+				product_id: 0,
+				currency: 'USD',
+				item_subtotal_integer: 0,
+				item_subtotal_display: '$0',
+				is_domain_registration: false,
+				meta: '',
+				volume: 1,
+				extra: [],
+				uuid: '0',
+			},
+			{
+				product_name: 'DotLive Domain',
+				product_slug: 'dotlive_domain',
+				product_id: 0,
+				currency: 'USD',
+				item_subtotal_integer: 0,
+				item_subtotal_display: '$0',
+				is_domain_registration: true,
+				meta: '',
+				volume: 1,
+				extra: [],
+				uuid: '1',
+			},
+		],
+		tax: {
+			display_taxes: true,
+			location: {
+				country_code: 'US',
+				postal_code: 90210,
+			},
+		},
+	};
+
+	it( 'preserves the tax location if set', function () {
+		const result = convertRawResponseCartToResponseCart( responseCart );
+		expect( result.tax.location.country_code ).toEqual( responseCart.tax.location.country_code );
+		expect( result.tax.location.postal_code ).toEqual( responseCart.tax.location.postal_code );
+		expect( result.tax.display_taxes ).toEqual( responseCart.tax.display_taxes );
+	} );
+
+	it( 'converts the tax location if the tax location is an array', function () {
+		const result = convertRawResponseCartToResponseCart( {
+			...responseCart,
+			tax: { location: [] },
+		} );
+		expect( Array.isArray( result.tax.location ) ).toBeFalsy();
+		expect( typeof result.tax.location === 'object' ).toBeTruthy();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/46532/commits/c773d18666010afe0e6ddb6b3f524c0fe54188a5 (part of https://github.com/Automattic/wp-calypso/pull/46532), I added a bug into `convertRawResponseCartToResponseCart` in the shopping cart code which broke the saving of tax information from the shopping cart.

This PR fixes the regression and adds unit tests so that it won't happen again.

Before this fix:

<img width="580" alt="Screen Shot 2020-11-02 at 7 30 01 PM" src="https://user-images.githubusercontent.com/2036909/97933826-d6dfc100-1d41-11eb-86d2-0a30ccee7e7f.png">

After this fix:

<img width="575" alt="Screen Shot 2020-11-02 at 7 28 20 PM" src="https://user-images.githubusercontent.com/2036909/97933786-b6176b80-1d41-11eb-9726-eb45f1ae0cb7.png">

#### Testing instructions

- Start with an empty shopping cart.
- Visit checkout with a URL that adds a product to the cart, like `/checkout/example.com/business`.
- If you do not have a country and postal code set, set them to something.
- Verify that you see taxes displayed at the bottom (even if they are $0).
- Click "Edit" on the order step to edit the order and change the plan length from one year to two years. Press "Save Order".
- Verify that when the page updates, taxes remain displayed at the bottom.

Fixes 41-gh-Automattic/payments-shilling