### PR TITLE
Add monorepo dependencies to tsconfig.json for Composite Checkout package

### DIFF
--- a/packages/composite-checkout/tsconfig.json
+++ b/packages/composite-checkout/tsconfig.json
@@ -32,5 +32,6 @@
 		"tsBuildInfoFile": "../../.tsc-cache/packages__composite-checkout"
 	},
 	"include": [ "src" ],
-	"exclude": [ "**/docs/*", "**/test/*" ]
+	"exclude": [ "**/docs/*", "**/test/*" ],
+	"references": [ { "path": "../react-i18n" } ]
 }


### PR DESCRIPTION
Similar to #47140

#### Changes proposed in this Pull Request

* List monorepo dependencies as references in the `tsconfig.json` file of `@automattic/composite-checkout` package.

#### Testing instructions

* In the project's root folder, run this command. It should run without errors:

`yarn clean:packages; ./node_modules/.bin/tsc --build packages/composite-checkout`
