### PR TITLE
Remove locale from `react-i18n` now that it is available in `i18n-utils`

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -65,4 +65,3 @@ export default withI18n( MyComponent );
 ## API
 
 The translation functions `__`, `_n`, `_nx`, and `_x` are exposed from [`@wordpress/i18n`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/i18n). Refer to their documentation there.
-`i18nLocale` is a `string` containing the current locale. This is determined from the provided localeData and will fall back to `en`.

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -11,7 +11,6 @@ export interface I18nReact {
 	_nx: I18n[ '_nx' ];
 	_x: I18n[ '_x' ];
 	isRTL: I18n[ 'isRTL' ];
-	i18nLocale: string;
 }
 
 const I18nContext = React.createContext< I18nReact >( makeContextValue() );
@@ -70,13 +69,11 @@ export const withI18n = createHigherOrderComponent< I18nReact >( ( InnerComponen
  */
 function makeContextValue( localeData?: LocaleData ): I18nReact {
 	const i18n = createI18n( localeData );
-	const i18nLocale = localeData?.[ '' ]?.localeSlug ?? 'en';
 	return {
 		__: i18n.__.bind( i18n ),
 		_n: i18n._n.bind( i18n ),
 		_nx: i18n._nx.bind( i18n ),
 		_x: i18n._x.bind( i18n ),
 		isRTL: i18n.isRTL.bind( i18n ),
-		i18nLocale,
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `react-i18n` library currently supplies the current locale slug, however that package is trying to do things in a way that will work for any Gutenberg user, and there is no standard way to access the current locale slug in Gutenberg/core WP.

Since #47566 the `@automattic/i18n-utils` package has had the ability to supply a locale slug, and after #47567 is merged there will no longer be any references to the locale from `react-i18n`. So this PR removes it.

* Remove `i18nLocale` from the `useI18n()` hook
* Update readme

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There should be no references to `i18nLocale` after #47567 has merged, so nothing specific to test other than smoke testing
