### PR TITLE
e2e package.json -> chromedriver 85 to 87

### DIFF
--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -26,7 +26,7 @@
 		"@xmpp/plugins": "^0.3.0",
 		"asana-phrase": "^0.0.8",
 		"cached-path-relative": ">=1.0.2",
-		"chromedriver": "^85.0.0",
+		"chromedriver": "^87.0.0",
 		"concurrently": "^3.6.1",
 		"config": "^1.28.0",
 		"cryptiles": ">=4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10029,10 +10029,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^85.0.0:
-  version "85.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-85.0.0.tgz#5b9b6a184569f5e2b22b45a928bbc66d1c4bb36f"
-  integrity sha512-Noinnkl9gRsfC1EYA5trcOVf9r/P6JJnWf+mU6KZS3xLjV9x/o71VZ+gqRl3oSI4PnTGnqYRISZFQk/teYVTRg==
+chromedriver@^87.0.0:
+  version "87.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-87.0.0.tgz#e8390deed8ada791719a67ad6bf1116614f1ba2d"
+  integrity sha512-PY7FnHOQKfH0oPfSdhpLx5nEy5g4dGYySf2C/WZGkAaCaldYH8/3lPPucZ8MlOCi4bCSGoKoCUTeG6+wYWavvw==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.19.2"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In test/e2e/package.json, change the chromedriver version from 85 to 87.

#### Testing instructions

* Try to run gutenboarding e2e tests.
* Decrypt secrets as mentioned in P7rd6c-2sR-p2
* `cd wp-calypso/test/e2e`
* `./node_modules/.bin/mocha specs/wp-gutenboarding-spec.js`

I kept getting the error 
>     SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 85
My system has chromium 87, which is the latest.

Only by bumping the chromedriver version and running `npm install` in this directory, I was able to get the e2e tests to run.

I'm a bit concerned by this change though, does it mean we'd have to update whenever there is a new chrome version?  Will this break any of the automated e2e testing infrastructure? (I've only made this change to help running tests locally)