### PR TITLE
Use JS to trigger hover and reposition the flyout

### DIFF
--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -60,6 +60,12 @@ export const ExpandableSidebarMenu = ( {
 	const submenu = useRef();
 	const [ submenuHovered, setSubmenuHovered ] = useState( false );
 
+	if ( submenu.current ) {
+		// Sets flyout to expand towards bottom
+		submenu.current.style.bottom = 'auto';
+		submenu.current.style.top = 0;
+	}
+
 	if ( null === expanded ) {
 		expanded = containsSelectedSidebarItem( children );
 	}
@@ -90,7 +96,9 @@ export const ExpandableSidebarMenu = ( {
 
 	useLayoutEffect( () => {
 		if ( submenuHovered && offScreen( submenu.current ) ) {
-			submenu.current.style = 'bottom: 0; top:auto';
+			// Sets flyout to expand towards top
+			submenu.current.style.bottom = 0;
+			submenu.current.style.top = 'auto';
 		}
 	}, [ submenuHovered ] );
 

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useLayoutEffect } from 'react';
 import { get, uniqueId } from 'lodash';
 
 /**
@@ -89,7 +89,7 @@ export const ExpandableSidebarMenu = ( {
 
 	const menuId = uniqueId( 'menu' );
 
-	useEffect( () => {
+	useLayoutEffect( () => {
 		if ( offScreen( submenu.current ) ) {
 			setSubmenuStyles( { bottom: 0 } );
 		}

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -72,12 +72,18 @@ export const ExpandableSidebarMenu = ( {
 	} );
 
 	const onEnter = () => {
-		if ( expanded || isTouch ) return;
+		if ( expanded || isTouch ) {
+			return;
+		}
+
 		setSubmenuHovered( true );
 	};
 
 	const onLeave = () => {
-		if ( expanded || isTouch ) return;
+		if ( expanded || isTouch ) {
+			return;
+		}
+
 		setSubmenuHovered( false );
 	};
 

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import { get, uniqueId } from 'lodash';
 
 /**
@@ -12,6 +12,10 @@ import { get, uniqueId } from 'lodash';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import ExpandableSidebarHeading from './expandable-heading';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
+import { hasTouch } from 'calypso/lib/touch-detect';
+import config from 'calypso/config';
+
+const isTouch = hasTouch();
 
 function containsSelectedSidebarItem( children ) {
 	let selectedItemFound = false;
@@ -48,6 +52,7 @@ export const ExpandableSidebarMenu = ( {
 	...props
 } ) => {
 	let { expanded } = props;
+	const [ submenuHovered, setSubmenuHovered ] = useState( false );
 
 	if ( null === expanded ) {
 		expanded = containsSelectedSidebarItem( children );
@@ -56,7 +61,18 @@ export const ExpandableSidebarMenu = ( {
 	const classes = classNames( className, {
 		'is-toggle-open': !! expanded,
 		'is-togglable': true,
+		hovered: submenuHovered,
 	} );
+
+	const onEnter = () => {
+		if ( expanded || isTouch ) return;
+		setSubmenuHovered( true );
+	};
+
+	const onLeave = () => {
+		if ( expanded || isTouch ) return;
+		setSubmenuHovered( false );
+	};
 
 	const menuId = uniqueId( 'menu' );
 
@@ -72,6 +88,8 @@ export const ExpandableSidebarMenu = ( {
 				materialIconStyle={ materialIconStyle }
 				expanded={ expanded }
 				menuId={ menuId }
+				onMouseEnter={ config.isEnabled( 'nav-unification' ) ? () => onEnter() : null }
+				onMouseLeave={ config.isEnabled( 'nav-unification' ) ? () => onLeave() : null }
 				{ ...props }
 			/>
 			<li role="region" id={ menuId } className="sidebar__expandable-content" hidden={ ! expanded }>

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -59,7 +59,6 @@ export const ExpandableSidebarMenu = ( {
 	let { expanded } = props;
 	const submenu = useRef();
 	const [ submenuHovered, setSubmenuHovered ] = useState( false );
-	const [ submenuStyles, setSubmenuStyles ] = useState( { top: 0 } );
 
 	if ( null === expanded ) {
 		expanded = containsSelectedSidebarItem( children );
@@ -90,8 +89,8 @@ export const ExpandableSidebarMenu = ( {
 	const menuId = uniqueId( 'menu' );
 
 	useLayoutEffect( () => {
-		if ( offScreen( submenu.current ) ) {
-			setSubmenuStyles( { bottom: 0 } );
+		if ( submenuHovered && offScreen( submenu.current ) ) {
+			submenu.current.style = 'bottom: 0; top:auto';
 		}
 	}, [ submenuHovered ] );
 
@@ -119,7 +118,6 @@ export const ExpandableSidebarMenu = ( {
 				id={ menuId }
 				className="sidebar__expandable-content"
 				hidden={ ! expanded }
-				style={ submenuStyles }
 			>
 				<ul>{ children }</ul>
 			</li>

--- a/client/layout/sidebar/menu.jsx
+++ b/client/layout/sidebar/menu.jsx
@@ -5,8 +5,10 @@
 import React from 'react';
 import classNames from 'classnames';
 
-const SidebarMenu = ( { children, className } ) => (
-	<ul className={ classNames( 'sidebar__menu', className ) }>{ children }</ul>
+const SidebarMenu = ( { children, className, ...props } ) => (
+	<ul className={ classNames( 'sidebar__menu', className ) } { ...props }>
+		{ children }
+	</ul>
 );
 
 export default SidebarMenu;

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -65,7 +65,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 				onClick={ () => {
 					if ( link ) {
 						if ( isExternal( link ) ) {
-							// If the URL is external, page() will fail to replace state between different domains
+							// If the URL is external, page() will fail to replace state between different domains.
 							externalRedirect( link );
 							return;
 						}

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -60,38 +60,40 @@ export const MySitesSidebarUnifiedMenu = ( {
 	}, [ selected, childIsSelected, reduxDispatch, sectionId, sidebarCollapsed ] );
 
 	return (
-		<ExpandableSidebarMenu
-			onClick={ () => {
-				if ( link ) {
-					if ( isExternal( link ) ) {
-						// If the URL is external, page() will fail to replace state between different domains
-						externalRedirect( link );
-						return;
+		<li>
+			<ExpandableSidebarMenu
+				onClick={ () => {
+					if ( link ) {
+						if ( isExternal( link ) ) {
+							// If the URL is external, page() will fail to replace state between different domains
+							externalRedirect( link );
+							return;
+						}
+						page( link );
 					}
-					page( link );
-				}
-				if ( ! sidebarCollapsed ) {
-					reduxDispatch( collapseAllMySitesSidebarSections() );
-					reduxDispatch( toggleSection( sectionId ) );
-				}
-			} }
-			expanded={ ! sidebarCollapsed && isExpanded }
-			title={ title }
-			customIcon={ <SidebarCustomIcon icon={ icon } /> }
-			className={ ( selected || childIsSelected ) && 'sidebar__menu--selected' }
-		>
-			{ children.map( ( item ) => {
-				const isSelected = selectedMenuItem?.url === item.url;
-				return (
-					<MySitesSidebarUnifiedItem
-						key={ item.slug }
-						{ ...item }
-						selected={ isSelected }
-						isSubItem={ true }
-					/>
-				);
-			} ) }
-		</ExpandableSidebarMenu>
+					if ( ! sidebarCollapsed ) {
+						reduxDispatch( collapseAllMySitesSidebarSections() );
+						reduxDispatch( toggleSection( sectionId ) );
+					}
+				} }
+				expanded={ ! sidebarCollapsed && isExpanded }
+				title={ title }
+				customIcon={ <SidebarCustomIcon icon={ icon } /> }
+				className={ ( selected || childIsSelected ) && 'sidebar__menu--selected' }
+			>
+				{ children.map( ( item ) => {
+					const isSelected = selectedMenuItem?.url === item.url;
+					return (
+						<MySitesSidebarUnifiedItem
+							key={ item.slug }
+							{ ...item }
+							selected={ isSelected }
+							isSubItem={ true }
+						/>
+					);
+				} ) }
+			</ExpandableSidebarMenu>
+		</li>
 	);
 };
 

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -502,6 +502,7 @@ $font-size: rem( 14px );
 			.sidebar__expandable-content {
 				display: block;
 				top: 0;
+				bottom: auto;
 				position: absolute;
 				left: var( --sidebar-width-max );
 				width: 160px;

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -483,7 +483,7 @@ $font-size: rem( 14px );
 			}
 		}
 
-		.sidebar__menu.is-togglable:not( .is-toggle-open ):hover {
+		.sidebar__menu.is-togglable:not( .is-toggle-open ).hovered {
 			position: relative;
 
 			.sidebar__heading {

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -501,7 +501,6 @@ $font-size: rem( 14px );
 			.sidebar__expandable-content {
 				display: block;
 				position: absolute;
-				top: 0;
 				left: var( --sidebar-width-max );
 				width: 160px;
 

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -500,6 +500,7 @@ $font-size: rem( 14px );
 			// flyout content
 			.sidebar__expandable-content {
 				display: block;
+				top: 0;
 				position: absolute;
 				left: var( --sidebar-width-max );
 				width: 160px;

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -484,6 +484,7 @@ $font-size: rem( 14px );
 		}
 
 		.sidebar__menu.is-togglable:not( .is-toggle-open ).hovered {
+			// .hovered is hanled in client/layout/sidebar/expandable.jsx. Needed for repositioning and hover intent.
 			position: relative;
 
 			.sidebar__heading {

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -484,7 +484,7 @@ $font-size: rem( 14px );
 		}
 
 		.sidebar__menu.is-togglable:not( .is-toggle-open ).hovered {
-			// .hovered is hanled in client/layout/sidebar/expandable.jsx. Needed for repositioning and hover intent.
+			// .hovered is handled in client/layout/sidebar/expandable.jsx. Needed for repositioning and hover intent.
 			position: relative;
 
 			.sidebar__heading {

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -1,4 +1,8 @@
 /**
+ * @jest-environment jsdom
+ */
+
+/**
  * External dependencies
  */
 import React from 'react';


### PR DESCRIPTION
Builds on https://github.com/Automattic/wp-calypso/pull/47198
#### Changes proposed in this Pull Request
We need to use JS instead of CSS for 2 reasons :
1) Reposition flyout in case it overflows to the bottom of the page
2) Prevent closing of the flyout when making a diagonal mouse movement (hover intent)(will be fixed in next PR) 

* Use JS instead of CSS to trigger hover of flyouts
* Reposition flyout to `bottom:0` if it is off the screen

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load Calypso and hover the sidebar items that have submenu it should feel exactly the same as in production except than when flyout was supposed to be off the screen, it now appears correctly.
* Repeat for mobile viewports

Before | After
-------|------
![](https://cln.sh/e1FmwH+) | ![](https://cln.sh/Y6UYuA+)

Fixes https://github.com/Automattic/wp-calypso/issues/46094