### PR TITLE
Remove theme notices from middleware

### DIFF
--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -55,7 +55,6 @@ import {
 	SITE_MONITOR_SETTINGS_UPDATE_SUCCESS,
 	SITE_MONITOR_SETTINGS_UPDATE_FAILURE,
 } from 'calypso/state/action-types';
-import { THEME_DELETE_FAILURE, THEME_DELETE_SUCCESS } from 'calypso/state/themes/action-types';
 import { purchasesRoot, billingHistoryReceipt } from 'calypso/me/purchases/paths';
 
 import {
@@ -231,23 +230,6 @@ export const onPublicizeConnectionUpdateFailure = ( { error } ) =>
 const onGuidedTransferHostDetailsSaveSuccess = () =>
 	successNotice( translate( 'Thanks for confirming those details!' ) );
 
-const onThemeDeleteSuccess = ( { themeName } ) =>
-	successNotice(
-		translate( 'Deleted theme %(themeName)s.', {
-			args: { themeName },
-			context: 'Themes: Theme delete confirmation',
-		} ),
-		{ duration: 5000 }
-	);
-
-const onThemeDeleteFailure = ( { themeId } ) =>
-	errorNotice(
-		translate( 'Problem deleting %(themeId)s. Check theme is not active.', {
-			args: { themeId },
-			context: 'Themes: Theme delete failure',
-		} )
-	);
-
 const onSiteMonitorSettingsUpdateSuccess = () =>
 	successNotice( translate( 'Settings saved successfully!' ) );
 
@@ -359,8 +341,6 @@ export const handlers = {
 	[ SITE_DELETE_RECEIVE ]: onSiteDeleteReceive,
 	[ SITE_MONITOR_SETTINGS_UPDATE_SUCCESS ]: onSiteMonitorSettingsUpdateSuccess,
 	[ SITE_MONITOR_SETTINGS_UPDATE_FAILURE ]: onSiteMonitorSettingsUpdateFailure,
-	[ THEME_DELETE_FAILURE ]: onThemeDeleteFailure,
-	[ THEME_DELETE_SUCCESS ]: onThemeDeleteSuccess,
 };
 
 /**

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { get, truncate, includes } from 'lodash';
+import { get, truncate } from 'lodash';
 
 /**
  * Internal dependencies
@@ -55,11 +55,7 @@ import {
 	SITE_MONITOR_SETTINGS_UPDATE_SUCCESS,
 	SITE_MONITOR_SETTINGS_UPDATE_FAILURE,
 } from 'calypso/state/action-types';
-import {
-	THEME_DELETE_FAILURE,
-	THEME_DELETE_SUCCESS,
-	THEME_ACTIVATE_FAILURE,
-} from 'calypso/state/themes/action-types';
+import { THEME_DELETE_FAILURE, THEME_DELETE_SUCCESS } from 'calypso/state/themes/action-types';
 import { purchasesRoot, billingHistoryReceipt } from 'calypso/me/purchases/paths';
 
 import {
@@ -252,13 +248,6 @@ const onThemeDeleteFailure = ( { themeId } ) =>
 		} )
 	);
 
-const onThemeActivateFailure = ( { error } ) => {
-	if ( includes( error.error, 'theme_not_found' ) ) {
-		return errorNotice( translate( 'Theme not yet available for this site' ) );
-	}
-	return errorNotice( translate( 'Unable to activate theme. Contact support.' ) );
-};
-
 const onSiteMonitorSettingsUpdateSuccess = () =>
 	successNotice( translate( 'Settings saved successfully!' ) );
 
@@ -372,7 +361,6 @@ export const handlers = {
 	[ SITE_MONITOR_SETTINGS_UPDATE_FAILURE ]: onSiteMonitorSettingsUpdateFailure,
 	[ THEME_DELETE_FAILURE ]: onThemeDeleteFailure,
 	[ THEME_DELETE_SUCCESS ]: onThemeDeleteSuccess,
-	[ THEME_ACTIVATE_FAILURE ]: onThemeActivateFailure,
 };
 
 /**

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { includes } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -54,7 +53,7 @@ export function activateTheme(
 					error,
 				} );
 
-				if ( includes( error.error, 'theme_not_found' ) ) {
+				if ( error.error === 'theme_not_found' ) {
 					dispatch( errorNotice( translate( 'Theme not yet available for this site' ) ) );
 				} else {
 					dispatch( errorNotice( translate( 'Unable to activate theme. Contact support.' ) ) );

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -1,9 +1,16 @@
 /**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+import { translate } from 'i18n-calypso';
+
+/**
  * Internal dependencies
  */
 import wpcom from 'calypso/lib/wp';
 import { THEME_ACTIVATE, THEME_ACTIVATE_FAILURE } from 'calypso/state/themes/action-types';
 import { themeActivated } from 'calypso/state/themes/actions/theme-activated';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 import 'calypso/state/themes/init';
 
@@ -46,6 +53,12 @@ export function activateTheme(
 					siteId,
 					error,
 				} );
+
+				if ( includes( error.error, 'theme_not_found' ) ) {
+					dispatch( errorNotice( translate( 'Theme not yet available for this site' ) ) );
+				} else {
+					dispatch( errorNotice( translate( 'Unable to activate theme. Contact support.' ) ) );
+				}
 			} );
 	};
 }

--- a/client/state/themes/actions/delete-theme.js
+++ b/client/state/themes/actions/delete-theme.js
@@ -1,7 +1,13 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
  * Internal dependencies
  */
 import wpcom from 'calypso/lib/wp';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import {
 	THEME_DELETE_FAILURE,
 	THEME_DELETE_SUCCESS,
@@ -28,13 +34,22 @@ export function deleteTheme( themeId, siteId ) {
 		return wpcom
 			.undocumented()
 			.deleteThemeFromJetpack( siteId, themeId )
-			.then( ( theme ) => {
+			.then( ( { name: themeName } ) => {
 				dispatch( {
 					type: THEME_DELETE_SUCCESS,
 					themeId,
 					siteId,
-					themeName: theme.name,
+					themeName,
 				} );
+				dispatch(
+					successNotice(
+						translate( 'Deleted theme %(themeName)s.', {
+							args: { themeName },
+							context: 'Themes: Theme delete confirmation',
+						} ),
+						{ duration: 5000 }
+					)
+				);
 			} )
 			.catch( ( error ) => {
 				dispatch( {
@@ -43,6 +58,14 @@ export function deleteTheme( themeId, siteId ) {
 					siteId,
 					error,
 				} );
+				dispatch(
+					errorNotice(
+						translate( 'Problem deleting %(themeId)s. Check theme is not active.', {
+							args: { themeId },
+							context: 'Themes: Theme delete failure',
+						} )
+					)
+				);
 			} );
 	};
 }


### PR DESCRIPTION
Removes several notice handlers from the global middleware and moves them to respective action thunk handlers:
- theme activation failure
- theme deletion (Jetpack sites) success and failure

That removes code from the `entrypoint-main` chunk and moves it to `themes`.

The entire middleware module should be eventually dismantled like this.
