### PR TITLE
Jetpack Cloud: make the Advanced Server Credentials form support sites that only have Jetpack Scan

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
@@ -319,7 +319,7 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 	return (
 		<div className="credentials-form">
 			<h3>{ translate( 'Provide your SSH, SFTP or FTP server credentials' ) }</h3>
-			<p class="credentials-form__intro-text">{ getSubHeaderText() }</p>
+			<p className="credentials-form__intro-text">{ getSubHeaderText() }</p>
 			{ renderCredentialLinks() }
 			<FormFieldset className="credentials-form__protocol-type">
 				<div className="credentials-form__support-info">
@@ -476,7 +476,7 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 			{ formMode === FormMode.Password ? renderPasswordForm() : renderPrivateKeyForm() }
 
 			<FormFieldset className="credentials-form__buttons">
-				<div class="credentials-form__buttons_flex">{ children }</div>
+				<div className="credentials-form__buttons-flex">{ children }</div>
 			</FormFieldset>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/style.scss
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/style.scss
@@ -19,7 +19,7 @@
 	}
 
 	.credentials-form__intro-text {
-		color: var(--color-text-subtle);
+		color: var( --color-text-subtle );
 		font-size: $font-body-small;
 	}
 
@@ -29,7 +29,7 @@
 		}
 	}
 
-	&__buttons .credentials-form__buttons_flex {
+	&__buttons .credentials-form__buttons-flex {
 		display: flex;
 		flex-direction: row;
 		align-items: center;

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
@@ -89,7 +89,7 @@ const AdvancedCredentials: FunctionComponent< Props > = ( { action, host, role }
 	);
 
 	const isRequestingCredentials = useSelector( ( state ) =>
-		isRequestingSiteCredentials( state, siteId )
+		isRequestingSiteCredentials( state, siteId as number )
 	);
 
 	const credentials = useSelector( ( state ) =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, the Advanced Server Credentials doesn't work well when a site has only Jetpack Scan. The real credentials status is not correct and we always show the `disconnected` state. This PR solves this issue by using the new `QuerySiteCredentials` component which fetches the real status of the credentials.
* I removed everything Rewind related since `QuerySiteCredentials` offers everything we need to know the state of the credentials.

#### Testing instructions

* Run this PR, Calypso Green build.
* Visit Jetpack Cloud with a site that only has Jetpack Scan.
* Visit the Settings section and complete the Server Credentials flow.
* Make sure that the form shows the `Connected` state.
* Delete the credentials.
* Make sure that you are back to step 1.
* Complete the credentials again.
* Make sure that the form shows the `Connected` state.
* Repeat the process with a site that has a paid plan or Jetpack Backup.

Fixes 1164141197617539-as-1198996805567597

#### Demo
##### After on the left, before (production) on the right
![image](https://user-images.githubusercontent.com/3418513/98010964-122bcf80-1dd6-11eb-9932-7e1a08cd5b43.png)
