### PR TITLE
Checkout: Fix checkout loader for tablet devices

### DIFF
--- a/packages/composite-checkout/src/components/loading-content.tsx
+++ b/packages/composite-checkout/src/components/loading-content.tsx
@@ -10,40 +10,6 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import styled from '../lib/styled';
 
-export default function LoadingContent() {
-	const { __ } = useI18n();
-
-	return (
-		<LoadingContentWrapper>
-			<LoadingContentInnerWrapper>
-				<LoadingCard>
-					<LoadingTitle>{ __( 'Loading checkout' ) }</LoadingTitle>
-					<LoadingCopy />
-					<LoadingCopy />
-				</LoadingCard>
-				<LoadingCard>
-					<LoadingTitle />
-					<LoadingCopy />
-					<LoadingCopy />
-				</LoadingCard>
-				<LoadingCard>
-					<LoadingTitle />
-				</LoadingCard>
-				<LoadingCard>
-					<LoadingTitle />
-				</LoadingCard>
-				<LoadingFooter />
-			</LoadingContentInnerWrapper>
-
-			<LoadingSidebar>
-				<SideBarLoadingCopy />
-				<SideBarLoadingCopy />
-				<SideBarLoadingCopy />
-			</LoadingSidebar>
-		</LoadingContentWrapper>
-	);
-}
-
 const LoadingContentWrapper = styled.div`
 	display: flex;
 
@@ -184,3 +150,37 @@ const LoadingFooter = styled.div`
 		height: 40px;
 	}
 `;
+
+export default function LoadingContent() {
+	const { __ } = useI18n();
+
+	return (
+		<LoadingContentWrapper>
+			<LoadingContentInnerWrapper>
+				<LoadingCard>
+					<LoadingTitle>{ __( 'Loading checkout' ) }</LoadingTitle>
+					<LoadingCopy />
+					<LoadingCopy />
+				</LoadingCard>
+				<LoadingCard>
+					<LoadingTitle />
+					<LoadingCopy />
+					<LoadingCopy />
+				</LoadingCard>
+				<LoadingCard>
+					<LoadingTitle />
+				</LoadingCard>
+				<LoadingCard>
+					<LoadingTitle />
+				</LoadingCard>
+				<LoadingFooter />
+			</LoadingContentInnerWrapper>
+
+			<LoadingSidebar>
+				<SideBarLoadingCopy />
+				<SideBarLoadingCopy />
+				<SideBarLoadingCopy />
+			</LoadingSidebar>
+		</LoadingContentWrapper>
+	);
+}

--- a/packages/composite-checkout/src/components/loading-content.tsx
+++ b/packages/composite-checkout/src/components/loading-content.tsx
@@ -47,7 +47,7 @@ export default function LoadingContent() {
 const LoadingContentWrapper = styled.div`
 	display: flex;
 
-	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		align-items: flex-start;
 		flex-direction: row;
 		justify-content: center;
@@ -62,6 +62,11 @@ const LoadingContentInnerWrapper = styled.div`
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 		max-width: 556px;
+		margin: 0 auto;
+	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		margin: 0;
 	}
 `;
 
@@ -69,7 +74,7 @@ const LoadingSidebar = styled.div`
 	display: none;
 	width: 100%;
 
-	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		display: block;
 		padding: 24px;
 		box-sizing: border-box;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a bug on the tablet version of checkout where we show the two column loader layout instead of a single column.

**Before**
![image](https://user-images.githubusercontent.com/6981253/98395351-20722980-202a-11eb-825d-8b40767e7f11.png)

**After**
<img width="868" alt="Screen Shot 2020-11-06 at 12 15 09 PM" src="https://user-images.githubusercontent.com/6981253/98395363-26680a80-202a-11eb-99d7-4f350ee45a2d.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Load checkout at different screen widths and confirm that the number of columns in the loader matches the final loaded state.

Fixes https://github.com/Automattic/payments-shilling/issues/42
