### PR TITLE
Nav unification: update Contrast color scheme to be compatible with Nav Unification

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
@@ -131,4 +131,10 @@
 	--color-sidebar-menu-hover-background: var( --studio-gray-60 );
 	--color-sidebar-menu-hover-background-rgb: var( --studio-gray-60-rgb );
 	--color-sidebar-menu-hover-text: var( --studio-white );
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: var( --studio-gray-90 );
+	--color-sidebar-submenu-text: var( --studio-gray-10 );
+	--color-sidebar-submenu-hover-text: var( --color-masterbar-unread-dot-background );
+	--color-sidebar-submenu-selected-text: var( --studio-white );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update Contrast color scheme to be compatible with Nav Unification

While working on porting Contrast to wp-admin in Automattic/jetpack#17828, I noticed we will need a few more changes to the color scheme in Calypso to work with Nav Unification.

|Before|After|
|-|-|
|<img width="461" alt="Screenshot 2020-11-25 at 15 51 19" src="https://user-images.githubusercontent.com/1562646/100246364-532c8500-2f39-11eb-828d-ae43e521e82c.png">|<img width="453" alt="Screenshot 2020-11-25 at 16 09 03" src="https://user-images.githubusercontent.com/1562646/100246370-56c00c00-2f39-11eb-84c9-b4d949195545.png">|

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Calypso live link below
* Navigate to /me/account and select the color scheme
* Add your user to `Treatment Variation` in Experiment (see paYJgx-1af-p2) to enable nav unification
* Compare against nav unification without this branch
