### PR TITLE
Add details to restore progress screen

### DIFF
--- a/client/my-sites/backup/rewind-flow/progress-bar.tsx
+++ b/client/my-sites/backup/rewind-flow/progress-bar.tsx
@@ -10,31 +10,40 @@ import React, { FunctionComponent } from 'react';
 import { ProgressBar } from '@automattic/components';
 
 interface Props {
+	isReady: boolean;
 	percent: number | null;
 	message?: string;
 	entry?: string;
 }
 
-const RewindFlowProgressBar: FunctionComponent< Props > = ( { percent, message, entry } ) => {
+const RewindFlowProgressBar: FunctionComponent< Props > = ( {
+	isReady,
+	percent,
+	message,
+	entry,
+} ) => {
 	const translate = useTranslate();
 	const filteredPercent = percent !== null ? percent : 0;
+
 	return (
 		<div className="rewind-flow__progress-bar">
 			<div className="rewind-flow__progress-bar-header">
-				<p className="rewind-flow__progress-bar-message">{ message }</p>
+				<p className="rewind-flow__progress-bar-message">
+					{ isReady ? message : translate( 'Initializing the restore process' ) }
+				</p>
 				<p className="rewind-flow__progress-bar-percent">
 					{ translate( '%(filteredPercent)d%% complete', { args: { filteredPercent } } ) }
 				</p>
 			</div>
 			<ProgressBar value={ filteredPercent } total={ 100 } />
-			{ entry && (
-				<p className="rewind-flow__progress-bar-entry">
-					{ translate( 'Currently restoring: %s', {
+			<p className="rewind-flow__progress-bar-entry">
+				{ isReady &&
+					entry &&
+					translate( 'Currently restoring: %s', {
 						args: entry,
 						comment: '%s entry is the file, table, etc. being restored',
 					} ) }
-				</p>
-			) }
+			</p>
 		</div>
 	);
 };

--- a/client/my-sites/backup/rewind-flow/progress-bar.tsx
+++ b/client/my-sites/backup/rewind-flow/progress-bar.tsx
@@ -11,15 +11,30 @@ import { ProgressBar } from '@automattic/components';
 
 interface Props {
 	percent: number | null;
+	message?: string;
+	entry?: string;
 }
 
-const RewindFlowProgressBar: FunctionComponent< Props > = ( { percent } ) => {
+const RewindFlowProgressBar: FunctionComponent< Props > = ( { percent, message, entry } ) => {
 	const translate = useTranslate();
 	const filteredPercent = percent !== null ? percent : 0;
 	return (
 		<div className="rewind-flow__progress-bar">
-			<p>{ translate( '%(filteredPercent)d%% complete', { args: { filteredPercent } } ) }</p>
+			<div className="rewind-flow__progress-bar-header">
+				<p className="rewind-flow__progress-bar-message">{ message }</p>
+				<p className="rewind-flow__progress-bar-percent">
+					{ translate( '%(filteredPercent)d%% complete', { args: { filteredPercent } } ) }
+				</p>
+			</div>
 			<ProgressBar value={ filteredPercent } total={ 100 } />
+			{ entry && (
+				<p className="rewind-flow__progress-bar-entry">
+					{ translate( 'Currently restoring: %s', {
+						args: entry,
+						comment: '%s entry is the file, table, etc. being restored',
+					} ) }
+				</p>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -21,7 +21,6 @@ import Gridicon from 'calypso/components/gridicon';
 import Loading from './loading';
 import ProgressBar from './progress-bar';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
-import QueryRewindRestoreStatus from 'calypso/components/data/query-rewind-restore-status';
 import RewindConfigEditor from './rewind-config-editor';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
 
@@ -50,25 +49,15 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	const [ userHasRequestedRestore, setUserHasRequestedRestore ] = useState< boolean >( false );
 
 	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) ) as RewindState;
-
-	const loading = rewindState.state === 'uninitialized';
-	const restoreId = rewindState.rewind?.restoreId;
-
-	// TODO: use selectors
-	const currentEntry = 'wp_options'; // useSelector( ( state ) => ( restoreId ? ... : undefined ) );
-	const message = 'Importing database'; // useSelector( ( state ) => ( restoreId ? ... : undefined ) );
 	const inProgressRewindStatus = useSelector( ( state ) =>
 		getInProgressRewindStatus( state, siteId, rewindId )
 	);
 	const inProgressRewindPercentComplete = useSelector( ( state ) =>
 		getInProgressRewindPercentComplete( state, siteId, rewindId )
 	);
-
 	const inProgressRewindEntryDetails = useSelector( ( state ) =>
 		getInProgressRewindEntryDetails( state, siteId, rewindId )
 	);
-
-	console.log( inProgressRewindEntryDetails );
 
 	const requestRestore = useCallback(
 		() => dispatch( rewindRestore( siteId, rewindId, rewindConfig ) ),
@@ -78,6 +67,9 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		setUserHasRequestedRestore( true );
 		requestRestore();
 	}, [ setUserHasRequestedRestore, requestRestore ] );
+
+	const loading = rewindState.state === 'uninitialized';
+	const { message, entry } = inProgressRewindEntryDetails;
 
 	const renderConfirm = () => (
 		<>
@@ -124,7 +116,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			<h3 className="rewind-flow__title">{ translate( 'Currently restoring your site' ) }</h3>
 			<ProgressBar
 				message={ message }
-				entry={ currentEntry }
+				entry={ entry }
 				percent={ inProgressRewindPercentComplete }
 			/>
 			<p className="rewind-flow__info">
@@ -218,7 +210,6 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	return (
 		<>
 			<QueryRewindState siteId={ siteId } />
-			{ restoreId && <QueryRewindRestoreStatus siteId={ siteId } restoreId={ restoreId } /> }
 			{ render() }
 		</>
 	);

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -14,6 +14,7 @@ import { rewindRestore } from 'calypso/state/activity-log/actions';
 import CheckYourEmail from './rewind-flow-notice/check-your-email';
 import Error from './error';
 import getInProgressRewindPercentComplete from 'calypso/state/selectors/get-in-progress-rewind-percent-complete';
+import getInProgressRewindEntryDetails from 'calypso/state/selectors/get-in-progress-rewind-entry-details';
 import getInProgressRewindStatus from 'calypso/state/selectors/get-in-progress-rewind-status';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import Gridicon from 'calypso/components/gridicon';
@@ -62,6 +63,12 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	const inProgressRewindPercentComplete = useSelector( ( state ) =>
 		getInProgressRewindPercentComplete( state, siteId, rewindId )
 	);
+
+	const inProgressRewindEntryDetails = useSelector( ( state ) =>
+		getInProgressRewindEntryDetails( state, siteId, rewindId )
+	);
+
+	console.log( inProgressRewindEntryDetails );
 
 	const requestRestore = useCallback(
 		() => dispatch( rewindRestore( siteId, rewindId, rewindConfig ) ),

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -69,7 +69,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	}, [ setUserHasRequestedRestore, requestRestore ] );
 
 	const loading = rewindState.state === 'uninitialized';
-	const { message, entry } = inProgressRewindEntryDetails;
+	const { message, currentEntry } = inProgressRewindEntryDetails;
 
 	const renderConfirm = () => (
 		<>
@@ -115,8 +115,9 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			</div>
 			<h3 className="rewind-flow__title">{ translate( 'Currently restoring your site' ) }</h3>
 			<ProgressBar
+				isReady={ 'running' === inProgressRewindStatus }
 				message={ message }
-				entry={ entry }
+				entry={ currentEntry }
 				percent={ inProgressRewindPercentComplete }
 			/>
 			<p className="rewind-flow__info">

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -20,6 +20,7 @@ import Gridicon from 'calypso/components/gridicon';
 import Loading from './loading';
 import ProgressBar from './progress-bar';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import QueryRewindRestoreStatus from 'calypso/components/data/query-rewind-restore-status';
 import RewindConfigEditor from './rewind-config-editor';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
 
@@ -48,6 +49,13 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	const [ userHasRequestedRestore, setUserHasRequestedRestore ] = useState< boolean >( false );
 
 	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) ) as RewindState;
+
+	const loading = rewindState.state === 'uninitialized';
+	const restoreId = rewindState.rewind?.restoreId;
+
+	// TODO: use selectors
+	const currentEntry = 'wp_options'; // useSelector( ( state ) => ( restoreId ? ... : undefined ) );
+	const message = 'Importing database'; // useSelector( ( state ) => ( restoreId ? ... : undefined ) );
 	const inProgressRewindStatus = useSelector( ( state ) =>
 		getInProgressRewindStatus( state, siteId, rewindId )
 	);
@@ -63,8 +71,6 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		setUserHasRequestedRestore( true );
 		requestRestore();
 	}, [ setUserHasRequestedRestore, requestRestore ] );
-
-	const loading = rewindState.state === 'uninitialized';
 
 	const renderConfirm = () => (
 		<>
@@ -109,7 +115,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 				<Gridicon icon="history" size={ 48 } />
 			</div>
 			<h3 className="rewind-flow__title">{ translate( 'Currently restoring your site' ) }</h3>
-			<ProgressBar percent={ inProgressRewindPercentComplete } />
+			<ProgressBar
+				message={ message }
+				entry={ currentEntry }
+				percent={ inProgressRewindPercentComplete }
+			/>
 			<p className="rewind-flow__info">
 				{ translate(
 					'We are restoring your site back to {{strong}}%(backupDisplayDate)s{{/strong}}.',
@@ -201,6 +211,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	return (
 		<>
 			<QueryRewindState siteId={ siteId } />
+			{ restoreId && <QueryRewindRestoreStatus siteId={ siteId } restoreId={ restoreId } /> }
 			{ render() }
 		</>
 	);

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -23,19 +23,16 @@ import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import RewindConfigEditor from './rewind-config-editor';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
 
+/**
+ * Type dependencies
+ */
+import { RewindState } from 'calypso/state/data-layer/wpcom/sites/rewind/type';
+
 interface Props {
 	backupDisplayDate: string;
 	rewindId: string;
 	siteId: number;
 	siteUrl: string;
-}
-
-//todo: move to dedicated types file
-interface RewindState {
-	state: string;
-	rewind?: {
-		status: 'queued' | 'running' | 'finished' | 'fail';
-	};
 }
 
 const BackupRestoreFlow: FunctionComponent< Props > = ( {

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -48,9 +48,6 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	const [ userHasRequestedRestore, setUserHasRequestedRestore ] = useState< boolean >( false );
 
 	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) ) as RewindState;
-
-	const loading = rewindState.state === 'uninitialized';
-
 	const inProgressRewindStatus = useSelector( ( state ) =>
 		getInProgressRewindStatus( state, siteId, rewindId )
 	);
@@ -62,11 +59,12 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		() => dispatch( rewindRestore( siteId, rewindId, rewindConfig ) ),
 		[ dispatch, rewindConfig, rewindId, siteId ]
 	);
-
-	const onConfirm = () => {
+	const onConfirm = useCallback( () => {
 		setUserHasRequestedRestore( true );
 		requestRestore();
-	};
+	}, [ setUserHasRequestedRestore, requestRestore ] );
+
+	const loading = rewindState.state === 'uninitialized';
 
 	const renderConfirm = () => (
 		<>

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -139,10 +139,27 @@ a.rewind-flow-notice__title-warning:visited {
 	margin-bottom: 22.5px;
 
 	p {
-		color: var( --color-neutral-light );
-		font-size: $font-body-extra-small;
+		font-size: $font-body-small;
 		margin: 0;
 	}
+}
+
+.rewind-flow__progress-bar-header {
+	display: flex;
+	justify-content: space-between;
+	flex-wrap: wrap;
+}
+
+.rewind-flow__progress-bar-percent {
+	color: var( --studio-gray-50 );
+}
+
+.rewind-flow__progress-bar-message {
+	font-weight: 700;
+}
+
+.rewind-flow__progress-bar-entry {
+	color: var( --studio-gray-50 );
 }
 
 .rewind-flow__info {

--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -49,9 +49,9 @@ const transformRewind = ( data ) =>
 			rewindId: data.rewind_id,
 			startedAt: new Date( data.started_at ),
 			status: data.status,
-			message: data.message,
-			currentEntry: data.current_entry,
 		},
+		data.message && { message: data.message },
+		data.current_entry && { currentEntry: data.current_entry },
 		data.progress && { progress: data.progress },
 		data.reason && { reason: data.reason },
 		data.links && data.links.dismiss && { dismiss: makeRewindDismisser( data.links.dismiss ) }

--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -49,6 +49,8 @@ const transformRewind = ( data ) =>
 			rewindId: data.rewind_id,
 			startedAt: new Date( data.started_at ),
 			status: data.status,
+			message: data.message,
+			currentEntry: data.current_entry,
 		},
 		data.progress && { progress: data.progress },
 		data.reason && { reason: data.reason },

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -49,6 +49,8 @@ export const rewind = {
 		started_at: { type: 'string' },
 		progress: { type: 'integer' },
 		reason: { type: 'string' },
+		message: { type: 'string' },
+		current_entry: { type: 'string' },
 	},
 	required: [ 'restore_id', 'rewind_id', 'status' ],
 };

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -49,8 +49,13 @@ export const rewind = {
 		started_at: { type: 'string' },
 		progress: { type: 'integer' },
 		reason: { type: 'string' },
-		message: { type: 'string' },
-		current_entry: { type: 'string' },
+		/**
+		 * Commenting these out temporarily because API is returning a null value for current_entry,
+		 * triggering a schema validation error. Once this is corrected on the backend (soon), we
+		 * will activate these properties again.
+		 **/
+		// message: { type: 'string' },
+		// current_entry: { type: 'string' },
 	},
 	required: [ 'restore_id', 'rewind_id', 'status' ],
 };

--- a/client/state/data-layer/wpcom/sites/rewind/type.ts
+++ b/client/state/data-layer/wpcom/sites/rewind/type.ts
@@ -1,0 +1,6 @@
+export interface RewindState {
+	state: string;
+	rewind?: {
+		status: 'queued' | 'running' | 'finished' | 'fail';
+	};
+}

--- a/client/state/data-layer/wpcom/sites/rewind/type.ts
+++ b/client/state/data-layer/wpcom/sites/rewind/type.ts
@@ -2,5 +2,6 @@ export interface RewindState {
 	state: string;
 	rewind?: {
 		status: 'queued' | 'running' | 'finished' | 'fail';
+		restoreId?: number;
 	};
 }

--- a/client/state/selectors/get-in-progress-rewind-entry-details.js
+++ b/client/state/selectors/get-in-progress-rewind-entry-details.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { pick } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import getRewindState from './get-rewind-state';
@@ -6,24 +11,23 @@ import getRewindState from './get-rewind-state';
 /**
  * @typedef {Object} EntryDetails
  * @property {string} message - The description of current action taking place
- * @property {string} entry - The value (filename/tablename) being processed
+ * @property {string} currentEntry - The value (filename/tablename) being processed
  */
 
 /**
  * Returns object containing rewind status current entry and message
  *
- * @param {object} state Global state tree
+ * @param {object} globalState Global state tree
  * @param {?number|string} siteId the site ID
  * @param {string} rewindId the id of the rewind to get the rewind status entry and message
  * @returns {EntryDetails} Details of the current rewind action
  */
-export default function getInProgressRewindEntryDetails( state, siteId, rewindId ) {
-	const maybeRewindState = getRewindState( state, siteId );
-	return maybeRewindState.state === 'active' &&
-		maybeRewindState.rewind &&
-		maybeRewindState.rewind.rewindId === rewindId &&
-		maybeRewindState.rewind.hasOwnProperty( 'message' ) &&
-		maybeRewindState.rewind.hasOwnProperty( 'currentEntry' )
-		? { message: maybeRewindState.rewind.message, entry: maybeRewindState.rewind.currentEntry }
-		: {};
+export default function getInProgressRewindEntryDetails( globalState, siteId, rewindId ) {
+	const { state, rewind } = getRewindState( globalState, siteId );
+
+	if ( 'active' === state && rewind?.rewindId === rewindId ) {
+		return pick( rewind, [ 'message', 'currentEntry' ] );
+	}
+
+	return {};
 }

--- a/client/state/selectors/get-in-progress-rewind-entry-details.js
+++ b/client/state/selectors/get-in-progress-rewind-entry-details.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import getRewindState from './get-rewind-state';
+
+/**
+ * @typedef {Object} EntryDetails
+ * @property {string} message - The description of current action taking place
+ * @property {string} entry - The value (filename/tablename) being processed
+ */
+
+/**
+ * Returns object containing rewind status current entry and message
+ *
+ * @param {object} state Global state tree
+ * @param {?number|string} siteId the site ID
+ * @param {string} rewindId the id of the rewind to get the rewind status entry and message
+ * @returns {EntryDetails} Details of the current rewind action
+ */
+export default function getInProgressRewindEntryDetails( state, siteId, rewindId ) {
+	const maybeRewindState = getRewindState( state, siteId );
+	return maybeRewindState.state === 'active' &&
+		maybeRewindState.rewind &&
+		maybeRewindState.rewind.rewindId === rewindId &&
+		maybeRewindState.rewind.hasOwnProperty( 'message' ) &&
+		maybeRewindState.rewind.hasOwnProperty( 'currentEntry' )
+		? { message: maybeRewindState.rewind.message, entry: maybeRewindState.rewind.currentEntry }
+		: {};
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds more details to the restore progress screen, so that users have a better understanding of what's happening in real-time. See captures below.

### Implementation notes

- @elliottprogrammer did the initial worked in #47071. I rebased the branch and updated the UI accordingly.
- The API doesn't return the type of the entry, so I needed to adjust the copy a little bit (`Currently restoring: [entry]`).

Note: the back-end returns _Unknown_ for the entry while it's being finalized. This should never be the case once done.

### Testing instructions

- Apply this patch D52234-code to your wpcom sandbox and point `public-api.wordpress.com` to it
- Run this PR in Calypso or Jetpack cloud
- Select a self-hosted Jetpack site that has a Backup product, and more than one backup
- Make sure you have set server credentials to enable restores
- Visit the _Backup_ section, select a backup to restore, and click _Restore to this point_, the _Confirm restore_
- Check that you see the message and current entry returned by the API, respectively above and below the progress bar

### Screenshots

#### Mockups
_Before_
<img width="707" alt="98129356-077d4300-1e87-11eb-9145-7d4331aa2fab" src="https://user-images.githubusercontent.com/1620183/98265383-061b4b80-1f57-11eb-9915-a751d8567d53.png">

_After_
![98129447-2085f400-1e87-11eb-9c46-36a3f54f48af](https://user-images.githubusercontent.com/1620183/98265394-09163c00-1f57-11eb-8d96-8e5046889888.png)



#### Implementation

 
<img width="613" alt="Screen Shot 2020-11-05 at 10 53 50 AM" src="https://user-images.githubusercontent.com/1620183/98265937-ab362400-1f57-11eb-82f8-b2be0b81df7b.png">
<img width="605" alt="Screen Shot 2020-11-05 at 10 52 22 AM" src="https://user-images.githubusercontent.com/1620183/98265951-b12c0500-1f57-11eb-948a-2ce7a1825dac.png">