### PR TITLE
Reader Lists: Prevent list management unless user is owner

### DIFF
--- a/client/reader/list-manage/README.md
+++ b/client/reader/list-manage/README.md
@@ -1,3 +1,3 @@
 # Reader List Management
 
-Allows creation, editing and deletion of Reader lists.
+Allows creation, editing, export and deletion of Reader lists.

--- a/client/reader/list-manage/README.md
+++ b/client/reader/list-manage/README.md
@@ -1,0 +1,3 @@
+# Reader List Management
+
+Allows creation, editing and deletion of Reader lists.

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -30,6 +30,8 @@ import Missing from 'calypso/reader/list-stream/missing';
 import ListDelete from './list-delete';
 import ListForm from './list-form';
 import ListItem from './list-item';
+import EmptyContent from 'calypso/components/empty-content';
+import { preventWidows } from 'calypso/lib/formatting';
 
 /**
  * Style dependencies
@@ -104,8 +106,18 @@ function ReaderListEdit( props ) {
 	const listItems = useSelector( ( state ) =>
 		list ? getListItems( state, list.ID ) : undefined
 	);
-
 	const sectionProps = { ...props, list, listItems };
+
+	// Only the list owner can manage the list
+	if ( list && ! list.is_owner ) {
+		return (
+			<EmptyContent
+				title={ preventWidows( translate( "You don't have permission to manage this list." ) ) }
+				illustration="/calypso/images/illustrations/error.svg"
+			/>
+		);
+	}
+
 	return (
 		<>
 			{ ! list && <QueryReaderList owner={ props.owner } slug={ props.slug } /> }

--- a/client/reader/list-stream/README.md
+++ b/client/reader/list-stream/README.md
@@ -1,5 +1,3 @@
 # Reader List Stream
 
 A stream of posts from a Reader list.
-
-Lists are a deprecated feature. Creation and editing of lists are not possible in Calypso, but it is still possible to view an existing list.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Prevent a user from accessing list management UI unless they own the Reader list.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a Reader list you don't own, like http://calypso.localhost:3000/read/list/blowery/comics. Try editing the list using:

http://calypso.localhost:3000/read/list/blowery/comics/edit
http://calypso.localhost:3000/read/list/blowery/comics/edit/items
http://calypso.localhost:3000/read/list/blowery/comics/delete
http://calypso.localhost:3000/read/list/blowery/comics/export

Ensure that you see this message:

<img width="857" alt="Screen Shot 2020-11-06 at 12 23 28" src="https://user-images.githubusercontent.com/17325/98307827-975bf200-202b-11eb-943c-b84689c401a1.png">

Try the same on a list you own and ensure you can access all the management functionality.
