### PR TITLE
Checkout: Remove onlyLoadPaymentMethods from CompositeCheckout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -486,9 +486,13 @@ export default function CompositeCheckout( {
 	const arePaymentMethodsLoading =
 		items.length < 1 ||
 		isInitialCartLoading ||
-		isLoadingStoredCards ||
-		( onlyLoadPaymentMethods
-			? onlyLoadPaymentMethods.includes( 'apple-pay' ) && isApplePayLoading
+		// Only wait for stored cards to load if we are using cards
+		( allowedPaymentMethods
+			? allowedPaymentMethods.includes( 'card' ) && isLoadingStoredCards
+			: isLoadingStoredCards ) ||
+		// Only wait for apple pay to load if we are using apple pay
+		( allowedPaymentMethods
+			? allowedPaymentMethods.includes( 'apple-pay' ) && isApplePayLoading
 			: isApplePayLoading );
 
 	const contactInfo: ManagedContactDetails | undefined = select( 'wpcom' )?.getContactInfo();

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -117,8 +117,7 @@ export default function CompositeCheckout( {
 	siteId,
 	productAliasFromUrl,
 	getStoredCards,
-	allowedPaymentMethods,
-	onlyLoadPaymentMethods,
+	allowedPaymentMethods: overridePaymentMethods,
 	overrideCountryList,
 	redirectTo,
 	feature,
@@ -136,7 +135,6 @@ export default function CompositeCheckout( {
 	productAliasFromUrl?: string | undefined;
 	getStoredCards?: () => StoredCard[];
 	allowedPaymentMethods?: CheckoutPaymentMethodSlug[];
-	onlyLoadPaymentMethods?: CheckoutPaymentMethodSlug[];
 	overrideCountryList?: CountryListItem[];
 	redirectTo?: string | undefined;
 	feature?: string | undefined;
@@ -467,7 +465,6 @@ export default function CompositeCheckout( {
 	} = useIsApplePayAvailable( stripe, stripeConfiguration, !! stripeLoadingError, items );
 
 	const paymentMethodObjects = useCreatePaymentMethods( {
-		onlyLoadPaymentMethods,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
@@ -479,6 +476,8 @@ export default function CompositeCheckout( {
 		siteSlug,
 	} );
 	debug( 'created payment method objects', paymentMethodObjects );
+
+	const allowedPaymentMethods = overridePaymentMethods || serverAllowedPaymentMethods;
 
 	// Once we pass paymentMethods into CompositeCheckout, we should try to avoid
 	// changing them because it can cause awkward UX. Here we try to wait for
@@ -506,7 +505,7 @@ export default function CompositeCheckout( {
 				total,
 				credits,
 				subtotal,
-				allowedPaymentMethods: allowedPaymentMethods || serverAllowedPaymentMethods,
+				allowedPaymentMethods,
 		  } );
 	debug( 'filtered payment method objects', paymentMethods );
 

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -617,17 +617,6 @@ export default function CompositeCheckout( {
 		[ couponItem, dataForProcessor, dataForRedirectProcessor, getThankYouUrl, transactionOptions ]
 	);
 
-	useRecordCheckoutLoaded( {
-		recordEvent,
-		isLoadingCart: isInitialCartLoading,
-		isApplePayAvailable,
-		isApplePayLoading,
-		isLoadingStoredCards,
-		responseCart,
-		storedCards,
-		productAliasFromUrl,
-	} );
-
 	const jetpackColors = isJetpackNotAtomic
 		? {
 				primary: colors[ 'Jetpack Green' ],
@@ -642,17 +631,28 @@ export default function CompositeCheckout( {
 		: {};
 	const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };
 
-	const isLoading =
-		isInitialCartLoading || isLoadingStoredCards || paymentMethods.length < 1 || items.length < 1;
+	const isLoading: boolean =
+		isInitialCartLoading ||
+		arePaymentMethodsLoading ||
+		paymentMethods.length < 1 ||
+		items.length < 1;
 	if ( isLoading ) {
 		debug( 'still loading because one of these is true', {
 			isInitialCartLoading,
-			isLoadingStoredCards,
 			paymentMethods: paymentMethods.length < 1,
 			arePaymentMethodsLoading: arePaymentMethodsLoading,
 			items: items.length < 1,
 		} );
 	}
+
+	useRecordCheckoutLoaded( {
+		recordEvent,
+		isLoading,
+		isApplePayAvailable,
+		responseCart,
+		storedCards,
+		productAliasFromUrl,
+	} );
 
 	if (
 		shouldShowEmptyCartPage( {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -93,7 +93,6 @@ import {
 	ManagedContactDetails,
 } from './types/wpcom-store-state';
 import { StoredCard } from './types/stored-cards';
-import { CheckoutPaymentMethodSlug } from './types/checkout-payment-method-slug';
 import { CountryListItem } from './types/country-list-item';
 import { TransactionResponse, Purchase } from './types/wpcom-store-state';
 import { WPCOMCartItem } from './types/checkout-cart';
@@ -117,7 +116,6 @@ export default function CompositeCheckout( {
 	siteId,
 	productAliasFromUrl,
 	getStoredCards,
-	allowedPaymentMethods: overridePaymentMethods,
 	overrideCountryList,
 	redirectTo,
 	feature,
@@ -134,7 +132,6 @@ export default function CompositeCheckout( {
 	siteId: number | undefined;
 	productAliasFromUrl?: string | undefined;
 	getStoredCards?: () => StoredCard[];
-	allowedPaymentMethods?: CheckoutPaymentMethodSlug[];
 	overrideCountryList?: CountryListItem[];
 	redirectTo?: string | undefined;
 	feature?: string | undefined;
@@ -258,7 +255,7 @@ export default function CompositeCheckout( {
 		total,
 		credits,
 		subtotal,
-		allowedPaymentMethods: serverAllowedPaymentMethods,
+		allowedPaymentMethods,
 	} = useMemo( () => translateResponseCartToWPCOMCart( responseCart ), [ responseCart ] );
 
 	useShowAddCouponSuccessMessage(
@@ -477,8 +474,6 @@ export default function CompositeCheckout( {
 	} );
 	debug( 'created payment method objects', paymentMethodObjects );
 
-	const allowedPaymentMethods = overridePaymentMethods || serverAllowedPaymentMethods;
-
 	// Once we pass paymentMethods into CompositeCheckout, we should try to avoid
 	// changing them because it can cause awkward UX. Here we try to wait for
 	// them to be all finished loading before we pass them along.
@@ -486,13 +481,9 @@ export default function CompositeCheckout( {
 		items.length < 1 ||
 		isInitialCartLoading ||
 		// Only wait for stored cards to load if we are using cards
-		( allowedPaymentMethods
-			? allowedPaymentMethods.includes( 'card' ) && isLoadingStoredCards
-			: isLoadingStoredCards ) ||
+		( allowedPaymentMethods.includes( 'card' ) && isLoadingStoredCards ) ||
 		// Only wait for apple pay to load if we are using apple pay
-		( allowedPaymentMethods
-			? allowedPaymentMethods.includes( 'apple-pay' ) && isApplePayLoading
-			: isApplePayLoading );
+		( allowedPaymentMethods.includes( 'apple-pay' ) && isApplePayLoading );
 
 	const contactInfo: ManagedContactDetails | undefined = select( 'wpcom' )?.getContactInfo();
 	const countryCode: string = contactInfo?.countryCode?.value ?? '';

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -100,6 +100,7 @@ import { WPCOMCartItem } from './types/checkout-cart';
 import doesValueExist from './lib/does-value-exist';
 import EmptyCart from './components/empty-cart';
 import getContactDetailsType from './lib/get-contact-details-type';
+import type { ReactStandardAction } from './types/analytics';
 
 const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
 
@@ -159,7 +160,11 @@ export default function CompositeCheckout( {
 	const createUserAndSiteBeforeTransaction = Boolean( isLoggedOutCart || isNoSiteCart );
 	const transactionOptions = { createUserAndSiteBeforeTransaction };
 	const reduxDispatch = useDispatch();
-	const recordEvent = useCallback( createAnalyticsEventHandler( reduxDispatch ), [] ); // eslint-disable-line react-hooks/exhaustive-deps
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	const recordEvent: ( action: ReactStandardAction ) => void = useCallback(
+		createAnalyticsEventHandler( reduxDispatch ),
+		[]
+	);
 
 	const showErrorMessage = useCallback(
 		( error ) => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
@@ -16,30 +16,21 @@ const debug = debugFactory( 'calypso:composite-checkout:use-record-checkout-load
 
 export default function useRecordCheckoutLoaded( {
 	recordEvent,
-	isLoadingCart,
+	isLoading,
 	isApplePayAvailable,
-	isApplePayLoading,
-	isLoadingStoredCards,
 	responseCart,
 	storedCards,
 	productAliasFromUrl,
 }: {
 	recordEvent: ( action: ReactStandardAction ) => void;
-	isLoadingCart: boolean;
+	isLoading: boolean;
 	isApplePayAvailable: boolean;
-	isApplePayLoading: boolean;
-	isLoadingStoredCards: boolean;
 	responseCart: ResponseCart;
 	storedCards: StoredCard[];
 	productAliasFromUrl: string | undefined | null;
 } ): void {
 	const hasRecordedCheckoutLoad = useRef( false );
-	if (
-		! isLoadingCart &&
-		! isLoadingStoredCards &&
-		! isApplePayLoading &&
-		! hasRecordedCheckoutLoad.current
-	) {
+	if ( ! isLoading && ! hasRecordedCheckoutLoad.current ) {
 		debug( 'composite checkout has loaded' );
 		recordEvent( {
 			type: 'CHECKOUT_LOADED',

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -85,8 +85,7 @@ export async function submitEbanxCardTransaction( transactionData, submit ) {
 }
 
 export async function submitRedirectTransaction( paymentMethodId, transactionData, submit ) {
-	const paymentMethodType = translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId )
-		?.name;
+	const paymentMethodType = translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId );
 	if ( ! paymentMethodType ) {
 		throw new Error( `No payment method found for type: ${ paymentMethodId }` );
 	}

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -52,8 +52,9 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
 							currency: action.payload.total.amount.currency,
 							payment_method:
-								translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
-									?.name || '',
+								translateCheckoutPaymentMethodToWpcomPaymentMethod(
+									action.payload.paymentMethodId
+								) || '',
 							total_cost,
 						} )
 					);
@@ -76,8 +77,9 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							total: action.payload.total.amount.value,
 							currency: action.payload.total.amount.currency,
 							payment_method:
-								translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
-									?.name || '',
+								translateCheckoutPaymentMethodToWpcomPaymentMethod(
+									action.payload.paymentMethodId
+								) || '',
 						} )
 					);
 				}
@@ -208,7 +210,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 								payment_method:
 									translateCheckoutPaymentMethodToWpcomPaymentMethod(
 										action.payload.paymentMethodId
-									)?.name || '',
+									) || '',
 							} )
 						);
 					}
@@ -262,8 +264,9 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_payment_error', {
 							error_code: null,
 							payment_method:
-								translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
-									?.name || '',
+								translateCheckoutPaymentMethodToWpcomPaymentMethod(
+									action.payload.paymentMethodId
+								) || '',
 							reason: String( action.payload.message ),
 						} )
 					);
@@ -296,16 +299,18 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_form_submit', {
 							credits: null,
 							payment_method:
-								translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
-									?.name || '',
+								translateCheckoutPaymentMethodToWpcomPaymentMethod(
+									action.payload.paymentMethodId
+								) || '',
 						} )
 					);
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
 							credits: null,
 							payment_method:
-								translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
-									?.name || '',
+								translateCheckoutPaymentMethodToWpcomPaymentMethod(
+									action.payload.paymentMethodId
+								) || '',
 						} )
 					);
 					const paymentMethodIdForTracks = action.payload.paymentMethodId

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -141,7 +141,7 @@ describe( 'CompositeCheckout', () => {
 				location: {},
 			},
 			temporary: false,
-			allowed_payment_methods: [ 'WPCOM_Billing_Stripe_Payment_Method' ],
+			allowed_payment_methods: [ 'WPCOM_Billing_PayPal_Express' ],
 			savings_total_integer: 0,
 			savings_total_display: 'R$0',
 			total_tax_integer: 700,
@@ -235,7 +235,6 @@ describe( 'CompositeCheckout', () => {
 						<CompositeCheckout
 							siteSlug={ 'foo.com' }
 							getStoredCards={ async () => [] }
-							allowedPaymentMethods={ [ 'paypal', 'full-credits', 'free-purchase' ] }
 							overrideCountryList={ countryList }
 							{ ...additionalProps }
 						/>
@@ -792,11 +791,7 @@ async function mockSetCartEndpoint( _, requestCart ) {
 		currency: requestCurrency,
 		credits_integer: 0,
 		credits_display: '0',
-		allowed_payment_methods: [
-			'WPCOM_Billing_Stripe_Payment_Method',
-			'WPCOM_Billing_Ebanx',
-			'WPCOM_Billing_Web_Payment',
-		],
+		allowed_payment_methods: [ 'WPCOM_Billing_PayPal_Express' ],
 		coupon_savings_total_display: requestCoupon ? 'R$10' : 'R$0',
 		coupon_savings_total_integer: requestCoupon ? 1000 : 0,
 		savings_total_display: requestCoupon ? 'R$10' : 'R$0',

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -235,8 +235,7 @@ describe( 'CompositeCheckout', () => {
 						<CompositeCheckout
 							siteSlug={ 'foo.com' }
 							getStoredCards={ async () => [] }
-							allowedPaymentMethods={ [ 'paypal' ] }
-							onlyLoadPaymentMethods={ [ 'paypal', 'full-credits', 'free-purchase' ] }
+							allowedPaymentMethods={ [ 'paypal', 'full-credits', 'free-purchase' ] }
 							overrideCountryList={ countryList }
 							{ ...additionalProps }
 						/>

--- a/client/my-sites/checkout/composite-checkout/types/backend/payment-method.ts
+++ b/client/my-sites/checkout/composite-checkout/types/backend/payment-method.ts
@@ -8,13 +8,13 @@ import { CheckoutPaymentMethodSlug } from '../checkout-payment-method-slug';
  * These need to be translated to the values expected by
  * composite-checkout.
  *
- * Defining these as interfaces allows WPCOMPaymentMethodClass
+ * Defining these as interfaces allows WPCOMPaymentMethod
  * to be treated as a discriminated union so the compiler
  * can do exhaustiveness checking. For example, in a switch
  * block such as
  *
- *     // method : WPCOMPaymentMethodClass
- *     switch ( method.name ) {
+ *     // method : WPCOMPaymentMethod
+ *     switch ( method ) {
  *       case ...
  *     }
  *
@@ -43,22 +43,7 @@ export type WPCOMPaymentMethod =
 	| 'WPCOM_Billing_Stripe_Source_Wechat'
 	| 'WPCOM_Billing_Web_Payment';
 
-export type WPCOMPaymentMethodClass = { name: WPCOMPaymentMethod };
-
-/**
- * Convert a payment method class name from a string to a
- * typed value. This function is extensionally equivalent to
- *
- *     ( slug ) => { name: slug }
- *
- * However the explicit switch is necessary for inferring the
- * correct type.
- *
- * @param slug Name of one of the payment method classes on WPCOM
- *
- * @returns Typed payment method slug or null
- */
-export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethodClass | null {
+export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod | null {
 	switch ( slug ) {
 		case 'WPCOM_Billing_WPCOM':
 		case 'WPCOM_Billing_Ebanx':
@@ -78,7 +63,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethodC
 		case 'WPCOM_Billing_Stripe_Source_Three_D_Secure':
 		case 'WPCOM_Billing_Stripe_Source_Wechat':
 		case 'WPCOM_Billing_Web_Payment':
-			return { name: slug };
+			return slug;
 	}
 	return null;
 }
@@ -90,9 +75,9 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethodC
  * @returns Payment method slug accepted by the checkout component
  */
 export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
-	paymentMethod: WPCOMPaymentMethodClass
+	paymentMethod: WPCOMPaymentMethod
 ): CheckoutPaymentMethodSlug {
-	switch ( paymentMethod.name ) {
+	switch ( paymentMethod ) {
 		case 'WPCOM_Billing_WPCOM':
 			return 'free-purchase';
 		case 'WPCOM_Billing_Ebanx':
@@ -134,49 +119,49 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 
 export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 	paymentMethod: CheckoutPaymentMethodSlug
-): WPCOMPaymentMethodClass | null {
+): WPCOMPaymentMethod | null {
 	// existing cards have unique paymentMethodIds
 	if ( paymentMethod.startsWith( 'existingCard' ) ) {
 		paymentMethod = 'card';
 	}
 	switch ( paymentMethod ) {
 		case 'ebanx':
-			return { name: 'WPCOM_Billing_Ebanx' };
+			return 'WPCOM_Billing_Ebanx';
 		case 'brazil-tef':
-			return { name: 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef' };
+			return 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef';
 		case 'netbanking':
-			return { name: 'WPCOM_Billing_Dlocal_Redirect_India_Netbanking' };
+			return 'WPCOM_Billing_Dlocal_Redirect_India_Netbanking';
 		case 'id_wallet':
-			return { name: 'WPCOM_Billing_Dlocal_Redirect_Indonesia_Wallet' };
+			return 'WPCOM_Billing_Dlocal_Redirect_Indonesia_Wallet';
 		case 'paypal-direct':
-			return { name: 'WPCOM_Billing_PayPal_Direct' };
+			return 'WPCOM_Billing_PayPal_Direct';
 		case 'paypal':
-			return { name: 'WPCOM_Billing_PayPal_Express' };
+			return 'WPCOM_Billing_PayPal_Express';
 		case 'card':
-			return { name: 'WPCOM_Billing_Stripe_Payment_Method' };
+			return 'WPCOM_Billing_Stripe_Payment_Method';
 		case 'alipay':
-			return { name: 'WPCOM_Billing_Stripe_Source_Alipay' };
+			return 'WPCOM_Billing_Stripe_Source_Alipay';
 		case 'bancontact':
-			return { name: 'WPCOM_Billing_Stripe_Source_Bancontact' };
+			return 'WPCOM_Billing_Stripe_Source_Bancontact';
 		case 'eps':
-			return { name: 'WPCOM_Billing_Stripe_Source_Eps' };
+			return 'WPCOM_Billing_Stripe_Source_Eps';
 		case 'giropay':
-			return { name: 'WPCOM_Billing_Stripe_Source_Giropay' };
+			return 'WPCOM_Billing_Stripe_Source_Giropay';
 		case 'ideal':
-			return { name: 'WPCOM_Billing_Stripe_Source_Ideal' };
+			return 'WPCOM_Billing_Stripe_Source_Ideal';
 		case 'p24':
-			return { name: 'WPCOM_Billing_Stripe_Source_P24' };
+			return 'WPCOM_Billing_Stripe_Source_P24';
 		case 'sofort':
-			return { name: 'WPCOM_Billing_Stripe_Source_Sofort' };
+			return 'WPCOM_Billing_Stripe_Source_Sofort';
 		case 'stripe-three-d-secure':
-			return { name: 'WPCOM_Billing_Stripe_Source_Three_D_Secure' };
+			return 'WPCOM_Billing_Stripe_Source_Three_D_Secure';
 		case 'wechat':
-			return { name: 'WPCOM_Billing_Stripe_Source_Wechat' };
+			return 'WPCOM_Billing_Stripe_Source_Wechat';
 		case 'apple-pay':
-			return { name: 'WPCOM_Billing_Web_Payment' };
+			return 'WPCOM_Billing_Web_Payment';
 		case 'full-credits':
-			return { name: 'WPCOM_Billing_WPCOM' };
+			return 'WPCOM_Billing_WPCOM';
 		case 'free-purchase':
-			return { name: 'WPCOM_Billing_WPCOM' };
+			return 'WPCOM_Billing_WPCOM';
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/types/backend/payment-method.ts
+++ b/client/my-sites/checkout/composite-checkout/types/backend/payment-method.ts
@@ -7,21 +7,6 @@ import { CheckoutPaymentMethodSlug } from '../checkout-payment-method-slug';
  * Payment method slugs as returned by the WPCOM backend.
  * These need to be translated to the values expected by
  * composite-checkout.
- *
- * Defining these as interfaces allows WPCOMPaymentMethod
- * to be treated as a discriminated union so the compiler
- * can do exhaustiveness checking. For example, in a switch
- * block such as
- *
- *     // method : WPCOMPaymentMethod
- *     switch ( method ) {
- *       case ...
- *     }
- *
- * the typescript compiler will raise an error if we forget to
- * handle all the cases.
- *
- * @see https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
  */
 export type WPCOMPaymentMethod =
 	| 'WPCOM_Billing_WPCOM'

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -51,31 +51,18 @@ import {
 	createNetBankingMethod,
 } from './payment-methods/netbanking';
 
-function useCreatePayPal( { onlyLoadPaymentMethods } ) {
-	const shouldLoadPayPalMethod = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'paypal' )
-		: true;
-	const paypalMethod = useMemo( () => {
-		if ( ! shouldLoadPayPalMethod ) {
-			return null;
-		}
-		return createPayPalMethod();
-	}, [ shouldLoadPayPalMethod ] );
+function useCreatePayPal() {
+	const paypalMethod = useMemo( createPayPalMethod, [] );
 	return paypalMethod;
 }
 
 function useCreateCreditCard( {
-	onlyLoadPaymentMethods,
 	isStripeLoading,
 	stripeLoadingError,
 	stripeConfiguration,
 	stripe,
 } ) {
-	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
-	const isStripeMethodAllowed = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'card' )
-		: true;
-	const shouldLoadStripeMethod = isStripeMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+	const shouldLoadStripeMethod = ! isStripeLoading && ! stripeLoadingError;
 	const stripePaymentMethodStore = useMemo( () => createCreditCardPaymentMethodStore(), [] );
 	const stripeMethod = useMemo(
 		() =>
@@ -91,18 +78,8 @@ function useCreateCreditCard( {
 	return stripeMethod;
 }
 
-function useCreateAlipay( {
-	onlyLoadPaymentMethods,
-	isStripeLoading,
-	stripeLoadingError,
-	stripeConfiguration,
-	stripe,
-} ) {
-	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
-	const isMethodAllowed = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'alipay' )
-		: true;
-	const shouldLoad = isMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+function useCreateAlipay( { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } ) {
+	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createAlipayPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
@@ -117,16 +94,8 @@ function useCreateAlipay( {
 	);
 }
 
-function useCreateP24( {
-	onlyLoadPaymentMethods,
-	isStripeLoading,
-	stripeLoadingError,
-	stripeConfiguration,
-	stripe,
-} ) {
-	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
-	const isMethodAllowed = onlyLoadPaymentMethods ? onlyLoadPaymentMethods.includes( 'p24' ) : true;
-	const shouldLoad = isMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+function useCreateP24( { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } ) {
+	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createP24PaymentMethodStore(), [] );
 	return useMemo(
 		() =>
@@ -142,17 +111,12 @@ function useCreateP24( {
 }
 
 function useCreateBancontact( {
-	onlyLoadPaymentMethods,
 	isStripeLoading,
 	stripeLoadingError,
 	stripeConfiguration,
 	stripe,
 } ) {
-	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
-	const isMethodAllowed = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'bancontact' )
-		: true;
-	const shouldLoad = isMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createBancontactPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
@@ -167,18 +131,8 @@ function useCreateBancontact( {
 	);
 }
 
-function useCreateGiropay( {
-	onlyLoadPaymentMethods,
-	isStripeLoading,
-	stripeLoadingError,
-	stripeConfiguration,
-	stripe,
-} ) {
-	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
-	const isMethodAllowed = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'giropay' )
-		: true;
-	const shouldLoad = isMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+function useCreateGiropay( { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } ) {
+	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createGiropayPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
@@ -194,18 +148,13 @@ function useCreateGiropay( {
 }
 
 function useCreateWeChat( {
-	onlyLoadPaymentMethods,
 	isStripeLoading,
 	stripeLoadingError,
 	stripeConfiguration,
 	stripe,
 	siteSlug,
 } ) {
-	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
-	const isMethodAllowed = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'wechat' )
-		: true;
-	const shouldLoad = isMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createWeChatPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
@@ -221,18 +170,8 @@ function useCreateWeChat( {
 	);
 }
 
-function useCreateIdeal( {
-	onlyLoadPaymentMethods,
-	isStripeLoading,
-	stripeLoadingError,
-	stripeConfiguration,
-	stripe,
-} ) {
-	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
-	const isMethodAllowed = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'ideal' )
-		: true;
-	const shouldLoad = isMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+function useCreateIdeal( { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } ) {
+	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createIdealPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
@@ -247,18 +186,8 @@ function useCreateIdeal( {
 	);
 }
 
-function useCreateSofort( {
-	onlyLoadPaymentMethods,
-	isStripeLoading,
-	stripeLoadingError,
-	stripeConfiguration,
-	stripe,
-} ) {
-	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
-	const isMethodAllowed = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'sofort' )
-		: true;
-	const shouldLoad = isMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+function useCreateSofort( { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } ) {
+	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createSofortPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
@@ -273,16 +202,8 @@ function useCreateSofort( {
 	);
 }
 
-function useCreateEps( {
-	onlyLoadPaymentMethods,
-	isStripeLoading,
-	stripeLoadingError,
-	stripeConfiguration,
-	stripe,
-} ) {
-	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
-	const isMethodAllowed = onlyLoadPaymentMethods ? onlyLoadPaymentMethods.includes( 'eps' ) : true;
-	const shouldLoad = isMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+function useCreateEps( { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } ) {
+	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createEpsPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
@@ -297,96 +218,54 @@ function useCreateEps( {
 	);
 }
 
-function useCreateNetbanking( { onlyLoadPaymentMethods } ) {
-	// If this PM is allowed by props and allowed by the cart, then create the PM.
-	const isMethodAllowed = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'netbanking' )
-		: true;
-	const shouldLoad = isMethodAllowed;
+function useCreateNetbanking() {
 	const paymentMethodStore = useMemo( () => createNetBankingPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
-			shouldLoad
-				? createNetBankingMethod( {
-						store: paymentMethodStore,
-				  } )
-				: null,
-		[ shouldLoad, paymentMethodStore ]
+			createNetBankingMethod( {
+				store: paymentMethodStore,
+			} ),
+		[ paymentMethodStore ]
 	);
 }
 
-function useCreateIdWallet( { onlyLoadPaymentMethods } ) {
-	// If this PM is allowed by props and allowed by the cart, then create the PM.
-	const isMethodAllowed = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'id_wallet' )
-		: true;
-	const shouldLoad = isMethodAllowed;
+function useCreateIdWallet() {
 	const paymentMethodStore = useMemo( () => createIdWalletPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
-			shouldLoad
-				? createIdWalletMethod( {
-						store: paymentMethodStore,
-				  } )
-				: null,
-		[ shouldLoad, paymentMethodStore ]
+			createIdWalletMethod( {
+				store: paymentMethodStore,
+			} ),
+		[ paymentMethodStore ]
 	);
 }
 
-function useCreateEbanxTef( { onlyLoadPaymentMethods } ) {
-	// If this PM is allowed by props and allowed by the cart, then create the PM.
-	const isMethodAllowed = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'ebanx-tef' )
-		: true;
-	const shouldLoad = isMethodAllowed;
+function useCreateEbanxTef() {
 	const paymentMethodStore = useMemo( () => createEbanxTefPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
-			shouldLoad
-				? createEbanxTefMethod( {
-						store: paymentMethodStore,
-				  } )
-				: null,
-		[ shouldLoad, paymentMethodStore ]
+			createEbanxTefMethod( {
+				store: paymentMethodStore,
+			} ),
+		[ paymentMethodStore ]
 	);
 }
 
-function useCreateFullCredits( { onlyLoadPaymentMethods, credits } ) {
-	const shouldLoadFullCreditsMethod = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'full-credits' )
-		: true;
-	const fullCreditsPaymentMethod = useMemo( () => {
-		if ( ! shouldLoadFullCreditsMethod ) {
-			return null;
-		}
-		return createFullCreditsMethod();
-	}, [ shouldLoadFullCreditsMethod ] );
-	if ( fullCreditsPaymentMethod ) {
-		fullCreditsPaymentMethod.label = <WordPressCreditsLabel credits={ credits } />;
-		fullCreditsPaymentMethod.inactiveContent = <WordPressCreditsSummary />;
-	}
+function useCreateFullCredits( { credits } ) {
+	const fullCreditsPaymentMethod = useMemo( createFullCreditsMethod, [] );
+	fullCreditsPaymentMethod.label = <WordPressCreditsLabel credits={ credits } />;
+	fullCreditsPaymentMethod.inactiveContent = <WordPressCreditsSummary />;
 	return fullCreditsPaymentMethod;
 }
 
-function useCreateFree( { onlyLoadPaymentMethods } ) {
-	const shouldLoadFreePaymentMethod = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'free-purchase' )
-		: true;
-	const freePaymentMethod = useMemo( () => {
-		if ( ! shouldLoadFreePaymentMethod ) {
-			return null;
-		}
-		return createFreePaymentMethod();
-	}, [ shouldLoadFreePaymentMethod ] );
-	if ( freePaymentMethod ) {
-		freePaymentMethod.label = <WordPressFreePurchaseLabel />;
-		freePaymentMethod.inactiveContent = <WordPressFreePurchaseSummary />;
-	}
+function useCreateFree() {
+	const freePaymentMethod = useMemo( createFreePaymentMethod, [] );
+	freePaymentMethod.label = <WordPressFreePurchaseLabel />;
+	freePaymentMethod.inactiveContent = <WordPressFreePurchaseSummary />;
 	return freePaymentMethod;
 }
 
 function useCreateApplePay( {
-	onlyLoadPaymentMethods,
 	isStripeLoading,
 	stripeLoadingError,
 	stripeConfiguration,
@@ -394,12 +273,9 @@ function useCreateApplePay( {
 	isApplePayAvailable,
 	isApplePayLoading,
 } ) {
-	const shouldLoadApplePay = onlyLoadPaymentMethods?.includes( 'apple-pay' ) ?? true;
-
 	const isStripeReady = ! isStripeLoading && ! stripeLoadingError && stripe && stripeConfiguration;
 
-	const shouldCreateApplePayMethod =
-		shouldLoadApplePay && isStripeReady && ! isApplePayLoading && isApplePayAvailable;
+	const shouldCreateApplePayMethod = isStripeReady && ! isApplePayLoading && isApplePayAvailable;
 
 	const applePayMethod = useMemo( () => {
 		return shouldCreateApplePayMethod ? createApplePayMethod( stripe, stripeConfiguration ) : null;
@@ -408,14 +284,8 @@ function useCreateApplePay( {
 	return applePayMethod;
 }
 
-function useCreateExistingCards( { onlyLoadPaymentMethods, storedCards, stripeConfiguration } ) {
-	const shouldLoadExistingCardsMethods = onlyLoadPaymentMethods
-		? onlyLoadPaymentMethods.includes( 'existingCard' )
-		: true;
+function useCreateExistingCards( { storedCards, stripeConfiguration } ) {
 	const existingCardMethods = useMemo( () => {
-		if ( ! shouldLoadExistingCardsMethods ) {
-			return [];
-		}
 		return storedCards.map( ( storedDetails ) =>
 			createExistingCardMethod( {
 				id: `existingCard-${ storedDetails.stored_details_id }`,
@@ -429,12 +299,11 @@ function useCreateExistingCards( { onlyLoadPaymentMethods, storedCards, stripeCo
 				stripeConfiguration,
 			} )
 		);
-	}, [ stripeConfiguration, storedCards, shouldLoadExistingCardsMethods ] );
+	}, [ stripeConfiguration, storedCards ] );
 	return existingCardMethods;
 }
 
 export default function useCreatePaymentMethods( {
-	onlyLoadPaymentMethods,
 	isStripeLoading,
 	stripeLoadingError,
 	stripeConfiguration,
@@ -445,12 +314,9 @@ export default function useCreatePaymentMethods( {
 	storedCards,
 	siteSlug,
 } ) {
-	const paypalMethod = useCreatePayPal( {
-		onlyLoadPaymentMethods,
-	} );
+	const paypalMethod = useCreatePayPal();
 
 	const idealMethod = useCreateIdeal( {
-		onlyLoadPaymentMethods,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
@@ -458,7 +324,6 @@ export default function useCreatePaymentMethods( {
 	} );
 
 	const alipayMethod = useCreateAlipay( {
-		onlyLoadPaymentMethods,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
@@ -466,7 +331,6 @@ export default function useCreatePaymentMethods( {
 	} );
 
 	const p24Method = useCreateP24( {
-		onlyLoadPaymentMethods,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
@@ -474,7 +338,6 @@ export default function useCreatePaymentMethods( {
 	} );
 
 	const bancontactMethod = useCreateBancontact( {
-		onlyLoadPaymentMethods,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
@@ -482,7 +345,6 @@ export default function useCreatePaymentMethods( {
 	} );
 
 	const giropayMethod = useCreateGiropay( {
-		onlyLoadPaymentMethods,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
@@ -490,21 +352,19 @@ export default function useCreatePaymentMethods( {
 	} );
 
 	const epsMethod = useCreateEps( {
-		onlyLoadPaymentMethods,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
 		stripe,
 	} );
 
-	const ebanxTefMethod = useCreateEbanxTef( { onlyLoadPaymentMethods } );
+	const ebanxTefMethod = useCreateEbanxTef();
 
-	const idWalletMethod = useCreateIdWallet( { onlyLoadPaymentMethods } );
+	const idWalletMethod = useCreateIdWallet();
 
-	const netbankingMethod = useCreateNetbanking( { onlyLoadPaymentMethods } );
+	const netbankingMethod = useCreateNetbanking();
 
 	const sofortMethod = useCreateSofort( {
-		onlyLoadPaymentMethods,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
@@ -512,7 +372,6 @@ export default function useCreatePaymentMethods( {
 	} );
 
 	const wechatMethod = useCreateWeChat( {
-		onlyLoadPaymentMethods,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
@@ -521,7 +380,6 @@ export default function useCreatePaymentMethods( {
 	} );
 
 	const stripeMethod = useCreateCreditCard( {
-		onlyLoadPaymentMethods,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
@@ -529,14 +387,12 @@ export default function useCreatePaymentMethods( {
 	} );
 
 	const fullCreditsPaymentMethod = useCreateFullCredits( {
-		onlyLoadPaymentMethods,
 		credits,
 	} );
 
-	const freePaymentMethod = useCreateFree( { onlyLoadPaymentMethods } );
+	const freePaymentMethod = useCreateFree();
 
 	const applePayMethod = useCreateApplePay( {
-		onlyLoadPaymentMethods,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
@@ -546,7 +402,6 @@ export default function useCreatePaymentMethods( {
 	} );
 
 	const existingCardMethods = useCreateExistingCards( {
-		onlyLoadPaymentMethods,
 		storedCards,
 		stripeConfiguration,
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In calypso's implementation of new checkout, `useCreatePaymentMethods` creates all the payment method objects and their necessary stores. Some payment methods are not created because of certain conditions (eg: if there is a stripe loading error, we don't bother trying to create apple pay which relies on stripe). Those payment methods are then filtered later by `filterAppropriatePaymentMethods` based on what the server has told us we can display.

This works fine in production, but when running unit tests, if we try to create all the payment methods we will get errors. Therefore, in order to get tests working I added an argument to `useCreatePaymentMethods` called `onlyLoadPaymentMethods` which is empty in production but used for tests to be able to prevent certain payment methods from being loaded.

Unfortunately, it means that every payment method creation function has to implement a check for that flag which clutters those functions.

This PR removes `onlyLoadPaymentMethods`. `filterAppropriatePaymentMethods` already uses an array of payment methods to remove payment methods we don't want, and that array can already be overridden in the tests by controlling the shopping cart endpoint response.

Fixes https://github.com/Automattic/wp-calypso/issues/45003

Depends on https://github.com/Automattic/wp-calypso/pull/46828

#### Example

This simplifies all payment method creator functions in calypso. As an example of the differences, here's the Free payment method creator before this PR:

```js
function useCreateFree( { onlyLoadPaymentMethods } ) {
	const shouldLoadFreePaymentMethod = onlyLoadPaymentMethods
		? onlyLoadPaymentMethods.includes( 'free-purchase' )
		: true;
	const freePaymentMethod = useMemo( () => {
		if ( ! shouldLoadFreePaymentMethod ) {
			return null;
		}
		return createFreePaymentMethod();
	}, [ shouldLoadFreePaymentMethod ] );
	if ( freePaymentMethod ) {
		freePaymentMethod.label = <WordPressFreePurchaseLabel />;
		freePaymentMethod.inactiveContent = <WordPressFreePurchaseSummary />;
	}
	return freePaymentMethod;
}
```

And here's the same function afterward:

```js
function useCreateFree() {
	const freePaymentMethod = useMemo( createFreePaymentMethod, [] );
	freePaymentMethod.label = <WordPressFreePurchaseLabel />;
	freePaymentMethod.inactiveContent = <WordPressFreePurchaseSummary />;
	return freePaymentMethod;
}
```

#### Testing instructions

Firstly, make sure all unit tests pass, since that was the original reason this value existed.

Secondly, load checkout and verify that you see payment methods listed. Notably, look for saved cards and paypal.

Try loading checkout with enough credits to fully cover a purchase. Verify that only the full-credits payment method loads.
