### PR TITLE
Nav unification: update Nightfall color scheme to be compatible with Nav Unification

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_nightfall.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_nightfall.scss
@@ -121,4 +121,10 @@
 	--color-sidebar-menu-hover-background: var( --studio-blue-70 );
 	--color-sidebar-menu-hover-background-rgb: var( --studio-blue-70-rgb );
 	--color-sidebar-menu-hover-text: var( --studio-white );
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: var( --studio-blue-90 );
+	--color-sidebar-submenu-text: var( --studio-white );
+	--color-sidebar-submenu-hover-text: var( --studio-blue-20 );
+	--color-sidebar-submenu-selected-text: var( --studio-white );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update Nightfall color scheme to be compatible with Nav Unification

While working on porting Nightfall to wp-admin in Automattic/jetpack#17828, I noticed we will need a few more changes to the color scheme in Calypso to work with Nav Unification.

|Before|After|
|-|-|
|<img width="455" alt="Screenshot 2020-11-25 at 16 52 07" src="https://user-images.githubusercontent.com/1562646/100252349-1021e000-2f40-11eb-9a9e-1892cea361bb.png">|<img width="458" alt="Screenshot 2020-11-25 at 16 51 32" src="https://user-images.githubusercontent.com/1562646/100252778-8de5eb80-2f40-11eb-976b-7ab14bdce8d6.png">|

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /me/account in production and select the color scheme
* Check out this branch, run `yarn && yarn start`, visit http://calypso.localhost:3000/
* Add your user to `Treatment Variation` in Experiment (see paYJgx-1af-p2) to enable nav unification
* Compare against nav unification without this branch
