### PR TITLE
Premium Content: Remove premium content block placeholder

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
@@ -4,8 +4,6 @@
 import { useEffect, useState, useRef } from '@wordpress/element';
 import {
 	Placeholder,
-	Button,
-	ExternalLink,
 	withNotices,
 	Spinner,
 	ToolbarGroup,
@@ -22,7 +20,6 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import Tabs from './tabs';
 import Blocks from './blocks';
 import Controls from './controls';
 import Inspector from './inspector';
@@ -97,7 +94,6 @@ function Edit( props ) {
 	const [ connectURL, setConnectURL ] = useState( defaultString );
 	const [ apiState, setApiState ] = useState( API_STATE_LOADING );
 	const [ shouldUpgrade, setShouldUpgrade ] = useState( false );
-	const [ upgradeURL, setUpgradeURL ] = useState( '' );
 	// @ts-ignore needed in some upgrade flows - depending how we implement this
 	const [ siteSlug, setSiteSlug ] = useState( '' ); // eslint-disable-line
 
@@ -242,7 +238,6 @@ function Edit( props ) {
 
 				setConnectURL( result.connect_url );
 				setShouldUpgrade( result.should_upgrade_to_access_memberships );
-				setUpgradeURL( result.upgrade_url );
 				setSiteSlug( result.site_slug );
 
 				if (
@@ -299,41 +294,6 @@ function Edit( props ) {
 					instructions={ __( 'Loading data…', 'full-site-editing' ) }
 				>
 					<Spinner />
-				</Placeholder>
-			</div>
-		);
-	}
-
-	if ( shouldUpgrade ) {
-		return (
-			<div className={ className } ref={ wrapperRef }>
-				{ props.noticeUI }
-				<Placeholder
-					icon="lock"
-					label={ __( 'Premium Content', 'full-site-editing' ) }
-					instructions={ __(
-						"You'll need to upgrade your plan to use the Premium Content block.",
-						'full-site-editing'
-					) }
-				>
-					<Button
-						/**
-						 * @see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42883
-						 */
-						// @ts-ignore isSecondary is missing from the type definition
-						isSecondary
-						isLarge
-						href={ upgradeURL }
-						target="_blank"
-						className="premium-content-block-nudge__button plan-nudge__button"
-					>
-						{ __( 'Upgrade Your Plan', 'full-site-editing' ) }
-					</Button>
-					<div className="membership-button__disclaimer">
-						<ExternalLink href="https://wordpress.com/support/premium-content-block/">
-							{ __( 'Read more about Premium Content and related fees.', 'full-site-editing' ) }
-						</ExternalLink>
-					</div>
 				</Placeholder>
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Do not use a placeholder when the user is not on the required plan. Allow them to see and edit content. This will allow patterns to render for folks without a plan.

This PR should be merged along with https://github.com/Automattic/jetpack/pull/17702 to allow the payments block to be interacted with without a plan.

**Before**
Only showing placeholder:

<img width="858" alt="Screen Shot 2020-11-03 at 12 03 59 PM" src="https://user-images.githubusercontent.com/1464705/98034984-aa24bb80-1dcc-11eb-805c-656ceb97a3f7.png">

**After**
Showing editable content:

<img width="794" alt="Screen Shot 2020-11-03 at 12 04 18 PM" src="https://user-images.githubusercontent.com/1464705/98035013-b4df5080-1dcc-11eb-9cab-edbe1415f7a6.png">

#### Testing instructions
* Check out this branch
* Sync to your sandbox using yarn dev --sync
* Insert a Premium Content block on your sandboxed site (**that has a free plan**) and confirm you can edit content.
* Save and reload the editor and confirm changes are saved
* Open the front end of the site and confirm that no content is visible. This will be fixed in https://github.com/Automattic/view-design/issues/95 and https://github.com/Automattic/view-design/issues/127

Fixes https://github.com/Automattic/view-design/issues/124
