### PR TITLE
Gutenboarding: Update Title & SubTitle to allow a className prop to be passed

### DIFF
--- a/packages/onboarding/src/titles/index.tsx
+++ b/packages/onboarding/src/titles/index.tsx
@@ -2,15 +2,22 @@
  * External dependencies
  */
 import * as React from 'react';
+import classnames from 'classnames';
 
 import './styles.scss';
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
+interface TitlesProps {
+	className?: string;
+}
 
-export const Title: React.FunctionComponent = ( { children } ) => (
-	<h1 className="onboarding-title">{ children }</h1>
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+export const Title: React.FunctionComponent< TitlesProps > = ( { className, children } ) => (
+	<h1 className={ classnames( 'onboarding-title', className ) }>{ children }</h1>
 );
 
-export const SubTitle: React.FunctionComponent = ( { children } ) => (
-	<h2 className="onboarding-subtitle">{ children }</h2>
+export const SubTitle: React.FunctionComponent< TitlesProps > = ( { className, children } ) => (
+	<h2 className={ classnames( 'onboarding-subtitle', className ) }>
+		{ className }
+		{ children }
+	</h2>
 );

--- a/packages/onboarding/src/titles/index.tsx
+++ b/packages/onboarding/src/titles/index.tsx
@@ -16,8 +16,5 @@ export const Title: React.FunctionComponent< TitlesProps > = ( { className, chil
 );
 
 export const SubTitle: React.FunctionComponent< TitlesProps > = ( { className, children } ) => (
-	<h2 className={ classnames( 'onboarding-subtitle', className ) }>
-		{ className }
-		{ children }
-	</h2>
+	<h2 className={ classnames( 'onboarding-subtitle', className ) }>{ children }</h2>
 );


### PR DESCRIPTION
In order to allow Title & SubTitle components to be more flexible (and reusable) we allow a className prop to be passed. Any className props will be merged with the default class selector.

#### Changes proposed in this Pull Request

* Introduce a `className` prop for `Title` & `SubTitle` components to accept any additional CSS classes.
* Merge provided classes with [classnames](https://www.npmjs.com/package/classnames).

#### Testing instructions

* Check out this branch on your machine and run `yarn`;
* Open `client/landing/gutenboarding/onboarding-block/domains/index.tsx` in an editor;
* Add a className to any `<Title/>` or `<SubTitle/>`;
* use `devTools` to check if the className is passed to the component.

Fixes #47496
