### PR TITLE
E2E Tests: Fix .deletePlan() flow

### DIFF
--- a/test/e2e/lib/pages/cancel-purchase-page.js
+++ b/test/e2e/lib/pages/cancel-purchase-page.js
@@ -13,7 +13,7 @@ const by = webdriver.By;
 
 export default class CancelPurchasePage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, by.css( '.cancel-purchase.main' ) );
+		super( driver, by.css( '.purchases__cancel.main' ) );
 		this.cancelButtonSelector = by.css( 'button.cancel-purchase__button' );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the main views selector for the purchase cancellations page so the tests can find the correct elements.

#### Testing instructions

1. If you haven't already, configure your local environment to run the E2E tests here PCYsg-7p3-p2
2. Once you have done the above. `cd test/e2e`.
3. `./node_modules/.bin/mocha specs/wp-signup-spec.js`.
4. The tests should successfully delete the plans and the following error should not be output to the console

`There was an error in the hooks that clean up the test account (delete plan) but since it is cleaning up we really don't care: 'TimeoutError: Timed out waiting for element with css selector of '.cancel-purchase.main' to be present and displayed
Wait timed out after 22216ms'`

Fixes https://github.com/Automattic/wp-calypso/issues/47284
