### PR TITLE
Jetpack Connect Install: show the WordPress.org credentials form only if there is a site in context

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -355,7 +355,7 @@ export class OrgCredentialsForm extends Component {
 						<JetpackRemoteInstallNotices noticeType={ this.getError( installError ) } />
 					</div>
 				) }
-				{ ( this.isInvalidCreds() || ! installError ) && (
+				{ ( this.isInvalidCreds() || ! installError ) && this.props.siteToConnect && (
 					<div className="jetpack-connect__site-url-entry-container">
 						{ this.renderHeadersText() }
 						<Card className="jetpack-connect__site-url-input-container">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Check if there is a site in context before rendering the WordPress.org credentials form, otherwise, and error will be thrown in the console.

#### Testing instructions

* Run this PR (Calypso Blue).
* Open the JavaScript console in DevTools.
* Visit `/jetpack/connect/install`.
* Make sure that there is no error thrown in the console (you will be redirected to `/jetpack/connect`).

Fixes 1164141197617539-as-1196859229849752

#### Demo

##### Before
![Kapture 2020-11-16 at 17 52 45](https://user-images.githubusercontent.com/3418513/99307066-c39a1e80-2834-11eb-94a8-b67f8c23b682.gif)

##### After
![Kapture 2020-11-16 at 17 55 28](https://user-images.githubusercontent.com/3418513/99307315-14aa1280-2835-11eb-8b67-16a9242c8de9.gif)
