### PR TITLE
Launch: use step-by-step launch flow after new onboarding with free plan

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -72,14 +72,18 @@ function updateEditor() {
 			// Disable href navigation
 			e.preventDefault();
 
-			// Clicking on the persisten "Launch" button (when added to the UI)
-			// would normally open the control launch flow by redirecting the
-			// page to `launchUrl`.
-			// But if the site was created via Gutenboarding (/new),
-			// and potentially depending on the browser's viewport, the control
-			// launch flow gets replaced by the "Step by Step" launch flow,
-			// appering in a modal on top of the editor (no redirect needed)
+			/*
+			 * Default:
+			 * Clicking on the "Launch" button would open the control launch flow
+			 * by redirecting the page to `launchUrl`.
+			 *
+			 * New Onboarding (with a free plan):
+			 * If the site was created via New Onboarding flow (starting at /new) with a free plan,
+			 * the control launch flow gets replaced by the "Step by Step" launch flow,
+			 * displayed in a modal on top of the editor (no redirect needed)
+			 */
 			const shouldOpenStepByStepLaunch = isGutenboarding;
+
 			// This currently comes from a feature flag, but should eventually be
 			// replaced with A/B testing logic
 			const shouldOpenFocusedLaunch = window?.calypsoifyGutenberg?.isFocusedLaunchFlow;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -21,9 +21,7 @@ interface CalypsoifyWindow extends Window {
 		launchUrl?: string;
 		isGutenboarding?: boolean;
 		isSiteUnlaunched?: boolean;
-		isNewLaunchMobile?: boolean;
 		isExperimental?: boolean;
-		isPersistentLaunchButton?: boolean;
 		[ key: string ]: unknown;
 	};
 }
@@ -38,7 +36,6 @@ domReady( () => {
 let handled = false;
 function updateEditor() {
 	const isGutenboarding = window?.calypsoifyGutenberg?.isGutenboarding;
-	const isPersistentLaunchButton = window?.calypsoifyGutenberg?.isPersistentLaunchButton;
 
 	if (
 		// Don't proceed if this function has already run
@@ -46,10 +43,7 @@ function updateEditor() {
 		// Don't proceed if the site has already been launched
 		! window?.calypsoifyGutenberg?.isSiteUnlaunched ||
 		// Don't proceed if the launch URL is missing
-		! window?.calypsoifyGutenberg?.launchUrl ||
-		// Don't proceed is the site wasn't created through Gutenbaording,
-		// or if the create/persistent-launch-button flag is enabled
-		! ( isGutenboarding || isPersistentLaunchButton )
+		! window?.calypsoifyGutenberg?.launchUrl
 	) {
 		return;
 	}
@@ -63,10 +57,6 @@ function updateEditor() {
 		}
 		clearInterval( awaitSettingsBar );
 
-		const BREAK_MEDIUM = 782;
-		const isMobileViewport = window.innerWidth < BREAK_MEDIUM;
-		// Enables the "step by step" flow also for mobile viewports
-		const isNewLaunchMobile = window?.calypsoifyGutenberg?.isNewLaunchMobile;
 		const isExperimental = window?.calypsoifyGutenberg?.isExperimental;
 
 		// Assert reason: We have an early return above with optional and falsy values. This should be a string.
@@ -89,8 +79,7 @@ function updateEditor() {
 			// and potentially depending on the browser's viewport, the control
 			// launch flow gets replaced by the "Step by Step" launch flow,
 			// appering in a modal on top of the editor (no redirect needed)
-			const shouldOpenStepByStepLaunch =
-				isGutenboarding && ( ! isMobileViewport || ( isMobileViewport && isNewLaunchMobile ) );
+			const shouldOpenStepByStepLaunch = isGutenboarding;
 			// This currently comes from a feature flag, but should eventually be
 			// replaced with A/B testing logic
 			const shouldOpenFocusedLaunch = window?.calypsoifyGutenberg?.isFocusedLaunchFlow;

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -372,12 +372,14 @@ class CalypsoifyIframe extends Component<
 		}
 
 		if ( EditorActions.GetGutenboardingStatus === action ) {
-			const isGutenboarding = this.props.siteCreationFlow === 'gutenboarding' && ! this.props.plan;
+			const isGutenboarding =
+				this.props.siteCreationFlow === 'gutenboarding' &&
+				( ! this.props.plan || this.props.plan.is_free ); // prevent showing StepByStepLaunch on sites with paid plans
 			const isSiteUnlaunched = this.props.isSiteUnlaunched;
 			const launchUrl = `${ window.location.origin }/start/launch-site?siteSlug=${ this.props.siteSlug }`;
-			const isNewLaunchMobile = config.isEnabled( 'gutenboarding/new-launch-mobile' );
-			const isExperimental = config.isEnabled( 'gutenboarding/feature-picker' );
-			const isPersistentLaunchButton = config.isEnabled( 'create/persistent-launch-button' );
+			const isNewLaunchMobile = config.isEnabled( 'gutenboarding/new-launch-mobile' ); // TODO: remove after ETK 2.8.6 is released
+			const isExperimental = config.isEnabled( 'gutenboarding/feature-picker' ); // TODO: remove after ETK 2.8.6 is released
+			const isPersistentLaunchButton = config.isEnabled( 'create/persistent-launch-button' ); // TODO: remove after ETK 2.8.6 is released
 			const isFocusedLaunchFlow = config.isEnabled( 'create/focused-launch-flow' );
 
 			ports[ 0 ].postMessage( {


### PR DESCRIPTION
***Editing Toolkit release notes**: N/A (this PR is just cleaning up some unused code)

#### Changes proposed in this Pull Request
* Improve the fix added in https://github.com/Automattic/wp-calypso/pull/47421/files#diff-94cbcc079892f7f8fb113398707b6a9b6394766e051b1f2c28f98334ad25015fR375 to cover also the case when there is a plan value in store but that plan is free.
* Cleanup unused code and add comments.

#### Testing instructions - what should stay unchanged
1. Go to `/new`
2. Create a site with a paid plan and complete purchase
3. When clicking _Launch_ button from the top bar in editor, you should be redirected to `/start/launch-site` which is the default Launch flow in Calypso.

#### Testing instructions - what should change
1. Go to `/new`
2. Create a site on a Free plan
3. Go to My Home and navigate to editor
4. Check if there is a plan object in store by executing `wp.data.select( 'automattic/site' ).getSite( _currentSiteId )?.plan` in `post.php` window in console.
3. When clicking _Launch_ button from the top bar in editor, Step-by-step Launch modal should open over the editor.

#### Context  
p1605290793102800-slack-CRNF6A9DX
#47421 
