### PR TITLE
Fix broken Jetpack e2e tests

### DIFF
--- a/client/my-sites/plans/current-plan/my-plan-card/index.jsx
+++ b/client/my-sites/plans/current-plan/my-plan-card/index.jsx
@@ -23,7 +23,7 @@ const MyPlanCard = ( { action, isError, isPlaceholder, details, product, tagline
 	const detailsClassNames = classNames( 'my-plan-card__details', { 'is-error': isError } );
 
 	return (
-		<Card className={ cardClassNames } compact>
+		<Card className={ cardClassNames } compact data-e2e-product-slug={ product }>
 			<div className="my-plan-card__primary">
 				<div className="my-plan-card__icon">
 					{ ! isPlaceholder && product && <ProductIcon slug={ product } /> }

--- a/test/e2e/lib/pages/external/jetpackcom-pricing-page.js
+++ b/test/e2e/lib/pages/external/jetpackcom-pricing-page.js
@@ -18,7 +18,7 @@ export default class JetpackComPricingPage extends AsyncBaseContainer {
 	}
 
 	async buyJetpackPlan( planSlug ) {
-		const planCTA = By.css( `[data-e2e-product-slug="${ planSlug }"]` );
+		const planCTA = By.css( `[data-e2e-product-slug="${ planSlug }"] .button` );
 		return await driverHelper.clickWhenClickable( this.driver, planCTA );
 	}
 }

--- a/test/e2e/lib/pages/external/jetpackcom-pricing-page.js
+++ b/test/e2e/lib/pages/external/jetpackcom-pricing-page.js
@@ -18,9 +18,7 @@ export default class JetpackComPricingPage extends AsyncBaseContainer {
 	}
 
 	async buyJetpackPlan( planSlug ) {
-		const planCTA = By.css(
-			`[data-e2e-product-slug="${ planSlug }"] .jetpack-product-card-alt__button`
-		);
+		const planCTA = By.css( `[data-e2e-product-slug="${ planSlug }"]` );
 		return await driverHelper.clickWhenClickable( this.driver, planCTA );
 	}
 }

--- a/test/e2e/lib/pages/my-plan-page.js
+++ b/test/e2e/lib/pages/my-plan-page.js
@@ -25,7 +25,7 @@ export default class MyPlanPage extends AsyncBaseContainer {
 	async isSecurityPlan() {
 		return await driverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
-			By.css( '.is-jetpack-security-v2' )
+			By.css( '[data-e2e-product-slug="jetpack_security_daily"]' )
 		);
 	}
 }

--- a/test/e2e/lib/pages/my-plan-page.js
+++ b/test/e2e/lib/pages/my-plan-page.js
@@ -25,7 +25,7 @@ export default class MyPlanPage extends AsyncBaseContainer {
 	async isSecurityPlan() {
 		return await driverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
-			By.css( '[data-e2e-product-slug="jetpack_security_daily"]' )
+			By.css( '.is-jetpack-security-v2' )
 		);
 	}
 }

--- a/test/e2e/lib/pages/plans-page.js
+++ b/test/e2e/lib/pages/plans-page.js
@@ -98,7 +98,7 @@ export default class PlansPage extends AsyncBaseContainer {
 	async selectJetpackSecurity() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			by.css( '[data-e2e-product-slug="jetpack_security_daily"] .jetpack-product-card-alt__button' )
+			by.css( '[data-e2e-product-slug="jetpack_security_daily"] .button' )
 		);
 	}
 }

--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -27,7 +27,7 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 
 	// Explicitly select the free button on jetpack without needing `host` above.
 	async selectFreePlanJetpack() {
-		const freePlanButton = By.css( '.jetpack-free-card-alt__main a.button' );
+		const freePlanButton = By.css( '[data-e2e-product-slug="free"] a' );
 		await driverHelper.scrollIntoView( this.driver, freePlanButton );
 		return await driverHelper.clickWhenClickable( this.driver, freePlanButton );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix Jetpack e2e tests that the new release of the Pricing page broke. Specifically, this PR will fix tests from the `specs-jetpack-calypso/wp-jetpack-connect-spec.js`, `specs-jetpack-calypso/wp-jetpack-plans-spec.js`,  and `specs/wp-plan-purchase-spec.js` files.

#### Testing instructions

* Code review.
* Make sure tests pass.

Fixes 1164141197617539-as-1199221059177321