### PR TITLE
Ensure we only load packages with a package.json

### DIFF
--- a/build-tools/lib/monorepo.js
+++ b/build-tools/lib/monorepo.js
@@ -14,6 +14,7 @@ const packagesInMonorepo = () =>
 	fs
 		.readdirSync( PACKAGES_DIR, { withFileTypes: true } )
 		.filter( ( file ) => file.isDirectory() )
+		.filter( ( dir ) => fs.existsSync( path.join( PACKAGES_DIR, dir.name, 'package.json' ) ) )
 		.map( ( packageDir ) => require( path.join( PACKAGES_DIR, packageDir.name, 'package.json' ) ) );
 
 module.exports = {


### PR DESCRIPTION
Existing, but empty, package directories may exist when
building calypso after switching brances and a new package
was recently added.

#### Changes proposed in this Pull Request

* Adds check to confirm existence of pakcage.json

#### Testing instructions

```
cd ~/wp/wp-calypso
mkdir packages/makesbuildfail
yarn start
git checkout <this branch>
yarn start
```

Props: @yuliyan for figuring this out
