### PR TITLE
Let "yarn start" be a one step process

### DIFF
--- a/client/server/index.js
+++ b/client/server/index.js
@@ -68,7 +68,36 @@ function createServer() {
 		return require( 'https' ).createServer( loadSslCert(), app );
 	}
 
+	setTimeout( getServerRoot, 1500 );
 	return require( 'http' ).createServer( app );
+}
+
+// Sends a "GET /" to the dev server in order to kickstart the compilation process.
+function getServerRoot() {
+	const thisHost = process.env.HOST || config( 'hostname' );
+	const thisPort = process.env.PORT || config( 'port' );
+
+	const http = require( 'http' );
+	const options = {
+		hostname: thisHost,
+		port: thisPort,
+		path: '/',
+		method: 'GET',
+	};
+
+	const req = http.request( options, ( res ) => {
+		console.log( `statusCode: ${ res.statusCode }` );
+
+		res.on( 'data', ( d ) => {
+			process.stdout.write( d );
+		} );
+	} );
+
+	req.on( 'error', ( error ) => {
+		console.error( error );
+	} );
+
+	req.end();
 }
 
 const server = createServer();


### PR DESCRIPTION
#### Problem to be solved

When I want to start working on calypso, I often `yarn start` and put my attention elsewhere, like reading a blog post or responding to a message.  When I turn back to calypso, I see `INFO calypso: wp-calypso booted`, but it isn't ready yet.  I load http://calypso.localhost:3000/ in my browser, and then I have to wait for a second step of the compilation process.  I would rather have these two steps happen consecutively without user intervention.

#### Changes proposed in this Pull Request

* When calypso is done booting, the booting code sends a "GET /" request to the server in order to kick off the next step of the process.

#### Possible Issues

* I know that calypso runs in a lot of different environments than simply `yarn start` in dev, like: production, unit tests, desktop etc... and I haven't tested this in any of them.  I don't want to make changes to these.
* The extra console messages might be spam and could be removed.
* `getServerRoot` sounds like an OO getter, not something that sends a GET request. :)

#### Testing instructions

* `yarn start`.  Wait a few minutes  and you should see the "Ready! You can load http://calypso.localhost:3000/ now. Have fun!" message without having to make a web request.

![2020-11-16_09-58](https://user-images.githubusercontent.com/937354/99276466-51084f00-27f2-11eb-8340-59b536f9254d.png)



