### PR TITLE
Coming Soon: enable in all envs

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -21,6 +21,7 @@
 		"always_use_logout_url": true,
 		"automated-transfer": true,
 		"blogger-plan": false,
+		"coming-soon-v2": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -17,6 +17,7 @@
 		"always_use_logout_url": true,
 		"blogger-plan": false,
 		"catch-js-errors": false,
+		"coming-soon-v2": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,

--- a/config/development.json
+++ b/config/development.json
@@ -33,6 +33,7 @@
 		"automated-transfer": true,
 		"blogger-plan": true,
 		"calypsoify/plugins": true,
+		"coming-soon-v2": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -20,6 +20,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
+		"coming-soon-v2": true,
 		"composite-checkout-testing": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,

--- a/config/production.json
+++ b/config/production.json
@@ -20,6 +20,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
+		"coming-soon-v2": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -21,6 +21,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
+		"coming-soon-v2": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -30,6 +30,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
+		"coming-soon-v2": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -23,6 +23,7 @@
 		"comments/management/threaded-view": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
+		"coming-soon-v2": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

⚠️ The following PRs should be merged before we release:

✅ ~https://github.com/Automattic/wp-calypso/pull/47442 (ETK deploy)~

Coming soon... no longer coming soon!

The plan is to enable Coming Soon v2 for all new sites in production and elsewhere.

Existing sites, which are either

1. unlaunched (and therefore in Coming Soon Private mode by default) or
2. launched and have Coming Soon enabled

will remain in v1 until they launch/toggle out of Coming Soon v1 mode.

#### Testing instructions

See: https://github.com/Automattic/wp-calypso/pull/47399
