### PR TITLE
P2+: revamp Plans page v1

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -313,10 +313,19 @@ export const FEATURE_LANGUAGE_SUPPORT_V2 = 'language-support-v2';
 export const FEATURE_SPELLING_CORRECTION_V2 = 'spelling-correction-v2';
 
 // P2 project features
-export const FEATURE_P2_TEST = 'p2-test-feature';
-export const FEATURE_P2_MENTIONS = 'p2-mentions';
-export const FEATURE_P2_NO_ADS = 'p2-no-ads';
-export const FEATURE_P2_VIDEO = 'p2-video';
+export const FEATURE_P2_3GB_STORAGE = 'p2-3gb-storage';
+export const FEATURE_P2_UNLIMITED_USERS = 'p2-unlimited-users';
+export const FEATURE_P2_UNLIMITED_POSTS_PAGES = 'p2-unlimited-posts-pages';
+export const FEATURE_P2_SIMPLE_SEARCH = 'p2-simple-search';
+export const FEATURE_P2_CUSTOMIZATION_OPTIONS = 'p2-customization-options';
+export const FEATURE_P2_13GB_STORAGE = 'p2-13gb-storage';
+export const FEATURE_P2_UNLIMITED_FREE_VIEWERS = 'p2-unlimited-free-viewers';
+export const FEATURE_P2_ADVANCED_SEARCH = 'p2-advanced-search';
+export const FEATURE_P2_VIDEO_SHARING = 'p2-video-sharing';
+export const FEATURE_P2_MORE_FILE_TYPES = 'p2-more-file-types';
+export const FEATURE_P2_PRIORITY_CHAT_EMAIL_SUPPORT = 'p2-priority-chat-email-support';
+export const FEATURE_P2_ACTIVITY_OVERVIEW = 'p2-activity-overview';
+export const FEATURE_P2_CUSTOM_DOMAIN = 'p2-custom-domain';
 
 // Meta grouping constants
 export const GROUP_WPCOM = 'GROUP_WPCOM';

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -50,6 +50,7 @@ export const PLAN_WPCOM_ENTERPRISE = 'wpcom-enterprise';
 export const PLAN_CHARGEBACK = 'chargeback';
 export const PLAN_VIP = 'vip';
 export const PLAN_P2_PLUS = 'wp_p2_plus_monthly';
+export const PLAN_P2_FREE = 'p2_free_plan'; // Not a real plan; it's a renamed WP.com Free for the P2 project.
 
 export const PLAN_BUSINESS_ONBOARDING_EXPIRE = '2021-07-31T00:00:00+00:00';
 export const PLAN_BUSINESS_2Y_ONBOARDING_EXPIRE = '2022-07-31T00:00:00+00:00';
@@ -310,6 +311,12 @@ export const FEATURE_ADVANCED_STATS_V2 = 'advanced-stats-v2';
 export const FEATURE_FILTERING_V2 = 'filtering-v2';
 export const FEATURE_LANGUAGE_SUPPORT_V2 = 'language-support-v2';
 export const FEATURE_SPELLING_CORRECTION_V2 = 'spelling-correction-v2';
+
+// P2 project features
+export const FEATURE_P2_TEST = 'p2-test-feature';
+export const FEATURE_P2_MENTIONS = 'p2-mentions';
+export const FEATURE_P2_NO_ADS = 'p2-no-ads';
+export const FEATURE_P2_VIDEO = 'p2-video';
 
 // Meta grouping constants
 export const GROUP_WPCOM = 'GROUP_WPCOM';

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1569,31 +1569,34 @@ export const FEATURES_LIST = {
 					strong: <strong />,
 				},
 			} ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () =>
+			i18n.translate( 'Upload images and documents and share them with your team.' ),
 	},
 
 	[ constants.FEATURE_P2_UNLIMITED_USERS ]: {
 		getSlug: () => constants.FEATURE_P2_UNLIMITED_USERS,
 		getTitle: () => i18n.translate( 'Unlimited users' ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () => i18n.translate( 'Invite as many people as you need to your P2.' ),
 	},
 
 	[ constants.FEATURE_P2_UNLIMITED_POSTS_PAGES ]: {
 		getSlug: () => constants.FEATURE_P2_UNLIMITED_POSTS_PAGES,
 		getTitle: () => i18n.translate( 'Unlimited posts and pages' ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () =>
+			i18n.translate( 'Communicate as often as you want, with full access to your archive.' ),
 	},
 
 	[ constants.FEATURE_P2_SIMPLE_SEARCH ]: {
 		getSlug: () => constants.FEATURE_P2_SIMPLE_SEARCH,
 		getTitle: () => i18n.translate( 'Simple search' ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () => i18n.translate( 'Easily find what you’re looking for.' ),
 	},
 
 	[ constants.FEATURE_P2_CUSTOMIZATION_OPTIONS ]: {
 		getSlug: () => constants.FEATURE_P2_CUSTOMIZATION_OPTIONS,
 		getTitle: () => i18n.translate( 'Customization options' ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () =>
+			i18n.translate( 'Make your team feel at home with some easy customization options.' ),
 	},
 
 	[ constants.FEATURE_P2_13GB_STORAGE ]: {
@@ -1604,49 +1607,60 @@ export const FEATURES_LIST = {
 					strong: <strong />,
 				},
 			} ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () => i18n.translate( 'Upload more files to your P2.' ),
 	},
 
 	[ constants.FEATURE_P2_UNLIMITED_FREE_VIEWERS ]: {
 		getSlug: () => constants.FEATURE_P2_UNLIMITED_FREE_VIEWERS,
 		getTitle: () => i18n.translate( 'Unlimited free viewers' ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () =>
+			i18n.translate( 'Viewers can read and comment posts, but can’t publish new ones.' ),
 	},
 
 	[ constants.FEATURE_P2_ADVANCED_SEARCH ]: {
 		getSlug: () => constants.FEATURE_P2_ADVANCED_SEARCH,
 		getTitle: () => i18n.translate( 'Advanced search' ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () =>
+			i18n.translate(
+				'A faster and more powerful search engine to make finding what you’re looking for easier.'
+			),
 	},
 
 	[ constants.FEATURE_P2_VIDEO_SHARING ]: {
 		getSlug: () => constants.FEATURE_P2_VIDEO_SHARING,
 		getTitle: () => i18n.translate( 'Easy video sharing' ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () =>
+			i18n.translate(
+				'Upload videos directly to your P2 for your team to see, without depending on external services.'
+			),
 	},
 
 	[ constants.FEATURE_P2_MORE_FILE_TYPES ]: {
 		getSlug: () => constants.FEATURE_P2_MORE_FILE_TYPES,
 		getTitle: () => i18n.translate( 'More file types' ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () => i18n.translate( 'Upload videos, audio, .zip and .key files.' ),
 	},
 
 	[ constants.FEATURE_P2_PRIORITY_CHAT_EMAIL_SUPPORT ]: {
 		getSlug: () => constants.FEATURE_P2_PRIORITY_CHAT_EMAIL_SUPPORT,
 		getTitle: () => i18n.translate( 'Priority chat and email support' ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () =>
+			i18n.translate(
+				'Live chat is available 24 hours a day from Monday through Friday. You can also email us any day of the week for personalized support.'
+			),
 	},
 
 	[ constants.FEATURE_P2_ACTIVITY_OVERVIEW ]: {
 		getSlug: () => constants.FEATURE_P2_ACTIVITY_OVERVIEW,
 		getTitle: () => i18n.translate( 'Activity overview panel' ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () =>
+			i18n.translate( 'A complete record of everything that happens on your P2.' ),
 	},
 
 	[ constants.FEATURE_P2_CUSTOM_DOMAIN ]: {
 		getSlug: () => constants.FEATURE_P2_CUSTOM_DOMAIN,
 		getTitle: () => i18n.translate( 'Custom domain' ),
-		getDescription: () => i18n.translate( 'Some description' ),
+		getDescription: () => i18n.translate( 'Make your P2 more memorable using your own domain.' ),
 	},
 };
 

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1561,27 +1561,91 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Spelling correction' ),
 	},
 
-	[ constants.FEATURE_P2_TEST ]: {
-		getSlug: () => constants.FEATURE_P2_TEST,
-		getTitle: () => i18n.translate( 'Testing p2 feature' ),
+	[ constants.FEATURE_P2_3GB_STORAGE ]: {
+		getSlug: () => constants.FEATURE_P2_3GB_STORAGE,
+		getTitle: () =>
+			i18n.translate( '{{strong}}3GB{{/strong}} storage space', {
+				components: {
+					strong: <strong />,
+				},
+			} ),
 		getDescription: () => i18n.translate( 'Some description' ),
 	},
 
-	[ constants.FEATURE_P2_MENTIONS ]: {
-		getSlug: () => constants.FEATURE_P2_MENTIONS,
-		getTitle: () => i18n.translate( 'Mentions' ),
+	[ constants.FEATURE_P2_UNLIMITED_USERS ]: {
+		getSlug: () => constants.FEATURE_P2_UNLIMITED_USERS,
+		getTitle: () => i18n.translate( 'Unlimited users' ),
 		getDescription: () => i18n.translate( 'Some description' ),
 	},
 
-	[ constants.FEATURE_P2_NO_ADS ]: {
-		getSlug: () => constants.FEATURE_P2_NO_ADS,
-		getTitle: () => i18n.translate( 'See no ads!' ),
+	[ constants.FEATURE_P2_UNLIMITED_POSTS_PAGES ]: {
+		getSlug: () => constants.FEATURE_P2_UNLIMITED_POSTS_PAGES,
+		getTitle: () => i18n.translate( 'Unlimited posts and pages' ),
 		getDescription: () => i18n.translate( 'Some description' ),
 	},
 
-	[ constants.FEATURE_P2_VIDEO ]: {
-		getSlug: () => constants.FEATURE_P2_VIDEO,
-		getTitle: () => i18n.translate( 'Upload videos' ),
+	[ constants.FEATURE_P2_SIMPLE_SEARCH ]: {
+		getSlug: () => constants.FEATURE_P2_SIMPLE_SEARCH,
+		getTitle: () => i18n.translate( 'Simple search' ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
+
+	[ constants.FEATURE_P2_CUSTOMIZATION_OPTIONS ]: {
+		getSlug: () => constants.FEATURE_P2_CUSTOMIZATION_OPTIONS,
+		getTitle: () => i18n.translate( 'Customization options' ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
+
+	[ constants.FEATURE_P2_13GB_STORAGE ]: {
+		getSlug: () => constants.FEATURE_P2_13GB_STORAGE,
+		getTitle: () =>
+			i18n.translate( '{{strong}}13GB{{/strong}} storage space', {
+				components: {
+					strong: <strong />,
+				},
+			} ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
+
+	[ constants.FEATURE_P2_UNLIMITED_FREE_VIEWERS ]: {
+		getSlug: () => constants.FEATURE_P2_UNLIMITED_FREE_VIEWERS,
+		getTitle: () => i18n.translate( 'Unlimited free viewers' ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
+
+	[ constants.FEATURE_P2_ADVANCED_SEARCH ]: {
+		getSlug: () => constants.FEATURE_P2_ADVANCED_SEARCH,
+		getTitle: () => i18n.translate( 'Advanced search' ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
+
+	[ constants.FEATURE_P2_VIDEO_SHARING ]: {
+		getSlug: () => constants.FEATURE_P2_VIDEO_SHARING,
+		getTitle: () => i18n.translate( 'Easy video sharing' ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
+
+	[ constants.FEATURE_P2_MORE_FILE_TYPES ]: {
+		getSlug: () => constants.FEATURE_P2_MORE_FILE_TYPES,
+		getTitle: () => i18n.translate( 'More file types' ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
+
+	[ constants.FEATURE_P2_PRIORITY_CHAT_EMAIL_SUPPORT ]: {
+		getSlug: () => constants.FEATURE_P2_PRIORITY_CHAT_EMAIL_SUPPORT,
+		getTitle: () => i18n.translate( 'Priority chat and email support' ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
+
+	[ constants.FEATURE_P2_ACTIVITY_OVERVIEW ]: {
+		getSlug: () => constants.FEATURE_P2_ACTIVITY_OVERVIEW,
+		getTitle: () => i18n.translate( 'Activity overview panel' ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
+
+	[ constants.FEATURE_P2_CUSTOM_DOMAIN ]: {
+		getSlug: () => constants.FEATURE_P2_CUSTOM_DOMAIN,
+		getTitle: () => i18n.translate( 'Custom domain' ),
 		getDescription: () => i18n.translate( 'Some description' ),
 	},
 };

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1560,6 +1560,30 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_SPELLING_CORRECTION_V2,
 		getTitle: () => i18n.translate( 'Spelling correction' ),
 	},
+
+	[ constants.FEATURE_P2_TEST ]: {
+		getSlug: () => constants.FEATURE_P2_TEST,
+		getTitle: () => i18n.translate( 'Testing p2 feature' ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
+
+	[ constants.FEATURE_P2_MENTIONS ]: {
+		getSlug: () => constants.FEATURE_P2_MENTIONS,
+		getTitle: () => i18n.translate( 'Mentions' ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
+
+	[ constants.FEATURE_P2_NO_ADS ]: {
+		getSlug: () => constants.FEATURE_P2_NO_ADS,
+		getTitle: () => i18n.translate( 'See no ads!' ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
+
+	[ constants.FEATURE_P2_VIDEO ]: {
+		getSlug: () => constants.FEATURE_P2_VIDEO,
+		getTitle: () => i18n.translate( 'Upload videos' ),
+		getDescription: () => i18n.translate( 'Some description' ),
+	},
 };
 
 export const getPlanFeaturesObject = ( planFeaturesList ) => {

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -1531,9 +1531,12 @@ export const PLANS_LIST = {
 		getShortDescription: () => i18n.translate( 'Some short description' ),
 		getPlanCompareFeatures: () => [
 			// pay attention to ordering, shared features should align on /plan page
+			constants.FEATURE_P2_TEST,
+			constants.FEATURE_P2_MENTIONS,
+			constants.FEATURE_P2_NO_ADS,
 			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 			constants.FEATURE_13GB_STORAGE,
-			constants.FEATURE_VIDEO_UPLOADS,
+			constants.FEATURE_P2_VIDEO,
 		],
 
 		// TODO: update this once we put P2+ in the signup.
@@ -1553,6 +1556,18 @@ export const PLANS_LIST = {
 		getStoreSlug: () => constants.PLAN_P2_PLUS,
 		getPathSlug: () => 'p2-plus',
 	},
+};
+
+PLANS_LIST[ constants.PLAN_P2_FREE ] = {
+	...PLANS_LIST[ constants.PLAN_FREE ],
+	getDescription: () => i18n.translate( 'P2 Free description' ),
+	getTitle: () => i18n.translate( 'P2 Free' ),
+	getPlanCompareFeatures: () => [
+		// pay attention to ordering, shared features should align on /plan page
+		constants.FEATURE_P2_TEST,
+		constants.FEATURE_P2_MENTIONS,
+		constants.FEATURE_P2_NO_ADS,
+	],
 };
 
 export const PLANS_CONSTANTS_LIST = Object.keys( PLANS_LIST );

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -1524,28 +1524,29 @@ export const PLANS_LIST = {
 		group: constants.GROUP_WPCOM,
 		type: constants.TYPE_P2_PLUS,
 		getTitle: () => i18n.translate( 'P2+' ),
-		getDescription: () => i18n.translate( 'Some long description' ),
+		getDescription: () =>
+			i18n.translate(
+				'Supercharge your P2 site and take it to next level! [placeholder, text needs updating]'
+			),
 		getShortDescription: () => i18n.translate( 'Some short description' ),
 		getPlanCompareFeatures: () => [
 			// pay attention to ordering, shared features should align on /plan page
-			constants.FEATURE_EMAIL_SUPPORT,
-			constants.FEATURE_BASIC_DESIGN,
+			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 			constants.FEATURE_13GB_STORAGE,
-			constants.FEATURE_NO_ADS,
+			constants.FEATURE_VIDEO_UPLOADS,
 		],
+
+		// TODO: update this once we put P2+ in the signup.
 		getSignupFeatures: () => [ constants.FEATURE_EMAIL_SUPPORT_SIGNUP ],
-		getBlogSignupFeatures: () => [
-			constants.FEATURE_EMAIL_SUPPORT_SIGNUP,
-			constants.FEATURE_ALL_FREE_FEATURES,
-		],
-		getPortfolioSignupFeatures: () => [ constants.FEATURE_EMAIL_SUPPORT_SIGNUP ],
+
+		// TODO: no idea about this, copied from the WP.com Premium plan.
 		// Features not displayed but used for checking plan abilities
 		getHiddenFeatures: () => [ constants.FEATURE_AUDIO_UPLOADS ],
 		getInferiorHiddenFeatures: () => [],
-		getAudience: () => i18n.translate( 'Best for P2ers' ),
-		getBlogAudience: () => i18n.translate( 'Best for P2ers' ),
-		getPortfolioAudience: () => i18n.translate( 'Best for P2ers' ),
-		getStoreAudience: () => i18n.translate( 'Best for P2ers' ),
+
+		// TODO: Calypso requires this prop but we probably don't need it. Refactor Calypso?
+		getAudience: () => i18n.translate( 'Best for bloggers' ),
+
 		...getMonthlyTimeframe(),
 		availableFor: ( plan ) => includes( [ constants.PLAN_FREE ], plan ), //TODO: only for P2 sites.
 		getProductId: () => 1040,

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -1526,7 +1526,8 @@ export const PLANS_LIST = {
 		getTitle: () => i18n.translate( 'P2+' ),
 		getDescription: () =>
 			i18n.translate(
-				'Supercharge your P2 site and take it to next level! [placeholder, text needs updating]'
+				'{{strong}}Best for professionals:{{/strong}} Enhance your P2 with more space for audio and video, advanced search, an activity overview panel, and priority customer support.',
+				plansDescriptionHeadingComponent
 			),
 		getShortDescription: () => i18n.translate( 'Some short description' ),
 		getPlanCompareFeatures: () => [
@@ -1562,7 +1563,11 @@ export const PLANS_LIST = {
 
 PLANS_LIST[ constants.PLAN_P2_FREE ] = {
 	...PLANS_LIST[ constants.PLAN_FREE ],
-	getDescription: () => i18n.translate( 'P2 Free description' ),
+	getDescription: () =>
+		i18n.translate(
+			'{{strong}}Best for small groups:{{/strong}} All the features needed to share, discuss, review, and collaborate with your team in one spot, without interruptions.',
+			plansDescriptionHeadingComponent
+		),
 	getTitle: () => i18n.translate( 'P2 Free' ),
 	getPlanCompareFeatures: () => [
 		// pay attention to ordering, shared features should align on /plan page

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -1531,12 +1531,13 @@ export const PLANS_LIST = {
 		getShortDescription: () => i18n.translate( 'Some short description' ),
 		getPlanCompareFeatures: () => [
 			// pay attention to ordering, shared features should align on /plan page
-			constants.FEATURE_P2_TEST,
-			constants.FEATURE_P2_MENTIONS,
-			constants.FEATURE_P2_NO_ADS,
-			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
-			constants.FEATURE_13GB_STORAGE,
-			constants.FEATURE_P2_VIDEO,
+			constants.FEATURE_P2_13GB_STORAGE,
+			constants.FEATURE_P2_UNLIMITED_FREE_VIEWERS,
+			constants.FEATURE_P2_ADVANCED_SEARCH,
+			constants.FEATURE_P2_VIDEO_SHARING,
+			constants.FEATURE_P2_MORE_FILE_TYPES,
+			constants.FEATURE_P2_PRIORITY_CHAT_EMAIL_SUPPORT,
+			constants.FEATURE_P2_ACTIVITY_OVERVIEW,
 		],
 
 		// TODO: update this once we put P2+ in the signup.
@@ -1565,9 +1566,11 @@ PLANS_LIST[ constants.PLAN_P2_FREE ] = {
 	getTitle: () => i18n.translate( 'P2 Free' ),
 	getPlanCompareFeatures: () => [
 		// pay attention to ordering, shared features should align on /plan page
-		constants.FEATURE_P2_TEST,
-		constants.FEATURE_P2_MENTIONS,
-		constants.FEATURE_P2_NO_ADS,
+		constants.FEATURE_P2_3GB_STORAGE,
+		constants.FEATURE_P2_UNLIMITED_USERS,
+		constants.FEATURE_P2_UNLIMITED_POSTS_PAGES,
+		constants.FEATURE_P2_SIMPLE_SEARCH,
+		constants.FEATURE_P2_CUSTOMIZATION_OPTIONS,
 	],
 };
 

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -1555,6 +1555,7 @@ export const PLANS_LIST = {
 		getProductId: () => 1040,
 		getStoreSlug: () => constants.PLAN_P2_PLUS,
 		getPathSlug: () => 'p2-plus',
+		getBillingTimeFrame: () => translate( 'per user per month' ),
 	},
 };
 

--- a/client/lib/plans/test/plan-lookups.js
+++ b/client/lib/plans/test/plan-lookups.js
@@ -52,6 +52,7 @@ import {
 	TYPE_PREMIUM,
 	TYPE_FREE,
 	PLAN_P2_PLUS,
+	PLAN_P2_FREE,
 } from '../constants';
 import { PLANS_LIST } from '../plans-list';
 import {
@@ -681,6 +682,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_JETPACK_SECURITY_DAILY,
 			PLAN_JETPACK_SECURITY_REALTIME,
 			PLAN_JETPACK_COMPLETE,
+			PLAN_P2_FREE,
 		] );
 		expect( findPlansKeys( { term: TERM_MONTHLY } ) ).to.deep.equal( [
 			PLAN_PERSONAL_MONTHLY,
@@ -701,6 +703,7 @@ describe( 'findPlansKeys', () => {
 		expect( findPlansKeys( { type: TYPE_FREE } ) ).to.deep.equal( [
 			PLAN_FREE,
 			PLAN_JETPACK_FREE,
+			PLAN_P2_FREE,
 		] );
 		expect( findPlansKeys( { type: TYPE_BLOGGER } ) ).to.deep.equal( [
 			PLAN_BLOGGER,
@@ -747,6 +750,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_ECOMMERCE,
 			PLAN_ECOMMERCE_2_YEARS,
 			PLAN_P2_PLUS,
+			PLAN_P2_FREE,
 		] );
 		expect( findPlansKeys( { group: GROUP_JETPACK } ) ).to.deep.equal( [
 			PLAN_JETPACK_FREE,

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -19,7 +19,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import PlanPrice from 'calypso/my-sites/plan-price';
 import PlanIntervalDiscount from 'calypso/my-sites/plan-interval-discount';
 import PlanPill from 'calypso/components/plans/plan-pill';
-import { TYPE_FREE, GROUP_WPCOM, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
+import { TYPE_FREE, GROUP_WPCOM, TERM_ANNUALLY, PLAN_P2_FREE } from 'calypso/lib/plans/constants';
 import { PLANS_LIST } from 'calypso/lib/plans/plans-list';
 import { getYearlyPlanByMonthly, planMatches, getPlanClass, isFreePlan } from 'calypso/lib/plans';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -30,7 +30,12 @@ import { planLevelsMatch } from 'calypso/lib/plans/index';
 
 export class PlanFeaturesHeader extends Component {
 	render() {
-		const { isInSignup, plansWithScroll } = this.props;
+		const { isInSignup, plansWithScroll, planType } = this.props;
+
+		if ( planType === PLAN_P2_FREE ) {
+			return this.renderPlansHeaderP2Free();
+		}
+
 		// Do not use the signup-specific header, unify plans for the plansWithScroll test
 		if ( plansWithScroll ) {
 			return this.renderPlansHeaderNoTabs();
@@ -112,6 +117,25 @@ export class PlanFeaturesHeader extends Component {
 					{ this.getIntervalDiscount() }
 				</div>
 			</span>
+		);
+	}
+
+	renderPlansHeaderP2Free() {
+		const { planType, isInSignup, translate } = this.props;
+
+		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ), {
+			'is-p2-free': true,
+		} );
+		const isCurrent = this.isPlanCurrent();
+
+		return (
+			<header className={ headerClasses }>
+				<div className="plan-features__header-text">
+					<h4 className="plan-features__header-title">P2</h4>
+					<h4 className="plan-features__header-title-free">{ translate( 'Free' ) }</h4>
+				</div>
+				{ ! isInSignup && isCurrent && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
+			</header>
 		);
 	}
 

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -19,7 +19,13 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import PlanPrice from 'calypso/my-sites/plan-price';
 import PlanIntervalDiscount from 'calypso/my-sites/plan-interval-discount';
 import PlanPill from 'calypso/components/plans/plan-pill';
-import { TYPE_FREE, GROUP_WPCOM, TERM_ANNUALLY, PLAN_P2_FREE } from 'calypso/lib/plans/constants';
+import {
+	TYPE_FREE,
+	GROUP_WPCOM,
+	TERM_ANNUALLY,
+	PLAN_P2_FREE,
+	PLAN_P2_PLUS,
+} from 'calypso/lib/plans/constants';
 import { PLANS_LIST } from 'calypso/lib/plans/plans-list';
 import { getYearlyPlanByMonthly, planMatches, getPlanClass, isFreePlan } from 'calypso/lib/plans';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -58,14 +64,18 @@ export class PlanFeaturesHeader extends Component {
 			translate,
 		} = this.props;
 
-		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
+		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ), {
+			'is-p2-plus': planType === PLAN_P2_PLUS,
+		} );
 		const isCurrent = this.isPlanCurrent();
 
 		return (
 			<header className={ headerClasses }>
-				<div className="plan-features__header-figure">
-					<ProductIcon slug={ planType } />
-				</div>
+				{ planType !== PLAN_P2_PLUS && (
+					<div className="plan-features__header-figure">
+						<ProductIcon slug={ planType } />
+					</div>
+				) }
 				<div className="plan-features__header-text">
 					<h4 className="plan-features__header-title">{ title }</h4>
 					{ this.getPlanFeaturesPrices() }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -75,6 +75,8 @@ import {
 	TYPE_BUSINESS,
 	GROUP_WPCOM,
 	FEATURE_BUSINESS_ONBOARDING,
+	TYPE_P2_PLUS,
+	TYPE_FREE,
 } from 'calypso/lib/plans/constants';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import PlanFeaturesScroller from './scroller';
@@ -811,7 +813,9 @@ export const isPrimaryUpgradeByPlanDelta = ( currentPlan, plan ) =>
 	( planMatches( currentPlan, { type: TYPE_PERSONAL, group: GROUP_WPCOM } ) &&
 		planMatches( plan, { type: TYPE_PREMIUM, group: GROUP_WPCOM } ) ) ||
 	( planMatches( currentPlan, { type: TYPE_PREMIUM, group: GROUP_WPCOM } ) &&
-		planMatches( plan, { type: TYPE_BUSINESS, group: GROUP_WPCOM } ) );
+		planMatches( plan, { type: TYPE_BUSINESS, group: GROUP_WPCOM } ) ) ||
+	( planMatches( currentPlan, { type: TYPE_FREE, group: GROUP_WPCOM } ) &&
+		planMatches( plan, { type: TYPE_P2_PLUS, group: GROUP_WPCOM } ) );
 
 export const calculatePlanCredits = ( state, siteId, planProperties ) =>
 	planProperties

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -196,6 +196,10 @@ $plan-features-sidebar-width: 272px;
 		padding-top: 0;
 	}
 
+	&.is-p2-free, &.is-p2-plus {
+		padding-left: 24px;
+	}
+
 	.plans-features-main__group.is-wpcom & {
 		&.is-blogger-plan {
 			border-bottom: solid 2px var( --color-plan-blogger );

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -347,8 +347,11 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__header-title-free {
-	font-size: 32px;
-	line-height: 38px;
+	font-size: 2rem;
+	line-height: 1.5;
+	font-weight: 400;
+	color: var( --color-neutral-70 );
+	padding-bottom: 32px;
 }
 
 .segmented-control.is-customer-type-toggle {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -192,6 +192,10 @@ $plan-features-sidebar-width: 272px;
 		padding: 12px 12px 0;
 	}
 
+	&.is-p2-free {
+		padding-top: 0;
+	}
+
 	.plans-features-main__group.is-wpcom & {
 		&.is-blogger-plan {
 			border-bottom: solid 2px var( --color-plan-blogger );
@@ -336,6 +340,11 @@ $plan-features-sidebar-width: 272px;
 			margin-bottom: 9px;
 		}
 	}
+}
+
+.plan-features__header-title-free {
+	font-size: 32px;
+	line-height: 38px;
 }
 
 .segmented-control.is-customer-type-toggle {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -196,8 +196,13 @@ $plan-features-sidebar-width: 272px;
 		padding-top: 0;
 	}
 
-	&.is-p2-free, &.is-p2-plus {
+	&.is-p2-free,
+	&.is-p2-plus {
 		padding-left: 24px;
+	}
+
+	&.is-p2-plus {
+		border-bottom-color: var( --p2-color-link );
 	}
 
 	.plans-features-main__group.is-wpcom & {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -192,10 +192,6 @@ $plan-features-sidebar-width: 272px;
 		padding: 12px 12px 0;
 	}
 
-	&.is-p2-free {
-		padding-top: 0;
-	}
-
 	&.is-p2-free,
 	&.is-p2-plus {
 		padding-left: 24px;
@@ -352,11 +348,18 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__header-title-free {
-	font-size: 2rem;
+	font-size: 1.5rem;
 	line-height: 1.5;
 	font-weight: 400;
 	color: var( --color-neutral-70 );
-	padding-bottom: 32px;
+	padding-bottom: 8px;
+
+	@include breakpoint-deprecated( '>960px' ) {
+		font-size: 2rem;
+	}
+	@media ( min-width: $plan-features-sidebar-width + 480px ) {
+		padding-bottom: 32px;
+	}
 }
 
 .segmented-control.is-customer-type-toggle {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -194,7 +194,10 @@ $plan-features-sidebar-width: 272px;
 
 	&.is-p2-free,
 	&.is-p2-plus {
-		padding-left: 24px;
+		padding-left: 12px;
+		@include breakpoint-deprecated( '>1040px' ) {
+			padding-left: 24px;
+		}
 	}
 
 	&.is-p2-plus {

--- a/client/my-sites/plans/p2-plans-main.jsx
+++ b/client/my-sites/plans/p2-plans-main.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PlanFeatures from 'calypso/my-sites/plan-features';
-import { PLAN_P2_PLUS } from 'calypso/lib/plans/constants';
+import { PLAN_P2_FREE, PLAN_P2_PLUS } from 'calypso/lib/plans/constants';
 import QueryPlans from 'calypso/components/data/query-plans';
 import QuerySites from 'calypso/components/data/query-sites';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
@@ -25,9 +25,9 @@ export class P2PlansMain extends Component {
 				<QuerySites siteId={ siteId } />
 				<QuerySitePlans siteId={ siteId } />
 				<PlanFeatures
-					plans={ [ PLAN_P2_PLUS ] }
+					plans={ [ PLAN_P2_FREE, PLAN_P2_PLUS ] }
 					redirectTo={ redirectTo }
-					visiblePlans={ [ PLAN_P2_PLUS ] }
+					visiblePlans={ [ PLAN_P2_FREE, PLAN_P2_PLUS ] }
 					selectedFeature={ selectedFeature }
 					selectedPlan={ selectedPlan }
 					siteId={ siteId }


### PR DESCRIPTION
In this PR, we revamp the Plans page a little bit for the P2+ plan. We still don't have the final designs yet so this revamp (v1) is just for internal call for testing.

![Screen Shot on 2020-11-20 at 11-50-11](https://user-images.githubusercontent.com/4988512/99791917-a14f1c00-2b26-11eb-8ca5-28b5cb68faf3.png)

The features section is quite short and empty but from all the features of the other WP.com plans, these were the only ones which made sense for a P2 site. We might need to create our own custom features with our own titles and descriptions.

It's missing custom domains but that's because we can't yet support custom domains (due to 3rd party cookies issue); "no ads on public sites" as that applies for all P2 sites, not just P2+ and "ability to run wordads" coz we haven't worked on that yet.

## Testing instructions

With a P2 site, navigate to the Plans page. Do you think it's okay for the internal testing?