### PR TITLE
Reader Lists: standardize success notices

### DIFF
--- a/client/state/data-layer/wpcom/read/lists/feeds/new/index.js
+++ b/client/state/data-layer/wpcom/read/lists/feeds/new/index.js
@@ -8,10 +8,11 @@ import { translate } from 'i18n-calypso';
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { READER_LIST_ITEM_ADD_FEED } from 'calypso/state/reader/action-types';
 import { receiveAddReaderListFeed } from 'calypso/state/reader/lists/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+import { DEFAULT_NOTICE_DURATION } from 'calypso/state/notices/constants';
 
 registerHandlers( 'state/data-layer/wpcom/read/lists/feeds/new/index.js', {
 	[ READER_LIST_ITEM_ADD_FEED ]: [
@@ -31,13 +32,19 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/feeds/new/index.js', {
 					},
 					action
 				),
-			onSuccess: ( action, apiResponse ) =>
-				receiveAddReaderListFeed(
-					action.listId,
-					action.listOwner,
-					action.listSlug,
-					apiResponse.feed_id
-				),
+			onSuccess: ( action, apiResponse ) => {
+				return [
+					receiveAddReaderListFeed(
+						action.listId,
+						action.listOwner,
+						action.listSlug,
+						apiResponse.feed_id
+					),
+					successNotice( translate( 'Feed added to list successfully.' ), {
+						duration: DEFAULT_NOTICE_DURATION,
+					} ),
+				];
+			},
 			onError: ( action, error ) => {
 				return errorNotice(
 					translate( 'Could not add feed to list: %(message)s', {

--- a/client/state/data-layer/wpcom/read/lists/index.js
+++ b/client/state/data-layer/wpcom/read/lists/index.js
@@ -48,7 +48,9 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 					return [
 						receiveReaderList( { list } ),
 						navigate( `/read/list/${ list.owner }/${ list.slug }/edit` ),
-						successNotice( translate( 'List created successfully!' ) ),
+						successNotice( translate( 'List created successfully.' ), {
+							duration: DEFAULT_NOTICE_DURATION,
+						} ),
 					];
 				}
 				// NOTE: Add better handling for unexpected response format here.
@@ -73,7 +75,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 				),
 			onSuccess: ( action, { list } ) => receiveReaderList( { list } ),
 			onError: ( action, error ) => [
-				errorNotice( String( error ), { duration: DEFAULT_NOTICE_DURATION } ),
+				errorNotice( String( error ) ),
 				handleReaderListRequestFailure( error ),
 			],
 		} ),
@@ -93,7 +95,9 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 			},
 			onSuccess: ( action, response ) => [
 				receiveUpdatedListDetails( response ),
-				successNotice( translate( 'List updated successfully!' ) ),
+				successNotice( translate( 'List updated successfully.' ), {
+					duration: DEFAULT_NOTICE_DURATION,
+				} ),
 			],
 			onError: ( action, error ) => [
 				errorNotice( String( error ) ),
@@ -113,7 +117,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 					action
 				),
 			onSuccess: ( action, apiResponse ) => receiveLists( apiResponse?.lists ),
-			onError: ( action, error ) => errorNotice( error ),
+			onError: ( action, error ) => errorNotice( String( error ) ),
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/lists/items/index.js
+++ b/client/state/data-layer/wpcom/read/lists/items/index.js
@@ -23,7 +23,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/items/index.js', {
 				),
 			onSuccess: ( action, apiResponse ) =>
 				receiveReaderListItems( apiResponse.list_ID, apiResponse.items ),
-			onError: ( action, error ) => errorNotice( error ),
+			onError: ( action, error ) => errorNotice( String( error ) ),
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/lists/sites/delete/index.js
+++ b/client/state/data-layer/wpcom/read/lists/sites/delete/index.js
@@ -29,7 +29,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/sites/delete/index.js', {
 			onSuccess: successNotice( translate( 'Site removed from list successfully.' ), {
 				duration: DEFAULT_NOTICE_DURATION,
 			} ),
-			onError: () => errorNotice( translate( 'Unable to remove site from list' ) ),
+			onError: () => errorNotice( translate( 'Unable to remove site from list.' ) ),
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/lists/tags/new/index.js
+++ b/client/state/data-layer/wpcom/read/lists/tags/new/index.js
@@ -1,12 +1,18 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
  * Internal dependencies
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { READER_LIST_ITEM_ADD_TAG } from 'calypso/state/reader/action-types';
 import { receiveReaderListAddTag } from 'calypso/state/reader/lists/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+import { DEFAULT_NOTICE_DURATION } from 'calypso/state/notices/constants';
 
 registerHandlers( 'state/data-layer/wpcom/read/lists/tags/new/index.js', {
 	[ READER_LIST_ITEM_ADD_TAG ]: [
@@ -23,14 +29,20 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/tags/new/index.js', {
 					},
 					action
 				),
-			onSuccess: ( action, apiResponse ) =>
-				receiveReaderListAddTag(
-					action.listOwner,
-					action.listSlug,
-					action.tagSlug,
-					apiResponse.tagId
-				),
-			onError: ( action, error ) => errorNotice( error ),
+			onSuccess: ( action, apiResponse ) => {
+				return [
+					receiveReaderListAddTag(
+						action.listOwner,
+						action.listSlug,
+						action.tagSlug,
+						apiResponse.tagId
+					),
+					successNotice( translate( 'Tag added to list successfully.' ), {
+						duration: DEFAULT_NOTICE_DURATION,
+					} ),
+				];
+			},
+			onError: ( action, error ) => errorNotice( String( error ) ),
 		} ),
 	],
 } );

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import impureLodash from 'calypso/lib/impure-lodash';
 const { uniqueId } = impureLodash;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Display success notices for all CRUD actions.
* Always auto-vanish success notices after 5 seconds.
* Use consistent punctuation in success notices.
* Don't auto-vanish error notices.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
`yarn test-client client/state/reader/lists`