### PR TITLE
Checkout: Remove paymentMethodClassName and PAYMENT_METHODS

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import url from 'url'; // eslint-disable-line no-restricted-imports
-import { get, invert } from 'lodash';
 import update, { extend as extendImmutabilityHelper } from 'immutability-helper';
 import { translate } from 'i18n-calypso';
 
@@ -119,11 +118,11 @@ export function removeCoupon() {
 	};
 }
 
-export const getTaxCountryCode = ( cart ) => get( cart, [ 'tax', 'location', 'country_code' ] );
+export const getTaxCountryCode = ( cart ) => cart?.tax?.location?.country_code;
 
-export const getTaxPostalCode = ( cart ) => get( cart, [ 'tax', 'location', 'postal_code' ] );
+export const getTaxPostalCode = ( cart ) => cart?.tax?.location?.postal_code;
 
-export const getTaxLocation = ( cart ) => get( cart, [ 'tax', 'location' ], {} );
+export const getTaxLocation = ( cart ) => cart?.tax?.location ?? {};
 
 export function setTaxCountryCode( countryCode ) {
 	return function ( cart ) {
@@ -375,5 +374,5 @@ export function hasPendingPayment( cart ) {
 }
 
 export function shouldShowTax( cart ) {
-	return get( cart, [ 'tax', 'display_taxes' ], false );
+	return cart?.tax?.display_taxes ?? false;
 }

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -330,16 +330,6 @@ export function getEnabledPaymentMethods( cart ) {
 }
 
 /**
- * Return a string that represents the WPCOM class name for a payment method
- *
- * @param {string} method -  payment method
- * @returns {string} the wpcom class name
- */
-export function paymentMethodClassName( method ) {
-	return PAYMENT_METHODS[ method ] || '';
-}
-
-/**
  * Return a string that represents the User facing name for payment method
  *
  * @param {string} method - payment method

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import url from 'url'; // eslint-disable-line no-restricted-imports
-import { get, isArray, invert } from 'lodash';
+import { get, invert } from 'lodash';
 import update, { extend as extendImmutabilityHelper } from 'immutability-helper';
 import { translate } from 'i18n-calypso';
 
@@ -23,6 +23,7 @@ import {
 } from 'calypso/lib/products-values';
 import { detectWebPaymentMethod } from 'calypso/lib/web-payment';
 import config from 'calypso/config';
+import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 
 // Auto-vivification from https://github.com/kolodny/immutability-helper#autovivification
 extendImmutabilityHelper( '$auto', function ( value, object ) {
@@ -364,6 +365,13 @@ export function paymentMethodName( method ) {
 	return paymentMethodsNames[ method ] || method;
 }
 
+/**
+ * Determines if a payment method is enabled
+ *
+ * @param {import('@automattic/shopping-cart').ResponseCart} cart The shopping cart
+ * @param {import('calypso/my-sites/checkout/composite-checkout/types/checkout-payment-method-slug').CheckoutPaymentMethodSlug} method The short payment method string
+ * @returns {boolean} true if enabled
+ */
 export function isPaymentMethodEnabled( cart, method ) {
 	const redirectPaymentMethods = [
 		'alipay',
@@ -378,28 +386,21 @@ export function isPaymentMethodEnabled( cart, method ) {
 		'wechat',
 		'sofort',
 	];
-	const methodClassName = paymentMethodClassName( method );
+	const methodClassName = translateCheckoutPaymentMethodToWpcomPaymentMethod( method );
 
-	if ( '' === methodClassName ) {
+	if ( ! methodClassName ) {
 		return false;
 	}
 
 	// Redirect payments might not be possible in some cases - for example in the desktop app
 	if (
-		redirectPaymentMethods.indexOf( method ) >= 0 &&
+		redirectPaymentMethods.includes( method ) &&
 		! config.isEnabled( 'upgrades/redirect-payments' )
 	) {
 		return false;
 	}
 
-	if ( 'web-payment' === method && null === detectWebPaymentMethod() ) {
-		return false;
-	}
-
-	return (
-		isArray( cart.allowed_payment_methods ) &&
-		cart.allowed_payment_methods.indexOf( methodClassName ) >= 0
-	);
+	return cart.allowed_payment_methods.includes( methodClassName );
 }
 
 export function getLocationOrigin( l ) {

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -340,7 +340,7 @@ export function paymentMethodName( method ) {
 	const paymentMethodsNames = {
 		alipay: 'Alipay',
 		bancontact: 'Bancontact',
-		'credit-card': translate( 'Credit or debit card' ),
+		card: translate( 'Credit or debit card' ),
 		eps: 'EPS',
 		giropay: 'Giropay',
 		id_wallet: 'OVO',
@@ -349,13 +349,7 @@ export function paymentMethodName( method ) {
 		paypal: 'PayPal',
 		p24: 'Przelewy24',
 		'brazil-tef': 'Transferência bancária',
-		// The web-payment method technically supports multiple digital
-		// wallets, but only Apple Pay is used for now. To enable other
-		// wallets, we'd need to split web-payment up into multiple methods
-		// anyway (so that each wallet is a separate payment choice for the
-		// user), so it's fine to just hardcode this to "Apple Pay" in the
-		// meantime.
-		'web-payment': 'Apple Pay',
+		'apple-pay': 'Apple Pay',
 		wechat: translate( 'WeChat Pay', {
 			comment: 'Name for WeChat Pay - https://pay.weixin.qq.com/',
 		} ),

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -28,7 +28,7 @@ import CreditCardExpiryField from './credit-card-expiry-field';
 import CreditCardCvvField from './credit-card-cvv-field';
 import { FieldRow, CreditCardFieldsWrapper, CreditCardField } from './form-layout-components';
 import CreditCardLoading from './credit-card-loading';
-import { paymentMethodClassName } from 'calypso/lib/cart-values';
+import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from '../../lib/translate-payment-method-names';
 
 export default function CreditCardFields() {
 	const { __ } = useI18n();
@@ -82,7 +82,11 @@ export default function CreditCardFields() {
 	);
 	const shouldShowContactFields =
 		contactCountryCode === 'BR' &&
-		Boolean( cart?.allowed_payment_methods?.includes( paymentMethodClassName( 'ebanx' ) ) );
+		Boolean(
+			cart?.allowed_payment_methods?.includes(
+				translateCheckoutPaymentMethodToWpcomPaymentMethod( 'ebanx' )
+			)
+		);
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -19,7 +19,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
  * Internal dependencies
  */
 import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
-import { paymentMethodClassName } from 'calypso/lib/cart-values';
+import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from '../../lib/translate-payment-method-names';
 
 const debug = debugFactory( 'calypso:composite-checkout:credit-card' );
 
@@ -113,7 +113,9 @@ function ButtonContents( { formStatus, total } ) {
 
 function getPaymentPartner( { cart, contactCountryCode } ) {
 	const isEbanxAvailable = Boolean(
-		cart?.allowed_payment_methods?.includes( paymentMethodClassName( 'ebanx' ) )
+		cart?.allowed_payment_methods?.includes(
+			translateCheckoutPaymentMethodToWpcomPaymentMethod( 'ebanx' )
+		)
 	);
 
 	let paymentPartner = 'stripe';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`lib/cart-values` contains several functions for querying the list of payment methods returned by the shopping-cart endpoint. Notably, it has functions for translating between the "long" versions of the names on the server (aka "class names", eg: `WPCOM_Billing_Ebanx_Redirect_Brazil_Tef`) into the "short" versions on the client (eg: `brazil-tef`). As new checkout has its own updated functions for this purpose, it makes sense to prevent keeping lists of these strings in two places. This PR removes or replaces uses of the old functions in favor of the new ones.

Depends on https://github.com/Automattic/wp-calypso/pull/47258
Depends on https://github.com/Automattic/wp-calypso/pull/47259

Fixes https://github.com/Automattic/wp-calypso/issues/44998
This is part of a chain of related PRs. The next one is https://github.com/Automattic/wp-calypso/pull/47216

#### Testing instructions

The only thing this really modifies in new checkout is the `shouldShowContactFields` variable that controls the ebanx contact details.

- Visit checkout.
- In the final step, choose "Credit or debit card".
- Verify that the form does not show the Ebanx fields (only cardholder name, number, expiry, and CVC).
- Apply D48147-code to your sandbox to pretend to be in Brazil and sandbox the API.
- Set your currency to `BRL`.
- In the contact information step, choose "Brazil" for the country.
- In the final step, choose "Credit or debit card".
- Verify that the form asks for all the Ebanx fields in addition to the credit card fields (Taxpayer Identification Number, Phone, etc.)