### PR TITLE
Restrict upgrade from annual to monthly plans

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
@@ -14,8 +14,11 @@ import joinClasses from './join-classes';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import { isLineItemADomain } from '../hooks/has-domains';
-import { isWpComPlan, getBillingMonthsForPlan } from 'calypso/lib/plans';
+import { isWpComPlan, getBillingMonthsForPlan, isWpComFreePlan } from 'calypso/lib/plans';
 import { getABTestVariation } from 'calypso/lib/abtest';
+import { isMonthly } from 'calypso/lib/plans/constants';
+import { useSelector } from 'react-redux';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 
 export default function WPCheckoutOrderReview( {
 	className,
@@ -28,6 +31,7 @@ export default function WPCheckoutOrderReview( {
 	siteUrl,
 	isSummary,
 	createUserAndSiteBeforeTransaction,
+	siteId,
 } ) {
 	const translate = useTranslate();
 	const [ items, total ] = useLineItems();
@@ -48,8 +52,15 @@ export default function WPCheckoutOrderReview( {
 	const hasRenewal = Boolean(
 		items.find( ( { wpcom_meta } ) => 'renewal' === wpcom_meta?.extra?.purchaseType )
 	);
+	const currentPlanProductSlug = useSelector( ( state ) => getCurrentPlan( state, siteId ) )
+		?.productSlug;
+	const hasFreeOrMonthlySubscription =
+		isWpComFreePlan( currentPlanProductSlug ) || isMonthly( currentPlanProductSlug );
 	const isMonthlyPricingTest =
-		hasDotcomPlan && ! hasRenewal && 'treatment' === getABTestVariation( 'monthlyPricing' );
+		hasDotcomPlan &&
+		! hasRenewal &&
+		hasFreeOrMonthlySubscription &&
+		'treatment' === getABTestVariation( 'monthlyPricing' );
 	const itemsForMonthlyPricing =
 		isMonthlyPricingTest && items.map( ( item ) => overrideItemSublabel( item, translate ) );
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
@@ -52,10 +52,12 @@ export default function WPCheckoutOrderReview( {
 	const hasRenewal = Boolean(
 		items.find( ( { wpcom_meta } ) => 'renewal' === wpcom_meta?.extra?.purchaseType )
 	);
-	const currentPlanProductSlug = useSelector( ( state ) => getCurrentPlan( state, siteId ) )
-		?.productSlug;
+	const currentPlanProductSlug = useSelector(
+		( state ) => siteId && getCurrentPlan( state, siteId )
+	)?.productSlug;
 	const hasFreeOrMonthlySubscription =
-		isWpComFreePlan( currentPlanProductSlug ) || isMonthly( currentPlanProductSlug );
+		currentPlanProductSlug &&
+		( isWpComFreePlan( currentPlanProductSlug ) || isMonthly( currentPlanProductSlug ) );
 	const isMonthlyPricingTest =
 		hasDotcomPlan &&
 		! hasRenewal &&

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -320,6 +320,7 @@ export default function WPCheckout( {
 							onChangePlanLength={ changePlanLength }
 							getItemVariants={ getItemVariants }
 							siteUrl={ siteUrl }
+							siteId={ siteId }
 							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						/>
 					}
@@ -330,6 +331,7 @@ export default function WPCheckout( {
 							couponStatus={ couponStatus }
 							couponFieldStateProps={ couponFieldStateProps }
 							siteUrl={ siteUrl }
+							siteId={ siteId }
 						/>
 					}
 					editButtonText={ translate( 'Edit' ) }

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -186,12 +186,12 @@ WPLineItem.propTypes = {
 };
 
 function LineItemPrice( { item, isSummary } ) {
-	const originalAmountDisplay =
-		item.wpcom_meta?.related_monthly_plan_cost_display ||
-		item.wpcom_meta?.item_original_subtotal_display;
-	const originalAmountInteger =
-		item.wpcom_meta?.related_monthly_plan_cost_integer ||
-		item.wpcom_meta?.item_original_subtotal_integer;
+	let originalAmountDisplay = item.wpcom_meta?.item_original_subtotal_display;
+	let originalAmountInteger = item.wpcom_meta?.item_original_subtotal_integer;
+	if ( item.wpcom_meta?.related_monthly_plan_cost_integer ) {
+		originalAmountInteger = item.wpcom_meta?.related_monthly_plan_cost_integer;
+		originalAmountDisplay = item.wpcom_meta?.related_monthly_plan_cost_display;
+	}
 	const isDiscounted = item.amount.value < originalAmountInteger && originalAmountDisplay;
 	const actualAmount = item.amount.displayValue;
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sets the `originalAmountDisplay` (string) variable only if the `originalAmountInteger` var exists and is non-zero.
* Shows the monthly plan only if the user is on a free or monthly plan. This effectively hides the monthly plan if upgrading from a yearly/biyearly plan.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
### Upgrading from a Premium annual to a Business monthly plan
* Assign yourself to `treatment` variant of the `monthlyPricing` AB test.
* Purchase the Premium annual plan
* From `/plans`, upgrade to the Business plan
* On the checkout screen, the original price (striked out) should be the original cost of the plan
* On clicking "Edit", the monthly plan should not be visible.
![image](https://user-images.githubusercontent.com/5436027/98543707-df437900-22b8-11eb-9691-1f0b3d190c4b.png)

### Purchasing a new monthly plan
* Assign yourself to `treatment` variant of the `monthlyPricing` AB test.
* Proceed with any paid plan
* The original price (striked out) should be the (cost of the monthly plan * 12) for yearly and (cost of the monthly plan * 24) for biyearly.
* The monthly plan should be visible in the picker.
* ![screenshot](https://d.pr/i/e823S1+) **Image Link:** https://d.pr/i/e823S1

### Upgrading from a monthly plan to another monthly plan
*  Assign yourself to `treatment` variant of the `monthlyPricing` AB test.
* Purchase the Business monthly plan
* From `/plans`, upgrade to the eCommerce plan
* On the checkout screen, the original price (striked out) should be the original cost of the plan
* On clicking "Edit", the monthly plan should be visible.
![screenshot](https://d.pr/i/7qEC2r+) **Image Link:** https://d.pr/i/7qEC2r