### PR TITLE
Checkout: fix form field height

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/field.js
+++ b/client/my-sites/checkout/composite-checkout/components/field.js
@@ -110,10 +110,11 @@ const Input = styled.input`
 	font-size: 16px;
 	border: 1px solid
 		${ ( props ) => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor ) };
-	padding: 13px ${ ( props ) => ( props.icon ? '60px' : '10px' ) } 12px 10px;
+	padding: 7px ${ ( props ) => ( props.icon ? '60px' : '10px' ) } 7px 10px;
+	line-height: 1.5;
 
 	.rtl & {
-		padding: 13px 10px 12px ${ ( props ) => ( props.icon ? '60px' : '10px' ) };
+		padding: 7px 10px 7px ${ ( props ) => ( props.icon ? '60px' : '10px' ) };
 	}
 
 	:focus {

--- a/packages/composite-checkout/src/lib/theme.ts
+++ b/packages/composite-checkout/src/lib/theme.ts
@@ -72,7 +72,7 @@ const theme: Theme = {
 		disabledPaymentButtons: swatches.gray0,
 		disabledPaymentButtonsAccent: swatches.gray5,
 		disabledButtons: swatches.gray20,
-		borderColor: swatches.gray20,
+		borderColor: swatches.gray10,
 		borderColorLight: swatches.gray5,
 		borderColorDark: swatches.gray50,
 		upcomingStepBackground: swatches.gray5,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the field height in checkout to match the fields being imported by Calypso.

**Before**
![image](https://user-images.githubusercontent.com/6981253/98583714-d3dd5700-2292-11eb-8e05-5937685bc0db.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/98583692-c58f3b00-2292-11eb-90dd-cafb4c9b98ea.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add only a plan to your cart and checkout. 
* Confirm that the fields in the billing info step have the same heights.
* Check fields in payment step to confirm they look right as well. 

Fixes https://github.com/Automattic/wp-calypso/issues/47158
