### PR TITLE
Reader Lists: improve error notices

### DIFF
--- a/client/state/data-layer/wpcom/read/lists/delete/index.js
+++ b/client/state/data-layer/wpcom/read/lists/delete/index.js
@@ -35,7 +35,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/delete/index.js', {
 					} ),
 				];
 			},
-			onError: () => errorNotice( translate( 'There was a problem deleting the list.' ) ),
+			onError: () => errorNotice( translate( 'Unable to delete list.' ) ),
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/lists/feeds/delete/index.js
+++ b/client/state/data-layer/wpcom/read/lists/feeds/delete/index.js
@@ -29,7 +29,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/feeds/delete/index.js', {
 			onSuccess: successNotice( translate( 'Feed removed from list successfully.' ), {
 				duration: DEFAULT_NOTICE_DURATION,
 			} ),
-			onError: () => errorNotice( translate( 'Unable to remove feed from list' ) ),
+			onError: () => errorNotice( translate( 'Unable to remove feed from list.' ) ),
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/lists/feeds/new/index.js
+++ b/client/state/data-layer/wpcom/read/lists/feeds/new/index.js
@@ -45,12 +45,8 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/feeds/new/index.js', {
 					} ),
 				];
 			},
-			onError: ( action, error ) => {
-				return errorNotice(
-					translate( 'Could not add feed to list: %(message)s', {
-						args: { message: error?.message },
-					} )
-				);
+			onError: () => {
+				return errorNotice( translate( 'Unable to add feed to list.' ) );
 			},
 		} ),
 	],

--- a/client/state/data-layer/wpcom/read/lists/index.js
+++ b/client/state/data-layer/wpcom/read/lists/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -57,11 +58,10 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 						} ),
 					];
 				}
-				// NOTE: Add better handling for unexpected response format here.
-				errorNotice( translate( 'List could not be created, please try again later.' ) );
+				errorNotice( translate( 'Unable to create new list.' ) );
 			},
 			onError: ( action, error ) => [
-				errorNotice( String( error ) ),
+				errorNotice( translate( 'Unable to create new list.' ) ),
 				handleReaderListRequestFailure( error ),
 			],
 		} ),
@@ -81,7 +81,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 			onSuccess: ( action, { list } ) => {
 				return receiveFollowList( list );
 			},
-			onError: ( action, error ) => [ errorNotice( String( error ) ) ],
+			onError: () => [ errorNotice( translate( 'Unable to follow list.' ) ) ],
 		} ),
 	],
 	[ READER_LIST_REQUEST ]: [
@@ -96,10 +96,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 					action
 				),
 			onSuccess: ( action, { list } ) => receiveReaderList( { list } ),
-			onError: ( action, error ) => [
-				errorNotice( String( error ) ),
-				handleReaderListRequestFailure( error ),
-			],
+			onError: ( action, error ) => [ handleReaderListRequestFailure( error ) ],
 		} ),
 	],
 	[ READER_LIST_UNFOLLOW ]: [
@@ -117,7 +114,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 			onSuccess: ( action, { list } ) => {
 				return receiveUnfollowList( list );
 			},
-			onError: ( action, error ) => [ errorNotice( String( error ) ) ],
+			onError: () => [ errorNotice( translate( 'Unable to unfollow list.' ) ) ],
 		} ),
 	],
 	[ READER_LIST_UPDATE ]: [
@@ -140,7 +137,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 				} ),
 			],
 			onError: ( action, error ) => [
-				errorNotice( String( error ) ),
+				errorNotice( translate( 'Unable to update list.' ) ),
 				handleUpdateListDetailsError( error, action.list ),
 			],
 		} ),
@@ -157,7 +154,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 					action
 				),
 			onSuccess: ( action, apiResponse ) => receiveLists( apiResponse?.lists ),
-			onError: ( action, error ) => errorNotice( String( error ) ),
+			onError: () => noop,
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/lists/items/index.js
+++ b/client/state/data-layer/wpcom/read/lists/items/index.js
@@ -1,9 +1,13 @@
 /**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import { errorNotice } from 'calypso/state/notices/actions';
 import { READER_LIST_ITEMS_REQUEST } from 'calypso/state/reader/action-types';
 import { receiveReaderListItems } from 'calypso/state/reader/lists/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
@@ -23,7 +27,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/items/index.js', {
 				),
 			onSuccess: ( action, apiResponse ) =>
 				receiveReaderListItems( apiResponse.list_ID, apiResponse.items ),
-			onError: ( action, error ) => errorNotice( String( error ) ),
+			onError: () => noop,
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/lists/tags/delete/index.js
+++ b/client/state/data-layer/wpcom/read/lists/tags/delete/index.js
@@ -29,7 +29,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/tags/delete/index.js', {
 			onSuccess: successNotice( translate( 'Tag removed from list successfully.' ), {
 				duration: DEFAULT_NOTICE_DURATION,
 			} ),
-			onError: () => errorNotice( translate( 'Unable to remove tag from list' ) ),
+			onError: () => errorNotice( translate( 'Unable to remove tag from list.' ) ),
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/lists/tags/new/index.js
+++ b/client/state/data-layer/wpcom/read/lists/tags/new/index.js
@@ -42,7 +42,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/tags/new/index.js', {
 					} ),
 				];
 			},
-			onError: ( action, error ) => errorNotice( String( error ) ),
+			onError: () => errorNotice( translate( 'Unable to add tag to list.' ) ),
 		} ),
 	],
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As @nb notes in https://github.com/Automattic/wp-calypso/issues/47219, Reader lists often hands the API error straight back to the user when something goes wrong.

This PR adds more human-friendly error messages for scenarios where the API request has failed.

I've also removed error notices for list loading and list item loading - these are situations where the user hasn't taken a CRUD action and we should handle problems more quietly with just loading placeholders I think (like loading Reader feeds).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On the development environment, create a new list and make sure the management UI works as expected:

http://calypso.localhost:3000/read/list/new

Fixes #47219.
