### PR TITLE
Checkout: Show empty cart view when cart is empty

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/empty-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/empty-cart.tsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { CheckoutStepBody } from '@automattic/composite-checkout';
+
+export default function EmptyCart(): JSX.Element {
+	return (
+		<CheckoutStepBody
+			stepId="empty-cart"
+			isStepActive={ false }
+			isStepComplete={ true }
+			titleContent={ <EmptyCartTitle /> }
+		/>
+	);
+}
+
+function EmptyCartTitle(): JSX.Element {
+	const translate = useTranslate();
+	return <>{ String( translate( 'You have no items in your cart' ) ) }</>;
+}

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -640,7 +640,7 @@ export default function CompositeCheckout( {
 		} );
 	}
 
-	if ( responseCart.products.length < 1 && ( areThereErrors || ! isInitialCartLoading ) ) {
+	if ( responseCart.products.length < 1 && doNotRedirect ) {
 		const goToPlans = () => ( siteSlug ? page( `/plans/${ siteSlug }` ) : page( '/plans' ) );
 		return (
 			<React.Fragment>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -6,7 +6,16 @@ import React, { useCallback, useMemo } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import debugFactory from 'debug';
 import { useSelector, useDispatch, useStore } from 'react-redux';
-import { CheckoutProvider, checkoutTheme, defaultRegistry } from '@automattic/composite-checkout';
+import {
+	CheckoutProvider,
+	CheckoutStepAreaWrapper,
+	MainContentWrapper,
+	SubmitButtonWrapper,
+	checkoutTheme,
+	defaultRegistry,
+	Button,
+} from '@automattic/composite-checkout';
+import { ThemeProvider } from 'emotion-theming';
 import { useShoppingCart, ResponseCart } from '@automattic/shopping-cart';
 import { colors } from '@automattic/color-studio';
 import { useStripe } from '@automattic/calypso-stripe';
@@ -92,6 +101,7 @@ import { CountryListItem } from './types/country-list-item';
 import { TransactionResponse, Purchase } from './types/wpcom-store-state';
 import { WPCOMCartItem } from './types/checkout-cart';
 import doesValueExist from './lib/does-value-exist';
+import EmptyCart from './components/empty-cart';
 
 const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
 
@@ -628,6 +638,32 @@ export default function CompositeCheckout( {
 			arePaymentMethodsLoading: arePaymentMethodsLoading,
 			items: items.length < 1,
 		} );
+	}
+
+	if ( responseCart.products.length < 1 ) {
+		const goToPlans = () => ( siteSlug ? page( `/plans/${ siteSlug }` ) : page( '/plans' ) );
+		return (
+			<React.Fragment>
+				<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />
+				<CartMessages
+					cart={ responseCart }
+					selectedSite={ { slug: siteSlug } }
+					isLoadingCart={ isInitialCartLoading }
+				/>
+				<ThemeProvider theme={ theme }>
+					<MainContentWrapper>
+						<CheckoutStepAreaWrapper>
+							<EmptyCart />
+							<SubmitButtonWrapper>
+								<Button buttonType="primary" fullWidth onClick={ goToPlans }>
+									{ translate( 'Browse our plans' ) }
+								</Button>
+							</SubmitButtonWrapper>
+						</CheckoutStepAreaWrapper>
+					</MainContentWrapper>
+				</ThemeProvider>
+			</React.Fragment>
+		);
 	}
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -640,7 +640,7 @@ export default function CompositeCheckout( {
 		} );
 	}
 
-	if ( responseCart.products.length < 1 ) {
+	if ( responseCart.products.length < 1 && ( areThereErrors || ! isInitialCartLoading ) ) {
 		const goToPlans = () => ( siteSlug ? page( `/plans/${ siteSlug }` ) : page( '/plans' ) );
 		return (
 			<React.Fragment>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -440,7 +440,7 @@ export default function CompositeCheckout( {
 	const areThereErrors =
 		[ ...errors, cartLoadingError, cartProductPrepError ].filter( doesValueExist ).length > 0;
 	const doNotRedirect = isInitialCartLoading || isCartPendingUpdate || areThereErrors;
-	useRedirectIfCartEmpty(
+	const areWeRedirecting = useRedirectIfCartEmpty(
 		doNotRedirect,
 		items,
 		cartEmptyRedirectUrl,
@@ -640,7 +640,12 @@ export default function CompositeCheckout( {
 		} );
 	}
 
-	if ( responseCart.products.length < 1 && doNotRedirect ) {
+	if (
+		responseCart.products.length < 1 &&
+		! areWeRedirecting &&
+		( areThereErrors || ! isCartPendingUpdate ) &&
+		( areThereErrors || ! isInitialCartLoading )
+	) {
 		const goToPlans = () => {
 			recordEvent( {
 				type: 'EMPTY_CART_CTA_CLICKED',

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -641,10 +641,13 @@ export default function CompositeCheckout( {
 	}
 
 	if (
-		responseCart.products.length < 1 &&
-		! areWeRedirecting &&
-		( areThereErrors || ! isCartPendingUpdate ) &&
-		( areThereErrors || ! isInitialCartLoading )
+		shouldShowEmptyCartPage( {
+			responseCart,
+			areWeRedirecting,
+			areThereErrors,
+			isCartPendingUpdate,
+			isInitialCartLoading,
+		} )
 	) {
 		const goToPlans = () => {
 			recordEvent( {
@@ -832,4 +835,35 @@ function displayRenewalSuccessNotice(
 		),
 		{ persistent: true }
 	);
+}
+
+function shouldShowEmptyCartPage( {
+	responseCart,
+	areWeRedirecting,
+	areThereErrors,
+	isCartPendingUpdate,
+	isInitialCartLoading,
+}: {
+	responseCart: ResponseCart;
+	areWeRedirecting: boolean;
+	areThereErrors: boolean;
+	isCartPendingUpdate: boolean;
+	isInitialCartLoading: boolean;
+} ): boolean {
+	if ( responseCart.products.length > 0 ) {
+		return false;
+	}
+	if ( areWeRedirecting ) {
+		return false;
+	}
+	if ( areThereErrors ) {
+		return true;
+	}
+	if ( isCartPendingUpdate ) {
+		return false;
+	}
+	if ( isInitialCartLoading ) {
+		return false;
+	}
+	return true;
 }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -641,7 +641,16 @@ export default function CompositeCheckout( {
 	}
 
 	if ( responseCart.products.length < 1 && doNotRedirect ) {
-		const goToPlans = () => ( siteSlug ? page( `/plans/${ siteSlug }` ) : page( '/plans' ) );
+		const goToPlans = () => {
+			recordEvent( {
+				type: 'EMPTY_CART_CTA_CLICKED',
+			} );
+			if ( siteSlug ) {
+				page( `/plans/${ siteSlug }` );
+			} else {
+				page( '/plans' );
+			}
+		};
 		return (
 			<React.Fragment>
 				<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />

--- a/client/my-sites/checkout/composite-checkout/hooks/use-redirect-if-cart-empty.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-redirect-if-cart-empty.ts
@@ -17,7 +17,7 @@ export default function useRedirectIfCartEmpty< T >(
 	items: Array< T >,
 	redirectUrl: string,
 	createUserAndSiteBeforeTransaction: boolean
-): void {
+): boolean {
 	const didRedirect = useRef< boolean >( false );
 	useEffect( () => {
 		if ( didRedirect.current || doNotRedirect ) {
@@ -46,4 +46,5 @@ export default function useRedirectIfCartEmpty< T >(
 			return;
 		}
 	}, [ redirectUrl, items, doNotRedirect, createUserAndSiteBeforeTransaction ] );
+	return didRedirect.current;
 }

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -404,6 +404,10 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							url: action.payload.url,
 						} )
 					);
+				case 'EMPTY_CART_CTA_CLICKED':
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_empty_cart_clicked' )
+					);
 				default:
 					debug( 'unknown checkout event', action );
 					return reduxDispatch(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a new view that renders in checkout when the cart is empty. Since typically a customer will be redirected to the plans page when the cart is empty, this should normally never be seen. However, if there is an error displayed on the screen which prevents the redirect, then this view will be shown instead of the loading animation.

Before:

<img width="1043" alt="Screen Shot 2020-11-04 at 7 51 00 PM" src="https://user-images.githubusercontent.com/2036909/98184021-61a5f480-1ed7-11eb-9a01-1b65cb03ac76.png">

After:

<img width="1047" alt="Screen Shot 2020-11-04 at 7 50 37 PM" src="https://user-images.githubusercontent.com/2036909/98184029-65397b80-1ed7-11eb-94a4-08a0afb4da02.png">

Fixes https://github.com/Automattic/wp-calypso/issues/45182

#### Testing instructions

- Add a plan to your cart and visit checkout. Verify that you see the loading animation until the cart finishes loading, and that it then renders checkout with the plan in the cart. Verify that you never see the empty cart view.
- Remove the product from your cart. Verify that you see the pending state on the form's buttons until the change completes, and that you are redirected to the plans page.  Verify that you never see the empty cart view.
- Visit a URL that adds a non-existent product like `/checkout/example.com/abcd`. Verify that you see the loading animation and then you see the new empty cart view with the appropriate error message.