### PR TITLE
Revert "Simulate E2E failure (part of onboarding process) (#47588)"

### DIFF
--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -39,10 +39,6 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 			await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'FAILING Test', function () {
-			assert.strictEqual( true, false, 'This should fail on purpose' );
-		} );
-
 		step( 'Can visit Gutenboarding page and see Onboarding block', async function () {
 			const page = await NewPage.Visit( driver );
 			const blockExists = await page.waitForBlock();


### PR DESCRIPTION
This REALLY reverts the failing E2E tests.
