### PR TITLE
CRO i5: Add i5 AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -197,9 +197,10 @@ export default {
 		variations: {
 			'v0 - Offer Reset': 0, // Offer Reset
 			'v1 - 3 cols layout': 0, // first Offer Reset iteration (3 layout columns + simpler cards)
-			'v2 - slide outs': 100, // second Offer Reset iteration (reorder & slide outs)
+			'i2 - slide outs': 100, // second Offer Reset iteration (reorder & slide outs)
+			'i5 - Saas table design': 0, // third Offer Reset iteration (Saas table design)
 		},
-		defaultVariation: 'v2 - slide outs',
+		defaultVariation: 'i2 - slide outs',
 		allowExistingUsers: true,
 	},
 	secureYourBrand: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -197,10 +197,10 @@ export default {
 		variations: {
 			'v0 - Offer Reset': 0, // Offer Reset
 			'v1 - 3 cols layout': 0, // first Offer Reset iteration (3 layout columns + simpler cards)
-			'i2 - slide outs': 100, // second Offer Reset iteration (reorder & slide outs)
+			'v2 - slide outs': 100, // second Offer Reset iteration (reorder & slide outs)
 			'i5 - Saas table design': 0, // third Offer Reset iteration (Saas table design)
 		},
-		defaultVariation: 'i2 - slide outs',
+		defaultVariation: 'v2 - slide outs',
 		allowExistingUsers: true,
 	},
 	secureYourBrand: {

--- a/client/my-sites/plans-v2/abtest.ts
+++ b/client/my-sites/plans-v2/abtest.ts
@@ -16,8 +16,10 @@ export const getJetpackCROActiveVersion = (): string => {
 			return 'v0';
 		case 'v1 - 3 cols layout':
 			return 'v1';
-		case 'v2 - slide outs':
+		case 'i2 - slide outs':
 			return 'v2';
+		case 'i5 - Saas table design':
+			return 'i5';
 	}
 
 	return 'v1';

--- a/client/my-sites/plans-v2/abtest.ts
+++ b/client/my-sites/plans-v2/abtest.ts
@@ -16,7 +16,7 @@ export const getJetpackCROActiveVersion = (): string => {
 			return 'v0';
 		case 'v1 - 3 cols layout':
 			return 'v1';
-		case 'i2 - slide outs':
+		case 'v2 - slide outs':
 			return 'v2';
 		case 'i5 - Saas table design':
 			return 'i5';

--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -32,41 +32,33 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 
 	const currentCROvariant = getJetpackCROActiveVersion();
 
-	if ( currentCROvariant === 'v1' ) {
-		context.primary = (
-			<SelectorPageAlt
-				defaultDuration={ duration }
-				rootUrl={ rootUrl }
-				siteSlug={ context.params.site || context.query.site }
-				urlQueryArgs={ urlQueryArgs }
-				header={ context.header }
-				footer={ context.footer }
-			/>
-		);
-	} else if ( currentCROvariant === 'v2' ) {
-		// TODO: render the new iteration. It's possible that we won't need a new
-		// Selector page for this. In that case, we should delete this if branch.
-		context.primary = (
-			<SelectorPageAlt
-				defaultDuration={ duration }
-				rootUrl={ rootUrl }
-				siteSlug={ context.params.site || context.query.site }
-				urlQueryArgs={ urlQueryArgs }
-				header={ context.header }
-				footer={ context.footer }
-			/>
-		);
-	} else {
-		context.primary = (
-			<SelectorPage
-				defaultDuration={ duration }
-				rootUrl={ rootUrl }
-				siteSlug={ context.params.site || context.query.site }
-				urlQueryArgs={ urlQueryArgs }
-				header={ context.header }
-				footer={ context.footer }
-			/>
-		);
+	switch ( currentCROvariant ) {
+		case 'i5':
+		case 'v1':
+		case 'v2':
+			context.primary = (
+				<SelectorPageAlt
+					defaultDuration={ duration }
+					rootUrl={ rootUrl }
+					siteSlug={ context.params.site || context.query.site }
+					urlQueryArgs={ urlQueryArgs }
+					header={ context.header }
+					footer={ context.footer }
+				/>
+			);
+			break;
+		default:
+			context.primary = (
+				<SelectorPage
+					defaultDuration={ duration }
+					rootUrl={ rootUrl }
+					siteSlug={ context.params.site || context.query.site }
+					urlQueryArgs={ urlQueryArgs }
+					header={ context.header }
+					footer={ context.footer }
+				/>
+			);
+			break;
 	}
 
 	next();

--- a/client/my-sites/plans-v2/products-grid-alt-3/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-alt-3/index.tsx
@@ -1,0 +1,180 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import React, {
+	ReactElement,
+	RefObject,
+	useMemo,
+	useState,
+	useCallback,
+	useEffect,
+	useRef,
+} from 'react';
+import { useSelector } from 'react-redux';
+import { sortBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { JETPACK_LEGACY_PLANS } from 'calypso/lib/plans/constants';
+import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card-alt';
+import { slugToSelectorProduct } from '../utils';
+import useGetPlansGridProducts from '../use-get-plans-grid-products';
+import { isJetpackPlanSlug } from 'calypso/lib/products-values';
+import { getProductPosition } from '../product-grid/products-order';
+import ProductCardAlt2 from '../product-card-alt-2';
+import { getPlansToDisplay, getProductsToDisplay, isConnectionFlow } from '../product-grid/utils';
+
+/**
+ * Type dependencies
+ */
+import type { Duration, PurchaseCallback, QueryArgs } from '../types';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const ProductsGridAlt3 = ( {
+	duration,
+	onSelectProduct,
+	urlQueryArgs,
+}: {
+	duration: Duration;
+	onSelectProduct: PurchaseCallback;
+	urlQueryArgs: QueryArgs;
+} ): ReactElement => {
+	const [ isPlanRowExpanded, setPlanRowExpanded ] = useState( true );
+	const [ isPlanRowWrapping, setPlanRowWrapping ] = useState( false );
+
+	const siteId = useSelector( getSelectedSiteId );
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const currentPlanSlug =
+		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
+
+	const { availableProducts, purchasedProducts, includedInPlanProducts } = useGetPlansGridProducts(
+		siteId
+	);
+
+	const plansToDisplay = useMemo( () => getPlansToDisplay( { duration, currentPlanSlug } ), [
+		duration,
+		currentPlanSlug,
+	] );
+	const productsToDisplay = useMemo(
+		() =>
+			getProductsToDisplay( {
+				duration,
+				availableProducts,
+				purchasedProducts,
+				includedInPlanProducts,
+			} ),
+		[ duration, availableProducts, includedInPlanProducts, purchasedProducts ]
+	);
+	const sortedGridItems = useMemo(
+		() =>
+			sortBy( [ ...plansToDisplay, ...productsToDisplay ], ( item ) =>
+				getProductPosition( item.productSlug )
+			),
+		[ plansToDisplay, productsToDisplay ]
+	);
+	const planItems = useMemo(
+		() => sortedGridItems.filter( ( { productSlug } ) => isJetpackPlanSlug( productSlug ) ),
+		[ sortedGridItems ]
+	);
+	const productItems = useMemo(
+		() => sortedGridItems.filter( ( { productSlug } ) => ! isJetpackPlanSlug( productSlug ) ),
+		[ sortedGridItems ]
+	);
+
+	const planGridRef: RefObject< HTMLDivElement > = useRef( null );
+
+	const onPlanRowFeaturesToggle = useCallback( () => setPlanRowExpanded( ! isPlanRowExpanded ), [
+		isPlanRowExpanded,
+	] );
+	const onResize = useCallback( () => {
+		if ( planGridRef ) {
+			const { current: grid } = planGridRef;
+
+			if ( grid ) {
+				const firstChild = grid.children[ 0 ];
+
+				if ( firstChild instanceof HTMLElement ) {
+					const firtRowItemCount = Math.floor( grid.offsetWidth / firstChild.offsetWidth );
+
+					setPlanRowWrapping( firtRowItemCount < planItems.length );
+				}
+			}
+		}
+	}, [ planGridRef, planItems ] );
+
+	const hasLegacyPlan = currentPlanSlug && JETPACK_LEGACY_PLANS.includes( currentPlanSlug );
+	const isInConnectFlow = useMemo( isConnectionFlow, [] );
+	const showJetpackFreeCard = isInConnectFlow || isJetpackCloud();
+	const currentPlan = currentPlanSlug && slugToSelectorProduct( currentPlanSlug );
+
+	useEffect( () => {
+		onResize();
+		window.addEventListener( 'resize', onResize );
+
+		return () => window.removeEventListener( 'resize', onResize );
+	}, [ onResize ] );
+
+	return (
+		<>
+			<h4>i5 - Saas table design</h4>
+			<div
+				className={ classNames( 'products-grid-alt-2 has-plans', {
+					'is-wrapping': isPlanRowWrapping,
+				} ) }
+				ref={ planGridRef }
+			>
+				{ planItems.map( ( product ) => (
+					<ProductCardAlt2
+						key={ product.iconSlug }
+						item={ product }
+						onClick={ onSelectProduct }
+						siteId={ siteId }
+						currencyCode={ currencyCode }
+						selectedTerm={ duration }
+						shouldExpand={ isPlanRowWrapping ? undefined : isPlanRowExpanded }
+						onFeaturesToggle={ isPlanRowWrapping ? undefined : onPlanRowFeaturesToggle }
+					/>
+				) ) }
+			</div>
+			<div className="products-grid-alt-2">
+				{ hasLegacyPlan && currentPlan && (
+					<ProductCardAlt2
+						key={ currentPlanSlug as string }
+						item={ currentPlan }
+						onClick={ onSelectProduct }
+						siteId={ siteId }
+						currencyCode={ currencyCode }
+						selectedTerm={ duration }
+					/>
+				) }
+
+				{ productItems.map( ( product ) => (
+					<ProductCardAlt2
+						key={ product.iconSlug }
+						item={ product }
+						onClick={ onSelectProduct }
+						siteId={ siteId }
+						currencyCode={ currencyCode }
+						selectedTerm={ duration }
+					/>
+				) ) }
+
+				{ showJetpackFreeCard && siteId && (
+					<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
+				) }
+			</div>
+		</>
+	);
+};
+
+export default ProductsGridAlt3;

--- a/client/my-sites/plans-v2/products-grid-alt-3/style.scss
+++ b/client/my-sites/plans-v2/products-grid-alt-3/style.scss
@@ -1,0 +1,45 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
+.products-grid-alt-2 {
+	.jetpack-free-card-alt {
+		/*
+		 * To match its top and bottom border with the borders
+		 * of the product cards next to it
+		 */
+		margin-block-start: calc( 24px + 32.5px );
+		margin-bottom: 24px;
+	}
+
+	.formatted-header__title {
+		font-size: 1.25rem;
+		color: var( --studio-color-gray-70 );
+	}
+}
+
+/*
+ * We really should be using @include break-small here,
+ * but Calypso's main Layout component doesn't play nicely with it yet.
+ */
+@include breakpoint-deprecated( '>660px' ) {
+	.products-grid-alt-2 {
+		display: grid;
+		grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
+		grid-gap: calc( 32.5px /* $jetpack-product-card-alt-2-circle-size/2 */ + 44px ) 16px;
+		align-items: flex-start;
+
+		margin-top: 24px;
+		padding-top: 32.5px; // $jetpack-product-card-alt-2-circle-size/2
+
+		&.has-plans {
+			margin-bottom: 44px;
+			padding-bottom: 44px;
+
+			border-bottom: 1px solid var( --color-border-subtle );
+		}
+
+		.jetpack-free-card-alt {
+			grid-column-end: span 2;
+		}
+	}
+}

--- a/client/my-sites/plans-v2/selector-alt.tsx
+++ b/client/my-sites/plans-v2/selector-alt.tsx
@@ -26,6 +26,7 @@ import QuerySites from 'calypso/components/data/query-sites';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import ProductsGridAlt from './products-grid-alt';
 import ProductsGridAlt2 from './products-grid-alt-2';
+import ProductsGridAlt3 from './products-grid-alt-3';
 
 /**
  * Type dependencies
@@ -142,9 +143,21 @@ const SelectorPageAlt = ( {
 		setDuration( selectedDuration );
 	};
 
+	const getProductsGrid = ( activeVariation = 'v0' ) => {
+		switch ( activeVariation ) {
+			case 'i5':
+				return ProductsGridAlt3;
+			case 'v2':
+				return ProductsGridAlt2;
+			default:
+				return ProductsGridAlt;
+		}
+	};
+
 	const viewTrackerPath = siteId ? `${ rootUrl }/:site` : rootUrl;
 	const viewTrackerProps = siteId ? { site: siteSlug } : {};
-	const Grid = getJetpackCROActiveVersion() === 'v2' ? ProductsGridAlt2 : ProductsGridAlt;
+	const currentABTestVariation = getJetpackCROActiveVersion();
+	const Grid = getProductsGrid( currentABTestVariation );
 
 	return (
 		<Main className="selector-alt__main" wideLayout>


### PR DESCRIPTION
### Changes proposed in this Pull Request

Add new AB test variation for the Jetpack Plans page.

#### Implementation notes:

I pointed the new AB test variation to a new `products-grid-alt-3` folder & component.

Additional note:  The features list in top 3 plans in this new products-grid-alt-3 page are not working correctly on this page. I didn't take the time to repair this because we will be changing these things in upcoming PR's.

### Testing instructions

1. Run this PR
2. Visit the Plans page: `http://calypso.localhost:3000/plans/:site`
3. Verify there is a new `jetpackConversionRateOptimization` AB test option labelled: `i5 - Saas table design`
4. Select the `i5 - Saas table design` variant.
5. Verify you can see the text "`i5 - Saas table design`" (See screenshot) - This means you are on the variant plans grid page (`ProductsGridAlt3`)
![Markup 2020-11-09 at 13 42 10](https://user-images.githubusercontent.com/11078128/98599823-7563a900-2291-11eb-83a1-ae5a86b27905.png)

6. Select the other A/B test variants to make sure they are all operating correctly. 


Fixes # 1196341175636977-as-1199149328812557/f