### PR TITLE
Editor NUX modal: Temporarily make text smaller in editor welcome modal for german language

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/style.scss
@@ -149,6 +149,16 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 	@media ( min-width: $wpcom-modal-breakpoint ) {
 		font-size: 42px;
 	}
+
+	// TODO: remove this hack once the welcome editor deals better with
+	// overflowing text
+	body.locale-de & {
+		font-size: 24px;
+
+		@media ( min-width: $wpcom-modal-breakpoint ) {
+			font-size: 28px;
+		}
+	}
 }
 
 .wpcom-block-editor-nux__description {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/style.scss
@@ -1,3 +1,6 @@
+// @TODO: remove the ignore rule and replace font sizes accordingly
+/* stylelint-disable scales/font-size */
+
 @import '~@automattic/typography/styles/fonts';
 @import '~@automattic/onboarding/styles/mixins';
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Smaller font size for heading in NUX modal when locale is German
* This is to avoid text clipping

## Testing instructions

* Follow instructions from https://github.com/Automattic/wp-calypso/pull/47136 but pick german as the language
* When the NUX modal is showing, go through the steps, the text should not be clipped


### Before

<img width="869" alt="Screenshot 2020-11-06 at 15 39 21" src="https://user-images.githubusercontent.com/1083581/98389097-e61d8200-2053-11eb-9404-d4aac162fa63.png">

### After

<img width="882" alt="Screenshot 2020-11-06 at 17 45 27" src="https://user-images.githubusercontent.com/1083581/98392146-e3bd2700-2057-11eb-82bb-ba34348a1d53.png">

