### PR TITLE
Patterns API: Use the user's language setting, not the site language setting

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -146,8 +146,7 @@ class Block_Patterns_From_API {
 	 * @return string ISO 639 locale string
 	 */
 	private function get_iso_639_locale() {
-		// Make sure to get blog locale, not user locale.
-		$language = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
+		$language = get_user_locale( get_current_user_id() );
 		$language = strtolower( $language );
 
 		if ( in_array( $language, array( 'pt_br', 'pt-br', 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ), true ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the code that requests patterns in the editor to ask for patterns in the user's language, not the site's language.

Fixes https://github.com/Automattic/wp-calypso/issues/46952

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update your user language setting to Spanish in https://wordpress.com/me/account
* Apply this patch, sync to your sandbox with `yarn dev --sync`
* Open a sandboxed site that has its language set to English
* Confirm that you see the patterns UI in Spanish, NOT English:

<img width="390" alt="Screen Shot 2020-11-10 at 1 40 15 PM" src="https://user-images.githubusercontent.com/1464705/98736918-554bec80-235a-11eb-91c4-9e9bb1c80611.png">
