### PR TITLE
Reader Lists: set up /read/lists/:owner/:slug/sites/:site/delete endpoint in data layer

### DIFF
--- a/client/state/data-layer/wpcom/read/lists/sites/delete/index.js
+++ b/client/state/data-layer/wpcom/read/lists/sites/delete/index.js
@@ -10,24 +10,24 @@ import { noop } from 'lodash';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
-import { READER_LIST_ITEM_DELETE_FEED } from 'calypso/state/reader/action-types';
+import { READER_LIST_ITEM_DELETE_SITE } from 'calypso/state/reader/action-types';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 
-registerHandlers( 'state/data-layer/wpcom/read/lists/feeds/delete/index.js', {
-	[ READER_LIST_ITEM_DELETE_FEED ]: [
+registerHandlers( 'state/data-layer/wpcom/read/lists/sites/delete/index.js', {
+	[ READER_LIST_ITEM_DELETE_SITE ]: [
 		dispatchRequest( {
 			fetch: ( action ) =>
 				http(
 					{
 						method: 'POST',
-						path: `/read/lists/${ action.listOwner }/${ action.listSlug }/feeds/${ action.feedId }/delete`,
+						path: `/read/lists/${ action.listOwner }/${ action.listSlug }/sites/${ action.siteId }/delete`,
 						apiVersion: '1.2',
 						body: {},
 					},
 					action
 				),
 			onSuccess: noop,
-			onError: () => errorNotice( translate( 'Unable to remove feed from list' ) ),
+			onError: () => errorNotice( translate( 'Unable to remove site from list' ) ),
 		} ),
 	],
 } );

--- a/client/state/reader/lists/actions.js
+++ b/client/state/reader/lists/actions.js
@@ -34,6 +34,7 @@ import 'calypso/state/data-layer/wpcom/read/lists';
 import 'calypso/state/data-layer/wpcom/read/lists/delete';
 import 'calypso/state/data-layer/wpcom/read/lists/items';
 import 'calypso/state/data-layer/wpcom/read/lists/feeds/delete';
+import 'calypso/state/data-layer/wpcom/read/lists/sites/delete';
 import 'calypso/state/data-layer/wpcom/read/lists/tags/delete';
 import 'calypso/state/data-layer/wpcom/read/lists/feeds/new';
 import 'calypso/state/reader/init';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Requires D44927-code.

Somewhat confusingly, the current way to remove a site from a Reader list is to call the feed delete endpoint with a $feed_id of 'site:$site_id'. This doesn't feel intuitive and does not match the behaviour of the add endpoints.

This PR switches to use the new `/read/lists/:owner/:slug/sites/:site/delete` endpoint instead for site deletions.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
`yarn test-client client/state/reader/lists`