### PR TITLE
Pricing page i5: update abtest config for production

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -193,14 +193,14 @@ export default {
 		localeTargets: [ 'en' ],
 	},
 	jetpackConversionRateOptimization: {
-		datestamp: '20201102',
+		datestamp: '20201115',
 		variations: {
 			'v0 - Offer Reset': 0, // Offer Reset
 			'v1 - 3 cols layout': 0, // first Offer Reset iteration (3 layout columns + simpler cards)
-			'v2 - slide outs': 100, // second Offer Reset iteration (reorder & slide outs)
-			'i5 - Saas table design': 0, // third Offer Reset iteration (Saas table design)
+			'v2 - slide outs': 0, // second Offer Reset iteration (reorder & slide outs)
+			'i5 - Saas table design': 100, // third Offer Reset iteration (Saas table design)
 		},
-		defaultVariation: 'v2 - slide outs',
+		defaultVariation: 'i5 - Saas table design',
 		allowExistingUsers: true,
 	},
 	secureYourBrand: {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the `jetpackConversionRateOptimization` config to display i5 in production.

Fixes 1196341175636977-as-1199178309577119

### Testing instructions

- Before deployment: code review
- After deployment: test page in production