### PR TITLE
Enable price decimals in pricing page i2

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
@@ -190,9 +190,7 @@ const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 								<>
 									<span className="jetpack-product-card-alt-2__raw-price">
 										<PlanPrice
-											rawPrice={ Math.floor(
-												( isDiscounted ? discountedPrice : originalPrice ) as number
-											) }
+											rawPrice={ ( isDiscounted ? discountedPrice : originalPrice ) as number }
 											discounted
 											currencyCode={ currencyCode }
 										/>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR displays decimals in i2 of the pricing page.

### Testing instructions

- Download the PR or visit the Calypso live link
- Make sure v2 of the pricing is selected (ping me if you don't know how)
- Select a self-hosted Jetpack site
- Visit the pricing page
- Notice the decimals (see capture)

### Screenshots

<img width="1078" alt="Screen Shot 2020-11-11 at 4 46 44 PM" src="https://user-images.githubusercontent.com/1620183/98868196-c4e6d800-243d-11eb-97af-acf3b1996346.png">
