### PR TITLE
Billing: Show loading indicator when removing subscription

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -14,6 +14,7 @@ import { getCurrencyDefaults } from '@automattic/format-currency';
 import config from 'calypso/config';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
 import { Dialog, Button } from '@automattic/components';
+import SpinnerButton from 'calypso/components/spinner-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -697,13 +698,16 @@ class CancelPurchaseForm extends React.Component {
 			onClick: this.downgradeClick,
 			isPrimary: true,
 		};
-		const remove = {
-			action: 'remove',
-			disabled,
-			label: translate( 'Remove Now' ),
-			onClick: this.onSubmit,
-			isPrimary: true,
-		};
+		const remove = (
+			<SpinnerButton
+				action="remove"
+				text="Remove Now"
+				loading={ this.props.disableButtons }
+				loadingText="Removing..."
+				onClick={ this.onSubmit }
+				isPrimary={ true }
+			/>
+		);
 
 		const firstButtons =
 			config.isEnabled( 'upgrades/precancellation-chat' ) && surveyStep !== 'happychat_step'

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -14,7 +14,6 @@ import { getCurrencyDefaults } from '@automattic/format-currency';
 import config from 'calypso/config';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
 import { Dialog, Button } from '@automattic/components';
-import SpinnerButton from 'calypso/components/spinner-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -699,14 +698,15 @@ class CancelPurchaseForm extends React.Component {
 			isPrimary: true,
 		};
 		const remove = (
-			<SpinnerButton
-				action="remove"
-				text="Remove Now"
-				loading={ this.props.disableButtons }
-				loadingText="Removing..."
+			<Button
+				disabled={ this.props.disableButtons }
+				busy={ this.props.disableButtons }
 				onClick={ this.onSubmit }
-				isPrimary={ true }
-			/>
+				primary
+				data-e2e-button="remove"
+			>
+				{ this.props.disableButtons ? 'Removing' : 'Remove It' }
+			</Button>
 		);
 
 		const firstButtons =

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -14,3 +14,7 @@
 	}
 }
 
+.dialog__action-buttons {
+	display: flex;
+	justify-content: flex-end;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

When removing/cancelling a plan or product, the endpoint for that can be really slow- sometimes seeing ~30s. Also noted in issue: https://github.com/Automattic/wp-calypso/issues/44950 . 

Although speeding up the endpoint would be the ultimate solution, changing the button to use the SpinnerButton UI  in the meantime would be a good enhancement to make users see that the process is working, instead of thinking something is broken or frozen.  This PR adds the SpinnerButton to the plan/product removal dialog.

Fixes: 1164141197617539-as-1189977108409575

### Testing instructions

- Checkout and run this PR 
- Select a site with a purchased Plan or Product. (Or purchase a plan or product subscription on a JN site)
- Go to Plans --> Billing 
- Select the plan or product subscription --> Scroll to bottom and select "Remove [plan/product name]" button.
- Complete the survey steps (if presented) and click the red "Remove It" button.  Verify you see a SpinnerButton indicator while the product is being removed (See before and after gif's below).

### Before
![chrome-capture (13)](https://user-images.githubusercontent.com/11078128/100160222-00cd6480-2e64-11eb-9204-5c5ab880672f.gif)

### After
![chrome-capture (12)](https://user-images.githubusercontent.com/11078128/100160256-117dda80-2e64-11eb-848c-6b2bc11d117d.gif)

