### PR TITLE
Gutenboarding: plans grid requests data in the correct locale

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
@@ -39,7 +39,7 @@ function enqueue_script_and_style() {
 		'a8c-fse-editor-site-launch-script',
 		'wpcomEditorSiteLaunch',
 		array(
-			'locale' => get_locale(),
+			'locale' => determine_locale(),
 		)
 	);
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
@@ -35,6 +35,14 @@ function enqueue_script_and_style() {
 
 	wp_set_script_translations( 'a8c-fse-editor-site-launch-script', 'full-site-editing' );
 
+	wp_localize_script(
+		'a8c-fse-editor-site-launch-script',
+		'wpcomEditorSiteLaunch',
+		array(
+			'locale' => get_locale(),
+		)
+	);
+
 	wp_enqueue_style(
 		'a8c-fse-editor-site-launch-style',
 		plugins_url( 'dist/editor-site-launch.css', __FILE__ ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/constants.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/constants.ts
@@ -1,1 +1,9 @@
 export const FLOW_ID = 'gutenboarding';
+
+declare global {
+	interface Window {
+		wpcomEditorSiteLaunch?: {
+			locale?: string;
+		};
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -36,7 +36,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 	const domain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
 	const plan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
 	const planPrices = useSelect( ( select ) =>
-		select( PLANS_STORE ).getPrices( document.documentElement.lang )
+		select( PLANS_STORE ).getPrices( window.wpcomEditorSiteLaunch?.locale || 'en' )
 	);
 	const LaunchStep = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchStep() );
 	const isStepCompleted = useSelect( ( select ) => select( LAUNCH_STORE ).isStepCompleted );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -35,7 +35,9 @@ const TickIcon = <Icon icon={ check } size={ 17 } />;
 const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, onPrevStep } ) => {
 	const domain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
 	const plan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
-	const planPrices = useSelect( ( select ) => select( PLANS_STORE ).getPrices() );
+	const planPrices = useSelect( ( select ) =>
+		select( PLANS_STORE ).getPrices( document.documentElement.lang )
+	);
 	const LaunchStep = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchStep() );
 	const isStepCompleted = useSelect( ( select ) => select( LAUNCH_STORE ).isStepCompleted );
 	const isFlowCompleted = useSelect( ( select ) => select( LAUNCH_STORE ).isFlowCompleted() );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -70,6 +70,7 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 					}
 					isExperimental={ isExperimental }
 					selectedFeatures={ selectedFeatures }
+					locale={ document.documentElement.lang }
 				/>
 			</div>
 			<div className="nux-launch-step__footer">

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -70,7 +70,7 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 					}
 					isExperimental={ isExperimental }
 					selectedFeatures={ selectedFeatures }
-					locale={ document.documentElement.lang }
+					locale={ window.wpcomEditorSiteLaunch?.locale || 'en' }
 				/>
 			</div>
 			<div className="nux-launch-step__footer">

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -28,7 +28,7 @@ interface Props {
 }
 
 const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
-	const { __ } = useI18n();
+	const { __, i18nLocale: locale } = useI18n();
 	const history = useHistory();
 	const makePath = usePath();
 	const { goBack, goNext } = useStepNavigation();
@@ -109,6 +109,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				onPickDomainClick={ handlePickDomain }
 				isExperimental={ isEnabled( 'gutenboarding/feature-picker' ) }
 				selectedFeatures={ selectedFeatures }
+				locale={ locale }
 			/>
 		</div>
 	);

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { controls } from '@wordpress/data-controls';
 import { registerStore } from '@wordpress/data';
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 
@@ -13,6 +12,7 @@ import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
 import * as resolvers from './resolvers';
+import { controls } from '../wpcom-request-controls';
 
 export type { State };
 export type { Plan, PlanSlug } from './types';
@@ -35,7 +35,7 @@ export function register(): typeof STORE_KEY {
 		registerStore< State >( STORE_KEY, {
 			resolvers,
 			actions,
-			controls,
+			controls: controls as any,
 			reducer: reducer as any,
 			selectors,
 		} );

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { stringify } from 'qs';
+
+/**
  * Internal dependencies
  */
 import { setFeatures, setFeaturesByType, setPlans, setPrices } from './actions';
@@ -12,7 +17,7 @@ import {
 	PLAN_ECOMMERCE,
 	plansProductSlugs,
 } from './constants';
-import { fetchAndParse } from '../wpcom-request-controls';
+import { fetchAndParse, wpcomRequest } from '../wpcom-request-controls';
 
 /**
  * Calculates the monthly price of a plan
@@ -36,10 +41,11 @@ function getMonthlyPrice( plan: APIPlan ) {
 	return `${ currency.symbol }${ price }`;
 }
 
-export function* getPrices() {
-	const { body: plans } = yield fetchAndParse( 'https://public-api.wordpress.com/rest/v1.5/plans', {
-		mode: 'cors',
-		credentials: 'omit',
+export function* getPrices( locale = 'en' ) {
+	const plans = yield wpcomRequest( {
+		path: '/plans',
+		query: stringify( { locale } ),
+		apiVersion: '1.5',
 	} );
 
 	// filter for supported plans

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -39,7 +39,7 @@ export const getPlansPaths = ( state: State ) => {
 	return getSupportedPlans( state ).map( ( plan ) => plan?.pathSlug );
 };
 
-export const getPrices = ( state: State ) => state.prices;
+export const getPrices = ( state: State, _: string ) => state.prices; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 export const isPlanEcommerce = ( _: State, planSlug?: PlanSlug ) => {
 	return planSlug === PLAN_ECOMMERCE;

--- a/packages/plans-grid/src/plans-accordion/index.tsx
+++ b/packages/plans-grid/src/plans-accordion/index.tsx
@@ -35,6 +35,7 @@ export interface Props {
 	onPickDomainClick?: () => void;
 	currentDomain?: DomainSuggestions.DomainSuggestion;
 	disabledPlans?: { [ planSlug: string ]: string };
+	locale: string;
 }
 
 const PlansTable: React.FunctionComponent< Props > = ( {
@@ -44,9 +45,10 @@ const PlansTable: React.FunctionComponent< Props > = ( {
 	onPickDomainClick,
 	currentDomain,
 	disabledPlans,
+	locale,
 } ) => {
 	const supportedPlans = useSelect( ( select ) => select( PLANS_STORE ).getSupportedPlans() );
-	const prices = useSelect( ( select ) => select( PLANS_STORE ).getPrices() );
+	const prices = useSelect( ( select ) => select( PLANS_STORE ).getPrices( locale ) );
 
 	const isLoading = ! supportedPlans?.length;
 	const placeholderPlans = [ 1, 2, 3, 4 ];

--- a/packages/plans-grid/src/plans-details/index.tsx
+++ b/packages/plans-grid/src/plans-details/index.tsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { useI18n } from '@automattic/react-i18n';
 import { useSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
@@ -22,16 +21,15 @@ const TickIcon = <Icon icon={ check } size={ 25 } />;
 
 type Props = {
 	onSelect: ( storeSlug: string ) => void;
+	locale: string;
 };
 
-const PlansDetails: React.FunctionComponent< Props > = ( { onSelect } ) => {
-	const { i18nLocale } = useI18n();
-
+const PlansDetails: React.FunctionComponent< Props > = ( { onSelect, locale } ) => {
 	const { features, featuresByType, plans } = useSelect( ( select ) =>
-		select( PLANS_STORE ).getPlansDetails( i18nLocale )
+		select( PLANS_STORE ).getPlansDetails( locale )
 	);
 
-	const prices = useSelect( ( select ) => select( PLANS_STORE ).getPrices() );
+	const prices = useSelect( ( select ) => select( PLANS_STORE ).getPrices( locale ) );
 	const supportedPlans = useSelect( ( select ) => select( PLANS_STORE ).getSupportedPlans() );
 
 	const isLoading = ! supportedPlans?.length;

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -33,6 +33,7 @@ export interface Props {
 	currentDomain?: DomainSuggestions.DomainSuggestion;
 	disabledPlans?: { [ planSlug: string ]: string };
 	isExperimental?: boolean;
+	locale: string;
 }
 
 const PlansGrid: React.FunctionComponent< Props > = ( {
@@ -44,6 +45,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 	onPickDomainClick,
 	disabledPlans,
 	isExperimental,
+	locale,
 } ) => {
 	// Note: isExperimental prop would be always false until "gutenboarding/feature-picker" feature flag is enabled
 	// and Gutenboarding flow is started with ?latest query param
@@ -63,6 +65,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 							currentDomain={ currentDomain }
 							onPickDomainClick={ onPickDomainClick }
 							disabledPlans={ disabledPlans }
+							locale={ locale }
 						></PlansAccordion>
 					) : (
 						<PlansTable
@@ -71,6 +74,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 							currentDomain={ currentDomain }
 							onPickDomainClick={ onPickDomainClick }
 							disabledPlans={ disabledPlans }
+							locale={ locale }
 						></PlansTable>
 					) }
 				</div>
@@ -81,7 +85,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 					<Title>{ __( 'Detailed comparison', __i18n_text_domain__ ) }</Title>
 				</div>
 				<div className="plans-grid__details-container">
-					<PlansDetails onSelect={ onPlanSelect } />
+					<PlansDetails onSelect={ onPlanSelect } locale={ locale } />
 				</div>
 			</div>
 		</div>

--- a/packages/plans-grid/src/plans-table/index.tsx
+++ b/packages/plans-grid/src/plans-table/index.tsx
@@ -22,6 +22,7 @@ export interface Props {
 	onPickDomainClick?: () => void;
 	currentDomain?: DomainSuggestions.DomainSuggestion;
 	disabledPlans?: { [ planSlug: string ]: string };
+	locale: string;
 }
 
 const PlansTable: React.FunctionComponent< Props > = ( {
@@ -30,9 +31,10 @@ const PlansTable: React.FunctionComponent< Props > = ( {
 	onPickDomainClick,
 	currentDomain,
 	disabledPlans,
+	locale,
 } ) => {
 	const supportedPlans = useSelect( ( select ) => select( PLANS_STORE ).getSupportedPlans() );
-	const prices = useSelect( ( select ) => select( PLANS_STORE ).getPrices() );
+	const prices = useSelect( ( select ) => select( PLANS_STORE ).getPrices( locale ) );
 	const [ allPlansExpanded, setAllPlansExpanded ] = useState( false );
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a number of i18n issues with the plans grid. It was already localised in gutenboarding but should now also work in the launch flow in ETK. Also fixed bug where the currency of the plans for logged in users was being guessed rather than using the currency that's set for that specific user.

* Send current locale to client as `wpcomEditorSiteLaunch.locale` global in ETK
* Plans store requests plan data using the `?locale` query param
  * Requests made in the ETK use `wpcomEditorSiteLaunch.locale` to set the locale param
  * Requests make in gutenboarding use the `useI18n()` hook to set the locale param
* Plan store no longer uses the `apiFetch()` from `@wordpress/data-controls` to request data, that way it's not running through WP core specific middleware that adds an unused `?_locale` query param
* Plan store's `/plans` request is now authenticated (it sends cookies too) so that the user's correct currency is used
* Update unit tests

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set your locale to something non-en
* Set your currency in Store Admin to something that wouldn't be a reasonable assumption based on your IP
* View the plans grid in gutenboarding: it should be translated and the prices should be in your selected currency
* Apply D52491-code and sandbox an unlaunched site.
* View the plans grid in the launch flow: it should be translated and the prices should be in your selected currency
* Open gutenboarding in incognito tab: the currency in the plans grid should be a decent guess given your IP
