### PR TITLE
Simplify verified=1 email confirmed text to 'Email confirmed' in all locales

### DIFF
--- a/client/components/email-verification/index.js
+++ b/client/components/email-verification/index.js
@@ -21,13 +21,7 @@ export default function emailVerification( context, next ) {
 	if ( showVerifiedNotice ) {
 		user().signalVerification();
 		setTimeout( () => {
-			// TODO: unify these once translations catch up
-			const message =
-				i18n.getLocaleSlug() === 'en'
-					? i18n.translate( 'Email confirmed!' )
-					: i18n.translate(
-							"Email confirmed! Now that you've confirmed your email address you can publish posts on your blog."
-					  );
+			const message = i18n.translate( 'Email confirmed!' );
 			const notice = successNotice( message, { duration: 10000 } );
 			context.store.dispatch( notice );
 		}, 100 ); // A delay is needed here, because the notice state seems to be cleared upon page load

--- a/client/components/email-verification/index.js
+++ b/client/components/email-verification/index.js
@@ -24,7 +24,7 @@ export default function emailVerification( context, next ) {
 			const message = i18n.translate( 'Email confirmed!' );
 			const notice = successNotice( message, { duration: 10000 } );
 			context.store.dispatch( notice );
-		}, 100 ); // A delay is needed here, because the notice state seems to be cleared upon page load
+		}, 500 ); // A delay is needed here, because the notice state seems to be cleared upon page load
 	}
 
 	next();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove conditional line for email confirmed text, and just use the "Email confirmed!" text.
* Increase the delay of the setTimeout to 500ms to allow enough time for translations to load (this is slightly hacky, but is a quick fix to side-step refactoring how this notice works, and avoids us having to watch for state changes before dispatching the success notice).

#### Screenshots

In English:

![image](https://user-images.githubusercontent.com/14988353/100050819-64f52600-2e6e-11eb-9209-3751d3716f2e.png)

In Spanish:

![image](https://user-images.githubusercontent.com/14988353/100050776-4c850b80-2e6e-11eb-9014-129aba011560.png)

In German:

![image](https://user-images.githubusercontent.com/14988353/100051232-7559d080-2e6f-11eb-9ec5-63dbf1009a49.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the calypso.live url and add `?verified=1` to the url to see the email confirmed notice. It should be `Email confirmed!`
* Switch to another locale (e.g. Spanish or German) and reload the page (making sure you've added `?verified=1` to the url. You should see the translated notice.

Fixes part of #47578 
