### PR TITLE
Shopping cart: Add Promise to each action that resolves when cart updates

### DIFF
--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -26,14 +26,17 @@ This is a React hook that can be used in any child component under [ShoppingCart
 - `loadingError: string | null | undefined`. If fetching or updating the cart causes an error, this will be a string that contains the error message.
 - `loadingErrorType: ShoppingCartError | undefined`. If fetching or updating the cart causes an error, this will contain a string that explains what type of error.
 - `couponStatus: 'fresh' | 'pending' | 'applied' | 'invalid' | 'rejected' | 'error'`. A string that can be used to determine if a coupon is applied.
-- `addProductsToCart: ( products: RequestCartProduct[] ) => void`. A function that requests adding new products to the cart.
-- `removeProductFromCart: ( uuidToRemove: string ) => void`. A function that requests removing a product from the cart.
-- `applyCoupon: ( couponId: string ) => void`. A function that requests applying a coupon to the cart (only one coupon can be applied at a time).
-- `removeCoupon: () => void`. A function that requests removing a coupon to the cart.
-- `updateLocation: ( location: CartLocation ) => void`. A function that can be used to change the tax location of the cart.
-- `replaceProductInCart: ( uuidToReplace: string, productPropertiesToChange: Partial< RequestCartProduct > ) => void`. A function that can replace one product in the cart with another, retaining the same UUID; useful for changing product variants.
-- `replaceProductsInCart: ( products: RequestCartProduct[] ) => void`. A function that replaces all the products in the cart with a new set of products. Can also be used to clear the cart.
-- `reloadFromServer: () => void`. A function to throw away the current cart cache and fetch it fresh from the shopping cart API.
+
+The following actions are also properties. Each one returns a Promise that resolves when the cart is next valid (this may be after several queued actions are complete).
+
+- `addProductsToCart: ( products: RequestCartProduct[] ) => Promise<void>`. A function that requests adding new products to the cart.
+- `removeProductFromCart: ( uuidToRemove: string ) => Promise<void>`. A function that requests removing a product from the cart.
+- `applyCoupon: ( couponId: string ) => Promise<void>`. A function that requests applying a coupon to the cart (only one coupon can be applied at a time).
+- `removeCoupon: () => Promise<void>`. A function that requests removing a coupon to the cart.
+- `updateLocation: ( location: CartLocation ) => Promise<void>`. A function that can be used to change the tax location of the cart.
+- `replaceProductInCart: ( uuidToReplace: string, productPropertiesToChange: Partial< RequestCartProduct > ) => Promise<void>`. A function that can replace one product in the cart with another, retaining the same UUID; useful for changing product variants.
+- `replaceProductsInCart: ( products: RequestCartProduct[] ) => Promise<void>`. A function that replaces all the products in the cart with a new set of products. Can also be used to clear the cart.
+- `reloadFromServer: () => Promise<void>`. A function to throw away the current cart cache and fetch it fresh from the shopping cart API.
 
 ## withShoppingCart
 

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -20,13 +20,7 @@
  */
 export interface RequestCart {
 	products: RequestCartProduct[];
-	tax: null | {
-		location: {
-			country_code: string | undefined;
-			postal_code: string | undefined;
-			subdivision_code: string | undefined;
-		};
-	};
+	tax: RequestCartTaxData;
 	coupon: string;
 	currency: string;
 	locale: string;
@@ -35,6 +29,14 @@ export interface RequestCart {
 	extra: string;
 	is_update?: boolean;
 }
+
+export type RequestCartTaxData = null | {
+	location: {
+		country_code: string | undefined;
+		postal_code: string | undefined;
+		subdivision_code: string | undefined;
+	};
+};
 
 /**
  * Product item schema for the shopping cart endpoint (request)
@@ -80,14 +82,16 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	is_signup: boolean;
 	messages?: ResponseCartMessages;
 	cart_generated_at_timestamp: number;
-	tax: {
-		location: {
-			country_code?: string;
-			postal_code?: string;
-			subdivision_code?: string;
-		};
-		display_taxes: boolean;
+	tax: ResponseCartTaxData;
+}
+
+export interface ResponseCartTaxData {
+	location: {
+		country_code?: string;
+		postal_code?: string;
+		subdivision_code?: string;
 	};
+	display_taxes: boolean;
 }
 
 /**

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -37,21 +37,21 @@ export interface ShoppingCartManager {
 export type ReplaceProductInCart = (
 	uuidToReplace: string,
 	productPropertiesToChange: Partial< RequestCartProduct >
-) => void;
+) => Promise< void >;
 
-export type ReloadCartFromServer = () => void;
+export type ReloadCartFromServer = () => Promise< void >;
 
-export type ReplaceProductsInCart = ( products: RequestCartProduct[] ) => void;
+export type ReplaceProductsInCart = ( products: RequestCartProduct[] ) => Promise< void >;
 
-export type AddProductsToCart = ( products: RequestCartProduct[] ) => void;
+export type AddProductsToCart = ( products: RequestCartProduct[] ) => Promise< void >;
 
-export type RemoveCouponFromCart = () => void;
+export type RemoveCouponFromCart = () => Promise< void >;
 
-export type ApplyCouponToCart = ( couponId: string ) => void;
+export type ApplyCouponToCart = ( couponId: string ) => Promise< void >;
 
-export type RemoveProductFromCart = ( uuidToRemove: string ) => void;
+export type RemoveProductFromCart = ( uuidToRemove: string ) => Promise< void >;
 
-export type UpdateTaxLocationInCart = ( location: CartLocation ) => void;
+export type UpdateTaxLocationInCart = ( location: CartLocation ) => Promise< void >;
 
 /**
  * The custom hook keeps a cached version of the server cart, as well as a

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -107,3 +107,5 @@ export type ShoppingCartState = {
 	loadingErrorType?: ShoppingCartError;
 	queuedActions: ShoppingCartAction[];
 };
+
+export type CartValidCallback = () => void;

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -116,7 +116,8 @@ export default function useShoppingCartManager( {
 
 	const isLoading = cacheStatus === 'fresh' || cacheStatus === 'fresh-pending' || ! cartKey;
 	const loadingErrorForManager = cacheStatus === 'error' ? loadingError : null;
-	const isPendingUpdate = cacheStatus !== 'valid' || ! cartKey;
+	const isPendingUpdate =
+		hookState.queuedActions.length > 0 || cacheStatus !== 'valid' || ! cartKey;
 
 	const responseCartWithoutTempProducts = useMemo(
 		() => convertTempResponseCartToResponseCart( responseCart ),

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -136,7 +136,7 @@ function ProductList( {
 			hasAddedCoupon.current = true;
 			applyCoupon( initialCoupon );
 		}
-	}, [ addProductsToCart, applyCoupon, initialProducts, initialCoupon ] );
+	}, [ applyCoupon, initialCoupon ] );
 	if ( responseCart.products.length === 0 ) {
 		return null;
 	}
@@ -478,6 +478,50 @@ describe( 'useShoppingCart', () => {
 				fireEvent.click( screen.getByText( 'Click me' ) );
 			} );
 			expect( screen.getByText( locationText ) ).toBeInTheDocument();
+		} );
+
+		it( 'returns a Promise that resolves after the update completes', async () => {
+			render(
+				<MockProvider>
+					<TestComponent />
+				</MockProvider>
+			);
+
+			await waitFor( () => screen.getByTestId( 'product-list' ) );
+			await act( async () => {
+				fireEvent.click( screen.getByText( 'Click me' ) );
+				expect( markUpdateComplete ).not.toHaveBeenCalled();
+			} );
+			expect( markUpdateComplete ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'reloadFromServer', () => {
+		const TestComponent = () => {
+			const { reloadFromServer } = useShoppingCart();
+			const onClick = () => {
+				reloadFromServer().then( () => markUpdateComplete() );
+			};
+			return (
+				<div>
+					<ProductList initialProducts={ [ planOne ] } />
+					<button onClick={ onClick }>Click me</button>
+				</div>
+			);
+		};
+
+		it( 'reloads the cart from the server', async () => {
+			render(
+				<MockProvider>
+					<TestComponent />
+				</MockProvider>
+			);
+			await waitFor( () => screen.getByTestId( 'product-list' ) );
+			expect( screen.getByText( planOne.product_name ) ).toBeInTheDocument();
+			await act( async () => {
+				fireEvent.click( screen.getByText( 'Click me' ) );
+			} );
+			expect( screen.queryByText( planOne.product_name ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'returns a Promise that resolves after the update completes', async () => {

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -93,12 +93,18 @@ function MockProvider( { children } ) {
 	);
 }
 
-describe( 'addProductsToCart', () => {
-	it( 'adds a product to the cart', async () => {
+describe( 'useShoppingCart', () => {
+	const markUpdateComplete = jest.fn();
+
+	beforeEach( () => {
+		markUpdateComplete.mockClear();
+	} );
+
+	describe( 'addProductsToCart', () => {
 		const TestComponent = () => {
 			const { addProductsToCart } = useShoppingCart();
 			const onClick = () => {
-				addProductsToCart( [ planWithoutDomain ] );
+				addProductsToCart( [ planWithoutDomain ] ).then( () => markUpdateComplete() );
 			};
 			return (
 				<div>
@@ -108,15 +114,29 @@ describe( 'addProductsToCart', () => {
 			);
 		};
 
-		render(
-			<MockProvider>
-				<TestComponent />
-			</MockProvider>
-		);
-		fireEvent.click( screen.getByText( 'Click me' ) );
-		await waitFor( () => screen.getByTestId( 'product-list' ) );
-		expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent(
-			planWithoutDomain.product_name
-		);
+		it( 'adds a product to the cart', async () => {
+			render(
+				<MockProvider>
+					<TestComponent />
+				</MockProvider>
+			);
+			fireEvent.click( screen.getByText( 'Click me' ) );
+			await waitFor( () => screen.getByTestId( 'product-list' ) );
+			expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent(
+				planWithoutDomain.product_name
+			);
+		} );
+
+		it( 'returns a Promise that resolves after the update completes', async () => {
+			render(
+				<MockProvider>
+					<TestComponent />
+				</MockProvider>
+			);
+			fireEvent.click( screen.getByText( 'Click me' ) );
+			expect( markUpdateComplete ).not.toHaveBeenCalled();
+			await waitFor( () => screen.getByTestId( 'product-list' ) );
+			expect( markUpdateComplete ).toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -15,7 +15,7 @@ import { useShoppingCart, ShoppingCartProvider } from '../index';
 import { emptyResponseCart } from '../src/empty-carts';
 import { RequestCartProduct, ResponseCartProduct, RequestCart, ResponseCart } from '../src/types';
 
-const planWithoutDomain = {
+const planOne = {
 	product_name: 'WordPress.com Personal',
 	product_slug: 'personal-bundle',
 	currency: 'BRL',
@@ -47,6 +47,38 @@ const planWithoutDomain = {
 	included_domain_purchase_amount: 0,
 };
 
+const planTwo = {
+	product_name: 'WordPress.com Business',
+	product_slug: 'business-bundle',
+	currency: 'BRL',
+	extra: {
+		context: 'signup',
+	},
+	free_trial: false,
+	meta: '',
+	product_id: 1010,
+	volume: 1,
+	item_original_cost_integer: 14400,
+	item_original_cost_display: 'R$144',
+	item_subtotal_integer: 14400,
+	item_subtotal_display: 'R$144',
+	product_cost_integer: 14400,
+	product_cost_display: 'R$144',
+	item_subtotal_monthly_cost_display: 'R$144',
+	item_subtotal_monthly_cost_integer: 14400,
+	item_original_subtotal_integer: 14400,
+	item_original_subtotal_display: 'R$144',
+	is_domain_registration: false,
+	is_bundled: false,
+	is_sale_coupon_applied: false,
+	months_per_bill_period: null,
+	uuid: 'product002',
+	cost: 144,
+	price: 144,
+	product_type: 'test',
+	included_domain_purchase_amount: 0,
+};
+
 const mainCartKey = '1';
 
 async function getCart( cartKey: string ) {
@@ -59,7 +91,9 @@ async function getCart( cartKey: string ) {
 function createProduct( productProps: RequestCartProduct ): ResponseCartProduct {
 	switch ( productProps.product_id ) {
 		case 1009:
-			return planWithoutDomain;
+			return planOne;
+		case 1010:
+			return planTwo;
 	}
 	throw new Error( 'Unknown product' );
 }
@@ -111,7 +145,7 @@ describe( 'useShoppingCart', () => {
 		const TestComponent = () => {
 			const { addProductsToCart } = useShoppingCart();
 			const onClick = () => {
-				addProductsToCart( [ planWithoutDomain ] ).then( () => markUpdateComplete() );
+				addProductsToCart( [ planOne ] ).then( () => markUpdateComplete() );
 			};
 			return (
 				<div>
@@ -129,9 +163,7 @@ describe( 'useShoppingCart', () => {
 			);
 			fireEvent.click( screen.getByText( 'Click me' ) );
 			await waitFor( () => screen.getByTestId( 'product-list' ) );
-			expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent(
-				planWithoutDomain.product_name
-			);
+			expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
 		} );
 
 		it( 'returns a Promise that resolves after the update completes', async () => {
@@ -158,7 +190,7 @@ describe( 'useShoppingCart', () => {
 			};
 			return (
 				<div>
-					<ProductList initialProducts={ [ planWithoutDomain ] } />
+					<ProductList initialProducts={ [ planOne ] } />
 					<button onClick={ onClick }>Click me</button>
 				</div>
 			);
@@ -171,11 +203,11 @@ describe( 'useShoppingCart', () => {
 				</MockProvider>
 			);
 			await waitFor( () => screen.getByTestId( 'product-list' ) );
-			expect( screen.getByText( planWithoutDomain.product_name ) ).toBeInTheDocument();
+			expect( screen.getByText( planOne.product_name ) ).toBeInTheDocument();
 			await act( async () => {
 				fireEvent.click( screen.getByText( 'Click me' ) );
 			} );
-			expect( screen.queryByText( planWithoutDomain.product_name ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( planOne.product_name ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'returns a Promise that resolves after the update completes', async () => {
@@ -186,7 +218,52 @@ describe( 'useShoppingCart', () => {
 			);
 
 			await waitFor( () => screen.getByTestId( 'product-list' ) );
-			expect( screen.getByText( planWithoutDomain.product_name ) ).toBeInTheDocument();
+			expect( screen.getByText( planOne.product_name ) ).toBeInTheDocument();
+			await act( async () => {
+				fireEvent.click( screen.getByText( 'Click me' ) );
+				expect( markUpdateComplete ).not.toHaveBeenCalled();
+			} );
+			expect( markUpdateComplete ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'replaceProductsInCart', () => {
+		const TestComponent = () => {
+			const { replaceProductsInCart } = useShoppingCart();
+			const onClick = () => {
+				replaceProductsInCart( [ planTwo ] ).then( () => markUpdateComplete() );
+			};
+			return (
+				<div>
+					<ProductList initialProducts={ [ planOne ] } />
+					<button onClick={ onClick }>Click me</button>
+				</div>
+			);
+		};
+
+		it( 'replaces a product in the cart', async () => {
+			render(
+				<MockProvider>
+					<TestComponent />
+				</MockProvider>
+			);
+			await waitFor( () => screen.getByTestId( 'product-list' ) );
+			expect( screen.getByText( planOne.product_name ) ).toBeInTheDocument();
+			await act( async () => {
+				fireEvent.click( screen.getByText( 'Click me' ) );
+			} );
+			expect( screen.queryByText( planOne.product_name ) ).not.toBeInTheDocument();
+			expect( screen.getByText( planTwo.product_name ) ).toBeInTheDocument();
+		} );
+
+		it( 'returns a Promise that resolves after the update completes', async () => {
+			render(
+				<MockProvider>
+					<TestComponent />
+				</MockProvider>
+			);
+
+			await waitFor( () => screen.getByTestId( 'product-list' ) );
 			await act( async () => {
 				fireEvent.click( screen.getByText( 'Click me' ) );
 				expect( markUpdateComplete ).not.toHaveBeenCalled();

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -1,0 +1,122 @@
+// This is required to fix the "regeneratorRuntime is not defined" error
+import '@automattic/calypso-polyfills';
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { screen, render, waitFor, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { useShoppingCart, ShoppingCartProvider } from '../index';
+import { emptyResponseCart } from '../src/empty-carts';
+import { RequestCartProduct, ResponseCartProduct, RequestCart, ResponseCart } from '../src/types';
+
+const planWithoutDomain = {
+	product_name: 'WordPress.com Personal',
+	product_slug: 'personal-bundle',
+	currency: 'BRL',
+	extra: {
+		context: 'signup',
+	},
+	free_trial: false,
+	meta: '',
+	product_id: 1009,
+	volume: 1,
+	item_original_cost_integer: 14400,
+	item_original_cost_display: 'R$144',
+	item_subtotal_integer: 14400,
+	item_subtotal_display: 'R$144',
+	product_cost_integer: 14400,
+	product_cost_display: 'R$144',
+	item_subtotal_monthly_cost_display: 'R$144',
+	item_subtotal_monthly_cost_integer: 14400,
+	item_original_subtotal_integer: 14400,
+	item_original_subtotal_display: 'R$144',
+	is_domain_registration: false,
+	is_bundled: false,
+	is_sale_coupon_applied: false,
+	months_per_bill_period: null,
+	uuid: 'product001',
+	cost: 144,
+	price: 144,
+	product_type: 'test',
+	included_domain_purchase_amount: 0,
+};
+
+const mainCartKey = '1';
+
+async function getCart( cartKey: string ) {
+	if ( cartKey === mainCartKey ) {
+		return emptyResponseCart;
+	}
+	throw new Error( 'Unknown cart key' );
+}
+
+function createProduct( productProps: RequestCartProduct ): ResponseCartProduct {
+	switch ( productProps.product_id ) {
+		case 1009:
+			return planWithoutDomain;
+	}
+	throw new Error( 'Unknown product' );
+}
+
+async function setCart( cartKey: string, newCart: RequestCart ): Promise< ResponseCart > {
+	if ( cartKey === mainCartKey ) {
+		return { ...emptyResponseCart, products: newCart.products.map( createProduct ) };
+	}
+	throw new Error( 'Unknown cart key' );
+}
+
+function ProductList() {
+	const { responseCart } = useShoppingCart();
+	if ( responseCart.products.length === 0 ) {
+		return null;
+	}
+	return (
+		<ul data-testid="product-list">
+			{ responseCart.products.map( ( product ) => {
+				return <li key={ product.uuid }>{ product.product_name }</li>;
+			} ) }
+		</ul>
+	);
+}
+
+function MockProvider( { children } ) {
+	return (
+		<ShoppingCartProvider cartKey={ mainCartKey } getCart={ getCart } setCart={ setCart }>
+			{ children }
+		</ShoppingCartProvider>
+	);
+}
+
+describe( 'addProductsToCart', () => {
+	it( 'adds a product to the cart', async () => {
+		const TestComponent = () => {
+			const { addProductsToCart } = useShoppingCart();
+			const onClick = () => {
+				addProductsToCart( [ planWithoutDomain ] );
+			};
+			return (
+				<div>
+					<ProductList />
+					<button onClick={ onClick }>Click me</button>
+				</div>
+			);
+		};
+
+		render(
+			<MockProvider>
+				<TestComponent />
+			</MockProvider>
+		);
+		fireEvent.click( screen.getByText( 'Click me' ) );
+		await waitFor( () => screen.getByTestId( 'product-list' ) );
+		expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent(
+			planWithoutDomain.product_name
+		);
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies all the action functions returned by `useShoppingCart` so that instead of returning `void`, each one returns a Promise that resolves when the cart is next valid. This may be as soon as the requested action completes, but it may also include other actions that are queued. It also may never complete if an action triggers a failure and the cart enters an error state. For that reason it's best not to rely on this Promise and instead react to the other properties of the cart manager, like `isPendingUpdate` and `loadingError`. The new behavior could be useful, however, for situations where an expensive or un-reversible action needs to occur after an update, like a redirect.

Depends on https://github.com/Automattic/wp-calypso/pull/47625 since this adds automated tests and that PR fixes some behavior that would otherwise be broken.

An example of how this could be useful follows. Here's some code that adds a product to the cart and then redirects to checkout:

```js
addProductsToCart( [ product ] );
redirectTo( '/checkout' );
```

However, this may trigger a race condition since it's very likely the redirect will occur before the cart is finished adding the product. If we end up in checkout with an empty cart (the update still pending), we may be redirected away. With this PR, we can instead do:

```js
addProductsToCart( [ product ] ).then( () => redirectTo( '/checkout' ) );
```

#### Testing instructions

See unit tests.