### PR TITLE
Adds ci-desktop image

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -97,17 +97,24 @@ object BuildBaseImages : BuildType({
 				VERSION="%build.number%"
 				BUILDER_IMAGE_NAME="registry.a8c.com/calypso/base"
 				CI_IMAGE_NAME="registry.a8c.com/calypso/ci"
+				CI_DESKTOP_IMAGE_NAME="registry.a8c.com/calypso/ci-desktop"
 				BUILDER_IMAGE="${'$'}{BUILDER_IMAGE_NAME}:${'$'}{VERSION}"
 				CI_IMAGE="${'$'}{CI_IMAGE_NAME}:${'$'}{VERSION}"
+				CI_DESKTOP_IMAGE="${'$'}{CI_DESKTOP_IMAGE_NAME}:${'$'}{VERSION}"
 
 				docker build -f Dockerfile.base --no-cache --target builder -t "${'$'}BUILDER_IMAGE" .
 				docker build -f Dockerfile.base --target ci -t "${'$'}CI_IMAGE" .
+				docker build -f Dockerfile.base --target ci-desktop -t "${'$'}CI_DESKTOP_IMAGE" .
 
 				docker tag "${'$'}BUILDER_IMAGE" "${'$'}{BUILDER_IMAGE_NAME}:latest"
 				docker tag "${'$'}CI_IMAGE" "${'$'}{CI_IMAGE_NAME}:latest"
+				docker tag "${'$'}CI_DESKTOP_IMAGE" "${'$'}{CI_DESKTOP_IMAGE_NAME}:latest"
 
 				docker push "${'$'}CI_IMAGE"
 				docker push "${'$'}{CI_IMAGE_NAME}:latest"
+
+				docker push "${'$'}CI_DESKTOP_IMAGE"
+				docker push "${'$'}{CI_DESKTOP_IMAGE_NAME}:latest"
 
 				docker push "${'$'}BUILDER_IMAGE"
 				docker push "${'$'}{BUILDER_IMAGE_NAME}:latest"

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -45,11 +45,47 @@ ENV NVM_DIR=/calypso/.nvm
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
 ENV HOME=/calypso
 
-RUN apt update && \
-	apt-get install -y git-restore-mtime libsecret-1-dev
-
 RUN chown $UID /calypso
 # Copy nvm cache so we don't need to download it again
 COPY --from=builder --chown=$UID /calypso/.nvm /calypso/.nvm
 # Copy all other caches (webpack, babel, yarn...)
 COPY --from=builder --chown=$UID /calypso/.cache /calypso/.cache
+
+
+#### ci-desktop image
+FROM ci as ci-desktop
+
+ENV ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
+ENV USE_HARD_LINKS=false
+ENV CHROME_VERSION="80.0.3987.163-1"
+ENV DISPLAY=:99
+
+RUN apt update \
+	&& apt-get install -y \
+		fonts-liberation \
+		git-restore-mtime \
+		gtk2-engines-pixbuf \
+		libappindicator3-1 \
+		libasound2 \
+		libatk-bridge2.0-0 \
+		libatspi2.0-0 \
+		libgtk-3-0 \
+		libnspr4 \
+		libnss3 \
+		libnss3 \
+		libsecret-1-dev \
+		libx11-xcb1 \
+		libxss1 \
+		libxss1 \
+		libxtst6 \
+		xdg-utils \
+		xfonts-100dpi \
+		xfonts-75dpi \
+		xfonts-base \
+		xfonts-cyrillic \
+		xfonts-scalable \
+		xvfb
+
+RUN wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
+	&& apt-get install -y ./google-chrome-stable_${CHROME_VERSION}_amd64.deb \
+	&& rm ./google-chrome-stable_${CHROME_VERSION}_amd64.deb


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Creates a new `ci-desktop` image based on `ci`, plus a few deb packages required to run Xvfb and Chrome. This image will be used to run `wp-desktop` tests in TeamCity.

The list of packages has been taken from [CircleCI base image](https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/node/images/12.18.4-stretch/browsers/Dockerfile)

The specific chrome version has been taken from [wp-desktop logs in CircleCI](https://circle-production-customer-artifacts.s3.amazonaws.com/picard/564252777885730b06016533/5fabff68ead39261733fc8da-0-build/artifacts/desktop/e2e/logs/2020-11-11T15-13-50.278Z/chromedriver-2020-11-11T15-13-50.278Z.log?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20201111T152349Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIAJR3Q6CR467H7Z55A%2F20201111%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=578028d1e9ca5f1d4f44b4bde98da6e4f96f9045f446721112f0ae37085642b0)

#### Testing instructions

First build the image locally with `docker build -f Dockerfile.base --target ci-desktop -t calypso/ci-desktop:latest .`. To make it faster, make these changes to `Dockerfile.base` (they are not related to this change, an without these changes it can take 30 minutes or more):
* Comment out the trailing `\` in line 27
* Comment out running `yarn` (line 29)
* Comment out running `yarn build-client-both` (line 31)
* Comment out copying from `/calypso/.cache` (line 55)

Once it is done, launch the image with `docker run --rm -ti --entrypoint /bin/bash calypso/ci-desktop:latest` and try:

* Start a framebuffer with `Xvfb :99 -screen 0 1280x1024x24`. It should start without errors (note: it doesn't generate any output)
* Start the framebuffer in the background (`Xvfb :99 -screen 0 1280x1024x24 &`) and start chrome by running `google-chrome --no-sandbox`. It shouldn't complain about missing dependencies or missing X display.

