### PR TITLE
Pricing page i5: Update 20% discount message.

### DIFF
--- a/client/my-sites/plans-v2/plans-filter-bar-i5/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar-i5/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -15,7 +15,6 @@ import { JETPACK_PRODUCTS_BY_TERM } from 'calypso/lib/products-values/constants'
 import { JETPACK_RESET_PLANS_BY_TERM } from 'calypso/lib/plans/constants';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
-import { masterbarIsVisible } from 'calypso/state/ui/selectors';
 import useDetectWindowBoundary from '../use-detect-window-boundary';
 import { getHighestAnnualDiscount } from '../utils';
 
@@ -67,11 +66,11 @@ const DiscountMessage: React.FC< DiscountMessageProps > = ( { primary } ) => {
 			<div>
 				<span className="plans-filter-bar-i5__discount-message-text">
 					{ isMobile
-						? translate( 'SAVE %(discount)s BY PAYING YEARLY', {
+						? translate( 'Save %(discount)s by paying yearly', {
 								args: { discount: highestAnnualDiscount },
 								comment: 'Discount is either a currency-formatted number or percentage',
 						  } )
-						: translate( 'SAVE %(discount)s', {
+						: translate( 'Save %(discount)s', {
 								args: { discount: highestAnnualDiscount },
 								comment: 'Discount is either a currency-formatted number or percentage',
 						  } ) }

--- a/client/my-sites/plans-v2/plans-filter-bar-i5/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar-i5/style.scss
@@ -21,7 +21,7 @@
 		justify-content: center;
 		align-items: center;
 		font-weight: 700;
-		padding-bottom: 20px;
+		padding-bottom: 10px;
 
 		.plans-filter-bar-i5__toggle-off-label {
 			color: var( --color-primary );
@@ -80,14 +80,12 @@
 }
 
 .plans-filter-bar-i5__discount-message {
-	padding: 6px 8px;
-	border-radius: 4px;
 	font-size: 0.8125rem;
 	font-weight: 600;
+	padding-top: 5px;
 
 	&.primary {
-		color: #fff;
-		background-color: var( --color-primary-light );
+		color: var( --color-primary );
 	}
 
 	.plans-filter-bar-i5__discount-message-text {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the "Save 20%" discount message on the Plans filter bar to no longer look like it is a green "button".

Fixes 1196341175636977-as-1199200712773353

### Testing instructions

- Download the PR or visit the Calypso live link
- Run Calypso or Jetpack cloud
- Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
- Visit the pricing page
- Verify that the 20% discount message no longer has the appearance of a "button" (See screenshots below)

### Screenshots

**BEFORE**

Desktop
![Screenshot on 2020-11-16 at 12-00-07](https://user-images.githubusercontent.com/11078128/99302010-a305a080-2803-11eb-92e9-249a2e3c6928.png)
Mobile
![Screenshot on 2020-11-16 at 12-00-38](https://user-images.githubusercontent.com/11078128/99302044-adc03580-2803-11eb-962e-6dda8b6773ce.png)

**AFTER**

Desktop
![Screenshot on 2020-11-16 at 12-01-09](https://user-images.githubusercontent.com/11078128/99302086-bc0e5180-2803-11eb-820f-5e9d4bbb38ff.png)
Mobile
![Screenshot on 2020-11-16 at 12-01-35](https://user-images.githubusercontent.com/11078128/99302103-c16b9c00-2803-11eb-852e-b96c26db9325.png)


