### PR TITLE
Upsell Nudge: Fix vertical alignment of button on compact variant

### DIFF
--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -23,13 +23,13 @@
 		fill: var( --color-text-inverted );
 		margin-right: -6px;
 	}
-	.banner__content {
-		color: var( --color-text-inverted );
-		padding: 0 0 0 8px;
-	}
 	.banner__action {
 		position: relative;
 		top: 1px;
+	}
+	.banner__content {
+		color: var( --color-text-inverted );
+		padding: 0 0 0 8px;
 	}
 	.banner__description {
 		color: var( --color-neutral-5 );
@@ -62,6 +62,7 @@
 .upsell-nudge.is-dismissible.is-compact .banner__action {
 	margin-top: 0;
 	margin-right: 28px;
+	top: 2px;
 }
 .upsell-nudge.banner.card.is-compact.is-card-link {
 	padding-right: 12px;

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -27,6 +27,10 @@
 		color: var( --color-text-inverted );
 		padding: 0 0 0 8px;
 	}
+	.banner__action {
+		position: relative;
+		top: 1px;
+	}
 	.banner__description {
 		color: var( --color-neutral-5 );
 	}
@@ -55,7 +59,8 @@
 	}
 }
 
-.upsell-nudge.is-dismissible.is-horizontal.is-compact .banner__action {
+.upsell-nudge.is-dismissible.is-compact .banner__action {
+	margin-top: 0;
 	margin-right: 28px;
 }
 .upsell-nudge.banner.card.is-compact.is-card-link {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The vertical alignment was a teensy bit off, so I'm nudging the button down 1px.
* There was also a visual regression with compact dismissible upsell nudges, so I've updated the CSS to fix that.

See #47161

Before | After
---- | -------
| <img width="311" alt="Screen Shot 2020-11-13 at 3 17 50 PM" src="https://user-images.githubusercontent.com/2124984/99117391-9e52a980-25c3-11eb-9fc3-aca510575c32.png"> | <img width="314" alt="Screen Shot 2020-11-13 at 2 40 55 PM" src="https://user-images.githubusercontent.com/2124984/99117399-a1e63080-25c3-11eb-9965-41aa64c2ba45.png"> |
| Dismissable variant |  After |
| <img width="343" alt="Screen Shot 2020-11-13 at 3 23 20 PM" src="https://user-images.githubusercontent.com/2124984/99117699-2c2e9480-25c4-11eb-9c71-da6746c735d0.png"> | <img width="332" alt="Screen Shot 2020-11-13 at 3 26 08 PM" src="https://user-images.githubusercontent.com/2124984/99117914-91828580-25c4-11eb-9366-b7d1c4c05b05.png"> |


#### Testing instructions

* Switch to this PR
* Navigate to a site with an upsell nudge in the sidebar, like the plan upgrade or the free domain claim
* Note the position of the content relative to the button; they should be vertically centered.
* Double-check on multiple plan types/site types to ensure I haven't introduced visual regressions.