### PR TITLE
Checkout: Return last valid responseCart when updating

### DIFF
--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -1,14 +1,15 @@
 /**
  * External dependencies
  */
-import { useCallback, useMemo, useEffect } from 'react';
+import { useCallback, useMemo, useEffect, useRef } from 'react';
 import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-import {
+import type {
 	TempResponseCart,
+	ResponseCart,
 	RequestCartProduct,
 	CartLocation,
 	ShoppingCartManager,
@@ -102,10 +103,15 @@ export default function useShoppingCartManager( {
 	const isLoading = cacheStatus === 'fresh' || cacheStatus === 'fresh-pending' || ! cartKey;
 	const loadingErrorForManager = cacheStatus === 'error' ? loadingError : null;
 	const isPendingUpdate = cacheStatus !== 'valid' || ! cartKey;
+
 	const responseCartWithoutTempProducts = useMemo(
 		() => convertTempResponseCartToResponseCart( responseCart ),
 		[ responseCart ]
 	);
+	const lastValidResponseCart = useRef< ResponseCart >( responseCartWithoutTempProducts );
+	if ( cacheStatus === 'valid' ) {
+		lastValidResponseCart.current = responseCartWithoutTempProducts;
+	}
 
 	const shoppingCartManager = useMemo(
 		() => ( {
@@ -122,10 +128,10 @@ export default function useShoppingCartManager( {
 			replaceProductInCart,
 			replaceProductsInCart,
 			reloadFromServer,
-			responseCart: responseCartWithoutTempProducts,
+			responseCart: lastValidResponseCart.current,
 		} ),
 		[
-			responseCartWithoutTempProducts,
+			lastValidResponseCart,
 			isLoading,
 			isPendingUpdate,
 			loadingErrorForManager,


### PR DESCRIPTION
When the shopping cart is modified, its `cacheStatus` is set to `invalid` and it sends the local cache of the cart off to the server. During this time, the `responseCart` is not to be trusted, since it does not have data verified and filled-in by the server. It notifies consumers of `useShoppingCart` of this state by making `isPendingUpdate` true.

However, it is possible that a consumer would like to continue to display certain aspects of the cart (eg: disabled line items) while such an update is in-progress.

Previously, when `useShoppingCart` returned the cart, it would return a version of the cart with all temp products removed. This allowed consumers to safely display the `responseCart` without risking displaying incomplete products that were in the process of being added. However, when a product is deleted, it is removed from the `responseCart` immediately, effectively performing an optimistic update, which we are trying to avoid due to the uncertainty of what the server might do.

With this change, we return only the most recently valid version of the `responseCart` (except for the initial one, which will be invalid until it loads). This should make sure that any change to the cart is only provided to consumers once the server has validated it.

Fixes https://github.com/Automattic/wp-calypso/issues/47163

Before:

<img width="917" alt="old-delete-behavior" src="https://user-images.githubusercontent.com/2036909/98309279-10116e80-1f98-11eb-99db-053182d647ac.png">

After:

![new-delete-behavior](https://user-images.githubusercontent.com/2036909/98309284-156eb900-1f98-11eb-8f26-fda8c6d9ed53.png)

#### Testing instructions

- Start with an empty shopping cart.
- Add a product to your shopping cart and visit checkout.
- Click to change the cart contents by clicking "Edit" on the first step.
- Click to remove the product from the cart and confirm the removal in the resulting modal.
- Verify that the cart continues to display the removed product for a moment with the rest of the form disabled.
- Verify that the page then redirects to the plans page. 

**NOTE:** you'll still see a flash of the loading animation just before the redirect, which happens because the (now empty) cart has been returned by the server, but it takes a full render before the redirect can occur since it is triggered after we know that the cart is empty. During this time there's no easy way to still have a copy of the cart with the deleted item (if we did, we wouldn't know to redirect) and therefore we have to display _something_. The two options I can think of are the loading animation or the empty cart page, either of which is different enough to cause a flash. Other ideas are welcome.