### PR TITLE
Reader Lists: Hide list creation link behind feature flag

### DIFF
--- a/client/reader/sidebar/reader-sidebar-lists/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import config from 'calypso/config';
 import ListItem from './list-item';
 import ListItemCreateLink from './list-item-create-link';
 
@@ -54,7 +55,9 @@ export class ReaderSidebarListsList extends React.Component {
 		return (
 			<ul className="sidebar__menu-list">
 				{ this.renderItems() }
-				<ListItemCreateLink key="create-item-link" path={ this.props.path } />
+				{ config.isEnabled( 'reader/list-management' ) && (
+					<ListItemCreateLink key="create-item-link" path={ this.props.path } />
+				) }
 			</ul>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hides the list creation link in the sidebar behind a feature flag.

<img width="269" alt="Screen Shot 2020-11-02 at 3 40 00 PM" src="https://user-images.githubusercontent.com/4044428/97927226-d33c4200-1d21-11eb-9abb-7f2ba426945c.png">


#### Testing instructions

* Ensure that the list creation link is shown according to the `reader/list-management` feature flag. (Enabled in development, disabled everywhere else.)