### PR TITLE
CRO i5: Implement new scroll behavior

### DIFF
--- a/client/my-sites/plans-v2/plans-filter-bar-i5/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar-i5/index.tsx
@@ -41,8 +41,9 @@ type DiscountMessageProps = {
 	primary?: boolean;
 };
 
+const CLOUD_MASTERBAR_STICKY = false;
 const CALYPSO_MASTERBAR_HEIGHT = 47;
-const CLOUD_MASTERBAR_HEIGHT = 94;
+const CLOUD_MASTERBAR_HEIGHT = CLOUD_MASTERBAR_STICKY ? 94 : 0;
 
 const DiscountMessage: React.FC< DiscountMessageProps > = ( { primary } ) => {
 	const translate = useTranslate();
@@ -86,17 +87,8 @@ const PlansFilterBarI5: React.FC< FilterBarProps > = ( {
 	duration,
 	onDurationChange,
 } ) => {
-	const isCloud = isJetpackCloud();
-	const masterbarSelector = isCloud ? '.jpcom-masterbar' : '.masterbar';
-	const masterbarDefaultHeight = isCloud ? CLOUD_MASTERBAR_HEIGHT : CALYPSO_MASTERBAR_HEIGHT;
-
-	const barRef = useRef< HTMLDivElement | null >( null );
-	const isMasterbarVisible = useSelector( masterbarIsVisible );
-	// if we can find the masterbar in the DOM, get its height directly from the element.
-	const masterbarHeight =
-		document.querySelector( masterbarSelector )?.offsetHeight || masterbarDefaultHeight;
-	const masterbarOffset = isMasterbarVisible || isCloud ? masterbarHeight : 0;
-	const hasCrossed = useDetectWindowBoundary( barRef, masterbarOffset );
+	const windowBoundaryOffset = isJetpackCloud() ? CLOUD_MASTERBAR_HEIGHT : CALYPSO_MASTERBAR_HEIGHT;
+	const [ barRef, hasCrossed ] = useDetectWindowBoundary( windowBoundaryOffset );
 
 	const [ durationChecked, setDurationChecked ] = useState(
 		duration === TERM_ANNUALLY ? true : false

--- a/client/my-sites/plans-v2/plans-filter-bar-i5/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar-i5/style.scss
@@ -111,18 +111,6 @@
 	.plans-filter-bar-i5.sticky {
 		top: 0;
 	}
-
-	@include breakpoint-deprecated( '>960px' ) {
-		.plans-filter-bar-i5.sticky {
-			top: 94px;
-		}
-	}
-}
-
-@include breakpoint-deprecated( '>960px' ) {
-	.is-group-jetpack-cloud.is-section-jetpack-cloud-pricing .plans-filter-bar-i5.sticky {
-		top: 94px;
-	}
 }
 
 // target Calypso pricing filter bar, not jetpack cloud

--- a/client/my-sites/plans-v2/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar/index.tsx
@@ -104,13 +104,12 @@ const PlansFilterBar = ( {
 	const masterbarSelector = isCloud ? '.jpcom-masterbar' : '.masterbar';
 	const masterbarDefaultHeight = isCloud ? CLOUD_MASTERBAR_HEIGHT : CALYPSO_MASTERBAR_HEIGHT;
 
-	const barRef = useRef< HTMLDivElement | null >( null );
 	const isMasterbarVisible = useSelector( masterbarIsVisible );
 	// if we can find the masterbar in the DOM, get its height directly from the element.
 	const masterbarHeight =
 		document.querySelector( masterbarSelector )?.offsetHeight || masterbarDefaultHeight;
 	const masterbarOffset = isMasterbarVisible || isCloud ? masterbarHeight : 0;
-	const hasCrossed = useDetectWindowBoundary( barRef, masterbarOffset );
+	const [ barRef, hasCrossed ] = useDetectWindowBoundary( masterbarOffset );
 
 	return (
 		<div ref={ barRef } className={ classNames( 'plans-filter-bar', { sticky: hasCrossed } ) }>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR finalizes the correct scroll behavior for the CRO i5 pricing page.  For Jetpack cloud, this means that the top navigation bar (Masterbar is no longer sticky, and the Plans filter bar becomes sticky when it reaches the top of the viewport.  For Calypso, scroll behavior remains the same where the Masterbar remains sticky, and the Plans filter bar becomes sticky when it reaches the bottom of the masterbar.

#### Implementation notes:
- Refactored the `useDetectWindowBoundary()` hook.  Prior to refactor, there was a bug which is now resolved.
- Steps to produce the bug were:
    - Go to https://cloud.jetpack.com/pricing
    - Scroll down
    - Click on a card
    - Go back in history
    - Scroll up. The filter bar remains stuck at the top, covering up the headline.

### Testing instructions

- Download the PR
- Run both Calypso and Jetpack cloud concurrently
- Select the `i5 - Saas table design` variant of the a/b test jetpackConversionRateOptimization
- Visit the Plans page
- In Jetpack Cloud, check:
    - That the top nav bar (masterbar) is no longer sticky, and that the plans filter bar is sticky when it reaches the top of viewport.
    - That this scroll behavior is working correctly in mobile view also.
- In Calypso, check:
    - That the plans filter bar becomes sticky when it reaches the bottom of the top nav bar (masterbar).
- Check the previous iteration (`v2- slide outs`) to make sure the scroll behavior is working correctly.

### Screenshots

Jetpack Cloud
![chrome-capture (10)](https://user-images.githubusercontent.com/11078128/98999103-0b930b80-24ec-11eb-9386-b35713659111.gif)

Calypso
![chrome-capture (11)](https://user-images.githubusercontent.com/11078128/98999169-2a919d80-24ec-11eb-99e1-49f02087e878.gif)

Fixes 1196341175636977-as-1199149328812597