### PR TITLE
Add i18n data store

### DIFF
--- a/packages/data-stores/src/i18n/actions.ts
+++ b/packages/data-stores/src/i18n/actions.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import type { LocalizedLanguageNames } from './types';
+
+export const setLocalizedLanguageNames = (
+	i18nLocale: string,
+	localizedLanguageNames: LocalizedLanguageNames
+) =>
+	( {
+		type: 'SET_LOCALIZED_LANGUAGE_NAMES' as const,
+		localizedLanguageNames,
+		i18nLocale,
+	} as const );
+
+export type I18nAction = ReturnType< typeof setLocalizedLanguageNames >;

--- a/packages/data-stores/src/i18n/constants.ts
+++ b/packages/data-stores/src/i18n/constants.ts
@@ -1,0 +1,1 @@
+export const STORE_KEY = 'automattic/i18n';

--- a/packages/data-stores/src/i18n/constants.ts
+++ b/packages/data-stores/src/i18n/constants.ts
@@ -1,1 +1,2 @@
 export const STORE_KEY = 'automattic/i18n';
+export const LANGUAGE_NAMES_URL = 'https://public-api.wordpress.com/wpcom/v2/i18n/language-names';

--- a/packages/data-stores/src/i18n/index.ts
+++ b/packages/data-stores/src/i18n/index.ts
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { controls } from '@wordpress/data-controls';
+import { registerStore } from '@wordpress/data';
+import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from './constants';
+import reducer, { State } from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+import * as resolvers from './resolvers';
+
+export type { State };
+export type { LocalizedLanguageNames } from './types';
+
+let isRegistered = false;
+
+export function register(): typeof STORE_KEY {
+	if ( ! isRegistered ) {
+		isRegistered = true;
+		registerStore< State >( STORE_KEY, {
+			resolvers,
+			actions,
+			controls,
+			reducer: reducer as any,
+			selectors,
+		} );
+	}
+	return STORE_KEY;
+}
+
+declare module '@wordpress/data' {
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+}

--- a/packages/data-stores/src/i18n/reducer.ts
+++ b/packages/data-stores/src/i18n/reducer.ts
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import type { I18nAction } from './actions';
+import type { LocalizedLanguageNames } from './types';
+
+export type State = {
+	localizedLanguageNames: { [ i18nLocale: string ]: LocalizedLanguageNames };
+};
+
+const DEFAULT_STATE: State = { localizedLanguageNames: {} };
+
+const reducer = ( state = DEFAULT_STATE, action: I18nAction ): State => {
+	switch ( action.type ) {
+		case 'SET_LOCALIZED_LANGUAGE_NAMES':
+			return {
+				...state,
+				localizedLanguageNames: {
+					...state.localizedLanguageNames,
+					[ action.i18nLocale ]: action.localizedLanguageNames,
+				},
+			};
+		default:
+			return state;
+	}
+};
+
+export default reducer;

--- a/packages/data-stores/src/i18n/resolvers.ts
+++ b/packages/data-stores/src/i18n/resolvers.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { apiFetch } from '@wordpress/data-controls';
+import type { APIFetchOptions } from '@wordpress/api-fetch';
+
+import { setLocalizedLanguageNames } from './actions';
+
+export function* getLocalizedLanguageNames( locale: string ) {
+	const localizedLanguageNames = yield apiFetch( {
+		// Forcefully add `_locale` here because the `data` parameter will re-write it as
+		// just `locale` (no underscore). Context here:
+		// https://github.com/Automattic/wp-calypso/pull/46328#discussion_r515674976
+		url: `https://public-api.wordpress.com/wpcom/v2/i18n/language-names?_locale=${ locale }`,
+		mode: 'cors',
+	} as APIFetchOptions );
+
+	yield setLocalizedLanguageNames( locale, localizedLanguageNames );
+}

--- a/packages/data-stores/src/i18n/resolvers.ts
+++ b/packages/data-stores/src/i18n/resolvers.ts
@@ -3,15 +3,15 @@
  */
 import { apiFetch } from '@wordpress/data-controls';
 import type { APIFetchOptions } from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 
 import { setLocalizedLanguageNames } from './actions';
 
 export function* getLocalizedLanguageNames( locale: string ) {
+	const url = 'https://public-api.wordpress.com/wpcom/v2/i18n/language-names';
+
 	const localizedLanguageNames = yield apiFetch( {
-		// Forcefully add `_locale` here because the `data` parameter will re-write it as
-		// just `locale` (no underscore). Context here:
-		// https://github.com/Automattic/wp-calypso/pull/46328#discussion_r515674976
-		url: `https://public-api.wordpress.com/wpcom/v2/i18n/language-names?_locale=${ locale }`,
+		url: addQueryArgs( url, { _locale: locale } ),
 		mode: 'cors',
 	} as APIFetchOptions );
 

--- a/packages/data-stores/src/i18n/resolvers.ts
+++ b/packages/data-stores/src/i18n/resolvers.ts
@@ -6,8 +6,7 @@ import type { APIFetchOptions } from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
 import { setLocalizedLanguageNames } from './actions';
-
-export const LANGUAGE_NAMES_URL = 'https://public-api.wordpress.com/wpcom/v2/i18n/language-names';
+import { LANGUAGE_NAMES_URL } from './constants';
 
 export function* getLocalizedLanguageNames( locale: string ) {
 	const localizedLanguageNames = yield apiFetch( {

--- a/packages/data-stores/src/i18n/resolvers.ts
+++ b/packages/data-stores/src/i18n/resolvers.ts
@@ -7,11 +7,11 @@ import { addQueryArgs } from '@wordpress/url';
 
 import { setLocalizedLanguageNames } from './actions';
 
-export function* getLocalizedLanguageNames( locale: string ) {
-	const url = 'https://public-api.wordpress.com/wpcom/v2/i18n/language-names';
+export const LANGUAGE_NAMES_URL = 'https://public-api.wordpress.com/wpcom/v2/i18n/language-names';
 
+export function* getLocalizedLanguageNames( locale: string ) {
 	const localizedLanguageNames = yield apiFetch( {
-		url: addQueryArgs( url, { _locale: locale } ),
+		url: addQueryArgs( LANGUAGE_NAMES_URL, { _locale: locale } ),
 		mode: 'cors',
 	} as APIFetchOptions );
 

--- a/packages/data-stores/src/i18n/selectors.ts
+++ b/packages/data-stores/src/i18n/selectors.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import type { State } from './reducer';
+import type { LocalizedLanguageNames } from './types';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getLocalizedLanguageNames = (
+	state: State,
+	i18nLocale: string
+): LocalizedLanguageNames => state?.localizedLanguageNames?.[ i18nLocale ];

--- a/packages/data-stores/src/i18n/selectors.ts
+++ b/packages/data-stores/src/i18n/selectors.ts
@@ -4,7 +4,6 @@
 import type { State } from './reducer';
 import type { LocalizedLanguageNames } from './types';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const getLocalizedLanguageNames = (
 	state: State,
 	i18nLocale: string

--- a/packages/data-stores/src/i18n/test/reducer.js
+++ b/packages/data-stores/src/i18n/test/reducer.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import reducer from '../reducer';
+import { setLocalizedLanguageNames } from '../actions';
+
+describe( 'i18n reducer', () => {
+	describe( 'localizedLanguageNames', () => {
+		it( 'should default to no localized language names', () => {
+			const { localizedLanguageNames } = reducer( undefined, { type: '' } );
+			expect( localizedLanguageNames ).toEqual( {} );
+		} );
+
+		it( 'should set the localized language names', () => {
+			const localizedLanguageNames = Symbol( 'localizedLanguageNames' );
+			const locale = 'fake-locale';
+
+			const action = setLocalizedLanguageNames( locale, localizedLanguageNames );
+
+			const state = reducer( undefined, action );
+
+			expect( state ).toEqual( {
+				localizedLanguageNames: {
+					[ locale ]: localizedLanguageNames,
+				},
+			} );
+		} );
+	} );
+} );

--- a/packages/data-stores/src/i18n/test/reducer.js
+++ b/packages/data-stores/src/i18n/test/reducer.js
@@ -25,5 +25,48 @@ describe( 'i18n reducer', () => {
 				},
 			} );
 		} );
+
+		it( 'should overwrite the existing locale', () => {
+			const localizedLanguageNames = Symbol( 'localizedLanguageNames' );
+			const locale = 'fake-locale';
+
+			const action = setLocalizedLanguageNames( locale, localizedLanguageNames );
+
+			const state = reducer(
+				{ localizedLanguageNames: { [ locale ]: Symbol( 'previous localizedLanguageNames' ) } },
+				action
+			);
+
+			expect( state ).toEqual( {
+				localizedLanguageNames: {
+					[ locale ]: localizedLanguageNames,
+				},
+			} );
+		} );
+
+		it( 'should add the new locale without overwriting the old one', () => {
+			const localizedLanguageNames = Symbol( 'localizedLanguageNames' );
+			const locale = 'fake-locale';
+			const anotherLocale = 'another-locale';
+			const anotherLocalesLocalizedLanguageNames = Symbol( 'another localizedLanguageNames' );
+
+			const action = setLocalizedLanguageNames( locale, localizedLanguageNames );
+
+			const state = reducer(
+				{
+					localizedLanguageNames: {
+						[ anotherLocale ]: anotherLocalesLocalizedLanguageNames,
+					},
+				},
+				action
+			);
+
+			expect( state ).toEqual( {
+				localizedLanguageNames: {
+					[ locale ]: localizedLanguageNames,
+					[ anotherLocale ]: anotherLocalesLocalizedLanguageNames,
+				},
+			} );
+		} );
 	} );
 } );

--- a/packages/data-stores/src/i18n/test/resolvers.js
+++ b/packages/data-stores/src/i18n/test/resolvers.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { getLocalizedLanguageNames } from '../resolvers';
+import { setLocalizedLanguageNames } from '../actions';
+
+describe( 'i18n resolvers', () => {
+	describe( 'getLocalizedLanguageNames', () => {
+		it( 'should set the localized language names', () => {
+			const iter = getLocalizedLanguageNames( 'en-us' );
+
+			expect( iter.next().value ).toEqual( {
+				type: 'API_FETCH',
+				request: expect.objectContaining( {
+					mode: 'cors',
+					url: expect.stringContaining( 'language-names?_locale=en-us' ),
+				} ),
+			} );
+
+			const localizedLanguageNames = Symbol( 'localizedLanguageNames' );
+
+			expect( iter.next( localizedLanguageNames ).value ).toEqual(
+				setLocalizedLanguageNames( 'en-us', localizedLanguageNames )
+			);
+		} );
+	} );
+} );

--- a/packages/data-stores/src/i18n/test/resolvers.js
+++ b/packages/data-stores/src/i18n/test/resolvers.js
@@ -7,8 +7,9 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { getLocalizedLanguageNames, LANGUAGE_NAMES_URL } from '../resolvers';
+import { getLocalizedLanguageNames } from '../resolvers';
 import { setLocalizedLanguageNames } from '../actions';
+import { LANGUAGE_NAMES_URL } from '../constants';
 
 describe( 'i18n resolvers', () => {
 	describe( 'getLocalizedLanguageNames', () => {

--- a/packages/data-stores/src/i18n/test/resolvers.js
+++ b/packages/data-stores/src/i18n/test/resolvers.js
@@ -1,7 +1,13 @@
 /**
+ * External dependencies
+ */
+import { apiFetch } from '@wordpress/data-controls';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
  * Internal dependencies
  */
-import { getLocalizedLanguageNames } from '../resolvers';
+import { getLocalizedLanguageNames, LANGUAGE_NAMES_URL } from '../resolvers';
 import { setLocalizedLanguageNames } from '../actions';
 
 describe( 'i18n resolvers', () => {
@@ -9,19 +15,20 @@ describe( 'i18n resolvers', () => {
 		it( 'should set the localized language names', () => {
 			const iter = getLocalizedLanguageNames( 'en-us' );
 
-			expect( iter.next().value ).toEqual( {
-				type: 'API_FETCH',
-				request: expect.objectContaining( {
+			expect( iter.next().value ).toEqual(
+				apiFetch( {
+					url: addQueryArgs( LANGUAGE_NAMES_URL, { _locale: 'en-us' } ),
 					mode: 'cors',
-					url: expect.stringContaining( 'language-names?_locale=en-us' ),
-				} ),
-			} );
+				} )
+			);
 
 			const localizedLanguageNames = Symbol( 'localizedLanguageNames' );
 
 			expect( iter.next( localizedLanguageNames ).value ).toEqual(
 				setLocalizedLanguageNames( 'en-us', localizedLanguageNames )
 			);
+
+			expect( iter.next().done ).toBeTruthy();
 		} );
 	} );
 } );

--- a/packages/data-stores/src/i18n/test/selectors.js
+++ b/packages/data-stores/src/i18n/test/selectors.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { getLocalizedLanguageNames } from '../selectors';
+
+describe( 'i18n selectors', () => {
+	describe( 'getLocalizedLanguageNames', () => {
+		it( 'should retrieve the localized language names for the locale', () => {
+			const localizedLanguageNames = Symbol( 'localizedLanguageNames en-us' );
+			const state = {
+				localizedLanguageNames: {
+					'en-us': localizedLanguageNames,
+				},
+			};
+
+			expect( getLocalizedLanguageNames( state, 'en-us' ) ).toBe( localizedLanguageNames );
+		} );
+
+		it( 'should return undefined if the locale is not set', () => {
+			const state = {};
+
+			expect( getLocalizedLanguageNames( state, 'en-us' ) ).toBeUndefined();
+		} );
+	} );
+} );

--- a/packages/data-stores/src/i18n/types.ts
+++ b/packages/data-stores/src/i18n/types.ts
@@ -1,0 +1,3 @@
+export type LocalizedLanguageNames = {
+	[ languageSlug: string ]: { name: string; en: string; localized: string };
+};

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -11,11 +11,13 @@ import * as Verticals from './verticals';
 import * as Launch from './launch';
 import * as WPCOMFeatures from './wpcom-features';
 import * as VerticalsTemplates from './verticals-templates';
+import * as I18n from './i18n';
 
 export {
 	Auth,
 	User,
 	DomainSuggestions,
+	I18n,
 	Site,
 	Verticals,
 	VerticalsTemplates,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new i18n data store to `data-stores` with a single selector/resolver pair for fetching localized language names.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure unit tests and build passes.
