### PR TITLE
Removes site badge color override

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -281,10 +281,6 @@ $font-size: rem( 14px );
 		color: var( --color-sidebar-text );
 	}
 
-	.site__badge {
-		background: var( --color-sidebar-text );
-	}
-
 	// client/blocks/upsell-nudge/style.scss
 	.upsell-nudge.banner.card.is-compact {
 		background-color: #fff;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes site badge color override

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/me/account and select `Blue` color scheme
* Go to http://calypso.localhost:3000/home?flags=nav-unification and select a site with a bade
* Check that the badge is legible

Before | After
-------|------
![](https://cln.sh/Ik90Rf+) | ![](https://cln.sh/YVSw8W+)

Fixes #47295
