### PR TITLE
State: Modularize Jetpack Sync state

### DIFF
--- a/client/state/jetpack-sync/actions.js
+++ b/client/state/jetpack-sync/actions.js
@@ -17,6 +17,8 @@ import {
 	JETPACK_SYNC_STATUS_ERROR,
 } from 'calypso/state/action-types';
 
+import 'calypso/state/jetpack-sync/init';
+
 /**
  *  Local variables;
  */

--- a/client/state/jetpack-sync/init.js
+++ b/client/state/jetpack-sync/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'jetpackSync' ], reducer );

--- a/client/state/jetpack-sync/package.json
+++ b/client/state/jetpack-sync/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/jetpack-sync/reducer.js
+++ b/client/state/jetpack-sync/reducer.js
@@ -2,7 +2,6 @@
  * External dependencis
  *
  */
-
 import { pick, get } from 'lodash';
 
 /**
@@ -16,7 +15,7 @@ import {
 	JETPACK_SYNC_STATUS_SUCCESS,
 	JETPACK_SYNC_STATUS_ERROR,
 } from 'calypso/state/action-types';
-import { combineReducers } from 'calypso/state/utils';
+import { combineReducers, withStorageKey } from 'calypso/state/utils';
 import { getExpectedResponseKeys } from './utils';
 
 export function fullSyncRequest( state = {}, action ) {
@@ -109,7 +108,9 @@ export function syncStatus( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	syncStatus,
 	fullSyncRequest,
 } );
+
+export default withStorageKey( 'jetpackSync', combinedReducer );

--- a/client/state/jetpack-sync/selectors.js
+++ b/client/state/jetpack-sync/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get, reduce } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/jetpack-sync/init';
 
 /**
  * Returns a sync status object by site ID.

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -25,7 +25,6 @@ import i18n from './i18n/reducer';
 import immediateLogin from './immediate-login/reducer';
 import importerNux from './importer-nux/reducer';
 import inlineSupportArticle from './inline-support-article/reducer';
-import jetpackSync from './jetpack-sync/reducer';
 import jitm from './jitm/reducer';
 import media from './media/reducer';
 import mySites from './my-sites/reducer';
@@ -60,7 +59,6 @@ const reducers = {
 	immediateLogin,
 	importerNux,
 	inlineSupportArticle,
-	jetpackSync,
 	jitm,
 	media,
 	mySites,


### PR DESCRIPTION
This PR is one of many working on the modularizing state in Calypso. This one handles Jetpack Sync state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42453.

#### Changes proposed in this Pull Request

* Modularise Jetpack Sync state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en) if you haven't yet.
* Open DevTools and switch to the Redux tab.
* Open Home on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `jetpackSync` key, even if you expand the list of keys. This indicates that the Jetpack Sync state hasn't been loaded yet.
* Go to `/settings/manage-connection/:site` where `:site` is one of your Jetpack sites.
* Verify that a `jetpackSync` key is added with the Jetpack Sync state. This indicates that the Jetpack Sync state has now been loaded.
* Tinker with the "Data synchronization" card - enable / disable the toggle; click the "initiate a sync manually" link to queue a new manual sync process and verify everything works like it did before.

#### Note

Linting errors are expected - they're coming from the non-modularized reducer, and will disappear once we modularize all of it.