### PR TITLE
Purchases: fix payment method screen

### DIFF
--- a/client/me/payment-methods/main.tsx
+++ b/client/me/payment-methods/main.tsx
@@ -21,7 +21,7 @@ export default function PaymentMethods(): JSX.Element {
 	const translate = useTranslate();
 
 	return (
-		<Main className="payment-methods is-wide-layout">
+		<Main className="payment-methods__main is-wide-layout">
 			<DocumentHead title={ translate( 'Payment Methods' ) } />
 			<PageViewTracker path="/me/purchases/payment-methods" title="Me > Payment Methods" />
 			<MeSidebarNavigation />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a bug when you navigate from plans > the account level payment methods.

Before
![image](https://user-images.githubusercontent.com/6981253/98853607-61ea4680-2427-11eb-8a2e-bacde029014a.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/98853620-69115480-2427-11eb-9c01-2e0ca016ba6e.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start at /plans for any site
* Navigate to the Payment Methods page (Me => Manage Purchases => Payments Methods)
* Confirm nothing is broken on desktop or mobile.

Fixes https://github.com/Automattic/wp-calypso/issues/47335
