### PR TITLE
Nav unification: update Classic Dark color scheme to be compatible with Nav Unification

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -326,4 +326,10 @@
 	/* WP Admin */
 	--color-wp-admin-button-background: #008ec2;
 	--color-wp-admin-button-border: #006799;
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: #32373c;
+	--color-sidebar-submenu-text: #b4b9be;
+	--color-sidebar-submenu-hover-text: #00b9eb;
+	--color-sidebar-submenu-selected-text: #ffffff;
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -331,5 +331,5 @@
 	--color-sidebar-submenu-background: #32373c;
 	--color-sidebar-submenu-text: #b4b9be;
 	--color-sidebar-submenu-hover-text: #00b9eb;
-	--color-sidebar-submenu-selected-text: #ffffff;
+	--color-sidebar-submenu-selected-text: var( --studio-white );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update Classic Dark color scheme to be compatible with Nav Unification



While working on porting Classic Dark to wp-admin in Automattic/jetpack#17828, I noticed we will need a few more changes to the color scheme in Calypso to work with Nav Unification.

|Before (with latest changes to default/Classic Bright applied)|After|
|-|-|
|<img width="445" alt="Screenshot 2020-11-25 at 11 16 34" src="https://user-images.githubusercontent.com/1562646/100214615-62e3a380-2f10-11eb-80a1-319433f47592.png">|<img width="452" alt="Screenshot 2020-11-25 at 11 15 30" src="https://user-images.githubusercontent.com/1562646/100214639-68d98480-2f10-11eb-970e-4986251ef3da.png">|

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out the branch locally
* Open `packages/calypso-color-schemes/src/shared/color-schemes/_default.scss`
* Change selector to `:root, :root .is-nav-unification { }`
* `yarn && yarn start` then open http://calypso.localhost:3000/
* Navigate to /me/account and select the color scheme
* Add `?flags=nav-unification` to the URL
* Compare to `?flags=nav-unification` in production
