### PR TITLE
Fix: BR users on Business monthly cannot see the plan prices

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -178,9 +178,11 @@ export default connect( ( state ) => {
 	const jetpackSite = isJetpackSite( state, selectedSiteId );
 	const isSiteAutomatedTransfer = isSiteAutomatedTransferSelector( state, selectedSiteId );
 	const currentPlan = getCurrentPlan( state, selectedSiteId );
-	const currentPlanIntervalType = getIntervalTypeForTerm(
-		getPlan( currentPlan?.productSlug )?.term
-	);
+	let currentPlanIntervalType = getIntervalTypeForTerm( getPlan( currentPlan?.productSlug )?.term );
+
+	if ( 'BRL' === currentPlan?.currencyCode ) {
+		currentPlanIntervalType = 'yearly';
+	}
 
 	return {
 		currentPlanIntervalType,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the bug that plans page doesn't show the prices to the Brazilian users on the Business monthly plan.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You should be a Brazilian user who's using the `BRL` currency.
* The current site should be on the Business monthly plan.
* Go to the `/plans` page of your site.
* The plans page should show _yearly_ plans instead of _monthly_ plans and all the prices should be displayed.
  <img width="963" alt="Plans_‹_As_Brazilian_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/98243140-e0bb2b80-1fb0-11eb-81a3-b8ee48b52919.png">
