### PR TITLE
Reader Lists: Remove duplicate ListForm component

### DIFF
--- a/client/reader/list-manage/list-form.jsx
+++ b/client/reader/list-manage/list-form.jsx
@@ -28,10 +28,8 @@ const INITIAL_CREATE_FORM_STATE = {
 	slug: '',
 };
 
-export default function ListForm( { isCreateForm, isSubmissionDisabled, list, onSubmit } ) {
+export default function ListForm( { isCreateForm, isSubmissionDisabled, list = {}, onSubmit } ) {
 	const translate = useTranslate();
-	const isNameValid = typeof list.title === 'string' && list.title.length > 0;
-	const isSlugValid = isCreateForm || ( typeof list.slug === 'string' && list.slug.length > 0 );
 	const [ formList, updateFormList ] = React.useState(
 		isCreateForm ? INITIAL_CREATE_FORM_STATE : { ...INITIAL_UPDATE_FORM_STATE, ...list }
 	);
@@ -42,6 +40,10 @@ export default function ListForm( { isCreateForm, isSubmissionDisabled, list, on
 		}
 		updateFormList( { ...formList, ...update } );
 	};
+
+	const isNameValid = typeof formList.title === 'string' && formList.title.length > 0;
+	const isSlugValid =
+		isCreateForm || ( typeof formList.slug === 'string' && formList.slug.length > 0 );
 
 	return (
 		<Card>

--- a/client/reader/list-manage/list-form.jsx
+++ b/client/reader/list-manage/list-form.jsx
@@ -65,11 +65,15 @@ export default function ListForm( { isCreateForm, isSubmissionDisabled, list = {
 					<FormLabel htmlFor="list-slug">{ translate( 'Slug (Required)' ) }</FormLabel>
 					<FormTextInput
 						data-key="slug"
+						// NOTE: Slug modification currently doesn't work in the API.
+						// TODO: Enable slug modification in the API and remove the disabled prop here.
+						disabled
 						id="list-slug"
-						isValid={ isSlugValid }
 						name="list-slug"
-						onChange={ onChange }
 						value={ formList.slug }
+						// TODO: Enable the following lines once API supports slug changes.
+						// isValid={ isSlugValid }
+						// onChange={ onChange }
 					/>
 					<FormSettingExplanation>
 						{ translate( 'The slug for the list. This is used to build the URL to the list.' ) }

--- a/client/reader/list-manage/list-form.jsx
+++ b/client/reader/list-manage/list-form.jsx
@@ -62,21 +62,17 @@ export default function ListForm( { isCreateForm, isSubmissionDisabled, list = {
 
 			{ ! isCreateForm && (
 				<FormFieldset>
-					<FormLabel htmlFor="list-slug">{ translate( 'Slug (Required)' ) }</FormLabel>
+					<FormLabel htmlFor="list-slug">{ translate( 'Slug' ) }</FormLabel>
 					<FormTextInput
 						data-key="slug"
 						// NOTE: Slug modification currently doesn't work in the API.
-						// TODO: Enable slug modification in the API and remove the disabled prop here.
 						disabled
 						id="list-slug"
 						name="list-slug"
 						value={ formList.slug }
-						// TODO: Enable the following lines once API supports slug changes.
-						// isValid={ isSlugValid }
-						// onChange={ onChange }
 					/>
 					<FormSettingExplanation>
-						{ translate( 'The slug for the list. This is used to build the URL to the list.' ) }
+						{ translate( 'This is used to build the URL to the list.' ) }
 					</FormSettingExplanation>
 				</FormFieldset>
 			) }

--- a/client/state/data-layer/wpcom/read/lists/index.js
+++ b/client/state/data-layer/wpcom/read/lists/index.js
@@ -77,7 +77,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 			],
 			onError: ( action, error ) => [
 				errorNotice( String( error ) ),
-				handleUpdateListDetailsError( error ),
+				handleUpdateListDetailsError( error, action.list ),
 			],
 		} ),
 	],

--- a/client/state/reader/lists/actions.js
+++ b/client/state/reader/lists/actions.js
@@ -226,12 +226,14 @@ export function receiveUpdatedListDetails( data ) {
  * Handle an error from the list update API.
  *
  * @param   {Error}  error Error during the list update process
+ * @param   {object} list List details to save
  * @returns {object} Action object
  */
-export function handleUpdateListDetailsError( error ) {
+export function handleUpdateListDetailsError( error, list ) {
 	return {
 		type: READER_LIST_UPDATE_FAILURE,
 		error,
+		list,
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes duplicate code introduced by a rebase error.
* Disables the slug text input for the update form.
* Slightly tweaks the `READER_LIST_UPDATE_FAILURE` action to propagate the list object causing the update failure.

#### Testing instructions

* Spin this up locally or enable the `reader/list-management` feature flag in the environment of your choice.
* Navigate to `/read/list/new` and ensure that the form works as expected.
* Navigate to `/read/list/:user/:listSlug/edit` and ensure that the form works as expected.