### PR TITLE
Editing Toolkit: Update to 2.8.5

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.4
+ * Version: 2.8.5
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.4' );
+define( 'PLUGIN_VERSION', '2.8.5' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -46,6 +46,8 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Premium Content: add block preview for the Premium Content block (https://github.com/Automattic/wp-calypso/pull/47200)
 * Premium Content: allow the payments button to know when it's inside the premium content block (https://github.com/Automattic/wp-calypso/pull/47245)
 * Enable persistent launch button in all environments (https://github.com/Automattic/wp-calypso/pull/46817)
+* Coming soon: remove cookie banner, open graph, gravatar and other unneeded features from coming soon page (https://github.com/Automattic/wp-calypso/pull/47400)
+* Coming soon: fix the localised login link on the coming soon page
 
 = 2.8.4 =
 * Editor NUX modal: Temporarily make text smaller in editor welcome modal for german language (https://github.com/Automattic/wp-calypso/pull/47193)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -45,7 +45,6 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Launch: support i18n in domain picker (https://github.com/Automattic/wp-calypso/pull/47178)
 * Premium Content: add block preview for the Premium Content block (https://github.com/Automattic/wp-calypso/pull/47200)
 * Premium Content: allow the payments button to know when it's inside the premium content block (https://github.com/Automattic/wp-calypso/pull/47245)
-* Enable persistent launch button in all environments (https://github.com/Automattic/wp-calypso/pull/46817)
 * Coming soon: remove cookie banner, open graph, gravatar and other unneeded features from coming soon page (https://github.com/Automattic/wp-calypso/pull/47400)
 * Coming soon: fix the localised login link on the coming soon page (https://github.com/Automattic/wp-calypso/pull/47307)
 * Comgin soon: don't cache the coming soon page (https://github.com/Automattic/wp-calypso/pull/47450)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -47,7 +47,8 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Premium Content: allow the payments button to know when it's inside the premium content block (https://github.com/Automattic/wp-calypso/pull/47245)
 * Enable persistent launch button in all environments (https://github.com/Automattic/wp-calypso/pull/46817)
 * Coming soon: remove cookie banner, open graph, gravatar and other unneeded features from coming soon page (https://github.com/Automattic/wp-calypso/pull/47400)
-* Coming soon: fix the localised login link on the coming soon page
+* Coming soon: fix the localised login link on the coming soon page (https://github.com/Automattic/wp-calypso/pull/47307)
+* Comgin soon: don't cache the coming soon page (https://github.com/Automattic/wp-calypso/pull/47450)
 
 = 2.8.4 =
 * Editor NUX modal: Temporarily make text smaller in editor welcome modal for german language (https://github.com/Automattic/wp-calypso/pull/47193)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.4
+Stable tag: 2.8.5
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,13 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.5 =
+* Launch: support i18n in plans grid (https://github.com/Automattic/wp-calypso/pull/47227)
+* Launch: support i18n in domain picker (https://github.com/Automattic/wp-calypso/pull/47178)
+* Premium Content: add block preview for the Premium Content block (https://github.com/Automattic/wp-calypso/pull/47200)
+* Premium Content: allow the payments button to know when it's inside the premium content block (https://github.com/Automattic/wp-calypso/pull/47245)
+* Enable persistent launch button in all environments (https://github.com/Automattic/wp-calypso/pull/46817)
 
 = 2.8.4 =
 * Editor NUX modal: Temporarily make text smaller in editor welcome modal for german language (https://github.com/Automattic/wp-calypso/pull/47193)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.4",
+	"version": "2.8.5",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Version bump and changelog

#### [Changes to Editing Toolkit since 2.8.4](https://github.com/Automattic/wp-calypso/commits/master/apps/editing-toolkit):

- [x] Gutenboarding: plans grid requests data in the correct locale (#47227)
- [x] [eslint] Adds rule `one-var` and autofixes all related errors (#47310)
- [x] Gutenboarding i18n: i18n for domain picker in the launch flow (#47178)
- [x] Add block preview for Premium Content block (#47200)
- [x] Provide block context to the payments button. (#47245) 
- ~~[ ] Persistent Launch Button: enable in all environments (#46817)~~ (was just a code comment change)
- [x] Coming Soon page: disable head/footer scripts, cookie banner and Gravatar scripts (#47400)
- [x] consolidate the places we've defined get_iso_639_locale() and reuse it for coming soon (#47307)
- [x] Coming Soon: Set the headers to prevent caching for the different browsers (#47450)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load the diff (D52773-code) on your sandbox and confirm that the above changes work correctly
2. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.
