### PR TITLE
Focused Launch: Split Summary into modular Steps

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -6,7 +6,7 @@
 import { Title } from '@automattic/onboarding';
 import { __ } from '@wordpress/i18n';
 import { TextControl, SVG, Path, Tooltip, Circle, Rect } from '@wordpress/components';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import DomainPicker, { LockedPurchasedItem } from '@automattic/domain-picker';
 import { Icon, check } from '@wordpress/icons';
 import { Link } from 'react-router-dom';
@@ -39,103 +39,122 @@ function noop( ...args: unknown[] ) {
 	return args;
 }
 
-interface Props {
-	siteId: number;
-}
+type SummaryStepProps = {
+	input: ReactNode;
+	commentary?: ReactNode;
+};
 
-const Summary: React.FunctionComponent< Props > = ( { siteId } ) => {
-	const { title, updateTitle, saveTitle } = useTitle( siteId );
-	const sitePrimaryDomain = useSelect( ( select ) =>
-		select( SITE_STORE ).getPrimarySiteDomain( siteId )
-	);
-	const siteSubdomain = useSelect( ( select ) => select( SITE_STORE ).getSiteSubdomain( siteId ) );
-	const hasPaidDomain = sitePrimaryDomain && ! sitePrimaryDomain?.is_subdomain;
+const SummaryStep: React.FunctionComponent< SummaryStepProps > = ( { input, commentary } ) => (
+	<div className="focused-launch-summary__step">
+		<div className="focused-launch-summary__data-input">
+			<div className="focused-launch-summary__section">{ input }</div>
+		</div>
+		<div className="focused-launch-summary__side-commentary">{ commentary }</div>
+	</div>
+);
 
-	const domainSearch = useDomainSearch();
+type CommonStepProps = {
+	stepIndex: number;
+};
 
-	let stepNumber = 1;
+// Props in common between all summary steps + a few props from <TextControl>
+type SiteNameStepProps = CommonStepProps &
+	Pick< React.ComponentProps< typeof TextControl >, 'value' | 'onChange' | 'onBlur' >;
+
+const SiteNameStep: React.FunctionComponent< SiteNameStepProps > = ( {
+	stepIndex,
+	value,
+	onChange,
+	onBlur,
+} ) => {
 	return (
-		<div className="focused-launch-summary__container">
-			<div className="focused-launch-summary__section">
-				<Title>{ __( "You're almost there", __i18n_text_domain__ ) }</Title>
-				<p className="focused-launch-summary__caption">
-					{ __(
-						'Prepare for launch! Confirm a few final things before you take it live.',
-						__i18n_text_domain__
-					) }
-				</p>
-			</div>
-			<div className="focused-launch-summary__step">
-				<div className="focused-launch-summary__data-input">
-					<div className="focused-launch-summary__section">
-						<TextControl
-							className="focused-launch-summary__input"
-							label={
-								<label className="focused-launch-summary__label">
-									{ stepNumber++ }. { __( 'Name your site', __i18n_text_domain__ ) }
-								</label>
+		<SummaryStep
+			input={
+				<TextControl
+					className="focused-launch-summary__input"
+					label={
+						<label className="focused-launch-summary__label">
+							{ stepIndex }. { __( 'Name your site', __i18n_text_domain__ ) }
+						</label>
+					}
+					value={ value }
+					onChange={ onChange }
+					onBlur={ onBlur }
+					// eslint-disable-next-line jsx-a11y/no-autofocus
+					autoFocus={ true }
+				/>
+			}
+		/>
+	);
+};
+
+// Props in common between all summary steps + a few props from <DomainPicker> +
+// the remaining extra props
+type DomainStepProps = CommonStepProps & { hasPaidDomain?: boolean } & Pick<
+		React.ComponentProps< typeof DomainPicker >,
+		'existingSubdomain' | 'currentDomain' | 'initialDomainSearch'
+	>;
+
+const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
+	stepIndex,
+	existingSubdomain,
+	currentDomain,
+	initialDomainSearch,
+	hasPaidDomain,
+} ) => {
+	return (
+		<SummaryStep
+			input={
+				hasPaidDomain ? (
+					<>
+						<label className="focused-launch-summary__label">
+							{ __( 'Your domain', __i18n_text_domain__ ) }
+							<Tooltip
+								position="top center"
+								text={ __(
+									'Changes to your purchased domain can be managed from your Domains page.',
+									__i18n_text_domain__
+								) }
+							>
+								{ info }
+							</Tooltip>
+						</label>
+						<LockedPurchasedItem domainName={ currentDomain || '' } />
+					</>
+				) : (
+					<>
+						<DomainPicker
+							header={
+								<>
+									<label className="focused-launch-summary__label">
+										{ stepIndex }. { __( 'Confirm your domain', __i18n_text_domain__ ) }
+									</label>
+									<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
+										<Icon icon={ bulb } /> 46.9% of globally registered domains are .com
+									</p>
+								</>
 							}
-							value={ title }
-							onChange={ updateTitle }
-							onBlur={ saveTitle }
-							// eslint-disable-next-line jsx-a11y/no-autofocus
-							autoFocus={ true }
+							existingSubdomain={ existingSubdomain }
+							currentDomain={ currentDomain }
+							onDomainSelect={ noop }
+							initialDomainSearch={ initialDomainSearch }
+							showSearchField={ false }
+							analyticsFlowId="focused-launch"
+							analyticsUiAlgo="focused_launch_domain_picker"
+							onDomainSearchBlur={ () => noop( 'TODO: on domain search blur' ) }
+							onSetDomainSearch={ () => noop( 'TODO: on set domain search' ) }
+							quantity={ 3 }
+							quantityExpanded={ 3 }
+							itemType="button"
 						/>
-					</div>
-				</div>
-				<div className="focused-launch-summary__side-commentary"></div>
-			</div>
-			<div className="focused-launch-summary__step">
-				<div className="focused-launch-summary__data-input">
-					<div className="focused-launch-summary__section">
-						{ hasPaidDomain ? (
-							<>
-								<label className="focused-launch-summary__label">
-									{ __( 'Your domain', __i18n_text_domain__ ) }
-									<Tooltip
-										position="top center"
-										text={ __(
-											'Changes to your purchased domain can be managed from your Domains page.',
-											__i18n_text_domain__
-										) }
-									>
-										{ info }
-									</Tooltip>
-								</label>
-								<LockedPurchasedItem domainName={ sitePrimaryDomain?.domain || '' } />
-							</>
-						) : (
-							<DomainPicker
-								header={
-									<>
-										<label className="focused-launch-summary__label">
-											{ stepNumber++ }. { __( 'Confirm your domain', __i18n_text_domain__ ) }
-										</label>
-										<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
-											<Icon icon={ bulb } /> 46.9% of globally registered domains are .com
-										</p>
-									</>
-								}
-								existingSubdomain={ siteSubdomain?.domain }
-								currentDomain={ sitePrimaryDomain?.domain }
-								onDomainSelect={ noop }
-								initialDomainSearch={ domainSearch }
-								showSearchField={ false }
-								analyticsFlowId="focused-launch"
-								analyticsUiAlgo="focused_launch_domain_picker"
-								onDomainSearchBlur={ () => noop( 'TODO: on domain search blur' ) }
-								onSetDomainSearch={ () => noop( 'TODO: on set domain search' ) }
-								quantity={ 3 }
-								quantityExpanded={ 3 }
-								itemType="button"
-							/>
-						) }
 						<Link to={ Route.DomainDetails }>
 							{ __( 'View all domains', __i18n_text_domain__ ) }
 						</Link>
-					</div>
-				</div>
-				<div className="focused-launch-summary__side-commentary">
+					</>
+				)
+			}
+			commentary={
+				<>
 					<p className="focused-launch-summary__side-commentary-title">
 						<strong>46.9%</strong> of globally registered domains are <strong>.com</strong>
 					</p>
@@ -150,21 +169,30 @@ const Summary: React.FunctionComponent< Props > = ( { siteId } ) => {
 							<Icon icon={ check } /> Builds brand recognition and trust
 						</li>
 					</ul>
-				</div>
-			</div>
-			<div className="focused-launch-summary__step">
-				<div className="focused-launch-summary__data-input">
-					<div className="focused-launch-summary__section">
-						<label className="focused-launch-summary__label">
-							{ stepNumber++ }. { __( 'Confirm your plan', __i18n_text_domain__ ) }
-						</label>
-						<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
-							<Icon icon={ bulb } /> Monetize your site with <strong>WordPress Premium</strong>
-						</p>
-						<Link to={ Route.PlanDetails }>{ __( 'View all plans', __i18n_text_domain__ ) }</Link>
-					</div>
-				</div>
-				<div className="focused-launch-summary__side-commentary">
+				</>
+			}
+		/>
+	);
+};
+
+type PlanStepProps = CommonStepProps;
+
+const PlanStep: React.FunctionComponent< PlanStepProps > = ( { stepIndex } ) => {
+	return (
+		<SummaryStep
+			input={
+				<>
+					<label className="focused-launch-summary__label">
+						{ stepIndex }. { __( 'Confirm your plan', __i18n_text_domain__ ) }
+					</label>
+					<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
+						<Icon icon={ bulb } /> Monetize your site with <strong>WordPress Premium</strong>
+					</p>
+					<Link to={ Route.PlanDetails }>{ __( 'View all plans', __i18n_text_domain__ ) }</Link>
+				</>
+			}
+			commentary={
+				<>
 					<p className="focused-launch-summary__side-commentary-title">
 						Monetize your site with <strong>WordPress Premium</strong>
 					</p>
@@ -179,8 +207,73 @@ const Summary: React.FunctionComponent< Props > = ( { siteId } ) => {
 							<Icon icon={ check } /> Accept payments
 						</li>
 					</ul>
-				</div>
+				</>
+			}
+		/>
+	);
+};
+
+type SummaryProps = {
+	siteId: number;
+};
+
+const Summary: React.FunctionComponent< SummaryProps > = ( { siteId } ) => {
+	const { title, updateTitle, saveTitle } = useTitle( siteId );
+	const sitePrimaryDomain = useSelect( ( select ) =>
+		select( SITE_STORE ).getPrimarySiteDomain( siteId )
+	);
+	const siteSubdomain = useSelect( ( select ) => select( SITE_STORE ).getSiteSubdomain( siteId ) );
+	const hasPaidDomain = true; //sitePrimaryDomain && ! sitePrimaryDomain?.is_subdomain;
+
+	const domainSearch = useDomainSearch();
+
+	// Prepare Steps
+	const renderSiteNameStep = ( index: number ) => (
+		<SiteNameStep
+			stepIndex={ index }
+			key={ index }
+			value={ title }
+			onChange={ updateTitle }
+			onBlur={ saveTitle }
+		/>
+	);
+	const renderDomainStep = ( index: number ) => (
+		<DomainStep
+			stepIndex={ index }
+			key={ index }
+			existingSubdomain={ siteSubdomain?.domain }
+			currentDomain={ sitePrimaryDomain?.domain }
+			initialDomainSearch={ domainSearch }
+			hasPaidDomain={ hasPaidDomain }
+		/>
+	);
+	const renderPlanStep = ( index: number ) => <PlanStep stepIndex={ index } key={ index } />;
+
+	// Steps that are not interactive (e.g. user has already selected domain/plan)
+	const disabledSteps = [ hasPaidDomain ? renderDomainStep : null ].filter(
+		( step ) => step !== null
+	) as ( ( index: number ) => JSX.Element )[];
+
+	// Steps that require the user interaction
+	const activeSteps = [
+		renderSiteNameStep,
+		hasPaidDomain ? null : renderDomainStep,
+		renderPlanStep,
+	].filter( ( step ) => step !== null ) as ( ( index: number ) => JSX.Element )[];
+
+	return (
+		<div className="focused-launch-summary__container">
+			<div className="focused-launch-summary__section">
+				<Title>{ __( "You're almost there", __i18n_text_domain__ ) }</Title>
+				<p className="focused-launch-summary__caption">
+					{ __(
+						'Prepare for launch! Confirm a few final things before you take it live.',
+						__i18n_text_domain__
+					) }
+				</p>
 			</div>
+			{ disabledSteps.map( ( step, stepIndex ) => step( stepIndex + 1 ) ) }
+			{ activeSteps.map( ( step, stepIndex ) => step( stepIndex + 1 ) ) }
 		</div>
 	);
 };

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -223,7 +223,7 @@ const Summary: React.FunctionComponent< SummaryProps > = ( { siteId } ) => {
 		select( SITE_STORE ).getPrimarySiteDomain( siteId )
 	);
 	const siteSubdomain = useSelect( ( select ) => select( SITE_STORE ).getSiteSubdomain( siteId ) );
-	const hasPaidDomain = true; //sitePrimaryDomain && ! sitePrimaryDomain?.is_subdomain;
+	const hasPaidDomain = sitePrimaryDomain && ! sitePrimaryDomain?.is_subdomain;
 
 	const domainSearch = useDomainSearch();
 

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -250,16 +250,13 @@ const Summary: React.FunctionComponent< SummaryProps > = ( { siteId } ) => {
 	const renderPlanStep = ( index: number ) => <PlanStep stepIndex={ index } key={ index } />;
 
 	// Steps that are not interactive (e.g. user has already selected domain/plan)
-	const disabledSteps = [ hasPaidDomain ? renderDomainStep : null ].filter(
-		( step ) => step !== null
-	) as ( ( index: number ) => JSX.Element )[];
+	// Steps that are not interactive (e.g. user has already selected domain/plan)
+	const disabledSteps = hasPaidDomain ? [ renderDomainStep ] : [];
 
 	// Steps that require the user interaction
-	const activeSteps = [
-		renderSiteNameStep,
-		hasPaidDomain ? null : renderDomainStep,
-		renderPlanStep,
-	].filter( ( step ) => step !== null ) as ( ( index: number ) => JSX.Element )[];
+	const activeSteps = hasPaidDomain
+		? [ renderSiteNameStep, renderPlanStep ]
+		: [ renderSiteNameStep, renderDomainStep, renderPlanStep ];
 
 	return (
 		<div className="focused-launch-summary__container">


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Refactor `<Summary />` component and split it into different steps.
* Introduce the concept of `activeSteps`(steps that require user interaction)  vs `disabledSteps` (steps that are not interactive, and only serve as a summary to the user)

These changes are part of the preparation work that facilitates the changes required by #46858

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Since this PR is a refactor, it's important to test that the Focused Launch modal as a whole still works like in production.

### Compare the in-editor versions (local vs production)

* Make sure you have an active connection to your sandbox, and that your sandbox is clean and up to date
* In two separate terminal windows, from the root of the project, run:
  - `yarn start`
  - `cd apps/editing-toolkit && yarn dev --sync`
* Sandbox an unlaunched WordPress site created via `/start` by adding it to your host file
* Visit the URL `/page/[SITE_ID]/home?flags=create/focused-launch-flow` on your local machine, and compare it to the production version, by visiting the same path on `wordpress.com`. There shouldn't be any difference between the local and the production version

### Check that the domain step renders on top of the other steps, when the site has already got an associated paid domain

* Make sure you have an active connection to your sandbox, and that your sandbox is clean and up to date
* In two separate terminal windows, from the root of the project, run:
  - `yarn start`
  - `cd apps/editing-toolkit && yarn dev --sync`
* Sandbox an unlaunched WordPress site created via `/start` by adding it to your host file. 
* **Add a paid domain to the site**
* Visit the URL `/page/[SITE_ID]/home?flags=create/focused-launch-flow` on your local machine, and compare it to the production version, by visiting the same path on `wordpress.com`. There shouldn't be any difference between the local and the production version

See https://github.com/Automattic/wp-calypso/pull/47125/files#r518118936 for more details

## Screenshots

Focused Launch, when the site doesn't have a paid domain already associated:

![Screenshot 2020-11-05 at 16 11 36](https://user-images.githubusercontent.com/1083581/98258795-979fb300-1f81-11eb-82f5-ef79245a5a7a.png)

Focused Launch, when the site already has a paid domain associated:

![Screenshot 2020-11-05 at 16 08 52](https://user-images.githubusercontent.com/1083581/98258617-60c99d00-1f81-11eb-9655-ade79d1917f0.png)

