### PR TITLE
PoC: A quick demonstration of adapting the ExPlat components into the Plan step page and the checkout page.

### DIFF
--- a/client/components/experiment/index.tsx
+++ b/client/components/experiment/index.tsx
@@ -61,6 +61,7 @@ function mapStateToProps( state: AppState, ownProps?: ExperimentProps ): Experim
 		};
 	}
 	const { name: experimentName } = ownProps;
+
 	return {
 		isLoading: isLoading( state ),
 		variation: getVariationForUser( state, experimentName ),

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -49,6 +49,7 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import Gridicon from 'calypso/components/gridicon';
 import { getABTestVariation } from 'calypso/lib/abtest';
 import getPlanFeatures from '../lib/get-plan-features';
+import ExplatExperiment, { DefaultVariation, Variation } from 'calypso/components/experiment';
 
 export default function WPCheckoutOrderSummary( {
 	onChangePlanLength,
@@ -73,6 +74,14 @@ export default function WPCheckoutOrderSummary( {
 			className={ isCartUpdating ? 'is-loading' : '' }
 			data-e2e-cart-is-loading={ isCartUpdating }
 		>
+			<ExplatExperiment name="monthly_pricing_test_phase_1">
+				<DefaultVariation name="control">
+					<p>All good!</p>
+				</DefaultVariation>
+				<Variation name="treatment">
+					<p>Profit!</p>
+				</Variation>
+			</ExplatExperiment>
 			<CheckoutSummaryFeatures>
 				<CheckoutSummaryFeaturesTitle>
 					{ translate( 'Included with your purchase' ) }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -32,6 +32,7 @@ import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
 import { getUrlParts } from 'calypso/lib/url/url-parts';
 import { isIgnoredAdSource } from 'calypso/lib/analytics/sem';
 import { abtest } from 'calypso/lib/abtest';
+import ExplatExperiment, { DefaultVariation, Variation } from 'calypso/components/experiment';
 
 /**
  * Style dependencies
@@ -143,31 +144,55 @@ export class PlansStep extends Component {
 			selectedSite,
 			planTypes,
 			flowName,
-			isMonthlyPricingTest,
+			// isMonthlyPricingTest,
 		} = this.props;
 
 		return (
 			<div>
 				<QueryPlans />
 
-				<PlansFeaturesMain
-					site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
-					hideFreePlan={ hideFreePlan }
-					isInSignup={ true }
-					isLaunchPage={ isLaunchPage }
-					intervalType={ this.getIntervalType() }
-					onUpgradeClick={ this.onSelectPlan }
-					showFAQ={ false }
-					displayJetpackPlans={ false }
-					domainName={ this.getDomainName() }
-					customerType={ this.getCustomerType() }
-					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-					plansWithScroll={ true }
-					planTypes={ planTypes }
-					flowName={ flowName }
-					customHeader={ this.getGutenboardingHeader() }
-					isMonthlyPricingTest={ isMonthlyPricingTest }
-				/>
+				<ExplatExperiment name="monthly_pricing_test_phase_1">
+					<DefaultVariation name="control">
+						<PlansFeaturesMain
+							site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+							hideFreePlan={ hideFreePlan }
+							isInSignup={ true }
+							isLaunchPage={ isLaunchPage }
+							intervalType={ this.getIntervalType() }
+							onUpgradeClick={ this.onSelectPlan }
+							showFAQ={ false }
+							displayJetpackPlans={ false }
+							domainName={ this.getDomainName() }
+							customerType={ this.getCustomerType() }
+							disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+							plansWithScroll={ true }
+							planTypes={ planTypes }
+							flowName={ flowName }
+							customHeader={ this.getGutenboardingHeader() }
+							isMonthlyPricingTest={ false }
+						/>
+					</DefaultVariation>
+					<Variation name="treatment">
+						<PlansFeaturesMain
+							site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+							hideFreePlan={ hideFreePlan }
+							isInSignup={ true }
+							isLaunchPage={ isLaunchPage }
+							intervalType={ this.getIntervalType() }
+							onUpgradeClick={ this.onSelectPlan }
+							showFAQ={ false }
+							displayJetpackPlans={ false }
+							domainName={ this.getDomainName() }
+							customerType={ this.getCustomerType() }
+							disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+							plansWithScroll={ true }
+							planTypes={ planTypes }
+							flowName={ flowName }
+							customHeader={ this.getGutenboardingHeader() }
+							isMonthlyPricingTest={ true }
+						/>
+					</Variation>
+				</ExplatExperiment>
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is just a quick PoC of adapting the ExPlat components into the Plan step page and the checkout page.

#### Testing instructions

##### Case 1
* Apply code-D52254 to the backend.
* Set the browser language to `en` and proxy through a US proxy.
* Sign up through /start/ so you are in the onboarding flow.
* Note that there will be a slight pause in the plans page. This means a query to the ExPlat API is happening. In the future, we should make use of the `<LoadVariation>` component to fill the gap. After the pause, you will either see a the treatment variation, i.e. the one with the monthly plans, or the control one, i.e. the original one with only the annual plans.
* Pick a plan and proceed to the checkout page. If you are in the control group, you will see "All Good!" in the cart summary. If you are in the treatment group, you will see "Profit!" in the cart summary.
* Go to the user report card and make sure you are seeing the expected assignment.

##### Case 2: the custom segment
* Follow the above step, but this time start the signup from an ineligible flow. e.g. /start/personal
* When you reach the checkout page, it should always be "All Good!".
* Go to the user report card and make sure you are not assigned to the monthly pricing test.