### PR TITLE
Focused Launch: ensure summary steps order

### DIFF
--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -101,6 +101,11 @@ export const enableExperimental = () =>
 		type: 'ENABLE_EXPERIMENTAL',
 	} as const );
 
+export const showSiteTitleStep = () =>
+	( {
+		type: 'SHOW_SITE_TITLE_STEP',
+	} as const );
+
 export type LaunchAction = ReturnType<
 	| typeof unsetDomain
 	| typeof setStep
@@ -116,4 +121,5 @@ export type LaunchAction = ReturnType<
 	| typeof enableExperimental
 	| typeof setSidebarFullscreen
 	| typeof unsetSidebarFullscreen
+	| typeof showSiteTitleStep
 >;

--- a/packages/data-stores/src/launch/index.ts
+++ b/packages/data-stores/src/launch/index.ts
@@ -29,7 +29,14 @@ export function register(): typeof STORE_KEY {
 			controls,
 			reducer: reducer as any,
 			selectors,
-			persist: [ 'domain', 'domainSearch', 'plan', 'confirmedDomainSelection', 'isExperimental' ],
+			persist: [
+				'domain',
+				'domainSearch',
+				'plan',
+				'confirmedDomainSelection',
+				'isExperimental',
+				'isSiteTitleStepVisible',
+			],
 		} );
 	}
 	return STORE_KEY;

--- a/packages/data-stores/src/launch/index.ts
+++ b/packages/data-stores/src/launch/index.ts
@@ -27,7 +27,7 @@ export function register(): typeof STORE_KEY {
 		registerStore< State >( STORE_KEY, {
 			actions,
 			controls,
-			reducer: reducer as any,
+			reducer,
 			selectors,
 			persist: [
 				'domain',

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -97,6 +97,14 @@ const isExperimental: Reducer< boolean, LaunchAction > = ( state = false, action
 	return state;
 };
 
+const isSiteTitleStepVisible: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
+	if ( action.type === 'SHOW_SITE_TITLE_STEP' ) {
+		return true;
+	}
+
+	return state;
+};
+
 const reducer = combineReducers( {
 	step,
 	domain,
@@ -107,6 +115,7 @@ const reducer = combineReducers( {
 	isSidebarFullscreen,
 	isExperimental,
 	isFocusedLaunchOpen,
+	isSiteTitleStepVisible,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -59,5 +59,5 @@ export const isFlowStarted = ( state: State ): boolean =>
 export const getFirstIncompleteStep = ( state: State ): LaunchStepType | undefined =>
 	LaunchSequence.find( ( step ) => ! isStepCompleted( state, step ) );
 
-// Get first incomplete step
+// Check if site title step should be displayed
 export const isSiteTitleStepVisible = ( state: State ): boolean => state.isSiteTitleStepVisible;

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -58,3 +58,6 @@ export const isFlowStarted = ( state: State ): boolean =>
 // Get first incomplete step
 export const getFirstIncompleteStep = ( state: State ): LaunchStepType | undefined =>
 	LaunchSequence.find( ( step ) => ! isStepCompleted( state, step ) );
+
+// Get first incomplete step
+export const isSiteTitleStepVisible = ( state: State ): boolean => state.isSiteTitleStepVisible;

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -23,6 +23,8 @@ import LaunchContext from '../../context';
 
 import './style.scss';
 
+const DEFAULT_SITE_NAME = 'Site Title';
+
 const bulb = (
 	<SVG viewBox="0 0 24 24">
 		<Path d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8 6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z" />
@@ -383,7 +385,13 @@ const Summary: React.FunctionComponent = () => {
 	const disabledSteps: ( ( index: number ) => ReactNode )[] = [];
 	const activeSteps: ( ( index: number ) => ReactNode )[] = [];
 
-	activeSteps.push( renderSiteNameStep );
+	// Only show site name step if the current site title is still the default one.
+	// The RegExp check is more relaxed on purpose — chances are that if the title
+	// matches (even it not exactly) the default title, the user would like want
+	// to change it before launch.
+	if ( new RegExp( DEFAULT_SITE_NAME, 'i' ).test( title ) ) {
+		activeSteps.push( renderSiteNameStep );
+	}
 	( hasPaidDomain ? disabledSteps : activeSteps ).push( renderDomainStep );
 	( hasPaidPlan ? disabledSteps : activeSteps ).push( renderPlanStep );
 

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -20,10 +20,9 @@ import { Route } from '../route';
 import { useTitle, useDomainSearch, useSiteDomains } from '../../hooks';
 import { LAUNCH_STORE } from '../../stores';
 import LaunchContext from '../../context';
+import { isDefaultSiteTitle } from '../../utils';
 
 import './style.scss';
-
-const DEFAULT_SITE_NAME = 'Site Title';
 
 const bulb = (
 	<SVG viewBox="0 0 24 24">
@@ -347,15 +346,11 @@ const Summary: React.FunctionComponent = () => {
 
 	const domainSearch = useDomainSearch();
 
-	// The RegExp check is more relaxed on purpose — chances are that if the title
-	// matches (even it not exactly) the default title, the user would like want
-	// to change it before launch.
-	const isDefaultSiteTitle = new RegExp( DEFAULT_SITE_NAME, 'i' ).test( title );
-
 	// Ensure that the Site Name step doesn't disappear as soon as the user
 	// edits its value. This is achieved by ignoring the `isDefaultSiteTitle`
 	// check after the Site Name steps renders for the first time.
-	const shouldRenderNameStep = forceSiteNameRender || isDefaultSiteTitle;
+	const shouldRenderNameStep =
+		forceSiteNameRender || isDefaultSiteTitle( { currentSiteTitle: title } );
 	useEffect( () => {
 		if ( shouldRenderNameStep ) {
 			setForceSiteNameRender( true );

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -343,6 +343,10 @@ const Summary: React.FunctionComponent = () => {
 
 	const domainSearch = useDomainSearch();
 
+	// @TODO: plan step to be implemented
+	// https://github.com/Automattic/wp-calypso/issues/46865
+	const hasPaidPlan = false;
+
 	// Prepare Steps
 	const renderSiteNameStep = ( index: number ) => (
 		<SiteNameStep
@@ -374,14 +378,14 @@ const Summary: React.FunctionComponent = () => {
 	);
 	const renderPlanStep = ( index: number ) => <PlanStep stepIndex={ index } key={ index } />;
 
-	// Steps that are not interactive (e.g. user has already selected domain/plan)
-	// Steps that are not interactive (e.g. user has already selected domain/plan)
-	const disabledSteps = hasPaidDomain ? [ renderDomainStep ] : [];
+	// Disabled steps are not interactive (e.g. user has already selected domain/plan)
+	// Active steps require user interaction
+	const disabledSteps: ( ( index: number ) => ReactNode )[] = [];
+	const activeSteps: ( ( index: number ) => ReactNode )[] = [];
 
-	// Steps that require the user interaction
-	const activeSteps = hasPaidDomain
-		? [ renderSiteNameStep, renderPlanStep ]
-		: [ renderSiteNameStep, renderDomainStep, renderPlanStep ];
+	activeSteps.push( renderSiteNameStep );
+	( hasPaidDomain ? disabledSteps : activeSteps ).push( renderDomainStep );
+	( hasPaidPlan ? disabledSteps : activeSteps ).push( renderPlanStep );
 
 	return (
 		<div className="focused-launch-summary__container">

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -7,7 +7,7 @@ import { Title } from '@automattic/onboarding';
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { TextControl, SVG, Path, Tooltip, Circle, Rect } from '@wordpress/components';
-import React, { ReactNode, useContext, useState, useEffect } from 'react';
+import React, { ReactNode, useContext, useEffect } from 'react';
 import DomainPicker, { LockedPurchasedItem } from '@automattic/domain-picker';
 import { Icon, check } from '@wordpress/icons';
 import { Link } from 'react-router-dom';
@@ -336,8 +336,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 };
 
 const Summary: React.FunctionComponent = () => {
-	const { title, updateTitle, saveTitle } = useTitle();
-	const [ forceSiteNameRender, setForceSiteNameRender ] = useState( false );
+	const { title, updateTitle, saveTitle, isSiteTitleStepVisible, showSiteTitleStep } = useTitle();
 
 	const { sitePrimaryDomain, siteSubdomain, hasPaidDomain } = useSiteDomains();
 	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
@@ -346,16 +345,13 @@ const Summary: React.FunctionComponent = () => {
 
 	const { locale } = useContext( LaunchContext );
 
-	// Ensure that the Site Name step doesn't disappear as soon as the user
-	// edits its value. This is achieved by ignoring the `isDefaultSiteTitle`
-	// check after the Site Name steps renders for the first time.
-	const shouldRenderNameStep =
-		forceSiteNameRender || isDefaultSiteTitle( { currentSiteTitle: title } );
+	// If the user needs to change the site title, always show the site title
+	// step to the user when in this launch flow.
 	useEffect( () => {
-		if ( shouldRenderNameStep ) {
-			setForceSiteNameRender( true );
+		if ( ! isSiteTitleStepVisible && isDefaultSiteTitle( { currentSiteTitle: title } ) ) {
+			showSiteTitleStep();
 		}
-	}, [ shouldRenderNameStep ] );
+	}, [ title, showSiteTitleStep, isSiteTitleStepVisible ] );
 
 	// @TODO: plan step to be implemented
 	// https://github.com/Automattic/wp-calypso/issues/46865
@@ -398,7 +394,7 @@ const Summary: React.FunctionComponent = () => {
 	// groups, and allows the actve steps to always show the correct step index.
 	const disabledSteps: ( ( index: number ) => ReactNode )[] = [];
 	const activeSteps: ( ( index: number ) => ReactNode )[] = [];
-	shouldRenderNameStep && activeSteps.push( renderSiteNameStep );
+	isSiteTitleStepVisible && activeSteps.push( renderSiteNameStep );
 	( hasPaidDomain ? disabledSteps : activeSteps ).push( renderDomainStep );
 	( hasPaidPlan ? disabledSteps : activeSteps ).push( renderPlanStep );
 

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -342,9 +342,9 @@ const Summary: React.FunctionComponent = () => {
 	const { sitePrimaryDomain, siteSubdomain, hasPaidDomain } = useSiteDomains();
 	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
 	const { setDomain, unsetDomain } = useDispatch( LAUNCH_STORE );
-	const { locale } = useContext( LaunchContext );
-
 	const domainSearch = useDomainSearch();
+
+	const { locale } = useContext( LaunchContext );
 
 	// Ensure that the Site Name step doesn't disappear as soon as the user
 	// edits its value. This is achieved by ignoring the `isDefaultSiteTitle`

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -394,6 +394,8 @@ const Summary: React.FunctionComponent = () => {
 
 	// Disabled steps are not interactive (e.g. user has already selected domain/plan)
 	// Active steps require user interaction
+	// Using this arrays allows to easily sort the steps correctly in both
+	// groups, and allows the actve steps to always show the correct step index.
 	const disabledSteps: ( ( index: number ) => ReactNode )[] = [];
 	const activeSteps: ( ( index: number ) => ReactNode )[] = [];
 	shouldRenderNameStep && activeSteps.push( renderSiteNameStep );

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -57,10 +57,10 @@ type CommonStepProps = {
 };
 
 // Props in common between all summary steps + a few props from <TextControl>
-type SiteNameStepProps = CommonStepProps &
+type SiteTitleStepProps = CommonStepProps &
 	Pick< React.ComponentProps< typeof TextControl >, 'value' | 'onChange' | 'onBlur' >;
 
-const SiteNameStep: React.FunctionComponent< SiteNameStepProps > = ( {
+const SiteTitleStep: React.FunctionComponent< SiteTitleStepProps > = ( {
 	stepIndex,
 	value,
 	onChange,
@@ -358,8 +358,8 @@ const Summary: React.FunctionComponent = () => {
 	const hasPaidPlan = false;
 
 	// Prepare Steps
-	const renderSiteNameStep = ( index: number ) => (
-		<SiteNameStep
+	const renderSiteTitleStep = ( index: number ) => (
+		<SiteTitleStep
 			stepIndex={ index }
 			key={ index }
 			value={ title }
@@ -394,7 +394,7 @@ const Summary: React.FunctionComponent = () => {
 	// groups, and allows the actve steps to always show the correct step index.
 	const disabledSteps: ( ( index: number ) => ReactNode )[] = [];
 	const activeSteps: ( ( index: number ) => ReactNode )[] = [];
-	isSiteTitleStepVisible && activeSteps.push( renderSiteNameStep );
+	isSiteTitleStepVisible && activeSteps.push( renderSiteTitleStep );
 	( hasPaidDomain ? disabledSteps : activeSteps ).push( renderDomainStep );
 	( hasPaidPlan ? disabledSteps : activeSteps ).push( renderPlanStep );
 

--- a/packages/launch/src/hooks/use-domain-search.ts
+++ b/packages/launch/src/hooks/use-domain-search.ts
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 
 /**
  * External dependencies
  */
 import { LAUNCH_STORE } from '../stores';
 import { useSite, useTitle } from './';
+import { isDefaultSiteTitle } from '../utils';
 
 export function useDomainSearch(): string {
 	const { domainSearch } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
@@ -17,7 +17,7 @@ export function useDomainSearch(): string {
 
 	let search = domainSearch.trim() || title;
 
-	if ( ! search || search === __( 'Site Title', __i18n_text_domain__ ) ) {
+	if ( ! search || isDefaultSiteTitle( { currentSiteTitle: search, exact: true } ) ) {
 		search = currentDomainName?.split( '.' )[ 0 ] ?? '';
 	}
 

--- a/packages/launch/src/hooks/use-title.ts
+++ b/packages/launch/src/hooks/use-title.ts
@@ -21,8 +21,8 @@ export function useTitle() {
 
 	const saveSiteTitle = useDispatch( SITE_STORE ).saveSiteTitle;
 
-	const isSiteTitleStepVisible = useSelect(
-		( select ) => select( LAUNCH_STORE ).isSiteTitleStepVisible
+	const isSiteTitleStepVisible = useSelect( ( select ) =>
+		select( LAUNCH_STORE ).isSiteTitleStepVisible()
 	);
 
 	const showSiteTitleStep = useDispatch( LAUNCH_STORE ).showSiteTitleStep;

--- a/packages/launch/src/hooks/use-title.ts
+++ b/packages/launch/src/hooks/use-title.ts
@@ -7,7 +7,7 @@ import { useContext, useEffect, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { SITE_STORE } from '../stores';
+import { SITE_STORE, LAUNCH_STORE } from '../stores';
 import LaunchContext from '../context';
 
 export function useTitle() {
@@ -21,6 +21,12 @@ export function useTitle() {
 
 	const saveSiteTitle = useDispatch( SITE_STORE ).saveSiteTitle;
 
+	const isSiteTitleStepVisible = useSelect(
+		( select ) => select( LAUNCH_STORE ).isSiteTitleStepVisible
+	);
+
+	const showSiteTitleStep = useDispatch( LAUNCH_STORE ).showSiteTitleStep;
+
 	return {
 		title: localStateTitle,
 		updateTitle: setLocalStateTitle,
@@ -32,5 +38,7 @@ export function useTitle() {
 			}
 			saveSiteTitle( siteId, localStateTitle );
 		},
+		isSiteTitleStepVisible,
+		showSiteTitleStep,
 	};
 }

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -8,7 +8,13 @@ const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
 // When `exact === false', the check is more relaxed — chances are that if the title
 // matches (even it not exactly) the default title, the user would like want
 // to change it before launch.
-export const isDefaultSiteTitle = ( { currentSiteTitle = '', exact = false } ): boolean =>
+export const isDefaultSiteTitle = ( {
+	currentSiteTitle = '',
+	exact = false,
+}: {
+	currentSiteTitle: string;
+	exact?: boolean;
+} ): boolean =>
 	exact
 		? currentSiteTitle === DEFAULT_SITE_NAME
 		: new RegExp( DEFAULT_SITE_NAME, 'i' ).test( currentSiteTitle );

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
+
+// When `exact === false', the check is more relaxed — chances are that if the title
+// matches (even it not exactly) the default title, the user would like want
+// to change it before launch.
+export const isDefaultSiteTitle = ( { currentSiteTitle = '', exact = false } ): boolean =>
+	exact
+		? currentSiteTitle === DEFAULT_SITE_NAME
+		: new RegExp( DEFAULT_SITE_NAME, 'i' ).test( currentSiteTitle );


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Ensure that steps in the summary view of the Focused Launch flow always appear in the correct order within the disabled/active group:
  1. Site name
  2. Domain
  3. Plan
* Show "Name Your Site" step only if the site title contains the string "Site Title"
* If the "Name Your Site" step is shown to the user, that step should _always_ be shown in the Focused Launch flow for that site, even if the user changes the site title to a different value from the initial one

## Testing instructions

#### Preparation steps:

* Check out the branch on your machine and run in two parallel terminal windows:
  - `yarn && yarn start`
  - `cd apps/editing-toolkit && yarn dev --sync`
* Create two different sites by visiting `calypso.localhost:3000/start` (`SITE_ID_1` and `SITE_ID_2`)
* Add both `SITE_ID_1` and `SITE_ID_2` to your sandbox, and refresh your hosts/DNS cache

#### Test the "Name Your Site" step visibility logic:

* Visit `calypso.localhost:3000/page/SITE_ID_1/home?flags=create/focused-launch-flow-calypso`
* The "Name your site" step should be visible. Change the site name to something different than "Site Title". Move the focus away from the input, in order to save the value
* Visit `calypso.localhost:3000/page/SITE_ID_1/home?flags=create/focused-launch-flow` and click on the "Launch" button
* The "Name your site" step _should not_ be visible, since the title is not the default one anymore
* Visit `calypso.localhost:3000/page/SITE_ID_2/home?flags=create/focused-launch-flow` and click on the "Launch" button
* The "Name your site" step _should_ be visible, since the title is still the default one
* Change the site name to something different than "Site Title". Move the focus away from the input, in order to save the value
* Refresh the site — the "Name your site" step _should still_ be visible, even if the title is not the default title anymore (this is due to the `isSiteTitleStepVisible` value from the `automattic/launch` data-store being persisted in the local storage)
* To make sure that this setting only affects `SITE_ID_2`, visit again `calypso.localhost:3000/page/SITE_ID_1/home?flags=create/focused-launch-flow` and make sure that the "Name your site" step is still _not_ visible

#### Test the order of the steps:

* Visit `calypso.localhost:3000/page/SITE_ID_1/home?flags=create/focused-launch-flow-calypso`
* By manually changing in the code the values of the variables `title`, `hasPaidDomain` and `hasPaidPlan`, check that the 3 steps, when in the same group ("disabled" or "active"), always respect this appearance order:
  1. Site name
  2. Domain
  3. Plan

Fixes #46858
Fixes #47243
