### PR TITLE
Pricing page i5: update activity log feature copy

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1316,10 +1316,7 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2 ]: {
 		getSlug: () => constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 		getIcon: () => 'clipboard',
-		getTitle: () =>
-			( {
-				i5: i18n.translate( "1-year's worth of activity events" ),
-			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'Activity log: 1-year archive' ) ),
+		getTitle: () => i18n.translate( 'Activity log: 1-year archive' ),
 		getDescription: () =>
 			i18n.translate(
 				'View every change to your site in the last year. Pairs with Backup to restore your site to any earlier version. {{link}}Learn more.{{/link}}',


### PR DESCRIPTION
### Changes proposed in this Pull Request

Copy update in pricing page i5.

Fixes 1196341175636977-as-1199200712773362

### Testing instructions

- Download the PR or visit the Calypso live link
- Run Calypso or Jetpack cloud
- Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
- Select a self-hosted Jetpack site
- Visit the pricing page
- Check in the _Back UP Real-time_ card that the copy for the AL feature is: **Activity log: 1-year archive**

### Screenshots

_Before_
![screenshot](https://user-images.githubusercontent.com/1620183/99296776-427f5f00-2815-11eb-9002-4351105f0690.png)


_After_
![screenshot (1)](https://user-images.githubusercontent.com/1620183/99296806-53c86b80-2815-11eb-9b50-46034857ea67.png)
