### PR TITLE
Add placeholder TeamCity project for Desktop

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -42,7 +42,7 @@ version = "2020.1"
 project {
 
 	vcsRoot(WpCalypso)
-
+	subProject(WpDesktop)
 	buildType(RunAllUnitTests)
 	buildType(BuildBaseImages)
 	buildType(CheckCodeStyle)
@@ -196,7 +196,6 @@ object BuildDockerImage : BuildType({
 		}
 	}
 })
-
 
 object RunAllUnitTests : BuildType({
 	name = "Run unit tests"
@@ -646,5 +645,15 @@ object WpCalypso : GitVcsRoot({
 	authMethod = uploadedKey {
 		uploadedKey = "Sergio TeamCity"
 	}
+})
+
+object WpDesktop : Project({
+	name = "Desktop"
+	buildType(WpDesktop_DesktopE2ETests)
+})
+
+object WpDesktop_DesktopE2ETests : BuildType({
+	name = "Desktop e2e tests"
+	steps {	}
 })
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a placeholder project for running wp-desktop tests in TeamCity.

The next step will be to populate the project with build steps in a branch, but the placeholder needs to be present in master before we can run those build steps in the branch.

#### Testing instructions

* Verify the TeamCity build for this branch doesn't throw any syntax error when applying the build plan (open `Run unit tests`, look for "Finalize build settings" in the log and verify there are no errors)

