### PR TITLE
Checkout: update edit button position

### DIFF
--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -732,7 +732,7 @@ const StepTitle = styled.span< StepTitleProps & React.HTMLAttributes< HTMLSpanEl
 	font-weight: ${ ( props ) =>
 		props.isActive ? props.theme.weights.bold : props.theme.weights.normal };
 	margin-right: ${ ( props ) => ( props.fullWidth ? '0' : '8px' ) };
-	flex: ${ ( props ) => ( props.fullWidth ? '1' : 'inherit' ) };
+	flex: 1;
 
 	.rtl & {
 		margin-right: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the location of the edit button to make it clearer to people where to go if they want to edit their cart. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/98573354-c91bc580-2284-11eb-8545-188975e6433a.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/98573325-ba351300-2284-11eb-86ba-b29824baf40e.png)


#### Testing instructions
* Add a product to your cart and visit checkout. 
* Make sure edit button appear on the right and are still functional. 
