### PR TITLE
Pages: hide count for non-posts on Jetpack sites

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -97,7 +97,7 @@ export class PostTypeFilter extends Component {
 				return memo.concat( {
 					key: `filter-${ status }`,
 					// Hide count in all sites mode; and in Jetpack mode for non-posts
-					count: ! siteId || ( jetpack && ! isPostOrPage ) ? null : count,
+					count: ! siteId || ( jetpack && query.type !== 'post' ) ? null : count,
 					path: compact( [
 						basePath,
 						isPostOrPage && query.author && 'my',


### PR DESCRIPTION
This hides the count in the post type filter for non-post views on Jetpack sites. It essentially returns to the behavior before #47443 was merged ([specific change](https://github.com/Automattic/wp-calypso/commit/c08e8cf00d50db34b10d8b323405cbf3a998f29d#diff-94d82a06e0c39348d9a805f1c072818378d6c4023c3d22a10e43408f253420c6L91)) and serves as a quick fix since I'm not sure why they were originally hidden.

Fixes #47706 

**To test:**
- on a simple site, visit Site > Pages
- verify that an accurate count is shown beside each item in the filter nav
- on a jetpack (or Atomic) site, visit Site > Pages
- verify that no count is shown