### PR TITLE
State: Use Array.prototype.reduceRight instead of _.reduceRight

### DIFF
--- a/client/state/utils/reducer-utils.js
+++ b/client/state/utils/reducer-utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, mapValues, pick, reduce, reduceRight } from 'lodash';
+import { get, mapValues, pick, reduce } from 'lodash';
 import { combineReducers as combine } from 'redux'; // eslint-disable-line no-restricted-imports
 
 /**
@@ -55,8 +55,7 @@ export function addReducer( origReducer, reducers ) {
 			//   })
 			// })
 			// ```
-			newReducer = reduceRight(
-				restKeys,
+			newReducer = restKeys.reduceRight(
 				( subreducer, subkey ) => createCombinedReducer( { [ subkey ]: subreducer } ),
 				setupReducerPersistence( reducer )
 			);


### PR DESCRIPTION
We have a single usage of lodash's `reduceRight` in our state utils. This PR removes it in favor of the corresponding array method.

This PR should not offer any visual or functional changes.

#### Changes proposed in this Pull Request

* State: Use `Array.prototype.reduceRight` instead of `_.reduceRight`

#### Testing instructions

* Smoke test state (both modular and non-modular trees).
* Verify all tests still pass.