### PR TITLE
Framework: Remove toLower in favor of String.prototype.toLowerCase

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -16,7 +16,6 @@ import {
 	merge,
 	reject,
 	some,
-	toLower,
 	uniq,
 } from 'lodash';
 import emailValidator from 'email-validator';
@@ -1183,7 +1182,9 @@ export function isNextDomainFree( cart, domain = '' ) {
 export function isDomainBundledWithPlan( cart, domain ) {
 	const bundledDomain = get( cart, 'bundled_domain', '' );
 
-	return '' !== bundledDomain && toLower( domain ) === toLower( get( cart, 'bundled_domain', '' ) );
+	return (
+		'' !== bundledDomain && domain.toLowerCase() === get( cart, 'bundled_domain', '' ).toLowerCase()
+	);
 }
 
 /**

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1182,7 +1182,7 @@ export function isNextDomainFree( cart, domain = '' ) {
 export function isDomainBundledWithPlan( cart, domain ) {
 	const bundledDomain = get( cart, 'bundled_domain', '' );
 
-	return '' !== bundledDomain && domain.toLowerCase() === bundledDomain.toLowerCase();
+	return '' !== bundledDomain && ( domain ?? '' ).toLowerCase() === bundledDomain.toLowerCase();
 }
 
 /**

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1182,9 +1182,7 @@ export function isNextDomainFree( cart, domain = '' ) {
 export function isDomainBundledWithPlan( cart, domain ) {
 	const bundledDomain = get( cart, 'bundled_domain', '' );
 
-	return (
-		'' !== bundledDomain && domain.toLowerCase() === get( cart, 'bundled_domain', '' ).toLowerCase()
-	);
+	return '' !== bundledDomain && domain.toLowerCase() === bundledDomain.toLowerCase();
 }
 
 /**

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -3,7 +3,7 @@
  */
 
 import { translate } from 'i18n-calypso';
-import { find, includes, toLower } from 'lodash';
+import { find, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -47,7 +47,7 @@ const showErrorNotice = ( error ) => {
 		incompatible: translate( 'The uploaded file is not a compatible plugin.' ),
 		unsupported_mime_type: translate( 'The uploaded file is not a valid zip.' ),
 	};
-	const errorString = toLower( error.error + error.message );
+	const errorString = `${ error.error }${ error.message }`.toLowerCase();
 	const knownError = find( knownErrors, ( v, key ) => includes( errorString, key ) );
 
 	if ( knownError ) {


### PR DESCRIPTION
Currently, we use lodash's `toLower` at a couple of locations, where we can just use `.toLowerCase`. This PR does that.

#### Changes proposed in this Pull Request

* Domains: Remove lodash `toLower` in favor of `String.prototype.toLowerCase`

#### Testing instructions

* Open `/plugins/upload/:site` where `:site` is a Jetpack site.
* Try uploading a plugin that is already installed and is active on the site.
* Verify you're still getting a "This plugin is already installed on your site." notice and not a cryptic one.
* Go to `/domains/add/mapping/:site?initialQuery=store.com` where `:site` is one of your WP.com sites with a paid plan without a domain purchased, and verify you see a "Free with your plan" message at the top right (cc @Automattic/cobalt if that's the best way to verify `isDomainBundledWithPlan` still works well).
