### PR TITLE
Editing toolkit: use `is_` WordPress checks and clean up hooks

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -33,6 +33,13 @@ function show_coming_soon_page() {
  * Renders a fallback coming soon page
  */
 function render_fallback_coming_soon_page() {
+	if ( ! defined( 'GRAVATAR_HOVERCARDS__DISABLE' ) ) {
+		define( 'GRAVATAR_HOVERCARDS__DISABLE', true );
+	}
+
+	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
+	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
+	// Disable WP scripts, social og meta, cookie banner.
 	remove_action( 'wp_enqueue_scripts', 'wpcom_actionbar_enqueue_scripts', 101 );
 	remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 	remove_action( 'wp_print_styles', 'print_emoji_styles' );
@@ -40,6 +47,8 @@ function render_fallback_coming_soon_page() {
 	remove_action( 'wp_head', 'global_css', 5 );
 	remove_action( 'wp_footer', 'wpcom_subs_js' );
 	remove_action( 'wp_footer', 'stats_footer', 101 );
+	add_filter( 'jetpack_disable_eu_cookie_law_widget', '__return_true', 1 );
+	add_filter( 'jetpack_enable_opengraph', '__return_false', 1 );
 	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), PLUGIN_VERSION );
 
 	include __DIR__ . '/fallback-coming-soon-page.php';
@@ -106,8 +115,6 @@ add_action( 'update_option_blog_public', __NAMESPACE__ . '\disable_coming_soon_o
 function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $network_id, $meta ) {
 	if ( 0 === $meta['public'] && 1 === (int) $meta['options']['wpcom_public_coming_soon'] ) {
 		add_blog_option( $blog_id, 'wpcom_public_coming_soon', 1 );
-	} else {
-		add_blog_option( $blog_id, 'wpcom_public_coming_soon', 0 );
 	}
 }
 // phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed
@@ -121,21 +128,6 @@ function coming_soon_page() {
 	if ( ! show_coming_soon_page() ) {
 		return;
 	}
-	if ( ! defined( 'GRAVATAR_HOVERCARDS__DISABLE' ) ) {
-		define( 'GRAVATAR_HOVERCARDS__DISABLE', true );
-	}
-	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
-	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
-	// Disable WP scripts, social og meta, cookie banner.
-	remove_action( 'wp_enqueue_scripts', 'wpcom_actionbar_enqueue_scripts', 101 );
-	remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
-	remove_action( 'wp_print_styles', 'print_emoji_styles' );
-	remove_action( 'wp_head', 'header_js', 5 );
-	remove_action( 'wp_head', 'global_css', 5 );
-	remove_action( 'wp_footer', 'wpcom_subs_js' );
-	remove_action( 'wp_footer', 'stats_footer', 101 );
-	add_filter( 'jetpack_disable_eu_cookie_law_widget', '__return_true', 1 );
-	add_filter( 'jetpack_enable_opengraph', '__return_false', 1 );
 
 	render_fallback_coming_soon_page();
 	die();

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -12,7 +12,7 @@ namespace A8C\FSE\Coming_soon;
  *
  * @return boolean
  */
-function show_coming_soon_page() {
+function should_show_coming_soon_page() {
 	global $post;
 
 	// Handle the case where we are not rendering a post.
@@ -125,7 +125,7 @@ add_action( 'wpmu_new_blog', __NAMESPACE__ . '\add_option_to_new_site', 10, 6 );
  * the redirect.
  */
 function coming_soon_page() {
-	if ( ! show_coming_soon_page() ) {
+	if ( ! should_show_coming_soon_page() ) {
 		return;
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -34,9 +34,7 @@ function render_fallback_coming_soon_page() {
 		define( 'GRAVATAR_HOVERCARDS__DISABLE', true );
 	}
 
-	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
-	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
-	// Disable WP scripts, social og meta, cookie banner.
+	// Disable WP scripts, likes, social og meta, cookie banner.
 	remove_action( 'wp_enqueue_scripts', 'wpcom_actionbar_enqueue_scripts', 101 );
 	remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 	remove_action( 'wp_print_styles', 'print_emoji_styles' );
@@ -46,6 +44,9 @@ function render_fallback_coming_soon_page() {
 	remove_action( 'wp_footer', 'stats_footer', 101 );
 	add_filter( 'jetpack_disable_eu_cookie_law_widget', '__return_true', 1 );
 	add_filter( 'jetpack_enable_opengraph', '__return_false', 1 );
+	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
+	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
+	
 	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), PLUGIN_VERSION );
 
 	include __DIR__ . '/fallback-coming-soon-page.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -46,7 +46,7 @@ function render_fallback_coming_soon_page() {
 	add_filter( 'jetpack_enable_opengraph', '__return_false', 1 );
 	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
 	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
-	
+
 	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), PLUGIN_VERSION );
 
 	include __DIR__ . '/fallback-coming-soon-page.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -13,10 +13,7 @@ namespace A8C\FSE\Coming_soon;
  * @return boolean
  */
 function should_show_coming_soon_page() {
-	global $post;
-
-	// Handle the case where we are not rendering a post.
-	if ( ! isset( $post ) ) {
+	if ( ! is_singular() && ! is_archive() && ! is_search() ) {
 		return false;
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -276,5 +276,6 @@ nocache_headers();
 			</div>
 		</div>
 		<?php wp_footer(); ?>
+		<!-- WordPress.com Editing Toolkit Plugin - Coming Soon -->
 	</body>
 </html>


### PR DESCRIPTION
### Changes proposed in this Pull Request

Hi ho!

This PR does 3 amazing things:

- Let's remove the duplicate action/filter hooks! 🕺 It should have no side-effects. Just janitorial. 
- Let's not set wpcom_public_coming_soon ito `0` by default if it's not in the site creation meta.  This is because some signup flows might NOT want to set that option at all. It should have no side-effects. Just janitorial.
- For some reason, Ecommerce AT sites have custom page types or something that doesn't pass our isset $page check, so we're checking for common WordPress page/post types. I asked here pbxlJb-xi-p2#comment-733

WOOT

### Testing instructions

#### Simple sites

1. Fire up the old sandbox
2. Get this patch up there via `yarn dev --sync`
3. Create a site over at `/start/domains?flags=coming-soon-v2`
4. Sandbox that site
5. Check that coming soon is enable on your simple site (incognito window).
6. Check the settings page `/settings/general/{your_site}?flags=coming-soon-v2`
7. (Launch site if necessary) Toggle Coming Soon mode on and off, check that it works in an incognito browser/logged-out session
8. Be kind to pets and children

#### Ecommerce

1. Create a site over at `/start/domains?flags=coming-soon-v2` 
2. Upgrade to Ecommerce
3. In your local `/apps/editing-toolkit` directory, run `yarn build`, then zip up `/apps/editing-toolkit/editing-toolkit-plugin`
4. Deactivate the existing WordPress Editing Toolkit over at `{your_site}/wp-admin/plugins.php?plugin_status=all&paged=1&s`
<img width="400" alt="Screen Shot 2020-11-20 at 8 03 32 pm" src="https://user-images.githubusercontent.com/6458278/99781783-65d74080-2b6c-11eb-96ee-2536fec2cbb9.png">
5. Now install your editing-toolkit-plugin.zip
<img width="400" alt="Screen Shot 2020-11-20 at 8 03 43 pm" src="https://user-images.githubusercontent.com/6458278/99781835-7687b680-2b6c-11eb-80b6-0a17ec5d4fbe.png">
6. Make sure to activate it
7. Check that coming soon is enable on your AT staging site (incognito window).
8. Check the settings page `/settings/general/{your_site}?flags=coming-soon-v2`
9. Launch (if you have to), then toggle Coming Soon mode. Check that it works



