### PR TITLE
Gutenboarding: make ecommerce plan public consistent with start

### DIFF
--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -52,18 +52,7 @@ export function useHasPaidPlanFromPath() {
 }
 
 export function useNewSiteVisibility(): Site.Visibility {
-	const currentSlug = useSelectedPlan()?.storeSlug;
-	const isEcommerce = useSelect( ( select ) =>
-		select( PLANS_STORE ).isPlanEcommerce( currentSlug )
-	);
-
-	if ( isEcommerce ) {
-		return Site.Visibility.PublicIndexed;
-	} else if ( isEnabled( 'coming-soon-v2' ) ) {
-		return Site.Visibility.PublicNotIndexed;
-	}
-
-	return Site.Visibility.Private;
+	return isEnabled( 'coming-soon-v2' ) ? Site.Visibility.PublicNotIndexed : Site.Visibility.Private;
 }
 
 export function useShouldRedirectToEditorAfterCheckout() {


### PR DESCRIPTION
## Changes proposed in this Pull Request

Ecommerce sites have not been created in public by default mode since https://github.com/Automattic/wp-calypso/pull/42039

Gutenboarding has been making them public by default since at least https://github.com/Automattic/wp-calypso/pull/42664

**Question** Which is correct? 

This PR makes things consistent between `/start` and `/new`

## Testing instructions

Create a new site over at `/new`, and select an ecommerce plan. You should land on an unlaunched site in Coming Soon private by default mode.


