### PR TITLE
Adds apt packages to CI image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -45,6 +45,9 @@ ENV NVM_DIR=/calypso/.nvm
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
 ENV HOME=/calypso
 
+RUN apt update && \
+	apt-get install -y git-restore-mtime
+
 RUN chown $UID /calypso
 # Copy nvm cache so we don't need to download it again
 COPY --from=builder --chown=$UID /calypso/.nvm /calypso/.nvm

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -46,7 +46,7 @@ ENV NODE_OPTIONS=--max-old-space-size=$node_memory
 ENV HOME=/calypso
 
 RUN apt update && \
-	apt-get install -y git-restore-mtime
+	apt-get install -y git-restore-mtime libsecret-1-dev
 
 RUN chown $UID /calypso
 # Copy nvm cache so we don't need to download it again


### PR DESCRIPTION
### Background

[Desktop build](https://github.com/Automattic/wp-calypso/blob/master/.circleci/config.yml#L700) uses [git-restore-mtime](https://manpages.debian.org/unstable/git-restore-mtime/git-restore-mtime.1.en.html) to restore the modification time of all files after a `git clone`. This improves build times as some caches are based on modification time.

It also uses `libsecret-1-dev` to run Linux tests.

### Changes proposed in this Pull Request

* Adds the following packages to the base CI image:
    * `git-restore-mtime`
    * `libsecret-1-dev`

#### Testing instructions

* N/A
