### PR TITLE
Pricing page i5: open comparison table in new tab

### DIFF
--- a/client/my-sites/plans-v2/more-info-box/index.tsx
+++ b/client/my-sites/plans-v2/more-info-box/index.tsx
@@ -30,7 +30,7 @@ type MoreInfoProps = {
 const MoreInfoBox: React.FC< MoreInfoProps > = ( { headline, buttonLabel } ) => (
 	<div className="more-info-box__more-container">
 		<h3 className="more-info-box__more-headline">{ headline }</h3>
-		<Button href={ PLAN_COMPARISON_PAGE } className="more-info-box__more-button">
+		<Button href={ PLAN_COMPARISON_PAGE } target="_blank" className="more-info-box__more-button">
 			{ buttonLabel }
 			<Gridicon className="more-info-box__icon" icon="external" />
 		</Button>

--- a/client/my-sites/plans-v2/more-info-box/style.scss
+++ b/client/my-sites/plans-v2/more-info-box/style.scss
@@ -27,6 +27,7 @@
 	display: flex;
 	align-items: center;
 
+	max-width: 310px;
 	margin: 0 auto;
 	padding: 10px 16px 10px 40px;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR opens the comparison table link in a new tab, and fixes some CSS on the same button.

Fixes 1196341175636977-as-1199186408618269

### Testing instructions

- Download the PR or visit the Calypso live link
- Run Calypso or Jetpack cloud
- Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
- Select a self-hosted Jetpack site
- Visit the pricing page
- Check that the button labelled _Compare all product bundles_ looks good (see captures) and opens a new tab

### Screenshots

_Before_
<img width="1062" alt="Screen Shot 2020-11-13 at 3 57 35 PM" src="https://user-images.githubusercontent.com/1620183/99121974-6a7b8200-25cb-11eb-9b4d-01814a5d36ca.png">
_After_
<img width="685" alt="Screen Shot 2020-11-13 at 4 13 07 PM" src="https://user-images.githubusercontent.com/1620183/99121977-6b141880-25cb-11eb-8d32-3375685656e9.png">
