### PR TITLE
🚧  👷🏼‍♀️ Welcome Tour: mechanics of tour window with minimization

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/index.js
@@ -5,3 +5,4 @@ import './src/store';
 import './src/disable-core-nux';
 import './src/wpcom-nux';
 import './src/wpcom-nux-tour';
+import './src/tour-card';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/index.js
@@ -3,6 +3,7 @@
  */
 import './src/store';
 import './src/disable-core-nux';
-import './src/wpcom-nux';
+// import './src/wpcom-nux';
 import './src/wpcom-nux-tour';
 import './src/tour-card';
+import './src/tour-content';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/index.js
@@ -4,3 +4,4 @@
 import './src/store';
 import './src/disable-core-nux';
 import './src/wpcom-nux';
+import './src/wpcom-nux-tour';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/slide-control.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/slide-control.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { times } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { SVG, Circle } from '@wordpress/primitives';
+import { Button } from '@wordpress/components';
+
+/*
+ * Copied from the Guide Component: https://github.com/WordPress/gutenberg/blob/4bbfbc13603d28fcc45368c529954164bf8581de/packages/components/src/guide/page-control.js#L3
+ * Note that it is styled by .components-guide-* styling that already exists from using the Guide package elsewhere
+ * TODO: make this into WP package?
+ */
+export default function PageControl( { currentPage, numberOfPages, setCurrentPage } ) {
+	return (
+		<ul
+			className="components-guide__page-control"
+			aria-label={ __( 'Guide controls', 'full-site-editing' ) }
+		>
+			{ times( numberOfPages, ( page ) => (
+				<li
+					key={ page }
+					// Set aria-current="step" on the active page, see https://www.w3.org/TR/wai-aria-1.1/#aria-current
+					aria-current={ page === currentPage ? 'step' : undefined }
+				>
+					<Button
+						key={ page }
+						icon={ <PageControlIcon isSelected={ page === currentPage } /> }
+						aria-label={ sprintf(
+							/* translators: 1: current page number 2: total number of pages */
+							__( 'Page %1$d of %2$d', 'full-site-editing' ),
+							page + 1,
+							numberOfPages
+						) }
+						onClick={ () => setCurrentPage( page ) }
+					/>
+				</li>
+			) ) }
+		</ul>
+	);
+}
+
+const PageControlIcon = ( { isSelected } ) => (
+	<SVG width="8" height="8" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<Circle cx="4" cy="4" r="4" fill={ isSelected ? '#419ECD' : '#E1E3E6' } />
+	</SVG>
+);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/slide-control.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/slide-control.js
@@ -1,3 +1,6 @@
+/*** THIS MUST BE THE FIRST THING EVALUATED IN THIS SCRIPT *****/
+import './public-path';
+
 /**
  * External dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/style-tour.scss
@@ -12,13 +12,42 @@
 	position: fixed;
 }
 
-.wpcom-block-editor-welcome-tour__card-heading,
-.wpcom-block-editor-welcome-tour__subheading {
-	padding: $grid-unit-05 $grid-unit-20;
+.welcome-tour-card__heading,
+.welcome-tour-card__subheading {
 	font-size: $big-font-size;
-	// margin: 0 0 8px;
+	padding: $grid-unit-05 $grid-unit-20;
 }
 
 .wpcom-editor-welcome-tour__minimized-container {
 	border-radius: 2px;
+}
+
+.wpcom-editor-welcome-tour__resume-btn {
+	background-color: $white;
+	border: 1px solid $light-gray-900;
+}
+
+.wpcom-editor-welcome-tour__resume-btn-text {
+	margin-right: 60px;
+}
+
+.welcome-tour-card {
+	max-width: 400px;
+	.components-card__footer {
+		border-top: none;
+	}
+}
+
+.welcome-tour-card__overlay-controls {
+	left: 0;
+	padding: 12px;
+	position: absolute;
+	right: 0;
+	.components-button {
+		background: $dark-gray-700;
+	}
+}
+
+.welcome-tour-card__next-btn {
+	margin-left: 10px;
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/style-tour.scss
@@ -1,0 +1,24 @@
+@import '~@wordpress/base-styles/colors';
+@import '~@wordpress/base-styles/mixins';
+@import '~@wordpress/base-styles/variables';
+@import '~@wordpress/base-styles/z-index';
+
+.wpcom-editor-welcome-tour-container {
+	background-color: $white;
+	border-radius: 2px;
+	bottom: 40px;
+	display: inline;
+	left: 40px;
+	position: fixed;
+}
+
+.wpcom-block-editor-welcome-tour__card-heading,
+.wpcom-block-editor-welcome-tour__subheading {
+	padding: $grid-unit-05 $grid-unit-20;
+	font-size: $big-font-size;
+	// margin: 0 0 8px;
+}
+
+.wpcom-editor-welcome-tour__minimized-container {
+	border-radius: 2px;
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/style-tour.scss
@@ -30,6 +30,16 @@
 .wpcom-editor-welcome-tour__resume-btn-text {
 	margin-right: 60px;
 }
+.wpcom-editor-welcome-tour-card-frame {
+	position: relative;
+
+	// TODO update markup/css  if this isn't ok
+	.components-guide__page-control {
+		bottom: 0;
+		left: 16px;
+		position: absolute;
+	}
+}
 
 .welcome-tour-card {
 	max-width: 400px;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
@@ -13,7 +13,7 @@ import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/
 
 // import { useEffect, useState } from '@wordpress/element';
 
-function WelcomeTourCard( { onMinimize, onDismiss } ) {
+function WelcomeTourCard( { cardIndex, heading, onMinimize, onDismiss } ) {
 	return (
 		<Card className="welcome-tour-card">
 			<CardOverlayControls onDismiss={ onDismiss } onMinimize={ onMinimize } />
@@ -24,7 +24,7 @@ function WelcomeTourCard( { onMinimize, onDismiss } ) {
 				/>
 			</CardMedia>
 			<CardBody>
-				<h2 className="welcome-tour-card__card-heading">Welcome to WordPress</h2>
+				<h2 className="welcome-tour-card__card-heading">{ heading }</h2>
 				<p>Learn the basic editor tools so you can edit and build your dream website.</p>
 			</CardBody>
 			<CardFooter>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
@@ -42,9 +42,19 @@ function WelcomeTourCard( {
 					setCurrentPage={ setCurrentCard }
 				/>
 				<div>
-					<Button isTertiary={ true } onClick={ () => onDismiss() }>
-						No thanks
-					</Button>
+					{ cardIndex === 0 ? (
+						<Button isTertiary={ true } onClick={ () => onDismiss() }>
+							No thanks
+						</Button>
+					) : (
+						<Button
+							className="welcome-tour-card__next-btn"
+							isTertiary={ true }
+							onClick={ () => setCurrentCard( cardIndex - 1 ) }
+						>
+							Back
+						</Button>
+					) }
 					{ cardIndex < lastCardIndex ? (
 						<Button
 							className="welcome-tour-card__next-btn"

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
@@ -13,27 +13,44 @@ import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/
 
 // import { useEffect, useState } from '@wordpress/element';
 
-function WelcomeTourCard( { cardIndex, heading, onMinimize, onDismiss } ) {
+function WelcomeTourCard( {
+	cardContent,
+	cardIndex,
+	lastCardIndex,
+	onMinimize,
+	onDismiss,
+	setCurrentCard,
+} ) {
+	const { description, heading, imgSrc } = cardContent;
 	return (
 		<Card className="welcome-tour-card">
 			<CardOverlayControls onDismiss={ onDismiss } onMinimize={ onMinimize } />
 			<CardMedia>
-				<img
-					alt="Editor Welcome Tour"
-					src="https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-1.jpg?resize=400px"
-				/>
+				<img alt="Editor Welcome Tour" src={ imgSrc } />
 			</CardMedia>
 			<CardBody>
 				<h2 className="welcome-tour-card__card-heading">{ heading }</h2>
-				<p>Learn the basic editor tools so you can edit and build your dream website.</p>
+				<p>{ description }</p>
 			</CardBody>
 			<CardFooter>
 				<div>• • • • • •</div>
 				<div>
-					<Button isTertiary={ true }>No thanks</Button>
-					<Button isPrimary={ true } className="welcome-tour-card__next-btn">
-						Let's start
+					<Button isTertiary={ true } onClick={ () => onDismiss() }>
+						No thanks
 					</Button>
+					{ cardIndex < lastCardIndex ? (
+						<Button
+							className="welcome-tour-card__next-btn"
+							isPrimary={ true }
+							onClick={ () => setCurrentCard( cardIndex + 1 ) }
+						>
+							{ cardIndex === 0 ? "Let's start" : 'Next' }
+						</Button>
+					) : (
+						<Button isPrimary={ true } onClick={ () => onDismiss() }>
+							Done
+						</Button>
+					) }
 				</div>
 			</CardFooter>
 		</Card>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
@@ -23,6 +23,7 @@ function WelcomeTourCard( {
 	setCurrentCard,
 } ) {
 	const { description, heading, imgSrc } = cardContent;
+
 	return (
 		<Card className="welcome-tour-card">
 			<CardOverlayControls onDismiss={ onDismiss } onMinimize={ onMinimize } />

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
@@ -14,20 +14,9 @@ import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/
 // import { useEffect, useState } from '@wordpress/element';
 
 function WelcomeTourCard( { onMinimize, onDismiss } ) {
-	console.log( 'WelcomeTourCard' );
 	return (
 		<Card className="welcome-tour-card">
-			<div className="welcome-tour-card__overlay-controls">
-				<Flex>
-					<Button
-						isPrimary
-						icon="pets"
-						iconSize={ 14 }
-						onClick={ () => onMinimize( true ) }
-					></Button>
-					<Button isPrimary icon="no-alt" iconSize={ 14 } onClick={ () => onDismiss() }></Button>
-				</Flex>
-			</div>
+			<CardOverlayControls onDismiss={ onDismiss } onMinimize={ onMinimize } />
 			<CardMedia>
 				<img
 					alt="Editor Welcome Tour"
@@ -48,6 +37,17 @@ function WelcomeTourCard( { onMinimize, onDismiss } ) {
 				</div>
 			</CardFooter>
 		</Card>
+	);
+}
+
+function CardOverlayControls( { onMinimize, onDismiss } ) {
+	return (
+		<div className="welcome-tour-card__overlay-controls">
+			<Flex>
+				<Button isPrimary icon="pets" iconSize={ 14 } onClick={ () => onMinimize( true ) }></Button>
+				<Button isPrimary icon="no-alt" iconSize={ 14 } onClick={ () => onDismiss() }></Button>
+			</Flex>
+		</div>
 	);
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
@@ -1,0 +1,54 @@
+/*** THIS MUST BE THE FIRST THING EVALUATED IN THIS SCRIPT *****/
+import './public-path';
+
+/**
+ * Internal dependencies
+ */
+import './style-tour.scss';
+
+/**
+ * External dependencies
+ */
+import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
+
+// import { useEffect, useState } from '@wordpress/element';
+
+function WelcomeTourCard( { onMinimize, onDismiss } ) {
+	console.log( 'WelcomeTourCard' );
+	return (
+		<Card className="welcome-tour-card">
+			<div className="welcome-tour-card__overlay-controls">
+				<Flex>
+					<Button
+						isPrimary
+						icon="pets"
+						iconSize={ 14 }
+						onClick={ () => onMinimize( true ) }
+					></Button>
+					<Button isPrimary icon="no-alt" iconSize={ 14 } onClick={ () => onDismiss() }></Button>
+				</Flex>
+			</div>
+			<CardMedia>
+				<img
+					alt="Editor Welcome Tour"
+					src="https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-1.jpg?resize=400px"
+				/>
+			</CardMedia>
+			<CardBody>
+				<h2 className="welcome-tour-card__card-heading">Welcome to WordPress</h2>
+				<p>Learn the basic editor tools so you can edit and build your dream website.</p>
+			</CardBody>
+			<CardFooter>
+				<div>• • • • • •</div>
+				<div>
+					<Button isTertiary={ true }>No thanks</Button>
+					<Button isPrimary={ true } className="welcome-tour-card__next-btn">
+						Let's start
+					</Button>
+				</div>
+			</CardFooter>
+		</Card>
+	);
+}
+
+export default WelcomeTourCard;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-card.js
@@ -5,6 +5,7 @@ import './public-path';
  * Internal dependencies
  */
 import './style-tour.scss';
+import SlideControl from './slide-control';
 
 /**
  * External dependencies
@@ -33,7 +34,13 @@ function WelcomeTourCard( {
 				<p>{ description }</p>
 			</CardBody>
 			<CardFooter>
-				<div>• • • • • •</div>
+				{ /* TODO: revist naming for this component */ }
+				<SlideControl
+					className=""
+					currentPage={ cardIndex }
+					numberOfPages={ lastCardIndex + 1 }
+					setCurrentPage={ setCurrentCard }
+				/>
 				<div>
 					<Button isTertiary={ true } onClick={ () => onDismiss() }>
 						No thanks

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-content.js
@@ -1,0 +1,35 @@
+/*** THIS MUST BE THE FIRST THING EVALUATED IN THIS SCRIPT *****/
+import './public-path';
+
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * This function returns a collection of NUX Tour slide data
+ *
+ * @returns { Array } a collection of <WelcomeTourCard /> props
+ */
+function getTourContent() {
+	return [
+		{
+			heading: __( 'Welcome to your website', 'full-site-editing' ),
+			description: __(
+				'Edit your homepage, add the pages you need, and change your site’s look and feel.',
+				'full-site-editing'
+			),
+			imgSrc: 'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-1.jpg?resize=400px',
+		},
+		// {
+		// 	heading: __( 'Everything is a block', 'full-site-editing' ),
+		// 	description: __(
+		// 		'Edit your homepage, add the pages you need, and change your site’s look and feel.',
+		// 		'full-site-editing'
+		// 	),
+		// 	imgSrc: 'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-1.jpg?resize=400px',
+		// },
+	];
+}
+
+export default getTourContent;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-content.js
@@ -14,20 +14,23 @@ import { __ } from '@wordpress/i18n';
 function getTourContent() {
 	return [
 		{
-			heading: __( 'Welcome to your website', 'full-site-editing' ),
+			heading: __( 'Learn the basics', 'full-site-editing' ),
 			description: __(
-				'Edit your homepage, add the pages you need, and change your site’s look and feel.',
+				'Take the tour to learn the fundamentals of the WordPress editor.',
 				'full-site-editing'
 			),
-			imgSrc: 'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-1.jpg?resize=400px',
+			imgSrc: 'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-0-2.jpg?resize=400px',
+			animation: null,
 		},
 		{
 			heading: __( 'Everything is a block', 'full-site-editing' ),
 			description: __(
-				'Edit your homepage, add the pages you need, and change your site’s look and feel.',
+				'In the WordPress Editor paragraphs, images, and videos, are all blocks.',
 				'full-site-editing'
 			),
-			imgSrc: 'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-1.jpg?resize=400px',
+			imgSrc:
+				'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-1-blocks-1.gif?resize=400px',
+			animation: null,
 		},
 		{
 			heading: __( 'Click a block to change it', 'full-site-editing' ),
@@ -35,7 +38,44 @@ function getTourContent() {
 				'Use the toolbar to change the appearance of a selected block. Try making it bold.',
 				'full-site-editing'
 			),
+			imgSrc:
+				'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-2-make-bold-1.gif?resize=400px',
+			animation: null,
+		},
+		{
+			heading: __( 'More Options', 'full-site-editing' ),
+			description: __( 'Click the settings icon to see even more options.', 'full-site-editing' ),
+			imgSrc:
+				'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-3-more_options.gif?resize=400px',
+			animation: null,
+		},
+		{
+			heading: __( 'Adding a new block', 'full-site-editing' ),
+			description: __(
+				'Click the add button to open the inserter. Then click the block you want to add.',
+				'full-site-editing'
+			),
+			imgSrc:
+				'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-4-add_block_zoomed.gif?resize=400px',
+			animation: 'block-inserter',
+		},
+		{
+			heading: __( 'Undo any mistake', 'full-site-editing' ),
+			description: __(
+				"Simply click the Undo button if you've made a mistake.",
+				'full-site-editing'
+			),
 			imgSrc: 'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-3.jpg?resize=400px',
+			animation: 'undo-button',
+		},
+		{
+			heading: __( 'Congratulations!', 'full-site-editing' ),
+			description: __(
+				"You've now learned the basics and are on your way to building your website!",
+				'full-site-editing'
+			),
+			imgSrc: 'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-3.jpg?resize=400px',
+			animation: 'block-inserter',
 		},
 	];
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/tour-content.js
@@ -21,14 +21,22 @@ function getTourContent() {
 			),
 			imgSrc: 'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-1.jpg?resize=400px',
 		},
-		// {
-		// 	heading: __( 'Everything is a block', 'full-site-editing' ),
-		// 	description: __(
-		// 		'Edit your homepage, add the pages you need, and change your site’s look and feel.',
-		// 		'full-site-editing'
-		// 	),
-		// 	imgSrc: 'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-1.jpg?resize=400px',
-		// },
+		{
+			heading: __( 'Everything is a block', 'full-site-editing' ),
+			description: __(
+				'Edit your homepage, add the pages you need, and change your site’s look and feel.',
+				'full-site-editing'
+			),
+			imgSrc: 'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-1.jpg?resize=400px',
+		},
+		{
+			heading: __( 'Click a block to change it', 'full-site-editing' ),
+			description: __(
+				'Use the toolbar to change the appearance of a selected block. Try making it bold.',
+				'full-site-editing'
+			),
+			imgSrc: 'https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-3.jpg?resize=400px',
+		},
 	];
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux-tour.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux-tour.js
@@ -1,0 +1,70 @@
+/*** THIS MUST BE THE FIRST THING EVALUATED IN THIS SCRIPT *****/
+import './public-path';
+
+/**
+ * Internal dependencies
+ */
+import './style-tour.scss';
+import editorImage from './images/editor.svg';
+
+/**
+ * External dependencies
+ */
+import { Button, Card, CardBody, CardFooter, Text } from '@wordpress/components';
+import { Icon, expand } from '@wordpress/icons';
+
+import { createPortal, useEffect, useState } from '@wordpress/element';
+import { registerPlugin } from '@wordpress/plugins';
+
+function LaunchWpcomNuxTour() {
+	console.log( 'LaunchWpcomNuxTour' );
+
+	// Create parent for welcome tour portal
+	const portalParent = document.createElement( 'div' );
+	useEffect( () => {
+		document.body.appendChild( portalParent );
+		return () => {
+			document.body.removeChild( portalParent );
+		};
+	} );
+
+	return <div>{ createPortal( <WelcomeTour />, portalParent ) }</div>;
+}
+
+function WelcomeTour() {
+	const [ isMinimized, setIsMinimized ] = useState( false );
+	// const containerClass = isMinimized ? 'minimized';
+	return (
+		<div className="wpcom-editor-welcome-tour-container">
+			{ ! isMinimized ? (
+				<Card>
+					<CardBody>
+						<h2 className="wpcom-editor-welcome-tour__card-heading">
+							Let's learn the basics of Block Editing
+						</h2>
+					</CardBody>
+					<CardFooter>
+						<Button isPrimary={ true } onClick={ () => setIsMinimized( true ) }>
+							Minimize Me
+						</Button>
+					</CardFooter>
+				</Card>
+			) : (
+				<div className="wpcom-editor-welcome-tour__minimized-container">
+					<Button icon="expand" onClick={ () => setIsMinimized( false ) }>
+						Expand to resume
+						{ /* <Icon icon={ expand } size={ 16 } /> */ }
+						{ /* // Hm, Icon not working */ }
+					</Button>
+				</div>
+			) }
+		</div>
+	);
+}
+
+// export default LaunchWpcomNuxTour;
+
+// For deving
+// registerPlugin( 'wpcom-block-editor-nux', {
+// 	render: () => <LaunchWpcomNuxTour />,
+// } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux-tour.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux-tour.js
@@ -5,20 +5,18 @@ import './public-path';
  * Internal dependencies
  */
 import './style-tour.scss';
-import editorImage from './images/editor.svg';
 
 /**
  * External dependencies
  */
-import { Button, Card, CardBody, CardFooter, Text } from '@wordpress/components';
-import { Icon, expand } from '@wordpress/icons';
+import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
+// import styled from '@emotion/styled';
+import { Icon, expand, chevronUp } from '@wordpress/icons';
 
 import { createPortal, useEffect, useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 
 function LaunchWpcomNuxTour() {
-	console.log( 'LaunchWpcomNuxTour' );
-
 	// Create parent for welcome tour portal
 	const portalParent = document.createElement( 'div' );
 	useEffect( () => {
@@ -33,28 +31,69 @@ function LaunchWpcomNuxTour() {
 
 function WelcomeTour() {
 	const [ isMinimized, setIsMinimized ] = useState( false );
+	// TODO: replace with wp.data
+	const [ isNuxEnabled, setIsNuxEnabled ] = useState( true );
+
+	const dismissWpcomNuxTour = () => {
+		// TODO recordTracksEvent
+		// setWpcomNuxStatus( { isNuxEnabled: false } );
+		setIsNuxEnabled( false );
+	};
+
+	if ( ! isNuxEnabled ) {
+		return null;
+	}
+
 	// const containerClass = isMinimized ? 'minimized';
 	return (
 		<div className="wpcom-editor-welcome-tour-container">
 			{ ! isMinimized ? (
-				<Card>
+				<Card className="welcome-tour-card">
+					<div className="welcome-tour-card__overlay-controls">
+						<Flex>
+							<Button
+								isPrimary
+								icon="pets"
+								iconSize={ 14 }
+								onClick={ () => setIsMinimized( true ) }
+							></Button>
+							<Button
+								isPrimary
+								icon="no-alt"
+								iconSize={ 14 }
+								onClick={ dismissWpcomNuxTour }
+							></Button>
+						</Flex>
+					</div>
+					<CardMedia>
+						<img
+							alt="Editor Welcome Tour"
+							src="https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-1.jpg?resize=400px"
+						/>
+					</CardMedia>
 					<CardBody>
-						<h2 className="wpcom-editor-welcome-tour__card-heading">
-							Let's learn the basics of Block Editing
-						</h2>
+						<h2 className="welcome-tour-card__card-heading">Welcome to WordPress</h2>
+						<p>Learn the basic editor tools so you can edit and build your dream website.</p>
 					</CardBody>
 					<CardFooter>
-						<Button isPrimary={ true } onClick={ () => setIsMinimized( true ) }>
-							Minimize Me
-						</Button>
+						<div>• • • • • •</div>
+						<div>
+							<Button isTertiary={ true }>No thanks</Button>
+							<Button isPrimary={ true } className="welcome-tour-card__next-btn">
+								Let's start
+							</Button>
+						</div>
 					</CardFooter>
 				</Card>
 			) : (
 				<div className="wpcom-editor-welcome-tour__minimized-container">
-					<Button icon="expand" onClick={ () => setIsMinimized( false ) }>
-						Expand to resume
-						{ /* <Icon icon={ expand } size={ 16 } /> */ }
-						{ /* // Hm, Icon not working */ }
+					<Button
+						onClick={ () => setIsMinimized( false ) }
+						className="wpcom-editor-welcome-tour__resume-btn"
+					>
+						<p className="wpcom-editor-welcome-tour__resume-btn-text"> Click to resume tutorial</p>
+						<Icon icon={ chevronUp } size={ 16 } />
+						{ /* expand icon is throwing an error <Icon icon={ expand } size={ 16 } /> */ }
 					</Button>
 				</div>
 			) }
@@ -62,9 +101,9 @@ function WelcomeTour() {
 	);
 }
 
-// export default LaunchWpcomNuxTour;
+export default LaunchWpcomNuxTour;
 
-// For deving
-// registerPlugin( 'wpcom-block-editor-nux', {
-// 	render: () => <LaunchWpcomNuxTour />,
-// } );
+// TODO rename to nuxtour?
+registerPlugin( 'wpcom-block-editor-nux', {
+	render: () => <LaunchWpcomNuxTour />,
+} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux-tour.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux-tour.js
@@ -34,7 +34,9 @@ function LaunchWpcomNuxTour() {
 }
 
 function WelcomeTourFrame() {
+	const cardContent = getTourContent();
 	const [ isMinimized, setIsMinimized ] = useState( false );
+	const [ currentCard, setCurrentCard ] = useState( 0 );
 	// TODO: replace with wp.data
 	const [ isNuxEnabled, setIsNuxEnabled ] = useState( true );
 	const dismissWpcomNuxTour = () => {
@@ -47,20 +49,18 @@ function WelcomeTourFrame() {
 		return null;
 	}
 
-	const cardContent = getTourContent();
-
 	return (
 		<div className="wpcom-editor-welcome-tour-container">
 			{ ! isMinimized ? (
-				cardContent.map( ( card, index ) => (
-					<WelcomeTourCard
-						cardIndex={ index }
-						heading={ card.heading }
-						key={ card.heading }
-						onDismiss={ dismissWpcomNuxTour }
-						onMinimize={ setIsMinimized }
-					/>
-				) )
+				<WelcomeTourCard
+					cardContent={ cardContent[ currentCard ] }
+					cardIndex={ currentCard }
+					key={ currentCard }
+					lastCardIndex={ cardContent.length - 1 }
+					onDismiss={ dismissWpcomNuxTour }
+					onMinimize={ setIsMinimized }
+					setCurrentCard={ setCurrentCard }
+				/>
 			) : (
 				// <WelcomeTourCard onDismiss={ dismissWpcomNuxTour } onMinimize={ setIsMinimized } />
 				<WelcomeTourMinimized onMaximize={ setIsMinimized } />

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux-tour.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux-tour.js
@@ -5,6 +5,7 @@ import './public-path';
  * Internal dependencies
  */
 import WelcomeTourCard from './tour-card';
+import getTourContent from './tour-content';
 import './style-tour.scss';
 
 /**
@@ -46,11 +47,22 @@ function WelcomeTourFrame() {
 		return null;
 	}
 
+	const cardContent = getTourContent();
+
 	return (
 		<div className="wpcom-editor-welcome-tour-container">
 			{ ! isMinimized ? (
-				<WelcomeTourCard onDismiss={ dismissWpcomNuxTour } onMinimize={ setIsMinimized } />
+				cardContent.map( ( card, index ) => (
+					<WelcomeTourCard
+						cardIndex={ index }
+						heading={ card.heading }
+						key={ card.heading }
+						onDismiss={ dismissWpcomNuxTour }
+						onMinimize={ setIsMinimized }
+					/>
+				) )
 			) : (
+				// <WelcomeTourCard onDismiss={ dismissWpcomNuxTour } onMinimize={ setIsMinimized } />
 				<WelcomeTourMinimized onMaximize={ setIsMinimized } />
 			) }
 		</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux-tour.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux-tour.js
@@ -51,17 +51,23 @@ function WelcomeTourFrame() {
 			{ ! isMinimized ? (
 				<WelcomeTourCard onDismiss={ dismissWpcomNuxTour } onMinimize={ setIsMinimized } />
 			) : (
-				<div className="wpcom-editor-welcome-tour__minimized-container">
-					<Button
-						onClick={ () => setIsMinimized( false ) }
-						className="wpcom-editor-welcome-tour__resume-btn"
-					>
-						<p className="wpcom-editor-welcome-tour__resume-btn-text"> Click to resume tutorial</p>
-						<Icon icon={ chevronUp } size={ 16 } />
-						{ /* expand icon is throwing an error <Icon icon={ expand } size={ 16 } /> */ }
-					</Button>
-				</div>
+				<WelcomeTourMinimized onMaximize={ setIsMinimized } />
 			) }
+		</div>
+	);
+}
+
+function WelcomeTourMinimized( { onMaximize } ) {
+	return (
+		<div className="wpcom-editor-welcome-tour__minimized-container">
+			<Button
+				onClick={ () => onMaximize( false ) }
+				className="wpcom-editor-welcome-tour__resume-btn"
+			>
+				<p className="wpcom-editor-welcome-tour__resume-btn-text"> Click to resume tutorial</p>
+				<Icon icon={ chevronUp } size={ 16 } />
+				{ /* expand icon is throwing an error <Icon icon={ expand } size={ 16 } /> */ }
+			</Button>
 		</div>
 	);
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux-tour.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux-tour.js
@@ -4,14 +4,15 @@ import './public-path';
 /**
  * Internal dependencies
  */
+import WelcomeTourCard from './tour-card';
 import './style-tour.scss';
 
 /**
  * External dependencies
  */
-import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
-// import styled from '@emotion/styled';
-import { Icon, expand, chevronUp } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
+import { Icon, chevronUp } from '@wordpress/icons';
+// TODO: fix issue with expand icon not found.  Probably to do with old icon lib version
 
 import { createPortal, useEffect, useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
@@ -19,21 +20,22 @@ import { registerPlugin } from '@wordpress/plugins';
 function LaunchWpcomNuxTour() {
 	// Create parent for welcome tour portal
 	const portalParent = document.createElement( 'div' );
+	portalParent.classList.add( 'wpcom-editor-welcome-tour-portal-parent' );
 	useEffect( () => {
 		document.body.appendChild( portalParent );
 		return () => {
+			// TODO: figure out how to unmount as this is not running when modal is closed
 			document.body.removeChild( portalParent );
 		};
 	} );
 
-	return <div>{ createPortal( <WelcomeTour />, portalParent ) }</div>;
+	return <div>{ createPortal( <WelcomeTourFrame />, portalParent ) }</div>;
 }
 
-function WelcomeTour() {
+function WelcomeTourFrame() {
 	const [ isMinimized, setIsMinimized ] = useState( false );
 	// TODO: replace with wp.data
 	const [ isNuxEnabled, setIsNuxEnabled ] = useState( true );
-
 	const dismissWpcomNuxTour = () => {
 		// TODO recordTracksEvent
 		// setWpcomNuxStatus( { isNuxEnabled: false } );
@@ -44,47 +46,10 @@ function WelcomeTour() {
 		return null;
 	}
 
-	// const containerClass = isMinimized ? 'minimized';
 	return (
 		<div className="wpcom-editor-welcome-tour-container">
 			{ ! isMinimized ? (
-				<Card className="welcome-tour-card">
-					<div className="welcome-tour-card__overlay-controls">
-						<Flex>
-							<Button
-								isPrimary
-								icon="pets"
-								iconSize={ 14 }
-								onClick={ () => setIsMinimized( true ) }
-							></Button>
-							<Button
-								isPrimary
-								icon="no-alt"
-								iconSize={ 14 }
-								onClick={ dismissWpcomNuxTour }
-							></Button>
-						</Flex>
-					</div>
-					<CardMedia>
-						<img
-							alt="Editor Welcome Tour"
-							src="https://nuxtourtest.files.wordpress.com/2020/11/mock-slide-1.jpg?resize=400px"
-						/>
-					</CardMedia>
-					<CardBody>
-						<h2 className="welcome-tour-card__card-heading">Welcome to WordPress</h2>
-						<p>Learn the basic editor tools so you can edit and build your dream website.</p>
-					</CardBody>
-					<CardFooter>
-						<div>• • • • • •</div>
-						<div>
-							<Button isTertiary={ true }>No thanks</Button>
-							<Button isPrimary={ true } className="welcome-tour-card__next-btn">
-								Let's start
-							</Button>
-						</div>
-					</CardFooter>
-				</Card>
+				<WelcomeTourCard onDismiss={ dismissWpcomNuxTour } onMinimize={ setIsMinimized } />
 			) : (
 				<div className="wpcom-editor-welcome-tour__minimized-container">
 					<Button

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -10,7 +10,7 @@ import { Guide, GuidePage } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { registerPlugin } from '@wordpress/plugins';
+// import { registerPlugin } from '@wordpress/plugins';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -170,7 +170,7 @@ function NuxPage( { pageNumber, isLastPage, alignBottom = false, heading, descri
 // If registered without this check, atomic sites without gutenberg enabled will error when loading the editor.
 // These seem to be the only dependencies here that are not supported there.
 if ( Guide && GuidePage ) {
-	registerPlugin( 'wpcom-block-editor-nux', {
-		render: () => <WpcomNux />,
-	} );
+	// registerPlugin( 'wpcom-block-editor-nux', {
+	// 	render: () => <WpcomNux />,
+	// } );
 }

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -123,6 +123,7 @@
 		"@wordpress/keycodes": "*",
 		"@wordpress/nux": "^3.20.5",
 		"@wordpress/plugins": "*",
+		"@wordpress/primitives": "*",
 		"@wordpress/rich-text": "*",
 		"@wordpress/scripts": "^12.1.1",
 		"@wordpress/server-side-render": "^1.16.5",


### PR DESCRIPTION
Feature work continued in https://github.com/Automattic/wp-calypso/pull/47779
-----------------------
## WIP 🚧  👷🏼‍♀️  

# What's going on here?

* Proof of Concept for Editor Welcome Tour
 	* current designs: p9Jlb4-1Vj-p2
* Sampling/trying a few different Gutenberg components to see what makes sense
* [Project discussions leaning towards ](pbAok1-1Dh-p2#comment-3274) replacing NUX modal with Welcome Tour UI

### Looking for feedback
* on best practices and other ETK or WP specific implementation things :) 
* specific items I tagged in https://github.com/Automattic/wp-calypso/pull/47354/files
* and any other sage advice anyone has for me!  🧙 

### Done (spike quality, much polishing still left to do)
- [x] create portal for the Tour component such that user can interact with either Tour or the Editor
- [x] Tour card can be minimized and then re-maximized
- [x] pagination
- [x] foundations that allow for conditional content (e.g. welcome content customized for different onboarding experiences)

### ToDo 
- [ ] sort out icon issues, currently the 
 [expand](https://github.com/WordPress/gutenberg/blob/master/packages/icons/src/library/expand.js) is undefined, I suspect the most up to date icons lib is not used when I run this in my sandbox
- [ ] animate minimization & maximization (nice to have)
- [ ]  wire up to wp.data, mostly can follow existing [data functionality in NUX Modal](https://github.com/Automattic/wp-calypso/blob/d36a2870da14a385e55417a7ae3279186cd70d11/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js#L25)
- [ ] spike the UI callout animations that Jon has demoed, in which part of the Editor UI will be highlighted when a specific Tour card is shown. For example: a card that illustrates usage of [+] blocker inserter will also trigger a little animation around the button.
- [ ] tidy code, add defense functionality & robustness
- [ ] incorporate feedback

### Visuals of the current state (as of 18 Nov 2020): 
Check out the Droplr screengrab:  https://d.pr/i/aMAKM8

![Screen Shot 2020-11-18 at 18 27 42](https://user-images.githubusercontent.com/5665959/99498572-cda25580-29cb-11eb-97bc-fe22513a5f27.png)



# Testing instructions




<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #