### PR TITLE
My home: Remove subheadings

### DIFF
--- a/client/my-sites/customer-home/cards/education/quick-start-video/index.jsx
+++ b/client/my-sites/customer-home/cards/education/quick-start-video/index.jsx
@@ -30,9 +30,6 @@ export const QuickStartVideo = ( { trackQuickStartImpression } ) => {
 
 	return (
 		<div className="quick-start-video">
-			<h2 className="quick-start-video__heading customer-home__section-heading">
-				{ translate( 'Watch this video to get started' ) }
-			</h2>
 			<Card>
 				<div className="quick-start-video__content educational-content">
 					<div className="quick-start-video__content-wrapper educational-content__wrapper">

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -6,6 +6,10 @@
 	}
 }
 
+.go-mobile.card {
+	padding: 16px 24px;
+}
+
 .go-mobile__app-badges {
 	display: flex;
 }

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -14,7 +14,7 @@ $min_results_height: 180px;
 		padding: 16px;
 
 		@include break-mobile {
-			padding: $card_padding_large;
+			padding: 16px 24px;
 		}
 	}
 

--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -84,9 +84,7 @@ export const StatsV2 = ( {
 					<QuerySiteStats siteId={ siteId } statType="statsTopPosts" query={ topPostsQuery } />
 				</>
 			) }
-			<h2 className="stats__heading customer-home__section-heading">
-				{ translate( 'Stats at a glance' ) }
-			</h2>
+
 			<Card>
 				{ isSiteUnlaunched && (
 					<Chart data={ placeholderChartData } isPlaceholder>

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -4,10 +4,6 @@
 	}
 }
 
-.customer-home__main .stats .card-heading {
-	margin-bottom: 4px;
-}
-
 .stats .chart {
 	margin: 0 -16px;
 

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -3,6 +3,7 @@
 	background: var( --color-surface );
 	box-shadow: 0 0 0 1px var( --color-border-subtle );
 	position: relative;
+	margin-bottom: 24px;
 
 	.task__text,
 	.task__illustration {

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 
 /**
@@ -34,8 +33,6 @@ const cardComponents = {
 };
 
 const LearnGrow = ( { cards, trackCards } ) => {
-	const translate = useTranslate();
-
 	useEffect( () => {
 		if ( cards && cards.length ) {
 			trackCards( cards );
@@ -48,9 +45,6 @@ const LearnGrow = ( { cards, trackCards } ) => {
 
 	return (
 		<>
-			<h2 className="learn-grow__heading customer-home__section-heading">
-				{ translate( 'Learn and grow' ) }
-			</h2>
 			<Card className="learn-grow__content">
 				{ cards.map(
 					( card, index ) =>

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -33,8 +32,6 @@ const cardComponents = {
 };
 
 const ManageSite = ( { cards, trackCards } ) => {
-	const translate = useTranslate();
-
 	useEffect( () => {
 		if ( cards && cards.length ) {
 			trackCards( cards );
@@ -47,9 +44,6 @@ const ManageSite = ( { cards, trackCards } ) => {
 
 	return (
 		<>
-			<h2 className="manage-site__heading customer-home__section-heading">
-				{ translate( 'Manage your site' ) }
-			</h2>
 			{ cards.map(
 				( card, index ) =>
 					cardComponents[ card ] &&

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -21,7 +21,6 @@
 
 .customer-home__heading {
 	display: flex;
-	border-bottom: 1px solid var( --color-neutral-5 );
 
 	@include breakpoint-deprecated( '<660px' ) {
 		padding-right: 16px;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -89,8 +89,6 @@
 }
 
 .customer-home__main .card-heading {
-	line-height: 1.3;
-	margin-top: -8px;
 	margin-bottom: 8px;
 }
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -70,6 +70,7 @@
 	& > .foldable-card.card,
 	& > .foldable-card.card.is-expanded {
 		margin-bottom: 24px;
+		margin-top: 0;
 	}
 }
 


### PR DESCRIPTION
#### Proposed changes

Removing the subheadings on My home to decrease the visual clutter on the screen.

**Before:**
![Screen Shot 2020-11-17 at 1 05 40 PM](https://user-images.githubusercontent.com/181733/99450713-f7795080-28d5-11eb-8540-001bb6a04160.png)

**After:**

![Screen Shot 2020-11-17 at 1 05 20 PM](https://user-images.githubusercontent.com/181733/99450760-0cee7a80-28d6-11eb-98d8-6475d5376a62.png)

#### Testing instructions

- Visit My home as a new user, as a returning user, and on each of our plan types.
- Notice the lack of subheadings.
- Does the screen flow? Is any spacing off?
