### PR TITLE
Login: Remove last usage of lodash's startCase()

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { startCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -80,8 +79,10 @@ export class Login extends React.Component {
 		let title = 'Login';
 
 		if ( twoFactorAuthType ) {
+			const authTypeTitle =
+				twoFactorAuthType.charAt( 0 ).toUpperCase() + twoFactorAuthType.slice( 1 );
 			url += `/${ twoFactorAuthType }`;
-			title += ` > Two-Step Authentication > ${ startCase( twoFactorAuthType ) }`;
+			title += ` > Two-Step Authentication > ${ authTypeTitle }`;
 		}
 
 		if ( socialConnect ) {


### PR DESCRIPTION
We have a single usage of lodash's `startCase` in login. This PR removes it.

This PR should not offer any visual or functional changes. 

#### Changes proposed in this Pull Request

* Login: Remove last `startCase` usage

#### Testing instructions

* Open Calypso as a logged out user.
* Type `localStorage.setItem('debug', 'calypso:analytics:ga');` in your browser console.
* Go to `/log-in/sms` with the browser console open.
* You'll be redirected to `/log-in` because this isn't following a proper 2FA login flow - that's expected.
* Verify you can see the right title in the console:

```
calypso:analytics:ga [Disallowed] analytics recordPageView( (2) ["/log-in/sms", "Login > Two-Step Authentication > Sms"] )
```

* Verify it is `Sms` and not `SMS` or `sms`.
