### PR TITLE
Typography: Update font weights and sizes on buttons to better match Gutenberg

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -18,8 +18,7 @@
 	text-decoration: none;
 	vertical-align: top;
 	box-sizing: border-box;
-	font-size: 14px;
-	font-weight: 600;
+	font-size: $font-body-small;
 	line-height: 22px;
 	border-radius: 2px;
 	padding: 8px 14px;
@@ -85,7 +84,7 @@
 	&.is-compact {
 		padding: 7px;
 		color: var( --color-text-subtle );
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		line-height: 1;
 
 		&:disabled {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the font sizes for buttons to use variables
* Update font weight for buttons to 400 weight from 600 weight to better line up with Gutenberg 
* I'm not sure how I overlooked these, possibly because the components are part of a package rather than in `/client`. 🤷‍♀️

**Before**

<img width="1665" alt="Screen Shot 2020-11-05 at 2 03 34 PM" src="https://user-images.githubusercontent.com/2124984/98284938-d6c50880-1f6f-11eb-898e-c60c85ae567f.png">

**After** 

<img width="1664" alt="Screen Shot 2020-11-05 at 2 03 00 PM" src="https://user-images.githubusercontent.com/2124984/98284949-daf12600-1f6f-11eb-9641-fa02eec91927.png">


#### Testing instructions

* Switch to this PR
* Look at all the pretty buttons! ;) 
* Check out many different screens and contexts to make sure there are no visual regressions.

Partial fix for #47161