### PR TITLE
Focused Launch: Reorder plans as spec'd

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -352,26 +352,6 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 						<div>
 							<FocusedLaunchSummaryItem
 								isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
-								readOnly={ hasPaidDomain || selectedPaidDomain }
-								onClick={ () => defaultFreePlan && setPlan( defaultFreePlan ) }
-								isSelected={ ! ( hasPaidDomain || selectedPaidDomain ) && selectedPlan?.isFree }
-							>
-								<LeadingContentSide
-									label={
-										/* translators: %s is WordPress.com plan name (eg: Premium Plan) */
-										sprintf( __( '%s Plan', __i18n_text_domain__ ), defaultFreePlan?.title ?? '' )
-									}
-								/>
-								<TrailingContentSide
-									nodeType={ hasPaidDomain || selectedPaidDomain ? 'WARNING' : 'PRICE' }
-								>
-									{ hasPaidDomain || selectedPaidDomain
-										? __( 'Not available with your domain selection', __i18n_text_domain__ )
-										: __( 'Free', __i18n_text_domain__ ) }
-								</TrailingContentSide>
-							</FocusedLaunchSummaryItem>
-							<FocusedLaunchSummaryItem
-								isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
 								onClick={ () => paidPlan && setPlan( paidPlan ) }
 								isSelected={ selectedPlan?.storeSlug === paidPlan?.storeSlug }
 							>
@@ -390,6 +370,26 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 											__( '/mo', __i18n_text_domain__ )
 										}
 									</span>
+								</TrailingContentSide>
+							</FocusedLaunchSummaryItem>
+							<FocusedLaunchSummaryItem
+								isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
+								readOnly={ hasPaidDomain || selectedPaidDomain }
+								onClick={ () => defaultFreePlan && setPlan( defaultFreePlan ) }
+								isSelected={ ! ( hasPaidDomain || selectedPaidDomain ) && selectedPlan?.isFree }
+							>
+								<LeadingContentSide
+									label={
+										/* translators: %s is WordPress.com plan name (eg: Premium Plan) */
+										sprintf( __( '%s Plan', __i18n_text_domain__ ), defaultFreePlan?.title ?? '' )
+									}
+								/>
+								<TrailingContentSide
+									nodeType={ hasPaidDomain || selectedPaidDomain ? 'WARNING' : 'PRICE' }
+								>
+									{ hasPaidDomain || selectedPaidDomain
+										? __( 'Not available with your domain selection', __i18n_text_domain__ )
+										: __( 'Free', __i18n_text_domain__ ) }
 								</TrailingContentSide>
 							</FocusedLaunchSummaryItem>
 						</div>

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -275,7 +275,9 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 
 	const { defaultPaidPlan, defaultFreePlan, planPrices } = usePlans();
 
-	const [ nonDefaultPaidPlan, setNonDefaultPaidPlan ] = useState< Plan | null | undefined >( null );
+	const [ nonDefaultPaidPlan, setNonDefaultPaidPlan ] = useState< Plan | undefined >();
+
+	const isPlanSelected = ( plan: Plan ) => plan && plan.storeSlug === selectedPlan?.storeSlug;
 
 	const sitePlan = useSite().sitePlan;
 
@@ -361,7 +363,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 							<FocusedLaunchSummaryItem
 								isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
 								onClick={ () => defaultPaidPlan && setPlan( defaultPaidPlan ) }
-								isSelected={ selectedPlan?.storeSlug === defaultPaidPlan?.storeSlug }
+								isSelected={ isPlanSelected( defaultPaidPlan ) }
 							>
 								<LeadingContentSide
 									label={
@@ -387,7 +389,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 								<FocusedLaunchSummaryItem
 									isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
 									onClick={ () => nonDefaultPaidPlan && setPlan( nonDefaultPaidPlan ) }
-									isSelected={ selectedPlan?.storeSlug === nonDefaultPaidPlan?.storeSlug }
+									isSelected={ isPlanSelected( nonDefaultPaidPlan ) }
 								>
 									<LeadingContentSide
 										label={


### PR DESCRIPTION
💡 **Note: for code review, it's probably easier to review the two comments separately. The first commit does next to nothing but messes up the diff.**

### Changes

- This PR meets every criterion in https://github.com/Automattic/wp-calypso/issues/47544. 

#### Testing instructions

1. Run `yarn start`. In apps/editing-toolkit run `yarn dev --sync`.
2. Sandbox YOUR_SITE.wordpress.com.
3. Visit https://YOUR_SITE.wordpress.com/wp-admin/post-new.php.
4. In console, type `wp.data.dispatch('automattic/launch' ).openFocusedLaunch()`.
5. Test against every checkbox in the issue #47544.

Fixes #47544
