### PR TITLE
Jetpack Upgrade Flow: Connecting Users

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -224,7 +224,8 @@ export class JetpackAuthorize extends Component {
 			this.isFromJpo() ||
 			this.isFromBlockEditor() ||
 			this.shouldRedirectJetpackStart() ||
-			getRoleFromScope( scope ) === 'subscriber'
+			getRoleFromScope( scope ) === 'subscriber' ||
+			this.isJetpackUpgradeFlow()
 		) {
 			debug(
 				'Going back to WP Admin.',
@@ -281,6 +282,17 @@ export class JetpackAuthorize extends Component {
 	isSso( props = this.props ) {
 		const { from, clientId } = props.authQuery;
 		return 'sso' === from && isSsoApproved( clientId );
+	}
+
+	/**
+	 * Check if the user is coming from the Jetpack upgrade flow.
+	 *
+	 * @returns {boolean} True if the user is coming from the Jetpack upgrade flow, false otherwise.
+	 */
+	isJetpackUpgradeFlow() {
+		return this.props.authQuery.redirectAfterAuth.includes(
+			'page=jetpack&action=authorize_redirect'
+		);
 	}
 
 	isWooRedirect = ( props = this.props ) => {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -287,12 +287,13 @@ export class JetpackAuthorize extends Component {
 	/**
 	 * Check if the user is coming from the Jetpack upgrade flow.
 	 *
-	 * @returns {boolean} True if the user is coming from the Jetpack upgrade flow, false otherwise.
+	 * @param  {object}  props           Props to test
+	 * @param  {?string} props.authQuery.redirectAfterAuth Where were we redirected after auth.
+	 * @returns {boolean}                True if the user is coming from the Jetpack upgrade flow, false otherwise.
 	 */
-	isJetpackUpgradeFlow() {
-		return this.props.authQuery.redirectAfterAuth.includes(
-			'page=jetpack&action=authorize_redirect'
-		);
+	isJetpackUpgradeFlow( props = this.props ) {
+		const { redirectAfterAuth } = props.authQuery;
+		return redirectAfterAuth.includes( 'page=jetpack&action=authorize_redirect' );
 	}
 
 	isWooRedirect = ( props = this.props ) => {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -202,4 +202,28 @@ describe( 'JetpackAuthorize', () => {
 			expect( result ).toBe( true );
 		} );
 	} );
+
+	describe( 'shouldSeePlans', () => {
+		const isJetpackUpgradeFlow = new JetpackAuthorize().isJetpackUpgradeFlow;
+
+		test( 'should see plans', () => {
+			const props = {
+				authQuery: {
+					redirectAfterAuth: 'page=jetpack&action=something_else',
+				},
+			};
+
+			expect( isJetpackUpgradeFlow( props ) ).toBe( false );
+		} );
+
+		test( 'should be sent back', () => {
+			const props = {
+				authQuery: {
+					redirectAfterAuth: 'page=jetpack&action=authorize_redirect',
+				},
+			};
+
+			expect( isJetpackUpgradeFlow( props ) ).toBe( true );
+		} );
+	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
If a Jetpack user is not connected to WP.com, the upgrade flow will lead them nowhere.
It is part of the solution that fixes the flow, which also includes Jetpack and WP.com changes.

This commit makes the authentication upgrade flow will be exempt from redirecting users to the Jetpack "Plans" page.
The flow is already a purchase process, so there's no need for the "Plans" page to show up.

Part of p9dueE-26z-p2
Related to https://github.com/Automattic/jetpack/pull/17822

#### Testing instructions
This PR alone doesn't bring any functional changes to the behavior, so it can't be fully tested.
The goal is to make sure that the existing behavior is not affected by the changes.

1. Switch Jetpack to the local Calypso. You could do that by defining the constant: `define( 'CALYPSO_ENV', 'development' );`
2. Connect Jetpack. Confirm that you got redirected to the Plans page.