### PR TITLE
Add monorepo dependencies to tsconfig.json for Launch, Domain Picker, Plans Grid and Onboarding packages

### DIFF
--- a/packages/domain-picker/tsconfig.json
+++ b/packages/domain-picker/tsconfig.json
@@ -33,8 +33,8 @@
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ],
 	"references": [
-		{
-			"path": "../data-stores"
-		}
+		{ "path": "../data-stores" },
+		{ "path": "../calypso-analytics" },
+		{ "path": "../react-i18n" }
 	]
 }

--- a/packages/launch/tsconfig.json
+++ b/packages/launch/tsconfig.json
@@ -32,5 +32,10 @@
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ],
-	"references": [ {} ]
+	"references": [
+		{ "path": "../data-stores" },
+		{ "path": "../domain-picker" },
+		{ "path": "../onboarding" },
+		{ "path": "../react-i18n" }
+	]
 }

--- a/packages/onboarding/tsconfig.json
+++ b/packages/onboarding/tsconfig.json
@@ -32,5 +32,5 @@
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ],
-	"references": [ {} ]
+	"references": [ { "path": "../data-stores" }, { "path": "../react-i18n" } ]
 }

--- a/packages/plans-grid/tsconfig.json
+++ b/packages/plans-grid/tsconfig.json
@@ -33,8 +33,8 @@
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ],
 	"references": [
-		{
-			"path": "../data-stores"
-		}
+		{ "path": "../data-stores" },
+		{ "path": "../onboarding" },
+		{ "path": "../react-i18n" }
 	]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

List monorepo dependencies as references in the `tsconfig.json` file of the following packages:

- `@automattic/launch`
- `@automattic/onboarding`
- `@automattic/plans-grid`
- `@automattic/domain-picker`

#### Testing instructions

In the project's root folder, run these commands. They should all run without errors:
- `yarn clean:packages; ./node_modules/.bin/tsc --build packages/launch`
- `yarn clean:packages; ./node_modules/.bin/tsc --build packages/onboarding`
- `yarn clean:packages; ./node_modules/.bin/tsc --build packages/plans-grid`
- `yarn clean:packages; ./node_modules/.bin/tsc --build packages/domain-picker`
