### PR TITLE
Nav Unification: uses experiment to set a feature flag

### DIFF
--- a/client/config/README.md
+++ b/client/config/README.md
@@ -25,6 +25,25 @@ if ( config.isEnabled( 'myFeature' ) ) {
 }
 ```
 
+### config.enable( key )
+
+Enable a feature.
+
+```js
+import config from 'calypso/config';
+
+config.enable( 'myFeature' );
+```
+### config.disable( key )
+
+Disable a feature.
+
+```js
+import config from 'calypso/config';
+
+config.disable( 'myFeature' );
+```
+
 The key should always be a literal string not a variable so that down the road
 we can process the compiled scripts and remove code for disabled features in
 production.

--- a/client/config/index.js
+++ b/client/config/index.js
@@ -74,3 +74,5 @@ const configApi = createConfig( configData );
 export default configApi;
 export const isEnabled = configApi.isEnabled;
 export const enabledFeatures = configApi.enabledFeatures;
+export const enable = configApi.enable;
+export const disable = configApi.disable;

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment, useLayoutEffect } from 'react';
+import React, { Fragment } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
 
@@ -25,7 +25,6 @@ import {
 } from 'calypso/state/immediate-login/selectors';
 import { getSiteFragment } from 'calypso/lib/route';
 import { hydrate } from './web-util.js';
-import { getVariationForUser } from 'calypso/state/experiments/selectors';
 import QueryExperiments from 'calypso/components/data/query-experiments';
 
 /**
@@ -45,17 +44,6 @@ export const ProviderWrappedLayout = ( {
 } ) => {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
-
-	// This code ( and <QueryExperiments /> ) should be removed when the nav-unification project has been rolled out to 100% of the customers.
-	useLayoutEffect( () => {
-		const variation = getVariationForUser( state, 'nav_unification_demo' );
-		if ( variation === 'treatment' ) {
-			// Hacky way to set a feature-flag.
-			window.configData.features[ 'nav-unification' ] = true;
-		} else {
-			window.configData.features[ 'nav-unification' ] = false;
-		}
-	} );
 
 	const layout = userLoggedIn ? (
 		<Fragment>

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
 
@@ -25,7 +25,6 @@ import {
 } from 'calypso/state/immediate-login/selectors';
 import { getSiteFragment } from 'calypso/lib/route';
 import { hydrate } from './web-util.js';
-import QueryExperiments from 'calypso/components/data/query-experiments';
 
 /**
  * Re-export
@@ -46,10 +45,7 @@ export const ProviderWrappedLayout = ( {
 	const userLoggedIn = isUserLoggedIn( state );
 
 	const layout = userLoggedIn ? (
-		<Fragment>
-			<QueryExperiments />
-			<Layout primary={ primary } secondary={ secondary } />
-		</Fragment>
+		<Layout primary={ primary } secondary={ secondary } />
 	) : (
 		<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
 	);

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment, useLayoutEffect } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
 
@@ -25,6 +25,8 @@ import {
 } from 'calypso/state/immediate-login/selectors';
 import { getSiteFragment } from 'calypso/lib/route';
 import { hydrate } from './web-util.js';
+import { getVariationForUser } from 'calypso/state/experiments/selectors';
+import QueryExperiments from 'calypso/components/data/query-experiments';
 
 /**
  * Re-export
@@ -44,8 +46,22 @@ export const ProviderWrappedLayout = ( {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
 
+	// This code ( and <QueryExperiments /> ) should be removed when the nav-unification project has been rolled out to 100% of the customers.
+	useLayoutEffect( () => {
+		const variation = getVariationForUser( state, 'nav_unification_demo' );
+		if ( variation === 'treatment' ) {
+			// Hacky way to set a feature-flag.
+			window.configData.features[ 'nav-unification' ] = true;
+		} else {
+			window.configData.features[ 'nav-unification' ] = false;
+		}
+	} );
+
 	const layout = userLoggedIn ? (
-		<Layout primary={ primary } secondary={ secondary } />
+		<Fragment>
+			<QueryExperiments />
+			<Layout primary={ primary } secondary={ secondary } />
+		</Fragment>
 	) : (
 		<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
 	);

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -84,13 +84,12 @@ class Layout extends Component {
 
 		// This code should be removed when the nav-unification project has been rolled out to 100% of the customers.
 		if ( this.props.navUnificationVariation === 'treatment' ) {
-			// Hacky way to set a feature-flag.
-			window.configData.features[ 'nav-unification' ] = true;
+			config.enable( 'nav-unification' );
 
 			window.addEventListener( 'scroll', scrollCallback );
 			window.addEventListener( 'resize', scrollCallback );
 		} else {
-			window.configData.features[ 'nav-unification' ] = false;
+			config.disable( 'nav-unification' );
 		}
 	}
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -84,18 +84,14 @@ class Layout extends Component {
 		}
 
 		// This code should be removed when the nav-unification project has been rolled out to 100% of the customers.
-		if ( this.props.navUnificationVariation === 'treatment' ) {
-			config.enable( 'nav-unification' );
-
+		if ( config.isEnabled( 'nav-unification' ) ) {
 			window.addEventListener( 'scroll', scrollCallback );
 			window.addEventListener( 'resize', scrollCallback );
-		} else {
-			config.disable( 'nav-unification' );
 		}
 	}
 
 	componentWillUnmount() {
-		if ( this.props.navUnificationVariation === 'treatment' ) {
+		if ( config.isEnabled( 'nav-unification' ) ) {
 			window.removeEventListener( 'scroll', scrollCallback );
 			window.removeEventListener( 'resize', scrollCallback );
 		}
@@ -178,6 +174,12 @@ class Layout extends Component {
 
 			return optionalProps;
 		};
+
+		if ( this.props.navUnificationVariation === 'treatment' ) {
+			config.enable( 'nav-unification' );
+		} else {
+			config.disable( 'nav-unification' );
+		}
 
 		const { shouldShowAppBanner } = this.props;
 		return (

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -43,6 +43,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import LayoutLoader from './loader';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { withCurrentRoute } from 'calypso/components/route';
+import { getVariationForUser } from 'calypso/state/experiments/selectors';
 
 /**
  * Style dependencies
@@ -80,14 +81,21 @@ class Layout extends Component {
 					.classList.add( `is-${ this.props.colorSchemePreference }` );
 			}
 		}
-		if ( config.isEnabled( 'nav-unification' ) ) {
+
+		// This code should be removed when the nav-unification project has been rolled out to 100% of the customers.
+		if ( this.props.navUnificationVariation === 'treatment' ) {
+			// Hacky way to set a feature-flag.
+			window.configData.features[ 'nav-unification' ] = true;
+
 			window.addEventListener( 'scroll', scrollCallback );
 			window.addEventListener( 'resize', scrollCallback );
+		} else {
+			window.configData.features[ 'nav-unification' ] = false;
 		}
 	}
 
 	componentWillUnmount() {
-		if ( config.isEnabled( 'nav-unification' ) ) {
+		if ( this.props.navUnificationVariation === 'treatment' ) {
 			window.removeEventListener( 'scroll', scrollCallback );
 			window.removeEventListener( 'resize', scrollCallback );
 		}
@@ -314,6 +322,7 @@ export default compose(
 			shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
 			isNewLaunchFlow,
 			isCheckoutFromGutenboarding,
+			navUnificationVariation: getVariationForUser( state, 'nav_unification_demo' ),
 		};
 	} )
 )( Layout );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -325,7 +325,7 @@ export default compose(
 			shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
 			isNewLaunchFlow,
 			isCheckoutFromGutenboarding,
-			navUnificationVariation: getVariationForUser( state, 'nav_unification_demo' ),
+			navUnificationVariation: getVariationForUser( state, 'nav_unification' ),
 		};
 	} )
 )( Layout );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -43,6 +43,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import LayoutLoader from './loader';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { withCurrentRoute } from 'calypso/components/route';
+import QueryExperiments from 'calypso/components/data/query-experiments';
 import { getVariationForUser } from 'calypso/state/experiments/selectors';
 
 /**
@@ -165,7 +166,7 @@ class Layout extends Component {
 				config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
 				isWooOAuth2Client( this.props.oauth2Client ) &&
 				this.props.wccomFrom,
-			'is-nav-unification': config.isEnabled( 'nav-unification' ),
+			'is-nav-unification': this.props.navUnificationVariation === 'treatment',
 		} );
 
 		const optionalBodyProps = () => {
@@ -181,6 +182,7 @@ class Layout extends Component {
 		const { shouldShowAppBanner } = this.props;
 		return (
 			<div className={ sectionClass }>
+				<QueryExperiments />
 				<BodySectionCssClass
 					group={ this.props.sectionGroup }
 					section={ this.props.sectionName }

--- a/client/lib/create-config/index.js
+++ b/client/lib/create-config/index.js
@@ -74,10 +74,39 @@ const isEnabled = ( data ) => ( /** @type {string} */ feature ) =>
 const enabledFeatures = ( data ) => () =>
 	Object.keys( data.features ).filter( ( feature ) => !! data.features[ feature ] );
 
+/**
+ * Enables a specific feature.
+ *
+ * @param {string} feature Feature name
+ * @param {object} data the json environment configuration to use for getting config values
+ * @api public
+ */
+const enable = ( data ) => ( feature ) => {
+	if ( data.features ) {
+		data.features[ feature ] = true;
+	}
+};
+
+/**
+ * Disables a specific feature.
+ *
+ * @param {string} feature Feature name
+ * @param {object} data the json environment configuration to use for getting config values
+ * @api public
+ */
+
+const disable = ( data ) => ( feature ) => {
+	if ( data.features ) {
+		data.features[ feature ] = false;
+	}
+};
+
 module.exports = ( data ) => {
 	const configApi = config( data );
 	configApi.isEnabled = isEnabled( data );
 	configApi.enabledFeatures = enabledFeatures( data );
+	configApi.enable = enable( data );
+	configApi.disable = disable( data );
 
 	return configApi;
 };

--- a/client/lib/create-config/index.js
+++ b/client/lib/create-config/index.js
@@ -77,11 +77,10 @@ const enabledFeatures = ( data ) => () =>
 /**
  * Enables a specific feature.
  *
- * @param {string} feature Feature name
  * @param {object} data the json environment configuration to use for getting config values
- * @api public
+ * @public
  */
-const enable = ( data ) => ( feature ) => {
+const enable = ( data ) => ( /** @type {string} */ feature ) => {
 	if ( data.features ) {
 		data.features[ feature ] = true;
 	}
@@ -90,12 +89,11 @@ const enable = ( data ) => ( feature ) => {
 /**
  * Disables a specific feature.
  *
- * @param {string} feature Feature name
  * @param {object} data the json environment configuration to use for getting config values
- * @api public
+ * @public
  */
 
-const disable = ( data ) => ( feature ) => {
+const disable = ( data ) => ( /** @type {string} */ feature ) => {
 	if ( data.features ) {
 		data.features[ feature ] = false;
 	}

--- a/client/lib/create-config/test/index.js
+++ b/client/lib/create-config/test/index.js
@@ -71,4 +71,64 @@ describe( 'index', () => {
 			} );
 		} );
 	} );
+
+	describe( 'config utilities', () => {
+		let config;
+
+		beforeEach( () => {
+			config = createConfig( {
+				features: {
+					flagA: false,
+					flagB: false,
+					flagC: true,
+				},
+			} );
+		} );
+
+		afterEach( () => {
+			config = null;
+		} );
+
+		describe( 'isEnabled', () => {
+			test( 'it correctly reports status of features', () => {
+				expect( config.isEnabled( 'flagA' ) ).to.be.false;
+				expect( config.isEnabled( 'flagC' ) ).to.be.true;
+			} );
+
+			test( 'it defaults to "false" when feature is not defined', () => {
+				expect( config.isEnabled( 'flagXYZ' ) ).to.be.false;
+			} );
+		} );
+
+		describe( 'enable', () => {
+			test( 'it can enable features which are not yet set', () => {
+				config.enable( 'flagD' );
+				config.enable( 'flagE' );
+				expect( config.isEnabled( 'flagD' ) ).to.be.true;
+				expect( config.isEnabled( 'flagE' ) ).to.be.true;
+			} );
+
+			test( 'it can toggle existing features to enable them', () => {
+				config.enable( 'flagA' );
+				expect( config.isEnabled( 'flagA' ) ).to.be.true;
+			} );
+		} );
+
+		describe( 'disable', () => {
+			test( 'it can toggle existing features to disable them', () => {
+				config.disable( 'flagC' );
+				expect( config.isEnabled( 'flagC' ) ).to.be.false;
+			} );
+
+			test( 'it retains existing disable setting for features that are already disabled', () => {
+				config.disable( 'flagA' );
+				expect( config.isEnabled( 'flagA' ) ).to.be.false;
+			} );
+
+			test( 'it will handle setting new features to a initial disabled state', () => {
+				config.disable( 'flagZXY' );
+				expect( config.isEnabled( 'flagZXY' ) ).to.be.false;
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Since that nav-unification project is touching many different parts of the code (eg search for `nav-unification`) it wouldn't make sense trying to create different components in order to utilise the experiment component
https://github.com/Automattic/wp-calypso/blob/a87658f46866d2455eb5d8f8c02df4da284cf014/client%2Fcomponents%2Fexperiment%2Freadme.md#L19-L37

Also, changes have to kick in really soon cause they are affecting the whole layout (masterbar, navbar).

* Use experiments internal tools to override feature flags in `layout` component

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply this patch and load calypso
* you should see the same UI as in production
* go to `nav_unification` experiment and click on `treatment` (paYJgx-Zj-p2#comment-1406)
* reload calypso twice, you should be seeing the nav unification UI / UX. Sometimes the api call is not triggered in subsequent requests.

Builds together with D52906-code, please test accordingly.

Fixes #47044