### PR TITLE
Gutenboarding: strings in onboarding and launch packages should be translatable

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -225,15 +225,15 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							<ul className="focused-launch-summary__side-commentary-list">
 								<li className="focused-launch-summary__side-commentary-list-item">
 									<Icon icon={ check } />
-									{ __( 'Stand out with a unique domain' ) }
+									{ __( 'Stand out with a unique domain', __i18n_text_domain__ ) }
 								</li>
 								<li className="focused-launch-summary__side-commentary-list-item">
 									<Icon icon={ check } />
-									{ __( 'Easy to remember and easy to share' ) }
+									{ __( 'Easy to remember and easy to share', __i18n_text_domain__ ) }
 								</li>
 								<li className="focused-launch-summary__side-commentary-list-item">
 									<Icon icon={ check } />
-									{ __( 'Builds brand recognition and trust' ) }
+									{ __( 'Builds brand recognition and trust', __i18n_text_domain__ ) }
 								</li>
 							</ul>
 						</>
@@ -332,15 +332,15 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 						<ul className="focused-launch-summary__side-commentary-list">
 							<li className="focused-launch-summary__side-commentary-list-item">
 								<Icon icon={ check } />
-								{ __( 'Advanced tools and customization' ) }
+								{ __( 'Advanced tools and customization', __i18n_text_domain__ ) }
 							</li>
 							<li className="focused-launch-summary__side-commentary-list-item">
 								<Icon icon={ check } />
-								{ __( 'Unlimited premium themes' ) }
+								{ __( 'Unlimited premium themes', __i18n_text_domain__ ) }
 							</li>
 							<li className="focused-launch-summary__side-commentary-list-item">
 								<Icon icon={ check } />
-								{ __( 'Accept payments' ) }
+								{ __( 'Accept payments', __i18n_text_domain__ ) }
 							</li>
 						</ul>
 					</>

--- a/packages/onboarding/src/action-buttons/index.tsx
+++ b/packages/onboarding/src/action-buttons/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import { Button } from '@wordpress/components';
-import { useI18n } from '@automattic/react-i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Style dependencies
@@ -40,7 +40,6 @@ export const BackButton: React.FunctionComponent< Button.ButtonProps > = ( {
 	children,
 	...buttonProps
 } ) => {
-	const { __ } = useI18n();
 	return (
 		<Button
 			className={ classnames( 'action_buttons__button action-buttons__back', className ) }
@@ -49,7 +48,7 @@ export const BackButton: React.FunctionComponent< Button.ButtonProps > = ( {
 		>
 			{ children ||
 				/* translators: Button label for going to previous step in onboarding */
-				__( 'Go back' ) }
+				__( 'Go back', __i18n_text_domain__ ) }
 		</Button>
 	);
 };
@@ -59,7 +58,6 @@ export const NextButton: React.FunctionComponent< Button.ButtonProps > = ( {
 	children,
 	...buttonProps
 } ) => {
-	const { __ } = useI18n();
 	return (
 		<Button
 			className={ classnames( 'action_buttons__button action-buttons__next', className ) }
@@ -68,7 +66,7 @@ export const NextButton: React.FunctionComponent< Button.ButtonProps > = ( {
 		>
 			{ children ||
 				/* translators: Button label for advancing to next step in onboarding */
-				__( 'Continue' ) }
+				__( 'Continue', __i18n_text_domain__ ) }
 		</Button>
 	);
 };
@@ -78,7 +76,6 @@ export const SkipButton: React.FunctionComponent< Button.ButtonProps > = ( {
 	children,
 	...buttonProps
 } ) => {
-	const { __ } = useI18n();
 	return (
 		<Button
 			className={ classnames( 'action_buttons__button action-buttons__skip', className ) }
@@ -86,7 +83,7 @@ export const SkipButton: React.FunctionComponent< Button.ButtonProps > = ( {
 		>
 			{ children ||
 				/* translators: Button label for skipping a step in onboarding */
-				__( 'Skip for now' ) }
+				__( 'Skip for now', __i18n_text_domain__ ) }
 		</Button>
 	);
 };

--- a/packages/onboarding/src/types.d.ts
+++ b/packages/onboarding/src/types.d.ts
@@ -1,0 +1,1 @@
+declare const __i18n_text_domain__: string;


### PR DESCRIPTION
Found a few more strings that weren't providing a text domain to the `__()` function.

The `react-i18n` package doesn't yet translate strings in the ETK environment, so switching to using `@wordpress/i18n` instead. We want strings in components to be reactive, so ideally component strings would use `react-i18n`, but we're not quite there yet (see #47352)

#### Changes proposed in this Pull Request

* Strings in `@automattic/launch` provide a text domain (that can be swapped for a real value at build time)
* Strings in `@automattic/onboarding` provide a text domain
* Switch strings in `@automattic/onboarding` from using `react-i18n` to `@wordpress/i18n`
* Define the `__i18n_text_domain__` constant which is provided at build time

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run launch and onboarding flows and they shouldn't crash and strings should still be visible.
