### PR TITLE
Pricing page i5: tweak styles at medium viewport

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-i5/style.scss
@@ -1,6 +1,7 @@
 .jetpack-product-card-i5 {
 	position: relative;
 
+	box-sizing: border-box;
 	height: 100%;
 
 	background: var( --color-surface );
@@ -8,7 +9,7 @@
 	border-radius: 8px;
 	box-shadow: 0px 4px 24px rgba( 0, 0, 0, 0.05 );
 
-	&.is-featured {
+	&.is-featured.is-aligned {
 		position: relative;
 		top: 8px;
 		z-index: 1;

--- a/client/my-sites/plans-v2/plans-filter-bar-i5/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar-i5/style.scss
@@ -82,7 +82,7 @@
 .plans-filter-bar-i5__discount-message {
 	font-size: 0.8125rem;
 	font-weight: 600;
-	padding-top: 5px;
+	padding-top: 2px;
 
 	&.primary {
 		color: var( --color-primary );

--- a/client/my-sites/plans-v2/products-grid-i5/index.tsx
+++ b/client/my-sites/plans-v2/products-grid-i5/index.tsx
@@ -149,7 +149,11 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 						</li>
 					) ) }
 				</ul>
-				<div className="products-grid-i5__more">
+				<div
+					className={ classNames( 'products-grid-i5__more', {
+						'is-detached': isPlanRowWrapping,
+					} ) }
+				>
 					<MoreInfoBox
 						headline={ translate( 'Need more info?' ) }
 						buttonLabel={ translate( 'Compare all product bundles' ) }

--- a/client/my-sites/plans-v2/products-grid-i5/style.scss
+++ b/client/my-sites/plans-v2/products-grid-i5/style.scss
@@ -79,3 +79,7 @@
 .products-grid-i5__free {
 	margin-top: 32px;
 }
+
+.products-grid-i5__more.is-detached {
+	margin-top: 48px;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes some styling issues happening in the pricing page i5 at medium viewport.

### Testing instructions

- Download the PR or visit the Calypso live link
- Run Calypso or Jetpack cloud
- Select a self-hosted Jetpack site
- Visit the Plans page
- Resize the viewport so that rows contain 2 product cards
- Check that the 3 issues below (see captures) are fixed
- Make sure the page still looks like production in large (3 cards per row) and small (1 card per row) screens

### Screenshots

#### Before

![screenshot (1)](https://user-images.githubusercontent.com/1620183/100248512-92db7880-2f09-11eb-8fdc-751d76d7c430.png)
![screenshot (2)](https://user-images.githubusercontent.com/1620183/100248518-953dd280-2f09-11eb-94c7-6f75575ce8ec.png)
![screenshot](https://user-images.githubusercontent.com/1620183/100248547-9ff86780-2f09-11eb-8618-b964d2fddb2a.png)




#### After

![screenshot (5)](https://user-images.githubusercontent.com/1620183/100248565-a38bee80-2f09-11eb-9d31-e4a60324ab8f.png)
![screenshot (4)](https://user-images.githubusercontent.com/1620183/100248578-a686df00-2f09-11eb-9aa4-1393738e3453.png)

![screenshot (3)](https://user-images.githubusercontent.com/1620183/100248526-9838c300-2f09-11eb-87bf-4d7439b2dae1.png)
