### PR TITLE
Modularise receipts state

### DIFF
--- a/client/state/receipts/actions.js
+++ b/client/state/receipts/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import i18n from 'i18n-calypso';
 
 /**
@@ -14,6 +13,8 @@ import {
 	RECEIPT_FETCH_FAILED,
 } from 'calypso/state/action-types';
 import wpcom from 'calypso/lib/wp';
+
+import 'calypso/state/receipts/init';
 
 export function fetchReceipt( receiptId ) {
 	return ( dispatch ) => {

--- a/client/state/receipts/init.js
+++ b/client/state/receipts/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import receiptsReducer from './reducer';
+
+registerReducer( [ 'receipts' ], receiptsReducer );

--- a/client/state/receipts/initial.js
+++ b/client/state/receipts/initial.js
@@ -1,0 +1,6 @@
+export const initialReceiptState = {
+	data: null,
+	error: null,
+	hasLoadedFromServer: false,
+	isRequesting: false,
+};

--- a/client/state/receipts/package.json
+++ b/client/state/receipts/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/receipts/reducer.js
+++ b/client/state/receipts/reducer.js
@@ -1,20 +1,13 @@
 /**
  * Internal dependencies
  */
-
 import {
 	RECEIPT_FETCH,
 	RECEIPT_FETCH_COMPLETED,
 	RECEIPT_FETCH_FAILED,
 } from 'calypso/state/action-types';
-import { combineReducers } from 'calypso/state/utils';
-
-export const initialReceiptState = {
-	data: null,
-	error: null,
-	hasLoadedFromServer: false,
-	isRequesting: false,
-};
+import { initialReceiptState } from 'calypso/state/receipts/initial';
+import { combineReducers, withStorageKey } from 'calypso/state/utils';
 
 /**
  * Returns a new state with the given attributes for the given receipt ID.
@@ -53,6 +46,8 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	items,
 } );
+
+export default withStorageKey( 'receipts', combinedReducer );

--- a/client/state/receipts/selectors.js
+++ b/client/state/receipts/selectors.js
@@ -1,7 +1,9 @@
 /**
  * Internal dependencies
  */
-import { initialReceiptState } from './reducer';
+import { initialReceiptState } from 'calypso/state/receipts/initial';
+
+import 'calypso/state/receipts/init';
 
 export function getReceiptById( state, receiptId ) {
 	return state.receipts.items[ receiptId ] || initialReceiptState;

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -35,7 +35,6 @@ import { unseenCount as notificationsUnseenCount } from './notifications';
 import orderTransactions from './order-transactions/reducer';
 import pageTemplates from './page-templates/reducer';
 import postFormats from './post-formats/reducer';
-import receipts from './receipts/reducer';
 import rewind from './rewind/reducer';
 import selectedEditor from './selected-editor/reducer';
 import simplePayments from './simple-payments/reducer';
@@ -77,7 +76,6 @@ const reducers = {
 	orderTransactions,
 	pageTemplates,
 	postFormats,
-	receipts,
 	rewind,
 	selectedEditor,
 	simplePayments,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles receipts state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42472.

#### Changes proposed in this Pull Request

* Modularise receipts state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open Home on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `receipts` key, even if you expand the list of keys. This indicates that the receipts state hasn't been loaded yet.
* Click `Plans` on the side bar, select a plan, and go to your cart.
* Verify that a `receipts` key is added with the receipts state. This indicates that the receipts state has now been loaded.