### PR TITLE
Coming soon: check for is_front_page as well

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -13,7 +13,7 @@ namespace A8C\FSE\Coming_soon;
  * @return boolean
  */
 function should_show_coming_soon_page() {
-	if ( ! is_singular() && ! is_archive() && ! is_search() ) {
+	if ( ! is_singular() && ! is_archive() && ! is_search() && ! is_front_page() ) {
 		return false;
 	}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

A follow up on https://github.com/Automattic/wp-calypso/pull/47563

Added is front page check for Coming Soon

This catches the blog roll as home page scenario

## Testing instructions

https://github.com/Automattic/wp-calypso/pull/47563
