### PR TITLE
Jetpack Cloud's Activity Log: Set date format according to user locale

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { isActivityBackup } from 'calypso/lib/jetpack/backup-utils';
 import { updateFilter } from 'calypso/state/activity-log/actions';
@@ -76,7 +77,14 @@ class ActivityCardList extends Component {
 	}
 
 	renderLogs( actualPage ) {
-		const { applySiteOffset, logs, pageSize, showDateSeparators, translate } = this.props;
+		const {
+			applySiteOffset,
+			logs,
+			pageSize,
+			showDateSeparators,
+			translate,
+			userLocale,
+		} = this.props;
 
 		const today = applySiteOffset ? applySiteOffset() : null;
 
@@ -90,13 +98,17 @@ class ActivityCardList extends Component {
 				? 'activity-card-list__secondary-card-with-more'
 				: 'activity-card-list__secondary-card';
 
+		const dateFormat = userLocale === 'en' ? 'MMM Do' : 'LL';
+
 		return this.splitLogsByDate( logs.slice( ( actualPage - 1 ) * pageSize ) ).map(
 			( { date, logs: dateLogs, hasMore }, index ) => (
 				<div key={ `activity-card-list__date-group-${ index }` }>
 					{ showDateSeparators && (
 						<div className="activity-card-list__date-group-date">
 							{ date &&
-								( today?.isSame( date, 'day' ) ? translate( 'Today' ) : date.format( 'MMM Do' ) ) }
+								( today?.isSame( date, 'day' )
+									? translate( 'Today' )
+									: date.format( dateFormat ) ) }
 						</div>
 					) }
 					<div className="activity-card-list__date-group-content">
@@ -247,11 +259,13 @@ const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
 	const filter = getActivityLogFilter( state, siteId );
+	const userLocale = getCurrentUserLocale( state );
 
 	return {
 		filter,
 		siteId,
 		siteSlug,
+		userLocale,
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, the date format we use is not localized, which means that it only works fine for English. This PR conditionally selects a format depending on whether users use English as their language. Users that use English won't see any change, while the rest of the users will see a localized format.

#### Testing instructions

* Run this PR (Calypso Green version is required).
* Select a Jetpack site that has some activity in the Activity Log.
* Make sure that your account language is English.
* Visit `http://jetpack.cloud.localhost:3001/activity-log/:site`.
* Verify that dates look like the capture for English in the demo section.
* Change your account language to a different one.
* Refresh the Activity Log page.
* Make sure that dates are formatted in a way that makes sense for the selected language. You can do this by comparing the date format against the one displayed in `https://wordpress.com/activity-log/:site`.

Fixes 1164141197617539-as-1176670093007911

#### Demo

Before
----
##### Incorrect format for Spanish
<img width="1277" alt="Screen Shot 2020-11-10 at 12 39 48" src="https://user-images.githubusercontent.com/3418513/98695972-00a47380-2352-11eb-8247-9d9f6a566a93.png">

After
----
##### English
<img width="1145" alt="Screen Shot 2020-11-10 at 12 11 32" src="https://user-images.githubusercontent.com/3418513/98694662-7f001600-2350-11eb-90e9-81310c4ff693.png">

French
<img width="1145" alt="Screen Shot 2020-11-10 at 12 12 07" src="https://user-images.githubusercontent.com/3418513/98694651-7ad3f880-2350-11eb-9c6d-7d82dda1cfcf.png">

##### German
<img width="1145" alt="Screen Shot 2020-11-10 at 12 12 50" src="https://user-images.githubusercontent.com/3418513/98694633-74458100-2350-11eb-8370-6d0c2c62d706.png">

##### Portuguese
<img width="1145" alt="Screen Shot 2020-11-10 at 12 13 27" src="https://user-images.githubusercontent.com/3418513/98694610-6bed4600-2350-11eb-909c-d36c62d24526.png">

##### Spanish
<img width="1145" alt="Screen Shot 2020-11-10 at 12 11 12" src="https://user-images.githubusercontent.com/3418513/98694590-64c63800-2350-11eb-811b-ad8e7f81cef3.png">
