### PR TITLE
Add `<LocaleProvider>` and `useLocale()` to `@automattic/i18n-utils`

### DIFF
--- a/packages/i18n-utils/README.md
+++ b/packages/i18n-utils/README.md
@@ -7,3 +7,25 @@ I18n-related utilities for use by client, server, apps, and packages.
 ```js
 import { localizeUrl } from '@automattic/i18n-utils';
 ```
+
+## Setting up the locale slug
+
+In order to make some i18n utils work in React you need to supply a locale
+slug to `<LocaleProvider>` somewhere high up in your react tree. How you
+get this locale slug will depend on the app `@automattic/i18n-utils` is
+being used in.
+
+```js
+import { LocaleProvider } from '@automattic/i18n-utils';
+
+function renderApp() {
+	return (
+		<LocaleProvider localeSlug="en">
+			<div>... your app components go here ...</div>
+		</LocaleProvider>
+	);
+}
+```
+
+Once a `<LocaleProvider>` is available near the root of your tree the
+`useLocale()` hook can be used in your components.

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -25,5 +25,10 @@
 		"@wordpress/compose": "^3.19.3",
 		"i18n-calypso": "^5.0.0",
 		"react": "^16.12.0"
+	},
+	"devDependencies": {
+		"@testing-library/jest-dom": "^5.11.6",
+		"@testing-library/react": "^11.2.0",
+		"@testing-library/react-hooks": "^3.4.2"
 	}
 }

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -22,6 +22,8 @@
 		"test": "yarn jest"
 	},
 	"dependencies": {
-		"i18n-calypso": "^5.0.0"
+		"@wordpress/compose": "^3.19.3",
+		"i18n-calypso": "^5.0.0",
+		"react": "^16.12.0"
 	}
 }

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -1,1 +1,2 @@
 export { localizeUrl } from './localize-url';
+export { LocaleProvider, useLocale, withLocale } from './locale-context';

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React, { createContext, useContext } from 'react';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+export const localeContext = createContext< string >( 'en' );
+
+interface Props {
+	localeSlug: string;
+}
+
+export const LocaleProvider: React.FC< Props > = ( { children, localeSlug } ) => (
+	<localeContext.Provider value={ localeSlug }>{ children }</localeContext.Provider>
+);
+
+/**
+ * React hook providing the current locale slug supplied to `<LocaleProvider>`.
+ *
+ * @example
+ *
+ * import { useLocale } from '@automattic/i18n-utils';
+ * function MyComponent() {
+ *   const locale = useLocale();
+ *   return <div>The current locale is: { locale }</div>;
+ * }
+ */
+export function useLocale(): string {
+	return useContext( localeContext );
+}
+
+/**
+ * HoC providing the current locale slug supplied to `<LocaleProvider>`.
+ *
+ * @param InnerComponent Component that will receive `locale` as a prop
+ * @returns Component enhanced with locale
+ *
+ * @example
+ *
+ * import { withLocale } from '@automattic/i18n-utils';
+ * function MyComponent( { locale } ) {
+ *   return <div>The current locale is: { locale }</div>;
+ * }
+ * export default withLocale( MyComponent );
+ */
+export const withLocale = createHigherOrderComponent< { locale: string } >( ( InnerComponent ) => {
+	return ( props ) => {
+		const locale = useLocale();
+		return <InnerComponent locale={ locale } { ...props } />;
+	};
+}, 'withLocale' );

--- a/packages/i18n-utils/src/test/locale-context.tsx
+++ b/packages/i18n-utils/src/test/locale-context.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import { LocaleProvider, useLocale, withLocale } from '../locale-context';
+
+describe( 'useLocale', () => {
+	it( 'returns "en" if there is no LocaleProvider', () => {
+		const { result } = renderHook( () => useLocale() );
+
+		expect( result.current ).toBe( 'en' );
+	} );
+
+	it( 'returns the slug supplied to LocaleProvider', () => {
+		const { result } = renderHook( () => useLocale(), {
+			wrapper: LocaleProvider,
+			initialProps: { localeSlug: 'ja' },
+		} );
+
+		expect( result.current ).toBe( 'ja' );
+	} );
+
+	it( 'returns the new locale when it changes', () => {
+		const { result, rerender } = renderHook( () => useLocale(), {
+			wrapper: LocaleProvider,
+			initialProps: { localeSlug: 'en' },
+		} );
+
+		rerender( { localeSlug: 'ar' } );
+
+		expect( result.current ).toBe( 'ar' );
+	} );
+} );
+
+describe( 'withLocale', () => {
+	const TestComponent = withLocale( ( { locale } ) => <div>current locale is: { locale }</div> );
+
+	it( 'returns "en" if there is no LocaleProvider', () => {
+		const { getByText } = render( <TestComponent /> );
+
+		expect( getByText( 'current locale is: en' ) ).toBeInTheDocument();
+	} );
+
+	it( 'returns the slug supplied to LocaleProvider', () => {
+		const { getByText } = render(
+			<LocaleProvider localeSlug="ja">
+				<TestComponent />
+			</LocaleProvider>
+		);
+
+		expect( getByText( 'current locale is: ja' ) ).toBeInTheDocument();
+	} );
+
+	it( 'returns the new locale when it changes', () => {
+		const { getByText, rerender } = render(
+			<LocaleProvider localeSlug="en">
+				<TestComponent />
+			</LocaleProvider>
+		);
+
+		rerender(
+			<LocaleProvider localeSlug="ar">
+				<TestComponent />
+			</LocaleProvider>
+		);
+
+		expect( getByText( 'current locale is: ar' ) ).toBeInTheDocument();
+	} );
+} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1960,6 +1960,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.5.4":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.3.3", "@babel/template@^7.4.0", "@babel/template@^7.7.4", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -2727,6 +2734,17 @@
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
   integrity sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
@@ -4465,6 +4483,20 @@
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
   integrity sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==
 
+"@testing-library/dom@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.27.1.tgz#b760182513357e4448a8461f9565d733a88d71d0"
+  integrity sha512-AF56RoeUU8bO4DOvLyMI44H3O1LVKZQi2D/m5fNDr+iR4drfOFikTr26hT6IY7YG+l8g69FXsHERa+uThaYYQg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
 "@testing-library/dom@^7.8.0":
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.8.0.tgz#f8b0df6bbf8346e7c5e7b314c6c109d0b3261531"
@@ -4474,6 +4506,20 @@
     aria-query "^4.0.2"
     dom-accessibility-api "^0.4.4"
     pretty-format "^25.5.0"
+
+"@testing-library/jest-dom@^5.11.6":
+  version "5.11.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.6.tgz#782940e82e5cd17bc0a36f15156ba16f3570ac81"
+  integrity sha512-cVZyUNRWwUKI0++yepYpYX7uhrP398I+tGz4zOlLVlUYnZS+Svuxv4fwLeCIy7TnBYKXUaOlQr3vopxL8ZfEnA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    lodash "^4.17.15"
+    redent "^3.0.0"
 
 "@testing-library/jest-dom@^5.9.0":
   version "5.9.0"
@@ -4490,6 +4536,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.4.2.tgz#8deb94f7684e0d896edd84a4c90e5b79a0810bc2"
+  integrity sha512-RfPG0ckOzUIVeIqlOc1YztKgFW+ON8Y5xaSPbiBkfj9nMkkiLhLeBXT5icfPX65oJV/zCZu4z8EVnUc6GY9C5A==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@types/testing-library__react-hooks" "^3.4.0"
+
 "@testing-library/react@^10.0.5":
   version "10.0.5"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.0.5.tgz#78c77a1d583777615bf0a8b8d7550b876de9f409"
@@ -4499,10 +4553,23 @@
     "@testing-library/dom" "^7.8.0"
     "@types/testing-library__react" "^10.0.1"
 
+"@testing-library/react@^11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.0.tgz#ce977a76b6342ea95c71ccd6de3012b1635fb559"
+  integrity sha512-90xKYJzskZ7q/AoSuWraQL4EGZlr75uZvDt3nrO4M+rugN02zjO45tmOBq/JBOgDiMIL1tkhHioKXjJsVaSINA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.27.1"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel__core@^7.0.0":
   version "7.1.9"
@@ -4909,6 +4976,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@*":
+  version "16.9.3"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
+  integrity sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"
@@ -4973,6 +5047,20 @@
   integrity sha512-LoZ3uonlnAbJUz4bg6UoeFl+frfndXngmkCItSjJ8DD5WlRfVqPC5/LgJASsY/dy7AHH2YJ7PcsdASOydcVeFA==
   dependencies:
     "@types/jest" "*"
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
+  integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+  dependencies:
+    "@types/jest" "*"
+
+"@types/testing-library__react-hooks@^3.4.0":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz#b8d7311c6c1f7db3103e94095fe901f8fef6e433"
+  integrity sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
+  dependencies:
+    "@types/react-test-renderer" "*"
 
 "@types/testing-library__react@^10.0.1":
   version "10.0.1"
@@ -11346,6 +11434,15 @@ css@^2.2.1, css@^2.2.4:
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
 
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
+
 cssdb@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/cssdb/-/cssdb-4.4.0.tgz#3bf2f2a68c10f5c6a08abd92378331ee803cddb0"
@@ -12170,6 +12267,11 @@ dom-accessibility-api@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.4.4.tgz#c2f9fb8b591bc19581e7ef3e6fe35baf1967c498"
   integrity sha512-XBM62jdDc06IXSujkqw6BugEWiDkp6jphtzVJf1kgPQGvfzaU7/jRtRSF/mxc8DBCIm2LS3bN1dCa5Sfxx982A==
+
+dom-accessibility-api@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -19508,6 +19610,11 @@ lunr@^2.3.8:
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.8.tgz#a8b89c31f30b5a044b97d2d28e2da191b6ba2072"
   integrity sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -23331,6 +23438,16 @@ pretty-format@^26.4.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -24097,6 +24214,11 @@ react-is@^16.10.2, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
 react-lazily-render@^1.2.0:
   version "1.2.0"
@@ -26942,6 +27064,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.4.15:
   version "0.4.18"


### PR DESCRIPTION
Split out from #47446 to make the changes easier to review

#### Changes proposed in this Pull Request

* Add `<LocaleProvider>` to `@automattic/i18n-utils`
* Add `useLocale()` and `withLocale()` to consume the locale supplied by `<LocaleProvider>`

The `react-i18n` library currently supplies the current locale slug, however that package is trying to do things in a way that will work for any Gutenberg user, and there is no standard way to access the current locale slug in Gutenberg/core WP.

Having an i18n util that's Calypso specific allows us to do things we know will work in an a8c specific environment.

The locale slug defaults to `'en'` because that seems to be the current practice in Calypso, and this is an a8c specific utility. Another option was to error if `useLocale()` or `withLocale()` is used when `<LocaleProvider>` hasn't been set up. This would help guide devs to do the right thing if they're bootstrapping a new app, but it didn't really fit in with providing a default which is what we usually do.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Provider not used anywhere yet, but inspect unit tests
