### PR TITLE
Focused Launch: Pixel perfect loading state

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -22,7 +22,7 @@ import './styles.scss';
 const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
 	const { plan, domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 	const { currentDomainName } = useSite();
-	const domainSearch = useDomainSearch();
+	const { domainSearch } = useDomainSearch();
 
 	const {
 		setDomain,

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -45,7 +45,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 	const { title } = useTitle();
 	const { currentDomainName } = useSite();
 	const domainSuggestion = useDomainSuggestion();
-	const domainSearch = useDomainSearch();
+	const { domainSearch } = useDomainSearch();
 
 	const { setStep } = useDispatch( LAUNCH_STORE );
 

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -14,6 +14,10 @@ import type { WpcomClientCredentials } from '../shared-types';
 import { wpcomRequest } from '../wpcom-request-controls';
 
 export function createActions( clientCreds: WpcomClientCredentials ) {
+	const fetchSite = () => ( {
+		type: 'FETCH_SITE' as const,
+	} );
+
 	const fetchNewSite = () => ( {
 		type: 'FETCH_NEW_SITE' as const,
 	} );
@@ -150,6 +154,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		saveSiteTitle,
 		receiveSiteTitle,
 		fetchNewSite,
+		fetchSite,
 		receiveNewSite,
 		receiveNewSiteFailed,
 		resetNewSiteFailed,
@@ -169,6 +174,7 @@ export type ActionCreators = ReturnType< typeof createActions >;
 export type Action =
 	| ReturnType<
 			| ActionCreators[ 'fetchNewSite' ]
+			| ActionCreators[ 'fetchSite' ]
 			| ActionCreators[ 'receiveSiteDomains' ]
 			| ActionCreators[ 'receiveNewSite' ]
 			| ActionCreators[ 'receiveSiteTitle' ]

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -71,7 +71,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		response,
 	} );
 
-	const receiveSiteTitle = ( siteId: number, title: string ) => ( {
+	const receiveSiteTitle = ( siteId: number, title: string | undefined ) => ( {
 		type: 'RECEIVE_SITE_TITLE' as const,
 		siteId,
 		title,
@@ -132,7 +132,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		return success;
 	}
 
-	function* saveSiteTitle( siteId: number, title: string ) {
+	function* saveSiteTitle( siteId: number, title: string | undefined ) {
 		try {
 			// extract this into its own function as a generic settings setter
 			yield wpcomRequest( {

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -57,6 +57,20 @@ export const isFetchingSite: Reducer< boolean | undefined, Action > = ( state = 
 	return state;
 };
 
+export const isFetchingSiteDetails: Reducer< boolean | undefined, Action > = (
+	state = false,
+	action
+) => {
+	switch ( action.type ) {
+		case 'FETCH_SITE':
+			return true;
+		case 'RECEIVE_SITE':
+		case 'RECEIVE_SITE_FAILED':
+			return false;
+	}
+	return state;
+};
+
 export const sites: Reducer< { [ key: number ]: SiteDetails | undefined }, Action > = (
 	state = {},
 	action
@@ -103,7 +117,13 @@ const newSite = combineReducers( {
 	isFetching: isFetchingSite,
 } );
 
-const reducer = combineReducers( { newSite, sites, launchStatus, sitesDomains } );
+const reducer = combineReducers( {
+	isFetchingSiteDetails,
+	newSite,
+	sites,
+	launchStatus,
+	sitesDomains,
+} );
 
 export type State = ReturnType< typeof reducer >;
 

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -18,6 +18,7 @@ import { STORE_KEY } from './constants';
  * @param siteId {number}	The site to look up
  */
 export function* getSite( siteId: number ) {
+	yield dispatch( STORE_KEY ).fetchSite();
 	try {
 		const existingSite = yield wpcomRequest( {
 			path: '/sites/' + encodeURIComponent( siteId ),

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -14,6 +14,7 @@ export const getState = ( state: State ) => state;
 export const getNewSite = ( state: State ) => state.newSite.data;
 export const getNewSiteError = ( state: State ) => state.newSite.error;
 export const isFetchingSite = ( state: State ) => state.newSite.isFetching;
+export const isFetchingSiteDetails = ( state: State ) => state.isFetchingSiteDetails;
 export const isNewSite = ( state: State ) => !! state.newSite.data;
 
 /**

--- a/packages/data-stores/src/site/test/resolvers.ts
+++ b/packages/data-stores/src/site/test/resolvers.ts
@@ -17,7 +17,7 @@ beforeAll( () => {
 } );
 
 describe( 'getSite', () => {
-	it( 'should return a receiveExistingSite action object on success', async () => {
+	it( 'should dispatch a fetchSite action object on boot and should return a receiveExistingSite action object on success', async () => {
 		const siteId = 123456;
 		const apiResponse = {
 			ID: 1,
@@ -28,7 +28,12 @@ describe( 'getSite', () => {
 
 		const generator = getSite( siteId );
 
-		expect( generator.next().value ).toEqual( {
+		// getSite dispatches a FETCH_SITE action on boot
+		expect( await generator.next().value ).toEqual( {
+			type: 'FETCH_SITE',
+		} );
+
+		expect( await generator.next().value ).toEqual( {
 			type: 'WPCOM_REQUEST',
 			request: expect.objectContaining( {
 				path: `/sites/${ siteId }`,
@@ -53,6 +58,11 @@ describe( 'getSite', () => {
 		};
 
 		const generator = getSite( siteId );
+
+		// getSite dispatches a FETCH_SITE action on boot
+		expect( await generator.next().value ).toEqual( {
+			type: 'FETCH_SITE',
+		} );
 
 		expect( generator.next().value ).toEqual( {
 			type: 'WPCOM_REQUEST',

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -76,7 +76,7 @@ export interface SiteDetailsPlan {
 
 export interface SiteDetails {
 	ID: number;
-	name: string;
+	name: string | undefined;
 	description: string;
 	URL: string;
 	launch_status: string;

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -206,6 +206,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	const showDomainSuggestionsResults = ! showErrorMessage && ! isDomainSearchEmpty;
 	const showDomainSuggestionsEmpty = ! showErrorMessage && isDomainSearchEmpty;
 
+	/* if we know the existing domain while the suggestions are loading, we need one less placeholder */
+	const neededPlaceholdersCount = quantity - ( existingSubdomain ? 1 : 0 );
+
 	return (
 		<div className="domain-picker">
 			{ header && header }
@@ -321,7 +324,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 											/>
 										);
 									} ) ) ||
-									times( quantity - ( existingSubdomain ? 1 : 0 ), ( i ) => (
+									times( neededPlaceholdersCount, ( i ) => (
 										<SuggestionItemPlaceholder type={ itemType } key={ i } />
 									) ) }
 							</ItemGrouper>

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -74,6 +74,9 @@ export interface Props {
 
 	existingSubdomain?: string;
 
+	/* this makes the domain picker in loading state */
+	areDependenciesLoading?: boolean;
+
 	/** The flow where the Domain Picker is used. Eg: Gutenboarding */
 	analyticsFlowId: string;
 
@@ -117,6 +120,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	showSearchField = true,
 	itemType = ITEM_TYPE_RADIO,
 	locale,
+	areDependenciesLoading = false,
 } ) => {
 	const label = __( 'Search for a domain', __i18n_text_domain__ );
 
@@ -238,7 +242,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					</Button>
 				</div>
 			) }
-			{ showDomainSuggestionsResults && (
+			{ ( showDomainSuggestionsResults || areDependenciesLoading ) && (
 				<div className="domain-picker__body">
 					{ showDomainCategories && (
 						<div className="domain-picker__aside">
@@ -278,44 +282,48 @@ const DomainPicker: FunctionComponent< Props > = ( {
 								</p>
 							) }
 							<ItemGrouper groupItems={ segregateFreeAndPaid }>
-								{ domainSuggestions?.map( ( suggestion, i ) => {
-									const index = existingSubdomain ? i + 1 : i;
-									const isRecommended = index === 1;
-									const availabilityStatus =
-										domainAvailabilities[ suggestion?.domain_name ]?.status;
-									// should availabilityStatus be falsy then we assume it is available as we have not checked yet.
-									const isAvailable = availabilityStatus
-										? domainIsAvailableStatus?.includes( availabilityStatus )
-										: true;
-									return (
-										<SuggestionItem
-											key={ suggestion.domain_name }
-											isUnavailable={ ! isAvailable }
-											domain={ suggestion.domain_name }
-											cost={ suggestion.cost }
-											isLoading={
-												currentDomain === suggestion.domain_name && isCheckingDomainAvailability
-											}
-											hstsRequired={ suggestion.hsts_required }
-											isFree={ suggestion.is_free }
-											isRecommended={ isRecommended }
-											railcarId={ baseRailcarId ? `${ baseRailcarId }${ index }` : undefined }
-											onRender={ () =>
-												handleItemRender(
-													suggestion.domain_name,
-													`${ baseRailcarId }${ index }`,
-													index,
-													isRecommended
-												)
-											}
-											onSelect={ () => {
-												onDomainSelect( suggestion );
-											} }
-											selected={ currentDomain === suggestion.domain_name }
-											type={ itemType }
-										/>
-									);
-								} ) ?? times( quantity, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
+								{ ( ! areDependenciesLoading &&
+									domainSuggestions?.map( ( suggestion, i ) => {
+										const index = existingSubdomain ? i + 1 : i;
+										const isRecommended = index === 1;
+										const availabilityStatus =
+											domainAvailabilities[ suggestion?.domain_name ]?.status;
+										// should availabilityStatus be falsy then we assume it is available as we have not checked yet.
+										const isAvailable = availabilityStatus
+											? domainIsAvailableStatus?.indexOf( availabilityStatus ) > -1
+											: true;
+										return (
+											<SuggestionItem
+												key={ suggestion.domain_name }
+												isUnavailable={ ! isAvailable }
+												domain={ suggestion.domain_name }
+												cost={ suggestion.cost }
+												isLoading={
+													currentDomain === suggestion.domain_name && isCheckingDomainAvailability
+												}
+												hstsRequired={ suggestion.hsts_required }
+												isFree={ suggestion.is_free }
+												isRecommended={ isRecommended }
+												railcarId={ baseRailcarId ? `${ baseRailcarId }${ index }` : undefined }
+												onRender={ () =>
+													handleItemRender(
+														suggestion.domain_name,
+														`${ baseRailcarId }${ index }`,
+														index,
+														isRecommended
+													)
+												}
+												onSelect={ () => {
+													onDomainSelect( suggestion );
+												} }
+												selected={ currentDomain === suggestion.domain_name }
+												type={ itemType }
+											/>
+										);
+									} ) ) ||
+									times( quantity - ( existingSubdomain ? 1 : 0 ), ( i ) => (
+										<SuggestionItemPlaceholder type={ itemType } key={ i } />
+									) ) }
 							</ItemGrouper>
 						</>
 
@@ -332,7 +340,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					</div>
 				</div>
 			) }
-			{ showDomainSuggestionsEmpty && (
+			{ showDomainSuggestionsEmpty && ! areDependenciesLoading && (
 				<div className="domain-picker__empty-state">
 					<p className="domain-picker__empty-state--text">
 						{ __(

--- a/packages/domain-picker/src/domain-picker/suggestion-item-placeholder.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item-placeholder.tsx
@@ -2,10 +2,14 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
+import classnames from 'classnames';
+import type { SUGGESTION_ITEM_TYPE } from './suggestion-item';
 
-const DomainPickerSuggestionItemPlaceholder: FunctionComponent = () => {
+const DomainPickerSuggestionItemPlaceholder: FunctionComponent< {
+	type: SUGGESTION_ITEM_TYPE;
+} > = ( { type } ) => {
 	return (
-		<div className="domain-picker__suggestion-item placeholder">
+		<div className={ classnames( 'domain-picker__suggestion-item placeholder', `type-${ type }` ) }>
 			<div className="domain-picker__suggestion-item-name placeholder" />
 			<div className="domain-picker__price placeholder"></div>
 		</div>

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -101,7 +101,7 @@ type DomainStepProps = CommonStepProps & { hasPaidDomain?: boolean } & Pick<
 		| 'onDomainSelect'
 		| 'onExistingSubdomainSelect'
 		| 'locale'
-	>;
+	> & { isLoading: boolean };
 
 const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 	stepIndex,
@@ -112,6 +112,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 	onDomainSelect,
 	onExistingSubdomainSelect,
 	locale,
+	isLoading,
 } ) => {
 	return (
 		<SummaryStep
@@ -173,6 +174,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 									</p>
 								</>
 							}
+							areDependenciesLoading={ isLoading }
 							existingSubdomain={ existingSubdomain }
 							currentDomain={ currentDomain }
 							onDomainSelect={ onDomainSelect }
@@ -437,7 +439,7 @@ const Summary: React.FunctionComponent = () => {
 	const { sitePrimaryDomain, siteSubdomain, hasPaidDomain } = useSiteDomains();
 	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
 	const { setDomain, unsetDomain } = useDispatch( LAUNCH_STORE );
-	const domainSearch = useDomainSearch();
+	const { domainSearch, isLoading } = useDomainSearch();
 
 	const site = useSite();
 
@@ -467,7 +469,7 @@ const Summary: React.FunctionComponent = () => {
 		<SiteTitleStep
 			stepIndex={ forwardStepIndex ? stepIndex : undefined }
 			key={ stepIndex }
-			value={ title }
+			value={ title || '' }
 			onChange={ updateTitle }
 			onBlur={ saveTitle }
 		/>
@@ -482,6 +484,7 @@ const Summary: React.FunctionComponent = () => {
 			initialDomainSearch={ domainSearch }
 			hasPaidDomain={ hasPaidDomain }
 			onDomainSelect={ setDomain }
+			isLoading={ isLoading }
 			/** NOTE: this makes the assumption that the user has a free domain,
 			 * thus when they click the free domain, we just remove the value from the store
 			 * this is a valid strategy in this context because they won't even see this step if

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -93,7 +93,7 @@ const SiteTitleStep: React.FunctionComponent< SiteTitleStepProps > = ( {
 
 // Props in common between all summary steps + a few props from <DomainPicker> +
 // the remaining extra props
-type DomainStepProps = CommonStepProps & { hasPaidDomain?: boolean } & Pick<
+type DomainStepProps = CommonStepProps & { hasPaidDomain?: boolean; isLoading: boolean } & Pick<
 		React.ComponentProps< typeof DomainPicker >,
 		| 'existingSubdomain'
 		| 'currentDomain'
@@ -101,7 +101,7 @@ type DomainStepProps = CommonStepProps & { hasPaidDomain?: boolean } & Pick<
 		| 'onDomainSelect'
 		| 'onExistingSubdomainSelect'
 		| 'locale'
-	> & { isLoading: boolean };
+	>;
 
 const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 	stepIndex,

--- a/packages/launch/src/hooks/use-domain-search.ts
+++ b/packages/launch/src/hooks/use-domain-search.ts
@@ -12,8 +12,8 @@ import { isDefaultSiteTitle } from '../utils';
 
 export function useDomainSearch(): { domainSearch: string; isLoading: boolean } {
 	const { domainSearch } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
-	const { title, isLoading: isTitleLoading } = useTitle();
-	const { currentDomainName, isLoading: isSiteLoading } = useSite();
+	const { title } = useTitle();
+	const { currentDomainName, isLoadingSite } = useSite();
 
 	let search = domainSearch.trim() || title;
 
@@ -23,6 +23,6 @@ export function useDomainSearch(): { domainSearch: string; isLoading: boolean } 
 
 	return {
 		domainSearch: search,
-		isLoading: isTitleLoading || isSiteLoading,
+		isLoading: isLoadingSite,
 	};
 }

--- a/packages/launch/src/hooks/use-domain-search.ts
+++ b/packages/launch/src/hooks/use-domain-search.ts
@@ -10,10 +10,10 @@ import { LAUNCH_STORE } from '../stores';
 import { useSite, useTitle } from './';
 import { isDefaultSiteTitle } from '../utils';
 
-export function useDomainSearch(): string {
+export function useDomainSearch(): { domainSearch: string; isLoading: boolean } {
 	const { domainSearch } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
-	const { title } = useTitle();
-	const { currentDomainName } = useSite();
+	const { title, isLoading: isTitleLoading } = useTitle();
+	const { currentDomainName, isLoading: isSiteLoading } = useSite();
 
 	let search = domainSearch.trim() || title;
 
@@ -21,5 +21,8 @@ export function useDomainSearch(): string {
 		search = currentDomainName?.split( '.' )[ 0 ] ?? '';
 	}
 
-	return search;
+	return {
+		domainSearch: search,
+		isLoading: isTitleLoading || isSiteLoading,
+	};
 }

--- a/packages/launch/src/hooks/use-domain-suggestion.ts
+++ b/packages/launch/src/hooks/use-domain-suggestion.ts
@@ -11,7 +11,7 @@ import { DOMAIN_SUGGESTIONS_STORE } from '../stores';
 import { useDomainSearch } from './';
 
 export function useDomainSuggestion(): DomainSuggestions.DomainSuggestion | undefined {
-	const domainSearch = useDomainSearch();
+	const { domainSearch } = useDomainSearch();
 
 	const suggestion = useSelect(
 		( select ) => {

--- a/packages/launch/src/hooks/use-site.ts
+++ b/packages/launch/src/hooks/use-site.ts
@@ -14,10 +14,7 @@ export function useSite() {
 	const { siteId } = React.useContext( LaunchContext );
 	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
 	const launchStatus = useSelect( ( select ) => select( SITE_STORE ).isLaunched( siteId ) );
-
-	const isLoading: boolean = useSelect( ( select ) =>
-		select( 'core/data' ).isResolving( SITE_STORE, 'getSite', [ siteId ] )
-	);
+	const isLoading = useSelect( ( select ) => select( SITE_STORE ).isFetchingSiteDetails() );
 
 	return {
 		sitePlan: site?.plan,
@@ -25,6 +22,6 @@ export function useSite() {
 		launchStatus,
 		currentDomainName: site?.URL && new URL( site?.URL ).hostname,
 		selectedFeatures: site?.options?.selected_features,
-		isLoading,
+		isLoadingSite: !! isLoading,
 	};
 }

--- a/packages/launch/src/hooks/use-site.ts
+++ b/packages/launch/src/hooks/use-site.ts
@@ -15,11 +15,16 @@ export function useSite() {
 	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
 	const launchStatus = useSelect( ( select ) => select( SITE_STORE ).isLaunched( siteId ) );
 
+	const isLoading: boolean = useSelect( ( select ) =>
+		select( 'core/data' ).isResolving( SITE_STORE, 'getSite', [ siteId ] )
+	);
+
 	return {
 		sitePlan: site?.plan,
 		isPaidPlan: site && ! site.plan?.is_free, // sometimes plan will not be available: https://github.com/Automattic/wp-calypso/pull/44895
 		launchStatus,
 		currentDomainName: site?.URL && new URL( site?.URL ).hostname,
 		selectedFeatures: site?.options?.selected_features,
+		isLoading,
 	};
 }

--- a/packages/launch/src/hooks/use-title.ts
+++ b/packages/launch/src/hooks/use-title.ts
@@ -13,10 +13,16 @@ import LaunchContext from '../context';
 export function useTitle() {
 	const { siteId } = useContext( LaunchContext );
 	const title = useSelect( ( select ) => select( SITE_STORE ).getSiteTitle( siteId ) );
-	const [ localStateTitle, setLocalStateTitle ] = useState< string >( title || '' );
+	const [ localStateTitle, setLocalStateTitle ] = useState< string | undefined >( title );
+
+	// watch get site (as opposed  to getSiteTitle) because the underlying resolver belongs to getSite
+	const isLoading: boolean =
+		useSelect( ( select ) =>
+			select( 'core/data' ).isResolving( SITE_STORE, 'getSite', [ siteId ] )
+		) || typeof title === 'undefined';
 
 	useEffect( () => {
-		setLocalStateTitle( title || '' );
+		setLocalStateTitle( title );
 	}, [ title ] );
 
 	const saveSiteTitle = useDispatch( SITE_STORE ).saveSiteTitle;
@@ -40,5 +46,6 @@ export function useTitle() {
 		},
 		isSiteTitleStepVisible,
 		showSiteTitleStep,
+		isLoading,
 	};
 }

--- a/packages/launch/src/hooks/use-title.ts
+++ b/packages/launch/src/hooks/use-title.ts
@@ -15,12 +15,6 @@ export function useTitle() {
 	const title = useSelect( ( select ) => select( SITE_STORE ).getSiteTitle( siteId ) );
 	const [ localStateTitle, setLocalStateTitle ] = useState< string | undefined >( title );
 
-	// watch get site (as opposed  to getSiteTitle) because the underlying resolver belongs to getSite
-	const isLoading: boolean =
-		useSelect( ( select ) =>
-			select( 'core/data' ).isResolving( SITE_STORE, 'getSite', [ siteId ] )
-		) || typeof title === 'undefined';
-
 	useEffect( () => {
 		setLocalStateTitle( title );
 	}, [ title ] );
@@ -46,6 +40,5 @@ export function useTitle() {
 		},
 		isSiteTitleStepVisible,
 		showSiteTitleStep,
-		isLoading,
 	};
 }

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -12,7 +12,7 @@ export const isDefaultSiteTitle = ( {
 	currentSiteTitle = '',
 	exact = false,
 }: {
-	currentSiteTitle: string;
+	currentSiteTitle: string | undefined;
 	exact?: boolean;
 } ): boolean =>
 	exact


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR changes the domain picker a bit to show an accurate loading state in the focused launch. 

I realize it's a backlog issue, but the loading was terribly janky that it might make the upcoming CfT look bad.

**Before:**
https://cloudup.com/c5uPXDg7x6l

**After:**
![loading state](https://user-images.githubusercontent.com/17054134/99440573-0e8c6280-2917-11eb-85ec-0368a17deb1b.gif)


#### Testing instructions

1. In apps/editing-toolkit run `yarn dev --sync`.
2. Sandbox YOUR_SITE.wordpress.com.
3. Visit https://YOUR_SITE.wordpress.com/wp-admin/post-new.php.
4. In console, type `wp.data.dispatch('automattic/launch' ).openFocusedLaunch()`.
5. You should see loading similar to the one in the GIF above.

Fixes https://github.com/Automattic/wp-calypso/issues/47410
