### PR TITLE
Framework: Remove _.reverse() in favor of Array.prototype.reverse()

### DIFF
--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { includes, isEmpty, noop, flowRight, has, trim, sortBy, reverse } from 'lodash';
+import { includes, isEmpty, noop, flowRight, has, trim, sortBy } from 'lodash';
 import url from 'url'; // eslint-disable-line no-restricted-imports
 import moment from 'moment';
 
@@ -120,10 +120,7 @@ class SiteImporterInputPane extends React.Component {
 					];
 				}, [] );
 				this.setState( {
-					availableEndpoints: reverse( sortBy( endpoints, 'lastModifiedTimestamp' ) ).slice(
-						0,
-						20
-					),
+					availableEndpoints: sortBy( endpoints, 'lastModifiedTimestamp' ).reverse().slice( 0, 20 ),
 				} );
 			} )
 			.catch( ( err ) => {

--- a/client/post-editor/media-modal/gallery/edit.jsx
+++ b/client/post-editor/media-modal/gallery/edit.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { map, noop, reverse, sortBy } from 'lodash';
+import { map, noop, sortBy } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -48,7 +48,7 @@ class EditorMediaModalGalleryEdit extends React.Component {
 		}
 
 		const orders = {
-			[ translate( 'Reverse order' ) ]: reverse( [ ...settings.items ] ),
+			[ translate( 'Reverse order' ) ]: [ ...settings.items ].reverse(),
 			[ translate( 'Order alphabetically' ) ]: sortBy( settings.items, 'title' ),
 			[ translate( 'Order chronologically' ) ]: sortBy( settings.items, 'date' ),
 		};

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { escapeRegExp, reverse, sortBy, trimStart, isEmpty } from 'lodash';
+import { escapeRegExp, sortBy, trimStart, isEmpty } from 'lodash';
 import page from 'page';
 import classnames from 'classnames';
 
@@ -78,7 +78,7 @@ class FollowingManageSubscriptions extends Component {
 			} );
 		}
 
-		return reverse( sortBy( follows, [ 'date_subscribed' ] ) );
+		return sortBy( follows, [ 'date_subscribed' ] ).reverse();
 	}
 
 	handleSortChange = ( sort ) => {


### PR DESCRIPTION
This PR removes the last usages of lodash's `reverse()` and instead updates those usages to `Array.prototype.reverse()`.

#### Changes proposed in this Pull Request

* Framework: Remove lodash `reverse()` in favor of `Array.prototype.reverse()`

#### Testing instructions

* Verify we're working with arrays in all of the updated instances and the `reverse()` usage is correct.