### PR TITLE
Implement product card of pricing page i5

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-i5/assets/checkmark.svg
+++ b/client/components/jetpack/card/jetpack-product-card-i5/assets/checkmark.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="20" height="20">
+<path d="M11 17.768L6.116 12.884L7.884 11.116L11 14.232L19.658 5.574C17.823 3.391 15.075 2 12 2C6.477 2 2 6.477 2 12C2 17.523 6.477 22 12 22C17.523 22 22 17.523 22 12C22 10.472 21.647 9.029 21.034 7.734L11 17.768Z" fill="white"/>
+</mask>
+<g mask="url(#mask0)">
+<rect width="24" height="24" fill="#64CA43"/>
+</g>
+</svg>

--- a/client/components/jetpack/card/jetpack-product-card-i5/assets/chevron.svg
+++ b/client/components/jetpack/card/jetpack-product-card-i5/assets/chevron.svg
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4 15L12 7L20 15L18.586 16.414L12 9.828L5.414 16.414" fill="#12181E"/>
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="4" y="7" width="16" height="10">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4 15L12 7L20 15L18.586 16.414L12 9.828L5.414 16.414" fill="white"/>
+</mask>
+<g mask="url(#mask0)">
+<rect x="24" y="24" width="24" height="24" transform="rotate(180 24 24)" fill="#646970"/>
+</g>
+</svg>

--- a/client/components/jetpack/card/jetpack-product-card-i5/assets/star.svg
+++ b/client/components/jetpack/card/jetpack-product-card-i5/assets/star.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="1" y="1" width="14" height="13">
+<path d="M7.99967 11.5133L12.1197 14L11.0263 9.31331L14.6663 6.15998L9.87301 5.75331L7.99967 1.33331L6.12634 5.75331L1.33301 6.15998L4.97301 9.31331L3.87967 14L7.99967 11.5133Z" fill="white"/>
+</mask>
+<g mask="url(#mask0)">
+<rect width="16" height="16" fill="white"/>
+</g>
+</svg>

--- a/client/components/jetpack/card/jetpack-product-card-i5/features-item.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-i5/features-item.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { preventWidows } from 'calypso/lib/formatting';
+
+/**
+ * Type dependencies
+ */
+import type { ProductCardFeaturesItem } from './types';
+
+/**
+ * Styles dependencies
+ */
+import checkmarkIcon from './assets/checkmark.svg';
+
+interface Props {
+	item: ProductCardFeaturesItem;
+}
+
+const JetpackProductCardFeaturesItem: React.FC< Props > = ( { item: { text } } ) => (
+	<li className="jetpack-product-card-i5__features-item">
+		<img className="jetpack-product-card-i5__features-icon" src={ checkmarkIcon } alt="" />
+		<p className="jetpack-product-card-i5__features-text">{ preventWidows( text ) }</p>
+	</li>
+);
+
+export default JetpackProductCardFeaturesItem;

--- a/client/components/jetpack/card/jetpack-product-card-i5/features.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-i5/features.tsx
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import React, { useState, useCallback } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FeaturesItem from './features-item';
+import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+
+/**
+ * Type dependencies
+ */
+import type { ProductCardFeatures, ProductCardFeaturesItem } from './types';
+
+/**
+ * Styles dependencies
+ */
+import chevronIcon from './assets/chevron.svg';
+
+export interface Props {
+	features: ProductCardFeatures;
+	showAllFeatures?: boolean;
+	productSlug: string;
+}
+
+interface TrackProps {
+	product_slug?: string;
+}
+
+const DEFAULT_ITEM_COUNT = 3;
+
+const JetpackProductCardFeatures: React.FC< Props > = ( {
+	features: { items },
+	showAllFeatures,
+	productSlug,
+} ) => {
+	const trackProps = {} as TrackProps;
+
+	if ( productSlug ) {
+		trackProps.product_slug = productSlug;
+	}
+
+	const translate = useTranslate();
+	const [ isExpanded, setExpanded ] = useState( false );
+
+	const trackShowFeatures = useTrackCallback(
+		undefined,
+		'calypso_product_features_open',
+		trackProps
+	);
+	const trackHideFeatures = useTrackCallback(
+		undefined,
+		'calypso_product_features_close',
+		trackProps
+	);
+	const onToggle = useCallback( () => {
+		if ( isExpanded ) {
+			trackHideFeatures();
+			setExpanded( false );
+		} else {
+			trackShowFeatures();
+			setExpanded( true );
+		}
+	}, [ isExpanded, setExpanded, trackShowFeatures, trackHideFeatures ] );
+
+	return (
+		<section
+			className={ classNames( 'jetpack-product-card-i5__features', {
+				'is-expanded': isExpanded,
+			} ) }
+		>
+			<ul className="jetpack-product-card-i5__features-list">
+				{ ( items.slice(
+					0,
+					isExpanded || showAllFeatures ? items.length : DEFAULT_ITEM_COUNT
+				) as ProductCardFeaturesItem[] ).map( ( item, i ) => (
+					<FeaturesItem key={ i } item={ item } />
+				) ) }
+			</ul>
+			{ ! showAllFeatures && (
+				<button className="jetpack-product-card-i5__features-toggle" onClick={ onToggle }>
+					<span>
+						{ isExpanded ? translate( 'Show less features' ) : translate( 'Show all features' ) }
+					</span>
+					<img className="jetpack-product-card-i5__features-chevron" src={ chevronIcon } alt="" />
+				</button>
+			) }
+		</section>
+	);
+};
+
+export default JetpackProductCardFeatures;

--- a/client/components/jetpack/card/jetpack-product-card-i5/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-i5/index.tsx
@@ -1,0 +1,141 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { isFinite, isNumber } from 'lodash';
+import React, { createElement, ReactNode } from 'react';
+import { Button, ProductIcon } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import JetpackProductCardTimeFrame from './time-frame';
+import { preventWidows } from 'calypso/lib/formatting';
+import PlanPrice from 'calypso/my-sites/plan-price';
+import JetpackProductCardFeatures, { Props as FeaturesProps } from './features';
+
+/**
+ * Type dependencies
+ */
+import type { Moment } from 'moment';
+import type { Duration, PurchaseCallback } from 'calypso/my-sites/plans-v2/types';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+import starIcon from './assets/star.svg';
+
+type OwnProps = {
+	iconSlug?: string;
+	productSlug: string;
+	productName: TranslateResult;
+	headingLevel?: number;
+	description?: ReactNode;
+	currencyCode: string | null;
+	originalPrice: number;
+	discountedPrice?: number;
+	billingTerm: Duration;
+	buttonLabel: TranslateResult;
+	buttonPrimary: boolean;
+	onButtonClick: PurchaseCallback;
+	expiryDate?: Moment;
+	isFeatured?: boolean;
+	isOwned?: boolean;
+	isDeprecated?: boolean;
+	isAligned?: boolean;
+};
+
+export type Props = OwnProps & Partial< FeaturesProps >;
+
+const JetpackProductCardAlt2: React.FC< Props > = ( {
+	iconSlug,
+	productSlug,
+	productName,
+	headingLevel,
+	description,
+	currencyCode,
+	originalPrice,
+	discountedPrice,
+	billingTerm,
+	buttonLabel,
+	buttonPrimary,
+	onButtonClick,
+	expiryDate,
+	isFeatured,
+	isOwned,
+	isDeprecated,
+	isAligned,
+	features,
+	showAllFeatures,
+}: Props ) => {
+	const translate = useTranslate();
+	const isDiscounted = isFinite( discountedPrice );
+	const parsedHeadingLevel = isNumber( headingLevel )
+		? Math.min( Math.max( Math.floor( headingLevel ), 1 ), 6 )
+		: 2;
+
+	return (
+		<div
+			className={ classNames( 'jetpack-product-card-i5', {
+				'is-owned': isOwned,
+				'is-deprecated': isDeprecated,
+				'is-aligned': isAligned,
+				'is-featured': isFeatured,
+				'without-icon': ! iconSlug,
+			} ) }
+			data-e2e-product-slug={ productSlug }
+		>
+			{ isFeatured && (
+				<div className="jetpack-product-card-i5__header">
+					<img className="jetpack-product-card-i5__header-icon" src={ starIcon } alt="" />
+					<span>{ translate( 'Recommended' ) }</span>
+				</div>
+			) }
+			<div className="jetpack-product-card-i5__body">
+				{ iconSlug && <ProductIcon className="jetpack-product-card-i5__icon" slug={ iconSlug } /> }
+				{ createElement(
+					`h${ parsedHeadingLevel }`,
+					{ className: 'jetpack-product-card-i5__product-name' },
+					<>{ preventWidows( productName ) }</>
+				) }
+				<p className="jetpack-product-card-i5__description">{ description }</p>
+				<div className="jetpack-product-card-i5__price">
+					{ currencyCode && originalPrice ? (
+						<>
+							<span className="jetpack-product-card-i5__raw-price">
+								<PlanPrice
+									rawPrice={ ( isDiscounted ? discountedPrice : originalPrice ) as number }
+									currencyCode={ currencyCode }
+								/>
+							</span>
+							<JetpackProductCardTimeFrame expiryDate={ expiryDate } billingTerm={ billingTerm } />
+						</>
+					) : (
+						<>
+							<div className="jetpack-product-card-i5__price-placeholder" />
+							<div className="jetpack-product-card-i5__time-frame-placeholder" />
+						</>
+					) }
+				</div>
+				<Button
+					primary={ buttonPrimary }
+					className="jetpack-product-card-i5__button"
+					onClick={ onButtonClick }
+				>
+					{ buttonLabel }
+				</Button>
+				{ features && features.items.length > 0 && (
+					<JetpackProductCardFeatures
+						features={ features }
+						showAllFeatures={ showAllFeatures }
+						productSlug={ productSlug }
+					/>
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default JetpackProductCardAlt2;

--- a/client/components/jetpack/card/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-i5/style.scss
@@ -1,0 +1,217 @@
+.jetpack-product-card-i5 {
+	position: relative;
+
+	background: var( --color-surface );
+	border: 1px solid var( --color-border-subtle );
+	border-radius: 8px;
+	box-shadow: 0px 4px 24px rgba( 0, 0, 0, 0.05 );
+
+	&.is-aligned {
+		height: 100%;
+	}
+
+	&.is-featured {
+		z-index: 1;
+	}
+}
+
+.jetpack-product-card-i5__header {
+	display: flex;
+
+	box-sizing: border-box;
+	width: 100%;
+	padding: 8px;
+
+	background-color: var( --studio-purple-50 );
+	border-top-left-radius: inherit;
+	border-top-right-radius: inherit;
+	color: var( --color-text-inverted );
+
+	font-size: 0.875rem;
+	font-weight: 700;
+
+	.is-aligned & {
+		position: absolute;
+		top: -16px;
+		left: 0;
+	}
+}
+
+.jetpack-product-card-i5__header-icon {
+	margin-right: 8px;
+}
+
+.jetpack-product-card-i5__body {
+	padding: 24px 32px;
+
+	.is-featured & {
+		border: solid 2px var( --studio-purple-50 );
+		border-top: none;
+		border-bottom-left-radius: inherit;
+		border-bottom-right-radius: inherit;
+	}
+
+	.is-featured.is-aligned & {
+		box-sizing: border-box;
+		height: calc( 100% + 8px );
+
+		background-color: inherit;
+	}
+}
+
+.jetpack-product-card-i5__icon {
+	width: 56px;
+}
+
+.jetpack-product-card-i5__product-name {
+	margin: 6px 0 12px;
+
+	color: var( --studio-gray-100 );
+
+	font-size: 1.875rem;
+	font-weight: 700;
+	line-height: 1.2;
+
+	.without-icon & {
+		margin: 12px 0 20px;
+	}
+
+	em {
+		font-style: normal;
+	}
+}
+
+.jetpack-product-card-i5__description {
+	color: var( --studio-gray-60 );
+
+	@include breakpoint-deprecated( '>660px' ) {
+		min-height: 100px;
+	}
+}
+
+.jetpack-product-card-i5__price {
+	display: flex;
+	align-items: center;
+
+	margin: 16px 0 8px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-top: -40px;
+	}
+}
+
+.jetpack-product-card-i5 .plan-price {
+	display: flex;
+
+	color: var( --studio-gray-100 );
+}
+
+.jetpack-product-card-i5 .plan-price__currency-symbol {
+	margin-top: 0.875rem;
+
+	color: inherit;
+
+	font-size: 1.5rem;
+}
+
+.jetpack-product-card-i5 .plan-price__integer {
+	font-size: 3.375rem;
+	font-weight: 700;
+}
+
+.jetpack-product-card-i5 .plan-price__fraction {
+	margin-top: 1rem;
+}
+
+.jetpack-product-card-i5__billing-time-frame,
+.jetpack-product-card-i5__expiration-date {
+	margin-left: 12px;
+
+	color: var( --studio-gray-40 );
+
+	font-size: 0.875rem;
+	line-height: 1.2;
+}
+
+.jetpack-product-card-i5__expiration-date {
+	color: var( --studio-pink-50 );
+}
+
+.jetpack-product-card-i5__button {
+	width: 100%;
+	height: 45px;
+
+	border-radius: 4px;
+
+	font-size: 1rem;
+	font-weight: 700;
+}
+
+.jetpack-product-card-i5__features {
+	margin-bottom: 10px;
+}
+
+.jetpack-product-card-i5__features-list {
+	margin: 32px 0;
+
+	list-style-type: none;
+}
+
+.jetpack-product-card-i5__features-item {
+	display: flex;
+	align-items: flex-start;
+
+	margin: 14px 0;
+}
+
+.jetpack-product-card-i5__features-icon {
+	margin-right: 12px;
+}
+
+.jetpack-product-card-i5__features-text {
+	margin: 0;
+
+	color: var( --studio-gray-100 );
+
+	font-weight: 700;
+}
+
+.jetpack-product-card-i5__features-toggle {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	width: 100%;
+
+	color: var( --studio-gray-50 );
+
+	font-size: 1rem;
+
+	cursor: pointer;
+}
+
+.jetpack-product-card-i5__features-chevron {
+	transform: rotate( 180deg );
+
+	.is-expanded & {
+		transform: rotate( 0deg );
+	}
+}
+
+/* Prices Loading state */
+.jetpack-product-card-i5__price-placeholder {
+	@include placeholder( --color-neutral-10 );
+
+	width: 80px;
+	height: 40px;
+	margin-bottom: 16px;
+	margin-top: 24px;
+}
+
+.jetpack-product-card-i5__time-frame-placeholder {
+	@include placeholder( --color-neutral-10 );
+
+	width: 80px;
+	height: 16px;
+	margin-left: 12px;
+}

--- a/client/components/jetpack/card/jetpack-product-card-i5/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-i5/time-frame.tsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { durationToText } from 'calypso/my-sites/plans-v2/utils';
+
+/**
+ * Type dependencies
+ */
+import type { Moment } from 'moment';
+import type { Duration } from 'calypso/my-sites/plans-v2/types';
+
+interface Props {
+	expiryDate?: Moment;
+	billingTerm: Duration;
+}
+
+const JetpackProductCardTimeFrame: React.FC< Props > = ( { expiryDate, billingTerm } ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const productExpiryDate =
+		moment.isMoment( expiryDate ) && expiryDate.isValid() ? expiryDate : null;
+
+	return productExpiryDate ? (
+		<time
+			className="jetpack-product-card-i5__expiration-date"
+			dateTime={ productExpiryDate.format( 'YYYY-DD-YY' ) }
+		>
+			{ translate( 'expires %(date)s', {
+				args: {
+					date: productExpiryDate.format( 'L' ),
+				},
+			} ) }
+		</time>
+	) : (
+		<span className="jetpack-product-card-i5__billing-time-frame">
+			{ durationToText( billingTerm ) }
+		</span>
+	);
+};
+
+export default JetpackProductCardTimeFrame;

--- a/client/components/jetpack/card/jetpack-product-card-i5/types.ts
+++ b/client/components/jetpack/card/jetpack-product-card-i5/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Type dependencies
+ */
+import type {
+	SelectorProductFeaturesItem,
+	SelectorProductFeatures,
+} from 'calypso/my-sites/plans-v2/types';
+
+export type ProductCardFeaturesItem = SelectorProductFeaturesItem;
+export type ProductCardFeatures = SelectorProductFeatures;

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -75,22 +75,6 @@
 		}
 	}
 
-	.plan-price {
-		font-size: rem( 21px );
-
-		@include break-medium {
-			font-size: rem( 30px );
-		}
-
-		&.is-original {
-			color: #8c8f94;
-		}
-
-		.plan-price__integer {
-			font-weight: 400;
-		}
-	}
-
 	.jetpack-product-card-alt {
 		background: var( --studio-gray-0 );
 

--- a/client/my-sites/plans-v2/product-card-i5/index.tsx
+++ b/client/my-sites/plans-v2/product-card-i5/index.tsx
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import PlanRenewalMessage from '../plan-renewal-message';
+import useItemPrice from '../use-item-price';
+import { productButtonLabel } from '../utils';
+import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card-i5';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { planHasFeature } from 'calypso/lib/plans';
+import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
+import { isJetpackPlanSlug } from 'calypso/lib/products-values';
+import { isCloseToExpiration } from 'calypso/lib/purchases';
+import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
+import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
+import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+
+/**
+ * Type dependencies
+ */
+import type { Duration, PurchaseCallback, SelectorProduct } from '../types';
+
+interface ProductCardProps {
+	item: SelectorProduct;
+	onClick: PurchaseCallback;
+	siteId: number | null;
+	currencyCode: string | null;
+	selectedTerm?: Duration;
+	isAligned?: boolean;
+	featuredPlans?: string[];
+}
+
+const ProductCardI5: React.FC< ProductCardProps > = ( {
+	item,
+	onClick,
+	siteId,
+	currencyCode,
+	selectedTerm,
+	isAligned,
+	featuredPlans,
+} ) => {
+	const moment = useLocalizedMoment();
+
+	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
+	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
+	const purchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+
+	// Determine whether product is owned.
+	const isOwned = useMemo( () => {
+		if ( sitePlan && sitePlan.product_slug === item.productSlug ) {
+			return true;
+		} else if ( siteProducts ) {
+			return siteProducts
+				.filter( ( product ) => ! product.expired )
+				.map( ( product ) => product.productSlug )
+				.includes( item.productSlug );
+		}
+		return false;
+	}, [ item.productSlug, sitePlan, siteProducts ] );
+
+	// Calculate the product price.
+	const { originalPrice, discountedPrice } = useItemPrice(
+		siteId,
+		item,
+		item?.monthlyProductSlug || ''
+	);
+
+	// If item is a plan feature, use the plan purchase object.
+	const isItemPlanFeature = !! (
+		sitePlan && planHasFeature( sitePlan.product_slug, item.productSlug )
+	);
+	const purchase = isItemPlanFeature
+		? getPurchaseByProductSlug( purchases, sitePlan?.product_slug || '' )
+		: getPurchaseByProductSlug( purchases, item.productSlug );
+
+	// Handles expiry.
+	const isExpiring = purchase && isCloseToExpiration( purchase );
+	const showExpiryNotice = item.legacy && isExpiring;
+
+	const isUpgradeableToYearly =
+		isOwned && selectedTerm === TERM_ANNUALLY && item.term === TERM_MONTHLY;
+	const isPlan = isJetpackPlanSlug( item.productSlug );
+
+	return (
+		<JetpackProductCard
+			iconSlug={ isPlan ? undefined : item.iconSlug } // dark
+			productSlug={ item.productSlug }
+			productName={ item.displayName }
+			headingLevel={ 3 }
+			description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description }
+			currencyCode={ item.displayCurrency || currencyCode }
+			originalPrice={ originalPrice }
+			discountedPrice={ discountedPrice }
+			billingTerm={ item.displayTerm || item.term }
+			buttonLabel={ productButtonLabel( item, isOwned, isUpgradeableToYearly, sitePlan ) }
+			buttonPrimary={ ! ( isOwned || isItemPlanFeature ) }
+			onButtonClick={ () => onClick( item, isUpgradeableToYearly, purchase ) }
+			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
+			isFeatured={ featuredPlans && featuredPlans.includes( item.productSlug ) }
+			isOwned={ isOwned }
+			isDeprecated={ item.legacy }
+			isAligned={ isAligned }
+			features={ item.features }
+			showAllFeatures={ isPlan }
+		/>
+	);
+};
+
+export default ProductCardI5;

--- a/client/my-sites/plans-v2/product-card-i5/index.tsx
+++ b/client/my-sites/plans-v2/product-card-i5/index.tsx
@@ -89,7 +89,7 @@ const ProductCardI5: React.FC< ProductCardProps > = ( {
 
 	return (
 		<JetpackProductCard
-			iconSlug={ isPlan ? undefined : item.iconSlug } // dark
+			iconSlug={ isPlan ? undefined : item.iconSlug }
 			productSlug={ item.productSlug }
 			productName={ item.displayName }
 			headingLevel={ 3 }

--- a/client/my-sites/plans-v2/products-grid-i5/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-i5/index.tsx
@@ -1,20 +1,25 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import { sortBy } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef, useState, useEffect, useCallback, RefObject } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import ProductCardAlt2 from '../product-card-alt-2';
+import ProductCardI5 from '../product-card-i5';
 import { getProductPosition } from '../product-grid/products-order';
 import { getPlansToDisplay, getProductsToDisplay, isConnectionFlow } from '../product-grid/utils';
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
 import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card-alt';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import {
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+} from 'calypso/lib/plans/constants';
 import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
@@ -37,6 +42,8 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 	urlQueryArgs,
 } ) => {
 	const translate = useTranslate();
+	const planGridRef: RefObject< HTMLUListElement > = useRef( null );
+	const [ isPlanRowWrapping, setPlanRowWrapping ] = useState( false );
 
 	const siteId = useSelector( getSelectedSiteId );
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
@@ -70,20 +77,53 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 		[ duration, availableProducts, includedInPlanProducts, purchasedProducts ]
 	);
 
+	const onResize = useCallback( () => {
+		if ( planGridRef ) {
+			const { current: grid } = planGridRef;
+
+			if ( grid ) {
+				const firstChild = grid.children[ 0 ];
+
+				if ( firstChild instanceof HTMLElement ) {
+					const itemCount = Math.round( grid.offsetWidth / firstChild.offsetWidth );
+
+					setPlanRowWrapping( itemCount < sortedPlans.length );
+				}
+			}
+		}
+	}, [ planGridRef, sortedPlans ] );
+
+	useEffect( () => {
+		onResize();
+		window.addEventListener( 'resize', onResize );
+
+		return () => window.removeEventListener( 'resize', onResize );
+	}, [ onResize ] );
+
 	return (
 		<>
 			<section className="products-grid-i5__section">
 				<h2 className="products-grid-i5__section-title">{ translate( 'Product Bundles' ) }</h2>
 				<div className="products-grid-i5__filter-bar"></div>
-				<ul className="products-grid-i5__plan-grid">
+				<ul
+					className={ classNames( 'products-grid-i5__plan-grid', {
+						'is-wrapping': isPlanRowWrapping,
+					} ) }
+					ref={ planGridRef }
+				>
 					{ sortedPlans.map( ( product ) => (
 						<li key={ product.iconSlug }>
-							<ProductCardAlt2
+							<ProductCardI5
 								item={ product }
 								onClick={ onSelectProduct }
 								siteId={ siteId }
 								currencyCode={ currencyCode }
 								selectedTerm={ duration }
+								isAligned={ ! isPlanRowWrapping }
+								featuredPlans={ [
+									PLAN_JETPACK_SECURITY_REALTIME,
+									PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+								] }
 							/>
 						</li>
 					) ) }
@@ -95,7 +135,7 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 				<ul className="products-grid-i5__product-grid">
 					{ sortedProducts.map( ( product ) => (
 						<li key={ product.iconSlug }>
-							<ProductCardAlt2
+							<ProductCardI5
 								item={ product }
 								onClick={ onSelectProduct }
 								siteId={ siteId }

--- a/client/my-sites/plans-v2/products-grid-i5/style.scss
+++ b/client/my-sites/plans-v2/products-grid-i5/style.scss
@@ -1,10 +1,17 @@
 .products-grid-i5__section {
 	margin-bottom: 70px;
+	padding-left: 20px;
+	padding-right: 20px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		padding-left: 0;
+		padding-right: 0;
+	}
 }
 
 .products-grid-i5__section-title {
-	margin-top: 56px;
-	margin-bottom: 28px;
+	margin-top: 60px;
+	margin-bottom: 40px;
 
 	font-size: 2.25rem;
 	font-weight: 700;
@@ -18,14 +25,24 @@
 
 	list-style-type: none;
 
-	@include breakpoint-deprecated( '>660px' ) {
-		display: grid;
-		grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
-	}
+	display: grid;
+	grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
+	grid-gap: 24px 16px;
 }
 
-.products-grid-i5__product-grid {
-	@include breakpoint-deprecated( '>660px' ) {
-		grid-gap: 24px 16px;
+.products-grid-i5__plan-grid:not( .is-wrapping ) {
+	grid-gap: 24px 0;
+
+	// Considering there are 3 plans
+	> li {
+		&:first-child {
+			position: relative;
+			left: 8px;
+		}
+
+		&:last-child {
+			position: relative;
+			left: -8px;
+		}
 	}
 }

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -119,6 +119,12 @@ export function durationToString( duration: Duration ): DurationString {
 }
 
 export function durationToText( duration: Duration ): TranslateResult {
+	if ( 'i5' === getJetpackCROActiveVersion() ) {
+		return duration === TERM_MONTHLY
+			? translate( 'per month{{br/}}billed monthly', { components: { br: createElement( 'br' ) } } )
+			: translate( 'per month{{br/}}billed yearly', { components: { br: createElement( 'br' ) } } );
+	}
+
 	return duration === TERM_MONTHLY
 		? translate( 'per month, billed monthly' )
 		: translate( 'per month, billed yearly' );
@@ -413,7 +419,7 @@ export function itemToSelectorProduct(
 		}
 
 		const currentCROvariant = getJetpackCROActiveVersion();
-		const iconSlug = [ 'v1', 'v2' ].includes( currentCROvariant )
+		const iconSlug = [ 'v1', 'v2', 'i5' ].includes( currentCROvariant )
 			? `${ yearlyProductSlug || item.product_slug }_v2_dark`
 			: `${ yearlyProductSlug || item.product_slug }_v2`;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR integrates the product cards of the new pricing page.

Fixes 1196341175636977-as-1199149328812562

### Implementation notes

Fixed in later PRs:
- Icon of CRM has a wrong colour
- Plan cards don't show features
- Spacing between description and price must be refined once copy is validated

### Testing instructions

- Download the PR
- Run Calypso and Jetpack cloud concurrently
- Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
- Select a self-hosted Jetpack site
- Visit the pricing page
- Compare the page with the mockups (see task) in both Calypso and cloud, and a various viewport widths
- Check that the feature toggle of a product card works

### Screenshots

_3 card layout_
<img width="1097" alt="Screen Shot 2020-11-11 at 5 52 27 PM" src="https://user-images.githubusercontent.com/1620183/98873610-bbae3900-2446-11eb-8bd3-d869c5ee05b5.png">

_2 card layout_
<img width="881" alt="Screen Shot 2020-11-11 at 5 46 47 PM" src="https://user-images.githubusercontent.com/1620183/98873630-c072ed00-2446-11eb-8b8c-b1dcbcff2646.png">

_1 card layout_
<img width="516" alt="Screen Shot 2020-11-11 at 5 46 57 PM" src="https://user-images.githubusercontent.com/1620183/98873636-c36ddd80-2446-11eb-8dd4-f5a4a568bb4a.png">