### PR TITLE
Nav Unification: New menu width

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -4,8 +4,8 @@
 // Override Global Vars
 .is-nav-unification {
 	// client/assets/stylesheets/shared/_variables.scss
-	--sidebar-width-max: 200px;
-	--sidebar-width-min: 200px;
+	--sidebar-width-max: 272px;
+	--sidebar-width-min: 272px;
 
 	--color-sidebar-background: #23282d;
 	--color-sidebar-background-rgb: 35, 40, 45;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* changes the width to 272, as agreed in the issue #46912

#### Testing instructions

* load calypso with `?flags=nav-unification`
* check the sidebar menu and make sure it is wider and still works in breakpoints etc…
* please check the same work done for wp-admin D52281-code

Fixes #46912