### PR TITLE
Modularise rewind state

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -34,7 +34,6 @@ import notices from './notices/reducer';
 import { unseenCount as notificationsUnseenCount } from './notifications';
 import orderTransactions from './order-transactions/reducer';
 import postFormats from './post-formats/reducer';
-import rewind from './rewind/reducer';
 import selectedEditor from './selected-editor/reducer';
 import simplePayments from './simple-payments/reducer';
 import siteAddressChange from './site-address-change/reducer';
@@ -74,7 +73,6 @@ const reducers = {
 	notificationsUnseenCount,
 	orderTransactions,
 	postFormats,
-	rewind,
 	selectedEditor,
 	simplePayments,
 	siteAddressChange,

--- a/client/state/rewind/backups/actions.js
+++ b/client/state/rewind/backups/actions.js
@@ -4,6 +4,7 @@
 import { REWIND_BACKUPS_REQUEST, REWIND_BACKUPS_SET } from 'calypso/state/action-types';
 
 import 'calypso/state/data-layer/wpcom/sites/rewind/backups';
+import 'calypso/state/rewind/init';
 
 export const requestRewindBackups = ( siteId ) => ( {
 	type: REWIND_BACKUPS_REQUEST,

--- a/client/state/rewind/capabilities/actions.js
+++ b/client/state/rewind/capabilities/actions.js
@@ -4,6 +4,7 @@
 import { REWIND_CAPABILITIES_REQUEST } from 'calypso/state/action-types';
 
 import 'calypso/state/data-layer/wpcom/sites/rewind/capabilities';
+import 'calypso/state/rewind/init';
 
 export const requestRewindCapabilities = ( siteId ) => ( {
 	type: REWIND_CAPABILITIES_REQUEST,

--- a/client/state/rewind/init.js
+++ b/client/state/rewind/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'rewind' ], reducer );

--- a/client/state/rewind/package.json
+++ b/client/state/rewind/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/rewind/reducer.js
+++ b/client/state/rewind/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, keyedReducer } from 'calypso/state/utils';
+import { combineReducers, keyedReducer, withStorageKey } from 'calypso/state/utils';
 import backups from './backups/reducer';
 import capabilities from './capabilities/reducer';
 import state from './state/reducer';
@@ -12,4 +12,6 @@ const rewind = combineReducers( {
 	state,
 } );
 
-export default keyedReducer( 'siteId', rewind );
+const reducer = keyedReducer( 'siteId', rewind );
+
+export default withStorageKey( 'rewind', reducer );

--- a/client/state/rewind/state/actions.js
+++ b/client/state/rewind/state/actions.js
@@ -4,6 +4,7 @@
 import { REWIND_STATE_REQUEST } from 'calypso/state/action-types';
 
 import 'calypso/state/data-layer/wpcom/sites/rewind';
+import 'calypso/state/rewind/init';
 
 export const requestRewindState = ( siteId ) => ( {
 	type: REWIND_STATE_REQUEST,

--- a/client/state/selectors/get-rewind-backups.js
+++ b/client/state/selectors/get-rewind-backups.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/rewind/init';
+
+/**
  * Get the list of Rewind backups
  *
  * @param {object} state Global state tree

--- a/client/state/selectors/get-rewind-capabilities.js
+++ b/client/state/selectors/get-rewind-capabilities.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/rewind/init';
+
 export default function getRewindCapabilities( state, siteId ) {
 	return state?.rewind?.[ siteId ]?.capabilities;
 }

--- a/client/state/selectors/get-rewind-state.ts
+++ b/client/state/selectors/get-rewind-state.ts
@@ -3,6 +3,8 @@
  */
 import { AppState } from 'calypso/types';
 
+import 'calypso/state/rewind/init';
+
 const uninitialized = {
 	state: 'uninitialized',
 };

--- a/client/state/selectors/get-site-threats.js
+++ b/client/state/selectors/get-site-threats.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/rewind/init';
+
 export default function getSiteThreats( state, siteId ) {
 	return state.rewind?.[ siteId ]?.state?.alerts?.threats ?? [];
 }


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles rewind state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42473.

#### Changes proposed in this Pull Request

* Modularise rewind state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `rewind` key, even if you expand the list of keys. This indicates that the rewind state hasn't been loaded yet.
* Click `My Sites` on the top bar.
* Verify that a `rewind` key is added with the rewind state. This indicates that the rewind state has now been loaded.
* Verify that rewind-related functionality still works correctly