### PR TITLE
Focused Launch: steps commentary logic

### DIFF
--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -47,6 +47,7 @@
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^4.22.3",
+		"@wordpress/element": "^2.16.0",
 		"@wordpress/i18n": "^3.14.0",
 		"react": "^16.8"
 	},

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -5,6 +5,7 @@
  */
 import { Title } from '@automattic/onboarding';
 import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
 import { TextControl, SVG, Path, Tooltip, Circle, Rect } from '@wordpress/components';
 import React, { ReactNode } from 'react';
 import DomainPicker, { LockedPurchasedItem } from '@automattic/domain-picker';
@@ -120,6 +121,18 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							>
 								{ info }
 							</Tooltip>
+							<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
+								<Icon icon={ bulb } />
+								{ createInterpolateElement(
+									__(
+										'<strong>Unique domains</strong> help build brand trust',
+										__i18n_text_domain__
+									),
+									{
+										strong: <strong />,
+									}
+								) }
+							</p>
 						</label>
 						<LockedPurchasedItem domainName={ currentDomain || '' } />
 					</>
@@ -132,7 +145,16 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 										{ stepIndex }. { __( 'Confirm your domain', __i18n_text_domain__ ) }
 									</label>
 									<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
-										<Icon icon={ bulb } /> 46.9% of globally registered domains are .com
+										<Icon icon={ bulb } />
+										{ createInterpolateElement(
+											__(
+												'<strong>46.9%</strong> of registered domains are <strong>.com</strong>',
+												__i18n_text_domain__
+											),
+											{
+												strong: <strong />,
+											}
+										) }
 									</p>
 								</>
 							}
@@ -156,20 +178,47 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 			}
 			commentary={
 				<>
-					<p className="focused-launch-summary__side-commentary-title">
-						<strong>46.9%</strong> of globally registered domains are <strong>.com</strong>
-					</p>
-					<ul className="focused-launch-summary__side-commentary-list">
-						<li className="focused-launch-summary__side-commentary-list-item">
-							<Icon icon={ check } /> Stand out with a unique domain
-						</li>
-						<li className="focused-launch-summary__side-commentary-list-item">
-							<Icon icon={ check } /> Easy to remember and easy to share
-						</li>
-						<li className="focused-launch-summary__side-commentary-list-item">
-							<Icon icon={ check } /> Builds brand recognition and trust
-						</li>
-					</ul>
+					{ hasPaidDomain ? (
+						<p className="focused-launch-summary__side-commentary-title">
+							{ createInterpolateElement(
+								__(
+									'<strong>Unique domains</strong> help build brand recongnition and trust',
+									__i18n_text_domain__
+								),
+								{
+									strong: <strong />,
+								}
+							) }
+						</p>
+					) : (
+						<>
+							<p className="focused-launch-summary__side-commentary-title">
+								{ createInterpolateElement(
+									__(
+										'<strong>46.9%</strong> of globally registered domains are <strong>.com</strong>',
+										__i18n_text_domain__
+									),
+									{
+										strong: <strong />,
+									}
+								) }
+							</p>
+							<ul className="focused-launch-summary__side-commentary-list">
+								<li className="focused-launch-summary__side-commentary-list-item">
+									<Icon icon={ check } />
+									{ __( 'Stand out with a unique domain' ) }
+								</li>
+								<li className="focused-launch-summary__side-commentary-list-item">
+									<Icon icon={ check } />
+									{ __( 'Easy to remember and easy to share' ) }
+								</li>
+								<li className="focused-launch-summary__side-commentary-list-item">
+									<Icon icon={ check } />
+									{ __( 'Builds brand recognition and trust' ) }
+								</li>
+							</ul>
+						</>
+					) }
 				</>
 			}
 		/>

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -225,39 +225,106 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 	);
 };
 
-type PlanStepProps = CommonStepProps;
+type PlanStepProps = CommonStepProps & { hasPaidPlan?: boolean };
 
-const PlanStep: React.FunctionComponent< PlanStepProps > = ( { stepIndex } ) => {
+const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
+	stepIndex,
+	hasPaidPlan = false,
+} ) => {
 	return (
 		<SummaryStep
 			input={
-				<>
-					<label className="focused-launch-summary__label">
-						{ stepIndex }. { __( 'Confirm your plan', __i18n_text_domain__ ) }
-					</label>
-					<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
-						<Icon icon={ bulb } /> Monetize your site with <strong>WordPress Premium</strong>
-					</p>
-					<Link to={ Route.PlanDetails }>{ __( 'View all plans', __i18n_text_domain__ ) }</Link>
-				</>
+				hasPaidPlan ? (
+					<>
+						<label className="focused-launch-summary__label">
+							{ __( 'Your plan', __i18n_text_domain__ ) }
+							<Tooltip
+								position="top center"
+								text={ __(
+									'Changes to your purchased plan can be managed from your Plans page.',
+									__i18n_text_domain__
+								) }
+							>
+								{ info }
+							</Tooltip>
+							<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
+								<Icon icon={ bulb } />
+								{ createInterpolateElement(
+									__(
+										'More than <strong>38%</strong> of the internet uses <strong>WordPress</strong>',
+										__i18n_text_domain__
+									),
+									{
+										strong: <strong />,
+									}
+								) }
+							</p>
+						</label>
+						{ /* @TODO: insert locked purchased plan item here */ }
+					</>
+				) : (
+					<>
+						<label className="focused-launch-summary__label">
+							{ stepIndex }. { __( 'Confirm your plan', __i18n_text_domain__ ) }
+						</label>
+						<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
+							<Icon icon={ bulb } />
+							{ createInterpolateElement(
+								__(
+									'Grow your business with <strong>WordPress Business</strong>',
+									__i18n_text_domain__
+								),
+								{
+									strong: <strong />,
+								}
+							) }
+						</p>
+						<Link to={ Route.PlanDetails }>{ __( 'View all plans', __i18n_text_domain__ ) }</Link>
+					</>
+				)
 			}
 			commentary={
-				<>
+				hasPaidPlan ? (
 					<p className="focused-launch-summary__side-commentary-title">
-						Monetize your site with <strong>WordPress Premium</strong>
+						{ createInterpolateElement(
+							__(
+								'More than <strong>38%</strong> of the internet uses <strong>WordPress</strong>',
+								__i18n_text_domain__
+							),
+							{
+								strong: <strong />,
+							}
+						) }
 					</p>
-					<ul className="focused-launch-summary__side-commentary-list">
-						<li className="focused-launch-summary__side-commentary-list-item">
-							<Icon icon={ check } /> Advanced tools and customization
-						</li>
-						<li className="focused-launch-summary__side-commentary-list-item">
-							<Icon icon={ check } /> Unlimited premium themes
-						</li>
-						<li className="focused-launch-summary__side-commentary-list-item">
-							<Icon icon={ check } /> Accept payments
-						</li>
-					</ul>
-				</>
+				) : (
+					<>
+						<p className="focused-launch-summary__side-commentary-title">
+							{ createInterpolateElement(
+								__(
+									'Monetize your site with <strong>WordPress Premium</strong>',
+									__i18n_text_domain__
+								),
+								{
+									strong: <strong />,
+								}
+							) }
+						</p>
+						<ul className="focused-launch-summary__side-commentary-list">
+							<li className="focused-launch-summary__side-commentary-list-item">
+								<Icon icon={ check } />
+								{ __( 'Advanced tools and customization' ) }
+							</li>
+							<li className="focused-launch-summary__side-commentary-list-item">
+								<Icon icon={ check } />
+								{ __( 'Unlimited premium themes' ) }
+							</li>
+							<li className="focused-launch-summary__side-commentary-list-item">
+								<Icon icon={ check } />
+								{ __( 'Accept payments' ) }
+							</li>
+						</ul>
+					</>
+				)
 			}
 		/>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Implement the logic described in #46862 and #46865 for the commentary text shown alongside the domain and plan summary steps

#### Testing instructions

* Check out this branch on your machine, and run `yarn start` in the project root
* Visit `calypso.localhost:3000/page/UNLAUNCHED_SITE_ID/home?flags=create/focused-launch-flow-calypso`
* By changing the `hasPaidDomain` and `hasPaidPlan` variables in the code, check that the commentary shows as follow:

  - Domain step:
    - When site doesn't have a pre-purchased domain:
      - [x] On desktop, reads  "46.9% of globally registered domains are .com" and shows additional list items
      - [x] On mobile, starts with a bulb icon, reads "46.9% of registered domains are .com" and doesn't show any list items
    - When site already has a pre-purchased domain:
      - [x] On desktop, reads  "Unique domains help build brand recognition and trust"
      - [x] On mobile, starts with a bulb icon, and reads "Unique domains help build brand trust"

  - Plan step:
    - When site doesn't have a pre-purchased plan:
      - [x] On desktop, reads  "Monetize your site with WordPress premium" and shows additional list items
      - [x] On mobile, starts with a bulb icon, reads "Grow your business with WordPress Business" and doesn't show any list 
    - When site already has a pre-purchased plan:
      - [x] For both mobile and desktop, reads  "More than 38% of the internet uses WordPress"

While working on the commentary logic, I also marked all currently available strings for translations

### Screenshots 

Please refer to #46862 and #46865 for screenshots of all the possible combinations


Fixes #47057
Partially implements #46862 and #46865

