### PR TITLE
Pricing page i5: update more info link

### DIFF
--- a/client/my-sites/plans-v2/more-info-box/index.tsx
+++ b/client/my-sites/plans-v2/more-info-box/index.tsx
@@ -5,6 +5,11 @@ import React from 'react';
 import { Button } from '@automattic/components';
 
 /**
+ * Internal dependencies
+ */
+import { PLAN_COMPARISON_PAGE } from 'calypso/my-sites/plans-v2/constants';
+
+/**
  * Type dependencies
  */
 import type { TranslateResult } from 'i18n-calypso';
@@ -18,13 +23,13 @@ import './style.scss';
 type MoreInfoProps = {
 	headline: TranslateResult;
 	buttonLabel: TranslateResult | ReactNode;
-	onButtonClick: () => void;
+	onButtonClick?: () => void;
 };
 
-const MoreInfoBox: React.FC< MoreInfoProps > = ( { headline, buttonLabel, onButtonClick } ) => (
+const MoreInfoBox: React.FC< MoreInfoProps > = ( { headline, buttonLabel } ) => (
 	<div className="more-info-box__more-container">
 		<h3 className="more-info-box__more-headline">{ headline }</h3>
-		<Button onClick={ onButtonClick } className="more-info-box__more-button" primary>
+		<Button href={ PLAN_COMPARISON_PAGE } className="more-info-box__more-button" primary>
 			{ buttonLabel }
 		</Button>
 	</div>

--- a/client/my-sites/plans-v2/products-grid-i5/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-i5/index.tsx
@@ -177,9 +177,9 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 					) }
 				</div>
 			</section>
-			<section ref={ bundleComparisonRef } className="products-grid-i5__section">
+			{ /* <section ref={ bundleComparisonRef } className="products-grid-i5__section">
 				<h2 className="products-grid-i5__section-title">{ translate( 'Bundle Comparison' ) }</h2>
-			</section>
+			</section> */ }
 		</>
 	);
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the behaviour of the "Compare all product bundles" button.

 Fixes 1196341175636977-as-1199175792010023

### Testing instructions

- Download the PR or visit the Calypso live link
- Run Calypso or Jetpack cloud
- Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
- Select a self-hosted Jetpack site
- Visit the pricing page
- Scroll to the "Need more info?" box
- Check that clicking on the button redirects you to https://jetpack.com/features/comparison/
- Make the the "Bundle comparison" section at the end of the page is not visible

### Screenshots

<img width="1101" alt="Screen Shot 2020-11-12 at 2 22 14 PM" src="https://user-images.githubusercontent.com/1620183/98986215-9971f500-24f2-11eb-883c-47ad98fba903.png">