### PR TITLE
Coming Soon: disable wp head/footer scripts

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -94,16 +94,16 @@ add_action( 'update_option_blog_public', __NAMESPACE__ . '\disable_coming_soon_o
 
 // phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed
 /**
- * Adds the `wpcom_public_coming_soon` option to new sites
+ * Adds the `wpcom_public_coming_soon` option to new sites  if requested by the client.
  *
  * @param int    $blog_id    Blog ID.
  * @param int    $user_id    User ID.
  * @param string $domain     Site domain.
  * @param string $path       Site path.
- * @param int    $site_id    Site ID.
+ * @param int    $network_id Network ID. Only relevant on multi-network installations.
  * @param array  $meta       Meta data. Used to set initial site options.
  */
-function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $site_id, $meta ) {
+function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $network_id, $meta ) {
 	if ( 0 === $meta['public'] && 1 === (int) $meta['options']['wpcom_public_coming_soon'] ) {
 		add_blog_option( $blog_id, 'wpcom_public_coming_soon', 1 );
 	} else {

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -124,6 +124,16 @@ function coming_soon_page() {
 
 	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
 	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
+	// Disable WP scripts, social og meta, cookie banner.
+	remove_action( 'wp_enqueue_scripts', 'wpcom_actionbar_enqueue_scripts', 101 );
+	remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+	remove_action( 'wp_print_styles', 'print_emoji_styles' );
+	remove_action( 'wp_head', 'header_js', 5 );
+	remove_action( 'wp_head', 'global_css', 5 );
+	remove_action( 'wp_footer', 'wpcom_subs_js' );
+	remove_action( 'wp_footer', 'stats_footer', 101 );
+	add_filter( 'jetpack_disable_eu_cookie_law_widget', '__return_true', 1 );
+	add_filter( 'jetpack_enable_opengraph', '__return_false', 1 );
 
 	render_fallback_coming_soon_page();
 	die();

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -121,7 +121,9 @@ function coming_soon_page() {
 	if ( ! show_coming_soon_page() ) {
 		return;
 	}
-
+	if ( ! defined( 'GRAVATAR_HOVERCARDS__DISABLE' ) ) {
+		define( 'GRAVATAR_HOVERCARDS__DISABLE', true );
+	}
 	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
 	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
 	// Disable WP scripts, social og meta, cookie banner.

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -68,17 +68,6 @@ function get_onboarding_url() {
 	return 'https://' . $locale_subdomain . 'wordpress.com/?ref=coming_soon';
 }
 
-// Disable WP scripts, social og meta, cookie banner.
-remove_action( 'wp_enqueue_scripts', 'wpcom_actionbar_enqueue_scripts', 101 );
-remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
-remove_action( 'wp_print_styles', 'print_emoji_styles' );
-remove_action( 'wp_head', 'header_js', 5 );
-remove_action( 'wp_head', 'global_css', 5 );
-remove_action( 'wp_footer', 'wpcom_subs_js' );
-remove_action( 'wp_footer', 'stats_footer', 101 );
-add_filter( 'jetpack_disable_eu_cookie_law_widget', '__return_true', 1 );
-add_filter( 'jetpack_enable_opengraph', '__return_false', 1 )
-
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -68,6 +68,17 @@ function get_onboarding_url() {
 	return 'https://' . $locale_subdomain . 'wordpress.com/?ref=coming_soon';
 }
 
+// Disable WP scripts, social og meta, cookie banner.
+remove_action( 'wp_enqueue_scripts', 'wpcom_actionbar_enqueue_scripts', 101 );
+remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+remove_action( 'wp_print_styles', 'print_emoji_styles' );
+remove_action( 'wp_head', 'header_js', 5 );
+remove_action( 'wp_head', 'global_css', 5 );
+remove_action( 'wp_footer', 'wpcom_subs_js' );
+remove_action( 'wp_footer', 'stats_footer', 101 );
+add_filter( 'jetpack_disable_eu_cookie_law_widget', '__return_true', 1 );
+add_filter( 'jetpack_enable_opengraph', '__return_false', 1 )
+
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR:

- disables wp head/footer scripts
- cookie banner (we don't set any)
- og tags

for the Coming Soon page.

#### Testing instructions

Create a new site at `/new?flags=coming-soon-v2`

Sandbox your new site

Checkout this branch and from `apps/editing-toolkit`, run `yarn dev --sync`

Visit the site in a logged-out state.

You **shouldn't** see the following:

The cookie banner. 

<img width="1283" alt="Screen Shot 2020-11-13 at 1 47 52 pm" src="https://user-images.githubusercontent.com/6458278/99022655-3d24d900-25b7-11eb-97a9-d4c919b07f5d.png">

The og tags

<img width="1035" alt="Screen Shot 2020-11-13 at 1 48 00 pm" src="https://user-images.githubusercontent.com/6458278/99022660-3eee9c80-25b7-11eb-8f04-4f9b2077fbd7.png">


Fixes: #46630

