### PR TITLE
Remove unused vars from global styles font pairings

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/font-pairings-panel.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/font-pairings-panel.js
@@ -18,11 +18,8 @@ export default ( { fontPairings, fontBase, fontHeadings, update } ) => {
 			{ fontPairings && fontHeadings && fontBase ? (
 				<div className="style-preview__font-options">
 					<div className="style-preview__font-options-desktop">
-						{ fontPairings.map( ( { label, headings, base, preview } ) => {
+						{ fontPairings.map( ( { label, headings, base } ) => {
 							const isSelected = headings === fontHeadings && base === fontBase;
-							const classes = classnames( 'font-pairings-panel', {
-								'is-selected': isSelected,
-							} );
 							return (
 								<Button
 									className={ classnames( 'style-preview__font-option', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* https://github.com/Automattic/wp-calypso/pull/46927 failed to remove some unused variables, which is breaking the code style build step. This PR removes them.

#### Testing instructions

I re-ran through the testing from the original PR, which was updating global font styles:

Check out the branch and sync to your sandbox using yarn dev --sync
Create a new post and open the Global Styles editor.

 - [ ] Verify that the five font pairings displayed match what is listed in the spreadsheet
 - [ ]  Verify that the UI has been updated to match Gutenboarding
 - [ ]  Select a new font pairing and verify that the text in the post updates
 - [ ]  Select 'Publish' in the global styles sidebar and verify that the new font selection persists when the page is refreshed
 - [ ]  Select a different heading or base font from the Font Selection panel and verify that the selection (blue outline) is removed from the Font Pairings window
 - [ ]  Manually select a font pairing by making the Heading and Base font selections from the Font Selection window (eg manually select "Cabin" and "Raleway" from the dropdowns) and verify that the matching font pairing is selected in the UI (eg, the blue outline appears around "Cabin / Raleway")
