### PR TITLE
Pricing page i5: tweak styles for Calypso

### DIFF
--- a/client/jetpack-cloud/sections/pricing/header/style.scss
+++ b/client/jetpack-cloud/sections/pricing/header/style.scss
@@ -20,6 +20,7 @@
 	.header__main-title
 	.formatted-header__title {
 	max-width: 280px;
+	margin-bottom: 60px;
 	margin-right: auto;
 	margin-left: auto;
 

--- a/client/my-sites/plans-v2/more-info-box/index.tsx
+++ b/client/my-sites/plans-v2/more-info-box/index.tsx
@@ -8,6 +8,7 @@ import { Button } from '@automattic/components';
  * Internal dependencies
  */
 import { PLAN_COMPARISON_PAGE } from 'calypso/my-sites/plans-v2/constants';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Type dependencies
@@ -29,8 +30,9 @@ type MoreInfoProps = {
 const MoreInfoBox: React.FC< MoreInfoProps > = ( { headline, buttonLabel } ) => (
 	<div className="more-info-box__more-container">
 		<h3 className="more-info-box__more-headline">{ headline }</h3>
-		<Button href={ PLAN_COMPARISON_PAGE } className="more-info-box__more-button" primary>
+		<Button href={ PLAN_COMPARISON_PAGE } className="more-info-box__more-button">
 			{ buttonLabel }
+			<Gridicon className="more-info-box__icon" icon="external" />
 		</Button>
 	</div>
 );

--- a/client/my-sites/plans-v2/more-info-box/style.scss
+++ b/client/my-sites/plans-v2/more-info-box/style.scss
@@ -2,7 +2,7 @@
 @import '~@wordpress/base-styles/mixins';
 
 .more-info-box__more-container {
-	background-color: rgba( var( --studio-jetpack-green-10-rgb ), 0.1 );
+	background-color: var( --color-surface );
 
 	margin: 24px 0;
 	padding: 30px 15px 26px;
@@ -26,4 +26,11 @@
 .more-info-box__more-button {
 	font-size: 1rem;
 	font-weight: 600;
+}
+
+/* I5 specifics */
+.is-section-jetpack-cloud-pricing {
+	.more-info-box__more-container {
+		background-color: rgba( var( --studio-jetpack-green-10-rgb ), 0.1 );
+	}
 }

--- a/client/my-sites/plans-v2/more-info-box/style.scss
+++ b/client/my-sites/plans-v2/more-info-box/style.scss
@@ -20,12 +20,28 @@
 .more-info-box__more-headline {
 	padding-bottom: 15px;
 	font-size: 1.5rem;
-	font-weight: 400;
+	font-weight: 700;
 }
 
-.more-info-box__more-button {
+.more-info-box__more-button.button {
+	display: flex;
+	align-items: center;
+
+	margin: 0 auto;
+	padding: 10px 16px 10px 40px;
+
+	border: solid 2px currentColor;
+	border-radius: 4px;
+	color: var( --studio-jetpack-green-40 );
+
 	font-size: 1rem;
-	font-weight: 600;
+	font-weight: 700;
+}
+
+.more-info-box__icon.gridicon {
+	top: 2px;
+
+	margin-left: 8px;
 }
 
 /* I5 specifics */

--- a/client/my-sites/plans-v2/products-grid-i5/style.scss
+++ b/client/my-sites/plans-v2/products-grid-i5/style.scss
@@ -26,7 +26,7 @@
 	text-align: center;
 
 	@include break-small {
-		margin-top: 60px;
+		margin-top: 40px;
 		margin-bottom: 40px;
 
 		font-size: 2.25rem;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the style of pricing page i5 in Calypso.

Fixes 1196341175636977-as-1199156455145573

### Testing instructions

_Note: don't mind the copy and missing features_

- Download the PR or visit the Calypso live link
- Run Calypso and Jetpack cloud
- Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
- Select a self-hosted Jetpack site
- Visit the pricing page in Jetpack cloud check that it still looks like staging (note that the _Compare all product bundles_ has been updated in Cloud as well)
- Check the page in Calypso against the mockups (see link in task)

### Screenshots

<img width="1103" alt="Screen Shot 2020-11-13 at 11 06 43 AM" src="https://user-images.githubusercontent.com/1620183/99093423-6f770c00-25a0-11eb-81f6-25ea50cade03.png">
<img width="1160" alt="Screen Shot 2020-11-13 at 11 44 13 AM" src="https://user-images.githubusercontent.com/1620183/99097538-c206f700-25a5-11eb-95a0-ba1a288696f1.png">
