### PR TITLE
Fix the Jetpack Scan file threat representation.

### DIFF
--- a/client/components/marked-lines/index.jsx
+++ b/client/components/marked-lines/index.jsx
@@ -86,6 +86,10 @@ const MarkedLines = ( { context } ) => {
 				{ map( lines, ( content, lineNumber ) => {
 					const hasMarks = marks.hasOwnProperty( lineNumber );
 
+					if ( content === '' ) {
+						content = ' ';
+					}
+
 					return (
 						<div
 							key={ lineNumber }


### PR DESCRIPTION
The MarkedLines component wouldn't properly render a line if the content was an empty string, this caused an issue where the line numbers were slightly misrepresented.

#### Changes proposed in this Pull Request

* Fix the MarkedLines component by replacing empty strings with a string with a single space in it.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a Jurassic Ninja site at https://jurassic.ninja/create/?shortlived
* Create a file named test.php with the following content:
```
X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*
X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*

X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*
```
* Connect the site to Jetpack and purchase a plan that includes scan with credits
* Scan the site and verify that a threat was added.

## Testing wordpress.com
* Go to https://calypso.live/scan/{test-site}?branch=fix/threat-file-representation
* Click on the new threat to open it's details.
* Verify that the file is being represented correctly in the details.

## Testing cloud.jetpack.com 
* Checkout and build this branch locally
* Go to http://jetpack.cloud.localhost:3000/scan/{test-site}
* Verify as for wordpress.com above

## Screenshots
Before, note how the blank line in the file isn't there, which causes the third eicar string instance to be represented in the wrong line: 
<img width="573" alt="Screen Shot 2020-11-13 at 11 10 54" src="https://user-images.githubusercontent.com/12788275/99081057-f4fabc00-25a0-11eb-97f4-ff4444576ef1.png">

After:
<img width="682" alt="Screen Shot 2020-11-13 at 11 17 56" src="https://user-images.githubusercontent.com/12788275/99081650-e95bc500-25a1-11eb-9174-08355846ef0a.png">
