### PR TITLE
Check for public coming soon mode and show the viewers tab

### DIFF
--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -24,6 +24,7 @@ import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import titlecase from 'to-title-case';
+import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 
 class People extends React.Component {
 	renderPeopleList() {
@@ -45,6 +46,7 @@ class People extends React.Component {
 
 	render() {
 		const {
+			isComingSoon,
 			isJetpack,
 			canViewPeople,
 			siteId,
@@ -88,6 +90,7 @@ class People extends React.Component {
 						<PeopleSectionNav
 							isJetpack={ isJetpack }
 							isPrivate={ isPrivate }
+							isComingSoon={ isComingSoon }
 							canViewPeople={ canViewPeople }
 							search={ search }
 							filter={ filter }
@@ -110,5 +113,6 @@ export default connect( ( state ) => {
 		isJetpack: isJetpackSite( state, siteId ),
 		isPrivate: isPrivateSite( state, siteId ),
 		canViewPeople: canCurrentUser( state, siteId, 'list_users' ),
+		isComingSoon: isSiteComingSoon( state, siteId ),
 	};
 } )( localize( People ) );

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -13,6 +13,7 @@ import SectionNav from 'calypso/components/section-nav';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import NavItem from 'calypso/components/section-nav/item';
 import PeopleSearch from 'calypso/my-sites/people/people-section-nav/people-search';
+import config from 'calypso/config';
 
 class PeopleNavTabs extends React.Component {
 	static displayName = 'PeopleNavTabs';
@@ -104,7 +105,13 @@ class PeopleSectionNav extends Component {
 			return false;
 		}
 
-		if ( 'viewers' === this.props.filter || ( ! this.props.isJetpack && this.props.isPrivate ) ) {
+		const wpcomPublicComingSoon = config.isEnabled( 'coming-soon-v2' ) && this.props.isComingSoon;
+		const isPrivateOrPublicComingSoon = this.props.isPrivate || wpcomPublicComingSoon;
+
+		if (
+			'viewers' === this.props.filter ||
+			( ! this.props.isJetpack && isPrivateOrPublicComingSoon )
+		) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
## Changes proposed in this Pull Request

Currently on WordPress.com simple sites you can add a "Viewer role" which will grant access to your private sites.

You can only administer your Viewers when your site is in private mode. Now that we're moving to Coming Soon (public by default), the Viewer tab will no longer show (because the site isn't private).

This PR preserves that functionality, by showing the Viewers tab when the site is in Coming Soon mode as well.

### What we're not doing

We're not allowing users to add Viewers while in Coming Soon mode (yet).

We're just ensuring that any Viewers created while the site is in private mode can also be administered (by showing the Viewers tab when the site is in Coming Soon mode).

## Testing instructions

Fire up the branch

Ensure your site is in private mode: `/settings/general/{your_site}?flags=coming-soon-v2`

<img width="733" alt="Screen Shot 2020-11-23 at 10 50 00 pm" src="https://user-images.githubusercontent.com/6458278/99961546-b7890080-2de2-11eb-9680-c20106b9706a.png">

Add a new user over at `/people/new/{your_site}`

<img width="763" alt="Screen Shot 2020-11-23 at 11 13 28 pm" src="https://user-images.githubusercontent.com/6458278/99960932-b0152780-2de1-11eb-8767-0a8bd12c8261.png">

Now switch to Coming Soon mode at `/settings/general/{your_site}?flags=coming-soon-v2`

<img width="728" alt="Screen Shot 2020-11-23 at 11 13 22 pm" src="https://user-images.githubusercontent.com/6458278/99960939-b2778180-2de1-11eb-852b-ee31ddfa3d5d.png">

You should still see the added user in the Viewers tab: `/people/viewers/{your_site}`

<img width="763" alt="Screen Shot 2020-11-23 at 11 13 28 pm" src="https://user-images.githubusercontent.com/6458278/99961662-e7380880-2de2-11eb-84e7-4d72a1e2c412.png">


Fixes #
