### PR TITLE
Editing Toolkit: Update to 2.8.4

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.3
+ * Version: 2.8.4
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.3' );
+define( 'PLUGIN_VERSION', '2.8.4' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.3
+Stable tag: 2.8.4
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,18 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.4 =
+* Editor NUX modal: Temporarily make text smaller in editor welcome modal for german language (https://github.com/Automattic/wp-calypso/pull/47193)
+* Editor Toolkit: update slide copy in NUX (https://github.com/Automattic/wp-calypso/pull/46674)
+* Focused Launch: fix domain picker not showing in summary page in Calypso (https://github.com/Automattic/wp-calypso/pull/47141)
+* Premium Content: Make text of Subscribe button editable (https://github.com/Automattic/wp-calypso/pull/46983)
+* Remove premium content block placeholder. (https://github.com/Automattic/wp-calypso/pull/47068)
+* Focused Launch: use site title hook in the name step (https://github.com/Automattic/wp-calypso/pull/46921)
+* Add block pattern dom validation tests (https://github.com/Automattic/wp-calypso/pull/45747)
+* Coming soon fallback page: namespace the class names, add an svg for the wp logo (https://github.com/Automattic/wp-calypso/pull/46994)
+* Update global font pairings (https://github.com/Automattic/wp-calypso/pull/46927)
+* Add recordTracksEvent for Editor NUX modal (https://github.com/Automattic/wp-calypso/pull/46796)
 
 = 2.8.3 =
 * Focused Launch: added WIP Focused Launch modal behind a flag (https://github.com/Automattic/wp-calypso/pull/46686)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.3",
+	"version": "2.8.4",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Version bump and changelog

### Changes to Editing Toolkit since 2.8.3:

* Editor NUX modal: Temporarily make text smaller in editor welcome modal for german language (#47193)
* Editor Toolkit: update slide copy in NUX (#46674)
* Focused Launch: fix domain picker not showing in summary page in Calypso (#47141)
* Reinstating condition (#47136)
* Make text of Premium Content's Subscribe button editable (#46983) 
* Remove premium content block placeholder. (#47068)
* Focused Launch: use site title hook in the name step (#46921)
* Add block pattern dom validation tests (#45747)
* For the coming soon fallback page: namespace the class names, add an svg for the wp logo (#46994)
* Remove unused vars (#47072)
* Update global font pairings (#46927)
* Add recordTracksEvent for Editor NUX modal (#46796)

### Testing instructions

1. Load the diff on your sandbox D52369-code and confirm that the above changes work correctly

2. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.