### PR TITLE
Notifications: Allow table markup

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -98,6 +98,13 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 		case 'h6':
 		case 'figure':
 		case 'figcaption':
+		case 'table':
+		case 'thead':
+		case 'tbody':
+		case 'tfoot':
+		case 'tr':
+		case 'th':
+		case 'td':
 			switch ( range_info_type ) {
 				case 'list':
 					range_info_type = 'span';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add all the tags used by tables to the list of allowed tags in notifications so tables are rendered correctly. This effectively enables us to remove the table block fallback (see D52562-code).

Before | After
--- | ---
<img width="388" alt="Screen Shot 2020-11-11 at 11 10 12" src="https://user-images.githubusercontent.com/1233880/98802653-e206b100-2413-11eb-8885-5d941f8af545.png"> | <img width="399" alt="Screen Shot 2020-11-11 at 11 37 45" src="https://user-images.githubusercontent.com/1233880/98802640-de732a00-2413-11eb-9665-da78dbef4122.png">


#### Testing instructions

- Apply D52562-code to your WP.com sandbox.
- Sandbox the API.
- Publish a post that contains a table block in a site you follow.
- Check the post on the masterbar notifications.
- Make sure the table block is rendered correctly.
