### PR TITLE
Enable Jetpack Settings for source sites of failed migrations

### DIFF
--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -15,6 +15,7 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 import NavItem from 'calypso/components/section-nav/item';
 import { siteHasScanProductPurchase } from 'calypso/state/purchases/selectors';
 import isJetpackSectionEnabledForSite from 'calypso/state/selectors/is-jetpack-section-enabled-for-site';
+import isSiteFailedMigrationSource from 'calypso/state/selectors/is-site-failed-migration-source';
 import isRewindActive from 'calypso/state/selectors/is-rewind-active';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -117,6 +118,8 @@ export default connect( ( state ) => {
 		shouldShowJetpackSettings:
 			siteId &&
 			isJetpackSectionEnabledForSite( state, siteId ) &&
-			( siteHasScanProductPurchase( state, siteId ) || isRewindActive( state, siteId ) ),
+			( siteHasScanProductPurchase( state, siteId ) ||
+				isRewindActive( state, siteId ) ||
+				isSiteFailedMigrationSource( state, siteId ) ),
 	};
 } )( localize( SiteSettingsNavigation ) );

--- a/client/my-sites/site-settings/settings-jetpack/main.jsx
+++ b/client/my-sites/site-settings/settings-jetpack/main.jsx
@@ -23,6 +23,7 @@ import { siteHasScanProductPurchase } from 'calypso/state/purchases/selectors';
 import isRewindActive from 'calypso/state/selectors/is-rewind-active';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import isSiteFailedMigrationSource from 'calypso/state/selectors/is-site-failed-migration-source';
 
 const SiteSettingsJetpack = ( { site, siteId, siteIsJetpack, showCredentials, translate } ) => {
 	//todo: this check makes sense in Jetpack section?
@@ -75,6 +76,9 @@ export default connect( ( state ) => {
 		site,
 		siteId,
 		siteIsJetpack: isJetpackSite( state, siteId ),
-		showCredentials: isRewindActive( state, siteId ) || siteHasScanProductPurchase( state, siteId ),
+		showCredentials:
+			isSiteFailedMigrationSource( state, siteId ) ||
+			isRewindActive( state, siteId ) ||
+			siteHasScanProductPurchase( state, siteId ),
 	};
 } )( localize( SiteSettingsJetpack ) );

--- a/client/state/selectors/is-site-failed-migration-source.js
+++ b/client/state/selectors/is-site-failed-migration-source.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getRawSite from 'state/selectors/get-raw-site';
+
+/**
+ * Returns true if the site has recently been the source of a failed migration attempt
+ *
+ * @param {object} state Global state tree
+ * @param {object} siteId Site ID
+ * @returns {boolean} True if site has recently been the source of a failed migration
+ */
+export default function isSiteFailedMigrationSource( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	const siteMigrationMeta = get( site, 'site_migration', {} );
+
+	return !! get( siteMigrationMeta, 'failed_backup_source', false );
+}

--- a/client/state/selectors/is-site-failed-migration-source.js
+++ b/client/state/selectors/is-site-failed-migration-source.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import getRawSite from 'state/selectors/get-raw-site';
+import getRawSite from 'calypso/state/selectors/get-raw-site';
 
 /**
  * Returns true if the site has recently been the source of a failed migration attempt


### PR DESCRIPTION
The Jetpack (credentials) settings are currently only visible if a site has Rewind/Scan active.

In a WP migration, we backup a source site that is usually without a JP plan.
Sometimes, a credentials-less backup fails and it's likely that it could have succeeded if we had credentials. 

#### Changes proposed in this Pull Request
This PR enables the credentials setting screen for JP sites that were the source of a migration that failed in the backup stage. 

Includes:
- Add a new selector to check the site migration meta if the site is a source for a failed migration
- Show the Jetpack settings page based on that selector


#### Testing instructions
- Choose a JP site without a JP backup/scan plan.
- Verify that the Jetpack settings are not available for that site: The settings menu in https://wordpress.com/settings/general/{SITE_URL} should show no Jetpack option, and visiting https://wordpress.com/settings/jetpack/{SITE_URL} will show a blank main section 
- Add the blog sticker `site-migration-backup-failed` to the chosen blog. You can do that using `wpsh` and `add_blog_sticker`
- Verify again - the settings should be available.

