### PR TITLE
Focused-Launch: Update <Title/>, <SubTitle/> & <p/> to improve a11y

### DIFF
--- a/packages/launch/src/focused-launch/plan-details/index.tsx
+++ b/packages/launch/src/focused-launch/plan-details/index.tsx
@@ -44,8 +44,8 @@ const PlanDetails: React.FunctionComponent = () => {
 			</div>
 			<div className="focused-launch-plan-details__header">
 				<div>
-					<Title>{ __( 'Select a plan', __i18n_text_domain__ ) }</Title>
-					<SubTitle>
+					<Title tagName="h2">{ __( 'Select a plan', __i18n_text_domain__ ) }</Title>
+					<SubTitle tagName="h3">
 						{ __(
 							"There's no risk, you can cancel for a full refund within 30 days.",
 							__i18n_text_domain__

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -48,8 +48,8 @@ const Success: React.FunctionComponent = () => {
 		<div className="focused-launch-success">
 			<div className="focused-launch-success__wrapper">
 				<Confetti className="focused-launch-success__confetti" />
-				<Title>{ __( 'Hooray!', __i18n_text_domain__ ) }</Title>
-				<SubTitle>
+				<Title tagName="h2">{ __( 'Hooray!', __i18n_text_domain__ ) }</Title>
+				<SubTitle tagName="h3">
 					{ __(
 						"Congratulations, your website is now live. We're excited to watch you grow with WordPress.",
 						__i18n_text_domain__

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { Title } from '@automattic/onboarding';
+import { SubTitle, Title } from '@automattic/onboarding';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { TextControl, SVG, Path, Tooltip, Circle, Rect } from '@wordpress/components';
@@ -130,8 +130,10 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							>
 								{ info }
 							</Tooltip>
-							{ /* @TODO: should use <Subtitle/> once https://github.com/Automattic/wp-calypso/issues/47418 is solved */ }
-							<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
+							<SubTitle
+								tagName="p"
+								className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only"
+							>
 								<Icon icon={ bulb } />
 								{ createInterpolateElement(
 									__(
@@ -142,7 +144,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 										strong: <strong />,
 									}
 								) }
-							</p>
+							</SubTitle>
 						</label>
 						<FocusedLaunchSummaryItem readOnly>
 							<LeadingContentSide label={ currentDomain || '' } />
@@ -518,12 +520,12 @@ const Summary: React.FunctionComponent = () => {
 	return (
 		<div className="focused-launch-summary__container">
 			<div className="focused-launch-summary__section">
-				<Title>
+				<Title tagName="h2">
 					{ hasPaidDomain && hasPaidPlan
 						? __( "You're ready to launch", __i18n_text_domain__ )
 						: __( "You're almost there", __i18n_text_domain__ ) }
 				</Title>
-				<p className="focused-launch-summary__caption">
+				<SubTitle tagName="p" className="focused-launch-summary__caption">
 					{ hasPaidDomain && hasPaidPlan
 						? __(
 								"You're good to go! Launch your site and share your site address.",
@@ -533,7 +535,7 @@ const Summary: React.FunctionComponent = () => {
 								'Prepare for launch! Confirm a few final things before you take it live.',
 								__i18n_text_domain__
 						  ) }
-				</p>
+				</SubTitle>
 			</div>
 			{ disabledSteps.map( ( disabledStepRenderer, disabledStepIndex ) =>
 				// Disabled steps don't show the step index

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -130,10 +130,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							>
 								{ info }
 							</Tooltip>
-							<SubTitle
-								tagName="p"
-								className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only"
-							>
+							<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
 								<Icon icon={ bulb } />
 								{ createInterpolateElement(
 									__(
@@ -144,7 +141,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 										strong: <strong />,
 									}
 								) }
-							</SubTitle>
+							</p>
 						</label>
 						<FocusedLaunchSummaryItem readOnly>
 							<LeadingContentSide label={ currentDomain || '' } />

--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -55,8 +55,6 @@
 
 .focused-launch-summary__caption {
 	margin: 12px 0;
-	font-size: 1rem;
-	color: #50575e;
 }
 
 .focused-launch-summary__step {

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -94,7 +94,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 
 			<div className="plans-grid__details">
 				<div className="plans-grid__details-heading">
-					<Title>{ __( 'Detailed comparison', __i18n_text_domain__ ) }</Title>
+					<Title tagName="h2">{ __( 'Detailed comparison', __i18n_text_domain__ ) }</Title>
 				</div>
 				<div className="plans-grid__details-container">
 					<PlansDetails onSelect={ onPlanSelect } locale={ locale } />


### PR DESCRIPTION
The focused launch modal has to be semantically correct to enable all users to enjoy its features, hence we added tagName props to the aforementioned elements to improve semantics. We also converted `<p/>` to `<SubTitle/>` where necessary to improve consistency.

#### Changes proposed in this Pull Request

* Add `tagName` props to `<Title/>`, `<SubTitle/>` & `<p/>`;
* Convert `<p/>` to `<SubTitle/>`.

#### Testing instructions

* Check out this branch on your machine and run `yarn && yarn start`;
* Navigate to the focused launch flow;
* Click on "View all plans";
* use `devTools` to inspect the "Select a plan" heading and confirm that's a `<h2/>`.
* use `devTools` to inspect the "There's no risk, you can cancel for a full refund within 30 days." subtitle and confirm that's a `<h3/>`.

Fixes #47497
