### PR TITLE
Nav unification: update Aquatic color scheme to be compatible with nav unification

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_aquatic.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_aquatic.scss
@@ -1,4 +1,5 @@
-.color-scheme.is-aquatic {
+.color-scheme.is-aquatic,
+.color-scheme.is-aquatic .is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-blue-50 );
 	--color-primary-rgb: var( --studio-blue-50-rgb );
@@ -120,4 +121,9 @@
 	--color-sidebar-menu-hover-background: var( --studio-blue-50 );
 	--color-sidebar-menu-hover-background-rgb: var( --studio-blue-50-rgb );
 	--color-sidebar-menu-hover-text: var( --studio-white );
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: var( --studio-blue-80 );
+	--color-sidebar-submenu-text: var( --studio-white );
+	--color-sidebar-submenu-hover-text: var( --studio-yellow-20 );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update Aquatic color scheme to be compatible with nav unification



While working on porting Aquatic to wp-admin in Automattic/jetpack#17828, I noticed we will need a few more changes to the color scheme in Calypso to work with Nav Unification.

|Before|After|
|-|-|
|<img width="463" alt="Screenshot 2020-11-19 at 13 37 50" src="https://user-images.githubusercontent.com/1562646/99667274-74d6c980-2a6c-11eb-8b67-3bad6ca91e1a.png">|<img width="450" alt="Screenshot 2020-11-19 at 13 24 04" src="https://user-images.githubusercontent.com/1562646/99666668-92effa00-2a6b-11eb-95d0-9757339a8af7.png">|

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Calypso live link below
* Navigate to /me/account and select the color scheme
* Add `?flags=nav-unification` to the URL
* Compare to `?flags=nav-unification` in production
