### PR TITLE
[Docker] - Add image for e2e tests

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -100,17 +100,17 @@ object BuildBaseImages : BuildType({
 				REGISTRY="registry.a8c.com/calypso"
 
 				function build {
-					imageName="$1"
-					buildArgs="$2"
+					imageName="${'$'}1"
+					buildArgs="${'$'}2"
 
-					imageVersioned="${REGISTRY}/${imageName}:${VERSION}"
-					imageLatest="${REGISTRY}/${imageName}:latest"
+					imageVersioned="${'$'}{REGISTRY}/${'$'}{imageName}:${'$'}{VERSION}"
+					imageLatest="${'$'}{REGISTRY}/${'$'}{imageName}:latest"
 
 					# Using eval because buildArgs is a single word and we need to expand it to multiple args
-					eval docker build -f Dockerfile.base "${buildArgs}" -t "${imageVersioned}" .
-					docker tag "${imageVersioned}" "${imageLatest}"
-					docker push "${imageVersioned}"
-					docker push "${imageLatest}"
+					eval docker build -f Dockerfile.base "${'$'}{buildArgs}" -t "${'$'}{imageVersioned}" .
+					docker tag "${'$'}{imageVersioned}" "${'$'}{imageLatest}"
+					docker push "${'$'}{imageVersioned}"
+					docker push "${'$'}{imageLatest}"
 				}
 
 				build "base" "--no-cache --target builder"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -93,30 +93,30 @@ object BuildBaseImages : BuildType({
 		script {
 			name = "Build docker images"
 			scriptContent = """
+				set -e
+				set -x
+
 				VERSION="%build.number%"
-				BUILDER_IMAGE_NAME="registry.a8c.com/calypso/base"
-				CI_IMAGE_NAME="registry.a8c.com/calypso/ci"
-				CI_DESKTOP_IMAGE_NAME="registry.a8c.com/calypso/ci-desktop"
-				BUILDER_IMAGE="${'$'}{BUILDER_IMAGE_NAME}:${'$'}{VERSION}"
-				CI_IMAGE="${'$'}{CI_IMAGE_NAME}:${'$'}{VERSION}"
-				CI_DESKTOP_IMAGE="${'$'}{CI_DESKTOP_IMAGE_NAME}:${'$'}{VERSION}"
+				REGISTRY="registry.a8c.com/calypso"
 
-				docker build -f Dockerfile.base --no-cache --target builder -t "${'$'}BUILDER_IMAGE" .
-				docker build -f Dockerfile.base --target ci -t "${'$'}CI_IMAGE" .
-				docker build -f Dockerfile.base --target ci-desktop -t "${'$'}CI_DESKTOP_IMAGE" .
+				function build {
+					imageName="$1"
+					buildArgs="$2"
 
-				docker tag "${'$'}BUILDER_IMAGE" "${'$'}{BUILDER_IMAGE_NAME}:latest"
-				docker tag "${'$'}CI_IMAGE" "${'$'}{CI_IMAGE_NAME}:latest"
-				docker tag "${'$'}CI_DESKTOP_IMAGE" "${'$'}{CI_DESKTOP_IMAGE_NAME}:latest"
+					imageVersioned="${REGISTRY}/${imageName}:${VERSION}"
+					imageLatest="${REGISTRY}/${imageName}:latest"
 
-				docker push "${'$'}CI_IMAGE"
-				docker push "${'$'}{CI_IMAGE_NAME}:latest"
+					# Using eval because buildArgs is a single word and we need to expand it to multiple args
+					eval docker build -f Dockerfile.base "${buildArgs}" -t "${imageVersioned}" .
+					docker tag "${imageVersioned}" "${imageLatest}"
+					docker push "${imageVersioned}"
+					docker push "${imageLatest}"
+				}
 
-				docker push "${'$'}CI_DESKTOP_IMAGE"
-				docker push "${'$'}{CI_DESKTOP_IMAGE_NAME}:latest"
-
-				docker push "${'$'}BUILDER_IMAGE"
-				docker push "${'$'}{BUILDER_IMAGE_NAME}:latest"
+				build "base" "--no-cache --target builder"
+				build "ci" "--target ci"
+				build "ci-desktop" "--target ci-desktop"
+				build "ci-e2e" "--target builder"
 			""".trimIndent()
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 			dockerRunParameters = "-u %env.UID%"

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -58,6 +58,7 @@ FROM ci as ci-desktop
 
 ENV ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
 ENV USE_HARD_LINKS=false
+# This chrome image is the latest version supported by wp-desktop's chromedriver, declared in desktop/package.json
 ENV CHROME_VERSION="80.0.3987.163-1"
 ENV DISPLAY=:99
 
@@ -86,6 +87,20 @@ RUN apt update \
 		xfonts-cyrillic \
 		xfonts-scalable \
 		xvfb
+
+RUN wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
+	&& apt-get install -y ./google-chrome-stable_${CHROME_VERSION}_amd64.deb \
+	&& rm ./google-chrome-stable_${CHROME_VERSION}_amd64.deb
+
+ENTRYPOINT [ "/bin/bash" ]
+
+#### ci-e2e image
+FROM ci-desktop as ci-e2e
+
+# This chrome image is the latest version that accepts SameSite=None
+# test/e2e/test/mocha.env.js will install a compatible chromedriver
+ENV CHROME_VERSION="84.0.4147.135-1"
+ENV DETECT_CHROMEDRIVER_VERSION=true
 
 RUN wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
 	&& apt-get install -y ./google-chrome-stable_${CHROME_VERSION}_amd64.deb \


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new Docker image to run e2e tests.

#### Testing instructions

First build the image locally with `docker build -f Dockerfile.base --target ci-e2e -t calypso/ci-e2e:latest .`. To make it faster, make these changes to `Dockerfile.base` (they are not related to this change, an without these changes it can take 30 minutes or more):

* Comment out the trailing `\` in line 27
* Comment out running `yarn` (line 29)
* Comment out running `yarn build-client-both` (line 31)
* Comment out copying from `/calypso/.cache` (line 55)

Once it is done, launch the image with `docker run --rm -ti --entrypoint /bin/bash calypso/ci-e2e:latest` and verify Chrome version is 84.0.4147.135-1 by running `google-chrome --version`
