### PR TITLE
CircleCI: Set DEFAULT_BRANCH variable for build new strings step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,7 @@ jobs:
           when: always
           command: |
             git clone --single-branch --depth=1 https://github.com/Automattic/gp-localci-client.git
-            bash gp-localci-client/generate-new-strings-pot.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1" "$CIRCLE_ARTIFACTS/translate"
+            DEFAULT_BRANCH=trunk bash gp-localci-client/generate-new-strings-pot.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1" "$CIRCLE_ARTIFACTS/translate"
             rm -rf gp-localci-client
       - store-artifacts-and-test-results
       - run:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set `DEFAULT_BRANCH` variable with `trunk` in **Build New Strings .pot** step of the **translate** job.

#### Testing instructions
- Inspect artifacts from **translate** job and confirm `localci-new-strings.pot` has been generated and has the test new string extracted

#### Merge instructions
Drop https://github.com/Automattic/wp-calypso/commit/be9639516116d060946e35c2ed9ec480ebaa64d1 before merging. It only serves a testing purpose and **should not** be merged.

_Requires changes from https://github.com/Automattic/gp-localci-client/pull/20_