### PR TITLE
Modularise order transactions state

### DIFF
--- a/client/state/order-transactions/actions.js
+++ b/client/state/order-transactions/actions.js
@@ -8,6 +8,7 @@ import {
 } from 'calypso/state/action-types';
 
 import 'calypso/state/data-layer/wpcom/me/transactions/order';
+import 'calypso/state/order-transactions/init';
 
 export const fetchOrderTransaction = ( orderId ) => ( {
 	type: ORDER_TRANSACTION_FETCH,

--- a/client/state/order-transactions/init.js
+++ b/client/state/order-transactions/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'orderTransactions' ], reducer );

--- a/client/state/order-transactions/package.json
+++ b/client/state/order-transactions/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/order-transactions/reducer.js
+++ b/client/state/order-transactions/reducer.js
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, keyedReducer, withoutPersistence } from 'calypso/state/utils';
+import {
+	combineReducers,
+	keyedReducer,
+	withoutPersistence,
+	withStorageKey,
+} from 'calypso/state/utils';
 
 import {
 	ORDER_TRANSACTION_FETCH,
@@ -59,8 +64,10 @@ export const errors = keyedReducer(
 	} )
 );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	items,
 	isFetching,
 	errors,
 } );
+
+export default withStorageKey( 'orderTransactions', combinedReducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -32,7 +32,6 @@ import media from './media/reducer';
 import mySites from './my-sites/reducer';
 import notices from './notices/reducer';
 import { unseenCount as notificationsUnseenCount } from './notifications';
-import orderTransactions from './order-transactions/reducer';
 import postFormats from './post-formats/reducer';
 import selectedEditor from './selected-editor/reducer';
 import simplePayments from './simple-payments/reducer';
@@ -71,7 +70,6 @@ const reducers = {
 	mySites,
 	notices,
 	notificationsUnseenCount,
-	orderTransactions,
 	postFormats,
 	selectedEditor,
 	simplePayments,

--- a/client/state/selectors/get-order-transaction-error.js
+++ b/client/state/selectors/get-order-transaction-error.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/order-transactions/init';
+
 export const getOrderTransactionError = ( state, orderId ) =>
 	get( state, [ 'orderTransactions', 'errors', orderId ], null );
 

--- a/client/state/selectors/get-order-transaction.js
+++ b/client/state/selectors/get-order-transaction.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/order-transactions/init';
+
 export const getOrderTransaction = ( state, orderId ) =>
 	get( state, [ 'orderTransactions', 'items', orderId ], null );
 

--- a/client/state/selectors/get-order-transactions-error.js
+++ b/client/state/selectors/get-order-transactions-error.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/order-transactions/init';
+
 export const getOrderTransactionError = ( state, orderId ) =>
 	get( state, [ 'orderTransactions', 'error', orderId ], null );
 

--- a/client/state/selectors/is-fetching-order-transaction.js
+++ b/client/state/selectors/is-fetching-order-transaction.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/order-transactions/init';
+
 export const isFetchingOrderTransaction = ( state, orderId ) =>
 	get( state, [ 'orderTransactions', 'isFetching', orderId ], false );
 


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles order transactions state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42465.

#### Changes proposed in this Pull Request

* Modularise order transactions state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open Home on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `orderTransactions` key, even if you expand the list of keys. This indicates that the order transactions state hasn't been loaded yet.
* Click `Plan`, followed by `Plans`, on the side bar.
* Pick a plan and add it to your cart.
* Open your cart.
* Verify that a `orderTransactions` key is added with the order transactions state. This indicates that the order transactions state has now been loaded.