### PR TITLE
Gutenberg: Fixes for Gutenberg v9.4.1

### DIFF
--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -309,7 +309,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 
 		const cartElement = await this.driver.findElement( this.getCartTotalSelector() );
 
-		const cartText = await cartElement.getText();
+		const cartText = await cartElement.getAttribute( 'innerText' );
 
 		// We need to remove the comma separator first, e.g. 1,024 or 2,048, so `match()` can parse out the whole number properly.
 		const amountMatches = cartText.replace( /,/g, '' ).match( /\d+\.?\d*/g );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { By, Key, until, webdriver } from 'selenium-webdriver';
+
+import webdriver, { By, Key, until } from 'selenium-webdriver';
 import { kebabCase } from 'lodash';
 
 /**

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -170,7 +170,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//div[@aria-label='Options']//button[. = 'Code editor']" )
+			By.xpath(
+				"//div[@aria-label='Options']//button[text()='Code editor']|//button[./span='Code editor']"
+			)
 		);
 
 		// Wait for the code editor element.

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -296,7 +296,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	 * @property {string} title The block title as it appears in the inserter
 	 * @property {string} blockClass The suffix that's part of a wrapper CSS class that's used to select the block button in the inserter.
 	 * Calcualted from the title if not present.
-	 * @property {string} prefix Also used to build the CSS class that's used t o select the block in the inserter.
+	 * @property {string} prefix Also used to build the CSS class that's used to select the block in the inserter.
 	 * @property {string} ariaLabel The aria label text used to select the block element wrapper in the editor. Calculated from the title if not present.
 	 * @property {boolean} initsWithChildFocus Whether or not the block gives focus to its first child upon being created/rendered in the editor.
 	 */

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -354,7 +354,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const selectorAriaLabel = ariaLabel || `Block: ${ title }`;
 
 		const inserterBlockItemSelector = By.css(
-			`.edit-post-layout__inserter-panel .block-editor-inserter__block-list button.editor-block-list-item-${ prefix }${ blockClass }`
+			`.edit-post-layout__inserter-panel .block-editor-block-types-list button.editor-block-list-item-${ prefix }${ blockClass }`
 		);
 
 		let insertedBlockSelector = By.css(

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -169,9 +169,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath(
-				"//div[@aria-label='Options']//button[text()='Code editor']|//button[./span='Code editor']"
-			)
+			By.xpath( "//div[@aria-label='Options']//button[. = 'Code editor']" )
 		);
 
 		// Wait for the code editor element.

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -275,6 +275,21 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.waitTillNotPresent( this.driver, inserterMenuSelector );
 	}
 
+	/**
+	 * Returns a list of titles for the block items currently shown in the main inserter.
+	 *
+	 * @returns {string[]} Array of block titles (i.e ['Open Table', 'Paypal']);
+	 */
+	async getShownBlockInserterItems() {
+		return this.driver
+			.findElements(
+				By.css(
+					'.edit-post-layout__inserter-panel .block-editor-block-types-list span.block-editor-block-types-list__item-title'
+				)
+			)
+			.then( ( els ) => Promise.all( els.map( ( el ) => el.getAttribute( 'innerText' ) ) ) );
+	}
+
 	// return blockID - top level block id which is looks like `block-b91ce479-fb2d-45b7-ad92-22ae7a58cf04`. Should be used for further interaction with added block.
 	async addBlock( title ) {
 		title = title.charAt( 0 ).toUpperCase() + title.slice( 1 ); // Capitalize block name

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -294,7 +294,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async addBlock( title ) {
 		title = title.charAt( 0 ).toUpperCase() + title.slice( 1 ); // Capitalize block name
 		let blockClass = kebabCase( title.toLowerCase() );
-		let hasChildBlocks = false;
+		const initsWithChildFocus = false;
 		let ariaLabel;
 		let prefix = '';
 		switch ( title ) {
@@ -324,7 +324,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				break;
 			case 'Pricing Table':
 				prefix = 'coblocks-';
-				hasChildBlocks = false;
 				break;
 			case 'Logos':
 				prefix = 'coblocks-';
@@ -351,7 +350,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				break;
 			case 'Contact Info':
 				prefix = 'jetpack-';
-				hasChildBlocks = true;
 				break;
 			case 'Slideshow':
 				prefix = 'jetpack-';
@@ -376,7 +374,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		let insertedBlockSelector = By.css(
 			`.block-editor-block-list__block.${
-				hasChildBlocks ? 'has-child-selected' : 'is-selected'
+				initsWithChildFocus ? 'has-child-selected' : 'is-selected'
 			}[aria-label*='${ selectorAriaLabel }']`
 		);
 
@@ -398,9 +396,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		// The normal click is needed to avoid hovering the element, which seems
 		// to cause the element to become stale.
 		await driverHelper.clickWhenClickable( this.driver, inserterBlockItemSelector );
-
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, insertedBlockSelector );
-		return await this.driver.findElement( insertedBlockSelector ).getAttribute( 'id' );
+
+		return this.driver.findElement( insertedBlockSelector ).getAttribute( 'id' );
 	}
 
 	/**

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -169,7 +169,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//div[@aria-label='Options']//button[text()='Code editor']" )
+			By.xpath(
+				"//div[@aria-label='Options']//button[text()='Code editor']|//button[./span='Code editor']"
+			)
 		);
 
 		// Wait for the code editor element.

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -315,6 +315,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			title: title.charAt( 0 ).toUpperCase() + title.slice( 1 ), // Capitalize block name
 			blockClass: kebabCase( title.toLowerCase() ),
 			initsWithChildFocus: false,
+			ariaLabel: `Block: ${ title }`,
+			prefix: '',
 		};
 
 		let blockSettings;
@@ -379,8 +381,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			title
 		);
 
-		const selectorAriaLabel = ariaLabel || `Block: ${ title }`;
-
 		// TODO Remove the `deprecatedInserterBlockItemSelector` definition and usage after we activate GB 9.4.0 on production.
 		const deprecatedInserterBlockItemSelector = `.edit-post-layout__inserter-panel .block-editor-inserter__block-list button.editor-block-list-item-${ prefix }${ blockClass }`;
 		const inserterBlockItemSelector = By.css(
@@ -390,15 +390,12 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		let insertedBlockSelector = By.css(
 			`.block-editor-block-list__block.${
 				initsWithChildFocus ? 'has-child-selected' : 'is-selected'
-			}[aria-label*='${ selectorAriaLabel }']`
+			}[aria-label*='${ ariaLabel }']`
 		);
 
 		// @TODO: Remove this condition when Gutenberg v9.1 is deployed for all sites.
 		if ( title === 'Heading' ) {
-			const deprecatedSelector = insertedBlockSelector.value.replace(
-				selectorAriaLabel,
-				'Write heading…'
-			);
+			const deprecatedSelector = insertedBlockSelector.value.replace( ariaLabel, 'Write heading…' );
 			insertedBlockSelector = By.css( `${ insertedBlockSelector.value }, ${ deprecatedSelector }` );
 		}
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -368,8 +368,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		const selectorAriaLabel = ariaLabel || `Block: ${ title }`;
 
+		// TODO Remove the `deprecatedInserterBlockItemSelector` definition and usage after we activate GB 9.4.0 on production.
+		const deprectedInserterBlockItemSelector = `.edit-post-layout__inserter-panel .block-editor-inserter__block-list button.editor-block-list-item-${ prefix }${ blockClass }`;
 		const inserterBlockItemSelector = By.css(
-			`.edit-post-layout__inserter-panel .block-editor-block-types-list button.editor-block-list-item-${ prefix }${ blockClass }`
+			`.edit-post-layout__inserter-panel .block-editor-block-types-list button.editor-block-list-item-${ prefix }${ blockClass }, ${ deprectedInserterBlockItemSelector }`
 		);
 
 		let insertedBlockSelector = By.css(

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { By, Key, until } from 'selenium-webdriver';
+import { By, Key, until, webdriver } from 'selenium-webdriver';
 import { kebabCase } from 'lodash';
 
 /**
@@ -285,7 +285,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 					'.edit-post-layout__inserter-panel .block-editor-block-types-list span.block-editor-block-types-list__item-title'
 				)
 			)
-			.then( ( els ) => Promise.all( els.map( ( el ) => el.getAttribute( 'innerText' ) ) ) );
+			.then( ( els ) => webdriver.promise.map( els, ( el ) => el.getAttribute( 'innerText' ) ) );
 	}
 
 	/**

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -363,7 +363,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				blockSettings = { prefix: 'a8c-' };
 				break;
 			case 'Subscription Form':
-				blockSettings = { prefix: 'jetpack', blockClass: 'subscriptions' };
+				blockSettings = { prefix: 'jetpack-', blockClass: 'subscriptions' };
 				break;
 			case 'Layout Grid':
 			case 'Tiled Gallery':

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -384,23 +384,17 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			title
 		);
 
-		// TODO Remove the `deprecatedInserterBlockItemSelector` definition and usage after we activate GB 9.4.0 on production.
+		// @TODO Remove the `deprecatedInserterBlockItemSelector` definition and usage after we activate GB 9.4.1 on production.
 		const deprecatedInserterBlockItemSelector = `.edit-post-layout__inserter-panel .block-editor-inserter__block-list button.editor-block-list-item-${ prefix }${ blockClass }`;
 		const inserterBlockItemSelector = By.css(
 			`.edit-post-layout__inserter-panel .block-editor-block-types-list button.editor-block-list-item-${ prefix }${ blockClass }, ${ deprecatedInserterBlockItemSelector }`
 		);
 
-		let insertedBlockSelector = By.css(
+		const insertedBlockSelector = By.css(
 			`.block-editor-block-list__block.${
 				initsWithChildFocus ? 'has-child-selected' : 'is-selected'
 			}[aria-label*='${ ariaLabel }']`
 		);
-
-		// @TODO: Remove this condition when Gutenberg v9.1 is deployed for all sites.
-		if ( title === 'Heading' ) {
-			const deprecatedSelector = insertedBlockSelector.value.replace( ariaLabel, 'Write heading…' );
-			insertedBlockSelector = By.css( `${ insertedBlockSelector.value }, ${ deprecatedSelector }` );
-		}
 
 		await this.openBlockInserterAndSearch( title );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -284,16 +284,18 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				await gEditorComponent.openBlockInserterAndSearch( 'earn' );
 				const shownItems = await gEditorComponent.getShownBlockInserterItems();
 
-				assert.strictEqual(
-					[
-						'Donations',
-						'OpenTable',
-						'Payments',
-						'Pay with PayPal',
-						'Premium Content',
-						'Pricing Table',
-					].every( ( v ) => shownItems.includes( v ) ),
-					true
+				[
+					'Donations',
+					'OpenTable',
+					'Payments',
+					'Pay with PayPal',
+					'Premium Content',
+					'Pricing Table',
+				].forEach( ( block ) =>
+					assert.ok(
+						shownItems.includes( block ),
+						`Block inserter doesn't show the ${ block } block`
+					)
 				);
 
 				await gEditorComponent.closeBlockInserter();
@@ -304,25 +306,27 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				await gEditorComponent.openBlockInserterAndSearch( 'grow' );
 				const shownItems = await gEditorComponent.getShownBlockInserterItems();
 
-				assert.strictEqual(
-					[
-						'Business Hours',
-						'Calendly',
-						'Form',
-						'Contact Info',
-						'Mailchimp',
-						'Revue',
-						'Subscription Form',
-						'Click to Tweet',
-						'Logos',
-						'Contact Form',
-						'RSVP Form',
-						'Registration Form',
-						'Appointment Form',
-						'Feedback Form',
-						'WhatsApp Button',
-					].every( ( v ) => shownItems.includes( v ) ),
-					true
+				[
+					'Business Hours',
+					'Calendly',
+					'Form',
+					'Contact Info',
+					'Mailchimp',
+					'Revue',
+					'Subscription Form',
+					'Click to Tweet',
+					'Logos',
+					'Contact Form',
+					'RSVP Form',
+					'Registration Form',
+					'Appointment Form',
+					'Feedback Form',
+					'WhatsApp Button',
+				].forEach( ( block ) =>
+					assert.ok(
+						shownItems.includes( block ),
+						`Block inserter doesn't show the ${ block } block`
+					)
 				);
 
 				await gEditorComponent.closeBlockInserter();

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -282,17 +282,19 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			step( 'Can see the Earn blocks', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.openBlockInserterAndSearch( 'earn' );
+				const shownItems = await gEditorComponent.getShownBlockInserterItems();
 
-				// With deepEqual we're also testing the sort order they're shown in the
-				// inserter. If that's not desirable, we can use the sameMembers matcher.
-				assert.deepEqual( await gEditorComponent.getShownBlockInserterItems(), [
-					'Donations',
-					'OpenTable',
-					'Payments',
-					'Pay with PayPal',
-					'Premium Content',
-					'Pricing Table',
-				] );
+				assert.strictEqual(
+					[
+						'Donations',
+						'OpenTable',
+						'Payments',
+						'Pay with PayPal',
+						'Premium Content',
+						'Pricing Table',
+					].every( ( v ) => shownItems.includes( v ) ),
+					true
+				);
 
 				await gEditorComponent.closeBlockInserter();
 			} );
@@ -300,24 +302,28 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			step( 'Can see the Grow blocks', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.openBlockInserterAndSearch( 'grow' );
+				const shownItems = await gEditorComponent.getShownBlockInserterItems();
 
-				assert.deepEqual( await gEditorComponent.getShownBlockInserterItems(), [
-					'Business Hours',
-					'Calendly',
-					'Form',
-					'Contact Info',
-					'Mailchimp',
-					'Revue',
-					'Subscription Form',
-					'Click to Tweet',
-					'Logos',
-					'Contact Form',
-					'RSVP Form',
-					'Registration Form',
-					'Appointment Form',
-					'Feedback Form',
-					'WhatsApp Button',
-				] );
+				assert.strictEqual(
+					[
+						'Business Hours',
+						'Calendly',
+						'Form',
+						'Contact Info',
+						'Mailchimp',
+						'Revue',
+						'Subscription Form',
+						'Click to Tweet',
+						'Logos',
+						'Contact Form',
+						'RSVP Form',
+						'Registration Form',
+						'Appointment Form',
+						'Feedback Form',
+						'WhatsApp Button',
+					].every( ( v ) => shownItems.includes( v ) ),
+					true
+				);
 
 				await gEditorComponent.closeBlockInserter();
 			} );

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -282,22 +282,43 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			step( 'Can see the Earn blocks', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.openBlockInserterAndSearch( 'earn' );
-				assert.strictEqual(
-					await gEditorComponent.isBlockCategoryPresent( 'Earn' ),
-					true,
-					'Earn (Jetpack) blocks are not present'
-				);
+
+				// With deepEqual we're also testing the sort order they're shown in the
+				// inserter. If that's not desirable, we can use the sameMembers matcher.
+				assert.deepEqual( await gEditorComponent.getShownBlockInserterItems(), [
+					'Donations',
+					'OpenTable',
+					'Payments',
+					'Pay with PayPal',
+					'Premium Content',
+					'Pricing Table',
+				] );
+
 				await gEditorComponent.closeBlockInserter();
 			} );
 
 			step( 'Can see the Grow blocks', async function () {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.openBlockInserterAndSearch( 'grow' );
-				assert.strictEqual(
-					await gEditorComponent.isBlockCategoryPresent( 'Grow' ),
-					true,
-					'Grow (Jetpack) blocks are not present'
-				);
+
+				assert.deepEqual( await gEditorComponent.getShownBlockInserterItems(), [
+					'Business Hours',
+					'Calendly',
+					'Form',
+					'Contact Info',
+					'Mailchimp',
+					'Revue',
+					'Subscription Form',
+					'Click to Tweet',
+					'Logos',
+					'Contact Form',
+					'RSVP Form',
+					'Registration Form',
+					'Appointment Form',
+					'Feedback Form',
+					'WhatsApp Button',
+				] );
+
 				await gEditorComponent.closeBlockInserter();
 			} );
 


### PR DESCRIPTION
### TODO

- [x] Fix tests while keeping them compatible with GB < 9.4

This also includes some additional improvements as per the discussion [here](https://github.com/Automattic/wp-calypso/pull/47723#discussion_r530995080). 