### PR TITLE
tsc commands in packages dir use --build mode (incremental builds)

### DIFF
--- a/packages/browser-data-collector/package.json
+++ b/packages/browser-data-collector/package.json
@@ -19,8 +19,8 @@
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
 		"prepublish": "yarn run clean",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
-		"watch": "tsc --project ./tsconfig.json --watch"
+		"prepare": "tsc --build ./tsconfig.json && tsc --build ./tsconfig-cjs.json",
+		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
 		"wpcom-proxy-request": "^6.0.0"

--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -27,8 +27,8 @@
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
 		"prepublish": "yarn run clean",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
-		"watch": "tsc --project ./tsconfig.json --watch"
+		"prepare": "tsc --build ./tsconfig.json && tsc --build ./tsconfig-cjs.json",
+		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
 		"@automattic/load-script": "^1.0.0",

--- a/packages/calypso-stripe/package.json
+++ b/packages/calypso-stripe/package.json
@@ -8,10 +8,10 @@
 	"sideEffects": false,
 	"scripts": {
 		"clean": "npx rimraf dist && tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
-		"build:esm": "tsc --project ./tsconfig.json",
-		"build:cjs": "tsc --project ./tsconfig-cjs.json",
+		"build:esm": "tsc --build ./tsconfig.json",
+		"build:cjs": "tsc --build ./tsconfig-cjs.json",
 		"prepare": "yarn run build:esm",
-		"watch": "tsc --project ./tsconfig.json --watch"
+		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"files": [
 		"dist",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,6 +48,6 @@
 	"scripts": {
 		"clean": "npx rimraf dist && tsc --build --clean",
 		"prepublish": "yarn run clean",
-		"prepare": "transpile && tsc && copy-assets"
+		"prepare": "transpile && tsc --build && copy-assets"
 	}
 }

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -8,9 +8,9 @@
 	"sideEffects": false,
 	"scripts": {
 		"clean": "npx rimraf dist \"../../.tsc-cache/packages__composite-checkout*\"",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
+		"prepare": "tsc --build ./tsconfig.json && tsc --build ./tsconfig-cjs.json",
 		"prepublish": "yarn run clean",
-		"watch": "tsc --project ./tsconfig.json --watch"
+		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"files": [
 		"dist",

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -27,9 +27,9 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
+		"prepare": "tsc --build ./tsconfig.json && tsc --build ./tsconfig-cjs.json",
 		"prepublish": "yarn run clean",
-		"watch": "tsc --project ./tsconfig.json --watch"
+		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "^3.18.0",

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -25,9 +25,9 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json && copy-assets",
+		"prepare": "tsc --build ./tsconfig.json && tsc --build ./tsconfig-cjs.json && copy-assets",
 		"prepublish": "yarn run clean",
-		"watch": "tsc --project ./tsconfig.json --watch"
+		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -16,8 +16,8 @@
 	"scripts": {
 		"clean": "npx rimraf dist",
 		"prepublish": "yarn run clean",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
-		"watch": "tsc --project ./tsconfig.json --watch",
+		"prepare": "tsc --build ./tsconfig.json && tsc --build ./tsconfig-cjs.json",
+		"watch": "tsc --build ./tsconfig.json --watch",
 		"download": "node bin/download.js",
 		"test": "yarn jest"
 	},

--- a/packages/language-picker/package.json
+++ b/packages/language-picker/package.json
@@ -41,8 +41,8 @@
 	},
 	"scripts": {
 		"clean": "npx rimraf dist && tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
-		"build:esm": "tsc --project ./tsconfig.json && copy-assets --esm",
-		"build:cjs": "tsc --project ./tsconfig-cjs.json && copy-assets --cjs",
+		"build:esm": "tsc --build ./tsconfig.json && copy-assets --esm",
+		"build:cjs": "tsc --build ./tsconfig-cjs.json && copy-assets --cjs",
 		"prepare": "yarn run build:esm",
 		"prepack": "yarn run clean && yarn run build:esm && yarn run build:cjs"
 	}

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -16,8 +16,8 @@
 	"scripts": {
 		"clean": "npx rimraf dist",
 		"prepublish": "yarn run clean",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
-		"watch": "tsc --project ./tsconfig.json --watch",
+		"prepare": "tsc --build ./tsconfig.json && tsc --build ./tsconfig-cjs.json",
+		"watch": "tsc --build ./tsconfig.json --watch",
 		"download": "node bin/download.js",
 		"test": "yarn jest"
 	},

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -25,9 +25,9 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json && copy-assets && npx copyfiles ./styles/** dist",
+		"prepare": "tsc --build ./tsconfig.json && tsc --build ./tsconfig-cjs.json && copy-assets && npx copyfiles ./styles/** dist",
 		"prepublish": "yarn run clean",
-		"watch": "tsc --project ./tsconfig.json --watch"
+		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
 		"@automattic/react-i18n": "^1.0.0-alpha.0",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -25,9 +25,9 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json && copy-assets && npx copyfiles ./styles/** dist",
+		"prepare": "tsc --build ./tsconfig.json && tsc --build ./tsconfig-cjs.json && copy-assets && npx copyfiles ./styles/** dist",
 		"prepublish": "yarn run clean",
-		"watch": "tsc --project ./tsconfig.json --watch"
+		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
 		"@automattic/react-i18n": "^1.0.0-alpha.0",

--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -25,9 +25,9 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json && copy-assets",
+		"prepare": "tsc --build ./tsconfig.json && tsc --build ./tsconfig-cjs.json && copy-assets",
 		"prepublish": "yarn run clean",
-		"watch": "tsc --project ./tsconfig.json --watch"
+		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
 		"@automattic/data-stores": "^1.0.0-alpha.1",

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -26,9 +26,9 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
+		"prepare": "tsc --build ./tsconfig.json && tsc --build ./tsconfig-cjs.json",
 		"prepublish": "yarn run clean",
-		"watch": "tsc --project ./tsconfig.json --watch"
+		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
 		"@wordpress/compose": "1.x.x - 3.x.x",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -47,8 +47,8 @@
 	},
 	"scripts": {
 		"clean": "npx rimraf dist && tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
-		"build:esm": "tsc --project ./tsconfig.json && copy-assets --esm",
-		"build:cjs": "tsc --project ./tsconfig-cjs.json && copy-assets --cjs",
+		"build:esm": "tsc --build ./tsconfig.json && copy-assets --esm",
+		"build:cjs": "tsc --build ./tsconfig-cjs.json && copy-assets --cjs",
 		"prepare": "yarn run build:esm",
 		"prepack": "yarn run clean && yarn run build:esm && yarn run build:cjs"
 	}

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -8,9 +8,9 @@
 	"sideEffects": false,
 	"scripts": {
 		"clean": "npx rimraf dist \"../../.tsc-cache/packages__shopping-cart*\"",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
+		"prepare": "tsc --build ./tsconfig.json && tsc --build ./tsconfig-cjs.json",
 		"prepublish": "yarn run clean",
-		"watch": "tsc --project ./tsconfig.json --watch"
+		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"files": [
 		"dist",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `tsc` commands in the `packages/` directory use `--build` mode, which enables [incremental builds](https://www.typescriptlang.org/docs/handbook/project-references.html).
  * `yarn start`, then control-c, then `yarn start` again won't rebuild all of the packages, because `tsc` in build mode uses [up-to-date checking](https://www.typescriptlang.org/docs/handbook/project-references.html).
* I don't know a lot about our mono-repo, so it's possible this breaks something.  However, simply using calypso seems to work fine for me.

#### Testing instructions

##### Establish Baseline Timings
* `git checkout master`
* `find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +`
* `yarn && yarn start`  _(note time taken to see "wp-calypso booted")_
* Control-C
* `yarn start` _(note time taken to see "wp-calypso booted")_

##### Try this branch
* `git checkout try/typescript-incremental-compilation`
* `find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +`
* `yarn && yarn start`  _(note time taken to see "wp-calypso booted")_
* Control-C
* `yarn start` _(note time taken to see "wp-calypso booted")_