### PR TITLE
Reset Olark identity to re-enable pre-sales chat for Jetpack Cloud

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -47,5 +47,5 @@
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
-	"olark_chat_identity": false
+	"olark_chat_identity": "5581-687-10-4070"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Revert the Olark identity in Jetpack Cloud production to its "real" value, so that pre-sales chat is re-enabled. (see: #47166)
