### PR TITLE
Domains: Modify HeaderCart to force cart to fetch when it mounts

### DIFF
--- a/client/my-sites/checkout/cart/header-cart.jsx
+++ b/client/my-sites/checkout/cart/header-cart.jsx
@@ -9,6 +9,7 @@ import React from 'react';
  */
 import { getAllCartItems } from 'calypso/lib/cart-values/cart-items';
 import PopoverCart from './popover-cart';
+import { reloadCart } from 'calypso/lib/cart/actions';
 
 class HeaderCart extends React.Component {
 	static propTypes = {
@@ -29,18 +30,21 @@ class HeaderCart extends React.Component {
 		} );
 	};
 
+	componentDidMount() {
+		reloadCart();
+	}
+
 	render() {
 		const isCartEmpty = getAllCartItems( this.props.cart ).length === 0;
-		let isVisible = this.state.isPopoverCartVisible;
 		if ( isCartEmpty ) {
-			isVisible = false;
+			return null;
 		}
 
 		return (
 			<PopoverCart
 				cart={ this.props.cart }
 				selectedSite={ this.props.selectedSite }
-				visible={ isVisible }
+				visible={ this.state.isPopoverCartVisible }
 				pinned={ false }
 				path={ this.props.currentRoute }
 				onToggle={ this.togglePopoverCart }

--- a/client/my-sites/checkout/cart/header-cart.jsx
+++ b/client/my-sites/checkout/cart/header-cart.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,15 +30,18 @@ class HeaderCart extends React.Component {
 	};
 
 	render() {
-		if ( isEmpty( getAllCartItems( this.props.cart ) ) ) {
-			return null;
+		const isCartEmpty = getAllCartItems( this.props.cart ).length === 0;
+		const noop = () => {};
+		let isVisible = this.props.isPopoverCartVisible;
+		if ( isCartEmpty ) {
+			isVisible = false;
 		}
 
 		return (
 			<PopoverCart
 				cart={ this.props.cart }
 				selectedSite={ this.props.selectedSite }
-				visible={ this.state.isPopoverCartVisible }
+				visible={ isVisible }
 				pinned={ false }
 				path={ this.props.currentRoute }
 				onToggle={ this.togglePopoverCart }

--- a/client/my-sites/checkout/cart/header-cart.jsx
+++ b/client/my-sites/checkout/cart/header-cart.jsx
@@ -31,7 +31,6 @@ class HeaderCart extends React.Component {
 
 	render() {
 		const isCartEmpty = getAllCartItems( this.props.cart ).length === 0;
-		const noop = () => {};
 		let isVisible = this.state.isPopoverCartVisible;
 		if ( isCartEmpty ) {
 			isVisible = false;
@@ -45,7 +44,6 @@ class HeaderCart extends React.Component {
 				pinned={ false }
 				path={ this.props.currentRoute }
 				onToggle={ this.togglePopoverCart }
-				closeSectionNavMobilePanel={ noop }
 				compact
 			/>
 		);

--- a/client/my-sites/checkout/cart/header-cart.jsx
+++ b/client/my-sites/checkout/cart/header-cart.jsx
@@ -32,7 +32,7 @@ class HeaderCart extends React.Component {
 	render() {
 		const isCartEmpty = getAllCartItems( this.props.cart ).length === 0;
 		const noop = () => {};
-		let isVisible = this.props.isPopoverCartVisible;
+		let isVisible = this.state.isPopoverCartVisible;
 		if ( isCartEmpty ) {
 			isVisible = false;
 		}

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -65,7 +65,7 @@ class PopoverCart extends React.Component {
 	}
 
 	onToggle = () => {
-		this.props.closeSectionNavMobilePanel();
+		this.props.closeSectionNavMobilePanel?.();
 		this.props.onToggle();
 	};
 


### PR DESCRIPTION
HeaderCart (added in https://github.com/Automattic/wp-calypso/pull/45339) currently does not render PopoverCart if the cart object it sees has no items. However, this can sometimes be inaccurate, since the cart object currently used by HeaderCart comes from the deprecated CartStore. When PopoverCart first mounts, it forces the CartStore to update, making sure that its data is as fresh as possible, but if PopoverCart is never rendered, that forced update will not occur, meaning that the HeaderCart could be out-of-date until the next time CartStore polls the shopping-cart endpoint.

This PR modifies HeaderCart to also force a cart fetch when it mounts. This does mean that the cart will be fetched twice if not empty, but that should be fine for the time being until PopoverCart can be refactored to work with the ShoppingCartProvider (this is in-progress).

The main purpose of this PR is to fix the `Managing Domains: (desktop) Adding a domain to an existing site Empty the cart - Empty the cart` e2e test, as discussed in https://github.com/Automattic/wp-calypso/pull/47379#issuecomment-728464578.

<img width="1086" alt="Screen Shot 2020-11-19 at 3 50 15 PM" src="https://user-images.githubusercontent.com/2036909/99722812-3ac2f300-2a7f-11eb-82a0-994330523464.png">

<img width="1108" alt="Screen Shot 2020-11-19 at 3 51 04 PM" src="https://user-images.githubusercontent.com/2036909/99722818-3dbde380-2a7f-11eb-9ddc-dfa36a52d575.png">


#### Testing instructions

- Start with an empty cart.
- Visit `/domains/add` and click to add a domain to your cart.
- You'll see the G Suite upsell page. Without confirming, click the "Domains" link in the sidebar (under "Manage").
- Verify that you see the cart icon with a "1" on it.
- Click the "Add a domain to this site" button at the top of the page.
- Verify that you see the cart icon with a "1" on it.
- Click on the cart icon and click the trash button to remove the domain from the cart.
- Verify that the cart icon disappears.
