### PR TITLE
Update QS upsell duration on purchases page

### DIFF
--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -75,10 +75,11 @@ class ConciergeBanner extends Component {
 			case CONCIERGE_HAS_AVAILABLE_INCLUDED_SESSION:
 				headerText = translate( 'Looking for Expert Help?' );
 				mainText = translate(
-					'Get 30 minutes dedicated to the success of your site. Schedule your free 1-1 Quick Start Session with a Happiness Engineer!',
+					'Get %(durationInMinutes)d minutes dedicated to the success of your site. Schedule your free 1-1 Quick Start Session with a Happiness Engineer!',
 					{
 						comment:
 							'Quick Start Session is a one-on-one video session between the user and our support staff.',
+						args: { durationInMinutes: 30 },
 					}
 				);
 				buttonText = translate( 'Schedule now' );

--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -100,10 +100,11 @@ class ConciergeBanner extends Component {
 			case CONCIERGE_SUGGEST_PURCHASE_CONCIERGE:
 				headerText = translate( 'Need an expert by your side?' );
 				mainText = translate(
-					'We offer one-on-one Quick Start sessions dedicated to your site’s success. Click the button to learn how we can help you during these 45 minute calls.',
+					'We offer one-on-one Quick Start sessions dedicated to your site’s success. Click the button to learn how we can help you during these %(durationInMinutes)d minute calls.',
 					{
 						comment:
 							'Quick Start Session is a one-on-one video session between the user and our support staff.',
+						args: { durationInMinutes: 30 },
 					}
 				);
 				buttonText = translate( 'Learn more' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

More info: p7DVsv-9JV-p2#comment-32376

This changes the duration of the purchasable QS upsell banner on /me/purchased.

<img width="640" alt="9aofi9" src="https://user-images.githubusercontent.com/2749938/98093222-51b6f200-1e90-11eb-95a0-dcb3a76ba951.png">


#### Testing instructions

* Create a new site (lower than eCommerce), or use a site without any purchased QS sessions
* Go to /me/purchases
* QS upsell banner should read: 

<img width="640" alt="Screenshot on 2020-11-04 at 11-26-29" src="https://user-images.githubusercontent.com/2749938/98093453-a65a6d00-1e90-11eb-90ce-f33a569afb9c.png">

##### eCommerce (regression test)
Used a variable instead of hardcoded 30 for the included QS session banner.
* Create a new site (eCommerce), or use a site with an included QS session
* Go to /me/purchases
* QS upsell banner should be unchanged:

<img width="640" alt="Screenshot on 2020-11-04 at 11-54-26" src="https://user-images.githubusercontent.com/2749938/98096531-89c03400-1e94-11eb-90ca-fd99e5506d17.png">
