### PR TITLE
Pricing page i5: Fix FoldableFAQ component tracking

### DIFF
--- a/client/components/foldable-faq/README.md
+++ b/client/components/foldable-faq/README.md
@@ -23,12 +23,13 @@ export default function FoldableFAQExample() {
 
 ## Props
 
-| Name         | Type         | Default       | Description                                               |
-| ------------ | ------------ | ------------- | --------------------------------------------------------- |
-| `id`\*       | `string`     | ''            | Unique id for the FAQ. Used for accessibility purposes.   |
-| `className`  | `string`     | ''            | Custom class added to the root element of the component   |
-| `question`\* | `React.Node` | none          | The question appearing above the answer                   |
-| `children`\* | `React.Node` | none          | The answer                                                |
-| `icon`       | `string`     | chevron-right | Gridicon string                                           |
-| `iconSize`   | `number`     | 24            | Size of the icon                                          |
-| `expanded`   | `boolean`    | false         | Whether or not the the answer starts off expanded/showing |
+| Name         | Type         | Default       | Description                                                      |
+| ------------ | ------------ | ------------- | ---------------------------------------------------------------- |
+| `id`\*       | `string`     | ''            | Unique id for the FAQ. Used for accessibility purposes.          |
+| `className`  | `string`     | ''            | Custom class added to the root element of the component          |
+| `question`\* | `React.Node` | none          | The question appearing above the answer                          |
+| `children`\* | `React.Node` | none          | The answer                                                       |
+| `icon`       | `string`     | chevron-right | Gridicon string                                                  |
+| `iconSize`   | `number`     | 24            | Size of the icon                                                 |
+| `expanded`   | `boolean`    | false         | Whether or not the the answer starts off expanded/showing answer |
+| `onToggle`   | `function`   | none          | A callback function that fires every time the FAQ is toggled     |

--- a/client/components/foldable-faq/index.tsx
+++ b/client/components/foldable-faq/index.tsx
@@ -63,7 +63,7 @@ const FoldableFAQ: React.FC< FAQProps > = ( {
 			height: targetHeight,
 		};
 		onToggle && onToggle( callbackArgs );
-	}, [ isExpanded, onToggle ] );
+	}, [ id, isExpanded, onToggle ] );
 
 	return (
 		<div className={ classNames( 'foldable-faq', className, { 'is-expanded': isExpanded } ) }>

--- a/client/components/foldable-faq/index.tsx
+++ b/client/components/foldable-faq/index.tsx
@@ -63,7 +63,7 @@ const FoldableFAQ: React.FC< FAQProps > = ( {
 			height: targetHeight,
 		};
 		onToggle && onToggle( callbackArgs );
-	}, [ isExpanded ] );
+	}, [ isExpanded, onToggle ] );
 
 	return (
 		<div className={ classNames( 'foldable-faq', className, { 'is-expanded': isExpanded } ) }>

--- a/client/components/foldable-faq/index.tsx
+++ b/client/components/foldable-faq/index.tsx
@@ -8,7 +8,6 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Gridicon from 'calypso/components/gridicon';
-import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 
 /**
  * Style dependencies
@@ -23,6 +22,7 @@ interface FAQProps {
 	icon?: string;
 	iconSize?: number;
 	expanded?: boolean;
+	onToggle?: ( callbackArgs: { id: string; isExpanded: boolean; height: number } ) => void;
 }
 
 const ICON_SIZE = 24;
@@ -35,29 +35,35 @@ const FoldableFAQ: React.FC< FAQProps > = ( {
 	icon = 'chevron-right',
 	iconSize = ICON_SIZE,
 	expanded = false,
+	onToggle,
 } ) => {
+	const firstRender = useRef< boolean >( true );
 	const answerRef = useRef< HTMLDivElement | null >( null );
 
 	const [ isExpanded, setIsExpanded ] = useState( expanded );
 	const [ height, setHeight ] = useState( 0 );
-
-	const trackProps = { faq_id: id };
-	const trackOpenFaq = useTrackCallback( undefined, 'calypso_plans_faq_open', trackProps );
-	const trackCloseFaq = useTrackCallback( undefined, 'calypso_plans_faq_closed', trackProps );
 
 	const toggleAnswer = useCallback( () => {
 		setIsExpanded( ( isExpanded ) => ! isExpanded );
 	}, [ setIsExpanded ] );
 
 	useLayoutEffect( () => {
-		if ( isExpanded ) {
-			setHeight( answerRef?.current?.scrollHeight || 250 );
-			trackOpenFaq();
-		} else {
-			setHeight( 0 );
-			trackCloseFaq();
+		const targetHeight = isExpanded ? answerRef?.current?.scrollHeight ?? 250 : 0;
+		setHeight( targetHeight );
+
+		// Run onToggle callback only when isExpanded changes, not on first render(mount).
+		if ( firstRender.current ) {
+			firstRender.current = false;
+			return;
 		}
-	}, [ isExpanded, trackCloseFaq, trackOpenFaq ] );
+
+		const callbackArgs = {
+			id,
+			isExpanded,
+			height: targetHeight,
+		};
+		onToggle && onToggle( callbackArgs );
+	}, [ isExpanded ] );
 
 	return (
 		<div className={ classNames( 'foldable-faq', className, { 'is-expanded': isExpanded } ) }>

--- a/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
+++ b/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
@@ -38,7 +38,7 @@ const JetpackFAQi5: React.FC = () => {
 				dispatch( recordTracksEvent( 'calypso_plans_faq_closed', tracksArgs ) );
 			}
 		},
-		[ dispatch ]
+		[ siteId, dispatch ]
 	);
 
 	return (

--- a/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
+++ b/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
@@ -23,20 +23,23 @@ const JetpackFAQi5: React.FC = () => {
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
 
-	const onFaqToggle = ( faqArgs: { id: string; isExpanded: boolean; height: number } ) => {
-		const { id, isExpanded } = faqArgs;
-		const tracksArgs = {
-			site_id: siteId,
-			faq_id: id,
-		};
-		if ( isExpanded ) {
-			// FAQ opened
-			dispatch( recordTracksEvent( 'calypso_plans_faq_open', tracksArgs ) );
-		} else {
-			// FAQ closed
-			dispatch( recordTracksEvent( 'calypso_plans_faq_closed', tracksArgs ) );
-		}
-	};
+	const onFaqToggle = useCallback(
+		( faqArgs: { id: string; isExpanded: boolean; height: number } ) => {
+			const { id, isExpanded } = faqArgs;
+			const tracksArgs = {
+				site_id: siteId,
+				faq_id: id,
+			};
+			if ( isExpanded ) {
+				// FAQ opened
+				dispatch( recordTracksEvent( 'calypso_plans_faq_open', tracksArgs ) );
+			} else {
+				// FAQ closed
+				dispatch( recordTracksEvent( 'calypso_plans_faq_closed', tracksArgs ) );
+			}
+		},
+		[ dispatch ]
+	);
 
 	return (
 		<>

--- a/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
+++ b/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -9,6 +10,8 @@ import { useTranslate } from 'i18n-calypso';
  */
 import FoldableFAQ from 'calypso/components/foldable-faq';
 import { getHelpLink } from '../jetpack-faq';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies
@@ -17,13 +20,34 @@ import './style.scss';
 
 const JetpackFAQi5: React.FC = () => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
+
+	const onFaqToggle = ( faqArgs: { id: string; isExpanded: boolean; height: number } ) => {
+		const { id, isExpanded } = faqArgs;
+		const tracksArgs = {
+			site_id: siteId,
+			faq_id: id,
+		};
+		if ( isExpanded ) {
+			// FAQ opened
+			dispatch( recordTracksEvent( 'calypso_plans_faq_open', tracksArgs ) );
+		} else {
+			// FAQ closed
+			dispatch( recordTracksEvent( 'calypso_plans_faq_closed', tracksArgs ) );
+		}
+	};
 
 	return (
 		<>
 			<section className="jetpack-faq-i5">
 				<h2 className="jetpack-faq-i5__heading">Frequently Asked Questions</h2>
 
-				<FoldableFAQ id="faq-1" question={ translate( 'What is the cancellation policy?' ) }>
+				<FoldableFAQ
+					id="faq-1"
+					question={ translate( 'What is the cancellation policy?' ) }
+					onToggle={ onFaqToggle }
+				>
 					{ translate(
 						'We want to make sure Jetpack is exactly what you need, so you can request a cancellation' +
 							' within 30 days of purchase and receive a full refund. If there’s something you’d like' +
@@ -34,7 +58,11 @@ const JetpackFAQi5: React.FC = () => {
 					) }
 				</FoldableFAQ>
 
-				<FoldableFAQ id="faq-2" question={ translate( 'Why do I need a WordPress.com account?' ) }>
+				<FoldableFAQ
+					id="faq-2"
+					question={ translate( 'Why do I need a WordPress.com account?' ) }
+					onToggle={ onFaqToggle }
+				>
 					{ translate(
 						"Many of Jetpack's core features make use of the WordPress.com cloud. In order to make sure everything" +
 							" works correctly, Jetpack requires you to connect a free WordPress.com account. If you don't already" +
@@ -42,7 +70,11 @@ const JetpackFAQi5: React.FC = () => {
 					) }
 				</FoldableFAQ>
 
-				<FoldableFAQ id="faq-3" question={ translate( 'What are the hosting requirements?' ) }>
+				<FoldableFAQ
+					id="faq-3"
+					question={ translate( 'What are the hosting requirements?' ) }
+					onToggle={ onFaqToggle }
+				>
 					{ translate(
 						'You should be running the latest version of WordPress and a publicly-accessible site with XML-RPC enabled.'
 					) }
@@ -51,6 +83,7 @@ const JetpackFAQi5: React.FC = () => {
 				<FoldableFAQ
 					id="faq-4"
 					question={ translate( 'Does this work with a multisite network?' ) }
+					onToggle={ onFaqToggle }
 				>
 					{ translate(
 						'Jetpack’s free features are compatible with WordPress Multisite networks. Paid features' +
@@ -59,7 +92,11 @@ const JetpackFAQi5: React.FC = () => {
 					) }
 				</FoldableFAQ>
 
-				<FoldableFAQ id="faq-5" question={ translate( 'Have more questions?' ) }>
+				<FoldableFAQ
+					id="faq-5"
+					question={ translate( 'Have more questions?' ) }
+					onToggle={ onFaqToggle }
+				>
 					{ translate(
 						'No problem! Feel free to {{helpLink}}get in touch{{/helpLink}} with our Happiness Engineers.',
 						{


### PR DESCRIPTION
### Changes proposed in this Pull Request

The FoldableFAQ component was firing the `calypso_plans_faq_closed` Tracks event on "mount", meaning 5 `calypso_plans_faq_closed` events were firing immediately on every render of the i5 pricing page. The `calypso_plans_faq_closed` Tracks event should only fire when a FoldableFAQ component is manually "closed"(collapsed).
This PR fixes this issue.

Implementation notes:
Prior to this PR, the the Tracks tracking was being implemented inside the FoldableFAQ component which is a major flaw because it limits the components re-usablilty (it's my fault, I implemented the tracking last week while in a hurry & not thinking). In this PR, I moved the Tracks tracking out of the FoldableFAQ component and into a 'onToggle' callback function prop that I added to the FoldableFAQ component.

### Testing instructions

First to view the issue:
1. Visit the Plans page in staging, ( `wordpress.com/plans/:site` )
2. Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
3. Open the console (Opt + Cmd + J), and enter `localStorage.setItem( 'debug', 'calypso:analytics' );`
4. Reload the page you'll see that the `calypso_plans_faq_closed` Tracks event is being fired for all 5 FAQ's on mount.

Verify issue is fixed:
1. checkout this PR or visit the Calypso live link.
2. Run Calypso or Jetpack cloud
3. Make sure you selected variant `i5` of a/b test `jetpackConversionRateOptimization`
4. Visit the pricing page
5. Open the console (Opt + Cmd + J), and enter `localStorage.setItem( 'debug', 'calypso:analytics' );`
6. Reload the pricing page and verify that the FAQ Tracks events (`calypso_plans_faq_open` & `calypso_plans_faq_closed`) only fire when the FAQ is manually opened and closed.

### Before

![Markup 2020-11-24 at 09 32 40](https://user-images.githubusercontent.com/11078128/100130834-204e9800-2e38-11eb-9554-9f40ff163e56.png)

### After

![Markup 2020-11-24 at 09 41 49](https://user-images.githubusercontent.com/11078128/100131793-5c362d00-2e39-11eb-9b97-474eb209d481.png)

