### PR TITLE
Domains: Fix error handling of transfer cancelation

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
@@ -24,7 +24,12 @@ class Unlocked extends React.Component {
 	};
 
 	componentDidUpdate( prevProps ) {
-		if ( this.state.sent && prevProps.isCancelingTransfer && ! this.props.isCancelingTransfer ) {
+		if (
+			this.state.sent &&
+			prevProps.isCancelingTransfer &&
+			! this.props.isCancelingTransfer &&
+			! this.props.isDomainPendingTransfer
+		) {
 			// eslint-disable-next-line react/no-did-update-set-state
 			this.setState( {
 				sent: false,
@@ -224,9 +229,11 @@ export default connect(
 		const domainInfo = getDomainWapiInfoByDomainName( state, selectedDomainName );
 		const isRequestingTransferCode = !! domainInfo.isRequestingTransferCode;
 		const isCancelingTransfer = !! domainInfo.isCancelingTransfer;
+		const isDomainPendingTransfer = !! domainInfo.data?.pendingTransfer;
 
 		return {
 			isCancelingTransfer,
+			isDomainPendingTransfer,
 			isSubmitting: isRequestingTransferCode || isCancelingTransfer,
 		};
 	},


### PR DESCRIPTION
In #47366 we reduxified the `wapi-domain-info` flux store. However, while reviewing it, @klimeryk [found and reported](https://github.com/Automattic/wp-calypso/pull/47366#discussion_r526347221) a regression in the way we're handling errors when canceling domain transfer requests:

> For some reason, when the API returns an error (I've just hardcoded a `return new WP_Error` on the backend), this button does not revert to the active state and remains disabled
> This looks like a regression because on production it becomes active on error (in other words, it turns active when there's a response from the server - regardless if it's a success or not)

This PR fixes that by doing an additional check for whether the transfer cancelation request was successful.

#### Changes proposed in this Pull Request

* Domains: Fix error handling of transfer cancelation

#### Testing instructions

* Follow the instructions on https://github.com/Automattic/wp-calypso/pull/47366#discussion_r526347221 or:
* Checkout this branch.
* Sandbox the WP.com API and in the domains transfer endpoint, `return new WP_Error( 'something' )` where we're handling the `cancel-transfer-request` command.
* Go to `/domains/manage/:site/transfer/out/:domain` to initiate a transfer to another registrar.
* Click the "Cancel Transfer" button.
* Verify that after seeing the error message, the "Cancel Transfer" button is available and not disabled.