### PR TITLE
Plans: Replace CartData with ShoppingCartProvider in header

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -3,7 +3,6 @@
  */
 import React, { useMemo, useEffect } from 'react';
 import { connect } from 'react-redux';
-import wp from 'calypso/lib/wp';
 import { Icon, wordpress } from '@wordpress/icons';
 import { ShoppingCartProvider, RequestCart } from '@automattic/shopping-cart';
 import { Modal } from '@wordpress/components';
@@ -19,6 +18,7 @@ import getCartKey from 'calypso/my-sites/checkout/get-cart-key';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 import userFactory from 'calypso/lib/user';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import wp from 'calypso/lib/wp';
 
 /**
  * Style dependencies
@@ -51,20 +51,11 @@ const EditorCheckoutModal = ( props: Props ) => {
 
 	const user = userFactory();
 	const isLoggedOutCart = ! user?.get();
-	const waitForOtherCartUpdates = false;
-	// We can assume if they're accessing the checkout in an editor that they have a site.
-	const isNoSiteCart = false;
 
-	const cartKey = useMemo(
-		() =>
-			getCartKey( {
-				selectedSite: site,
-				isLoggedOutCart,
-				isNoSiteCart,
-				waitForOtherCartUpdates,
-			} ),
-		[ waitForOtherCartUpdates, site, isLoggedOutCart, isNoSiteCart ]
-	);
+	const cartKey = useMemo( () => getCartKey( { selectedSite: site, isLoggedOutCart } ), [
+		site,
+		isLoggedOutCart,
+	] );
 
 	useEffect( () => {
 		return () => {
@@ -80,7 +71,7 @@ const EditorCheckoutModal = ( props: Props ) => {
 	const productSlugs = hasEmptyCart
 		? null
 		: cartData.products.map( ( product ) => product.product_slug );
-	const commaSeparatedProductSlugs = productSlugs?.join( ',' ) || null;
+	const commaSeparatedProductSlugs = productSlugs?.join( ',' );
 
 	return hasEmptyCart ? null : (
 		<Modal

--- a/client/my-sites/checkout/get-cart-key.ts
+++ b/client/my-sites/checkout/get-cart-key.ts
@@ -9,10 +9,10 @@ export default function getCartKey( {
 	isNoSiteCart,
 	waitForOtherCartUpdates,
 }: {
-	selectedSite: SiteData;
-	isLoggedOutCart: boolean;
-	isNoSiteCart: boolean;
-	waitForOtherCartUpdates: boolean;
+	selectedSite: SiteData | undefined | null;
+	isLoggedOutCart?: boolean;
+	isNoSiteCart?: boolean;
+	waitForOtherCartUpdates?: boolean;
 } ): string | number | undefined {
 	// We have to monitor the old cart manager in case it's waiting on a
 	// requested change. To prevent race conditions, we will return undefined in

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -98,6 +98,7 @@ class PlansNavigation extends React.Component {
 		if (
 			! config.isEnabled( 'upgrades/checkout' ) ||
 			! this.props.shoppingCartManager ||
+			this.props.shoppingCartManager.isLoading ||
 			! this.props.site
 		) {
 			return null;

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -22,7 +23,6 @@ import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 
 class PlansNavigation extends React.Component {
 	static propTypes = {
-		cart: PropTypes.object,
 		isJetpack: PropTypes.bool,
 		path: PropTypes.string.isRequired,
 		shouldShowMyPlan: PropTypes.bool,
@@ -95,13 +95,17 @@ class PlansNavigation extends React.Component {
 	};
 
 	cartToggleButton() {
-		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! this.props.cart || ! this.props.site ) {
+		if (
+			! config.isEnabled( 'upgrades/checkout' ) ||
+			! this.props.shoppingCartManager ||
+			! this.props.site
+		) {
 			return null;
 		}
 
 		return (
 			<PopoverCart
-				cart={ this.props.cart }
+				cart={ this.props.shoppingCartManager.responseCart }
 				selectedSite={ this.props.site }
 				onToggle={ this.toggleCartVisibility }
 				pinned={ isMobile() }
@@ -122,4 +126,4 @@ export default connect( ( state ) => {
 		shouldShowMyPlan: ! isOnFreePlan || isJetpack,
 		site,
 	};
-} )( localize( PlansNavigation ) );
+} )( withShoppingCart( localize( PlansNavigation ) ) );

--- a/packages/shopping-cart/src/shopping-cart-provider.tsx
+++ b/packages/shopping-cart/src/shopping-cart-provider.tsx
@@ -19,7 +19,7 @@ export default function ShoppingCartProvider( {
 	cartKey: string | number | null | undefined;
 	setCart: ( cartKey: string, requestCart: RequestCart ) => Promise< ResponseCart >;
 	getCart: ( cartKey: string ) => Promise< ResponseCart >;
-	children: JSX.Element;
+	children: React.ReactNode;
 } ): JSX.Element {
 	const shoppingCartManager = useShoppingCartManager( {
 		cartKey,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the plans v2 header (`PlansHeader`) so that in order to access the shopping cart, it uses `ShoppingCartProvider` and `withShoppingCart` from `@automattic/shopping-cart` instead of the deprecated `CartData` wrapper.

The biggest notable difference between the two mechanisms, besides the API for accessing the cart object, is that `CartData` connects to an always-on polling system for the cart that downloads a new copy about every 12 seconds. The `ShoppingCartProvider` will only download a copy of the cart when it first mounts.

From what I can tell, the only reason that the cart is involved in `PlansHeader` at all is the `PopoverCart` component which displays cart messages in the header. `PopoverCart` forces the `CartStore` to refresh its copy of the cart immediately on mount, and that works differently when using `ShoppingCartProvider` since they are separate systems. However, that shouldn't be an issue here since the shopping cart will be refreshed on every mount of `ShoppingCartProvider`. Eventually, `PopoverCart` itself should be updated to use the new system, but that component is used in several other places and it will be easier to update them one at a time for now.

#### To do

Since PopoverCart directly uses CartStore actions to refresh and remove items from the cart, I think that it should be refactored first rather than trying to do it here. At the least, we should make those actions injected rather than hard-wired.

#### Testing instructions

- View the `/plans` page and verify that the cart icon displays in the header.
- Add something to your cart, then visit the plans page again and verify that the icon displays a notification dot and that clicking it displays the contents of the cart.
- Inside the popup, click to remove items from the cart. Verify that they disappear.
- Reload the plans page and verify that the removed cart products remain removed.