### PR TITLE
Reset Secure Your Brand Experiment - with isFulfilledCallback

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -204,13 +204,12 @@ export default {
 		allowExistingUsers: true,
 	},
 	secureYourBrand: {
-		datestamp: '20201026',
+		datestamp: '20201124',
 		variations: {
-			test: 0,
-			control: 100,
+			test: 50,
+			control: 50,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: false,
-		countryCodeTargets: [ 'US' ],
 	},
 };

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -13,6 +13,7 @@ import {
 	omitBy,
 	pick,
 	startsWith,
+	has,
 } from 'lodash';
 import cookie from 'cookie';
 
@@ -859,14 +860,20 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 }
 
 export function isSecureYourBrandFulfilled( stepName, defaultDependencies, nextProps ) {
+	const hasDomain = has( nextProps, 'signupDependencies.domainItem' );
+	const hasPlan = has( nextProps, 'signupDependencies.cartItem' );
 	const { submitSignupStep } = nextProps;
 	const domainItem = get( nextProps, 'signupDependencies.domainItem', false );
 	const cartItem = get( nextProps, 'signupDependencies.cartItem', false );
 	const skipSecureYourBrand = get( nextProps, 'skipSecureYourBrand', false );
 	const isNotRegistration = domainItem && ! isDomainRegistration( domainItem );
-	const planDoesNotSupportUpsell = isPersonal( cartItem );
+	const planDoesNotSupportUpsell = ! cartItem || isPersonal( cartItem );
 	const cookies = cookie.parse( document.cookie );
 	const isUs = cookies?.country_code === 'US';
+
+	if ( ! hasDomain || ! hasPlan ) {
+		return;
+	}
 
 	if (
 		isNotRegistration ||

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -866,7 +866,7 @@ export function isSecureYourBrandFulfilled( stepName, defaultDependencies, nextP
 	const domainItem = get( nextProps, 'signupDependencies.domainItem', false );
 	const cartItem = get( nextProps, 'signupDependencies.cartItem', false );
 	const skipSecureYourBrand = get( nextProps, 'skipSecureYourBrand', false );
-	const isNotRegistration = domainItem && ! isDomainRegistration( domainItem );
+	const isNotRegistration = ! ( domainItem && isDomainRegistration( domainItem ) );
 	const planDoesNotSupportUpsell = ! cartItem || isPersonal( cartItem );
 	const cookies = cookie.parse( document.cookie );
 	const isUs = cookies?.country_code === 'US';

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -115,20 +115,13 @@ export function generateFlows( {
 		},
 
 		onboarding: {
-			steps: [ 'user', 'domains', 'plans' ],
+			steps: [ 'user', 'domains', 'plans', 'secure-your-brand' ],
 			destination: getSignupDestination,
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
-			lastModified: '2020-03-03',
+			lastModified: '2020-11-24',
 			showRecaptcha: true,
 		},
 
-		'onboarding-secure-your-brand': {
-			steps: [ 'user', 'domains', 'secure-your-brand', 'plans' ],
-			destination: getSignupDestination,
-			description: 'Onboarding flow with an additional step to upsell domains',
-			lastModified: '2020-10-08',
-			showRecaptcha: true,
-		},
 		'onboarding-registrationless': {
 			steps: [ 'domains', 'plans-new', 'user-new' ],
 			destination: getSignupDestination,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -36,6 +36,7 @@ export function generateSteps( {
 	isSiteTypeFulfilled = noop,
 	isSiteTopicFulfilled = noop,
 	maybeRemoveStepForUserlessCheckout = noop,
+	isSecureYourBrandFulfilled = noop,
 } = {} ) {
 	return {
 		survey: {
@@ -327,6 +328,7 @@ export function generateSteps( {
 			stepName: 'secure-your-brand',
 			dependencies: [ 'domainItem', 'siteSlug' ],
 			providesDependencies: [ 'domainUpsellItems' ],
+			fulfilledStepCallback: isSecureYourBrandFulfilled,
 		},
 
 		'domains-store': {

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -22,6 +22,7 @@ import {
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
 	maybeRemoveStepForUserlessCheckout,
+	isSecureYourBrandFulfilled,
 } from 'calypso/lib/signup/step-actions';
 import { abtest } from 'calypso/lib/abtest';
 import { generateSteps } from './steps-pure';
@@ -42,6 +43,7 @@ export default generateSteps( {
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
 	maybeRemoveStepForUserlessCheckout,
+	isSecureYourBrandFulfilled,
 } );
 
 export function isDomainStepSkippable( flowName ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defer, get, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -53,7 +52,7 @@ import { isDomainStepSkippable } from 'calypso/signup/config/steps';
 import { fetchUsernameSuggestion } from 'calypso/state/signup/optional-dependencies/actions';
 import { isSitePreviewVisible } from 'calypso/state/signup/preview/selectors';
 import { hideSitePreview, showSitePreview } from 'calypso/state/signup/preview/actions';
-import { abtest, getABTestVariation } from 'calypso/lib/abtest';
+import { getABTestVariation } from 'calypso/lib/abtest';
 import getSitesItems from 'calypso/state/selectors/get-sites-items';
 import { isPlanStepExistsAndSkipped } from 'calypso/state/signup/progress/selectors';
 import { getStepModuleName } from 'calypso/signup/config/step-components';
@@ -172,21 +171,6 @@ class DomainsStep extends React.Component {
 
 	isEligibleVariantForDomainTest() {
 		return this.showTestCopy;
-	}
-
-	getGeoLocationFromCookie() {
-		const cookies = cookie.parse( document.cookie );
-
-		return cookies.country_code;
-	}
-
-	isEligibleForSecureYourBrandTest( isPurchasingItem ) {
-		return (
-			includes( [ 'onboarding', 'onboarding-secure-your-brand' ], this.props.flowName ) &&
-			isPurchasingItem &&
-			! this.props.skipSecureYourBrand &&
-			'test' === abtest( 'secureYourBrand', this.getGeoLocationFromCookie() )
-		);
 	}
 
 	getMapDomainUrl = () => {
@@ -335,12 +319,7 @@ class DomainsStep extends React.Component {
 		);
 
 		this.props.setDesignType( this.getDesignType() );
-
-		if ( this.isEligibleForSecureYourBrandTest( isPurchasingItem ) ) {
-			this.props.goToNextStep( 'onboarding-secure-your-brand' );
-		} else {
-			this.props.goToNextStep();
-		}
+		this.props.goToNextStep();
 
 		// Start the username suggestion process.
 		siteUrl && this.props.fetchUsernameSuggestion( siteUrl.split( '.' )[ 0 ] );


### PR DESCRIPTION
This is a proposal to restart the Secure Your Brand experiment by moving the step to the main onboarding flow. We previously used a separate signup flow but moving the step to the end of the flow presented challenges for the signup framework - `this.props.flowName` used in too many places.

#47586 worked just fine until the user clicked back twice.
#47545 had some code that attempted to fix the issues with `this.props.flowName` but the code started growing too much

#### Changes proposed in this Pull Request

Restarts the Secure Your Brand test with some modification:
- The upsell step will come after plans
- It will not be triggered for Personal plan users

#### Testing instructions

1. Make sure your country code is `not US`, and the language is in the browser settings is English

**For `test` group in the secureYourBrand experiment**
2. Sign up with a free domain and site. It should work
3. Sign up with a paid domain and a Personal plan. It should work as before, no upsells
4. Sign up with a paid domain and a Premium plan. You should see the upsell
5. Experiment going back after selecting a Premium plan, switch to Personal. No upsell at the end of the flow. Also try to click back twice

**For the `control` group
6. Sign up with a paid domain and a Premium plan, no upsell should be visible

This is the upsell as step 4 of the flow:
<img width="599" alt="Screenshot 2020-11-20 at 11 31 16" src="https://user-images.githubusercontent.com/82778/99784102-f89fbd00-2b23-11eb-9c60-0d785c68c080.png">

Note that in order to check if the actual discount works, you'll need to either search for a non .com/.net/.org domain, or not use the Store Sandbox.