### PR TITLE
Calypso Green: Don't show pre-sales chat in production

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -47,5 +47,5 @@
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
-	"olark_chat_identity": "5581-687-10-4070"
+	"olark_chat_identity": false
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR ensures that the pre-sales chat is not present in production Calypso Green yet.
