### PR TITLE
desktop: use contextBridge for IPC message passing

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -461,7 +461,11 @@ function waitForCookieAuth( user ) {
 		return new Promise( function ( resolve ) {
 			const sendUserAuth = () => {
 				debug( 'Sending user info to desktop...' );
-				window.electron.send( 'user-auth', user, getToken() );
+				window.electron.send(
+					'user-auth',
+					{ id: user.data.ID, username: user.data.username },
+					getToken()
+				);
 			};
 
 			if ( loggedIn ) {

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -445,7 +445,6 @@ const boot = ( currentUser, registerRoutes ) => {
 function waitForCookieAuth( user ) {
 	const timeoutMs = 1500;
 	const loggedIn = user.get() !== false;
-	const ipc = require( 'electron' ).ipcRenderer;
 
 	const promiseTimeout = ( ms, promise ) => {
 		const timeout = new Promise( ( _, reject ) => {
@@ -462,12 +461,12 @@ function waitForCookieAuth( user ) {
 		return new Promise( function ( resolve ) {
 			const sendUserAuth = () => {
 				debug( 'Sending user info to desktop...' );
-				ipc.send( 'user-auth', user, getToken() );
+				window.electron.send( 'user-auth', user, getToken() );
 			};
 
 			if ( loggedIn ) {
 				debug( 'Desktop user logged in, waiting on cookie authentication...' );
-				ipc.on( 'cookie-auth-complete', function () {
+				window.electron.receive( 'cookie-auth-complete', function () {
 					debug( 'Desktop cookies set, rendering main layout...' );
 					resolve();
 				} );

--- a/client/desktop/env.js
+++ b/client/desktop/env.js
@@ -39,6 +39,12 @@ process.env.CALYPSO_ENV = config.calypso_config;
 // Set app config path
 app.setPath( 'userData', appData );
 
+// Default value of false deprecated in Electron v9
+app.allowRendererProcessReuse = true;
+
+// Force sandbox: true for all BrowserWindow instances
+app.enableSandbox();
+
 if ( Settings.isDebug() ) {
 	process.env.DEBUG = config.debug.namespace;
 }
@@ -73,9 +79,3 @@ if ( Settings.getSetting( 'proxy-type' ) === '' ) {
 		app.commandLine.appendSwitch( 'proxy-pac-url', Settings.getSetting( 'proxy-pac' ) );
 	}
 }
-
-// Define a global 'desktop' variable that can be used in browser windows to access config and settings
-global.desktop = {
-	config: config,
-	settings: Settings,
-};

--- a/client/desktop/lib/config/index.js
+++ b/client/desktop/lib/config/index.js
@@ -19,4 +19,12 @@ config.isBeta = function () {
 	return this.build === 'beta';
 };
 
+// Do not send function and DOM objects (exception in Electron v9).
+config.toRenderer = function () {
+	return {
+		build: this.build,
+		version: this.version,
+	};
+};
+
 module.exports = config;

--- a/client/desktop/lib/cookie-auth/index.js
+++ b/client/desktop/lib/cookie-auth/index.js
@@ -105,11 +105,9 @@ function auth( window, onAuthorized ) {
 	ipc.on( 'user-auth', async function ( _, user, token ) {
 		log.info( `Handling 'user-auth' IPC event, setting session cookies...` );
 
-		if ( user && user.data ) {
-			const userData = user.data;
-
+		if ( user ) {
 			try {
-				const response = await authorize( userData.username, token );
+				const response = await authorize( user.username, token );
 				await setSessionCookies( window, response );
 				onAuthorized();
 

--- a/client/desktop/lib/settings/index.js
+++ b/client/desktop/lib/settings/index.js
@@ -35,7 +35,6 @@ Settings.prototype.isDebug = function () {
  */
 Settings.prototype.getSetting = function ( setting ) {
 	const value = this._getAll()[ setting ];
-	const log = require( 'calypso/desktop/lib/logger' )( 'desktop:settings' );
 
 	if ( typeof value === 'undefined' ) {
 		if ( typeof Config.default_settings[ setting ] !== 'undefined' ) {
@@ -51,8 +50,6 @@ Settings.prototype.getSetting = function ( setting ) {
  * Get a group of settings
  */
 Settings.prototype.getSettingGroup = function ( existing, group, values ) {
-	const log = require( 'calypso/desktop/lib/logger' )( 'desktop:settings' );
-
 	const settingsGroup = this._getAll()[ group ];
 
 	if ( typeof settingsGroup !== 'undefined' ) {
@@ -73,6 +70,18 @@ Settings.prototype.getSettingGroup = function ( existing, group, values ) {
 
 Settings.prototype.saveSetting = function ( group, groupData ) {
 	this.settings = settingsFile.save( group, groupData );
+};
+
+// Do not send function and DOM objects (exception in Electron v9).
+Settings.prototype.toRenderer = function () {
+	const all = this._getAll();
+	const exported = {};
+	if ( all ) {
+		for ( const [ key ] of Object.entries( all ) ) {
+			exported[ key ] = this.getSetting( key );
+		}
+	}
+	return exported;
 };
 
 if ( ! settings ) {

--- a/client/desktop/lib/state/index.js
+++ b/client/desktop/lib/state/index.js
@@ -23,7 +23,7 @@ State.prototype.login = async function ( { user, token } ) {
 
 	if ( user && token ) {
 		this.user = {
-			id: user.data.ID,
+			id: user.id,
 			token: `${ token }`,
 		};
 		keychain.setUserInfo( this.user );

--- a/client/desktop/lib/window-manager/index.js
+++ b/client/desktop/lib/window-manager/index.js
@@ -5,6 +5,7 @@ const electron = require( 'electron' );
 const BrowserWindow = electron.BrowserWindow;
 const app = electron.app;
 const path = require( 'path' );
+const preloadDirectory = path.resolve( __dirname, '..', '..', '..', '..', 'public_desktop' );
 
 // HACK(sendhilp, 9/6/2016): The reason for this strange importing is there seems to be a
 // bug post Electron 1.1.1 in which attempting to access electron.screen
@@ -35,22 +36,26 @@ const windows = {
 		file: 'about.html',
 		config: 'aboutWindow',
 		handle: null,
+		preload: path.join( preloadDirectory, 'preload_about.js' ),
 	},
 	preferences: {
 		file: 'preferences.html',
 		config: 'preferencesWindow',
 		handle: null,
+		preload: path.resolve( preloadDirectory, 'preload_preferences.js' ),
 	},
 	secret: {
 		file: 'secret.html',
 		config: 'secretWindow',
 		handle: null,
+		preload: null,
 	},
 	wapuu: {
 		file: 'wapuu.html',
 		config: 'secretWindow',
 		full: true,
 		handle: null,
+		preload: null,
 	},
 };
 
@@ -72,12 +77,11 @@ async function openWindow( windowName ) {
 			let config = Config[ settings.config ];
 			config = setDimensions( config );
 
-			// nodeIntegration is necessary to support usage of `require` in preload and HTML scripts.
-			// FIXME: Refactor preload to use contextBridge instead (contextIsolation: true, nodeIntegration: false).
 			const webPreferences = Object.assign( {}, config.webPreferences, {
-				contextIsolation: false,
-				nodeIntegration: true,
-				preload: path.resolve( __dirname, '..', '..', '..', '..', 'public_desktop', 'preload.js' ),
+				preload: windows[ windowName ].preload,
+				contextIsolation: true,
+				enableRemoteModule: false,
+				nodeIntegration: false,
 			} );
 			config.webPreferences = webPreferences;
 

--- a/client/desktop/server/index.js
+++ b/client/desktop/server/index.js
@@ -52,7 +52,7 @@ function showAppWindow() {
 	} );
 
 	mainWindow.webContents.on( 'did-finish-load', function () {
-		mainWindow.webContents.send( 'app-config', Config, Settings.isDebug(), System.getDetails() );
+		mainWindow.webContents.send( 'app-config', System.getDetails() );
 
 		ipc.on( 'mce-contextmenu', function ( ev ) {
 			mainWindow.webContents.send( 'mce-contextmenu', ev );

--- a/client/desktop/server/index.js
+++ b/client/desktop/server/index.js
@@ -55,7 +55,7 @@ function showAppWindow() {
 		mainWindow.webContents.send( 'app-config', Config, Settings.isDebug(), System.getDetails() );
 
 		ipc.on( 'mce-contextmenu', function ( ev ) {
-			mainWindow.send( 'mce-contextmenu', ev );
+			mainWindow.webContents.send( 'mce-contextmenu', ev );
 		} );
 	} );
 
@@ -92,8 +92,15 @@ function showAppWindow() {
 		callback( { cancel: false } );
 	} );
 
+	ipc.handle( 'get-config', () => {
+		return Config.toRenderer();
+	} );
+
+	ipc.handle( 'get-settings', () => {
+		return Settings.toRenderer();
+	} );
+
 	mainWindow.loadURL( appUrl );
-	// mainWindow.openDevTools();
 
 	mainWindow.on( 'close', function () {
 		const currentURL = mainWindow.webContents.getURL();

--- a/client/desktop/window-handlers/debug-tools/index.js
+++ b/client/desktop/window-handlers/debug-tools/index.js
@@ -2,6 +2,6 @@ const { ipcMain: ipc } = require( 'electron' );
 
 module.exports = function ( mainWindow ) {
 	ipc.on( 'toggle-dev-tools', function () {
-		mainWindow.webContents.toggleDevTools();
+		mainWindow.toggleDevTools();
 	} );
 };

--- a/client/desktop/window-handlers/notifications/index.js
+++ b/client/desktop/window-handlers/notifications/index.js
@@ -100,6 +100,7 @@ module.exports = function ( mainWindow ) {
 
 				if ( navigate ) {
 					// if we have a specific URL, then navigate Calypso there
+					log.info( `Navigating user to URL: ${ navigate }` );
 					mainWindow.webContents.send( 'navigate', navigate );
 				} else {
 					// else just display the notifications panel

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -148,7 +148,12 @@ const Desktop = {
 
 		debug( 'Sending logged-in = ' + status );
 
-		window.electron.send( 'user-login-status', status, user(), oAuthToken.getToken() );
+		window.electron.send(
+			'user-login-status',
+			status,
+			{ id: user().data.ID },
+			oAuthToken.getToken()
+		);
 	},
 
 	onToggleNotifications: function () {

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -9,7 +9,6 @@ import debugFactory from 'debug';
 import { newPost } from 'calypso/lib/paths';
 import store from 'store';
 import user from 'calypso/lib/user';
-import { ipcRenderer as ipc } from 'electron';
 import userUtilities from 'calypso/lib/user/utils';
 import * as oAuthToken from 'calypso/lib/oauth-token';
 import { getStatsPathForTab } from 'calypso/lib/route';
@@ -43,21 +42,27 @@ const Desktop = {
 		debug( 'Registering IPC listeners' );
 
 		// Register IPC listeners
-		ipc.on( 'page-my-sites', this.onShowMySites.bind( this ) );
-		ipc.on( 'page-reader', this.onShowReader.bind( this ) );
-		ipc.on( 'page-profile', this.onShowProfile.bind( this ) );
-		ipc.on( 'new-post', this.onNewPost.bind( this ) );
-		ipc.on( 'signout', this.onSignout.bind( this ) );
-		ipc.on( 'toggle-notification-bar', this.onToggleNotifications.bind( this ) );
-		ipc.on( 'notifications-panel-show', this.onNotificationsPanelShow.bind( this ) );
-		ipc.on( 'notifications-panel-refresh', this.onNotificationsPanelRefresh.bind( this ) );
-		ipc.on( 'notification-clicked', this.onNotificationClicked.bind( this ) );
-		ipc.on( 'page-help', this.onShowHelp.bind( this ) );
-		ipc.on( 'navigate', this.onNavigate.bind( this ) );
-		ipc.on( 'request-site', this.onRequestSite.bind( this ) );
-		ipc.on( 'enable-site-option', this.onActivateJetpackSiteModule.bind( this ) );
-		ipc.on( 'enable-notification-badge', this.sendNotificationUnseenCount );
-		ipc.on( 'request-user-login-status', this.sendUserLoginStatus );
+		window.electron.receive( 'page-my-sites', this.onShowMySites.bind( this ) );
+		window.electron.receive( 'page-reader', this.onShowReader.bind( this ) );
+		window.electron.receive( 'page-profile', this.onShowProfile.bind( this ) );
+		window.electron.receive( 'new-post', this.onNewPost.bind( this ) );
+		window.electron.receive( 'signout', this.onSignout.bind( this ) );
+		window.electron.receive( 'toggle-notification-bar', this.onToggleNotifications.bind( this ) );
+		window.electron.receive(
+			'notifications-panel-show',
+			this.onNotificationsPanelShow.bind( this )
+		);
+		window.electron.receive(
+			'notifications-panel-refresh',
+			this.onNotificationsPanelRefresh.bind( this )
+		);
+		window.electron.receive( 'notification-clicked', this.onNotificationClicked.bind( this ) );
+		window.electron.receive( 'page-help', this.onShowHelp.bind( this ) );
+		window.electron.receive( 'navigate', this.onNavigate.bind( this ) );
+		window.electron.receive( 'request-site', this.onRequestSite.bind( this ) );
+		window.electron.receive( 'enable-site-option', this.onActivateJetpackSiteModule.bind( this ) );
+		window.electron.receive( 'enable-notification-badge', this.sendNotificationUnseenCount );
+		window.electron.receive( 'request-user-login-status', this.sendUserLoginStatus );
 
 		window.addEventListener(
 			NOTIFY_DESKTOP_CANNOT_USE_EDITOR,
@@ -108,14 +113,14 @@ const Desktop = {
 		const unseenCount = store.get( 'wpnotes_unseen_count' );
 		if ( unseenCount !== null ) {
 			debug( `Sending unseen count: ${ unseenCount }` );
-			ipc.send( 'unread-notices-count', unseenCount );
+			window.electron.send( 'unread-notices-count', unseenCount );
 		}
 	},
 
 	onUnseenCountUpdated: function ( event ) {
 		const { unseenCount } = event.detail;
 		debug( `Sending unseen count: ${ unseenCount }` );
-		ipc.send( 'unread-notices-count', unseenCount );
+		window.electron.send( 'unread-notices-count', unseenCount );
 	},
 
 	onNotificationClicked: function ( _, notification ) {
@@ -143,7 +148,7 @@ const Desktop = {
 
 		debug( 'Sending logged-in = ' + status );
 
-		ipc.send( 'user-login-status', status, user(), oAuthToken.getToken() );
+		window.electron.send( 'user-login-status', status, user(), oAuthToken.getToken() );
 	},
 
 	onToggleNotifications: function () {
@@ -219,14 +224,14 @@ const Desktop = {
 			canUserManageOptions,
 		};
 
-		ipc.send( 'cannot-use-editor', payload );
+		window.electron.send( 'cannot-use-editor', payload );
 	},
 
 	onViewPostClicked: function ( event ) {
 		const { url } = event.detail;
 		debug( `Received window event: "View Post" clicked for URL: ${ url }` );
 
-		ipc.send( 'view-post-clicked', url );
+		window.electron.send( 'view-post-clicked', url );
 	},
 
 	onActivateJetpackSiteModule: function ( event, info ) {
@@ -243,7 +248,7 @@ const Desktop = {
 			if ( Number( siteId ) !== Number( responseSiteId ) ) {
 				error = `Expected response for siteId: ${ siteId }, got: ${ responseSiteId }`;
 			}
-			ipc.send( 'enable-site-option-response', { status, siteId, error } );
+			window.electron.send( 'enable-site-option-response', { status, siteId, error } );
 		}
 		window.addEventListener(
 			response,
@@ -266,7 +271,7 @@ const Desktop = {
 			if ( Number( siteId ) !== Number( responseSiteId ) ) {
 				error = `Expected response for siteId: ${ siteId }, got: ${ responseSiteId }`;
 			}
-			ipc.send( 'request-site-response', { siteId, status, error } );
+			window.electron.send( 'request-site-response', { siteId, status, error } );
 		}
 		window.addEventListener( response, onDidRequestSite.bind( onDidRequestSite ) );
 
@@ -287,7 +292,7 @@ const Desktop = {
 	},
 
 	print: function ( title, html ) {
-		ipc.send( 'print', title, html );
+		window.electron.send( 'print', title, html );
 	},
 };
 

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -117,13 +117,14 @@ const Desktop = {
 		}
 	},
 
+	// window event
 	onUnseenCountUpdated: function ( event ) {
 		const { unseenCount } = event.detail;
 		debug( `Sending unseen count: ${ unseenCount }` );
 		window.electron.send( 'unread-notices-count', unseenCount );
 	},
 
-	onNotificationClicked: function ( _, notification ) {
+	onNotificationClicked: function ( notification ) {
 		debug( `Notification ${ notification.id } clicked` );
 
 		const { id, type } = notification;
@@ -162,7 +163,7 @@ const Desktop = {
 		this.toggleNotificationsPanel();
 	},
 
-	onNotificationsPanelShow: function ( _, show ) {
+	onNotificationsPanelShow: function ( show ) {
 		const isOpen = isNotificationsOpen( this.store.getState() );
 
 		if ( show ) {
@@ -213,6 +214,7 @@ const Desktop = {
 		this.navigate( '/help' );
 	},
 
+	// window event
 	onCannotOpenEditor: function ( event ) {
 		const { site, reason, editorUrl, wpAdminLoginUrl } = event.detail;
 		debug( 'Received window event: unable to load editor for site: ', site.URL );
@@ -232,6 +234,7 @@ const Desktop = {
 		window.electron.send( 'cannot-use-editor', payload );
 	},
 
+	// window event
 	onViewPostClicked: function ( event ) {
 		const { url } = event.detail;
 		debug( `Received window event: "View Post" clicked for URL: ${ url }` );
@@ -239,7 +242,7 @@ const Desktop = {
 		window.electron.send( 'view-post-clicked', url );
 	},
 
-	onActivateJetpackSiteModule: function ( event, info ) {
+	onActivateJetpackSiteModule: function ( info ) {
 		const { siteId, option } = info;
 		debug( `User enabling option '${ option }' for siteId ${ siteId }` );
 
@@ -263,7 +266,7 @@ const Desktop = {
 		this.store.dispatch( activateModule( siteId, option ) );
 	},
 
-	onRequestSite: function ( event, siteId ) {
+	onRequestSite: function ( siteId ) {
 		debug( 'Refreshing redux state for siteId: ', siteId );
 
 		const response = NOTIFY_DESKTOP_DID_REQUEST_SITE;
@@ -283,7 +286,7 @@ const Desktop = {
 		this.store.dispatch( requestSite( siteId ) );
 	},
 
-	onNavigate: function ( event, url ) {
+	onNavigate: function ( url ) {
 		debug( 'Navigating to URL: ', url );
 
 		if ( url ) {
@@ -291,6 +294,7 @@ const Desktop = {
 		}
 	},
 
+	// window event
 	onSendToPrinter: function ( event ) {
 		const { title, contents } = event.detail;
 		this.print( title, contents );

--- a/client/webpack.config.desktop.js
+++ b/client/webpack.config.desktop.js
@@ -76,7 +76,6 @@ module.exports = {
 	},
 	externals: [
 		'webpack',
-		'electron',
 		'keytar',
 
 		// These are Calypso server modules we don't need, so let's not bundle them

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -377,7 +377,7 @@ const webpackConfig = {
 
 		! isDesktop && new ExtractManifestPlugin(),
 	].filter( Boolean ),
-	externals: [ 'electron', 'keytar' ],
+	externals: [ 'keytar' ],
 };
 
 module.exports = webpackConfig;

--- a/desktop/desktop-config/config-base.json
+++ b/desktop/desktop-config/config-base.json
@@ -18,9 +18,10 @@
 		"useContentSize": true,
 		"width": 900,
 		"webPreferences": {
-			"overlayScrollbars": false,
+			"contextIsolation": true,
+			"enableRemoteModule": false,
 			"nodeIntegration": false,
-			"contextIsolation": false
+			"overlayScrollbars": false
 		}
 	},
 	"preferencesWindow": {
@@ -58,6 +59,8 @@
 		"transparent": true,
 		"width": "full",
 		"webPreferences": {
+			"contextIsolation": true,
+			"enableRemoteModule": false,
 			"nodeIntegration": false
 		},
 		"wpDragAndDropDisabled": true

--- a/desktop/public_desktop/about.html
+++ b/desktop/public_desktop/about.html
@@ -64,10 +64,10 @@
 <body>
 
 <script type="text/javascript">
-	var electron = require( 'electron' );
-	var version = electron.remote.getGlobal( 'desktop' ).config.version;
-	var build = electron.remote.getGlobal( 'desktop' ).config.build
-	var ipc = electron.ipcRenderer;
+	const config = window.electron.config;
+
+	const version = config.version;
+	const build = config.build;
 
 	if ( build === 'development' )
 		version += ' dev';
@@ -99,7 +99,7 @@ Proudly released under the GPL</p>
 	var keyPos = 0;
 
 	document.querySelector( 'a' ).addEventListener( 'click', function() {
-		ipc.send( 'secrets', 0 );
+		window.electron.send( 'secrets', 0 );
 		return false;
 	} );
 
@@ -109,7 +109,7 @@ Proudly released under the GPL</p>
 
 			if ( keyPos === KONAMI.length ) {
 				keyPos = 0;
-				ipc.send( 'secrets', 1 );
+				window.electron.send( 'secrets', 1 );
 			}
 		}
 		else {

--- a/desktop/public_desktop/desktop-app.js
+++ b/desktop/public_desktop/desktop-app.js
@@ -1,6 +1,3 @@
-'use strict';
-/* global electron */
-
 let startApp = function () {
 	document.location.replace( '/desktop/hey.html' );
 };
@@ -44,7 +41,7 @@ function startDesktopApp() {
 
 		if ( notIcon ) {
 			notIcon.addEventListener( 'click', function () {
-				electron.ipcRenderer.send( 'unread-notices-count', 0 );
+				window.electron.send( 'unread-notices-count', 0 );
 			} );
 		}
 	}
@@ -73,7 +70,7 @@ function startDesktopApp() {
 		) {
 			window.history.back();
 		} else if ( ev.keyCode === 73 && ev.shiftKey === true && ev.ctrlKey === true ) {
-			electron.ipcRenderer.send( 'toggle-dev-tools' );
+			window.electron.send( 'toggle-dev-tools' );
 		}
 	}
 
@@ -83,8 +80,7 @@ function startDesktopApp() {
 		}
 	}
 
-	// Uses the logger object instantiated by preload.js
-	log = logger( 'desktop:renderer:browser' ); // eslint-disable-line no-undef
+	log = window.electron.logger( 'desktop:renderer:browser' ); // eslint-disable-line no-undef
 
 	// Everything is ready, start Calypso
 	log.info( 'Received app configuration, starting in browser' );
@@ -118,7 +114,8 @@ function startDesktopApp() {
 			}
 		} );
 
-		document.documentElement.classList.add( 'build-' + electron.getBuild() );
+		const build = window.electron.config.build;
+		document.documentElement.classList.add( 'build-' + build );
 
 		if ( navigator.onLine ) {
 			startCalypso();
@@ -137,11 +134,11 @@ function startDesktopApp() {
 // Wrap this in an exception handler. If it fails then it means Electron is not present, and we are in a browser
 // This will then cause the browser to redirect to hey.html
 try {
-	electron.ipcRenderer.on( 'is-calypso', function () {
-		electron.ipcRenderer.send( 'is-calypso-response', document.getElementById( 'wpcom' ) !== null );
+	window.electron.receive( 'is-calypso', function () {
+		window.electron.receive( 'is-calypso-response', document.getElementById( 'wpcom' ) !== null );
 	} );
 
-	electron.ipcRenderer.on( 'app-config', function ( event, config, debug, details ) {
+	window.electron.receive( 'app-config', function ( event, config, debug, details ) {
 		// if this is the first run, and on the login page, show Windows and Mac users a pin app reminder
 		if ( details.firstRun && document.querySelectorAll( '.logged-out-auth' ).length > 0 ) {
 			if ( details.platform === 'windows' || details.platform === 'darwin' ) {
@@ -182,7 +179,7 @@ try {
 		}
 	} );
 } catch ( e ) {
-	console.log( 'Failed to initialize calypso', e.message );
+	log.error( 'Failed to initialize calypso', e.message );
 }
 
 startDesktopApp();

--- a/desktop/public_desktop/desktop-app.js
+++ b/desktop/public_desktop/desktop-app.js
@@ -138,7 +138,7 @@ try {
 		window.electron.receive( 'is-calypso-response', document.getElementById( 'wpcom' ) !== null );
 	} );
 
-	window.electron.receive( 'app-config', function ( event, config, debug, details ) {
+	window.electron.receive( 'app-config', function ( _, details ) {
 		// if this is the first run, and on the login page, show Windows and Mac users a pin app reminder
 		if ( details.firstRun && document.querySelectorAll( '.logged-out-auth' ).length > 0 ) {
 			if ( details.platform === 'windows' || details.platform === 'darwin' ) {

--- a/desktop/public_desktop/preferences.html
+++ b/desktop/public_desktop/preferences.html
@@ -153,18 +153,18 @@
 <script>
 	function Preferences( settings ) {
 		this.setValues( settings );
-		this.updateProxyView( settings.getSetting( 'proxy-type' ) );
+		this.updateProxyView( settings[ 'proxy-type' ] );
 	}
 
 	Preferences.prototype.setValues = function( settings ) {
 		var inputs = document.querySelectorAll( 'input[type=checkbox]' );
 
 		for ( var i = 0; i < inputs.length; i++ ) {
-			inputs[i].checked = settings.getSetting( inputs[i].getAttribute( 'name' ) );
+			inputs[i].checked = settings[ inputs[i].getAttribute( 'name' ) ];
 		}
 
 		[ 'proxy-url', 'proxy-port', 'proxy-pac' ].forEach( function( item ) {
-			document.querySelector( 'input[name=' + item + ']' ).value = settings.getSetting( item );
+			document.querySelector( 'input[name=' + item + ']' ).value = settings[ item ];
 		} );
 
 		if ( navigator.platform === 'Win32' ) {
@@ -175,8 +175,8 @@
 			document.querySelector( '.option-notifications' ).style.display = 'none';
 		}
 
-		this.setSelect( 'select[name=proxy-type]', settings.getSetting( 'proxy-type' ) );
-		this.setSelect( 'select[name=release-channel]', settings.getSetting( 'release-channel' ) );
+		this.setSelect( 'select[name=proxy-type]', settings[ 'proxy-type' ] );
+		this.setSelect( 'select[name=release-channel]', settings[ 'release-channel' ] );
 	};
 
 	Preferences.prototype.setSelect = function( item, value ) {
@@ -207,8 +207,8 @@
 	};
 
 	Preferences.prototype.save = function( name, value ) {
-		ipc.send( 'preferences-changed', { name: name, value: value } );
-		ipc.send( 'preferences-changed-' + name, value );
+		window.electron.send( 'preferences-changed', { name: name, value: value } );
+		window.electron.send( 'preferences-changed-' + name, value );
 	};
 
 	Preferences.prototype.updateProxyView = function( proxyType ) {
@@ -250,9 +250,7 @@
 		return document.querySelector( 'select[name=proxy-type]' ).value
 	};
 
-	var electron = require( 'electron' );
-	var ipc = electron.ipcRenderer;
-	var pref = new Preferences( electron.remote.getGlobal( 'desktop' ).settings );
+	var pref = new Preferences ( window.electron.preferences );
 
 	pref.monitorChanges();
 </script>

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -1,36 +1,66 @@
-const { ipcRenderer, remote } = require( 'electron' );
+const { ipcRenderer, contextBridge } = require( 'electron' );
 
-const logger = ( namespace, options ) => {
-	// FIXME: The `remote` module is being deprecated and will be excluded
-	// from Electron v9.x.
+// Outgoing IPC message channels from Renderer to Main process.
+// Maintain this list in alphabetical order.
+const sendChannels = [
+	'cannot-use-editor',
+	'get-config',
+	'get-settings',
+	'log',
+	'request-site-response',
+	'unread-notices-count',
+	'user-auth',
+	'user-login-status',
+];
 
-	// It is possible to use the `remote` module to directly require the
-	// main process logging module. However, this is a security concern and is
-	// discouraged. Instead, we post log messages to the main process via ipc.
-	const send = ( level, message, meta ) => {
-		ipcRenderer.send( 'log', level, namespace, options, message, meta );
-	};
+// Incoming IPC message channels from Main process to Renderer.
+// Maintain this list in alphabetical order.
+const receiveChannels = [
+	'cookie-auth-complete',
+	'enable-notification-badge',
+	'enable-site-option',
+	'navigate',
+	'new-post',
+	'notification-clicked',
+	'notifications-panel-refresh',
+	'notifications-panel-show',
+	'page-help',
+	'page-my-sites',
+	'page-profile',
+	'page-reader',
+	'request-site',
+	'request-user-login-status',
+	'signout',
+	'toggle-notification-bar',
+];
 
-	return {
-		error: ( message, meta ) => send( 'error', namespace, options, message, meta ),
-		warn: ( message, meta ) => send( 'warn', namespace, options, message, meta ),
-		info: ( message, meta ) => send( 'info', namespace, options, message, meta ),
-		debug: ( message, meta ) => send( 'debug', namespace, options, message, meta ),
-		silly: ( message, meta ) => send( 'silly', namespace, options, message, meta ),
-	};
-};
-window.logger = logger; // expose logger interface to other renderer processes
+( async () => {
+	const config = await ipcRenderer.invoke( 'get-config' );
+	contextBridge.exposeInMainWorld( 'electron', {
+		send: ( channel, ...args ) => {
+			if ( sendChannels.includes( channel ) ) {
+				ipcRenderer.send( channel, ...args );
+			}
+		},
+		receive: ( channel, callback ) => {
+			if ( receiveChannels.includes( channel ) ) {
+				// exclude event with sender info
+				ipcRenderer.on( channel, ( _, ...args ) => callback( ...args ) );
+			}
+		},
+		logger: ( namespace, options ) => {
+			const send = ( level, message, meta ) => {
+				ipcRenderer.send( 'log', level, namespace, options, message, meta );
+			};
 
-const desktop = remote.getGlobal( 'desktop' );
-
-// WARNING WARNING WARNING
-// This is exposed to the web renderer. Be careful about putting stuff in here as client JS will have access to it
-// WARNING WARNING WARNING
-
-// TODO: Either merge this with the `desktop` object or find a way to completely get rid of this
-window.electron = {
-	ipcRenderer,
-	getCurrentWindow: remote.getCurrentWindow,
-	getBuild: () => desktop.config.build,
-	isDebug: () => desktop.settings.isDebug(),
-};
+			return {
+				error: ( message, meta ) => send( 'error', message, meta ),
+				warn: ( message, meta ) => send( 'warn', message, meta ),
+				info: ( message, meta ) => send( 'info', message, meta ),
+				debug: ( message, meta ) => send( 'debug', message, meta ),
+				silly: ( message, meta ) => send( 'silly', message, meta ),
+			};
+		},
+		config,
+	} );
+} )();

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -42,10 +42,11 @@ const receiveChannels = [
 				ipcRenderer.send( channel, ...args );
 			}
 		},
-		receive: ( channel, callback ) => {
+		receive: ( channel, onReceived ) => {
 			if ( receiveChannels.includes( channel ) ) {
 				// exclude event with sender info
-				ipcRenderer.on( channel, ( _, ...args ) => callback( ...args ) );
+				const callback = ( _, ...args ) => onReceived( ...args );
+				ipcRenderer.on( channel, callback );
 			}
 		},
 		logger: ( namespace, options ) => {

--- a/desktop/public_desktop/preload_about.js
+++ b/desktop/public_desktop/preload_about.js
@@ -1,0 +1,8 @@
+const { ipcRenderer, contextBridge } = require( 'electron' );
+
+( async () => {
+	const config = await ipcRenderer.invoke( 'get-config' );
+	contextBridge.exposeInMainWorld( 'electron', {
+		config,
+	} );
+} )();

--- a/desktop/public_desktop/preload_preferences.js
+++ b/desktop/public_desktop/preload_preferences.js
@@ -1,0 +1,15 @@
+const { ipcRenderer, contextBridge } = require( 'electron' );
+
+const sendChannels = [ 'preferences-changed', 'preferences-changed-' ];
+
+( async () => {
+	const preferences = await ipcRenderer.invoke( 'get-settings' );
+	contextBridge.exposeInMainWorld( 'electron', {
+		send: ( channel, data ) => {
+			if ( sendChannels.includes( channel ) ) {
+				ipcRenderer.send( channel, data );
+			}
+		},
+		preferences,
+	} );
+} )();

--- a/desktop/public_desktop/preload_preferences.js
+++ b/desktop/public_desktop/preload_preferences.js
@@ -1,12 +1,11 @@
 const { ipcRenderer, contextBridge } = require( 'electron' );
 
-const sendChannels = [ 'preferences-changed', 'preferences-changed-' ];
-
 ( async () => {
 	const preferences = await ipcRenderer.invoke( 'get-settings' );
 	contextBridge.exposeInMainWorld( 'electron', {
 		send: ( channel, data ) => {
-			if ( sendChannels.includes( channel ) ) {
+			// Possible values: preferences-changed or preferences-changed-<preference_name>
+			if ( channel.startsWith( 'preferences-changed' ) ) {
 				ipcRenderer.send( channel, data );
 			}
 		},


### PR DESCRIPTION
### Description

This PR migrates WP Desktop IPC messaging to use the safer and more secure `contextBridge` protocol ([docs](https://www.electronjs.org/docs/api/context-bridge#contextbridge)). The primary motivation for this change is that as of Electron v9.x, the remote module will be deprecated (and presumably excluded entirely at some point).

Because of this change, we can now enable all of the following security settings in the Desktop app:

**Enable Context Isolation** ([docs](https://www.electronjs.org/docs/tutorial/context-isolation))

Context Isolation is a feature that ensures that both your preload scripts and Electron's internal logic run in a separate context to the website you load in a webContents. This is important for security purposes as it helps prevent the website from accessing Electron internals or the powerful APIs your preload script has access to.

**Enable Sandbox** ([docs](https://www.electronjs.org/docs/api/sandbox-option))

With this option enabled, the renderer must communicate via IPC to the main process in order to access node APIs. One of the key security features of Chromium is that all blink rendering/JavaScript code is executed within a sandbox. This sandbox uses OS-specific features to ensure that exploits in the renderer process cannot harm the system.

**Disable Node Integration** ([docs](https://www.electronjs.org/docs/tutorial/security#2-do-not-enable-nodejs-integration-for-remote-content))

It is paramount that you do not enable Node.js integration in any renderer (`BrowserWindow`, `BrowserView`, or `<webview>`) that loads remote content. The goal is to limit the powers you grant to remote content, thus making it dramatically more difficult for an attacker to harm your users should they gain the ability to execute JavaScript on your website.

A cross-site-scripting (XSS) attack is more dangerous if an attacker can jump out of the renderer process and execute code on the user's computer. Cross-site-scripting attacks are fairly common - and while an issue, their power is usually limited to messing with the website that they are executed on. Disabling Node.js integration helps prevent an XSS from being escalated into a so-called "Remote Code Execution" (RCE) attack.

**Disable Remote Module** ([Medium article](https://medium.com/@nornagon/electrons-remote-module-considered-harmful-70d69500f31))

> ... it’s possible for a compromised renderer process to formulate and send a request to ask the main process to do whatever it wants. Effectively, the remote module makes sandboxing almost useless. Electron provides an option to disable the remote module, and if you’re using the sandbox in your app, you should definitely also be disabling remote.