### PR TITLE
Email: Fix email page when no custom domain

### DIFF
--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -50,6 +50,7 @@ import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import EmailProvidersComparison from '../email-providers-comparison';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
+import { type as domainTypes } from 'calypso/lib/domains/constants';
 
 /**
  * Style dependencies
@@ -135,11 +136,19 @@ class EmailManagement extends React.Component {
 
 		const domainList = selectedDomainName ? [ getSelectedDomain( this.props ) ] : domains;
 
-		if ( domainList.some( hasGSuiteWithUs ) || domainList.some( hasTitanMailWithUs ) ) {
+		const validDomains = domainList.filter(
+			( domain ) => domain.type === domainTypes.REGISTERED || domain.type === domainTypes.MAPPED
+		);
+
+		if ( validDomains.some( hasGSuiteWithUs ) || validDomains.some( hasTitanMailWithUs ) ) {
 			return this.googleAppsUsersCard();
 		}
 
-		const selectedDomain = domainList[ 0 ];
+		if ( validDomains.length === 0 ) {
+			return this.emptyContent();
+		}
+
+		const selectedDomain = validDomains[ 0 ];
 		return (
 			<EmailProvidersComparison
 				domain={ selectedDomain }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix email page when there is no custom domain. When there are no custom domains, show the prompt to purchase domains:

<img width="1014" alt="Screenshot 2020-11-05 at 6 57 15 PM" src="https://user-images.githubusercontent.com/13062352/98278332-bb222800-1f98-11eb-93a9-adace330ddb8.png">

#### Testing instructions

For a site without a custom domain:

 - Go to /email/<site>
 - Before the patch you should see the email comparison page
 - After applying the patch, you should see the same view as in the screenshot above
