### PR TITLE
Jetpack Cloud: make the Jetpack Free card appear on the Pricing page

### DIFF
--- a/client/my-sites/plans-v2/products-grid-i5/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-i5/index.tsx
@@ -172,7 +172,7 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 					) ) }
 				</ul>
 				<div className="products-grid-i5__free">
-					{ ( isInConnectFlow || isInJetpackCloud ) && siteId && (
+					{ ( isInConnectFlow || isInJetpackCloud ) && (
 						<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
 					) }
 				</div>

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -65,7 +65,7 @@ export interface WithRedirectToSelectorProps extends BasePageProps {
 
 export interface JetpackFreeProps {
 	urlQueryArgs: QueryArgs;
-	siteId?: number;
+	siteId: number | null;
 }
 
 export type SelectorProductSlug = typeof PRODUCTS_WITH_OPTIONS[ number ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove check that hides the Jetpack Free card.

#### Testing instructions

* Run this PR (Calypso Blue and Green).
* Visit the Pricing page in `http://jetpack.cloud.localhost:3001/pricing`.
* Verify that the Jetpack Free card appears at the bottom of the page.
* Visit the Pricing/Plans page in `http://calypso.localhost:3000/plans/:site`.
* Verify that the Jetpack Free card doesn't appear at the bottom of the page.

#### Demo
##### Calypso Green (the card appears)
![image](https://user-images.githubusercontent.com/3418513/99124541-25fae100-25e1-11eb-9578-f838957abba3.png)

##### Calypso Blue (the card doesn't appear)
![image](https://user-images.githubusercontent.com/3418513/99124620-45920980-25e1-11eb-9909-5678690e133b.png)


