### PR TITLE
Activity Log: Refactor FormattedBlock to remove top-level side effects

### DIFF
--- a/client/components/notes-formatted-block/blocks.jsx
+++ b/client/components/notes-formatted-block/blocks.jsx
@@ -9,23 +9,11 @@ import { startsWith } from 'lodash';
  */
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
-const blocksByType = {};
-export function getBlockByType( type ) {
-	return blocksByType[ type ];
-}
-
-function assignBlockType( type, block ) {
-	blocksByType[ type ] = block;
-}
-
 export const Strong = ( { children } ) => <strong>{ children }</strong>;
-assignBlockType( 'b', Strong );
 
 export const Emphasis = ( { children } ) => <em>{ children }</em>;
-assignBlockType( 'i', Emphasis );
 
 export const Preformatted = ( { children } ) => <pre>{ children }</pre>;
-assignBlockType( 'pre', Preformatted );
 
 export const Link = ( { content, onClick, children } ) => {
 	const { url: originalUrl, activity, section, intent } = content;
@@ -52,15 +40,12 @@ export const Link = ( { content, onClick, children } ) => {
 		</a>
 	);
 };
-assignBlockType( 'a', Link );
-assignBlockType( 'link', Link );
 
 export const FilePath = ( { children } ) => (
 	<div>
 		<code>{ children }</code>
 	</div>
 );
-assignBlockType( 'filepath', FilePath );
 
 export const Post = ( { content, children } ) => {
 	// Don't render links to WordPress.com inside Jetpack Cloud
@@ -78,7 +63,6 @@ export const Post = ( { content, children } ) => {
 		</a>
 	);
 };
-assignBlockType( 'post', Post );
 
 export const Comment = ( { content, children } ) => {
 	// Don't render links to WordPress.com inside Jetpack Cloud
@@ -94,7 +78,6 @@ export const Comment = ( { content, children } ) => {
 		</a>
 	);
 };
-assignBlockType( 'comment', Comment );
 
 export const Person = ( { content, onClick, meta, children } ) => {
 	// Don't render links to WordPress.com inside Jetpack Cloud
@@ -114,7 +97,6 @@ export const Person = ( { content, onClick, meta, children } ) => {
 		</a>
 	);
 };
-assignBlockType( 'person', Person );
 
 export const Plugin = ( { content, onClick, meta, children } ) => {
 	// Don't render links to WordPress.com inside Jetpack Cloud
@@ -134,7 +116,6 @@ export const Plugin = ( { content, onClick, meta, children } ) => {
 		</a>
 	);
 };
-assignBlockType( 'plugin', Plugin );
 
 export const Theme = ( { content, onClick, meta, children } ) => {
 	const { themeUri, themeSlug, siteSlug } = content;
@@ -173,4 +154,3 @@ export const Theme = ( { content, onClick, meta, children } ) => {
 		</a>
 	);
 };
-assignBlockType( 'theme', Theme );

--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -6,9 +6,13 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { getBlockByType } from './blocks';
+import * as Blocks from './blocks';
 
-const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) => {
+export const FormattedBlockRenderer = ( blockTypeMapping ) => ( {
+	content = {},
+	onClick = null,
+	meta = {},
+} ) => {
 	if ( 'string' === typeof content ) {
 		return content;
 	}
@@ -23,12 +27,25 @@ const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) => {
 		<FormattedBlock key={ key } content={ child } onClick={ onClick } meta={ meta } />
 	) );
 
-	const blockToRender = getBlockByType( type );
+	const blockToRender = blockTypeMapping[ type ];
 	if ( blockToRender ) {
 		return blockToRender( { content, onClick, meta, children } );
 	}
 
 	return <>{ children }</>;
 };
+
+const FormattedBlock = FormattedBlockRenderer( {
+	b: Blocks.Strong,
+	i: Blocks.Emphasis,
+	pre: Blocks.Preformatted,
+	a: Blocks.Link,
+	link: Blocks.Link,
+	filepath: Blocks.FilePath,
+	post: Blocks.Post,
+	person: Blocks.Person,
+	plugin: Blocks.Plugin,
+	theme: Blocks.Theme,
+} );
 
 export default FormattedBlock;

--- a/client/components/notes-formatted-block/test/index.js
+++ b/client/components/notes-formatted-block/test/index.js
@@ -5,15 +5,9 @@ import React from 'react';
 import { render, shallow } from 'enzyme';
 
 /**
- * Mock dependencies
- */
-jest.mock( 'components/notes-formatted-block/blocks' );
-import { getBlockByType } from '../blocks';
-
-/**
  * Internal dependencies
  */
-import FormattedBlock from '..';
+import FormattedBlock, { FormattedBlockRenderer } from '..';
 
 describe( 'FormattedBlock', () => {
 	beforeEach( () => jest.resetAllMocks() );
@@ -64,16 +58,17 @@ describe( 'FormattedBlock', () => {
 	} );
 
 	test( 'displays the correct block with correct props if the content type is supported', () => {
-		const myBlock = ( props ) => <div type="myfakeblock" { ...props }></div>;
-		getBlockByType.mockImplementation( () => myBlock );
+		const MockBlockMapping = FormattedBlockRenderer( {
+			myBlock: ( props ) => <div type="myfakeblock" { ...props }></div>,
+		} );
 
 		const onClick = jest.fn();
 		const meta = {};
 		const children = [ {}, {}, {} ];
-		const content = { type: 'doesnotmatter', children };
+		const content = { type: 'myBlock', children };
 
 		const block = shallow(
-			<FormattedBlock content={ content } onClick={ onClick } meta={ meta } />
+			<MockBlockMapping content={ content } onClick={ onClick } meta={ meta } />
 		);
 
 		expect( block.type() ).toEqual( 'div' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the mapping for `FormattedBlock` types into `index.jsx`.
* Get rid of `getBlockByType`, which introduced side effects and is unnecessary with the above change.

Follows up on #45591.

#### Testing instructions

* Make sure all unit tests pass.
* Follow instructions for #45591, copied here for convenience:

* For both Jetpack Cloud and Calypso, test that all behavior for Activity Log cards -- and specifically, all links -- matches the current production deployment. Here's a list of notable events that have their own cards:
  * Post changes (created, modified, deleted)
  * Comment changes (modified, deleted, etc.)
  * People changes (added to/removed from your site's team, etc.)
  * Plugin changes (installed, removed, etc.)
  * Theme changes (for WordPress.com, but also for other sites like WordPress.org)

#### Reference screenshots

<img width="356" alt="Screen Shot 2020-09-11 at 14 24 33" src="https://user-images.githubusercontent.com/670067/92965889-343f4c00-f43c-11ea-834e-e2aec41c8042.png">
<img width="1057" alt="Screen Shot 2020-09-11 at 14 36 30" src="https://user-images.githubusercontent.com/670067/92965892-34d7e280-f43c-11ea-8528-e1c447461d76.png">
