### PR TITLE
Include package.json in the final docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN apk add --no-cache tini
 COPY --from=builder --chown=nobody:nobody /calypso/build /calypso/build
 COPY --from=builder --chown=nobody:nobody /calypso/public /calypso/public
 COPY --from=builder --chown=nobody:nobody /calypso/config /calypso/config
+COPY --from=builder --chown=nobody:nobody /calypso/package.json /calypso/package.json
 
 USER nobody
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Include `package.json` in the final build. 

It is used when deciding if a browser should get `evergreen` or `fallback`, as we match the UserAgent against the `evergreen` browserlist, defined in `package.json`


#### Testing instructions

* Check that calypso.live works with an evergreen and a fallback (i.e. IE11) browser.
