### PR TITLE
Jetpack Connect: improvements UX around plan/product selection

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card-alt/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card-alt/index.tsx
@@ -1,20 +1,14 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import { useSelector } from 'react-redux';
-import { Button } from '@automattic/components';
+import React, { FC } from 'react';
 import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import FeaturesItem from '../jetpack-product-card-alt/features-item';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
-import { addQueryArgs } from 'calypso/lib/route';
-import getJetpackWpAdminUrl from 'calypso/state/selectors/get-jetpack-wp-admin-url';
-import { JPC_PATH_REMOTE_INSTALL } from 'calypso/jetpack-connect/constants';
+import JetpackFreeCardButton from 'calypso/components/jetpack/card/jetpack-free-card-button';
 
 /**
  * Type dependencies
@@ -26,17 +20,8 @@ import type { JetpackFreeProps } from 'calypso/my-sites/plans/jetpack-plans/type
  */
 import './style.scss';
 
-const JetpackFreeCardAlt = ( { siteId, urlQueryArgs }: JetpackFreeProps ) => {
+const JetpackFreeCardAlt: FC< JetpackFreeProps > = ( { siteId, urlQueryArgs } ) => {
 	const translate = useTranslate();
-	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
-
-	const startHref = isJetpackCloud()
-		? addQueryArgs( urlQueryArgs, `https://wordpress.com${ JPC_PATH_REMOTE_INSTALL }` )
-		: wpAdminUrl || JPC_PATH_REMOTE_INSTALL;
-
-	const onClickTrack = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
-		site_id: siteId || undefined,
-	} );
 
 	const freeFeaturesOne = [
 		{
@@ -71,9 +56,7 @@ const JetpackFreeCardAlt = ( { siteId, urlQueryArgs }: JetpackFreeProps ) => {
 						{ translate( 'Included for free with all products' ) }
 					</div>
 				</header>
-				<Button primary href={ startHref } onClick={ onClickTrack }>
-					{ translate( 'Start for free' ) }
-				</Button>
+				<JetpackFreeCardButton primary siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
 			</div>
 			<div className="jetpack-free-card-alt__features">
 				<ul className="jetpack-free-card-alt__features-list">

--- a/client/components/jetpack/card/jetpack-free-card-button/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card-button/index.tsx
@@ -18,9 +18,9 @@ import { JPC_PATH_BASE } from 'calypso/jetpack-connect/constants';
 /**
  * Type dependencies
  */
-import type { QueryArgs } from 'calypso/my-sites/plans-v2/types';
+import type { QueryArgs } from 'calypso/my-sites/plans/jetpack-plans/types';
 
-interface JetpackFreeCardButton {
+interface JetpackFreeCardButtonProps {
 	className?: string;
 	label?: TranslateResult;
 	primary?: boolean;
@@ -28,7 +28,7 @@ interface JetpackFreeCardButton {
 	urlQueryArgs: QueryArgs;
 }
 
-const JetpackFreeCardButton: FC< JetpackFreeCardButton > = ( {
+const JetpackFreeCardButton: FC< JetpackFreeCardButtonProps > = ( {
 	className,
 	label,
 	primary = false,
@@ -41,14 +41,14 @@ const JetpackFreeCardButton: FC< JetpackFreeCardButton > = ( {
 		site_id: siteId || undefined,
 	} );
 
-	// Jetpack Connect flow uses `url` instead of `site` for a site URL
+	// Jetpack Connect flow uses `url` instead of `site` as the query parameter for a site URL
 	const { site: url, ...restQueryArgs } = urlQueryArgs;
 	const startHref = isJetpackCloud()
 		? addQueryArgs( { url, ...restQueryArgs }, `https://wordpress.com${ JPC_PATH_BASE }` )
 		: wpAdminUrl || JPC_PATH_BASE;
 	return (
 		<Button primary={ primary } className={ className } href={ startHref } onClick={ onClickTrack }>
-			{ label ? label : translate( 'Start for free' ) }
+			{ label || translate( 'Start for free' ) }
 		</Button>
 	);
 };

--- a/client/components/jetpack/card/jetpack-free-card-button/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card-button/index.tsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import React, { FC } from 'react';
+import { useSelector } from 'react-redux';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { Button } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import { addQueryArgs } from 'calypso/lib/route';
+import getJetpackWpAdminUrl from 'calypso/state/selectors/get-jetpack-wp-admin-url';
+import { JPC_PATH_BASE } from 'calypso/jetpack-connect/constants';
+
+/**
+ * Type dependencies
+ */
+import type { QueryArgs } from 'calypso/my-sites/plans-v2/types';
+
+interface JetpackFreeCardButton {
+	className?: string;
+	label?: TranslateResult;
+	primary?: boolean;
+	siteId: number | null;
+	urlQueryArgs: QueryArgs;
+}
+
+const JetpackFreeCardButton: FC< JetpackFreeCardButton > = ( {
+	className,
+	label,
+	primary = false,
+	siteId,
+	urlQueryArgs,
+} ) => {
+	const translate = useTranslate();
+	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
+	const onClickTrack = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
+		site_id: siteId || undefined,
+	} );
+
+	// Jetpack Connect flow uses `url` instead of `site` for a site URL
+	const { site: url, ...restQueryArgs } = urlQueryArgs;
+	const startHref = isJetpackCloud()
+		? addQueryArgs( { url, ...restQueryArgs }, `https://wordpress.com${ JPC_PATH_BASE }` )
+		: wpAdminUrl || JPC_PATH_BASE;
+	return (
+		<Button primary={ primary } className={ className } href={ startHref } onClick={ onClickTrack }>
+			{ label ? label : translate( 'Start for free' ) }
+		</Button>
+	);
+};
+
+export default JetpackFreeCardButton;

--- a/client/components/jetpack/card/jetpack-free-card-i5/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card-i5/index.tsx
@@ -1,20 +1,14 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { FC } from 'react';
 import { useTranslate } from 'i18n-calypso';
-import { Button } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
 import Gridicon from 'calypso/components/gridicon';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
-import { addQueryArgs } from 'calypso/lib/route';
-import getJetpackWpAdminUrl from 'calypso/state/selectors/get-jetpack-wp-admin-url';
-import { JPC_PATH_REMOTE_INSTALL } from 'calypso/jetpack-connect/constants';
+import JetpackFreeCardButton from 'calypso/components/jetpack/card/jetpack-free-card-button';
 
 /**
  * Type dependencies
@@ -26,15 +20,8 @@ import type { JetpackFreeProps } from 'calypso/my-sites/plans/jetpack-plans/type
  */
 import './style.scss';
 
-const JetpackFreeCardAlt: React.FC< JetpackFreeProps > = ( { siteId, urlQueryArgs } ) => {
+const JetpackFreeCardAlt: FC< JetpackFreeProps > = ( { siteId, urlQueryArgs } ) => {
 	const translate = useTranslate();
-	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
-	const onClickTrack = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
-		site_id: siteId || undefined,
-	} );
-	const startHref = isJetpackCloud()
-		? addQueryArgs( urlQueryArgs, `https://wordpress.com${ JPC_PATH_REMOTE_INSTALL }` )
-		: wpAdminUrl || JPC_PATH_REMOTE_INSTALL;
 
 	return (
 		<div className="jetpack-free-card-i5 jetpack-product-card-i5" data-e2e-product-slug="free">
@@ -43,13 +30,11 @@ const JetpackFreeCardAlt: React.FC< JetpackFreeProps > = ( { siteId, urlQueryArg
 				<p className="jetpack-free-card-i5__subheadline">
 					{ translate( 'Included for free with all products' ) }
 				</p>
-				<Button
+				<JetpackFreeCardButton
 					className="jetpack-free-card-i5__button"
-					href={ startHref }
-					onClick={ onClickTrack }
-				>
-					{ translate( 'Start for free' ) }
-				</Button>
+					siteId={ siteId }
+					urlQueryArgs={ urlQueryArgs }
+				/>
 			</header>
 			<ul className="jetpack-free-card-i5__features-list">
 				{ [

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -54,6 +54,7 @@ import {
 	XMLRPC_ERROR,
 } from './connection-notice-types';
 import {
+	clearPlan,
 	isCalypsoStartedConnection,
 	isSsoApproved,
 	retrieveMobileRedirect,
@@ -622,6 +623,9 @@ export class JetpackAuthorize extends Component {
 			productSlug.includes( 'jetpack' )
 		);
 		if ( jetpackCheckoutSlugs.includes( this.props.selectedPlanSlug ) ) {
+			// Once we decide we want to redirect the user to the checkout page and that there is a
+			// valid plan, we can safely remove it from the session storage
+			clearPlan();
 			return '/checkout/' + urlToSlug( homeUrl ) + '/' + this.props.selectedPlanSlug;
 		}
 

--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -4,6 +4,7 @@ export const CALYPSO_REDIRECTION_PAGE = '/posts/';
 export const IS_DOT_COM_GET_SEARCH = 'isDotComGetSearch';
 export const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 export const JETPACK_MINIMUM_WORDPRESS_VERSION = '4.7';
+export const JPC_PATH_BASE = '/jetpack/connect';
 export const JPC_PATH_PLANS = '/jetpack/connect/plans';
 export const JPC_PATH_REMOTE_INSTALL = '/jetpack/connect/install';
 export const MINIMUM_JETPACK_VERSION = '3.9.6';

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -78,6 +78,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 				! forceRemoteInstall &&
 				! this.state.redirecting
 			) {
+				debug( `Redirecting to remote_auth ${ this.props.siteHomeUrl }` );
 				this.redirect( 'remote_auth', this.props.siteHomeUrl );
 			}
 
@@ -85,8 +86,10 @@ const jetpackConnection = ( WrappedComponent ) => {
 				const currentPlan = retrievePlan();
 				clearPlan();
 				if ( currentPlan ) {
+					debug( `Redirecting to checkout with ${ currentPlan } plan retrieved from cookies` );
 					this.redirect( 'checkout', url, currentPlan, queryArgs );
 				} else {
+					debug( 'Redirecting to plans_selection' );
 					this.redirect( 'plans_selection', url );
 				}
 			}
@@ -106,8 +109,10 @@ const jetpackConnection = ( WrappedComponent ) => {
 					! isMobileAppFlow &&
 					! skipRemoteInstall
 				) {
+					debug( 'Redirecting to remote_install' );
 					this.redirect( 'remote_install' );
 				} else {
+					debug( 'Redirecting to install_instructions' );
 					this.redirect( 'install_instructions', url );
 				}
 			}

--- a/client/jetpack-connect/persistence-utils.js
+++ b/client/jetpack-connect/persistence-utils.js
@@ -9,25 +9,25 @@ import cookie from 'cookie';
 import { JETPACK_CONNECT_TTL_SECONDS } from 'calypso/state/jetpack-connect/constants';
 import { urlToSlug } from 'calypso/lib/url';
 
+const SESSION_STORAGE_SELECTED_PLAN = 'jetpack_connect_selected_plan';
+
 /**
  * Utilities for storing jetpack connect state that needs to persist across
- * logins and redirects. Cookies work well for this, since redux
+ * logins and redirects. Session Storage work well for this, since redux
  * state is not guaranteed to be persisted in these scenarios.
+ *
+ * @param planSlug A plan/product unique identifier
  */
-
 export const storePlan = ( planSlug ) => {
-	const options = { path: '/' };
-	document.cookie = cookie.serialize( 'jetpack_connect_selected_plan', planSlug, options );
+	window.sessionStorage.setItem( SESSION_STORAGE_SELECTED_PLAN, planSlug );
 };
 
 export const clearPlan = () => {
-	const options = { path: '/' };
-	document.cookie = cookie.serialize( 'jetpack_connect_selected_plan', '', options );
+	window.sessionStorage.removeItem( SESSION_STORAGE_SELECTED_PLAN );
 };
 
 export const retrievePlan = () => {
-	const cookies = cookie.parse( document.cookie );
-	return cookies.jetpack_connect_selected_plan;
+	return window.sessionStorage.getItem( SESSION_STORAGE_SELECTED_PLAN );
 };
 
 export const persistSession = ( url ) => {

--- a/client/my-sites/plans/jetpack-plans/products-grid-alt-2/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/products-grid-alt-2/index.tsx
@@ -156,7 +156,7 @@ const ProductsGridAlt2: React.FC< ProductsGridProps > = ( {
 					/>
 				) ) }
 
-				{ showJetpackFreeCard && siteId && (
+				{ showJetpackFreeCard && (
 					<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
 				) }
 			</div>


### PR DESCRIPTION
#### Motivation

The primary objective of this PR is to improve the UX around the Jetpack Connect flow. Specifically, we want to fix these odd redirections to the checkout page with something in the cart that sometimes happens after connecting a site.

#### Changes proposed in this Pull Request

**Primary changes**
* Replace cookies as the storage mechanism for the selected plan/product with session storage. The problem with cookies, in this context, is that they are shared across sessions/tabs until the browser is closed. This means that if at some point I selected a plan X, and then I change my mind and close the tab or change the URL, the selected plan will remain stored in my browser for as long as I keep the browser open. So, if later I decide to connect an entirely different site, the app will see that there is a selected plan stored in a cookie and will redirect me directly to the checkout page with the selected plan in the cart. This is one of the reasons behind those odds cases in which we connect a site and then we are suddenly redirected to the checkout page with something in the cart. Here is a report about this same problem https://github.com/Automattic/wp-calypso/issues/47560. 

* Remove the selected plan from the storage (session storage from now on) once the user arrives on the checkout page. At that point, the user will either purchase the plan or abort the process. If the user decides to abort the process, there is no reason to keep the selected plan stored in the browser.

**Secondary changes**
* Create a new component called `JetpackFreeCardButton` which abstracts the logic behind this button – setting the right `href` according to the context and event tracks. The idea is to avoid duplicating this logic on every `JetpackFreeCard` component we create for every new design.
* In the context of `cloud.jetpack.com/pricing`, make the `JetpackFreeCardButton` point to `/jetpack/connect/` instead than to `/jetpack/connect/install`. This is because the decision about whether the site needs the Jetpack plugin to be installed is decided in the controller behind this route, not in the other.

#### Notes

I still think we can do better in follow-up PR if we want to proceed with these changes. We could store in the session the site that was in context when the user was going through the purchase flow. This way, we could avoid considering the selected plan if the user is now using a different site.

This implementation with Session Storage assumes that the whole purchase flow is meant to be completed in the same browser tab. If for some reason a flow requires the user to use more than one tab to complete the process, this solution might not work for that case. This is because Session Storage is scoped on a tab basis, it isn't shared across browser tabs.

#### Testing instructions

**Replicate the in production**
* Visit `cloud.jetpack.com/pricing`.
* Select any product.
* Close the tab.
* Open a new tab.
* Visit `cloud.jetpack.com/pricing` and select Jetpack Free.
* Once in `/jetpack/connect`, enter a valid Jetpack site address.
* Verify that you are redirected to the Checkout page and that the product you selected before is in the cart.

**Test the changes**

To facilitate testing, I strongly encourage you to replace the line in https://github.com/Automattic/wp-calypso/blob/fix/pricing-page-jetpack-free-ux/client/my-sites/plans-v2/utils.ts#L697
```
		window.location.href = addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` );
```
with 
```
		window.location.href = addQueryArgs( urlQueryArgs, `http://calypso.localhost:3000${ path }` );
```

This will let you easily jump between your local version of the Pricing page and your local version of Calypso Blue. Additionally, if you want to make the `JetpackFreeCard` button take you to your local Calypso Blue, you should read this https://github.com/Automattic/wp-calypso/pull/47598/files#r527694477. 

* Run this PR locally building both Calypsos (Calypso Blue: `yarn start`, Calypso Green: `yarn start-jetpack-cloud-p`).
* Visit `jetpack.cloud.localhost:3001/pricing`.
* Select any product.
* Close the tab.
* Open a new tab.
* Visit `cloud.jetpack.com/pricing` and select Jetpack Free.
* Once in `/jetpack/connect`, enter a valid Jetpack site address.
* Verify that you are not redirected to the Checkout page and that you are redirected to the Plans grid.

Fixes 1164141197617539-as-1199221059177329

#### Demo (before)

Pay attention to how after connecting the site, I was redirected to the checkout page with the product I selected in the other tab. You have to keep in mind that this could have happened even if I attempted connection hours after I choose the product in the first tab. 

![Kapture 2020-11-19 at 14 44 25](https://user-images.githubusercontent.com/3418513/99703846-5e357000-2a76-11eb-9f33-2ae9effb8bf3.gif)