### PR TITLE
Makes sure color-schemes are correctly applied when nav-unification is enabled

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-blue.scss
@@ -1,4 +1,5 @@
-.color-scheme.is-classic-blue {
+.color-scheme.is-classic-blue,
+.color-scheme.is-classic-blue .is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-blue-50 );
 	--color-primary-rgb: var( --studio-blue-50-rgb );
@@ -74,7 +75,7 @@
 	--color-masterbar-toggle-drafts-editor-background: var( --studio-gray-40 );
 	--color-masterbar-toggle-drafts-editor-hover-background: var( --studio-gray-40 );
 	--color-masterbar-toggle-drafts-editor-border: var( --studio-gray-10 );
-	
+
 	--color-sidebar-background: var( --studio-gray-5 );
 	--color-sidebar-background-rgb: var( --studio-gray-5-rgb );
 	--color-sidebar-border: var( --studio-gray-10 );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -1,4 +1,5 @@
-.color-scheme.is-classic-dark {
+.color-scheme.is-classic-dark,
+.color-scheme.is-classic-dark .is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-gray-90 );
 	--color-primary-rgb: var( --studio-gray-90-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
@@ -1,4 +1,5 @@
-.color-scheme.is-contrast {
+.color-scheme.is-contrast,
+.color-scheme.is-contrast .is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-gray-80 );
 	--color-primary-rgb: var( --studio-gray-80-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
@@ -1,4 +1,5 @@
-.color-scheme.is-midnight {
+.color-scheme.is-midnight,
+.color-scheme.is-midnight .is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-gray-70 );
 	--color-primary-rgb: var( --studio-gray-70-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_nightfall.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_nightfall.scss
@@ -1,4 +1,5 @@
-.color-scheme.is-nightfall {
+.color-scheme.is-nightfall,
+.color-scheme.is-nightfall .is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-gray-90 );
 	--color-primary-rgb: var( --studio-gray-90-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_powder-snow.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_powder-snow.scss
@@ -1,4 +1,5 @@
-.color-scheme.is-powder-snow {
+.color-scheme.is-powder-snow,
+.color-scheme.is-powder-snow .is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-gray-90 );
 	--color-primary-rgb: var( --studio-gray-90-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
@@ -1,4 +1,5 @@
-.color-scheme.is-sakura {
+.color-scheme.is-sakura,
+.color-scheme.is-sakura .is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-celadon-50 );
 	--color-primary-rgb: var( --studio-celadon-50-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunset.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunset.scss
@@ -1,4 +1,5 @@
-.color-scheme.is-sunset {
+.color-scheme.is-sunset,
+.color-scheme.is-sunset .is-nav-unification {
 	/* Theme Properties */
 	--color-primary: var( --studio-red-50 );
 	--color-primary-rgb: var( --studio-red-50-rgb );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a temporary `* .is-nav-unification` css rule so that color schemes override the rules that are currently set here 

https://github.com/Automattic/wp-calypso/blob/d669c0f7b2dee5e4c9e95c5ee962a0ca79e67c1c/client%2Fmy-sites%2Fsidebar-unified%2Fstyle.scss#L5

All these overrides will be removed once nav-unifications has rolled out to 100%.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/me/account and repeat the next step for each of these themes: `classic-blue`, `classic-dark`, `contrast`, `midnight`, `nightfall`, `powder-snow`, `sakura`, `sunset`.
* Go to http://calypso.localhost:3000/home?flags=nav-unification select a site and make sure the color scheme is applied by inspecting the masterbar and left navbar.

Before the Sunset | [After the Sunset](https://www.imdb.com/title/tt0367479/)
-------|------
![](https://cln.sh/IiUvMH+) | ![](https://cln.sh/sp3Iu5+)
