### PR TITLE
Purchases: Add price to subscription listing

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -70,9 +70,9 @@ class PurchaseItem extends Component {
 		if ( isRenewing( purchase ) && purchase.renewDate ) {
 			const renewDate = moment( purchase.renewDate );
 
-			return translate( 'Renews at %(price)s on %(date)s', {
+			return translate( 'Renews at %(amount)s on %(date)s.', {
 				args: {
-					price: purchase.priceText,
+					amount: purchase.priceText,
 					date: renewDate.format( 'LL' ),
 				},
 			} );

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -69,8 +69,12 @@ class PurchaseItem extends Component {
 
 		if ( isRenewing( purchase ) && purchase.renewDate ) {
 			const renewDate = moment( purchase.renewDate );
-			return translate( 'Renews on %s', {
-				args: renewDate.format( 'LL' ),
+
+			return translate( 'Renews at %(price)s on %(date)s', {
+				args: {
+					price: purchase.priceText,
+					date: renewDate.format( 'LL' ),
+				},
 			} );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the renewal price to the purchase listing screen.

**Before**
![image](https://user-images.githubusercontent.com/6981253/99010339-cdabdc80-2517-11eb-9e61-ec8c1b17ad75.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/99010298-b7058580-2517-11eb-8b75-ecea02bbaf88.png)

![image](https://user-images.githubusercontent.com/6981253/99010317-c258b100-2517-11eb-97ee-a17fa0a97b3f.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the purchase listing screens at the site and account level. 
* Confirm you see a renewal price for products that have auto-renew enabled.

Fixes https://github.com/Automattic/wp-calypso/issues/46724
