### PR TITLE
Fetch restore progress details from `/restore` endpoint

### DIFF
--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -25,7 +25,18 @@ const startProgress = ( state, { timestamp } ) => ( {
 
 const updateProgress = (
 	state,
-	{ errorCode, failureReason, message, percent, restoreId, status, timestamp, rewindId, context }
+	{
+		errorCode,
+		failureReason,
+		message,
+		percent,
+		restoreId,
+		status,
+		timestamp,
+		rewindId,
+		context,
+		currentEntry,
+	}
 ) => ( {
 	errorCode,
 	failureReason,
@@ -36,6 +47,7 @@ const updateProgress = (
 	timestamp,
 	rewindId,
 	context,
+	currentEntry,
 } );
 
 export const restoreProgress = withSchemaValidation(

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -65,6 +65,7 @@ export const fromApi = ( {
 		status = '',
 		rewind_id = '',
 		context = '',
+		current_entry = '',
 	} = {},
 } ) => ( {
 	errorCode: error_code,
@@ -74,6 +75,7 @@ export const fromApi = ( {
 	status,
 	rewindId: rewind_id,
 	context,
+	currentEntry: current_entry,
 } );
 
 export const updateProgress = ( { siteId, restoreId, timestamp }, data ) =>

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
@@ -24,6 +24,7 @@ const FINISHED_RESPONSE = deepFreeze( {
 		status: 'finished',
 		rewindId: '',
 		context: 'main',
+		currentEntry: '',
 	},
 } );
 
@@ -38,6 +39,7 @@ describe( 'receiveRestoreProgress', () => {
 			status: 'finished',
 			rewindId: '',
 			context: 'main',
+			currentEntry: '',
 		} );
 		expect( action ).toEqual( expectedAction );
 	} );

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/type.ts
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/type.ts
@@ -1,0 +1,10 @@
+export interface RestoreProgress {
+	errorCode: string;
+	failureReason: string;
+	message: string;
+	percent: number;
+	status: string;
+	rewindId: string;
+	context: string;
+	currentEntry: string;
+}

--- a/client/state/selectors/get-restore-progress.ts
+++ b/client/state/selectors/get-restore-progress.ts
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Type dependencies
+ */
+import { AppState } from 'calypso/types';
+import type { RestoreProgress } from 'calypso/state/data-layer/wpcom/activity-log/rewind/restore-status/type';
+
+/**
+ * Get the progress details of a restore for a specified site
+ *
+ * @param {AppState} state Global state tree
+ * @param {number | string} siteId the site ID
+ * @returns {RestoreProgress} Progress details
+ */
+export default function getRestoreProgress(
+	state: AppState,
+	siteId: number | string
+): RestoreProgress | undefined {
+	return state.activityLog?.restoreProgress?.[ siteId ];
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR is a sequel of #47153. It retrieves data from a different endpoint in order to show more granular percentage and to display the entry being restored.

### Testing instructions

- Run this PR in Calypso or Jetpack cloud
- Select a self-hosted Jetpack site that has a Backup product, and more than one backup
- Make sure you have set server credentials to enable restores
- Visit the _Backup_ section, select a backup to restore, and click _Restore to this point_, the _Confirm restore_
- Check that you see the message and current entry returned by the API, respectively above and below the progress bar
- Make sure the order of messages makes sense and that there's no big jump in the progress bar
