### PR TITLE
Jetpack Cloud: fix OAuthOverride controller

### DIFF
--- a/client/jetpack-cloud/index.js
+++ b/client/jetpack-cloud/index.js
@@ -44,7 +44,7 @@ const landingController = ( context, next ) => {
 };
 
 export const handleOAuthOverride = () => {
-	debug( 'controller: handleOAuthOverride', context );
+	debug( 'controller: handleOAuthOverride' );
 	startJetpackCloudOAuthOverride();
 	window.location.replace( '/' );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The app throws an error when it hit the line because `context` is not defined. This breaks the `Switch to User (in Jetpack Cloud)` tool.

* Remove the `context` variable from the `debug` call site.

#### Testing instructions

* Code review.
