### PR TITLE
Inline Help: Update icon, fix focus state outline

### DIFF
--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -154,7 +154,7 @@ class InlineHelp extends Component {
 					title={ translate( 'Help' ) }
 					ref={ this.inlineHelpToggleRef }
 				>
-					<Gridicon icon="help-outline" size={ 36 } />
+					<Gridicon icon="help" size={ 36 } />
 				</Button>
 				{ isPopoverVisible && (
 					<InlineHelpPopover

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -154,7 +154,7 @@ class InlineHelp extends Component {
 					title={ translate( 'Help' ) }
 					ref={ this.inlineHelpToggleRef }
 				>
-					<Gridicon icon="help" size={ 36 } />
+					<Gridicon icon="help" size={ 48 } />
 				</Button>
 				{ isPopoverVisible && (
 					<InlineHelpPopover

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -61,6 +61,8 @@
 	border: 1px solid var( --color-primary-dark );
 	transition: all 0.2s ease-in-out;
 	overflow: visible;
+	width: 40px;
+	height: 40px;
 
 	&::before {
 		width: 28px;
@@ -81,10 +83,10 @@
 
 	.gridicon {
 		fill: var( --color-primary );
-		margin: 0;
+		margin: -3px 0 0 -3px;
 		top: 0;
-		height: 36px;
-		width: 36px;
+		height: 42px;
+		width: 42px;
 
 		> use:first-child,
 		> g:first-child {

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -62,13 +62,25 @@
 	transition: all 0.2s ease-in-out;
 	overflow: visible;
 
+	&::before {
+		width: 28px;
+		height: 28px;
+		display: block;
+		position: absolute;
+		top: 5px;
+		left: 5px;
+		content: '';
+		background: white;
+		border-radius: 100%;
+	}
+
 	&:focus {
 		background-color: var( --color-primary );
 		box-shadow: 0 0 0 2px var( --color-primary-light );
 	}
 
 	.gridicon {
-		fill: var( --color-text-inverted );
+		fill: var( --color-primary );
 		margin: 0;
 		top: 0;
 		height: 36px;
@@ -459,7 +471,7 @@
 .inline-help__results-placeholder-item {
 	height: 16px;
 	margin: 16px 0;
-	border-radius: 16px;
+	border-radius: 16px; /* stylelint-disable-line scales/radii */
 	background-color: var( --color-neutral-0 );
 	color: transparent;
 	animation: inline-help__results-placeholder-loading 2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 ) infinite;

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -70,7 +70,7 @@
 		top: 5px;
 		left: 5px;
 		content: '';
-		background: white;
+		background: var( --color-surface );
 		border-radius: 100%;
 	}
 

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -176,13 +176,24 @@
 
 		.search {
 			border-radius: 2px 2px 0 0;
+			border: 6px solid var( --color-surface );
+
+			&.is-open {
+				width: auto;
+				max-width: 100%;
+			}
 
 			&.is-open.has-focus {
-				box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 6px var( --color-primary-light );
+				box-shadow: none;
+				border-color: var( --color-primary-light );
 
 				@include breakpoint-deprecated( '>660px' ) {
-					box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 4px var( --color-primary-light );
+					box-shadow: none;
 				}
+			}
+
+			@include breakpoint-deprecated( '>660px' ) {
+				border-width: 4px;
 			}
 
 			.search__input {

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -107,7 +107,7 @@ const HelpSearch = ( { searchQuery, hideInlineHelpUI, showInlineHelpUI, openDial
 				<div className="help-search__footer">
 					<a className="help-search__cta" href="/help">
 						<span className="help-search__help-icon">
-							<Gridicon icon="help" size={ 24 } />
+							<Gridicon icon="help" size={ 36 } />
 						</span>
 						{ translate( 'More help' ) }
 						<Gridicon className="help-search__go-icon" icon="chevron-right" size={ 24 } />

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -107,7 +107,7 @@ const HelpSearch = ( { searchQuery, hideInlineHelpUI, showInlineHelpUI, openDial
 				<div className="help-search__footer">
 					<a className="help-search__cta" href="/help">
 						<span className="help-search__help-icon">
-							<Gridicon icon="help-outline" size={ 24 } />
+							<Gridicon icon="help" size={ 24 } />
 						</span>
 						{ translate( 'More help' ) }
 						<Gridicon className="help-search__go-icon" icon="chevron-right" size={ 24 } />

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -50,14 +50,27 @@ $min_results_height: 180px;
 		width: 26px;
 		height: 26px;
 		margin-right: 12px;
+		position: relative;
 
 		background: var( --color-primary );
 		box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
 		border: 1px solid var( --color-primary );
 		border-radius: 100%;
 
+		&::before {
+			width: 18px;
+			height: 18px;
+			display: block;
+			position: absolute;
+			top: 4px;
+			left: 4px;
+			content: '';
+			background: var( --color-surface );
+			border-radius: 100%;
+		}
+
 		.gridicon {
-			fill: var( --color-text-inverted );
+			fill: var( --color-primary );
 			height: 24px;
 			width: 24px;
 			transform: translate( 1px, 1px );
@@ -171,7 +184,7 @@ $min_results_height: 180px;
 	.inline-help__results-placeholder-item {
 		height: 15px;
 		margin: 20px $card_padding_large 0;
-		border-radius: 16px;
+		border-radius: 16px; /* stylelint-disable-line scales/radii */
 		background-color: var( --color-neutral-5 );
 
 		&:first-child {

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -71,9 +71,9 @@ $min_results_height: 180px;
 
 		.gridicon {
 			fill: var( --color-primary );
-			height: 24px;
-			width: 24px;
-			transform: translate( 1px, 1px );
+			height: 28px;
+			width: 28px;
+			transform: translate( -2px, -2px );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the non-border version of the help/info icon for a cleaner look. Also update the same icon on My Home for consistency.
* Use a border color change rather than a box-shadow to avoid the form focus overhanging the container.

**Before** | **After**
--------|-----------
 | <img width="349" alt="Screen Shot 2020-11-17 at 3 28 43 PM" src="https://user-images.githubusercontent.com/2124984/99444116-c3a82600-28e9-11eb-804a-5bf0c9ba112a.png"> | <img width="349" alt="Screen Shot 2020-11-18 at 11 06 36 AM" src="https://user-images.githubusercontent.com/2124984/99555380-3d91eb00-298e-11eb-9702-b1a41d0bc1ae.png"> |
| <img width="372" alt="Screen Shot 2020-11-17 at 3 17 45 PM" src="https://user-images.githubusercontent.com/2124984/99444154-d3c00580-28e9-11eb-85b9-3e94c4108adf.png"> | <img width="271" alt="Screen Shot 2020-11-18 at 11 06 24 AM" src="https://user-images.githubusercontent.com/2124984/99555334-31a62900-298e-11eb-99b9-e5957d421ca9.png"> |

#### Testing instructions

* Switch to this PR
* Look at any screen with the Help icon; you should see visual differences like the above.
* Check out My Home and note visual differences there as well.