### PR TITLE
Onboarding: fix the plans correct language displaying in the plans grid

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
 import { doAction, hasAction } from '@wordpress/hooks';
 import { LaunchContext } from '@automattic/launch';
+import { LocaleProvider } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -41,9 +42,11 @@ registerPlugin( 'a8c-editor-site-launch', {
 		}
 
 		return (
-			<LaunchContext.Provider value={ { siteId: window._currentSiteId } }>
-				<LaunchModal onClose={ closeSidebar } />
-			</LaunchContext.Provider>
+			<LocaleProvider localeSlug={ window.wpcomEditorSiteLaunch?.locale }>
+				<LaunchContext.Provider value={ { siteId: window._currentSiteId } }>
+					<LaunchModal onClose={ closeSidebar } />
+				</LaunchContext.Provider>
+			</LocaleProvider>
 		);
 	},
 } );

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -1,10 +1,14 @@
 /**
+ * External dependencies
+ */
+import { select } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import type { State } from './reducer';
 import { DEFAULT_PAID_PLAN, PLAN_ECOMMERCE, PLAN_FREE, STORE_KEY } from './constants';
 import type { Plan, PlanFeature, PlanFeatureType, PlanSlug } from './types';
-import { select } from '@wordpress/data';
 
 export const getFeatures = ( state: State ): Record< string, PlanFeature > => state.features;
 
@@ -14,12 +18,12 @@ export const getPlanBySlug = ( state: State, slug: PlanSlug ): Plan => {
 	return state.plans[ slug ] ?? undefined;
 };
 
-export const getDefaultPaidPlan = (): Plan => {
-	return select( STORE_KEY ).getPlansDetails( '' )?.plans[ DEFAULT_PAID_PLAN ];
+export const getDefaultPaidPlan = ( _: State, locale: string ): Plan => {
+	return select( STORE_KEY ).getPlansDetails( locale )?.plans[ DEFAULT_PAID_PLAN ];
 };
 
-export const getDefaultFreePlan = (): Plan => {
-	return select( STORE_KEY ).getPlansDetails( '' )?.plans[ PLAN_FREE ];
+export const getDefaultFreePlan = ( _: State, locale: string ): Plan => {
+	return select( STORE_KEY ).getPlansDetails( locale )?.plans[ PLAN_FREE ];
 };
 
 export const getSupportedPlans = ( state: State ): Plan[] => {

--- a/packages/launch/src/hooks/use-plans.tsx
+++ b/packages/launch/src/hooks/use-plans.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -9,8 +10,14 @@ import { useSelect } from '@wordpress/data';
 import { PLANS_STORE } from '../stores';
 
 export const usePlans = function usePlans() {
-	const defaultPaidPlan = useSelect( ( select ) => select( PLANS_STORE ).getDefaultPaidPlan() );
-	const defaultFreePlan = useSelect( ( select ) => select( PLANS_STORE ).getDefaultFreePlan() );
+	const locale = useLocale();
+
+	const defaultPaidPlan = useSelect( ( select ) =>
+		select( PLANS_STORE ).getDefaultPaidPlan( locale )
+	);
+	const defaultFreePlan = useSelect( ( select ) =>
+		select( PLANS_STORE ).getDefaultFreePlan( locale )
+	);
 	const planPrices = useSelect( ( select ) => select( PLANS_STORE ).getPrices( '' ) );
 
 	return { defaultPaidPlan, defaultFreePlan, planPrices };

--- a/packages/plans-grid/src/plans-accordion/index.tsx
+++ b/packages/plans-grid/src/plans-accordion/index.tsx
@@ -54,7 +54,7 @@ const PlansTable: React.FunctionComponent< Props > = ( {
 	const placeholderPlans = [ 1, 2, 3, 4 ];
 
 	// Primary plan
-	const popularPlan = useSelect( ( select ) => select( PLANS_STORE ).getDefaultPaidPlan() );
+	const popularPlan = useSelect( ( select ) => select( PLANS_STORE ).getDefaultPaidPlan( locale ) );
 	const recommendedPlanSlug = useSelect( ( select ) =>
 		select( WPCOM_FEATURES_STORE ).getRecommendedPlanSlug( selectedFeatures )
 	);


### PR DESCRIPTION
pavWQK-F4-p2#comment-1511

#### Changes proposed in this Pull Request

The plans grid is requesting data with the correct locale and then quickly afterwards requests again with `locale=''`. We need to use the same locale slug so that we don't re-request.

This diff adds the `useLocale()` hook, which depends on the `<LocaleProvider>` being somewhere high-ish in the React tree. That's why `<LocaleProvider>` has been added to ETK (`<LocaleProvider>` is already set up in gutenboarding)

Bug introduced by #47378

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To see the buggy behaviour
  * Go to `/new/fr` and navigate through onboarding until you get to `/new/plans/fr`
  * The plan details are quickly shown in French before switching to English
  * In the editor, open the network dev tools and filter by `details`, then open the launch flow
  * Notice there are two requests to `/wpcom/v2/plans/details`; one with `?locale=fr` and one with `?locale=''`
* Check out this branch and try again to see the behaviour is fixed
* Use `yarn dev --sync` to update ETK on a sandboxed site, it should now only make a single request to `/wpcom/v2/plans/details`
