### PR TITLE
Framework: Remove lodash clamp() usage

### DIFF
--- a/client/my-sites/plan-features/scroller.jsx
+++ b/client/my-sites/plan-features/scroller.jsx
@@ -4,7 +4,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'calypso/components/gridicon';
-import { clamp, inRange, range, round } from 'lodash';
+import { inRange, range, round } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -147,7 +147,10 @@ export default class PlanFeaturesScroller extends PureComponent {
 				let index = 0;
 
 				if ( planCount > visibleCount ) {
-					index = clamp( round( initialSelectedIndex - visibleCount / 2 ), minIndex, maxIndex );
+					index = Math.min(
+						Math.max( round( initialSelectedIndex - visibleCount / 2 ), minIndex ),
+						maxIndex
+					);
 				}
 
 				this.scrollBy( index );

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flatMap, last, clamp } from 'lodash';
+import { flatMap, last } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -135,10 +135,9 @@ export function getDistanceBetweenRecs( totalSubs ) {
 		// push recs to the max.
 		return MAX_DISTANCE_BETWEEN_RECS;
 	}
-	const distance = clamp(
-		Math.floor( Math.log( totalSubs ) * Math.LOG2E * 5 - 6 ),
-		MIN_DISTANCE_BETWEEN_RECS,
+
+	return Math.min(
+		Math.max( Math.floor( Math.log( totalSubs ) * Math.LOG2E * 5 - 6 ), MIN_DISTANCE_BETWEEN_RECS ),
 		MAX_DISTANCE_BETWEEN_RECS
 	);
-	return distance;
 }


### PR DESCRIPTION
We have only a couple of usages of lodash's `clamp`. This PR removes them.

This PR should not offer any visual or functional changes.

#### Changes proposed in this Pull Request

* Framework: Remove lodash `clamp()` usage

#### Testing instructions

* For testing the plans change, go to `/plans/:site`, enable `withScroll` prop of `PlanFeaturesScroller` in your browser, and try scrolling. While it's broken right now, it's not in use anywhere AFAIK. Just verify it works the same way it does in production.
* Follow the test instructions on #9490 for testing the reader streams change; compare to production and ensure everything works the same way.
* Verify tests pass.
