### PR TITLE
Rename close label from My Home to Dashboard

### DIFF
--- a/client/state/selectors/get-editor-close-config.js
+++ b/client/state/selectors/get-editor-close-config.js
@@ -52,7 +52,7 @@ export default function getEditorCloseConfig( state, siteId, postType, fseParent
 	if ( ! lastNonEditorRoute || ! postType || doesRouteMatch( /^\/home\/?/ ) ) {
 		return {
 			url: `/home/${ getSiteSlug( state, siteId ) }`,
-			label: translate( 'My Home' ),
+			label: translate( 'Dashboard' ),
 		};
 	}
 


### PR DESCRIPTION
This is a very small PR to resolve #47054 making it slightly clearer how a user can get to their dashboard.

#### Changes proposed in this Pull Request

* Change the default back button label text in the editor from "My Home" to "Dashboard".

#### Screenshot

![image](https://user-images.githubusercontent.com/14988353/99484806-4a760500-29b5-11eb-85b2-a968a5f57a12.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to create a new site from calypso.localhost:3000/new and once you land in the editor, click on the W icon in the top left. The back button should now say "Dashboard" instead of "My Home"
* Go to the dashboard / Calypso and select Pages and a page of your site. Make sure that the back button still says View Pages.

Note: you don't need to sandbox the editing toolkit plugin for this change, as the text is generated on the Calypso side.

Fixes #47054 
