### PR TITLE
Update/i18n utils unreverted

### DIFF
--- a/client/components/calypso-i18n-provider/index.tsx
+++ b/client/components/calypso-i18n-provider/index.tsx
@@ -4,10 +4,12 @@
 import * as React from 'react';
 import { setLocaleData as setWpI18nLocaleData } from '@wordpress/i18n';
 import { I18nProvider } from '@automattic/react-i18n';
+import { LocaleProvider } from '@automattic/i18n-utils';
 import i18n from 'i18n-calypso';
 
 const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 	const [ localeData, setLocaleData ] = React.useState( i18n.getLocale() );
+	const [ localeSlug ] = React.useState( i18n.getLocaleSlug() );
 
 	React.useEffect( () => {
 		const onChange = () => {
@@ -25,7 +27,11 @@ const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 		};
 	}, [] );
 
-	return <I18nProvider localeData={ localeData }>{ children }</I18nProvider>;
+	return (
+		<LocaleProvider localeSlug={ localeSlug || 'en' }>
+			<I18nProvider localeData={ localeData }>{ children }</I18nProvider>
+		</LocaleProvider>
+	);
 };
 
 export default CalypsoI18nProvider;

--- a/client/components/calypso-i18n-provider/index.tsx
+++ b/client/components/calypso-i18n-provider/index.tsx
@@ -9,7 +9,7 @@ import i18n from 'i18n-calypso';
 
 const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 	const [ localeData, setLocaleData ] = React.useState( i18n.getLocale() );
-	const [ localeSlug ] = React.useState( i18n.getLocaleSlug() );
+	const localeSlug = i18n.getLocaleSlug();
 
 	React.useEffect( () => {
 		const onChange = () => {

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -7,6 +7,7 @@ import { useSelect } from '@wordpress/data';
 import { Icon, chevronDown } from '@wordpress/icons';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
+import { useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -22,7 +23,8 @@ import { DOMAIN_SUGGESTIONS_STORE } from '../../stores/domain-suggestions';
 import './style.scss';
 
 const DomainPickerButton: React.FunctionComponent = () => {
-	const { __, i18nLocale } = useI18n();
+	const { __ } = useI18n();
+	const locale = useLocale();
 	const makePath = usePath();
 	const { domain, selectedDesign, siteTitle, siteVertical } = useSelect( ( select ) =>
 		select( ONBOARD_STORE ).getState()
@@ -43,7 +45,7 @@ const DomainPickerButton: React.FunctionComponent = () => {
 				include_wordpressdotcom: false,
 				include_dotblogsubdomain: false,
 				quantity: 1, // this will give the recommended domain only
-				locale: i18nLocale,
+				locale,
 			} );
 		},
 		[ suggestionQuery ]

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -34,6 +34,7 @@
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
+		"@automattic/i18n-utils": "^1.0.0",
 		"@wordpress/base-styles": "^2.0.1",
 		"@wordpress/components": "^10.0.5",
 		"@wordpress/compose": "^3.19.3",

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { FunctionComponent, useEffect, useState } from 'react';
-import { __ } from '@wordpress/i18n';
+
 import { createInterpolateElement } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -11,7 +11,8 @@ import { sprintf } from '@wordpress/i18n';
 import { v4 as uuid } from 'uuid';
 import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
-
+import { useI18n } from '@automattic/react-i18n';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 /**
  * Internal dependencies
  */
@@ -58,6 +59,8 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	selected,
 	type = ITEM_TYPE_RADIO,
 } ) => {
+	const { __ } = useI18n();
+	const localizeUrl = useLocalizeUrl();
 	const isMobile = useViewportMatch( 'small', '<' );
 
 	const dotPos = domain.indexOf( '.' );
@@ -162,7 +165,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 										<a
 											target="_blank"
 											rel="noreferrer"
-											href="https://wordpress.com/support/https-ssl"
+											href={ localizeUrl( 'https://wordpress.com/support/https-ssl' ) }
 										/>
 									), // TODO Wrap this in `localizeUrl` from lib/i18n-utils
 								}

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -22,6 +22,7 @@
 		"test": "yarn jest"
 	},
 	"dependencies": {
-		"i18n-calypso": "^5.0.0"
+		"i18n-calypso": "^5.0.0",
+		"react": "^16.12.0"
 	}
 }

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -22,7 +22,6 @@
 		"test": "yarn jest"
 	},
 	"dependencies": {
-		"i18n-calypso": "^5.0.0",
 		"react": "^16.12.0"
 	}
 }

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -22,6 +22,7 @@
 		"test": "yarn jest"
 	},
 	"dependencies": {
+		"@testing-library/react-hooks": "^3.4.2",
 		"react": "^16.12.0"
 	}
 }

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -1,1 +1,2 @@
 export { localizeUrl } from './localize-url';
+export { LocaleProvider, useLocale } from './locale-context';

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -1,25 +1,5 @@
 /**
  * Internal dependencies
  */
-import { localizeUrl } from './localize-url';
-import { Locale } from './locales';
-import { LocaleProvider, useLocale } from './locale-context';
-
-export { LocaleProvider, useLocale, localizeUrl };
-
-export interface I18nUtils {
-	localizeUrl: typeof localizeUrl;
-}
-
-export function useI18nUtils(): I18nUtils {
-	const providerLocale = useLocale();
-
-	return {
-		localizeUrl: ( fullUrl: string, locale?: Locale ) => {
-			if ( locale ) {
-				return localizeUrl( fullUrl, locale );
-			}
-			return localizeUrl( fullUrl, providerLocale );
-		},
-	};
-}
+export { localizeUrl, useLocalizeUrl } from './localize-url';
+export { LocaleProvider, useLocale } from './locale-context';

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -1,2 +1,25 @@
-export { localizeUrl } from './localize-url';
-export { LocaleProvider, useLocale } from './locale-context';
+/**
+ * Internal dependencies
+ */
+import { localizeUrl } from './localize-url';
+import { Locale } from './locales';
+import { LocaleProvider, useLocale } from './locale-context';
+
+export { LocaleProvider, useLocale };
+
+export interface I18nUtils {
+	localizeUrl: typeof localizeUrl;
+}
+
+export function useI18nUtils(): I18nUtils {
+	const locale = useLocale();
+
+	return {
+		localizeUrl: ( fullUrl: string, toLocale?: Locale ) => {
+			if ( toLocale ) {
+				return localizeUrl( fullUrl, toLocale );
+			}
+			return localizeUrl( fullUrl, locale );
+		},
+	};
+}

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -12,14 +12,14 @@ export interface I18nUtils {
 }
 
 export function useI18nUtils(): I18nUtils {
-	const locale = useLocale();
+	const providerLocale = useLocale();
 
 	return {
-		localizeUrl: ( fullUrl: string, toLocale?: Locale ) => {
-			if ( toLocale ) {
-				return localizeUrl( fullUrl, toLocale );
+		localizeUrl: ( fullUrl: string, locale?: Locale ) => {
+			if ( locale ) {
+				return localizeUrl( fullUrl, locale );
 			}
-			return localizeUrl( fullUrl, locale );
+			return localizeUrl( fullUrl, providerLocale );
 		},
 	};
 }

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -5,7 +5,7 @@ import { localizeUrl } from './localize-url';
 import { Locale } from './locales';
 import { LocaleProvider, useLocale } from './locale-context';
 
-export { LocaleProvider, useLocale };
+export { LocaleProvider, useLocale, localizeUrl };
 
 export interface I18nUtils {
 	localizeUrl: typeof localizeUrl;

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import React, { createContext, useContext } from 'react';
+
+export const localeContext = createContext< string >( 'en' );
+
+interface Props {
+	localeSlug: string;
+}
+
+export const LocaleProvider: React.FC< Props > = ( { children, localeSlug } ) => (
+	<localeContext.Provider value={ localeSlug }>{ children }</localeContext.Provider>
+);
+
+export function useLocale(): string {
+	return useContext( localeContext );
+}

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -3,16 +3,16 @@
  */
 import React, { createContext, useContext } from 'react';
 
-export const localeContext = createContext< string >( 'en' );
+export const LocaleContext = createContext< string >( 'en' );
 
 interface Props {
 	localeSlug: string;
 }
 
 export const LocaleProvider: React.FC< Props > = ( { children, localeSlug } ) => (
-	<localeContext.Provider value={ localeSlug }>{ children }</localeContext.Provider>
+	<LocaleContext.Provider value={ localeSlug }>{ children }</LocaleContext.Provider>
 );
 
 export function useLocale(): string {
-	return useContext( localeContext );
+	return useContext( LocaleContext );
 }

--- a/packages/i18n-utils/src/localize-url.ts
+++ b/packages/i18n-utils/src/localize-url.ts
@@ -129,7 +129,7 @@ export function localizeUrl( fullUrl: string, locale: Locale ): string {
 	return fullUrl;
 }
 
-export function useLocalizeUrl(): typeof localizeUrl {
+export function useLocalizeUrl(): ( fullUrl: string, locale?: Locale ) => string {
 	const providerLocale = useLocale();
 
 	return ( fullUrl: string, locale?: Locale ) => {

--- a/packages/i18n-utils/src/localize-url.ts
+++ b/packages/i18n-utils/src/localize-url.ts
@@ -12,6 +12,7 @@ import {
 	jetpackComLocales,
 	Locale,
 } from './locales';
+import { useLocale } from './locale-context';
 
 const INVALID_URL = `http://__domain__.invalid`;
 
@@ -126,4 +127,15 @@ export function localizeUrl( fullUrl: string, locale: Locale ): string {
 
 	// Nothing needed to be changed, just return it unmodified.
 	return fullUrl;
+}
+
+export function useLocalizeUrl(): typeof localizeUrl {
+	const providerLocale = useLocale();
+
+	return ( fullUrl: string, locale?: Locale ) => {
+		if ( locale ) {
+			return localizeUrl( fullUrl, locale );
+		}
+		return localizeUrl( fullUrl, providerLocale );
+	};
 }

--- a/packages/i18n-utils/src/localize-url.ts
+++ b/packages/i18n-utils/src/localize-url.ts
@@ -1,8 +1,6 @@
 /**
  * Internal dependencies
  */
-import { getLocaleSlug } from 'i18n-calypso';
-
 import {
 	localesWithBlog,
 	localesWithPrivacyPolicy,
@@ -86,10 +84,7 @@ const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
 };
 
-export function localizeUrl( fullUrl: string, toLocale?: Locale ): string {
-	const locale =
-		toLocale || ( typeof getLocaleSlug === 'function' ? getLocaleSlug() || 'en' : 'en' );
-
+export function localizeUrl( fullUrl: string, locale: Locale ): string {
 	const url = new URL( String( fullUrl ), INVALID_URL );
 
 	// Ignore and passthrough /relative/urls that have no host specified

--- a/packages/i18n-utils/test/localize-url.js
+++ b/packages/i18n-utils/test/localize-url.js
@@ -10,17 +10,18 @@ import { renderHook } from '@testing-library/react-hooks';
  */
 import { useI18nUtils } from '../src';
 
-jest.mock( '@automattic/react-i18n', () => {
-	const original = jest.requireActual( '@automattic/react-i18n' );
+jest.mock( '../src/locale-context', () => {
+	const original = jest.requireActual( '../src/locale-context' );
 	return Object.assign( Object.create( Object.getPrototypeOf( original ) ), original, {
-		useI18n: jest.fn( () => ( { i18nLocale: 'en' } ) ),
+		useLocale: jest.fn( () => 'en' ),
 	} );
 } );
-const { useI18n } = jest.requireMock( '@automattic/react-i18n' );
+
+const { useLocale } = jest.requireMock( '../src/locale-context' );
 
 describe( '#localizeUrl', () => {
-	function useLocalizeUrl( locale = 'en' ) {
-		useI18n.mockImplementation( () => ( { i18nLocale: locale } ) );
+	function testLocalizeUrl( locale = 'en' ) {
+		useLocale.mockImplementation( () => locale );
 		const {
 			result: {
 				current: { localizeUrl },
@@ -29,16 +30,16 @@ describe( '#localizeUrl', () => {
 		return localizeUrl;
 	}
 
-	const localizeUrl = useLocalizeUrl( 'en' );
+	const localizeUrl = testLocalizeUrl( 'en' );
 
-	test( 'should use react-i18n useI18n hook for locale fallback', () => {
+	test( 'should use useLocale for current provider locale as the switch to locale when none is specified', () => {
 		let localizeUrl;
 
-		localizeUrl = useLocalizeUrl( 'pt-br' );
+		localizeUrl = testLocalizeUrl( 'pt-br' );
 		expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
 			'https://br.forums.wordpress.com/'
 		);
-		localizeUrl = useLocalizeUrl( 'en' );
+		localizeUrl = testLocalizeUrl( 'en' );
 		expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
 			'https://en.forums.wordpress.com/'
 		);

--- a/packages/i18n-utils/test/localize-url.js
+++ b/packages/i18n-utils/test/localize-url.js
@@ -8,7 +8,7 @@ import { renderHook } from '@testing-library/react-hooks';
 /**
  * Internal dependencies
  */
-import { useI18nUtils } from '../src';
+import { localizeUrl, useLocalizeUrl } from '../src';
 
 jest.mock( '../src/locale-context', () => {
 	const original = jest.requireActual( '../src/locale-context' );
@@ -23,14 +23,10 @@ describe( '#localizeUrl', () => {
 	function testLocalizeUrl( locale = 'en' ) {
 		useLocale.mockImplementation( () => locale );
 		const {
-			result: {
-				current: { localizeUrl },
-			},
-		} = renderHook( () => useI18nUtils() ); // eslint-disable-line react-hooks/rules-of-hooks -- being called within renderHook context
+			result: { current: localizeUrl },
+		} = renderHook( () => useLocalizeUrl() ); // eslint-disable-line react-hooks/rules-of-hooks -- being called within renderHook context
 		return localizeUrl;
 	}
-
-	const localizeUrl = testLocalizeUrl( 'en' );
 
 	test( 'should use useLocale for current provider locale as the switch to locale when none is specified', () => {
 		let localizeUrl;

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -11,7 +11,6 @@ export interface I18nReact {
 	_nx: I18n[ '_nx' ];
 	_x: I18n[ '_x' ];
 	isRTL: I18n[ 'isRTL' ];
-	i18nLocale: string;
 }
 
 const I18nContext = React.createContext< I18nReact >( makeContextValue() );
@@ -70,13 +69,11 @@ export const withI18n = createHigherOrderComponent< I18nReact >( ( InnerComponen
  */
 function makeContextValue( localeData?: LocaleData ): I18nReact {
 	const i18n = createI18n( localeData );
-	const i18nLocale = localeData?.[ '' ]?.localeSlug ?? 'en';
 	return {
 		__: i18n.__.bind( i18n ),
 		_n: i18n._n.bind( i18n ),
 		_nx: i18n._nx.bind( i18n ),
 		_x: i18n._x.bind( i18n ),
 		isRTL: i18n.isRTL.bind( i18n ),
-		i18nLocale,
 	};
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,6 +1269,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.5.4":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.3.3", "@babel/template@^7.4.0", "@babel/template@^7.7.4", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -3719,6 +3726,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.4.2.tgz#8deb94f7684e0d896edd84a4c90e5b79a0810bc2"
+  integrity sha512-RfPG0ckOzUIVeIqlOc1YztKgFW+ON8Y5xaSPbiBkfj9nMkkiLhLeBXT5icfPX65oJV/zCZu4z8EVnUc6GY9C5A==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@types/testing-library__react-hooks" "^3.4.0"
+
 "@testing-library/react@^10.0.5":
   version "10.0.5"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.0.5.tgz#78c77a1d583777615bf0a8b8d7550b876de9f409"
@@ -4064,6 +4079,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@*":
+  version "16.9.3"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
+  integrity sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-textarea-autosize@^4.3.3":
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.5.tgz#6c4d2753fa1864c98c0b2b517f67bb1f6e4c46de"
@@ -4128,6 +4150,13 @@
   integrity sha512-LoZ3uonlnAbJUz4bg6UoeFl+frfndXngmkCItSjJ8DD5WlRfVqPC5/LgJASsY/dy7AHH2YJ7PcsdASOydcVeFA==
   dependencies:
     "@types/jest" "*"
+
+"@types/testing-library__react-hooks@^3.4.0":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz#b8d7311c6c1f7db3103e94095fe901f8fef6e433"
+  integrity sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
+  dependencies:
+    "@types/react-test-renderer" "*"
 
 "@types/testing-library__react@^10.0.1":
   version "10.0.1"


### PR DESCRIPTION
Context: https://github.com/Automattic/wp-calypso/pull/47352#discussion_r523896855

Follows up on @p-jackson's #47446 to introduce `useLocale`, incorporates some changes from #47358 to decouple i18n-utils from `getLocaleSlug` (i18n-calypso package), but instead of replacing getLocaleSlug with `react-i18n`'s `useI18n`, it uses its own `useLocale`.

i18n-utils is now completely free of all deps but does expect the LocaleProvider to be configured.

warning: Pretty sure I haven't got this set up right yet. Manual testing was showing localizeUrl wasn't working in the `/new/domains/es` gutenboarding context.

Please suggest anything you see that can be dropped from this PR without causing any knock on effects - e.g. we can probably drop changes to domain-picker.

#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
