### PR TITLE
Fixes eslint rule wpcalypso/no-package-relative-imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,12 +67,23 @@ module.exports = {
 			},
 		},
 		{
-			// Eventually the whole repo should follow this rule. This is the list of the folders we have
-			// already cleaned up. Once we have cleaned all repo, this override should dissapear and the rule
-			// should be enabled as a regular `rule`.
 			files: [ 'packages/**/*' ],
 			rules: {
-				'import/no-extraneous-dependencies': 'error',
+				// These two rules are to ensure packages don't import form calypso by accident to avoid circular deps.
+				'no-restricted-imports': [
+					'error',
+					{
+						patterns: [ 'calypso/*' ],
+						message: "Packages shouldn't import from calypso",
+					},
+				],
+				'no-restricted-modules': [
+					'error',
+					{
+						patterns: [ 'calypso/*' ],
+						message: "Packages shouldn't import from calypso",
+					},
+				],
 			},
 		},
 		{
@@ -348,7 +359,6 @@ module.exports = {
 				],
 			},
 		],
-		// Disabled for now until we finish the migration
 		'wpcalypso/no-package-relative-imports': [
 			'error',
 			{

--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -6,5 +6,12 @@ module.exports = {
 				'import/no-nodejs-modules': 'off',
 			},
 		},
+		{
+			// These are consumed only by Calypso's webpack build, it is ok to import other Calypso components
+			files: [ '**/docs/example.jsx' ],
+			rules: {
+				'no-restricted-imports': 'off',
+			},
+		},
 	],
 };

--- a/packages/components/src/button/docs/example.jsx
+++ b/packages/components/src/button/docs/example.jsx
@@ -2,14 +2,14 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
 import Button from '..';
 import Card from '../../card';
-import DocsExample from 'devdocs/docs-example';
+import DocsExample from 'calypso/devdocs/docs-example';
 
 export default class ButtonExample extends React.PureComponent {
 	static displayName = 'ButtonExample';

--- a/packages/components/src/suggestions/docs/example.jsx
+++ b/packages/components/src/suggestions/docs/example.jsx
@@ -6,7 +6,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 /**
  * Internal dependencies
  */
-import FormTextInput from 'components/forms/form-text-input';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import Suggestions from '..';
 
 export default function SuggestionsExample() {

--- a/packages/webpack-config-flag-plugin/test/fixtures/.eslintrc.js
+++ b/packages/webpack-config-flag-plugin/test/fixtures/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
 		// Test fixtures import fake modules a lot just for testing the behaviour of this plugin
 		'import/no-extraneous-dependencies': 'off',
 		'wpcalypso/import-docblock': 0,
+		'wpcalypso/no-package-relative-imports': 'off',
 		'no-unused-vars': 0,
 		'no-empty': 0,
 		'no-shadow': 0,

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line wpcalypso/no-package-relative-imports
 import config from 'config';
 import { By, promise, until } from 'selenium-webdriver';
 

--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line wpcalypso/no-package-relative-imports
 import config from 'config';
 import { By } from 'selenium-webdriver';
 

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import assert from 'assert';
-// eslint-disable-next-line wpcalypso/no-package-relative-imports
 import config from 'config';
 
 /**

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line wpcalypso/no-package-relative-imports
 import config from 'config';
 
 /**

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line wpcalypso/no-package-relative-imports
 import config from 'config';
 import assert from 'assert';
 


### PR DESCRIPTION
### Background

See #44602

### Changes

Final cleanup of `wpcalypso/no-package-relative-imports` across the whole repo.

### Testing instructions

* Check all tests passes (ignore lint errors, there will be a ton).
* Do a smoke test on the live branch
* Verify there are no huge changes in package size in ICFY report.
