### PR TITLE
Activity Log: Fix method typo to allow backup downloads to be canceled

### DIFF
--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -379,7 +379,7 @@ class ActivityLogItem extends Component {
 					<ActivityLogConfirmDialog
 						key="activity-backup-dialog"
 						confirmTitle={ translate( 'Create download' ) }
-						onClose={ this.cancelBackupIntent }
+						onClose={ this.cancelDownloadIntent }
 						onConfirm={ this.confirmBackup }
 						onSettingsChange={ this.downloadSettingsChange }
 						supportLink="https://jetpack.com/support/backup"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the `ActivityLogItem` component, replace an undefined reference to `this.cancelBackupIntent` with the correct method, `this.cancelDownloadIntent`.

#### Testing instructions

* Select a site in Calypso Blue that has Jetpack Backup.
* Open the Activity Log page.
* Find an activity that allows downloading or restoring from a backup.
* Click the three-dot menu button next to the activity and select 'Download backup.'
* When the backup details panel is displayed, click the Cancel button that appears at the bottom.
* Verify that the details panel is correctly dismissed.

#### Reference screenshots

<img width="700" alt="Screen Shot 2020-11-13 at 08 37 26" src="https://user-images.githubusercontent.com/670067/99083710-88c18d80-258b-11eb-8747-773da7e91c01.png">
<img width="252" alt="Screen Shot 2020-11-13 at 08 42 55" src="https://user-images.githubusercontent.com/670067/99084182-3fbe0900-258c-11eb-8806-41e34207b1a8.png">
<img width="700" alt="Screen Shot 2020-11-13 at 08 37 36" src="https://user-images.githubusercontent.com/670067/99083711-88c18d80-258b-11eb-9e66-bb5f7a54f929.png">