### PR TITLE
Focused Launch: hide step index in active steps if there are less than 2 active steps

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -350,6 +350,11 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 	);
 };
 
+type StepIndexRenderFunction = ( renderOptions: {
+	stepIndex: number;
+	forwardStepIndex: boolean;
+} ) => ReactNode;
+
 const Summary: React.FunctionComponent = () => {
 	const { title, updateTitle, saveTitle, isSiteTitleStepVisible, showSiteTitleStep } = useTitle();
 
@@ -373,20 +378,20 @@ const Summary: React.FunctionComponent = () => {
 	const hasPaidPlan = false;
 
 	// Prepare Steps
-	const renderSiteTitleStep = ( index: number ) => (
+	const renderSiteTitleStep: StepIndexRenderFunction = ( { stepIndex, forwardStepIndex } ) => (
 		<SiteTitleStep
-			stepIndex={ index }
-			key={ index }
+			stepIndex={ forwardStepIndex ? stepIndex : undefined }
+			key={ stepIndex }
 			value={ title }
 			onChange={ updateTitle }
 			onBlur={ saveTitle }
 		/>
 	);
 
-	const renderDomainStep = ( index: number ) => (
+	const renderDomainStep: StepIndexRenderFunction = ( { stepIndex, forwardStepIndex } ) => (
 		<DomainStep
-			stepIndex={ index }
-			key={ index }
+			stepIndex={ forwardStepIndex ? stepIndex : undefined }
+			key={ stepIndex }
 			existingSubdomain={ siteSubdomain?.domain }
 			currentDomain={ selectedDomain?.domain_name ?? sitePrimaryDomain?.domain }
 			initialDomainSearch={ domainSearch }
@@ -401,14 +406,16 @@ const Summary: React.FunctionComponent = () => {
 			locale={ locale }
 		/>
 	);
-	const renderPlanStep = ( index: number ) => <PlanStep stepIndex={ index } key={ index } />;
+	const renderPlanStep: StepIndexRenderFunction = ( { stepIndex, forwardStepIndex } ) => (
+		<PlanStep stepIndex={ forwardStepIndex ? stepIndex : undefined } key={ stepIndex } />
+	);
 
 	// Disabled steps are not interactive (e.g. user has already selected domain/plan)
 	// Active steps require user interaction
 	// Using this arrays allows to easily sort the steps correctly in both
 	// groups, and allows the actve steps to always show the correct step index.
-	const disabledSteps: ( ( index: number ) => ReactNode )[] = [];
-	const activeSteps: ( ( index: number ) => ReactNode )[] = [];
+	const disabledSteps: StepIndexRenderFunction[] = [];
+	const activeSteps: StepIndexRenderFunction[] = [];
 	isSiteTitleStepVisible && activeSteps.push( renderSiteTitleStep );
 	( hasPaidDomain ? disabledSteps : activeSteps ).push( renderDomainStep );
 	( hasPaidPlan ? disabledSteps : activeSteps ).push( renderPlanStep );

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -431,8 +431,17 @@ const Summary: React.FunctionComponent = () => {
 					) }
 				</p>
 			</div>
-			{ disabledSteps.map( ( step, stepIndex ) => step( stepIndex + 1 ) ) }
-			{ activeSteps.map( ( step, stepIndex ) => step( stepIndex + 1 ) ) }
+			{ disabledSteps.map( ( disabledStepRenderer, disabledStepIndex ) =>
+				// Disabled steps don't show the step index
+				disabledStepRenderer( { stepIndex: disabledStepIndex + 1, forwardStepIndex: false } )
+			) }
+			{ activeSteps.map( ( activeStepRenderer, activeStepIndex ) =>
+				// Active steps show the step index only if there are at least 2 steps
+				activeStepRenderer( {
+					stepIndex: activeStepIndex + 1,
+					forwardStepIndex: activeSteps.length > 1,
+				} )
+			) }
 		</div>
 	);
 };

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -56,7 +56,7 @@ const SummaryStep: React.FunctionComponent< SummaryStepProps > = ( { input, comm
 );
 
 type CommonStepProps = {
-	stepIndex: number;
+	stepIndex?: number;
 };
 
 // Props in common between all summary steps + a few props from <TextControl>
@@ -76,7 +76,8 @@ const SiteTitleStep: React.FunctionComponent< SiteTitleStepProps > = ( {
 					className="focused-launch-summary__input"
 					label={
 						<label className="focused-launch-summary__label">
-							{ stepIndex }. { __( 'Name your site', __i18n_text_domain__ ) }
+							{ stepIndex && `${ stepIndex }. ` }
+							{ __( 'Name your site', __i18n_text_domain__ ) }
 						</label>
 					}
 					value={ value }
@@ -158,7 +159,8 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							header={
 								<>
 									<label className="focused-launch-summary__label">
-										{ stepIndex }. { __( 'Confirm your domain', __i18n_text_domain__ ) }
+										{ stepIndex && `${ stepIndex }. ` }
+										{ __( 'Confirm your domain', __i18n_text_domain__ ) }
 									</label>
 									<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
 										<Icon icon={ bulb } />
@@ -282,7 +284,8 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 				) : (
 					<>
 						<label className="focused-launch-summary__label">
-							{ stepIndex }. { __( 'Confirm your plan', __i18n_text_domain__ ) }
+							{ stepIndex && `${ stepIndex }. ` }
+							{ __( 'Confirm your plan', __i18n_text_domain__ ) }
 						</label>
 						<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
 							<Icon icon={ bulb } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If there is only one active step, that step shouldn't show a step index before its title
* This is achieved by making the `stepIndex` prop optional for each step component, and by adding some simple logic in the Summary view component

#### Testing instructions

* Check out the branch on your machine and run `yarn && yarn start`
* Visit`calypso.localhost:3000/page/UNLAUNCHED_SITE_ID/home?flags=create/focused-launch-flow-calypso`
* By changing in code the values of `isSiteTitleStepVisible`, `hasPaidDomain` and `hasPaidPlan`, simulate all the combinations of these steps being in the "disabled" or in the "active" groups
  * Make sure that the step index is _never_ shown for _disabled_ steps
  * Make sure that the step index is only shown for _active_ steps when there are _at least_ 2 active steps

If there are at least 2 active steps, the step index should be shown before each step title:

![Screenshot 2020-11-12 at 20 02 27](https://user-images.githubusercontent.com/1083581/98984083-005ad280-2522-11eb-9956-e78acaad4c25.png)

If there is only one active step, that step shouldn't show a step index before its title

![Screenshot 2020-11-12 at 20 02 06](https://user-images.githubusercontent.com/1083581/98984235-3730e880-2522-11eb-91dc-6b1abee10dcd.png)



Fixes #47276 
