### PR TITLE
Premium Content: Add default subscriber content

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/subscriber-view/edit.js
@@ -34,10 +34,14 @@ function Edit( { hasInnerBlocks, parentClientId, isSelected } ) {
 						templateInsertUpdatesSelection={ false }
 						template={ [
 							[
+								'core/heading',
+								{ content: __( 'Subscriber Content', 'full-site-editing' ), level: 3 },
+							],
+							[
 								'core/paragraph',
 								{
-									placeholder: __(
-										'Insert the piece of content you want your visitors to see after they subscribe.',
+									content: __(
+										'Add content here that will only be visible to your subscribers.',
 										'full-site-editing'
 									),
 								},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace the placeholder prompt and add default subscriber content so something will show up for admins in the preview.

Before:

<img width="684" alt="Screen Shot 2020-11-19 at 2 35 09 PM" src="https://user-images.githubusercontent.com/1464705/99732497-72786d80-2a74-11eb-99ce-cd1ec75aadc2.png">

After:

<img width="709" alt="Screen Shot 2020-11-19 at 2 34 13 PM" src="https://user-images.githubusercontent.com/1464705/99732502-74dac780-2a74-11eb-9bc9-a927df7d4bd3.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Insert a Premium content block
* Confirm that the default content in the after screenshot above shows up.

Fixes https://github.com/Automattic/view-design/issues/138
