### PR TITLE
Update provider so the `useI18n()` hook can use the global translation functions from `@wordpress/i18n`

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/index.tsx
@@ -3,7 +3,7 @@
  */
 import * as React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -19,6 +19,7 @@ interface Props {
 }
 
 const LaunchMenu: React.FunctionComponent< Props > = ( { onMenuItemClick } ) => {
+	const { __ } = useI18n();
 	const { step: currentStep } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 	const LaunchStep = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchStep() );
 	const LaunchSequence = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchSequence() );

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -65,4 +65,3 @@ export default withI18n( MyComponent );
 ## API
 
 The translation functions `__`, `_n`, `_nx`, and `_x` are exposed from [`@wordpress/i18n`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/i18n). Refer to their documentation there.
-`i18nLocale` is a `string` containing the current locale. This is determined from the provided localeData and will fall back to `en`.

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import { createI18n, I18n, LocaleData } from '@wordpress/i18n';
+import { createI18n, I18n, LocaleData, __, _n, _nx, _x, isRTL } from '@wordpress/i18n';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 export interface I18nReact {
@@ -69,8 +69,14 @@ export const withI18n = createHigherOrderComponent< I18nReact >( ( InnerComponen
  * @returns The context value with bound translation functions
  */
 function makeContextValue( localeData?: LocaleData ): I18nReact {
-	const i18n = createI18n( localeData );
 	const i18nLocale = localeData?.[ '' ]?.localeSlug ?? 'en';
+
+	if ( ! localeData ) {
+		return { __, _n, _nx, _x, isRTL, i18nLocale };
+	}
+
+	const i18n = createI18n( localeData );
+
 	return {
 		__: i18n.__.bind( i18n ),
 		_n: i18n._n.bind( i18n ),

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -11,7 +11,6 @@ export interface I18nReact {
 	_nx: I18n[ '_nx' ];
 	_x: I18n[ '_x' ];
 	isRTL: I18n[ 'isRTL' ];
-	i18nLocale: string;
 }
 
 const I18nContext = React.createContext< I18nReact >( makeContextValue() );
@@ -69,10 +68,8 @@ export const withI18n = createHigherOrderComponent< I18nReact >( ( InnerComponen
  * @returns The context value with bound translation functions
  */
 function makeContextValue( localeData?: LocaleData ): I18nReact {
-	const i18nLocale = localeData?.[ '' ]?.localeSlug ?? 'en';
-
 	if ( ! localeData ) {
-		return { __, _n, _nx, _x, isRTL, i18nLocale };
+		return { __, _n, _nx, _x, isRTL };
 	}
 
 	const i18n = createI18n( localeData );
@@ -83,6 +80,5 @@ function makeContextValue( localeData?: LocaleData ): I18nReact {
 		_nx: i18n._nx.bind( i18n ),
 		_x: i18n._x.bind( i18n ),
 		isRTL: i18n.isRTL.bind( i18n ),
-		i18nLocale,
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`@automattic/react-i18n` works by providing locale data somewhere near the root of your component tree (using `<I18nProvider>`), and using the `useI18n()` hook in your components to get access to translation functions that use the provided locale data.

However we don't always have access to the locale data. In the ETK, core initialises `@wordpress/i18n` with the locale data and we don't get access to it. That means `__` from `@wordpress/i18n` works, but `__` from `useI18n()` does not.

This PR ~~adds a `<GlobalI18nProvider>` provider that is useful~~ changes the `<I18nProvider>` provider so it is useful in situations where we don't have access to the raw locale data.  When this provider is used, `useI18n()` will provide access to the global translation functions from `@wordpress/i18n`.

~~You still need to provide the current locale to `<GlobalI18nProvider>` somehow. You may also need to provide the current locale to `<I18nProvider>` somehow. That's because `@wordpress/i18n` doesn't give access to what the current locale is for some reason and `react-i18n` does.~~ (doing #47446 instead)

In this PR I've tested it out by translating a few strings in the launch flow ~~and I've gotten the current locale by having the server render it to a global. I previously thought I'd be able to grab the locale slug from `document.documentElement.lang` but unfortunately it doesn't always match the locale slug (e.g. sometimes the locale is `fr` and the `<html lang="...">` attribute is `fr_CA`)~~

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D52644-code to sandbox
* Sandbox an unlaunched gutenboarding site
* Ensure language is something other than `en`
* Open the block editor for your test site and click the launch button in the top right
* The 4 steps in the sidebar should still be translated
  ![Screen Shot on 2020-11-12 at 18:24:39](https://user-images.githubusercontent.com/1500769/98899387-5a549b80-2514-11eb-802e-80defaa0ea9c.png)
