### PR TITLE
Don't upsell Jetpack Anti-spam if site has active Akismet.

### DIFF
--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -68,7 +68,10 @@ const SpamFilteringSettings = ( {
 		return null;
 	}
 
-	if ( ! ( hasAkismetFeature || hasAntiSpamFeature || hasJetpackAntiSpamProduct ) ) {
+	if (
+		! ( hasAkismetFeature || hasAntiSpamFeature || hasJetpackAntiSpamProduct ) &&
+		! akismetActive
+	) {
 		return (
 			<UpsellNudge
 				title={ translate( 'Automatically clear spam from comments and forms' ) }


### PR DESCRIPTION
### Changes proposed in this Pull Request

Prior to this PR, we were upselling Jetpack Anti-spam to sites that already have Akismet, which was confusing from a user perspective. This PR makes it so that we do **not** show the Jetpack Anti-spam upsell if the site already has Akismet _**or**_ if the site has Jetpack Anti-spam product or anti-spam is included in the site's Plan. (See screenshot below)

Fixes 1164141197617539-as-1199197816689479

**This screenshot below is on a Jetpack Free site with Akismet plugin activated with a Akismet Personal (Free non-commercial license)**. You see in the image that the upsell banner is showing but the upsell should not be showing because Akismet _**is**_ actually protecting the site from spam.
Calypso --> Settings --> Security

![Markup 2020-11-23 at 13 47 01](https://user-images.githubusercontent.com/11078128/100019152-6ea95b80-2d92-11eb-8de2-52de85c47b76.png)


### Testing instructions
First, to see the issue in action:
1. Open the wp-admin dashboard of a site with Jetpack Free (either already previously created site or create a new jurassic.ninja site)
3. In wp-admin, go to Plugins --> click button "Set up your Akismet account"  (if you don't have this option, you will need to [add Akismet](https://akismet.com/wordpress/) Personal license to your user account)
4. Go to Calypso --> Settings --> Security (`wordpress.com/settings/security/:site`)
5. Verify that you see the Jetpack Anti-spam upsell (image below), even though Akismet is valid and active.  This is the bug. The upsell should not be showing since Akismet _**is**_ actually protecting the site from spam.
![Markup 2020-11-23 at 14 18 07](https://user-images.githubusercontent.com/11078128/100021703-c053e500-2d96-11eb-8c55-a0f3f3963b8d.png)


Now checkout and run this PR:
1. Select the site above that you activated Akismet on.
2. Go to Calypso --> Settings --> Security (`calypso.localhost:3000/settings/security/:site`)
3. Verify that you no longer see the upsell, but instead showing "Your site is protected from spam."
![Markup 2020-11-23 at 14 17 39](https://user-images.githubusercontent.com/11078128/100021874-06a94400-2d97-11eb-9259-d699631bea5d.png)

4. Select a site with Jetpack Free plan (Akismet not activated), verify that the Anti-spam upsell **_is_** showing.
5. Select a site with Jetpack Anti-spam product, or Anti-spam included in Plan. Verify that the upsell **_is not_** showing
