### PR TITLE
Update z-index value for editor-checkout-modal to reveal notice.

### DIFF
--- a/client/blocks/editor-checkout-modal/style.scss
+++ b/client/blocks/editor-checkout-modal/style.scss
@@ -3,6 +3,8 @@
 @import '~@wordpress/base-styles/mixins';
 
 .editor-checkout-modal {
+	z-index: z-index( 'root', '.main.calypsoify.is-iframe' );
+
 	.components-modal__frame {
 		top: auto;
 		right: auto;


### PR DESCRIPTION
This was reintroduced by https://github.com/Automattic/wp-calypso/pull/46942

#### Changes proposed in this Pull Request

* Add a lower z-index to the checkout modal to avoid notices getting hidden behind it when the modal is open and an incorrect coupon code gets entered.

#### Testing instructions

* On a site that is on the free plan, open the editor and add a premium block.
* Click "Upgrade" which should display the checkout modal
* Once the modal successfully loads, click "Add a coupon code" to reveal the input field.
* Add a random set of characters and hit "Apply"
* Error notice should successfully appear over the checkout modal.
* It is also worth checking no other unwanted elements within the editor overlay the checkout modal when its open as we've lowered the `z-index`

Alternatively, [watch here](https://www.loom.com/share/62176fddf1394f61b8870e4fcf38a9ef) for testing steps.

Fixes https://github.com/Automattic/wp-calypso/issues/46906
