### PR TITLE
Reset Secure Your Brand - alternative approach

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -204,10 +204,10 @@ export default {
 		allowExistingUsers: true,
 	},
 	secureYourBrand: {
-		datestamp: '20201026',
+		datestamp: '20201119',
 		variations: {
-			test: 0,
-			control: 100,
+			test: 50,
+			control: 50,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: false,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -211,6 +211,5 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: false,
-		countryCodeTargets: [ 'US' ],
 	},
 };

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -123,7 +123,7 @@ export function generateFlows( {
 		},
 
 		'onboarding-secure-your-brand': {
-			steps: [ 'user', 'domains', 'secure-your-brand', 'plans' ],
+			steps: [ 'user', 'domains', 'plans', 'secure-your-brand' ],
 			destination: getSignupDestination,
 			description: 'Onboarding flow with an additional step to upsell domains',
 			lastModified: '2020-10-08',

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defer, get, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
+import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -173,11 +174,18 @@ class DomainsStep extends React.Component {
 		return this.showTestCopy;
 	}
 
+	getGeoLocationFromCookie() {
+		const cookies = cookie.parse( document.cookie );
+
+		return cookies.country_code;
+	}
+
 	isEligibleForSecureYourBrandTest( isPurchasingItem ) {
 		return (
 			includes( [ 'onboarding', 'onboarding-secure-your-brand' ], this.props.flowName ) &&
 			isPurchasingItem &&
-			! this.props.skipSecureYourBrand
+			! this.props.skipSecureYourBrand &&
+			'US' !== this.getGeoLocationFromCookie()
 		);
 	}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defer, get, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -53,7 +52,7 @@ import { isDomainStepSkippable } from 'calypso/signup/config/steps';
 import { fetchUsernameSuggestion } from 'calypso/state/signup/optional-dependencies/actions';
 import { isSitePreviewVisible } from 'calypso/state/signup/preview/selectors';
 import { hideSitePreview, showSitePreview } from 'calypso/state/signup/preview/actions';
-import { abtest, getABTestVariation } from 'calypso/lib/abtest';
+import { getABTestVariation } from 'calypso/lib/abtest';
 import getSitesItems from 'calypso/state/selectors/get-sites-items';
 import { isPlanStepExistsAndSkipped } from 'calypso/state/signup/progress/selectors';
 import { getStepModuleName } from 'calypso/signup/config/step-components';
@@ -174,18 +173,11 @@ class DomainsStep extends React.Component {
 		return this.showTestCopy;
 	}
 
-	getGeoLocationFromCookie() {
-		const cookies = cookie.parse( document.cookie );
-
-		return cookies.country_code;
-	}
-
 	isEligibleForSecureYourBrandTest( isPurchasingItem ) {
 		return (
 			includes( [ 'onboarding', 'onboarding-secure-your-brand' ], this.props.flowName ) &&
 			isPurchasingItem &&
-			! this.props.skipSecureYourBrand &&
-			'test' === abtest( 'secureYourBrand', this.getGeoLocationFromCookie() )
+			! this.props.skipSecureYourBrand
 		);
 	}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { parse as parseQs } from 'qs';
 import { Button } from '@automattic/components';
+import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -32,6 +33,7 @@ import { getUrlParts } from 'calypso/lib/url/url-parts';
 import QueryExperiments from 'calypso/components/data/query-experiments';
 import { isTreatmentInMonthlyPricingTest } from 'calypso/state/marketing/selectors';
 import { isPersonal } from 'calypso/lib/products-values';
+import { abtest } from 'calypso/lib/abtest';
 
 /**
  * Style dependencies
@@ -80,12 +82,25 @@ export class PlansStep extends Component {
 		this.props.submitSignupStep( step, {
 			cartItem,
 		} );
-		if ( flowName === 'onboarding-secure-your-brand' && isPersonal( cartItem ) ) {
+
+		// The last step of onboarding-secure-your-brand flow is the secure-your-brand upsell. It should not be visible
+		// if the plan is Personal or the user is in the control group
+		if (
+			flowName === 'onboarding-secure-your-brand' &&
+			( isPersonal( cartItem ) ||
+				'test' !== abtest( 'secureYourBrand', this.getGeoLocationFromCookie() ) )
+		) {
 			this.props.goToNextStep( 'onboarding' );
 		} else {
 			this.props.goToNextStep();
 		}
 	};
+
+	getGeoLocationFromCookie() {
+		const cookies = cookie.parse( document.cookie );
+
+		return cookies.country_code;
+	}
 
 	getDomainName() {
 		return (

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -31,6 +31,7 @@ import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
 import { getUrlParts } from 'calypso/lib/url/url-parts';
 import QueryExperiments from 'calypso/components/data/query-experiments';
 import { isTreatmentInMonthlyPricingTest } from 'calypso/state/marketing/selectors';
+import { isPersonal } from 'calypso/lib/products-values';
 
 /**
  * Style dependencies
@@ -79,7 +80,11 @@ export class PlansStep extends Component {
 		this.props.submitSignupStep( step, {
 			cartItem,
 		} );
-		this.props.goToNextStep();
+		if ( flowName === 'onboarding-secure-your-brand' && isPersonal( cartItem ) ) {
+			this.props.goToNextStep( 'onboarding' );
+		} else {
+			this.props.goToNextStep();
+		}
 	};
 
 	getDomainName() {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -10,7 +10,6 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { parse as parseQs } from 'qs';
 import { Button } from '@automattic/components';
-import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -87,20 +86,13 @@ export class PlansStep extends Component {
 		// if the plan is Personal or the user is in the control group
 		if (
 			flowName === 'onboarding-secure-your-brand' &&
-			( isPersonal( cartItem ) ||
-				'test' !== abtest( 'secureYourBrand', this.getGeoLocationFromCookie() ) )
+			( isPersonal( cartItem ) || 'test' !== abtest( 'secureYourBrand' ) )
 		) {
 			this.props.goToNextStep( 'onboarding' );
 		} else {
 			this.props.goToNextStep();
 		}
 	};
-
-	getGeoLocationFromCookie() {
-		const cookies = cookie.parse( document.cookie );
-
-		return cookies.country_code;
-	}
 
 	getDomainName() {
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Restarts the Secure Your Brand test with some modification:
- The upsell step will come after plans
- It will not be triggered for Personal plan users

There's a back-and-forth switching between flows to make this work. The reasoning is that adding a signup step after the final step of the flow triggers unexpected issues and needs a large refactoring to be done cleanly. [Here's the direction I attempted before implementing this PR](https://github.com/Automattic/wp-calypso/pull/47545/files). It also doesn't help that the SignupProcessingScreen now has a timeout.

#### Testing instructions

1. Make sure your country code is `not US`, and the language is in the browser settings is English

**For `test` group in the secureYourBrand experiment**
2. Sign up with a free domain and site. It should work
3. Sign up with a paid domain and a Personal plan. It should work as before, no upsells
4. Sign up with a paid domain and a Premium plan. You should see the upsell
5. Experiment going back after selecting a Premium plan, switch to Personal. No upsell at the end of the flow

**For the `control` group
6. Sign up with a paid domain and a Premium plan, no upsell should be visible

This is the upsell as step 4 of the flow:
<img width="599" alt="Screenshot 2020-11-20 at 11 31 16" src="https://user-images.githubusercontent.com/82778/99784102-f89fbd00-2b23-11eb-9c60-0d785c68c080.png">

Note that in order to check if the actual discount works, you'll need to either search for a non .com/.net/.org domain, or not use the Store Sandbox.