### PR TITLE
Improve `chooseTerserEcmaVersion`

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `--esm` and `--cjs` options to `copy-assets` and `transpile` to do only one kind of
   the build (ESM or CJS) instead of both that are done by default
+- Add more target ECMAScript versions to Terser config and switch dependencies
 
 ## 6.4.0
 

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -36,6 +36,7 @@
 	"dependencies": {
 		"@automattic/mini-css-extract-plugin-with-rtl": "^0.8.0",
 		"@babel/cli": "^7.12.1",
+		"@babel/compat-data": "^7.12.5",
 		"@babel/core": "^7.12.3",
 		"@babel/helpers": "^7.12.5",
 		"@babel/plugin-proposal-class-properties": "^7.12.1",
@@ -53,7 +54,6 @@
 		"babel-loader": "^8.2.1",
 		"browserslist": "^4.8.2",
 		"cache-loader": "^4.1.0",
-		"caniuse-api": "^3.0.0",
 		"css-loader": "^3.4.2",
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",
 		"enzyme-adapter-react-16": "^1.15.1",
@@ -67,6 +67,7 @@
 		"postcss-loader": "^3.0.0",
 		"recursive-copy": "^2.0.10",
 		"sass-loader": "^8.0.0",
+		"semver": "^7.3.2",
 		"terser-webpack-plugin": "^4.2.2",
 		"thread-loader": "^2.1.3",
 		"typescript": "^4.0.3",

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -3,33 +3,100 @@
  */
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const browserslist = require( 'browserslist' );
-const caniuse = require( 'caniuse-api' );
+const babelPlugins = require( '@babel/compat-data/plugins' );
+const semver = require( 'semver' );
 
 const supportedBrowsers = browserslist( null, { env: process.env.BROWSERSLIST_ENV || 'defaults' } );
+
+// The list of browsers to check, that are supported by babel compat-data.
+// Babel compat-data also includes non-browser environments, which we want to exclude.
+const browsersToCheck = [ 'chrome', 'opera', 'edge', 'firefox', 'safari', 'ios', 'ie' ];
+
+// Check if a feature is supported by all browsers in the provided browserslist.
+function isFeatureSupported( feature, browsers ) {
+	const featureMinVersions = babelPlugins[ feature ];
+
+	for ( const featureBrowser of browsersToCheck ) {
+		let featureRange;
+
+		if ( ! featureMinVersions[ featureBrowser ] ) {
+			// No browser entry, which means no version of the browser supports the feature.
+			featureRange = `>=999999`;
+		} else {
+			featureRange = `>=${ featureMinVersions[ featureBrowser ] }`;
+		}
+
+		const listRanges = browsers.filter( ( b ) => b.startsWith( featureBrowser ) );
+
+		for ( let listRange of listRanges ) {
+			// Remove browser name from range.
+			listRange = listRange.split( ' ' )[ 1 ];
+			// Massage range syntax into something `semver` accepts.
+			listRange = listRange.replace( '-', ' - ' );
+
+			if ( ! semver.subset( listRange, featureRange ) ) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
 
 /**
  * Auxiliary method to help in picking an ECMAScript version based on a list
  * of supported browser versions.
+ *
+ * If Terser ever supports `browserslist`, this method will no longer be needed
+ * and the world will be a better place.
  *
  * @param {Array<string>} browsers The list of supported browsers.
  *
  * @returns {number} The maximum supported ECMAScript version.
  */
 function chooseTerserEcmaVersion( browsers ) {
-	if ( ! caniuse.isSupported( 'arrow-functions', browsers ) ) {
+	// Test for ES2015 features. If missing fall back to ES5.
+	if (
+		! isFeatureSupported( 'transform-arrow-functions', browsers ) ||
+		! isFeatureSupported( 'transform-classes', browsers )
+	) {
 		return 5;
 	}
-	if ( ! caniuse.isSupported( 'es6-class', browsers ) ) {
-		return 5;
-	}
-	if ( ! caniuse.isSupported( 'array-includes', browsers ) ) {
+
+	// Test for ES2016 features. If missing fall back to ES2015.
+	if ( ! isFeatureSupported( 'transform-exponentiation-operator', browsers ) ) {
 		return 2015;
 	}
-	if ( ! caniuse.isSupported( 'object-entries', browsers ) ) {
+
+	// Test for ES2017 features. If missing fall back to ES2016.
+	if ( ! isFeatureSupported( 'transform-async-to-generator', browsers ) ) {
 		return 2016;
 	}
 
-	return 2017;
+	// Test for ES2018 features. If missing fall back to ES2017.
+	if (
+		! isFeatureSupported( 'proposal-object-rest-spread', browsers ) ||
+		! isFeatureSupported( 'transform-named-capturing-groups-regex', browsers ) ||
+		! isFeatureSupported( 'proposal-unicode-property-regex', browsers )
+	) {
+		return 2017;
+	}
+
+	// Test for ES2019 features. If missing fall back to ES2018.
+	if ( ! isFeatureSupported( 'proposal-optional-catch-binding', browsers ) ) {
+		return 2018;
+	}
+
+	// Test for ES2020 features. If missing fall back to ES2019.
+	if (
+		! isFeatureSupported( 'proposal-optional-chaining', browsers ) ||
+		! isFeatureSupported( 'proposal-nullish-coalescing-operator', browsers )
+	) {
+		return 2019;
+	}
+
+	// Looks like everything we tested for is supported, so default to latest
+	// available ES spec that Terser can handle.
+	return 2020;
 }
 
 /**

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -21,7 +21,7 @@ function isFeatureSupported( feature, browsers ) {
 
 		if ( ! featureMinVersions[ featureBrowser ] ) {
 			// No browser entry, which means no version of the browser supports the feature.
-			featureRange = `>=999999`;
+			featureRange = '>=999999';
 		} else {
 			featureRange = `>=${ featureMinVersions[ featureBrowser ] }`;
 		}


### PR DESCRIPTION
`chooseTerserEcmaVersion` is currently used in `calypso-build` to provide Terser with the version of ES that it can expect to be available in the target browsers, for the target currently being built. This method is necessary because Terser, unlike all of our other build tools, does not support `browserslist` natively.

We were checking for this data with `caniuse-api`, and we now want to extend the check to support newer versions of ES. However, `caniuse-api` no longer seems to have all the data we need, so this PR instead switches to using `@babel/compat-data`, which is already part of the build process anyway.

It also adds the missing checks for all ES versions from 5 to 2020.

#### Changes proposed in this Pull Request

* Switch `chooseTerserEcmaVersion` to using Babel data instead of `caniuse-api` data
* Add checks for missing ES versions up to 2020

#### Testing instructions

* Ensure that there are no built-time errors introduced, particularly when building the `evergreen` target
* Ensure that the fallback build continues to work correctly in older browsers, such as IE 11
