### PR TITLE
Fix add-card page for Brazil addresses

### DIFF
--- a/client/blocks/credit-card-form/README.md
+++ b/client/blocks/credit-card-form/README.md
@@ -10,7 +10,6 @@ import CreditCardForm from 'calypso/blocks/credit-card-form';
 function render() {
 	return (
 		<CreditCardForm
-			createCardToken={ createCardToken }
 			initialValues={ initialValues }
 			recordFormSubmitEvent={ noop }
 			saveStoredCard={ saveStoredCard }
@@ -22,7 +21,6 @@ function render() {
 
 ## Props
 
-- `createCardToken`: Function to be executed when a valid form is submitted. It is responsible for a credit card token creation which is the part of the flow.
 - `initialValues`: Optional object containing initial values for the form fields. At the moment only `name` is supported.
 - `purchase`: Optional object representing an existing purchase that the credit card will be used for. If this is passed along with `siteSlug` and if the purchase is up for renewal, the message that is displayed after successfully saving the card will give the user information about renewing the purchase with the new credit card.
 - `recordFormSubmitEvent`: Function to be executed when the user clicks the _Save Card_ button.

--- a/client/blocks/credit-card-form/docs/example.jsx
+++ b/client/blocks/credit-card-form/docs/example.jsx
@@ -10,7 +10,6 @@ import React from 'react';
  */
 import CreditCardForm from 'calypso/blocks/credit-card-form';
 
-const createCardToken = ( cardDetails, callback ) => callback( null, 'token' );
 const saveStoredCard = () => Promise.reject( { message: 'This is an example error.' } );
 
 const CreditCardFormExample = () => {
@@ -20,12 +19,10 @@ const CreditCardFormExample = () => {
 
 	return (
 		<CreditCardForm
-			createCardToken={ createCardToken }
 			initialValues={ initialValues }
 			recordFormSubmitEvent={ noop }
 			saveStoredCard={ saveStoredCard }
 			successCallback={ noop }
-			autoFocus={ false }
 		/>
 	);
 };

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -36,7 +36,6 @@ import {
 	areFormFieldsEmpty,
 	useDebounce,
 	saveOrUpdateCreditCard,
-	makeAsyncCreateCardToken,
 } from './helpers';
 
 /**
@@ -48,7 +47,6 @@ const debug = debugFactory( 'calypso:credit-card-form' );
 
 export function CreditCardForm( {
 	apiParams = {},
-	createCardToken,
 	countriesList,
 	initialValues = undefined,
 	purchase = undefined,
@@ -73,10 +71,7 @@ export function CreditCardForm( {
 	const [ touchedFormFields, setTouchedFormFields ] = useState( {} );
 	const [ formFieldErrors, setFormFieldErrors ] = useState(
 		camelCaseFormFields(
-			validatePaymentDetails(
-				kebabCaseFormFields( formFieldValues ),
-				stripe ? 'stripe' : 'credit-card'
-			).errors
+			validatePaymentDetails( kebabCaseFormFields( formFieldValues ), 'stripe' ).errors
 		)
 	);
 	const [ debouncedFieldErrors, setDebouncedFieldErrors ] = useDebounce( formFieldErrors, 1000 );
@@ -91,10 +86,7 @@ export function CreditCardForm( {
 		// Debounce updating validation errors
 		setFormFieldErrors(
 			camelCaseFormFields(
-				validatePaymentDetails(
-					kebabCaseFormFields( newValues ),
-					stripe ? 'stripe' : 'credit-card'
-				).errors
+				validatePaymentDetails( kebabCaseFormFields( newValues ), 'stripe' ).errors
 			)
 		);
 	};
@@ -121,7 +113,6 @@ export function CreditCardForm( {
 				throw new Error( translate( 'Your credit card information is not valid' ) );
 			}
 			recordFormSubmitEvent();
-			const createCardTokenAsync = makeAsyncCreateCardToken( createCardToken );
 			const createStripeSetupIntentAsync = async ( paymentDetails ) => {
 				const { name, country, 'postal-code': zip } = paymentDetails;
 				const paymentDetailsForStripe = {
@@ -134,9 +125,8 @@ export function CreditCardForm( {
 				return createStripeSetupIntent( stripe, stripeConfiguration, paymentDetailsForStripe );
 			};
 			const parseStripeToken = ( response ) => response.payment_method;
-			const parsePaygateToken = ( response ) => response.token;
 			await saveOrUpdateCreditCard( {
-				createCardToken: stripe ? createStripeSetupIntentAsync : createCardTokenAsync,
+				createCardToken: createStripeSetupIntentAsync,
 				saveStoredCard,
 				translate,
 				apiParams,
@@ -144,7 +134,7 @@ export function CreditCardForm( {
 				siteSlug,
 				formFieldValues,
 				stripeConfiguration,
-				parseTokenFromResponse: stripe ? parseStripeToken : parsePaygateToken,
+				parseTokenFromResponse: parseStripeToken,
 			} );
 			successCallback();
 		} catch ( error ) {

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -191,7 +191,6 @@ export function CreditCardForm( {
 
 CreditCardForm.propTypes = {
 	apiParams: PropTypes.object,
-	createCardToken: PropTypes.func.isRequired,
 	countriesList: PropTypes.array.isRequired,
 	initialValues: PropTypes.object,
 	purchase: PropTypes.object,

--- a/client/blocks/credit-card-form/test/index.js
+++ b/client/blocks/credit-card-form/test/index.js
@@ -24,6 +24,19 @@ jest.mock( '@automattic/calypso-stripe', () => ( {
 		isStripeLoading: false,
 		stripeLoadingError: {},
 	} ),
+	withStripeProps: ( WrappedComponent ) => {
+		return ( props ) => {
+			const stripeData = {
+				stripe: {},
+				stripeConfiguration: {},
+				setStripeError: () => {},
+				isStripeLoading: false,
+				stripeLoadingError: {},
+			};
+			const newProps = { ...props, ...stripeData };
+			return <WrappedComponent { ...newProps } />;
+		};
+	},
 } ) );
 
 describe( 'Credit Card Form', () => {

--- a/client/blocks/credit-card-form/test/index.js
+++ b/client/blocks/credit-card-form/test/index.js
@@ -74,15 +74,6 @@ describe( 'Credit Card Form', () => {
 		expect( getErrorMessage( 'number' ) ).toEqual( '' );
 	} );
 
-	test( 'has getErrorMessage return the correct errors', () => {
-		const initialValues = { number: '234' };
-		const props = { ...defaultProps, initialValues };
-		const wrapper = shallow( <CreditCardForm { ...props } /> );
-		const child = wrapper.find( CreditCardFormFields );
-		const getErrorMessage = child.prop( 'getErrorMessage' );
-		expect( getErrorMessage( 'number' )[ 0 ] ).toMatch( /invalid/ );
-	} );
-
 	describe( 'getParamsForApi()', () => {
 		test( 'should return expected api params from form credit card values', () => {
 			expect(

--- a/client/blocks/credit-card-form/test/index.js
+++ b/client/blocks/credit-card-form/test/index.js
@@ -16,11 +16,20 @@ import { CreditCardForm } from '../';
 import { getParamsForApi } from '../helpers';
 import CreditCardFormFields from 'calypso/components/credit-card-form-fields';
 
+jest.mock( '@automattic/calypso-stripe', () => ( {
+	useStripe: () => ( {
+		stripe: {},
+		stripeConfiguration: {},
+		setStripeError: () => {},
+		isStripeLoading: false,
+		stripeLoadingError: {},
+	} ),
+} ) );
+
 describe( 'Credit Card Form', () => {
 	const defaultProps = {
 		translate: identity,
 		countriesList: [],
-		createCardToken: noop,
 		recordFormSubmitEvent: noop,
 		successCallback: noop,
 	};

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -78,7 +78,7 @@ StripeElementErrors.propTypes = {
 	fieldName: PropTypes.string.isRequired,
 };
 
-function CreditCardNumberField( { translate, getErrorMessage } ) {
+function CreditCardNumberField( { translate, getErrorMessage, disabled } ) {
 	const cardNumberLabel = translate( 'Card number', {
 		comment: 'Card number label on credit card form',
 	} );
@@ -93,11 +93,15 @@ function CreditCardNumberField( { translate, getErrorMessage } ) {
 		<div className="credit-card-form-fields__field number">
 			<FormLabel className="credit-card-form-fields__label">
 				{ cardNumberLabel }
-				<CardNumberElementWithValidation
-					fieldName="card_number"
-					getErrorMessage={ getErrorMessage }
-					classes={ elementClasses }
-				/>
+				{ disabled ? (
+					<LoadingField />
+				) : (
+					<CardNumberElementWithValidation
+						fieldName="card_number"
+						getErrorMessage={ getErrorMessage }
+						classes={ elementClasses }
+					/>
+				) }
 			</FormLabel>
 		</div>
 	);
@@ -110,7 +114,7 @@ CreditCardNumberField.propTypes = {
 	card: PropTypes.object.isRequired,
 };
 
-function CreditCardExpiryAndCvvFields( { translate, getErrorMessage } ) {
+function CreditCardExpiryAndCvvFields( { translate, getErrorMessage, disabled } ) {
 	const cvcLabel = translate( 'Security code' );
 
 	const expiryLabel = translate( 'Expiry date' );
@@ -126,22 +130,30 @@ function CreditCardExpiryAndCvvFields( { translate, getErrorMessage } ) {
 			<div className="credit-card-form-fields__field expiration-date">
 				<FormLabel className="credit-card-form-fields__label">
 					{ expiryLabel }
-					<CardExpiryElementWithValidation
-						fieldName="card_expiry"
-						getErrorMessage={ getErrorMessage }
-						classes={ elementClasses }
-					/>
+					{ disabled ? (
+						<LoadingField />
+					) : (
+						<CardExpiryElementWithValidation
+							fieldName="card_expiry"
+							getErrorMessage={ getErrorMessage }
+							classes={ elementClasses }
+						/>
+					) }
 				</FormLabel>
 			</div>
 			<div className="credit-card-form-fields__cvv-wrapper">
 				<div className="credit-card-form-fields__field cvv">
 					<FormLabel className="credit-card-form-fields__label">
 						{ cvcLabel }
-						<CardCvcElementWithValidation
-							fieldName="card_cvc"
-							getErrorMessage={ getErrorMessage }
-							classes={ elementClasses }
-						/>
+						{ disabled ? (
+							<LoadingField />
+						) : (
+							<CardCvcElementWithValidation
+								fieldName="card_cvc"
+								getErrorMessage={ getErrorMessage }
+								classes={ elementClasses }
+							/>
+						) }
 					</FormLabel>
 					<CvvCard />
 				</div>
@@ -156,6 +168,10 @@ CreditCardExpiryAndCvvFields.propTypes = {
 	getErrorMessage: PropTypes.func.isRequired,
 	card: PropTypes.object.isRequired,
 };
+
+function LoadingField() {
+	return <Input disabled={ true } />;
+}
 
 export class CreditCardFormFields extends React.Component {
 	static propTypes = {
@@ -253,6 +269,7 @@ export class CreditCardFormFields extends React.Component {
 						createField={ this.createField }
 						getErrorMessage={ this.props.getErrorMessage }
 						card={ this.props.card }
+						disabled={ disabled }
 					/>
 				</div>
 
@@ -262,6 +279,7 @@ export class CreditCardFormFields extends React.Component {
 						createField={ this.createField }
 						getErrorMessage={ this.props.getErrorMessage }
 						card={ this.props.card }
+						disabled={ disabled }
 					/>
 					{ this.createField( 'country', PaymentCountrySelect, {
 						label: translate( 'Country' ),

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { CardCvcElement, CardExpiryElement, CardNumberElement } from 'react-stripe-elements';
 import { isEmpty, noop } from 'lodash';
 import { localize, useTranslate } from 'i18n-calypso';
-import { useStripe } from '@automattic/calypso-stripe';
+import { useStripe, withStripeProps } from '@automattic/calypso-stripe';
 
 /**
  * Internal dependencies
@@ -229,10 +229,16 @@ export class CreditCardFormFields extends React.Component {
 	};
 
 	render() {
-		const { translate, countriesList, autoFocus } = this.props;
+		const { translate, countriesList, autoFocus, isStripeLoading, stripeLoadingError } = this.props;
 		const creditCardFormFieldsExtrasClassNames = classNames( {
 			'credit-card-form-fields__extras': true,
 		} );
+
+		const disabled = isFieldDisabled( {
+			isStripeLoading,
+			stripeLoadingError,
+		} );
+
 		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
 			<div className="credit-card-form-fields">
@@ -263,11 +269,13 @@ export class CreditCardFormFields extends React.Component {
 						countriesList,
 						onChange: noop,
 						onCountrySelected: this.updateFieldValues,
+						disabled,
 					} ) }
 
 					{ this.createField( 'postal-code', Input, {
 						label: translate( 'Postal code' ),
 						placeholder: ' ',
+						disabled,
 					} ) }
 				</div>
 			</div>
@@ -282,7 +290,6 @@ function CardholderNameField( { createField, autoFocus } ) {
 	const disabled = isFieldDisabled( {
 		isStripeLoading,
 		stripeLoadingError,
-		isUsingEbanx: false,
 	} );
 
 	return (
@@ -333,4 +340,4 @@ function CvvCard( { className = '' } ) {
 	);
 }
 
-export default localize( CreditCardFormFields );
+export default withStripeProps( localize( CreditCardFormFields ) );

--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -13,12 +13,7 @@ import { identity, noop } from 'lodash';
  * Internal dependencies
  */
 import { CreditCardFormFields } from '../';
-import { shouldRenderAdditionalCountryFields } from 'calypso/lib/checkout/processor-specific';
 import CountrySpecificPaymentFields from 'calypso/my-sites/checkout/checkout/country-specific-payment-fields';
-
-jest.mock( 'lib/checkout/processor-specific', () => ( {
-	shouldRenderAdditionalCountryFields: jest.fn( false ),
-} ) );
 
 const defaultProps = {
 	card: {},
@@ -39,26 +34,5 @@ describe( 'CreditCardFormFields', () => {
 	test( 'should not render ebanx fields', () => {
 		const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
 		expect( wrapper.find( CountrySpecificPaymentFields ) ).toHaveLength( 0 );
-	} );
-
-	describe( 'with ebanx activated', () => {
-		beforeAll( () => {
-			shouldRenderAdditionalCountryFields.mockReturnValue( true );
-		} );
-		afterAll( () => {
-			shouldRenderAdditionalCountryFields.mockReturnValue( false );
-		} );
-
-		test( 'should display Ebanx fields when an Ebanx payment country is selected and there is a transaction in process', () => {
-			const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
-			wrapper.setProps( { card: { country: 'BR' } } );
-			expect( wrapper.find( CountrySpecificPaymentFields ) ).toHaveLength( 1 );
-		} );
-
-		test( 'should not display Ebanx fields when there is a transaction in process', () => {
-			const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
-			wrapper.setProps( { card: { country: 'BR' }, isNewTransaction: false } );
-			expect( wrapper.find( CountrySpecificPaymentFields ) ).toHaveLength( 0 );
-		} );
 	} );
 } );

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/add-credit-card-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/add-credit-card-modal.js
@@ -16,7 +16,7 @@ import { closeAddCardDialog } from 'woocommerce/woocommerce-services/state/label
 import { getLabelSettingsForm } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
 import CreditCardForm from 'calypso/blocks/credit-card-form';
 import { addStoredCard } from 'calypso/state/stored-cards/actions';
-import { createCardToken, getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 
@@ -28,7 +28,6 @@ function AddCardDialog( {
 	addStoredCard: saveStoredCard,
 	locale,
 } ) {
-	const createCardAddToken = ( ...args ) => createCardToken( 'card_add', ...args );
 	const recordFormSubmitEvent = () => recordTracksEvent( 'calypso_add_credit_card_form_submit' );
 	const onClose = () => closeDialog( siteId );
 
@@ -44,7 +43,6 @@ function AddCardDialog( {
 				fetchStripeConfiguration={ getStripeConfiguration }
 			>
 				<CreditCardForm
-					createCardToken={ createCardAddToken }
 					recordFormSubmitEvent={ recordFormSubmitEvent }
 					saveStoredCard={ saveStoredCard }
 					successCallback={ onClose }

--- a/client/lib/checkout/processor-specific.js
+++ b/client/lib/checkout/processor-specific.js
@@ -29,7 +29,7 @@ export function isEbanxCreditCardProcessingEnabledForCountry( countryCode = '', 
 		! isUndefined( PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ countryCode ] ) &&
 		isPaymentMethodEnabled(
 			'ebanx',
-			cart.allowed_payment_methods.map( translateWpcomPaymentMethodToCheckoutPaymentMethod )
+			cart.allowed_payment_methods?.map( translateWpcomPaymentMethodToCheckoutPaymentMethod )
 		)
 	);
 }

--- a/client/me/purchases/add-credit-card/index.jsx
+++ b/client/me/purchases/add-credit-card/index.jsx
@@ -13,7 +13,7 @@ import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { addStoredCard } from 'calypso/state/stored-cards/actions';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { concatTitle } from 'calypso/lib/react-helpers';
-import { createCardToken, getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CreditCardForm from 'calypso/blocks/credit-card-form';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -28,7 +28,6 @@ import Column from 'calypso/components/layout/column';
 import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
 
 function AddCreditCard( props ) {
-	const createAddCardToken = ( ...args ) => createCardToken( 'card_add', ...args );
 	const goToPaymentMethods = () => page( paymentMethods );
 	const recordFormSubmitEvent = () => recordTracksEvent( 'calypso_add_credit_card_form_submit' );
 
@@ -48,7 +47,6 @@ function AddCreditCard( props ) {
 						fetchStripeConfiguration={ getStripeConfiguration }
 					>
 						<CreditCardForm
-							createCardToken={ createAddCardToken }
 							recordFormSubmitEvent={ recordFormSubmitEvent }
 							saveStoredCard={ props.addStoredCard }
 							successCallback={ goToPaymentMethods }

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -17,7 +17,7 @@ import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import { clearPurchases } from 'calypso/state/purchases/actions';
-import { createCardToken, getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
@@ -32,7 +32,6 @@ import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method
 import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
 
 function AddCardDetails( props ) {
-	const createCardUpdateToken = ( ...args ) => createCardToken( 'card_update', ...args );
 	const isDataLoading = ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;
 	const isDataValid = ( { purchase, selectedSite } ) => purchase && selectedSite;
 
@@ -86,7 +85,6 @@ function AddCardDetails( props ) {
 					>
 						<CreditCardForm
 							apiParams={ { purchaseId: props.purchase.id } }
-							createCardToken={ createCardUpdateToken }
 							purchase={ props.purchase }
 							recordFormSubmitEvent={ recordFormSubmitEvent }
 							siteSlug={ props.siteSlug }

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -18,7 +18,7 @@ import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import { clearPurchases } from 'calypso/state/purchases/actions';
-import { createCardToken, getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
@@ -68,8 +68,6 @@ function EditCardDetails( props ) {
 		page( props.getManagePurchaseUrlFor( props.siteSlug, id ) );
 	};
 
-	const createCardUpdateToken = ( ...args ) => createCardToken( 'card_update', ...args );
-
 	return (
 		<Fragment>
 			<TrackPurchasePageView
@@ -94,7 +92,6 @@ function EditCardDetails( props ) {
 					>
 						<CreditCardForm
 							apiParams={ { purchaseId: props.purchase.id } }
-							createCardToken={ createCardUpdateToken }
 							initialValues={ props.card }
 							purchase={ props.purchase }
 							recordFormSubmitEvent={ recordFormSubmitEvent }

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -21,7 +21,7 @@ import HeaderCake from 'calypso/components/header-cake';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getAddNewPaymentMethod, getPaymentMethodsUrlFor } from '../paths';
 import CreditCardForm from 'calypso/blocks/credit-card-form';
-import { createCardToken, getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import titles from 'calypso/me/purchases/titles';
 import { addStoredCard } from 'calypso/state/stored-cards/actions';
 import SiteLevelPurchasesErrorBoundary from 'calypso/my-sites/purchases/site-level-purchases-error-boundary';
@@ -86,7 +86,6 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ): JSX.Elemen
 
 export function AddNewPaymentMethod( { siteSlug }: { siteSlug: string } ): JSX.Element {
 	const translate = useTranslate();
-	const createAddCardToken = ( ...args: unknown[] ) => createCardToken( 'card_add', ...args );
 	const goToBillingHistory = () => page( getPaymentMethodsUrlFor( siteSlug ) );
 	const recordFormSubmitEvent = () => recordTracksEvent( 'calypso_add_credit_card_form_submit' );
 	const reduxDispatch = useDispatch();
@@ -121,7 +120,6 @@ export function AddNewPaymentMethod( { siteSlug }: { siteSlug: string } ): JSX.E
 							fetchStripeConfiguration={ getStripeConfiguration }
 						>
 							<CreditCardForm
-								createCardToken={ createAddCardToken }
 								recordFormSubmitEvent={ recordFormSubmitEvent }
 								saveStoredCard={ saveStoredCard }
 								successCallback={ goToBillingHistory }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the "add credit card" form for users who have BRL as their currency and choose Brazil as the country.

#### Testing instructions

This component is used in two contexts.

1. On the "add/update card" page in billing management, both site and account level. For the site level context, visit `/purchases/subscriptions/:siteurl/:purchaseId` or navigate to `Plan > Billing`, select a purchase, and choose "Add/Update Payment Method".
    1.1. After loading the payment method screen, check that the stripe fields have loaded (you'll know when the card number field is autoformatted and when typing '2' in the expiry field automatically prepends a '0'.)
    1.2. Check that the stripe fields remain loaded if you change your country to Brazil.
    1.3. Check that form validation works (try an incomplete or invalid CC number), and also verify that you can actually update the payment method if the data is valid.

2. Repeat 1.1-1.3 in the account level billing management context. To get there, visit `/me/purchases/:siteUrl/:purchaseId` or from the account view navigate to `Manage Purchases`, select a purchase, and choose "Add/Update Payment Method".

3. Repeat steps 1.1-1.3 on the shipping label page. (TODO)

Fixes #47436
