### PR TITLE
Checkout: Remove getEnabledPaymentMethods

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -20,7 +20,6 @@ import {
 	isDomainRedemption,
 	allowedProductAttributes,
 } from 'calypso/lib/products-values';
-import { translateWpcomPaymentMethodToCheckoutPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 
 // Auto-vivification from https://github.com/kolodny/immutability-helper#autovivification
 extendImmutabilityHelper( '$auto', function ( value, object ) {
@@ -278,16 +277,6 @@ export function getRefundPolicy( cart ) {
 	}
 
 	return 'genericRefund';
-}
-
-/**
- * Returns a list of enabled payment methods
- *
- * @param {import('@automattic/shopping-cart').ResponseCart} cart The shopping cart
- * @returns {import('calypso/my-sites/checkout/composite-checkout/types/checkout-payment-method-slug.ts').CheckoutPaymentMethodSlug[]} An array of payment method ids
- */
-export function getEnabledPaymentMethods( cart ) {
-	return cart.allowed_payment_methods.map( translateWpcomPaymentMethodToCheckoutPaymentMethod );
 }
 
 /**

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -14,11 +14,7 @@ import { format as formatUrl, parse as parseUrl } from 'url';
  * Internal dependencies
  */
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import {
-	shouldShowTax,
-	hasPendingPayment,
-	getEnabledPaymentMethods,
-} from 'calypso/lib/cart-values';
+import { shouldShowTax, hasPendingPayment } from 'calypso/lib/cart-values';
 import {
 	conciergeSessionItem,
 	domainMapping,
@@ -835,7 +831,6 @@ export class Checkout extends React.Component {
 				cart={ cart }
 				transaction={ transaction }
 				cards={ cards }
-				paymentMethods={ this.paymentMethodsAbTestFilter() }
 				products={ productsList }
 				selectedSite={ selectedSite }
 				setHeaderText={ setHeaderText }
@@ -903,12 +898,6 @@ export class Checkout extends React.Component {
 		} );
 		replaceItem( product, cartItem );
 	};
-
-	paymentMethodsAbTestFilter() {
-		// This methods can be used to filter payment methods
-		// For example, for the purpose of AB tests.
-		return getEnabledPaymentMethods( this.props.cart );
-	}
 
 	isLoading() {
 		const isLoadingCart = ! this.props.cart.hasLoadedFromServer;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the `getEnabledPaymentMethods` function from `lib/cart-values`. As we are working on removing that library and migrating all its functionality to new checkout, this is a major piece and completes a process started with https://github.com/Automattic/wp-calypso/pull/47258.

Depends on https://github.com/Automattic/wp-calypso/pull/47262

#### Testing instructions

Verify calypso loads.