### PR TITLE
Reader Lists: Update export button styling

### DIFF
--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -11,6 +11,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import wpcom from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
 import Gridicon from 'calypso/components/gridicon';
@@ -75,17 +76,18 @@ class ReaderExportButton extends React.Component {
 
 	render() {
 		return (
-			<button
+			<Button
 				className={ classnames( {
 					'reader-export-button': true,
 					'is-disabled': this.props.disabled || this.state.disabled,
 				} ) }
-				onClick={ this.onClick }
 				disabled={ this.props.disabled || this.state.disabled }
+				onClick={ this.onClick }
+				primary
 			>
 				<Gridicon icon="cloud-download" className="reader-export-button__icon" />
 				<span className="reader-export-button__label">{ this.props.translate( 'Export' ) }</span>
-			</button>
+			</Button>
 		);
 	}
 }

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -27,6 +27,7 @@ import './style.scss';
 
 class ReaderExportButton extends React.Component {
 	static propTypes = {
+		borderless: PropTypes.bool,
 		disabled: PropTypes.bool,
 		exportType: PropTypes.oneOf( [ READER_EXPORT_TYPE_SUBSCRIPTIONS, READER_EXPORT_TYPE_LIST ] ),
 		filename: PropTypes.string,
@@ -34,6 +35,7 @@ class ReaderExportButton extends React.Component {
 	};
 
 	static defaultProps = {
+		borderless: false,
 		filename: 'reader-export.opml',
 		exportType: READER_EXPORT_TYPE_SUBSCRIPTIONS,
 		disabled: false,
@@ -77,13 +79,14 @@ class ReaderExportButton extends React.Component {
 	render() {
 		return (
 			<Button
+				borderless={ this.props.borderless }
 				className={ classnames( {
 					'reader-export-button': true,
 					'is-disabled': this.props.disabled || this.state.disabled,
 				} ) }
 				disabled={ this.props.disabled || this.state.disabled }
 				onClick={ this.onClick }
-				primary
+				primary={ ! this.props.borderless }
 			>
 				<Gridicon icon="cloud-download" className="reader-export-button__icon" />
 				<span className="reader-export-button__label">{ this.props.translate( 'Export' ) }</span>

--- a/client/blocks/reader-export-button/style.scss
+++ b/client/blocks/reader-export-button/style.scss
@@ -11,14 +11,18 @@
 		}
 	}
 
-	&.is-disabled {
-		cursor: default;
+	&.button[disabled] {
+		cursor: not-allowed;
 	}
 }
 
 .reader-export-button__icon {
 	fill: var( --color-neutral-light );
 	vertical-align: middle;
+}
+.reader-export-button .gridicon.reader-export-button__icon {
+	top: 0;
+	margin-top: 0;
 }
 
 .reader-export-button__label {

--- a/client/blocks/reader-export-button/style.scss
+++ b/client/blocks/reader-export-button/style.scss
@@ -1,23 +1,12 @@
 .reader-export-button {
 	cursor: pointer;
 
-	&:hover:not( .is-disabled ) {
-		.reader-export-button__icon {
-			fill: var( --color-accent );
-		}
-
-		.reader-export-button__label {
-			color: var( --color-accent );
-		}
-	}
-
 	&.button[disabled] {
 		cursor: not-allowed;
 	}
 }
 
 .reader-export-button__icon {
-	fill: var( --color-neutral-light );
 	vertical-align: middle;
 }
 .reader-export-button .gridicon.reader-export-button__icon {
@@ -27,6 +16,5 @@
 
 .reader-export-button__label {
 	font-size: $font-body-small;
-	color: var( --color-text-subtle );
 	padding-left: 4px;
 }

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -22,10 +22,12 @@ import './style.scss';
 
 class ReaderImportButton extends React.Component {
 	static propTypes = {
+		borderless: PropTypes.bool,
 		onProgress: PropTypes.func,
 	};
 
 	static defaultProps = {
+		borderless: true,
 		onProgress: noop,
 	};
 
@@ -99,7 +101,12 @@ class ReaderImportButton extends React.Component {
 
 	render() {
 		return (
-			<div className="reader-import-button">
+			// .button.is-borderless is from Button in '@automattic/components';
+			<div
+				className={ `reader-import-button button ${
+					this.props.borderless ? 'is-borderless' : ''
+				}` }
+			>
 				<FilePicker accept=".xml,.opml" onClick={ this.onClick } onPick={ this.onPick }>
 					<Gridicon icon="cloud-upload" className="reader-import-button__icon" />
 					<span className="reader-import-button__label">{ this.props.translate( 'Import' ) }</span>

--- a/client/blocks/reader-import-button/style.scss
+++ b/client/blocks/reader-import-button/style.scss
@@ -1,24 +1,12 @@
 .reader-import-button {
 	cursor: pointer;
-
-	&:hover {
-		.reader-import-button__icon {
-			fill: var( --color-accent );
-		}
-
-		.reader-import-button__label {
-			color: var( --color-accent );
-		}
-	}
 }
 
 .reader-import-button__icon {
-	fill: var( --color-neutral-light );
 	vertical-align: middle;
 }
 
 .reader-import-button__label {
 	font-size: $font-body-small;
-	color: var( --color-text-subtle );
 	padding-left: 4px;
 }

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -150,9 +150,21 @@
 }
 
 .following-manage__subscriptions-import-export-menu-item {
+	.reader-import-button,
+	.reader-export-button {
+		padding: 0;
+		font-weight: 400;
+	}
+
 	.reader-import-button__icon,
 	.reader-export-button__icon {
+		fill: var( --color-neutral-light );
 		vertical-align: middle;
+	}
+
+	.reader-import-button__label,
+	.reader-export-button__label {
+		color: var( --color-text-subtle );
 	}
 
 	&:hover,

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -127,7 +127,7 @@ class FollowingManageSubscriptions extends Component {
 								className="following-manage__subscriptions-import-export-menu-item"
 								itemComponent="div"
 							>
-								<ReaderExportButton exportType={ READER_EXPORT_TYPE_SUBSCRIPTIONS } />
+								<ReaderExportButton borderless exportType={ READER_EXPORT_TYPE_SUBSCRIPTIONS } />
 							</PopoverMenuItem>
 						</EllipsisMenu>
 					</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates our custom button component to use `Button` from `@automattic/components`.

Before (disabled and enabled are visually identical):
<img width="744" alt="Screen Shot 2020-11-03 at 3 04 02 PM" src="https://user-images.githubusercontent.com/4044428/98045640-08aa6380-1de6-11eb-8b2f-b4492be88340.png">

After (disabled and enabled):
<img width="744" alt="Screen Shot 2020-11-03 at 3 01 11 PM" src="https://user-images.githubusercontent.com/4044428/98045646-09db9080-1de6-11eb-8217-f8f755bc8a46.png">
<img width="744" alt="Screen Shot 2020-11-03 at 3 04 04 PM" src="https://user-images.githubusercontent.com/4044428/98045637-0811cd00-1de6-11eb-8f42-9f62d665c993.png">


#### Testing instructions

* Navigate to `/read/list/:userId/:listSlug/export`. Ensure that the button renders as expected.