### PR TITLE
Nav Unification: Flyout indicator arrow uses submenu background color

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -499,7 +499,7 @@ $font-size: rem( 14px );
 			// indicator arrow
 			.sidebar__heading::after {
 				display: block;
-				border-right-color: var( --color-sidebar-menu-hover-background );
+				border-right-color: var( --color-sidebar-submenu-background );
 			}
 
 			// flyout content


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When using nav unification, the "flyout menu arrow indicator" will use the submenu background color, instead of the menu hover background color.

On ported themes from wp-admin, this makes the arrow match wp-admin:

Calypso, Nav unification, Ectoplasm theme, before change (Arrow is green):
![2020-11-09_15-00](https://user-images.githubusercontent.com/937354/98596985-e5782c00-229d-11eb-935d-3d7a02cdb84f.png)

Calypso, Nav unification, Ectoplasm theme, after Change (Arrow is dark purple):
![2020-11-09_15-03](https://user-images.githubusercontent.com/937354/98597014-f32db180-229d-11eb-8085-996191d10b51.png)

Calypso, default theme, before change:
![2020-11-09_15-07](https://user-images.githubusercontent.com/937354/98597100-13f60700-229e-11eb-8b0b-23b0574b6e08.png)

Calypso, default theme, after change (same as before):
![2020-11-09_15-07_1](https://user-images.githubusercontent.com/937354/98597107-16f0f780-229e-11eb-93b2-2cad0a14443a.png)


#### Testing instructions

* Visit calypso.localhost:3000/?flags=nav-unification , ensure flyout menu arrow still works with no apparent changes.
  * Can also try change on `add/color-scheme-ectoplasm-alt` if desired (screenshots above).