### PR TITLE
Nav unification: update Classic Blue color scheme to be compatible with Nav Unification

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-blue.scss
@@ -89,4 +89,9 @@
 	--color-sidebar-menu-hover-background: var( --color-surface );
 	--color-sidebar-menu-hover-background-rgb: var( --studio-white-rgb );
 	--color-sidebar-menu-hover-text: var( --studio-blue-50 );
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: var( --studio-blue-60 );
+	--color-sidebar-submenu-text: var( --studio-white );
+	--color-sidebar-submenu-hover-text: var( --studio-orange-30 );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update Classic Blue color scheme to be compatible with Nav Unification



While working on porting Classic Blue to wp-admin in Automattic/jetpack#17828, I noticed we will need a few more changes to the color scheme in Calypso to work with Nav Unification.

|Before|After|
|-|-|
|<img width="461" alt="Screenshot 2020-11-24 at 16 50 29" src="https://user-images.githubusercontent.com/1562646/100117537-329af700-2e75-11eb-8ace-8dade7b0f8f1.png">|<img width="446" alt="Screenshot 2020-11-24 at 16 50 03" src="https://user-images.githubusercontent.com/1562646/100117547-362e7e00-2e75-11eb-836b-8a617688248e.png">|

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Calypso live link below
* Navigate to /me/account and select the color scheme
* Add `?flags=nav-unification` to the URL
* Compare to `?flags=nav-unification` in production
