### PR TITLE
Add the word annual to free domain explainer

### DIFF
--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -45,19 +45,25 @@ class FreeDomainExplainer extends React.Component {
 	}
 
 	render() {
-		const { translate, isReskinned } = this.props;
+		const { translate, isReskinned, locale } = this.props;
 		const { TextWrapper } = this;
 
 		return (
 			<div className="free-domain-explainer card is-compact">
 				<header>
 					<h1 className="free-domain-explainer__title">
-						{ translate( 'Get a free one-year domain registration with any paid plan.' ) }
+						{ locale === 'en'
+							? translate( 'Get a free one-year domain registration with any paid annual plan.' )
+							: translate( 'Get a free one-year domain registration with any paid plan.' ) }
 					</h1>
 					<TextWrapper className="free-domain-explainer__subtitle">
-						{ translate(
-							"We'll pay the registration fees for your new domain when you choose a paid plan during the next step."
-						) }
+						{ locale === 'en'
+							? translate(
+									"We'll pay the registration fees for your new domain when you choose an annual plan during the next step."
+							  )
+							: translate(
+									"We'll pay the registration fees for your new domain when you choose a paid plan during the next step."
+							  ) }
 					</TextWrapper>
 					<TextWrapper className="free-domain-explainer__subtitle">
 						{ translate( "You can claim your free custom domain later if you aren't ready yet." ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change will only add the word annual if the locale is 'en' to prevent the string from appearing non-updated

See 671-gh-martech

#### Testing instructions

1. Sign up with a new user, with an 'en' locale (the locale can be changed by adding /en to the signup URL)
2. Domain step should display the word 'annual' in the Free domain explainer component

<img width="976" alt="Screenshot 2020-11-03 at 17 52 39" src="https://user-images.githubusercontent.com/82778/98009050-d147b100-1dfd-11eb-8601-0055144034f3.png">

3. Change the locale to something else. The screenshot is with Spanish
4. Old copy, no annual, should be there

<img width="976" alt="Screenshot 2020-11-03 at 17 52 01" src="https://user-images.githubusercontent.com/82778/98009060-d3aa0b00-1dfd-11eb-8562-6cdb523241bd.png">