### PR TITLE
Fix premium plan features for monthly pricing test

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -664,6 +664,13 @@ export const FEATURES_LIST = {
 			),
 	},
 
+	[ constants.FEATURE_LIVE_CHAT_SUPPORT ]: {
+		getSlug: () => constants.FEATURE_LIVE_CHAT_SUPPORT,
+		getTitle: () => i18n.translate( 'Live chat support' ),
+		getDescription: () =>
+			i18n.translate( 'Live chat is available 24 hours a day from Monday through Friday.' ),
+	},
+
 	[ constants.FEATURE_PREMIUM_SUPPORT ]: {
 		getSlug: () => constants.FEATURE_PREMIUM_SUPPORT,
 		getTitle: () => i18n.translate( 'Priority Support' ),

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -35,6 +35,7 @@ const getDotcomPlanDetails = () => ( {
 			constants.FEATURE_CUSTOM_DOMAIN,
 			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
 			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
+			constants.FEATURE_LIVE_CHAT_SUPPORT,
 		] ),
 } );
 
@@ -288,7 +289,7 @@ const getPlanPremiumDetails = () => ( {
 	],
 	getSignupFeatures: ( _, { isMonthlyPricingTest = false } = {} ) =>
 		compact( [
-			isMonthlyPricingTest && constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
+			isMonthlyPricingTest && constants.FEATURE_LIVE_CHAT_SUPPORT,
 			constants.FEATURE_ADVANCED_CUSTOMIZATION,
 			! isMonthlyPricingTest && constants.FEATURE_PREMIUM_THEMES,
 			constants.FEATURE_ALL_PERSONAL_FEATURES,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the signup flow with the monthly pricing test, the first feature of Premium Plan should be "Live chat support" instead of "Email & Live chat support".

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you're not in the `monthlyPricing` test or you're in the `control` of the test.
* The Premium features in the `onboarding` signup flow look as below:
  <img width="1247" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/98232550-2112ad80-1fa1-11eb-9972-cfefb0616caf.png">
* Assign yourself to the `treatment` and the Premium plan would look as following:
  <img width="1234" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/98232682-4b646b00-1fa1-11eb-976d-aa042b99d4f9.png">
  <img width="1234" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/98232722-5b7c4a80-1fa1-11eb-840e-66d2bde894d4.png">
  <img width="1234" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/98232815-79e24600-1fa1-11eb-978d-52e80453e0d6.png">