### PR TITLE
Editing Toolkit: Update to 2.8.6

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.5
+ * Version: 2.8.6
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.5' );
+define( 'PLUGIN_VERSION', '2.8.6' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.5
+Stable tag: 2.8.6
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.6 =
+* Premium Content: Compatibility fix for Gutenberg >= 9.3.0 (https://github.com/Automattic/wp-calypso/pull/47467)
 
 = 2.8.5 =
 * Launch: support i18n in plans grid (https://github.com/Automattic/wp-calypso/pull/47227)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.5",
+	"version": "2.8.6",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Version bump and changelog

#### [Changes to Editing Toolkit since 2.8.5](https://github.com/Automattic/wp-calypso/commits/master/apps/editing-toolkit):

- [x] Premium Content: Compatibility fix for Gutenberg >= 9.3.0 (#47467)
- [x] Plans Grid: enable accordion view as non-experimental (#47491)
- [x] Launch: use step-by-step launch flow after new onboarding with free plan (#47493)
 
#### Testing instructions

1. Load the diff (D52891-code) on your sandbox and confirm that the above changes work correctly
2. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.