### PR TITLE
Adds the plan name and term to ticket plain text

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -71,6 +71,7 @@ import getInlineHelpSupportVariation, {
 	SUPPORT_TICKET,
 	SUPPORT_UPWORK_TICKET,
 } from 'calypso/state/selectors/get-inline-help-support-variation';
+import { getPlanTermLabel } from 'calypso/lib/plans';
 
 /**
  * Style dependencies
@@ -189,12 +190,19 @@ class HelpContact extends React.Component {
 
 	submitKayakoTicket = ( contactForm ) => {
 		const { subject, message, howCanWeHelp, howYouFeel, site } = contactForm;
-		const { currentUserLocale, supportVariation } = this.props;
-
+		const { currentUserLocale, supportVariation, translate } = this.props;
+		let plan = 'N/A';
+		if ( site ) {
+			plan = `${ site.plan.product_name_short } (${ getPlanTermLabel(
+				site.plan.product_slug,
+				translate
+			) })`;
+		}
 		const ticketMeta = [
 			'How can you help: ' + howCanWeHelp,
 			'How I feel: ' + howYouFeel,
 			'Site I need help with: ' + ( site ? site.URL : 'N/A' ),
+			'Plan: ' + plan,
 		];
 
 		const kayakoMessage = [ ...ticketMeta, '\n', message ].join( '\n' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds the plan name and subscription term to the ticket plain text. For example, if the user is on a monthly Business plan, the text `Plan: Business (Monthly subscription)` will be added to the ticket.

![image](https://user-images.githubusercontent.com/5436027/97964198-6044d100-1dde-11eb-97fb-46b9b3212fbb.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Login as a user with a valid plan.
* Create a ticket by clicking on the "?" icon in the bottom right and select "Contact Us".
* Inspect the network response for the request sent to create the ticket.
* The plan name and term should be present in the message body.