### PR TITLE
Launch: check if site is on Free plan after rendering editor Launch button

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -7,6 +7,7 @@ import { addAction } from '@wordpress/hooks';
 import { select, dispatch } from '@wordpress/data';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import 'a8c-fse-common-data-stores';
+import type { Site } from '@automattic/data-stores';
 
 // Depend on `core/editor` store.
 import '@wordpress/editor';
@@ -50,17 +51,17 @@ function updateEditor() {
 
 	handled = true;
 
-	// Asynchronously load plan data to check if site is on a free or paid plan
+	// Asynchronously load site data to check if site is on a free or paid plan
 	// 'select' function is first returning 'undefined' so we retry every 100ms
-	let currentPlan = select( 'automattic/site' ).getSite( window._currentSiteId )?.plan;
-	const awaitSite = setInterval( () => {
-		currentPlan = select( 'automattic/site' ).getSite( window._currentSiteId )?.plan;
-		if ( ! currentPlan ) {
+	let site: Site.SiteDetails | undefined;
+	const awaitSiteData = setInterval( () => {
+		site = select( 'automattic/site' ).getSite( window._currentSiteId );
+		if ( ! site ) {
 			return;
 		}
-		clearInterval( awaitSite );
+		clearInterval( awaitSiteData );
 	}, 100 );
-	const getIsFreePlan = () => currentPlan?.is_free;
+	const getIsFreePlan = () => site?.plan?.is_free;
 
 	const awaitSettingsBar = setInterval( () => {
 		const settingsBar = document.querySelector( '.edit-post-header__settings' );
@@ -80,7 +81,7 @@ function updateEditor() {
 			window.top.location.href = launchHref;
 		};
 
-		const handleLaunch = async ( e: Event ) => {
+		const handleLaunch = ( e: Event ) => {
 			// Disable href navigation
 			e.preventDefault();
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -372,9 +372,7 @@ class CalypsoifyIframe extends Component<
 		}
 
 		if ( EditorActions.GetGutenboardingStatus === action ) {
-			const isGutenboarding =
-				this.props.siteCreationFlow === 'gutenboarding' &&
-				( ! this.props.plan || this.props.plan.is_free ); // prevent showing StepByStepLaunch on sites with paid plans
+			const isGutenboarding = this.props.siteCreationFlow === 'gutenboarding';
 			const isSiteUnlaunched = this.props.isSiteUnlaunched;
 			const launchUrl = `${ window.location.origin }/start/launch-site?siteSlug=${ this.props.siteSlug }`;
 			const isNewLaunchMobile = config.isEnabled( 'gutenboarding/new-launch-mobile' ); // TODO: remove after ETK 2.8.6 is released


### PR DESCRIPTION
***Editing Toolkit release notes**: New Onboarding Launch: open launch modal only for free sites

#### Changes proposed in this Pull Request
* Replace the check for Free plan in Calypso with a similar check in ET plugin.
* Pass `isGutenboarding` through the iframe correctly everytime.

#### Testing instructions
* Create a site using `/new` on a Free plan
* Sandbox the site and sync ET plugin
* Clicking Launch in editor should open step-by-step launch modal
* Repeat the process but this time select a paid plan and complete purchase
* Clicking Launch in editor should redirect to Calypso default launch flow

Fixes #47504 (solution B)
