### PR TITLE
Fix broken MD formatting in calypso-build/CHANGELOG.md

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## 6.4.0
 
-- Removed the exceptions for the `import/no-extraneous-dependencies` eslint rule for '_.md.jsx' and '_.md.js' files
+- Removed the exceptions for the `import/no-extraneous-dependencies` eslint rule for `*.md.jsx` and `*.md.js` files
 - Upgraded dependencies
   - typescript to ^4.0.3
   - terser-webpack-plugin to "4.2.2


### PR DESCRIPTION
Fixes a regression from https://github.com/Automattic/wp-calypso/pull/47002/files#r518539663 by adding backticks. Prevents `*` being treated as Markdown syntax rather than a real star.
