### PR TITLE
Jetpack Credentials: Make it clearer in the heading that we have guessed the host

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/host-selection/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/host-selection/index.tsx
@@ -104,7 +104,7 @@ const HostSelection: FunctionComponent = () => {
 				</h3>
 				{ providerGuessName && (
 					<p>
-						{ translate( 'It looks like your host is %(providerGuessName)s', {
+						{ translate( 'It looks like your host may be %(providerGuessName)s', {
 							args: { providerGuessName },
 						} ) }
 					</p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Small copy change on the new Jetpack credentials flow to make it clear we have guessed the host:

**Before:**

It looks like your host is ___

**After:**

It looks like your host may be ___


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull this PR
* Test the cloud.jetpack.com entry point and head to settings
* Test with a guessed host (e.g. Bluehost)
