### PR TITLE
Nav unification: update Powder Snow color scheme to be compatible with Nav Unification

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_powder-snow.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_powder-snow.scss
@@ -121,4 +121,10 @@
 	--color-sidebar-menu-hover-background: var( --color-surface );
 	--color-sidebar-menu-hover-background-rgb: var( --studio-white-rgb );
 	--color-sidebar-menu-hover-text: var( --studio-blue-60 );
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: var( --studio-gray-10 );
+	--color-sidebar-submenu-text: var( --studio-gray-80 );
+	--color-sidebar-submenu-hover-text: var( --studio-blue-60 );
+	--color-sidebar-submenu-selected-text: var( --studio-gray-80 );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update Powder Snow color scheme to be compatible with Nav Unification

While working on porting Powder Snow to wp-admin in Automattic/jetpack#17828, I noticed we will need a few more changes to the color scheme in Calypso to work with Nav Unification.

|Before|After|
|-|-|
|<img width="463" alt="Screenshot 2020-11-25 at 17 32 08" src="https://user-images.githubusercontent.com/1562646/100257411-2cc11680-2f46-11eb-8809-a21cca78d3fd.png">|<img width="453" alt="Screenshot 2020-11-25 at 17 41 34" src="https://user-images.githubusercontent.com/1562646/100257348-1f0b9100-2f46-11eb-8ec7-fd532752a518.png">|

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /me/account in production and select the color scheme
* Check out this branch, run `yarn && yarn start`, visit http://calypso.localhost:3000/
* Add your user to `Treatment Variation` in Experiment (see paYJgx-1af-p2) to enable nav unification
* Compare against nav unification without this branch
