### PR TITLE
Plugins: Fix plugin action alignment styles

### DIFF
--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -23,8 +23,21 @@
 		}
 	}
 
-	.components-toggle-control .components-base-control__field {
-		margin-bottom: 5px;
+	.components-toggle-control {
+		.components-base-control__field {
+			display: inline-block;
+			margin-bottom: 5px;
+
+			.components-form-toggle {
+				margin-right: 0;
+			}
+		}
+
+		.components-toggle-control__label {
+			float: left;
+			font-size: $font-body-small;
+			margin-right: 8px;
+		}
 	}
 }
 

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -57,12 +57,13 @@
 
 	.has-disabled-info & {
 		cursor: default;
+		flex-direction: row;
 	}
 }
 
 .plugin-action__disabled-info.info-popover {
 	flex: none;
-	margin: -1px 4px;
+	margin: 0 4px -1px;
 
 	.gridicon {
 		display: block;

--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -39,7 +39,7 @@
 
 .plugin-activate-toggle__icon {
 	flex: none;
-	margin: -1px 3px;
+	margin: -1px 0 -1px 3px;
 
 	.gridicon {
 		display: block;

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -174,18 +174,21 @@
 	}
 }
 
-.plugin-item .plugin-activate-toggle__link,
 .plugin-item .plugin-activate-toggle__disabled {
 	@include breakpoint-deprecated( '>1040px' ) {
 		flex-direction: row;
-		margin-right: 12px;
+	}
+}
+
+.plugin-item .plugin-activate-toggle__link {
+	@include breakpoint-deprecated( '>1040px' ) {
+		flex-direction: row-reverse;
 	}
 }
 
 .plugin-item .plugin-activate-toggle__label {
 	@include breakpoint-deprecated( '>1040px' ) {
-		margin-left: 8px;
-		margin-right: 0;
+		margin-right: 8px;
 	}
 }
 

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -98,6 +98,10 @@
 		right: inherit;
 	}
 
+	.plugin-remove-button__remove-icon {
+		margin: -2px 8px 0 18px;
+	}
+
 	@include breakpoint-deprecated( '>480px' ) {
 		min-width: 22%;
 		border: none;
@@ -117,8 +121,7 @@
 	}
 
 	.plugin-activate-toggle__disabled,
-	.plugin-activate-toggle__link,
-	.plugin-remove-button__remove-link .plugin-action__children {
+	.plugin-activate-toggle__link {
 		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 		}

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -7,10 +7,6 @@
 	display: block;
 }
 
-.plugin-remove-button__remove-link {
-	margin-left: 12px;
-}
-
 .plugin-meta__actions .plugin-remove-button__remove-link {
 	margin-left: 0;
 }

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -23,15 +23,6 @@
 	.site__content {
 		padding: 0;
 	}
-
-	.plugin-activate-toggle__disabled,
-	.plugin-activate-toggle__link {
-		margin-left: 12px;
-	}
-}
-
-.plugin-site-jetpack .plugin-action__disabled-info.info-popover .gridicons-info-outline {
-	transform: translate( 2px, -2px );
 }
 
 .plugin-site-jetpack__automanage-notice {

--- a/client/my-sites/plugins/plugin-site-network/style.scss
+++ b/client/my-sites/plugins/plugin-site-network/style.scss
@@ -29,10 +29,6 @@
 		}
 	}
 
-	.plugin-action {
-		padding: 8px;
-	}
-
 	.all-sites-icon {
 		display: inline-block;
 		margin: 0;
@@ -57,7 +53,8 @@
 	}
 }
 
-.plugin-site__secondary-sites {
+.plugin-site__secondary-sites,
+.plugin-site-network__secondary-site-actions {
 	padding-top: 16px;
 }
 

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -39,11 +39,11 @@
 
 		.plugin-item__count,
 		.plugin-item__actions {
-			align-self: flex-start;
+			align-self: flex-end;
 			flex-direction: column;
 			margin-top: -6px;
 			padding-top: 0;
-			text-align: left;
+			text-align: right;
 		}
 
 		.plugin-item__count {


### PR DESCRIPTION
As brought up by @enejb in p9Jlb4-1Q9-p2 in #46945 we broke the plugin action toggle alignment when we migrated to `@wordpress/components` toggles. This PR fixes them.

#### Changes proposed in this Pull Request

Single plugin page on site - before we merged #46945:
![](https://cldup.com/vOVcwnyuoA.png)

Single plugin page on site - after we merged #46945:
![](https://cldup.com/xYA_RIRMe2.png)

Single plugin page on site - after (in this branch):
![](https://cldup.com/SGLki35Fxt.png)

Single plugin page for all sites - before we merged #46945:
![](https://cldup.com/i7WVOJurwj.png)

Single plugin page for all sites - after we merged #46945:
![](https://cldup.com/IkOwclP92I.png)

Single plugin page for all sites - after (in this branch):
![](https://cldup.com/AzJwwCglq2.png)

#### Testing instructions

* Go to `/plugins/:plugin/:site` where `:plugin` is the slug of a plugin, installed on your site, and `:site` is a Jetpack site.
* Verify plugin actions look well, as shown on the third screenshot.
* Go to `/plugins/:plugin` where `:plugin` is the slug of a plugin, installed on your one or more of your Jetpack sites.
* Verify plugin actions look well, as shown on the sixth screenshot.
