### PR TITLE
Domains: Fix transfer end date parsing

### DIFF
--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -22,7 +22,7 @@ export const createSiteDomainObject = ( domain ) => {
 	if ( domain.transfer_start_date ) {
 		transferEndDate = new Date( domain.transfer_start_date );
 		transferEndDate.setDate( transferEndDate.getDate() + 7 ); // Add 7 days.
-		transferEndDate = transferEndDate.toIsoString();
+		transferEndDate = transferEndDate.toISOString();
 	}
 
 	return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a typo introduced in #37073 where we attempt to call `toIsoString` instead of `toISOString`.

#### Testing instructions

Inspect the code 👀 
