### PR TITLE
Add storybook scripts to unit test CI

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -417,6 +417,63 @@ object RunAllUnitTests : BuildType({
 			dockerImage = "%docker_image%"
 			dockerRunParameters = "-u %env.UID%"
 		}
+		script {
+			name = "Build components storybook"
+			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+			scriptContent = """
+				set -e
+				export HOME="/calypso"
+				export NODE_ENV="production"
+
+				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
+				nvm install
+
+				yarn components:storybook:start --ci --smoke-test
+			""".trimIndent()
+			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
+			dockerPull = true
+			dockerImage = "%docker_image%"
+			dockerRunParameters = "-u %env.UID%"
+		}
+		script {
+			name = "Build media-library storybook"
+			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+			scriptContent = """
+				set -e
+				export HOME="/calypso"
+				export NODE_ENV="production"
+
+				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
+				nvm install
+
+				yarn media-library:storybook:start --ci --smoke-test -h localhost
+			""".trimIndent()
+			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
+			dockerPull = true
+			dockerImage = "%docker_image%"
+			dockerRunParameters = "-u %env.UID%"
+		}
+		script {
+			name = "Build search storybook"
+			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+			scriptContent = """
+				set -e
+				export HOME="/calypso"
+				export NODE_ENV="production"
+
+				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
+				nvm install
+
+				yarn search:storybook:start --ci --smoke-test
+			""".trimIndent()
+			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
+			dockerPull = true
+			dockerImage = "%docker_image%"
+			dockerRunParameters = "-u %env.UID%"
+		}
 	}
 
 	triggers {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add three new scripts to the unit test CI in TeamCity to smoke test storybook.

Adding these should help prevent us from mysteriously breaking storybook with dependency updates or other changes. (see https://github.com/Automattic/wp-calypso/pull/47098, for example where we have to fix these things without knowing what caused them)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that unit test TeamCity passes

Fixes #
