### PR TITLE
Pricing page i5: update free card styles

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card-i5/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card-i5/index.tsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { Button } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'calypso/components/gridicon';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import { addQueryArgs } from 'calypso/lib/route';
+import getJetpackWpAdminUrl from 'calypso/state/selectors/get-jetpack-wp-admin-url';
+import { JPC_PATH_REMOTE_INSTALL } from 'calypso/jetpack-connect/constants';
+
+/**
+ * Type dependencies
+ */
+import type { JetpackFreeProps } from 'calypso/my-sites/plans-v2/types';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const JetpackFreeCardAlt: React.FC< JetpackFreeProps > = ( { siteId, urlQueryArgs } ) => {
+	const translate = useTranslate();
+	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
+	const onClickTrack = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
+		site_id: siteId || undefined,
+	} );
+	const startHref = isJetpackCloud()
+		? addQueryArgs( urlQueryArgs, `https://wordpress.com${ JPC_PATH_REMOTE_INSTALL }` )
+		: wpAdminUrl || JPC_PATH_REMOTE_INSTALL;
+
+	return (
+		<div className="jetpack-free-card-i5 jetpack-product-card-i5">
+			<header className="jetpack-free-card-i5__header">
+				<h3 className="jetpack-free-card-i5__title">{ translate( 'Jetpack Free' ) }</h3>
+				<p className="jetpack-free-card-i5__subheadline">
+					{ translate( 'Included for free with all products' ) }
+				</p>
+				<Button
+					className="jetpack-free-card-i5__button"
+					href={ startHref }
+					onClick={ onClickTrack }
+				>
+					{ translate( 'Start for free' ) }
+				</Button>
+			</header>
+			<ul className="jetpack-free-card-i5__features-list">
+				{ [
+					{
+						text: translate( 'Site stats' ),
+					},
+					{
+						text: translate( 'Brute force attack protection' ),
+					},
+					{
+						text: translate( 'Content Delivery Network' ),
+					},
+					{
+						text: translate( 'Automated social media posting' ),
+					},
+					{
+						text: translate( 'Downtime monitoring' ),
+					},
+					{
+						text: translate( 'Activity Log' ),
+					},
+				].map( ( feature, index ) => (
+					<li key={ index }>
+						<Gridicon icon="checkmark" />
+						<span className="jetpack-free-card-i5__features-text">{ feature.text }</span>
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+};
+
+export default JetpackFreeCardAlt;

--- a/client/components/jetpack/card/jetpack-free-card-i5/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card-i5/style.scss
@@ -1,0 +1,93 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
+.jetpack-free-card-i5 {
+	padding: 24px 32px;
+
+	@include break-small {
+		display: flex;
+	}
+}
+
+.jetpack-free-card-i5__header {
+	@include break-small {
+		flex: 1;
+	}
+}
+
+.jetpack-free-card-i5__title {
+	color: var( --studio-gray-100 );
+
+	font-size: 1.875rem;
+	font-weight: 700;
+}
+
+.jetpack-free-card-i5__subheadline {
+	color: var( --studio-gray-60 );
+}
+
+.jetpack-free-card-i5__button.button {
+	display: block;
+
+	width: 100%;
+	max-width: 210px;
+	margin: 24px 0;
+
+	color: var( --studio-jetpack-green-40 );
+	border: solid 2px currentColor;
+	border-radius: 4px;
+
+	font-size: 1rem;
+	font-weight: 700;
+
+	@include break-large {
+		margin-bottom: 0;
+	}
+}
+
+.jetpack-free-card-i5__features-list {
+	margin: 28px 0 0;
+
+	color: var( --studio-gray-100 );
+	list-style-type: none;
+
+	> li {
+		display: flex;
+		justify-content: flex-start;
+
+		margin: 12px 0;
+
+		fill: var( --studio-jetpack-green-40 );
+	}
+
+	@include break-small {
+		flex: 1;
+
+		margin-top: 0;
+		padding-left: 28px;
+	}
+
+	@include break-large {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		flex: 2 1;
+
+		padding-left: 0;
+
+		> li {
+			width: 50%;
+			margin: 0;
+		}
+	}
+}
+
+.jetpack-free-card-i5__features-list .gridicon {
+	margin-right: 12px;
+
+	color: var( --studio-jetpack-green-40 );
+}
+
+.jetpack-free-card-i5__features-text {
+	flex: 1;
+}

--- a/client/my-sites/plans-v2/products-grid-i5/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-i5/index.tsx
@@ -16,7 +16,7 @@ import ProductCardI5 from '../product-card-i5';
 import { getProductPosition } from '../product-grid/products-order';
 import { getPlansToDisplay, getProductsToDisplay, isConnectionFlow } from '../product-grid/utils';
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
-import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card-alt';
+import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card-i5';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	PLAN_JETPACK_SECURITY_REALTIME,

--- a/client/my-sites/plans-v2/products-grid-i5/style.scss
+++ b/client/my-sites/plans-v2/products-grid-i5/style.scss
@@ -55,3 +55,7 @@
 	height: 63px;
 	padding-bottom: 50px;
 }
+
+.products-grid-i5__free {
+	margin-top: 32px;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the styles of the Jetpack Free product card.

Fixes 1196341175636977-as-1199149328812615

### Testing instructions

- Download the PR or visit the Calypso live link
- Run Calypso
- Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
- Select a self-hosted Jetpack site
- Visit `/jetpack/connect/plans/<site>`
- Check that the Jetpack Free card matches the mockups (see board)

### Screenshots

<img width="504" alt="Screen Shot 2020-11-12 at 1 42 02 PM" src="https://user-images.githubusercontent.com/1620183/98984169-d4bef480-24ef-11eb-8c55-93f27f1df247.png">
<img width="787" alt="Screen Shot 2020-11-12 at 1 42 08 PM" src="https://user-images.githubusercontent.com/1620183/98984172-d5f02180-24ef-11eb-859e-cefb85591bfe.png">
<img width="1091" alt="Screen Shot 2020-11-12 at 1 58 47 PM" src="https://user-images.githubusercontent.com/1620183/98984173-d7214e80-24ef-11eb-995b-e55a47a28f21.png">