### PR TITLE
Gutenboarding: show Launch modal in editor just on free sites

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -21,6 +21,7 @@ import {
 	isJetpackSite,
 	getSite,
 } from 'calypso/state/sites/selectors';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { addQueryArgs } from 'calypso/lib/route';
 import { getEnabledFilters, getDisabledDataSources, mediaCalypsoToGutenberg } from './media-utils';
 import { replaceHistory, navigate } from 'calypso/state/ui/actions';
@@ -371,7 +372,7 @@ class CalypsoifyIframe extends Component<
 		}
 
 		if ( EditorActions.GetGutenboardingStatus === action ) {
-			const isGutenboarding = this.props.siteCreationFlow === 'gutenboarding';
+			const isGutenboarding = this.props.siteCreationFlow === 'gutenboarding' && ! this.props.plan;
 			const isSiteUnlaunched = this.props.isSiteUnlaunched;
 			const launchUrl = `${ window.location.origin }/start/launch-site?siteSlug=${ this.props.siteSlug }`;
 			const isNewLaunchMobile = config.isEnabled( 'gutenboarding/new-launch-mobile' );
@@ -786,6 +787,7 @@ const mapStateToProps = (
 	const currentRoute = getCurrentRoute( state );
 	const postTypeTrashUrl = getPostTypeTrashUrl( state, postType );
 	const siteOption = isJetpackSite( state, siteId ) ? 'jetpack_frame_nonce' : 'frame_nonce';
+	const plan = getCurrentPlan( state, siteId );
 
 	let queryArgs = pickBy( {
 		post: postId,
@@ -861,6 +863,7 @@ const mapStateToProps = (
 		isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 		site: getSite( state, siteId ),
 		parentPostId,
+		plan,
 	};
 };
 


### PR DESCRIPTION
Fix p1605290793102800-slack-CRNF6A9DX by sending users with a paid plan to Calypso launch flow.

**Testing instructions**
1. Go to [/new](https://calypso.live/new?branch=fix/gutenboarding-launch-from-editor-on-paid-plan) 
2. Create a site with a paid plan and complete purchase
3. When clicking _Launch_ button from the top bar in editor, you should be redirected to `/start/launch-site` which is the default Launch flow in Calypso.