### PR TITLE
Editor Checkout: enable in all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -101,6 +101,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"post-editor/checkout-overlay": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"publicize-preview": true,

--- a/config/production.json
+++ b/config/production.json
@@ -107,6 +107,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"post-editor/checkout-overlay": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -114,6 +114,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"post-editor/checkout-overlay": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"press-this": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* After the integration between Premium blocks and editor checkout has been tested internally (p58i-9C7-p2) and is currently covered by E2E tests (https://github.com/Automattic/wp-calypso/pull/47231), we can proceed to enable `"post-editor/checkout-overlay"` feature flag in all environments.