### PR TITLE
ETP: Premium Content: Remove __experimentalAlignmentHookSettingsProvider dep

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
@@ -2,11 +2,7 @@
  * WordPress dependencies
  */
 // eslint-disable-next-line wpcalypso/import-docblock
-import {
-	__experimentalAlignmentHookSettingsProvider as AlignmentHookSettingsProvider,
-	InnerBlocks,
-	__experimentalBlock as Block,
-} from '@wordpress/block-editor';
+import { InnerBlocks, __experimentalBlock as Block } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -18,11 +14,6 @@ const ALLOWED_BLOCKS = [
 	'jetpack/recurring-payments',
 	'premium-content/login-button',
 ];
-
-// Inside buttons block alignment options are not supported.
-const alignmentHooksSetting = {
-	isEmbedButton: true,
-};
 
 function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 	const planId = context ? context[ 'premium-content/planId' ] : null;
@@ -91,14 +82,13 @@ function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Block.div className="wp-block-buttons">
-			<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
-				<InnerBlocks
-					allowedBlocks={ ALLOWED_BLOCKS }
-					template={ isPreview ? previewTemplate : template }
-					__experimentalMoverDirection="horizontal"
-					templateInsertUpdatesSelection={ false }
-				/>
-			</AlignmentHookSettingsProvider>
+			<InnerBlocks
+				allowedBlocks={ ALLOWED_BLOCKS }
+				template={ isPreview ? previewTemplate : template }
+				templateInsertUpdatesSelection={ false }
+				__experimentalLayout={ { type: 'default', alignments: [] } }
+				__experimentalMoverDirection="horizontal"
+			/>
 		</Block.div>
 	);
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/editor.css
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/editor.css
@@ -149,3 +149,7 @@
 .wp-block-premium-content-container .jetpack-block-nudge {
 	display: none;
 }
+
+.wp-block-premium-content-login-button {
+	display: inline-block;
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/index.js
@@ -8,10 +8,7 @@ import { mergeWith } from 'lodash';
  */
 import apiFetch from '@wordpress/api-fetch';
 import { getBlockType, registerBlockType, unregisterBlockType } from '@wordpress/blocks';
-import {
-	__experimentalAlignmentHookSettingsProvider,
-	__experimentalBlock,
-} from '@wordpress/block-editor';
+import { __experimentalBlock } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -22,9 +19,7 @@ import * as loggedOutView from './blocks/logged-out-view';
 import * as buttons from './blocks/buttons';
 import * as loginButton from './blocks/login-button';
 
-const supportsDecoupledBlocks = !! (
-	__experimentalAlignmentHookSettingsProvider && __experimentalBlock
-);
+const supportsDecoupledBlocks = !! __experimentalBlock;
 
 /**
  * Function to register an individual block.

--- a/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
@@ -25,7 +25,6 @@ const gutenbergUser =
 const EXPERIMENTAL_FEATURES = {
 	'@wordpress/block-editor': [
 		// Used in the premium content block in the Editing Toolkit plugin
-		'__experimentalAlignmentHookSettingsProvider',
 		'__experimentalBlock',
 	],
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Premium Content blocks would be broken by the GB 9.3 upgrade on WP.com. This PR attempts a fix.
The reason for the breakage is that `__experimentalAlignmentHookSettingsProvider` was removed in https://github.com/WordPress/gutenberg/pull/26380.

##### With GB 9.2.2:

![image](https://user-images.githubusercontent.com/96308/99315041-4f766f80-2862-11eb-9cab-6d489925129d.png)

##### With GB 9.3.0:

![image](https://user-images.githubusercontent.com/96308/99282504-10c9c080-2834-11eb-8020-845d029049cb.png)

##### With GB 9.3.0 and this fix applied: 

![image](https://user-images.githubusercontent.com/96308/99284864-1543a880-2837-11eb-9046-7797f03de8f0.png)

The changed layout is discussed in the 'Questions' section at the bottom of this PR description. _I would like to land this PR regardless of whether or not we manage to fix the layout, as it would otherwise block us from upgrading Gutenberg versions altogether. A fix for the layout could be attempted in a follow-up PR._

The changes in this PR are largely modeled after this file in aforementioned PR: https://github.com/WordPress/gutenberg/pull/26380/files#diff-4347ded500d1f93237e9e254af2e2f5a01896b5d1736c61f965f6d333847f8bd.

#### Testing instructions

- Choose a WP.com Simple Site for testing. It should have the Premium Content block enabled. As that requires a bit of doing, you can ask team #good-mountain for a test site.
- Sandbox that site, and the REST API.
- Open a post that contains the Premium Content block in the post editor, and verify that it works.
- Update that site's block editor to 9.3.0 by running the following command in your sandbox: `bin/gutenberg-plugin-activate.sh -e prod 9.3.0`.
- Reload the post that you used for testing, and verify that the block is now broken (with an error message as seen in the screenshot above).
- Apply the WP.com companion patch (D52816-code) to your site.
- Reload your test post once more, and verify that the block is working again.

Verify that the same patch also works with GB 9.2.2.

- To that end, revert the version bump: `bin/gutenberg-plugin-activate.sh -e prod 9.2.2`, reload your test post, and proceed testing.

#### Questions

##### Changed Layout

**Open question:** The layout has changed (buttons appear on top of each other, instead of next to each other, as desired). Inspection of DOM elements revealed that because of the `.wp-block-buttons` class, there's now `display: flex` (and a number of flex-related styles) applied, which previously weren't (even though the `<div />` had the same class) :thinking: 
Edit: I think those are coming from [here](https://github.com/WordPress/gutenberg/blob/b2beb83150590001e3d5d3b1ab84069b3e683ea4/packages/block-library/src/buttons/style.scss#L1-L4), which was last touched by #23168. We might have to study that PR and actually might need to pass a higher-level attribute/settings to the Buttons inner block here.

![image](https://user-images.githubusercontent.com/96308/99314882-15a56900-2862-11eb-91dd-09e9e6ccd9aa.png)

##### Alignment toolbar removal

It seems that the `__experimentalAlignmentHookSettingsProvider` stuff was originally used to suppress the alignment toolbar from the block (at least https://github.com/WordPress/gutenberg/pull/26380 suggests that that's what it was mostly used for). As the setting was applied to the Premium Content buttons inner block, I was assuming that it would apply to them; however, I was able to see the alignment toolbar option in production. (Note that the toolbar seems to be attached to the parent Premium Content block rather than to the child Premium Content _buttons_ block; that glitch is also pre-existing.)

![image](https://user-images.githubusercontent.com/96308/99295580-e54fd180-2845-11eb-966a-443bc9f64c0c.png)

I'm thus not quite sure if this was possibly broken before.