### PR TITLE
Adding placeholder link to upcoming Payments tutorial video section.

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -497,7 +497,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			align: 'right',
 		},
 		body: translate(
-			'Accept credit card payments today for just about anything – physical and digital goods, services, donations and tips, or access to your exclusive content. {{a}}{{b}}Watch our tutorial videos to get started{{/b}}{{/a}}.',
+			'Accept credit card payments today for just about anything – physical and digital goods, services, donations and tips, or access to your exclusive content. {{a}}Watch our tutorial videos to get started{{/a}}.',
 			{
 				components: {
 					a: (
@@ -507,7 +507,6 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 							rel="noopener noreferrer"
 						/>
 					),
-					b: <strong />,
 				},
 			}
 		),

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -500,7 +500,13 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			'Accept credit card payments today for just about anything – physical and digital goods, services, donations and tips, or access to your exclusive content. {{a}}{{b}}Watch our tutorial videos to get started{{/b}}{{/a}}.',
 			{
 				components: {
-					a: <a href="https://wordpress.com/LINK" target="_blank" rel="noopener noreferrer" />,
+					a: (
+						<a
+							href="https://wordpress.com/support/video-tutorials-add-payments-features-to-your-site-with-our-guides/"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
 					b: <strong />,
 				},
 			}

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -219,7 +219,6 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		return {
 			title,
 			body,
-			badge: translate( 'New' ),
 			icon: 'money',
 			actions: {
 				cta,
@@ -268,7 +267,6 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		return {
 			title,
 			body,
-			badge: translate( 'New' ),
 			icon: 'heart-outline',
 			actions: {
 				cta,
@@ -333,7 +331,6 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		return {
 			title,
 			body,
-			badge: translate( 'New' ),
 			icon: 'bookmark-outline',
 			actions: {
 				cta,
@@ -383,7 +380,6 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		return {
 			title,
 			body,
-			badge: translate( 'New' ),
 			icon: 'mail',
 			actions: {
 				cta,
@@ -501,7 +497,13 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			align: 'right',
 		},
 		body: translate(
-			'Accept credit card payments today for just about anything – physical and digital goods, services, donations and tips, or access to your exclusive content. Turn your website into a reliable source of income with payments and ads.'
+			'Accept credit card payments today for just about anything – physical and digital goods, services, donations and tips, or access to your exclusive content. {{a}}{{b}}Watch our tutorial videos to get started{{/b}}{{/a}}.',
+			{
+				components: {
+					a: <a href="https://wordpress.com/LINK" target="_blank" rel="noopener noreferrer" />,
+					b: <strong />,
+				},
+			}
 		),
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Adding a link on the Earn page header card that points users to a WPcom support page with tutorial videos. pbMlHh-I2-p2 and pbMlHh-Ix-p2

Here's a screenshot of the page update:
<img width="1228" alt="Screen Shot 2020-11-19 at 2 31 28 PM" src="https://user-images.githubusercontent.com/35781181/99726554-99d73680-2a84-11eb-8d6e-2f037cd4857e.png">


#### Testing instructions
* Checkout this PR and start Calypso
* Navigate to the Earn page (/earn/SITESLUG)
* Confirm that the updated title card that includes the link displays.
* Click the link and confirm that you're taken to the correct support page (linked to from pbMlHh-Ix-p2).

