### PR TITLE
ICFY: migrate icfy-stats task from master branch to trunk

### DIFF
--- a/.github/workflows/icfy-stats.yml
+++ b/.github/workflows/icfy-stats.yml
@@ -42,12 +42,12 @@ jobs:
         env:
           ICFY_SECRET: ${{ secrets.ICFY_SECRET }}
         run: |
-          ANCESTOR_SHA1=$(git merge-base HEAD origin/master)
+          ANCESTOR_SHA1=$(git merge-base HEAD origin/trunk)
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          curl -X POST --globoff                                                                 \
-            "http://api.iscalypsofastyet.com:5000/submit-stats?from=github&secret=$ICFY_SECRET"  \
-            -H 'Cache-Control: no-cache'                                                         \
-            -H 'Content-Type: application/json'                                                  \
+          curl -X POST --globoff                                                       \
+            "http://iscalypsofastyet.com/submit-stats?from=github&secret=$ICFY_SECRET" \
+            -H 'Cache-Control: no-cache'                                               \
+            -H 'Content-Type: application/json'                                        \
             -d '{
                   "payload": {
                     "branch": "'"$CURRENT_BRANCH"'",


### PR DESCRIPTION
When calculating stats for a branch build and submitting them to ICFY via a webhook, one of the things that the task computes is the "ancestor" commit SHA, i.e., the point in the `trunk` branch from where the PR branch was created.

This will now have to look at `trunk` instead of `master`. If we don't do this, bundle size diffs will be calculated against the last `master` commit instead of the `trunk` one. As `master` will be frozen and will stop moving forward, the diffs would be increasingly incorrect.

As a drive-by fix, I'm changing the URL of the webhook endpoint. The `api.` prefix and the 5000 port have been optional for a long time now.

Looking at #45234, this change is not there.