### PR TITLE
Modularise page templates state

### DIFF
--- a/client/state/page-templates/actions.js
+++ b/client/state/page-templates/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'calypso/lib/wp';
 import {
 	PAGE_TEMPLATES_RECEIVE,
@@ -9,6 +8,8 @@ import {
 	PAGE_TEMPLATES_REQUEST_FAILURE,
 	PAGE_TEMPLATES_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
+
+import 'calypso/state/page-templates/init';
 
 /**
  * Returns an action object used in signalling that a set of templates has been

--- a/client/state/page-templates/init.js
+++ b/client/state/page-templates/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'pageTemplates' ], reducer );

--- a/client/state/page-templates/package.json
+++ b/client/state/page-templates/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/page-templates/reducer.js
+++ b/client/state/page-templates/reducer.js
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'calypso/state/utils';
+import {
+	combineReducers,
+	withoutPersistence,
+	withSchemaValidation,
+	withStorageKey,
+} from 'calypso/state/utils';
 import { itemsSchema } from './schema';
 import {
 	PAGE_TEMPLATES_RECEIVE,
@@ -57,7 +62,9 @@ export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) =
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	requesting,
 	items,
 } );
+
+export default withStorageKey( 'pageTemplates', combinedReducer );

--- a/client/state/page-templates/selectors.js
+++ b/client/state/page-templates/selectors.js
@@ -1,12 +1,16 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/page-templates/init';
+
+/**
  * Returns true if a request is in progress to retrieve the page templates for
  * the specified site, or false otherwise.
  *
- *
- * @param {number}  siteId Site ID
- * @returns {boolean}        Whether a request is in progress
+ * @param {object} state  Global state tree
+ * @param {number} siteId Site ID
+ * @returns {boolean} Whether a request is in progress
  */
-
 export function isRequestingPageTemplates( state, siteId ) {
 	return !! state.pageTemplates.requesting[ siteId ];
 }

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -33,7 +33,6 @@ import mySites from './my-sites/reducer';
 import notices from './notices/reducer';
 import { unseenCount as notificationsUnseenCount } from './notifications';
 import orderTransactions from './order-transactions/reducer';
-import pageTemplates from './page-templates/reducer';
 import postFormats from './post-formats/reducer';
 import receipts from './receipts/reducer';
 import rewind from './rewind/reducer';
@@ -75,7 +74,6 @@ const reducers = {
 	notices,
 	notificationsUnseenCount,
 	orderTransactions,
-	pageTemplates,
 	postFormats,
 	receipts,
 	rewind,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles receipts state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42466.

#### Changes proposed in this Pull Request

* Modularise page templates state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open Home on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `pageTemplates` key, even if you expand the list of keys. This indicates that the receipts state hasn't been loaded yet.

As far as I can tell, page templates aren't being used anywhere at the moment, so there should be no way for the key to ever load.