### PR TITLE
Framework: Remove usages of lodash transform()

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -146,9 +146,7 @@ export function normalizeCompatibilityList( compatibilityList ) {
 export function normalizePluginData( plugin, pluginData ) {
 	plugin = getAllowedPluginData( assign( plugin, pluginData ) );
 
-	return Object.keys( plugin ).reduce( ( returnData, key ) => {
-		const item = plugin[ key ];
-
+	return Object.entries( plugin ).reduce( ( returnData, [ key, item ] ) => {
 		switch ( key ) {
 			case 'short_description':
 			case 'description':

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { assign, filter, map, pick, sortBy, transform } from 'lodash';
+import { assign, filter, map, pick, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -146,7 +146,9 @@ export function normalizeCompatibilityList( compatibilityList ) {
 export function normalizePluginData( plugin, pluginData ) {
 	plugin = getAllowedPluginData( assign( plugin, pluginData ) );
 
-	return transform( plugin, function ( returnData, item, key ) {
+	return Object.keys( plugin ).reduce( ( returnData, key ) => {
+		const item = plugin[ key ];
+
 		switch ( key ) {
 			case 'short_description':
 			case 'description':
@@ -198,7 +200,9 @@ export function normalizePluginData( plugin, pluginData ) {
 			default:
 				returnData[ key ] = item;
 		}
-	} );
+
+		return returnData;
+	}, {} );
 }
 
 export function normalizePluginsList( pluginsList ) {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -141,10 +141,8 @@ export class SiteNotice extends React.Component {
 
 		const { site, currencyCode, productsList, translate } = this.props;
 
-		const priceAndSaleInfo = Object.keys( productsList ).reduce(
-			function ( result, key ) {
-				const value = productsList[ key ];
-
+		const priceAndSaleInfo = Object.entries( productsList ).reduce(
+			function ( result, [ key, value ] ) {
 				if ( value.is_domain_registration && value.available ) {
 					const regularPrice = getUnformattedDomainPrice( key, productsList );
 					const minRegularPrice = get( result, 'minRegularPrice', regularPrice );

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -8,7 +8,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import config, { isEnabled } from 'calypso/config';
-import { get, reject, transform } from 'lodash';
+import { get, reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -141,9 +141,10 @@ export class SiteNotice extends React.Component {
 
 		const { site, currencyCode, productsList, translate } = this.props;
 
-		const priceAndSaleInfo = transform(
-			productsList,
-			function ( result, value, key ) {
+		const priceAndSaleInfo = Object.keys( productsList ).reduce(
+			function ( result, key ) {
+				const value = productsList[ key ];
+
 				if ( value.is_domain_registration && value.available ) {
 					const regularPrice = getUnformattedDomainPrice( key, productsList );
 					const minRegularPrice = get( result, 'minRegularPrice', regularPrice );
@@ -156,6 +157,8 @@ export class SiteNotice extends React.Component {
 						result.saleTlds.push( value.tld );
 					}
 				}
+
+				return result;
 			},
 			{ saleTlds: [] }
 		);


### PR DESCRIPTION
We have only a couple usages of lodash's `transform()` method. They can be refactored to use native methods. This PR removes them, in order to make us a bit less dependent on lodash.

This PR should not offer any visual or functional changes.

#### Changes proposed in this Pull Request

* Framework: Remove usages of lodash `transform()`

#### Testing instructions

* Go to `/plugins/:site` where `:site` is a Jetpack site, navigate around the plugins a bit, and verify everything loads and works the same way, without any changes or errors in the console.
* Ensuring you're running a WP.com simple site (not Jetpack, not WP for teams) that bought a domain within the last week, you're the plan owner, you haven't dismissed the `domain_upsell_nudge_dismiss` nudge, make sure you're seeing this notice in the sidebar:

![](https://cldup.com/UCLz7r__jS.png)

Since this last step can be hard to test, I'm pinging @eltongo @daledupreez and @delputnam who worked on this in #36208.