### PR TITLE
Pricing page i5: add Tracks event to the comparison CTA

### DIFF
--- a/client/my-sites/plans-v2/more-info-box/index.tsx
+++ b/client/my-sites/plans-v2/more-info-box/index.tsx
@@ -7,6 +7,7 @@ import { Button } from '@automattic/components';
 /**
  * Internal dependencies
  */
+import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { PLAN_COMPARISON_PAGE } from 'calypso/my-sites/plans-v2/constants';
 import Gridicon from 'calypso/components/gridicon';
 
@@ -27,14 +28,23 @@ type MoreInfoProps = {
 	onButtonClick?: () => void;
 };
 
-const MoreInfoBox: React.FC< MoreInfoProps > = ( { headline, buttonLabel } ) => (
-	<div className="more-info-box__more-container">
-		<h3 className="more-info-box__more-headline">{ headline }</h3>
-		<Button href={ PLAN_COMPARISON_PAGE } target="_blank" className="more-info-box__more-button">
-			{ buttonLabel }
-			<Gridicon className="more-info-box__icon" icon="external" />
-		</Button>
-	</div>
-);
+const MoreInfoBox: React.FC< MoreInfoProps > = ( { headline, buttonLabel } ) => {
+	const onClick = useTrackCallback( undefined, 'calypso_plans_comparison_table_link_click' );
+
+	return (
+		<div className="more-info-box__more-container">
+			<h3 className="more-info-box__more-headline">{ headline }</h3>
+			<Button
+				onClick={ onClick }
+				href={ PLAN_COMPARISON_PAGE }
+				target="_blank"
+				className="more-info-box__more-button"
+			>
+				{ buttonLabel }
+				<Gridicon className="more-info-box__icon" icon="external" />
+			</Button>
+		</div>
+	);
+};
 
 export default MoreInfoBox;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a Tracks event to the button labelled _Compare all product bundles_ in pricing page i5.

Fixes 1196341175636977-as-1199149328812583

### Implementation notes

Event name is `calypso_plans_comparison_table_link_click`.

### Testing instructions

- Download the PR or visit the Calypso live link
- Run Calypso and Jetpack cloud concurrently
- Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
- Select a self-hosted Jetpack site
- Enabled analytics debug mode (run `localStorage.setItem('debug', 'calypso:analytics');` in your browser's console) and refresh the page
- Visit the pricing page
- Check that the button labelled _Compare all product bundles_ tracks the event mentioned above
- Check that all interactions in the plans page in both Calypso and Jetpack cloud are still tracked

### Screenshots

<img width="1100" alt="Screen Shot 2020-11-16 at 9 25 04 AM" src="https://user-images.githubusercontent.com/1620183/99263765-a130e280-27ed-11eb-9507-22413dc6fcba.png">