### PR TITLE
Checkout: Disallow redirect payment methods in desktop app with new checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -11,8 +11,23 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 import { CheckoutCartItem } from '../types/checkout-cart';
 import { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
 import doesPurchaseHaveFullCredits from './does-purchase-have-full-credits';
+import config from 'calypso/config';
 
 const debug = debugFactory( 'calypso:composite-checkout:filter-appropriate-payment-methods' );
+
+const redirectPaymentMethods = [
+	'alipay',
+	'bancontact',
+	'eps',
+	'giropay',
+	'ideal',
+	'netbanking',
+	'paypal',
+	'p24',
+	'brazil-tef',
+	'wechat',
+	'sofort',
+];
 
 export default function filterAppropriatePaymentMethods( {
 	paymentMethodObjects,
@@ -97,9 +112,18 @@ function isPaymentMethodEnabled(
 	method: CheckoutPaymentMethodSlug,
 	allowedPaymentMethods: null | CheckoutPaymentMethodSlug[]
 ): boolean {
+	// Redirect payments might not be possible in some cases - for example in the desktop app
+	if (
+		redirectPaymentMethods.includes( method ) &&
+		! config.isEnabled( 'upgrades/redirect-payments' )
+	) {
+		return false;
+	}
+
 	// By default, allow all payment methods
 	if ( ! allowedPaymentMethods?.length ) {
 		return true;
 	}
+
 	return allowedPaymentMethods.includes( method );
 }

--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -11,7 +11,10 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 import type { CheckoutCartItem } from '../types/checkout-cart';
 import type { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
 import doesPurchaseHaveFullCredits from './does-purchase-have-full-credits';
-import { isRedirectPaymentMethod } from './translate-payment-method-names';
+import {
+	isRedirectPaymentMethod,
+	readCheckoutPaymentMethodSlug,
+} from './translate-payment-method-names';
 import config from 'calypso/config';
 
 const debug = debugFactory( 'calypso:composite-checkout:filter-appropriate-payment-methods' );
@@ -75,15 +78,19 @@ export default function filterAppropriatePaymentMethods( {
 			if ( methodObject.id.startsWith( 'existingCard-' ) ) {
 				return isPaymentMethodEnabled( 'card', allowedPaymentMethods );
 			}
-			if ( methodObject.id === 'full-credits' ) {
+			const slug = readCheckoutPaymentMethodSlug( methodObject.id );
+			if ( ! slug ) {
+				return false;
+			}
+			if ( slug === 'full-credits' ) {
 				// If the full-credits payment method still exists here (see above filter), it's enabled
 				return true;
 			}
-			if ( methodObject.id === 'free-purchase' ) {
+			if ( slug === 'free-purchase' ) {
 				// If the free payment method still exists here (see above filter), it's enabled
 				return true;
 			}
-			return isPaymentMethodEnabled( methodObject.id, allowedPaymentMethods );
+			return isPaymentMethodEnabled( slug, allowedPaymentMethods );
 		} )
 		.filter( ( methodObject ) => ! isPaymentMethodLegallyRestricted( methodObject.id ) );
 }

--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -11,11 +11,8 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 import type { CheckoutCartItem } from '../types/checkout-cart';
 import type { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
 import doesPurchaseHaveFullCredits from './does-purchase-have-full-credits';
-import {
-	isRedirectPaymentMethod,
-	readCheckoutPaymentMethodSlug,
-} from './translate-payment-method-names';
-import config from 'calypso/config';
+import { readCheckoutPaymentMethodSlug } from './translate-payment-method-names';
+import isPaymentMethodEnabled from './is-payment-method-enabled';
 
 const debug = debugFactory( 'calypso:composite-checkout:filter-appropriate-payment-methods' );
 
@@ -92,21 +89,4 @@ export default function filterAppropriatePaymentMethods( {
 			}
 			return isPaymentMethodEnabled( slug, allowedPaymentMethods );
 		} );
-}
-
-function isPaymentMethodEnabled(
-	slug: CheckoutPaymentMethodSlug,
-	allowedPaymentMethods: null | CheckoutPaymentMethodSlug[]
-): boolean {
-	// Redirect payments might not be possible in some cases - for example in the desktop app
-	if ( isRedirectPaymentMethod( slug ) && ! config.isEnabled( 'upgrades/redirect-payments' ) ) {
-		return false;
-	}
-
-	// By default, allow all payment methods
-	if ( ! allowedPaymentMethods?.length ) {
-		return true;
-	}
-
-	return allowedPaymentMethods.includes( slug );
 }

--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -91,15 +91,7 @@ export default function filterAppropriatePaymentMethods( {
 				return true;
 			}
 			return isPaymentMethodEnabled( slug, allowedPaymentMethods );
-		} )
-		.filter( ( methodObject ) => ! isPaymentMethodLegallyRestricted( methodObject.id ) );
-}
-
-function isPaymentMethodLegallyRestricted( paymentMethodId: CheckoutPaymentMethodSlug ): boolean {
-	// Add the names of any legally-restricted payment methods to this list.
-	const restrictedPaymentMethods: CheckoutPaymentMethodSlug[] = [];
-
-	return restrictedPaymentMethods.includes( paymentMethodId );
+		} );
 }
 
 function isPaymentMethodEnabled(

--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -8,26 +8,13 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 /**
  * Internal dependencies
  */
-import { CheckoutCartItem } from '../types/checkout-cart';
-import { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
+import type { CheckoutCartItem } from '../types/checkout-cart';
+import type { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
 import doesPurchaseHaveFullCredits from './does-purchase-have-full-credits';
+import { isRedirectPaymentMethod } from './translate-payment-method-names';
 import config from 'calypso/config';
 
 const debug = debugFactory( 'calypso:composite-checkout:filter-appropriate-payment-methods' );
-
-const redirectPaymentMethods = [
-	'alipay',
-	'bancontact',
-	'eps',
-	'giropay',
-	'ideal',
-	'netbanking',
-	'paypal',
-	'p24',
-	'brazil-tef',
-	'wechat',
-	'sofort',
-];
 
 export default function filterAppropriatePaymentMethods( {
 	paymentMethodObjects,
@@ -109,14 +96,11 @@ function isPaymentMethodLegallyRestricted( paymentMethodId: CheckoutPaymentMetho
 }
 
 function isPaymentMethodEnabled(
-	method: CheckoutPaymentMethodSlug,
+	slug: CheckoutPaymentMethodSlug,
 	allowedPaymentMethods: null | CheckoutPaymentMethodSlug[]
 ): boolean {
 	// Redirect payments might not be possible in some cases - for example in the desktop app
-	if (
-		redirectPaymentMethods.includes( method ) &&
-		! config.isEnabled( 'upgrades/redirect-payments' )
-	) {
+	if ( isRedirectPaymentMethod( slug ) && ! config.isEnabled( 'upgrades/redirect-payments' ) ) {
 		return false;
 	}
 
@@ -125,5 +109,5 @@ function isPaymentMethodEnabled(
 		return true;
 	}
 
-	return allowedPaymentMethods.includes( method );
+	return allowedPaymentMethods.includes( slug );
 }

--- a/client/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled.ts
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import type { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
+import { isRedirectPaymentMethod } from './translate-payment-method-names';
+import config from 'calypso/config';
+
+export default function isPaymentMethodEnabled(
+	slug: CheckoutPaymentMethodSlug,
+	allowedPaymentMethods: null | CheckoutPaymentMethodSlug[]
+): boolean {
+	// Redirect payments might not be possible in some cases - for example in the desktop app
+	if ( isRedirectPaymentMethod( slug ) && ! config.isEnabled( 'upgrades/redirect-payments' ) ) {
+		return false;
+	}
+
+	// By default, allow all payment methods
+	if ( ! allowedPaymentMethods?.length ) {
+		return true;
+	}
+
+	return allowedPaymentMethods.includes( slug );
+}

--- a/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
@@ -132,6 +132,32 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 	return null;
 }
 
+export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMethodSlug | null {
+	switch ( slug ) {
+		case 'ebanx':
+		case 'brazil-tef':
+		case 'netbanking':
+		case 'id_wallet':
+		case 'paypal-direct':
+		case 'paypal':
+		case 'card':
+		case 'alipay':
+		case 'bancontact':
+		case 'eps':
+		case 'giropay':
+		case 'ideal':
+		case 'p24':
+		case 'sofort':
+		case 'stripe-three-d-secure':
+		case 'wechat':
+		case 'apple-pay':
+		case 'full-credits':
+		case 'free-purchase':
+			return slug;
+	}
+	return null;
+}
+
 export function translateCheckoutPaymentMethodToTracksPaymentMethod(
 	paymentMethod: CheckoutPaymentMethodSlug
 ): string {

--- a/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
@@ -148,3 +148,20 @@ export function translateCheckoutPaymentMethodToTracksPaymentMethod(
 	}
 	return snakeCase( paymentMethodSlug );
 }
+
+export function isRedirectPaymentMethod( slug: CheckoutPaymentMethodSlug ): boolean {
+	const redirectPaymentMethods = [
+		'alipay',
+		'bancontact',
+		'eps',
+		'giropay',
+		'ideal',
+		'netbanking',
+		'paypal',
+		'p24',
+		'brazil-tef',
+		'wechat',
+		'sofort',
+	];
+	return redirectPaymentMethods.includes( slug );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `upgrades/redirect-payments` config option, disabled in the desktop app, is supposed to control if redirect payment methods are available. It does not do so in new checkout. This PR fixes that oversight.

Fixes https://github.com/Automattic/wp-calypso/issues/47214

Depends on https://github.com/Automattic/wp-calypso/pull/47260
This is part of a chain of related PRs. The next one is https://github.com/Automattic/wp-calypso/pull/47261

#### Testing instructions

- Visit checkout in a browser. Verify that the PayPal payment method is listed.
- Visit checkout in a desktop app. Verify that the PayPal payment method is _not_ listed. You can simulate this by changing the `upgrades/redirect-payments` config option to be `false` in `config/development.json`.