### PR TITLE
Adapt require-chunk-callback-plugin to work in Webpack 5

### DIFF
--- a/build-tools/webpack/require-chunk-callback-plugin.js
+++ b/build-tools/webpack/require-chunk-callback-plugin.js
@@ -17,6 +17,10 @@ class RequireChunkCallbackPlugin {
 		compiler.hooks.thisCompilation.tap( PLUGIN_NAME, ( compilation ) => {
 			const { mainTemplate } = compilation;
 
+			const chunkIdToURL = webpack.RuntimeGlobals
+				? webpack.RuntimeGlobals.getChunkScriptFilename
+				: 'jsonpScriptSrc';
+
 			mainTemplate.hooks.localVars.tap( PLUGIN_NAME, ( source ) => {
 				return Template.asString( [
 					source,
@@ -50,7 +54,7 @@ class RequireChunkCallbackPlugin {
 
 						RequireChunkCallback.prototype.getInstalledChunks = function() {
 							return Object.keys( installedChunks ).map( function( chunkId ) {
-								return jsonpScriptSrc( chunkId )
+								return ${ chunkIdToURL }( chunkId )
 									.replace( __webpack_require__.p, '' )
 									.replace( /\\.js$/, '' );
 							} );
@@ -74,7 +78,7 @@ class RequireChunkCallbackPlugin {
 					`requireChunkCallback.trigger( {
 						chunkId: chunkId,
 						publicPath: __webpack_require__.p,
-						scriptSrc: jsonpScriptSrc( chunkId )
+						scriptSrc: ${ chunkIdToURL }( chunkId )
 					}, promises )`,
 				] );
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The original plugin uses the hardcoded function `jsonpScriptSrc` to translate a `chunkId` into a script name. In Webpack 4, this function is part of the webpack runtime, hardcoded in https://github.com/webpack/webpack/blob/c572c15a413ef7d086b52ccc78d9512a192954d7/lib/web/JsonpMainTemplatePlugin.js#L129

In Webpack 5 the function was renamed, but the name is now exported in https://github.com/webpack/webpack/blob/master/lib/RuntimeGlobals.js#L184


#### Testing instructions

N/A