### PR TITLE
Jetpack Connect: fix broken redirection to login page

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -111,7 +111,7 @@ export function offerResetRedirects( context, next ) {
 			'controller: offerResetRedirects -> redirecting to /plans since site has a plan or is not a Jetpack site',
 			context.params
 		);
-		return page.redirect( CALYPSO_PLANS_PAGE + selectedSite.slug );
+		return externalRedirect( CALYPSO_PLANS_PAGE + selectedSite.slug );
 	}
 
 	// If current user is not an admin (can't purchase plans), redirect the user to /posts if

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -115,7 +115,7 @@ export default function () {
 
 	if ( isLoggedOut ) {
 		page( '/jetpack/connect/plans/:interval(yearly|monthly)?/:site', ( { path } ) =>
-			page.redirect( login( { isNative: true, redirectTo: path } ) )
+			page( login( { isNative: true, isJetpack: true, redirectTo: path } ) )
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix broken redirection to `/log-in/jetpack`. Currently, unauthenticated users that visit `/jetpack/connect` are redirected to the login page after entering a site address, but the redirect never happens. 
* Improve UX of the redirection from `/jetpack/connect/plans/:site` to `/plans/:site`. Currently, if you visit `/jetpack/connect/plans/:site` with a site that has a paid plan, you will be redirected to `/plans/:site`. This UX is broken because Calypso Blue styles aren't being loaded properly (the masterbar is missing and the primary color is green instead of blue).

#### Testing instructions

* Run this PR (horizon is enough).

**Test 1: Fix broken redirection to `/log-in/jetpack`**
* Open an incognito window.
* Visit `/jetpack/connect`.
* Enter a Jetpack site address.
* Verify that you are redirected to the login page and that you actually see the login form.

**Test 2: Improve UX of the redirection from `/jetpack/connect/plans/:site` to `/plans/:site`**
* While being authenticated, visit `/jetpack/connect/plans/:site` with a Jetpack site.
* Verify that you are redirected to the `/plans/:site` and that the masterbar is present.

Fixes 1164141197617539-as-1198696277379358


#### Demo

#### Before – Login page issue

![Kapture 2020-11-23 at 13 04 13](https://user-images.githubusercontent.com/3418513/99985042-91d10c80-2d8c-11eb-94b7-08b49571074f.gif)

#### After – Login page issue

![Kapture 2020-11-23 at 13 05 19](https://user-images.githubusercontent.com/3418513/99985063-97c6ed80-2d8c-11eb-840e-8f0ebef2a96e.gif)

#### Before – Plans page redirection

![Kapture 2020-11-23 at 13 02 44](https://user-images.githubusercontent.com/3418513/99985073-9bf30b00-2d8c-11eb-9fc9-1d458be537a5.gif)

#### After – Plans page redirection

![Kapture 2020-11-23 at 13 01 45](https://user-images.githubusercontent.com/3418513/99985086-9eedfb80-2d8c-11eb-91f7-25b03ecfdd54.gif)

