### PR TITLE
P2 signup: remove help icon

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -116,7 +116,7 @@ class Layout extends Component {
 
 		const exemptedSections = [ 'jetpack-connect', 'happychat', 'devdocs', 'help' ];
 		const exemptedRoutes = [ '/log-in/jetpack', '/me/account/closed' ];
-		const exemptedRoutesStartingWith = [ '/start/p2', '/something/else' ];
+		const exemptedRoutesStartingWith = [ '/start/p2' ];
 
 		return (
 			! exemptedSections.includes( this.props.sectionName ) &&

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { startsWith, flowRight as compose } from 'lodash';
+import { startsWith, flowRight as compose, some } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -116,10 +116,14 @@ class Layout extends Component {
 
 		const exemptedSections = [ 'jetpack-connect', 'happychat', 'devdocs', 'help' ];
 		const exemptedRoutes = [ '/log-in/jetpack', '/me/account/closed' ];
+		const exemptedRoutesStartingWith = [ '/start/p2', '/something/else' ];
 
 		return (
 			! exemptedSections.includes( this.props.sectionName ) &&
-			! exemptedRoutes.includes( this.props.currentRoute )
+			! exemptedRoutes.includes( this.props.currentRoute ) &&
+			! some( exemptedRoutesStartingWith, ( startsWithString ) =>
+				this.props.currentRoute?.startsWith( startsWithString )
+			)
 		);
 	}
 


### PR DESCRIPTION
@evilluendas pointed out that there's the Help icon during the P2 signup. Since clicking that icon might take the user away from the P2 signup flow, we are going to hide it for the P2 signup flow.

## Testing instructions

Navigate to `/start/p2` as logged in and make sure you don't see the Help icon in the bottom right corner of your screen. Try using incognito window and do the same. Last but not least, please verify the help icon is not hidden for any other signup flow than the P2 one and is not hidden anywhere else. The code also should make sense.