### PR TITLE
Comments: release reader/user-mention-suggestions to production

### DIFF
--- a/client/blocks/comments/form-textarea.jsx
+++ b/client/blocks/comments/form-textarea.jsx
@@ -9,7 +9,6 @@ import React from 'react';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import withUserMentions from 'calypso/blocks/user-mentions/index';
 import withPasteToLink from 'calypso/lib/paste-to-link';
-import { isEnabled } from 'calypso/config';
 
 /* eslint-disable jsx-a11y/no-autofocus */
 const PostCommentFormTextarea = React.forwardRef( ( props, ref ) => (
@@ -29,10 +28,4 @@ const PostCommentFormTextarea = React.forwardRef( ( props, ref ) => (
 ) );
 /* eslint-enable jsx-a11y/no-autofocus */
 
-let component = withPasteToLink( PostCommentFormTextarea );
-
-if ( isEnabled( 'reader/user-mention-suggestions' ) ) {
-	component = withUserMentions( component );
-}
-
-export default component;
+export default withUserMentions( withPasteToLink( PostCommentFormTextarea ) );

--- a/client/blocks/user-mentions/README.md
+++ b/client/blocks/user-mentions/README.md
@@ -25,4 +25,4 @@ Note: you'll need to wrap the child component with `React.forwardRef`, and pass 
 
 `connectUserMentions` (connect.jsx) provides a list of user suggestions from the API to the wrapped component.
 
-`withUserMentions` (index.jsx) combines the two higher-order components above. This HOC is used by the Reader comments box.
+`withUserMentions` (index.jsx) combines the two higher-order components above. This HOC is used by the comments block.

--- a/client/blocks/user-mentions/suggestion-list.jsx
+++ b/client/blocks/user-mentions/suggestion-list.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -190,9 +190,7 @@ export default class AppComponents extends React.Component {
 					<PostComment />
 					<ConversationCaterpillar readmeFilePath="conversation-caterpillar" />
 					<ConversationFollowButton />
-					{ isEnabled( 'reader/user-mention-suggestions' ) && (
-						<UserMentions readmeFilePath="user-mentions" />
-					) }
+					<UserMentions readmeFilePath="user-mentions" />
 					<SupportArticleDialog />
 					<ImageSelector readmeFilePath="image-selector" />
 					<TimeMismatchWarning readmeFilePath="time-mismatch-warning" />

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -85,7 +85,6 @@
 		"press-this": false,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/user-mention-suggestions": false,
 		"republicize": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,

--- a/config/development.json
+++ b/config/development.json
@@ -159,7 +159,6 @@
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"reader/seen-posts": true,
-		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,
 		"republicize": true,
 		"rum-tracking/logstash": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -109,7 +109,6 @@
 		"privacy-policy": true,
 		"reader": true,
 		"reader/seen-posts": true,
-		"reader/user-mention-suggestions": true,
 		"republicize": true,
 		"safari-idb-mitigation": true,
 		"server-side-rendering": true,

--- a/config/production.json
+++ b/config/production.json
@@ -118,7 +118,6 @@
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/seen-posts": false,
-		"reader/user-mention-suggestions": false,
 		"republicize": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -125,7 +125,6 @@
 		"reader/full-errors": false,
 		"reader/list-management": true,
 		"reader/seen-posts": true,
-		"reader/user-mention-suggestions": true,
 		"republicize": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,

--- a/config/test.json
+++ b/config/test.json
@@ -92,7 +92,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/seen-posts": true,
-		"reader/user-mention-suggestions": true,
 		"republicize": true,
 		"rum-tracking/logstash": false,
 		"server-side-rendering": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,7 +130,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/seen-posts": true,
-		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,
 		"republicize": true,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In p5PDj3-4Wr-p2, @guarani noticed that user mention suggestions are not offered when he's not using the internal proxy. This is because the feature was not launched to the production environment (it was live on staging which is the most common environment for internal users).

This PR enables user mentions suggestions on production. As more external users create P2 sites on WordPress.com, it makes sense for all users to have access to this feature.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
On an existing testing site, invite a different test user to administer your site:

https://wordpress.com/people/team/<your_url>

Go through the process of accepting the invite.

Now you should be able to @mention the other user in Reader comments for the test site. Go to a full post in Reader from the test site and scroll down to create a new comment.

![90846694-d085ae00-e3bc-11ea-9e38-3ad35971efc2](https://user-images.githubusercontent.com/17325/100023701-4aa95100-2e4a-11eb-9021-fd151cfafe46.gif)

You can also check out the component in Devdocs.

* Visit http://calypso.localhost:3000/devdocs/blocks/user-mentions
* Press '@' and start typing for user matches
* User suggestions show up and textarea remains in focus, allowing the user to perform keyboard operations as expected.