### PR TITLE
Pricing page i5: prevent duplicate FAQ in connection flow

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -75,6 +75,8 @@ import {
 import { getProductFromSlug } from 'calypso/lib/products-values/get-product-from-slug';
 import { getJetpackProductDisplayName } from 'calypso/lib/products-values/get-jetpack-product-display-name';
 import { externalRedirect } from 'calypso/lib/route/path';
+import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
+import { Iterations } from 'calypso/my-sites/plans-v2/iterations';
 
 /**
  * Module variables
@@ -144,7 +146,11 @@ export function offerResetRedirects( context, next ) {
 export function offerResetContext( context, next ) {
 	debug( 'controller: offerResetContext', context.params );
 	context.header = <StoreHeader />;
-	context.footer = <StoreFooter />;
+
+	if ( getJetpackCROActiveVersion() !== Iterations.I5 ) {
+		context.footer = <StoreFooter />;
+	}
+
 	next();
 }
 

--- a/client/jetpack-connect/store-footer.tsx
+++ b/client/jetpack-connect/store-footer.tsx
@@ -6,16 +6,16 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans-v2/abtest';
-import JetpackFAQ from 'calypso/my-sites/plans-features-main/jetpack-faq';
-import JetpackFAQi5 from 'calypso/my-sites/plans-features-main/jetpack-faq-i5';
+import { getFaqComponent } from 'calypso/my-sites/plans-v2/iterations';
 
-export default function StoreFooter() {
-	const JetpackFAQComponent = getJetpackCROActiveVersion() === 'i5' ? JetpackFAQi5 : JetpackFAQ;
+const StoreFooter: React.FC = () => {
+	const JetpackFAQComponent = getFaqComponent();
 
-	return (
-		<>
-			<JetpackFAQComponent />
-		</>
-	);
-}
+	if ( JetpackFAQComponent ) {
+		return <JetpackFAQComponent />;
+	}
+
+	return null;
+};
+
+export default StoreFooter;

--- a/client/my-sites/plans-features-main/jetpack-faq.jsx
+++ b/client/my-sites/plans-features-main/jetpack-faq.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -29,7 +29,9 @@ export const getHelpLink = ( context ) => {
 	);
 };
 
-const JetpackFAQ = ( { translate } ) => {
+const JetpackFAQ = () => {
+	const translate = useTranslate();
+
 	return (
 		<FAQ>
 			<FAQItem
@@ -82,4 +84,4 @@ const JetpackFAQ = ( { translate } ) => {
 	);
 };
 
-export default localize( JetpackFAQ );
+export default JetpackFAQ;

--- a/client/my-sites/plans-v2/iterations.ts
+++ b/client/my-sites/plans-v2/iterations.ts
@@ -4,6 +4,8 @@
 import ProductsGridAlt from './products-grid-alt';
 import ProductsGridAlt2 from './products-grid-alt-2';
 import ProductsGridI5 from './products-grid-i5';
+import JetpackFAQ from 'calypso/my-sites/plans-features-main/jetpack-faq';
+import JetpackFAQi5 from 'calypso/my-sites/plans-features-main/jetpack-faq-i5';
 
 import SelectorPageAlt from './selector-alt';
 import { getJetpackCROActiveVersion as getIteration } from 'calypso/my-sites/plans-v2/abtest';
@@ -40,6 +42,14 @@ export function getGridComponent(): React.FC< ProductsGridProps > | undefined {
 		[ Iterations.V1 ]: ProductsGridAlt,
 		[ Iterations.V2 ]: ProductsGridAlt2,
 		[ Iterations.I5 ]: ProductsGridI5,
+	}[ getIteration() as Iterations ];
+}
+
+export function getFaqComponent(): React.FC | undefined {
+	return {
+		[ Iterations.V1 ]: JetpackFAQ,
+		[ Iterations.V2 ]: JetpackFAQ,
+		[ Iterations.I5 ]: JetpackFAQi5,
 	}[ getIteration() as Iterations ];
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes the FAQ being show twice in the connection flow.

### Testing instructions

- Download the PR
- Run both Calypso and Jetpack cloud concurrently
- In Calypso, visit `/plans/:site` and `/jetpack/connect/store`, and check that you see the FAQ once
- In Jetpack cloud, visit `/pricing`, and check that you see the FAQ once

### Screenshots

![image](https://user-images.githubusercontent.com/1620183/99558052-518b1c00-2991-11eb-86d6-0874ebf33838.png)
