### PR TITLE
Nav Unification: add missing variable for selected menu text

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -155,10 +155,10 @@ $font-size: rem( 14px );
 			&.selected {
 				.sidebar__menu-link {
 					background: var( --color-sidebar-menu-selected-background );
-					color: white;
+					color: var( --color-sidebar-menu-selected-text );
 
 					.sidebar__menu-icon {
-						color: white;
+						color: var( --color-sidebar-menu-selected-text );
 					}
 
 					img.sidebar__menu-icon {

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -13,6 +13,7 @@
 	--color-sidebar-menu-hover-background-rgb: rgb( var( --color-sidebar-menu-hover-background ) );
 	--color-sidebar-menu-hover-text: #00b9eb;
 	--color-sidebar-menu-selected-background: #0073aa;
+	--color-sidebar-menu-selected-text: white;
 	--color-sidebar-border: #333333;
 	--color-sidebar-text: #eee;
 	--color-sidebar-text-alternative: #a2aab2;
@@ -223,10 +224,10 @@ $font-size: rem( 14px );
 			// Is toggled open and selected
 			&.sidebar__menu--selected .sidebar__heading {
 				background: var( --color-sidebar-menu-selected-background );
-				color: white;
+				color: var( --color-sidebar-menu-selected-text );
 
 				.sidebar__menu-icon {
-					color: #fff;
+					color: var( --color-sidebar-menu-selected-text );
 				}
 				img.sidebar__menu-icon {
 					opacity: 1;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a missing variable for selected menu text

The text color for selected menu items varies between color schemes. We need to account for this in the nav unification styles. 

I noticed this one as I was working on some further adjustments to Aquatic in Calypso in parallel to porting Aquatic to wp-admin in https://github.com/Automattic/jetpack/pull/17828

|Before|After|
|-|-|
|<img width="272" alt="Screenshot 2020-11-19 at 12 28 23" src="https://user-images.githubusercontent.com/1562646/99662244-486b7f00-2a65-11eb-9684-40b34dcfd47f.png">|<img width="273" alt="Screenshot 2020-11-19 at 12 40 40" src="https://user-images.githubusercontent.com/1562646/99662253-4b666f80-2a65-11eb-977d-7f43cb267778.png">|

|Before|After|
|-|-|
|<img width="272" alt="Screenshot 2020-11-19 at 12 52 12" src="https://user-images.githubusercontent.com/1562646/99662852-160e5180-2a66-11eb-8921-df37d2683942.png">|<img width="273" alt="Screenshot 2020-11-19 at 12 50 48" src="https://user-images.githubusercontent.com/1562646/99662768-fbd47380-2a65-11eb-8df6-dbbe01032515.png">|

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the Calypso live link below
* Compare selected colors to the same colors in nav unification on production (they should look identical)
* The color differences shown in the screenshots above will only be visible once we add some more changes to the actual themes (Aquatic shown above) to override colors in nav unification
