### PR TITLE
Gutenboarding's default locale slug should come from config

### DIFF
--- a/client/landing/gutenboarding/components/locale-context/index.tsx
+++ b/client/landing/gutenboarding/components/locale-context/index.tsx
@@ -91,7 +91,7 @@ export const LocaleContext: React.FunctionComponent = ( { children } ) => {
 
 	return (
 		<ChangeLocaleContext.Provider value={ changeLocale }>
-			<LocaleProvider localeSlug={ contextLocaleData?.[ '' ]?.localeSlug ?? 'en' }>
+			<LocaleProvider localeSlug={ contextLocaleData?.[ '' ]?.localeSlug ?? DEFAULT_LOCALE_SLUG }>
 				<I18nProvider localeData={ contextLocaleData }>
 					{ localeDataLoaded ? children : null }
 				</I18nProvider>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Get gutenboardings fallback locale slug from `config`

I looked into updating `<LocaleProvider>`'s default locale slug too but I don't think I should import `calypso/config` into the `@automattic/i18n-utils` package.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Should be a no-op
