### PR TITLE
Editing Toolkit: add monorepo package references to tsconfig.json

### DIFF
--- a/apps/editing-toolkit/tsconfig.json
+++ b/apps/editing-toolkit/tsconfig.json
@@ -38,6 +38,7 @@
 		{ "path": "../../packages/calypso-analytics" },
 		{ "path": "../../packages/composite-checkout" },
 		{ "path": "../../packages/domain-picker" },
+		{ "path": "../../packages/format-currency" },
 		{ "path": "../../packages/onboarding" },
 		{ "path": "../../packages/launch" },
 		{ "path": "../../packages/plans-grid" },

--- a/apps/editing-toolkit/tsconfig.json
+++ b/apps/editing-toolkit/tsconfig.json
@@ -33,5 +33,14 @@
 		"jsx": "preserve"
 	},
 	"exclude": [ "node_modules" ],
-	"references": [ "../../packages/data-stores" ]
+	"references": [
+		{ "path": "../../packages/data-stores" },
+		{ "path": "../../packages/calypso-analytics" },
+		{ "path": "../../packages/composite-checkout" },
+		{ "path": "../../packages/domain-picker" },
+		{ "path": "../../packages/onboarding" },
+		{ "path": "../../packages/launch" },
+		{ "path": "../../packages/plans-grid" },
+		{ "path": "../../packages/react-i18n" }
+	]
 }

--- a/packages/format-currency/tsconfig.json
+++ b/packages/format-currency/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "@automattic/calypso-build/tsconfig",
 	"exclude": [ "node_modules" ],
 	"compilerOptions": {
-		"allowJs": true
+		"allowJs": true,
+		"composite": true
 	}
 }


### PR DESCRIPTION
**Editing toolkit release notes**: This PR can be ignored

#### Changes proposed in this Pull Request

Similarly to what done in #47140 and #47308, add monorepo package references to tsconfig.json for the following packages:

- `@automattic/calypso-analytics`
- `@automattic/composite-checkout`
- `@automattic/domain-picker`
- `@automattic/format-currency`
- `@automattic/onboarding`
- `@automattic/launch`
- `@automattic/plans-grid`
- `@automattic/react-i18n`

Notes:
- The `@automattic/data-stores` package was already listed
- In order to be able to reference the `@automattic/format-currency` package, the `"composite": true` compiler option was added to the package's `tsconfig.json` file

#### Testing instructions

Build the project and make sure that everything builds and works as expected:

* Run `yarn clean:packages; yarn && yarn start` in the project root
* In a separate terminal window, run `cd apps/editing-toolkit && yarn dev --sync` 
* Add a site to the sandbox, open the site editor and do a smoke test to verify that everything works as expected
