### PR TITLE
Pages: add author filter

### DIFF
--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -40,6 +40,8 @@ class SectionNav extends Component {
 		mobileOpen: false,
 	};
 
+	hasPinnedSearch = false;
+
 	UNSAFE_componentWillMount() {
 		this.checkForSiblingControls( this.props.children );
 	}
@@ -95,6 +97,7 @@ class SectionNav extends Component {
 	}
 
 	getChildren() {
+		this.hasPinnedSearch = false;
 		return React.Children.map( this.props.children, ( child ) => {
 			const extraProps = {
 				hasSiblingControls: this.hasSiblingControls,

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -198,16 +198,6 @@
 }
 
 // -------- Search --------
-.section-nav {
-	.search {
-		overflow: hidden;
-	}
-
-	.search.is-expanded-to-container {
-		height: 50px;
-
-		@include breakpoint-deprecated( '<480px' ) {
-			height: 46px;
-		}
-	}
+.section-nav .search {
+	overflow: hidden;
 }

--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -7,8 +7,13 @@ import React from 'react';
  * Internal Dependencies
  */
 import Pages from './main';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 
 export function pages( context, next ) {
-	context.primary = <Pages status={ context.params.status } search={ context.query.s } />;
+	const author =
+		context.params.author === 'my' ? getCurrentUserId( context.store.getState() ) : null;
+	context.primary = (
+		<Pages status={ context.params.status } search={ context.query.s } author={ author } />
+	);
 	next();
 }

--- a/client/my-sites/pages/index.js
+++ b/client/my-sites/pages/index.js
@@ -13,7 +13,7 @@ import { getSiteFragment } from 'calypso/lib/route';
 
 export default function () {
 	page(
-		'/pages/:status(published|drafts|scheduled|trashed)/:domain?',
+		'/pages/:author(my)?/:status(published|drafts|scheduled|trashed)?/:domain?',
 		siteSelection,
 		navigation,
 		pages,

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -78,14 +78,7 @@ class PagesMain extends React.Component {
 	}
 
 	render() {
-		const {
-			siteId,
-			search,
-			status = 'published',
-			translate,
-			searchPagesPlaceholder,
-			queryType,
-		} = this.props;
+		const { siteId, search, status = 'published', translate, queryType, author } = this.props;
 
 		const filterStrings = {
 			published: translate( 'Published', { context: 'Filter label for pages list' } ),
@@ -94,12 +87,11 @@ class PagesMain extends React.Component {
 			trashed: translate( 'Trashed', { context: 'Filter label for pages list' } ),
 		};
 
-		const isSingleSite = !! siteId;
-
 		const query = {
 			number: 20, // all-sites mode, i.e the /me/posts endpoint, only supports up to 20 results at a time
 			search,
 			site_visibility: ! siteId ? 'visible' : undefined,
+			author,
 			// When searching, search across all statuses so the user can
 			// always find what they are looking for, regardless of what tab
 			// the search was initiated from. Use POST_STATUSES rather than

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -17,12 +17,11 @@ import DocumentHead from 'calypso/components/data/document-head';
 import urlSearch from 'calypso/lib/url-search';
 import Main from 'calypso/components/main';
 import PostTypeFilter from 'calypso/my-sites/post-type-filter';
-import NavItem from 'calypso/components/section-nav/item';
 import PageList from './page-list';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { mapPostStatus as mapStatus } from 'calypso/lib/route';
+import { mapPostStatus } from 'calypso/lib/route';
 import { POST_STATUSES } from 'calypso/state/posts/constants';
 import { getPostTypeLabel } from 'calypso/state/post-types/selectors';
 import { Experiment } from 'calypso/components/experiment';
@@ -31,8 +30,6 @@ import { Experiment } from 'calypso/components/experiment';
  * Style dependencies
  */
 import './style.scss';
-
-const statuses = [ 'published', 'drafts', 'scheduled', 'trashed' ];
 
 class PagesMain extends React.Component {
 	static displayName = 'Pages';
@@ -76,14 +73,8 @@ class PagesMain extends React.Component {
 	}
 
 	render() {
-		const { siteId, search, status = 'published', translate, queryType, author } = this.props;
-
-		const filterStrings = {
-			published: translate( 'Published', { context: 'Filter label for pages list' } ),
-			drafts: translate( 'Drafts', { context: 'Filter label for pages list' } ),
-			scheduled: translate( 'Scheduled', { context: 'Filter label for pages list' } ),
-			trashed: translate( 'Trashed', { context: 'Filter label for pages list' } ),
-		};
+		const { siteId, search, status, translate, queryType, author } = this.props;
+		const postStatus = mapPostStatus( status );
 
 		const query = {
 			number: 20, // all-sites mode, i.e the /me/posts endpoint, only supports up to 20 results at a time
@@ -94,7 +85,7 @@ class PagesMain extends React.Component {
 			// always find what they are looking for, regardless of what tab
 			// the search was initiated from. Use POST_STATUSES rather than
 			// "any" to do this, since the latter excludes trashed posts.
-			status: search ? POST_STATUSES.join( ',' ) : mapStatus( status ),
+			status: search ? POST_STATUSES.join( ',' ) : postStatus,
 			type: queryType,
 		};
 
@@ -109,7 +100,7 @@ class PagesMain extends React.Component {
 					headerText={ translate( 'Pages' ) }
 					align="left"
 				/>
-				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ filterStrings[ status ] } />
+				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ status } />
 				<PageList siteId={ siteId } status={ status } search={ search } query={ query } />
 
 				{ /* ExPlat's Evergreen A/A Test Experiment:
@@ -130,28 +121,6 @@ class PagesMain extends React.Component {
 				/>
 			</Main>
 		);
-	}
-
-	getNavItems( filterStrings, currentStatus ) {
-		const { site, siteId } = this.props;
-		const sitePart = ( site && site.slug ) || siteId;
-		const siteFilter = sitePart ? '/' + sitePart : '';
-
-		return statuses.map( function ( status ) {
-			let path = `/pages${ siteFilter }`;
-			if ( status !== 'publish' ) {
-				path = `/pages/${ status }${ siteFilter }`;
-			}
-			return (
-				<NavItem
-					path={ path }
-					selected={ currentStatus === status }
-					key={ `page-filter-${ status }` }
-				>
-					{ filterStrings[ status ] }
-				</NavItem>
-			);
-		} );
 	}
 }
 

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -16,12 +16,10 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import DocumentHead from 'calypso/components/data/document-head';
 import urlSearch from 'calypso/lib/url-search';
 import Main from 'calypso/components/main';
+import PostTypeFilter from 'calypso/my-sites/post-type-filter';
 import NavItem from 'calypso/components/section-nav/item';
-import NavTabs from 'calypso/components/section-nav/tabs';
 import PageList from './page-list';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import Search from 'calypso/components/search';
-import SectionNav from 'calypso/components/section-nav';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { mapPostStatus as mapStatus } from 'calypso/lib/route';
@@ -111,24 +109,7 @@ class PagesMain extends React.Component {
 					headerText={ translate( 'Pages' ) }
 					align="left"
 				/>
-				<SectionNav selectedText={ filterStrings[ status ] }>
-					<NavTabs label={ translate( 'Status', { context: 'Filter page group label for tabs' } ) }>
-						{ this.getNavItems( filterStrings, status ) }
-					</NavTabs>
-					{ /* Disable search in all-sites mode because it doesn't work. */ }
-					{ isSingleSite && (
-						<Search
-							pinned
-							fitsContainer
-							isOpen={ this.props.getSearchOpen() }
-							onSearch={ this.props.doSearch }
-							initialValue={ search }
-							placeholder={ `${ searchPagesPlaceholder }…` }
-							analyticsGroup="Pages"
-							delaySearch={ true }
-						/>
-					) }
-				</SectionNav>
+				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ filterStrings[ status ] } />
 				<PageList siteId={ siteId } status={ status } search={ search } query={ query } />
 
 				{ /* ExPlat's Evergreen A/A Test Experiment:

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -318,7 +318,7 @@ class Pages extends Component {
 		return (
 			<div id="pages" className="pages__page-list">
 				<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
-				{ this.renderSectionHeader() }
+				{ site && this.renderSectionHeader() }
 				{ rows }
 				{ this.renderListEnd() }
 			</div>
@@ -357,7 +357,7 @@ class Pages extends Component {
 				{ showBlogPostsPage && (
 					<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
 				) }
-				{ this.renderSectionHeader() }
+				{ site && this.renderSectionHeader() }
 				{ rows }
 				<InfiniteScroll nextPageMethod={ this.fetchPages } />
 				{ this.renderListEnd() }

--- a/client/my-sites/post-type-filter/author-segmented.jsx
+++ b/client/my-sites/post-type-filter/author-segmented.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -17,17 +16,24 @@ import NavSegmented from 'calypso/components/section-nav/segmented';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 
-const AuthorSegmented = ( { author, siteSlug, statusSlug, translate, user } ) => {
+const AuthorSegmented = ( { author, siteSlug, statusSlug, translate, user, type } ) => {
 	const scopes = {
 		me: translate( 'Me', { context: 'Filter label for posts list' } ),
 		everyone: translate( 'Everyone', { context: 'Filter label for posts list' } ),
 	};
 
+	const basePath = type === 'page' ? '/pages' : '/posts';
+
 	return (
 		<NavSegmented label={ translate( 'Author', { context: 'Filter group label for segmented' } ) }>
 			{ map( scopes, ( label, scope ) => {
 				const isMe = 'me' === scope;
-				const path = compact( [ isMe ? '/posts/my' : '/posts', statusSlug, siteSlug ] ).join( '/' );
+				const path = compact( [
+					basePath,
+					isMe ? 'my' : null,
+					statusSlug.toLowerCase(),
+					siteSlug,
+				] ).join( '/' );
 
 				return (
 					<NavItem key={ scope } path={ path } selected={ isMe === !! author }>
@@ -44,6 +50,7 @@ AuthorSegmented.propTypes = {
 	author: PropTypes.number,
 	siteId: PropTypes.number,
 	statusSlug: PropTypes.string,
+	type: PropTypes.string,
 	// Connected Props
 	siteSlug: PropTypes.string,
 	translate: PropTypes.func.isRequired,

--- a/client/my-sites/post-type-filter/author-segmented.jsx
+++ b/client/my-sites/post-type-filter/author-segmented.jsx
@@ -31,7 +31,7 @@ const AuthorSegmented = ( { author, siteSlug, statusSlug, translate, user, type 
 				const path = compact( [
 					basePath,
 					isMe ? 'my' : null,
-					statusSlug.toLowerCase(),
+					statusSlug?.toLowerCase(),
 					siteSlug,
 				] ).join( '/' );
 

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -182,7 +182,7 @@ export default flow(
 	connect( ( state, { query } ) => {
 		const siteId = getSelectedSiteId( state );
 		let authorToggleHidden = false;
-		if ( query && query.type === 'post' ) {
+		if ( query && ( query.type === 'post' || query.type === 'page' ) ) {
 			if ( siteId ) {
 				authorToggleHidden = isSingleUserSite( state, siteId ) || isJetpackSite( state, siteId );
 			} else {

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -156,7 +156,12 @@ export class PostTypeFilter extends Component {
 						) ) }
 					</NavTabs>
 					{ ! authorToggleHidden && (
-						<AuthorSegmented author={ query.author } siteId={ siteId } statusSlug={ statusSlug } />
+						<AuthorSegmented
+							author={ query.author }
+							siteId={ siteId }
+							statusSlug={ statusSlug }
+							type={ query.type }
+						/>
 					) }
 					{ /* Disable search in all-sites mode because it doesn't work. */ }
 					{ isSingleSite && (

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -51,6 +51,15 @@ export class PostTypeFilter extends Component {
 	getNavItems() {
 		const { query, siteId, siteSlug, statusSlug, jetpack, counts } = this.props;
 
+		const isPostOrPage = query.type === 'post' || query.type === 'page';
+
+		let basePath = '/types/' + query.type;
+		if ( query.type === 'page' ) {
+			basePath = '/pages';
+		} else if ( query.type === 'post' ) {
+			basePath = '/posts';
+		}
+
 		return reduce(
 			counts,
 			( memo, count, status ) => {
@@ -88,10 +97,10 @@ export class PostTypeFilter extends Component {
 				return memo.concat( {
 					key: `filter-${ status }`,
 					// Hide count in all sites mode; and in Jetpack mode for non-posts
-					count: ! siteId || ( jetpack && query.type !== 'post' ) ? null : count,
+					count: ! siteId || ( jetpack && ! isPostOrPage ) ? null : count,
 					path: compact( [
-						query.type === 'post' ? '/posts' : '/types/' + query.type,
-						query.type === 'post' && query.author && 'my',
+						basePath,
+						isPostOrPage && query.author && 'my',
 						pathStatus,
 						siteSlug,
 					] ).join( '/' ),

--- a/client/my-sites/post-type-filter/style.scss
+++ b/client/my-sites/post-type-filter/style.scss
@@ -3,6 +3,11 @@
 	height: 50px;
 }
 
+.post-type-filter .section-nav .gravatar {
+	margin-left: 6px;
+	vertical-align: middle;
+}
+
 @include breakpoint-deprecated( '660px-800px' ) {
 	$width-search: 40px;
 	$space-between-nav-and-search: 5px;

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -21,11 +21,6 @@ import { POST_STATUSES } from 'calypso/state/posts/constants';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { mapPostStatus } from 'calypso/lib/route';
 
-/**
- * Style dependencies
- */
-import './style.scss';
-
 class PostsMain extends React.Component {
 	getAnalyticsPath() {
 		const { siteId, statusSlug, author } = this.props;

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -1,4 +1,0 @@
-.posts .section-nav .gravatar {
-	margin-left: 6px;
-	vertical-align: middle;
-}


### PR DESCRIPTION
This adds an author filter to the Pages and All Sites > Pages lists, and makes use of the `PostTypeFilter` component for post status filtering and searching.

**To test:**
- visit a site's page list (`/pages/{siteSlug}`) on a site with multiple authors
- verify that all published pages for the site are shown by default
- verify that the post status tabs, author filter, and search functionality work as expected
- visit the all sites page list
- verify that all published pages for all of the user's sites are shown by default
- verify that the post status tabs, author filter, and search functionality work as expected