### PR TITLE
Server: Remove editor static asset

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -57,7 +57,7 @@ const debug = debugFactory( 'calypso:pages' );
 const SERVER_BASE_PATH = '/public';
 const calypsoEnv = config( 'env_id' );
 
-const staticFiles = [ { path: 'editor.css' }, { path: 'tinymce/skins/wordpress/wp-content.css' } ];
+const staticFiles = [ { path: 'tinymce/skins/wordpress/wp-content.css' } ];
 
 const staticFilesUrls = staticFiles.reduce( ( result, file ) => {
 	if ( ! file.hash ) {

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -644,7 +644,6 @@ const assertDefaultContext = ( { url, entry } ) => {
 		const { request } = await app.run();
 		const staticUrls = request.context.app.staticUrls;
 		expect( staticUrls ).toEqual( {
-			'editor.css': '/calypso/editor.css?v=hash',
 			'tinymce/skins/wordpress/wp-content.css':
 				'/calypso/tinymce/skins/wordpress/wp-content.css?v=hash',
 		} );


### PR DESCRIPTION
In #47236 we removed lots of tinymce code, and with that, we removed the `build-css:editor` script because the `editor` was no longer necessary. However, we missed to remove `editor.css` from the list of static files, served by the Calypso server. This PR removes it.

#### Changes proposed in this Pull Request

* Remove `editor.css` static asset from server

#### Testing instructions

* Verify the `editor.css` asset isn't used anywhere.
* Verify the `/calypso/tinymce/skins/wordpress/wp-content.css?v=hash` where `hash` is the hash provided on the server side is still accessible (you can see that if you view the page source on any calypso page).
* Verify server tests pass.
