### PR TITLE
Jetpack Cloud: Remove extra space/padding around Gravatar in logout menu

### DIFF
--- a/client/components/jetpack/profile-dropdown/style.scss
+++ b/client/components/jetpack/profile-dropdown/style.scss
@@ -23,7 +23,6 @@
 		position: initial;
 		width: 64px;
 		height: 64px;
-		padding: 0 8px;
 	}
 
 	&__logout-username {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `padding` rule from `profile-dropdown__logout-gravatar`, as it was making the Gravatar border look wonky.

Fixes `1164141197617539-as-1199203273219765`.

#### Testing instructions

* Open Calypso Green and make sure you're logged in.
* Click your Gravatar in the upper-right corner to open the menu.
* Verify that the thin white border surrounds your Gravatar on all sides, instead of creating an oval shape (see screenshots for more details).

#### Reference screenshots

##### Mobile (before / after)

<img width="300" alt="Screen Shot 2020-11-23 at 10 23 14" src="https://user-images.githubusercontent.com/670067/99988737-79a2c280-2d77-11eb-9a0c-47544bff1020.png"> <img width="300" alt="Screen Shot 2020-11-23 at 10 23 23" src="https://user-images.githubusercontent.com/670067/99988739-79a2c280-2d77-11eb-918e-26136211f876.png">

##### Desktop (before / after)

<img width="350" alt="Screen Shot 2020-11-23 at 10 23 01" src="https://user-images.githubusercontent.com/670067/99988795-89baa200-2d77-11eb-99a0-d3351f159846.png"> <img width="350" alt="Screen Shot 2020-11-23 at 10 22 50" src="https://user-images.githubusercontent.com/670067/99988792-89220b80-2d77-11eb-8bce-4717d1de1553.png">