### PR TITLE
Add basic GB upgrade (regression) tests for the Premium Content block

### DIFF
--- a/test/e2e/lib/gutenberg/blocks/index.js
+++ b/test/e2e/lib/gutenberg/blocks/index.js
@@ -16,3 +16,4 @@ export { default as EmbedsBlockComponent } from './embeds-block-component';
 export { default as GutenbergBlockComponent } from './gutenberg-block-component';
 export { default as MarkdownBlockComponent } from './markdown-block-component';
 export { default as SimplePaymentBlockComponent } from './payment-block-component';
+export { PremiumContentBlockComponent } from './premium-content-block-component';

--- a/test/e2e/lib/gutenberg/blocks/premium-content-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/premium-content-block-component.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import GutenbergBlockComponent from './gutenberg-block-component';
+
+class PremiumContentBlockComponent extends GutenbergBlockComponent {
+	static blockTitle = 'Premium Content';
+	static blockName = 'premium-content/container';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-premium-content-container' );
+}
+
+export { PremiumContentBlockComponent };

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -374,6 +374,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			case 'Star Rating':
 				blockSettings = { prefix: 'jetpack-', blockClass: 'rating-star' };
 				break;
+			case 'Premium Content':
+				blockClass = 'premium-content-container';
+				break;
 		}
 
 		return { ...defaultSettings, ...blockSettings };

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -375,7 +375,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				blockSettings = { prefix: 'jetpack-', blockClass: 'rating-star' };
 				break;
 			case 'Premium Content':
-				blockClass = 'premium-content-container';
+				blockSettings = { blockClass: 'premium-content-container' };
 				break;
 		}
 

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -42,6 +42,7 @@ import {
 	SubscriptionsBlockComponent,
 	TiledGalleryBlockComponent,
 	YoutubeBlockComponent,
+	PremiumContentBlockComponent,
 } from '../lib/gutenberg/blocks';
 
 let driver;
@@ -300,6 +301,7 @@ describe( `[${ host }] Test Gutenberg upgrade from non-edge to edge across most 
 		SubscriptionsBlockComponent,
 		TiledGalleryBlockComponent,
 		YoutubeBlockComponent,
+		PremiumContentBlockComponent,
 	].forEach( ( blockClass ) => {
 		themedSites.forEach( ( siteName ) => {
 			describe( `Test the ${ blockClass.blockName } block on ${ siteName } @parallel`, function () {


### PR DESCRIPTION
### Changes proposed in this Pull Request

#### Add basic GB upgrade tests for the Premium Content block:

- Make sure it doesn't error in the editor and that it renders in the frontend;
- Make sure it works well after upgrade to GB edge (this is done automatically as part of the upgrade test).

This aims at preventing the regression of issues like https://github.com/Automattic/wp-calypso/pull/47467 in the future.

### Testing instructions

* High-level: Make sure the `[Status] Needs e2e Testing Gutenberg Edge` label is applied to this PR. If you want to restart tests, remove and apply it again. All Github checks in the PR should be green 🟢 
* Specific: All tests in https://github.com/Automattic/wp-calypso/blob/add/gb-upgrade-test-for-premium-block/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js should pass 🟢 

### Observations

**This branches off** [this PR](https://github.com/Automattic/wp-calypso/pull/47533) (since it hasn't been merged yet). The specific GB 9.4.1 fixes there are needed because we are currently running 9.4.1 on edge sites. **Upgrade tests need to run on edge sites too**. 

#### Stripe connection

This required me to setup a Stripe connection for the Premium Content block for all the sites under the `gutenbergUpgradeUser` (see your `local-decrypted.json`) WPCOM account. Stripe test account info was kindly handed to me by @apeatling. 

Closes: https://github.com/Automattic/wp-calypso/issues/47552

