### PR TITLE
i18n: Fix signup sub header title remaining untraslated with async translations

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { identity, includes, isEmpty, omit, get } from 'lodash';
 import classNames from 'classnames';
 
@@ -98,7 +98,17 @@ export class UserStep extends Component {
 		}
 
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
+
+		i18n.on( 'change', this.handleI18nChange );
 	}
+
+	componentWillUnmount() {
+		i18n.off( 'change', this.handleI18nChange );
+	}
+
+	handleI18nChange = () => {
+		this.setSubHeaderText( this.props );
+	};
 
 	setSubHeaderText( props ) {
 		const { flowName, oauth2Client, positionInFlow, translate, wccomFrom } = props;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Subscribe UserStep component from the signup process to i18n changes, so it re-computes the sub header title when translations get updated asynchronous (e.g. from translation chunks require hook).

**Before:**
![image](https://user-images.githubusercontent.com/2722412/98367635-a5ffd480-203e-11eb-908b-b757d51fb6f0.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/98367646-a9935b80-203e-11eb-8526-4eb2c66d254d.png)

#### Testing instructions

- Boot Calypso locally with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks yarn start` or use calypso.live build. For calypso.live, you'll need to enable translation chunks by adding `?useTranslationChunks`  flag to the URL
- Set your browser primary language to any of the Mag-16, and go to `/start` (w/o the locale slug) in an incognito tab

Fixes 171-gh-i18n-issues
