### PR TITLE
Fix: BR users aren't able to pick business monthly on the checkout page

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker.tsx
@@ -11,7 +11,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { WPCOMCartItem } from '../types/checkout-cart';
 import RadioButton from './radio-button';
-import { isWpComPlan } from 'calypso/lib/plans';
+import { isWpComPlan, isWpComBusinessPlan } from 'calypso/lib/plans';
 import { isMonthly } from 'calypso/lib/plans/constants';
 
 export type WPCOMProductSlug = string;
@@ -45,6 +45,9 @@ export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > 
 	isMonthlyPricingTest = false,
 } ) => {
 	const variants = getItemVariants( selectedItem.wpcom_meta.product_slug );
+	const isBRLCurrency = 'BRL' === selectedItem?.amount?.currency;
+	const showBusinessMonthly =
+		isBRLCurrency && isWpComBusinessPlan( selectedItem.wpcom_meta.product_slug );
 
 	if ( variants.length < 2 ) {
 		return null;
@@ -54,7 +57,9 @@ export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > 
 		<TermOptions>
 			{ variants.map(
 				( productVariant: WPCOMProductVariant ) =>
-					( isMonthlyPricingTest || ! isWpcomMonthlyPlan( productVariant ) ) && (
+					( isMonthlyPricingTest ||
+						! isWpcomMonthlyPlan( productVariant ) ||
+						showBusinessMonthly ) && (
 						<ProductVariant
 							key={ productVariant.variantLabel }
 							selectedItem={ selectedItem }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the bug that BR users aren't able to pick Business monthly on the checkout page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Buy a Business plan as a Brazil users who's using the `BRL` currency.
* Note that you may need sandboxed `public-api.wordpress.com`. The checkout page might be stuck in the _loading_ status.
* Go to the checkout page and you should be able to select the monthly term.
  <img width="577" alt="Checkout_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/98238407-ae5a0000-1fa9-11eb-868c-eb81631596cd.png">
