### PR TITLE
Focused Launch: Connect domain picker step with the launch store

### DIFF
--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import { useSelect } from '@wordpress/data';
-import { times } from 'lodash';
+import { noop, times } from 'lodash';
 import { Button, TextControl } from '@wordpress/components';
 import { Icon, search } from '@wordpress/icons';
 import { getNewRailcarId, recordTrainTracksRender } from '@automattic/calypso-analytics';
@@ -67,7 +67,7 @@ export interface Props {
 	quantityExpanded?: number;
 
 	/** Called when the user leaves the search box */
-	onDomainSearchBlur: ( value: string ) => void;
+	onDomainSearchBlur?: ( value: string ) => void;
 
 	currentDomain?: string;
 
@@ -85,7 +85,7 @@ export interface Props {
 	initialDomainSearch?: string;
 
 	/** Called when the domain search query is changed */
-	onSetDomainSearch: ( value: string ) => void;
+	onSetDomainSearch?: ( value: string ) => void;
 
 	/** Whether to segregate free and paid domains from each other */
 	segregateFreeAndPaid?: boolean;
@@ -104,11 +104,11 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	onExistingSubdomainSelect,
 	quantity = PAID_DOMAINS_TO_SHOW,
 	quantityExpanded = PAID_DOMAINS_TO_SHOW_EXPANDED,
-	onDomainSearchBlur,
+	onDomainSearchBlur = noop,
 	analyticsFlowId,
 	analyticsUiAlgo,
 	initialDomainSearch = '',
-	onSetDomainSearch,
+	onSetDomainSearch = noop,
 	currentDomain,
 	isCheckingDomainAvailability,
 	existingSubdomain,

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -198,6 +198,11 @@ $accent-blue: #117ac9;
 		}
 	}
 
+	// hide the radio button in individual mode
+	&.type-individual-item input[type='radio'].domain-picker__suggestion-radio-button {
+		display: none;
+	}
+
 	.components-spinner {
 		margin: 1px 10px 0 0;
 	}

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -121,7 +121,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 				`type-${ type }`
 			) }
 		>
-			{ type === ITEM_TYPE_RADIO &&
+			{ [ ITEM_TYPE_RADIO, ITEM_TYPE_INDIVIDUAL_ITEM ].indexOf( type ) > -1 &&
 				( isLoading ? (
 					<Spinner />
 				) : (

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -214,11 +214,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( { stepIndex } ) => 
 	);
 };
 
-type SummaryProps = {
-	siteId: number;
-};
-
-const Summary: React.FunctionComponent< SummaryProps > = () => {
+const Summary: React.FunctionComponent = () => {
 	const { title, updateTitle, saveTitle } = useTitle();
 	const { sitePrimaryDomain, siteSubdomain, hasPaidDomain } = useSiteDomains();
 	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Connects the domain step to the launch store

#### Testing instructions - requires sandboxing 

1. In apps/editing-toolkit run `yarn dev --sync`.
2. Sandbox testingfocusedflow.wordpress.com.
3. Visit https://testingfocusedflow.wordpress.com/wp-admin/post-new.php.
4. In console, type `wp.data.dispatch('automattic/launch' ).openFocusedLaunch()`.
5. Play with domain picker. You should be able to pick a paid and a free domain.

Partially fixes #46862