### PR TITLE
Removing redundant fallback headline from launch flow.

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -291,9 +291,6 @@ export function generateSteps( {
 			props: {
 				headerText: i18n.translate( 'Getting ready to launch your website' ),
 				subHeaderText: i18n.translate( "Pick a plan that's right for you. Upgrade as you grow." ),
-				fallbackHeaderText: i18n.translate(
-					"Almost there, pick a plan that's right for you. Upgrade as you grow."
-				),
 				isLaunchPage: true,
 			},
 		},


### PR DESCRIPTION
This PR removes repetitive copy currently displayed on the Plans page step of the site launch flow. Here's a screenshot of the current experience:
<img width="898" alt="Screen Shot 2020-11-11 at 11 36 51 AM" src="https://user-images.githubusercontent.com/35781181/98855278-be4e6580-2429-11eb-8b35-db7a1a7ee24c.png">

The page was using the fallbackHeaderText instead of the desired headerText copy, and it worked properly when the fallback was removed. I didn't encounter any use cases that depended on the fallbackHeader - @michaeldcain I see you worked on this page, am I missing anything?
 
Here's a screenshot of the updated page showing the correct copy:
<img width="930" alt="Screen Shot 2020-11-11 at 2 04 43 PM" src="https://user-images.githubusercontent.com/35781181/98856750-0cfcff00-242c-11eb-917e-a91aa5f71e82.png">

And the corresponding page in the Gutenboarding skin:
<img width="1318" alt="Screen Shot 2020-11-11 at 2 42 42 PM" src="https://user-images.githubusercontent.com/35781181/98856856-328a0880-242c-11eb-98d8-a6129c88d764.png">


#### Testing instructions
* Checkout this branch and start Calypso.
* Create a new site go through the checklist, up to the site launch step.
* Start the launch flow and check the Plans page for the correct headline.
* Assign yourself to the correct tests and examine the page in both the control and Gutenboarding skins (or create new sites until you get one of each).
