### PR TITLE
Gutenboarding: Update Title & SubTitle to allow a tagName prop to be passed

### DIFF
--- a/packages/onboarding/src/titles/index.tsx
+++ b/packages/onboarding/src/titles/index.tsx
@@ -6,15 +6,31 @@ import classnames from 'classnames';
 
 import './styles.scss';
 
+type AllowedTagNames = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
 interface TitlesProps {
 	className?: string;
+	tagName?: AllowedTagNames;
 }
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-export const Title: React.FunctionComponent< TitlesProps > = ( { className, children } ) => (
-	<h1 className={ classnames( 'onboarding-title', className ) }>{ children }</h1>
-);
+export const Title: React.FunctionComponent< TitlesProps > = ( {
+	className,
+	children,
+	tagName = 'h1',
+} ) =>
+	React.createElement(
+		tagName,
+		{ className: classnames( 'onboarding-title', className ) },
+		children
+	);
 
-export const SubTitle: React.FunctionComponent< TitlesProps > = ( { className, children } ) => (
-	<h2 className={ classnames( 'onboarding-subtitle', className ) }>{ children }</h2>
-);
+export const SubTitle: React.FunctionComponent< TitlesProps > = ( {
+	className,
+	children,
+	tagName = 'h2',
+} ) =>
+	React.createElement(
+		tagName,
+		{ className: classnames( 'onboarding-subtitle', className ) },
+		children
+	);


### PR DESCRIPTION
We want to improve accessibility of Gutenboarding, hence we need to allow `<Title/>` & `<SubTitle/>` to render <h*/> & <p/> tags. To enable this we've introduced a `tagName` props that allow `h1`-`h6` & `p` to be passed.

#### Changes proposed in this Pull Request

* Introduce a `tagName` prop for `<Title/>` & `<SubTitle/>`

#### Testing instructions

* Check out this branch on your machine and run yarn;
* Open client/landing/gutenboarding/onboarding-block/domains/index.tsx in an editor;
* Add a `tagName` prop to any `<Title/>` or `<SubTitle/>` with `h6` as value;
* use devTools to check if the className is passed to the component.

#### Other considerations
I considered abstracting `React.createElement` to a separate (factory) method to make things DRY. But this method would be way too generic since it has to accept all kinds of structures/interfaces/props (it has to support other, more complex, components as well).

IMHO, It doesn't contribute to the readability of the code and makes things way too complex for now. 
We might want to consider it if the number of components is increasing.

Fixes #47418
