### PR TITLE
Nav unification: consolidate color-sidebar-menu-hover and -text variable

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -12,7 +12,6 @@
 	--color-sidebar-menu-hover-background: #32373c;
 	--color-sidebar-menu-hover-background-rgb: rgb( #32373c );
 	--color-sidebar-menu-hover-heading-background: #1a1e23;
-	--color-sidebar-menu-hover: #00b9eb;
 	--color-sidebar-menu-hover-text: #00b9eb;
 	--color-sidebar-menu-selected-background: #0073aa;
 	--color-sidebar-border: #333333;
@@ -81,7 +80,7 @@ $font-size: rem( 14px );
 			&:hover,
 			&:focus {
 				background-color: var( --color-sidebar-menu-hover-heading-background );
-				color: var( --color-sidebar-menu-hover );
+				color: var( --color-sidebar-menu-hover-text );
 			}
 
 			&::after {
@@ -178,7 +177,7 @@ $font-size: rem( 14px );
 		.sidebar__menu-link {
 			&:hover {
 				.sidebar__menu-icon {
-					color: var( --color-sidebar-menu-hover );
+					color: var( --color-sidebar-menu-hover-text );
 				}
 				img.sidebar__menu-icon {
 					opacity: 1;
@@ -208,7 +207,7 @@ $font-size: rem( 14px );
 
 				&:hover {
 					.sidebar__menu-icon {
-						color: var( --color-sidebar-menu-hover );
+						color: var( --color-sidebar-menu-hover-text );
 					}
 					img.sidebar__menu-icon {
 						opacity: 1;
@@ -496,7 +495,7 @@ $font-size: rem( 14px );
 
 			.sidebar__heading {
 				background-color: var( --color-sidebar-menu-hover-heading-background );
-				color: var( --color-sidebar-menu-hover );
+				color: var( --color-sidebar-menu-hover-text );
 			}
 
 			// indicator arrow

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
@@ -137,7 +137,6 @@ Used studio-blue for the primary+accent.
 
 	/* Sidebar Hover - Nav unification */
 	--color-sidebar-menu-hover-background: var( --theme-highlight-color );
-	--color-sidebar-menu-hover: var( --theme-text-color );
 	--color-sidebar-menu-hover-heading-background: var( --theme-highlight-color );
 
 	/* Sidebar Submenu - Nav Unification */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
@@ -174,7 +174,6 @@ Created this definition in color-studio to generate 0-100 shades:
 
 	/* Sidebar Hover - Nav unification */
 	--color-sidebar-menu-hover-background: var( --theme-highlight-color );
-	--color-sidebar-menu-hover: var( --theme-text-color );
 	--color-sidebar-menu-hover-heading-background: var( --theme-highlight-color );
 
 	/* Sidebar Submenu - Nav Unification */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
@@ -153,7 +153,6 @@ Primary+Accent is studio blue.
 	--color-sidebar-menu-hover-heading-background: #888;
 
 	/* Sidebar Hover - Nav unification */
-	--color-sidebar-menu-hover: #fff;
 
 	/* Sidebar Submenu - Nav Unification */
 	--color-sidebar-submenu-background: var( --theme-submenu-background-color );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -140,7 +140,6 @@ Used studio-blue for the primary+accent.
 
 	/* Sidebar Hover - Nav unification */
 	--color-sidebar-menu-hover-background: var( --theme-highlight-color );
-	--color-sidebar-menu-hover: var( --theme-text-color );
 	--color-sidebar-menu-hover-heading-background: var( --theme-highlight-color );
 
 	/* Sidebar Submenu - Nav Unification */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
@@ -139,7 +139,6 @@ Well use studio-orange for both the primary and accent colors
 
 	/* Sidebar Hover - Nav unification */
 	--color-sidebar-menu-hover-background: var( --theme-highlight-color );
-	--color-sidebar-menu-hover: var( --theme-text-color );
 	--color-sidebar-menu-hover-heading-background: var( --theme-highlight-color );
 
 	/* Sidebar Submenu - Nav Unification */


### PR DESCRIPTION


#### Background

This is relatively straightforward and an easy change with no downsides, in my opinion.

* This is considering the color of text when hovering over sidebar items.
* Before we started the nav-unification project, calypso color schemes used `color-sidebar-menu-hover-text`.
* When we first added nav unification styles, we defined two variables, with the same color value:
  * `color-sidebar-menu-hover-text`
    * This matches the calypso variable, but wasn't used anywhere.
  * `color-sidebar-menu-hover`
    * This was a new variable that only existed in nav unification.

#### Changes proposed in this Pull Request

* Change all references of `color-sidebar-menu-hover` to `color-sidebar-menu-hover-text`.
* Remove all theme definitions of `color-sidebar-menu-hover`.
  * The existing definitions of `color-sidebar-menu-hover-text` will work in their place.  All themes had the same values for both.

#### Benefits

* One less variable
* Less changes needed to calypso schemes when porting to nav-unification calypso.

#### Testing instructions

Visit calypso with nav unification turned on, http://calypso.localhost:3000/?flags=nav-unification. Hovering text should still work (in most themes it's white, but it's blue in the default nav unification theme).

![2020-11-10_15-11](https://user-images.githubusercontent.com/937354/98734920-49ffbd80-2368-11eb-8e63-a74645143680.png)

### Reference Issues

* Main Issue #45435
  * Color Schemes Issue + Direction  #45675
    * Add the necessary wp-admin styles to support all color schemes available in Calypso #47040
      * Nav unification: Example of extending sakura to work on nav-unification #47292