### PR TITLE
Masterbar: remove from loading state

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -143,7 +143,6 @@ class Document extends React.Component {
 									'is-wccom-oauth-flow': isWCComConnect,
 								} ) }
 							>
-								<div className="masterbar" />
 								<div className="layout__content">
 									<LoadingLogo size={ 72 } className="wpcom-site__logo" />
 								</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove masterbar from loading state until we have shipped Nav Unification to 100% of users

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* load calypso
* make sure masterbar doesn't appear in loading state
* check both without `?flags=nav-unification` and with `?flags=nav-unification`

Before | After
-------|------
![](https://cln.sh/fj3JjS+) | ![](https://cln.sh/Nf1lyo+)

Relates to https://github.com/Automattic/wp-calypso/issues/47044#issuecomment-721821286
