### PR TITLE
Gutenboarding i18n: i18n for domain picker in the launch flow

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -24,6 +24,12 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 			return null;
 		}
 
-		return <FocusedLaunchModal siteId={ window._currentSiteId } onClose={ closeFocusedLaunch } />;
+		return (
+			<FocusedLaunchModal
+				siteId={ window._currentSiteId }
+				onClose={ closeFocusedLaunch }
+				locale={ document.documentElement.lang }
+			/>
+		);
 	},
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -86,6 +86,7 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 					onExistingSubdomainSelect={ handleExistingSubdomainSelect }
 					analyticsUiAlgo="editor_domain_modal"
 					segregateFreeAndPaid
+					locale={ document.documentElement.lang }
 				/>
 			</div>
 			<div className="nux-launch-step__footer">

--- a/client/blocks/editor-launch-modal/index.tsx
+++ b/client/blocks/editor-launch-modal/index.tsx
@@ -6,18 +6,22 @@ import FocusedLaunchModal from '@automattic/launch';
 import noop from 'lodash/noop';
 import { connect } from 'react-redux';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 
 interface Props {
 	siteId: number;
+	locale: string;
 }
 
-const EditorLaunchModal: React.FunctionComponent< Props > = ( { siteId } ) => {
-	return <FocusedLaunchModal onClose={ noop } siteId={ siteId } />;
+const EditorLaunchModal: React.FunctionComponent< Props > = ( { siteId, locale } ) => {
+	return <FocusedLaunchModal onClose={ noop } siteId={ siteId } locale={ locale } />;
 };
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state ) as number;
+	const locale = getCurrentUserLocale( state );
 	return {
 		siteId,
+		locale,
 	};
 } )( EditorLaunchModal );

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -40,7 +40,7 @@ interface Props {
 }
 
 const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
-	const { __ } = useI18n();
+	const { __, i18nLocale: locale } = useI18n();
 	const history = useHistory();
 	const { goBack, goNext } = useStepNavigation();
 
@@ -147,6 +147,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				isCheckingDomainAvailability={ isCheckingDomainAvailability }
 				onDomainSelect={ onDomainSelect }
 				analyticsUiAlgo={ isModal ? 'domain_modal' : 'domain_page' }
+				locale={ locale }
 			/>
 		</div>
 	);

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -7,7 +7,6 @@ import { noop, times } from 'lodash';
 import { Button, TextControl } from '@wordpress/components';
 import { Icon, search } from '@wordpress/icons';
 import { getNewRailcarId, recordTrainTracksRender } from '@automattic/calypso-analytics';
-import { useI18n } from '@automattic/react-i18n';
 import type { DomainSuggestions } from '@automattic/data-stores';
 import { DataStatus } from '@automattic/data-stores/src/domain-suggestions/constants';
 import { __ } from '@wordpress/i18n';
@@ -95,6 +94,8 @@ export interface Props {
 
 	/** Whether to show radio button or select button. Defaults to radio button */
 	itemType?: SUGGESTION_ITEM_TYPE;
+
+	locale?: string;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {
@@ -115,6 +116,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	segregateFreeAndPaid = false,
 	showSearchField = true,
 	itemType = ITEM_TYPE_RADIO,
+	locale,
 } ) => {
 	const label = __( 'Search for a domain', __i18n_text_domain__ );
 
@@ -133,13 +135,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		errorMessage: domainSuggestionErrorMessage,
 		state: domainSuggestionState,
 		retryRequest: retryDomainSuggestionRequest,
-	} =
-		useDomainSuggestions(
-			domainSearch.trim(),
-			quantityExpanded,
-			domainCategory,
-			useI18n().i18nLocale
-		) || {};
+	} = useDomainSuggestions( domainSearch.trim(), quantityExpanded, domainCategory, locale ) || {};
 
 	const domainSuggestions = allDomainSuggestions?.slice(
 		existingSubdomain ? 1 : 0,

--- a/packages/launch/src/context.ts
+++ b/packages/launch/src/context.ts
@@ -5,10 +5,12 @@ import * as React from 'react';
 
 interface LaunchContext {
 	siteId: number;
+	locale: string;
 }
 
 const LaunchContext = React.createContext< LaunchContext >( {
 	siteId: 0,
+	locale: 'en',
 } );
 
 export default LaunchContext;

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -6,7 +6,7 @@
 import { Title } from '@automattic/onboarding';
 import { __ } from '@wordpress/i18n';
 import { TextControl, SVG, Path, Tooltip, Circle, Rect } from '@wordpress/components';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useContext } from 'react';
 import DomainPicker, { LockedPurchasedItem } from '@automattic/domain-picker';
 import { Icon, check } from '@wordpress/icons';
 import { Link } from 'react-router-dom';
@@ -18,6 +18,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { Route } from '../route';
 import { useTitle, useDomainSearch, useSiteDomains } from '../../hooks';
 import { LAUNCH_STORE } from '../../stores';
+import LaunchContext from '../../context';
 
 import './style.scss';
 
@@ -93,6 +94,7 @@ type DomainStepProps = CommonStepProps & { hasPaidDomain?: boolean } & Pick<
 		| 'initialDomainSearch'
 		| 'onDomainSelect'
 		| 'onExistingSubdomainSelect'
+		| 'locale'
 	>;
 
 const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
@@ -103,6 +105,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 	hasPaidDomain,
 	onDomainSelect,
 	onExistingSubdomainSelect,
+	locale,
 } ) => {
 	return (
 		<SummaryStep
@@ -147,6 +150,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							quantity={ 3 }
 							quantityExpanded={ 3 }
 							itemType="individual-item"
+							locale={ locale }
 						/>
 						<Link to={ Route.DomainDetails }>
 							{ __( 'View all domains', __i18n_text_domain__ ) }
@@ -219,6 +223,7 @@ const Summary: React.FunctionComponent = () => {
 	const { sitePrimaryDomain, siteSubdomain, hasPaidDomain } = useSiteDomains();
 	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
 	const { setDomain, unsetDomain } = useDispatch( LAUNCH_STORE );
+	const { locale } = useContext( LaunchContext );
 
 	const domainSearch = useDomainSearch();
 
@@ -248,6 +253,7 @@ const Summary: React.FunctionComponent = () => {
 			 * they already have a paid domain
 			 * */
 			onExistingSubdomainSelect={ unsetDomain }
+			locale={ locale }
 		/>
 	);
 	const renderPlanStep = ( index: number ) => <PlanStep stepIndex={ index } key={ index } />;

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -16,9 +16,10 @@ import './styles.scss';
 interface Props {
 	onClose: () => void;
 	siteId: number;
+	locale: string;
 }
 
-const FocusedLaunchModal: React.FunctionComponent< Props > = ( { onClose, siteId } ) => {
+const FocusedLaunchModal: React.FunctionComponent< Props > = ( { onClose, siteId, locale } ) => {
 	return (
 		<Modal
 			open={ true }
@@ -31,7 +32,7 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( { onClose, siteId
 		>
 			<div className="launch__focused-modal-wrapper ">
 				<div className="launch__focused-modal-body">
-					<LaunchContext.Provider value={ { siteId } }>
+					<LaunchContext.Provider value={ { siteId, locale } }>
 						<FocusedLaunch />
 					</LaunchContext.Provider>
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `<DomainPicker>` was using the `useI18n()` hook from `@automattic/react-i18n` to get the current locale. The `<DomainPicker>` is a shared component with it's own package, so every use of the component depended on `@automattic/react-i18n` working.

The problem is that the component is used in the launch flow (within the editing toolkit), and `@automattic/react-i18n` isn't being correctly set up to work in that environment. It'd need to to have a `<I18nProvider localeData={ ... }>` component somewhere near the root of the React tree and to have the server render `localeData` as part of the payload. But core already injects translations into the payload to make it available to `@wordpress/i18n`; doing it twice would be wasteful.

`@automattic/react-i18n` might progress enough to the point where core WordPress provides it with the correct strings, but for the purposes of fixing the domain picker in the launch flow, I'm just requiring users of `<DomainPicker>` to provide an explicit `locale` prop.

* `<DomainPicker>` accepts a locale prop (instead of depending on `@automattic/react-i18n`) to request domains with the correct locale information
* The domain step in the launch flow uses `document.documentElement.lang` to get the current locale
* The domain step in gutenboarding uses `@automattic/react-i18n` to get the current locale
* The (WIP) focused-launch-modal uses:
  * `document.documentElement.lang` when it's being used from the editing environment
  * the locale in the Calypso store when used from the calypso environment

#### Screenshots

![before](https://user-images.githubusercontent.com/1500769/98327412-49a9ae80-2058-11eb-8822-d592e59e49cd.png)

![after](https://user-images.githubusercontent.com/1500769/98327415-4adadb80-2058-11eb-8b79-91e4c2c026f2.png)

Note that there might be something else that changing the `?locale` query param might change. Maybe it changes the suggestions that come back. I just found the decimal seperator the easiest thing to test with.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Clone branch so you can test calypso locally
* Sync the editing toolkit changes to your sandbox with `yarn dev --sync`
* Change your user's language to French (or something that uses a comma for the decimal separator)
* Test the domain picker in the following situations by checking that the price is rendered using a comma e.g. "NZ$25,00"
  * `calypso.localhost:3000/new/domains` (this already works in production, just checking it still works)
  * With a sandboxed and unlaunched site, `calypso.localhost:3000/page/{sandboxed-site}/home` and click the blue launch button in the top right
  * With a sandboxed site, go to `calypso.localhost:3000/page/{sandboxed-site}/{id}`, open the console and switch to the `*.php` frame, paste this command `wp.data.dispatch('automattic/launch' ).openFocusedLaunch()` (this opens a WIP launch modal, just check the domain search is localised)
  * `calypso.localhost:3000/page/{some-site}/{id}?flags=create/focused-launch-flow-calypso`. This opens the same WIP launch modal but it's hosted in Calypso, not the editing toolkit. I couldn't really get the domain searching to work (it is a WIP so I think that's fine) but I did confirm in the React dev tools that the `locale` prop was set to `fr`.
