### PR TITLE
Calypso Feature List: add missing 'key' property

### DIFF
--- a/client/lib/features-helper/feature-list.js
+++ b/client/lib/features-helper/feature-list.js
@@ -9,10 +9,10 @@ import React from 'react';
 import config from 'calypso/config';
 import { Card } from '@automattic/components';
 
-const headerClass = ' features-helper__feature-header';
-const itemClass = ' features-helper__feature-item';
-const enabledClass = ' features-helper__feature-item-enabled';
-const disabledClass = ' features-helper__feature-item-disabled';
+const headerClass = 'features-helper__feature-header';
+const itemClass = 'features-helper__feature-item';
+const enabledClass = 'features-helper__feature-item-enabled';
+const disabledClass = 'features-helper__feature-item-disabled';
 
 export const FeatureList = React.memo( () => {
 	const currentXLProjects = [ 'anchor-fm', 'nav-unification' ];
@@ -23,10 +23,15 @@ export const FeatureList = React.memo( () => {
 			<Card className="features-helper__current-features">
 				<div className={ headerClass }>Current XL Projects</div>
 				{ currentXLProjects.map( ( flag ) => {
-					if ( config.isEnabled( flag ) ) {
-						return <div className={ itemClass + enabledClass }>{ flag } ON</div>;
-					}
-					return <div className={ itemClass + disabledClass }>{ flag } OFF</div>;
+					const isFlagEnabled = config.isEnabled( flag );
+					return (
+						<div
+							key={ flag }
+							className={ [ itemClass, isFlagEnabled ? enabledClass : disabledClass ].join( ' ' ) }
+						>
+							{ flag } { isFlagEnabled ? 'ON' : 'OFF' }
+						</div>
+					);
 				} ) }
 				<div className={ headerClass }>All Enabled Features</div>
 				{ enabledFeatures.map( ( flag ) => (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add missing `key` property in `<FeatureList>` component when iterating over `currentXLProjects` flags — this fixes a console warning logged by React when in dev mode
* Removed trailing spaces from classNames, using Array.join(` `) instead

![Markup 2020-11-23 at 18 06 52](https://user-images.githubusercontent.com/1083581/99992490-b2ae5780-2db6-11eb-826d-137f3efa173e.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn start`
* Open browser devtools
* Visit `/calypso.localhost:3000`
* Notice how the React warning about missing `key` property is not printed in the console anymore
* Check that the `<FeatureList>` component keeps behaving as before
