### PR TITLE
Pricing page: align CTA button in Jetpack cloud

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/style.scss
@@ -462,4 +462,8 @@ button.components-button.jetpack-product-card-alt-2__slideout-button {
 	.jetpack-product-card-alt-2 {
 		background-color: #f6f7f7;
 	}
+
+	.jetpack-product-card-alt-2__product-name {
+		letter-spacing: -0.5px; // Prevent names from falling on 2 lines
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR aligns the cards content in Jetpack cloud, see capture.

### Testing instructions

- Run Jetpack cloud
- Visit the pricing page
- Notice CTA buttons of the first row of cards are aligned

### Screenshots

Before
<img width="1101" alt="Screen Shot 2020-11-03 at 9 38 43 AM" src="https://user-images.githubusercontent.com/1620183/98000127-2530a680-1dba-11eb-99bb-60ef38e844b5.png">

After
<img width="1098" alt="Screen Shot 2020-11-03 at 9 45 24 AM" src="https://user-images.githubusercontent.com/1620183/98000147-29f55a80-1dba-11eb-9628-7cbf61840875.png">
