### PR TITLE
Removing menu step from checklist and making steps skippable.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -141,6 +141,7 @@ export const getTask = (
 				actionText: translate( 'Name your site' ),
 				actionUrl: `/settings/general/${ siteSlug }`,
 				tour: 'checklistSiteTitle',
+				isSkippable: true,
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.MOBILE_APP_INSTALLED:
@@ -170,6 +171,7 @@ export const getTask = (
 				actionDispatch: launchSiteOrRedirectToLaunchSignupFlow,
 				actionDispatchArgs: [ siteId ],
 				actionDisableOnComplete: true,
+				isSkippable: true,
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.FRONT_PAGE_UPDATED:
@@ -181,6 +183,7 @@ export const getTask = (
 				),
 				actionText: translate( 'Edit homepage' ),
 				actionUrl: taskUrls?.front_page_updated,
+				isSkippable: true,
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.SITE_MENU_UPDATED:

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -21,7 +21,6 @@ export const CHECKLIST_KNOWN_TASKS = {
 	MOBILE_APP_INSTALLED: 'mobile_app_installed',
 	SITE_LAUNCHED: 'site_launched',
 	FRONT_PAGE_UPDATED: 'front_page_updated',
-	SITE_MENU_UPDATED: 'site_menu_updated',
 	JETPACK_BACKUPS: 'jetpack_backups',
 	JETPACK_MONITOR: 'jetpack_monitor',
 	JETPACK_PLUGIN_UPDATES: 'jetpack_plugin_updates',


### PR DESCRIPTION
As @rickybanister mentioned in #47334, the checklist on My Home doesn't do a great job of easing people into our product.

The `Create a site menu` step in particular throws new customers into a confusing step inside of Customizer.

This PR removes that step from the checklist. I also made the steps skippable so people could get past the Checklist if they don't find it useful.

#### Testing instructions
* Checkout this branch and start Calypso
* Create a new site and navigate to My Home
* Confirm that the Create a site menu step is no longer in the checklist
* Complete the tasks and confirm that the checklist works as expected.
* Create another new site and complete the checklist by skipping steps.

Fixes #
#47334 