### PR TITLE
Jetpack Cloud: fix broken landing UX for accounts with one site

### DIFF
--- a/client/jetpack-cloud/index.js
+++ b/client/jetpack-cloud/index.js
@@ -46,5 +46,5 @@ export default function () {
 	page( '/landing/:site', siteSelection, landingController, makeLayout, clientRender );
 	page( '/landing', siteSelection, selectionPrompt, sites, makeLayout, clientRender );
 	page( '/oauth-override', handleOAuthOverride );
-	page( '/', siteSelection, redirectToPrimarySiteLanding );
+	page( '/', redirectToPrimarySiteLanding );
 }

--- a/client/jetpack-cloud/index.js
+++ b/client/jetpack-cloud/index.js
@@ -20,7 +20,7 @@ const selectionPrompt = ( context, next ) => {
 		// (see rule for "".sites__select-heading strong")
 		// Jetpack.com displays as Jetpack.Com in some browsers (e.g., Chrome)
 		translate( 'Select a site to open {{strong}}Jetpack.com{{/strong}}', {
-			components: { strong: <strong style={ { 'text-transform': 'none' } } /> },
+			components: { strong: <strong style={ { textTransform: 'none' } } /> },
 		} );
 	next();
 };

--- a/client/jetpack-cloud/index.js
+++ b/client/jetpack-cloud/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import Debug from 'debug';
 import page from 'page';
 import React from 'react';
 
@@ -14,7 +15,10 @@ import { startJetpackCloudOAuthOverride } from 'calypso/lib/jetpack/oauth-overri
 import { translate } from 'i18n-calypso';
 import Landing from './sections/landing';
 
+const debug = new Debug( 'calypso:jetpack-cloud:controller' );
+
 const selectionPrompt = ( context, next ) => {
+	debug( 'controller: selectionPrompt', context );
 	context.getSiteSelectionHeaderText = () =>
 		// When "text-transform: capitalize;" is active,
 		// (see rule for "".sites__select-heading strong")
@@ -26,6 +30,7 @@ const selectionPrompt = ( context, next ) => {
 };
 
 const redirectToPrimarySiteLanding = ( context ) => {
+	debug( 'controller: redirectToPrimarySiteLanding', context );
 	const state = context.store.getState();
 	const currentUser = getCurrentUser( state );
 
@@ -33,11 +38,13 @@ const redirectToPrimarySiteLanding = ( context ) => {
 };
 
 const landingController = ( context, next ) => {
+	debug( 'controller: landingController', context );
 	context.primary = <Landing />;
 	next();
 };
 
 export const handleOAuthOverride = () => {
+	debug( 'controller: handleOAuthOverride', context );
 	startJetpackCloudOAuthOverride();
 	window.location.replace( '/' );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When visiting cloud.jetpack.com, users that have only one site end up seeing a blank screen. This happens because the `siteSelection` controller redirects these types of users to `cloud.jetpack.com/:site` which is a path that doesn't exist in the cloud.

* Remove the `siteSelection` controller from the `/` route. This will make the app rely on the primary site first, and then use the `siteSelection` controller if necessary (if there is no primary site).

#### Testing instructions

**Prerequisite: a WordPress.com account with only one site.**

* Run this PR locally (you need Calypso Green).
* Visit cloud.jetpack.com.
* Verify that you are redirected to `cloud.jetpack.com/:site` and that you see a blank screen.
* Visit `jetpack.cloud.localhost:3001` (the base route of your local Calypso Green env).
* Verify that you are redirected to, `jetpack.cloud.localhost:3001/landing/:site`, and then to `jetpack.cloud.localhost:3001/backup/:site`.

Fixes 1164141197617539-as-1199202377313720

#### Demo

##### After
![Kapture 2020-11-17 at 11 35 39](https://user-images.githubusercontent.com/3418513/99403290-0dccdf80-28c9-11eb-99cf-912a0d3519de.gif)

##### Before
![Kapture 2020-11-17 at 11 34 33](https://user-images.githubusercontent.com/3418513/99403144-e544e580-28c8-11eb-852a-a8c1774caef2.gif)
