### PR TITLE
Pricing page i5: update copy

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-i5/style.scss
@@ -145,6 +145,10 @@
 
 	font-size: 1rem;
 	font-weight: 700;
+
+	em {
+		font-style: normal;
+	}
 }
 
 .jetpack-product-card-i5__features {
@@ -155,6 +159,10 @@
 	margin: 32px 0;
 
 	list-style-type: none;
+
+	em {
+		font-style: normal;
+	}
 }
 
 .jetpack-product-card-i5__features-item {

--- a/client/components/jetpack/card/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-i5/style.scss
@@ -85,7 +85,7 @@
 	color: var( --studio-gray-60 );
 
 	@include breakpoint-deprecated( '>660px' ) {
-		min-height: 100px;
+		min-height: 108px;
 	}
 }
 

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -30,7 +30,9 @@ const Header: React.FC = () => {
 		{
 			[ Iterations.V1 ]: translate( 'Security, performance, and growth tools for WordPress' ),
 			[ Iterations.V2 ]: translate( 'Security, performance, and growth tools for WordPress' ),
-			[ Iterations.I5 ]: translate( 'Security, performance, and growth tools for WordPress' ),
+			[ Iterations.I5 ]: translate(
+				'Security, performance, and marketing tools made for WordPress'
+			),
 		}[ iteration ] ?? translate( 'Security, performance, and marketing tools for WordPress' );
 	const tagline =
 		{

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1101,18 +1101,20 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
 		getIcon: () => 'cloud-upload',
 		getTitle: () =>
-			getJetpackCROActiveVersion() === 'v2'
-				? i18n.translate( 'Backup {{strong}}{{em}}Daily{{/em}}{{/strong}}', {
-						components: {
-							em: <em />,
-							strong: <strong />,
-						},
-				  } )
-				: i18n.translate( 'Backup {{em}}Daily{{/em}}', {
-						components: {
-							em: <em />,
-						},
-				  } ),
+			( {
+				v2: i18n.translate( 'Backup {{strong}}{{em}}Daily{{/em}}{{/strong}}', {
+					components: {
+						em: <em />,
+						strong: <strong />,
+					},
+				} ),
+				i5: i18n.translate( 'Backup Daily (off-site)' ),
+			}[ getJetpackCROActiveVersion() ] ||
+			i18n.translate( 'Backup {{em}}Daily{{/em}}', {
+				components: {
+					em: <em />,
+				},
+			} ) ),
 		getDescription: () =>
 			i18n.translate(
 				'Automatic daily backups of your entire site, with unlimited, WordPress-optimized secure storage. {{link}}Learn more{{/link}}.',
@@ -1129,20 +1131,22 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
 		getIcon: () => 'cloud-upload',
 		getTitle: () =>
-			getJetpackCROActiveVersion() === 'v2'
-				? i18n.translate( 'Backup {{strong}}{{em}}Real{{nbh/}}time{{/em}}{{/strong}}', {
-						components: {
-							em: <em />,
-							strong: <strong />,
-							nbh: <>&#8209;</>,
-						},
-						comment: '{{nbh}} represents a non breakable hyphen',
-				  } )
-				: i18n.translate( 'Backup {{em}}Real-time{{/em}}', {
-						components: {
-							em: <em />,
-						},
-				  } ),
+			( {
+				v2: i18n.translate( 'Backup {{strong}}{{em}}Real{{nbh/}}time{{/em}}{{/strong}}', {
+					components: {
+						em: <em />,
+						strong: <strong />,
+						nbh: <>&#8209;</>,
+					},
+					comment: '{{nbh}} represents a non breakable hyphen',
+				} ),
+				i5: i18n.translate( 'Backup Real-time (off-site)' ),
+			}[ getJetpackCROActiveVersion() ] ||
+			i18n.translate( 'Backup {{em}}Real-time{{/em}}', {
+				components: {
+					em: <em />,
+				},
+			} ) ),
 		getDescription: () =>
 			i18n.translate(
 				'Real-time backups of your entire site and database with unlimited secure storage. {{link}}Learn more{{/link}}.',
@@ -1204,11 +1208,14 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_PRODUCT_SCAN_DAILY_V2,
 		getIcon: () => ( { icon: 'security', component: MaterialIcon } ),
 		getTitle: () =>
+			( {
+				i5: i18n.translate( 'Scan Daily (automated)' ),
+			}[ getJetpackCROActiveVersion() ] ||
 			i18n.translate( 'Scan {{em}}Daily{{/em}}', {
 				components: {
 					em: <em />,
 				},
-			} ),
+			} ) ),
 		getDescription: () =>
 			i18n.translate(
 				'Automated daily scanning for security vulnerabilities or threats on your site. Includes instant notifications and automatic security fixes. {{link}}Learn more{{/link}}.',
@@ -1229,11 +1236,14 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
 		getIcon: () => ( { icon: 'security', component: MaterialIcon } ),
 		getTitle: () =>
+			( {
+				i5: i18n.translate( 'Real-time Scan (automated)' ),
+			}[ getJetpackCROActiveVersion() ] ||
 			i18n.translate( 'Scan {{em}}Real-time{{/em}}', {
 				components: {
 					em: <em />,
 				},
-			} ),
+			} ) ),
 		getDescription: () =>
 			i18n.translate(
 				'Automated real-time scanning for security vulnerabilities or threats on your site. Includes instant notifications and automatic security fixes. {{link}}Learn more{{/link}}.',
@@ -1248,7 +1258,10 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_ANTISPAM_V2 ]: {
 		getSlug: () => constants.FEATURE_ANTISPAM_V2,
-		getTitle: () => i18n.translate( 'Automated spam protection' ),
+		getTitle: () =>
+			( {
+				i5: i18n.translate( 'Always-on spam protection' ),
+			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'Automated spam protection' ) ),
 	},
 
 	[ constants.FEATURE_PRODUCT_ANTISPAM_V2 ]: {
@@ -1300,7 +1313,10 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2 ]: {
 		getSlug: () => constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 		getIcon: () => 'clipboard',
-		getTitle: () => i18n.translate( 'Activity log: 1-year archive' ),
+		getTitle: () =>
+			( {
+				i5: i18n.translate( "1-year's worth of activity events" ),
+			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'Activity log: 1-year archive' ) ),
 		getDescription: () =>
 			i18n.translate(
 				'View every change to your site in the last year. Pairs with Backup to restore your site to any earlier version. {{link}}Learn more.{{/link}}',
@@ -1321,14 +1337,16 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_PRODUCT_SEARCH_V2,
 		getIcon: () => ( getJetpackCROActiveVersion() === 'v2' ? 'search' : null ),
 		getTitle: () =>
-			getJetpackCROActiveVersion() === 'v2'
-				? i18n.translate( 'Jetpack Search {{strong}}{{em}}Up to 100k records{{/em}}{{/strong}}', {
-						components: {
-							em: <em />,
-							strong: <strong />,
-						},
-				  } )
-				: i18n.translate( 'Search: up to 100k records' ),
+			( {
+				v2: i18n.translate( 'Jetpack Search {{strong}}{{em}}Up to 100k records{{/em}}{{/strong}}', {
+					components: {
+						em: <em />,
+						strong: <strong />,
+					},
+				} ),
+				i5: i18n.translate( 'Site Search: up to 100k records' ),
+			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'Search: up to 100k records' ) ),
+
 		getDescription: () =>
 			i18n.translate(
 				'Help your site visitors find answers instantly so they keep reading and buying. Powerful filtering and customization options. {{link}}Learn more.{{/link}}',

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1078,7 +1078,10 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_BACKUP_REALTIME_V2 ]: {
 		getSlug: () => constants.FEATURE_BACKUP_REALTIME_V2,
-		getTitle: () => i18n.translate( 'Automated real-time site backups' ),
+		getTitle: () =>
+			( {
+				i5: i18n.translate( 'Automated real-time backups' ),
+			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'Automated real-time site backups' ) ),
 	},
 
 	[ constants.FEATURE_PRODUCT_BACKUP_V2 ]: {
@@ -1514,7 +1517,11 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_ONE_CLICK_RESTORE_V2 ]: {
 		getSlug: () => constants.FEATURE_ONE_CLICK_RESTORE_V2,
-		getTitle: () => i18n.translate( 'One-click restores from desktop or mobile' ),
+		getTitle: () =>
+			( {
+				i5: i18n.translate( 'One-click restores' ),
+			}[ getJetpackCROActiveVersion() ] ||
+			i18n.translate( 'One-click restores from desktop or mobile' ) ),
 	},
 
 	[ constants.FEATURE_ONE_CLICK_FIX_V2 ]: {

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -559,7 +559,10 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 const getPlanJetpackCompleteDetails = () => ( {
 	group: constants.GROUP_JETPACK,
 	type: constants.TYPE_ALL,
-	getTitle: () => translate( 'Jetpack Complete' ),
+	getTitle: () =>
+		getJetpackCROActiveVersion() === 'i5'
+			? translate( 'Complete' )
+			: translate( 'Jetpack Complete' ),
 	getAudience: () => translate(),
 	availableFor: ( plan ) =>
 		[

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -406,14 +406,19 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 	availableFor: ( plan ) =>
 		[ constants.PLAN_JETPACK_FREE, ...constants.JETPACK_LEGACY_PLANS ].includes( plan ),
 	getDescription: () =>
-		getJetpackCROActiveVersion() === 'v2'
-			? translate(
-					'All of the essential Jetpack Security features in one package including Backup, Scan, Anti-spam and more.'
-			  )
-			: translate(
-					'Enjoy the peace of mind of complete site protection. ' +
-						'Great for brochure sites, restaurants, blogs, and resume sites.'
-			  ),
+		( {
+			v2: translate(
+				'All of the essential Jetpack Security features in one package including Backup, Scan, Anti-spam and more.'
+			),
+			i5: translate(
+				'All of the essential Jetpack Security features in one package including Backup, Scan, Anti-spam and more.'
+			),
+		}[ getJetpackCROActiveVersion() ] ||
+		translate(
+			'Enjoy the peace of mind of complete site protection. ' +
+				'Great for brochure sites, restaurants, blogs, and resume sites.'
+		) ),
+
 	getTagline: () => {
 		if ( getJetpackCROActiveVersion() === 'v1' ) {
 			return translate( 'Backup, Scan, and Anti-spam in one package' );
@@ -427,32 +432,37 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 	},
 	getPlanCompareFeatures: () => [],
 	getPlanCardFeatures: () =>
-		getJetpackCROActiveVersion() === 'v2'
-			? [
-					constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
-					constants.FEATURE_PRODUCT_SCAN_V2,
-					constants.FEATURE_PRODUCT_ANTISPAM_V2,
-					constants.FEATURE_ACTIVITY_LOG_30_DAYS_V2,
-					constants.FEATURE_VIDEO_HOSTING_V2,
-					constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
-					constants.FEATURE_SITE_MONETIZATION_V2,
-					constants.FEATURE_GOOGLE_ANALYTICS,
-			  ]
-			: {
-					[ constants.FEATURE_CATEGORY_SECURITY ]: [
-						constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
-						constants.FEATURE_PRODUCT_SCAN_V2,
-						constants.FEATURE_PRODUCT_ANTISPAM_V2,
-						constants.FEATURE_ACTIVITY_LOG_30_DAYS_V2,
-					],
-					[ constants.FEATURE_CATEGORY_OTHER ]: [
-						constants.FEATURE_VIDEO_HOSTING_V2,
-						constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
-						constants.FEATURE_COLLECT_PAYMENTS_V2,
-						constants.FEATURE_SITE_MONETIZATION_V2,
-						constants.FEATURE_PRIORITY_SUPPORT_V2,
-					],
-			  },
+		( {
+			v2: [
+				constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
+				constants.FEATURE_PRODUCT_SCAN_V2,
+				constants.FEATURE_PRODUCT_ANTISPAM_V2,
+				constants.FEATURE_ACTIVITY_LOG_30_DAYS_V2,
+				constants.FEATURE_VIDEO_HOSTING_V2,
+				constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
+				constants.FEATURE_SITE_MONETIZATION_V2,
+			],
+			i5: [
+				constants.FEATURE_ALL_FREE_FEATURES,
+				constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
+				constants.FEATURE_PRODUCT_SCAN_DAILY_V2,
+				constants.FEATURE_ANTISPAM_V2,
+			],
+		}[ getJetpackCROActiveVersion() ] || {
+			[ constants.FEATURE_CATEGORY_SECURITY ]: [
+				constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
+				constants.FEATURE_PRODUCT_SCAN_V2,
+				constants.FEATURE_PRODUCT_ANTISPAM_V2,
+				constants.FEATURE_ACTIVITY_LOG_30_DAYS_V2,
+			],
+			[ constants.FEATURE_CATEGORY_OTHER ]: [
+				constants.FEATURE_VIDEO_HOSTING_V2,
+				constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
+				constants.FEATURE_COLLECT_PAYMENTS_V2,
+				constants.FEATURE_SITE_MONETIZATION_V2,
+				constants.FEATURE_PRIORITY_SUPPORT_V2,
+			],
+		} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
 		constants.FEATURE_JETPACK_BACKUP_DAILY,
@@ -493,44 +503,55 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 			...constants.JETPACK_LEGACY_PLANS,
 		].includes( plan ),
 	getDescription: () =>
-		getJetpackCROActiveVersion() === 'v2'
-			? translate(
-					'Get next level protection. Includes all essential security tools, but with on-demand scan, real time backup & more.'
-			  )
-			: translate(
-					'Additional security for sites with 24/7 activity. ' +
-						'Recommended for eCommerce stores, news organizations, and online forums.'
-			  ),
+		( {
+			v2: translate(
+				'Get next level protection. Includes all essential security tools, but with on-demand scan, real time backup & more.'
+			),
+			i5: translate(
+				'Get next-level protection with real-time backups, real-time scan and all essential security tools.'
+			),
+		}[ getJetpackCROActiveVersion() ] ||
+		translate(
+			'Additional security for sites with 24/7 activity. ' +
+				'Recommended for eCommerce stores, news organizations, and online forums.'
+		) ),
 	getTagline: () =>
 		getJetpackCROActiveVersion() === 'v2'
 			? translate( 'Always on protection, backs up as you edit' )
 			: translate( 'Best for sites with frequent updates' ),
 	getPlanCompareFeatures: () => [],
 	getPlanCardFeatures: () =>
-		getJetpackCROActiveVersion() === 'v2'
-			? [
-					constants.FEATURE_PLAN_SECURITY_DAILY,
-					constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
-					constants.FEATURE_PRODUCT_SCAN_V2_NO_SLIDEOUT,
-					constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
-					constants.FEATURE_PREMIUM_THEMES_V2,
-			  ]
-			: {
-					[ constants.FEATURE_CATEGORY_SECURITY ]: [
-						constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
-						constants.FEATURE_PRODUCT_SCAN_V2,
-						constants.FEATURE_PRODUCT_ANTISPAM_V2,
-						constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
-					],
-					[ constants.FEATURE_CATEGORY_OTHER ]: [
-						constants.FEATURE_PREMIUM_THEMES_V2,
-						constants.FEATURE_VIDEO_HOSTING_V2,
-						constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
-						constants.FEATURE_COLLECT_PAYMENTS_V2,
-						constants.FEATURE_SITE_MONETIZATION_V2,
-						constants.FEATURE_PRIORITY_SUPPORT_V2,
-					],
-			  },
+		( {
+			v2: [
+				constants.FEATURE_PLAN_SECURITY_DAILY,
+				constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
+				constants.FEATURE_PRODUCT_SCAN_V2_NO_SLIDEOUT,
+				constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
+				constants.FEATURE_PREMIUM_THEMES_V2,
+			],
+			i5: [
+				constants.FEATURE_PLAN_SECURITY_DAILY,
+				constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
+				constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
+				constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
+			],
+		}[ getJetpackCROActiveVersion() ] || {
+			[ constants.FEATURE_CATEGORY_SECURITY ]: [
+				constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
+				constants.FEATURE_PRODUCT_SCAN_V2,
+				constants.FEATURE_PRODUCT_ANTISPAM_V2,
+				constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
+			],
+			[ constants.FEATURE_CATEGORY_OTHER ]: [
+				constants.FEATURE_PREMIUM_THEMES_V2,
+				constants.FEATURE_VIDEO_HOSTING_V2,
+				constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
+				constants.FEATURE_COLLECT_PAYMENTS_V2,
+				constants.FEATURE_SITE_MONETIZATION_V2,
+				constants.FEATURE_PRIORITY_SUPPORT_V2,
+			],
+		} ),
+
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
 		constants.FEATURE_JETPACK_BACKUP_REALTIME,
@@ -577,37 +598,42 @@ const getPlanJetpackCompleteDetails = () => ( {
 	getTagline: () => translate( 'For best-in-class WordPress sites' ),
 	getPlanCompareFeatures: () => [],
 	getPlanCardFeatures: () =>
-		getJetpackCROActiveVersion() === 'v2'
-			? [
-					constants.FEATURE_PLAN_SECURITY_REALTIME,
-					constants.FEATURE_CRM_V2,
-					constants.FEATURE_PRODUCT_SEARCH_V2,
-			  ]
-			: {
-					[ constants.FEATURE_CATEGORY_SECURITY ]: [
-						[
-							constants.FEATURE_SECURITY_REALTIME_V2,
-							[
-								constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
-								constants.FEATURE_PRODUCT_SCAN_V2,
-								constants.FEATURE_PRODUCT_ANTISPAM_V2,
-								constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
-							],
-						],
+		( {
+			v2: [
+				constants.FEATURE_PLAN_SECURITY_REALTIME,
+				constants.FEATURE_CRM_V2,
+				constants.FEATURE_PRODUCT_SEARCH_V2,
+			],
+			i5: [
+				constants.FEATURE_PLAN_SECURITY_REALTIME,
+				constants.FEATURE_CRM_V2,
+				constants.FEATURE_PRODUCT_SEARCH_V2,
+			],
+		}[ getJetpackCROActiveVersion() ] || {
+			[ constants.FEATURE_CATEGORY_SECURITY ]: [
+				[
+					constants.FEATURE_SECURITY_REALTIME_V2,
+					[
+						constants.FEATURE_PRODUCT_BACKUP_REALTIME_V2,
+						constants.FEATURE_PRODUCT_SCAN_V2,
+						constants.FEATURE_PRODUCT_ANTISPAM_V2,
+						constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 					],
-					[ constants.FEATURE_CATEGORY_PERFORMANCE ]: [
-						constants.FEATURE_PRODUCT_SEARCH_V2,
-						constants.FEATURE_VIDEO_HOSTING_V2,
-					],
-					[ constants.FEATURE_CATEGORY_GROWTH ]: [
-						constants.FEATURE_CRM_V2,
-						constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
-						constants.FEATURE_COLLECT_PAYMENTS_V2,
-						constants.FEATURE_SITE_MONETIZATION_V2,
-					],
-					[ constants.FEATURE_CATEGORY_DESIGN ]: [ constants.FEATURE_PREMIUM_THEMES_V2 ],
-					[ constants.FEATURE_CATEGORY_OTHER ]: [ constants.FEATURE_PRIORITY_SUPPORT_V2 ],
-			  },
+				],
+			],
+			[ constants.FEATURE_CATEGORY_PERFORMANCE ]: [
+				constants.FEATURE_PRODUCT_SEARCH_V2,
+				constants.FEATURE_VIDEO_HOSTING_V2,
+			],
+			[ constants.FEATURE_CATEGORY_GROWTH ]: [
+				constants.FEATURE_CRM_V2,
+				constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
+				constants.FEATURE_COLLECT_PAYMENTS_V2,
+				constants.FEATURE_SITE_MONETIZATION_V2,
+			],
+			[ constants.FEATURE_CATEGORY_DESIGN ]: [ constants.FEATURE_PREMIUM_THEMES_V2 ],
+			[ constants.FEATURE_CATEGORY_OTHER ]: [ constants.FEATURE_PRIORITY_SUPPORT_V2 ],
+		} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
 		constants.FEATURE_JETPACK_BACKUP_REALTIME,

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -216,21 +216,36 @@ export const getJetpackProductsTaglines = () => {
 };
 
 export const getJetpackProductsDescriptions = () => {
-	const backupDailyDescription = translate(
-		'Never lose a word, image, page, or time worrying about your site.'
-	);
+	const backupDailyDescription =
+		{
+			i5: translate(
+				'Never lose a word, image, page, or time worrying about your site with automated backups & one-click restores.'
+			),
+		}[ getJetpackCROActiveVersion() ] ||
+		translate( 'Never lose a word, image, page, or time worrying about your site.' );
 	const backupRealtimeDescription = translate(
 		'Real-time backups save every change and one-click restores get you back online quickly.'
 	);
-	const searchDescription = translate(
-		'Help your site visitors find answers instantly so they keep reading and buying.'
-	);
+	const searchDescription =
+		{
+			i5: translate(
+				'Help your site visitors find answers instantly so they keep reading and buying. Great for sites with a lot of content.'
+			),
+		}[ getJetpackCROActiveVersion() ] ||
+		translate( 'Help your site visitors find answers instantly so they keep reading and buying.' );
+
 	const scanDescription = translate(
 		'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
 	);
-	const antiSpamDescription = translate(
-		'Automated spam protection for comments and forms. Save time, get more responses, and give your visitors a better experience.'
-	);
+	const antiSpamDescription =
+		{
+			i5: translate(
+				'Save time, get more responses, and give your visitors a better experience, by automatically blocking spam.'
+			),
+		}[ getJetpackCROActiveVersion() ] ||
+		translate(
+			'Automated spam protection for comments and forms. Save time, get more responses, and give your visitors a better experience.'
+		);
 
 	return {
 		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_DAILY ]: backupDailyDescription,

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -136,7 +136,10 @@ export const getJetpackProductsCallToAction = () => {
 		</>
 	);
 	const search =
-		currentCROvariant === 'v1' ? translate( 'Get Jetpack Search' ) : translate( 'Get Search' );
+		{
+			v1: translate( 'Get Jetpack Search' ),
+			i5: translate( 'Get Site Search' ),
+		}[ currentCROvariant ] || translate( 'Get Search' );
 	const scan =
 		currentCROvariant === 'v1' ? translate( 'Get Jetpack Scan' ) : translate( 'Get Scan' );
 	const antiSpam =

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -87,9 +87,17 @@ export const getJetpackProductsDisplayNames = () => {
 		</>
 	);
 	const search =
-		currentCROvariant === 'v2' ? translate( 'Jetpack Site Search' ) : translate( 'Jetpack Search' );
-	const scan = translate( 'Jetpack Scan' );
-	const antiSpam = <>{ translate( 'Jetpack Anti-spam' ) }</>;
+		{
+			v2: translate( 'Jetpack Site Search' ),
+			i5: translate( 'Site Search' ),
+		}[ currentCROvariant ] || translate( 'Jetpack Search' );
+	const scan = currentCROvariant === 'i5' ? translate( 'Scan' ) : translate( 'Jetpack Scan' );
+	const antiSpam =
+		currentCROvariant === 'i5' ? (
+			translate( 'Anti-spam' )
+		) : (
+			<>{ translate( 'Jetpack Anti-spam' ) }</>
+		);
 
 	return {
 		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_DAILY ]: backupDaily,

--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -235,7 +235,7 @@ export const getJetpackProductsDescriptions = () => {
 		translate( 'Help your site visitors find answers instantly so they keep reading and buying.' );
 
 	const scanDescription = translate(
-		'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
+		'Automatic scanning and one-click fixes keep your site one step ahead of security threats and malware.'
 	);
 	const antiSpamDescription =
 		{

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -301,19 +301,23 @@ export const EXTERNAL_PRODUCT_CRM: SelectorProduct = {
 		? 'jetpack_crm_dark'
 		: 'jetpack_crm',
 	displayName:
-		getJetpackCROActiveVersion() === 'v2'
-			? translate( 'Jetpack CRM {{em}}Entrepreneur{{/em}}', {
-					components: {
-						em: createElement( 'em' ),
-					},
-			  } )
-			: translate( 'Jetpack CRM' ),
+		{
+			v2: translate( 'Jetpack CRM {{em}}Entrepreneur{{/em}}', {
+				components: {
+					em: createElement( 'em' ),
+				},
+			} ),
+			i5: translate( 'CRM Entrepreneur' ),
+		}[ getJetpackCROActiveVersion() ] || translate( 'Jetpack CRM' ),
+
 	shortName:
-		getJetpackCROActiveVersion() === 'v2'
-			? translate( 'Jetpack CRM ' )
-			: translate( 'CRM', {
-					comment: 'Short name of the Jetpack CRM',
-			  } ),
+		{
+			v2: translate( 'Jetpack CRM ' ),
+			i5: translate( 'CRM Entrepreneur' ),
+		}[ getJetpackCROActiveVersion() ] ||
+		translate( 'CRM', {
+			comment: 'Short name of the Jetpack CRM',
+		} ),
 	tagline: translate( 'Manage contacts effortlessly' ),
 	// Jetpack CRM isn't considered as a product like others for the time being (and therefore not
 	// available via the API). Rather like a third-party product.


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the copy of pricing page i5.

Fixes 1196341175636977-as-1199149328812578

### Implementation notes

- Iteration checks are not ideal, it's gonna be dealt with later in another PR
- Case of features is not consistent in the mockups, don't mind it
- Don't check the FAQ
- First feature in _Anti-spam_ should probably be "Always-on spam protection" to match the feature in _Security Daily_

### Testing instructions

- Download the PR or visit the Calypso live link
- Run Calypso or Jetpack cloud
- Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
- Select a self-hosted Jetpack site
- Visit the pricing page
- Check that the copy matches  the mockups (link attached in task). Specifically:
    - Check the titles of the plans and products cards
    - Check that _Search_ has been replaced by _Site Search_ everywhere
    - Check the features lists

