### PR TITLE
Activity Log, Jetpack Backup, Jetpack Scan, Jetpack Cloud: Show 'not authorized' page for non-admins

### DIFF
--- a/client/components/jetpack/current-user-has-capabilities-switch/index.tsx
+++ b/client/components/jetpack/current-user-has-capabilities-switch/index.tsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import React, { FC, ReactElement, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import type { AppState } from 'calypso/types';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import RenderSwitch from 'calypso/components/jetpack/render-switch';
+
+const getCurrentUserCapabilities = ( state: AppState, siteId: number | null ) => {
+	if ( ! siteId ) {
+		return [];
+	}
+
+	return state.currentUser.capabilities[ siteId ];
+};
+
+const CurrentUserHasCapabilitiesSwitch: FC< Props > = ( {
+	capabilities,
+	trueComponent,
+	falseComponent,
+} ) => {
+	const siteId = useSelector( getSelectedSiteId );
+	const userCapabilities = useSelector( ( state ) => getCurrentUserCapabilities( state, siteId ) );
+
+	const hasCapabilities = useCallback(
+		() => capabilities.every( ( p: string ) => userCapabilities[ p ] ),
+		[ capabilities, userCapabilities ]
+	);
+
+	return (
+		<RenderSwitch
+			renderCondition={ hasCapabilities }
+			trueComponent={ trueComponent }
+			falseComponent={ falseComponent }
+		/>
+	);
+};
+
+type Props = {
+	capabilities: string[];
+	trueComponent: ReactElement;
+	falseComponent: ReactElement;
+};
+
+export default CurrentUserHasCapabilitiesSwitch;

--- a/client/components/jetpack/is-current-user-admin-switch/index.tsx
+++ b/client/components/jetpack/is-current-user-admin-switch/index.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CurrentUserHasCapabilitiesSwitch from 'calypso/components/jetpack/current-user-has-capabilities-switch';
+
+const ADMIN_CAPABILITIES = [ 'manage_options' ];
+
+const IsCurrentUserAdminSwitch: React.FC< Props > = ( { trueComponent, falseComponent } ) => (
+	<CurrentUserHasCapabilitiesSwitch
+		capabilities={ ADMIN_CAPABILITIES }
+		trueComponent={ trueComponent }
+		falseComponent={ falseComponent }
+	/>
+);
+
+type Props = {
+	trueComponent: ReactElement;
+	falseComponent: ReactElement;
+};
+
+export default IsCurrentUserAdminSwitch;

--- a/client/components/jetpack/not-authorized-page/index.tsx
+++ b/client/components/jetpack/not-authorized-page/index.tsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'calypso/components/main';
+import EmptyContent from 'calypso/components/empty-content';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+
+const NotAuthorizedPage: React.FC = () => {
+	const translate = useTranslate();
+
+	return (
+		<Main>
+			<SidebarNavigation />
+			<EmptyContent
+				illustration="/calypso/images/illustrations/illustration-404.svg"
+				title={ translate( 'You are not authorized to view this page' ) }
+			/>
+		</Main>
+	);
+};
+
+export default NotAuthorizedPage;

--- a/client/components/jetpack/render-switch/index.tsx
+++ b/client/components/jetpack/render-switch/index.tsx
@@ -7,7 +7,7 @@ import React, { ReactComponent, ReactNode } from 'react';
  * @typedef RenderSwitchArgs
  */
 type RenderSwitchArgs = {
-	loadingCondition: () => boolean;
+	loadingCondition?: () => boolean;
 	renderCondition: () => boolean;
 	queryComponent?: ReactNode;
 	loadingComponent?: ReactNode;
@@ -28,7 +28,7 @@ type RenderSwitchArgs = {
  * @param {ReactNode} [props.falseComponent] - The component to render when the renderCondition evaluates to false.
  */
 const RenderSwitch: ReactComponent = ( {
-	loadingCondition,
+	loadingCondition = () => false,
 	renderCondition,
 	queryComponent,
 	loadingComponent,

--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -3,6 +3,7 @@
  */
 import { useDispatch, useSelector } from 'react-redux';
 import React from 'react';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ import { backupPath, scanPath } from 'calypso/lib/jetpack/paths';
 import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import { useTranslate } from 'i18n-calypso';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import getSiteScanProgress from 'calypso/state/selectors/get-site-scan-progress';
@@ -46,24 +47,28 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 	};
 	const currentPathMatches = ( url ) => itemLinkMatches( [ url ], path );
 
+	const isAdmin = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
+
 	return (
 		<>
 			<QueryScanState siteId={ siteId } />
-			<SidebarItem
-				tipTarget="activity"
-				icon={ showIcons ? 'clipboard' : undefined }
-				label={ translate( 'Activity Log', {
-					comment: 'Jetpack sidebar menu item',
-				} ) }
-				link={ `/activity-log/${ siteSlug }` }
-				onNavigate={ onNavigate( tracksEventNames.activityClicked ) }
-				selected={ currentPathMatches( `/activity-log/${ siteSlug }` ) }
-				expandSection={ expandSection }
-			/>
+			{ isAdmin && (
+				<SidebarItem
+					tipTarget="activity"
+					icon={ showIcons ? 'clipboard' : undefined }
+					label={ translate( 'Activity Log', {
+						comment: 'Jetpack sidebar menu item',
+					} ) }
+					link={ `/activity-log/${ siteSlug }` }
+					onNavigate={ onNavigate( tracksEventNames.activityClicked ) }
+					selected={ currentPathMatches( `/activity-log/${ siteSlug }` ) }
+					expandSection={ expandSection }
+				/>
+			) }
 			{
 				// Backup does not work in wp-desktop. Disable in the desktop app until
 				// it can be revisited: https://github.com/Automattic/wp-desktop/issues/943
-				! isDesktop && ! isWPForTeamsSite && (
+				isAdmin && ! isDesktop && ! isWPForTeamsSite && (
 					<SidebarItem
 						materialIcon={ showIcons ? 'backup' : undefined }
 						materialIconStyle="filled"
@@ -75,7 +80,7 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 					/>
 				)
 			}
-			{ ! isWPCOM && ! isWPForTeamsSite && (
+			{ isAdmin && ! isWPCOM && ! isWPForTeamsSite && (
 				<SidebarItem
 					materialIcon={ showIcons ? 'security' : undefined }
 					materialIconStyle="filled"

--- a/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
+++ b/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
@@ -3,12 +3,13 @@
  */
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { useTranslate } from 'i18n-calypso';
-import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
@@ -19,6 +20,7 @@ import JetpackSidebarMenuItems from '.';
 export default ( { path } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const onNavigate = () => {
@@ -27,6 +29,10 @@ export default ( { path } ) => {
 		setNextLayoutFocus( 'content' );
 		window.scrollTo( 0, 0 );
 	};
+
+	const shouldShowSettings = useSelector( ( state ) =>
+		canCurrentUser( state, siteId, 'manage_options' )
+	);
 
 	return (
 		<>
@@ -39,16 +45,18 @@ export default ( { path } ) => {
 					scanClicked: 'calypso_jetpack_sidebar_scan_clicked',
 				} }
 			/>
-			<SidebarItem
-				materialIcon="settings"
-				materialIconStyle="filled"
-				label={ translate( 'Settings', {
-					comment: 'Jetpack sidebar navigation item',
-				} ) }
-				link={ settingsPath( siteSlug ) }
-				onNavigate={ onNavigate }
-				selected={ itemLinkMatches( [ settingsPath( siteSlug ) ], path ) }
-			/>
+			{ shouldShowSettings && (
+				<SidebarItem
+					materialIcon="settings"
+					materialIconStyle="filled"
+					label={ translate( 'Settings', {
+						comment: 'Jetpack sidebar navigation item',
+					} ) }
+					link={ settingsPath( siteSlug ) }
+					onNavigate={ onNavigate }
+					selected={ itemLinkMatches( [ settingsPath( siteSlug ) ], path ) }
+				/>
+			) }
 		</>
 	);
 };

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -6,6 +6,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
+import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';
 import AdvancedCredentials from './advanced-credentials';
 import SettingsPage from './main';
 
@@ -17,5 +19,16 @@ export const settings: PageJS.Callback = ( context, next ) => {
 export const advancedCredentials: PageJS.Callback = ( context, next ) => {
 	const { host, action } = context.query;
 	context.primary = <AdvancedCredentials action={ action } host={ host } role="main" />;
+	next();
+};
+
+export const showNotAuthorizedForNonAdmins: PageJS.Callback = ( context, next ) => {
+	context.primary = (
+		<IsCurrentUserAdminSwitch
+			trueComponent={ context.primary }
+			falseComponent={ <NotAuthorizedPage /> }
+		/>
+	);
+
 	next();
 };

--- a/client/jetpack-cloud/sections/settings/index.js
+++ b/client/jetpack-cloud/sections/settings/index.js
@@ -8,7 +8,11 @@ import page from 'page';
  */
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
-import { settings, advancedCredentials } from 'calypso/jetpack-cloud/sections/settings/controller';
+import {
+	settings,
+	advancedCredentials,
+	showNotAuthorizedForNonAdmins,
+} from 'calypso/jetpack-cloud/sections/settings/controller';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
 import { isEnabled } from 'calypso/config';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -21,6 +25,7 @@ export default function () {
 			siteSelection,
 			navigation,
 			isEnabled( 'jetpack/server-credentials-advanced-flow' ) ? advancedCredentials : settings,
+			showNotAuthorizedForNonAdmins,
 			makeLayout,
 			clientRender
 		);

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -57,7 +57,6 @@ import {
 	rewindBackup,
 	updateFilter,
 } from 'calypso/state/activity-log/actions';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getBackupProgress from 'calypso/state/selectors/get-backup-progress';
 import getRequestedBackup from 'calypso/state/selectors/get-requested-backup';
@@ -523,20 +522,7 @@ class ActivityLog extends Component {
 	}
 
 	render() {
-		const { canViewActivityLog, siteId, translate } = this.props;
-
-		if ( ! canViewActivityLog ) {
-			return (
-				<Main>
-					<QuerySitePurchases siteId={ siteId } />
-					<SidebarNavigation />
-					<EmptyContent
-						title={ translate( 'You are not authorized to view this page' ) }
-						illustration={ '/calypso/images/illustrations/illustration-404.svg' }
-					/>
-				</Main>
-			);
-		}
+		const { siteId, translate } = this.props;
 
 		const { context, rewindState, siteSettingsUrl } = this.props;
 
@@ -583,7 +569,6 @@ export default connect(
 		const isJetpack = isJetpackSite( state, siteId );
 
 		return {
-			canViewActivityLog: canCurrentUser( state, siteId, 'manage_options' ),
 			gmtOffset,
 			enableRewind:
 				'active' === rewindState.state &&

--- a/client/my-sites/activity/controller.jsx
+++ b/client/my-sites/activity/controller.jsx
@@ -7,14 +7,16 @@ import { isEqual } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { queryToFilterState } from 'calypso/state/activity-log/utils';
+import config from 'calypso/config';
 import { recordTrack } from 'calypso/reader/stats';
+import { queryToFilterState } from 'calypso/state/activity-log/utils';
 import { setFilter } from 'calypso/state/activity-log/actions';
+import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
+import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';
 import ActivityLog from 'calypso/my-sites/activity/activity-log';
 import ActivityLogV2 from 'calypso/my-sites/activity/activity-log-v2';
-import config from 'calypso/config';
-import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 
 function queryFilterToStats( filter ) {
 	// These values are hardcoded so that the attributes that we collect via stats are not unbound
@@ -72,6 +74,17 @@ export function activity( context, next ) {
 		<ActivityLogV2 />
 	) : (
 		<ActivityLog siteId={ siteId } context={ context } />
+	);
+
+	next();
+}
+
+export function showNotAuthorizedForNonAdmins( context, next ) {
+	context.primary = (
+		<IsCurrentUserAdminSwitch
+			trueComponent={ context.primary }
+			falseComponent={ <NotAuthorizedPage /> }
+		/>
 	);
 
 	next();

--- a/client/my-sites/activity/index.js
+++ b/client/my-sites/activity/index.js
@@ -6,7 +6,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { activity } from './controller';
+import { activity, showNotAuthorizedForNonAdmins } from './controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import wrapInSiteOffsetProvider from 'calypso/lib/wrap-in-site-offset';
@@ -19,6 +19,7 @@ export default function () {
 		siteSelection,
 		navigation,
 		activity,
+		showNotAuthorizedForNonAdmins,
 		wrapInSiteOffsetProvider,
 		makeLayout,
 		clientRender

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -24,6 +24,8 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isJetpackBackupSlug } from 'calypso/lib/products-values';
 import HasVaultPressSwitch from 'calypso/components/jetpack/has-vaultpress-switch';
 import IsJetpackDisconnectedSwitch from 'calypso/components/jetpack/is-jetpack-disconnected-switch';
+import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
+import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';
 
 const debug = new Debug( 'calypso:my-sites:backup:controller' );
 
@@ -68,6 +70,17 @@ export function showJetpackIsDisconnected( context, next ) {
 			falseComponent={ context.primary }
 		/>
 	);
+	next();
+}
+
+export function showNotAuthorizedForNonAdmins( context, next ) {
+	context.primary = (
+		<IsCurrentUserAdminSwitch
+			trueComponent={ context.primary }
+			falseComponent={ <NotAuthorizedPage /> }
+		/>
+	);
+
 	next();
 }
 

--- a/client/my-sites/backup/index.js
+++ b/client/my-sites/backup/index.js
@@ -11,6 +11,7 @@ import {
 	backupRestore,
 	backups,
 	showJetpackIsDisconnected,
+	showNotAuthorizedForNonAdmins,
 	showUpsellIfNoBackup,
 	showUnavailableForVaultPressSites,
 	showUnavailableForMultisites,
@@ -50,6 +51,7 @@ export default function () {
 		showUnavailableForVaultPressSites,
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
@@ -67,6 +69,7 @@ export default function () {
 			showUnavailableForVaultPressSites,
 			showJetpackIsDisconnected,
 			showUnavailableForMultisites,
+			showNotAuthorizedForNonAdmins,
 			notFoundIfNotEnabled,
 			makeLayout,
 			clientRender
@@ -85,6 +88,7 @@ export default function () {
 		showUnavailableForVaultPressSites,
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -15,7 +15,6 @@ import { isEnabled } from 'calypso/config';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
@@ -25,7 +24,6 @@ import QueryRewindCapabilities from 'calypso/components/data/query-rewind-capabi
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
-import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -46,13 +44,8 @@ import {
  */
 import './style.scss';
 
-const isCurrentUserAdmin = ( state, siteId ) => canCurrentUser( state, siteId, 'manage_options' );
-
 const BackupPage = ( { queryDate } ) => {
-	const translate = useTranslate();
-
 	const siteId = useSelector( getSelectedSiteId );
-	const isAdmin = useSelector( ( state ) => isCurrentUserAdmin( state, siteId ) );
 
 	const moment = useLocalizedMoment();
 	const parsedQueryDate = queryDate ? moment( queryDate, INDEX_FORMAT ) : moment();
@@ -75,14 +68,7 @@ const BackupPage = ( { queryDate } ) => {
 					<FormattedHeader headerText="Jetpack Backup" align="left" brandFont />
 				) }
 
-				{ isAdmin ? (
-					<AdminContent selectedDate={ selectedDate } />
-				) : (
-					<EmptyContent
-						illustration="/calypso/images/illustrations/illustration-404.svg"
-						title={ translate( 'You are not authorized to view this page' ) }
-					/>
-				) }
+				<AdminContent selectedDate={ selectedDate } />
 			</Main>
 		</div>
 	);

--- a/client/my-sites/scan/controller.js
+++ b/client/my-sites/scan/controller.js
@@ -22,6 +22,8 @@ import ScanPlaceholder from 'calypso/components/jetpack/scan-placeholder';
 import ScanHistoryPlaceholder from 'calypso/components/jetpack/scan-history-placeholder';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isJetpackScanSlug } from 'calypso/lib/products-values';
+import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
+import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';
 
 export function showUpsellIfNoScan( context, next ) {
 	context.primary = scanUpsellSwitcher( <ScanPlaceholder />, context.primary );
@@ -30,6 +32,17 @@ export function showUpsellIfNoScan( context, next ) {
 
 export function showUpsellIfNoScanHistory( context, next ) {
 	context.primary = scanUpsellSwitcher( <ScanHistoryPlaceholder />, context.primary );
+	next();
+}
+
+export function showNotAuthorizedForNonAdmins( context, next ) {
+	context.primary = (
+		<IsCurrentUserAdminSwitch
+			trueComponent={ context.primary }
+			falseComponent={ <NotAuthorizedPage /> }
+		/>
+	);
+
 	next();
 }
 

--- a/client/my-sites/scan/history/index.tsx
+++ b/client/my-sites/scan/history/index.tsx
@@ -4,21 +4,17 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
-import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import DocumentHead from 'calypso/components/data/document-head';
-import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import ThreatHistoryList from 'calypso/components/jetpack/threat-history-list';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import ScanNavigation from '../navigation';
 
 /**
@@ -32,8 +28,6 @@ interface Props {
 
 export default function ScanHistoryPage( { filter }: Props ) {
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
-	const isAdmin = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
 	const isJetpackPlatform = isJetpackCloud();
 
 	return (
@@ -48,25 +42,16 @@ export default function ScanHistoryPage( { filter }: Props ) {
 			{ ! isJetpackPlatform && (
 				<FormattedHeader headerText={ 'Jetpack Scan' } align="left" brandFont />
 			) }
-			{ ! isAdmin && (
-				<EmptyContent
-					illustration="/calypso/images/illustrations/illustration-404.svg"
-					title={ translate( 'You are not authorized to view this page' ) }
-				/>
-			) }
-			{ isAdmin && (
-				<>
-					<ScanNavigation section={ 'history' } />
-					<section className="history__body">
-						<p className="history__description">
-							{ translate(
-								'The scanning history contains a record of all previously active threats on your site.'
-							) }
-						</p>
-						<ThreatHistoryList filter={ filter } />
-					</section>
-				</>
-			) }
+
+			<ScanNavigation section={ 'history' } />
+			<section className="history__body">
+				<p className="history__description">
+					{ translate(
+						'The scanning history contains a record of all previously active threats on your site.'
+					) }
+				</p>
+				<ThreatHistoryList filter={ filter } />
+			</section>
 		</Main>
 	);
 }

--- a/client/my-sites/scan/index.js
+++ b/client/my-sites/scan/index.js
@@ -15,6 +15,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import isJetpackSectionEnabledForSite from 'calypso/state/selectors/is-jetpack-section-enabled-for-site';
 import {
 	showJetpackIsDisconnected,
+	showNotAuthorizedForNonAdmins,
 	showUpsellIfNoScan,
 	showUpsellIfNoScanHistory,
 	showUnavailableForVaultPressSites,
@@ -51,6 +52,7 @@ export default function () {
 		showUnavailableForVaultPressSites,
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
@@ -67,6 +69,7 @@ export default function () {
 		showUnavailableForVaultPressSites,
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
@@ -83,6 +86,7 @@ export default function () {
 		showUnavailableForVaultPressSites,
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -19,13 +19,11 @@ import SecurityIcon from 'calypso/components/jetpack/security-icon';
 import ScanPlaceholder from 'calypso/components/jetpack/scan-placeholder';
 import ScanThreats from 'calypso/components/jetpack/scan-threats';
 import { Scan, Site } from 'calypso/my-sites/scan/types';
-import EmptyContent from 'calypso/components/empty-content';
 import Gridicon from 'calypso/components/gridicon';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
 import getSiteScanProgress from 'calypso/state/selectors/get-site-scan-progress';
 import getSiteScanIsInitial from 'calypso/state/selectors/get-site-scan-is-initial';
@@ -271,7 +269,7 @@ class ScanPage extends Component< Props > {
 	}
 
 	render() {
-		const { isAdmin, siteId, siteSettingsUrl } = this.props;
+		const { siteId, siteSettingsUrl } = this.props;
 		const isJetpackPlatform = isJetpackCloud();
 
 		if ( ! siteId ) {
@@ -291,21 +289,12 @@ class ScanPage extends Component< Props > {
 				{ ! isJetpackPlatform && (
 					<FormattedHeader headerText={ 'Jetpack Scan' } align="left" brandFont />
 				) }
-				{ isAdmin && (
-					<>
-						<QueryJetpackScan siteId={ siteId } />
-						<ScanNavigation section={ 'scanner' } />
-						<Card>
-							<div className="scan__content">{ this.renderScanState() }</div>
-						</Card>
-					</>
-				) }
-				{ ! isAdmin && (
-					<EmptyContent
-						illustration="/calypso/images/illustrations/illustration-404.svg"
-						title={ translate( 'You are not authorized to view this page' ) }
-					/>
-				) }
+
+				<QueryJetpackScan siteId={ siteId } />
+				<ScanNavigation section={ 'scanner' } />
+				<Card>
+					<div className="scan__content">{ this.renderScanState() }</div>
+				</Card>
 			</Main>
 		);
 	}
@@ -327,7 +316,6 @@ export default connect(
 		const scanProgress = getSiteScanProgress( state, siteId ) ?? undefined;
 		const isRequestingScan = isRequestingJetpackScan( state, siteId );
 		const isInitialScan = getSiteScanIsInitial( state, siteId );
-		const isAdmin = canCurrentUser( state, siteId, 'manage_options' );
 
 		return {
 			site,
@@ -338,7 +326,6 @@ export default connect(
 			isInitialScan,
 			siteSettingsUrl,
 			isRequestingScan,
-			isAdmin,
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes `1164141197617539-as-1185093824054377`.

* In Calypso Green, set sidebar menu items to be hidden if the current user is not an administrator.
* Create new render-switch component `IsCurrentUserAdminSwitch`, to conditionally render based on whether the current user is an admin on a given site.
* Create new `NotAuthorizedPage` component, to standardize our look and feel for people who find themselves on pages they're not allowed to see.
* Add `showNotAuthorizedForNonAdmins` controller methods to Settings (in Calypso Green), Backup, Scan, and Activity Log.
* Call `showNotAuthorizedForNonAdmins` in all site-specific routes for the above-specified pages.
* Remove `canViewActivityLog` check in the `ActivityLog` component itself, since the auth check now happens earlier.
* In `RenderSwitch`, make `loadingCondition` an optional argument that defaults to a function that always returns false (i.e., the component will assume loading is immediately complete).

#### Known issues

* The `/landing` page in Calypso Green may not work for all scenarios when the user is not an admin. This is unrelated to this PR and I'm sure we'll address it separately in the future.

#### Testing instructions

**Important:** Test this PR in both mobile and desktop layouts.

##### Prerequisites

* One site where you are an admin, and one site where you are not an admin. Alternatively, two users on the same site where one is an admin and one is not.
* A valid backup point from which you can choose to restore or download a copy. (Save the URL; you'll need it when testing the non-admin user.)

##### In Calypso Green specifically

* For the admin user, check that you're able to see and navigate to all sidebar links: **Activity Log**, **Backup**, **Scan**, and **Settings**.
* For the non-admin user, check that the above-mentioned sidebar links are *not* visible.
* For the admin user, click the **Settings** link in the sidebar navigation menu and verify you're brought to the **Settings** page when you click it.
* For the non-admin user, manually navigate to the following paths in your browser and verify that you see the Not Authorized page for each one:
  * `/activity-log/<site>`
  * `/backup/<site>`
  * `/backup/<site>/download/<rewind_id>` (for a valid backup point)
  * `/backup/<site>/restore/<rewind_id>` (for a valid backup point)
  * `/scan/<site>`
  * `/scan/history/<site>`
  * `/settings/<site>`

##### In Calypso Blue and Calypso Green

* For the admin user, check that you're able to navigate to all the pages mentioned above without seeing any Not Authorized pages.

#### Reference screenshots

##### Menu for admins (mobile, desktop)

<img height="500" alt="image" src="https://user-images.githubusercontent.com/670067/100249666-6ec86900-2f02-11eb-9c97-98af0767c248.png"> <img height="500" alt="image" src="https://user-images.githubusercontent.com/670067/100249625-62dca700-2f02-11eb-95ba-799a8a09daee.png">

##### Menu for non-admins (mobile, desktop)

<img height="500" alt="image" src="https://user-images.githubusercontent.com/670067/100250055-dc749500-2f02-11eb-8a15-108dcb652058.png"> <img height="500" alt="image" src="https://user-images.githubusercontent.com/670067/100250003-cb2b8880-2f02-11eb-8460-5474b3dbafe9.png">

##### "Not authorized" page for non-admins (mobile, desktop)

<img width="300" alt="image" src="https://user-images.githubusercontent.com/670067/100249451-3163db80-2f02-11eb-83e6-330661beb751.png"> <img width="1308" alt="image" src="https://user-images.githubusercontent.com/670067/100249486-3aed4380-2f02-11eb-8f2b-9d5e01792786.png">