### PR TITLE
Plugins: Reduxify plugin activation and deactivation

### DIFF
--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -138,19 +138,19 @@ Update a plugin on a site.
 
 Toggle a plugin active state on a site.
 
-#### PluginsActions.togglePluginActivation( site, plugin );
+This action has been migrated to Redux. Please use to the `togglePluginActivation` Redux action.
 
 ---
 
 Activate a plugin on a site.
 
-#### PluginsActions.activatePlugin( site, plugin );
+This action has been migrated to Redux. Please use to the `activatePlugin` Redux action.
 
 ---
 
 Deactivate a plugin on a site.
 
-#### PluginsActions.deactivatePlugin( site, plugin );
+This action has been migrated to Redux. Please use to the `deactivatePlugin` Redux action.
 
 ---
 

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -15,6 +15,7 @@ import PluginsActions from 'calypso/lib/plugins/actions';
 import PluginsLog from 'calypso/lib/plugins/log-store';
 import PluginAction from 'calypso/my-sites/plugins/plugin-action/plugin-action';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { togglePluginActivation } from 'calypso/state/plugins/installed/actions';
 
 /**
  * Style dependencies
@@ -35,7 +36,7 @@ export class PluginActivateToggle extends Component {
 			return;
 		}
 
-		PluginsActions.togglePluginActivation( site, plugin );
+		this.props.togglePluginActivation( site.ID, plugin );
 		PluginsActions.removePluginsNotices( 'completed', 'error' );
 
 		if ( plugin.active ) {
@@ -148,4 +149,5 @@ PluginActivateToggle.defaultProps = {
 export default connect( null, {
 	recordGoogleEvent,
 	recordTracksEvent,
+	togglePluginActivation,
 } )( localize( PluginActivateToggle ) );

--- a/client/my-sites/plugins/plugin-activate-toggle/test/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/index.jsx
@@ -14,7 +14,6 @@ import { spy } from 'sinon';
  * Internal dependencies
  */
 import fixtures from './fixtures';
-import mockedActions from './mocks/actions';
 import { PluginActivateToggle } from 'calypso/my-sites/plugins/plugin-activate-toggle';
 
 jest.mock( 'my-sites/plugins/plugin-action/plugin-action', () =>
@@ -23,37 +22,37 @@ jest.mock( 'my-sites/plugins/plugin-action/plugin-action', () =>
 jest.mock( 'lib/plugins/actions', () => require( './mocks/actions' ) );
 
 describe( 'PluginActivateToggle', () => {
-	const analyticsMock = {
+	const mockedProps = {
 		recordGoogleEvent: spy(),
 		recordTracksEvent: spy(),
+		togglePluginActivation: spy(),
 		translate: spy(),
 	};
 
 	afterEach( () => {
-		mockedActions.togglePluginActivation.resetHistory();
-		analyticsMock.recordGoogleEvent.resetHistory();
+		mockedProps.recordGoogleEvent.resetHistory();
 	} );
 
 	test( 'should render the component', () => {
-		const wrapper = mount( <PluginActivateToggle { ...analyticsMock } { ...fixtures } /> );
+		const wrapper = mount( <PluginActivateToggle { ...mockedProps } { ...fixtures } /> );
 
 		expect( wrapper.find( '.plugin-action' ) ).to.have.lengthOf( 1 );
 	} );
 
 	test( 'should register an event when the subcomponent action is executed', () => {
-		const wrapper = mount( <PluginActivateToggle { ...analyticsMock } { ...fixtures } /> );
+		const wrapper = mount( <PluginActivateToggle { ...mockedProps } { ...fixtures } /> );
 
 		wrapper.simulate( 'click' );
 
-		expect( analyticsMock.recordGoogleEvent.called ).to.equal( true );
-		expect( analyticsMock.recordTracksEvent.called ).to.equal( true );
+		expect( mockedProps.recordGoogleEvent.called ).to.equal( true );
+		expect( mockedProps.recordTracksEvent.called ).to.equal( true );
 	} );
 
 	test( 'should call an action when the subcomponent action is executed', () => {
-		const wrapper = mount( <PluginActivateToggle { ...analyticsMock } { ...fixtures } /> );
+		const wrapper = mount( <PluginActivateToggle { ...mockedProps } { ...fixtures } /> );
 
 		wrapper.simulate( 'click' );
 
-		expect( mockedActions.togglePluginActivation.called ).to.equal( true );
+		expect( mockedProps.togglePluginActivation.called ).to.equal( true );
 	} );
 } );

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -1,11 +1,8 @@
 /**
- * External dependencies
- */
-import wpcom from 'calypso/lib/wp';
-
-/**
  * Internal dependencies
  */
+import Dispatcher from 'calypso/dispatcher';
+import wpcom from 'calypso/lib/wp';
 import {
 	PLUGINS_RECEIVE,
 	PLUGINS_REQUEST,
@@ -42,6 +39,9 @@ import {
 	INSTALL_PLUGIN,
 	REMOVE_PLUGIN,
 } from './constants';
+import { getSite } from 'calypso/state/sites/selectors';
+import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 import 'calypso/state/plugins/init';
 
@@ -58,7 +58,9 @@ const getPluginHandler = ( siteId, pluginId ) => {
 };
 
 export function activatePlugin( siteId, plugin ) {
-	return ( dispatch ) => {
+	return ( dispatch, getState ) => {
+		const state = getState();
+		const site = getSite( state, siteId );
 		const pluginId = plugin.id;
 		const defaultAction = {
 			action: ACTIVATE_PLUGIN,
@@ -67,8 +69,57 @@ export function activatePlugin( siteId, plugin ) {
 		};
 		dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST } );
 
+		// TODO: Remove when this flux action is completely reduxified
+		Dispatcher.handleViewAction( {
+			type: 'ACTIVATE_PLUGIN',
+			action: 'ACTIVATE_PLUGIN',
+			site,
+			plugin,
+		} );
+
+		const afterActivationCallback = ( data, error ) => {
+			// TODO: Remove when this flux action is completely reduxified
+			Dispatcher.handleServerAction( {
+				type: 'RECEIVE_ACTIVATED_PLUGIN',
+				action: 'ACTIVATE_PLUGIN',
+				site,
+				plugin,
+				data,
+				error,
+			} );
+
+			// Sometime data can be empty or the plugin always
+			// return the active state even when the error is empty.
+			// Activation error is ok, because it means the plugin is already active
+			if (
+				( error && error.error !== 'activation_error' ) ||
+				( ! ( data && data.active ) && ! error )
+			) {
+				dispatch( bumpStat( 'calypso_plugin_activated', 'failed' ) );
+				dispatch(
+					recordTracksEvent( 'calypso_plugin_activated_error', {
+						error: error && error.error ? error.error : 'Undefined activation error',
+						site: siteId,
+						plugin: plugin.slug,
+					} )
+				);
+
+				return;
+			}
+
+			dispatch( bumpStat( 'calypso_plugin_activated', 'succeeded' ) );
+			dispatch(
+				recordTracksEvent( 'calypso_plugin_activated_success', {
+					site: siteId,
+					plugin: plugin.slug,
+				} )
+			);
+		};
+
 		const successCallback = ( data ) => {
 			dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST_SUCCESS, data } );
+
+			afterActivationCallback( data, undefined );
 		};
 
 		const errorCallback = ( error ) => {
@@ -77,6 +128,8 @@ export function activatePlugin( siteId, plugin ) {
 				successCallback( plugin );
 			}
 			dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST_FAILURE, error } );
+
+			afterActivationCallback( undefined, error );
 		};
 
 		return getPluginHandler( siteId, pluginId )
@@ -87,7 +140,9 @@ export function activatePlugin( siteId, plugin ) {
 }
 
 export function deactivatePlugin( siteId, plugin ) {
-	return ( dispatch ) => {
+	return ( dispatch, getState ) => {
+		const state = getState();
+		const site = getSite( state, siteId );
 		const pluginId = plugin.id;
 		const defaultAction = {
 			action: DEACTIVATE_PLUGIN,
@@ -96,8 +151,52 @@ export function deactivatePlugin( siteId, plugin ) {
 		};
 		dispatch( { ...defaultAction, type: PLUGIN_DEACTIVATE_REQUEST } );
 
+		// TODO: Remove when this flux action is completely reduxified
+		Dispatcher.handleViewAction( {
+			type: 'DEACTIVATE_PLUGIN',
+			action: 'DEACTIVATE_PLUGIN',
+			site,
+			plugin,
+		} );
+
+		const afterDeactivationCallback = ( data, error ) => {
+			// TODO: Remove when this flux action is completely reduxified
+			Dispatcher.handleServerAction( {
+				type: 'RECEIVE_DEACTIVATED_PLUGIN',
+				action: 'DEACTIVATE_PLUGIN',
+				site,
+				plugin,
+				data,
+				error,
+			} );
+
+			// Sometime data can be empty or the plugin always
+			// return the active state even when the error is empty.
+			// Activation error is ok, because it means the plugin is already active
+			if ( error && error.error !== 'deactivation_error' ) {
+				dispatch( bumpStat( 'calypso_plugin_deactivated', 'failed' ) );
+				dispatch(
+					recordTracksEvent( 'calypso_plugin_deactivated_error', {
+						error: error.error ? error.error : 'Undefined deactivation error',
+						site: siteId,
+						plugin: plugin.slug,
+					} )
+				);
+
+				return;
+			}
+			dispatch( bumpStat( 'calypso_plugin_deactivated', 'succeeded' ) );
+			dispatch(
+				recordTracksEvent( 'calypso_plugin_deactivated_success', {
+					site: siteId,
+					plugin: plugin.slug,
+				} )
+			);
+		};
+
 		const successCallback = ( data ) => {
 			dispatch( { ...defaultAction, type: PLUGIN_DEACTIVATE_REQUEST_SUCCESS, data } );
+			afterDeactivationCallback( data, undefined );
 		};
 
 		const errorCallback = ( error ) => {
@@ -106,12 +205,27 @@ export function deactivatePlugin( siteId, plugin ) {
 				successCallback( plugin );
 			}
 			dispatch( { ...defaultAction, type: PLUGIN_DEACTIVATE_REQUEST_FAILURE, error } );
+			afterDeactivationCallback( undefined, error );
 		};
 
 		return getPluginHandler( siteId, pluginId )
 			.deactivate()
 			.then( successCallback )
 			.catch( errorCallback );
+	};
+}
+
+export function togglePluginActivation( siteId, plugin ) {
+	return ( dispatch, getState ) => {
+		if ( ! canCurrentUser( getState(), siteId, 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! plugin.active ) {
+			dispatch( activatePlugin( siteId, plugin ) );
+		} else {
+			dispatch( deactivatePlugin( siteId, plugin ) );
+		}
 	};
 }
 

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -77,7 +77,7 @@ export function activatePlugin( siteId, plugin ) {
 			plugin,
 		} );
 
-		const afterActivationCallback = ( data, error ) => {
+		const afterActivationCallback = ( error, data ) => {
 			// TODO: Remove when this flux action is completely reduxified
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_ACTIVATED_PLUGIN',
@@ -119,7 +119,7 @@ export function activatePlugin( siteId, plugin ) {
 		const successCallback = ( data ) => {
 			dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST_SUCCESS, data } );
 
-			afterActivationCallback( data, undefined );
+			afterActivationCallback( undefined, data );
 		};
 
 		const errorCallback = ( error ) => {
@@ -129,7 +129,7 @@ export function activatePlugin( siteId, plugin ) {
 			}
 			dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST_FAILURE, error } );
 
-			afterActivationCallback( undefined, error );
+			afterActivationCallback( error, undefined );
 		};
 
 		return getPluginHandler( siteId, pluginId )
@@ -159,7 +159,7 @@ export function deactivatePlugin( siteId, plugin ) {
 			plugin,
 		} );
 
-		const afterDeactivationCallback = ( data, error ) => {
+		const afterDeactivationCallback = ( error, data ) => {
 			// TODO: Remove when this flux action is completely reduxified
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_DEACTIVATED_PLUGIN',
@@ -196,7 +196,7 @@ export function deactivatePlugin( siteId, plugin ) {
 
 		const successCallback = ( data ) => {
 			dispatch( { ...defaultAction, type: PLUGIN_DEACTIVATE_REQUEST_SUCCESS, data } );
-			afterDeactivationCallback( data, undefined );
+			afterDeactivationCallback( undefined, data );
 		};
 
 		const errorCallback = ( error ) => {
@@ -205,7 +205,7 @@ export function deactivatePlugin( siteId, plugin ) {
 				successCallback( plugin );
 			}
 			dispatch( { ...defaultAction, type: PLUGIN_DEACTIVATE_REQUEST_FAILURE, error } );
-			afterDeactivationCallback( undefined, error );
+			afterDeactivationCallback( error, undefined );
 		};
 
 		return getPluginHandler( siteId, pluginId )

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -69,7 +69,7 @@ export function activatePlugin( siteId, plugin ) {
 		};
 		dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST } );
 
-		// TODO: Remove when this flux action is completely reduxified
+		// @TODO: Remove when this flux action is completely reduxified
 		Dispatcher.handleViewAction( {
 			type: 'ACTIVATE_PLUGIN',
 			action: 'ACTIVATE_PLUGIN',
@@ -78,7 +78,7 @@ export function activatePlugin( siteId, plugin ) {
 		} );
 
 		const afterActivationCallback = ( error, data ) => {
-			// TODO: Remove when this flux action is completely reduxified
+			// @TODO: Remove when this flux action is completely reduxified
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_ACTIVATED_PLUGIN',
 				action: 'ACTIVATE_PLUGIN',
@@ -151,7 +151,7 @@ export function deactivatePlugin( siteId, plugin ) {
 		};
 		dispatch( { ...defaultAction, type: PLUGIN_DEACTIVATE_REQUEST } );
 
-		// TODO: Remove when this flux action is completely reduxified
+		// @TODO: Remove when this flux action is completely reduxified
 		Dispatcher.handleViewAction( {
 			type: 'DEACTIVATE_PLUGIN',
 			action: 'DEACTIVATE_PLUGIN',
@@ -160,7 +160,7 @@ export function deactivatePlugin( siteId, plugin ) {
 		} );
 
 		const afterDeactivationCallback = ( error, data ) => {
-			// TODO: Remove when this flux action is completely reduxified
+			// @TODO: Remove when this flux action is completely reduxified
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_DEACTIVATED_PLUGIN',
 				action: 'DEACTIVATE_PLUGIN',

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -64,6 +64,23 @@ describe( 'actions', () => {
 		sandbox.stub( console, 'error' );
 	} );
 
+	const getState = () => ( {
+		currentUser: {
+			capabilities: {
+				2916284: {
+					manage_options: true,
+				},
+			},
+		},
+		sites: {
+			items: {
+				2916284: {
+					ID: 2916284,
+				},
+			},
+		},
+	} );
+
 	describe( '#fetchPlugins()', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
@@ -151,7 +168,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch request action when triggered', () => {
-			activatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet' } )( spy );
+			activatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet' } )( spy, getState );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: PLUGIN_ACTIVATE_REQUEST,
@@ -162,7 +179,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch plugin activate request success action when request completes', () => {
-			const response = activatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet' } )( spy );
+			const response = activatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet' } )(
+				spy,
+				getState
+			);
 			return response.then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PLUGIN_ACTIVATE_REQUEST_SUCCESS,
@@ -175,7 +195,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch fail action when request fails', () => {
-			const response = activatePlugin( 2916284, { slug: 'fake', id: 'fake/fake' } )( spy );
+			const response = activatePlugin( 2916284, { slug: 'fake', id: 'fake/fake' } )(
+				spy,
+				getState
+			);
 			return response.then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PLUGIN_ACTIVATE_REQUEST_FAILURE,
@@ -202,7 +225,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch request action when triggered', () => {
-			deactivatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet' } )( spy );
+			deactivatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet' } )( spy, getState );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: PLUGIN_DEACTIVATE_REQUEST,
@@ -214,7 +237,8 @@ describe( 'actions', () => {
 
 		test( 'should dispatch plugin deactivate request success action when request completes', () => {
 			const response = deactivatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet' } )(
-				spy
+				spy,
+				getState
 			);
 			return response.then( () => {
 				expect( spy ).to.have.been.calledWith( {
@@ -228,7 +252,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch fail action when request fails', () => {
-			const response = deactivatePlugin( 2916284, { slug: 'fake', id: 'fake/fake' } )( spy );
+			const response = deactivatePlugin( 2916284, { slug: 'fake', id: 'fake/fake' } )(
+				spy,
+				getState
+			);
 			return response.then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PLUGIN_DEACTIVATE_REQUEST_FAILURE,


### PR DESCRIPTION
We have several plugins stores, and they're pretty tightly coupled with a lot of functionality. They're also some of the most complex flux stores that remain. In #24180 we're working on reduxifying them step by step. This incremental approach is required because migration in a single PR is not a feasible task.

This PR reduxifies plugin activation and deactivation actions. In order to keep the store and only reduxify the flux actions, it updates the redux action creators to also dispatch the corresponding flux actions and updates all the component flux action usage with redux.

As a next step, we can start reduxifying the corresponding flux store functionality for activation and deactivation.

This is part of #24180.

#### Changes proposed in this Pull Request

* State: Trigger plugin `(de)?activation` flux actions from Redux.
* Plugins: Use Redux `(de)?activation` actions instead of flux.
* Plugins: Delete obsolete `(de)?activation` flux actions.

#### Testing instructions

* Verify activation and deactivation of plugins still works everywhere - test with a Jetpack site:
  * `/plugins/:plugin/:site`
  * `/plugins/:plugin`
  * `/plugins`
  * `/plugins/manage/:site` - for a single plugin
  * `/plugins/manage/:site` - for multiple selected plugins (bulk `(de)?activation` is enabled by clicking the "Edit All" button)
* Verify all tests still pass.
