### PR TITLE
Domains: Remove toUpper in favor of String.prototype.toUpperCase

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
-import { defaults, get, identity, isEmpty, isString, map, noop, set, toUpper, uniq } from 'lodash';
+import { defaults, get, identity, isEmpty, isString, map, noop, set, uniq } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,7 +38,7 @@ function onlyNumericCharacters( string ) {
  * letters, plus or star symbols.
  */
 export function sanitizeVat( string ) {
-	return isString( string ) ? toUpper( string ).replace( /[^0-9A-Z+*]/g, '' ) : '';
+	return isString( string ) ? string.toUpperCase().replace( /[^0-9A-Z+*]/g, '' ) : '';
 }
 
 // If we set a field to null, react decides it's uncontrolled and complains

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { find, isEmpty, startsWith, toUpper } from 'lodash';
+import { find, isEmpty, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
 
@@ -75,7 +75,7 @@ class SelectIpsTag extends Component {
 		return this.state.ipsTagList
 			.filter(
 				( hint ) =>
-					this.state.currentQuery && startsWith( hint.tag, toUpper( this.state.currentQuery ) )
+					this.state.currentQuery && startsWith( hint.tag, this.state.currentQuery.toUpperCase() )
 			)
 			.map( ( hint ) => ( { label: hint.tag + '  (' + hint.registrarName + ')' } ) );
 	}
@@ -89,7 +89,7 @@ class SelectIpsTag extends Component {
 		let selectedRegistrar = this.getRegistrarInfo( ipsTagInput, ipsTagList );
 
 		if ( isEmpty( selectedRegistrar ) ) {
-			selectedRegistrar = { tag: toUpper( ipsTagInput ), registrarName: '', registrarUrl: '' };
+			selectedRegistrar = { tag: ipsTagInput.toUpperCase(), registrarName: '', registrarUrl: '' };
 		}
 
 		this.setState( {


### PR DESCRIPTION
Currently, we use lodash's `toUpper` at a couple of locations, where we can just use `.toUpperCase`. This PR does that.

#### Changes proposed in this Pull Request

* Domains: Remove lodash `toUpper` in favor of `String.prototype.toUpperCase`

#### Testing instructions

Due to my limited understanding of the domains code, those might not be 100% accurate, cc @Automattic/cobalt just in case:

* Verify transferring a `.uk` domain (specifically, IPS tag suggestions and selecting an IPS tag) still works well.
* Verify that when purchasing a `.fr` domain for a company we still properly uppercase the VAT ID.
