### PR TITLE
Modularise site address change state

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -28,9 +28,9 @@ import {
 	requestSiteAddressAvailability,
 	clearValidationError,
 } from 'calypso/state/site-address-change/actions';
-import getSiteAddressAvailabilityPending from 'calypso/state/selectors/get-site-address-availability-pending';
-import getSiteAddressValidationError from 'calypso/state/selectors/get-site-address-validation-error';
-import isRequestingSiteAddressChange from 'calypso/state/selectors/is-requesting-site-address-change';
+import { getSiteAddressAvailabilityPending } from 'calypso/state/site-address-change/selectors/get-site-address-availability-pending';
+import { getSiteAddressValidationError } from 'calypso/state/site-address-change/selectors/get-site-address-validation-error';
+import { isRequestingSiteAddressChange } from 'calypso/state/site-address-change/selectors/is-requesting-site-address-change';
 import { isSiteAddressValidationAvailable } from 'calypso/state/site-address-change/selectors/is-site-address-validation-available';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -31,6 +31,7 @@ import {
 import getSiteAddressAvailabilityPending from 'calypso/state/selectors/get-site-address-availability-pending';
 import getSiteAddressValidationError from 'calypso/state/selectors/get-site-address-validation-error';
 import isRequestingSiteAddressChange from 'calypso/state/selectors/is-requesting-site-address-change';
+import { isSiteAddressValidationAvailable } from 'calypso/state/site-address-change/selectors/is-site-address-validation-available';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 /**
@@ -376,17 +377,11 @@ export default flow(
 			const selectedSite = getSelectedSite( state );
 			const siteId = selectedSite.ID;
 			const selectedSiteSlug = selectedSite.slug;
-			const isAvailable = get( state, [
-				'siteAddressChange',
-				'validation',
-				siteId,
-				'isAvailable',
-			] );
 
 			return {
 				siteId,
 				selectedSiteSlug,
-				isAvailable,
+				isAvailable: isSiteAddressValidationAvailable( state, siteId ),
 				isSiteAddressChangeRequesting: isRequestingSiteAddressChange( state, siteId ),
 				isAvailabilityPending: getSiteAddressAvailabilityPending( state, siteId ),
 				validationError: getSiteAddressValidationError( state, siteId ),

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -37,7 +37,6 @@ import postFormats from './post-formats/reducer';
 import rewind from './rewind/reducer';
 import selectedEditor from './selected-editor/reducer';
 import simplePayments from './simple-payments/reducer';
-import siteAddressChange from './site-address-change/reducer';
 import siteKeyrings from './site-keyrings/reducer';
 import siteRoles from './site-roles/reducer';
 import sites from './sites/reducer';
@@ -77,7 +76,6 @@ const reducers = {
 	rewind,
 	selectedEditor,
 	simplePayments,
-	siteAddressChange,
 	siteKeyrings,
 	siteRoles,
 	sites,

--- a/client/state/selectors/get-site-address-availability-pending.js
+++ b/client/state/selectors/get-site-address-availability-pending.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/site-address-change/init';
+
 export default function ( state, siteId ) {
 	return get( state, [ 'siteAddressChange', 'validation', siteId, 'pending' ] );
 }

--- a/client/state/selectors/get-site-address-validation-error.js
+++ b/client/state/selectors/get-site-address-validation-error.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/site-address-change/init';
+
 export default function ( state, siteId ) {
 	return get( state, [ 'siteAddressChange', 'validation', siteId, 'error' ] );
 }

--- a/client/state/selectors/get-site-rename-status.js
+++ b/client/state/selectors/get-site-rename-status.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/site-address-change/init';
+
+/**
  * @param {object} state 	Global app state
  * @param {number} siteId site ID
  * @returns {object} An object that represents the current status for site rename requests.

--- a/client/state/selectors/is-requesting-site-address-change.js
+++ b/client/state/selectors/is-requesting-site-address-change.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/site-address-change/init';
+
+/**
  * @param {object} state Global app state
  * @param {number} siteId - site ID
  * @returns {boolean} Signals whether or not there is currently a request in progress for the given siteId

--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -24,6 +24,8 @@ import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import { requestSite } from 'calypso/state/sites/actions';
 import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
 
+import 'calypso/state/site-address-change/init';
+
 // @TODO proper redux data layer stuff for the nonce
 function fetchNonce( siteId ) {
 	return wpcom.undocumented().getRequestSiteAddressChangeNonce( siteId );

--- a/client/state/site-address-change/init.js
+++ b/client/state/site-address-change/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'siteAddressChange' ], reducer );

--- a/client/state/site-address-change/package.json
+++ b/client/state/site-address-change/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/site-address-change/reducer.js
+++ b/client/state/site-address-change/reducer.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withoutPersistence, withStorageKey } from 'calypso/state/utils';
 import {
 	SITE_ADDRESS_AVAILABILITY_REQUEST,
 	SITE_ADDRESS_AVAILABILITY_SUCCESS,
@@ -162,8 +162,10 @@ export const validation = withoutPersistence( ( state = {}, action ) => {
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	validation,
 	status,
 	requesting,
 } );
+
+export default withStorageKey( 'siteAddressChange', combinedReducer );

--- a/client/state/site-address-change/selectors/get-site-address-availability-pending.js
+++ b/client/state/site-address-change/selectors/get-site-address-availability-pending.js
@@ -8,6 +8,6 @@ import { get } from 'lodash';
  */
 import 'calypso/state/site-address-change/init';
 
-export default function ( state, siteId ) {
+export function getSiteAddressAvailabilityPending( state, siteId ) {
 	return get( state, [ 'siteAddressChange', 'validation', siteId, 'pending' ] );
 }

--- a/client/state/site-address-change/selectors/get-site-address-availability-pending.js
+++ b/client/state/site-address-change/selectors/get-site-address-availability-pending.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import 'calypso/state/site-address-change/init';
 
 export function getSiteAddressAvailabilityPending( state, siteId ) {
-	return get( state, [ 'siteAddressChange', 'validation', siteId, 'pending' ] );
+	return state.siteAddressChange.validation[ siteId ]?.pending;
 }

--- a/client/state/site-address-change/selectors/get-site-address-validation-error.js
+++ b/client/state/site-address-change/selectors/get-site-address-validation-error.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import 'calypso/state/site-address-change/init';
 
 export function getSiteAddressValidationError( state, siteId ) {
-	return get( state, [ 'siteAddressChange', 'validation', siteId, 'error' ] );
+	return state.siteAddressChange.validation[ siteId ]?.error;
 }

--- a/client/state/site-address-change/selectors/get-site-address-validation-error.js
+++ b/client/state/site-address-change/selectors/get-site-address-validation-error.js
@@ -8,6 +8,6 @@ import { get } from 'lodash';
  */
 import 'calypso/state/site-address-change/init';
 
-export default function ( state, siteId ) {
+export function getSiteAddressValidationError( state, siteId ) {
 	return get( state, [ 'siteAddressChange', 'validation', siteId, 'error' ] );
 }

--- a/client/state/site-address-change/selectors/get-site-rename-status.js
+++ b/client/state/site-address-change/selectors/get-site-rename-status.js
@@ -13,4 +13,6 @@ import 'calypso/state/site-address-change/init';
  * @param {number} siteId site ID
  * @returns {object} An object that represents the current status for site rename requests.
  */
-export default ( state, siteId ) => get( state, [ 'siteAddressChange', 'status', siteId ], {} );
+export function getSiteRenameStatus( state, siteId ) {
+	return get( state, [ 'siteAddressChange', 'status', siteId ], {} );
+}

--- a/client/state/site-address-change/selectors/get-site-rename-status.js
+++ b/client/state/site-address-change/selectors/get-site-rename-status.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import 'calypso/state/site-address-change/init';
@@ -14,5 +9,5 @@ import 'calypso/state/site-address-change/init';
  * @returns {object} An object that represents the current status for site rename requests.
  */
 export function getSiteRenameStatus( state, siteId ) {
-	return get( state, [ 'siteAddressChange', 'status', siteId ], {} );
+	return state.siteAddressChange.status[ siteId ] ?? {};
 }

--- a/client/state/site-address-change/selectors/is-requesting-site-address-change.js
+++ b/client/state/site-address-change/selectors/is-requesting-site-address-change.js
@@ -13,5 +13,6 @@ import 'calypso/state/site-address-change/init';
  * @param {number} siteId - site ID
  * @returns {boolean} Signals whether or not there is currently a request in progress for the given siteId
  */
-export default ( state, siteId ) =>
-	get( state, [ 'siteAddressChange', 'requesting', siteId ], null );
+export function isRequestingSiteAddressChange( state, siteId ) {
+	return get( state, [ 'siteAddressChange', 'requesting', siteId ], null );
+}

--- a/client/state/site-address-change/selectors/is-requesting-site-address-change.js
+++ b/client/state/site-address-change/selectors/is-requesting-site-address-change.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import 'calypso/state/site-address-change/init';
@@ -14,5 +9,5 @@ import 'calypso/state/site-address-change/init';
  * @returns {boolean} Signals whether or not there is currently a request in progress for the given siteId
  */
 export function isRequestingSiteAddressChange( state, siteId ) {
-	return get( state, [ 'siteAddressChange', 'requesting', siteId ], null );
+	return state.siteAddressChange.requesting[ siteId ] ?? null;
 }

--- a/client/state/site-address-change/selectors/is-site-address-validation-available.js
+++ b/client/state/site-address-change/selectors/is-site-address-validation-available.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/site-address-change/init';
+
+export function isSiteAddressValidationAvailable( state, siteId ) {
+	return state.siteAddressChange.validation[ siteId ]?.isAvailable;
+}


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles site address change state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42478.

#### Changes proposed in this Pull Request

* Modularise site address change state
* Turn existing inline selector into a proper selector
* Move existing selectors to `state/site-address-change`
* Replace `_.get` with optional chaining in existing selectors

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open Home on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `siteAddressChange` key, even if you expand the list of keys. This indicates that the site address change state hasn't been loaded yet.
* Click `Manage`, followed by `Settings`, on the side bar.
* Click `Change your site address` near the bottom of the page.
* Verify that a `siteAddressChange` key is added with the site address change state. This indicates that the site address change state has now been loaded.
* Verify that site address change-related functionality still works correctly.