### PR TITLE
Focused Launch: fix domain suggestions update when editing site title

### DIFF
--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -169,6 +169,13 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		}
 	}, [ allDomainSuggestions, setBaseRailcarId ] );
 
+	// Update domain search query using initialDomainSearch prop if there is no search field
+	useEffect( () => {
+		if ( ! showSearchField ) {
+			setDomainSearch( initialDomainSearch );
+		}
+	}, [ initialDomainSearch, showSearchField ] );
+
 	const handleItemRender = (
 		domain: string,
 		railcarId: string,


### PR DESCRIPTION
Depends on https://github.com/Automattic/wp-calypso/pull/47141

#### Changes proposed in this Pull Request

* Domain picker should update `domainSearch` state using `initialDomainSearch` prop when `showSearchField` prop is true.

#### Testing instructions

* Open Focused Launch modal (in editor or Calypso).
* Make sure domain suggestions are displayed.
* Edit site title and advance to domain selection step. 
* Domain suggestions should be updated.

Fixes #47137
