### PR TITLE
Checkout: Show tax contact details for full credits purchases

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -241,7 +241,7 @@ export default function WPCheckout( {
 
 	const updateCartContactDetails = useCallback( () => {
 		// Update tax location in cart
-		const nonTaxPaymentMethods = [ 'full-credits', 'free-purchase' ];
+		const nonTaxPaymentMethods = [ 'free-purchase' ];
 		if ( ! activePaymentMethod || ! contactInfo ) {
 			return;
 		}

--- a/client/my-sites/checkout/composite-checkout/lib/get-contact-details-type.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-contact-details-type.ts
@@ -33,7 +33,7 @@ export default function getContactDetailsType( responseCart: ResponseCart ): Con
 		return 'gsuite';
 	}
 
-	if ( isPurchaseFree || isFullCredits ) {
+	if ( isPurchaseFree && ! isFullCredits ) {
 		return 'none';
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As of some recent changes (see more info in #47480), we now properly charge taxes on full credits purchases. However, we neglected to enable the tax contact form for such purchases, which this PR corrects.

Fixes 64-gh-Automattic/payments-shilling

Before:

<img width="579" alt="Screen Shot 2020-11-20 at 4 52 32 PM" src="https://user-images.githubusercontent.com/2036909/99853343-cce6fc00-2b50-11eb-8cff-e89288023ce2.png">

After:

<img width="589" alt="Screen Shot 2020-11-20 at 4 52 14 PM" src="https://user-images.githubusercontent.com/2036909/99853350-cfe1ec80-2b50-11eb-84e3-1bc00f9f5964.png">


#### Testing instructions

- Add enough credits to your account to completely cover a purchase.
- Add a product to your cart (for which the credits will be enough, including taxes) and visit checkout.
- Verify that you see a contact details step (it may be automatically skipped if you already have saved details, but you should be able to go edit it if you need to).
- Enter a postal code and country that collects taxes like 10001, US and press "Continue".
- Verify that the cart total includes taxes.
