### PR TITLE
Editor Checkout: Prevent the modal from closing when clicking outside of it

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -88,6 +88,7 @@ const EditorCheckoutModal = ( props: Props ) => {
 			overlayClassName="editor-checkout-modal"
 			onRequestClose={ onClose }
 			title=""
+			shouldCloseOnClickOutside={ false }
 			icon={ <Icon icon={ wordpress } size={ 36 } /> }
 		>
 			<ShoppingCartProvider cartKey={ cartKey } getCart={ wpcomGetCart } setCart={ wpcomSetCart }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `shouldCloseOnClickOutside` prop to `<Modal />` component inside the Editor Checkout
* Since the modal is full screen anyway, users should not be able to click "outside" the modal and only be able to close via the keyboard or clicking the "X" in the corner.

#### Testing instructions

The easiest way to test this is...

1. Checkout this branch and on your _local environment_, open a post in the editor for a site with a free plan
2. Add a premium block such as PayPal
3. Click on the "Upgrade" button to open the checkout modal
3. When you see the Stripe HTTPS notice, click it
4. The modal should _not_ close.

* Before [video](https://www.loom.com/share/d5e38562aa8f49bb857787f0a66b08af)
* After [video](https://www.loom.com/share/be29b71e23fe4d5e8846b739fa58f16c)

Fixes https://github.com/Automattic/wp-calypso/issues/47267
