### PR TITLE
Focused Launch: Show different title/subtitle if site has already a paid plan AND a paid domain

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -413,12 +413,21 @@ const Summary: React.FunctionComponent = () => {
 	return (
 		<div className="focused-launch-summary__container">
 			<div className="focused-launch-summary__section">
-				<Title>{ __( "You're almost there", __i18n_text_domain__ ) }</Title>
+				<Title>
+					{ hasPaidDomain && hasPaidPlan
+						? __( "You're ready to launch", __i18n_text_domain__ )
+						: __( "You're almost there", __i18n_text_domain__ ) }
+				</Title>
 				<p className="focused-launch-summary__caption">
-					{ __(
-						'Prepare for launch! Confirm a few final things before you take it live.',
-						__i18n_text_domain__
-					) }
+					{ hasPaidDomain && hasPaidPlan
+						? __(
+								"You're good to go! Launch your site and share your site address.",
+								__i18n_text_domain__
+						  )
+						: __(
+								'Prepare for launch! Confirm a few final things before you take it live.',
+								__i18n_text_domain__
+						  ) }
 				</p>
 			</div>
 			{ disabledSteps.map( ( step, stepIndex ) => step( stepIndex + 1 ) ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When the site has already both a purchased domain and a purchased plan associated, the title/subtitle of the Summary view of the Focused Launch modal should change from the ones that normally shown
* Note that there is no need to store this option in the `automattic/launch` data store, as these conditions (site has purchased domain and plan) can't change while the user is interacting with the summary step

#### Testing instructions

* Check out this branch on your machine and run `yarn && yarn start`
* Visit`calypso.localhost:3000/page/UNLAUNCHED_SITE_ID/home?flags=create/focused-launch-flow-calypso`
* By changing in code the values of `hasPaidDomain` and `hasPaidPlan`, simulate all the combinations (refreshing the page each time)
  * is both variables are `true`, the title of the modal should read _"You're ready to launch"_ and the subtitle should read _"You're good to go! Launch your site and share your site address."_

![Screenshot 2020-11-12 at 20 56 07](https://user-images.githubusercontent.com/1083581/98989785-da393080-2529-11eb-9a2b-f169dab62237.png)

  * otherwise, the title of the modal should read _"You're almost there"_ and the subtitle should read _"Prepare for launch! Confirm a few final things before you take it live."_

![Screenshot 2020-11-12 at 20 56 17](https://user-images.githubusercontent.com/1083581/98989772-d60d1300-2529-11eb-96f9-576e8cd44b68.png)

Fixes #47240 
