### PR TITLE
Show skip purchase after domain search results during launch

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -24,7 +24,7 @@ import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors'
 import { DESIGN_TYPE_STORE } from 'calypso/signup/constants';
 import { hideSitePreview } from 'calypso/state/signup/preview/actions';
 import { isSitePreviewVisible } from 'calypso/state/signup/preview/selectors';
-
+import DomainSkipSuggestion from 'calypso/components/domains/domain-skip-suggestion';
 /**
  * Style dependencies
  */
@@ -240,6 +240,7 @@ class DomainSearchResults extends React.Component {
 		let featuredSuggestionElement;
 		let suggestionElements;
 		let unavailableOffer;
+		let domainSkipSuggestion;
 
 		if ( ! this.props.isLoadingSuggestions && this.props.suggestions ) {
 			suggestionCount = (
@@ -313,6 +314,13 @@ class DomainSearchResults extends React.Component {
 					/>
 				);
 			}
+
+			domainSkipSuggestion = (
+				<DomainSkipSuggestion
+					selectedSiteSlug={ this.props.selectedSite.slug }
+					onButtonClick={ this.props.onSkip }
+				/>
+			);
 		} else {
 			featuredSuggestionElement = <FeaturedDomainSuggestions showPlaceholders />;
 			suggestionElements = this.renderPlaceholders();
@@ -325,6 +333,7 @@ class DomainSearchResults extends React.Component {
 				{ featuredSuggestionElement }
 				{ suggestionElements }
 				{ unavailableOffer }
+				{ domainSkipSuggestion }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -54,6 +54,8 @@ class DomainSearchResults extends React.Component {
 		onClickMapping: PropTypes.func,
 		onClickTransfer: PropTypes.func,
 		onClickUseYourDomain: PropTypes.func,
+		showSkipButton: PropTypes.bool,
+		onSkip: PropTypes.func,
 		isSignupStep: PropTypes.bool,
 		showStrikedOutPrice: PropTypes.bool,
 		railcarId: PropTypes.string,
@@ -333,7 +335,7 @@ class DomainSearchResults extends React.Component {
 				{ featuredSuggestionElement }
 				{ suggestionElements }
 				{ unavailableOffer }
-				{ domainSkipSuggestion }
+				{ this.props.showSkipButton && domainSkipSuggestion }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -319,7 +319,7 @@ class DomainSearchResults extends React.Component {
 
 			domainSkipSuggestion = (
 				<DomainSkipSuggestion
-					selectedSiteSlug={ this.props.selectedSite.slug }
+					selectedSiteSlug={ this.props.selectedSite?.slug }
 					onButtonClick={ this.props.onSkip }
 				/>
 			);

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -342,6 +342,19 @@ body.is-section-signup.is-white-signup {
 					margin-left: 0;
 				}
 			}
+
+			&.domain-skip-suggestion {
+				$cod-grey: #2b2d2f;
+
+				.domain-suggestion__action {
+					color: $cod-grey;
+					text-decoration-line: underline;
+				}
+				.domain-suggestion__chevron {
+					fill: $cod-grey;
+					margin-left: 0;
+				}
+			}
 		}
 	}
 }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -151,6 +151,8 @@ class RegisterDomainStep extends React.Component {
 		recordFiltersReset: PropTypes.func.isRequired,
 		vertical: PropTypes.string,
 		isReskinned: PropTypes.bool,
+		showSkipButton: PropTypes.bool,
+		onSkip: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -165,6 +167,8 @@ class RegisterDomainStep extends React.Component {
 		onSave: noop,
 		vendor: getSuggestionsVendor(),
 		showExampleSuggestions: false,
+		onSkip: noop,
+		showSkipButton: false,
 	};
 
 	constructor( props ) {
@@ -1343,6 +1347,8 @@ class RegisterDomainStep extends React.Component {
 				cart={ this.props.cart }
 				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 				unavailableDomains={ this.state.unavailableDomains }
+				onSkip={ this.props.onSkip }
+				showSkipButton={ this.props.showSkipButton }
 			>
 				{ hasResults && isFreeDomainExplainerVisible && this.renderFreeDomainExplainer() }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Always ensure a skip purchase option is available during the launch flow. Free users are currently blocked from launching if they happen to execute a search for a new domain.

This pr adds the skip option to the search results which was otherwise getting cleared out in the launch flow.

In `/start`'s sign up flow there are two `/domains/suggestions` requests made, one for *.wordpress.com domains, one for non *.wordpress.com domains. 

In `/start/launch-site` there is an option to skip the purchase shown before any new search is made for domains. Once a search is made there is no option to skip purchases.

This fix optionally adds the skip purchase option to search results but only configures it in the `/start/launch-site` flow.

Remains the same:
- `/start/launch-site` initial state already has this option displayed (don't even know if it uses search results to render this page?)
- `/start` sign up flow (already has its own method for showing a *.wordpress.com choice)
- `/domains/add` doesn't make sense here - nothing to skip, site already has a free domain applied to the site at this point.

#### Testing instructions

![Screenshot_2020-11-23 Launch your site — WordPress com](https://user-images.githubusercontent.com/811776/99938320-a8428c80-2dbb-11eb-890a-4a574f4b76f6.png)

* Keep "Skip purchase" option in the launch flow regardless of whether you issue a search for a new domain
* The skip purchase option should show during both signup and launch flows e.g:
* http://calypso.localhost:3000/start/launch-site/domains-launch?siteSlug=...
* http://calypso.localhost:3000/start/domains
* Skip purchase option should not show anywhere that doesn't make sense, e.g. the doamins page outside of signup

Fixes #47664
