### PR TITLE
Purchases: Show Stripe configuration errors

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -5,14 +5,13 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { camelCase, values } from 'lodash';
-import { connect, useDispatch } from 'react-redux';
+import { connect } from 'react-redux';
 import debugFactory from 'debug';
 import { Card } from '@automattic/components';
 import {
 	createStripeSetupIntent,
 	StripeSetupIntentError,
 	StripeValidationError,
-	StripeConfigurationError,
 	useStripe,
 } from '@automattic/calypso-stripe';
 
@@ -29,8 +28,6 @@ import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'calypso/lib/url/support';
 import getCountries from 'calypso/state/selectors/get-countries';
 import QueryPaymentCountries from 'calypso/components/data/query-countries/payments';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { logToLogstash } from 'calypso/state/logstash/actions';
-import config from 'calypso/config';
 import {
 	getInitializedFields,
 	camelCaseFormFields,
@@ -84,7 +81,6 @@ export function CreditCardForm( {
 		)
 	);
 	const [ debouncedFieldErrors, setDebouncedFieldErrors ] = useDebounce( formFieldErrors, 1000 );
-	const reduxDispatch = useDispatch();
 
 	const onFieldChange = ( rawDetails ) => {
 		const newValues = { ...formFieldValues, ...camelCaseFormFields( rawDetails ) };
@@ -157,21 +153,6 @@ export function CreditCardForm( {
 			setFormSubmitting( false );
 			error && setStripeError && setStripeError( error );
 			error && displayError( { translate, error } );
-
-			if ( error instanceof StripeConfigurationError ) {
-				reduxDispatch(
-					logToLogstash( {
-						feature: 'calypso_client',
-						message: 'Stripe configuration error',
-						severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-						extra: {
-							env: config( 'env_id' ),
-							type: 'stripe_configuration_error',
-							message: String( error ),
-						},
-					} )
-				);
-			}
 		}
 	};
 

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { camelCase, values } from 'lodash';
@@ -156,14 +156,13 @@ export function CreditCardForm( {
 		}
 	};
 
-	if ( stripeLoadingError ) {
-		displayError( { translate, stripeLoadingError } );
-		return <div>{ translate( 'An unexpected error occurred. Please try again later.' ) }</div>;
-	}
+	useEffect( () => {
+		if ( stripeLoadingError ) {
+			displayError( { translate, stripeLoadingError } );
+		}
+	}, [ stripeLoadingError, translate ] );
 
-	if ( isStripeLoading ) {
-		return translate( 'Loading…' );
-	}
+	const disabled = isStripeLoading || stripeLoadingError;
 
 	return (
 		<form onSubmit={ onSubmit }>
@@ -189,7 +188,11 @@ export function CreditCardForm( {
 					showUsedForExistingPurchasesInfo={ showUsedForExistingPurchasesInfo }
 				/>
 
-				<SaveButton translate={ translate } formSubmitting={ formSubmitting } />
+				<SaveButton
+					translate={ translate }
+					disabled={ disabled }
+					formSubmitting={ formSubmitting }
+				/>
 
 				{ onCancel && (
 					<FormButton type="button" isPrimary={ false } onClick={ onCancel }>
@@ -218,9 +221,9 @@ CreditCardForm.propTypes = {
 	translate: PropTypes.func.isRequired,
 };
 
-function SaveButton( { translate, formSubmitting } ) {
+function SaveButton( { translate, disabled, formSubmitting } ) {
 	return (
-		<FormButton disabled={ formSubmitting } type="submit">
+		<FormButton disabled={ disabled || formSubmitting } type="submit">
 			{ formSubmitting
 				? translate( 'Saving card…', {
 						context: 'Button label',

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -5,13 +5,14 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { camelCase, values } from 'lodash';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import debugFactory from 'debug';
 import { Card } from '@automattic/components';
 import {
 	createStripeSetupIntent,
 	StripeSetupIntentError,
 	StripeValidationError,
+	StripeConfigurationError,
 	useStripe,
 } from '@automattic/calypso-stripe';
 
@@ -28,6 +29,8 @@ import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'calypso/lib/url/support';
 import getCountries from 'calypso/state/selectors/get-countries';
 import QueryPaymentCountries from 'calypso/components/data/query-countries/payments';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { logToLogstash } from 'calypso/state/logstash/actions';
+import config from 'calypso/config';
 import {
 	getInitializedFields,
 	camelCaseFormFields,
@@ -81,6 +84,7 @@ export function CreditCardForm( {
 		)
 	);
 	const [ debouncedFieldErrors, setDebouncedFieldErrors ] = useDebounce( formFieldErrors, 1000 );
+	const reduxDispatch = useDispatch();
 
 	const onFieldChange = ( rawDetails ) => {
 		const newValues = { ...formFieldValues, ...camelCaseFormFields( rawDetails ) };
@@ -153,6 +157,21 @@ export function CreditCardForm( {
 			setFormSubmitting( false );
 			error && setStripeError && setStripeError( error );
 			error && displayError( { translate, error } );
+
+			if ( error instanceof StripeConfigurationError ) {
+				reduxDispatch(
+					logToLogstash( {
+						feature: 'calypso_client',
+						message: 'Stripe configuration error',
+						severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+						extra: {
+							env: config( 'env_id' ),
+							type: 'stripe_configuration_error',
+							message: String( error ),
+						},
+					} )
+				);
+			}
 		}
 	};
 

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -62,7 +62,13 @@ export function CreditCardForm( {
 	onCancel = undefined,
 	translate,
 } ) {
-	const { stripe, stripeConfiguration, setStripeError } = useStripe();
+	const {
+		stripe,
+		stripeConfiguration,
+		setStripeError,
+		isStripeLoading,
+		stripeLoadingError,
+	} = useStripe();
 	const [ formSubmitting, setFormSubmitting ] = useState( false );
 	const [ formFieldValues, setFormFieldValues ] = useState( getInitializedFields( initialValues ) );
 	const [ touchedFormFields, setTouchedFormFields ] = useState( {} );
@@ -149,6 +155,15 @@ export function CreditCardForm( {
 			error && displayError( { translate, error } );
 		}
 	};
+
+	if ( stripeLoadingError ) {
+		displayError( { translate, stripeLoadingError } );
+		return <div>{ translate( 'An unexpected error occurred. Please try again later.' ) }</div>;
+	}
+
+	if ( isStripeLoading ) {
+		return translate( 'Loading…' );
+	}
 
 	return (
 		<form onSubmit={ onSubmit }>

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -158,7 +158,7 @@ export function CreditCardForm( {
 
 	useEffect( () => {
 		if ( stripeLoadingError ) {
-			displayError( { translate, stripeLoadingError } );
+			displayError( { translate, error: stripeLoadingError } );
 		}
 	}, [ stripeLoadingError, translate ] );
 

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -135,10 +135,11 @@ function CreditCardNumberField( { translate, createField, getErrorMessage, card 
 		);
 	}
 
-	const disabled =
-		isStripeLoading || stripeLoadingError
-			? ! shouldRenderAdditionalCountryFields( card.country )
-			: false;
+	const disabled = isFieldDisabled( {
+		isStripeLoading,
+		stripeLoadingError,
+		isUsingEbanx: shouldRenderAdditionalCountryFields( card.country ),
+	} );
 
 	return createField( 'number', CreditCardNumberInput, {
 		inputMode: 'numeric',
@@ -201,10 +202,11 @@ function CreditCardExpiryAndCvvFields( { translate, createField, getErrorMessage
 		);
 	}
 
-	const disabled =
-		isStripeLoading || stripeLoadingError
-			? ! shouldRenderAdditionalCountryFields( card.country )
-			: false;
+	const disabled = isFieldDisabled( {
+		isStripeLoading,
+		stripeLoadingError,
+		isUsingEbanx: shouldRenderAdditionalCountryFields( card.country ),
+	} );
 
 	return (
 		<React.Fragment>
@@ -385,8 +387,11 @@ function CardholderNameField( { createField, shouldRenderCountrySpecificFields, 
 	const translate = useTranslate();
 	const { isStripeLoading, stripeLoadingError } = useStripe();
 
-	const disabled =
-		isStripeLoading || stripeLoadingError ? ! shouldRenderCountrySpecificFields() : false;
+	const disabled = isFieldDisabled( {
+		isStripeLoading,
+		stripeLoadingError,
+		isUsingEbanx: shouldRenderCountrySpecificFields(),
+	} );
 
 	return (
 		<>
@@ -403,6 +408,17 @@ function CardholderNameField( { createField, shouldRenderCountrySpecificFields, 
 			} ) }
 		</>
 	);
+}
+
+function isFieldDisabled( { isStripeLoading, stripeLoadingError, isUsingEbanx } ) {
+	const isStripeNotReady = isStripeLoading || stripeLoadingError;
+	if ( isUsingEbanx ) {
+		return false;
+	}
+	if ( isStripeNotReady ) {
+		return true;
+	}
+	return false;
 }
 
 export default localize( CreditCardFormFields );

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { CardCvcElement, CardExpiryElement, CardNumberElement } from 'react-stripe-elements';
 import { isEmpty, noop } from 'lodash';
-import { localize } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
 import { useStripe } from '@automattic/calypso-stripe';
 
 /**
@@ -17,7 +17,6 @@ import CreditCardNumberInput from 'calypso/components/upgrades/credit-card-numbe
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
 import InfoPopover from 'calypso/components/info-popover';
-import notices from 'calypso/notices';
 import PaymentCountrySelect from 'calypso/components/payment-country-select';
 import { Input } from 'calypso/my-sites/domains/components/form';
 import { maskField, unmaskField, getCreditCardType } from 'calypso/lib/checkout';
@@ -158,9 +157,6 @@ CreditCardNumberField.propTypes = {
 
 function CreditCardExpiryAndCvvFields( { translate, createField, getErrorMessage, card } ) {
 	const { stripe, isStripeLoading, stripeLoadingError } = useStripe();
-	if ( stripeLoadingError && ! shouldRenderAdditionalCountryFields( card.country ) ) {
-		notices.error( stripeLoadingError.message || 'Error loading Stripe' );
-	}
 
 	const cvcLabel = translate( 'Security Code {{span}}("CVC" or "CVV"){{/span}}', {
 		components: {

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -327,19 +327,14 @@ export class CreditCardFormFields extends React.Component {
 			'credit-card-form-fields__extras': true,
 			'ebanx-details-required': countryDetailsRequired,
 		} );
-
+		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
 			<div className="credit-card-form-fields">
-				{ this.createField( 'name', Input, {
-					autoFocus,
-					label: translate( 'Cardholder Name {{span}}(as written on card){{/span}}', {
-						comment: 'Cardholder name label on credit card form',
-						components: {
-							span: <span className="credit-card-form-fields__explainer" />,
-						},
-					} ),
-					placeholder: ' ',
-				} ) }
+				<CardholderNameField
+					autoFocus={ autoFocus }
+					createField={ this.createField }
+					shouldRenderCountrySpecificFields={ this.shouldRenderCountrySpecificFields }
+				/>
 				<div className="credit-card-form-fields__field number">
 					<CreditCardNumberField
 						translate={ this.props.translate }
@@ -384,6 +379,30 @@ export class CreditCardFormFields extends React.Component {
 			</div>
 		);
 	}
+}
+
+function CardholderNameField( { createField, shouldRenderCountrySpecificFields, autoFocus } ) {
+	const translate = useTranslate();
+	const { isStripeLoading, stripeLoadingError } = useStripe();
+
+	const disabled =
+		isStripeLoading || stripeLoadingError ? ! shouldRenderCountrySpecificFields() : false;
+
+	return (
+		<>
+			{ createField( 'name', Input, {
+				disabled,
+				autoFocus,
+				label: translate( 'Cardholder Name {{span}}(as written on card){{/span}}', {
+					comment: 'Cardholder name label on credit card form',
+					components: {
+						span: <span className="credit-card-form-fields__explainer" />,
+					},
+				} ),
+				placeholder: ' ',
+			} ) }
+		</>
+	);
 }
 
 export default localize( CreditCardFormFields );

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -310,7 +310,7 @@ export class CreditCardFormFields extends React.Component {
 		this.updateFieldValues( event.target.name, event.target.value );
 	};
 
-	shouldRenderCountrySpecificFields() {
+	shouldRenderCountrySpecificFields = () => {
 		// The add/update card endpoints do not process Ebanx payment details
 		// so we only show Ebanx fields at checkout,
 		// i.e., when there is a current transaction.
@@ -318,7 +318,7 @@ export class CreditCardFormFields extends React.Component {
 			this.props.isNewTransaction &&
 			shouldRenderAdditionalCountryFields( this.getFieldValue( 'country' ) )
 		);
-	}
+	};
 
 	render() {
 		const { translate, countriesList, autoFocus } = this.props;

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -47,7 +47,7 @@ function useLogPaymentMethodsError( message: string ) {
 				} )
 			);
 		},
-		[ reduxDispatch ]
+		[ reduxDispatch, message ]
 	);
 }
 

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -52,7 +52,7 @@ function useLogPaymentMethodsError( message: string ) {
 }
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-export function PaymentMethods( { siteSlug }: { siteSlug: string } ) {
+export function PaymentMethods( { siteSlug }: { siteSlug: string } ): JSX.Element {
 	const translate = useTranslate();
 	const logPaymentMethodsError = useLogPaymentMethodsError(
 		'site level payment methods load error'
@@ -81,7 +81,7 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ) {
 	);
 }
 
-export function AddNewPaymentMethod( { siteSlug }: { siteSlug: string } ) {
+export function AddNewPaymentMethod( { siteSlug }: { siteSlug: string } ): JSX.Element {
 	const translate = useTranslate();
 	const createAddCardToken = ( ...args: unknown[] ) => createCardToken( 'card_add', ...args );
 	const goToBillingHistory = () => page( getPaymentMethodsUrlFor( siteSlug ) );

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -406,7 +406,7 @@ function useStripeJs(
  */
 function useStripeConfiguration(
 	fetchStripeConfiguration: GetStripeConfiguration,
-	requestArgs: undefined | null | GetStripeConfigurationArgs = null
+	requestArgs?: undefined | null | GetStripeConfigurationArgs
 ): { stripeConfiguration: StripeConfiguration | undefined; setStripeError: SetStripeError } {
 	const [ stripeError, setStripeError ] = useState< undefined | string >();
 	const [ stripeConfiguration, setStripeConfiguration ] = useState<

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -138,6 +138,8 @@ export class StripeValidationError extends Error {
 	}
 }
 
+export class StripeConfigurationError extends Error {}
+
 /**
  * An error related to a Setup Intent
  *
@@ -225,7 +227,7 @@ export async function createStripeSetupIntent(
 	debug( 'creating setup intent...', paymentDetails );
 	if ( ! stripeConfiguration.setup_intent_id ) {
 		debug( 'Unable to create setup intent; missing intent ID' );
-		throw new Error(
+		throw new StripeConfigurationError(
 			'There is a problem with the credit card system configuration. Please try reloading the page.'
 		);
 	}

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -228,7 +228,7 @@ export async function createStripeSetupIntent(
 	if ( ! stripeConfiguration.setup_intent_id ) {
 		debug( 'Unable to create setup intent; missing intent ID' );
 		throw new StripeConfigurationError(
-			'There is a problem with the credit card system configuration. Please try reloading the page.'
+			'There is a problem with the payment method system configuration.'
 		);
 	}
 	let stripeResponse: HandleCardSetupResponse | undefined;
@@ -441,7 +441,7 @@ function useStripeConfiguration(
 				if ( requestArgs?.needs_intent && ! configuration.setup_intent_id ) {
 					debug( 'invalid stripe configuration; missing setup_intent_id', configuration );
 					throw new StripeConfigurationError(
-						'Error loading new credit card form. Received invalid data from the server.'
+						'Error loading new payment method configuration. Received invalid data from the server.'
 					);
 				}
 				if (
@@ -451,7 +451,7 @@ function useStripeConfiguration(
 				) {
 					debug( 'invalid stripe configuration; missing some data', configuration );
 					throw new StripeConfigurationError(
-						'Error loading credit card form. Received invalid data from the server.'
+						'Error loading payment method configuration. Received invalid data from the server.'
 					);
 				}
 				debug( 'stripe configuration received', configuration );

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -413,10 +413,9 @@ function useStripeConfiguration(
 		undefined | StripeConfiguration
 	>();
 	useEffect( () => {
-		const getConfig = fetchStripeConfiguration;
 		debug( 'loading stripe configuration' );
 		let isSubscribed = true;
-		getConfig( requestArgs || {} ).then(
+		fetchStripeConfiguration( requestArgs || {} ).then(
 			( configuration ) => isSubscribed && setStripeConfiguration( configuration )
 		);
 		return () => {

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -223,6 +223,12 @@ export async function createStripeSetupIntent(
 	paymentDetails: PaymentDetails
 ): Promise< StripeSetupIntent > {
 	debug( 'creating setup intent...', paymentDetails );
+	if ( ! stripeConfiguration.setup_intent_id ) {
+		debug( 'Unable to create setup intent; missing intent ID' );
+		throw new Error(
+			'There is a problem with the credit card system configuration. Please try reloading the page.'
+		);
+	}
 	let stripeResponse: HandleCardSetupResponse | undefined;
 	try {
 		stripeResponse = await stripe.handleCardSetup( stripeConfiguration.setup_intent_id, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When creating a `StripeHookProvider` (used for displaying and submitting Stripe credit card fields and other Stripe operations), you can pass in a request to create a "setup intent". We need a setup intent if we want to submit a new credit card to Stripe without making a purchase (eg: when updating credit cards for an existing subscription). That request is sent to the `/me/stripe-configuration` HTTP API endpoint, but there are certain cases where this process could fail.

For example, if the customer's account does not have its email address verified, then the API endpoint will return the configuration without the setup intent included. There are other reasons why it might fail, but this is the easiest to reproduce. In such a case, the `StripeHookProvider` will unknowingly save the returned stripe configuration with the setup intent missing. When the customer then tries to submit a new credit card, the `createStripeSetupIntent` function will throw a cryptic error that reads `Invalid PaymentIntent client secret passed to handleCardPayment. Expected string, got undefined.` Needless to say, this is very poor UX for the customer.

See also pNPgK-5go-p2

In this PR we do several things to help with these situations.

1. We make sure that the credit card form remains completely in a disabled state if Stripe is not ready or has an error (previously this was mostly true but the submit button and the cardholder name were unaffected).
1. We make sure to show an error notice if Stripe has an error (previously this was mostly true, but the display process was inside the CVV field component and now it is at the top of the credit card form and includes special messaging for certain types of errors).
1. We make sure `createStripeSetupIntent` will throw an explicit error if it is called without a setup intent, since one is required by that function.
1. We validate all the data returned by the stripe configuration endpoint, including the setup intent, if one is requested; if any data is missing, we throw an explicit error before we even allow the credit card form to load.

Note that in testing this, I discovered that the credit card form is broken for Brazil (Ebanx) cards. This is an unrelated issue which I've documented in https://github.com/Automattic/wp-calypso/issues/47436

#### Screenshots

Before this PR:

![before](https://user-images.githubusercontent.com/2036909/99158233-b5b29500-269e-11eb-9bf5-7d2bc640be5f.png)

After this PR:

<img width="695" alt="Screen Shot 2020-11-14 at 5 47 41 PM" src="https://user-images.githubusercontent.com/2036909/99158515-83566700-26a1-11eb-975d-932319ce0fef.png">

After this PR and D52769-code, which causes the server to return an error message if setup intent fails:

<img width="748" alt="Screen Shot 2020-11-14 at 5 38 41 PM" src="https://user-images.githubusercontent.com/2036909/99158501-60c44e00-26a1-11eb-85e7-a3bf1ad58521.png">

#### Testing instructions

First use an account with a verified email address to test the normal behavior.

- Visit `/me/purchases/add-credit-card` and verify that you see the disabled credit card form for a moment while Stripe is loading. Verify that you then see the form become functional once Stripe has loaded.
- Enter a credit card and click to save. Verify that the card saves successfully.

Next we need to cause the endpoint to fail. There are two options here:

- Sign up for a new account and do not validate the email address.  **OR** Apply D52768-code to break the setup intent feature of the stripe configuration endpoint.

Then we test the card form:

- Visit `/me/purchases/add-credit-card` and verify that you see the disabled credit card form permanently. Verify that you see an error message displayed.

Lastly, we should make sure this does not break other uses of Stripe, ie: checkout:

- Add a product to your cart and visit checkout. Choose to add a new credit card, fill out the form, and submit the purchase.
- Verify that the purchase is successful.