### PR TITLE
CRO i5: Remove jpcom masterbar fixed behavior on desktop.

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useRef, useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 
@@ -12,7 +12,8 @@ import { Button } from '@automattic/components';
 import ExternalLink from 'calypso/components/external-link';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import useDetectWindowBoundary from 'calypso/my-sites/plans-v2/use-detect-window-boundary';
+import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
+import { Iterations } from 'calypso/my-sites/plans-v2/iterations';
 
 /**
  * Style dependencies
@@ -40,16 +41,16 @@ const MENU_ITEMS = [
 ];
 
 const JetpackComMasterbar = () => {
+	const iteration = useMemo( getJetpackCROActiveVersion, [] ) as Iterations;
+
 	const [ isMenuOpen, setIsMenuOpen ] = useState( false );
-	const barRef = useRef< HTMLDivElement | null >( null );
-	const hasCrossed = useDetectWindowBoundary( barRef );
 
 	const toggleMenu = () => {
 		setIsMenuOpen( ( currentState ) => ! currentState );
 	};
 
 	return (
-		<div ref={ barRef } className={ classNames( 'jpcom-masterbar', { sticky: hasCrossed } ) }>
+		<div className={ `jpcom-masterbar iteration-${ iteration }` }>
 			<div className="jpcom-masterbar__inner">
 				<ExternalLink
 					className="jpcom-masterbar__logo"

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -45,6 +45,11 @@ $jpcom-gray-darken30: darken( $jpcom-gray, 30% ); // #3d596d
 
 	@include break-large {
 		flex-wrap: nowrap;
+
+		max-width: 1040px;
+
+		margin: 0 auto;
+		padding: 0 32px;
 	}
 }
 
@@ -52,24 +57,18 @@ $jpcom-gray-darken30: darken( $jpcom-gray, 30% ); // #3d596d
 	padding-top: 0.25em;
 }
 
-.jpcom-masterbar.sticky {
+.jpcom-masterbar {
 	// Pin to the top only on screens wider than `break-large`.
+	// ( and only if not "iteration-i5", iteration-i5 has static, free scrolling masterbar )
 	@include break-large {
-		position: fixed;
-		top: 0;
-		left: 0;
+		&:not( .iteration-i5 ) {
+			position: fixed;
+			top: 0;
+			left: 0;
+			z-index: 3;
 
-		width: 100%;
-
-		margin-top: 0;
-
-		z-index: 3;
-
-		.jpcom-masterbar__inner {
-			max-width: 1040px;
-
-			margin: 0 auto;
-			padding: 0 32px;
+			width: 100%;
+			margin-top: 0;
 		}
 	}
 }

--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -133,3 +133,9 @@
 		margin-top: 80px;
 	}
 }
+.plans-filter-bar.sticky + .products-grid-alt-2 {
+	transform: translateY( 95px );
+}
+.plans-filter-bar.sticky + .products-grid-alt {
+	transform: translateY( 70px );
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes the jpcom masterbar fixed on scroll behavior, making it static full-time - But only for jetpackConversionRateOptimization A/B test variant: `i5 - Saas table design`.

#### Additional implementation notes:

- In the `JetpackComMasterbar` component, I removed the `useDetectWindowBoundary()` hook and `ref` to go along with it.  This hook was detecting when the masterbar reaches the top of the viewport (which is immediately on page load) and makes the element "sticky", however the same behavior was already being accomplished with css so there was no need for this hook here, or the overhead to go along with it.
- I also fixed an issue with previous iterations (`v1 - 3 cols layout` & `v2 - slide outs`) where the plans grid UI was "jumping up" every time the plans-filter-bar goes to 'sticky' position. Scrolling the plans page on these iterations is much smoother now.

### Testing instructions

- Download the PR
- Run both Calypso and Jetpack cloud concurrently.
- Select the `i5 - Saas table design` variant of the a/b test `jetpackConversionRateOptimization`
- Visit `jetpack.cloud.localhost:3001/pricing` page.
- Verify that the top jpcom Masterbar is no longer "sticky" (fixed to the top) on scroll.
- Select previous iterations, and verify that the Masterbar **_is_** fixed on scroll on these iterations.  (all iterations except `i5`)
- While you're viewing previous iterations, notice that the plans page is no longer "_Jumping up_" when the plans-filter-bar goes sticky/fixed. You can visit wordpress.com to view the undesired jumping behavior.

Fixes 1196341175636977-as-1199168581500326