### PR TITLE
Revert calypso localizeUrl's move to i18n-utils package

### DIFF
--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -20,6 +20,64 @@ import {
 	isMagnificentLocale,
 } from 'calypso/lib/i18n-utils';
 
+jest.mock( 'config', () => ( key ) => {
+	if ( 'i18n_default_locale_slug' === key ) {
+		return 'en';
+	}
+
+	if ( 'support_site_locales' === key ) {
+		return [ 'en', 'es', 'de', 'ja', 'pt-br' ];
+	}
+
+	if ( 'forum_locales' === key ) {
+		return [ 'en', 'es', 'de', 'ja', 'pt-br', 'th' ];
+	}
+
+	if ( 'magnificent_non_en_locales' === key ) {
+		return [
+			'es',
+			'pt-br',
+			'de',
+			'fr',
+			'he',
+			'ja',
+			'it',
+			'nl',
+			'ru',
+			'tr',
+			'id',
+			'zh-cn',
+			'zh-tw',
+			'ko',
+			'ar',
+			'sv',
+		];
+	}
+
+	if ( 'jetpack_com_locales' === key ) {
+		return [
+			'en',
+			'ar',
+			'de',
+			'es',
+			'fr',
+			'he',
+			'id',
+			'it',
+			'ja',
+			'ko',
+			'nl',
+			'pt-br',
+			'ro',
+			'ru',
+			'sv',
+			'tr',
+			'zh-cn',
+			'zh-tw',
+		];
+	}
+} );
+
 // Mock only the getLocaleSlug function from i18n-calypso, and use
 // original references for all the other functions
 function mockFunctions() {
@@ -32,14 +90,6 @@ jest.mock( 'i18n-calypso', () => mockFunctions() );
 const { getLocaleSlug } = jest.requireMock( 'i18n-calypso' );
 
 describe( 'utils', () => {
-	// todo: remove once all usage is moved over to the @automattic/i18n-utils package version
-	describe( '#localizeUrl', () => {
-		test( 'localizeUrl is still provided by client/lib/i18n-utisl', () => {
-			expect( localizeUrl( 'https://wordpress.com/', 'de' ) ).toEqual(
-				'https://de.wordpress.com/'
-			);
-		} );
-	} );
 	describe( '#isDefaultLocale', () => {
 		test( 'should return false when a non-default locale provided', () => {
 			expect( isDefaultLocale( 'fr' ) ).toEqual( false );
@@ -191,6 +241,324 @@ describe( 'utils', () => {
 
 		test( 'should return true for languages not in the exception list', () => {
 			expect( canBeTranslated( 'de' ) ).toEqual( true );
+		} );
+	} );
+
+	describe( '#localizeUrl', () => {
+		test( 'should not change URL for `en`', () => {
+			[
+				'https://wordpress.com/',
+				'https://de.wordpress.com/',
+				'https://wordpress.com/start/',
+				'https://wordpress.com/wp-login.php?action=lostpassword',
+			].forEach( ( fullUrl ) => {
+				getLocaleSlug.mockImplementationOnce( () => 'en' );
+				expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
+			} );
+		} );
+
+		test( 'should not change relative URLs', () => {
+			[ '/me/account', '/settings' ].forEach( ( fullUrl ) => {
+				getLocaleSlug.mockImplementationOnce( () => 'en' );
+				expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
+				getLocaleSlug.mockImplementationOnce( () => 'fr' );
+				expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
+			} );
+		} );
+
+		test( 'handles invalid URLs', () => {
+			[ undefined, null, [], {}, { href: 'https://test' }, 'not-a-url', () => {} ].forEach(
+				( fullUrl ) => {
+					getLocaleSlug.mockImplementationOnce( () => 'en' );
+					expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
+					getLocaleSlug(); // make sure to consume it.
+					getLocaleSlug.mockImplementationOnce( () => 'en' );
+					expect( localizeUrl( fullUrl, 'fr' ) ).toEqual( fullUrl );
+					getLocaleSlug(); // make sure to consume it.
+					getLocaleSlug.mockImplementationOnce( () => 'fr' );
+					expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
+					getLocaleSlug(); // make sure to consume it.
+				}
+			);
+		} );
+
+		test( 'handles double localizeUrl', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'de' ).mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( localizeUrl( 'https://automattic.com/cookies/' ) ) ).toEqual(
+				'https://automattic.com/de/cookies/'
+			);
+			getLocaleSlug();
+			getLocaleSlug(); // make sure to consume it.
+
+			getLocaleSlug.mockImplementationOnce( () => 'de' ).mockImplementationOnce( () => 'de' );
+			expect(
+				localizeUrl( localizeUrl( 'https://en.support.wordpress.com/all-about-domains/' ) )
+			).toEqual( 'https://wordpress.com/de/support/all-about-domains/' );
+			getLocaleSlug();
+			getLocaleSlug(); // make sure to consume it.
+
+			getLocaleSlug.mockImplementationOnce( () => 'de' ).mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( localizeUrl( 'https://wordpress.com/' ) ) ).toEqual(
+				'https://de.wordpress.com/'
+			);
+			getLocaleSlug();
+			getLocaleSlug(); // make sure to consume it.
+
+			getLocaleSlug.mockImplementationOnce( () => 'de' ).mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( localizeUrl( 'https://en.blog.wordpress.com/' ) ) ).toEqual(
+				'https://wordpress.com/blog/'
+			);
+			getLocaleSlug();
+			getLocaleSlug(); // make sure to consume it.
+		} );
+
+		test( 'trailing slash variations', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
+				'https://automattic.com/de/cookies/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://automattic.com/cookies' ) ).toEqual(
+				'https://automattic.com/de/cookies/'
+			);
+		} );
+
+		test( 'overriding locale', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'ru' );
+			expect( localizeUrl( 'https://automattic.com/cookies/', 'de' ) ).toEqual(
+				'https://automattic.com/de/cookies/'
+			);
+			getLocaleSlug(); // make sure to consume it.
+
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://automattic.com/cookies', 'fr' ) ).toEqual(
+				'https://automattic.com/fr/cookies/'
+			);
+			getLocaleSlug(); // make sure to consume it.
+
+			// Finally make sure that no overriding has stuck and it uses the getLocaleSlug() when no override is specified.
+			getLocaleSlug.mockImplementationOnce( () => 'ru' );
+			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
+				'https://automattic.com/cookies/'
+			);
+			getLocaleSlug(); // make sure to consume it.
+
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
+				'https://automattic.com/de/cookies/'
+			);
+			getLocaleSlug(); // make sure to consume it.
+		} );
+
+		test( 'logged-out homepage', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://wordpress.com/' ) ).toEqual( 'https://wordpress.com/' );
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://wordpress.com/' ) ).toEqual( 'https://de.wordpress.com/' );
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://wordpress.com/' ) ).toEqual( 'https://br.wordpress.com/' );
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://wordpress.com/' ) ).toEqual( 'https://wordpress.com/' );
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://en.wordpress.com/' ) ).toEqual( 'https://wordpress.com/' );
+		} );
+
+		test( 'blog url', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
+				'https://wordpress.com/blog/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
+				'https://wordpress.com/blog/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
+				'https://wordpress.com/br/blog/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
+				'https://wordpress.com/blog/'
+			);
+			// Don't rewrite specific blog posts
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://en.blog.wordpress.com/2020/01/01/test/' ) ).toEqual(
+				'https://wordpress.com/blog/2020/01/01/test/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://wordpress.com/blog/2020/01/01/test/' ) ).toEqual(
+				'https://wordpress.com/blog/2020/01/01/test/'
+			);
+		} );
+
+		test( 'support url', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
+				'https://wordpress.com/support/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
+				'https://wordpress.com/de/support/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
+				'https://wordpress.com/br/support/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
+				'https://wordpress.com/support/'
+			);
+
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
+				'https://wordpress.com/support/path/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
+				'https://wordpress.com/de/support/path/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
+				'https://wordpress.com/br/support/path/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
+				'https://wordpress.com/support/path/'
+			);
+
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
+				'https://wordpress.com/support/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
+				'https://wordpress.com/de/support/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
+				'https://wordpress.com/br/support/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
+				'https://wordpress.com/support/'
+			);
+
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
+				'https://wordpress.com/support/path/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
+				'https://wordpress.com/de/support/path/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
+				'https://wordpress.com/br/support/path/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
+				'https://wordpress.com/support/path/'
+			);
+		} );
+
+		test( 'forums url', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
+				'https://en.forums.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
+				'https://de.forums.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
+				'https://br.forums.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'th' );
+			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
+				'https://th.forums.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
+				'https://en.forums.wordpress.com/'
+			);
+		} );
+
+		test( 'privacy policy', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://automattic.com/privacy/' ) ).toEqual(
+				'https://automattic.com/privacy/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://automattic.com/privacy/' ) ).toEqual(
+				'https://automattic.com/de/privacy/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://automattic.com/privacy/' ) ).toEqual(
+				'https://automattic.com/privacy/'
+			);
+		} );
+
+		test( 'cookie policy', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
+				'https://automattic.com/cookies/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
+				'https://automattic.com/de/cookies/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
+				'https://automattic.com/cookies/'
+			);
+		} );
+
+		test( 'tos', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://wordpress.com/tos/' ) ).toEqual( 'https://wordpress.com/tos/' );
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://wordpress.com/tos/' ) ).toEqual(
+				'https://de.wordpress.com/tos/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://wordpress.com/tos/' ) ).toEqual( 'https://wordpress.com/tos/' );
+			getLocaleSlug.mockImplementationOnce( () => 'th' );
+			expect( localizeUrl( 'https://wordpress.com/tos/' ) ).toEqual( 'https://wordpress.com/tos/' );
+		} );
+
+		test( 'jetpack', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
+				'https://jetpack.com/features/comparison/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
+				'https://de.jetpack.com/features/comparison/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
+				'https://br.jetpack.com/features/comparison/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'zh-tw' );
+			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
+				'https://zh-tw.jetpack.com/features/comparison/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
+				'https://jetpack.com/features/comparison/'
+			);
+		} );
+
+		test( 'WordPress.com URLs', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword' ) ).toEqual(
+				'https://wordpress.com/wp-login.php?action=lostpassword'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword' ) ).toEqual(
+				'https://de.wordpress.com/wp-login.php?action=lostpassword'
+			);
 		} );
 	} );
 

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -9,8 +9,7 @@ import i18n, { getLocaleSlug } from 'i18n-calypso';
  */
 import config from 'calypso/config';
 import languages from '@automattic/languages';
-import { getUrlParts } from 'calypso/lib/url/url-parts';
-export { localizeUrl } from '@automattic/i18n-utils';
+import { getUrlParts, getUrlFromParts } from 'calypso/lib/url/url-parts';
 
 /**
  * a locale can consist of three component
@@ -155,6 +154,133 @@ export function addLocaleToPath( path, locale ) {
 	const queryString = urlParts.search || '';
 
 	return removeLocaleFromPath( urlParts.pathname ) + `/${ locale }` + queryString;
+}
+
+const localesWithBlog = [ 'en', 'ja', 'es', 'pt', 'fr', 'pt-br' ];
+const localesWithPrivacyPolicy = [ 'en', 'fr', 'de' ];
+const localesWithCookiePolicy = [ 'en', 'fr', 'de' ];
+const localesToSubdomains = {
+	'pt-br': 'br',
+	br: 'bre',
+	zh: 'zh-cn',
+	'zh-hk': 'zh-tw',
+	'zh-sg': 'zh-cn',
+	kr: 'ko',
+};
+
+const setLocalizedUrlHost = ( hostname, validLocales = [] ) => ( urlParts, localeSlug ) => {
+	if ( typeof validLocales === 'string' ) {
+		validLocales = config( validLocales );
+	}
+
+	if ( validLocales.includes( localeSlug ) && localeSlug !== 'en' ) {
+		// Avoid changing the hostname when the locale is set via the path.
+		if ( urlParts.pathname.substr( 0, localeSlug.length + 2 ) !== '/' + localeSlug + '/' ) {
+			urlParts.host = `${ localesToSubdomains[ localeSlug ] || localeSlug }.${ hostname }`;
+		}
+	}
+	return urlParts;
+};
+
+const setLocalizedWpComPath = ( prefix, validLocales = [], limitPathMatch = null ) => (
+	urlParts,
+	localeSlug
+) => {
+	urlParts.host = 'wordpress.com';
+	if (
+		typeof limitPathMatch === 'object' &&
+		limitPathMatch instanceof RegExp &&
+		! limitPathMatch.test( urlParts.pathname )
+	) {
+		validLocales = []; // only rewrite to English.
+	}
+	urlParts.pathname = prefix + urlParts.pathname;
+
+	if ( typeof validLocales === 'string' ) {
+		validLocales = config( validLocales );
+	}
+
+	if ( validLocales.includes( localeSlug ) && localeSlug !== 'en' ) {
+		urlParts.pathname = ( localesToSubdomains[ localeSlug ] || localeSlug ) + urlParts.pathname;
+	}
+	return urlParts;
+};
+
+const prefixLocalizedUrlPath = ( validLocales = [], limitPathMatch = null ) => (
+	urlParts,
+	localeSlug
+) => {
+	if ( typeof validLocales === 'string' ) {
+		validLocales = config( validLocales );
+	}
+
+	if ( typeof limitPathMatch === 'object' && limitPathMatch instanceof RegExp ) {
+		if ( ! limitPathMatch.test( urlParts.pathname ) ) {
+			return urlParts; // No rewriting if not matches the path.
+		}
+	}
+
+	if ( validLocales.includes( localeSlug ) && localeSlug !== 'en' ) {
+		urlParts.pathname = ( localesToSubdomains[ localeSlug ] || localeSlug ) + urlParts.pathname;
+	}
+	return urlParts;
+};
+
+const urlLocalizationMapping = {
+	'wordpress.com/support/': prefixLocalizedUrlPath( 'support_site_locales' ),
+	'wordpress.com/blog/': prefixLocalizedUrlPath( localesWithBlog, /^\/blog\/?$/ ),
+	'wordpress.com/tos/': setLocalizedUrlHost( 'wordpress.com', 'magnificent_non_en_locales' ),
+	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', 'jetpack_com_locales' ),
+	'en.support.wordpress.com': setLocalizedWpComPath( '/support', 'support_site_locales' ),
+	'en.blog.wordpress.com': setLocalizedWpComPath( '/blog', localesWithBlog, /^\/$/ ),
+	'en.forums.wordpress.com': setLocalizedUrlHost( 'forums.wordpress.com', 'forum_locales' ),
+	'automattic.com/privacy/': prefixLocalizedUrlPath( localesWithPrivacyPolicy ),
+	'automattic.com/cookies/': prefixLocalizedUrlPath( localesWithCookiePolicy ),
+	'wordpress.com': setLocalizedUrlHost( 'wordpress.com', 'magnificent_non_en_locales' ),
+};
+
+export function localizeUrl( fullUrl, locale ) {
+	const localeSlug = locale || ( typeof getLocaleSlug === 'function' ? getLocaleSlug() : 'en' );
+	const urlParts = getUrlParts( String( fullUrl ) );
+
+	if ( ! urlParts.host ) {
+		return fullUrl;
+	}
+
+	// Let's unify the URL.
+	urlParts.protocol = 'https:';
+	// Let's use `host` for everything.
+	delete urlParts.hostname;
+
+	if ( ! urlParts.pathname.endsWith( '.php' ) ) {
+		urlParts.pathname = ( urlParts.pathname + '/' ).replace( /\/+$/, '/' );
+	}
+
+	if ( ! localeSlug || 'en' === localeSlug ) {
+		if ( 'en.wordpress.com' === urlParts.host ) {
+			urlParts.host = 'wordpress.com';
+			return getUrlFromParts( urlParts ).href;
+		}
+	}
+
+	if ( 'en.wordpress.com' === urlParts.host ) {
+		urlParts.host = 'wordpress.com';
+	}
+
+	const lookup = [
+		urlParts.host,
+		urlParts.host + urlParts.pathname,
+		urlParts.host + urlParts.pathname.substr( 0, 1 + urlParts.pathname.indexOf( '/', 1 ) ),
+	];
+
+	for ( let i = lookup.length - 1; i >= 0; i-- ) {
+		if ( lookup[ i ] in urlLocalizationMapping ) {
+			return getUrlFromParts( urlLocalizationMapping[ lookup[ i ] ]( urlParts, localeSlug ) ).href;
+		}
+	}
+
+	// Nothing needed to be changed, just return it unmodified.
+	return fullUrl;
 }
 
 /**

--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,6 @@
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/format-currency": "^1.0.0-alpha.0",
-		"@automattic/i18n-utils": "^1.0.0",
 		"@automattic/languages": "^1.0.0",
 		"@automattic/language-picker": "^1.0.0",
 		"@automattic/lasagna": "^0.6.1",


### PR DESCRIPTION
Reverts localizeUrl to its state prior to the move to i18n-utils package.

This is an intermediate PR, to make deploying the changes needed in #47492 a bit easier.

#### Testing instructions

* Follow #46998 

