### PR TITLE
Pricing page i5: Fix sticky filter-bar on connection flow pricing page 

### DIFF
--- a/client/my-sites/plans-v2/plans-filter-bar-i5/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar-i5/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -14,6 +14,7 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { JETPACK_PRODUCTS_BY_TERM } from 'calypso/lib/products-values/constants';
 import { JETPACK_RESET_PLANS_BY_TERM } from 'calypso/lib/plans/constants';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { isConnectStore } from 'calypso/my-sites/plans-v2/product-grid/utils';
 import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
 import useDetectWindowBoundary from '../use-detect-window-boundary';
 import { getHighestAnnualDiscount } from '../utils';
@@ -86,7 +87,10 @@ const PlansFilterBarI5: React.FC< FilterBarProps > = ( {
 	duration,
 	onDurationChange,
 } ) => {
-	const windowBoundaryOffset = isJetpackCloud() ? CLOUD_MASTERBAR_HEIGHT : CALYPSO_MASTERBAR_HEIGHT;
+	const isInConnectStore = useMemo( isConnectStore, [] );
+	const isInJetpackCloud = useMemo( isJetpackCloud, [] );
+	const windowBoundaryOffset =
+		isInJetpackCloud || isInConnectStore ? CLOUD_MASTERBAR_HEIGHT : CALYPSO_MASTERBAR_HEIGHT;
 	const [ barRef, hasCrossed ] = useDetectWindowBoundary( windowBoundaryOffset );
 
 	const [ durationChecked, setDurationChecked ] = useState(

--- a/client/my-sites/plans-v2/plans-filter-bar-i5/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar-i5/style.scss
@@ -104,7 +104,7 @@
 
 	z-index: 2;
 }
-
+.is-section-jetpack-connect,
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing {
 	.plans-filter-bar-i5.sticky {
 		top: 0;

--- a/client/my-sites/plans-v2/product-grid/utils.ts
+++ b/client/my-sites/plans-v2/product-grid/utils.ts
@@ -94,3 +94,5 @@ export const getProductsToDisplay = ( {
 export const isConnectionFlow = (): boolean =>
 	/jetpack\/connect\/plans/.test( window.location.href ) ||
 	/source=jetpack-connect-plans/.test( window.location.href );
+
+export const isConnectStore = (): boolean => /jetpack\/connect\/store/.test( window.location.href );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes the plans-filter-bar to stick at top:0 when scrolling.  Prior to this, the plans-filter-bar was sticking 47px down the page.  (See "Before" screenshots)

### Testing instructions

- Download the PR
- Run both Calypso and Jetpack cloud concurrently
- In Calypso, visit `/jetpack/connect/store`, scroll down the page and verify that the plans-filter-bar sticks to the top:0 when it reaches top:0.
- In Calypso, visit `/plans/:site`, scroll down the page and verify that the plans-filter-bar sticks just below the blue masterbar (top: 47px).
- In Jetpack cloud, visit `/pricing`, and verify that the plans-filter-bar sticks to the top:0 when it reaches top:0.
- Verify the scroll behavior works correctly on mobile viewport sizes also.

### Screenshots

**BEFORE**
(on `/jetpack/connect/store`)
![Markup 2020-11-18 at 09 28 42](https://user-images.githubusercontent.com/11078128/99565672-c570f880-2980-11eb-91ef-3a7b27bb8574.png)



**AFTER**
( on `/jetpack/connect/store`)
![Screenshot on 2020-11-18 at 09-29-26](https://user-images.githubusercontent.com/11078128/99565706-d02b8d80-2980-11eb-893c-86d45cdf96b6.png)

