### PR TITLE
Checkout: Show G Suite user list for extra license products

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -20,7 +20,7 @@ import { useSelector } from 'react-redux';
 import joinClasses from './join-classes';
 import { useHasDomainsInCart } from '../hooks/has-domains';
 import { ItemVariationPicker } from './item-variation-picker';
-import { isGSuiteProductSlug } from 'calypso/lib/gsuite';
+import { isGSuiteProductSlug, isGSuiteOrExtraLicenseProductSlug } from 'calypso/lib/gsuite';
 import { planMatches, isWpComPlan } from 'calypso/lib/plans';
 import {
 	isMonthly as isMonthlyPlan,
@@ -73,7 +73,7 @@ function WPLineItem( {
 	const isRenewal = item.wpcom_meta?.extra?.purchaseId;
 	// Show the variation picker when this is not a renewal
 	const shouldShowVariantSelector = getItemVariants && item.wpcom_meta && ! isRenewal;
-	const isGSuite = isGSuiteProductSlug( item.wpcom_meta?.product_slug );
+	const isGSuite = isGSuiteOrExtraLicenseProductSlug( item.wpcom_meta?.product_slug );
 
 	const productSlug = item.wpcom_meta?.product_slug;
 
@@ -503,7 +503,7 @@ function LineItemSublabelAndPrice( { item, isMonthlyPricingTest = false } ) {
 	const translate = useTranslate();
 	const isDomainRegistration = item.wpcom_meta?.is_domain_registration;
 	const isDomainMap = item.type === 'domain_map';
-	const isGSuite = isGSuiteProductSlug( item.wpcom_meta?.product_slug );
+	const isGSuite = isGSuiteOrExtraLicenseProductSlug( item.wpcom_meta?.product_slug );
 
 	if ( item.type === 'plan' && item.wpcom_meta?.months_per_bill_period > 1 ) {
 		if ( isMonthlyPricingTest ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The order review step of checkout displays a list of email addresses being purchased for a new G Suite subscription, but it does not display them when buying extra licenses for an existing subscription. This PR corrects that oversight.

Fixes https://github.com/Automattic/wp-calypso/issues/45787

#### Testing instructions

- Add a G Suite extra license product to your cart (I don't actually know how to do this. 😅  Please help, @stephanethomas !)
- Verify that you see the list of new email addresses displayed in the "Your order" section of checkout.