### PR TITLE
Add block preview for Premium Content block

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
@@ -24,8 +24,21 @@ const alignmentHooksSetting = {
 	isEmbedButton: true,
 };
 
-function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
+function ButtonsEdit( { attributes, context, subscribeButton, setSubscribeButtonPlan } ) {
+	const { isPreview } = attributes;
 	const planId = context ? context[ 'premium-content/planId' ] : null;
+
+	const previewTemplate = [
+		[
+			'core/button',
+			{
+				element: 'a',
+				uniqueId: 'recurring-payments-id',
+				text: __( 'Subscribe', 'full-site-editing' ),
+			},
+		],
+		[ 'premium-content/login-button' ],
+	];
 
 	const template = [
 		[
@@ -81,7 +94,7 @@ function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 			<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
 				<InnerBlocks
 					allowedBlocks={ ALLOWED_BLOCKS }
-					template={ template }
+					template={ isPreview ? previewTemplate : template }
 					__experimentalMoverDirection="horizontal"
 					templateInsertUpdatesSelection={ false }
 				/>

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
@@ -24,9 +24,9 @@ const alignmentHooksSetting = {
 	isEmbedButton: true,
 };
 
-function ButtonsEdit( { attributes, context, subscribeButton, setSubscribeButtonPlan } ) {
-	const { isPreview } = attributes;
+function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 	const planId = context ? context[ 'premium-content/planId' ] : null;
+	const isPreview = context ? context[ 'premium-content/isPreview' ] : false;
 
 	const previewTemplate = [
 		[

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/index.js
@@ -23,6 +23,12 @@ const settings = {
 		'full-site-editing'
 	),
 	icon,
+	attributes: {
+		isPreview: {
+			type: 'boolean',
+			default: false,
+		},
+	},
 	supports: {
 		align: true,
 		alignWide: false,

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/index.js
@@ -23,12 +23,6 @@ const settings = {
 		'full-site-editing'
 	),
 	icon,
-	attributes: {
-		isPreview: {
-			type: 'boolean',
-			default: false,
-		},
-	},
 	supports: {
 		align: true,
 		alignWide: false,
@@ -37,7 +31,7 @@ const settings = {
 	keywords: [ __( 'link', 'full-site-editing' ) ],
 	edit,
 	save,
-	usesContext: [ 'premium-content/planId' ],
+	usesContext: [ 'premium-content/planId', 'premium-content/isPreview' ],
 };
 
 export { name, category, settings };

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
@@ -9,7 +9,7 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 } from '@wordpress/components';
-import { BlockControls, InnerBlocks } from '@wordpress/block-editor';
+import { BlockControls } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -311,24 +311,6 @@ function Edit( props ) {
 
 		return false;
 	};
-
-	if ( isPreview ) {
-		return (
-			<div className="premium-content-wrapper">
-				<InnerBlocks
-					templateLock={ false }
-					templateInsertUpdatesSelection={ false }
-					template={ [
-						[ 'premium-content/logged-out-view',
-							{
-								isPreview: true,
-							},
-						],
-					] }
-				/>
-			</div>
-		);
-	}
 
 	return (
 		<>

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
@@ -319,17 +319,7 @@ function Edit( props ) {
 					templateLock={ false }
 					templateInsertUpdatesSelection={ false }
 					template={ [
-						[
-							'core/heading',
-							{ content: __( 'Subscribe to get access', 'full-site-editing' ), level: 3 },
-						],
-						[
-							'core/paragraph',
-							{
-								content: __( 'Read more of this content when you subscribe today.', 'full-site-editing' ),
-							},
-						],
-						[ 'premium-content/buttons',
+						[ 'premium-content/logged-out-view',
 							{
 								isPreview: true,
 							},

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/edit.js
@@ -9,7 +9,7 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 } from '@wordpress/components';
-import { BlockControls } from '@wordpress/block-editor';
+import { BlockControls, InnerBlocks } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -96,6 +96,7 @@ function Edit( props ) {
 	const [ shouldUpgrade, setShouldUpgrade ] = useState( false );
 	// @ts-ignore needed in some upgrade flows - depending how we implement this
 	const [ siteSlug, setSiteSlug ] = useState( '' ); // eslint-disable-line
+	const { isPreview } = props.attributes;
 
 	/**
 	 * Hook to save a new plan.
@@ -212,6 +213,10 @@ function Edit( props ) {
 	const { isSelected, className } = props;
 
 	useEffect( () => {
+		if ( isPreview ) {
+			return;
+		}
+
 		const origin = getQueryArg( window.location.href, 'origin' );
 		const path = addQueryArgs( '/wpcom/v2/memberships/status', {
 			source: origin === 'https://wordpress.com' ? 'gutenberg-wpcom' : 'gutenberg',
@@ -284,7 +289,7 @@ function Edit( props ) {
 		setTimeout( () => props.selectBlock(), 1000 );
 	}, [] );
 
-	if ( apiState === API_STATE_LOADING ) {
+	if ( apiState === API_STATE_LOADING && ! isPreview ) {
 		return (
 			<div className={ className } ref={ wrapperRef }>
 				{ props.noticeUI }
@@ -306,6 +311,34 @@ function Edit( props ) {
 
 		return false;
 	};
+
+	if ( isPreview ) {
+		return (
+			<div className="premium-content-wrapper">
+				<InnerBlocks
+					templateLock={ false }
+					templateInsertUpdatesSelection={ false }
+					template={ [
+						[
+							'core/heading',
+							{ content: __( 'Subscribe to get access', 'full-site-editing' ), level: 3 },
+						],
+						[
+							'core/paragraph',
+							{
+								content: __( 'Read more of this content when you subscribe today.', 'full-site-editing' ),
+							},
+						],
+						[ 'premium-content/buttons',
+							{
+								isPreview: true,
+							},
+						],
+					] }
+				/>
+			</div>
+		);
+	}
 
 	return (
 		<>

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/index.js
@@ -154,6 +154,7 @@ const settings = {
 	save,
 	providesContext: {
 		'premium-content/planId': 'selectedPlanId',
+		'premium-content/isPreview': 'isPreview',
 	},
 };
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/index.js
@@ -66,6 +66,10 @@ const settings = {
 			type: 'number',
 			default: 0,
 		},
+		isPreview: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 	/**
 	 * This is the display title for your block, which can be translated with `i18n` functions.
@@ -90,6 +94,12 @@ const settings = {
 	 * These can be any of WordPress’ Dashicons, or a custom svg element.
 	 */
 	icon,
+
+	example: {
+		attributes: {
+			isPreview: true,
+		},
+	},
 
 	/**
 	 * Optional block extended support features.

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/edit.js
@@ -12,7 +12,7 @@ import { useEffect } from '@wordpress/element';
  */
 import Context from '../container/context';
 
-function Edit( { parentClientId, isSelected } ) {
+function Edit( { attributes, parentClientId, isSelected } ) {
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 
 	useEffect( () => {
@@ -45,7 +45,12 @@ function Edit( { parentClientId, isSelected } ) {
 									),
 								},
 							],
-							[ 'premium-content/buttons' ],
+							[
+								'premium-content/buttons',
+								{
+									isPreview: attributes.isPreview,
+								},
+							],
 						] }
 					/>
 				</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/edit.js
@@ -12,7 +12,7 @@ import { useEffect } from '@wordpress/element';
  */
 import Context from '../container/context';
 
-function Edit( { attributes, parentClientId, isSelected } ) {
+function Edit( { parentClientId, isSelected } ) {
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 
 	useEffect( () => {
@@ -45,12 +45,7 @@ function Edit( { attributes, parentClientId, isSelected } ) {
 									),
 								},
 							],
-							[
-								'premium-content/buttons',
-								{
-									isPreview: attributes.isPreview,
-								},
-							],
+							[ 'premium-content/buttons' ],
 						] }
 					/>
 				</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/index.js
@@ -26,12 +26,6 @@ const category = getCategoryWithFallbacks( 'design', 'common' );
 const settings = {
 	name,
 	category,
-	attributes: {
-		isPreview: {
-			type: 'boolean',
-			default: false,
-		},
-	},
 	/* translators: block name */
 	title: __( 'Logged Out View', 'full-site-editing' ),
 	/* translators: block description */

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/logged-out-view/index.js
@@ -26,7 +26,12 @@ const category = getCategoryWithFallbacks( 'design', 'common' );
 const settings = {
 	name,
 	category,
-	attributes: {},
+	attributes: {
+		isPreview: {
+			type: 'boolean',
+			default: false,
+		},
+	},
 	/* translators: block name */
 	title: __( 'Logged Out View', 'full-site-editing' ),
 	/* translators: block description */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a block preview for the Premium Content block.


##### Notes
For the block preview it is necessary to stub out the subscription logic. Most of the logic in this PR controls stubbing out the api calls and rendering a core button instead of the jetpack `recurring-payments` block when the block is being previewed.


<img width="530" alt="Screen Shot 2020-11-06 at 11 14 40 AM" src="https://user-images.githubusercontent.com/63313398/98405571-5363ef80-2021-11eb-89d9-124a97795d4f.png">

#### Testing instructions



* Create a new post and add a Premium Content block
- [ ] Make sure that the block renders correctly in the post body
- [ ] Verify that the "Subscribe" button for the block in the post body is a jetpack/recurring-payments block (you should be able to see this as `data-type` on the div in the browser inspector)

* Open the block list in the side panel and hover over the 'Premium Content' block in the search results
- [ ] Verify that the block preview displays correctly

