### PR TITLE
Pricing page i5: remove feature toggle and align cards

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-i5/assets/chevron.svg
+++ b/client/components/jetpack/card/jetpack-product-card-i5/assets/chevron.svg
@@ -1,9 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M4 15L12 7L20 15L18.586 16.414L12 9.828L5.414 16.414" fill="#12181E"/>
-<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="4" y="7" width="16" height="10">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M4 15L12 7L20 15L18.586 16.414L12 9.828L5.414 16.414" fill="white"/>
-</mask>
-<g mask="url(#mask0)">
-<rect x="24" y="24" width="24" height="24" transform="rotate(180 24 24)" fill="#646970"/>
-</g>
-</svg>

--- a/client/components/jetpack/card/jetpack-product-card-i5/features.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-i5/features.tsx
@@ -1,94 +1,30 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
-import React, { useState, useCallback } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import FeaturesItem from './features-item';
-import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 
 /**
  * Type dependencies
  */
 import type { ProductCardFeatures, ProductCardFeaturesItem } from './types';
 
-/**
- * Styles dependencies
- */
-import chevronIcon from './assets/chevron.svg';
-
 export interface Props {
 	features: ProductCardFeatures;
-	showAllFeatures?: boolean;
-	productSlug: string;
 }
 
-interface TrackProps {
-	product_slug?: string;
-}
-
-const DEFAULT_ITEM_COUNT = 3;
-
-const JetpackProductCardFeatures: React.FC< Props > = ( {
-	features: { items },
-	showAllFeatures,
-	productSlug,
-} ) => {
-	const trackProps = {} as TrackProps;
-
-	if ( productSlug ) {
-		trackProps.product_slug = productSlug;
-	}
-
-	const translate = useTranslate();
-	const [ isExpanded, setExpanded ] = useState( false );
-
-	const trackShowFeatures = useTrackCallback(
-		undefined,
-		'calypso_product_features_open',
-		trackProps
-	);
-	const trackHideFeatures = useTrackCallback(
-		undefined,
-		'calypso_product_features_close',
-		trackProps
-	);
-	const onToggle = useCallback( () => {
-		if ( isExpanded ) {
-			trackHideFeatures();
-			setExpanded( false );
-		} else {
-			trackShowFeatures();
-			setExpanded( true );
-		}
-	}, [ isExpanded, setExpanded, trackShowFeatures, trackHideFeatures ] );
-
+const JetpackProductCardFeatures: React.FC< Props > = ( { features: { items } } ) => {
 	return (
-		<section
-			className={ classNames( 'jetpack-product-card-i5__features', {
-				'is-expanded': isExpanded,
-			} ) }
-		>
+		<section className="jetpack-product-card-i5__features">
 			<ul className="jetpack-product-card-i5__features-list">
-				{ ( items.slice(
-					0,
-					isExpanded || showAllFeatures ? items.length : DEFAULT_ITEM_COUNT
-				) as ProductCardFeaturesItem[] ).map( ( item, i ) => (
+				{ ( items as ProductCardFeaturesItem[] ).map( ( item, i ) => (
 					<FeaturesItem key={ i } item={ item } />
 				) ) }
 			</ul>
-			{ ! showAllFeatures && (
-				<button className="jetpack-product-card-i5__features-toggle" onClick={ onToggle }>
-					<span>
-						{ isExpanded ? translate( 'Show less features' ) : translate( 'Show all features' ) }
-					</span>
-					<img className="jetpack-product-card-i5__features-chevron" src={ chevronIcon } alt="" />
-				</button>
-			) }
 		</section>
 	);
 };

--- a/client/components/jetpack/card/jetpack-product-card-i5/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-i5/index.tsx
@@ -127,11 +127,7 @@ const JetpackProductCardAlt2: React.FC< Props > = ( {
 					{ buttonLabel }
 				</Button>
 				{ features && features.items.length > 0 && (
-					<JetpackProductCardFeatures
-						features={ features }
-						showAllFeatures={ showAllFeatures }
-						productSlug={ productSlug }
-					/>
+					<JetpackProductCardFeatures features={ features } />
 				) }
 			</div>
 		</div>

--- a/client/components/jetpack/card/jetpack-product-card-i5/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-i5/index.tsx
@@ -68,7 +68,6 @@ const JetpackProductCardAlt2: React.FC< Props > = ( {
 	isDeprecated,
 	isAligned,
 	features,
-	showAllFeatures,
 }: Props ) => {
 	const translate = useTranslate();
 	const isDiscounted = isFinite( discountedPrice );

--- a/client/components/jetpack/card/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-i5/style.scss
@@ -1,14 +1,12 @@
 .jetpack-product-card-i5 {
 	position: relative;
 
+	height: 100%;
+
 	background: var( --color-surface );
 	border: 1px solid var( --color-border-subtle );
 	border-radius: 8px;
 	box-shadow: 0px 4px 24px rgba( 0, 0, 0, 0.05 );
-
-	&.is-aligned {
-		height: 100%;
-	}
 
 	&.is-featured {
 		z-index: 1;
@@ -182,28 +180,6 @@
 	color: var( --studio-gray-100 );
 
 	font-weight: 700;
-}
-
-.jetpack-product-card-i5__features-toggle {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-
-	width: 100%;
-
-	color: var( --studio-gray-50 );
-
-	font-size: 1rem;
-
-	cursor: pointer;
-}
-
-.jetpack-product-card-i5__features-chevron {
-	transform: rotate( 180deg );
-
-	.is-expanded & {
-		transform: rotate( 0deg );
-	}
 }
 
 /* Prices Loading state */

--- a/client/components/jetpack/card/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-i5/style.scss
@@ -9,7 +9,11 @@
 	box-shadow: 0px 4px 24px rgba( 0, 0, 0, 0.05 );
 
 	&.is-featured {
+		position: relative;
+		top: 8px;
 		z-index: 1;
+
+		margin-left: -8px;
 	}
 }
 
@@ -47,13 +51,6 @@
 		border-top: none;
 		border-bottom-left-radius: inherit;
 		border-bottom-right-radius: inherit;
-	}
-
-	.is-featured.is-aligned & {
-		box-sizing: border-box;
-		height: calc( 100% + 8px );
-
-		background-color: inherit;
 	}
 }
 

--- a/client/my-sites/plans-v2/product-card-i5/index.tsx
+++ b/client/my-sites/plans-v2/product-card-i5/index.tsx
@@ -14,7 +14,6 @@ import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { planHasFeature } from 'calypso/lib/plans';
 import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
-import { isJetpackPlanSlug } from 'calypso/lib/products-values';
 import { isCloseToExpiration } from 'calypso/lib/purchases';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
@@ -85,7 +84,6 @@ const ProductCardI5: React.FC< ProductCardProps > = ( {
 
 	const isUpgradeableToYearly =
 		isOwned && selectedTerm === TERM_ANNUALLY && item.term === TERM_MONTHLY;
-	const isPlan = isJetpackPlanSlug( item.productSlug );
 
 	return (
 		<JetpackProductCard
@@ -106,7 +104,6 @@ const ProductCardI5: React.FC< ProductCardProps > = ( {
 			isDeprecated={ item.legacy }
 			isAligned={ isAligned }
 			features={ item.features }
-			showAllFeatures={ isPlan }
 		/>
 	);
 };

--- a/client/my-sites/plans-v2/products-grid-i5/style.scss
+++ b/client/my-sites/plans-v2/products-grid-i5/style.scss
@@ -61,6 +61,12 @@
 	}
 }
 
+.products-grid-i5__product-grid {
+	> li {
+		height: 100%;
+	}
+}
+
 .products-grid-i5__filter-bar {
 	height: 63px;
 	margin-bottom: 70px;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes the "Show all features" toggle in the product cards, and align cards properly.

Fixes 1196341175636977-as-1199200712773351

### Testing instructions

- Download the PR or visit the Calypso live link
- Run Calypso or Jetpack cloud
- Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
- Select a self-hosted Jetpack site
- Visit the pricing page
- In the _Individual Products_ section, check that you see all features, that the "Show all features" toggles have been removed, and that cards of the same row all have the same height
- In the _Product Bundles_ section, check that the featured card is not flush with the other cards (see captures)

### Screenshots

_Before_


<img width="720" alt="Screen Shot 2020-11-16 at 2 20 27 PM" src="https://user-images.githubusercontent.com/1620183/99298274-76f41a80-2817-11eb-9a78-ba8a2f156249.png">
<img width="720" alt="Screen Shot 2020-11-16 at 2 20 27 PM" src="https://user-images.githubusercontent.com/1620183/99299525-54fb9780-2819-11eb-8227-b8b79480bcd2.png">




_After_
<img width="714" alt="Screen Shot 2020-11-16 at 2 21 41 PM" src="https://user-images.githubusercontent.com/1620183/99298292-7ce9fb80-2817-11eb-9aac-62688bdacb4c.png">
![screenshot](https://user-images.githubusercontent.com/1620183/99299272-ffbf8600-2818-11eb-8cd7-78c48b8942a5.png)
