### PR TITLE
Pricing page i5: tweak styles on mobile

### DIFF
--- a/client/jetpack-cloud/sections/pricing/header/style.scss
+++ b/client/jetpack-cloud/sections/pricing/header/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .header {
 	text-align: center;
 }
@@ -16,7 +19,19 @@
 	.header.i5
 	.header__main-title
 	.formatted-header__title {
-	font-size: 2rem;
+	max-width: 280px;
+	margin-right: auto;
+	margin-left: auto;
+
+	font-size: 1.5rem;
 	font-weight: 700;
 	letter-spacing: -1px;
+	line-height: 1.4;
+
+	@include break-small {
+		max-width: none;
+
+		font-size: 2rem;
+		line-height: 1.2;
+	}
 }

--- a/client/my-sites/plans-v2/more-info-box/style.scss
+++ b/client/my-sites/plans-v2/more-info-box/style.scss
@@ -1,11 +1,20 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .more-info-box__more-container {
 	background-color: rgba( var( --studio-jetpack-green-10-rgb ), 0.1 );
 
-	margin: 0 30px;
+	margin: 24px 0;
 	padding: 30px 15px 26px;
-	border-bottom-left-radius: 8px;
-	border-bottom-right-radius: 8px;
+	border-radius: 8px;
+
 	text-align: center;
+
+	@include break-small {
+		margin: 0 30px;
+
+		border-radius: 0 0 8px 8px;
+	}
 }
 
 .more-info-box__more-headline {

--- a/client/my-sites/plans-v2/products-grid-i5/style.scss
+++ b/client/my-sites/plans-v2/products-grid-i5/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .products-grid-i5__section {
 	margin-bottom: 70px;
 	padding-left: 20px;
@@ -14,13 +17,20 @@
 }
 
 .products-grid-i5__section-title {
-	margin-top: 60px;
-	margin-bottom: 40px;
+	margin-top: 36px;
+	margin-bottom: 20px;
 
-	font-size: 2.25rem;
+	font-size: 2rem;
 	font-weight: 700;
 	letter-spacing: -1px;
 	text-align: center;
+
+	@include break-small {
+		margin-top: 60px;
+		margin-bottom: 40px;
+
+		font-size: 2.25rem;
+	}
 }
 
 .products-grid-i5__plan-grid,
@@ -53,5 +63,9 @@
 
 .products-grid-i5__filter-bar {
 	height: 63px;
-	padding-bottom: 50px;
+	margin-bottom: 70px;
+
+	@include break-small {
+		margin-bottom: 50px;
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the style of pricing page i5 on mobile.

Fixes 1196341175636977-as-1199149328812622

### Testing instructions

- Download the PR or visit the Calypso live link
- Run Calypso and Jetpack cloud
- Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
- Select a self-hosted Jetpack site
- Visit the pricing page on desktop and check that it still looks like staging
- Check the page on mobile against the mockups (see link in task)

### Screenshots

<img width="375" alt="Screen Shot 2020-11-13 at 10 29 35 AM" src="https://user-images.githubusercontent.com/1620183/99089371-35efd200-259b-11eb-8f9c-1f45240ad68d.png">

<img width="373" alt="Screen Shot 2020-11-13 at 10 29 43 AM" src="https://user-images.githubusercontent.com/1620183/99089372-36886880-259b-11eb-9ed7-4ebe3cc10121.png">

<img width="371" alt="Screen Shot 2020-11-13 at 10 29 51 AM" src="https://user-images.githubusercontent.com/1620183/99089375-3720ff00-259b-11eb-83c4-1adfb9313031.png">

