### PR TITLE
Fix/jest resolve module

### DIFF
--- a/build-tools/lib/monorepo.js
+++ b/build-tools/lib/monorepo.js
@@ -1,7 +1,6 @@
 /**
  * **** WARNING: No ES6 modules here. Not transpiled! ****
  */
-/* eslint-disable import/no-nodejs-modules */
 
 /**
  * External dependencies

--- a/build-tools/lib/monorepo.js
+++ b/build-tools/lib/monorepo.js
@@ -1,0 +1,22 @@
+/**
+ * **** WARNING: No ES6 modules here. Not transpiled! ****
+ */
+/* eslint-disable import/no-nodejs-modules */
+
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const PACKAGES_DIR = path.join( __dirname, '../../packages' );
+
+const packagesInMonorepo = () =>
+	fs
+		.readdirSync( PACKAGES_DIR, { withFileTypes: true } )
+		.filter( ( file ) => file.isDirectory() )
+		.map( ( packageDir ) => require( path.join( PACKAGES_DIR, packageDir.name, 'package.json' ) ) );
+
+module.exports = {
+	packagesInMonorepo,
+};

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -58,7 +58,7 @@ function getExternals() {
 				// Force all monorepo packages to be bundled. We can guarantee that they are safe
 				// to bundle, and can avoid shipping the entire contents of the `packages/` folder
 				// (there are symlinks into `packages/` from the `node_modules` folder)
-				...packagesInMonorepo().map( ( pgk ) => new RegExp( `^${ pgk.name }(/|$)` ) ),
+				...packagesInMonorepo().map( ( pkg ) => new RegExp( `^${ pkg.name }(/|$)` ) ),
 
 				// bundle the core-js polyfills. We pick only a very small subset of the library
 				// to polyfill a few things that are not supported by the latest LTS Node.js,

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -7,8 +7,6 @@
 /**
  * External dependencies
  */
-const fs = require( 'fs' );
-const globby = require( 'globby' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 
@@ -25,6 +23,7 @@ const { shouldTranspileDependency } = require( '@automattic/calypso-build/webpac
 const nodeExternals = require( 'webpack-node-externals' );
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const ExternalModulesWriter = require( './server/bundler/external-modules' );
+const { packagesInMonorepo } = require( '../build-tools/lib/monorepo' );
 
 /**
  * Internal variables
@@ -43,16 +42,6 @@ const fileLoader = FileConfig.loader( {
 
 const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
 
-function getMonorepoPackages() {
-	// find package.json files in all 1st level subdirectories of packages/
-	return globby.sync( 'packages/*/package.json' ).map( ( pkgJsonPath ) => {
-		// read the package.json file
-		const pkgJson = JSON.parse( fs.readFileSync( pkgJsonPath ) );
-		// create a package name regexp that matches all requests that start with it
-		return new RegExp( `^${ pkgJson.name }(/|$)` );
-	} );
-}
-
 /**
  * This lists modules that must use commonJS `require()`s
  * All modules listed here need to be ES5.
@@ -69,7 +58,7 @@ function getExternals() {
 				// Force all monorepo packages to be bundled. We can guarantee that they are safe
 				// to bundle, and can avoid shipping the entire contents of the `packages/` folder
 				// (there are symlinks into `packages/` from the `node_modules` folder)
-				...getMonorepoPackages(),
+				...packagesInMonorepo().map( ( pgk ) => new RegExp( `^${ pgk.name }(/|$)` ) ),
 
 				// bundle the core-js polyfills. We pick only a very small subset of the library
 				// to polyfill a few things that are not supported by the latest LTS Node.js,

--- a/test/module-resolver.js
+++ b/test/module-resolver.js
@@ -1,3 +1,6 @@
+const { packagesInMonorepo } = require( '../build-tools/lib/monorepo' );
+
+const packages = packagesInMonorepo().map( ( pkg ) => pkg.name );
 /**
  * Implements a custom resolver that uses `pkg['calypso:src']` isntead of `pkg.main` for packages from the monorepo.
  *
@@ -20,10 +23,10 @@ module.exports = ( request, options ) => {
 		packageFilter: ( pkg ) => {
 			//TODO: when Jest moves to resolver v2, this method will receive a second argument that points to the real package file (ie: no symlink)
 			//We can use it to determine if the package file is within the repo
-			if ( 'calypso:src' in pkg ) {
+			if ( packages.includes( pkg.name ) ) {
 				return {
 					...pkg,
-					main: pkg[ 'calypso:src' ] || pkg.module,
+					main: pkg[ 'calypso:src' ] || pkg.module || pkg.main,
 				};
 			}
 			return pkg;

--- a/test/module-resolver.js
+++ b/test/module-resolver.js
@@ -2,17 +2,27 @@ const { packagesInMonorepo } = require( '../build-tools/lib/monorepo' );
 
 const packages = packagesInMonorepo().map( ( pkg ) => pkg.name );
 /**
- * Implements a custom resolver that uses `pkg['calypso:src']` isntead of `pkg.main` for packages from the monorepo.
+ * Implements a custom resolver for Jest.
+ *
+ * If the package to be resolved is outside `./packages`, the resolver won't change anything (i.e. Jest will read the main file from `pkg.main`).
+ * If the package is in `./packages` it will tell Jest to resolve from these fields in this order (if they are present):
+ *
+ *   1) `calypso:src`: For JavaScript packages this points to the _untranspiled_ source code (usually `./src/index.js`). This allows us to
+ *      skip any package transpilation before it can be used by Webpack or Jest, saving some developer time.
+ *   2) `module`: This points to the ESM transpilation of the package (usually `./dist/esm`). For TypeScript packages this is populated when
+ *      running `yarn prepare`, which happens as a `postinstall` hook.
+ *   3) `main`: This is the default, it points to a CJS transpilation (usually `./dist/cjs`). This is _not_ automatically populated and therefore
+ *      not safe to use for Jest as it probably points to a file that doesn't exist. This is only populated when the package is packed when it is
+ *      about to be published in the NPM repository.
  *
  * Doc: https://jestjs.io/docs/en/configuration#resolver-string
  *
- * Jest will call this method with the package to be resolved. We'll call back the default resolver but passing
- * an extra `packageFilter`. The default resolver will call `resolve` (https://www.npmjs.com/package/resolve). That
- * library will read `package.json` from the requested module and pass it through `packageFilter` to pre-process it
- * before trying to read the entrypoint.
+ * How it works:
  *
- * If the requested package _name_ is one of the packages we have under `./packages`, we tell the resolver to use `pkg['calypso:src']`
- * to read the main file.
+ * Jest will call this method with the package to be resolved (`request`). We'll call back the default resolver (`options.defaultResolver`)
+ * but passing an extra `packageFilter`. The default resolver is an instance of `resolve` (https://www.npmjs.com/package/resolve), which will
+ * call `packageFilter` to pre-process `package.json` content before sending it back to Jest. We change `pkg.main` to point to `calypso:src`,
+ * `module` or `main`, depending on which one is present.
  *
  * @param {string} request The package being requested
  * @param {*} options Options for the resolver


### PR DESCRIPTION
### Background

#47002 introduced a change where we don't compile `packages/` as CJS by default. In those packages, in their package.json usually `main` points to a CJS compilation and `module` to a ESM.

This is fine when those packages are used in webpack, as it will read the file from `module`. However Jest only looks for `main`, so the tests will fail to resolve those modules.

### Change

This PR changes our custom Jest resolver to look for `module` and then `main` if the package comes from `packages/`.

### Testing instructions

* Check all tests are passing
* Rebase onto `add/use-lp-in-calypso`, and verify all tests pass when you run `yarn test-client`. 
