### PR TITLE
Gutenboarding: Use font-size variable for domain picker suggestion item badge.

### DIFF
--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -297,8 +297,7 @@ $accent-blue: #117ac9;
 		// stylelint-disable-next-line scales/radii
 		border-radius: 4px;
 		text-transform: unset;
-		// stylelint-disable-next-line scales/font-size
-		font-size: $font-body-extra-small; // typography-exception smaller size needed
+		font-size: $font-body-extra-small;
 	}
 
 	&.is-selected {

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -298,7 +298,7 @@ $accent-blue: #117ac9;
 		border-radius: 4px;
 		text-transform: unset;
 		// stylelint-disable-next-line scales/font-size
-		font-size: 12px; // typography-exception smaller size needed
+		font-size: $font-body-extra-small; // typography-exception smaller size needed
 	}
 
 	&.is-selected {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the font-size variable instead of hardcoded value.

#### Testing instructions

* Check out this branch on your machine and run `yarn && yarn start`;
* Open a new browser tab and navigate to http://calypso.localhost:3000/new/domains;
* Open another browser tab and navigate to https://wordpress.com/new/domains;
* Search for a domain name in both tabs;
* Inspect the "Recommended" badge's font-size;
* Verify that the font size of the domain picker suggestion item badge is the same on both pages.

Fixes #47232
