### PR TITLE
Apply ExPlat to the monthly pricing test 2nd phase

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -212,15 +212,4 @@ export default {
 		allowExistingUsers: false,
 		countryCodeTargets: [ 'US' ],
 	},
-	monthlyPricing: {
-		datestamp: '20201031',
-		variations: {
-			control: 90,
-			treatment: 10,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: false,
-		countryCodeTargets: [ 'US' ],
-		localeTargets: [ 'en' ],
-	},
 };

--- a/client/lib/analytics/sem.js
+++ b/client/lib/analytics/sem.js
@@ -9,7 +9,6 @@ import { pushEventToTracksQueue } from '@automattic/calypso-analytics';
  * Internal dependencies.
  */
 import { urlParseAmpCompatible } from 'calypso/lib/analytics/utils';
-import { decodeURIComponentIfValid } from 'calypso/lib/url';
 
 /**
  * Const variables.
@@ -119,42 +118,4 @@ export function updateQueryParamsTracking() {
 		setUtmCookie( 'ad_details', sanitizedQueryString );
 		setUtmCookie( 'ad_timestamp', Math.floor( new Date().getTime() / 1000 ) );
 	}
-}
-
-export function isIgnoredAdSource() {
-	const cookies = cookie.parse( document.cookie );
-	const adDetails = new URLSearchParams( decodeURIComponentIfValid( cookies.ad_details || '' ) );
-
-	return [
-		'ads',
-		'adwords',
-		'adwords-yt',
-		'akismet',
-		'bing',
-		'bingads',
-		'brmarketingemail',
-		'display',
-		'email',
-		'facebook',
-		'facebook.com',
-		'facebook_page',
-		'fbads',
-		'google',
-		'houseads',
-		'hs_email',
-		'iterable',
-		'linkedin',
-		'oath',
-		'outbrain',
-		'pinterest',
-		'shrinkify',
-		'social',
-		'spotify',
-		'twitter',
-		'twitter.com',
-		'woocommerce',
-		'wordadsiponweb',
-		'yelp',
-		'youtube',
-	].includes( adDetails.get( 'utm_source' ) );
 }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
@@ -15,7 +16,7 @@ import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import { isLineItemADomain } from '../hooks/has-domains';
 import { isWpComPlan, getBillingMonthsForPlan } from 'calypso/lib/plans';
-import { getABTestVariation } from 'calypso/lib/abtest';
+import { isTreatmentInMonthlyPricingTest } from 'calypso/state/marketing/selectors';
 
 export default function WPCheckoutOrderReview( {
 	className,
@@ -49,7 +50,7 @@ export default function WPCheckoutOrderReview( {
 		items.find( ( { wpcom_meta } ) => 'renewal' === wpcom_meta?.extra?.purchaseType )
 	);
 	const isMonthlyPricingTest =
-		hasDotcomPlan && ! hasRenewal && 'treatment' === getABTestVariation( 'monthlyPricing' );
+		useSelector( isTreatmentInMonthlyPricingTest ) && hasDotcomPlan && ! hasRenewal;
 	const itemsForMonthlyPricing =
 		isMonthlyPricingTest && items.map( ( item ) => overrideItemSublabel( item, translate ) );
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
@@ -59,7 +59,10 @@ export default function WPCheckoutOrderReview( {
 		currentPlanProductSlug &&
 		( isWpComFreePlan( currentPlanProductSlug ) || isMonthly( currentPlanProductSlug ) );
 	const isMonthlyPricingTest =
-		useSelector( isTreatmentInMonthlyPricingTest ) && hasDotcomPlan && ! hasRenewal && hasFreeOrMonthlySubscription;
+		useSelector( isTreatmentInMonthlyPricingTest ) &&
+		hasDotcomPlan &&
+		! hasRenewal &&
+		hasFreeOrMonthlySubscription;
 	const itemsForMonthlyPricing =
 		isMonthlyPricingTest && items.map( ( item ) => overrideItemSublabel( item, translate ) );
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -47,7 +47,8 @@ import isSupportVariationDetermined from 'calypso/state/selectors/is-support-var
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import Gridicon from 'calypso/components/gridicon';
-import { getABTestVariation } from 'calypso/lib/abtest';
+import { useIsLoading } from 'calypso/state/experiments/hooks';
+import { isTreatmentInMonthlyPricingTest } from 'calypso/state/marketing/selectors';
 import getPlanFeatures from '../lib/get-plan-features';
 
 export default function WPCheckoutOrderSummary( {
@@ -65,8 +66,9 @@ export default function WPCheckoutOrderSummary( {
 	const plan = usePlanInCart();
 	const hasMonthlyPlan = Boolean( plan && isMonthly( plan?.wpcom_meta?.product_slug ) );
 	const hasRenewalInCart = useHasRenewalInCart();
+	const isExperimentLoading = useIsLoading();
 	const isMonthlyPricingTest =
-		plan && ! hasRenewalInCart && 'treatment' === getABTestVariation( 'monthlyPricing' );
+		useSelector( isTreatmentInMonthlyPricingTest ) && plan && ! hasRenewalInCart;
 
 	return (
 		<CheckoutSummaryCard
@@ -77,7 +79,7 @@ export default function WPCheckoutOrderSummary( {
 				<CheckoutSummaryFeaturesTitle>
 					{ translate( 'Included with your purchase' ) }
 				</CheckoutSummaryFeaturesTitle>
-				{ isCartUpdating ? (
+				{ isCartUpdating || isExperimentLoading ? (
 					<LoadingCheckoutSummaryFeaturesList />
 				) : (
 					<CheckoutSummaryFeaturesList
@@ -86,7 +88,7 @@ export default function WPCheckoutOrderSummary( {
 						nextDomainIsFree={ nextDomainIsFree }
 					/>
 				) }
-				{ ! isMonthlyPricingTest && <CheckoutSummaryHelp /> }
+				{ ! isMonthlyPricingTest && ! isExperimentLoading && <CheckoutSummaryHelp /> }
 				{ isMonthlyPricingTest && hasMonthlyPlan && (
 					<SwitchToAnnualPlan plan={ plan } onChangePlanLength={ onChangePlanLength } />
 				) }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -54,6 +54,7 @@ import {
 	hasDomainRegistration,
 	hasTransferProduct,
 } from 'calypso/lib/cart-values/cart-items';
+import QueryExperiments from 'calypso/components/data/query-experiments';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
@@ -275,6 +276,7 @@ export default function WPCheckout( {
 
 	return (
 		<Checkout>
+			<QueryExperiments />
 			<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
 				<CheckoutSummaryTitleLink onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }>
 					<CheckoutSummaryTitle>

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.js
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.js
@@ -22,8 +22,8 @@ import {
 } from 'calypso/lib/plans/constants';
 import { requestProductsList } from 'calypso/state/products-list/actions';
 import { myFormatCurrency } from 'calypso/blocks/subscription-length-picker';
-import { getABTestVariation } from 'calypso/lib/abtest';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { isTreatmentInMonthlyPricingTest } from 'calypso/state/marketing/selectors';
 
 const debug = debugFactory( 'calypso:composite-checkout:product-variants' );
 
@@ -35,8 +35,7 @@ export function useProductVariants( { siteId, productSlug } ) {
 
 	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, siteId ) );
 	const shouldOverride =
-		isWpComFreePlan( currentPlan?.productSlug ) &&
-		'treatment' === getABTestVariation( 'monthlyPricing' );
+		useSelector( isTreatmentInMonthlyPricingTest ) && isWpComFreePlan( currentPlan?.productSlug );
 
 	const productsWithPrices = useSelector( ( state ) => {
 		return computeProductsWithPrices(

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -31,6 +31,8 @@ jest.mock( 'page', () => ( {
 	redirect: jest.fn(),
 } ) );
 
+jest.mock( 'components/data/query-experiments' );
+
 const domainProduct = {
 	product_name: '.cash Domain',
 	product_slug: 'domain_reg',

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { Primitive } from 'utility-types';
 import { omit } from 'lodash';
+import styled from '@emotion/styled';
 
 /**
  * Internal dependencies
@@ -108,6 +109,15 @@ export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 type MonthlyPricingProps = { isMonthlyPricingTest?: boolean };
 type IntervalTypeProps = Pick< Props, 'intervalType' > & MonthlyPricingProps;
 
+const IntervalTypeToggleWrapper = styled.div`
+	display: flex;
+	align-content: space-between;
+
+	> .segmented-control {
+		width: auto;
+	}
+`;
+
 export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
 	const translate = useTranslate();
 	const { intervalType, isMonthlyPricingTest } = props;
@@ -119,28 +129,30 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 	const popupIsVisible = Boolean( isMonthlyPricingTest && intervalType === 'monthly' );
 
 	return (
-		<SegmentedControl compact className={ segmentClasses } primary={ true }>
-			<SegmentedControl.Item
-				selected={ intervalType === 'monthly' }
-				path={ generatePath( props, { intervalType: 'monthly' } ) }
-			>
-				<span>
-					{ isMonthlyPricingTest ? translate( 'Pay monthly' ) : translate( 'Monthly billing' ) }
-				</span>
-			</SegmentedControl.Item>
+		<IntervalTypeToggleWrapper>
+			<SegmentedControl compact className={ segmentClasses } primary={ true }>
+				<SegmentedControl.Item
+					selected={ intervalType === 'monthly' }
+					path={ generatePath( props, { intervalType: 'monthly' } ) }
+				>
+					<span>
+						{ isMonthlyPricingTest ? translate( 'Pay monthly' ) : translate( 'Monthly billing' ) }
+					</span>
+				</SegmentedControl.Item>
 
-			<SegmentedControl.Item
-				selected={ intervalType === 'yearly' }
-				path={ generatePath( props, { intervalType: 'yearly' } ) }
-			>
-				<span ref={ ( ref ) => ref && setSpanRef( ref ) }>
-					{ isMonthlyPricingTest ? translate( 'Pay annually' ) : translate( 'Yearly billing' ) }
-				</span>
-				<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
-					{ translate( 'Save up to 43% by paying annually and get a free domain for one year' ) }
-				</PopupMessages>
-			</SegmentedControl.Item>
-		</SegmentedControl>
+				<SegmentedControl.Item
+					selected={ intervalType === 'yearly' }
+					path={ generatePath( props, { intervalType: 'yearly' } ) }
+				>
+					<span ref={ ( ref ) => ref && setSpanRef( ref ) }>
+						{ isMonthlyPricingTest ? translate( 'Pay annually' ) : translate( 'Yearly billing' ) }
+					</span>
+					<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
+						{ translate( 'Save up to 43% by paying annually and get a free domain for one year' ) }
+					</PopupMessages>
+				</SegmentedControl.Item>
+			</SegmentedControl>
+		</IntervalTypeToggleWrapper>
 	);
 };
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -81,6 +81,7 @@ class DomainsStep extends React.Component {
 		selectedSite: PropTypes.object,
 		vertical: PropTypes.string,
 		isReskinned: PropTypes.bool,
+		hasAnonId: PropTypes.bool,
 	};
 
 	getDefaultState = () => ( {
@@ -816,7 +817,7 @@ export default connect(
 			sites: getSitesItems( state ),
 			isReskinned,
 			isPlanStepSkipped: isPlanStepExistsAndSkipped( state ),
-			hasAnonId: tracksAnonymousUserId( state ) || false,
+			hasAnonId: !! tracksAnonymousUserId( state ),
 		};
 	},
 	{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -57,6 +57,8 @@ import { abtest, getABTestVariation } from 'calypso/lib/abtest';
 import getSitesItems from 'calypso/state/selectors/get-sites-items';
 import { isPlanStepExistsAndSkipped } from 'calypso/state/signup/progress/selectors';
 import { getStepModuleName } from 'calypso/signup/config/step-components';
+import { tracksAnonymousUserId } from 'calypso/lib/analytics/ad-tracking';
+import QueryExperiments from 'calypso/components/data/query-experiments';
 /**
  * Style dependencies
  */
@@ -744,6 +746,7 @@ class DomainsStep extends React.Component {
 				fallbackSubHeaderText={ fallbackSubHeaderText }
 				stepContent={
 					<div>
+						{ ! this.props.hasAnonId && <QueryExperiments /> }
 						{ ! this.props.productsLoaded && <QueryProductsList /> }
 						{ this.renderContent() }
 					</div>
@@ -813,6 +816,7 @@ export default connect(
 			sites: getSitesItems( state ),
 			isReskinned,
 			isPlanStepSkipped: isPlanStepExistsAndSkipped( state ),
+			hasAnonId: tracksAnonymousUserId( state ) || false,
 		};
 	},
 	{

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -10,7 +10,6 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { parse as parseQs } from 'qs';
 import { Button } from '@automattic/components';
-import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -30,8 +29,8 @@ import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
 import { getUrlParts } from 'calypso/lib/url/url-parts';
-import { isIgnoredAdSource } from 'calypso/lib/analytics/sem';
-import { abtest } from 'calypso/lib/abtest';
+import QueryExperiments from 'calypso/components/data/query-experiments';
+import { isTreatmentInMonthlyPricingTest } from 'calypso/state/marketing/selectors';
 
 /**
  * Style dependencies
@@ -149,6 +148,7 @@ export class PlansStep extends Component {
 		return (
 			<div>
 				<QueryPlans />
+				<QueryExperiments />
 
 				<PlansFeaturesMain
 					site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
@@ -267,23 +267,8 @@ export const isDotBlogDomainRegistration = ( domainItem ) => {
 	return is_domain_registration && getTld( meta ) === 'blog';
 };
 
-function isEligibleForMonthlyPricingTest( flowName ) {
-	if ( 'onboarding' !== flowName ) {
-		return false;
-	}
-
-	if ( isIgnoredAdSource() ) {
-		return false;
-	}
-
-	const countryCode = cookie.parse( document.cookie )?.country_code;
-	const variation = abtest( 'monthlyPricing', countryCode || '' );
-
-	return 'treatment' === variation;
-}
-
 export default connect(
-	( state, { path, signupDependencies: { siteSlug, domainItem }, flowName } ) => ( {
+	( state, { path, signupDependencies: { siteSlug, domainItem } } ) => ( {
 		// Blogger plan is only available if user chose either a free domain or a .blog domain registration
 		disableBloggerPlanWithNonBlogDomain:
 			domainItem && ! isSubdomain( domainItem.meta ) && ! isDotBlogDomainRegistration( domainItem ),
@@ -295,7 +280,7 @@ export default connect(
 		siteGoals: getSiteGoals( state ) || '',
 		siteType: getSiteType( state ),
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
-		isMonthlyPricingTest: isEligibleForMonthlyPricingTest( flowName ),
+		isMonthlyPricingTest: isTreatmentInMonthlyPricingTest( state ),
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep }
 )( localize( PlansStep ) );

--- a/client/state/marketing/selectors.ts
+++ b/client/state/marketing/selectors.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal Dependencies
+ */
+import type { AppState } from 'calypso/types';
+import { getVariationForUser } from 'calypso/state/experiments/selectors';
+
+export function isTreatmentInMonthlyPricingTest( state: AppState ): boolean {
+	return (
+		'treatment' === getVariationForUser( state, 'monthly_pricing_test_phase_2_us_en' ) ||
+		'treatment' === getVariationForUser( state, 'monthly_pricing_test_phase_2_eu' ) ||
+		[ 'control', 'treatment' ].includes(
+			getVariationForUser( state, 'monthly_pricing_test_phase_2_latam' ) || ''
+		)
+	);
+}

--- a/client/state/marketing/selectors.ts
+++ b/client/state/marketing/selectors.ts
@@ -1,15 +1,21 @@
 /**
+ * External Dependencies
+ */
+import cookie from 'cookie';
+
+/**
  * Internal Dependencies
  */
 import type { AppState } from 'calypso/types';
 import { getVariationForUser } from 'calypso/state/experiments/selectors';
 
 export function isTreatmentInMonthlyPricingTest( state: AppState ): boolean {
+	const countryCode =
+		typeof document !== 'undefined' && cookie.parse( document.cookie )?.country_code;
+
 	return (
 		'treatment' === getVariationForUser( state, 'monthly_pricing_test_phase_2_us_en' ) ||
 		'treatment' === getVariationForUser( state, 'monthly_pricing_test_phase_2_eu' ) ||
-		[ 'control', 'treatment' ].includes(
-			getVariationForUser( state, 'monthly_pricing_test_phase_2_latam' ) || ''
-		)
+		[ 'AR', 'CL', 'CO' ].includes( countryCode || '' )
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Apply ExPlat to the monthly pricing test 2nd phase. The first phase of the same test was based on the old a/b test framework but the current phase is going to adopt the new experiment platform.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensture that you're proxied.
* Make sure you're in the `treatment` variation of any following experiments: `monthly_pricing_test_phase_2_us_en`, or `monthly_pricing_test_phase_2_eu`
* Or the value of the `country_code` cookie should be either `AR`, `CL`, or `CO`.
* Try to sign up through the `onboarding` flow.
* You should be able to see the monthly plans in the plans step.
  ![image-11](https://user-images.githubusercontent.com/212034/98643859-f5157480-2372-11eb-8b34-0cd1684eecdd.png)
* When you choose a paid plan, you should be able to see the monthly plan option in the checkout page too.
  <img width="932" alt="Checkout_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/98679282-1ee68f80-23a3-11eb-912b-7a6c43feee0d.png">
  _Note: In the above screenshot, the annual/biennial plan options don't show the monthly price x 12 next to the own price. That bug is not in the scope of this PR and will be handled in a following backend diff._

