### PR TITLE
Allows underscore when matching calypso.live subdomains

### DIFF
--- a/client/config/index.js
+++ b/client/config/index.js
@@ -24,8 +24,9 @@ const configData = window.configData;
 
 // calypso.live matches
 // hash-abcd1234.calypso.live matches
+// container-abcd_1234.calypso.live matches
 // calypso.live.com doesn't match
-const CALYPSO_LIVE_REGEX = /^([a-zA-Z0-9-]+\.)?calypso\.live$/;
+const CALYPSO_LIVE_REGEX = /^([a-zA-Z0-9_-]+\.)?calypso\.live$/;
 
 // check if the current browser location is *.calypso.live
 export function isCalypsoLive() {


### PR DESCRIPTION
#### Background

When going to `http://calypso.live?image=<image>`, `dserve` will pull the image, start the container and redirect to `http://container-<container-name>.calypso.live`. The container name is generated by Docker, and has the form `<string>_<string>`.

#### Changes proposed in this Pull Request

* Allow `_` when matching calypso.live subdomains.

#### Testing instructions

* N/A
