### PR TITLE
Nav unification: Example of extending sakura to work on nav-unification

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
@@ -1,4 +1,5 @@
-.color-scheme.is-sakura {
+.color-scheme.is-sakura,
+.color-scheme.is-sakura .is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-celadon-50 );
 	--color-primary-rgb: var( --studio-celadon-50-rgb );
@@ -119,4 +120,16 @@
 	--color-sidebar-menu-hover-background: var( --studio-pink-10 );
 	--color-sidebar-menu-hover-background-rgb: var( --studio-pink-10-rgb );
 	--color-sidebar-menu-hover-text: var( --studio-pink-90 );
+
+	/* Sidebar Hover - Nav unification */
+	--color-sidebar-menu-hover-heading-background: var( --studio-pink-10 );
+	--color-sidebar-menu-hover: var( --studio-pink-90 );
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: var( --studio-pink-20 );
+	--color-sidebar-submenu-text: var( --studio-pink-90 );
+	/*
+	--color-sidebar-submenu-hover-text: var( --theme-highlight-color );
+	--color-sidebar-submenu-hover-background: transparent;
+	*/
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
@@ -121,10 +121,6 @@
 	--color-sidebar-menu-hover-background-rgb: var( --studio-pink-10-rgb );
 	--color-sidebar-menu-hover-text: var( --studio-pink-90 );
 
-	/* Sidebar Hover - Nav unification */
-	--color-sidebar-menu-hover-heading-background: var( --studio-pink-10 );
-	--color-sidebar-menu-hover: var( --studio-pink-90 );
-
 	/* Sidebar Submenu - Nav Unification */
 	--color-sidebar-submenu-background: var( --studio-pink-20 );
 	--color-sidebar-submenu-text: var( --studio-pink-90 );


### PR DESCRIPTION
### Overview

This is an example for #47040, where I point out that calypso color schemes that we port to wp-admin will need a small amount of changes to work in calypso+nav-unification as well.

### Screenshots

Before (Calypso Nav Unification Off, Calypso Nav Unification On)
![2020-11-10_14-10](https://user-images.githubusercontent.com/937354/98729157-1a4cb780-2360-11eb-87f3-800743faeaaf.png)


After  (Calypso Nav Unification Off, Calypso Nav Unification On)
![2020-11-10_14-17](https://user-images.githubusercontent.com/937354/98729169-1f116b80-2360-11eb-819b-656f5692bd4f.png)


### Reference Issues

* Main Issue #45435
  * Color Schemes Issue + Direction  #45675
    * Add the necessary wp-admin styles to support all color schemes available in Calypso #47040