### PR TITLE
Translate the retry button in the domain picker

### DIFF
--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -241,7 +241,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 						className="domain-picker__error-retry-btn"
 						onClick={ retryDomainSuggestionRequest }
 					>
-						Retry
+						{ __( 'Retry', __i18n_text_domain__ ) }
 					</Button>
 				</div>
 			) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* localise the Retry button in the domain picker

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new/domains` step in onboarding, search for a domain with non-latin characters, and the retry button should still appear just like before

