### PR TITLE
Changes site loading bg color to be darker than pulse-light so the animation is visible

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -16,12 +16,13 @@
 
 		.site-icon {
 			animation: pulse-light 0.8s ease-in-out infinite;
+			background-color: var( --color-neutral-10 );
 		}
 
 		.site__title,
 		.site__domain {
 			animation: pulse-light 0.8s ease-in-out infinite;
-			background-color: var( --color-neutral-0 );
+			background-color: var( --color-neutral-10 );
 			color: transparent;
 			width: 95%;
 

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -15,13 +15,13 @@
 		pointer-events: none;
 
 		.site-icon {
-			animation: pulse-light 0.8s ease-in-out infinite;
+			animation: pulse-light 1.8s ease-in-out infinite;
 			background-color: var( --color-neutral-10 );
 		}
 
 		.site__title,
 		.site__domain {
-			animation: pulse-light 0.8s ease-in-out infinite;
+			animation: pulse-light 1.8s ease-in-out infinite;
 			background-color: var( --color-neutral-10 );
 			color: transparent;
 			width: 95%;

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -23,14 +23,6 @@
 	&.is-large .site-selector__sites {
 		border-top: 1px solid var( --color-neutral-10 );
 	}
-
-	.site.is-loading {
-		.site-icon,
-		.site__title,
-		.site__domain {
-			background-color: var( --color-neutral-0 );
-		}
-	}
 }
 
 // Styles for Site elements within the Selector
@@ -46,9 +38,7 @@
 		.site__domain {
 			color: var( --color-sidebar-menu-selected-text );
 			&::after {
-				@include long-content-fade(
-					$color: var( --color-sidebar-menu-selected-background-rgb )
-				);
+				@include long-content-fade( $color: var( --color-sidebar-menu-selected-background-rgb ) );
 			}
 		}
 
@@ -102,7 +92,8 @@
 	position: absolute;
 
 	// ensure sufficient selector specificity for .search.is-open, too
-	&, &.is-open {
+	&,
+	&.is-open {
 		width: auto;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
In an attempt to address static white (actually they were `--color-neutral-0 === --studio-gray-0`) placeholders for sites loading in the sidebar

![image](https://user-images.githubusercontent.com/12430020/100102057-c071e480-2e6b-11eb-8f99-012ca25945fa.png)

I initially tried to color them depending on the current color-scheme selected. There is where I found that there was an animation in place 

https://github.com/Automattic/wp-calypso/blob/e51ed0b0a3562b022639834b42b72be003773c40/client%2Fblocks%2Fsite%2Fstyle.scss#L23-L24

which due to the fact that animation `background-color` and the element `background-color` where the same there was no animation visible and it appeared as static grey boxes. 

In that attempt the results where the following (site-icon not changed in this demo)

either by using `--color-sidebar-menu-selected-background`

![SS 2020-11-24 at 15 48 22](https://user-images.githubusercontent.com/12430020/100102620-87863f80-2e6c-11eb-9197-43c884d6c472.gif)

or `--color-sidebar-background`

![SS 2020-11-24 at 15 49 31](https://user-images.githubusercontent.com/12430020/100102750-b4d2ed80-2e6c-11eb-9fa6-7c3e1ca33a9c.gif)

I then thought that they were too aggressive for placeholders. The placeholder is meant to indicate that something **will** load to that very specific place but they are not meant to catch your attention. So I did a quick exploration in [https://wordpress.com/read](https://wordpress.com/read) where I remembered some good placeholders. As you can see the placeholders are actually alternating variations of grey to give the effect that something is loading. In our current `site-selector` in production (either in the sidebar or in https://wordpress.com/home or wherever a `site` component exists) the placeholder appears as a grey static box with no indication that something is loading. You can try it yourself by entering `document.getElementsByClassName('site')[0].classList.add('is-loading')` in your Browser Console.

**Before**
Color Scheme with white bgcolor | Color Scheme with dark bgcolor
-------|------
![](https://cln.sh/8EeZsh+) | ![image](https://user-images.githubusercontent.com/12430020/100103674-e00a0c80-2e6d-11eb-8e3d-2c58641fc068.png)

Especially in the darker backgrounds it appears as something is off - broken. I took the liberty to make the animation visible

**After**
Color Scheme with white bgcolor | Color Scheme with dark bgcolor
-------|------
![SS 2020-11-24 at 16 00 46](https://user-images.githubusercontent.com/12430020/100103963-3c6d2c00-2e6e-11eb-93ea-cdb458f7ac2a.gif) | ![SS 2020-11-24 at 16 01 34](https://user-images.githubusercontent.com/12430020/100104041-59a1fa80-2e6e-11eb-9620-4a895668d833.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You may either use `document.getElementsByClassName('site')[0].classList.add('is-loading')` in the console so that the first site selected appears in a loading state OR clear the indexed DB so you get full loading experience.
* In the site selector, check that a site's loading state is visible whichever color-scheme is selected.

Fixes #47303
