### PR TITLE
Reader Lists: move single list request to use data layer

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1319,13 +1319,6 @@ Undocumented.prototype.readTagImages = function ( query, fn ) {
 	);
 };
 
-Undocumented.prototype.readList = function ( query, fn ) {
-	const params = omit( query, [ 'owner', 'slug' ] );
-	debug( '/read/list' );
-	params.apiVersion = '1.2';
-	return this.wpcom.req.get( '/read/lists/' + query.owner + '/' + query.slug, params, fn );
-};
-
 Undocumented.prototype.followList = function ( query, fn ) {
 	const params = omit( query, [ 'owner', 'slug' ] );
 	debug( '/read/lists/:owner/:slug/follow' );

--- a/client/state/data-layer/wpcom/read/lists/index.js
+++ b/client/state/data-layer/wpcom/read/lists/index.js
@@ -11,6 +11,7 @@ import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import {
 	READER_LIST_CREATE,
+	READER_LIST_REQUEST,
 	READER_LIST_UPDATE,
 	READER_LISTS_REQUEST,
 } from 'calypso/state/reader/action-types';
@@ -23,6 +24,7 @@ import {
 } from 'calypso/state/reader/lists/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { navigate } from 'calypso/state/ui/actions';
+import { DEFAULT_NOTICE_DURATION } from 'calypso/state/notices/constants';
 
 registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 	[ READER_LIST_CREATE ]: [
@@ -54,6 +56,24 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 			},
 			onError: ( action, error ) => [
 				errorNotice( String( error ) ),
+				handleReaderListRequestFailure( error ),
+			],
+		} ),
+	],
+	[ READER_LIST_REQUEST ]: [
+		dispatchRequest( {
+			fetch: ( action ) =>
+				http(
+					{
+						method: 'GET',
+						path: `/read/lists/${ action.listOwner }/${ action.listSlug }`,
+						apiVersion: '1.2',
+					},
+					action
+				),
+			onSuccess: ( action, { list } ) => receiveReaderList( { list } ),
+			onError: ( action, error ) => [
+				errorNotice( String( error ), { duration: DEFAULT_NOTICE_DURATION } ),
 				handleReaderListRequestFailure( error ),
 			],
 		} ),

--- a/client/state/reader/lists/actions.js
+++ b/client/state/reader/lists/actions.js
@@ -67,39 +67,14 @@ export function createReaderList( list ) {
 }
 
 /**
- * Triggers a network request to fetch a single Reader list.
+ * Request a single Reader list.
  *
- * @param  {string}  owner List owner
- * @param  {string}  slug List slug
- * @returns {Function}        Action thunk
+ * @param  {string}  listOwner List owner
+ * @param  {string}  listSlug List slug
+ * @returns {object}       Action object
  */
-export function requestList( owner, slug ) {
-	return ( dispatch ) => {
-		dispatch( {
-			type: READER_LIST_REQUEST,
-		} );
-
-		const query = createQuery( owner, slug );
-
-		return new Promise( ( resolve, reject ) => {
-			wpcom.undocumented().readList( query, ( error, data ) => {
-				if ( error ) {
-					const errorInfo = {
-						error,
-						owner,
-						slug,
-					};
-					reject( errorInfo );
-				} else {
-					resolve( data );
-				}
-			} );
-		} )
-			.then( ( data ) => {
-				dispatch( receiveReaderList( data ) );
-			} )
-			.catch( ( errorInfo ) => dispatch( handleReaderListRequestFailure( errorInfo ) ) );
-	};
+export function requestList( listOwner, listSlug ) {
+	return { type: READER_LIST_REQUEST, listOwner, listSlug };
 }
 
 export function receiveReaderList( data ) {

--- a/client/state/reader/lists/test/actions.js
+++ b/client/state/reader/lists/test/actions.js
@@ -41,22 +41,13 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestList()', () => {
-		useNock( ( nock ) => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.2/read/lists/listowner/listslug' )
-				.reply( 200, {
-					list: {
-						ID: 123,
-						title: 'My test list',
-					},
-				} );
-		} );
+		test( 'should return an action object', () => {
+			const action = requestList( 'pob', 'things-i-like' );
 
-		test( 'should dispatch fetch action when thunk triggered', () => {
-			requestList()( spy );
-
-			expect( spy ).toHaveBeenCalledWith( {
+			expect( action ).toEqual( {
 				type: READER_LIST_REQUEST,
+				listOwner: 'pob',
+				listSlug: 'things-i-like',
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Modernize the code used to fetch a single Reader list, using data layer instead of thunks and `wpcom.undocumented()`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load Reader at http://calypso.localhost:3000/read. Click on one of your subscribed lists in the Reader sidebar.

Ensure that a request to /read/lists/:owner/:slug was fired off during list load:

<img width="1426" alt="Screen Shot 2020-11-04 at 14 46 18" src="https://user-images.githubusercontent.com/17325/98059917-2a225280-1ead-11eb-8dc8-b70040cfec5e.png">

No functional changes.
