### PR TITLE
Only attempt to build packages where package.json file exists

### DIFF
--- a/build-tools/lib/monorepo.js
+++ b/build-tools/lib/monorepo.js
@@ -14,7 +14,9 @@ const packagesInMonorepo = () =>
 	fs
 		.readdirSync( PACKAGES_DIR, { withFileTypes: true } )
 		.filter( ( file ) => file.isDirectory() )
-		.map( ( packageDir ) => require( path.join( PACKAGES_DIR, packageDir.name, 'package.json' ) ) );
+		.map( ( packageDir ) => path.join( PACKAGES_DIR, packageDir.name, 'package.json' ) )
+		.filter( ( packageJson ) => fs.existsSync( packageJson ) )
+		.map( ( packageJson ) => require( packageJson ) );
 
 module.exports = {
 	packagesInMonorepo,


### PR DESCRIPTION
When a package is removed, and other devs do a `git pull`, the package
dir will still exist on their local machine. That's because the `git
pull` won't remove and `dist` folders.

Having these folders with only `dist` files breaks the build because the
build script assumes every folder inside `packages/` is buildable.

Changes to `calypso-ui` and `composite-checkout-wpcom` is what caught me
out.

With this change the build will ignore packages that don't have a
`package.json` file, which means it'll skip the `dist` only dirs. You
could argue that devs should clean up these dirs, but the build error
isn't necessarily that easy to figure out so I think it's more ergonomic
to just ignore them.
