### PR TITLE
Focused Launch: add "Ask for Help" section

### DIFF
--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -119,12 +119,12 @@ $accent-blue: #117ac9;
 		border-bottom-right-radius: 5px; /* stylelint-disable-line scales/radii */
 	}
 
-	+ .domain-picker__suggestion-item {
+	& + & {
 		margin-top: -1px;
 	}
 
-	+ .domain-picker__suggestion-item.type-individual-item {
-		margin: 12px 0;
+	& + &.type-individual-item {
+		margin-top: 12px;
 	}
 
 	&.is-unavailable {

--- a/packages/launch/src/_variables.scss
+++ b/packages/launch/src/_variables.scss
@@ -7,3 +7,4 @@ $launch-padding-h-wide: 80px;
 // @TODO: refactor to common variable in onboarding
 // see https://github.com/Automattic/wp-calypso/issues/47181
 $focused-launch-accent-blue: #117ac9;
+$focused-launch-warning: #d67709;

--- a/packages/launch/src/focused-launch/summary/focused-launch-summary-item/style.scss
+++ b/packages/launch/src/focused-launch/summary/focused-launch-summary-item/style.scss
@@ -23,15 +23,16 @@
 
 	.focused-launch-summary-item__leading-side-badge {
 		margin-left: 10px;
-		display: inline-block;
 		height: 20px;
+		display: inline-flex;
+		align-items: center;
+		line-height: 1;
 		font-size: $font-body-extra-small;
 		background-color: var( --studio-green-5 );
 		color: var( --studio-green-80 );
 		padding: 0 10px;
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 4px;
-		line-height: 1.5;
 	}
 
 	&.is-selected .focused-launch-summary-item__leading-side-badge {
@@ -44,6 +45,7 @@
 		font-size: $font-body-small;
 		// stylelint-disable-next-line scales/font-weight
 		font-weight: 500;
+		line-height: 1;
 	}
 
 	&:not( .is-selected ):not( .is-readonly ) .focused-launch-summary-item__leading-side-label {

--- a/packages/launch/src/focused-launch/summary/focused-launch-summary-item/style.scss
+++ b/packages/launch/src/focused-launch/summary/focused-launch-summary-item/style.scss
@@ -77,7 +77,7 @@
 	}
 
 	.focused-launch-summary-item__warning-note {
-		color: #d67709;
+		color: $focused-launch-warning;
 	}
 
 	* {

--- a/packages/launch/src/focused-launch/summary/focused-launch-summary-item/style.scss
+++ b/packages/launch/src/focused-launch/summary/focused-launch-summary-item/style.scss
@@ -14,6 +14,13 @@
 	align-items: center;
 	width: 100%;
 
+	.focused-launch-summary-item__leading-side {
+		flex-shrink: 0;
+		margin-right: 8px;
+		display: inline-flex;
+		align-items: center;
+	}
+
 	.focused-launch-summary-item__leading-side-badge {
 		margin-left: 10px;
 		display: inline-block;
@@ -78,6 +85,7 @@
 
 	.focused-launch-summary-item__warning-note {
 		color: $focused-launch-warning;
+		text-align: right;
 	}
 
 	* {

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { SubTitle, Title } from '@automattic/onboarding';
+import { ActionButtons, Title, SubTitle } from '@automattic/onboarding';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { TextControl, SVG, Path, Tooltip, Circle, Rect } from '@wordpress/components';
@@ -557,8 +557,17 @@ const Summary: React.FunctionComponent = () => {
 				} )
 			) }
 
-			{ /* @TODO: placeholder for https://github.com/Automattic/wp-calypso/issues/47392 */ }
-			<Link to={ Route.Success }>{ __( 'Launch your site', __i18n_text_domain__ ) }</Link>
+			<div className="focused-launch-summary__actions-wrapper">
+				<ActionButtons className="focused-launch-summary__launch-action-bar">
+					{ /* @TODO: placeholder for https://github.com/Automattic/wp-calypso/issues/47392 */ }
+					<Link to={ Route.Success }>{ __( 'Launch your site', __i18n_text_domain__ ) }</Link>
+				</ActionButtons>
+
+				<div className="focused-launch-summary__ask-for-help">
+					<p>{ __( 'Questions? Our experts can assist.', __i18n_text_domain__ ) }</p>
+					<a href="/help">{ __( 'Ask a Happiness Engineer', __i18n_text_domain__ ) }</a>
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -453,7 +453,7 @@ const Summary: React.FunctionComponent = () => {
 
 	const site = useSite();
 
-	const { locale } = useContext( LaunchContext );
+	const { locale, redirectTo } = useContext( LaunchContext );
 
 	const { setModalDismissible, showModalTitle } = useDispatch( LAUNCH_STORE );
 
@@ -473,6 +473,17 @@ const Summary: React.FunctionComponent = () => {
 	}, [ title, showSiteTitleStep, isSiteTitleStepVisible ] );
 
 	const hasPaidPlan = site.isPaidPlan;
+
+	const onAskForHelpClick = ( event: React.MouseEvent< HTMLAnchorElement, MouseEvent > ) => {
+		const helpHref = ( event.target as HTMLAnchorElement ).getAttribute( 'href' );
+
+		if ( ! helpHref ) {
+			return;
+		}
+
+		redirectTo( helpHref );
+		event.preventDefault();
+	};
 
 	// Prepare Steps
 	const renderSiteTitleStep: StepIndexRenderFunction = ( { stepIndex, forwardStepIndex } ) => (
@@ -565,7 +576,9 @@ const Summary: React.FunctionComponent = () => {
 
 				<div className="focused-launch-summary__ask-for-help">
 					<p>{ __( 'Questions? Our experts can assist.', __i18n_text_domain__ ) }</p>
-					<a href="/help">{ __( 'Ask a Happiness Engineer', __i18n_text_domain__ ) }</a>
+					<a href="/help" onClick={ onAskForHelpClick }>
+						{ __( 'Ask a Happiness Engineer', __i18n_text_domain__ ) }
+					</a>
 				</div>
 			</div>
 		</div>

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -196,7 +196,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							itemType="individual-item"
 							locale={ locale }
 						/>
-						<Link to={ Route.DomainDetails }>
+						<Link to={ Route.DomainDetails } className="focused-launch-summary__details-link">
 							{ __( 'View all domains', __i18n_text_domain__ ) }
 						</Link>
 					</>
@@ -385,7 +385,9 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 								</TrailingContentSide>
 							</FocusedLaunchSummaryItem>
 						</div>
-						<Link to={ Route.PlanDetails }>{ __( 'View all plans', __i18n_text_domain__ ) }</Link>
+						<Link to={ Route.PlanDetails } className="focused-launch-summary__details-link">
+							{ __( 'View all plans', __i18n_text_domain__ ) }
+						</Link>
 					</>
 				)
 			}

--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -176,7 +176,7 @@ $commentary-column-gap-wide: 100px;
 
 .focused-launch-summary__ask-for-help {
 	// to make scrolling space for sticky action bar
-	margin-bottom: 80px;
+	margin-bottom: $onboarding-footer-height;
 
 	@include break-small {
 		margin-bottom: 0;

--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -128,11 +128,3 @@
 		flex: 0.6;
 	}
 }
-
-.onboarding-title {
-	@include onboarding-font-recoleta;
-
-	font-size: 2.25rem;
-	line-height: 40px;
-	color: #101517;
-}

--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -6,6 +6,12 @@
 @import '~@automattic/onboarding/styles/variables';
 @import '~@automattic/onboarding/styles/mixins';
 
+$commentary-column-width-medium: 280px;
+$commentary-column-width-large: 320px;
+$commentary-column-gap-small: 40px;
+$commentary-column-gap-large: 80px;
+$commentary-column-gap-wide: 100px;
+
 .focused-launch-summary__input {
 	.components-text-control__input {
 		font-size: 1rem;
@@ -37,6 +43,10 @@
 	font-size: 1.25rem;
 	color: var( --studio-gray-90 );
 	line-height: 24px;
+
+	@include break-medium {
+		margin-bottom: 12px;
+	}
 }
 
 .focused-launch-summary__info-icon {
@@ -54,15 +64,17 @@
 
 .focused-launch-summary__step {
 	display: flex;
+	gap: $commentary-column-gap-small;
+	justify-content: space-between;
 	opacity: 0.5;
 	transition: opacity 0.5s ease-in-out;
 
-	@include break-medium {
-		gap: 50px;
+	@include break-large {
+		gap: $commentary-column-gap-large;
 	}
 
-	@include break-large {
-		gap: 100px;
+	@include break-wide {
+		gap: $commentary-column-gap-wide;
 	}
 }
 
@@ -92,9 +104,10 @@
 		border-left: 1px solid #eee;
 		display: flex;
 		flex-direction: column;
-		flex: 0.4;
-		padding: 0 42.5px;
-		max-width: 350px;
+		padding-left: 40px;
+		width: $commentary-column-width-medium;
+		flex-grow: 0;
+		flex-shrink: 0;
 
 		&-title {
 			font-size: 1.25rem;
@@ -119,18 +132,69 @@
 			margin-right: 12px;
 		}
 	}
+
+	@include break-large {
+		width: $commentary-column-width-large;
+	}
 }
 
 .focused-launch-summary__data-input {
-	flex: 1;
-
-	@include break-medium {
-		flex: 0.6;
-	}
+	flex-grow: 1;
+	flex-shrink: 1;
 }
 
 .focused-launch-summary__details-link {
 	display: block;
 	margin-top: 14px;
 	color: var( --studio-gray-60 );
+}
+
+.focused-launch-summary__actions-wrapper {
+	@include break-small {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	@include break-medium {
+		flex-direction: column-reverse;
+		align-items: flex-start;
+		gap: 20px;
+		width: calc( 100% - #{$commentary-column-width-medium + $commentary-column-gap-small} );
+	}
+
+	@include break-large {
+		flex-direction: row;
+		align-items: center;
+		width: calc( 100% - #{$commentary-column-width-large + $commentary-column-gap-large} );
+	}
+
+	@include break-wide {
+		width: calc( 100% - #{$commentary-column-width-large + $commentary-column-gap-wide} );
+	}
+}
+
+.focused-launch-summary__ask-for-help {
+	// to make scrolling space for sticky action bar
+	margin-bottom: 80px;
+
+	@include break-small {
+		margin-bottom: 0;
+	}
+
+	> * {
+		margin: 0;
+	}
+}
+
+.focused-launch-summary__launch-action-bar {
+	// Overrides original component styles
+	&.action-buttons:not( .is-sticky ) {
+		margin-left: 0;
+	}
+
+	@include break-small {
+		flex-shrink: 0;
+		margin-right: 8px;
+	}
 }

--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -128,3 +128,9 @@
 		flex: 0.6;
 	}
 }
+
+.focused-launch-summary__details-link {
+	display: block;
+	margin-top: 14px;
+	color: var( --studio-gray-60 );
+}


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Add "Ask for help" section
* This caused some partially related refactors in the Summary view

## Testing instructions

### Prepare for testing

* Check out the branch on your machine and run in two parallel terminal windows:
  - `yarn && yarn start`
  - `cd apps/editing-toolkit && yarn dev --sync`
* Add an _unlaunched_ site created with `/start` to your sandbox (for convenience, `SITE_ID`)
* Visit `/page/SITE_ID.wordpress.com/home?flags=create/focused-launch-flow`
* Click on "Launch" button — Focused Launch modal should appear

### Testing checklist

- [x] Check that links to Domain and Step details are have the correct margin top and text color
- [x] Check that the "Free plan" item suggestion in the Plan step doesn't break the line on narrow screens
- [x] Check that the "Ask for help" section follow the specs highlighted in #47395 (note: between medium and large breakpoints, the "ask for help" section and the "launch" button are vertically stacked, since there wouldn't be enough space to have them side to side)

Fixes #47395
Fixes #47380
