### PR TITLE
Update desktop to Electron v11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -867,6 +867,9 @@ jobs:
       - store_artifacts:
           when: always
           path: desktop/e2e/logs
+      - store_artifacts:
+          when: always
+          path: desktop/e2e/screenshots
       - persist_to_workspace:
           root: ~/wp-calypso
           paths:

--- a/.teamcity/docker-seccomp.json
+++ b/.teamcity/docker-seccomp.json
@@ -1,0 +1,1535 @@
+{
+	"defaultAction": "SCMP_ACT_ERRNO",
+	"syscalls": [
+		{
+			"name": "accept",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "accept4",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "access",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "alarm",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "arch_prctl",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "bind",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "brk",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "capget",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "capset",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "chdir",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "chmod",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "chown",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "chown32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "chroot",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "clock_getres",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "clock_gettime",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "clock_nanosleep",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "clone",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "close",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "connect",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "creat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "dup",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "dup2",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "dup3",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "epoll_create",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "epoll_create1",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "epoll_ctl",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "epoll_ctl_old",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "epoll_pwait",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "epoll_wait",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "epoll_wait_old",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "eventfd",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "eventfd2",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "execve",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "execveat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "exit",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "exit_group",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "faccessat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fadvise64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fadvise64_64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fallocate",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fanotify_init",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fanotify_mark",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fchdir",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fchmod",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fchmodat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fchown",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fchown32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fchownat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fcntl",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fcntl64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fdatasync",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fgetxattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "flistxattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "flock",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fork",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fremovexattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fsetxattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fstat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fstat64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fstatat64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fstatfs",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fstatfs64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "fsync",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "ftruncate",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "ftruncate64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "futex",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "futimesat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getcpu",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getcwd",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getdents",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getdents64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getegid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getegid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "geteuid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "geteuid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getgid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getgid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getgroups",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getgroups32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getitimer",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getpeername",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getpgid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getpgrp",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getpid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getppid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getpriority",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getrandom",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getresgid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getresgid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getresuid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getresuid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getrlimit",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "get_robust_list",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getrusage",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getsid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getsockname",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getsockopt",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "get_thread_area",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "gettid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "gettimeofday",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getuid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getuid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "getxattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "inotify_add_watch",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "inotify_init",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "inotify_init1",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "inotify_rm_watch",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "io_cancel",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "ioctl",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "io_destroy",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "io_getevents",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "ioprio_get",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "ioprio_set",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "io_setup",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "io_submit",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "kill",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "lchown",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "lchown32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "lgetxattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "link",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "linkat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "listen",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "listxattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "llistxattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "_llseek",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "lremovexattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "lseek",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "lsetxattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "lstat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "lstat64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "madvise",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "memfd_create",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mincore",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mkdir",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mkdirat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mknod",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mknodat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mlock",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mlockall",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mmap",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mmap2",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mprotect",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mq_getsetattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mq_notify",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mq_open",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mq_timedreceive",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mq_timedsend",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mq_unlink",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "mremap",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "msgctl",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "msgget",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "msgrcv",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "msgsnd",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "msync",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "munlock",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "munlockall",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "munmap",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "name_to_handle_at",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "nanosleep",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "newfstatat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "_newselect",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "open",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "open_by_handle_at",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "openat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "pause",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "pipe",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "pipe2",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "poll",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "ppoll",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "prctl",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "pread64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "preadv",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "prlimit64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "pselect6",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "pwrite64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "pwritev",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "read",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "readahead",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "readlink",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "readlinkat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "readv",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "recvfrom",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "recvmmsg",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "recvmsg",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "remap_file_pages",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "removexattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "rename",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "renameat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "renameat2",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "rmdir",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "rt_sigaction",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "rt_sigpending",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "rt_sigprocmask",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "rt_sigqueueinfo",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "rt_sigreturn",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "rt_sigsuspend",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "rt_sigtimedwait",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "rt_tgsigqueueinfo",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sched_getaffinity",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sched_getattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sched_getparam",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sched_get_priority_max",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sched_get_priority_min",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sched_getscheduler",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sched_rr_get_interval",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sched_setaffinity",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sched_setattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sched_setparam",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sched_setscheduler",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sched_yield",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "seccomp",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "select",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "semctl",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "semget",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "semop",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "semtimedop",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sendfile",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sendfile64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sendmmsg",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sendmsg",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sendto",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setdomainname",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setfsgid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setfsgid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setfsuid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setfsuid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setgid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setgid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setgroups",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setgroups32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sethostname",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setitimer",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setns",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setpgid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setpriority",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setregid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setregid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setresgid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setresgid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setresuid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setresuid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setreuid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setreuid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setrlimit",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "set_robust_list",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setsid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setsockopt",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "set_thread_area",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "set_tid_address",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setuid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setuid32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "setxattr",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "shmat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "shmctl",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "shmdt",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "shmget",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "shutdown",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sigaltstack",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "signalfd",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "signalfd4",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "socket",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "socketpair",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "splice",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "stat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "stat64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "statfs",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "statfs64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "symlink",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "symlinkat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sync",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sync_file_range",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "syncfs",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "sysinfo",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "syslog",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "tee",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "tgkill",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "time",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "timer_create",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "timer_delete",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "timerfd_create",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "timerfd_gettime",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "timerfd_settime",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "timer_getoverrun",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "timer_gettime",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "timer_settime",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "times",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "tkill",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "truncate",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "truncate64",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "ugetrlimit",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "umask",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "uname",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "unlink",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "unlinkat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "unshare",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "utime",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "utimensat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "utimes",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "vfork",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "vhangup",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "vmsplice",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "wait4",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "waitid",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "write",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		},
+		{
+			"name": "writev",
+			"action": "SCMP_ACT_ALLOW",
+			"args": null
+		}
+	]
+}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -859,15 +859,19 @@ object WpDesktop_DesktopE2ETests : BuildType({
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 			dockerPull = true
 			dockerImage = "%docker_image_dekstop%"
-			dockerRunParameters = "-u %env.UID%"
+			// See https://stackoverflow.com/a/53975412 and https://blog.jessfraz.com/post/how-to-use-new-docker-seccomp-profiles/
+			// TDLR: Chrome needs access to some kernel level operations to create a sandbox, this option unblocks them.
+			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json"
 		}
 
 		script {
 			name = "Clean up artifacts"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
 			scriptContent = """
-				set -e
-				set -x
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
 
 				# Delete artifacts if branch is not trunk
 				if [ "%teamcity.build.branch.is_default%" != "true" ]; then
@@ -877,9 +881,7 @@ object WpDesktop_DesktopE2ETests : BuildType({
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 			dockerPull = true
 			dockerImage = "%docker_image_dekstop%"
-			// See https://stackoverflow.com/a/53975412 and https://blog.jessfraz.com/post/how-to-use-new-docker-seccomp-profiles/
-			// TDLR: Chrome needs access to some kernel level operations to create a sandbox, this option unblocks them.
-			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json"
+			dockerRunParameters = "-u %env.UID% "
 		}
 	}
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -877,7 +877,9 @@ object WpDesktop_DesktopE2ETests : BuildType({
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 			dockerPull = true
 			dockerImage = "%docker_image_dekstop%"
-			dockerRunParameters = "-u %env.UID%"
+			// See https://stackoverflow.com/a/53975412 and https://blog.jessfraz.com/post/how-to-use-new-docker-seccomp-profiles/
+			// TDLR: Chrome needs access to some kernel level operations to create a sandbox, this option unblocks them.
+			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json"
 		}
 	}
 

--- a/client/desktop/app-handlers/crash-reporting/index.js
+++ b/client/desktop/app-handlers/crash-reporting/index.js
@@ -15,8 +15,10 @@ module.exports = function () {
 			log.info( 'Crash reporter started' );
 
 			crashReporter.start( {
+				globalExtra: {
+					_companyName: Config.author,
+				},
 				productName: Config.description,
-				companyName: Config.author,
 				submitURL: Config.crash_reporter.url,
 				uploadToServer: true,
 			} );

--- a/client/desktop/env.js
+++ b/client/desktop/env.js
@@ -42,6 +42,7 @@ app.setPath( 'userData', appData );
 // Default value of false deprecated in Electron v9
 app.allowRendererProcessReuse = true;
 
+// Fixes rendering bug on Linux when sandbox === true (Electron 11.0)
 if ( process.platform === 'linux' ) {
 	app.disableHardwareAcceleration();
 }

--- a/client/desktop/env.js
+++ b/client/desktop/env.js
@@ -42,6 +42,10 @@ app.setPath( 'userData', appData );
 // Default value of false deprecated in Electron v9
 app.allowRendererProcessReuse = true;
 
+if ( process.platform === 'linux' ) {
+	app.disableHardwareAcceleration();
+}
+
 // Force sandbox: true for all BrowserWindow instances
 app.enableSandbox();
 

--- a/desktop/e2e/run.js
+++ b/desktop/e2e/run.js
@@ -18,8 +18,6 @@ const APP_ARGS = [
 	'--disable-http-cache',
 	'--start-maximized',
 	'--remote-debugging-port=9222',
-	'--disable-setuid-sandbox',
-	'--no-sandbox',
 ];
 
 let BUILT_APP_DIR;

--- a/desktop/e2e/run.js
+++ b/desktop/e2e/run.js
@@ -18,6 +18,7 @@ const APP_ARGS = [
 	'--disable-http-cache',
 	'--start-maximized',
 	'--remote-debugging-port=9222',
+	'--disable-dev-shm-usage',
 ];
 
 let BUILT_APP_DIR;

--- a/desktop/e2e/run.js
+++ b/desktop/e2e/run.js
@@ -20,6 +20,7 @@ const APP_ARGS = [
 	'--remote-debugging-port=9222',
 	'--disable-dev-shm-usage',
 	'--disable-setuid-sandbox',
+	'--no-sandbox',
 ];
 
 let BUILT_APP_DIR;

--- a/desktop/e2e/run.js
+++ b/desktop/e2e/run.js
@@ -19,6 +19,7 @@ const APP_ARGS = [
 	'--start-maximized',
 	'--remote-debugging-port=9222',
 	'--disable-dev-shm-usage',
+	'--disable-setuid-sandbox',
 ];
 
 let BUILT_APP_DIR;

--- a/desktop/e2e/run.js
+++ b/desktop/e2e/run.js
@@ -18,9 +18,6 @@ const APP_ARGS = [
 	'--disable-http-cache',
 	'--start-maximized',
 	'--remote-debugging-port=9222',
-	'--disable-dev-shm-usage',
-	'--disable-setuid-sandbox',
-	'--no-sandbox',
 ];
 
 let BUILT_APP_DIR;

--- a/desktop/e2e/tests/lib/video-recorder.js
+++ b/desktop/e2e/tests/lib/video-recorder.js
@@ -12,8 +12,38 @@ const ffmpeg = require( 'ffmpeg-static' );
 
 const E2E_DIR = path.resolve( __dirname, '../../' );
 
+// Helper to get device/display identifier (Linux)
+function getFreeDisplay() {
+	let i = 0;
+	while ( ! fs.existsSync( `/tmp/.X${ i }-lock` ) && i < 200 ) {
+		i++;
+	}
+	return i;
+}
+
 let file;
 let ffVideo;
+let ffDisplay;
+let ffFileExt;
+let ffFramework;
+let ffVideoSize;
+
+switch ( process.platform ) {
+	case 'darwin':
+		ffDisplay = '0:none';
+		ffVideoSize = '1440x1000';
+		ffFramework = 'avfoundation';
+		ffFileExt = 'mpg';
+		break;
+	case 'linux':
+		ffDisplay = `:${ getFreeDisplay() }`;
+		ffVideoSize = '1280x1024';
+		ffFramework = 'x11grab';
+		ffFileExt = 'mp4';
+		break;
+	default:
+		throw 'unsupported platform!';
+}
 
 exports.createDir = function ( dir ) {
 	dir = path.resolve( dir );
@@ -39,20 +69,20 @@ exports.startVideo = function () {
 		return;
 	}
 	const dateTime = new Date().toISOString().split( '.' )[ 0 ].replace( /:/g, '-' );
-	const fileName = `e2e-test-run-${ dateTime }.mpg`;
+	const fileName = `e2e-test-run-${ dateTime }.${ ffFileExt }`;
 	file = path.join( E2E_DIR, 'screenshots', 'videos', fileName );
 	this.createDir( path.dirname( file ) );
 	ffVideo = child_process.spawn(
 		ffmpeg.path,
 		[
 			'-f',
-			'avfoundation',
+			ffFramework,
 			'-video_size',
-			'1440x1000',
+			ffVideoSize,
 			'-r',
 			30,
 			'-i',
-			'0:none',
+			ffDisplay,
 			'-pix_fmt',
 			'yuv420p',
 			'-loglevel',

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -27,7 +27,7 @@
 	"devDependencies": {
 		"asana-phrase": "0.0.8",
 		"chai": "3.5.0",
-		"electron": "8.3.0",
+		"electron": "11.0.0",
 		"electron-builder": "^22.4.0",
 		"electron-chromedriver": "4.2.0",
 		"electron-mocha": "8.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -30,7 +30,7 @@
 		"electron": "11.0.0",
 		"electron-builder": "^22.4.0",
 		"electron-chromedriver": "4.2.0",
-		"electron-mocha": "8.0.0",
+		"electron-mocha": "9.3.1",
 		"electron-notarize": "^0.1.1",
 		"ffmpeg-static": "2.4.0",
 		"lodash": "^4.17.15",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -42,6 +42,6 @@
 		"selenium-webdriver": "4.0.0-alpha.1"
 	},
 	"dependencies": {
-		"keytar": "6.0.1"
+		"keytar": "7.1.0"
 	}
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -27,7 +27,7 @@
 	"devDependencies": {
 		"asana-phrase": "0.0.8",
 		"chai": "3.5.0",
-		"electron": "11.0.0",
+		"electron": "11.0.4",
 		"electron-builder": "^22.4.0",
 		"electron-chromedriver": "4.2.0",
 		"electron-mocha": "9.3.1",

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -31,6 +31,34 @@
     global-agent "^2.0.2"
     global-tunnel-ng "^2.7.1"
 
+"@shiftkey/node-abi@2.19.2-pre":
+  version "2.19.2-pre"
+  resolved "https://registry.yarnpkg.com/@shiftkey/node-abi/-/node-abi-2.19.2-pre.tgz#02599b37253e414f8f6ef3c67ea704e37da640a9"
+  integrity sha512-+LfXo6nd2uZ8cGSJ66zL3OuddvG2oMWMc9GzpDoX2ZNMLmYpu+ReoEKXtmoKVwd6JSavDymldebCxSJh9NQ9cg==
+  dependencies:
+    semver "^5.4.1"
+
+"@shiftkey/prebuild-install@6.0.1-pre2":
+  version "6.0.1-pre2"
+  resolved "https://registry.yarnpkg.com/@shiftkey/prebuild-install/-/prebuild-install-6.0.1-pre2.tgz#8cea022dd9aa0eb064164987b6ab12539efb892e"
+  integrity sha512-wDV1DgFxi0F+kTpyGNdnDctdw3Rb9aP8RBAGFE2wXr1+pXSCJRRA+Qh5ko5dKc0LeNIBZzjEECjmtAykajv+Xw==
+  dependencies:
+    "@shiftkey/node-abi" "2.19.2-pre"
+    detect-libc "^1.0.3"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    noop-logger "^0.1.1"
+    npmlog "^4.0.1"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^3.0.3"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+    which-pm-runs "^1.0.0"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1762,13 +1790,13 @@ jszip@^3.1.3:
     readable-stream "~2.3.6"
     set-immediate-shim "~1.0.1"
 
-keytar@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/keytar/-/keytar-6.0.1.tgz#996961abdebf300b2d34bb2eab6e42a8096b1ed8"
-  integrity sha512-1Ihpf2tdM3sLwGMkYHXYhVC/hx5BDR7CWFL4IrBA3IDZo0xHhS2nM+tU9Y+u/U7okNfbVkwmKsieLkcWRMh93g==
+keytar@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/keytar/-/keytar-7.1.0.tgz#961e6c5cf0615f2c184a48752d3265063e492925"
+  integrity sha512-ciDrtCcvhKpmVfPMVAiKSeKKQd+8S2VWOIcJP0Rdwz/ezSxHxYrycpwufDGpEHJqLyi/F7C7iwoz0eKGllzcMw==
   dependencies:
+    "@shiftkey/prebuild-install" "6.0.1-pre2"
     node-addon-api "^3.0.0"
-    prebuild-install "5.3.4"
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -1949,12 +1977,12 @@ minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-mkdirp-classic@^0.5.2:
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@^0.5.1, mkdirp@^0.5.4, mkdirp@~0.5.1:
+mkdirp@^0.5.4, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -2071,13 +2099,6 @@ ncp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
-
-node-abi@^2.7.0:
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.1.tgz#6aa32561d0a5e2fdb6810d8c25641b657a8cea85"
-  integrity sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==
-  dependencies:
-    semver "^5.4.1"
 
 node-addon-api@^3.0.0:
   version "3.0.2"
@@ -2331,27 +2352,6 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
-
-prebuild-install@5.3.4:
-  version "5.3.4"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.4.tgz#6982d10084269d364c1856550b7d090ea31fa293"
-  integrity sha512-AkKN+pf4fSEihjapLEEj8n85YIw/tN6BQqkhzbDc0RvEZGdkpJBGMUYx66AAMcPG2KzmPQS7Cm16an4HVBRRMA==
-  dependencies:
-    detect-libc "^1.0.3"
-    expand-template "^2.0.3"
-    github-from-package "0.0.0"
-    minimist "^1.2.3"
-    mkdirp "^0.5.1"
-    napi-build-utils "^1.0.1"
-    node-abi "^2.7.0"
-    noop-logger "^0.1.1"
-    npmlog "^4.0.1"
-    pump "^3.0.0"
-    rc "^1.2.7"
-    simple-get "^3.0.3"
-    tar-fs "^2.0.0"
-    tunnel-agent "^0.6.0"
-    which-pm-runs "^1.0.0"
 
 prepend-http@^2.0.0:
   version "2.0.0"

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -82,6 +82,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@ungap/promise-all-settled@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
+  integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
+
 ajv-keywords@^3.4.1:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.0.tgz#5c894537098785926d71e696114a53ce768ed773"
@@ -104,20 +109,10 @@ ansi-align@^3.0.0:
   dependencies:
     string-width "^3.0.0"
 
-ansi-colors@3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
-  integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
-
-ansi-colors@4.1.1:
+ansi-colors@4.1.1, ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
-
-ansi-colors@^3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
-  integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -441,6 +436,11 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
+camelcase@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
+  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -455,7 +455,7 @@ chai@3.5.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-chalk@^2.0.1, chalk@^2.4.2:
+chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -500,6 +500,21 @@ chokidar@3.4.2:
   optionalDependencies:
     fsevents "~2.1.2"
 
+chokidar@3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
+  integrity sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
@@ -537,6 +552,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-response@^1.0.2:
   version "1.0.2"
@@ -655,19 +679,19 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@3.2.6, debug@^3.0.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
 debug@4.1.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@4.2.0, debug@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
 
 debug@^2.1.3, debug@^2.2.0, debug@^2.6.9:
   version "2.6.9"
@@ -676,17 +700,22 @@ debug@^2.1.3, debug@^2.2.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
-  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+debug@^3.0.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
-    ms "2.1.2"
+    ms "^2.1.1"
 
 decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decamelize@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
+  integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
 decompress-response@^3.3.0:
   version "3.3.0"
@@ -745,11 +774,6 @@ detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
-
-diff@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 diff@4.0.2:
   version "4.0.2"
@@ -848,18 +872,18 @@ electron-download@^4.1.1:
     semver "^5.4.1"
     sumchecker "^2.0.2"
 
-electron-mocha@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/electron-mocha/-/electron-mocha-8.0.0.tgz#bf222b8b1cb3c260ba9331ebbbb38cbc0e147fb5"
-  integrity sha512-SGUCBiWP5Xekg9Hp0EQVk3ObzztjVFxEXYomSAG2u+tyAL9ok/frLaXXVsJis8XI5OcmJCSeKaKa6RjFcpVDNg==
+electron-mocha@9.3.1:
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/electron-mocha/-/electron-mocha-9.3.1.tgz#00b6d2b8f8dd5ffbfbc6d6e73a421176c3a1f9a2"
+  integrity sha512-uskvTwyTXrbgqVIllenz4S0UHeq9ztKktWqCOvr5CAwvm1xToVbpE76a1ggx/FRShlkV48Q+R+ED7YU5Zyh7ig==
   dependencies:
-    ansi-colors "^3.2.4"
+    ansi-colors "^4.1.1"
     electron-window "^0.8.0"
-    fs-extra "^7.0.1"
-    log-symbols "^2.2.0"
-    mocha "^6.1.1"
-    which "^1.3.1"
-    yargs "^13.2.2"
+    fs-extra "^9.0.1"
+    log-symbols "^4.0.0"
+    mocha "^8.2.0"
+    which "^2.0.2"
+    yargs "^16.1.0"
 
 electron-notarize@^0.1.1:
   version "0.1.1"
@@ -987,20 +1011,25 @@ es6-error@^4.1.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
 escape-goat@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
   integrity sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
 escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 esprima@^4.0.0:
   version "4.0.1"
@@ -1073,13 +1102,6 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-up@3.0.0, find-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
-  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
-  dependencies:
-    locate-path "^3.0.0"
-
 find-up@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
@@ -1096,6 +1118,13 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -1110,6 +1139,11 @@ flat@^4.1.0:
   integrity sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
   dependencies:
     is-buffer "~2.0.3"
+
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -1139,15 +1173,6 @@ fs-extra@^4.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-extra@^8.0.1, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -1157,7 +1182,7 @@ fs-extra@^8.0.1, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0:
+fs-extra@^9.0.0, fs-extra@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
   integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
@@ -1196,7 +1221,7 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -1238,18 +1263,6 @@ glob-parent@~5.1.0:
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
-
-glob@7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 glob@7.1.6, glob@^7.1.3:
   version "7.1.6"
@@ -1576,6 +1589,11 @@ is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
 is-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
@@ -1667,14 +1685,6 @@ jake@^10.6.1:
     chalk "^2.4.2"
     filelist "^1.0.1"
     minimatch "^3.0.4"
-
-js-yaml@3.13.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
-  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
 
 js-yaml@3.14.0, js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.0"
@@ -1824,14 +1834,7 @@ lodash@^4.17.10, lodash@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-log-symbols@2.2.0, log-symbols@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
-  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
-  dependencies:
-    chalk "^2.0.1"
-
-log-symbols@4.0.0:
+log-symbols@4.0.0, log-symbols@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
   integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
@@ -1951,13 +1954,6 @@ mkdirp-classic@^0.5.2:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.4.tgz#fd01504a6797ec5c9be81ff43d204961ed64a512"
-  integrity sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==
-  dependencies:
-    minimist "^1.2.5"
-
 mkdirp@^0.5.1, mkdirp@^0.5.4, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
@@ -1988,35 +1984,6 @@ mocha-steps@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/mocha-steps/-/mocha-steps-1.3.0.tgz#2449231ec45ec56810f65502cb22e2571862957f"
   integrity sha512-KZvpMJTqzLZw3mOb+EEuYi4YZS41C9iTnb7skVFRxHjUd1OYbl64tCMSmpdIRM9LnwIrSOaRfPtNpF5msgv6Eg==
-
-mocha@^6.1.1:
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-6.2.3.tgz#e648432181d8b99393410212664450a4c1e31912"
-  integrity sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==
-  dependencies:
-    ansi-colors "3.2.3"
-    browser-stdout "1.3.1"
-    debug "3.2.6"
-    diff "3.5.0"
-    escape-string-regexp "1.0.5"
-    find-up "3.0.0"
-    glob "7.1.3"
-    growl "1.10.5"
-    he "1.2.0"
-    js-yaml "3.13.1"
-    log-symbols "2.2.0"
-    minimatch "3.0.4"
-    mkdirp "0.5.4"
-    ms "2.1.1"
-    node-environment-flags "1.0.5"
-    object.assign "4.1.0"
-    strip-json-comments "2.0.1"
-    supports-color "6.0.0"
-    which "1.3.1"
-    wide-align "1.1.3"
-    yargs "13.3.2"
-    yargs-parser "13.1.2"
-    yargs-unparser "1.6.0"
 
 mocha@^8.1.3:
   version "8.1.3"
@@ -2049,20 +2016,51 @@ mocha@^8.1.3:
     yargs-parser "13.1.2"
     yargs-unparser "1.6.1"
 
+mocha@^8.2.0:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.2.1.tgz#f2fa68817ed0e53343d989df65ccd358bc3a4b39"
+  integrity sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==
+  dependencies:
+    "@ungap/promise-all-settled" "1.1.2"
+    ansi-colors "4.1.1"
+    browser-stdout "1.3.1"
+    chokidar "3.4.3"
+    debug "4.2.0"
+    diff "4.0.2"
+    escape-string-regexp "4.0.0"
+    find-up "5.0.0"
+    glob "7.1.6"
+    growl "1.10.5"
+    he "1.2.0"
+    js-yaml "3.14.0"
+    log-symbols "4.0.0"
+    minimatch "3.0.4"
+    ms "2.1.2"
+    nanoid "3.1.12"
+    serialize-javascript "5.0.1"
+    strip-json-comments "3.1.1"
+    supports-color "7.2.0"
+    which "2.0.2"
+    wide-align "1.1.3"
+    workerpool "6.0.2"
+    yargs "13.3.2"
+    yargs-parser "13.1.2"
+    yargs-unparser "2.0.0"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
-  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
-
 ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+nanoid@3.1.12:
+  version "3.1.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
+  integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
 
 napi-build-utils@^1.0.1:
   version "1.0.2"
@@ -2085,14 +2083,6 @@ node-addon-api@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.0.2.tgz#04bc7b83fd845ba785bb6eae25bc857e1ef75681"
   integrity sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg==
-
-node-environment-flags@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.5.tgz#fa930275f5bf5dae188d6192b24b4c8bbac3d76a"
-  integrity sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==
-  dependencies:
-    object.getownpropertydescriptors "^2.0.3"
-    semver "^5.7.0"
 
 noop-logger@^0.1.1:
   version "0.1.1"
@@ -2189,14 +2179,6 @@ object.assign@4.1.0, object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
-
-object.getownpropertydescriptors@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
-  integrity sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -2532,6 +2514,13 @@ readdirp@~3.4.0:
   dependencies:
     picomatch "^2.2.1"
 
+readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -2679,7 +2668,7 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.7.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -2705,6 +2694,13 @@ serialize-javascript@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
+
+serialize-javascript@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
   dependencies:
     randombytes "^2.1.0"
 
@@ -2930,15 +2926,20 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 strip-json-comments@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
+
+strip-json-comments@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 sumchecker@^2.0.2:
   version "2.0.2"
@@ -2954,17 +2955,17 @@ sumchecker@^3.0.1:
   dependencies:
     debug "^4.1.0"
 
-supports-color@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.0.0.tgz#76cfe742cf1f41bb9b1c29ad03068c05b4c0e40a"
-  integrity sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==
-  dependencies:
-    has-flag "^3.0.0"
-
 supports-color@7.1.0, supports-color@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
@@ -3202,14 +3203,7 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@1.3.1, which@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
-  dependencies:
-    isexe "^2.0.0"
-
-which@2.0.2:
+which@2.0.2, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
@@ -3235,6 +3229,11 @@ workerpool@6.0.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.0.0.tgz#85aad67fa1a2c8ef9386a1b43539900f61d03d58"
   integrity sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==
 
+workerpool@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.0.2.tgz#e241b43d8d033f1beb52c7851069456039d1d438"
+  integrity sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==
+
 wrap-ansi@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
@@ -3248,6 +3247,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -3303,6 +3311,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+y18n@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
@@ -3332,14 +3345,10 @@ yargs-parser@^18.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-unparser@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-1.6.0.tgz#ef25c2c769ff6bd09e4b0f9d7c605fb27846ea9f"
-  integrity sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==
-  dependencies:
-    flat "^4.1.0"
-    lodash "^4.17.15"
-    yargs "^13.3.0"
+yargs-parser@^20.2.2:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs-unparser@1.6.1:
   version "1.6.1"
@@ -3352,7 +3361,17 @@ yargs-unparser@1.6.1:
     is-plain-obj "^1.1.0"
     yargs "^14.2.3"
 
-yargs@13.3.2, yargs@^13.2.2, yargs@^13.3.0:
+yargs-unparser@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
+  integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
+  dependencies:
+    camelcase "^6.0.0"
+    decamelize "^4.0.0"
+    flat "^5.0.2"
+    is-plain-obj "^2.1.0"
+
+yargs@13.3.2:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
   integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
@@ -3401,6 +3420,19 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.1"
+
+yargs@^16.1.0:
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.1.1.tgz#5a4a095bd1ca806b0a50d0c03611d38034d219a1"
+  integrity sha512-hAD1RcFP/wfgfxgMVswPE+z3tlPFtxG8/yWUrG2i17sTWGCGqWnxKcLTF4cUKDUK8fzokwsmO9H0TDkRbMHy8w==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yauzl@^2.10.0:
   version "2.10.0"

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -942,10 +942,10 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.0.0.tgz#e4966d358832e47189069444799e3b72224e37d9"
-  integrity sha512-bbT6vmc04I0+cuG5e26+2rAOQYLH90Exf11a+NpGCSMTXsSjSpSZdjWGffWRIowOJzSwcSk8EHdCKdeet1rz9A==
+electron@11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.0.4.tgz#78b54760294eb42a36f33308a7987bf0b3dd6125"
+  integrity sha512-ipfQ28Km52iuDSe9VK0G5uuyxi8qy8szg+01kQTRXZFCLlpgsgU+vQxWkld2tkhXWdu+H3dmgYHvWtoijOvhjw==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -890,10 +890,10 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-8.3.0.tgz#c2b565a4c10d6d287d20164bcd5a478468b940a9"
-  integrity sha512-XRjiIJICZCgUr2vKSUI2PTkfP0gPFqCtqJUaTJSfCTuE3nTrxBKOUNeRMuCzEqspKkpFQU3SB3MdbMSHmZARlQ==
+electron@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.0.0.tgz#e4966d358832e47189069444799e3b72224e37d9"
+  integrity sha512-bbT6vmc04I0+cuG5e26+2rAOQYLH90Exf11a+NpGCSMTXsSjSpSZdjWGffWRIowOJzSwcSk8EHdCKdeet1rz9A==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
### Description

Update to Electron v11 to support Apple Silicon.

This is ready-to-go but hold off on merging so we can stagger this into our next desktop release.

#### CI

- [x] Mac
- [x] Linux (Circle)
- [x] Linux (TeamCity)

#### Manual Smoke Testing

- [x] Mac
- [x] Linux
- [x] Windows