### PR TITLE
Jetpack Cloud: Load Download/Restore Backup pages in UTC if timezone isn't available

### DIFF
--- a/client/my-sites/backup/rewind-flow/index.tsx
+++ b/client/my-sites/backup/rewind-flow/index.tsx
@@ -4,14 +4,16 @@
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent, useEffect } from 'react';
+import { Card } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
-import { applySiteOffsetType, useApplySiteOffset } from 'calypso/components/site-offset';
-import { Card } from '@automattic/components';
+import { applySiteOffset } from 'calypso/lib/site/timezone';
 import { getHttpData, DataState } from 'calypso/state/data-layer/http-data';
 import { getRequestActivityId, requestActivity } from 'calypso/state/data-getters';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { RewindFlowPurpose } from './types';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -36,7 +38,6 @@ interface Props {
 }
 
 const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) => {
-	const applySiteOffset = useApplySiteOffset();
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 
@@ -53,34 +54,12 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 		activityRequestState
 	);
 
+	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
+	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
+
 	useEffect( () => {
 		requestActivity( siteId, rewindId );
 	}, [ siteId, rewindId ] );
-
-	const renderContent = ( loadedApplySiteOffset: applySiteOffsetType ) => {
-		const backupDisplayDate = loadedApplySiteOffset(
-			moment( parseFloat( rewindId ) * 1000 )
-		)?.format( 'LLL' );
-		if ( siteId && rewindId && backupDisplayDate ) {
-			return purpose === RewindFlowPurpose.RESTORE ? (
-				<BackupRestoreFlow
-					backupDisplayDate={ backupDisplayDate }
-					rewindId={ rewindId }
-					siteId={ siteId }
-					siteUrl={ siteUrl }
-				/>
-			) : (
-				<BackupDownloadFlow
-					backupDisplayDate={ backupDisplayDate }
-					rewindId={ rewindId }
-					siteId={ siteId }
-					siteUrl={ siteUrl }
-				/>
-			);
-		}
-		// TODO: improve this placeholder
-		return <Spinner />;
-	};
 
 	const render = () => {
 		if ( null === applySiteOffset || loadingActivity ) {
@@ -111,7 +90,31 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 				/>
 			);
 		}
-		return renderContent( applySiteOffset );
+
+		const backupDisplayDate = applySiteOffset( moment( parseFloat( rewindId ) * 1000 ), {
+			gmtOffset,
+			timezone,
+		} ).format( 'LLL' );
+		if ( siteId && rewindId && backupDisplayDate ) {
+			return purpose === RewindFlowPurpose.RESTORE ? (
+				<BackupRestoreFlow
+					backupDisplayDate={ backupDisplayDate }
+					rewindId={ rewindId }
+					siteId={ siteId }
+					siteUrl={ siteUrl }
+				/>
+			) : (
+				<BackupDownloadFlow
+					backupDisplayDate={ backupDisplayDate }
+					rewindId={ rewindId }
+					siteId={ siteId }
+					siteUrl={ siteUrl }
+				/>
+			);
+		}
+
+		// TODO: improve this placeholder
+		return <Spinner />;
 	};
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switch to using `applySiteOffset` manually as is done elsewhere in Calypso (as opposed to using `useApplySiteOffset` or `withApplySiteOffset`), which does not require timezone info to be loaded before it is callable.

#### Known issues

* If we're unable to retrieve timezone information, the UI defaults to displaying everything in UTC. We may address this in the future, but for now it's at least consistent with everything else in Calypso.

#### Testing instructions

**TIP:** You can simulate a broken connection by re-writing API responses with a debugging proxy. Alternatively, try using Redux DevTools to find and re-send a modified version the action responsible for retrieving/storing site settings with null `gmt_offset` and `timezone` option fields.

1. In Calypso Blue or Green, select a site with Jetpack Backup and at least one backup, but that has a broken Jetpack connection.
2. Find an existing backup on the Backup page and select either **Download backup** or **Restore from this point**.
3. Verify that the page loads, and that you're able to either download or restore your backup.

#### Screenshots

##### Before

<img width="732" alt="image" src="https://user-images.githubusercontent.com/670067/98992773-3339a200-24f3-11eb-99aa-4f02fa7eaaa1.png">

##### After

<img width="711" alt="image" src="https://user-images.githubusercontent.com/670067/98992661-100ef280-24f3-11eb-8aba-63ea6e04219d.png">
