### PR TITLE
Coming soon: update login URL for Atomic

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -19,10 +19,15 @@ function should_show_coming_soon_page() {
 
 	$should_show = ( (int) get_option( 'wpcom_public_coming_soon' ) === 1 );
 
+	// Everyone from Administrator to Subscriber will be able to see the site.
+	// See https://wordpress.org/support/article/roles-and-capabilities/ for all roles and capabilities.
+	// We can update to `edit_post` to be stricter, or open it up as an editable feature.
 	if ( is_user_logged_in() && current_user_can( 'read' ) ) {
 		$should_show = false;
 	}
 
+	// Allow folks to hook into this method to set their own rules.
+	// We'll use to on WordPress.com to check further user privileges.
 	return apply_filters( 'a8c_show_coming_soon_page', $should_show );
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -46,6 +46,7 @@ function render_fallback_coming_soon_page() {
 	add_filter( 'jetpack_enable_opengraph', '__return_false', 1 );
 	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
 	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
+	add_filter( 'jetpack_implode_frontend_css', '__return_false', 99 ); // Jetpack "implodes" all registered CSS files into one file.
 
 	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), PLUGIN_VERSION );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -60,11 +60,9 @@ function get_wpcom_redirect_to() {
  * @return string The login URL
  */
 function get_login_url() {
-	$redirect_to = get_wpcom_redirect_to();
-
 	// If we're on WPCOM use a WordPress.com login URL.
 	if ( function_exists( 'localized_wpcom_url' ) ) {
-		return localized_wpcom_url( '//wordpress.com/log-in?redirect_to=' . $redirect_to );
+		return localized_wpcom_url( '//wordpress.com/log-in?redirect_to=' . get_wpcom_redirect_to() );
 	}
 
 	return site_url() . '/wp-login.php?redirect_to=' . set_url_scheme( original_request_url() );

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -21,11 +21,30 @@ function get_current_locale() {
 }
 
 /**
- * Returns a redirect URL for post-login flow
+ * Returns request URL for self-hosted and/or Atomic sites (non-WordPress.com sites)
  *
  * @return string The redirect URL
  */
-function get_redirect_to() {
+function original_request_url() {
+	if ( empty( $_SERVER['SERVER_NAME'] ) || empty( $_SERVER['REQUEST_URI'] ) ) {
+		return get_marketing_home_url();
+	}
+
+	$origin = ( is_ssl() ? 'https://' : 'http://' ) . sanitize_text_field( wp_unslash( $_SERVER['SERVER_NAME'] ) );
+
+	if ( ! empty( $_SERVER['SERVER_PORT'] ) && ! in_array( $_SERVER['SERVER_PORT'], array( 80, 443 ), true ) ) {
+		$origin .= ':' . sanitize_text_field( wp_unslash( $_SERVER['SERVER_PORT'] ) );
+	}
+
+	return $origin . strtok( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '?' );
+}
+
+/**
+ * Returns a redirect URL for post-login flow in WordPress.com
+ *
+ * @return string The redirect URL
+ */
+function get_wpcom_redirect_to() {
 	// Redirect to the current URL.
 	// If, for any reason, the superglobals aren't available, set a default redirect.
 	if ( empty( $_SERVER['HTTP_HOST'] ) || empty( $_SERVER['REQUEST_URI'] ) ) {
@@ -41,16 +60,14 @@ function get_redirect_to() {
  * @return string The login URL
  */
 function get_login_url() {
-	$redirect_to = get_redirect_to();
+	$redirect_to = get_wpcom_redirect_to();
 
+	// If we're on WPCOM use a WordPress.com login URL.
 	if ( function_exists( 'localized_wpcom_url' ) ) {
 		return localized_wpcom_url( '//wordpress.com/log-in?redirect_to=' . $redirect_to );
 	}
 
-	$locale              = get_current_locale();
-	$locale_url_fragment = 'en' === $locale ? '' : '/' . $locale;
-
-	return '//wordpress.com/log-in' . $locale_url_fragment . '?redirect_to=' . $redirect_to;
+	return site_url() . '/wp-login.php?redirect_to=' . set_url_scheme( original_request_url() );
 }
 
 /**


### PR DESCRIPTION
## Changes proposed in this Pull Request

Ensure that we show the right login links for Simple and Atomic sites.

<img width="1016" alt="Screen Shot 2020-11-23 at 10 31 38 pm" src="https://user-images.githubusercontent.com/6458278/99957384-b902fa80-2ddb-11eb-99e9-a53c14a31923.png">

## Testing instructions

### Simple sites

1. Fire up the old sandbox
2. Get this patch up there via yarn dev --sync
3. Create a site over at /start/domains?flags=coming-soon-v2
4. Sandbox that site
5. Check that coming soon is enable on your simple site (incognito window).
6. Make sure the login button links to wordpress.com, e.g., `https://wordpress.com/log-in?redirect_to=...`

### Atomic sites

1. Upgrade to Atomic (add Business plan and install a plugin)
2. Check the settings page /settings/general/{your_site}?flags=coming-soon-v2 and set the site to Coming Soon
3. Check that coming soon is enable on your simple site (incognito window).
4. Make sure the login button links to wordpress.com, e.g., `https://{$your_site}.wpcomstaging.com/wp-login.php?redirect_to=https://{$your_site}.wpcomstaging.com/`

Note: to actually login to an Atomic site you'll need to have an account on that site. You can create one for another account (Account B) by going to `/people/new/($your_site}.wpcomstaging.com`. 

Give Account B Subscriber or Author access, or any [read-access role](https://wordpress.org/support/article/roles-and-capabilities/).

Account B should accept the invitation. Account B should be able to login successfully the Atomic site, e.g., https://($your_site}.wpcomstaging.com/

