### PR TITLE
Coming soon v2 soft launch spike

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -18,6 +18,7 @@ import SiteIcon from 'calypso/blocks/site-icon';
 import SiteIndicator from 'calypso/my-sites/site-indicator';
 import { getSite, getSiteSlug, isSitePreviewable } from 'calypso/state/sites/selectors';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isSiteCreatedInPublicComingSoonMode } from 'calypso/state/selectors/is-site-coming-soon';
 
 /**
  * Style dependencies
@@ -97,7 +98,7 @@ class Site extends React.Component {
 	};
 
 	render() {
-		const { site, translate } = this.props;
+		const { site, translate, isPublicComingSoonSite } = this.props;
 
 		if ( ! site ) {
 			// we could move the placeholder state here
@@ -118,7 +119,7 @@ class Site extends React.Component {
 
 		// To ensure two Coming Soon badges don't appear while we introduce public coming soon
 		const isPublicComingSoon =
-			isEnabled( 'coming-soon-v2' ) && ! site.is_private && this.props.site.is_coming_soon;
+			isPublicComingSoonSite && ! site.is_private && this.props.site.is_coming_soon;
 
 		return (
 			<div className={ siteClass }>
@@ -196,12 +197,14 @@ class Site extends React.Component {
 function mapStateToProps( state, ownProps ) {
 	const siteId = ownProps.siteId || ownProps.site.ID;
 	const site = siteId ? getSite( state, siteId ) : ownProps.site;
+	const isPublicComingSoonSite = isSiteCreatedInPublicComingSoonMode( state, siteId );
 
 	return {
 		siteId,
 		site,
 		isPreviewable: isSitePreviewable( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
+		isPublicComingSoonSite,
 	};
 }
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -31,7 +31,9 @@ import { isBusiness } from 'calypso/lib/products-values';
 import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'calypso/lib/plans/constants';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import { isJetpackSite, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
-import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
+import isSiteComingSoon, {
+	isSiteCreatedInPublicComingSoonMode,
+} from 'calypso/state/selectors/is-site-coming-soon';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -632,7 +634,13 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	privacySettings() {
-		const { isRequestingSettings, translate, handleSubmitForm, isSavingSettings } = this.props;
+		const {
+			isRequestingSettings,
+			translate,
+			handleSubmitForm,
+			isSavingSettings,
+			isPublicComingSoonSite,
+		} = this.props;
 
 		return (
 			<>
@@ -646,8 +654,8 @@ export class SiteSettingsFormGeneral extends Component {
 				/>
 				<Card>
 					<form>
-						{ ! config.isEnabled( 'coming-soon-v2' ) && this.visibilityOptionsComingSoon() }
-						{ config.isEnabled( 'coming-soon-v2' ) && this.visibilityOptionsComingSoonV2() }
+						{ ! isPublicComingSoonSite && this.visibilityOptionsComingSoon() }
+						{ isPublicComingSoonSite && this.visibilityOptionsComingSoonV2() }
 					</form>
 				</Card>
 			</>
@@ -783,10 +791,12 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 		const siteIsJetpack = isJetpackSite( state, siteId );
 		const selectedSite = getSelectedSite( state );
+		const isPublicComingSoonSite = isSiteCreatedInPublicComingSoonMode( state, siteId );
 
 		return {
 			isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
 			isComingSoon: isSiteComingSoon( state, siteId ),
+			isPublicComingSoonSite,
 			needsVerification: ! isCurrentUserEmailVerified( state ),
 			siteIsJetpack,
 			siteIsVip: isVipSite( state, siteId ),

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -38,7 +38,9 @@ import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-ro
 import isHiddenSite from 'calypso/state/selectors/is-hidden-site';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
-import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
+import isSiteComingSoon, {
+	isSiteCreatedInPublicComingSoonMode,
+} from 'calypso/state/selectors/is-site-coming-soon';
 import { toApi as seoTitleToApi } from 'calypso/components/seo/meta-title-editor/mappings';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -58,7 +60,6 @@ import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import { requestSiteSettings, saveSiteSettings } from 'calypso/state/site-settings/actions';
 import WebPreview from 'calypso/components/web-preview';
 import { getFirstConflictingPlugin } from 'calypso/lib/seo';
-import { isEnabled } from 'calypso/config';
 
 /**
  * Style dependencies
@@ -274,6 +275,7 @@ export class SeoForm extends React.Component {
 		const {
 			conflictedSeoPlugin,
 			isFetchingSite,
+			isPublicComingSoonSite,
 			siteId,
 			siteIsJetpack,
 			siteIsComingSoon,
@@ -322,7 +324,7 @@ export class SeoForm extends React.Component {
 						} ),
 			  };
 		// To ensure two Coming Soon badges don't appear while we introduce public coming soon
-		const isPublicComingSoon = isEnabled( 'coming-soon-v2' ) && ! isSitePrivate && siteIsComingSoon;
+		const isPublicComingSoon = isPublicComingSoonSite && ! isSitePrivate && siteIsComingSoon;
 
 		return (
 			<div>
@@ -497,6 +499,8 @@ const mapStateToProps = ( state ) => {
 	const conflictedSeoPlugin = siteIsJetpack
 		? getFirstConflictingPlugin( activePlugins ) // Pick first one to keep the notice short.
 		: null;
+	const isPublicComingSoonSite = isSiteCreatedInPublicComingSoonMode( state, siteId );
+
 	return {
 		conflictedSeoPlugin,
 		isFetchingSite: isRequestingSite( state, siteId ),
@@ -515,6 +519,7 @@ const mapStateToProps = ( state ) => {
 		isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),
 		saveError: getSiteSettingsSaveError( state, siteId ),
 		path: getCurrentRouteParameterized( state, siteId ),
+		isPublicComingSoonSite,
 	};
 };
 

--- a/client/state/selectors/is-site-coming-soon.js
+++ b/client/state/selectors/is-site-coming-soon.js
@@ -4,6 +4,7 @@
 
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import { getSiteSettings } from 'calypso/state/site-settings/selectors';
+import { getSiteOption } from 'calypso/state/sites/selectors';
 
 /**
  * Returns true if the site is coming_soon
@@ -27,4 +28,18 @@ export default function isSiteComingSoon( state, siteId ) {
 	}
 
 	return false;
+}
+
+/**
+ * Determines if a site has been created in public coming soon mode by checking for the `wpcom_public_coming_soon_site` option.
+ * We add this option so we can distinguish sites created in public coming soon (v2) and private by default coming soon (v1) modes.
+ * We'll gradually phase out v1 but we want to be able to show different UIs to each version until we do.
+ *
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @returns {boolean} true if the site is created in public coming soon mode
+ */
+export function isSiteCreatedInPublicComingSoonMode( state, siteId ) {
+	const publicComingSoon = getSiteOption( state, siteId, 'wpcom_public_coming_soon_site' );
+	return parseInt( publicComingSoon, 10 ) === 1;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

SPIKE ONLY. This is garbage.

We need to be able to tell which site was started in coming soon mode and which isn't.

To do this, this PR sets a new option `wpcom_public_coming_soon_site`. 

We check this option so we can distinguish sites created in public coming soon (v2) and private by default coming soon (v1) modes.

We'll gradually phase out v1 but we want to be able to show different UIs to each version until we do, hence the static option.

#### Testing instructions

D52645-code

TBC


