### PR TITLE
Proof of Concept: Config Enable/Disable API

### DIFF
--- a/client/config/index.js
+++ b/client/config/index.js
@@ -73,3 +73,5 @@ const configApi = createConfig( configData );
 
 export default configApi;
 export const isEnabled = configApi.isEnabled;
+export const enable = configApi.enable;
+export const disable = configApi.disable;

--- a/client/lib/create-config/index.js
+++ b/client/lib/create-config/index.js
@@ -66,9 +66,23 @@ const config = ( data ) => ( key ) => {
 const isEnabled = ( data ) => ( feature ) =>
 	( data.features && !! data.features[ feature ] ) || false;
 
+const enable = ( data ) => ( feature ) => {
+	if ( data.features ) {
+		data.features[ feature ] = true;
+	}
+};
+
+const disable = ( data ) => ( feature ) => {
+	if ( data.features ) {
+		data.features[ feature ] = false;
+	}
+};
+
 module.exports = ( data ) => {
 	const configApi = config( data );
 	configApi.isEnabled = isEnabled( data );
+	configApi.enable = enable( data );
+	configApi.disable = disable( data );
 
 	return configApi;
 };

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -12,6 +12,7 @@
  */
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,8 +31,10 @@ import Spinner from 'calypso/components/spinner';
 import { itemLinkMatches } from '../sidebar/utils';
 import { getSidebarIsCollapsed } from 'calypso/state/ui/selectors';
 import './style.scss';
+import config from 'calypso/config';
 
 export const MySitesSidebarUnified = ( { path } ) => {
+	const [ renderCount, setRenderCount ] = useState( 0 );
 	const menuItems = useSiteMenuItems();
 	const isAllDomainsView = useDomainsViewStatus();
 	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
@@ -75,6 +78,34 @@ export const MySitesSidebarUnified = ( { path } ) => {
 				return <MySitesSidebarUnifiedItem key={ item.slug } selected={ isSelected } { ...item } />;
 			} ) }
 			<CollapseSidebar key="collapse" title="Collapse menu" icon="dashicons-admin-collapse" />
+			<li>
+				Feature "foo" is: { config.isEnabled( 'foo' ) ? 'ON' : 'OFF' }
+				<br />
+				<span
+					role="link"
+					tabIndex={ -10 }
+					onKeyDown={ () => setRenderCount( renderCount + 1 ) /* Pass accessibility lint */ }
+					onClick={ () => {
+						config.enable( 'foo' );
+						setRenderCount( renderCount + 1 ); // Force Rerender, since config changes don't
+					} }
+				>
+					Click to Enable
+				</span>
+				<br />
+				<span
+					role="link"
+					tabIndex={ -11 }
+					onKeyDown={ () => setRenderCount( renderCount + 1 ) }
+					onClick={ () => {
+						config.disable( 'foo' );
+						setRenderCount( renderCount + 1 ); // Force Rerender, since config changes don't
+					} }
+				>
+					Click to Disable
+				</span>
+				<br />
+			</li>
 		</Sidebar>
 	);
 };


### PR DESCRIPTION
Proof of Concept: Config Enable/Disable API

### Testing Instructions

* Visit calypso with nav-unification turned on
* Look at the bottom of the sidebar, click on the poorly decorated links to set the config variable on and off
![2020-11-17_17-59](https://user-images.githubusercontent.com/937354/99464873-c5301900-28fe-11eb-91df-94adc5a37f7d.png)
