### PR TITLE
Nav unification: update Classic Bright color scheme to be compatible with Nav Unification

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -336,4 +336,10 @@
 	--theme-highlight-color: #0073aa; /* Direct from wp-admin */
 	--theme-highlight-color-rgb: 0, 115, 170;
 	--theme-notification-color: #d54e21; /* Direct from wp-admin */
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: var( --studio-blue-0 );
+	--color-sidebar-submenu-text: var( --studio-blue-70 );
+	--color-sidebar-submenu-hover-text: var( --color-accent );
+	--color-sidebar-submenu-selected-text: var( --color-accent );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update Classic Bright color scheme to be compatible with Nav Unification



While working on porting Classic Bright to wp-admin in Automattic/jetpack#17828, I noticed we will need a few more changes to the color scheme in Calypso to work with Nav Unification.

|Before|After|
|-|-|
|<img width="463" alt="Screenshot 2020-11-25 at 08 44 57" src="https://user-images.githubusercontent.com/1562646/100197824-31aca880-2efb-11eb-8236-b3cae69c9fc5.png">|<img width="452" alt="Screenshot 2020-11-25 at 08 44 13" src="https://user-images.githubusercontent.com/1562646/100197836-35402f80-2efb-11eb-9075-8be04e27b090.png">|

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out the branch locally
* Open `packages/calypso-color-schemes/src/shared/color-schemes/_default.scss`
* Change selector to `:root, :root .is-nav-unification { }`
* `yarn && yarn start` then open http://calypso.localhost:3000/
* Navigate to /me/account and select the color scheme
* Add `?flags=nav-unification` to the URL
* Compare to `?flags=nav-unification` in production
