### PR TITLE
Nav-unification: Selected submenu color is chosen by variable

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -25,6 +25,8 @@
 	--color-sidebar-submenu-text: #b4b9be;
 	--color-sidebar-submenu-hover-background: transparent;
 	--color-sidebar-submenu-hover-text: #00b9eb;
+	--color-sidebar-submenu-selected-background: transparent;
+	--color-sidebar-submenu-selected-text: white;
 
 	.is-sidebar-collapsed:not( .is-section-reader ):not( .is-section-me ) & {
 		--sidebar-width-max: 36px;
@@ -131,8 +133,8 @@ $font-size: rem( 14px );
 			}
 
 			.selected .sidebar__menu-link {
-				background-color: transparent;
-				color: white;
+				background-color: var( --color-sidebar-submenu-selected-background );
+				color: var( --color-sidebar-submenu-selected-text );
 				font-weight: 600;
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When the nav unification flag is on, the expandable submenu will have customizable colors for its currently selected item.  Previously, they were hardcoded to white fg and transparent bg.
  * This works fine for most themes, except **light** from wp-admin.  It already has a white background so I need to be able to override the text cleanly.
  * Very similar to #47249, which covered unselected and hovered items.  This adds selected (or active) items.

#### Testing instructions

* With nav unification on ( http://calypso.localhost:3000/?flags=nav-unification ), check the colors of the selected item in an expandable menu.  It should look the same before and after.

![2020-11-10_13-24](https://user-images.githubusercontent.com/937354/98724072-cb4f5400-2358-11eb-9299-596d7969ae74.png)


