### PR TITLE
Show preview of Premium Content on frontend for admin

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/index.js
@@ -28,15 +28,6 @@ const settings = {
 		alignWide: false,
 		lightBlockWrapper: true,
 	},
-	attributes: {
-		isPremiumContentChild: {
-			type: 'bool',
-			default: true,
-		},
-	},
-	providesContext: {
-		isPremiumContentChild: 'isPremiumContentChild',
-	},
 	keywords: [ __( 'link', 'full-site-editing' ) ],
 	edit,
 	save,

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/index.js
@@ -70,6 +70,10 @@ const settings = {
 			type: 'boolean',
 			default: false,
 		},
+		isPremiumContentChild: {
+			type: 'boolean',
+			default: true,
+		},
 	},
 	/**
 	 * This is the display title for your block, which can be translated with `i18n` functions.
@@ -155,6 +159,7 @@ const settings = {
 	providesContext: {
 		'premium-content/planId': 'selectedPlanId',
 		'premium-content/isPreview': 'isPreview',
+		isPremiumContentChild: 'isPremiumContentChild',
 	},
 };
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
@@ -260,7 +260,7 @@ function premium_content_required_plan_checks() {
 /**
  * Determines if the block should be rendered. Returns true
  * if the memberships module is set up, or if it has not been
- * set up but the user is an admin.
+ * set up but the user can edit the post.
  *
  * @return bool Whether the block should be rendered.
  */
@@ -274,15 +274,15 @@ function premium_content_pre_render_checks() {
 /**
  * Determines if the a preview of the block with disconnected
  * buttons should be shown on the frontend. Returns true
- * if the memberships module is not set up, but the user is
- * an admin.
+ * user can edit the post, but the site requires an upgrade
+ * or Stripe connection in order to support the block.
  *
  * @return bool Whether the frontend preview should be shown
  */
 function premium_content_should_render_frontend_preview() {
 	return (
-		! premium_content_membership_checks() &&
-		premium_content_current_user_can_edit()
+		premium_content_current_user_can_edit() &&
+		( ! premium_content_membership_checks() || ! premium_content_required_plan_checks() )
 	);
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
@@ -347,16 +347,13 @@ function premium_content_render_upgrade_nudge() {
  */
 function premium_content_render_stripe_nudge() {
 	if ( function_exists( 'jetpack_require_lib' ) ) {
-		// TODO: Build stripe url.
-		$stripe_connect_url = '';
-
 		jetpack_require_lib( 'components' );
 		return \Jetpack_Components::render_component(
 			'stripe-nudge',
 			array(
 				'blockName'        => 'premium-content',
 				'postId'           => $post_id,
-				'stripeConnectUrl' => $stripe_connect_url,
+				'stripeConnectUrl' => null,
 			)
 		);
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
@@ -331,7 +331,7 @@ function premium_content_render_upgrade_nudge() {
 
 	if ( function_exists( 'jetpack_require_lib' ) ) {
 		jetpack_require_lib( 'components' );
-		return Jetpack_Components::render_upgrade_nudge(
+		return \Jetpack_Components::render_upgrade_nudge(
 			array(
 				'plan' => $required_plan,
 			)
@@ -352,7 +352,7 @@ function premium_content_render_stripe_nudge() {
 			'stripe-nudge',
 			array(
 				'blockName'        => 'premium-content',
-				'postId'           => $post_id,
+				'postId'           => get_the_ID(),
 				'stripeConnectUrl' => null,
 			)
 		);
@@ -403,7 +403,10 @@ function premium_content_block_logged_out_view_render( $attributes, $content, $b
  * @return string Final content to render.
  */
 function premium_content_block_subscriber_view_render( $attributes, $content, $block = null ) {
-	if ( ! premium_content_pre_render_checks() ) {
+	if (
+		! premium_content_pre_render_checks() ||
+		premium_content_should_render_frontend_preview()
+	) {
 		return '';
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
@@ -133,6 +133,12 @@ function register_blocks() {
 				'premium-content/planId' => 'selectedPlanId',
 				'isPremiumContentChild'  => 'isPremiumContentChild',
 			),
+			'attributes'      => array(
+				'isPremiumContentChild' => array(
+					'type'    => 'boolean',
+					'default' => true,
+				),
+			),
 		)
 	);
 	register_block_type(
@@ -346,7 +352,6 @@ function premium_content_render_stripe_nudge() {
 	}
 	return '';
 }
-
 
 /**
  * Server-side rendering for the `premium-content/logged-out-view` block.

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
@@ -347,8 +347,18 @@ function premium_content_render_upgrade_nudge() {
  */
 function premium_content_render_stripe_nudge() {
 	if ( function_exists( 'jetpack_require_lib' ) ) {
+		// TODO: Build stripe url.
+		$stripe_connect_url = '';
+
 		jetpack_require_lib( 'components' );
-		return \Jetpack_Components::render_stripe_nudge( 'premium-content' );
+		return \Jetpack_Components::render_component(
+			'stripe-nudge',
+			array(
+				'blockName'        => 'premium-content',
+				'postId'           => $post_id,
+				'stripeConnectUrl' => $stripe_connect_url,
+			)
+		);
 	}
 	return '';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, when the Premium Content block is not configured correctly -- either a plan upgrade is necessary, or a Stripe account needs to be connected -- it does not render on the frontend. This PR changes that behavior to instead display a preview of the block (the Logged Out View with the buttons disconnected) if the user viewing it is an admin.
This allows them to preview what the block will look like on the frontend of their site when they finish configuring it.

It is intended to be merged in conjunction with Automattic/jetpack#17793, which enables the same behavior for the Recurring Payments block.

The plan upgrade and Stripe connection nudges should also display in the frontend when relevant; the Stripe nudge will display without the `Connect` button since the url cannot be fully built in the SSR-rendered component. The user must return to the editor to connect to Stripe.

#### Testing instructions
Make sure you have Automattic/jetpack#17793 checked out as well. 

Should be tested using instructions from Automattic/jetpack#17793.




