### PR TITLE
Update PopoverCart to use shopping-cart package

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -3,7 +3,6 @@
  */
 import React, { useMemo, useEffect } from 'react';
 import { connect } from 'react-redux';
-import wp from 'calypso/lib/wp';
 import { Icon, wordpress } from '@wordpress/icons';
 import { ShoppingCartProvider, RequestCart } from '@automattic/shopping-cart';
 import { Modal } from '@wordpress/components';
@@ -20,6 +19,7 @@ import getCartKey from 'calypso/my-sites/checkout/get-cart-key';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 import userFactory from 'calypso/lib/user';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import wp from 'calypso/lib/wp';
 
 /**
  * Style dependencies
@@ -54,20 +54,11 @@ const EditorCheckoutModal = ( props: Props ) => {
 
 	const user = userFactory();
 	const isLoggedOutCart = ! user?.get();
-	const waitForOtherCartUpdates = false;
-	// We can assume if they're accessing the checkout in an editor that they have a site.
-	const isNoSiteCart = false;
 
-	const cartKey = useMemo(
-		() =>
-			getCartKey( {
-				selectedSite: site,
-				isLoggedOutCart,
-				isNoSiteCart,
-				waitForOtherCartUpdates,
-			} ),
-		[ waitForOtherCartUpdates, site, isLoggedOutCart, isNoSiteCart ]
-	);
+	const cartKey = useMemo( () => getCartKey( { selectedSite: site, isLoggedOutCart } ), [
+		site,
+		isLoggedOutCart,
+	] );
 
 	useEffect( () => {
 		return () => {
@@ -83,7 +74,7 @@ const EditorCheckoutModal = ( props: Props ) => {
 	const productSlugs = hasEmptyCart
 		? null
 		: cartData.products.map( ( product ) => product.product_slug );
-	const commaSeparatedProductSlugs = productSlugs?.join( ',' ) || null;
+	const commaSeparatedProductSlugs = productSlugs?.join( ',' );
 
 	return (
 		isOpen && (

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -4,7 +4,7 @@
 import React, { useMemo, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { Icon, wordpress } from '@wordpress/icons';
-import { ShoppingCartProvider, RequestCart } from '@automattic/shopping-cart';
+import type { RequestCart } from '@automattic/shopping-cart';
 import { Modal } from '@wordpress/components';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { useTranslate } from 'i18n-calypso';
@@ -20,6 +20,7 @@ import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 import userFactory from 'calypso/lib/user';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import wp from 'calypso/lib/wp';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 /**
  * Style dependencies
@@ -27,10 +28,6 @@ import wp from 'calypso/lib/wp';
 import './style.scss';
 
 const wpcom = wp.undocumented();
-
-const wpcomGetCart = ( cartKey: string ) => wpcom.getCart( cartKey );
-const wpcomSetCart = ( cartKey: string, requestCart: RequestCart ) =>
-	wpcom.setCart( cartKey, requestCart );
 
 function fetchStripeConfigurationWpcom( args: Record< string, unknown > ) {
 	return fetchStripeConfiguration( args, wpcom );
@@ -86,7 +83,7 @@ const EditorCheckoutModal = ( props: Props ) => {
 				shouldCloseOnClickOutside={ false }
 				icon={ <Icon icon={ wordpress } size={ 36 } /> }
 			>
-				<ShoppingCartProvider cartKey={ cartKey } getCart={ wpcomGetCart } setCart={ wpcomSetCart }>
+				<CalypsoShoppingCartProvider cartKey={ cartKey }>
 					<StripeHookProvider
 						fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
 						locale={ props.locale }
@@ -98,7 +95,7 @@ const EditorCheckoutModal = ( props: Props ) => {
 							productAliasFromUrl={ commaSeparatedProductSlugs }
 						/>
 					</StripeHookProvider>
-				</ShoppingCartProvider>
+				</CalypsoShoppingCartProvider>
 			</Modal>
 		)
 	);

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -23,6 +23,7 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import StoreConnection from 'calypso/components/data/store-connection';
 import UsersStore from 'calypso/lib/users/store';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 function getStateFromStores( props ) {
 	return {
@@ -105,19 +106,21 @@ class DomainManagementData extends React.Component {
 				{ selectedSite && needsPlans && <QuerySitePlans siteId={ selectedSite.ID } /> }
 				{ needsProductsList && <QueryProductsList /> }
 
-				<StoreConnection
-					component={ this.props.component }
-					context={ this.props.context }
-					currentUser={ this.props.currentUser }
-					domains={ this.props.domains }
-					getStateFromStores={ getStateFromStores }
-					isRequestingSiteDomains={ this.props.isRequestingSiteDomains }
-					products={ this.props.productsList }
-					selectedDomainName={ this.props.selectedDomainName }
-					selectedSite={ selectedSite }
-					sitePlans={ this.props.sitePlans }
-					stores={ stores }
-				/>
+				<CalypsoShoppingCartProvider>
+					<StoreConnection
+						component={ this.props.component }
+						context={ this.props.context }
+						currentUser={ this.props.currentUser }
+						domains={ this.props.domains }
+						getStateFromStores={ getStateFromStores }
+						isRequestingSiteDomains={ this.props.isRequestingSiteDomains }
+						products={ this.props.productsList }
+						selectedDomainName={ this.props.selectedDomainName }
+						selectedSite={ selectedSite }
+						sitePlans={ this.props.sitePlans }
+						stores={ stores }
+					/>
+				</CalypsoShoppingCartProvider>
 			</div>
 		);
 	}

--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { ShoppingCartProvider } from '@automattic/shopping-cart';
+import type { RequestCart, ResponseCart } from '@automattic/shopping-cart';
+
+/**
+ * Internal Dependencies
+ */
+import wp from 'calypso/lib/wp';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import getCartKey from './get-cart-key';
+
+// Aliasing wpcom functions explicitly bound to wpcom is required here;
+// otherwise we get `this is not defined` errors.
+const wpcom = wp.undocumented();
+const wpcomGetCart = ( cartKey: string ) => wpcom.getCart( cartKey );
+const wpcomSetCart = ( cartKey: string, cartData: RequestCart ) =>
+	wpcom.setCart( cartKey, cartData );
+
+export default function CalypsoShoppingCartProvider( {
+	children,
+	cartKey,
+	getCart,
+}: {
+	children: React.ReactNode;
+	cartKey?: string | number | null | undefined;
+	getCart?: ( cartKey: string ) => Promise< ResponseCart >;
+} ): JSX.Element {
+	const selectedSite = useSelector( getSelectedSite );
+
+	return (
+		<ShoppingCartProvider
+			cartKey={ cartKey || getCartKey( { selectedSite } ) }
+			getCart={ getCart || wpcomGetCart }
+			setCart={ wpcomSetCart }
+		>
+			{ children }
+		</ShoppingCartProvider>
+	);
+}

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -2,9 +2,10 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { getCurrencyObject } from '@automattic/format-currency';
+import { localize } from 'i18n-calypso';
+import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -26,11 +27,7 @@ import {
 	isDomainProduct,
 } from 'calypso/lib/products-values';
 import { isGSuiteProductSlug } from 'calypso/lib/gsuite';
-import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
-import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
 import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from 'calypso/lib/gsuite/constants';
-import { removeItem } from 'calypso/lib/cart/actions';
-import { localize } from 'i18n-calypso';
 import { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } from 'calypso/lib/plans';
 
 export class CartItem extends React.Component {
@@ -42,7 +39,7 @@ export class CartItem extends React.Component {
 			'Product ID',
 			this.props.cartItem.product_id
 		);
-		removeItem( this.props.cartItem, this.props.domainsWithPlansOnly );
+		this.props.shoppingCartManager.removeProductFromCart( this.props.cartItem.uuid );
 	};
 
 	price() {
@@ -359,6 +356,4 @@ export class CartItem extends React.Component {
 	}
 }
 
-export default connect( ( state ) => ( {
-	domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
-} ) )( localize( withLocalizedMoment( CartItem ) ) );
+export default withShoppingCart( localize( withLocalizedMoment( CartItem ) ) );

--- a/client/my-sites/checkout/cart/header-cart.jsx
+++ b/client/my-sites/checkout/cart/header-cart.jsx
@@ -10,7 +10,6 @@ import { withShoppingCart } from '@automattic/shopping-cart';
  */
 import { getAllCartItems } from 'calypso/lib/cart-values/cart-items';
 import PopoverCart from './popover-cart';
-import { reloadCart } from 'calypso/lib/cart/actions';
 
 class HeaderCart extends React.Component {
 	static propTypes = {
@@ -32,7 +31,7 @@ class HeaderCart extends React.Component {
 	};
 
 	componentDidMount() {
-		reloadCart();
+		this.props.shoppingCartManager.reloadFromServer();
 	}
 
 	render() {

--- a/client/my-sites/checkout/cart/header-cart.jsx
+++ b/client/my-sites/checkout/cart/header-cart.jsx
@@ -14,7 +14,7 @@ import { reloadCart } from 'calypso/lib/cart/actions';
 
 class HeaderCart extends React.Component {
 	static propTypes = {
-		cart: PropTypes.object,
+		cart: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object.isRequired,
 		currentRoute: PropTypes.string,
 	};

--- a/client/my-sites/checkout/cart/header-cart.jsx
+++ b/client/my-sites/checkout/cart/header-cart.jsx
@@ -3,6 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -42,7 +43,6 @@ class HeaderCart extends React.Component {
 
 		return (
 			<PopoverCart
-				cart={ this.props.cart }
 				selectedSite={ this.props.selectedSite }
 				visible={ this.state.isPopoverCartVisible }
 				pinned={ false }
@@ -54,4 +54,4 @@ class HeaderCart extends React.Component {
 	}
 }
 
-export default HeaderCart;
+export default withShoppingCart( HeaderCart );

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { reject } from 'lodash';
 import classNames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
+import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -33,6 +34,7 @@ import './style.scss';
 class PopoverCart extends React.Component {
 	static propTypes = {
 		cart: PropTypes.object.isRequired,
+		shoppingCartManager: PropTypes.object.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		onToggle: PropTypes.func.isRequired,
 		closeSectionNavMobilePanel: PropTypes.func,
@@ -57,7 +59,10 @@ class PopoverCart extends React.Component {
 	}
 
 	itemCount() {
-		if ( ! this.props.cart.hasLoadedFromServer || this.props.cart.hasPendingServerUpdates ) {
+		if (
+			this.props.shoppingCartManager.isLoading ||
+			this.props.shoppingCartManager.isPendingUpdate
+		) {
 			return;
 		}
 
@@ -85,7 +90,7 @@ class PopoverCart extends React.Component {
 	};
 
 	render() {
-		const { cart, selectedSite } = this.props;
+		const { cart, selectedSite, shoppingCartManager } = this.props;
 		let countBadge;
 		const classes = classNames( 'popover-cart', {
 			pinned: this.props.pinned,
@@ -105,7 +110,7 @@ class PopoverCart extends React.Component {
 				<CartMessages
 					cart={ cart }
 					selectedSite={ selectedSite }
-					isLoadingCart={ ! cart.hasLoadedFromServer }
+					isLoadingCart={ ! shoppingCartManager.isLoading }
 				/>
 				<div className={ classes }>
 					<HeaderButton
@@ -157,7 +162,10 @@ class PopoverCart extends React.Component {
 	}
 
 	renderCartBody() {
-		if ( ! this.props.cart.hasLoadedFromServer || this.props.cart.hasPendingServerUpdates ) {
+		if (
+			this.props.shoppingCartManager.isLoading ||
+			this.props.shoppingCartManager.isPendingUpdate
+		) {
 			return <CartBodyLoadingPlaceholder />;
 		}
 
@@ -174,4 +182,4 @@ class PopoverCart extends React.Component {
 	}
 }
 
-export default localize( PopoverCart );
+export default withShoppingCart( localize( PopoverCart ) );

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -37,7 +37,6 @@ class PopoverCart extends React.Component {
 		shoppingCartManager: PropTypes.object.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		onToggle: PropTypes.func.isRequired,
-		closeSectionNavMobilePanel: PropTypes.func,
 		visible: PropTypes.bool.isRequired,
 		pinned: PropTypes.bool.isRequired,
 		compact: PropTypes.bool,
@@ -70,7 +69,6 @@ class PopoverCart extends React.Component {
 	}
 
 	onToggle = () => {
-		this.props.closeSectionNavMobilePanel?.();
 		this.props.onToggle();
 	};
 

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -24,7 +24,6 @@ import Popover from 'calypso/components/popover';
 import CartEmpty from './cart-empty';
 import { isCredits } from 'calypso/lib/products-values';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { reloadCart } from 'calypso/lib/cart/actions';
 
 /**
  * Style dependencies
@@ -50,7 +49,7 @@ class PopoverCart extends React.Component {
 	hasUnmounted = false;
 
 	componentDidMount() {
-		reloadCart();
+		this.props.shoppingCartManager.reloadFromServer();
 	}
 
 	componentWillUnmount() {

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -42,6 +42,7 @@ import { canUserPurchaseGSuite } from 'calypso/lib/gsuite';
 import { addItem } from 'calypso/lib/cart/actions';
 import { planItem } from 'calypso/lib/cart-values/cart-items';
 import { PLAN_PERSONAL } from 'calypso/lib/plans/constants';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 const domainsAddHeader = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () => {
@@ -80,9 +81,9 @@ const domainSearch = ( context, next ) => {
 		<Main wideLayout>
 			<PageViewTracker path="/domains/add/:site" title="Domain Search > Domain Registration" />
 			<DocumentHead title={ translate( 'Domain Search' ) } />
-			<CartData>
+			<CalypsoShoppingCartProvider>
 				<DomainSearch basePath={ sectionify( context.path ) } context={ context } />
-			</CartData>
+			</CalypsoShoppingCartProvider>
 		</Main>
 	);
 	next();

--- a/client/my-sites/domains/domain-management/list/test/index.js
+++ b/client/my-sites/domains/domain-management/list/test/index.js
@@ -7,9 +7,10 @@
  */
 import deepFreeze from 'deep-freeze';
 import React from 'react';
-import { Provider } from 'react-redux';
+import { Provider as ReduxProvider } from 'react-redux';
 import { shallow, mount } from 'enzyme';
 import { noop } from 'lodash';
+import { ShoppingCartProvider, emptyResponseCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -23,6 +24,22 @@ jest.mock( 'lib/wp', () => ( {
 		getSitePlans: () => {},
 	} ),
 } ) );
+
+function getCart() {
+	return Promise.resolve( emptyResponseCart );
+}
+
+function setCart() {
+	return Promise.resolve( emptyResponseCart );
+}
+
+function TestProvider( { store, children } ) {
+	return (
+		<ShoppingCartProvider cartKey="1" getCart={ getCart } setCart={ setCart }>
+			<ReduxProvider store={ store }>{ children }</ReduxProvider>
+		</ShoppingCartProvider>
+	);
+}
 
 describe( 'index', () => {
 	let component;
@@ -80,7 +97,7 @@ describe( 'index', () => {
 			}
 		);
 		return mount( <DomainList { ...props } />, {
-			wrappingComponent: Provider,
+			wrappingComponent: TestProvider,
 			wrappingComponentProps: { store },
 		} );
 	}

--- a/client/my-sites/domains/domain-management/list/test/index.js
+++ b/client/my-sites/domains/domain-management/list/test/index.js
@@ -10,7 +10,7 @@ import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { shallow, mount } from 'enzyme';
 import { noop } from 'lodash';
-import { ShoppingCartProvider, emptyResponseCart } from '@automattic/shopping-cart';
+import { ShoppingCartProvider, getEmptyResponseCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -24,6 +24,8 @@ jest.mock( 'lib/wp', () => ( {
 		getSitePlans: () => {},
 	} ),
 } ) );
+
+const emptyResponseCart = getEmptyResponseCart();
 
 function getCart() {
 	return Promise.resolve( emptyResponseCart );

--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -9,7 +9,6 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
-import CartData from 'calypso/components/data/cart';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Notice from 'calypso/components/notice';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -21,9 +20,7 @@ import { JETPACK_PRODUCTS_LIST } from 'calypso/lib/products-values/constants';
 const StandardPlansHeader = () => (
 	<>
 		<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
-		<CartData>
-			<PlansNavigation path={ '/plans' } />
-		</CartData>
+		<PlansNavigation path={ '/plans' } />
 	</>
 );
 const ConnectFlowPlansHeader = () => (
@@ -36,9 +33,7 @@ const ConnectFlowPlansHeader = () => (
 				brandFont
 			/>
 		</div>
-		<CartData>
-			<PlansNavigation path={ '/plans' } />
-		</CartData>
+		<PlansNavigation path={ '/plans' } />
 	</>
 );
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -31,7 +30,6 @@ import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import CartData from 'calypso/components/data/cart';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getPlan, isWpComPlan } from 'calypso/lib/plans';
@@ -135,9 +133,7 @@ class Plans extends React.Component {
 						<>
 							<FormattedHeader brandFont headerText={ translate( 'Plans' ) } align="left" />
 							<div id="plans" className="plans plans__has-sidebar">
-								<CartData>
-									<PlansNavigation path={ this.props.context.path } />
-								</CartData>
+								<PlansNavigation path={ this.props.context.path } />
 								{ isEnabled( 'p2/p2-plus' ) && isWPForTeamsSite ? (
 									<P2PlansMain
 										selectedPlan={ this.props.selectedPlan }

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -22,7 +22,6 @@ import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 
 class PlansNavigation extends React.Component {
 	static propTypes = {
-		cart: PropTypes.object,
 		isJetpack: PropTypes.bool,
 		path: PropTypes.string.isRequired,
 		shouldShowMyPlan: PropTypes.bool,

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -19,6 +19,7 @@ import PopoverCart from 'calypso/my-sites/checkout/cart/popover-cart';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 class PlansNavigation extends React.Component {
 	static propTypes = {
@@ -115,13 +116,15 @@ function CartToggleButton( {
 	};
 
 	return (
-		<PopoverCart
-			selectedSite={ site }
-			onToggle={ onToggle }
-			pinned={ isMobile() }
-			visible={ cartVisible }
-			path={ path }
-		/>
+		<CalypsoShoppingCartProvider>
+			<PopoverCart
+				selectedSite={ site }
+				onToggle={ onToggle }
+				pinned={ isMobile() }
+				visible={ cartVisible }
+				path={ path }
+			/>
+		</CalypsoShoppingCartProvider>
 	);
 }
 

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -52,8 +52,7 @@ class PlansNavigation extends React.Component {
 		const { site, shouldShowMyPlan, translate } = this.props;
 		const path = sectionify( this.props.path );
 		const sectionTitle = this.getSectionTitle( path );
-		const cartToggleButton = this.cartToggleButton();
-		const hasPinnedItems = isMobile() && cartToggleButton != null;
+		const hasPinnedItems = isMobile() && config.isEnabled( 'upgrades/checkout' ) && site;
 
 		return (
 			site && (
@@ -80,7 +79,12 @@ class PlansNavigation extends React.Component {
 							</NavItem>
 						) }
 					</NavTabs>
-					{ cartToggleButton }
+					<CartToggleButton
+						site={ this.props.site }
+						toggleCartVisibility={ this.toggleCartVisibility }
+						cartVisible={ this.state.cartVisible }
+						path={ this.props.path }
+					/>
 				</SectionNav>
 			)
 		);
@@ -93,23 +97,22 @@ class PlansNavigation extends React.Component {
 	onMobileNavPanelOpen = () => {
 		this.setState( { cartVisible: false } );
 	};
+}
 
-	cartToggleButton() {
-		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! this.props.cart || ! this.props.site ) {
-			return null;
-		}
-
-		return (
-			<PopoverCart
-				cart={ this.props.cart }
-				selectedSite={ this.props.site }
-				onToggle={ this.toggleCartVisibility }
-				pinned={ isMobile() }
-				visible={ this.state.cartVisible }
-				path={ this.props.path }
-			/>
-		);
+function CartToggleButton( { site, toggleCartVisibility, cartVisible, path } ) {
+	if ( ! config.isEnabled( 'upgrades/checkout' ) || ! site ) {
+		return null;
 	}
+
+	return (
+		<PopoverCart
+			selectedSite={ site }
+			onToggle={ toggleCartVisibility }
+			pinned={ isMobile() }
+			visible={ cartVisible }
+			path={ path }
+		/>
+	);
 }
 
 export default connect( ( state ) => {

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -98,15 +98,26 @@ class PlansNavigation extends React.Component {
 	};
 }
 
-function CartToggleButton( { site, toggleCartVisibility, cartVisible, path } ) {
+function CartToggleButton( {
+	site,
+	toggleCartVisibility,
+	cartVisible,
+	path,
+	closeSectionNavMobilePanel,
+} ) {
 	if ( ! config.isEnabled( 'upgrades/checkout' ) || ! site ) {
 		return null;
 	}
 
+	const onToggle = () => {
+		closeSectionNavMobilePanel();
+		toggleCartVisibility();
+	};
+
 	return (
 		<PopoverCart
 			selectedSite={ site }
-			onToggle={ toggleCartVisibility }
+			onToggle={ onToggle }
 			pinned={ isMobile() }
 			visible={ cartVisible }
 			path={ path }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the `PopoverCart` component (a header button that can display the current contents of the shopping cart) so that it uses the `@automattic/shopping-cart` package, rather than the deprecated `CartStore`. (This is one step toward removing the `CartStore` entirely.)

Since `ShoppingCartProvider` requires several props (cartKey, getCart, setCart), this creates a calypso component called `CalypsoShoppingCartProvider` which can be used instead to avoid needing to always provide those props. It does allow overriding cartKey and getCart, however, for the places that doing so is required.

![popovercart](https://user-images.githubusercontent.com/2036909/99748498-9fe00e00-2aaa-11eb-8d7d-5ca56acf4a53.gif)

Depends on https://github.com/Automattic/wp-calypso/pull/47625

#### Testing instructions

1. Start with an empty cart.
1. Add a product to your cart and visit checkout.
1. Close checkout with the "X" in the masterbar. This will bring you to the plans page.
1. Verify that the "Cart" icon in the plans page header shows a "1" and that clicking on it displays the product you added.
1. In the popup, click to remove the product from the cart.
1. Verify that a loading animation is displayed, the product is removed, and the "1" disappears.

Next, the domains list page:

1. Start with an empty cart.
1. Visit the domains management page at `/domains/manage`.
1. Verify that you see no "Cart" icon present.
1. Click Plans > Plan in the sidebar to visit the plans page.
1. Click to add a plan to your cart.
1. Close checkout with the "X" in the masterbar. This will bring you to the plans page.
1. Click Manage > Domains to return to the domains management page.
1. Verify that the "Cart" icon in the plans page header shows a "1" and that clicking on it displays the product you added.
1. In the popup, click to remove the product from the cart.
1. Verify that a loading animation is displayed, the product is removed, and whole icon disappears.

Finally, the domains add page:

1. Start with an empty cart.
1. Visit the domains add page at `/domains/add`.
1. Verify that you see no "Cart" icon present.
1. Click Plans > Plan in the sidebar to visit the plans page.
1. Click to add a plan to your cart.
1. Close checkout with the "X" in the masterbar. This will bring you to the plans page.
1. Visit `/domains/add` to return to the domains add page.
1. Verify that the "Cart" icon in the plans page header shows a "1" and that clicking on it displays the product you added.
1. In the popup, click to remove the product from the cart.
1. Verify that a loading animation is displayed, the product is removed, and whole icon disappears.
