### PR TITLE
Checkout: fix full credits payment method behavior

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -88,7 +88,7 @@ export default function PaymentMethodStep( {
 					<LineItem tax key={ tax.id } item={ tax } />
 				) ) }
 				{ credits && <LineItem subtotal item={ credits } /> }
-				<WPOrderReviewTotal total={ isFullCredits ? subtotal : total } />
+				<WPOrderReviewTotal total={ total } />
 			</WPOrderReviewSection>
 		</>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -87,7 +87,7 @@ export default function PaymentMethodStep( {
 				{ taxes.map( ( tax ) => (
 					<LineItem tax key={ tax.id } item={ tax } />
 				) ) }
-				{ credits && <LineItem subtotal item={ credits } /> }
+				{ credits && subtotal.amount.value > 0 && <LineItem subtotal item={ credits } /> }
 				<WPOrderReviewTotal total={ total } />
 			</WPOrderReviewSection>
 		</>

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -12,7 +12,6 @@ import type { LineItem as LineItemType } from '@automattic/composite-checkout';
  */
 import CheckoutTerms from '../components/checkout-terms';
 import { WPOrderReviewTotal, WPOrderReviewSection, LineItem } from './wp-order-review-line-items';
-import doesPurchaseHaveFullCredits from '../lib/does-purchase-have-full-credits';
 
 const CheckoutTermsWrapper = styled.div`
 	& > * {
@@ -74,9 +73,7 @@ export default function PaymentMethodStep( {
 } ): JSX.Element {
 	const { responseCart } = useShoppingCart();
 	const [ items, total ] = useLineItems();
-	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
-	// NOTE: if we have full credits, we currently do not charge taxes. This may not be ideal, but it's how the back-end works.
-	const taxes = isFullCredits ? [] : items.filter( ( item ) => item.type === 'tax' );
+	const taxes = items.filter( ( item ) => item.type === 'tax' );
 	return (
 		<>
 			{ activeStepContent }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -465,7 +465,6 @@ export default function CompositeCheckout( {
 		stripeLoadingError,
 		stripeConfiguration,
 		stripe,
-		credits,
 		isApplePayAvailable,
 		isApplePayLoading,
 		storedCards,

--- a/client/my-sites/checkout/composite-checkout/lib/does-purchase-have-full-credits.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/does-purchase-have-full-credits.ts
@@ -6,5 +6,7 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 export default function doesPurchaseHaveFullCredits( cart: ResponseCart ): boolean {
 	const credits = cart.credits_integer;
 	const subtotal = cart.sub_total_integer;
-	return credits > 0 && subtotal > 0 && credits >= subtotal;
+	const taxes = cart.total_tax_integer;
+	const totalBeforeCredits = subtotal + taxes;
+	return credits > 0 && totalBeforeCredits > 0 && credits >= totalBeforeCredits;
 }

--- a/client/my-sites/checkout/composite-checkout/lib/does-purchase-have-full-credits.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/does-purchase-have-full-credits.ts
@@ -5,5 +5,6 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 
 export default function doesPurchaseHaveFullCredits( cart: ResponseCart ): boolean {
 	const credits = cart.credits_integer;
-	return credits > 0 && credits >= cart.sub_total_integer;
+	const subtotal = cart.sub_total_integer;
+	return credits > 0 && subtotal > 0 && credits >= subtotal;
 }

--- a/client/my-sites/checkout/composite-checkout/lib/does-purchase-have-full-credits.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/does-purchase-have-full-credits.ts
@@ -4,7 +4,6 @@
 import type { ResponseCart } from '@automattic/shopping-cart';
 
 export default function doesPurchaseHaveFullCredits( cart: ResponseCart ): boolean {
-	const isPurchaseFree = cart.total_cost_integer === 0;
 	const credits = cart.credits_integer;
-	return ! isPurchaseFree && credits > 0 && credits >= cart.sub_total_integer;
+	return credits > 0 && credits >= cart.sub_total_integer;
 }

--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -49,9 +49,9 @@ export default function filterAppropriatePaymentMethods( {
 		.filter( ( methodObject ) => {
 			// If the purchase is free, only display the free-purchase method
 			if ( methodObject.id === 'free-purchase' ) {
-				return isPurchaseFree ? true : false;
+				return isPurchaseFree && ! isFullCredits ? true : false;
 			}
-			return isPurchaseFree ? false : true;
+			return isPurchaseFree && ! isFullCredits ? false : true;
 		} )
 		.filter( ( methodObject ) => {
 			// If the purchase is full-credits, only display the full-credits method

--- a/client/my-sites/checkout/composite-checkout/lib/get-contact-details-type.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-contact-details-type.ts
@@ -13,6 +13,7 @@ import {
 	hasOnlyRenewalItems,
 } from 'calypso/lib/cart-values/cart-items';
 import { isGSuiteProductSlug } from 'calypso/lib/gsuite';
+import doesPurchaseHaveFullCredits from './does-purchase-have-full-credits';
 
 export default function getContactDetailsType( responseCart: ResponseCart ): ContactDetailsType {
 	const hasDomainProduct =
@@ -22,10 +23,7 @@ export default function getContactDetailsType( responseCart: ResponseCart ): Con
 	);
 	const isOnlyRenewals = hasOnlyRenewalItems( responseCart );
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
-	const isFullCredits =
-		! isPurchaseFree &&
-		responseCart.credits_integer > 0 &&
-		responseCart.credits_integer >= responseCart.sub_total_integer;
+	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
 
 	if ( hasDomainProduct && ! isOnlyRenewals ) {
 		return 'domain';

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -21,7 +21,6 @@ import {
 import { isPlan, isDomainTransferProduct, isDomainProduct } from 'calypso/lib/products-values';
 import { isRenewal } from 'calypso/lib/cart-values/cart-items';
 import doesValueExist from './does-value-exist';
-import doesPurchaseHaveFullCredits from './does-purchase-have-full-credits';
 
 /**
  * Translate a cart object as returned by the WPCOM cart endpoint to
@@ -50,8 +49,6 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		coupon,
 		tax,
 	} = serverCart;
-
-	const isFullCredits = doesPurchaseHaveFullCredits( serverCart );
 
 	const taxLineItem: CheckoutCartItem = {
 		id: 'tax-line-item',
@@ -143,7 +140,7 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		items: products.filter( isRealProduct ).map( translateReponseCartProductToWPCOMCartItem ),
 		tax: tax.display_taxes ? taxLineItem : null,
 		coupon: coupon && coupon_savings_total_integer ? couponLineItem : null,
-		total: isFullCredits ? subtotalItem : totalItem,
+		total: totalItem,
 		savings: savings_total_integer > 0 ? savingsLineItem : null,
 		subtotal: subtotalItem,
 		credits: credits_integer > 0 ? creditsLineItem : null,

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -21,6 +21,7 @@ import {
 import { isPlan, isDomainTransferProduct, isDomainProduct } from 'calypso/lib/products-values';
 import { isRenewal } from 'calypso/lib/cart-values/cart-items';
 import doesValueExist from './does-value-exist';
+import doesPurchaseHaveFullCredits from './does-purchase-have-full-credits';
 
 /**
  * Translate a cart object as returned by the WPCOM cart endpoint to
@@ -87,7 +88,14 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 			currency: currency,
 			value: credits_integer,
 			displayValue: String(
-				translate( '- %(discountAmount)s', { args: { discountAmount: credits_display } } )
+				translate( '- %(discountAmount)s', {
+					args: {
+						// Clamp the credits display value to the total
+						discountAmount: doesPurchaseHaveFullCredits( serverCart )
+							? sub_total_display
+							: credits_display,
+					},
+				} )
 			),
 		},
 		wpcom_meta: {

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -39,6 +39,7 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		total_cost_display,
 		coupon_savings_total_display,
 		coupon_savings_total_integer,
+		sub_total_with_taxes_display,
 		savings_total_display,
 		savings_total_integer,
 		currency,
@@ -92,7 +93,7 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 					args: {
 						// Clamp the credits display value to the total
 						discountAmount: doesPurchaseHaveFullCredits( serverCart )
-							? sub_total_display
+							? sub_total_with_taxes_display
 							: credits_display,
 					},
 				} )

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -317,9 +317,9 @@ export async function fullCreditsProcessor(
 			...submitData,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
-			// this data is intentionally empty so we do not charge taxes
-			country: null,
-			postalCode: null,
+			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+			postalCode: submitData.postalCode || getPostalCode(),
+			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 		},
 		wpcomTransaction,
 		transactionOptions

--- a/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
@@ -18,10 +18,10 @@ import { useShoppingCart } from '@automattic/shopping-cart';
  */
 import WordPressLogo from '../components/wordpress-logo';
 
-export function createFullCreditsMethod( { credits } ) {
+export function createFullCreditsMethod() {
 	return {
 		id: 'full-credits',
-		label: <WordPressCreditsLabel credits={ credits } />,
+		label: <WordPressCreditsLabel />,
 		submitButton: <FullCreditsSubmitButton />,
 		inactiveContent: <WordPressCreditsSummary />,
 		getAriaLabel: ( __ ) => __( 'Credits' ),
@@ -65,14 +65,15 @@ function ButtonContents( { formStatus, total } ) {
 	return __( 'Please wait…' );
 }
 
-function WordPressCreditsLabel( { credits } ) {
+function WordPressCreditsLabel() {
 	const { __ } = useI18n();
+	const { responseCart } = useShoppingCart();
 
 	return (
 		<React.Fragment>
 			<div>
 				{ sprintf( __( 'WordPress.com Credits: %(amount)s available' ), {
-					amount: credits.wpcom_meta.credits_display,
+					amount: responseCart.available_credits_display,
 				} ) }
 			</div>
 			<WordPressLogo />

--- a/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
@@ -73,7 +73,7 @@ function WordPressCreditsLabel() {
 		<React.Fragment>
 			<div>
 				{ sprintf( __( 'WordPress.com Credits: %(amount)s available' ), {
-					amount: responseCart.available_credits_display,
+					amount: responseCart.credits_display,
 				} ) }
 			</div>
 			<WordPressLogo />

--- a/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
@@ -49,7 +49,10 @@ function FullCreditsSubmitButton( { disabled, onClick } ) {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } total={ responseCart.sub_total_display } />
+			<ButtonContents
+				formStatus={ formStatus }
+				total={ responseCart.sub_total_with_taxes_display }
+			/>
 		</Button>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
@@ -11,6 +11,7 @@ import {
 	useFormStatus,
 	useEvents,
 } from '@automattic/composite-checkout';
+import { useShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -28,7 +29,8 @@ export function createFullCreditsMethod( { credits } ) {
 }
 
 function FullCreditsSubmitButton( { disabled, onClick } ) {
-	const [ items, total ] = useLineItems();
+	const [ items ] = useLineItems();
+	const { responseCart } = useShoppingCart();
 	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
 
@@ -47,7 +49,7 @@ function FullCreditsSubmitButton( { disabled, onClick } ) {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } total={ total } />
+			<ButtonContents formStatus={ formStatus } total={ responseCart.sub_total_display } />
 		</Button>
 	);
 }
@@ -58,7 +60,7 @@ function ButtonContents( { formStatus, total } ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
-		return sprintf( __( 'Pay %s with credits' ), total.amount.displayValue );
+		return sprintf( __( 'Pay %s with credits' ), total );
 	}
 	return __( 'Please wait…' );
 }

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -322,7 +322,12 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'renders the full credits payment method option when full credits are available', async () => {
 		let renderResult;
-		const cartChanges = { credits_integer: 15600, credits_display: 'R$156' };
+		const cartChanges = {
+			sub_total_integer: 0,
+			sub_total_display: '0',
+			credits_integer: 15600,
+			credits_display: 'R$156',
+		};
 		await act( async () => {
 			renderResult = render( <MyCheckout cartChanges={ cartChanges } />, container );
 		} );
@@ -332,7 +337,12 @@ describe( 'CompositeCheckout', () => {
 
 	it( 'does not render the other payment method options when full credits are available', async () => {
 		let renderResult;
-		const cartChanges = { credits_integer: 15600, credits_display: 'R$156' };
+		const cartChanges = {
+			sub_total_integer: 0,
+			sub_total_display: '0',
+			credits_integer: 15600,
+			credits_display: 'R$156',
+		};
 		await act( async () => {
 			renderResult = render( <MyCheckout cartChanges={ cartChanges } />, container );
 		} );
@@ -364,6 +374,8 @@ describe( 'CompositeCheckout', () => {
 		const cartChanges = {
 			sub_total_integer: 0,
 			sub_total_display: '0',
+			total_tax_integer: 0,
+			total_tax_display: 'R$0',
 			total_cost_integer: 0,
 			total_cost_display: '0',
 			credits_integer: 15600,

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -362,6 +362,8 @@ describe( 'CompositeCheckout', () => {
 	it( 'does not render the full credits payment method option when full credits are available but the purchase is free', async () => {
 		let renderResult;
 		const cartChanges = {
+			sub_total_integer: 0,
+			sub_total_display: '0',
 			total_cost_integer: 0,
 			total_cost_display: '0',
 			credits_integer: 15600,

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -245,8 +245,8 @@ function useCreateEbanxTef() {
 	);
 }
 
-function useCreateFullCredits( { credits } ) {
-	return useMemo( () => createFullCreditsMethod( { credits } ), [ credits ] );
+function useCreateFullCredits() {
+	return useMemo( () => createFullCreditsMethod(), [] );
 }
 
 function useCreateFree() {
@@ -296,7 +296,6 @@ export default function useCreatePaymentMethods( {
 	stripeLoadingError,
 	stripeConfiguration,
 	stripe,
-	credits,
 	isApplePayAvailable,
 	isApplePayLoading,
 	storedCards,
@@ -374,9 +373,7 @@ export default function useCreatePaymentMethods( {
 		stripe,
 	} );
 
-	const fullCreditsPaymentMethod = useCreateFullCredits( {
-		credits,
-	} );
+	const fullCreditsPaymentMethod = useCreateFullCredits();
 
 	const freePaymentMethod = useCreateFree();
 

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -18,6 +18,8 @@ export const emptyResponseCart: ResponseCart = {
 	coupon_savings_total_display: '0',
 	savings_total_integer: 0,
 	savings_total_display: '0',
+	sub_total_with_taxes_integer: 0,
+	sub_total_with_taxes_display: '0',
 	sub_total_integer: 0,
 	sub_total_display: '0',
 	currency: 'USD',

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -21,8 +21,6 @@ export const emptyResponseCart: ResponseCart = {
 	sub_total_integer: 0,
 	sub_total_display: '0',
 	currency: 'USD',
-	available_credits_integer: 0,
-	available_credits_display: '0',
 	credits_integer: 0,
 	credits_display: '0',
 	allowed_payment_methods: [],

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -21,6 +21,8 @@ export const emptyResponseCart: ResponseCart = {
 	sub_total_integer: 0,
 	sub_total_display: '0',
 	currency: 'USD',
+	available_credits_integer: 0,
+	available_credits_display: '0',
 	credits_integer: 0,
 	credits_display: '0',
 	allowed_payment_methods: [],

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -64,6 +64,8 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	coupon_savings_total_display: string;
 	savings_total_integer: number;
 	savings_total_display: string;
+	sub_total_with_taxes_integer: number;
+	sub_total_with_taxes_display: string;
 	sub_total_integer: number;
 	sub_total_display: string;
 	currency: string;

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -67,6 +67,8 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	sub_total_integer: number;
 	sub_total_display: string;
 	currency: string;
+	available_credits_integer: number;
+	available_credits_display: string;
 	credits_integer: number;
 	credits_display: string;
 	allowed_payment_methods: string[];

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -67,8 +67,6 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	sub_total_integer: number;
 	sub_total_display: string;
 	currency: string;
-	available_credits_integer: number;
-	available_credits_display: string;
 	credits_integer: number;
 	credits_display: string;
 	allowed_payment_methods: string[];

--- a/packages/shopping-cart/test/shopping-cart-endpoint.js
+++ b/packages/shopping-cart/test/shopping-cart-endpoint.js
@@ -20,6 +20,8 @@ const cart = {
 	total_cost_integer: 0,
 	total_cost_display: '$0',
 	currency: 'USD',
+	available_credits_integer: 0,
+	available_credits_display: '$0',
 	credits_integer: 0,
 	credits_display: '$0',
 	allowed_payment_methods: [],

--- a/packages/shopping-cart/test/shopping-cart-endpoint.js
+++ b/packages/shopping-cart/test/shopping-cart-endpoint.js
@@ -20,8 +20,6 @@ const cart = {
 	total_cost_integer: 0,
 	total_cost_display: '$0',
 	currency: 'USD',
-	available_credits_integer: 0,
-	available_credits_display: '$0',
 	credits_integer: 0,
 	credits_display: '$0',
 	allowed_payment_methods: [],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The shopping-cart endpoint, prior to D52836-code, will report the total without _any_ credits applied if the number of credits equals or exceeds the cart subtotal. With the above diff, those inconsistencies are no longer present.

Because of this, we can remove some of the hacks that were in place on the front-end (many of which were added in https://github.com/Automattic/wp-calypso/pull/47305). This PR does that. We also will need to more clearly differentiate between "free" and "full credits" because now with a 0 total, full credits will also be free. Because we want to always display full credits differently, this PR modifies the logic where free purchases are concerned and makes it more explicit.

Fixes 56-gh-Automattic/payments-shilling

Before, with full credits (enough to completely cover the total + taxes):

<img width="563" alt="before-taxes-changes" src="https://user-images.githubusercontent.com/2036909/99317582-4bcbf400-2834-11eb-894f-38ce78f0a691.png">

After, with full credits (enough to completely cover the total + taxes):

<img width="566" alt="Screen Shot 2020-11-18 at 5 28 06 PM" src="https://user-images.githubusercontent.com/2036909/99595912-739d9200-29c3-11eb-8a4a-e6530f3e85da.png">

Before, with just taxes (enough credits to cover the subtotal, but not taxes):

<img width="564" alt="Screen Shot 2020-11-17 at 6 31 37 PM" src="https://user-images.githubusercontent.com/2036909/99463209-3c67ac00-2903-11eb-9da7-a0aa80b29b02.png">

After, with just taxes (enough credits to cover the subtotal, but not taxes):

<img width="567" alt="just-enough-credits-except-taxes-after" src="https://user-images.githubusercontent.com/2036909/99462873-9156f280-2902-11eb-9036-26e3ce234786.png">

Before and after, with partial credits:

<img width="558" alt="before-partial-credits-taxes" src="https://user-images.githubusercontent.com/2036909/99317938-d44a9480-2834-11eb-9b3e-48e33efb681a.png">

Before, with a free purchase and credits:

<img width="568" alt="Screen Shot 2020-11-16 at 7 21 37 PM" src="https://user-images.githubusercontent.com/2036909/99323831-fd712200-2840-11eb-8793-2fab547dfd1e.png">

After, with a free purchase and credits:

<img width="567" alt="Screen Shot 2020-11-16 at 7 20 20 PM" src="https://user-images.githubusercontent.com/2036909/99323839-0104a900-2841-11eb-93f9-35499f94bfda.png">


#### Testing instructions

- Apply D52836-code.
- Visit checkout without any credits, proceed to the last step, and verify that the subtotal, taxes, and total lines look correct and no credits are listed.
- Visit checkout with some credits (but not enough to cover the entire transaction), proceed to the last step, and verify that the subtotal, taxes, credits, and total lines look correct.
- Visit checkout with enough credits to cover the subtotal, excluding taxes, proceed to the last step, and verify that the subtotal, taxes, credits, and total lines look correct (the total should be just the taxes and you should be required to use a real payment method).
- Visit checkout with enough credits to cover the entire transaction, including taxes, proceed to the last step, and verify that the subtotal, taxes, credits, and total lines look correct (the total should be 0 and you should see the "pay with credits" payment method).
- Visit checkout with just a free product in your cart (the simplest thing is probably to use a coupon with a 100% discount) and with some credits (but not enough to cover the entire transaction or you won't see the button to add a coupon); verify that the subtotal, taxes, and total lines look correct, there are no credits listed, and that you see the "free purchase" payment method, not the "pay with credits" payment method.