### PR TITLE
Checkout: Update npm package configs to match other packages

### DIFF
--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -7,9 +7,10 @@
 	"types": "dist/types/public-api.d.ts",
 	"sideEffects": false,
 	"scripts": {
-		"clean": "npx rimraf dist \"../../.tsc-cache/packages__composite-checkout*\"",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
-		"prepublish": "yarn run clean",
+		"clean": "npx rimraf dist && tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
+		"build:esm": "tsc --project ./tsconfig.json",
+		"build:cjs": "tsc --project ./tsconfig-cjs.json",
+		"prepare": "yarn run build:esm",
 		"watch": "tsc --project ./tsconfig.json --watch"
 	},
 	"files": [

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -7,9 +7,10 @@
 	"types": "dist/types/index.d.ts",
 	"sideEffects": false,
 	"scripts": {
-		"clean": "npx rimraf dist \"../../.tsc-cache/packages__shopping-cart*\"",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
-		"prepublish": "yarn run clean",
+		"clean": "npx rimraf dist && tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
+		"build:esm": "tsc --project ./tsconfig.json",
+		"build:cjs": "tsc --project ./tsconfig-cjs.json",
+		"prepare": "yarn run build:esm",
 		"watch": "tsc --project ./tsconfig.json --watch"
 	},
 	"files": [

--- a/packages/shopping-cart/tsconfig.json
+++ b/packages/shopping-cart/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"target": "ES5",
-		"lib": [ "DOM", "ES2015", "ES2017" ],
+		"lib": [ "DOM", "ESNext" ],
 
 		"baseUrl": ".",
-		"module": "esnext",
+		"module": "ESNext",
 		"allowJs": true,
 		"jsx": "react",
 		"declaration": true,

--- a/packages/shopping-cart/webpack.config.js
+++ b/packages/shopping-cart/webpack.config.js
@@ -2,7 +2,7 @@ const path = require( 'path' );
 const cachePath = path.resolve( '.cache', 'shopping-cart' );
 
 module.exports = {
-	entry: './src/public-api.js',
+	entry: './index.js',
 	mode: 'development',
 	module: {
 		rules: [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/46973, which adds a new `calypso-stripe` package using the techniques from https://github.com/Automattic/wp-calypso/pull/44824 and https://github.com/Automattic/wp-calypso/pull/47002 and https://github.com/Automattic/wp-calypso/pull/46953. In this PR, we also apply those changes to the other checkout packages: `composite-checkout` and `shopping-cart`.

#### Testing instructions

TBD