### PR TITLE
Add (regression) E2E test to make sure the line height setting is present

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -25,7 +25,8 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 			names.map( ( name ) => `.edit-post-sidebar__panel-tab[aria-label^=${ name }]` ).join()
 		);
 		await driverHelper.scrollIntoView( this.driver, by );
-		return driverHelper.clickWhenClickable( this.driver, by );
+		await driverHelper.clickWhenClickable( this.driver, by );
+		return driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.components-panel' ) );
 	}
 
 	async selectDocumentTab() {
@@ -33,10 +34,10 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 		// Older versions use "Document"
 		// @TODO: Remove "Document"
 		await this.selectTab( 'Post', 'Page', 'Document' );
-		return await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			By.css( '.components-panel' )
-		);
+	}
+
+	async selectBlockTab() {
+		await this.selectTab( 'Block' );
 	}
 
 	async expandStatusAndVisibility() {
@@ -190,6 +191,12 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 		const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 		await gEditorComponent.openSidebar();
 		return this.selectDocumentTab();
+	}
+
+	async chooseBlockSettings() {
+		const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+		await gEditorComponent.openSidebar();
+		return this.selectBlockTab();
 	}
 
 	async setVisibilityToPasswordProtected( password ) {

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -924,6 +924,27 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 					);
 				} );
 
+				step( 'Can see the Line Height setting for the paragraph', async function () {
+					const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+
+					// Give focus to the first paragraph block found
+					await driverHelper.clickWhenClickable(
+						driver,
+						By.css( 'p.block-editor-rich-text__editable:first-of-type' )
+					);
+
+					await gSidebarComponent.displayComponentIfNecessary();
+
+					await gSidebarComponent.chooseBlockSettings();
+
+					const lineHeighSettingPresent = await driverHelper.isElementPresent(
+						driver,
+						By.css( '.block-editor-line-height-control' )
+					);
+
+					assert.ok( lineHeighSettingPresent, 'Line height setting not found' );
+				} );
+
 				step(
 					'Can set the new title and update it, and link to the updated post',
 					async function () {
@@ -1295,28 +1316,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const content = await editor.getContent();
 			assert.strictEqual( title, originalTitle, 'The restored post title is not correct' );
 			assert.strictEqual( content, originalContent, 'The restored post content is not correct' );
-		} );
-	} );
-
-	describe( 'Settings @parallel', function () {
-		step( 'Can log in', async function () {
-			const loginFlow = new LoginFlow( driver, gutenbergUser );
-			await loginFlow.loginAndStartNewPost( null, true );
-		} );
-
-		step( 'Line height setting is available', async function () {
-			const editor = await GutenbergEditorComponent.Expect( driver );
-			await editor.enterText( 'Foobar' );
-
-			const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
-			await gSidebarComponent.displayComponentIfNecessary();
-			await gSidebarComponent.chooseBlockSettings();
-
-			const lineHeighSettingPresent = await driverHelper.isElementPresent(
-				driver,
-				By.css( '.block-editor-line-height-control' )
-			);
-			assert.strictEqual( lineHeighSettingPresent, true, 'Line height setting not found' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1306,9 +1306,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 		step( 'Line height setting is available', async function () {
 			const editor = await GutenbergEditorComponent.Expect( driver );
-			const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
-
 			await editor.enterText( 'Foobar' );
+
+			const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gSidebarComponent.displayComponentIfNecessary();
 			await gSidebarComponent.chooseBlockSettings();
 

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -927,6 +927,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				step( 'Can see the Line Height setting for the paragraph', async function () {
 					const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 
+					if ( driverManager.currentScreenSize() === 'mobile' )
+						await gSidebarComponent.hideComponentIfNecessary();
+
 					// Give focus to the first paragraph block found
 					await driverHelper.clickWhenClickable(
 						driver,
@@ -940,6 +943,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 						driver,
 						By.css( '.block-editor-line-height-control' )
 					);
+
+					if ( driverManager.currentScreenSize() === 'mobile' )
+						await gSidebarComponent.hideComponentIfNecessary();
 
 					assert.ok( lineHeighSettingPresent, 'Line height setting not found' );
 				} );

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -934,7 +934,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 					);
 
 					await gSidebarComponent.displayComponentIfNecessary();
-
 					await gSidebarComponent.chooseBlockSettings();
 
 					const lineHeighSettingPresent = await driverHelper.isElementPresent(

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -3,6 +3,7 @@
  */
 import assert from 'assert';
 import config from 'config';
+import { By } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
@@ -1294,6 +1295,28 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const content = await editor.getContent();
 			assert.strictEqual( title, originalTitle, 'The restored post title is not correct' );
 			assert.strictEqual( content, originalContent, 'The restored post content is not correct' );
+		} );
+	} );
+
+	describe( 'Settings @parallel', function () {
+		step( 'Can log in', async function () {
+			const loginFlow = new LoginFlow( driver, gutenbergUser );
+			await loginFlow.loginAndStartNewPost( null, true );
+		} );
+
+		step( 'Line height setting is available', async function () {
+			const editor = await GutenbergEditorComponent.Expect( driver );
+			const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+
+			await editor.enterText( 'Foobar' );
+			await gSidebarComponent.displayComponentIfNecessary();
+			await gSidebarComponent.chooseBlockSettings();
+
+			const lineHeighSettingPresent = await driverHelper.isElementPresent(
+				driver,
+				By.css( '.block-editor-line-height-control' )
+			);
+			assert.strictEqual( lineHeighSettingPresent, true, 'Line height setting not found' );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Changes proposed in this Pull Request

Closes #46880

Adds a regression test in the client block E2E spec to make sure the `line-height` setting is preset for paragraphs and avoid the regression of this issue: https://github.com/Automattic/wp-calypso/issues/46880.

### How to test

1. Setup your env to run Calypso E2E tests (search for "Automated end-to-end Testing") in the FG;
1. Edit `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-post-editor-spec.js` and call `.only` after `describe` for this test in order to restrict the spec to it;
1. Run with `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-post-editor-spec.js`;
1. It should pass 🟢 

#### Negative scenario

1. Setup your env to run Calypso E2E tests (search for "Automated end-to-end Testing") in the FG;
1. Update your WPCOM sandbox with the latest changes from upstream, make sure you're running at least GB 9.2;
1. Open `wp-calypso/test/e2e/config/local-decrypted.json`, find the entry for `gutenbergSimpleSiteUser`, grab the WP test site address from there
1. Map this address to your sandbox
1. ssh into your sandbox
1. Open `full-site-site-editing.php` in `mu-plugins` and find the `get_current_prod_version` function. Grab the value of the `$__autogen_plugin_version_prod` var;
1. Now go to the `ET` directory in the `plugins` directory and open the right version directory. Edit `common/index.php`. Remove or comment-out line 155 (`add_theme_support( 'custom-line-height' );`). Exit your sandbox;
1. Edit `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-post-editor-spec.js` and call `.only` after `describe` for this test in order to restrict the spec to it;
1. Run the spec with `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-post-editor-spec.js`;
1. It should fail 🔴 


### Observations and questions

1. I'm still not sure if this test belongs in that spec (`wp-calypso-gutenberg-post-editor-spec.js`) or if it should be moved somewhere else. Still pondering. Any hints?;
1. Should we test this for the page editor as well? (I assume not, since the behavior should be the same);
1. I'm just checking for the presence of the div that wraps the setting UI control, which is enough for the purposes of the regression test.

### TODO 

- [x] Deal with the mobile viewport, tests are failing


