### PR TITLE
Focused Launch: Add Launch your site button

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -13,6 +13,10 @@ import FocusedLaunchModal from '@automattic/launch';
  */
 import { LAUNCH_STORE } from './stores';
 
+const redirectParentWindow = ( url: string ) => {
+	window.top.location.href = url;
+};
+
 const HOOK_OPEN_CHECKOUT_MODAL = 'a8c.wpcom-block-editor.openCheckoutModal';
 
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
@@ -43,7 +47,7 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 				// Redirect to My Home after checkout only if the selected plan is not eCommerce
 				...( ! isEcommerce && { redirect_to: `/home/${ siteId }` } ),
 			} );
-			window.top.location.href = checkoutUrl;
+			redirectParentWindow( checkoutUrl );
 		};
 
 		return (
@@ -54,7 +58,7 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 				redirectTo={ ( url: string ) => {
 					const origin = 'https://wordpress.com';
 					const path = url.startsWith( '/' ) ? url : `/${ url }`;
-					window.top.location.href = `${ origin }${ path }`;
+					redirectParentWindow( `${ origin }${ path }` );
 				} }
 			/>
 		);

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -34,7 +34,7 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 		const handleCheckout = ( siteId = currentSiteId, isEcommerce = false ) => {
 			// open checkout modal assuming the cart is already updated
 			if ( hasAction( HOOK_OPEN_CHECKOUT_MODAL ) ) {
-				doAction( HOOK_OPEN_CHECKOUT_MODAL, { isEcommerce } );
+				doAction( HOOK_OPEN_CHECKOUT_MODAL );
 				return;
 			}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -4,17 +4,13 @@
 import * as React from 'react';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
 import { useSelect } from '@wordpress/data';
-import { doAction, hasAction } from '@wordpress/hooks';
-import { addQueryArgs } from '@wordpress/url';
 import FocusedLaunchModal from '@automattic/launch';
 
 /**
  * Internal dependencies
  */
 import { LAUNCH_STORE } from './stores';
-import { redirectParentWindow, redirectToWpcomPath } from './utils';
-
-const HOOK_OPEN_CHECKOUT_MODAL = 'a8c.wpcom-block-editor.openCheckoutModal';
+import { openCheckout, redirectToWpcomPath } from './utils';
 
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,27 +28,12 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 			return null;
 		}
 
-		const handleCheckout = ( siteId = currentSiteId, isEcommerce = false ) => {
-			// open checkout modal assuming the cart is already updated
-			if ( hasAction( HOOK_OPEN_CHECKOUT_MODAL ) ) {
-				doAction( HOOK_OPEN_CHECKOUT_MODAL );
-				return;
-			}
-
-			// fallback: redirect to /checkout page
-			const checkoutUrl = addQueryArgs( `https://wordpress.com/checkout/${ siteId }`, {
-				// Redirect to My Home after checkout only if the selected plan is not eCommerce
-				...( ! isEcommerce && { redirect_to: `/home/${ siteId }` } ),
-			} );
-			redirectParentWindow( checkoutUrl );
-		};
-
 		return (
 			<FocusedLaunchModal
-				siteId={ currentSiteId }
-				openCheckout={ handleCheckout }
-				locale={ document.documentElement.lang }
+				locale={ window.wpcomEditorSiteLaunch?.locale }
+				openCheckout={ openCheckout }
 				redirectTo={ redirectToWpcomPath }
+				siteId={ currentSiteId }
 			/>
 		);
 	},

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -3,7 +3,9 @@
  */
 import * as React from 'react';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
+import { doAction, hasAction } from '@wordpress/hooks';
+import { addQueryArgs } from '@wordpress/url';
 import FocusedLaunchModal from '@automattic/launch';
 
 /**
@@ -11,26 +13,43 @@ import FocusedLaunchModal from '@automattic/launch';
  */
 import { LAUNCH_STORE } from './stores';
 
+const HOOK_OPEN_CHECKOUT_MODAL = 'a8c.wpcom-block-editor.openCheckoutModal';
+
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	originalRegisterPlugin( name, settings as any );
 
 registerPlugin( 'a8c-editor-editor-focused-launch', {
 	render: function LaunchSidebar() {
+		const currentSiteId = window._currentSiteId;
+
 		const isFocusedLaunchOpen = useSelect( ( select ) =>
 			select( LAUNCH_STORE ).isFocusedLaunchOpen()
 		);
-
-		const { closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
 
 		if ( ! isFocusedLaunchOpen ) {
 			return null;
 		}
 
+		const handleCheckout = ( siteId = currentSiteId, isEcommerce = false ) => {
+			// open checkout modal assuming the cart is already updated
+			if ( hasAction( HOOK_OPEN_CHECKOUT_MODAL ) ) {
+				doAction( HOOK_OPEN_CHECKOUT_MODAL, { isEcommerce } );
+				return;
+			}
+
+			// fallback: redirect to /checkout page
+			const checkoutUrl = addQueryArgs( `https://wordpress.com/checkout/${ siteId }`, {
+				// Redirect to My Home after checkout only if the selected plan is not eCommerce
+				...( ! isEcommerce && { redirect_to: `/home/${ siteId }` } ),
+			} );
+			window.top.location.href = checkoutUrl;
+		};
+
 		return (
 			<FocusedLaunchModal
-				siteId={ window._currentSiteId }
-				onClose={ closeFocusedLaunch }
+				siteId={ currentSiteId }
+				openCheckout={ handleCheckout }
 				locale={ document.documentElement.lang }
 				redirectTo={ ( url: string ) => {
 					const origin = 'https://wordpress.com';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -12,10 +12,7 @@ import FocusedLaunchModal from '@automattic/launch';
  * Internal dependencies
  */
 import { LAUNCH_STORE } from './stores';
-
-const redirectParentWindow = ( url: string ) => {
-	window.top.location.href = url;
-};
+import { redirectParentWindow, redirectToWpcomPath } from './utils';
 
 const HOOK_OPEN_CHECKOUT_MODAL = 'a8c.wpcom-block-editor.openCheckoutModal';
 
@@ -55,11 +52,7 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 				siteId={ currentSiteId }
 				openCheckout={ handleCheckout }
 				locale={ document.documentElement.lang }
-				redirectTo={ ( url: string ) => {
-					const origin = 'https://wordpress.com';
-					const path = url.startsWith( '/' ) ? url : `/${ url }`;
-					redirectParentWindow( `${ origin }${ path }` );
-				} }
+				redirectTo={ redirectToWpcomPath }
 			/>
 		);
 	},

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
@@ -13,6 +13,7 @@ import { LocaleProvider } from '@automattic/i18n-utils';
  */
 import LaunchModal from './launch-modal';
 import { LAUNCH_STORE } from './stores';
+import { FLOW_ID } from './constants';
 
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -43,7 +44,7 @@ registerPlugin( 'a8c-editor-site-launch', {
 
 		return (
 			<LocaleProvider localeSlug={ window.wpcomEditorSiteLaunch?.locale }>
-				<LaunchContext.Provider value={ { siteId: window._currentSiteId } }>
+				<LaunchContext.Provider value={ { siteId: window._currentSiteId, flow: FLOW_ID } }>
 					<LaunchModal onClose={ closeSidebar } />
 				</LaunchContext.Provider>
 			</LocaleProvider>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
@@ -14,7 +14,7 @@ import { LocaleProvider } from '@automattic/i18n-utils';
 import LaunchModal from './launch-modal';
 import { LAUNCH_STORE } from './stores';
 import { FLOW_ID } from './constants';
-import { redirectToWpcomPath } from './utils';
+import { openCheckout, redirectToWpcomPath } from './utils';
 
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -50,6 +50,7 @@ registerPlugin( 'a8c-editor-site-launch', {
 						siteId: window._currentSiteId,
 						flow: FLOW_ID,
 						redirectTo: redirectToWpcomPath,
+						openCheckout,
 					} }
 				>
 					<LaunchModal onClose={ closeSidebar } />

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
@@ -14,6 +14,7 @@ import { LocaleProvider } from '@automattic/i18n-utils';
 import LaunchModal from './launch-modal';
 import { LAUNCH_STORE } from './stores';
 import { FLOW_ID } from './constants';
+import { redirectToWpcomPath } from './utils';
 
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -44,7 +45,13 @@ registerPlugin( 'a8c-editor-site-launch', {
 
 		return (
 			<LocaleProvider localeSlug={ window.wpcomEditorSiteLaunch?.locale }>
-				<LaunchContext.Provider value={ { siteId: window._currentSiteId, flow: FLOW_ID } }>
+				<LaunchContext.Provider
+					value={ {
+						siteId: window._currentSiteId,
+						flow: FLOW_ID,
+						redirectTo: redirectToWpcomPath,
+					} }
+				>
 					<LaunchModal onClose={ closeSidebar } />
 				</LaunchContext.Provider>
 			</LocaleProvider>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/constants.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/constants.ts
@@ -5,5 +5,6 @@ declare global {
 		wpcomEditorSiteLaunch?: {
 			locale?: string;
 		};
+		_currentSiteId: number;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/index.tsx
@@ -2,17 +2,17 @@
  * External dependencies
  */
 import * as React from 'react';
+import classnames from 'classnames';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Modal, Button } from '@wordpress/components';
 import { Icon, wordpress, close } from '@wordpress/icons';
-import classnames from 'classnames';
-import { useSite, useOnLaunch } from '@automattic/launch';
+import { LaunchContext, useOnLaunch } from '@automattic/launch';
 
 /**
  * Internal dependencies
  */
-import { LAUNCH_STORE } from '../stores';
+import { LAUNCH_STORE, SITE_STORE } from '../stores';
 import Launch from '../launch';
 import LaunchSidebar from '../launch-sidebar';
 import LaunchProgress from '../launch-progress';
@@ -24,23 +24,19 @@ interface Props {
 }
 
 const LaunchModal: React.FunctionComponent< Props > = ( { onClose } ) => {
+	const { siteId } = React.useContext( LaunchContext );
+
 	const { step: currentStep, isSidebarFullscreen } = useSelect( ( select ) =>
 		select( LAUNCH_STORE ).getState()
 	);
-	const { launchSite } = useDispatch( LAUNCH_STORE );
-
 	const [ isLaunching, setIsLaunching ] = React.useState( false );
 
-	const { isPaidPlan } = useSite();
+	const { launchSite } = useDispatch( SITE_STORE );
 
 	const handleLaunch = () => {
+		launchSite( siteId );
 		setIsLaunching( true );
-		launchSite();
 	};
-
-	if ( isPaidPlan && ! isLaunching ) {
-		handleLaunch();
-	}
 
 	// handle redirects to checkout / my home after launch
 	useOnLaunch();

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
@@ -1,0 +1,9 @@
+export const redirectParentWindow = ( url: string ) => {
+	window.top.location.href = url;
+};
+
+export const redirectToWpcomPath = ( url: string ) => {
+	const origin = 'https://wordpress.com';
+	const path = url.startsWith( '/' ) ? url : `/${ url }`;
+	redirectParentWindow( `${ origin }${ path }` );
+};

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
@@ -1,3 +1,19 @@
+/**
+ * External dependencies
+ */
+import { doAction, hasAction } from '@wordpress/hooks';
+import { addQueryArgs } from '@wordpress/url';
+
+interface CalypsoifyWindow extends Window {
+	currentSiteId?: number;
+	calypsoifyGutenberg?: {
+		isSiteUnlaunched?: boolean;
+		isFocusedLaunchFlow?: boolean;
+		[ key: string ]: unknown;
+	};
+}
+declare const window: CalypsoifyWindow;
+
 export const redirectParentWindow = ( url: string ) => {
 	window.top.location.href = url;
 };
@@ -6,4 +22,22 @@ export const redirectToWpcomPath = ( url: string ) => {
 	const origin = 'https://wordpress.com';
 	const path = url.startsWith( '/' ) ? url : `/${ url }`;
 	redirectParentWindow( `${ origin }${ path }` );
+};
+
+export const openCheckout = ( siteId = window?.currentSiteId, isEcommerce = false ) => {
+	const HOOK_OPEN_CHECKOUT_MODAL = 'a8c.wpcom-block-editor.openCheckoutModal';
+	const isFocusedLaunchFlow = window?.calypsoifyGutenberg?.isFocusedLaunchFlow;
+
+	// only in focused launch, open checkout modal assuming the cart is already updated
+	if ( hasAction( HOOK_OPEN_CHECKOUT_MODAL ) && isFocusedLaunchFlow ) {
+		doAction( HOOK_OPEN_CHECKOUT_MODAL );
+		return;
+	}
+
+	// fallback: redirect to /checkout page
+	const checkoutUrl = addQueryArgs( `/checkout/${ siteId }`, {
+		// Redirect to My Home after checkout only if the selected plan is not eCommerce
+		...( ! isEcommerce && { redirect_to: `/home/${ siteId }` } ),
+	} );
+	redirectToWpcomPath( checkoutUrl );
 };

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -89,6 +89,7 @@
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/format-currency": "^1.0.0-alpha.0",
+		"@automattic/i18n-utils": "^1.0.0",
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/launch": "^1.0.0",
 		"@automattic/plans-grid": "^1.0.0-alpha.0",

--- a/apps/editing-toolkit/tsconfig.json
+++ b/apps/editing-toolkit/tsconfig.json
@@ -42,6 +42,7 @@
 		{ "path": "../../packages/onboarding" },
 		{ "path": "../../packages/launch" },
 		{ "path": "../../packages/plans-grid" },
-		{ "path": "../../packages/react-i18n" }
+		{ "path": "../../packages/react-i18n" },
+		{ "path": "../../packages/i18n-utils" }
 	]
 }

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -46,7 +46,7 @@ function removeHashFromUrl(): void {
 }
 
 const EditorCheckoutModal = ( props: Props ) => {
-	const { site, isOpen, onClose, cartData } = props;
+	const { site, isOpen, onClose, cartData, isEcommerce } = props;
 	const hasEmptyCart = ! cartData.products || cartData.products.length < 1;
 
 	const user = userFactory();
@@ -82,29 +82,31 @@ const EditorCheckoutModal = ( props: Props ) => {
 		: cartData.products.map( ( product ) => product.product_slug );
 	const commaSeparatedProductSlugs = productSlugs?.join( ',' ) || null;
 
-	return hasEmptyCart ? null : (
-		<Modal
-			open={ isOpen }
-			overlayClassName="editor-checkout-modal"
-			onRequestClose={ onClose }
-			title=""
-			shouldCloseOnClickOutside={ false }
-			icon={ <Icon icon={ wordpress } size={ 36 } /> }
-		>
-			<ShoppingCartProvider cartKey={ cartKey } getCart={ wpcomGetCart } setCart={ wpcomSetCart }>
-				<StripeHookProvider
-					fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
-					locale={ props.locale }
-				>
-					<CompositeCheckout
-						isInEditor
-						siteId={ site.ID }
-						siteSlug={ site.slug }
-						productAliasFromUrl={ commaSeparatedProductSlugs }
-					/>
-				</StripeHookProvider>
-			</ShoppingCartProvider>
-		</Modal>
+	return (
+		isOpen && (
+			<Modal
+				open={ isOpen }
+				overlayClassName="editor-checkout-modal"
+				onRequestClose={ onClose }
+				title=""
+				shouldCloseOnClickOutside={ false }
+				icon={ <Icon icon={ wordpress } size={ 36 } /> }
+			>
+				<ShoppingCartProvider cartKey={ cartKey } getCart={ wpcomGetCart } setCart={ wpcomSetCart }>
+					<StripeHookProvider
+						fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
+						locale={ props.locale }
+					>
+						<CompositeCheckout
+							isInEditor={ ! isEcommerce }
+							siteId={ site.ID }
+							siteSlug={ site.slug }
+							productAliasFromUrl={ commaSeparatedProductSlugs }
+						/>
+					</StripeHookProvider>
+				</ShoppingCartProvider>
+			</Modal>
+		)
 	);
 };
 
@@ -114,12 +116,14 @@ type Props = {
 	onClose: () => void;
 	isOpen: boolean;
 	locale: string | undefined;
+	isEcommerce: boolean;
 };
 
 EditorCheckoutModal.defaultProps = {
 	isOpen: false,
 	onClose: () => null,
 	cartData: {},
+	isEcommerce: false,
 };
 
 export default connect( ( state ) => ( {

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -46,7 +46,7 @@ function removeHashFromUrl(): void {
 }
 
 const EditorCheckoutModal = ( props: Props ) => {
-	const { site, isOpen, onClose, cartData, isEcommerce } = props;
+	const { site, isOpen, onClose, cartData } = props;
 	const hasEmptyCart = ! cartData.products || cartData.products.length < 1;
 
 	const user = userFactory();
@@ -98,7 +98,7 @@ const EditorCheckoutModal = ( props: Props ) => {
 						locale={ props.locale }
 					>
 						<CompositeCheckout
-							isInEditor={ ! isEcommerce }
+							isInEditor
 							siteId={ site.ID }
 							siteSlug={ site.slug }
 							productAliasFromUrl={ commaSeparatedProductSlugs }
@@ -116,14 +116,12 @@ type Props = {
 	onClose: () => void;
 	isOpen: boolean;
 	locale: string | undefined;
-	isEcommerce: boolean;
 };
 
 EditorCheckoutModal.defaultProps = {
 	isOpen: false,
 	onClose: () => null,
 	cartData: {},
-	isEcommerce: false,
 };
 
 export default connect( ( state ) => ( {

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -8,6 +8,7 @@ import { Icon, wordpress } from '@wordpress/icons';
 import { ShoppingCartProvider, RequestCart } from '@automattic/shopping-cart';
 import { Modal } from '@wordpress/components';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -49,6 +50,8 @@ const EditorCheckoutModal = ( props: Props ) => {
 	const { site, isOpen, onClose, cartData } = props;
 	const hasEmptyCart = ! cartData.products || cartData.products.length < 1;
 
+	const translate = useTranslate();
+
 	const user = userFactory();
 	const isLoggedOutCart = ! user?.get();
 	const waitForOtherCartUpdates = false;
@@ -88,7 +91,7 @@ const EditorCheckoutModal = ( props: Props ) => {
 				open={ isOpen }
 				overlayClassName="editor-checkout-modal"
 				onRequestClose={ onClose }
-				title=""
+				title={ translate( 'Checkout modal' ) }
 				shouldCloseOnClickOutside={ false }
 				icon={ <Icon icon={ wordpress } size={ 36 } /> }
 			>

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -91,7 +91,7 @@ const EditorCheckoutModal = ( props: Props ) => {
 				open={ isOpen }
 				overlayClassName="editor-checkout-modal"
 				onRequestClose={ onClose }
-				title={ translate( 'Checkout modal' ) }
+				title={ String( translate( 'Checkout modal' ) ) }
 				shouldCloseOnClickOutside={ false }
 				icon={ <Icon icon={ wordpress } size={ 36 } /> }
 			>

--- a/client/blocks/editor-checkout-modal/style.scss
+++ b/client/blocks/editor-checkout-modal/style.scss
@@ -24,4 +24,18 @@
 			border: none;
 		}
 	}
+
+	// @TODO: re-use onboarding-screen-reader-text()
+	// See https://github.com/Automattic/wp-calypso/pull/47601#discussion_r530570891
+	.components-modal__header-heading {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect( 0, 0, 0, 0 );
+		white-space: nowrap;
+		border-width: 0;
+	}
 }

--- a/client/blocks/editor-launch-modal/index.tsx
+++ b/client/blocks/editor-launch-modal/index.tsx
@@ -14,14 +14,7 @@ interface Props {
 }
 
 const EditorLaunchModal: React.FunctionComponent< Props > = ( { siteId, locale } ) => {
-	return (
-		<FocusedLaunchModal
-			onClose={ noop }
-			siteId={ siteId }
-			locale={ locale }
-			openCheckout={ noop }
-		/>
-	);
+	return <FocusedLaunchModal siteId={ siteId } locale={ locale } openCheckout={ noop } />;
 };
 
 export default connect( ( state ) => {

--- a/client/blocks/editor-launch-modal/index.tsx
+++ b/client/blocks/editor-launch-modal/index.tsx
@@ -14,7 +14,14 @@ interface Props {
 }
 
 const EditorLaunchModal: React.FunctionComponent< Props > = ( { siteId, locale } ) => {
-	return <FocusedLaunchModal onClose={ noop } siteId={ siteId } locale={ locale } />;
+	return (
+		<FocusedLaunchModal
+			onClose={ noop }
+			siteId={ siteId }
+			locale={ locale }
+			openCheckout={ noop }
+		/>
+	);
 };
 
 export default connect( ( state ) => {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -97,7 +97,6 @@ interface State {
 	postUrl?: T.URL;
 	previewUrl: T.URL;
 	cartData?: RequestCart;
-	isEcommerce: boolean;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -142,7 +141,6 @@ class CalypsoifyIframe extends Component<
 		previewUrl: 'about:blank',
 		currentIFrameUrl: '',
 		cartData: {},
-		isEcommerce: false,
 	};
 
 	iframeRef: React.RefObject< HTMLIFrameElement > = React.createRef();
@@ -291,11 +289,7 @@ class CalypsoifyIframe extends Component<
 		}
 
 		if ( EditorActions.OpenCheckoutModal === action ) {
-			this.setState( {
-				isCheckoutModalVisible: true,
-				cartData: { products: payload.products },
-				isEcommerce: payload.isEcommerce,
-			} );
+			this.setState( { isCheckoutModalVisible: true, cartData: payload } );
 		}
 
 		if ( EditorActions.GetCheckoutModalStatus === action ) {
@@ -706,7 +700,6 @@ class CalypsoifyIframe extends Component<
 			editedPost,
 			currentIFrameUrl,
 			cartData,
-			isEcommerce,
 		} = this.state;
 
 		const isUsingClassicBlock = !! classicBlockEditorId;
@@ -756,7 +749,6 @@ class CalypsoifyIframe extends Component<
 						cartData={ cartData }
 						placeholder={ null }
 						isOpen={ isCheckoutModalVisible }
-						isEcommerce={ isEcommerce }
 					/>
 				) }
 				{ isFocusedLaunchCalypsoEnabled && (

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -3,12 +3,12 @@
  */
 import type * as DomainSuggestions from '../domain-suggestions';
 import type * as Plans from '../plans';
-import { dispatch, select } from '@wordpress/data-controls';
+import { select } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
  */
-import { SITE_ID, SITE_STORE, PLANS_STORE } from './constants';
+import { PLANS_STORE } from './constants';
 import type { LaunchStepType } from './types';
 
 export const setSidebarFullscreen = () =>
@@ -64,16 +64,6 @@ export const unsetPlan = () =>
 export function* updatePlan( planSlug: Plans.PlanSlug ) {
 	const plan: Plans.Plan = yield select( PLANS_STORE, 'getPlanBySlug', planSlug );
 	yield setPlan( plan );
-}
-
-/* eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types */
-export function* launchSite() {
-	try {
-		const success = yield dispatch( SITE_STORE, 'launchSite', SITE_ID );
-		return success;
-	} catch ( error ) {
-		// console.log( 'launch error', error );
-	}
 }
 
 export const openSidebar = () =>

--- a/packages/data-stores/src/launch/constants.ts
+++ b/packages/data-stores/src/launch/constants.ts
@@ -1,10 +1,3 @@
 export const STORE_KEY = 'automattic/launch';
 export const SITE_STORE = 'automattic/site';
 export const PLANS_STORE = 'automattic/onboard/plans';
-
-declare global {
-	interface Window {
-		_currentSiteId: number;
-	}
-}
-export const SITE_ID = window._currentSiteId;

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -7,6 +7,8 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import { LaunchSequence, LaunchStep } from './data';
+import { STORE_KEY as LAUNCH_STORE } from './constants';
+
 import type { State } from './reducer';
 import type { LaunchStepType } from './types';
 import type * as DomainSuggestions from '../domain-suggestions';
@@ -35,7 +37,12 @@ export const getSelectedPlan = ( state: State ): Plans.Plan | undefined => state
  */
 export const getPaidPlan = ( state: State ): Plans.Plan | undefined => state.paidPlan;
 
+// Check if a domain has been explicitly selected (including free subdomain)
+export const hasSelectedDomain = ( state: State ): boolean =>
+	!! getSelectedDomain( state ) || state.confirmedDomainSelection;
+
 // Completion status of steps is derived from the state of the launch flow
+// Warning: because it's using getEntityRecord it works only inside the editor
 export const isStepCompleted = ( state: State, step: LaunchStepType ): boolean => {
 	if ( step === LaunchStep.Plan ) {
 		return !! getSelectedPlan( state );
@@ -49,7 +56,7 @@ export const isStepCompleted = ( state: State, step: LaunchStepType ): boolean =
 		return !! site?.title;
 	}
 	if ( step === LaunchStep.Domain ) {
-		return !! getSelectedDomain( state ) || state.confirmedDomainSelection;
+		return select( LAUNCH_STORE ).hasSelectedDomain();
 	}
 	return false;
 };

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -95,18 +95,24 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		type: 'RESET_RECEIVE_NEW_SITE_FAILED' as const,
 	} );
 
-	const launchedSite = ( siteId: number ) => ( {
-		type: 'LAUNCHED_SITE' as const,
+	const launchSiteStart = ( siteId: number ) => ( {
+		type: 'LAUNCH_SITE_START' as const,
+		siteId,
+	} );
+
+	const launchSiteComplete = ( siteId: number ) => ( {
+		type: 'LAUNCH_SITE_COMPLETE' as const,
 		siteId,
 	} );
 
 	function* launchSite( siteId: number ) {
+		yield launchSiteStart( siteId );
 		yield wpcomRequest( {
 			path: `/sites/${ siteId }/launch`,
 			apiVersion: '1.1',
 			method: 'post',
 		} );
-		yield launchedSite( siteId );
+		yield launchSiteComplete( siteId );
 		return true;
 	}
 
@@ -163,7 +169,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveSiteFailed,
 		reset,
 		launchSite,
-		launchedSite,
+		launchSiteStart,
+		launchSiteComplete,
 		getCart,
 		setCart,
 	};
@@ -183,7 +190,8 @@ export type Action =
 			| ActionCreators[ 'receiveSiteFailed' ]
 			| ActionCreators[ 'reset' ]
 			| ActionCreators[ 'resetNewSiteFailed' ]
-			| ActionCreators[ 'launchedSite' ]
+			| ActionCreators[ 'launchSiteStart' ]
+			| ActionCreators[ 'launchSiteComplete' ]
 	  >
 	// Type added so we can dispatch actions in tests, but has no runtime cost
 	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -102,14 +102,14 @@ export const sitesDomains: Reducer< { [ key: number ]: Domain[] }, Action > = (
 };
 
 export const launchStatus: Reducer<
-	{ [ key: number ]: { isLaunched: boolean; isSiteLaunching: boolean } },
+	{ [ key: number ]: { isSiteLaunched: boolean; isSiteLaunching: boolean } },
 	Action
 > = ( state = {}, action ) => {
 	if ( action.type === 'LAUNCH_SITE_START' ) {
-		return { ...state, [ action.siteId ]: { isLaunched: false, isSiteLaunching: true } };
+		return { ...state, [ action.siteId ]: { isSiteLaunched: false, isSiteLaunching: true } };
 	}
 	if ( action.type === 'LAUNCH_SITE_COMPLETE' ) {
-		return { ...state, [ action.siteId ]: { isLaunched: true, isSiteLaunching: false } };
+		return { ...state, [ action.siteId ]: { isSiteLaunched: true, isSiteLaunching: false } };
 	}
 	return state;
 };

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -101,12 +101,15 @@ export const sitesDomains: Reducer< { [ key: number ]: Domain[] }, Action > = (
 	return state;
 };
 
-export const launchStatus: Reducer< { [ key: number ]: boolean }, Action > = (
-	state = {},
-	action
-) => {
-	if ( action.type === 'LAUNCHED_SITE' ) {
-		return { ...state, [ action.siteId ]: true };
+export const launchStatus: Reducer<
+	{ [ key: number ]: { isLaunched: boolean; isSiteLaunching: boolean } },
+	Action
+> = ( state = {}, action ) => {
+	if ( action.type === 'LAUNCH_SITE_START' ) {
+		return { ...state, [ action.siteId ]: { isLaunched: false, isSiteLaunching: true } };
+	}
+	if ( action.type === 'LAUNCH_SITE_COMPLETE' ) {
+		return { ...state, [ action.siteId ]: { isLaunched: true, isSiteLaunching: false } };
 	}
 	return state;
 };

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -32,8 +32,8 @@ export const getSite = ( state: State, siteId: number ) => {
 export const getSiteTitle = ( _: State, siteId: number ) =>
 	select( STORE_KEY ).getSite( siteId )?.name;
 
-export const isLaunched = ( state: State, siteId: number ) => {
-	return state.launchStatus[ siteId ]?.isLaunched;
+export const isSiteLaunched = ( state: State, siteId: number ) => {
+	return state.launchStatus[ siteId ]?.isSiteLaunched;
 };
 
 export const isSiteLaunching = ( state: State, siteId: number ) => {

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -33,7 +33,11 @@ export const getSiteTitle = ( _: State, siteId: number ) =>
 	select( STORE_KEY ).getSite( siteId )?.name;
 
 export const isLaunched = ( state: State, siteId: number ) => {
-	return state.launchStatus[ siteId ];
+	return state.launchStatus[ siteId ]?.isLaunched;
+};
+
+export const isSiteLaunching = ( state: State, siteId: number ) => {
+	return state.launchStatus[ siteId ]?.isSiteLaunching;
 };
 
 export const getSiteDomains = ( state: State, siteId: number ) => {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -67,7 +67,6 @@ export interface SiteDetailsPlan {
 	product_slug: string;
 	product_name: string;
 	product_name_short: string;
-	product_name_short_with_suffix: string;
 	expired: boolean;
 	billing_period: string;
 	user_is_owner: boolean;

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -34,6 +34,7 @@
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
+		"@automattic/i18n-utils": "^1.0.0",
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/plans-grid": "^1.0.0-alpha.0",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",

--- a/packages/launch/src/context.ts
+++ b/packages/launch/src/context.ts
@@ -6,7 +6,6 @@ import { addQueryArgs } from '@wordpress/url';
 
 interface LaunchContext {
 	siteId: number;
-	locale: string;
 	redirectTo: ( url: string ) => void;
 	openCheckout: ( siteId: number, isEcommerce?: boolean ) => void;
 	flow: string;
@@ -19,7 +18,6 @@ const defaultRedirectTo = ( url: string ) => {
 
 const LaunchContext = React.createContext< LaunchContext >( {
 	siteId: 0,
-	locale: 'en',
 	redirectTo: defaultRedirectTo,
 	openCheckout: ( siteId, isEcommerce ) => {
 		defaultRedirectTo(

--- a/packages/launch/src/context.ts
+++ b/packages/launch/src/context.ts
@@ -12,6 +12,11 @@ interface LaunchContext {
 	flow: string;
 }
 
+const defaultRedirectTo = ( url: string ) => {
+	// Won't work if trying to redirect the parent frame
+	window.location.href = url;
+};
+
 const LaunchContext = React.createContext< LaunchContext >( {
 	siteId: 0,
 	locale: 'en',
@@ -20,11 +25,13 @@ const LaunchContext = React.createContext< LaunchContext >( {
 		window.location.href = url;
 	},
 	openCheckout: ( siteId, isEcommerce ) => {
-		window.top.location.href = addQueryArgs( `https://wordpress.com/checkout/${ siteId }`, {
-			preLaunch: 1,
-			// Redirect to My Home after checkout only if the selected plan is not eCommerce
-			...( ! isEcommerce && { redirect_to: `/home/${ siteId }` } ),
-		} );
+		defaultRedirectTo(
+			addQueryArgs( `https://wordpress.com/checkout/${ siteId }`, {
+				preLaunch: 1,
+				// Redirect to My Home after checkout only if the selected plan is not eCommerce
+				...( ! isEcommerce && { redirect_to: `/home/${ siteId }` } ),
+			} )
+		);
 	},
 	flow: 'launch',
 } );

--- a/packages/launch/src/context.ts
+++ b/packages/launch/src/context.ts
@@ -2,11 +2,14 @@
  * External dependencies
  */
 import * as React from 'react';
+import { addQueryArgs } from '@wordpress/url';
 
 interface LaunchContext {
 	siteId: number;
 	locale: string;
 	redirectTo: ( url: string ) => void;
+	openCheckout: ( siteId: number | string, isEcommerce?: boolean ) => void;
+	flow: string;
 }
 
 const LaunchContext = React.createContext< LaunchContext >( {
@@ -16,6 +19,14 @@ const LaunchContext = React.createContext< LaunchContext >( {
 		// Won't work if trying to redirect the parent frame
 		window.location.href = url;
 	},
+	openCheckout: ( siteId, isEcommerce ) => {
+		window.top.location.href = addQueryArgs( `https://wordpress.com/checkout/${ siteId }`, {
+			preLaunch: 1,
+			// Redirect to My Home after checkout only if the selected plan is not eCommerce
+			...( ! isEcommerce && { redirect_to: `/home/${ siteId }` } ),
+		} );
+	},
+	flow: 'launch',
 } );
 
 export default LaunchContext;

--- a/packages/launch/src/context.ts
+++ b/packages/launch/src/context.ts
@@ -20,13 +20,10 @@ const defaultRedirectTo = ( url: string ) => {
 const LaunchContext = React.createContext< LaunchContext >( {
 	siteId: 0,
 	locale: 'en',
-	redirectTo: ( url: string ) => {
-		// Won't work if trying to redirect the parent frame
-		window.location.href = url;
-	},
+	redirectTo: defaultRedirectTo,
 	openCheckout: ( siteId, isEcommerce ) => {
 		defaultRedirectTo(
-			addQueryArgs( `https://wordpress.com/checkout/${ siteId }`, {
+			addQueryArgs( `/checkout/${ siteId }`, {
 				preLaunch: 1,
 				// Redirect to My Home after checkout only if the selected plan is not eCommerce
 				...( ! isEcommerce && { redirect_to: `/home/${ siteId }` } ),

--- a/packages/launch/src/context.ts
+++ b/packages/launch/src/context.ts
@@ -8,7 +8,7 @@ interface LaunchContext {
 	siteId: number;
 	locale: string;
 	redirectTo: ( url: string ) => void;
-	openCheckout: ( siteId: number | string, isEcommerce?: boolean ) => void;
+	openCheckout: ( siteId: number, isEcommerce?: boolean ) => void;
 	flow: string;
 }
 

--- a/packages/launch/src/focused-launch/domain-details/index.tsx
+++ b/packages/launch/src/focused-launch/domain-details/index.tsx
@@ -11,6 +11,7 @@ import DomainPicker, { mockDomainSuggestion, ITEM_TYPE_BUTTON } from '@automatti
 import { Title, SubTitle } from '@automattic/onboarding';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import type { DomainSuggestions } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -24,6 +25,8 @@ import './style.scss';
 const ANALYTICS_UI_LOCATION = 'domain_step';
 
 const DomainDetails: React.FunctionComponent = () => {
+	const locale = useLocale();
+
 	const { currentDomainName } = useSite();
 	const { domainSearch, setDomainSearch } = useDomainSearch();
 	const { onDomainSelect, onExistingSubdomainSelect, selectedDomain } = useDomainSelection();
@@ -69,7 +72,7 @@ const DomainDetails: React.FunctionComponent = () => {
 					analyticsFlowId={ FOCUSED_LAUNCH_FLOW_ID }
 					analyticsUiAlgo={ ANALYTICS_UI_LOCATION }
 					segregateFreeAndPaid
-					locale={ document.documentElement.lang }
+					locale={ locale }
 					itemType={ ITEM_TYPE_BUTTON }
 				/>
 			</div>

--- a/packages/launch/src/focused-launch/go-back-button/index.tsx
+++ b/packages/launch/src/focused-launch/go-back-button/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import * as React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronLeft } from '@wordpress/icons';
 import type { Button } from '@wordpress/components';

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -17,17 +17,17 @@ import Success from './success';
 import './style.scss';
 
 const FocusedLaunch: React.FunctionComponent = () => {
-	const { isLaunched, isSiteLaunching } = useSite();
+	const { isSiteLaunched, isSiteLaunching } = useSite();
 
 	React.useEffect( () => {
-		if ( isLaunched || isSiteLaunching ) {
+		if ( isSiteLaunched || isSiteLaunching ) {
 			document.body.classList.add( 'is-focused-launch-complete' );
 		}
-	}, [ isLaunched, isSiteLaunching ] );
+	}, [ isSiteLaunched, isSiteLaunching ] );
 
 	return (
 		<Router initialEntries={ [ FocusedLaunchRoute.Summary ] }>
-			{ ( isLaunched || isSiteLaunching ) && <Redirect to={ FocusedLaunchRoute.Success } /> }
+			{ ( isSiteLaunched || isSiteLaunching ) && <Redirect to={ FocusedLaunchRoute.Success } /> }
 			<Switch>
 				<Route path={ FocusedLaunchRoute.DomainDetails }>
 					<DomainDetails />

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import React from 'react';
-import { MemoryRouter as Router, Switch, Route } from 'react-router-dom';
+import { MemoryRouter as Router, Switch, Route, Redirect } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
+import { useSite } from '../hooks';
 import { Route as FocusedLaunchRoute } from './route';
 import Summary from './summary';
 import DomainDetails from './domain-details';
@@ -15,24 +16,35 @@ import Success from './success';
 
 import './style.scss';
 
-const FocusedLaunch: React.FunctionComponent = () => (
-	<Router initialEntries={ [ FocusedLaunchRoute.Summary ] }>
-		<Switch>
-			<Route path={ FocusedLaunchRoute.DomainDetails }>
-				<DomainDetails />
-			</Route>
-			<Route path={ FocusedLaunchRoute.PlanDetails }>
-				<PlanDetails />
-			</Route>
-			<Route path={ FocusedLaunchRoute.Success }>
-				<Success />
-			</Route>
-			{ /* Summary route matches every path that is not matched by routes above */ }
-			<Route path={ FocusedLaunchRoute.Summary }>
-				<Summary />
-			</Route>
-		</Switch>
-	</Router>
-);
+const FocusedLaunch: React.FunctionComponent = () => {
+	const { isLaunched, isSiteLaunching } = useSite();
+
+	React.useEffect( () => {
+		if ( isLaunched || isSiteLaunching ) {
+			document.body.classList.add( 'is-focused-launch-complete' );
+		}
+	}, [ isLaunched, isSiteLaunching ] );
+
+	return (
+		<Router initialEntries={ [ FocusedLaunchRoute.Summary ] }>
+			{ ( isLaunched || isSiteLaunching ) && <Redirect to={ FocusedLaunchRoute.Success } /> }
+			<Switch>
+				<Route path={ FocusedLaunchRoute.DomainDetails }>
+					<DomainDetails />
+				</Route>
+				<Route path={ FocusedLaunchRoute.PlanDetails }>
+					<PlanDetails />
+				</Route>
+				<Route path={ FocusedLaunchRoute.Success }>
+					<Success />
+				</Route>
+				{ /* Summary route matches every path that is not matched by routes above */ }
+				<Route path={ FocusedLaunchRoute.Summary }>
+					<Summary />
+				</Route>
+			</Switch>
+		</Router>
+	);
+};
 
 export default FocusedLaunch;

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -12,33 +12,27 @@ import Summary from './summary';
 import DomainDetails from './domain-details';
 import PlanDetails from './plan-details';
 import Success from './success';
-import { useOnLaunch } from '../hooks';
 
 import './style.scss';
 
-const FocusedLaunch: React.FunctionComponent = () => {
-	// handle redirects to checkout / my home after launch
-	useOnLaunch();
-
-	return (
-		<Router initialEntries={ [ FocusedLaunchRoute.Summary ] }>
-			<Switch>
-				<Route path={ FocusedLaunchRoute.DomainDetails }>
-					<DomainDetails />
-				</Route>
-				<Route path={ FocusedLaunchRoute.PlanDetails }>
-					<PlanDetails />
-				</Route>
-				<Route path={ FocusedLaunchRoute.Success }>
-					<Success />
-				</Route>
-				{ /* Summary route matches every path that is not matched by routes above */ }
-				<Route path={ FocusedLaunchRoute.Summary }>
-					<Summary />
-				</Route>
-			</Switch>
-		</Router>
-	);
-};
+const FocusedLaunch: React.FunctionComponent = () => (
+	<Router initialEntries={ [ FocusedLaunchRoute.Summary ] }>
+		<Switch>
+			<Route path={ FocusedLaunchRoute.DomainDetails }>
+				<DomainDetails />
+			</Route>
+			<Route path={ FocusedLaunchRoute.PlanDetails }>
+				<PlanDetails />
+			</Route>
+			<Route path={ FocusedLaunchRoute.Success }>
+				<Success />
+			</Route>
+			{ /* Summary route matches every path that is not matched by routes above */ }
+			<Route path={ FocusedLaunchRoute.Summary }>
+				<Summary />
+			</Route>
+		</Switch>
+	</Router>
+);
 
 export default FocusedLaunch;

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import * as React from 'react';
 import { MemoryRouter as Router, Switch, Route, Redirect } from 'react-router-dom';
 
 /**

--- a/packages/launch/src/focused-launch/plan-details/index.tsx
+++ b/packages/launch/src/focused-launch/plan-details/index.tsx
@@ -10,6 +10,7 @@ import { Plans } from '@automattic/data-stores';
 import PlansGrid from '@automattic/plans-grid';
 import { Title, SubTitle } from '@automattic/onboarding';
 import { useHistory } from 'react-router-dom';
+import { useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -20,6 +21,7 @@ import GoBackButton from '../go-back-button';
 import './style.scss';
 
 const PlanDetails: React.FunctionComponent = () => {
+	const locale = useLocale();
 	const domain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
 	const selectedPlan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
 	const history = useHistory();
@@ -74,7 +76,7 @@ const PlanDetails: React.FunctionComponent = () => {
 							: undefined
 					}
 					CTAVariation="FULL_WIDTH"
-					locale="user"
+					locale={ locale }
 				/>
 			</div>
 		</div>

--- a/packages/launch/src/focused-launch/style.scss
+++ b/packages/launch/src/focused-launch/style.scss
@@ -2,6 +2,10 @@
 @import '~@wordpress/base-styles/variables';
 @import '~@wordpress/base-styles/breakpoints';
 
+body.is-focused-launch-complete .editor-gutenberg-launch__launch-button {
+	display: none;
+}
+
 .focused-launch-container {
 	width: 100%;
 	max-width: 980px;

--- a/packages/launch/src/focused-launch/success/confetti.tsx
+++ b/packages/launch/src/focused-launch/success/confetti.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import * as React from 'react';
 import { SVG, Rect, Circle } from '@wordpress/components';
 
 const Confetti: React.FunctionComponent< { className?: string } > = ( { className } ) => (

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useEffect, useContext } from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Title, SubTitle, NextButton, BackButton } from '@automattic/onboarding';
 import { Icon, external } from '@wordpress/icons';
@@ -21,7 +21,7 @@ import { LAUNCH_STORE, SITE_STORE } from '../../stores';
 import './style.scss';
 
 const Success: React.FunctionComponent = () => {
-	const { redirectTo, siteId } = useContext( LaunchContext );
+	const { redirectTo, siteId } = React.useContext( LaunchContext );
 
 	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
 
@@ -29,16 +29,16 @@ const Success: React.FunctionComponent = () => {
 
 	const { siteSubdomain, sitePrimaryDomain } = useSiteDomains();
 
-	const [ displayedSiteUrl, setDisplayedSiteUrl ] = useState( '' );
-	const [ hasCopied, setHasCopied ] = useState( false );
+	const [ displayedSiteUrl, setDisplayedSiteUrl ] = React.useState( '' );
+	const [ hasCopied, setHasCopied ] = React.useState( false );
 
-	useEffect( () => {
+	React.useEffect( () => {
 		setDisplayedSiteUrl( `https://${ sitePrimaryDomain?.domain }` );
 	}, [ sitePrimaryDomain ] );
 
 	// When in the Success view, the user can't dismiss the modal anymore,
 	// and the modal title is hidden
-	useEffect( () => {
+	React.useEffect( () => {
 		unsetModalDismissible();
 		hideModalTitle();
 	}, [ unsetModalDismissible, hideModalTitle ] );

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 import { Title, SubTitle, NextButton, BackButton } from '@automattic/onboarding';
 import { Icon, external } from '@wordpress/icons';
 import { ClipboardButton } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -16,17 +16,20 @@ import { useDispatch } from '@wordpress/data';
 import { useSiteDomains } from '../../hooks';
 import Confetti from './confetti';
 import LaunchContext from '../../context';
-import { LAUNCH_STORE } from '../../stores';
+import { LAUNCH_STORE, SITE_STORE } from '../../stores';
 
 import './style.scss';
 
 const Success: React.FunctionComponent = () => {
-	const { redirectTo } = useContext( LaunchContext );
+	const { redirectTo, siteId } = useContext( LaunchContext );
+
+	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
+
+	const { unsetModalDismissible, hideModalTitle, closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
 
 	const { siteSubdomain, sitePrimaryDomain } = useSiteDomains();
-	const { unsetModalDismissible, hideModalTitle, closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
-	const [ displayedSiteUrl, setDisplayedSiteUrl ] = useState( '' );
 
+	const [ displayedSiteUrl, setDisplayedSiteUrl ] = useState( '' );
 	const [ hasCopied, setHasCopied ] = useState( false );
 
 	useEffect( () => {
@@ -49,47 +52,52 @@ const Success: React.FunctionComponent = () => {
 			<Confetti className="focused-launch-success__confetti" />
 			<Title tagName="h2">{ __( 'Hooray!', __i18n_text_domain__ ) }</Title>
 			<SubTitle tagName="h3">
-				{ __(
-					"Congratulations, your website is now live. We're excited to watch you grow with WordPress.",
-					__i18n_text_domain__
-				) }
+				{ isSiteLaunching
+					? __( 'Your site will be live shortly.', '__i18n_text_domain__' )
+					: __(
+							"Congratulations, your website is now live. We're excited to watch you grow with WordPress.",
+							__i18n_text_domain__
+					  ) }
 			</SubTitle>
+			{ ! isSiteLaunching && (
+				<>
+					<div className="focused-launch-success__url-wrapper">
+						<span className="focused-launch-success__url-field">{ displayedSiteUrl }</span>
+						<a
+							href={ displayedSiteUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+							className="focused-launch-success__url-link"
+							// translators: text accessible to screen readers
+							aria-label={ __( 'Visit site', __i18n_text_domain__ ) }
+						>
+							<Icon icon={ external } size={ 16 } />
+						</a>
+						<ClipboardButton
+							text={ displayedSiteUrl }
+							onCopy={ () => setHasCopied( true ) }
+							onFinishCopy={ () => setHasCopied( false ) }
+							className="focused-launch-success__url-copy-button"
+						>
+							{ hasCopied
+								? __( 'Copied!', __i18n_text_domain__ )
+								: __( 'Copy Link', __i18n_text_domain__ ) }
+						</ClipboardButton>
+					</div>
 
-			<div className="focused-launch-success__url-wrapper">
-				<span className="focused-launch-success__url-field">{ displayedSiteUrl }</span>
-				<a
-					href={ displayedSiteUrl }
-					target="_blank"
-					rel="noopener noreferrer"
-					className="focused-launch-success__url-link"
-					// translators: text accessible to screen readers
-					aria-label={ __( 'Visit site', __i18n_text_domain__ ) }
-				>
-					<Icon icon={ external } size={ 16 } />
-				</a>
-				<ClipboardButton
-					text={ displayedSiteUrl }
-					onCopy={ () => setHasCopied( true ) }
-					onFinishCopy={ () => setHasCopied( false ) }
-					className="focused-launch-success__url-copy-button"
-				>
-					{ hasCopied
-						? __( 'Copied!', __i18n_text_domain__ )
-						: __( 'Copy Link', __i18n_text_domain__ ) }
-				</ClipboardButton>
-			</div>
+					{ /* @TODO: at the moment this only works when the modal is in the block editor. */ }
+					<NextButton
+						onClick={ closeFocusedLaunch }
+						className="focused-launch-success__continue-editing-button"
+					>
+						{ __( 'Continue Editing', __i18n_text_domain__ ) }
+					</NextButton>
 
-			{ /* @TODO: at the moment this only works when the modal is in the block editor. */ }
-			<NextButton
-				onClick={ closeFocusedLaunch }
-				className="focused-launch-success__continue-editing-button"
-			>
-				{ __( 'Continue Editing', __i18n_text_domain__ ) }
-			</NextButton>
-
-			<BackButton onClick={ redirectToHome }>
-				{ __( 'Back home', __i18n_text_domain__ ) }
-			</BackButton>
+					<BackButton onClick={ redirectToHome }>
+						{ __( 'Back home', __i18n_text_domain__ ) }
+					</BackButton>
+				</>
+			) }
 		</div>
 	);
 };

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -20,6 +20,8 @@ import { LAUNCH_STORE, SITE_STORE } from '../../stores';
 
 import './style.scss';
 
+// Success is shown when the site is launched but also while the site is still launching.
+// This view is technically going to be the selected view in the modal even while the user goes through the checkout flow (which is rendered on top of this view).
 const Success: React.FunctionComponent = () => {
 	const { redirectTo, siteId } = React.useContext( LaunchContext );
 

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import * as React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Title, SubTitle, NextButton, BackButton } from '@automattic/onboarding';
 import { Icon, external } from '@wordpress/icons';

--- a/packages/launch/src/focused-launch/success/style.scss
+++ b/packages/launch/src/focused-launch/success/style.scss
@@ -103,19 +103,3 @@
 		width: auto;
 	}
 }
-
-.focused-launch-success__go-back-button {
-	color: var( --studio-gray-50 );
-}
-
-.focused-launch-container .action-buttons:not( .is-sticky ) {
-	margin-left: 0;
-}
-
-.focused-launch-summary__launch-button {
-	flex: 1;
-
-	@include break-small {
-		flex: 0;
-	}
-}

--- a/packages/launch/src/focused-launch/success/style.scss
+++ b/packages/launch/src/focused-launch/success/style.scss
@@ -103,3 +103,15 @@
 		width: auto;
 	}
 }
+
+.focused-launch-success__go-back-button {
+	color: var( --studio-gray-50 );
+}
+
+.focused-launch-summary__launch-button {
+	flex: 1;
+
+	@include break-small {
+		flex: 0;
+	}
+}

--- a/packages/launch/src/focused-launch/success/style.scss
+++ b/packages/launch/src/focused-launch/success/style.scss
@@ -108,6 +108,10 @@
 	color: var( --studio-gray-50 );
 }
 
+.focused-launch-container .action-buttons:not( .is-sticky ) {
+	margin-left: 0;
+}
+
 .focused-launch-summary__launch-button {
 	flex: 1;
 

--- a/packages/launch/src/focused-launch/summary/focused-launch-summary-item/index.tsx
+++ b/packages/launch/src/focused-launch/summary/focused-launch-summary-item/index.tsx
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
-import React, { ReactNode } from 'react';
+import * as React from 'react';
 import classnames from 'classnames';
 import './style.scss';
+
+type ReactNode = React.ReactNode;
 
 interface LeadingSideProps {
 	label: ReactNode;

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -24,7 +24,7 @@ import {
 	useDomainSelection,
 	useSite,
 	usePlans,
-	useOnLaunch,
+	useCart,
 } from '../../hooks';
 import FocusedLaunchSummaryItem, {
 	LeadingContentSide,
@@ -502,7 +502,7 @@ const Summary: React.FunctionComponent = () => {
 	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
 	const selectedPlan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
 
-	const { launchedSite } = useDispatch( SITE_STORE );
+	const { launchSite } = useDispatch( SITE_STORE );
 	const { setModalDismissible, showModalTitle } = useDispatch( LAUNCH_STORE );
 
 	const { title, updateTitle, saveTitle, isSiteTitleStepVisible, showSiteTitleStep } = useTitle();
@@ -512,9 +512,8 @@ const Summary: React.FunctionComponent = () => {
 	const { isPaidPlan: hasPaidPlan } = useSite();
 
 	const { locale, siteId, redirectTo } = React.useContext( LaunchContext );
-	const [ isLaunching, setIsLaunching ] = React.useState( false );
 
-	useOnLaunch();
+	const { goToCheckout } = useCart();
 
 	// When the summary view is active, the modal should be dismissible, and
 	// the modal title should be visible
@@ -532,11 +531,10 @@ const Summary: React.FunctionComponent = () => {
 	}, [ title, showSiteTitleStep, isSiteTitleStepVisible ] );
 
 	const handleLaunch = () => {
-		setIsLaunching( true );
-
-		// @TODO: replace with 'launcheSite' action
-		// this won't actually launch the site. it is the success action dispatch after lunch
-		launchedSite( siteId );
+		launchSite( siteId );
+		if ( selectedPlan && ! selectedPlan?.isFree ) {
+			goToCheckout();
+		}
 	};
 
 	const onAskForHelpClick = ( event: React.MouseEvent< HTMLAnchorElement, MouseEvent > ) => {
@@ -637,7 +635,7 @@ const Summary: React.FunctionComponent = () => {
 				<ActionButtons className="focused-launch-summary__launch-action-bar">
 					<NextButton
 						className="focused-launch-summary__launch-button"
-						disabled={ ! title || ! hasSelectedDomain || ! selectedPlan || isLaunching }
+						disabled={ ! title || ! hasSelectedDomain || ! selectedPlan }
 						onClick={ handleLaunch }
 					>
 						{ __( 'Launch your site', __i18n_text_domain__ ) }

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -3,19 +3,16 @@
 /**
  * External dependencies
  */
-import { ActionButtons, Title, SubTitle } from '@automattic/onboarding';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { ActionButtons, NextButton, SubTitle, Title } from '@automattic/onboarding';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { TextControl, SVG, Path, Tooltip, Circle, Rect } from '@wordpress/components';
-import React, { ReactNode, useContext, useEffect, useState } from 'react';
 import DomainPicker, { mockDomainSuggestion } from '@automattic/domain-picker';
 import { Icon, check } from '@wordpress/icons';
-import { Link } from 'react-router-dom';
 import { useSelect, useDispatch } from '@wordpress/data';
-import FocusedLaunchSummaryItem, {
-	LeadingContentSide,
-	TrailingContentSide,
-} from './focused-launch-summary-item';
+
 /**
  * Internal dependencies
  */
@@ -27,9 +24,13 @@ import {
 	useDomainSelection,
 	useSite,
 	usePlans,
+	useOnLaunch,
 } from '../../hooks';
-
-import { LAUNCH_STORE, Plan } from '../../stores';
+import FocusedLaunchSummaryItem, {
+	LeadingContentSide,
+	TrailingContentSide,
+} from './focused-launch-summary-item';
+import { LAUNCH_STORE, SITE_STORE, Plan } from '../../stores';
 import LaunchContext from '../../context';
 import { isDefaultSiteTitle } from '../../utils';
 import { FOCUSED_LAUNCH_FLOW_ID } from '../../constants';
@@ -51,8 +52,8 @@ const info = (
 );
 
 type SummaryStepProps = {
-	input: ReactNode;
-	commentary?: ReactNode;
+	input: React.ReactNode;
+	commentary?: React.ReactNode;
 };
 
 const SummaryStep: React.FunctionComponent< SummaryStepProps > = ( { input, commentary } ) => (
@@ -275,13 +276,13 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 
 	const { defaultPaidPlan, defaultFreePlan, planPrices } = usePlans();
 
-	const [ nonDefaultPaidPlan, setNonDefaultPaidPlan ] = useState< Plan | undefined >();
+	const [ nonDefaultPaidPlan, setNonDefaultPaidPlan ] = React.useState< Plan | undefined >();
 
 	const isPlanSelected = ( plan: Plan ) => plan && plan.storeSlug === selectedPlan?.storeSlug;
 
 	const sitePlan = useSite().sitePlan;
 
-	useEffect( () => {
+	React.useEffect( () => {
 		// To keep the launch store state valid,
 		// unselect the free plan if the user selected a paid domain.
 		// free plans don't support paid domains.
@@ -293,7 +294,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 	// if the user picks a non-default paid plan, we need to keep track of it
 	// this allows us to keep showing it when they change their mind, we don't want
 	// it to disappear once they pick the default paid plan
-	useEffect( () => {
+	React.useEffect( () => {
 		if ( onceSelectedPaidPlan !== defaultPaidPlan ) {
 			setNonDefaultPaidPlan( onceSelectedPaidPlan );
 		}
@@ -494,38 +495,49 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 type StepIndexRenderFunction = ( renderOptions: {
 	stepIndex: number;
 	forwardStepIndex: boolean;
-} ) => ReactNode;
+} ) => React.ReactNode;
 
 const Summary: React.FunctionComponent = () => {
-	const { title, updateTitle, saveTitle, isSiteTitleStepVisible, showSiteTitleStep } = useTitle();
+	const hasSelectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).hasSelectedDomain() );
+	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
+	const selectedPlan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
 
+	const { launchedSite } = useDispatch( SITE_STORE );
+	const { setModalDismissible, showModalTitle } = useDispatch( LAUNCH_STORE );
+
+	const { title, updateTitle, saveTitle, isSiteTitleStepVisible, showSiteTitleStep } = useTitle();
 	const { sitePrimaryDomain, siteSubdomain, hasPaidDomain } = useSiteDomains();
 	const { onDomainSelect, onExistingSubdomainSelect } = useDomainSelection();
-	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
 	const { domainSearch, isLoading } = useDomainSearch();
+	const { isPaidPlan: hasPaidPlan } = useSite();
 
-	const site = useSite();
+	const { locale, siteId, redirectTo } = React.useContext( LaunchContext );
+	const [ isLaunching, setIsLaunching ] = React.useState( false );
 
-	const { locale, redirectTo } = useContext( LaunchContext );
-
-	const { setModalDismissible, showModalTitle } = useDispatch( LAUNCH_STORE );
+	useOnLaunch();
 
 	// When the summary view is active, the modal should be dismissible, and
 	// the modal title should be visible
-	useEffect( () => {
+	React.useEffect( () => {
 		setModalDismissible();
 		showModalTitle();
 	}, [ setModalDismissible, showModalTitle ] );
 
 	// If the user needs to change the site title, always show the site title
 	// step to the user when in this launch flow.
-	useEffect( () => {
+	React.useEffect( () => {
 		if ( ! isSiteTitleStepVisible && isDefaultSiteTitle( { currentSiteTitle: title } ) ) {
 			showSiteTitleStep();
 		}
 	}, [ title, showSiteTitleStep, isSiteTitleStepVisible ] );
 
-	const hasPaidPlan = site.isPaidPlan;
+	const handleLaunch = () => {
+		setIsLaunching( true );
+
+		// @TODO: replace with 'launcheSite' action
+		// this won't actually launch the site. it is the success action dispatch after lunch
+		launchedSite( siteId );
+	};
 
 	const onAskForHelpClick = ( event: React.MouseEvent< HTMLAnchorElement, MouseEvent > ) => {
 		const helpHref = ( event.target as HTMLAnchorElement ).getAttribute( 'href' );
@@ -623,8 +635,13 @@ const Summary: React.FunctionComponent = () => {
 
 			<div className="focused-launch-summary__actions-wrapper">
 				<ActionButtons className="focused-launch-summary__launch-action-bar">
-					{ /* @TODO: placeholder for https://github.com/Automattic/wp-calypso/issues/47392 */ }
-					<Link to={ Route.Success }>{ __( 'Launch your site', __i18n_text_domain__ ) }</Link>
+					<NextButton
+						className="focused-launch-summary__launch-button"
+						disabled={ ! title || ! hasSelectedDomain || ! selectedPlan || isLaunching }
+						onClick={ handleLaunch }
+					>
+						{ __( 'Launch your site', __i18n_text_domain__ ) }
+					</NextButton>
 				</ActionButtons>
 
 				<div className="focused-launch-summary__ask-for-help">

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -12,6 +12,7 @@ import { TextControl, SVG, Path, Tooltip, Circle, Rect } from '@wordpress/compon
 import DomainPicker, { mockDomainSuggestion } from '@automattic/domain-picker';
 import { Icon, check } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -110,7 +111,6 @@ type DomainStepProps = CommonStepProps & { hasPaidDomain?: boolean; isLoading: b
 		| 'initialDomainSearch'
 		| 'onDomainSelect'
 		| 'onExistingSubdomainSelect'
-		| 'locale'
 	>;
 
 const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
@@ -121,9 +121,10 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 	hasPaidDomain,
 	onDomainSelect,
 	onExistingSubdomainSelect,
-	locale,
 	isLoading,
 } ) => {
+	const locale = useLocale();
+
 	return (
 		<SummaryStep
 			input={
@@ -516,7 +517,7 @@ const Summary: React.FunctionComponent = () => {
 	const { domainSearch, isLoading } = useDomainSearch();
 	const { isPaidPlan: hasPaidPlan } = useSite();
 
-	const { locale, siteId, redirectTo } = React.useContext( LaunchContext );
+	const { siteId, redirectTo } = React.useContext( LaunchContext );
 
 	const { goToCheckout } = useCart();
 
@@ -580,7 +581,6 @@ const Summary: React.FunctionComponent = () => {
 			 * they already have a paid domain
 			 * */
 			onExistingSubdomainSelect={ onExistingSubdomainSelect }
-			locale={ locale }
 		/>
 	);
 

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -333,7 +333,12 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 						</label>
 						<div>
 							<FocusedLaunchSummaryItem readOnly={ true }>
-								<LeadingContentSide label={ sitePlan?.product_name_short_with_suffix } />
+								<LeadingContentSide
+									label={
+										/* translators: Purchased plan label where %s is the WordPress.com plan name (eg: Personal, Premium, Business) */
+										sprintf( __( '%s Plan', __i18n_text_domain__ ), sitePlan?.product_name_short )
+									}
+								/>
 								<TrailingContentSide nodeType="PRICE">
 									<Icon icon={ check } size={ 18 } /> { __( 'Purchased', __i18n_text_domain__ ) }
 								</TrailingContentSide>

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -604,6 +604,15 @@ const Summary: React.FunctionComponent = () => {
 	( hasPaidDomain ? disabledSteps : activeSteps ).push( renderDomainStep );
 	( hasPaidPlan ? disabledSteps : activeSteps ).push( renderPlanStep );
 
+	/*
+	 * Enable the launch button if:
+	 * - the site title input is not empty
+	 * - there is a purchased or selected domain
+	 * - there is a purchased or selected plan
+	 */
+	const isReadyToLaunch =
+		title && ( hasPaidDomain || hasSelectedDomain ) && ( hasPaidPlan || selectedPlan );
+
 	return (
 		<div className="focused-launch-container">
 			<div className="focused-launch-summary__section">
@@ -635,12 +644,11 @@ const Summary: React.FunctionComponent = () => {
 					forwardStepIndex: activeSteps.length > 1,
 				} )
 			) }
-
 			<div className="focused-launch-summary__actions-wrapper">
 				<ActionButtons className="focused-launch-summary__launch-action-bar">
 					<NextButton
 						className="focused-launch-summary__launch-button"
-						disabled={ ! title || ! hasSelectedDomain || ! selectedPlan }
+						disabled={ ! isReadyToLaunch }
 						onClick={ handleLaunch }
 					>
 						{ __( 'Launch your site', __i18n_text_domain__ ) }

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -537,7 +537,7 @@ const Summary: React.FunctionComponent = () => {
 
 	const handleLaunch = () => {
 		launchSite( siteId );
-		if ( selectedPlan && ! selectedPlan?.isFree ) {
+		if ( selectedDomain || ( selectedPlan && ! selectedPlan?.isFree ) ) {
 			goToCheckout();
 		}
 	};

--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -199,6 +199,14 @@ $commentary-column-gap-wide: 100px;
 		margin-left: 0;
 	}
 
+	.focused-launch-summary__launch-button {
+		flex: 1;
+
+		@include break-small {
+			flex: 0;
+		}
+	}
+
 	@include break-small {
 		flex-shrink: 0;
 		margin-right: 8px;

--- a/packages/launch/src/hooks/index.ts
+++ b/packages/launch/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './use-domain-selection';
 export * from './use-title';
 export * from './use-site-domains';
 export * from './use-plans';
+export * from './use-cart';

--- a/packages/launch/src/hooks/use-cart.ts
+++ b/packages/launch/src/hooks/use-cart.ts
@@ -11,7 +11,7 @@ import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
 import LaunchContext from '../context';
 import { getPlanProduct, getDomainProduct } from '../utils';
 
-export function useCart() {
+export function useCart(): { goToCheckout: () => Promise< void > } {
 	const { siteId, flow, openCheckout } = React.useContext( LaunchContext );
 
 	const { plan, domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );

--- a/packages/launch/src/hooks/use-cart.ts
+++ b/packages/launch/src/hooks/use-cart.ts
@@ -21,8 +21,9 @@ export function useCart() {
 
 	const { getCart, setCart } = useDispatch( SITE_STORE );
 
-	// this can be extracted to an action creator on the Launch data-store
 	const goToCheckout = async () => {
+		// setting the cart with Launch products can be extracted
+		// to an action creator on the Launch data-store
 		const planProduct = plan && getPlanProduct( plan, flow );
 		const domainProduct = domain && getDomainProduct( domain, flow );
 
@@ -31,6 +32,8 @@ export function useCart() {
 			...cart,
 			products: [ planProduct, domainProduct ],
 		} );
+
+		// open checkout modal or redirect to /checkout only after the cart is updated
 		openCheckout( siteId, isEcommercePlan );
 	};
 

--- a/packages/launch/src/hooks/use-cart.ts
+++ b/packages/launch/src/hooks/use-cart.ts
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
+import LaunchContext from '../context';
+import { getPlanProduct, getDomainProduct } from '../utils';
+
+export function useCart() {
+	const { siteId, flow, openCheckout } = React.useContext( LaunchContext );
+
+	const { plan, domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+	const isEcommercePlan = useSelect( ( select ) =>
+		select( PLANS_STORE ).isPlanEcommerce( plan?.storeSlug )
+	);
+
+	const { getCart, setCart } = useDispatch( SITE_STORE );
+
+	// this can be extracted to an action creator on the Launch data-store
+	const goToCheckout = async () => {
+		const planProduct = plan && getPlanProduct( plan, flow );
+		const domainProduct = domain && getDomainProduct( domain, flow );
+
+		const cart = await getCart( siteId );
+		await setCart( siteId, {
+			...cart,
+			products: [ planProduct, domainProduct ],
+		} );
+		openCheckout( siteId, isEcommercePlan );
+	};
+
+	return {
+		goToCheckout,
+	};
+}

--- a/packages/launch/src/hooks/use-domain-suggestion.ts
+++ b/packages/launch/src/hooks/use-domain-suggestion.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useLocale } from '@automattic/i18n-utils';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
 /**
@@ -11,6 +12,7 @@ import { DOMAIN_SUGGESTIONS_STORE } from '../stores';
 import { useDomainSearch } from './';
 
 export function useDomainSuggestion(): DomainSuggestions.DomainSuggestion | undefined {
+	const locale = useLocale();
 	const { domainSearch } = useDomainSearch();
 
 	const suggestion = useSelect(
@@ -23,8 +25,7 @@ export function useDomainSuggestion(): DomainSuggestions.DomainSuggestion | unde
 				include_wordpressdotcom: false,
 				include_dotblogsubdomain: false,
 				quantity: 1, // this will give the recommended domain only
-				// TODO: support i18n
-				locale: 'en',
+				locale,
 			} );
 		},
 		[ domainSearch ]

--- a/packages/launch/src/hooks/use-on-launch.ts
+++ b/packages/launch/src/hooks/use-on-launch.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
+import { useHistory } from 'react-router-dom';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -11,6 +12,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useSite } from './';
 import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
 import LaunchContext from '../context';
+import { Route } from '../focused-launch/route';
 
 export const useOnLaunch = () => {
 	const { siteId } = React.useContext( LaunchContext );
@@ -21,6 +23,8 @@ export const useOnLaunch = () => {
 	);
 
 	const { getCart, setCart } = useDispatch( SITE_STORE );
+
+	const history = useHistory();
 
 	React.useEffect( () => {
 		if ( launchStatus ) {
@@ -70,7 +74,9 @@ export const useOnLaunch = () => {
 				go();
 				return;
 			}
-			window.top.location.href = `https://wordpress.com/home/${ siteId }`;
+			history
+				? history.push( Route.Success )
+				: ( window.top.location.href = `https://wordpress.com/home/${ siteId }` );
 		}
-	}, [ launchStatus ] );
+	}, [ launchStatus ] ); // eslint-disable-line react-hooks/exhaustive-deps
 };

--- a/packages/launch/src/hooks/use-on-launch.ts
+++ b/packages/launch/src/hooks/use-on-launch.ts
@@ -15,7 +15,7 @@ import { getPlanProduct, getDomainProduct } from '../utils';
 
 // Hook used exclusively in Step-by-step launch flow
 export const useOnLaunch = () => {
-	const { siteId, flow } = React.useContext( LaunchContext );
+	const { siteId, flow, redirectTo } = React.useContext( LaunchContext );
 
 	const { plan, domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 	const isEcommercePlan = useSelect( ( select ) =>
@@ -47,20 +47,20 @@ export const useOnLaunch = () => {
 					// 	: `block-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
 					// window.location.href = `https://wordpress.com/checkout/${ siteId }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2F${ editorUrl }`;
 
-					const checkoutUrl = addQueryArgs( `https://wordpress.com/checkout/${ siteId }`, {
+					const checkoutUrl = addQueryArgs( `/checkout/${ siteId }`, {
 						preLaunch: 1,
 						// Redirect to My Home after checkout only if the selected plan is not eCommerce
 						...( ! isEcommercePlan && { redirect_to: `/home/${ siteId }` } ),
 					} );
 
-					window.top.location.href = checkoutUrl;
+					redirectTo( checkoutUrl );
 				};
 
 				// TODO: record tracks event
 				go();
 				return;
 			}
-			window.top.location.href = `https://wordpress.com/home/${ siteId }`;
+			redirectTo( `/home/${ siteId }` );
 		}
 	}, [ isSiteLaunched ] ); // eslint-disable-line react-hooks/exhaustive-deps
 };

--- a/packages/launch/src/hooks/use-on-launch.ts
+++ b/packages/launch/src/hooks/use-on-launch.ts
@@ -16,7 +16,7 @@ import { getPlanProduct, getDomainProduct } from '../utils';
 // Hook used exclusively in Step-by-step launch flow
 export const useOnLaunch = () => {
 	const { siteId, flow } = React.useContext( LaunchContext );
-	const { launchStatus } = useSite();
+
 	const { plan, domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 	const isEcommercePlan = useSelect( ( select ) =>
 		select( PLANS_STORE ).isPlanEcommerce( plan?.storeSlug )
@@ -24,8 +24,10 @@ export const useOnLaunch = () => {
 
 	const { getCart, setCart } = useDispatch( SITE_STORE );
 
+	const { isLaunched } = useSite();
+
 	React.useEffect( () => {
-		if ( launchStatus ) {
+		if ( isLaunched ) {
 			if ( plan && ! plan?.isFree ) {
 				const planProduct = getPlanProduct( plan, flow );
 				const domainProduct = domain && getDomainProduct( domain, flow );
@@ -60,5 +62,5 @@ export const useOnLaunch = () => {
 			}
 			window.top.location.href = `https://wordpress.com/home/${ siteId }`;
 		}
-	}, [ launchStatus ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ isLaunched ] ); // eslint-disable-line react-hooks/exhaustive-deps
 };

--- a/packages/launch/src/hooks/use-on-launch.ts
+++ b/packages/launch/src/hooks/use-on-launch.ts
@@ -2,64 +2,33 @@
  * External dependencies
  */
 import * as React from 'react';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { useSite } from './';
-import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
+import { LAUNCH_STORE } from '../stores';
 import LaunchContext from '../context';
-import { getPlanProduct, getDomainProduct } from '../utils';
+import { useCart } from '../hooks';
+import { useSite } from './';
 
-// Hook used exclusively in Step-by-step launch flow
+// Hook used exclusively in Step-by-step launch flow until it will be using Editor Checkout Modal
 export const useOnLaunch = () => {
-	const { siteId, flow, redirectTo } = React.useContext( LaunchContext );
+	const { siteId, redirectTo } = React.useContext( LaunchContext );
 
-	const { plan, domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
-	const isEcommercePlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).isPlanEcommerce( plan?.storeSlug )
-	);
-
-	const { getCart, setCart } = useDispatch( SITE_STORE );
+	const { plan } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 
 	const { isSiteLaunched } = useSite();
+	const { goToCheckout } = useCart();
 
 	React.useEffect( () => {
 		if ( isSiteLaunched ) {
+			// if a paid plan is selected, set cart and redirect to /checkout
 			if ( plan && ! plan?.isFree ) {
-				const planProduct = getPlanProduct( plan, flow );
-				const domainProduct = domain && getDomainProduct( domain, flow );
-
-				const go = async () => {
-					const cart = await getCart( siteId );
-					await setCart( siteId, {
-						...cart,
-						products: [ ...cart.products, planProduct, domainProduct ],
-					} );
-
-					// TODO: reset store on launch
-
-					// TODO: add paid upgrade flow without launch
-					// const editorUrl = design?.is_fse
-					// 	? `site-editor%2F${ newSite.site_slug }`
-					// 	: `block-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
-					// window.location.href = `https://wordpress.com/checkout/${ siteId }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2F${ editorUrl }`;
-
-					const checkoutUrl = addQueryArgs( `/checkout/${ siteId }`, {
-						preLaunch: 1,
-						// Redirect to My Home after checkout only if the selected plan is not eCommerce
-						...( ! isEcommercePlan && { redirect_to: `/home/${ siteId }` } ),
-					} );
-
-					redirectTo( checkoutUrl );
-				};
-
-				// TODO: record tracks event
-				go();
+				goToCheckout();
 				return;
 			}
+			// if free plan is selected, redirect to My Home
 			redirectTo( `/home/${ siteId }` );
 		}
 	}, [ isSiteLaunched ] ); // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/launch/src/hooks/use-on-launch.ts
+++ b/packages/launch/src/hooks/use-on-launch.ts
@@ -24,10 +24,10 @@ export const useOnLaunch = () => {
 
 	const { getCart, setCart } = useDispatch( SITE_STORE );
 
-	const { isLaunched } = useSite();
+	const { isSiteLaunched } = useSite();
 
 	React.useEffect( () => {
-		if ( isLaunched ) {
+		if ( isSiteLaunched ) {
 			if ( plan && ! plan?.isFree ) {
 				const planProduct = getPlanProduct( plan, flow );
 				const domainProduct = domain && getDomainProduct( domain, flow );
@@ -62,5 +62,5 @@ export const useOnLaunch = () => {
 			}
 			window.top.location.href = `https://wordpress.com/home/${ siteId }`;
 		}
-	}, [ isLaunched ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ isSiteLaunched ] ); // eslint-disable-line react-hooks/exhaustive-deps
 };

--- a/packages/launch/src/hooks/use-site.ts
+++ b/packages/launch/src/hooks/use-site.ts
@@ -13,13 +13,15 @@ import LaunchContext from '../context';
 export function useSite() {
 	const { siteId } = React.useContext( LaunchContext );
 	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
-	const launchStatus = useSelect( ( select ) => select( SITE_STORE ).isLaunched( siteId ) );
+	const isLaunched = useSelect( ( select ) => select( SITE_STORE ).isLaunched( siteId ) );
+	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
 	const isLoading = useSelect( ( select ) => select( SITE_STORE ).isFetchingSiteDetails() );
 
 	return {
 		sitePlan: site?.plan,
 		isPaidPlan: site && ! site.plan?.is_free, // sometimes plan will not be available: https://github.com/Automattic/wp-calypso/pull/44895
-		launchStatus,
+		isLaunched,
+		isSiteLaunching,
 		currentDomainName: site?.URL && new URL( site?.URL ).hostname,
 		selectedFeatures: site?.options?.selected_features,
 		isLoadingSite: !! isLoading,

--- a/packages/launch/src/hooks/use-site.ts
+++ b/packages/launch/src/hooks/use-site.ts
@@ -13,14 +13,14 @@ import LaunchContext from '../context';
 export function useSite() {
 	const { siteId } = React.useContext( LaunchContext );
 	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
-	const isLaunched = useSelect( ( select ) => select( SITE_STORE ).isLaunched( siteId ) );
+	const isSiteLaunched = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunched( siteId ) );
 	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
 	const isLoading = useSelect( ( select ) => select( SITE_STORE ).isFetchingSiteDetails() );
 
 	return {
 		sitePlan: site?.plan,
 		isPaidPlan: site && ! site.plan?.is_free, // sometimes plan will not be available: https://github.com/Automattic/wp-calypso/pull/44895
-		isLaunched,
+		isSiteLaunched,
 		isSiteLaunching,
 		currentDomainName: site?.URL && new URL( site?.URL ).hostname,
 		selectedFeatures: site?.options?.selected_features,

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Modal } from '@wordpress/components';
 import { Icon, wordpress } from '@wordpress/icons';
 import classNames from 'classnames';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,32 +14,35 @@ import { useSelect } from '@wordpress/data';
 import FocusedLaunch from '../focused-launch';
 import LaunchContext from '../context';
 import { LAUNCH_STORE } from '../stores';
+import { FOCUSED_LAUNCH_FLOW_ID } from '../constants';
 import './styles.scss';
 
 interface Props {
-	onClose: () => void;
 	siteId: number;
 	locale: string;
 	redirectTo?: ( url: string ) => void;
+	openCheckout: ( siteId: number | string, isEcommerce?: boolean ) => void;
 }
 
 const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
-	onClose,
 	siteId,
 	locale,
 	redirectTo = ( url: string ) => {
 		// Won't work if trying to redirect the parent frame
 		window.location.href = url;
 	},
+	openCheckout,
 } ) => {
 	const isModalDismissible = useSelect( ( select ) => select( LAUNCH_STORE ).isModalDismissible() );
 	const isModalTitleVisible = useSelect( ( select ) =>
 		select( LAUNCH_STORE ).isModalTitleVisible()
 	);
 
-	const onModalRequestClose = useCallback( () => {
-		isModalDismissible && onClose();
-	}, [ isModalDismissible, onClose ] );
+	const { closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
+
+	const onModalRequestClose = () => {
+		closeFocusedLaunch();
+	};
 
 	return (
 		<Modal
@@ -55,7 +58,9 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
 			isDismissible={ isModalDismissible }
 		>
 			<div className="launch__focused-modal-body">
-				<LaunchContext.Provider value={ { siteId, locale, redirectTo } }>
+				<LaunchContext.Provider
+					value={ { siteId, locale, redirectTo, openCheckout, flow: FOCUSED_LAUNCH_FLOW_ID } }
+				>
 					<FocusedLaunch />
 				</LaunchContext.Provider>
 			</div>

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import * as React from 'react';
+import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Modal } from '@wordpress/components';
 import { Icon, wordpress } from '@wordpress/icons';
-import classNames from 'classnames';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { LocaleProvider } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -18,17 +19,17 @@ import { FOCUSED_LAUNCH_FLOW_ID } from '../constants';
 import './styles.scss';
 
 interface Props {
+	locale?: string;
 	siteId: number;
-	locale: string;
-	redirectTo: ( path: string ) => void;
 	openCheckout: ( siteId: number, isEcommerce?: boolean ) => void;
+	redirectTo: ( path: string ) => void;
 }
 
 const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
+	locale = 'en',
 	siteId,
-	locale,
-	redirectTo,
 	openCheckout,
+	redirectTo,
 } ) => {
 	const isModalDismissible = useSelect( ( select ) => select( LAUNCH_STORE ).isModalDismissible() );
 	const isModalTitleVisible = useSelect( ( select ) =>
@@ -38,28 +39,30 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
 	const { closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
 
 	return (
-		<Modal
-			open={ true }
-			className={ classNames( 'launch__focused-modal', {
-				'launch__focused-modal--hide-title': ! isModalTitleVisible,
-			} ) }
-			overlayClassName="launch__focused-modal-overlay"
-			bodyOpenClassName="has-focused-launch-modal"
-			onRequestClose={ closeFocusedLaunch }
-			title={ __( 'Complete setup', __i18n_text_domain__ ) }
-			icon={ <Icon icon={ wordpress } size={ 36 } /> }
-			isDismissible={ isModalDismissible }
-			shouldCloseOnEsc={ isModalDismissible }
-			shouldCloseOnClickOutside={ isModalDismissible }
-		>
-			<div className="launch__focused-modal-body">
-				<LaunchContext.Provider
-					value={ { siteId, locale, redirectTo, openCheckout, flow: FOCUSED_LAUNCH_FLOW_ID } }
-				>
-					<FocusedLaunch />
-				</LaunchContext.Provider>
-			</div>
-		</Modal>
+		<LocaleProvider localeSlug={ locale }>
+			<Modal
+				open={ true }
+				className={ classNames( 'launch__focused-modal', {
+					'launch__focused-modal--hide-title': ! isModalTitleVisible,
+				} ) }
+				overlayClassName="launch__focused-modal-overlay"
+				bodyOpenClassName="has-focused-launch-modal"
+				onRequestClose={ closeFocusedLaunch }
+				title={ __( 'Complete setup', __i18n_text_domain__ ) }
+				icon={ <Icon icon={ wordpress } size={ 36 } /> }
+				isDismissible={ isModalDismissible }
+				shouldCloseOnEsc={ isModalDismissible }
+				shouldCloseOnClickOutside={ isModalDismissible }
+			>
+				<div className="launch__focused-modal-body">
+					<LaunchContext.Provider
+						value={ { siteId, redirectTo, openCheckout, flow: FOCUSED_LAUNCH_FLOW_ID } }
+					>
+						<FocusedLaunch />
+					</LaunchContext.Provider>
+				</div>
+			</Modal>
+		</LocaleProvider>
 	);
 };
 

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -20,17 +20,14 @@ import './styles.scss';
 interface Props {
 	siteId: number;
 	locale: string;
-	redirectTo?: ( url: string ) => void;
+	redirectTo: ( path: string ) => void;
 	openCheckout: ( siteId: number | string, isEcommerce?: boolean ) => void;
 }
 
 const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
 	siteId,
 	locale,
-	redirectTo = ( url: string ) => {
-		// Won't work if trying to redirect the parent frame
-		window.location.href = url;
-	},
+	redirectTo,
 	openCheckout,
 } ) => {
 	const isModalDismissible = useSelect( ( select ) => select( LAUNCH_STORE ).isModalDismissible() );

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -40,10 +40,6 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
 
 	const { closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
 
-	const onModalRequestClose = () => {
-		closeFocusedLaunch();
-	};
-
 	return (
 		<Modal
 			open={ true }
@@ -52,10 +48,12 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
 			} ) }
 			overlayClassName="launch__focused-modal-overlay"
 			bodyOpenClassName="has-focused-launch-modal"
-			onRequestClose={ onModalRequestClose }
+			onRequestClose={ closeFocusedLaunch }
 			title={ __( 'Complete setup', __i18n_text_domain__ ) }
 			icon={ <Icon icon={ wordpress } size={ 36 } /> }
 			isDismissible={ isModalDismissible }
+			shouldCloseOnEsc={ isModalDismissible }
+			shouldCloseOnClickOutside={ isModalDismissible }
 		>
 			<div className="launch__focused-modal-body">
 				<LaunchContext.Provider

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import * as React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Modal } from '@wordpress/components';
 import { Icon, wordpress } from '@wordpress/icons';

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -21,7 +21,7 @@ interface Props {
 	siteId: number;
 	locale: string;
 	redirectTo: ( path: string ) => void;
-	openCheckout: ( siteId: number | string, isEcommerce?: boolean ) => void;
+	openCheckout: ( siteId: number, isEcommerce?: boolean ) => void;
 }
 
 const FocusedLaunchModal: React.FunctionComponent< Props > = ( {

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -3,6 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 
+import type { Plans, DomainSuggestions } from '@automattic/data-stores';
+
 const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
 
 // When `exact === false', the check is more relaxed — chances are that if the title
@@ -18,3 +20,21 @@ export const isDefaultSiteTitle = ( {
 	exact
 		? currentSiteTitle === DEFAULT_SITE_NAME
 		: new RegExp( DEFAULT_SITE_NAME, 'i' ).test( currentSiteTitle );
+
+export const getPlanProduct = ( plan: Plans.Plan, flow: string ) => ( {
+	product_id: plan.productId,
+	product_slug: plan.storeSlug,
+	extra: {
+		source: flow,
+	},
+} );
+
+export const getDomainProduct = ( domain: DomainSuggestions.DomainSuggestion, flow: string ) => ( {
+	meta: domain?.domain_name,
+	product_id: domain?.product_id,
+	extra: {
+		privacy_available: domain?.supports_privacy,
+		privacy: domain?.supports_privacy,
+		source: flow,
+	},
+} );

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -21,7 +21,15 @@ export const isDefaultSiteTitle = ( {
 		? currentSiteTitle === DEFAULT_SITE_NAME
 		: new RegExp( DEFAULT_SITE_NAME, 'i' ).test( currentSiteTitle );
 
-export const getPlanProduct = ( plan: Plans.Plan, flow: string ) => ( {
+type PlanProduct = {
+	product_id: number;
+	product_slug: string;
+	extra: {
+		source: string;
+	};
+};
+
+export const getPlanProduct = ( plan: Plans.Plan, flow: string ): PlanProduct => ( {
 	product_id: plan.productId,
 	product_slug: plan.storeSlug,
 	extra: {
@@ -29,7 +37,20 @@ export const getPlanProduct = ( plan: Plans.Plan, flow: string ) => ( {
 	},
 } );
 
-export const getDomainProduct = ( domain: DomainSuggestions.DomainSuggestion, flow: string ) => ( {
+type DomainProduct = {
+	meta: string;
+	product_id: number;
+	extra: {
+		privacy_available: boolean;
+		privacy: boolean;
+		source: string;
+	};
+};
+
+export const getDomainProduct = (
+	domain: DomainSuggestions.DomainSuggestion,
+	flow: string
+): DomainProduct => ( {
 	meta: domain?.domain_name,
 	product_id: domain?.product_id,
 	extra: {

--- a/packages/launch/tsconfig.json
+++ b/packages/launch/tsconfig.json
@@ -39,6 +39,7 @@
 		{ "path": "../onboarding" },
 		{ "path": "../domain-picker" },
 		{ "path": "../plans-grid" },
-		{ "path": "../calypso-analytics" }
+		{ "path": "../calypso-analytics" },
+		{ "path": "../i18n-utils" }
 	]
 }

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -14,7 +14,6 @@ import PlansTable from '../plans-table';
 import PlansAccordion from '../plans-accordion';
 import PlansDetails from '../plans-details';
 import type { CTAVariation, CustomTagLinesMap, PopularBadgeVariation } from '../plans-table/types';
-export type { CTAVariation, CustomTagLinesMap, PopularBadgeVariation } from '../plans-table/types';
 
 /**
  * Style dependencies


### PR DESCRIPTION
### Changes proposed in this Pull Request

- Display _"Launch your site"_ button sticky and full-width on mobile
- Disable _"Launch your site"_ button if at least one of the active steps doesn't have a valid selected value. Enable it otherwise.
- When pressing the button, show the loading screen first (success screen without buttons and with slightly different copy) cc: @ollierozdarz since this is not in designs; added to Screenshots section below.
- When the site is launched, show the Success view.
- If the user selected paid items during Launch flow, show Checkout overlay.
- Ignore any previous items existing in cart (eg: additional domains) and populate the cart only with selected items from Launch flow.

#### Todo (or follow up):
- [x]  When redirecting the user back to the editor from the thank you page or they navigate themselves to editor from plans page / My home / other pages in Calypso, Success View should be displayed unless the user clicks one of the action buttons to close it. (https://github.com/Automattic/wp-calypso/pull/47808)
- [x] Enable _"Launch your site"_ button if there is a paid plan and selected domain or paid plan and domain. https://github.com/Automattic/wp-calypso/pull/47601#discussion_r529772106
- [x] When pressing _"Launch your site"_ button, don't show checkout if:
   - there is a purchased plan and a purchased domain
   - there is a purchased plan and subdomain selected

## Testing instructions
1. Check out the branch on your machine and run in two parallel terminal windows:
  - `yarn && yarn start`
  - `cd apps/editing-toolkit && yarn dev --sync`
2. Add an _unlaunched_ site created with `/start` to your sandbox (for convenience, `SITE_ID`)
3. Visit `calypso.localhost:3000/page/SITE_ID/home?flags=create/focused-launch-flow` and click on the "Launch" button. The Focused Launch modal should appear.

#### Testing instructions (Focused launch free and paid flows)
4. Select free domain and plan and click "Launch your site" at the bottom => the loading view and then Success view should appear.
5. Repeat steps 2-3 and select a paid domain and a paid plan => the loading view and then checkout overlay should be displayed. Closing the checkout overlay should reveal the Success view so you can continue editing (no redirect).
6. Repeat steps 2, 3, 5 and complete purchase for a plan. You should be redirected to thank-you page (depending on the plan) and after skipping the upsell you should be redirected back to editor (WIP to show success view here).

#### Testing instructions (regression testing - Step by step launch)
8. Create a site on a free plan starting at `/new` and sandbox it.
9. Press launch in editor and launch flow with sidebar should appear.
10. Complete the flow by selecting a free plan => redirect to My home
11. Complete the flow by selecting a paid plan => redirect to `/checkout` with some known error mentioned in #47150

* Note: testing this in calypso overlay (using `?flags=create/focused-launch-flow-calypso` flag) will launch the site, add any selected paid items to cart, but won't open Checkout modal.

### Screenshot
<img width="702" alt="Screenshot 2020-11-24 at 11 50 05" src="https://user-images.githubusercontent.com/14192054/100077682-51849380-2e4b-11eb-8e53-cceb417dc25b.png">

Fixes #47392
Fixes #47241
Fixes #47734