### PR TITLE
Nav-unification: Submenu colors are controlled by variable

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -21,6 +21,11 @@
 	--color-sidebar-gridicon-fill: #a2aab2;
 	--color-sidebar-notice-background: #3c434a;
 
+	--color-sidebar-submenu-background: #32373c;
+	--color-sidebar-submenu-text: #b4b9be;
+	--color-sidebar-submenu-hover-background: transparent;
+	--color-sidebar-submenu-hover-text: #00b9eb;
+
 	.is-sidebar-collapsed:not( .is-section-reader ):not( .is-section-me ) & {
 		--sidebar-width-max: 36px;
 		--sidebar-width-min: 36px;
@@ -107,7 +112,7 @@ $font-size: rem( 14px );
 		}
 
 		.sidebar__expandable-content {
-			background: #32373c;
+			background: var( --color-sidebar-submenu-background );
 			padding: 7px 0 8px;
 
 			.sidebar__menu-link {
@@ -116,12 +121,12 @@ $font-size: rem( 14px );
 				font-size: rem( 13px );
 				line-height: 1.4;
 				font-weight: 400;
-				color: #b4b9be;
+				color: var( --color-sidebar-submenu-text );
 
 				&:hover,
 				&:focus {
-					background-color: transparent;
-					color: var( --color-sidebar-menu-hover );
+					background-color: var( --color-sidebar-submenu-hover-background );
+					color: var( --color-sidebar-submenu-hover-text );
 				}
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When the nav unification flag is on, the submenus (covers both flyout menus and expandable menus) will have colors controlled by their own theme variables, instead of hard coded colors.
  * Wp-admin color themes can specify submenu colors.  This will allow wp-admin ported themes to be more accurate, providing a seamless experience when switching between calypso and wp-admin.  
  * When calypso themes are ported to wp-admin, we will have to add submenu colors to both calypso and wp-admin sides. 

#### Testing instructions

* With nav unification on ( http://calypso.localhost:3000/?flags=nav-unification ), check both expandable and flyout menus.  There should be no change before and after the PR is applied (but the PR applied allows for more flexibility).

Flyout
![2020-11-09_13-29](https://user-images.githubusercontent.com/937354/98587880-6a5c4900-2290-11eb-97e2-31780e60364c.png)

Expandable
![2020-11-09_13-29_1](https://user-images.githubusercontent.com/937354/98587886-6cbea300-2290-11eb-8b39-dcc7e2cff03a.png)

