### PR TITLE
Updates default site icon to globe and makes it smaller

### DIFF
--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -48,7 +48,7 @@ function SiteIcon( { siteId, site, iconUrl, size, imgSize, isTransientIcon } ) {
 			{ iconSrc ? (
 				<MediaImage component={ Image } className="site-icon__img" src={ iconSrc } alt="" />
 			) : (
-				<Gridicon icon="site" size={ Math.round( size / 1.3 ) } />
+				<Gridicon icon="globe" size={ Math.round( size / 1.8 ) } />
 			) }
 			{ isTransientIcon && <Spinner /> }
 		</div>

--- a/client/blocks/site-icon/style.scss
+++ b/client/blocks/site-icon/style.scss
@@ -1,4 +1,3 @@
-
 .site-icon {
 	position: relative;
 	overflow: hidden;
@@ -9,6 +8,9 @@
 	// Globe icon for sites without an icon
 	&.is-blank {
 		background: var( --color-neutral-10 );
+		display: flex;
+		align-items: center;
+		justify-content: center;
 		.gridicon {
 			color: var( --color-surface );
 			z-index: z-index( 'root', '.site-icon.is-blank .gridicon' );

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -538,6 +538,11 @@ $font-size: rem( 14px );
 				padding: 11px 8px 11px 38px;
 			}
 
+			.site__home {
+				left: 12px;
+				top: 18px;
+			}
+
 			.current-site__switch-sites .button.is-borderless .gridicon {
 				top: 14px;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Update site icon to globe to match the new nav-unification [figma designs ](https://www.figma.com/file/9cy0DIowQkPAu0rodb9jsL/WP-Admin-for-Dotcom?viewport=0%2C0%2C1)

Note: **this change will affect all users immediately** 

* Updates default site icon to globe and makes it smaller

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before | After
-------|------
![](https://cln.sh/6QfeKY+) | ![](https://cln.sh/QNvK8s+)

* load a site without icon in http://calypso.localhost:3000/
* Please also test D52653-code which fixes the icon color in wp-admin