### PR TITLE
Jetpack Pricing: Don't display decimal prices for non-USD currencies

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-alt-2/index.tsx
@@ -143,6 +143,14 @@ const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 		[ dispatch, siteId ]
 	);
 
+	// We should only display the decimal amount for USD prices
+	let displayPrice;
+	if ( 'USD' === currencyCode ) {
+		displayPrice = isDiscounted ? discountedPrice : originalPrice;
+	} else {
+		displayPrice = Math.floor( isDiscounted ? discountedPrice : originalPrice );
+	}
+
 	return (
 		<div
 			className={ classNames( className, 'jetpack-product-card-alt-2', {
@@ -189,11 +197,7 @@ const JetpackProductCardAlt2: FunctionComponent< Props > = ( {
 							{ currencyCode && originalPrice ? (
 								<>
 									<span className="jetpack-product-card-alt-2__raw-price">
-										<PlanPrice
-											rawPrice={ ( isDiscounted ? discountedPrice : originalPrice ) as number }
-											discounted
-											currencyCode={ currencyCode }
-										/>
+										<PlanPrice rawPrice={ displayPrice } discounted currencyCode={ currencyCode } />
 										{ searchRecordsDetails && (
 											<InfoPopover
 												className="jetpack-product-card-alt-2__search-price-popover"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* https://github.com/Automattic/wp-calypso/pull/47343 brought back decimal pricing, but it was supposed to be only for USD. This PR ensures that we are only showing decimal pricing for the USD currency.

#### Testing instructions

* Check the pricing page with currencyCode set to USD. You should see pricing with `.95`. 
* Now check the pricing page with a currencyCode set to something other than USD. You should see whole-number pricing.
