### PR TITLE
Updates sidebar site notices color

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -235,7 +235,6 @@ $font-size: rem( 14px );
 		}
 
 		.notice {
-			background-color: var( --color-sidebar-notice-background );
 			/* stylelint-disable-next-line scales/font-weight */
 			font-weight: 300;
 
@@ -255,12 +254,7 @@ $font-size: rem( 14px );
 					width: 18px;
 					height: 18px;
 					border-radius: 50%;
-					background: var( --color-sidebar-gridicon-fill );
 				}
-			}
-
-			.gridicon {
-				fill: var( --color-sidebar-notice-background );
 			}
 
 			.notice__content {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust the colour of site notices as @sfougnier suggests https://github.com/Automattic/wp-calypso/pull/46819#issuecomment-719000053

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before | After
-------|------
![image](https://user-images.githubusercontent.com/12430020/98929353-b0f5b180-24e3-11eb-9781-b6c4ea56840e.png)| ![image](https://user-images.githubusercontent.com/12430020/98929332-a9360d00-24e3-11eb-8a5c-adba1e1b3f54.png)

* Please follow the same instructions https://github.com/Automattic/wp-calypso/pull/46819#issue-510954125
