### PR TITLE
Focused Launch: Fix promotional mobile styling

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -141,15 +141,17 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							</Tooltip>
 							<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
 								<Icon icon={ bulb } />
-								{ createInterpolateElement(
-									__(
-										'<strong>Unique domains</strong> help build brand trust',
-										__i18n_text_domain__
-									),
-									{
-										strong: <strong />,
-									}
-								) }
+								<span>
+									{ createInterpolateElement(
+										__(
+											'<strong>Unique domains</strong> help build brand trust',
+											__i18n_text_domain__
+										),
+										{
+											strong: <strong />,
+										}
+									) }
+								</span>
 							</p>
 						</label>
 						<FocusedLaunchSummaryItem readOnly>
@@ -170,15 +172,17 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 									</label>
 									<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
 										<Icon icon={ bulb } />
-										{ createInterpolateElement(
-											__(
-												'<strong>46.9%</strong> of registered domains are <strong>.com</strong>',
-												__i18n_text_domain__
-											),
-											{
-												strong: <strong />,
-											}
-										) }
+										<span>
+											{ createInterpolateElement(
+												__(
+													'<strong>46.9%</strong> of registered domains are <strong>.com</strong>',
+													__i18n_text_domain__
+												),
+												{
+													strong: <strong />,
+												}
+											) }
+										</span>
 									</p>
 								</>
 							}
@@ -303,15 +307,17 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 							</Tooltip>
 							<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
 								<Icon icon={ bulb } />
-								{ createInterpolateElement(
-									__(
-										'More than <strong>38%</strong> of the internet uses <strong>WordPress</strong>',
-										__i18n_text_domain__
-									),
-									{
-										strong: <strong />,
-									}
-								) }
+								<span>
+									{ createInterpolateElement(
+										__(
+											'More than <strong>38%</strong> of the internet uses <strong>WordPress</strong>',
+											__i18n_text_domain__
+										),
+										{
+											strong: <strong />,
+										}
+									) }
+								</span>
 							</p>
 						</label>
 						<div>
@@ -331,15 +337,17 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 						</label>
 						<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
 							<Icon icon={ bulb } />
-							{ createInterpolateElement(
-								__(
-									'Grow your business with <strong>WordPress Business</strong>',
-									__i18n_text_domain__
-								),
-								{
-									strong: <strong />,
-								}
-							) }
+							<span>
+								{ createInterpolateElement(
+									__(
+										'Grow your business with <strong>WordPress Business</strong>',
+										__i18n_text_domain__
+									),
+									{
+										strong: <strong />,
+									}
+								) }
+							</span>
 						</p>
 						<div>
 							<FocusedLaunchSummaryItem

--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -26,8 +26,15 @@
 .focused-launch-summary__mobile-commentary {
 	font-size: 0.875rem;
 	color: var( --studio-gray-60 );
+	display: flex;
+	align-items: flex-start;
 	svg {
 		vertical-align: bottom;
+		fill: var( --studio-gray-20 );
+		margin-right: 3px;
+
+		// compensate for the gap in the svg top
+		margin-top: -1px;
 	}
 }
 


### PR DESCRIPTION
_3-4 minutes review_

#### Changes proposed in this Pull Request

* Fix focused Launch promotional commentary styling on mobile.

#### Testing instructions

1. In apps/editing-toolkit run `yarn dev --sync`.
2. Sandbox YOUR_SITE.wordpress.com.
3. Visit https://YOUR_SITE.wordpress.com/wp-admin/post-new.php.
4. In console, type `wp.data.dispatch('automattic/launch' ).openFocusedLaunch()`.
5. Compare against the screeshots in #47277

Fixes #47277
