### PR TITLE
Update/docker load nvm 2

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,8 +13,7 @@ ENV CHROMEDRIVER_SKIP_DOWNLOAD=true
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 ENV HOME=/calypso
 
-RUN git clone https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
-	&& git -C "$NVM_DIR" checkout v0.35.3 \
+RUN git clone --branch v0.37.0 --depth 1 https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
 	&& echo ". ${NVM_DIR}/nvm.sh" >> "${HOME}/.bashrc"
 
 COPY . .

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -51,6 +51,7 @@ COPY --from=builder --chown=$UID /calypso/.nvm /calypso/.nvm
 COPY --from=builder --chown=$UID /calypso/.cache /calypso/.cache
 COPY --from=builder --chown=$UID /calypso/.bashrc /calypso/.bashrc
 
+ENTRYPOINT [ "/bin/bash" ]
 
 #### ci-desktop image
 FROM ci as ci-desktop
@@ -89,3 +90,5 @@ RUN apt update \
 RUN wget --no-verbose https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
 	&& apt-get install -y ./google-chrome-stable_${CHROME_VERSION}_amd64.deb \
 	&& rm ./google-chrome-stable_${CHROME_VERSION}_amd64.deb
+
+ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -49,6 +49,7 @@ RUN chown $UID /calypso
 COPY --from=builder --chown=$UID /calypso/.nvm /calypso/.nvm
 # Copy all other caches (webpack, babel, yarn...)
 COPY --from=builder --chown=$UID /calypso/.cache /calypso/.cache
+COPY --from=builder --chown=$UID /calypso/.bashrc /calypso/.bashrc
 
 
 #### ci-desktop image


### PR DESCRIPTION
Follow up of #47405 (I forgot to push a few local changes before merging it 🤦 )


#### Changes proposed in this Pull Request

* Use one-liner to fetch NVM
* Update NVM to 0.37.0
* Change entrypoint to /bin/bash

#### Testing instructions

First build the image locally with `docker build -f Dockerfile.base --target ci -t calypso/ci:local`. To make it faster, make these changes to `Dockerfile.base` (they are not related to this change, an without these changes it can take 30 minutes or more):

* Comment out the trailing `\` in line 26
* Comment out running `yarn` (line 28)
* Comment out running `yarn build-client-both` (line 30)
* Comment out copying from `/calypso/.cache` (line 51)

Once it is done, launch the image with `docker run --rm -ti calypso/ci:local` and verify: 
* The shell is Bash (before it was Node's REPL)
* You can run `nvm ls`.
