### PR TITLE
UI changes to Jetpack Scan for Codeable partnership

### DIFF
--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -161,8 +161,8 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 			<h1 className="scan-threats scan__header">{ translate( 'Your site may be at risk' ) }</h1>
 			<p>
 				{ translate(
-					'The scan found {{strong}}%(threatCount)s{{/strong}} potential threat with {{strong}}%(siteName)s{{/strong}}.',
-					'The scan found {{strong}}%(threatCount)s{{/strong}} potential threats with {{strong}}%(siteName)s{{/strong}}.',
+					'Jetpack Scan found {{strong}}%(threatCount)s{{/strong}} potential threat on {{strong}}%(siteName)s{{/strong}}.',
+					'Jetpack Scan found {{strong}}%(threatCount)s{{/strong}} potential threats on {{strong}}%(siteName)s{{/strong}}.',
 					{
 						args: {
 							siteName: site.name,
@@ -174,9 +174,8 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 						count: threats.length,
 					}
 				) }
-				<br />
 				{ translate(
-					'Please review them below and take action. If you have any questions, we are {{a}}here to help{{/a}}.',
+					'Please review and take action. If you have any questions, we are {{a}}here to help{{/a}}.',
 					{
 						components: {
 							a: (

--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -161,8 +161,8 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 			<h1 className="scan-threats scan__header">{ translate( 'Your site may be at risk' ) }</h1>
 			<p>
 				{ translate(
-					'Jetpack Scan found {{strong}}%(threatCount)s{{/strong}} potential threat on {{strong}}%(siteName)s{{/strong}}. Please review the threat and take action. If you have any questions, we are {{a}}here to help{{/a}}.',
-					'Jetpack Scan found {{strong}}%(threatCount)s{{/strong}} potential threats on {{strong}}%(siteName)s{{/strong}}. Please review each threat and take action. If you have any questions, we are {{a}}here to help{{/a}}.',
+					'Jetpack Scan found {{strong}}%(threatCount)s{{/strong}} potential threat on {{strong}}%(siteName)s{{/strong}}. Please review the threat and take action.',
+					'Jetpack Scan found {{strong}}%(threatCount)s{{/strong}} potential threats on {{strong}}%(siteName)s{{/strong}}. Please review each threat and take action.',
 					{
 						args: {
 							siteName: site.name,
@@ -170,13 +170,6 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 						},
 						components: {
 							strong: <strong />,
-							a: (
-								<a
-									href={ contactSupportUrl( site.URL ) }
-									rel="noopener noreferrer"
-									target="_blank"
-								/>
-							),
 						},
 						comment:
 							'%(threatCount)s represents the number of threats currently identified on the site, and $(siteName)s is the name of the site. The {{a}} tag is a link that goes to a contact support page.',

--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -187,14 +187,42 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 			<div className="scan-threats__threats">
 				<div className="scan-threats__buttons">
 					{ hasFixableThreats && (
-						<Button
-							primary
-							className="scan-threats__fix-all-threats-button"
-							onClick={ openFixAllThreatsDialog }
-							disabled={ ! hasFixableThreats || updatingThreats.length > 0 }
-						>
-							{ translate( 'Fix all' ) }
-						</Button>
+						<>
+							<p>
+								{ translate(
+									'Jetpack can auto fix 1 found threat.',
+									'Jetpack can auto fix %(fixableCount)s of %(threatCount)s found threats.',
+									{
+										args: {
+											fixableCount: numberFormat( allFixableThreats.length, 0 ),
+											threatCount: numberFormat( threats.length, 0 ),
+										},
+										comment:
+											'%(fixableCount)s represents the number of auto fixable threats, %(threatCount)s represents the number of threats currently identified on the site',
+										count: allFixableThreats.length,
+									}
+								) }
+							</p>
+							<Button
+								primary
+								className="scan-threats__fix-all-threats-button"
+								onClick={ openFixAllThreatsDialog }
+								disabled={ ! hasFixableThreats || updatingThreats.length > 0 }
+							>
+								{ translate(
+									'Auto fix %(fixableCount)s threat',
+									'Auto fix %(fixableCount)s threats',
+									{
+										args: {
+											fixableCount: numberFormat( allFixableThreats.length, 0 ),
+										},
+										comment:
+											'%(fixableCount)s represents the number of auto fixable threats on the site',
+										count: allFixableThreats.length,
+									}
+								) }
+							</Button>
+						</>
 					) }
 				</div>
 				{ threats.map( ( threat ) => (

--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -240,16 +240,21 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 
 			{ ! error && (
 				<div className="scan-threats__rerun">
-					{ translate(
-						'If you have manually fixed any of the threats listed above, you can {{button}}run a manual scan now{{/button}} or wait for Jetpack to scan your site later today.',
-						{
-							components: {
-								button: (
-									<Button className="scan-threats__run-scan-button" onClick={ dispatchScanRun } />
-								),
-							},
-						}
-					) }
+					<p className="scan-threats__rerun-help">
+						{ translate(
+							'If you have manually fixed any of the threats above, you can {{button}}run a scan now{{/button}} or wait for Jetpack to scan your site later today.',
+							{
+								components: {
+									button: (
+										<Button className="scan-threats__run-scan-button" onClick={ dispatchScanRun } />
+									),
+								},
+							}
+						) }
+					</p>
+					<Button className="scan-threats__run-scan-main-button" onClick={ dispatchScanRun }>
+						{ translate( 'Scan again' ) }
+					</Button>
 				</div>
 			) }
 

--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -161,23 +161,15 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 			<h1 className="scan-threats scan__header">{ translate( 'Your site may be at risk' ) }</h1>
 			<p>
 				{ translate(
-					'Jetpack Scan found {{strong}}%(threatCount)s{{/strong}} potential threat on {{strong}}%(siteName)s{{/strong}}.',
-					'Jetpack Scan found {{strong}}%(threatCount)s{{/strong}} potential threats on {{strong}}%(siteName)s{{/strong}}.',
+					'Jetpack Scan found {{strong}}%(threatCount)s{{/strong}} potential threat on {{strong}}%(siteName)s{{/strong}}. Please review the threat and take action. If you have any questions, we are {{a}}here to help{{/a}}.',
+					'Jetpack Scan found {{strong}}%(threatCount)s{{/strong}} potential threats on {{strong}}%(siteName)s{{/strong}}. Please review each threat and take action. If you have any questions, we are {{a}}here to help{{/a}}.',
 					{
 						args: {
 							siteName: site.name,
 							threatCount: numberFormat( threats.length, 0 ),
 						},
-						components: { strong: <strong /> },
-						comment:
-							'%(threatCount)s represents the number of threats currently identified on the site, and $(siteName)s is the name of the site.',
-						count: threats.length,
-					}
-				) }
-				{ translate(
-					'Please review and take action. If you have any questions, we are {{a}}here to help{{/a}}.',
-					{
 						components: {
+							strong: <strong />,
 							a: (
 								<a
 									href={ contactSupportUrl( site.URL ) }
@@ -186,7 +178,9 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 								/>
 							),
 						},
-						comment: 'The {{a}} tag is a link that goes to a contact support page.',
+						comment:
+							'%(threatCount)s represents the number of threats currently identified on the site, and $(siteName)s is the name of the site. The {{a}} tag is a link that goes to a contact support page.',
+						count: threats.length,
 					}
 				) }
 			</p>

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -3,12 +3,42 @@
 		margin: 16px 0;
 	}
 
-	&__error, &__rerun {
+	&__error {
 		text-align: center;
 		font-size: $font-body-small;
 		line-height: 20px;
 		color: var( --studio-gray-40 );
 		margin-top: 24px;
+	}
+
+	&__rerun {
+		margin-top: 32px;
+		display: flex;
+		flex-direction: column;
+
+		@include breakpoint-deprecated( '>800px' ) {
+			flex-direction: row;
+		}
+
+		.scan-threats__rerun-help {
+			font-size: $font-body-small;
+			line-height: 20px;
+			color: var( --studio-gray-40 );
+
+			@include breakpoint-deprecated( '>800px' ) {
+				margin-bottom: 0;
+			}
+		}
+
+		.scan-threats__run-scan-main-button {
+			flex: 1 1 40%;
+			padding: 10px 30px;
+
+			@include breakpoint-deprecated( '>800px' ) {
+				flex: 0 0 170px;
+				margin-left: 8px;
+			}
+		}
 	}
 
 	&__run-scan-button.scan-threats__run-scan-button {

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -40,16 +40,29 @@
 
 	&__buttons {
 		display: flex;
-		justify-content: space-between;
 		margin-bottom: 16px;
+		border-top: 1px solid var( --studio-gray-5 );
+		padding-top: 16px;
+		flex-direction: column;
 
 		@include breakpoint-deprecated( '>800px' ) {
-			justify-content: flex-end;
+			flex-direction: row;
+		}
+
+		> p {
+			padding-top: 8px;
+			font-weight: bold;
+
+			@include breakpoint-deprecated( '>800px' ) {
+				flex-grow: 1;
+				padding-top: 10px;
+				margin: 0 !important;
+			}
 		}
 	}
 
 	&__fix-all-threats-button {
-		flex: 1 1 75%;
+		flex: 1 1 40%;
 		padding: 10px 30px;
 
 		@include breakpoint-deprecated( '>800px' ) {

--- a/client/components/jetpack/threat-description/index.tsx
+++ b/client/components/jetpack/threat-description/index.tsx
@@ -58,16 +58,6 @@ class ThreatDescription extends React.PureComponent< Props > {
 					<strong>{ translate( 'What was the problem?' ) }</strong>
 				</p>
 				{ this.renderTextOrNode( problem ) }
-				{ fix && (
-					<p className="threat-description__section-title">
-						<strong>
-							{ status === 'fixed'
-								? translate( 'How did Jetpack fix it?' )
-								: translate( 'How we will fix it?' ) }
-						</strong>
-					</p>
-				) }
-				{ fix && this.renderTextOrNode( fix ) }
 				{ ( filename || context || diff ) && (
 					<p className="threat-description__section-title">
 						<strong>{ translate( 'The technical details' ) }</strong>
@@ -76,6 +66,16 @@ class ThreatDescription extends React.PureComponent< Props > {
 				{ this.renderFilename() }
 				{ context && <MarkedLines context={ context } /> }
 				{ diff && <DiffViewer diff={ diff } /> }
+				{ fix && (
+					<p className="threat-description__section-title threat-description__section-title-fix">
+						<strong>
+							{ status === 'fixed'
+								? translate( 'How did Jetpack fix it?' )
+								: translate( 'How we will fix it?' ) }
+						</strong>
+					</p>
+				) }
+				{ fix && this.renderTextOrNode( fix ) }
 				{ children }
 			</div>
 		);

--- a/client/components/jetpack/threat-description/index.tsx
+++ b/client/components/jetpack/threat-description/index.tsx
@@ -24,11 +24,34 @@ export interface Props {
 	context?: object;
 	diff?: string;
 	filename?: string;
+	isFixable: bool;
 }
 
 class ThreatDescription extends React.PureComponent< Props > {
 	renderTextOrNode( content: string | TranslateResult | ReactNode ) {
-		return <p className="threat-description__section-text">{ content }</p>;
+		return <>{ content }</>;
+	}
+
+	renderFixTitle() {
+		const { status, isFixable } = this.props;
+
+		switch ( status ) {
+			case 'fixed':
+				return translate( 'How did Jetpack fix it?' );
+				break;
+
+			case 'current':
+				if ( isFixable ) {
+					return translate( 'How will we fix it?' );
+				} else {
+					return translate( 'Resolving the threat' );
+				}
+				break;
+
+			default:
+				return translate( 'How we will fix it?' );
+				break;
+		}
 	}
 
 	renderFilename(): ReactNode | null {
@@ -57,7 +80,7 @@ class ThreatDescription extends React.PureComponent< Props > {
 				<p className="threat-description__section-title">
 					<strong>{ translate( 'What was the problem?' ) }</strong>
 				</p>
-				{ this.renderTextOrNode( problem ) }
+				{ this.renderTextOrNode( <p className="threat-description__section-text">{ problem }</p> ) }
 				{ ( filename || context || diff ) && (
 					<p className="threat-description__section-title">
 						<strong>{ translate( 'The technical details' ) }</strong>
@@ -68,11 +91,7 @@ class ThreatDescription extends React.PureComponent< Props > {
 				{ diff && <DiffViewer diff={ diff } /> }
 				{ fix && (
 					<p className="threat-description__section-title threat-description__section-title-fix">
-						<strong>
-							{ status === 'fixed'
-								? translate( 'How did Jetpack fix it?' )
-								: translate( 'How we will fix it?' ) }
-						</strong>
+						<strong>{ this.renderFixTitle() }</strong>
 					</p>
 				) }
 				{ fix && this.renderTextOrNode( fix ) }

--- a/client/components/jetpack/threat-description/style.scss
+++ b/client/components/jetpack/threat-description/style.scss
@@ -10,6 +10,10 @@
 		line-height: 1.3; /* 24/18 */
 	}
 
+	&__section-title-fix {
+		margin-top: 20px;
+	}
+
 	&__section-text {
 		margin-bottom: 16px;
 

--- a/client/components/jetpack/threat-description/style.scss
+++ b/client/components/jetpack/threat-description/style.scss
@@ -19,7 +19,6 @@
 
 		color: var( --color-text-subtle );
 		font-size: $font-body-small;
-		line-height: 1.3; /* 21/16 */
 
 		@include breakpoint-deprecated( '>660px' ) {
 			margin-bottom: 24px;

--- a/client/components/jetpack/threat-item-subheader/index.tsx
+++ b/client/components/jetpack/threat-item-subheader/index.tsx
@@ -23,6 +23,7 @@ import './style.scss';
 
 interface Props {
 	threat: Threat;
+	isFixable: bool;
 }
 
 const entryActionClassNames = ( threat: Threat ) => {
@@ -66,11 +67,21 @@ const getThreatStatusMessage = ( translate, threat: Threat ) => {
 	return null;
 };
 
+const getAutoFixBadge = ( translate, threat: Threat, isFixable ) => {
+	if ( isFixable && threat.status !== 'fixed' ) {
+		return (
+			<Badge className={ classnames( 'threat-item-subheader__badge', 'is-auto-fix' ) }>
+				<small>{ translate( 'Auto fix' ) }</small>
+			</Badge>
+		);
+	}
+	return null;
+};
+
 // This renders two different kind of sub-headers. One is for current threats (displayed
 // in the Scanner section), and the other for threats in the History section.
-const ThreatItemSubheader: React.FC< Props > = ( { threat } ) => {
+const ThreatItemSubheader: React.FC< Props > = ( { threat, isFixable } ) => {
 	const translate = useTranslate();
-
 	if ( threat.status === 'current' ) {
 		switch ( getThreatType( threat ) ) {
 			case 'file':
@@ -85,10 +96,16 @@ const ThreatItemSubheader: React.FC< Props > = ( { threat } ) => {
 								),
 							},
 						} ) }
+						{ getAutoFixBadge( translate, threat, isFixable ) }
 					</>
 				);
 			default:
-				return <> { getThreatVulnerability( threat ) }</>;
+				return (
+					<>
+						{ getThreatVulnerability( threat ) }
+						{ getAutoFixBadge( translate, threat, isFixable ) }
+					</>
+				);
 		}
 	} else {
 		const threatStatusMessage = getThreatStatusMessage( translate, threat );

--- a/client/components/jetpack/threat-item-subheader/style.scss
+++ b/client/components/jetpack/threat-item-subheader/style.scss
@@ -54,10 +54,12 @@
 		}
 
 		&.is-auto-fix {
-			margin-top: 6px;
-			margin-left: 8px;
+			margin-top: 0px;
+			margin-left: 4px;
 			color: var( --studio-jetpack-green-40 );
 			background-color: var( --studio-jetpack-green-0 );
+			position: relative;
+			top: -1px;
 		}
 	}
 

--- a/client/components/jetpack/threat-item-subheader/style.scss
+++ b/client/components/jetpack/threat-item-subheader/style.scss
@@ -42,6 +42,7 @@
 		text-align: center;
 		text-transform: uppercase;
 		border-radius: var( --jetpack-corners-soft );
+		font-weight: 600;
 		color: #fff;
 
 		&.is-fixed {
@@ -50,6 +51,13 @@
 
 		&.is-ignored {
 			background-color: var( --studio-gray-50 );
+		}
+
+		&.is-auto-fix {
+			margin-top: 6px;
+			margin-left: 8px;
+			color: var( --studio-jetpack-green-40 );
+			background-color: var( --studio-jetpack-green-0 );
 		}
 	}
 

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -142,7 +142,7 @@ const ThreatItem: React.FC< Props > = ( {
 				'is-current': threat.status === 'current',
 			} ) }
 			header={ <ThreatItemHeader threat={ threat } isStyled={ true } /> }
-			subheader={ <ThreatItemSubheader threat={ threat } /> }
+			subheader={ <ThreatItemSubheader threat={ threat } isFixable={ isFixable } /> }
 			{ ...( threat.status === 'current' ? { highlight: 'error' } : {} ) }
 			clickableHeader={ true }
 			onClick={ onOpenTrackEvent }

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -85,17 +85,31 @@ const ThreatItem: React.FC< Props > = ( {
 		}
 
 		if ( ! threat.fixable ) {
-			return translate(
-				'Jetpack Scan cannot automatically fix this threat. You can fix it manually and re-run scan afterwards, or {{link}}contact us{{/link}} for help.',
-				{
-					components: {
-						link: <a href={ contactSupportUrl } rel="noopener noreferrer" target="_blank" />,
-					},
-				}
+			return (
+				<>
+					<p className="threat-description__section-text">
+						{ translate(
+							'Jetpack Scan cannot automatically fix this threat. Consider resolving the threat manually. Check WordPress, your theme, and plugins are up to date. ' +
+								'You may also consider removing the offending code, plugin or theme from your site.'
+						) }
+					</p>
+					<p className="threat-description__section-text">
+						{ translate(
+							'For further help, we recommend our partners {{strong}}Codeable{{/strong}}. Their pricing ranges from $70-120/hour, with no obligation to hire. ' +
+								'Codeable is a WordPress-exclusive freelancer marketplace with a community of 530+ highly vetted security experts. ' +
+								'Get a free, no obligation estimate for resolving this threat.',
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+				</>
 			);
 		}
 
-		return getThreatFix( threat.fixable );
+		return <p className="threat-description__section-text">{ getThreatFix( threat.fixable ) }</p>;
 	}, [ contactSupportUrl, threat ] );
 
 	const isFixable = React.useMemo(
@@ -140,6 +154,7 @@ const ThreatItem: React.FC< Props > = ( {
 				context={ threat.context }
 				diff={ threat.diff }
 				filename={ threat.filename }
+				isFixable={ isFixable }
 			/>
 
 			<div className="threat-item__buttons">

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -7,6 +7,7 @@ import { translate } from 'i18n-calypso';
 import classnames from 'classnames';
 import { Button } from '@automattic/components';
 import { noop } from 'lodash';
+import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 
 /**
  * Internal dependencies
@@ -169,15 +170,16 @@ const ThreatItem: React.FC< Props > = ( {
 					</Button>
 				) }
 				{ ! isFixable && (
-					<Button
-						primary
-						className="threat-item__codeable-button"
+					<ExternalLinkWithTracking
+						className="button is-primary threat-item__codeable-button"
 						href="https://codeable.io/partners/jetpack-scan/"
 						target="_blank"
 						rel="noopener noreferrer"
+						tracksEventName="calypso_jetpack_scan_threat_codeable_estimate"
+						onClick={ () => {} }
 					>
 						{ translate( 'Get a free estimate' ) }
-					</Button>
+					</ExternalLinkWithTracking>
 				) }
 				{ isFixable && renderFixThreatButton( 'is-details' ) }
 			</div>

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -67,7 +67,7 @@ const ThreatItem: React.FC< Props > = ( {
 			};
 			return (
 				<Button
-					compact
+					primary
 					className={ classnames( 'threat-item__fix-button', className ) }
 					onClick={ onClickHandler }
 					disabled={ isFixing }
@@ -158,11 +158,9 @@ const ThreatItem: React.FC< Props > = ( {
 			/>
 
 			<div className="threat-item__buttons">
-				{ isFixable && renderFixThreatButton( 'is-details' ) }
 				{ threat.status === 'current' && (
 					<Button
 						scary
-						compact
 						className="threat-item__ignore-button"
 						onClick={ onIgnoreThreat }
 						disabled={ isFixing }
@@ -170,6 +168,18 @@ const ThreatItem: React.FC< Props > = ( {
 						{ translate( 'Ignore threat' ) }
 					</Button>
 				) }
+				{ ! isFixable && (
+					<Button
+						primary
+						className="threat-item__codeable-button"
+						href="https://codeable.io/partners/jetpack-scan/"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ translate( 'Get a free estimate' ) }
+					</Button>
+				) }
+				{ isFixable && renderFixThreatButton( 'is-details' ) }
 			</div>
 		</LogItem>
 	);

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -90,15 +90,15 @@ const ThreatItem: React.FC< Props > = ( {
 				<>
 					<p className="threat-description__section-text">
 						{ translate(
-							'Jetpack Scan cannot automatically fix this threat. Consider resolving the threat manually. Check WordPress, your theme, and plugins are up to date. ' +
-								'You may also consider removing the offending code, plugin or theme from your site.'
+							'Jetpack Scan cannot automatically fix this threat. We suggest that you resolve the threat manually: ' +
+								'ensure that WordPress, your theme, and all of your plugins are up to date, and remove ' +
+								'the offending code, theme, or plugin from your site.'
 						) }
 					</p>
 					<p className="threat-description__section-text">
 						{ translate(
-							'For further help, we recommend our partners {{strong}}Codeable{{/strong}}. Their pricing ranges from $70-120/hour, with no obligation to hire. ' +
-								'Codeable is a WordPress-exclusive freelancer marketplace with a community of 530+ highly vetted security experts. ' +
-								'Get a free, no obligation estimate for resolving this threat.',
+							'If you need more help on resolving this threat, we recommend {{strong}}Codeable{{/strong}}, a WordPress freelancer marketplace of 530+ highly vetted security experts. ' +
+								'Pricing ranges from $70-120/hour, and you can get a free estimate with no obligation to hire.',
 							{
 								components: {
 									strong: <strong />,

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -129,12 +129,6 @@ const ThreatItem: React.FC< Props > = ( {
 			} ) }
 			header={ <ThreatItemHeader threat={ threat } isStyled={ true } /> }
 			subheader={ <ThreatItemSubheader threat={ threat } /> }
-			{ ...( isFixable
-				? {
-						summary: renderFixThreatButton( 'is-summary' ),
-						expandedSummary: renderFixThreatButton( 'is-summary' ),
-				  }
-				: {} ) }
 			{ ...( threat.status === 'current' ? { highlight: 'error' } : {} ) }
 			clickableHeader={ true }
 			onClick={ onOpenTrackEvent }

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -43,14 +43,11 @@
 	&__buttons {
 		display: flex;
 		justify-content: flex-end;
+
 	}
 
 	.foldable-card__action.foldable-card__expand {
 		border: none;
-	}
-
-	.foldable-card__header {
-		border-bottom: 1px solid var( --studio-gray-5 );
 	}
 }
 

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -18,7 +18,7 @@
 			font-size: $font-title-small;
 		}
 	}
-	
+
 	.threat-item-header__alert-filename {
 		word-break: break-all;
 	}
@@ -42,30 +42,7 @@
 
 	&__buttons {
 		display: flex;
-		justify-content: space-evenly;
-
-		> button {
-			margin-top: 20px;
-		}
-	}
-
-	&__fix-button.is-summary {
-		display: none;
-
-		@include breakpoint-deprecated( '>800px' ) {
-			display: inline-block;
-			margin-left: 20px;
-		}
-	}
-
-	&__fix-button.is-details {
-		display: inline-block;
-		width: 100%;
-		margin-left: 0;
-
-		@include breakpoint-deprecated( '>800px' ) {
-			display: none;
-		}
+		justify-content: flex-end;
 	}
 
 	.foldable-card__action.foldable-card__expand {
@@ -77,11 +54,10 @@
 	}
 }
 
-.button.is-compact {
+.button {
 	&.threat-item__fix-button,
+	&.threat-item__codeable-button,
 	&.threat-item__ignore-button {
-		width: 170px;
-		padding: 10px 30px;
 		margin-inline-start: 5px;
 		margin-inline-end: 5px;
 		border-width: 1px;

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -185,7 +185,7 @@ class ScanPage extends Component< Props > {
 				) }
 				<p>
 					{ translate(
-						'We will send you an email if security threats are found, in the meantime feel ' +
+						'We will send you an email if security threats are found. In the meantime feel ' +
 							'free to continue to use your site as normal, you can check back on ' +
 							'progress at any time.'
 					) }

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -185,7 +185,7 @@ class ScanPage extends Component< Props > {
 				) }
 				<p>
 					{ translate(
-						'We will send you an email once the scan completes, in the meantime feel ' +
+						'We will send you an email if security threats are found, in the meantime feel ' +
 							'free to continue to use your site as normal, you can check back on ' +
 							'progress at any time.'
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Forked from previous PR https://github.com/Automattic/wp-calypso/pull/47274, looking to merge that one first. 

This PR introduces some UI refinements to the Jetpack Scan product to support a new partnership with Codeable. Some context can be found here:

p1HpG7-aAg-p2
p1HpG7-ayK-p2

**For copy review:**

We have two new paragraphs for security threats that cannot be fixed automatically, they are:

> Jetpack Scan cannot automatically fix this threat. Consider resolving the threat manually. Check WordPress, your theme, and plugins are up to date. You may also consider removing the offending code, plugin or theme from your site.

> For further help, we recommend our partners Codeable. Their pricing ranges from $70-120/hour, with no obligation to hire. Codeable is a WordPress-exclusive freelancer marketplace with a community of 530+ highly vetted security experts. Get a free, no obligation estimate for resolving this threat.

Some of this was supplied to us, but would love your thoughts on how we might better structure the sentences. 

**For code review:**

Please check that the external link is being properly tracked and logged. I would also like a sanity check on some of the other changes, like being able to support two paragraphs in the threat description.

**For design review:**

I have tweaked the paragraph spacing and made some other layout changes around the new buttons and copy. Please check they look as expected. Please also check in Calypso blue: https://calypso.live/?branch=new/jetpack-scan-codeable

Before:

![cloud jetpack com_backup_meaningful-ape jurassic ninja_site=scottsweb wordpress com](https://user-images.githubusercontent.com/411945/99249807-f62f2180-280a-11eb-93a3-ac0f10317b00.png)

After:

![jetpack cloud localhost_3000_scan_meaningful-ape jurassic ninja](https://user-images.githubusercontent.com/411945/99249719-d26bdb80-280a-11eb-82fe-501f4397d4c0.png)

![hash-b92983cef842ab85a509eb40adede489203c5ee1 calypso live_scan_meaningful-ape jurassic ninja](https://user-images.githubusercontent.com/411945/99250276-af8df700-280b-11eb-96d2-9b0d430f1842.png)

#### Testing instructions

* Grab this PR
* Run `npm start start-jetpack-cloud`
* Visit `http://jetpack.cloud.localhost:3000/`
* Make sure you have a Jetpack site with some security threats
* Check the new page as per above, also check the history of threats to make sure there are no breaking changes