### PR TITLE
Editing Toolkit: Update to 2.8.7

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.6
+ * Version: 2.8.7
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.6' );
+define( 'PLUGIN_VERSION', '2.8.7' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.6
+Stable tag: 2.8.7
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.7 =
+*
 
 = 2.8.6 =
 * Premium Content: Compatibility fix for Gutenberg >= 9.3.0 (https://github.com/Automattic/wp-calypso/pull/47467)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -41,7 +41,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 2.8.7 =
-*
+* Launch: open launch modal in editor only for free sites created in New Onboarding (https://github.com/Automattic/wp-calypso/pull/47514)
+* Focused Launch: add launch success view (https://github.com/Automattic/wp-calypso/pull/47404)
+* Premium Content: Use snackbar for error and success messages (https://github.com/Automattic/wp-calypso/pull/47477)
 
 = 2.8.6 =
 * Premium Content: Compatibility fix for Gutenberg >= 9.3.0 (https://github.com/Automattic/wp-calypso/pull/47467)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -44,6 +44,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Launch: open launch modal in editor only for free sites created in New Onboarding (https://github.com/Automattic/wp-calypso/pull/47514)
 * Focused Launch: add launch success view (https://github.com/Automattic/wp-calypso/pull/47404)
 * Premium Content: Use snackbar for error and success messages (https://github.com/Automattic/wp-calypso/pull/47477)
+* Coming soon: only show the coming soon page for singular, archive and search posts (https://github.com/Automattic/wp-calypso/pull/47563)
 
 = 2.8.6 =
 * Premium Content: Compatibility fix for Gutenberg >= 9.3.0 (https://github.com/Automattic/wp-calypso/pull/47467)
@@ -55,7 +56,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Premium Content: allow the payments button to know when it's inside the premium content block (https://github.com/Automattic/wp-calypso/pull/47245)
 * Coming soon: remove cookie banner, open graph, gravatar and other unneeded features from coming soon page (https://github.com/Automattic/wp-calypso/pull/47400)
 * Coming soon: fix the localised login link on the coming soon page (https://github.com/Automattic/wp-calypso/pull/47307)
-* Comgin soon: don't cache the coming soon page (https://github.com/Automattic/wp-calypso/pull/47450)
+* Coming soon: don't cache the coming soon page (https://github.com/Automattic/wp-calypso/pull/47450)
 
 = 2.8.4 =
 * Editor NUX modal: Temporarily make text smaller in editor welcome modal for german language (https://github.com/Automattic/wp-calypso/pull/47193)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -45,6 +45,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Focused Launch: add launch success view (https://github.com/Automattic/wp-calypso/pull/47404)
 * Premium Content: Use snackbar for error and success messages (https://github.com/Automattic/wp-calypso/pull/47477)
 * Coming soon: only show the coming soon page for singular, archive and search posts (https://github.com/Automattic/wp-calypso/pull/47563)
+* Patterns: Support skipping registering patterns with a requires-align-wide tag (https://github.com/Automattic/wp-calypso/pull/47571)
 
 = 2.8.6 =
 * Premium Content: Compatibility fix for Gutenberg >= 9.3.0 (https://github.com/Automattic/wp-calypso/pull/47467)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.6",
+	"version": "2.8.7",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Version bump and changelog

#### [Changes to Editing Toolkit since 2.8.6](https://github.com/Automattic/wp-calypso/commits/master/apps/editing-toolkit):

- [x] Editing Toolkit: add monorepo package references to tsconfig.json (#47499)  
- [x] Launch: check if site is on Free plan after rendering editor Launch button (#47514)
- [x] Focused Launch: add Success view (#47404)
- [x] Remove old block pattern files and code. (#47299)
- [x] Switch out inline notices in the block for snackbar notices. (#47477)
- [x] Focused Launch: Pixel perfect loading state (#47528)
- [x] Focused Launch: Add DomainPicker to DomainDetail view (#47318)
- [x] Coming soon: only show the coming soon page for singular, archive and search posts (https://github.com/Automattic/wp-calypso/pull/47563)
- [x] Patterns: Support skipping registering patterns with a requires-align-wide tag (https://github.com/Automattic/wp-calypso/pull/47571)
- [x] Onboarding: fix the plans correct language displaying in the plans grid (https://github.com/Automattic/wp-calypso/pull/47611)
- [x] Premium Content: Add default subscriber content (#47603) 

#### Testing instructions

1. Load the diff (D53018-code) on your sandbox and confirm that the above changes work correctly
2. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.