### PR TITLE
Modularise simple payments state

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -35,7 +35,6 @@ import { unseenCount as notificationsUnseenCount } from './notifications';
 import orderTransactions from './order-transactions/reducer';
 import postFormats from './post-formats/reducer';
 import selectedEditor from './selected-editor/reducer';
-import simplePayments from './simple-payments/reducer';
 import siteAddressChange from './site-address-change/reducer';
 import siteKeyrings from './site-keyrings/reducer';
 import siteRoles from './site-roles/reducer';
@@ -74,7 +73,6 @@ const reducers = {
 	orderTransactions,
 	postFormats,
 	selectedEditor,
-	simplePayments,
 	siteAddressChange,
 	siteKeyrings,
 	siteRoles,

--- a/client/state/selectors/get-simple-payments.js
+++ b/client/state/selectors/get-simple-payments.js
@@ -9,13 +9,15 @@ import { get, find, orderBy } from 'lodash';
  */
 import createSelector from 'calypso/lib/create-selector';
 
+import 'calypso/state/simple-payments/init';
+
 /**
  * Get all Simple Payment or the one specified by `simplePaymentId`. They will be returned ordered by
  * ID from the largest to the lowest number (the same as ordering by creation date DESC).
  *
  * @param {object} state           Global state tree
- * @param {int}    siteId          Site which the Simple Payment belongs to.
- * @param {int}    simplePaymentId The ID of the Simple Payment to get. Optional.
+ * @param {number} siteId          Site which the Simple Payment belongs to.
+ * @param {number} simplePaymentId The ID of the Simple Payment to get. Optional.
  * @returns {Array|object|null}     Array of Simple Payment objects or an object if `simplePaymentId` specified.
  */
 export default createSelector(

--- a/client/state/simple-payments/init.js
+++ b/client/state/simple-payments/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'simplePayments' ], reducer );

--- a/client/state/simple-payments/package.json
+++ b/client/state/simple-payments/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/simple-payments/product-list/actions.js
+++ b/client/state/simple-payments/product-list/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import {
 	SIMPLE_PAYMENTS_PRODUCT_GET,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST,
@@ -12,6 +11,7 @@ import {
 } from 'calypso/state/action-types';
 
 import 'calypso/state/data-layer/wpcom/sites/simple-payments';
+import 'calypso/state/simple-payments/init';
 
 export const requestProducts = ( siteId ) => ( {
 	siteId,

--- a/client/state/simple-payments/reducer.js
+++ b/client/state/simple-payments/reducer.js
@@ -2,9 +2,11 @@
  * Internal dependencies
  */
 
-import { combineReducers } from 'calypso/state/utils';
+import { combineReducers, withStorageKey } from 'calypso/state/utils';
 import productList from './product-list/reducer';
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	productList,
 } );
+
+export default withStorageKey( 'simplePayments', combinedReducer );


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles simple payments state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42477.

#### Changes proposed in this Pull Request

* Modularise simple payments state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open Home on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `simplePayments` key, even if you expand the list of keys. This indicates that the simple payments state hasn't been loaded yet.

It doesn't seem to be easy to verify when `simplePayments` state eventually gets loading, as it seems to be tied to a classic editor TinyMCE plugin. Instancing a `QuerySimplePayments` component could be an option.