### PR TITLE
Pricing page i5: remove all products icons

### DIFF
--- a/client/my-sites/plans-v2/product-card-i5/index.tsx
+++ b/client/my-sites/plans-v2/product-card-i5/index.tsx
@@ -89,7 +89,6 @@ const ProductCardI5: React.FC< ProductCardProps > = ( {
 
 	return (
 		<JetpackProductCard
-			iconSlug={ isPlan ? undefined : item.iconSlug }
 			productSlug={ item.productSlug }
 			productName={ item.displayName }
 			headingLevel={ 3 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

Remove icons of individual products in pricing page i5

Fixes 1196341175636977-as-1199169204272054

### Testing instructions

- Download the PR or visit the Calypso live link
- Run Calypso or Jetpack cloud
- Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
- Select a self-hosted Jetpack site
- Visit the pricing page
- Check that individual product cards don't show any icon

### Screenshots

![screenshot](https://user-images.githubusercontent.com/1620183/98965673-50ad4280-24d8-11eb-9420-5c59953d3a54.png)