### PR TITLE
Manage Purchase: use site level query component in site level context

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -522,6 +522,7 @@ class ManagePurchase extends Component {
 	renderPlaceholder() {
 		const {
 			siteSlug,
+			hasLoadedPurchasesFromServer,
 			getManagePurchaseUrlFor,
 			getAddCardDetailsPathFor,
 			getAddPaymentMethodUrlFor,
@@ -545,6 +546,7 @@ class ManagePurchase extends Component {
 					<PurchaseMeta
 						purchaseId={ false }
 						siteSlug={ siteSlug }
+						hasLoadedPurchasesFromServer={ hasLoadedPurchasesFromServer }
 						getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 						getAddCardDetailsPathFor={ getAddCardDetailsPathFor }
 						getEditCardDetailsPathFor={ getEditCardDetailsPathFor }
@@ -582,6 +584,7 @@ class ManagePurchase extends Component {
 			getManagePurchaseUrlFor,
 			siteSlug,
 			getEditPaymentMethodUrlFor,
+			hasLoadedPurchasesFromServer,
 		} = this.props;
 
 		const classes = classNames( 'manage-purchase__info', {
@@ -628,6 +631,7 @@ class ManagePurchase extends Component {
 						<PurchaseMeta
 							purchaseId={ purchase.id }
 							siteSlug={ siteSlug }
+							hasLoadedPurchasesFromServer={ hasLoadedPurchasesFromServer }
 							getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 							getEditPaymentMethodUrlFor={ getEditPaymentMethodUrlFor }
 						/>

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -524,8 +524,6 @@ class ManagePurchase extends Component {
 			siteSlug,
 			hasLoadedPurchasesFromServer,
 			getManagePurchaseUrlFor,
-			getAddCardDetailsPathFor,
-			getAddPaymentMethodUrlFor,
 			getEditCardDetailsPathFor,
 		} = this.props;
 
@@ -548,9 +546,7 @@ class ManagePurchase extends Component {
 						siteSlug={ siteSlug }
 						hasLoadedPurchasesFromServer={ hasLoadedPurchasesFromServer }
 						getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
-						getAddCardDetailsPathFor={ getAddCardDetailsPathFor }
 						getEditCardDetailsPathFor={ getEditCardDetailsPathFor }
-						getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
 					/>
 				</Card>
 				<PurchasePlanDetails isPlaceholder />

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -114,7 +114,7 @@ class ManagePurchase extends Component {
 		getManagePurchaseUrlFor: PropTypes.func,
 		hasLoadedDomains: PropTypes.bool,
 		hasLoadedSites: PropTypes.bool.isRequired,
-		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
+		hasLoadedPurchasesFromServer: PropTypes.bool.isRequired,
 		hasNonPrimaryDomainsFlag: PropTypes.bool,
 		isAtomicSite: PropTypes.bool,
 		renewableSitePurchases: PropTypes.arrayOf( PropTypes.object ),
@@ -329,7 +329,7 @@ class ManagePurchase extends Component {
 		return (
 			<RemovePurchase
 				hasLoadedSites={ hasLoadedSites }
-				hasLoadedUserPurchasesFromServer={ this.props.hasLoadedUserPurchasesFromServer }
+				hasLoadedUserPurchasesFromServer={ this.props.hasLoadedPurchasesFromServer }
 				hasNonPrimaryDomainsFlag={ hasNonPrimaryDomainsFlag }
 				hasCustomPrimaryDomain={ hasCustomPrimaryDomain }
 				site={ site }
@@ -748,9 +748,9 @@ export default connect( ( state, props ) => {
 	return {
 		hasLoadedDomains,
 		hasLoadedSites,
-		hasLoadedUserPurchasesFromServer: selectedSiteId
+		hasLoadedPurchasesFromServer: selectedSiteId
 			? hasLoadedSitePurchasesFromServer( state )
-			: hasLoadedUserPurchasesFromServer( state ), // TODO: refactor this
+			: hasLoadedUserPurchasesFromServer( state ),
 		hasNonPrimaryDomainsFlag: getCurrentUser( state )
 			? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
 			: false,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -39,7 +39,7 @@ import {
 	purchaseType,
 	getName,
 } from 'calypso/lib/purchases';
-import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '../utils';
+import { canEditPaymentDetails, getEditCardDetailsPath } from '../utils';
 import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
@@ -169,8 +169,12 @@ class ManagePurchase extends Component {
 		}
 	}
 
+	isDataLoading( props = this.props ) {
+		return ! props.hasLoadedSites || ! props.hasLoadedPurchasesFromServer;
+	}
+
 	isDataValid( props = this.props ) {
-		if ( isDataLoading( props ) ) {
+		if ( this.isDataLoading( props ) ) {
 			return true;
 		}
 
@@ -566,7 +570,7 @@ class ManagePurchase extends Component {
 	}
 
 	renderPurchaseDetail( preventRenewal ) {
-		if ( isDataLoading( this.props ) || this.isDomainsLoading( this.props ) ) {
+		if ( this.isDataLoading( this.props ) || this.isDomainsLoading( this.props ) ) {
 			return this.renderPlaceholder();
 		}
 
@@ -666,7 +670,7 @@ class ManagePurchase extends Component {
 		} = this.props;
 
 		let editCardDetailsPath = false;
-		if ( ! isDataLoading( this.props ) && site && canEditPaymentDetails( purchase ) ) {
+		if ( ! this.isDataLoading( this.props ) && site && canEditPaymentDetails( purchase ) ) {
 			editCardDetailsPath = getEditPaymentMethodUrlFor( siteSlug, purchase );
 		}
 
@@ -701,7 +705,7 @@ class ManagePurchase extends Component {
 					</Notice>
 				) : (
 					<PurchaseNotice
-						isDataLoading={ isDataLoading( this.props ) }
+						isDataLoading={ this.isDataLoading( this.props ) }
 						handleRenew={ this.handleRenew }
 						handleRenewMultiplePurchases={ this.handleRenewMultiplePurchases }
 						selectedSite={ site }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -118,49 +118,6 @@ class PurchaseMeta extends Component {
 		} );
 	}
 
-	renderPaymentInfo() {
-		const { purchase, translate, moment } = this.props;
-		const payment = purchase?.payment;
-
-		if ( isIncludedWithPlan( purchase ) ) {
-			return translate( 'Included with plan' );
-		}
-
-		if ( hasPaymentMethod( purchase ) ) {
-			let paymentInfo = null;
-
-			if ( isPaidWithCredits( purchase ) ) {
-				return translate( 'Credits' );
-			}
-
-			if (
-				( isExpired( purchase ) || isExpiring( purchase ) ) &&
-				! isPaidWithCredits( purchase )
-			) {
-				return translate( 'None' );
-			}
-
-			if ( isPaidWithCreditCard( purchase ) ) {
-				paymentInfo = payment.creditCard.number;
-			} else if ( isPaidWithPayPalDirect( purchase ) ) {
-				paymentInfo = translate( 'expiring %(cardExpiry)s', {
-					args: {
-						cardExpiry: moment( payment.expiryDate, 'MM/YY' ).format( 'MMMM YYYY' ),
-					},
-				} );
-			}
-
-			return (
-				<>
-					<PaymentLogo type={ paymentLogoType( purchase ) } />
-					{ paymentInfo }
-				</>
-			);
-		}
-
-		return translate( 'None' );
-	}
-
 	handleEditPaymentMethodClick = () => {
 		recordTracksEvent( 'calypso_purchases_edit_payment_method' );
 	};
@@ -175,7 +132,7 @@ class PurchaseMeta extends Component {
 		const paymentDetails = (
 			<span>
 				<em className="manage-purchase__detail-label">{ translate( 'Payment method' ) }</em>
-				<span className="manage-purchase__detail">{ this.renderPaymentInfo() }</span>
+				<span className="manage-purchase__detail">{ renderPaymentInfo( this.props ) }</span>
 			</span>
 		);
 
@@ -465,6 +422,45 @@ function renderOwner( { translate, owner } ) {
 			</span>
 		</li>
 	);
+}
+
+function renderPaymentInfo( { purchase, translate, moment } ) {
+	const payment = purchase?.payment;
+
+	if ( isIncludedWithPlan( purchase ) ) {
+		return translate( 'Included with plan' );
+	}
+
+	if ( hasPaymentMethod( purchase ) ) {
+		let paymentInfo = null;
+
+		if ( isPaidWithCredits( purchase ) ) {
+			return translate( 'Credits' );
+		}
+
+		if ( ( isExpired( purchase ) || isExpiring( purchase ) ) && ! isPaidWithCredits( purchase ) ) {
+			return translate( 'None' );
+		}
+
+		if ( isPaidWithCreditCard( purchase ) ) {
+			paymentInfo = payment.creditCard.number;
+		} else if ( isPaidWithPayPalDirect( purchase ) ) {
+			paymentInfo = translate( 'expiring %(cardExpiry)s', {
+				args: {
+					cardExpiry: moment( payment.expiryDate, 'MM/YY' ).format( 'MMMM YYYY' ),
+				},
+			} );
+		}
+
+		return (
+			<>
+				<PaymentLogo type={ paymentLogoType( purchase ) } />
+				{ paymentInfo }
+			</>
+		);
+	}
+
+	return translate( 'None' );
 }
 
 export default connect( ( state, props ) => {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
@@ -56,67 +56,63 @@ import { TERM_BIENNIALLY, TERM_MONTHLY, JETPACK_LEGACY_PLANS } from 'calypso/lib
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-class PurchaseMeta extends Component {
-	render() {
-		const {
-			translate,
-			purchaseId,
-			hasLoadedSites,
-			hasLoadedPurchasesFromServer,
-			owner,
-			isJetpack,
-			purchase,
-			site,
-			siteSlug,
-			moment,
-			isAutorenewalEnabled,
-			isProductOwner,
-			hideAutoRenew,
-			getEditPaymentMethodUrlFor,
-			getManagePurchaseUrlFor,
-		} = this.props;
+function PurchaseMeta( {
+	translate,
+	purchaseId,
+	hasLoadedSites,
+	hasLoadedPurchasesFromServer,
+	owner,
+	isJetpack,
+	purchase,
+	site,
+	siteSlug,
+	moment,
+	isAutorenewalEnabled,
+	isProductOwner,
+	hideAutoRenew,
+	getEditPaymentMethodUrlFor,
+	getManagePurchaseUrlFor,
+} ) {
+	const isDataLoading = ! hasLoadedSites || ! hasLoadedPurchasesFromServer;
 
-		const isDataLoading = ! hasLoadedSites || ! hasLoadedPurchasesFromServer;
-
-		if ( isDataLoading || ! purchaseId ) {
-			return renderPlaceholder();
-		}
-
-		return (
-			<>
-				<ul className="manage-purchase__meta">
-					{ renderOwner( { translate, owner } ) }
-					<li>
-						<em className="manage-purchase__detail-label">{ translate( 'Price' ) }</em>
-						<span className="manage-purchase__detail">
-							{ renderPrice( { purchase, translate } ) }
-						</span>
-					</li>
-					{ renderExpiration( {
-						purchase,
-						site,
-						siteSlug,
-						translate,
-						moment,
-						isAutorenewalEnabled,
-						isProductOwner,
-						hideAutoRenew,
-						getEditPaymentMethodUrlFor,
-						getManagePurchaseUrlFor,
-					} ) }
-					{ renderPaymentDetails( {
-						purchase,
-						translate,
-						getEditPaymentMethodUrlFor,
-						siteSlug,
-						site,
-						moment,
-					} ) }
-				</ul>
-				{ renderRenewErrorMessage( { isJetpack, purchase, translate, site } ) }
-			</>
-		);
+	if ( isDataLoading || ! purchaseId ) {
+		return renderPlaceholder();
 	}
+
+	return (
+		<>
+			<ul className="manage-purchase__meta">
+				{ renderOwner( { translate, owner } ) }
+				<li>
+					<em className="manage-purchase__detail-label">{ translate( 'Price' ) }</em>
+					<span className="manage-purchase__detail">
+						{ renderPrice( { purchase, translate } ) }
+					</span>
+				</li>
+				{ renderExpiration( {
+					purchase,
+					site,
+					siteSlug,
+					translate,
+					moment,
+					isAutorenewalEnabled,
+					isProductOwner,
+					hideAutoRenew,
+					getEditPaymentMethodUrlFor,
+					getManagePurchaseUrlFor,
+				} ) }
+				{ renderPaymentDetails( {
+					purchase,
+					translate,
+					getEditPaymentMethodUrlFor,
+					siteSlug,
+					site,
+					moment,
+				} ) }
+			</ul>
+			{ renderRenewErrorMessage( { isJetpack, purchase, translate, site } ) }
+		</>
+	);
 }
 
 PurchaseMeta.propTypes = {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -75,95 +75,6 @@ class PurchaseMeta extends Component {
 		getManagePurchaseUrlFor: managePurchase,
 	};
 
-	renderExpiration() {
-		const {
-			purchase,
-			site,
-			siteSlug,
-			translate,
-			moment,
-			isAutorenewalEnabled,
-			isProductOwner,
-			hideAutoRenew,
-			getEditPaymentMethodUrlFor,
-			getManagePurchaseUrlFor,
-		} = this.props;
-
-		if ( isDomainTransfer( purchase ) ) {
-			return null;
-		}
-
-		if (
-			( isDomainRegistration( purchase ) || isPlan( purchase ) || isGoogleApps( purchase ) ) &&
-			! isExpired( purchase )
-		) {
-			const dateSpan = <span className="manage-purchase__detail-date-span" />;
-			const subsRenewText = isAutorenewalEnabled
-				? translate( 'Auto-renew is ON' )
-				: translate( 'Auto-renew is OFF' );
-			const subsBillingText =
-				isAutorenewalEnabled && ! hideAutoRenew
-					? translate( 'You will be billed on {{dateSpan}}%(renewDate)s{{/dateSpan}}', {
-							args: {
-								renewDate: purchase.renewDate && moment( purchase.renewDate ).format( 'LL' ),
-							},
-							components: {
-								dateSpan,
-							},
-					  } )
-					: translate( 'Expires on {{dateSpan}}%(expireDate)s{{/dateSpan}}', {
-							args: {
-								expireDate: moment( purchase.expiryDate ).format( 'LL' ),
-							},
-							components: {
-								dateSpan,
-							},
-					  } );
-			return (
-				<li>
-					<em className="manage-purchase__detail-label">{ translate( 'Subscription Renewal' ) }</em>
-					{ ! hideAutoRenew && <span className="manage-purchase__detail">{ subsRenewText }</span> }
-					<span
-						className={ classNames( 'manage-purchase__detail', {
-							'is-expiring': isCloseToExpiration( purchase ),
-						} ) }
-					>
-						{ subsBillingText }
-					</span>
-					{ site && ! hideAutoRenew && isProductOwner && (
-						<span className="manage-purchase__detail">
-							<AutoRenewToggle
-								planName={ site.plan.product_name_short }
-								siteDomain={ site.domain }
-								siteSlug={ site.slug }
-								purchase={ purchase }
-								toggleSource="manage-purchase"
-								getEditPaymentMethodUrlFor={ getEditPaymentMethodUrlFor }
-							/>
-						</span>
-					) }
-				</li>
-			);
-		}
-
-		return (
-			<li>
-				<em className="manage-purchase__detail-label">
-					{ renderRenewsOrExpiresOnLabel( { purchase, translate } ) }
-				</em>
-				<span className="manage-purchase__detail">
-					{ renderRenewsOrExpiresOn( {
-						moment,
-						purchase,
-						siteSlug,
-						translate,
-						getManagePurchaseUrlFor,
-					} ) }
-				</span>
-			</li>
-		);
-	}
-
 	isDataLoading( props ) {
 		return ! props.hasLoadedSites || ! props.hasLoadedPurchasesFromServer;
 	}
@@ -183,7 +94,7 @@ class PurchaseMeta extends Component {
 						<em className="manage-purchase__detail-label">{ translate( 'Price' ) }</em>
 						<span className="manage-purchase__detail">{ renderPrice( this.props ) }</span>
 					</li>
-					{ this.renderExpiration() }
+					{ renderExpiration( this.props ) }
 					{ renderPaymentDetails( this.props ) }
 				</ul>
 				{ renderRenewErrorMessage( this.props ) }
@@ -474,6 +385,93 @@ function renderRenewErrorMessage( { isJetpack, purchase, translate, site } ) {
 				}
 			) }
 		</div>
+	);
+}
+
+function renderExpiration( {
+	purchase,
+	site,
+	siteSlug,
+	translate,
+	moment,
+	isAutorenewalEnabled,
+	isProductOwner,
+	hideAutoRenew,
+	getEditPaymentMethodUrlFor,
+	getManagePurchaseUrlFor,
+} ) {
+	if ( isDomainTransfer( purchase ) ) {
+		return null;
+	}
+
+	if (
+		( isDomainRegistration( purchase ) || isPlan( purchase ) || isGoogleApps( purchase ) ) &&
+		! isExpired( purchase )
+	) {
+		const dateSpan = <span className="manage-purchase__detail-date-span" />;
+		const subsRenewText = isAutorenewalEnabled
+			? translate( 'Auto-renew is ON' )
+			: translate( 'Auto-renew is OFF' );
+		const subsBillingText =
+			isAutorenewalEnabled && ! hideAutoRenew
+				? translate( 'You will be billed on {{dateSpan}}%(renewDate)s{{/dateSpan}}', {
+						args: {
+							renewDate: purchase.renewDate && moment( purchase.renewDate ).format( 'LL' ),
+						},
+						components: {
+							dateSpan,
+						},
+				  } )
+				: translate( 'Expires on {{dateSpan}}%(expireDate)s{{/dateSpan}}', {
+						args: {
+							expireDate: moment( purchase.expiryDate ).format( 'LL' ),
+						},
+						components: {
+							dateSpan,
+						},
+				  } );
+		return (
+			<li>
+				<em className="manage-purchase__detail-label">{ translate( 'Subscription Renewal' ) }</em>
+				{ ! hideAutoRenew && <span className="manage-purchase__detail">{ subsRenewText }</span> }
+				<span
+					className={ classNames( 'manage-purchase__detail', {
+						'is-expiring': isCloseToExpiration( purchase ),
+					} ) }
+				>
+					{ subsBillingText }
+				</span>
+				{ site && ! hideAutoRenew && isProductOwner && (
+					<span className="manage-purchase__detail">
+						<AutoRenewToggle
+							planName={ site.plan.product_name_short }
+							siteDomain={ site.domain }
+							siteSlug={ site.slug }
+							purchase={ purchase }
+							toggleSource="manage-purchase"
+							getEditPaymentMethodUrlFor={ getEditPaymentMethodUrlFor }
+						/>
+					</span>
+				) }
+			</li>
+		);
+	}
+
+	return (
+		<li>
+			<em className="manage-purchase__detail-label">
+				{ renderRenewsOrExpiresOnLabel( { purchase, translate } ) }
+			</em>
+			<span className="manage-purchase__detail">
+				{ renderRenewsOrExpiresOn( {
+					moment,
+					purchase,
+					siteSlug,
+					translate,
+					getManagePurchaseUrlFor,
+				} ) }
+			</span>
+		</li>
 	);
 }
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -118,32 +118,6 @@ class PurchaseMeta extends Component {
 		} );
 	}
 
-	renderRenewsOrExpiresOn() {
-		const { moment, purchase, siteSlug, translate, getManagePurchaseUrlFor } = this.props;
-
-		if ( isIncludedWithPlan( purchase ) ) {
-			const attachedPlanUrl = getManagePurchaseUrlFor( siteSlug, purchase.attachedToPurchaseId );
-
-			return (
-				<span>
-					<a href={ attachedPlanUrl }>{ translate( 'Renews with Plan' ) }</a>
-				</span>
-			);
-		}
-
-		if ( isExpiring( purchase ) || isExpired( purchase ) ) {
-			return moment( purchase.expiryDate ).format( 'LL' );
-		}
-
-		if ( isRenewing( purchase ) ) {
-			return moment( purchase.renewDate ).format( 'LL' );
-		}
-
-		if ( isOneTimePurchase( purchase ) ) {
-			return translate( 'Never Expires' );
-		}
-	}
-
 	renderPaymentInfo() {
 		const { purchase, translate, moment } = this.props;
 		const payment = purchase?.payment;
@@ -370,21 +344,8 @@ class PurchaseMeta extends Component {
 				<em className="manage-purchase__detail-label">
 					{ renderRenewsOrExpiresOnLabel( this.props ) }
 				</em>
-				<span className="manage-purchase__detail">{ this.renderRenewsOrExpiresOn() }</span>
+				<span className="manage-purchase__detail">{ renderRenewsOrExpiresOn( this.props ) }</span>
 			</li>
-		);
-	}
-
-	renderPlaceholder() {
-		return (
-			<ul className="manage-purchase__meta">
-				{ times( 4, ( i ) => (
-					<li key={ i }>
-						<em className="manage-purchase__detail-label" />
-						<span className="manage-purchase__detail" />
-					</li>
-				) ) }
-			</ul>
 		);
 	}
 
@@ -396,7 +357,7 @@ class PurchaseMeta extends Component {
 		const { translate, purchaseId } = this.props;
 
 		if ( this.isDataLoading( this.props ) || ! purchaseId ) {
-			return this.renderPlaceholder();
+			return renderPlaceholder();
 		}
 
 		return (
@@ -462,6 +423,49 @@ function renderRenewsOrExpiresOnLabel( { purchase, translate } ) {
 	}
 
 	return null;
+}
+
+function renderRenewsOrExpiresOn( {
+	moment,
+	purchase,
+	siteSlug,
+	translate,
+	getManagePurchaseUrlFor,
+} ) {
+	if ( isIncludedWithPlan( purchase ) ) {
+		const attachedPlanUrl = getManagePurchaseUrlFor( siteSlug, purchase.attachedToPurchaseId );
+
+		return (
+			<span>
+				<a href={ attachedPlanUrl }>{ translate( 'Renews with Plan' ) }</a>
+			</span>
+		);
+	}
+
+	if ( isExpiring( purchase ) || isExpired( purchase ) ) {
+		return moment( purchase.expiryDate ).format( 'LL' );
+	}
+
+	if ( isRenewing( purchase ) ) {
+		return moment( purchase.renewDate ).format( 'LL' );
+	}
+
+	if ( isOneTimePurchase( purchase ) ) {
+		return translate( 'Never Expires' );
+	}
+}
+
+function renderPlaceholder() {
+	return (
+		<ul className="manage-purchase__meta">
+			{ times( 4, ( i ) => (
+				<li key={ i }>
+					<em className="manage-purchase__detail-label" />
+					<span className="manage-purchase__detail" />
+				</li>
+			) ) }
+		</ul>
+	);
 }
 
 export default connect( ( state, props ) => {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -75,60 +75,6 @@ class PurchaseMeta extends Component {
 		getManagePurchaseUrlFor: managePurchase,
 	};
 
-	renderRenewErrorMessage() {
-		const { isJetpack, purchase, translate, site } = this.props;
-
-		if ( site ) {
-			return null;
-		}
-
-		if ( isJetpack ) {
-			return (
-				<div className="manage-purchase__footnotes">
-					{ translate(
-						'%(purchaseName)s expired on %(siteSlug)s, and the site is no longer connected to WordPress.com. ' +
-							'To renew this purchase, please reconnect %(siteSlug)s to your WordPress.com account, then complete your purchase. ' +
-							'Now sure how to reconnect? {{supportPageLink}}Here are the instructions{{/supportPageLink}}.',
-						{
-							args: {
-								purchaseName: getName( purchase ),
-								siteSlug: purchase.domain,
-							},
-							components: {
-								supportPageLink: (
-									<a
-										href={
-											JETPACK_SUPPORT + 'reconnecting-reinstalling-jetpack/#reconnecting-jetpack'
-										}
-									/>
-								),
-							},
-						}
-					) }
-				</div>
-			);
-		}
-
-		return (
-			<div className="manage-purchase__footnotes">
-				{ translate(
-					'You are the owner of %(purchaseName)s but because you are no longer a user on %(siteSlug)s, ' +
-						'renewing it will require staff assistance. Please {{contactSupportLink}}contact support{{/contactSupportLink}}, ' +
-						'and consider transferring this purchase to another active user on %(siteSlug)s to avoid this issue in the future.',
-					{
-						args: {
-							purchaseName: getName( purchase ),
-							siteSlug: purchase.domain,
-						},
-						components: {
-							contactSupportLink: <a href={ CALYPSO_CONTACT } />,
-						},
-					}
-				) }
-			</div>
-		);
-	}
-
 	renderExpiration() {
 		const {
 			purchase,
@@ -230,7 +176,7 @@ class PurchaseMeta extends Component {
 					{ this.renderExpiration() }
 					{ renderPaymentDetails( this.props ) }
 				</ul>
-				{ this.renderRenewErrorMessage() }
+				{ renderRenewErrorMessage( this.props ) }
 			</>
 		);
 	}
@@ -466,6 +412,58 @@ function renderPaymentDetails( {
 				{ paymentDetails }
 			</a>
 		</li>
+	);
+}
+
+function renderRenewErrorMessage( { isJetpack, purchase, translate, site } ) {
+	if ( site ) {
+		return null;
+	}
+
+	if ( isJetpack ) {
+		return (
+			<div className="manage-purchase__footnotes">
+				{ translate(
+					'%(purchaseName)s expired on %(siteSlug)s, and the site is no longer connected to WordPress.com. ' +
+						'To renew this purchase, please reconnect %(siteSlug)s to your WordPress.com account, then complete your purchase. ' +
+						'Now sure how to reconnect? {{supportPageLink}}Here are the instructions{{/supportPageLink}}.',
+					{
+						args: {
+							purchaseName: getName( purchase ),
+							siteSlug: purchase.domain,
+						},
+						components: {
+							supportPageLink: (
+								<a
+									href={
+										JETPACK_SUPPORT + 'reconnecting-reinstalling-jetpack/#reconnecting-jetpack'
+									}
+								/>
+							),
+						},
+					}
+				) }
+			</div>
+		);
+	}
+
+	return (
+		<div className="manage-purchase__footnotes">
+			{ translate(
+				'You are the owner of %(purchaseName)s but because you are no longer a user on %(siteSlug)s, ' +
+					'renewing it will require staff assistance. Please {{contactSupportLink}}contact support{{/contactSupportLink}}, ' +
+					'and consider transferring this purchase to another active user on %(siteSlug)s to avoid this issue in the future.',
+				{
+					args: {
+						purchaseName: getName( purchase ),
+						siteSlug: purchase.domain,
+					},
+					components: {
+						contactSupportLink: <a href={ CALYPSO_CONTACT } />,
+					},
+				}
+			) }
+		</div>
 	);
 }
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -118,56 +118,6 @@ class PurchaseMeta extends Component {
 		} );
 	}
 
-	renderRenewsOrExpiresOnLabel() {
-		const { purchase, translate } = this.props;
-
-		if ( isExpiring( purchase ) ) {
-			if ( isDomainRegistration( purchase ) ) {
-				return translate( 'Domain expires on' );
-			}
-
-			if ( isSubscription( purchase ) ) {
-				return translate( 'Subscription expires on' );
-			}
-
-			if ( isOneTimePurchase( purchase ) ) {
-				return translate( 'Expires on' );
-			}
-		}
-
-		if ( isExpired( purchase ) ) {
-			if ( isDomainRegistration( purchase ) ) {
-				return translate( 'Domain expired on' );
-			}
-
-			if ( isConciergeSession( purchase ) ) {
-				return translate( 'Session used on' );
-			}
-
-			if ( isSubscription( purchase ) ) {
-				return translate( 'Subscription expired on' );
-			}
-
-			if ( isOneTimePurchase( purchase ) ) {
-				return translate( 'Expired on' );
-			}
-		}
-
-		if ( isDomainRegistration( purchase ) ) {
-			return translate( 'Domain renews on' );
-		}
-
-		if ( isSubscription( purchase ) ) {
-			return translate( 'Subscription renews on' );
-		}
-
-		if ( isOneTimePurchase( purchase ) ) {
-			return translate( 'Renews on' );
-		}
-
-		return null;
-	}
-
 	renderRenewsOrExpiresOn() {
 		const { moment, purchase, siteSlug, translate, getManagePurchaseUrlFor } = this.props;
 
@@ -417,7 +367,9 @@ class PurchaseMeta extends Component {
 
 		return (
 			<li>
-				<em className="manage-purchase__detail-label">{ this.renderRenewsOrExpiresOnLabel() }</em>
+				<em className="manage-purchase__detail-label">
+					{ renderRenewsOrExpiresOnLabel( this.props ) }
+				</em>
 				<span className="manage-purchase__detail">{ this.renderRenewsOrExpiresOn() }</span>
 			</li>
 		);
@@ -462,6 +414,54 @@ class PurchaseMeta extends Component {
 			</>
 		);
 	}
+}
+
+function renderRenewsOrExpiresOnLabel( { purchase, translate } ) {
+	if ( isExpiring( purchase ) ) {
+		if ( isDomainRegistration( purchase ) ) {
+			return translate( 'Domain expires on' );
+		}
+
+		if ( isSubscription( purchase ) ) {
+			return translate( 'Subscription expires on' );
+		}
+
+		if ( isOneTimePurchase( purchase ) ) {
+			return translate( 'Expires on' );
+		}
+	}
+
+	if ( isExpired( purchase ) ) {
+		if ( isDomainRegistration( purchase ) ) {
+			return translate( 'Domain expired on' );
+		}
+
+		if ( isConciergeSession( purchase ) ) {
+			return translate( 'Session used on' );
+		}
+
+		if ( isSubscription( purchase ) ) {
+			return translate( 'Subscription expired on' );
+		}
+
+		if ( isOneTimePurchase( purchase ) ) {
+			return translate( 'Expired on' );
+		}
+	}
+
+	if ( isDomainRegistration( purchase ) ) {
+		return translate( 'Domain renews on' );
+	}
+
+	if ( isSubscription( purchase ) ) {
+		return translate( 'Subscription renews on' );
+	}
+
+	if ( isOneTimePurchase( purchase ) ) {
+		return translate( 'Renews on' );
+	}
+
+	return null;
 }
 
 export default connect( ( state, props ) => {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -79,12 +79,14 @@ class PurchaseMeta extends Component {
 		const {
 			purchase,
 			site,
+			siteSlug,
 			translate,
 			moment,
 			isAutorenewalEnabled,
 			isProductOwner,
 			hideAutoRenew,
 			getEditPaymentMethodUrlFor,
+			getManagePurchaseUrlFor,
 		} = this.props;
 
 		if ( isDomainTransfer( purchase ) ) {
@@ -147,9 +149,17 @@ class PurchaseMeta extends Component {
 		return (
 			<li>
 				<em className="manage-purchase__detail-label">
-					{ renderRenewsOrExpiresOnLabel( this.props ) }
+					{ renderRenewsOrExpiresOnLabel( { purchase, translate } ) }
 				</em>
-				<span className="manage-purchase__detail">{ renderRenewsOrExpiresOn( this.props ) }</span>
+				<span className="manage-purchase__detail">
+					{ renderRenewsOrExpiresOn( {
+						moment,
+						purchase,
+						siteSlug,
+						translate,
+						getManagePurchaseUrlFor,
+					} ) }
+				</span>
 			</li>
 		);
 	}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -254,22 +254,6 @@ class PurchaseMeta extends Component {
 		);
 	}
 
-	renderOwner() {
-		const { translate, owner } = this.props;
-		if ( ! owner ) {
-			return null;
-		}
-
-		return (
-			<li>
-				<em className="manage-purchase__detail-label">{ translate( 'Owner' ) }</em>
-				<span className="manage-purchase__detail">
-					<UserItem user={ { ...owner, name: owner.display_name } } />
-				</span>
-			</li>
-		);
-	}
-
 	renderExpiration() {
 		const {
 			purchase,
@@ -363,7 +347,7 @@ class PurchaseMeta extends Component {
 		return (
 			<>
 				<ul className="manage-purchase__meta">
-					{ this.renderOwner() }
+					{ renderOwner( this.props ) }
 					<li>
 						<em className="manage-purchase__detail-label">{ translate( 'Price' ) }</em>
 						<span className="manage-purchase__detail">{ this.renderPrice() }</span>
@@ -465,6 +449,21 @@ function renderPlaceholder() {
 				</li>
 			) ) }
 		</ul>
+	);
+}
+
+function renderOwner( { translate, owner } ) {
+	if ( ! owner ) {
+		return null;
+	}
+
+	return (
+		<li>
+			<em className="manage-purchase__detail-label">{ translate( 'Owner' ) }</em>
+			<span className="manage-purchase__detail">
+				<UserItem user={ { ...owner, name: owner.display_name } } />
+			</span>
+		</li>
 	);
 }
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -75,12 +75,12 @@ class PurchaseMeta extends Component {
 		getManagePurchaseUrlFor: managePurchase,
 	};
 
-	handleEditPaymentMethodClick = () => {
-		recordTracksEvent( 'calypso_purchases_edit_payment_method' );
-	};
-
 	renderPaymentDetails() {
-		const { purchase, translate, getEditPaymentMethodUrlFor, siteSlug } = this.props;
+		const { purchase, translate, getEditPaymentMethodUrlFor, siteSlug, site, moment } = this.props;
+
+		const handleEditPaymentMethodClick = () => {
+			recordTracksEvent( 'calypso_purchases_edit_payment_method' );
+		};
 
 		if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
 			return null;
@@ -89,7 +89,9 @@ class PurchaseMeta extends Component {
 		const paymentDetails = (
 			<span>
 				<em className="manage-purchase__detail-label">{ translate( 'Payment method' ) }</em>
-				<span className="manage-purchase__detail">{ renderPaymentInfo( this.props ) }</span>
+				<span className="manage-purchase__detail">
+					{ renderPaymentInfo( { purchase, translate, moment } ) }
+				</span>
 			</span>
 		);
 
@@ -97,7 +99,7 @@ class PurchaseMeta extends Component {
 			! canEditPaymentDetails( purchase ) ||
 			! isPaidWithCreditCard( purchase ) ||
 			! cardProcessorSupportsUpdates( purchase ) ||
-			! this.props.site
+			! site
 		) {
 			return <li>{ paymentDetails }</li>;
 		}
@@ -106,7 +108,7 @@ class PurchaseMeta extends Component {
 			<li>
 				<a
 					href={ getEditPaymentMethodUrlFor( siteSlug, purchase ) }
-					onClick={ this.handleEditPaymentMethodClick }
+					onClick={ handleEditPaymentMethodClick }
 				>
 					{ paymentDetails }
 				</a>

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -57,24 +57,6 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 class PurchaseMeta extends Component {
-	static propTypes = {
-		hasLoadedSites: PropTypes.bool.isRequired,
-		hasLoadedPurchasesFromServer: PropTypes.bool.isRequired,
-		purchaseId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.bool ] ).isRequired,
-		purchase: PropTypes.object,
-		site: PropTypes.object,
-		siteSlug: PropTypes.string.isRequired,
-		getManagePurchaseUrlFor: PropTypes.func,
-		getEditPaymentMethodUrlFor: PropTypes.func,
-	};
-
-	static defaultProps = {
-		hasLoadedSites: false,
-		hasLoadedPurchasesFromServer: false,
-		purchaseId: false,
-		getManagePurchaseUrlFor: managePurchase,
-	};
-
 	render() {
 		const { translate, purchaseId, hasLoadedSites, hasLoadedPurchasesFromServer } = this.props;
 
@@ -100,6 +82,24 @@ class PurchaseMeta extends Component {
 		);
 	}
 }
+
+PurchaseMeta.propTypes = {
+	hasLoadedSites: PropTypes.bool.isRequired,
+	hasLoadedPurchasesFromServer: PropTypes.bool.isRequired,
+	purchaseId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.bool ] ).isRequired,
+	purchase: PropTypes.object,
+	site: PropTypes.object,
+	siteSlug: PropTypes.string.isRequired,
+	getManagePurchaseUrlFor: PropTypes.func,
+	getEditPaymentMethodUrlFor: PropTypes.func,
+};
+
+PurchaseMeta.defaultProps = {
+	hasLoadedSites: false,
+	hasLoadedPurchasesFromServer: false,
+	purchaseId: false,
+	getManagePurchaseUrlFor: managePurchase,
+};
 
 function renderRenewsOrExpiresOnLabel( { purchase, translate } ) {
 	if ( isExpiring( purchase ) ) {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { times } from 'lodash';
 
 /**
@@ -47,21 +47,22 @@ import AutoRenewToggle from './auto-renew-toggle';
 import PaymentLogo from 'calypso/components/payment-logo';
 import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'calypso/lib/url/support';
 import UserItem from 'calypso/components/user';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { canEditPaymentDetails } from '../utils';
 import { TERM_BIENNIALLY, TERM_MONTHLY, JETPACK_LEGACY_PLANS } from 'calypso/lib/plans/constants';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-function PurchaseMeta( {
-	translate,
+export default function PurchaseMeta( {
 	purchaseId,
 	hasLoadedPurchasesFromServer,
 	siteSlug,
-	moment,
 	getEditPaymentMethodUrlFor,
 	getManagePurchaseUrlFor,
 } ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
 	const purchase = useSelector( ( state ) => getByPurchaseId( state, purchaseId ) );
 	const isProductOwner = purchase?.userId === useSelector( getCurrentUserId );
 	const isAutorenewalEnabled = purchase ? ! isExpiring( purchase ) : null;
@@ -508,5 +509,3 @@ function renderExpiration( {
 		</li>
 	);
 }
-
-export default localize( withLocalizedMoment( PurchaseMeta ) );

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -75,49 +75,6 @@ class PurchaseMeta extends Component {
 		getManagePurchaseUrlFor: managePurchase,
 	};
 
-	renderPrice() {
-		const { purchase, translate } = this.props;
-		const { priceText, currencyCode, productSlug } = purchase;
-		const plan = getPlan( productSlug ) || getProductFromSlug( productSlug );
-		let period = translate( 'year' );
-
-		if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
-			return translate( '%(priceText)s %(currencyCode)s {{period}}(one-time){{/period}}', {
-				args: { priceText, currencyCode },
-				components: {
-					period: <span className="manage-purchase__time-period" />,
-				},
-			} );
-		}
-
-		if ( isIncludedWithPlan( purchase ) ) {
-			return translate( 'Free with Plan' );
-		}
-
-		if ( plan && plan.term ) {
-			switch ( plan.term ) {
-				case TERM_BIENNIALLY:
-					period = translate( 'two years' );
-					break;
-
-				case TERM_MONTHLY:
-					period = translate( 'month' );
-					break;
-			}
-		}
-
-		return translate( '%(priceText)s %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
-			args: {
-				priceText,
-				currencyCode,
-				period,
-			},
-			components: {
-				period: <span className="manage-purchase__time-period" />,
-			},
-		} );
-	}
-
 	handleEditPaymentMethodClick = () => {
 		recordTracksEvent( 'calypso_purchases_edit_payment_method' );
 	};
@@ -307,7 +264,7 @@ class PurchaseMeta extends Component {
 					{ renderOwner( this.props ) }
 					<li>
 						<em className="manage-purchase__detail-label">{ translate( 'Price' ) }</em>
-						<span className="manage-purchase__detail">{ this.renderPrice() }</span>
+						<span className="manage-purchase__detail">{ renderPrice( this.props ) }</span>
 					</li>
 					{ this.renderExpiration() }
 					{ this.renderPaymentDetails() }
@@ -461,6 +418,48 @@ function renderPaymentInfo( { purchase, translate, moment } ) {
 	}
 
 	return translate( 'None' );
+}
+
+function renderPrice( { purchase, translate } ) {
+	const { priceText, currencyCode, productSlug } = purchase;
+	const plan = getPlan( productSlug ) || getProductFromSlug( productSlug );
+	let period = translate( 'year' );
+
+	if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
+		return translate( '%(priceText)s %(currencyCode)s {{period}}(one-time){{/period}}', {
+			args: { priceText, currencyCode },
+			components: {
+				period: <span className="manage-purchase__time-period" />,
+			},
+		} );
+	}
+
+	if ( isIncludedWithPlan( purchase ) ) {
+		return translate( 'Free with Plan' );
+	}
+
+	if ( plan && plan.term ) {
+		switch ( plan.term ) {
+			case TERM_BIENNIALLY:
+				period = translate( 'two years' );
+				break;
+
+			case TERM_MONTHLY:
+				period = translate( 'month' );
+				break;
+		}
+	}
+
+	return translate( '%(priceText)s %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
+		args: {
+			priceText,
+			currencyCode,
+			period,
+		},
+		components: {
+			period: <span className="manage-purchase__time-period" />,
+		},
+	} );
 }
 
 export default connect( ( state, props ) => {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -81,7 +81,7 @@ export default function PurchaseMeta( {
 	const isDataLoading = ! hasLoadedSites || ! hasLoadedPurchasesFromServer;
 
 	if ( isDataLoading || ! purchaseId ) {
-		return renderPlaceholder();
+		return <PurchaseMetaPlaceholder />;
 	}
 
 	return (
@@ -216,7 +216,7 @@ function renderRenewsOrExpiresOn( {
 	}
 }
 
-function renderPlaceholder() {
+function PurchaseMetaPlaceholder() {
 	return (
 		<ul className="manage-purchase__meta">
 			{ times( 4, ( i ) => (

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -4,7 +4,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { connect, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
 
@@ -509,4 +509,4 @@ function renderExpiration( {
 	);
 }
 
-export default connect( () => {} )( localize( withLocalizedMoment( PurchaseMeta ) ) );
+export default localize( withLocalizedMoment( PurchaseMeta ) );

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -54,11 +54,11 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 export default function PurchaseMeta( {
-	purchaseId,
-	hasLoadedPurchasesFromServer,
+	purchaseId = false,
+	hasLoadedPurchasesFromServer = false,
 	siteSlug,
 	getEditPaymentMethodUrlFor,
-	getManagePurchaseUrlFor,
+	getManagePurchaseUrlFor = managePurchase,
 } ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
@@ -112,12 +112,6 @@ PurchaseMeta.propTypes = {
 	siteSlug: PropTypes.string.isRequired,
 	getManagePurchaseUrlFor: PropTypes.func,
 	getEditPaymentMethodUrlFor: PropTypes.func,
-};
-
-PurchaseMeta.defaultProps = {
-	hasLoadedPurchasesFromServer: false,
-	purchaseId: false,
-	getManagePurchaseUrlFor: managePurchase,
 };
 
 function renderRenewsOrExpiresOnLabel( { purchase, translate } ) {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -76,9 +76,9 @@ class PurchaseMeta extends Component {
 	};
 
 	renderRenewErrorMessage() {
-		const { isJetpack, purchase, translate } = this.props;
+		const { isJetpack, purchase, translate, site } = this.props;
 
-		if ( this.props.site ) {
+		if ( site ) {
 			return null;
 		}
 
@@ -92,7 +92,7 @@ class PurchaseMeta extends Component {
 						{
 							args: {
 								purchaseName: getName( purchase ),
-								siteSlug: this.props.purchase.domain,
+								siteSlug: purchase.domain,
 							},
 							components: {
 								supportPageLink: (
@@ -118,7 +118,7 @@ class PurchaseMeta extends Component {
 					{
 						args: {
 							purchaseName: getName( purchase ),
-							siteSlug: this.props.purchase.domain,
+							siteSlug: purchase.domain,
 						},
 						components: {
 							contactSupportLink: <a href={ CALYPSO_CONTACT } />,

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -115,7 +115,12 @@ export default function PurchaseMeta( {
 					moment,
 				} ) }
 			</ul>
-			{ renderRenewErrorMessage( { isJetpack, purchase, translate, site } ) }
+			<RenewErrorMessage
+				isJetpack={ isJetpack }
+				purchase={ purchase }
+				translate={ translate }
+				site={ site }
+			/>
 		</>
 	);
 }
@@ -371,7 +376,7 @@ function renderPaymentDetails( {
 	);
 }
 
-function renderRenewErrorMessage( { isJetpack, purchase, translate, site } ) {
+function RenewErrorMessage( { isJetpack, purchase, translate, site } ) {
 	if ( site ) {
 		return null;
 	}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -51,7 +51,7 @@ import PaymentLogo from 'calypso/components/payment-logo';
 import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'calypso/lib/url/support';
 import UserItem from 'calypso/components/user';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { canEditPaymentDetails, isDataLoading } from '../utils';
+import { canEditPaymentDetails } from '../utils';
 import { TERM_BIENNIALLY, TERM_MONTHLY, JETPACK_LEGACY_PLANS } from 'calypso/lib/plans/constants';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -59,7 +59,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 class PurchaseMeta extends Component {
 	static propTypes = {
 		hasLoadedSites: PropTypes.bool.isRequired,
-		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
+		hasLoadedPurchasesFromServer: PropTypes.bool.isRequired,
 		purchaseId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.bool ] ).isRequired,
 		purchase: PropTypes.object,
 		site: PropTypes.object,
@@ -70,7 +70,7 @@ class PurchaseMeta extends Component {
 
 	static defaultProps = {
 		hasLoadedSites: false,
-		hasLoadedUserPurchasesFromServer: false,
+		hasLoadedPurchasesFromServer: false,
 		purchaseId: false,
 		getManagePurchaseUrlFor: managePurchase,
 	};
@@ -436,10 +436,14 @@ class PurchaseMeta extends Component {
 		);
 	}
 
+	isDataLoading( props ) {
+		return ! props.hasLoadedSites || ! props.hasLoadedPurchasesFromServer;
+	}
+
 	render() {
 		const { translate, purchaseId } = this.props;
 
-		if ( isDataLoading( this.props ) || ! purchaseId ) {
+		if ( this.isDataLoading( this.props ) || ! purchaseId ) {
 			return this.renderPlaceholder();
 		}
 
@@ -460,13 +464,15 @@ class PurchaseMeta extends Component {
 	}
 }
 
-export default connect( ( state, { purchaseId } ) => {
+export default connect( ( state, props ) => {
+	const { purchaseId } = props;
 	const purchase = getByPurchaseId( state, purchaseId );
 	const isProductOwner = purchase && purchase.userId === getCurrentUserId( state );
 
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
-		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+		hasLoadedPurchasesFromServer:
+			props.hasLoadedPurchasesFromServer ?? hasLoadedUserPurchasesFromServer( state ),
 		purchase,
 		site: purchase ? getSite( state, purchase.siteId ) : null,
 		isProductOwner,

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -75,47 +75,6 @@ class PurchaseMeta extends Component {
 		getManagePurchaseUrlFor: managePurchase,
 	};
 
-	renderPaymentDetails() {
-		const { purchase, translate, getEditPaymentMethodUrlFor, siteSlug, site, moment } = this.props;
-
-		const handleEditPaymentMethodClick = () => {
-			recordTracksEvent( 'calypso_purchases_edit_payment_method' );
-		};
-
-		if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
-			return null;
-		}
-
-		const paymentDetails = (
-			<span>
-				<em className="manage-purchase__detail-label">{ translate( 'Payment method' ) }</em>
-				<span className="manage-purchase__detail">
-					{ renderPaymentInfo( { purchase, translate, moment } ) }
-				</span>
-			</span>
-		);
-
-		if (
-			! canEditPaymentDetails( purchase ) ||
-			! isPaidWithCreditCard( purchase ) ||
-			! cardProcessorSupportsUpdates( purchase ) ||
-			! site
-		) {
-			return <li>{ paymentDetails }</li>;
-		}
-
-		return (
-			<li>
-				<a
-					href={ getEditPaymentMethodUrlFor( siteSlug, purchase ) }
-					onClick={ handleEditPaymentMethodClick }
-				>
-					{ paymentDetails }
-				</a>
-			</li>
-		);
-	}
-
 	renderRenewErrorMessage() {
 		const { isJetpack, purchase, translate } = this.props;
 
@@ -269,7 +228,7 @@ class PurchaseMeta extends Component {
 						<span className="manage-purchase__detail">{ renderPrice( this.props ) }</span>
 					</li>
 					{ this.renderExpiration() }
-					{ this.renderPaymentDetails() }
+					{ renderPaymentDetails( this.props ) }
 				</ul>
 				{ this.renderRenewErrorMessage() }
 			</>
@@ -462,6 +421,52 @@ function renderPrice( { purchase, translate } ) {
 			period: <span className="manage-purchase__time-period" />,
 		},
 	} );
+}
+
+function renderPaymentDetails( {
+	purchase,
+	translate,
+	getEditPaymentMethodUrlFor,
+	siteSlug,
+	site,
+	moment,
+} ) {
+	const handleEditPaymentMethodClick = () => {
+		recordTracksEvent( 'calypso_purchases_edit_payment_method' );
+	};
+
+	if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
+		return null;
+	}
+
+	const paymentDetails = (
+		<span>
+			<em className="manage-purchase__detail-label">{ translate( 'Payment method' ) }</em>
+			<span className="manage-purchase__detail">
+				{ renderPaymentInfo( { purchase, translate, moment } ) }
+			</span>
+		</span>
+	);
+
+	if (
+		! canEditPaymentDetails( purchase ) ||
+		! isPaidWithCreditCard( purchase ) ||
+		! cardProcessorSupportsUpdates( purchase ) ||
+		! site
+	) {
+		return <li>{ paymentDetails }</li>;
+	}
+
+	return (
+		<li>
+			<a
+				href={ getEditPaymentMethodUrlFor( siteSlug, purchase ) }
+				onClick={ handleEditPaymentMethodClick }
+			>
+				{ paymentDetails }
+			</a>
+		</li>
+	);
 }
 
 export default connect( ( state, props ) => {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -39,10 +39,7 @@ import {
 	getProductFromSlug,
 } from 'calypso/lib/products-values';
 import { getPlan } from 'calypso/lib/plans';
-import {
-	getByPurchaseId,
-	hasLoadedUserPurchasesFromServer,
-} from 'calypso/state/purchases/selectors';
+import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { getUser } from 'calypso/state/users/selectors';
 import { managePurchase } from '../paths';
@@ -512,11 +509,4 @@ function renderExpiration( {
 	);
 }
 
-export default connect( ( state, props ) => {
-	const { hasLoadedPurchasesFromServer } = props;
-
-	return {
-		hasLoadedPurchasesFromServer:
-			hasLoadedPurchasesFromServer ?? hasLoadedUserPurchasesFromServer( state ),
-	};
-} )( localize( withLocalizedMoment( PurchaseMeta ) ) );
+export default connect( () => {} )( localize( withLocalizedMoment( PurchaseMeta ) ) );

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -58,7 +58,23 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 class PurchaseMeta extends Component {
 	render() {
-		const { translate, purchaseId, hasLoadedSites, hasLoadedPurchasesFromServer } = this.props;
+		const {
+			translate,
+			purchaseId,
+			hasLoadedSites,
+			hasLoadedPurchasesFromServer,
+			owner,
+			isJetpack,
+			purchase,
+			site,
+			siteSlug,
+			moment,
+			isAutorenewalEnabled,
+			isProductOwner,
+			hideAutoRenew,
+			getEditPaymentMethodUrlFor,
+			getManagePurchaseUrlFor,
+		} = this.props;
 
 		const isDataLoading = ! hasLoadedSites || ! hasLoadedPurchasesFromServer;
 
@@ -69,15 +85,35 @@ class PurchaseMeta extends Component {
 		return (
 			<>
 				<ul className="manage-purchase__meta">
-					{ renderOwner( this.props ) }
+					{ renderOwner( { translate, owner } ) }
 					<li>
 						<em className="manage-purchase__detail-label">{ translate( 'Price' ) }</em>
-						<span className="manage-purchase__detail">{ renderPrice( this.props ) }</span>
+						<span className="manage-purchase__detail">
+							{ renderPrice( { purchase, translate } ) }
+						</span>
 					</li>
-					{ renderExpiration( this.props ) }
-					{ renderPaymentDetails( this.props ) }
+					{ renderExpiration( {
+						purchase,
+						site,
+						siteSlug,
+						translate,
+						moment,
+						isAutorenewalEnabled,
+						isProductOwner,
+						hideAutoRenew,
+						getEditPaymentMethodUrlFor,
+						getManagePurchaseUrlFor,
+					} ) }
+					{ renderPaymentDetails( {
+						purchase,
+						translate,
+						getEditPaymentMethodUrlFor,
+						siteSlug,
+						site,
+						moment,
+					} ) }
 				</ul>
-				{ renderRenewErrorMessage( this.props ) }
+				{ renderRenewErrorMessage( { isJetpack, purchase, translate, site } ) }
 			</>
 		);
 	}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -419,10 +419,7 @@ function PurchaseMetaExpiration( {
 	const isProductOwner = purchase?.userId === useSelector( getCurrentUserId );
 	const isAutorenewalEnabled = purchase ? ! isExpiring( purchase ) : null;
 	const hideAutoRenew =
-		purchase &&
-		shouldShowOfferResetFlow() &&
-		JETPACK_LEGACY_PLANS.includes( purchase.productSlug ) &&
-		! isRenewable( purchase );
+		purchase && JETPACK_LEGACY_PLANS.includes( purchase.productSlug ) && ! isRenewable( purchase );
 
 	if ( isDomainTransfer( purchase ) ) {
 		return null;

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -75,14 +75,12 @@ class PurchaseMeta extends Component {
 		getManagePurchaseUrlFor: managePurchase,
 	};
 
-	isDataLoading( props ) {
-		return ! props.hasLoadedSites || ! props.hasLoadedPurchasesFromServer;
-	}
-
 	render() {
-		const { translate, purchaseId } = this.props;
+		const { translate, purchaseId, hasLoadedSites, hasLoadedPurchasesFromServer } = this.props;
 
-		if ( this.isDataLoading( this.props ) || ! purchaseId ) {
+		const isDataLoading = ! hasLoadedSites || ! hasLoadedPurchasesFromServer;
+
+		if ( isDataLoading || ! purchaseId ) {
 			return renderPlaceholder();
 		}
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -87,33 +87,33 @@ export default function PurchaseMeta( {
 	return (
 		<>
 			<ul className="manage-purchase__meta">
-				{ renderOwner( { translate, owner } ) }
+				<PurchaseMetaOwner translate={ translate } owner={ owner } />
 				<li>
 					<em className="manage-purchase__detail-label">{ translate( 'Price' ) }</em>
 					<span className="manage-purchase__detail">
-						{ renderPrice( { purchase, translate } ) }
+						<PurchaseMetaPrice purchase={ purchase } translate={ translate } />
 					</span>
 				</li>
-				{ renderExpiration( {
-					purchase,
-					site,
-					siteSlug,
-					translate,
-					moment,
-					isAutorenewalEnabled,
-					isProductOwner,
-					hideAutoRenew,
-					getEditPaymentMethodUrlFor,
-					getManagePurchaseUrlFor,
-				} ) }
-				{ renderPaymentDetails( {
-					purchase,
-					translate,
-					getEditPaymentMethodUrlFor,
-					siteSlug,
-					site,
-					moment,
-				} ) }
+				<PurchaseMetaExpiration
+					purchase={ purchase }
+					site={ site }
+					siteSlug={ siteSlug }
+					translate={ translate }
+					moment={ moment }
+					isAutorenewalEnabled={ isAutorenewalEnabled }
+					isProductOwner={ isProductOwner }
+					hideAutoRenew={ hideAutoRenew }
+					getEditPaymentMethodUrlFor={ getEditPaymentMethodUrlFor }
+					getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+				/>
+				<PurchaseMetaPaymentDetails
+					purchase={ purchase }
+					translate={ translate }
+					getEditPaymentMethodUrlFor={ getEditPaymentMethodUrlFor }
+					siteSlug={ siteSlug }
+					site={ site }
+					moment={ moment }
+				/>
 			</ul>
 			<RenewErrorMessage
 				isJetpack={ isJetpack }
@@ -234,7 +234,7 @@ function PurchaseMetaPlaceholder() {
 	);
 }
 
-function renderOwner( { translate, owner } ) {
+function PurchaseMetaOwner( { translate, owner } ) {
 	if ( ! owner ) {
 		return null;
 	}
@@ -288,7 +288,7 @@ function renderPaymentInfo( { purchase, translate, moment } ) {
 	return translate( 'None' );
 }
 
-function renderPrice( { purchase, translate } ) {
+function PurchaseMetaPrice( { purchase, translate } ) {
 	const { priceText, currencyCode, productSlug } = purchase;
 	const plan = getPlan( productSlug ) || getProductFromSlug( productSlug );
 	let period = translate( 'year' );
@@ -330,7 +330,7 @@ function renderPrice( { purchase, translate } ) {
 	} );
 }
 
-function renderPaymentDetails( {
+function PurchaseMetaPaymentDetails( {
 	purchase,
 	translate,
 	getEditPaymentMethodUrlFor,
@@ -428,7 +428,7 @@ function RenewErrorMessage( { isJetpack, purchase, translate, site } ) {
 	);
 }
 
-function renderExpiration( {
+function PurchaseMetaExpiration( {
 	purchase,
 	site,
 	siteSlug,


### PR DESCRIPTION
We're currently using the user level purchase query component in ManagePurchase in both the site-level and account-level contexts, which for users with a lot of sites is extremely slow.

#### Changes proposed in this Pull Request

* Conditionally use the site level query component for loading purchases. The first 4 commits handle this; the rest are refactoring `PurchaseMeta` to a functional component.

#### Testing instructions

We need to test for two things: that performance improves in the site-level context, and that the behavior is preserved in the account-level context.

Site-level:
- Navigate to `/purchases/subscriptions/:site_url`.
- Wait for your list of purchases to load.
- Select a purchase to navigate to the Purchase Settings screen, and check that this screen loads correctly.
- In the network tab, check that you do not see an api request to `me/purchases`.
- To see the performance improvement, you'll need to test as a user with lots of purchases. For example, my test user has ~60 purchases, and the request to `me/purchases` takes about a minute, but `sites/:site_id/purchases` is about 500ms.

Account-level:
- Navigate to `/me/purchases`.
- Wait for your list of purchases to load (should take longer if your user has a lot of purchases).
- Select a purchase to navigate to the Purchase Settings screen, and check that the Purchase Settings screen loads correctly.
