### PR TITLE
Reader Lists: hide list editing routes behind feature flag

### DIFF
--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -16,44 +16,47 @@ import {
 } from './controller';
 import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import config from 'calypso/config';
 
 export default function () {
-	page(
-		'/read/list/:user/:list/edit/items',
-		updateLastRoute,
-		sidebar,
-		editListItems,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/read/list/:user/:list/edit',
-		updateLastRoute,
-		sidebar,
-		editList,
-		makeLayout,
-		clientRender
-	);
+	if ( config.isEnabled( 'reader/list-management' ) ) {
+		page(
+			'/read/list/:user/:list/edit/items',
+			updateLastRoute,
+			sidebar,
+			editListItems,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/read/list/:user/:list/edit',
+			updateLastRoute,
+			sidebar,
+			editList,
+			makeLayout,
+			clientRender
+		);
 
-	page( '/read/list/new', updateLastRoute, sidebar, createList, makeLayout, clientRender );
+		page( '/read/list/new', updateLastRoute, sidebar, createList, makeLayout, clientRender );
 
-	page(
-		'/read/list/:user/:list/export',
-		updateLastRoute,
-		sidebar,
-		exportList,
-		makeLayout,
-		clientRender
-	);
+		page(
+			'/read/list/:user/:list/export',
+			updateLastRoute,
+			sidebar,
+			exportList,
+			makeLayout,
+			clientRender
+		);
 
-	page(
-		'/read/list/:user/:list/delete',
-		updateLastRoute,
-		sidebar,
-		deleteList,
-		makeLayout,
-		clientRender
-	);
+		page(
+			'/read/list/:user/:list/delete',
+			updateLastRoute,
+			sidebar,
+			deleteList,
+			makeLayout,
+			clientRender
+		);
+	}
 
 	page( '/read/list/:user/:list', updateLastRoute, sidebar, listListing, makeLayout, clientRender );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

@blowery spotted that, although we gate the display of the list edit button behind the `reader/list-management` feature flag, we don't actually prevent the user from accessing the tools via their URLs. For example, you can currently add `/edit` to any list URL in production and access the editing tools.

Since this is still a work in progress, this PR hides those pages when the feature flag is set to false.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In development.json, set the `reader/list-management` feature flag to `false`. Run `yarn start`.

Ensure that you can't reach 'Edit List' by adding `/edit` to a list URL.
