### PR TITLE
Editing Toolkit: set translations for NUX modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
@@ -60,6 +60,8 @@ class WPCOM_Block_Editor_NUX {
 			plugins_url( 'dist/', __FILE__ )
 		);
 
+		wp_set_script_translations( 'wpcom-block-editor-nux-script', 'full-site-editing' );
+
 		$style_path = 'dist/wpcom-block-editor-nux' . ( is_rtl() ? '.rtl' : '' ) . '.css';
 		wp_enqueue_style(
 			'wpcom-block-editor-nux-style',


### PR DESCRIPTION
## Changes proposed in this Pull Request

This one, magic line ensures that the NUX modal content is translated:

`wp_set_script_translations( 'wpcom-block-editor-nux-script', 'full-site-editing' );`

🧙  IT'S MAGIC!

<img width="798" alt="Screen Shot 2020-11-05 at 7 57 50 pm" src="https://user-images.githubusercontent.com/6458278/98219747-8a92bc00-1fa1-11eb-96ed-af43150aa763.png">

## Testing instructions

Check out the branch

Get your sandbox running

Run `cd apps/editing-toolkit && yarn dev --sync` from your Calypso root

Create a new site at `wordpress.com/new{de|es|fr|mag16 locale of your choice}`

Check that the NUX modal is translated 👍 

The other quick way (if you don't want to create a new site) is to comment out the [following lines](https://github.com/Automattic/wp-calypso/blob/master/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js#L62) in [wpcom-nux.js](https://github.com/Automattic/wp-calypso/blob/master/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js#L62):

```
	if ( ! isWpcomNuxEnabled || isSPTOpen ) {
		return null;
	}
```




