### PR TITLE
Jetpack: Add Olark pre-sales chat to Jetpack pricing page

### DIFF
--- a/client/components/olark-chat/index.jsx
+++ b/client/components/olark-chat/index.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+class OlarkChat extends Component {
+	componentDidMount() {
+		const { identity } = this.props;
+		const script = document.createElement( 'script' );
+		script.setAttribute( 'id', 'olark-chat' );
+		script.setAttribute( 'type', 'text/javascript' );
+		script.setAttribute( 'async', true );
+		script.innerHTML = `
+			;(function(o,l,a,r,k,y){if(o.olark)return; r="script";y=l.createElement(r);r=l.getElementsByTagName(r)[0]; y.async=1;y.src="//"+a;r.parentNode.insertBefore(y,r); y=o.olark=function(){k.s.push(arguments);k.t.push(+new Date)}; y.extend=function(i,j){y("extend",i,j)}; y.identify=function(i){y("identify",k.i=i)}; y.configure=function(i,j){y("configure",i,j);k.c[i]=j}; k=y._={s:[],t:[+new Date],c:{},l:a}; })(window,document,"static.olark.com/jsclient/loader.js");
+			olark.identify('${ identity }');
+		`;
+		document.body.appendChild( script );
+	}
+
+	shouldComponentUpdate() {
+		return false;
+	}
+
+	render() {
+		return <div id="olark-chat" />;
+	}
+}
+
+export default OlarkChat;

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -11,6 +11,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { preventWidows } from 'calypso/lib/formatting';
 import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
 import JetpackComMasterbar from '../jpcom-masterbar';
+import OlarkChat from 'calypso/components/olark-chat';
 
 /**
  * Style dependencies
@@ -26,6 +27,7 @@ const Header = () => {
 
 	return (
 		<>
+			<OlarkChat identity={ '5581-687-10-4070' } />
 			<JetpackComMasterbar />
 			<div className="header">
 				<FormattedHeader

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -12,6 +12,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
 import JetpackComMasterbar from '../jpcom-masterbar';
 import OlarkChat from 'calypso/components/olark-chat';
+import config from 'calypso/config';
 
 /**
  * Style dependencies
@@ -25,9 +26,11 @@ const Header = () => {
 		? translate( 'Security, performance, and growth tools for WordPress' )
 		: translate( 'Security, performance, and marketing tools for WordPress' );
 
+	const identity = config( 'olark_chat_identity' );
+
 	return (
 		<>
-			<OlarkChat identity={ '5581-687-10-4070' } />
+			{ identity && <OlarkChat { ...{ identity } } /> }
 			<JetpackComMasterbar />
 			<div className="header">
 				<FormattedHeader

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -27,6 +27,7 @@
 	"logout_url": false,
 	"mc_analytics_enabled": false,
 	"oauth_client_id": false,
+	"olark_chat_identity": false,
 	"protocol": "http",
 	"port": 3000,
 	"happychat_url": "https://happychat.io/customer",

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -47,5 +47,6 @@
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
-	"theme_color": "#2fb41f"
+	"theme_color": "#2fb41f",
+	"olark_chat_identity": "5581-687-10-4070"
 }

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -41,5 +41,6 @@
 		"scan": true
 	},
 	"site_filter": [ "jetpack" ],
-	"theme": "jetpack-cloud"
+	"theme": "jetpack-cloud",
+	"olark_chat_identity": "5581-687-10-4070"
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -46,5 +46,6 @@
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
-	"theme_color": "#2fb41f"
+	"theme_color": "#2fb41f",
+	"olark_chat_identity": "5581-687-10-4070"
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -45,5 +45,6 @@
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
-	"theme_color": "#2fb41f"
+	"theme_color": "#2fb41f",
+	"olark_chat_identity": "5581-687-10-4070"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a new component, `OlarkChat`, and uses that component on the non-logged-in Jetpack.com pricing page.
* This will enable customers to chat with HE's to ask questions before purchasing a product or plan.

#### Testing instructions

1. Load the PR locally and do `npm run start-jetpack-cloud`.
2. In one browser tab, head to Olark (check with me for creds).
3. In another browser tab, head to the pricing page at `jetpack.cloud.localhost:3000/pricing`.
4. After a few moments, the "Chat with us" bubble should appear at the bottom right. Click on it and ensure the chat works.
