### PR TITLE
State: Always use notice action creators

### DIFF
--- a/client/state/mailchimp/settings/actions.js
+++ b/client/state/mailchimp/settings/actions.js
@@ -7,9 +7,9 @@ import {
 	MAILCHIMP_SETTINGS_UPDATE,
 	MAILCHIMP_SETTINGS_UPDATE_SUCCESS,
 	MAILCHIMP_SETTINGS_UPDATE_FAILURE,
-	NOTICE_CREATE,
 } from 'calypso/state/action-types';
 import wpcom from 'calypso/lib/wp';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 import 'calypso/state/data-layer/wpcom/sites/mailchimp';
 import 'calypso/state/mailchimp/init';
@@ -43,14 +43,11 @@ export const requestSettingsUpdate = ( siteId, settings, noticeText ) => {
 					siteId,
 					settings: data,
 				} );
-				dispatch( {
-					type: NOTICE_CREATE,
-					notice: {
+				dispatch(
+					successNotice( noticeText, {
 						duration: 5000,
-						text: noticeText,
-						status: 'is-success',
-					},
-				} );
+					} )
+				);
 			} )
 			.catch( ( error ) => {
 				dispatch( {
@@ -58,14 +55,11 @@ export const requestSettingsUpdate = ( siteId, settings, noticeText ) => {
 					siteId,
 					error,
 				} );
-				dispatch( {
-					type: NOTICE_CREATE,
-					notice: {
+				dispatch(
+					errorNotice( error.message, {
 						duration: 10000,
-						text: error.message,
-						status: 'is-error',
-					},
-				} );
+					} )
+				);
 			} );
 	};
 };

--- a/client/state/memberships/product-list/actions.js
+++ b/client/state/memberships/product-list/actions.js
@@ -8,11 +8,11 @@ import {
 	MEMBERSHIPS_PRODUCT_ADD_FAILURE,
 	MEMBERSHIPS_PRODUCT_UPDATE,
 	MEMBERSHIPS_PRODUCT_UPDATE_FAILURE,
-	NOTICE_CREATE,
 	MEMBERSHIPS_PRODUCT_DELETE,
 	MEMBERSHIPS_PRODUCT_DELETE_FAILURE,
 } from 'calypso/state/action-types';
 import wpcom from 'calypso/lib/wp';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { membershipProductFromApi } from 'calypso/state/data-layer/wpcom/sites/memberships';
 
 import 'calypso/state/memberships/init';
@@ -57,14 +57,11 @@ export const requestAddProduct = ( siteId, product, noticeText ) => {
 			.then( ( newProduct ) => {
 				const membershipProduct = membershipProductFromApi( newProduct.product );
 				dispatch( receiveUpdateProduct( siteId, membershipProduct ) );
-				dispatch( {
-					type: NOTICE_CREATE,
-					notice: {
+				dispatch(
+					successNotice( noticeText, {
 						duration: 5000,
-						text: noticeText,
-						status: 'is-success',
-					},
-				} );
+					} )
+				);
 				return membershipProduct;
 			} )
 			.catch( ( error ) => {
@@ -73,14 +70,11 @@ export const requestAddProduct = ( siteId, product, noticeText ) => {
 					siteId,
 					error,
 				} );
-				dispatch( {
-					type: NOTICE_CREATE,
-					notice: {
+				dispatch(
+					errorNotice( error.message, {
 						duration: 10000,
-						text: error.message,
-						status: 'is-error',
-					},
-				} );
+					} )
+				);
 			} );
 	};
 };
@@ -104,14 +98,11 @@ export const requestUpdateProduct = ( siteId, product, noticeText ) => {
 			.then( ( newProduct ) => {
 				const membershipProduct = membershipProductFromApi( newProduct.product );
 				dispatch( receiveUpdateProduct( siteId, membershipProduct ) );
-				dispatch( {
-					type: NOTICE_CREATE,
-					notice: {
+				dispatch(
+					successNotice( noticeText, {
 						duration: 5000,
-						text: noticeText,
-						status: 'is-success',
-					},
-				} );
+					} )
+				);
 				return membershipProduct;
 			} )
 			.catch( ( error ) => {
@@ -120,14 +111,11 @@ export const requestUpdateProduct = ( siteId, product, noticeText ) => {
 					siteId,
 					error,
 				} );
-				dispatch( {
-					type: NOTICE_CREATE,
-					notice: {
+				dispatch(
+					errorNotice( error.message, {
 						duration: 10000,
-						text: error.message,
-						status: 'is-error',
-					},
-				} );
+					} )
+				);
 			} );
 	};
 };
@@ -146,14 +134,11 @@ export const requestDeleteProduct = ( siteId, product, noticeText ) => {
 				path: `/sites/${ siteId }/memberships/product/${ product.ID }/delete`,
 			} )
 			.then( () => {
-				dispatch( {
-					type: NOTICE_CREATE,
-					notice: {
+				dispatch(
+					successNotice( noticeText, {
 						duration: 5000,
-						text: noticeText,
-						status: 'is-success',
-					},
-				} );
+					} )
+				);
 				return product.ID;
 			} )
 			.catch( ( error ) => {
@@ -163,14 +148,11 @@ export const requestDeleteProduct = ( siteId, product, noticeText ) => {
 					error,
 					product,
 				} );
-				dispatch( {
-					type: NOTICE_CREATE,
-					notice: {
+				dispatch(
+					errorNotice( error.message, {
 						duration: 10000,
-						text: error.message,
-						status: 'is-error',
-					},
-				} );
+					} )
+				);
 			} );
 	};
 };

--- a/client/state/memberships/settings/actions.js
+++ b/client/state/memberships/settings/actions.js
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import { MEMBERSHIPS_SETTINGS, NOTICE_CREATE } from 'calypso/state/action-types';
+import { errorNotice, successNotice, warningNotice } from 'calypso/state/notices/actions';
+import { MEMBERSHIPS_SETTINGS } from 'calypso/state/action-types';
 import wpcom from 'calypso/lib/wp';
 
 import 'calypso/state/data-layer/wpcom/sites/memberships';
@@ -19,37 +20,28 @@ export const requestDisconnectStripeAccount = (
 	noticeTextOnSuccess
 ) => {
 	return ( dispatch ) => {
-		dispatch( {
-			type: NOTICE_CREATE,
-			notice: {
+		dispatch(
+			warningNotice( noticeTextOnProcessing, {
 				duration: 10000,
-				text: noticeTextOnProcessing,
-				status: 'is-warning',
-			},
-		} );
+			} )
+		);
 
 		return wpcom.req
 			.get( `/me/connected_account/stripe/${ connectedAccountId }/disconnect` )
 			.then( () => {
 				dispatch( requestSettings( siteId ) );
-				dispatch( {
-					type: NOTICE_CREATE,
-					notice: {
+				dispatch(
+					successNotice( noticeTextOnSuccess, {
 						duration: 5000,
-						text: noticeTextOnSuccess,
-						status: 'is-success',
-					},
-				} );
+					} )
+				);
 			} )
 			.catch( ( error ) => {
-				dispatch( {
-					type: NOTICE_CREATE,
-					notice: {
+				dispatch(
+					errorNotice( error.message, {
 						duration: 10000,
-						text: error.message,
-						status: 'is-error',
-					},
-				} );
+					} )
+				);
 			} );
 	};
 };

--- a/client/state/memberships/subscribers/actions.js
+++ b/client/state/memberships/subscribers/actions.js
@@ -6,9 +6,9 @@ import {
 	MEMBERSHIPS_SUBSCRIPTION_STOP,
 	MEMBERSHIPS_SUBSCRIPTION_STOP_SUCCESS,
 	MEMBERSHIPS_SUBSCRIPTION_STOP_FAILURE,
-	NOTICE_CREATE,
 } from 'calypso/state/action-types';
 import wpcom from 'calypso/lib/wp';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 import 'calypso/state/data-layer/wpcom/sites/memberships';
 import 'calypso/state/memberships/init';
@@ -41,14 +41,11 @@ export const requestSubscriptionStop = ( siteId, subscriber, noticeText ) => {
 						errorMsg,
 					} );
 
-					dispatch( {
-						type: NOTICE_CREATE,
-						notice: {
+					dispatch(
+						errorNotice( errorMsg, {
 							duration: 5000,
-							text: errorMsg,
-							status: 'is-error',
-						},
-					} );
+						} )
+					);
 				}
 
 				dispatch( {
@@ -57,13 +54,7 @@ export const requestSubscriptionStop = ( siteId, subscriber, noticeText ) => {
 					subscriptionId: subscriber.id,
 				} );
 
-				dispatch( {
-					type: NOTICE_CREATE,
-					notice: {
-						text: noticeText,
-						status: 'is-success',
-					},
-				} );
+				dispatch( successNotice( noticeText ) );
 			} )
 			.catch( ( error ) => {
 				dispatch( {


### PR DESCRIPTION
As reported by @jsnajdr there are some areas in Memberships in Mailchimp where we directly create an action using the `NOTICE_CREATE` action type, but instead, we should be using the existing notices action creators. @jsnajdr suggested that in a recent review: https://github.com/Automattic/wp-calypso/pull/47619#discussion_r527709543 This PR takes care of that.

#### Changes proposed in this Pull Request

* State: Always use notice action creators in Memberships and Mailchimp

#### Testing instructions

* Verify all tests still pass.
* If you're enthusiastic to test further, you. can try dispatching each action we're touching and verify the same notice is displayed as before.
