### PR TITLE
Reader Lists: make buttons consistent

### DIFF
--- a/client/reader/list-manage/feed-item.tsx
+++ b/client/reader/list-manage/feed-item.tsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -62,6 +63,8 @@ function FeedItem( props: {
 	feed: Feed | FeedError;
 } ) {
 	const { feed, item, onRemove } = props;
+	const translate = useTranslate();
+
 	return ! feed ? (
 		// TODO: Add support for removing invalid feed list item
 		<>
@@ -71,8 +74,8 @@ function FeedItem( props: {
 	) : (
 		<>
 			{ isFeedError( feed ) ? renderFeedError( feed ) : renderFeed( feed ) }
-			<Button scary primary onClick={ onRemove }>
-				Remove from list
+			<Button primary onClick={ onRemove }>
+				{ translate( 'Remove' ) }
 			</Button>
 		</>
 	);

--- a/client/reader/list-manage/list-delete.jsx
+++ b/client/reader/list-manage/list-delete.jsx
@@ -21,7 +21,7 @@ function ListDelete( { list } ) {
 			{ deleteState === '' && (
 				<Card>
 					<p>{ translate( 'Delete the list forever. Be careful - this is not reversible.' ) }</p>
-					<Button scary primary onClick={ () => setDeleteState( 'confirming' ) }>
+					<Button primary onClick={ () => setDeleteState( 'confirming' ) }>
 						{ translate( 'Delete list' ) }
 					</Button>
 				</Card>

--- a/client/reader/list-manage/site-item.tsx
+++ b/client/reader/list-manage/site-item.tsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -58,6 +59,7 @@ function renderSiteError( err: SiteError ) {
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export default function SiteItem( props: { item: Item; onRemove: ( e: MouseEvent ) => void } ) {
 	const site: Site | SiteError = props.item.meta?.data?.site as Site | SiteError;
+	const translate = useTranslate();
 
 	if ( ! site ) {
 		// TODO: Add support for removing invalid site list item
@@ -67,8 +69,8 @@ export default function SiteItem( props: { item: Item; onRemove: ( e: MouseEvent
 	return (
 		<>
 			{ isSiteError( site ) ? renderSiteError( site ) : renderSite( site ) }
-			<Button scary primary onClick={ props.onRemove }>
-				Remove from list
+			<Button primary onClick={ props.onRemove }>
+				{ translate( 'Remove' ) }
 			</Button>
 		</>
 	);

--- a/client/reader/list-manage/tag-item.tsx
+++ b/client/reader/list-manage/tag-item.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,6 +15,7 @@ import { Item, Tag } from './types';
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export default function TagItem( props: { item: Item; onRemove: ( e: MouseEvent ) => void } ) {
 	const tag: Tag = props.item.meta?.data?.tag?.tag as Tag;
+	const translate = useTranslate();
 
 	return ! tag ? (
 		// TODO: Add support for removing invalid tag list item
@@ -32,8 +34,8 @@ export default function TagItem( props: { item: Item; onRemove: ( e: MouseEvent 
 					</div>
 				</a>
 			</div>
-			<Button scary primary onClick={ props.onRemove }>
-				Remove from list
+			<Button primary onClick={ props.onRemove }>
+				{ translate( 'Remove' ) }
 			</Button>
 		</>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the same style for all buttons
* Translate button text 

<img width="634" alt="Screen Shot 2020-11-04 at 15 53 43" src="https://user-images.githubusercontent.com/17325/98064180-8f2e7600-1eb6-11eb-8983-7a215b67c587.png">
<img width="760" alt="Screen Shot 2020-11-04 at 15 54 18" src="https://user-images.githubusercontent.com/17325/98064187-9190d000-1eb6-11eb-8cca-64b9c25f0f9b.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Edit one of your existing Reader lists. Ensure the buttons look consistent across all tabs.
