### PR TITLE
Premium Content: Provide block context to the payments button

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/index.js
@@ -28,6 +28,15 @@ const settings = {
 		alignWide: false,
 		lightBlockWrapper: true,
 	},
+	attributes: {
+		isPremiumContentChild: {
+			type: 'bool',
+			default: true,
+		},
+	},
+	providesContext: {
+		isPremiumContentChild: 'isPremiumContentChild',
+	},
 	keywords: [ __( 'link', 'full-site-editing' ) ],
 	edit,
 	save,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Provide a context to allow the payments button to know when it's inside the premium content block.

#### Testing instructions

Should be tested using instructions from https://github.com/Automattic/jetpack/pull/17702
