### PR TITLE
Reader Lists: indicate when a list is private

### DIFF
--- a/client/components/gridicon/index.tsx
+++ b/client/components/gridicon/index.tsx
@@ -22,7 +22,7 @@ interface Props {
 type AllProps = Assign< React.SVGProps< SVGSVGElement >, Props >;
 
 const Gridicon = React.forwardRef< SVGSVGElement, AllProps >( ( props: AllProps, ref ) => {
-	const { size = 24, icon, onClick, className, ...otherProps } = props;
+	const { size = 24, icon, onClick, className, title, ...otherProps } = props;
 	const isModulo18 = size % 18 === 0;
 
 	// Using a missing icon doesn't produce any errors, just a blank icon, which is the exact intended behaviour.
@@ -47,6 +47,7 @@ const Gridicon = React.forwardRef< SVGSVGElement, AllProps >( ( props: AllProps,
 			ref={ ref }
 			{ ...otherProps }
 		>
+			{ title && <title>{ title }</title> }
 			<use xlinkHref={ `${ spritePath }#${ iconName }` } />
 		</svg>
 	);

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -42,14 +42,8 @@ const ListStreamHeader = ( {
 				<div className="list-stream__header-title">
 					<h1>{ title }</h1>
 					{ ! isPublic && (
-						<div
-							className="list-stream__header-title-privacy"
-							title={ translate( 'Private list' ) }
-						>
-							<Gridicon icon="lock" size={ 18 } />
-							<span className="list-stream__header-title-privacy-label screen-reader-text">
-								{ translate( '(private)' ) }
-							</span>
+						<div className="list-stream__header-title-privacy">
+							<Gridicon icon="lock" size={ 18 } title={ translate( 'Private list' ) } />
 						</div>
 					) }
 				</div>

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -48,7 +48,7 @@ const ListStreamHeader = ( {
 						>
 							<Gridicon icon="lock" size={ 18 } />
 							<span className="list-stream__header-title-privacy-label screen-reader-text">
-								{ translate( '(private list)' ) }
+								{ translate( '(private)' ) }
 							</span>
 						</div>
 					) }

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -16,6 +16,7 @@ import FollowButton from 'calypso/blocks/follow-button/button';
 
 const ListStreamHeader = ( {
 	isPlaceholder,
+	isPublic,
 	title,
 	description,
 	showEdit,
@@ -38,7 +39,20 @@ const ListStreamHeader = ( {
 			</span>
 
 			<div className="list-stream__header-details">
-				<h1 className="list-stream__header-title">{ title }</h1>
+				<div className="list-stream__header-title">
+					<h1>{ title }</h1>
+					{ ! isPublic && (
+						<div
+							className="list-stream__header-title-privacy"
+							title={ translate( 'Private list' ) }
+						>
+							<Gridicon icon="lock" size={ 18 } />
+							<span className="list-stream__header-title-privacy-label screen-reader-text">
+								{ translate( '(private list)' ) }
+							</span>
+						</div>
+					) }
+				</div>
 				{ description && <p className="list-stream__header-description">{ description }</p> }
 			</div>
 
@@ -54,7 +68,9 @@ const ListStreamHeader = ( {
 						<span className="list-stream__header-action-icon">
 							<Gridicon icon="cog" size={ 24 } />
 						</span>
-						<span className="list-stream__header-action-label">{ translate( 'Edit' ) }</span>
+						<span className="list-stream__header-action-label screen-reader-text">
+							{ translate( 'Edit' ) }
+						</span>
 					</a>
 				</div>
 			) }
@@ -64,6 +80,7 @@ const ListStreamHeader = ( {
 
 ListStreamHeader.propTypes = {
 	isPlaceholder: PropTypes.bool,
+	isPublic: PropTypes.bool,
 	title: PropTypes.string,
 	description: PropTypes.string,
 	showEdit: PropTypes.bool,

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -88,7 +88,7 @@ class ListStream extends React.Component {
 				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
 				<ListStreamHeader
 					isPlaceholder={ ! list }
-					isPublic={ list && list.is_public }
+					isPublic={ list?.is_public }
 					icon={
 						<svg
 							className={ listStreamIconClasses }
@@ -109,7 +109,7 @@ class ListStream extends React.Component {
 						</svg>
 					}
 					title={ this.title }
-					description={ list && list.description }
+					description={ list?.description }
 					showFollow={ shouldShowFollow }
 					following={ this.props.isSubscribed }
 					onFollowToggle={ this.toggleFollowing }

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 /**
@@ -89,6 +88,7 @@ class ListStream extends React.Component {
 				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
 				<ListStreamHeader
 					isPlaceholder={ ! list }
+					isPublic={ list && list.is_public }
 					icon={
 						<svg
 							className={ listStreamIconClasses }
@@ -129,13 +129,5 @@ export default connect(
 			isMissing: isMissingByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
 		};
 	},
-	( dispatch ) => {
-		return bindActionCreators(
-			{
-				followList,
-				unfollowList,
-			},
-			dispatch
-		);
-	}
+	{ followList, unfollowList }
 )( localize( ListStream ) );

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -51,7 +51,18 @@
 
 .list-stream__header-title {
 	color: var( --color-neutral-70 );
+	display: flex;
 	font-size: $font-body;
+
+	.gridicon {
+		color: var( --color-text-subtle );
+		height: 14px;
+	}
+}
+
+.list-stream__header-title-privacy {
+	margin-left: 2px;
+	margin-top: 1px;
 }
 
 .list-stream__header-description {
@@ -123,10 +134,6 @@
 
 .list-stream__header-edit {
 	margin-left: auto;
-
-	.list-stream__header-action-label {
-		display: none;
-	}
 
 	.list-stream__header-action-icon .gridicon {
 		fill: var( --color-neutral-light );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the list stream header, show a padlock icon when viewing a private list (with a text alternative for screen readers).

<img width="356" alt="Screen Shot 2020-11-17 at 17 32 06" src="https://user-images.githubusercontent.com/17325/99347040-edb61400-28fa-11eb-8513-566225e3be41.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit a public list like http://calypso.localhost:3000/read/list/blowery/comics and verify that no icon is shown.

Visit a private list that you own, and verify that a padlock is shown.
