### PR TITLE
Checkout: Add credits to order review

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -91,7 +91,7 @@ export default function PaymentMethodStep( {
 					<LineItem tax key={ tax.id } item={ tax } />
 				) ) }
 				{ credits && <LineItem subtotal item={ credits } /> }
-				<WPOrderReviewTotal total={ total } />
+				<WPOrderReviewTotal total={ isFullCredits ? subtotal : total } />
 			</WPOrderReviewSection>
 		</>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useLineItems } from '@automattic/composite-checkout';
+import { useShoppingCart } from '@automattic/shopping-cart';
+import styled from '@emotion/styled';
+import type { LineItem as LineItemType } from '@automattic/composite-checkout';
+
+/**
+ * Internal dependencies
+ */
+import CheckoutTerms from '../components/checkout-terms';
+import { WPOrderReviewTotal, WPOrderReviewSection, LineItem } from './wp-order-review-line-items';
+
+const CheckoutTermsWrapper = styled.div`
+	& > * {
+		margin: 16px 0 16px -24px;
+		padding-left: 24px;
+		position: relative;
+	}
+
+	.rtl & > * {
+		margin: 16px -24px 16px 0;
+		padding-right: 24px;
+		padding-left: 0;
+	}
+
+	& div:first-of-type {
+		padding-right: 0;
+		padding-left: 0;
+		margin-right: 0;
+		margin-left: 0;
+		margin-top: 32px;
+	}
+
+	svg {
+		width: 16px;
+		height: 16px;
+		position: absolute;
+		top: 0;
+		left: 0;
+
+		.rtl & {
+			left: auto;
+			right: 0;
+		}
+	}
+
+	p {
+		font-size: 12px;
+		margin: 0;
+		word-break: break-word;
+	}
+
+	a {
+		text-decoration: underline;
+	}
+
+	a:hover {
+		text-decoration: none;
+	}
+`;
+
+export default function PaymentMethodStep( {
+	subtotal,
+	activeStepContent,
+}: {
+	subtotal: LineItemType;
+	activeStepContent: JSX.Element;
+} ): JSX.Element {
+	const { responseCart } = useShoppingCart();
+	const [ items, total ] = useLineItems();
+	const taxes = items.filter( ( item ) => item.type === 'tax' );
+	return (
+		<>
+			{ activeStepContent }
+
+			<CheckoutTermsWrapper>
+				<CheckoutTerms cart={ responseCart } />
+			</CheckoutTermsWrapper>
+
+			<WPOrderReviewSection>
+				{ subtotal && <LineItem subtotal item={ subtotal } /> }
+				{ taxes.map( ( tax ) => (
+					<LineItem tax key={ tax.id } item={ tax } />
+				) ) }
+				<WPOrderReviewTotal total={ total } />
+			</WPOrderReviewSection>
+		</>
+	);
+}

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -12,6 +12,7 @@ import type { LineItem as LineItemType } from '@automattic/composite-checkout';
  */
 import CheckoutTerms from '../components/checkout-terms';
 import { WPOrderReviewTotal, WPOrderReviewSection, LineItem } from './wp-order-review-line-items';
+import doesPurchaseHaveFullCredits from '../lib/does-purchase-have-full-credits';
 
 const CheckoutTermsWrapper = styled.div`
 	& > * {
@@ -73,7 +74,9 @@ export default function PaymentMethodStep( {
 } ): JSX.Element {
 	const { responseCart } = useShoppingCart();
 	const [ items, total ] = useLineItems();
-	const taxes = items.filter( ( item ) => item.type === 'tax' );
+	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
+	// NOTE: if we have full credits, we currently do not charge taxes. This may not be ideal, but it's how the back-end works.
+	const taxes = isFullCredits ? [] : items.filter( ( item ) => item.type === 'tax' );
 	return (
 		<>
 			{ activeStepContent }

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -64,9 +64,11 @@ const CheckoutTermsWrapper = styled.div`
 
 export default function PaymentMethodStep( {
 	subtotal,
+	credits,
 	activeStepContent,
 }: {
 	subtotal: LineItemType;
+	credits: LineItemType;
 	activeStepContent: JSX.Element;
 } ): JSX.Element {
 	const { responseCart } = useShoppingCart();
@@ -85,6 +87,7 @@ export default function PaymentMethodStep( {
 				{ taxes.map( ( tax ) => (
 					<LineItem tax key={ tax.id } item={ tax } />
 				) ) }
+				{ credits && <LineItem subtotal item={ credits } /> }
 				<WPOrderReviewTotal total={ total } />
 			</WPOrderReviewSection>
 		</>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -28,7 +28,6 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 /**
  * Internal dependencies
  */
-import CheckoutTerms from '../components/checkout-terms';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
 import useUpdateCartLocationWhenPaymentMethodChanges from '../hooks/use-update-cart-location-when-payment-method-changes';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
@@ -36,7 +35,6 @@ import WPCheckoutOrderSummary from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import WPContactFormSummary from './wp-contact-form-summary';
 import { isCompleteAndValid } from '../types/wpcom-store-state';
-import { WPOrderReviewTotal, WPOrderReviewSection, LineItem } from './wp-order-review-line-items';
 import MaterialIcon from 'calypso/components/material-icon';
 import Gridicon from 'calypso/components/gridicon';
 import SecondaryCartPromotions from './secondary-cart-promotions';
@@ -56,6 +54,7 @@ import {
 	hasTransferProduct,
 } from 'calypso/lib/cart-values/cart-items';
 import QueryExperiments from 'calypso/components/data/query-experiments';
+import PaymentMethodStep from './payment-method-step';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
@@ -391,7 +390,10 @@ export default function WPCheckout( {
 					<CheckoutStep
 						stepId="payment-method-step"
 						activeStepContent={
-							<PaymentMethodStep responseCart={ responseCart } subtotal={ subtotal } />
+							<PaymentMethodStep
+								activeStepContent={ paymentMethodStep.activeStepContent }
+								subtotal={ subtotal }
+							/>
 						}
 						completeStepContent={ paymentMethodStep.completeStepContent }
 						titleContent={ paymentMethodStep.titleContent }
@@ -501,77 +503,6 @@ const CheckoutSummaryBody = styled.div`
 		max-width: 328px;
 		position: fixed;
 		width: 100%;
-	}
-`;
-
-function PaymentMethodStep( { responseCart, subtotal } ) {
-	const [ items, total ] = useLineItems();
-	const taxes = items.filter( ( item ) => item.type === 'tax' );
-	return (
-		<>
-			{ paymentMethodStep.activeStepContent }
-
-			<CheckoutTermsWrapper>
-				<CheckoutTerms cart={ responseCart } />
-			</CheckoutTermsWrapper>
-
-			<WPOrderReviewSection>
-				{ subtotal && <LineItem subtotal item={ subtotal } /> }
-				{ taxes.map( ( tax ) => (
-					<LineItem tax key={ tax.id } item={ tax } />
-				) ) }
-				<WPOrderReviewTotal total={ total } />
-			</WPOrderReviewSection>
-		</>
-	);
-}
-
-const CheckoutTermsWrapper = styled.div`
-	& > * {
-		margin: 16px 0 16px -24px;
-		padding-left: 24px;
-		position: relative;
-	}
-
-	.rtl & > * {
-		margin: 16px -24px 16px 0;
-		padding-right: 24px;
-		padding-left: 0;
-	}
-
-	& div:first-of-type {
-		padding-right: 0;
-		padding-left: 0;
-		margin-right: 0;
-		margin-left: 0;
-		margin-top: 32px;
-	}
-
-	svg {
-		width: 16px;
-		height: 16px;
-		position: absolute;
-		top: 0;
-		left: 0;
-
-		.rtl & {
-			left: auto;
-			right: 0;
-		}
-	}
-
-	p {
-		font-size: 12px;
-		margin: 0;
-		word-break: break-word;
-	}
-
-	a {
-		text-decoration: underline;
-	}
-
-	a:hover {
-		text-decoration: none;
 	}
 `;
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -28,6 +28,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 /**
  * Internal dependencies
  */
+import CheckoutTerms from '../components/checkout-terms';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
 import useUpdateCartLocationWhenPaymentMethodChanges from '../hooks/use-update-cart-location-when-payment-method-changes';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
@@ -96,7 +97,6 @@ export default function WPCheckout( {
 	changePlanLength,
 	siteId,
 	siteUrl,
-	CheckoutTerms,
 	countriesList,
 	StateSelect,
 	getItemVariants,
@@ -391,11 +391,7 @@ export default function WPCheckout( {
 					<CheckoutStep
 						stepId="payment-method-step"
 						activeStepContent={
-							<PaymentMethodStep
-								CheckoutTerms={ CheckoutTerms }
-								responseCart={ responseCart }
-								subtotal={ subtotal }
-							/>
+							<PaymentMethodStep responseCart={ responseCart } subtotal={ subtotal } />
 						}
 						completeStepContent={ paymentMethodStep.completeStepContent }
 						titleContent={ paymentMethodStep.titleContent }
@@ -508,7 +504,7 @@ const CheckoutSummaryBody = styled.div`
 	}
 `;
 
-function PaymentMethodStep( { CheckoutTerms, responseCart, subtotal } ) {
+function PaymentMethodStep( { responseCart, subtotal } ) {
 	const [ items, total ] = useLineItems();
 	const taxes = items.filter( ( item ) => item.type === 'tax' );
 	return (

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -102,6 +102,7 @@ export default function WPCheckout( {
 	responseCart,
 	addItemToCart,
 	subtotal,
+	credits,
 	isCartPendingUpdate,
 	showErrorMessageBriefly,
 	isLoggedOutCart,
@@ -393,6 +394,7 @@ export default function WPCheckout( {
 							<PaymentMethodStep
 								activeStepContent={ paymentMethodStep.activeStepContent }
 								subtotal={ subtotal }
+								credits={ credits }
 							/>
 						}
 						completeStepContent={ paymentMethodStep.completeStepContent }

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -168,6 +168,8 @@ function WPLineItem( {
 WPLineItem.propTypes = {
 	className: PropTypes.string,
 	total: PropTypes.bool,
+	tax: PropTypes.bool,
+	subtotal: PropTypes.bool,
 	isSummary: PropTypes.bool,
 	hasDeleteButton: PropTypes.bool,
 	removeProductFromCart: PropTypes.func,
@@ -179,6 +181,8 @@ WPLineItem.propTypes = {
 	} ),
 	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
+	createUserAndSiteBeforeTransaction: PropTypes.bool,
+	isMonthlyPricingTest: PropTypes.bool,
 };
 
 function LineItemPrice( { item, isSummary } ) {
@@ -318,7 +322,7 @@ function DeleteIcon( { uniqueID, product } ) {
 	);
 }
 
-export function WPOrderReviewTotal( { total, className } ) {
+export function WPOrderReviewTotal( { total, className = null } ) {
 	return (
 		<div className={ joinClasses( [ className, 'order-review-total' ] ) }>
 			<LineItem total item={ total } />

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -729,6 +729,7 @@ export default function CompositeCheckout( {
 					responseCart={ responseCart }
 					addItemToCart={ addItemWithEssentialProperties }
 					subtotal={ subtotal }
+					credits={ credits }
 					isCartPendingUpdate={ isCartPendingUpdate }
 					showErrorMessageBriefly={ showErrorMessageBriefly }
 					isLoggedOutCart={ isLoggedOutCart }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -53,7 +53,6 @@ import {
 	clearSignupDestinationCookie,
 } from 'calypso/signup/storageUtils';
 import CartMessages from 'calypso/my-sites/checkout/cart/cart-messages';
-import CheckoutTerms from './components/checkout-terms';
 import useIsApplePayAvailable from './hooks/use-is-apple-pay-available';
 import filterAppropriatePaymentMethods from './lib/filter-appropriate-payment-methods';
 import useStoredCards from './hooks/use-stored-cards';
@@ -731,7 +730,6 @@ export default function CompositeCheckout( {
 					addItemToCart={ addItemWithEssentialProperties }
 					subtotal={ subtotal }
 					isCartPendingUpdate={ isCartPendingUpdate }
-					CheckoutTerms={ CheckoutTerms }
 					showErrorMessageBriefly={ showErrorMessageBriefly }
 					isLoggedOutCart={ isLoggedOutCart }
 					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -496,6 +496,7 @@ export default function CompositeCheckout( {
 				credits,
 				subtotal,
 				allowedPaymentMethods,
+				responseCart,
 		  } );
 	debug( 'filtered payment method objects', paymentMethods );
 

--- a/client/my-sites/checkout/composite-checkout/lib/does-purchase-have-full-credits.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/does-purchase-have-full-credits.ts
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+export default function doesPurchaseHaveFullCredits( cart: ResponseCart ): boolean {
+	const isPurchaseFree = cart.total_cost_integer === 0;
+	const credits = cart.credits_integer;
+	return ! isPurchaseFree && credits > 0 && credits >= cart.sub_total_integer;
+}

--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -3,12 +3,14 @@
  */
 import debugFactory from 'debug';
 import type { PaymentMethod, LineItem } from '@automattic/composite-checkout';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
 import { CheckoutCartItem } from '../types/checkout-cart';
 import { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
+import doesPurchaseHaveFullCredits from './does-purchase-have-full-credits';
 
 const debug = debugFactory( 'calypso:composite-checkout:filter-appropriate-payment-methods' );
 
@@ -18,6 +20,7 @@ export default function filterAppropriatePaymentMethods( {
 	total,
 	credits,
 	subtotal,
+	responseCart,
 	allowedPaymentMethods,
 }: {
 	paymentMethodObjects: PaymentMethod[];
@@ -26,13 +29,10 @@ export default function filterAppropriatePaymentMethods( {
 	credits: CheckoutCartItem | null;
 	subtotal: CheckoutCartItem;
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
+	responseCart: ResponseCart;
 } ): PaymentMethod[] {
 	const isPurchaseFree = total.amount.value === 0;
-	const isFullCredits =
-		! isPurchaseFree &&
-		credits &&
-		credits.amount.value > 0 &&
-		credits.amount.value >= subtotal.amount.value;
+	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
 	debug( 'filtering payment methods with this input', {
 		total,
 		credits,

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -21,6 +21,7 @@ import {
 import { isPlan, isDomainTransferProduct, isDomainProduct } from 'calypso/lib/products-values';
 import { isRenewal } from 'calypso/lib/cart-values/cart-items';
 import doesValueExist from './does-value-exist';
+import doesPurchaseHaveFullCredits from './does-purchase-have-full-credits';
 
 /**
  * Translate a cart object as returned by the WPCOM cart endpoint to
@@ -49,6 +50,8 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		coupon,
 		tax,
 	} = serverCart;
+
+	const isFullCredits = doesPurchaseHaveFullCredits( serverCart );
 
 	const taxLineItem: CheckoutCartItem = {
 		id: 'tax-line-item',
@@ -140,7 +143,7 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		items: products.filter( isRealProduct ).map( translateReponseCartProductToWPCOMCartItem ),
 		tax: tax.display_taxes ? taxLineItem : null,
 		coupon: coupon && coupon_savings_total_integer ? couponLineItem : null,
-		total: totalItem,
+		total: isFullCredits ? subtotalItem : totalItem,
 		savings: savings_total_integer > 0 ? savingsLineItem : null,
 		subtotal: subtotalItem,
 		credits: credits_integer > 0 ? creditsLineItem : null,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a "Credits" line item to the review step of checkout just before the final payment button, if any credits are available. That way, the math of that step adds up. Previously, the credits were implied (they are shown with the individual line items near the top of the page) and it made the math seem incorrect.

In addition, when the customer has enough credits to fully cover the purchase price before taxes, we do not charge taxes on the purchase (I don't know why this is, but it's how the backend appears to work); this PR corrects a bug wherein if you have enough credits to fully cover the purchase but the taxes would bump it above that amount, the review step would display a strange total of the difference, but still allow you to pay with credits.

Fixes 49-gh-Automattic/payments-shilling
Part of the fix for https://github.com/Automattic/wp-calypso/issues/47306 but we should still correct the backend

#### Screenshots

Before, with partial credits:

<img width="570" alt="before-partial" src="https://user-images.githubusercontent.com/2036909/98750510-2b132280-238c-11eb-80ea-ecbbf10561e6.png">

After, with partial credits:

<img width="568" alt="after-partial" src="https://user-images.githubusercontent.com/2036909/98750517-30706d00-238c-11eb-8729-7f0569241633.png">

Before, with enough credits to cover subtotal but not taxes:

<img width="567" alt="wrong-full" src="https://user-images.githubusercontent.com/2036909/98835671-b46b3900-240e-11eb-8268-9ef5f6a2fb6f.png">

After, with enough credits to cover subtotal but not taxes:

<img width="560" alt="Screen Shot 2020-11-11 at 11 03 57 AM" src="https://user-images.githubusercontent.com/2036909/98835708-be8d3780-240e-11eb-9e07-cf95e1feef03.png">


#### Testing instructions

- Visit checkout without any credits, proceed to the last step, and verify that the subtotal, taxes, and total lines look correct and no credits are listed.
- Visit checkout with some credits (but not enough to cover the entire transaction), proceed to the last step, and verify that the subtotal, taxes, credits, and total lines look correct.
- Visit checkout with enough credits to cover the entire transaction, proceed to the last step, and verify that the subtotal, taxes, credits, and total lines look correct.
