### PR TITLE
Fix the alignment of SMS recovery phone number

### DIFF
--- a/client/me/security-account-recovery/recovery-phone.jsx
+++ b/client/me/security-account-recovery/recovery-phone.jsx
@@ -23,7 +23,7 @@ class RecoveryPhone extends Component {
 				title={ translate( 'Recovery SMS number', {
 					comment: 'Account security',
 				} ) }
-				subtitle={ phone ? '\u200e' + phone.numberFull : translate( 'Not set' ) }
+				subtitle={ phone ? <span dir="ltr">{ phone.numberFull }</span> : translate( 'Not set' ) }
 				hasValue={ !! phone }
 				disabled={ disabled }
 				onSave={ this.onSave }

--- a/client/me/security-account-recovery/recovery-phone.jsx
+++ b/client/me/security-account-recovery/recovery-phone.jsx
@@ -23,7 +23,7 @@ class RecoveryPhone extends Component {
 				title={ translate( 'Recovery SMS number', {
 					comment: 'Account security',
 				} ) }
-				subtitle={ phone ? phone.numberFull : translate( 'Not set' ) }
+				subtitle={ phone ? '\u200e' + phone.numberFull : translate( 'Not set' ) }
 				hasValue={ !! phone }
 				disabled={ disabled }
 				onSave={ this.onSave }

--- a/client/me/security-checkup/account-recovery-phone.jsx
+++ b/client/me/security-checkup/account-recovery-phone.jsx
@@ -55,10 +55,10 @@ class SecurityCheckupAccountRecoveryPhone extends React.Component {
 				'You still need to verify your recovery SMS number: {{strong}}%(recoveryPhoneNumber)s{{/strong}}',
 				{
 					args: {
-						recoveryPhoneNumber: '\u200e' + accountRecoveryPhone.numberFull,
+						recoveryPhoneNumber: accountRecoveryPhone.numberFull,
 					},
 					components: {
-						strong: <strong />,
+						strong: <strong dir="ltr" />,
 					},
 				}
 			);
@@ -68,10 +68,10 @@ class SecurityCheckupAccountRecoveryPhone extends React.Component {
 				'You have set {{strong}}%(recoveryPhoneNumber)s{{/strong}} as your recovery SMS number.',
 				{
 					args: {
-						recoveryPhoneNumber: '\u200e' + accountRecoveryPhone.numberFull,
+						recoveryPhoneNumber: accountRecoveryPhone.numberFull,
 					},
 					components: {
-						strong: <strong />,
+						strong: <strong dir="ltr" />,
 					},
 				}
 			);

--- a/client/me/security-checkup/account-recovery-phone.jsx
+++ b/client/me/security-checkup/account-recovery-phone.jsx
@@ -55,7 +55,7 @@ class SecurityCheckupAccountRecoveryPhone extends React.Component {
 				'You still need to verify your recovery SMS number: {{strong}}%(recoveryPhoneNumber)s{{/strong}}',
 				{
 					args: {
-						recoveryPhoneNumber: accountRecoveryPhone.numberFull,
+						recoveryPhoneNumber: '\u200e' + accountRecoveryPhone.numberFull,
 					},
 					components: {
 						strong: <strong />,
@@ -68,7 +68,7 @@ class SecurityCheckupAccountRecoveryPhone extends React.Component {
 				'You have set {{strong}}%(recoveryPhoneNumber)s{{/strong}} as your recovery SMS number.',
 				{
 					args: {
-						recoveryPhoneNumber: accountRecoveryPhone.numberFull,
+						recoveryPhoneNumber: '\u200e' + accountRecoveryPhone.numberFull,
 					},
 					components: {
 						strong: <strong />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Right now the SMS Recovery phone numbers appear with the plus sign to the right of the number in RTL locales.
This PR adds the LRM UTF-8 character in the components before the phone number to force them to be displayed left to right.

Before:
<img width="360" alt="Image 2020-11-20 at 4 23 59 PM" src="https://user-images.githubusercontent.com/7847633/99837312-aed8c600-2b67-11eb-82f6-82e12c1a6250.png">
<img width="1011" alt="Image 2020-11-20 at 4 22 57 PM" src="https://user-images.githubusercontent.com/7847633/99837315-b0a28980-2b67-11eb-84ef-99c3c3566b84.png">

After:
<img width="360" alt="Image 2020-11-20 at 7 51 11 PM" src="https://user-images.githubusercontent.com/7847633/99838734-e0529100-2b69-11eb-9e20-1005daad1bef.png">
<img width="1014" alt="Image 2020-11-20 at 7 50 37 PM" src="https://user-images.githubusercontent.com/7847633/99838742-e21c5480-2b69-11eb-9dca-7c338fc6cf39.png">


#### Testing instructions

1. Change your language in Calypso to Arabic or Hebrew.
2. Checkout the branch and navigate to http://calypso.localhost:3000/me/security/account-recovery
3. Enter a phone number and confirm that it's displayed correctly with the plus sign on the left both on the http://calypso.localhost:3000/me/security/account-recovery and http://calypso.localhost:3000/me/security pages.
4. Change the language to an LTR locale and test for regression issues.
