### PR TITLE
Reader Lists: order lists by title in sidebar

### DIFF
--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -41,7 +41,6 @@ export class ReaderSidebarLists extends Component {
 					title={ translate( 'Lists' ) }
 					onClick={ onClick }
 					materialIcon={ 'list' }
-					hideAddButton
 				>
 					<li>
 						<ReaderSidebarListsList { ...passedProps } />

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -45,23 +45,25 @@ export class ReaderSidebarListsListItem extends Component {
 		const { list, translate } = this.props;
 		const listRelativeUrl = `/read/list/${ list.owner }/${ list.slug }`;
 		const listManagementUrls = [
-			listRelativeUrl + '/tags',
+			listRelativeUrl + '/items',
 			listRelativeUrl + '/edit',
-			listRelativeUrl + '/sites',
+			listRelativeUrl + '/export',
+			listRelativeUrl + '/delete',
 		];
 
 		const lastPathSegment = last( this.props.path.split( '/' ) );
 		const isCurrentList =
 			lastPathSegment &&
+			// Prevents partial slug matches (e.g. bluefuton/test and bluefuton/test2)
 			lastPathSegment.toLowerCase() === list.slug.toLowerCase() &&
 			ReaderSidebarHelper.pathStartsWithOneOf( [ listRelativeUrl ], this.props.path );
-		const isActionButtonSelected = ReaderSidebarHelper.pathStartsWithOneOf(
+		const isCurrentListManage = ReaderSidebarHelper.pathStartsWithOneOf(
 			listManagementUrls,
 			this.props.path
 		);
 
 		const classes = classNames( 'sidebar__menu-item--reader-list', {
-			selected: isCurrentList || isActionButtonSelected,
+			selected: isCurrentList || isCurrentListManage,
 		} );
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -63,9 +63,10 @@ export const getSubscribedLists = createSelector(
 		sortBy(
 			filter( state.reader.lists.items, ( item ) => {
 				// Is the user subscribed to this list?
-				return includes( state.reader.lists.subscribedLists, item.ID );
+				return state.reader.lists.subscribedLists.includes( item.ID );
 			} ),
-			'slug'
+			// Enable case-insensitive sort by title
+			( item ) => item.title?.toLowerCase()
 		),
 	( state ) => [ state.reader.lists.items, state.reader.lists.subscribedLists ]
 );

--- a/client/state/reader/lists/test/selectors.js
+++ b/client/state/reader/lists/test/selectors.js
@@ -85,7 +85,7 @@ describe( 'selectors', () => {
 			expect( subscribedLists ).toEqual( [] );
 		} );
 
-		test( 'should retrieve items in a-z slug order', () => {
+		test( 'should retrieve items in title order', () => {
 			const subscribedLists = getSubscribedLists( {
 				reader: {
 					lists: {
@@ -93,10 +93,12 @@ describe( 'selectors', () => {
 							123: {
 								ID: 123,
 								slug: 'bananas',
+								title: 'def',
 							},
 							456: {
 								ID: 456,
 								slug: 'ants',
+								title: 'abc',
 							},
 						},
 						subscribedLists: [ 123, 456 ],
@@ -105,8 +107,8 @@ describe( 'selectors', () => {
 			} );
 
 			expect( subscribedLists ).toEqual( [
-				{ ID: 456, slug: 'ants' },
-				{ ID: 123, slug: 'bananas' },
+				{ ID: 456, slug: 'ants', title: 'abc' },
+				{ ID: 123, slug: 'bananas', title: 'def' },
 			] );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reader Lists are currently sorted by slug in the sidebar. This worked fine until the title of lists could be edited. Now that functionality has been added, this PR switches to sort by title instead (case-insensitive).

(Note: ideally, it'd be good if the edited list name scrolls into view. For example, if I have 30 lists and rename "Aaaa" to "Zzzz" it should scroll me to the bottom. I've noted this and will pick it up in a future PR.)

<img width="279" alt="Screen Shot 2020-11-18 at 16 00 38" src="https://user-images.githubusercontent.com/17325/99477371-3f23d900-29b7-11eb-9307-943ea356566f.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Update the title of an existing list. Make sure the sidebar position is updated correctly to reflect the updated title.

