### PR TITLE
Domains: Allow transfer of mappings to other administrators on site 

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -298,7 +298,6 @@ export default {
 				component={ DomainManagement.TransferToOtherUser }
 				context={ pageContext }
 				needsDomains
-				needsDomainInfo
 				needsUsers
 				selectedDomainName={ pageContext.params.domain }
 			/>

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -66,7 +66,7 @@ function Transfer( props ) {
 						{ translate( 'Transfer to another registrar' ) }
 					</VerticalNavItem>
 				) }
-				{ ! isMapping && ! isDomainOnly && (
+				{ ! isDomainOnly && (
 					<VerticalNavItem
 						path={ domainManagementTransferToAnotherUser( slug, selectedDomainName, currentRoute ) }
 					>

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -20,7 +20,7 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import wp from 'calypso/lib/wp';
-import { getSelectedDomain } from 'calypso/lib/domains';
+import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
@@ -45,7 +45,6 @@ class TransferOtherUser extends React.Component {
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		users: PropTypes.array.isRequired,
-		wapiDomainInfo: PropTypes.object.isRequired,
 	};
 
 	constructor( props ) {
@@ -161,8 +160,8 @@ class TransferOtherUser extends React.Component {
 			return <DomainMainPlaceholder goBack={ this.goToEdit } />;
 		}
 
-		const { selectedSite, selectedDomainName, currentRoute } = this.props,
-			{ slug } = selectedSite;
+		const { selectedSite, selectedDomainName, translate, currentRoute } = this.props;
+		const { slug } = selectedSite;
 
 		return (
 			<Main>
@@ -170,7 +169,9 @@ class TransferOtherUser extends React.Component {
 					selectedDomainName={ selectedDomainName }
 					backHref={ domainManagementTransfer( slug, selectedDomainName, currentRoute ) }
 				>
-					{ this.props.translate( 'Transfer Domain To Another User' ) }
+					{ this.props.isMapping
+						? translate( 'Transfer Domain Mapping To Another User' )
+						: translate( 'Transfer Domain To Another User' ) }
 				</Header>
 				{ this.renderSection() }
 			</Main>
@@ -179,21 +180,19 @@ class TransferOtherUser extends React.Component {
 
 	renderDialog() {
 		const buttons = [
-				{
-					action: 'cancel',
-					label: this.props.translate( 'Cancel' ),
-					disabled: this.state.disableDialogButtons,
-				},
-				{
-					action: 'confirm',
-					label: this.props.translate( 'Confirm transfer' ),
-					onClick: this.handleConfirmTransferDomain,
-					disabled: this.state.disableDialogButtons,
-					isPrimary: true,
-				},
-			],
-			domainName = this.props.selectedDomainName,
-			selectedUserDisplay = this.getSelectedUserDisplayName();
+			{
+				action: 'cancel',
+				label: this.props.translate( 'Cancel' ),
+				disabled: this.state.disableDialogButtons,
+			},
+			{
+				action: 'confirm',
+				label: this.props.translate( 'Confirm transfer' ),
+				onClick: this.handleConfirmTransferDomain,
+				disabled: this.state.disableDialogButtons,
+				isPrimary: true,
+			},
+		];
 		return (
 			<Dialog
 				className="transfer-to-other-user__confirmation-dialog"
@@ -202,47 +201,55 @@ class TransferOtherUser extends React.Component {
 				onClose={ this.handleDialogClose }
 			>
 				<h1>{ this.props.translate( 'Confirm Transfer' ) }</h1>
-				<p>
-					{ this.props.translate(
-						'Do you want to transfer the ownership of {{strong}}%(domainName)s{{/strong}} ' +
-							'to {{strong}}%(selectedUserDisplay)s{{/strong}}?',
-						{
-							args: { domainName, selectedUserDisplay },
-							components: { strong: <strong /> },
-						}
-					) }
-				</p>
+				<p>{ this.getDialogMessage() }</p>
 			</Dialog>
 		);
 	}
 
+	getDialogMessage() {
+		const { selectedDomainName: domainName, isMapping, translate } = this.props;
+		const selectedUserDisplay = this.getSelectedUserDisplayName();
+
+		if ( isMapping ) {
+			return translate(
+				'Do you want to transfer the domain mapping of {{strong}}%(domainName)s{{/strong}} ' +
+					'to {{strong}}%(selectedUserDisplay)s{{/strong}}?',
+				{
+					args: { domainName, selectedUserDisplay },
+					components: { strong: <strong /> },
+				}
+			);
+		}
+
+		return translate(
+			'Do you want to transfer the ownership of {{strong}}%(domainName)s{{/strong}} ' +
+				'to {{strong}}%(selectedUserDisplay)s{{/strong}}?',
+			{
+				args: { domainName, selectedUserDisplay },
+				components: { strong: <strong /> },
+			}
+		);
+	}
+
 	renderSection() {
-		const { selectedDomainName: domainName, translate, users, selectedSite } = this.props,
-			availableUsers = this.filterAvailableUsers( users ),
-			{ currentUserCanManage, domainRegistrationAgreementUrl } = getSelectedDomain( this.props ),
-			saveButtonLabel = translate( 'Transfer domain' );
+		const { currentUserCanManage, domainRegistrationAgreementUrl } = getSelectedDomain(
+			this.props
+		);
 
 		if ( ! currentUserCanManage ) {
 			return <NonOwnerCard { ...omit( this.props, [ 'children' ] ) } />;
 		}
 
+		const { isMapping, translate, users } = this.props;
+		const availableUsers = this.filterAvailableUsers( users );
+		const saveButtonLabel = isMapping
+			? translate( 'Transfer domain mapping' )
+			: translate( 'Transfer domain' );
+
 		return (
 			<Fragment>
 				<Card>
-					<p>
-						{ translate(
-							'Transferring a domain to another user will give all the rights of the domain to that user. ' +
-								'Please choose an administrator to transfer {{strong}}%(domainName)s{{/strong}} to.',
-							{ args: { domainName }, components: { strong: <strong /> } }
-						) }
-					</p>
-					<p>
-						{ translate(
-							'You can transfer this domain to any administrator on this site. If the user you want to ' +
-								'transfer is not currently an administrator, please {{a}}add them to the site first{{/a}}.',
-							{ components: { a: <a href={ `/people/new/${ selectedSite.slug }` } /> } }
-						) }
-					</p>
+					{ this.renderTransferInformation() }
 					<FormFieldset>
 						<FormSelect
 							disabled={ availableUsers.length === 0 }
@@ -265,10 +272,12 @@ class TransferOtherUser extends React.Component {
 							) }
 						</FormSelect>
 					</FormFieldset>
-					<DesignatedAgentNotice
-						domainRegistrationAgreementUrl={ domainRegistrationAgreementUrl }
-						saveButtonLabel={ saveButtonLabel }
-					/>
+					{ ! isMapping && (
+						<DesignatedAgentNotice
+							domainRegistrationAgreementUrl={ domainRegistrationAgreementUrl }
+							saveButtonLabel={ saveButtonLabel }
+						/>
+					) }
 					<FormButton
 						disabled={ ! this.state.selectedUserId }
 						onClick={ this.handleTransferDomain }
@@ -281,6 +290,49 @@ class TransferOtherUser extends React.Component {
 		);
 	}
 
+	renderTransferInformation() {
+		const { isMapping, selectedDomainName: domainName, selectedSite, translate } = this.props;
+
+		if ( isMapping ) {
+			return (
+				<>
+					<p>
+						{ translate(
+							'Please choose an administrator to transfer domain mapping of {{strong}}%(domainName)s{{/strong}} to.',
+							{ args: { domainName }, components: { strong: <strong /> } }
+						) }
+					</p>
+					<p>
+						{ translate(
+							'You can transfer this domain mapping to any administrator on this site. If the user you want to ' +
+								'transfer is not currently an administrator, please {{a}}add them to the site first{{/a}}.',
+							{ components: { a: <a href={ `/people/new/${ selectedSite.slug }` } /> } }
+						) }
+					</p>
+				</>
+			);
+		}
+
+		return (
+			<>
+				<p>
+					{ translate(
+						'Transferring a domain to another user will give all the rights of the domain to that user. ' +
+							'Please choose an administrator to transfer {{strong}}%(domainName)s{{/strong}} to.',
+						{ args: { domainName }, components: { strong: <strong /> } }
+					) }
+				</p>
+				<p>
+					{ translate(
+						'You can transfer this domain to any administrator on this site. If the user you want to ' +
+							'transfer is not currently an administrator, please {{a}}add them to the site first{{/a}}.',
+						{ components: { a: <a href={ `/people/new/${ selectedSite.slug }` } /> } }
+					) }
+				</p>
+			</>
+		);
+	}
+
 	filterAvailableUsers( users ) {
 		return users.filter(
 			( user ) =>
@@ -290,21 +342,22 @@ class TransferOtherUser extends React.Component {
 	}
 
 	isDataReady() {
-		return (
-			this.props.hasSiteDomainsLoaded &&
-			this.props.wapiDomainInfo.hasLoadedFromServer &&
-			! this.props.isRequestingSiteDomains
-		);
+		return this.props.hasSiteDomainsLoaded && ! this.props.isRequestingSiteDomains;
 	}
 }
 
 export default connect(
-	( state, ownProps ) => ( {
-		currentUser: getCurrentUser( state ),
-		isAtomic: isSiteAutomatedTransfer( state, ownProps.selectedSite.ID ),
-		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, ownProps.selectedSite.ID ),
-		currentRoute: getCurrentRoute( state ),
-	} ),
+	( state, ownProps ) => {
+		const domain = ! ownProps.isRequestingSiteDomains && getSelectedDomain( ownProps );
+
+		return {
+			currentUser: getCurrentUser( state ),
+			isAtomic: isSiteAutomatedTransfer( state, ownProps.selectedSite.ID ),
+			isMapping: Boolean( domain ) && isMappedDomain( domain ),
+			hasSiteDomainsLoaded: hasLoadedSiteDomains( state, ownProps.selectedSite.ID ),
+			currentRoute: getCurrentRoute( state ),
+		};
+	},
 	{
 		successNotice,
 		errorNotice,


### PR DESCRIPTION
Follow-up to #46418. This time allowing users to transfer domain mapping subscriptions to other admins on the same site. This should bring feature parity between mappings and registrations.

#### Testing instructions
Note that this is based on work from #46418 (don't want to merge during US elections). So the only new changes are in this one commit: https://github.com/Automattic/wp-calypso/pull/47060/commits/eb6f9a1033d347c6f40b3fc59280374d7806dfb6

Requires D52223-code on the backend.

You need a site where you own a mapping subscription and there's at least one more admin on the site (preferably your other test user ;)).
Go to Domains -> yourmappeddomain.com -> Transfer mapping -> Transfer to another user.

Make sure the copy you see is mapping-specific and makes sense in the context of mapping (as opposed to domain registrations). Transfer the mapping - it should be quite quick. Verify that the subscription does not appear in your purchases anymore (`/me/purchases`).

<img width="749" alt="Screenshot 2020-11-03 at 16 28 17" src="https://user-images.githubusercontent.com/3392497/98012976-a5bec980-1df1-11eb-8084-604951ea16e5.png">

<img width="568" alt="Screenshot 2020-11-03 at 16 28 37" src="https://user-images.githubusercontent.com/3392497/98012989-a9eae700-1df1-11eb-9e67-29b55417c112.png">


