### PR TITLE
Modularise user devices state

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -38,7 +38,6 @@ import sites from './sites/reducer';
 import storedCards from './stored-cards/reducer';
 import support from './support/reducer';
 import ui from './ui/reducer';
-import userDevices from './user-devices/reducer';
 import userProfileLinks from './profile-links/reducer';
 import userSettings from './user-settings/reducer';
 import users from './users/reducer';
@@ -72,7 +71,6 @@ const reducers = {
 	storedCards,
 	support,
 	ui,
-	userDevices,
 	userProfileLinks,
 	userSettings,
 	users,

--- a/client/state/selectors/get-user-devices.js
+++ b/client/state/selectors/get-user-devices.js
@@ -1,14 +1,19 @@
 /**
  * External dependencies
  */
-
 import { values } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/user-devices/init';
 
 /**
  * Returns the current user's devices
  *
- * @param  {object} userDevices user's devices slice of the state tree
- * @returns {Array}              current user's devices
+ * @param  {object} options             options object
+ * @param  {object} options.userDevices user's devices slice of the state tree
+ * @returns {Array}                     current user's devices
  */
 export const getUserDevices = ( { userDevices } ) => values( userDevices );
 

--- a/client/state/user-devices/actions.js
+++ b/client/state/user-devices/actions.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-
 import { USER_DEVICES_REQUEST, USER_DEVICES_ADD } from 'calypso/state/action-types';
 
 import 'calypso/state/data-layer/wpcom/me/devices';
+import 'calypso/state/user-devices/init';
 
 /**
  * Returns an action object to signal the request of the user's devices.

--- a/client/state/user-devices/init.js
+++ b/client/state/user-devices/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'userDevices' ], reducer );

--- a/client/state/user-devices/package.json
+++ b/client/state/user-devices/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/user-devices/reducer.js
+++ b/client/state/user-devices/reducer.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 
-import { withoutPersistence } from 'calypso/state/utils';
+import { withoutPersistence, withStorageKey } from 'calypso/state/utils';
 import { USER_DEVICES_ADD } from 'calypso/state/action-types';
 
-export default withoutPersistence( ( state = {}, action ) => {
+const reducer = withoutPersistence( ( state = {}, action ) => {
 	switch ( action.type ) {
 		case USER_DEVICES_ADD: {
 			const { devices } = action;
@@ -15,3 +15,5 @@ export default withoutPersistence( ( state = {}, action ) => {
 
 	return state;
 } );
+
+export default withStorageKey( 'userDevices', reducer );


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles user devices state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42487.

#### Changes proposed in this Pull Request

* Modularise user devices state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/me` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `userDevices` key, even if you expand the list of keys. This indicates that the user devices state hasn't been loaded yet.
* Click `Notification Settings` on the side bar.
* Verify that a `userDevices` key is added with the user devices state. This indicates that the user devices state has now been loaded.