### PR TITLE
Reader Lists: fix success notices in data layer

### DIFF
--- a/client/state/data-layer/wpcom/read/lists/feeds/delete/index.js
+++ b/client/state/data-layer/wpcom/read/lists/feeds/delete/index.js
@@ -26,9 +26,10 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/feeds/delete/index.js', {
 					},
 					action
 				),
-			onSuccess: successNotice( translate( 'Feed removed from list successfully.' ), {
-				duration: DEFAULT_NOTICE_DURATION,
-			} ),
+			onSuccess: () =>
+				successNotice( translate( 'Feed removed from list successfully.' ), {
+					duration: DEFAULT_NOTICE_DURATION,
+				} ),
 			onError: () => errorNotice( translate( 'Unable to remove feed from list.' ) ),
 		} ),
 	],

--- a/client/state/data-layer/wpcom/read/lists/sites/delete/index.js
+++ b/client/state/data-layer/wpcom/read/lists/sites/delete/index.js
@@ -26,9 +26,10 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/sites/delete/index.js', {
 					},
 					action
 				),
-			onSuccess: successNotice( translate( 'Site removed from list successfully.' ), {
-				duration: DEFAULT_NOTICE_DURATION,
-			} ),
+			onSuccess: () =>
+				successNotice( translate( 'Site removed from list successfully.' ), {
+					duration: DEFAULT_NOTICE_DURATION,
+				} ),
 			onError: () => errorNotice( translate( 'Unable to remove site from list.' ) ),
 		} ),
 	],

--- a/client/state/data-layer/wpcom/read/lists/tags/delete/index.js
+++ b/client/state/data-layer/wpcom/read/lists/tags/delete/index.js
@@ -26,9 +26,10 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/tags/delete/index.js', {
 					},
 					action
 				),
-			onSuccess: successNotice( translate( 'Tag removed from list successfully.' ), {
-				duration: DEFAULT_NOTICE_DURATION,
-			} ),
+			onSuccess: () =>
+				successNotice( translate( 'Tag removed from list successfully.' ), {
+					duration: DEFAULT_NOTICE_DURATION,
+				} ),
 			onError: () => errorNotice( translate( 'Unable to remove tag from list.' ) ),
 		} ),
 	],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Eagle-eyed @jsnmoon noticed that, in a few cases, we're returning the successNotice invocation instead of a function that invokes successNotice.

This PR adds the missing `() =>` where needed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Try removing a feed, tag and site from an existing Reader list and ensure that a success notice appears.
