### PR TITLE
Purchases: add button event for adding payment method

### DIFF
--- a/client/me/purchases/credit-cards/index.jsx
+++ b/client/me/purchases/credit-cards/index.jsx
@@ -23,6 +23,7 @@ import {
 } from 'calypso/state/stored-cards/selectors';
 import QueryStoredCards from 'calypso/components/data/query-stored-cards';
 import SectionHeader from 'calypso/components/section-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 /**
  * Style dependencies
@@ -53,6 +54,7 @@ class CreditCards extends Component {
 	}
 
 	goToAddCreditCard = () => {
+		recordTracksEvent( 'calypso_purchases_click_add_new_payment_method' );
 		page( this.props.addPaymentMethodUrl );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds event tracking on the `add credit card` button on our payment method screen.

![image](https://user-images.githubusercontent.com/6981253/98397508-76949c00-202d-11eb-8779-033f5b4151e1.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit payment method screen (At the site and account level)
* Click "Add credit card" button. 
* Confirm `calypso_purchases_click_add_new_payment_method` event fires.

