### PR TITLE
Pages: filter for blog visibility

### DIFF
--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -99,6 +99,7 @@ class PagesMain extends React.Component {
 		const query = {
 			number: 20, // all-sites mode, i.e the /me/posts endpoint, only supports up to 20 results at a time
 			search,
+			site_visibility: ! siteId ? 'visible' : undefined,
 			// When searching, search across all statuses so the user can
 			// always find what they are looking for, regardless of what tab
 			// the search was initiated from. Use POST_STATUSES rather than


### PR DESCRIPTION
For users with a large number of hidden blogs (automatticians), the All Sites > Pages list is effectively broken. This passes the `site_visibilty: visible` query argument when in all sites mode ([like we do for All Sites > Posts](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/posts/main.jsx#L68)).

**To test:**
- with an a11n account, visit wordpress.com/pages
- verify that no pages are listed
- visit calypso.localhost:3000/pages
- verify that you can see visible pages