### PR TITLE
Purchases: Add contextual inline help for site-level purchases

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -277,6 +277,33 @@ const getContextLinksForSection = () => ( {
 			),
 		},
 	],
+	'site-purchases': [
+		{
+			link: localizeUrl( 'https://wordpress.com/support/manage-purchases/' ),
+			post_id: 111349,
+			title: translate( 'Managing Purchases, Renewals, and Cancellations' ),
+			description: translate(
+				'Have a question or need to change something about a purchase you have made? Learn how.'
+			),
+		},
+		{
+			link: localizeUrl( 'https://wordpress.com/support/auto-renewal/' ),
+			post_id: 110924,
+			title: translate( 'Subscriptions for Plans and Domains' ),
+			description: translate(
+				'Your WordPress.com plans and any domains you add to your sites are based ' +
+					'on a yearly subscription that renews automatically.'
+			),
+		},
+		{
+			link: localizeUrl( 'https://wordpress.com/support/discover-the-wordpress-com-plans/' ),
+			post_id: 140323,
+			title: translate( 'Explore the WordPress.com Plans' ),
+			description: translate(
+				"Upgrading your plan unlocks a ton of features! We'll help you pick the best fit for your needs and goals."
+			),
+		},
+	],
 	'notification-settings': [
 		{
 			link: localizeUrl( 'https://wordpress.com/support/notifications/' ),

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -151,7 +151,8 @@ function HelpSearchResults( {
 			! isSearching &&
 			! hasAPIResults &&
 			! hasPurchases &&
-			sectionName !== 'purchases'
+			sectionName !== 'purchases' &&
+			sectionName !== 'site-purchases'
 		) {
 			return null;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds contextual inline help for the site-level purchase screens.

**Before**
![image](https://user-images.githubusercontent.com/6981253/99463321-7afd6680-2903-11eb-976e-348b94d26964.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/99463299-6f11a480-2903-11eb-8aff-35370f5fa303.png)


#### Testing instructions

* Visit the site and account level purchase screens and confirm that they both have the same contextual help links when you expand the help.

Fixes: https://github.com/Automattic/wp-calypso/issues/47359