### PR TITLE
Add calypso-stripe and shopping-cart to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,8 @@
 /client/state/stored-cards/ @Automattic/payments
 /client/state/sites/plans/ @Automattic/payments
 /packages/composite-checkout/ @Automattic/shilling
+/packages/calypso-stripe/ @Automattic/shilling
+/packages/shopping-cart/ @Automattic/shilling
 
 # Reader
 /client/reader @Automattic/reader


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds two new checkout-related packages, `@automattic/shopping-cart` and `@automattic/calypso-stripe` to CODEOWNERS for the Shilling Payments team.

Fixes https://github.com/Automattic/wp-calypso/issues/47064
Fixes https://github.com/Automattic/wp-calypso/issues/47129

#### Testing instructions

None