### PR TITLE
Apply LocaleProvider to calypso

### DIFF
--- a/client/components/calypso-i18n-provider/index.tsx
+++ b/client/components/calypso-i18n-provider/index.tsx
@@ -28,7 +28,7 @@ const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 	}, [] );
 
 	return (
-		<LocaleProvider localeSlug={ localeSlug || i18nDefaultLocaleSlug }>
+		<LocaleProvider localeSlug={ localeSlug || config( 'i18n_default_locale_slug' ) }>
 			<I18nProvider localeData={ localeData }>{ children }</I18nProvider>
 		</LocaleProvider>
 	);

--- a/client/components/calypso-i18n-provider/index.tsx
+++ b/client/components/calypso-i18n-provider/index.tsx
@@ -5,9 +5,11 @@ import * as React from 'react';
 import { setLocaleData as setWpI18nLocaleData } from '@wordpress/i18n';
 import { I18nProvider } from '@automattic/react-i18n';
 import i18n from 'i18n-calypso';
+import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
 
 const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 	const [ localeData, setLocaleData ] = React.useState( i18n.getLocale() );
+	const localeSlug = i18n.getLocaleSlug();
 
 	React.useEffect( () => {
 		const onChange = () => {
@@ -25,7 +27,11 @@ const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 		};
 	}, [] );
 
-	return <I18nProvider localeData={ localeData }>{ children }</I18nProvider>;
+	return (
+		<LocaleProvider localeSlug={ localeSlug || i18nDefaultLocaleSlug }>
+			<I18nProvider localeData={ localeData }>{ children }</I18nProvider>
+		</LocaleProvider>
+	);
 };
 
 export default CalypsoI18nProvider;

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -31,8 +31,6 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import FormattedHeader from 'calypso/components/formatted-header';
 
-import { localizeUrl as libLocalizeUrl } from 'calypso/lib/i18n-utils';
-
 const TRACKS_OPT_OUT_USER_SETTINGS_KEY = 'tracks_opt_out';
 
 /* eslint-disable react/prefer-es6-class */
@@ -87,7 +85,7 @@ const Privacy = createReactClass( {
 		);
 
 		const cookiePolicyLink = (
-			<ExternalLink href={ libLocalizeUrl( 'https://automattic.com/cookies' ) } target="_blank" />
+			<ExternalLink href={ localizeUrl( 'https://automattic.com/cookies' ) } target="_blank" />
 		);
 		const privacyPolicyLink = (
 			<ExternalLink href={ localizeUrl( 'https://automattic.com/privacy' ) } target="_blank" />

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -7,7 +7,7 @@ import { flowRight as compose } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-
+import { withLocalizeUrl } from '@automattic/i18n-utils';
 /**
  * Internal dependencies
  */
@@ -20,7 +20,6 @@ import FormToggle from 'calypso/components/forms/form-toggle';
 import Main from 'calypso/components/main';
 import observe from 'calypso/lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
 import { protectForm } from 'calypso/lib/protect-form';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
 import SectionHeader from 'calypso/components/section-header';
@@ -31,6 +30,8 @@ import { requestHttpData, getHttpData } from 'calypso/state/data-layer/http-data
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import FormattedHeader from 'calypso/components/formatted-header';
+
+import { localizeUrl as libLocalizeUrl } from 'calypso/lib/i18n-utils';
 
 const TRACKS_OPT_OUT_USER_SETTINGS_KEY = 'tracks_opt_out';
 
@@ -77,7 +78,7 @@ const Privacy = createReactClass( {
 	},
 
 	render() {
-		const { markChanged, translate, userSettings } = this.props;
+		const { markChanged, translate, userSettings, localizeUrl } = this.props;
 
 		const isSubmitButtonDisabled = ! userSettings.hasUnsavedSettings() || this.getDisabledState();
 
@@ -86,7 +87,7 @@ const Privacy = createReactClass( {
 		);
 
 		const cookiePolicyLink = (
-			<ExternalLink href={ localizeUrl( 'https://automattic.com/cookies' ) } target="_blank" />
+			<ExternalLink href={ libLocalizeUrl( 'https://automattic.com/cookies' ) } target="_blank" />
 		);
 		const privacyPolicyLink = (
 			<ExternalLink href={ localizeUrl( 'https://automattic.com/privacy' ) } target="_blank" />
@@ -233,6 +234,7 @@ const dpaRequestState = ( request ) => {
 
 export default compose(
 	localize,
+	withLocalizeUrl,
 	protectForm,
 	connect(
 		() => ( {

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -35,6 +35,7 @@
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
+		"@automattic/i18n-utils": "^1.0.0",
 		"@wordpress/base-styles": "^2.0.1",
 		"@wordpress/components": "^10.0.5",
 		"@wordpress/compose": "^3.19.3",

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -11,6 +11,7 @@ import { sprintf } from '@wordpress/i18n';
 import { v4 as uuid } from 'uuid';
 import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -58,6 +59,8 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	selected,
 	type = ITEM_TYPE_RADIO,
 } ) => {
+	const localizeUrl = useLocalizeUrl();
+
 	const isMobile = useViewportMatch( 'small', '<' );
 
 	const dotPos = domain.indexOf( '.' );
@@ -162,9 +165,9 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 										<a
 											target="_blank"
 											rel="noreferrer"
-											href="https://wordpress.com/support/https-ssl"
+											href={ localizeUrl( 'https://wordpress.com/support/https-ssl' ) }
 										/>
-									), // TODO Wrap this in `localizeUrl` from lib/i18n-utils
+									),
 								}
 							) }
 						</InfoTooltip>

--- a/packages/domain-picker/tsconfig.json
+++ b/packages/domain-picker/tsconfig.json
@@ -35,6 +35,7 @@
 	"references": [
 		{ "path": "../data-stores" },
 		{ "path": "../calypso-analytics" },
-		{ "path": "../react-i18n" }
+		{ "path": "../react-i18n" },
+		{ "path": "../i18n-utils" }
 	]
 }

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -1,3 +1,3 @@
-export { localizeUrl, useLocalizeUrl } from './localize-url';
+export { localizeUrl, useLocalizeUrl, withLocalizeUrl } from './localize-url';
 export { LocaleProvider, useLocale, withLocale } from './locale-context';
 export * from './locales';

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -1,2 +1,3 @@
 export { localizeUrl, useLocalizeUrl } from './localize-url';
 export { LocaleProvider, useLocale, withLocale } from './locale-context';
+export * from './locales';

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -150,7 +150,7 @@ export function useLocalizeUrl(): ( fullUrl: string, locale?: Locale ) => string
 }
 
 export const withLocalizeUrl = createHigherOrderComponent< {
-	localizeUrl: ( fullUrl: string, locale?: Locale ) => string;
+	localizeUrl: ReturnType< typeof useLocalizeUrl >;
 } >( ( InnerComponent ) => {
 	return ( props ) => {
 		const localizeUrl = useLocalizeUrl();

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
+import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -147,3 +148,12 @@ export function useLocalizeUrl(): ( fullUrl: string, locale?: Locale ) => string
 		[ providerLocale ]
 	);
 }
+
+export const withLocalizeUrl = createHigherOrderComponent< {
+	localizeUrl: ( fullUrl: string, locale?: Locale ) => string;
+} >( ( InnerComponent ) => {
+	return ( props ) => {
+		const localizeUrl = useLocalizeUrl();
+		return <InnerComponent localizeUrl={ localizeUrl } { ...props } />;
+	};
+}, 'withLocalizeUrl' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Implements usage of LocaleProvider, useLocalizeUrl
* Implements withLocalizeUrl 
* Makes use of both with/useLocalizeUrl
* adds i18n-utils to domain-picker package

#### Testing instructions

* Check url is localized as shown in #45610
* Check urls is localized on the privacy settings screen
* Check existing localized urls still localize elsewhere in calypso
 
Fixes #45610 :tada: 
