### PR TITLE
ci: run CI on main and release branches only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1098,6 +1098,8 @@ workflows:
               only:
                 - master
                 - trunk
+                - release/*
+                - desktop/release/*
       - wp-desktop-mac:
           requires:
             - wp-desktop-source

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1096,10 +1096,9 @@ workflows:
           filters:
             branches:
               only:
-                - master
                 - trunk
                 - release/*
-                - desktop/release/*
+                - desktop/*
       - wp-desktop-mac:
           requires:
             - wp-desktop-source

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1092,7 +1092,12 @@ workflows:
           slack-webhook: '$SLACK_WOO'
   wp-desktop:
     jobs:
-      - wp-desktop-source
+      - wp-desktop-source:
+          filters:
+            branches:
+              only:
+                - master
+                - trunk
       - wp-desktop-mac:
           requires:
             - wp-desktop-source

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1101,9 +1101,10 @@ workflows:
       - wp-desktop-mac:
           requires:
             - wp-desktop-source
-      - wp-desktop-linux:
-          requires:
-            - wp-desktop-source
+      # Use TeamCity to run Linux build
+      # - wp-desktop-linux:
+      #     requires:
+      #       - wp-desktop-source
       - wp-desktop-windows:
           requires:
             - wp-desktop-source

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1102,10 +1102,14 @@ workflows:
       - wp-desktop-mac:
           requires:
             - wp-desktop-source
-      # Use TeamCity to run Linux build
-      # - wp-desktop-linux:
-      #     requires:
-      #       - wp-desktop-source
+      # Even though a TeamCity Linux job is ran against trunk,
+      # we should continue to periodically validate the Circle
+      # job to ensure CircleCI continues to work on all
+      # platforms since the application is deployed via CircleCI.
+      # This also provides a benchmark and fallback for TeamCity.
+      - wp-desktop-linux:
+          requires:
+            - wp-desktop-source
       - wp-desktop-windows:
           requires:
             - wp-desktop-source


### PR DESCRIPTION
### Description

Following migration of day-to-day PRs from Circle to TeamCity, this PR limits Circle usage to master/trunk branch merges and releases only.

### Blockers

Prior to landing this, we need to make sure a couple of things are in place:

- [x] TeamCity CI for all Calypso PRs (see #47478)
- ~~[ ] Automated Github reviews for TeamCity Linux jobs~~ (not necessary if the Desktop job is set as mandatory)