### PR TITLE
Coming Soon: Set the headers to prevent caching for the different browsers.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -70,7 +70,6 @@ function get_onboarding_url() {
 }
 
 nocache_headers();
-header( 'Content-Type: ' . get_bloginfo( 'html_type' ) . '; charset=' . get_bloginfo( 'charset' ) );
 
 ?>
 <!DOCTYPE html>

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -69,6 +69,9 @@ function get_onboarding_url() {
 	return 'https://' . $locale_subdomain . 'wordpress.com/?ref=coming_soon';
 }
 
+nocache_headers();
+header( 'Content-Type: ' . get_bloginfo( 'html_type' ) . '; charset=' . get_bloginfo( 'charset' ) );
+
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Let's make sure we don't allow caching for the Coming Soon pages. 
~~We'll also set the html and char types from bloginfo~~

#### Testing instructions

Create a coming soon v2 site over at wordpress.com/new?flags=coming-soon-v2

I used Firefox, which seems to have a fairly aggressive caching approach.

With your new site in coming soon mode, open it in Firefox (logged out) and take a look at the network tab in the console for the HTML page.

<img width="542" alt="Screen Shot 2020-11-16 at 8 38 59 pm" src="https://user-images.githubusercontent.com/6458278/99237122-2a770200-284c-11eb-8b3a-d8ebe22bc2ea.png">

Now run `yarn dev --sync` on this branch, and sandbox your new site.

Refresh and make sure you can see expiry headers (in the past so as to invalidate the cache)

<img width="498" alt="Screen Shot 2020-11-16 at 8 40 06 pm" src="https://user-images.githubusercontent.com/6458278/99237190-44b0e000-284c-11eb-8653-c3b8a7d621d8.png">


