### PR TITLE
Site Deletion: use "paid upgrades" instead of "premium upgrades"

### DIFF
--- a/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
+++ b/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
@@ -32,10 +32,10 @@ function DeleteSiteWarningDialog( { isVisible, onClose } ) {
 			onClose={ onClose }
 			className="delete-site-warning-dialog"
 		>
-			<h1>{ translate( 'Premium Upgrades' ) }</h1>
+			<h1>{ translate( 'Paid Upgrades' ) }</h1>
 			<p>
 				{ translate(
-					'You have active premium upgrades on your site. ' +
+					'You have active paid upgrades on your site. ' +
 						'Please cancel your upgrades prior to deleting your site.'
 				) }
 			</p>


### PR DESCRIPTION
"Premium Upgrades" is outdated and confusing, since we have a premium plan. This updates the site deletion modal to use "Paid Upgrades" instead.

ref: c/TN2RtIjw-tr/406-replace-premium-upgrades-with-paid-upgrades

**To test:**
- On a site with an active subscription, visit Manage > Settings
- Click "Delete your site permanently"
- Verify that the modal title and text says "paid upgrades"