### PR TITLE
Jetpack Plans: Add data attributes to "Free" plan card

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card-alt/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card-alt/index.tsx
@@ -63,7 +63,7 @@ const JetpackFreeCardAlt = ( { siteId, urlQueryArgs }: JetpackFreeProps ) => {
 	];
 
 	return (
-		<div className="jetpack-free-card-alt">
+		<div className="jetpack-free-card-alt" data-e2e-product-slug="free">
 			<div className="jetpack-free-card-alt__main">
 				<header>
 					<h2>{ translate( 'Jetpack Free' ) }</h2>

--- a/client/components/jetpack/card/jetpack-free-card-i5/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card-i5/index.tsx
@@ -37,7 +37,7 @@ const JetpackFreeCardAlt: React.FC< JetpackFreeProps > = ( { siteId, urlQueryArg
 		: wpAdminUrl || JPC_PATH_REMOTE_INSTALL;
 
 	return (
-		<div className="jetpack-free-card-i5 jetpack-product-card-i5">
+		<div className="jetpack-free-card-i5 jetpack-product-card-i5" data-e2e-product-slug="free">
 			<header className="jetpack-free-card-i5__header">
 				<h3 className="jetpack-free-card-i5__title">{ translate( 'Jetpack Free' ) }</h3>
 				<p className="jetpack-free-card-i5__subheadline">

--- a/client/components/jetpack/card/jetpack-free-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card/index.tsx
@@ -38,7 +38,7 @@ const JetpackFreeCard = ( { siteId, urlQueryArgs }: JetpackFreeProps ) => {
 	} );
 
 	return (
-		<div className="jetpack-free-card">
+		<div className="jetpack-free-card" data-e2e-product-slug="free">
 			<header className="jetpack-free-card__header">
 				<h3>{ translate( 'Jetpack Free' ) }</h3>
 			</header>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* add `data-e2e-product-slug` to all iterations of "Free" plan cards

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through Jetpack connection
* Once redirected to the plans page, make sure that `data-e2e-product-slug="free"` attribute is present in the Free plan card.
