### PR TITLE
Render PurchasesList with either sites or subscriptions

### DIFF
--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -52,7 +52,7 @@ class PurchasesList extends Component {
 			return true;
 		}
 
-		return ! this.props.sites.length;
+		return ! this.props.sites.length && ! this.props.subscriptions.length;
 	}
 
 	renderConciergeBanner() {

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -131,7 +131,11 @@ class PurchasesList extends Component {
 			);
 		}
 
-		if ( this.props.hasLoadedUserPurchasesFromServer && ! this.props.purchases.length && ! this.props.subscriptions.length ) {
+		if (
+			this.props.hasLoadedUserPurchasesFromServer &&
+			! this.props.purchases.length &&
+			! this.props.subscriptions.length
+		) {
 			if ( ! this.props.sites.length ) {
 				return (
 					<Main>

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -131,7 +131,7 @@ class PurchasesList extends Component {
 			);
 		}
 
-		if ( this.props.hasLoadedUserPurchasesFromServer && ! this.props.purchases.length ) {
+		if ( this.props.hasLoadedUserPurchasesFromServer && ! this.props.purchases.length && ! this.props.subscriptions.length ) {
 			if ( ! this.props.sites.length ) {
 				return (
 					<Main>


### PR DESCRIPTION
For users who do not have WordPress sites, the `NoSitesMessage` component was displayed within the Purchases tab on `/me/purchases` because of a conditional that looked only at the `sites` array. For users who have memberships on other sites, their purchases will appear in the `subscriptions` array which are already rendered within the `PurchasesList` component.

#### Changes proposed in this Pull Request

* Only enter the logic for users with no purchases if they also have no subscriptions (includes both `NoSitesMessage` and "Looking to upgrade?" content).
* `isDataLoading` had a fallback to return `true` if `sites` was empty. Add logic to make `subscriptions` part of this logic so that if either content exists in the fallback, it will return `false`.

#### Testing instructions

Use an account with no sites but a membership to another site.

As a fallback, [create an account with no sites](https://wordpress.com/start/user) and apply the following patch which will hardcode a subscription.

```diff
diff --git a/client/me/purchases/purchases-list/index.jsx b/client/me/purchases/purchases-list/index.jsx
index 83986ad4a7..a38650af24 100644
--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -196,7 +196,22 @@ export default connect(
 			isBusinessPlanUser: isBusinessPlanUser( state ),
 			isFetchingUserPurchases: isFetchingUserPurchases( state ),
 			purchases: getUserPurchases( state, userId ),
-			subscriptions: getAllSubscriptions( state ),
+			subscriptions: [
+				{
+					ID: 'ID',
+					currency: 'currency',
+					end_date: 'end_date',
+					product_id: 'product_id',
+					renew_interval: 'renew_interval',
+					renewal_price: 'renewal_price',
+					site_id: 'site_id',
+					site_title: 'site_title',
+					site_url: 'site_url',
+					start_date: 'start_date',
+					status: 'status',
+					title: 'title',
+				},
+			],
 			sites: getSites( state ),
 			nextAppointment: getConciergeNextAppointment( state ),
 			scheduleId: getConciergeScheduleId( state ),
```

Fixes #47515
