### PR TITLE
Jetpack Cloud: remove custom styles from Activity Log's pagination component

### DIFF
--- a/client/components/activity-card-list/style.scss
+++ b/client/components/activity-card-list/style.scss
@@ -2,30 +2,6 @@
 	.filterbar {
 		margin-bottom: 2rem;
 	}
-
-	.pagination__list-item {
-		.pagination__list-item:last-child .pagination__list-button.button.is-borderless,
-		.button.pagination__list-button.is-borderless,
-		&.pagination__ellipsis > span {
-			color: var( --color-text );
-			border: none;
-			border-radius: 8px;
-
-			&:disabled {
-				color: var( --studio-gray-10 );
-			}
-		}
-
-		&:not( .is-selected ) .button.pagination__list-button.is-borderless,
-		&.pagination__ellipsis > span {
-			background-color: var( --color-surface-backdrop );
-		}
-
-		&.is-selected .button.pagination__list-button.is-borderless {
-			background-color: var( --color-primary );
-			color: var( --color-text-inverted );
-		}
-	}
 }
 
 .activity-card-list__pagination-bottom {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We want to use the default style which is used in WordPress.com and in the Scan History section.

#### Testing instructions

* Run this PR (you need to build Calypso Green).
* Visit `http://jetpack.cloud.localhost:3001/activity-log/:site` with a Jetpack Site.
* Make sure that the Pagination component looks like in the after capture.

Fixes 1164141197617539-as-1198830230995148

#### Demo

##### Before
![image](https://user-images.githubusercontent.com/3418513/98990319-127c4700-2509-11eb-9167-a0c560cbeddc.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/98990300-098b7580-2509-11eb-97be-6085a510ab09.png)