### PR TITLE
Modularise ui state

### DIFF
--- a/apps/notifications/src/panel/state/selectors/get-keyboard-shortcuts-enabled.js
+++ b/apps/notifications/src/panel/state/selectors/get-keyboard-shortcuts-enabled.js
@@ -1,1 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
 export default ( state ) => state.ui?.keyboardShortcutsAreEnabled;

--- a/apps/notifications/src/panel/state/selectors/get-ui.js
+++ b/apps/notifications/src/panel/state/selectors/get-ui.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
 export const getUI = ( state ) => state.ui;
 
 export default getUI;

--- a/client/landing/login/store.js
+++ b/client/landing/login/store.js
@@ -15,9 +15,6 @@ import {
 } from 'calypso/state/data-layer/http-data';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
 import documentHead from 'calypso/state/document-head/reducer';
-import language from 'calypso/state/ui/language/reducer';
-import masterbarVisibility from 'calypso/state/ui/masterbar-visibility/reducer';
-import section from 'calypso/state/ui/section/reducer';
 import notices from 'calypso/state/notices/reducer';
 import i18n from 'calypso/state/i18n/reducer';
 import users from 'calypso/state/users/reducer';
@@ -32,11 +29,6 @@ const rootReducer = combineReducers( {
 	i18n,
 	users,
 	currentUser,
-	ui: combineReducers( {
-		language,
-		masterbarVisibility,
-		section,
-	} ),
 } );
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;

--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import EmptyContent from 'calypso/components/empty-content';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { SECTION_SET } from 'calypso/state/action-types';
+import { setSection } from 'calypso/state/ui/section/actions';
 
 /**
  * Module variables
@@ -46,10 +46,7 @@ export function retry( chunkName ) {
 export function show( context, chunkName ) {
 	log( 'Chunk %s could not be loaded', chunkName );
 	bumpStat( 'calypso_chunk_error', chunkName );
-	context.store.dispatch( {
-		type: SECTION_SET,
-		section: false,
-	} );
+	context.store.dispatch( setSection( false, { section: false } ) );
 	context.primary = <LoadingErrorMessage />;
 	makeLayout( context, noop );
 	clientRender( context );

--- a/client/my-sites/exporter/export-card/post-type-options.jsx
+++ b/client/my-sites/exporter/export-card/post-type-options.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -19,9 +18,10 @@ import {
 	getSelectedPostType,
 	isDateRangeValid as isExportDateRangeValid,
 } from 'calypso/state/exporter/selectors';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
 const mapStateToProps = ( state, ownProps ) => {
-	const siteId = state.ui.selectedSiteId;
+	const siteId = getSelectedSiteId( state );
 
 	return {
 		siteId,

--- a/client/my-sites/media-library/test/data-source.jsx
+++ b/client/my-sites/media-library/test/data-source.jsx
@@ -16,6 +16,7 @@ import { Provider as ReduxProvider } from 'react-redux';
  */
 import MediaLibraryDataSource from 'calypso/my-sites/media-library/data-source';
 import { createReduxStore } from 'calypso/state';
+import { setStore } from 'calypso/state/redux-store';
 
 // we need to check the correct children are rendered, so this mocks the
 // PopoverMenu component with one that simply renders the children
@@ -34,6 +35,7 @@ describe( 'MediaLibraryDataSource', () => {
 	describe( 'render data sources', () => {
 		test( 'does not exclude any data sources by default', () => {
 			const store = createReduxStore();
+			setStore( store );
 			const wrapper = mount(
 				<ReduxProvider store={ store }>
 					<MediaLibraryDataSource
@@ -49,6 +51,7 @@ describe( 'MediaLibraryDataSource', () => {
 
 		test( 'excludes data sources listed in disabledSources', () => {
 			const store = createReduxStore();
+			setStore( store );
 			const wrapper = mount(
 				<ReduxProvider store={ store }>
 					<MediaLibraryDataSource

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -29,13 +29,12 @@ jest.mock( 'lib/analytics/track-component-view', () => 'TrackComponentView' );
 jest.mock( 'my-sites/sidebar/utils', () => ( {
 	itemLinkMatches: jest.fn( () => true ),
 } ) );
-jest.mock( 'config', () => ( {
-	isEnabled: jest.fn( () => true ),
-} ) );
 
-jest.mock( 'config/index', () => ( {
-	isEnabled: jest.fn( () => true ),
-} ) );
+jest.mock( 'config', () => {
+	const configMock = () => '';
+	configMock.isEnabled = jest.fn( () => true );
+	return configMock;
+} );
 
 describe( 'MySitesSidebar', () => {
 	describe( 'MySitesSidebar.store()', () => {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -331,10 +331,12 @@ function setUpLoggedInRoute( req, res, next ) {
 
 				if ( data.localeSlug ) {
 					req.context.lang = data.localeSlug;
-					req.context.store.dispatch( {
-						type: LOCALE_SET,
-						localeSlug: data.localeSlug,
-						localeVariant: data.localeVariant,
+					import( 'calypso/state/ui/init' ).then( () => {
+						req.context.store.dispatch( {
+							type: LOCALE_SET,
+							localeSlug: data.localeSlug,
+							localeVariant: data.localeVariant,
+						} );
 					} );
 				}
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -331,12 +331,10 @@ function setUpLoggedInRoute( req, res, next ) {
 
 				if ( data.localeSlug ) {
 					req.context.lang = data.localeSlug;
-					import( 'calypso/state/ui/init' ).then( () => {
-						req.context.store.dispatch( {
-							type: LOCALE_SET,
-							localeSlug: data.localeSlug,
-							localeVariant: data.localeVariant,
-						} );
+					req.context.store.dispatch( {
+						type: LOCALE_SET,
+						localeSlug: data.localeSlug,
+						localeVariant: data.localeVariant,
 					} );
 				}
 

--- a/client/state/document-head/selectors/get-document-head-formatted-title.js
+++ b/client/state/document-head/selectors/get-document-head-formatted-title.js
@@ -15,6 +15,11 @@ import { getDocumentHeadTitle } from 'calypso/state/document-head/selectors/get-
 import { getDocumentHeadCappedUnreadCount } from 'calypso/state/document-head/selectors/get-document-head-capped-unread-count';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
+/**
  * Returns the formatted document title, based on the currently set title,
  * capped unreadCount, and selected site.
  *

--- a/client/state/editor/actions.js
+++ b/client/state/editor/actions.js
@@ -31,6 +31,7 @@ import { getPreference } from 'calypso/state/preferences/selectors';
 import { editPost } from 'calypso/state/posts/actions';
 
 import 'calypso/state/editor/init';
+import 'calypso/state/ui/init';
 
 /**
  * Constants

--- a/client/state/guided-tours/actions.js
+++ b/client/state/guided-tours/actions.js
@@ -10,6 +10,7 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 
 import 'calypso/state/guided-tours/init';
+import 'calypso/state/ui/init';
 
 export function quitGuidedTour( { tour, stepName, finished } ) {
 	const quitAction = {

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -33,7 +33,6 @@ import selectedEditor from './selected-editor/reducer';
 import siteRoles from './site-roles/reducer';
 import sites from './sites/reducer';
 import support from './support/reducer';
-import ui from './ui/reducer';
 import userSettings from './user-settings/reducer';
 import users from './users/reducer';
 
@@ -61,7 +60,6 @@ const reducers = {
 	siteRoles,
 	sites,
 	support,
-	ui,
 	userSettings,
 	users,
 };

--- a/client/state/route/actions.js
+++ b/client/state/route/actions.js
@@ -3,6 +3,8 @@
  */
 import { ROUTE_CLEAR_LAST_NON_EDITOR, ROUTE_SET } from 'calypso/state/action-types';
 
+import 'calypso/state/ui/init';
+
 /**
  * Returns an action object signalling that the current route is to be changed
  *

--- a/client/state/selectors/get-checkout-upgrade-intent.js
+++ b/client/state/selectors/get-checkout-upgrade-intent.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
+/**
  * Retrieve the "intent" that the client implied prior to upgrading so we can send them to the appropriate route after checkout
  *
  * @param {object} state  Global state tree

--- a/client/state/selectors/get-current-locale-slug.js
+++ b/client/state/selectors/get-current-locale-slug.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
+/**
  * Gets the current ui locale slug
  *
  * @param {object} state - global redux state

--- a/client/state/selectors/get-current-locale-variant.js
+++ b/client/state/selectors/get-current-locale-variant.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
+/**
  * Gets the current ui locale variant
  *
  * @param {object} state - global redux state

--- a/client/state/selectors/get-selected-or-all-sites-jetpack-can-manage.js
+++ b/client/state/selectors/get-selected-or-all-sites-jetpack-can-manage.js
@@ -1,11 +1,12 @@
 /**
  * Internal dependencies
  */
-
 import createSelector from 'calypso/lib/create-selector';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+
+import 'calypso/state/ui/init';
 
 /**
  * Return an array with the selected site or all sites Jetpack can manage

--- a/client/state/selectors/get-selected-or-all-sites-with-plugins.js
+++ b/client/state/selectors/get-selected-or-all-sites-with-plugins.js
@@ -1,12 +1,13 @@
 /**
  * Internal dependencies
  */
-
 import createSelector from 'calypso/lib/create-selector';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+
+import 'calypso/state/ui/init';
 
 /**
  * Return an array with the selected site or all sites able to have plugins

--- a/client/state/selectors/has-initialized-sites.js
+++ b/client/state/selectors/has-initialized-sites.js
@@ -1,10 +1,14 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
+/**
  * Returns true if site selection has occured, else false
  *
  * @param {object}  state Global state tree
  * @returns {boolean}       Has site selection occurred
  */
-
 export default function hasInitializedSites( state ) {
 	return state.ui.siteSelectionInitialized;
 }

--- a/client/state/selectors/is-notifications-open.js
+++ b/client/state/selectors/is-notifications-open.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
 
 /**
  * Returns true if the notifications panel is open.

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -16,6 +16,7 @@ import { normalizeSettings } from './utils';
 
 import 'calypso/state/data-layer/wpcom/sites/homepage';
 import 'calypso/state/site-settings/init';
+import 'calypso/state/ui/init';
 
 /**
  * Returns an action object to be used in signalling that site settings have been received.

--- a/client/state/ui/action-log/selectors.js
+++ b/client/state/ui/action-log/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { findLast, last } from 'lodash';
 
 /**
@@ -9,6 +8,8 @@ import { findLast, last } from 'lodash';
  */
 import createSelector from 'calypso/lib/create-selector';
 import { ROUTE_SET } from 'calypso/state/action-types';
+
+import 'calypso/state/ui/init';
 
 /**
  * Returns a log of actions from certain types that have previously been

--- a/client/state/ui/actions/history.js
+++ b/client/state/ui/actions/history.js
@@ -3,6 +3,8 @@
  */
 import { HISTORY_REPLACE } from 'calypso/state/action-types';
 
+import 'calypso/state/ui/init';
+
 /**
  * Replaces the current url and modifies the browser history entry. Equivalent to window.replaceHistory
  *

--- a/client/state/ui/actions/navigate.js
+++ b/client/state/ui/actions/navigate.js
@@ -3,6 +3,8 @@
  */
 import { NAVIGATE } from 'calypso/state/action-types';
 
+import 'calypso/state/ui/init';
+
 /**
  * Returns an action object signalling navigation to the given path.
  *

--- a/client/state/ui/actions/notifications.js
+++ b/client/state/ui/actions/notifications.js
@@ -3,6 +3,8 @@
  */
 import { NOTIFICATIONS_PANEL_TOGGLE } from 'calypso/state/action-types';
 
+import 'calypso/state/ui/init';
+
 /**
  * Sets ui state to toggle the notifications panel
  *

--- a/client/state/ui/actions/package.json
+++ b/client/state/ui/actions/package.json
@@ -1,3 +1,0 @@
-{
-	"sideEffects": false
-}

--- a/client/state/ui/actions/preview.js
+++ b/client/state/ui/actions/preview.js
@@ -3,6 +3,8 @@
  */
 import { PREVIEW_IS_SHOWING } from 'calypso/state/action-types';
 
+import 'calypso/state/ui/init';
+
 export function setPreviewShowing( isShowing ) {
 	return {
 		type: PREVIEW_IS_SHOWING,

--- a/client/state/ui/actions/set-sites.js
+++ b/client/state/ui/actions/set-sites.js
@@ -3,6 +3,8 @@
  */
 import { SELECTED_SITE_SET } from 'calypso/state/action-types';
 
+import 'calypso/state/ui/init';
+
 /**
  * Returns an action object to be used in signalling that a site has been set
  * as selected.

--- a/client/state/ui/actions/sidebar-visibilty.js
+++ b/client/state/ui/actions/sidebar-visibilty.js
@@ -3,6 +3,8 @@
  */
 import { SIDEBAR_TOGGLE_VISIBILITY } from 'calypso/state/action-types';
 
+import 'calypso/state/ui/init';
+
 /**
  * Expand the sidebar.
  *

--- a/client/state/ui/checkout/actions.js
+++ b/client/state/ui/checkout/actions.js
@@ -3,6 +3,8 @@
  */
 import { CHECKOUT_TOGGLE_CART_ON_MOBILE } from 'calypso/state/action-types';
 
+import 'calypso/state/ui/init';
+
 export function toggleCartOnMobile() {
 	return { type: CHECKOUT_TOGGLE_CART_ON_MOBILE };
 }

--- a/client/state/ui/checkout/selectors.js
+++ b/client/state/ui/checkout/selectors.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
 export function isShowingCartOnMobile( state ) {
 	return state.ui.checkout.isShowingCartOnMobile;
 }

--- a/client/state/ui/init.js
+++ b/client/state/ui/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'ui' ], reducer );

--- a/client/state/ui/language/actions.js
+++ b/client/state/ui/language/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import switchLocale from 'calypso/lib/i18n-utils/switch-locale';
 import i18n from 'i18n-calypso';
 
@@ -9,6 +8,8 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import { LOCALE_SET } from 'calypso/state/action-types';
+
+import 'calypso/state/ui/init';
 
 /**
  * Set the ui locale

--- a/client/state/ui/layout-focus/actions.js
+++ b/client/state/ui/layout-focus/actions.js
@@ -1,12 +1,13 @@
 /**
  * Internal dependencies
  */
-
 import {
 	LAYOUT_FOCUS_SET,
 	LAYOUT_NEXT_FOCUS_SET,
 	LAYOUT_NEXT_FOCUS_ACTIVATE,
 } from 'calypso/state/action-types';
+
+import 'calypso/state/ui/init';
 
 export function setLayoutFocus( area ) {
 	return {

--- a/client/state/ui/layout-focus/selectors.js
+++ b/client/state/ui/layout-focus/selectors.js
@@ -1,11 +1,15 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
+/**
  * Returns the current layout focus area
  *
  *
  * @param {object}  state Global state tree
  * @returns {?string}  The current layout focus area
  */
-
 export function getCurrentLayoutFocus( state ) {
 	return state.ui.layoutFocus.current;
 }

--- a/client/state/ui/masterbar-visibility/actions.js
+++ b/client/state/ui/masterbar-visibility/actions.js
@@ -3,6 +3,8 @@
  */
 import { MASTERBAR_TOGGLE_VISIBILITY } from 'calypso/state/action-types';
 
+import 'calypso/state/ui/init';
+
 /**
  * Hide the masterbar.
  *

--- a/client/state/ui/media-modal/actions.js
+++ b/client/state/ui/media-modal/actions.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import { MEDIA_MODAL_VIEW_SET } from 'calypso/state/action-types';
+
+import 'calypso/state/ui/init';
 
 /**
  * Returns an action object used in signalling that the media modal current
@@ -10,7 +11,7 @@ import { MEDIA_MODAL_VIEW_SET } from 'calypso/state/action-types';
  *
  * @see ./constants.js (ModalViews)
  *
- * @param  {ModalViews} view Media view
+ * @param  {any} view Media view
  * @returns {object}          Action object
  */
 export function setMediaModalView( view ) {
@@ -26,7 +27,6 @@ export function setMediaModalView( view ) {
  *
  * @see ./constants.js (ModalViews)
  *
- * @param  {ModalViews} view Media view
  * @returns {object}          Action object
  */
 export function resetMediaModalView() {

--- a/client/state/ui/media-modal/selectors.js
+++ b/client/state/ui/media-modal/selectors.js
@@ -1,13 +1,17 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
+/**
  * Returns the current media modal view.
  *
  *
  *
  * @see ./constants.js (MediaView)
  * @param {object}    state Global state tree
- * @returns {MediaView}       Current media view
+ * @returns {any}       Current media view
  */
-
 export function getMediaModalView( state ) {
 	return state.ui.mediaModal.view;
 }

--- a/client/state/ui/package.json
+++ b/client/state/ui/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/ui/post-type-list/actions.js
+++ b/client/state/ui/post-type-list/actions.js
@@ -6,6 +6,8 @@ import {
 	POST_TYPE_LIST_SHARE_PANEL_TOGGLE,
 } from 'calypso/state/action-types';
 
+import 'calypso/state/ui/init';
+
 export function hideActiveSharePanel() {
 	return {
 		type: POST_TYPE_LIST_SHARE_PANEL_HIDE,

--- a/client/state/ui/post-type-list/selectors.js
+++ b/client/state/ui/post-type-list/selectors.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
 export function isSharePanelOpen( state, postGlobalId ) {
 	if ( ! postGlobalId ) {
 		// Avoid returning `true` if an invalid post ID is passed.

--- a/client/state/ui/preview/actions.js
+++ b/client/state/ui/preview/actions.js
@@ -1,9 +1,10 @@
 /**
  * Internal dependencies
  */
-
 import { PREVIEW_SITE_SET, PREVIEW_URL_CLEAR, PREVIEW_URL_SET } from 'calypso/state/action-types';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+
+import 'calypso/state/ui/init';
 
 export function setPreviewUrl( url ) {
 	return {

--- a/client/state/ui/preview/selectors.js
+++ b/client/state/ui/preview/selectors.js
@@ -1,14 +1,10 @@
 /**
- * External dependencies
- */
-
-// None
-
-/**
  * Internal dependencies
  */
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+import 'calypso/state/ui/init';
 
 /**
  * Returns the URL if SitePreview currently has one.

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -8,7 +8,7 @@ import {
 	SIDEBAR_TOGGLE_VISIBILITY,
 	NOTIFICATIONS_PANEL_TOGGLE,
 } from 'calypso/state/action-types';
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withoutPersistence, withStorageKey } from 'calypso/state/utils';
 import actionLog from './action-log/reducer';
 import checkout from './checkout/reducer';
 import language from './language/reducer';
@@ -111,4 +111,4 @@ const reducer = combineReducers( {
 	siteSelectionInitialized,
 } );
 
-export default reducer;
+export default withStorageKey( 'ui', reducer );

--- a/client/state/ui/section/actions.js
+++ b/client/state/ui/section/actions.js
@@ -3,6 +3,8 @@
  */
 import { SECTION_SET, SECTION_LOADING_SET } from 'calypso/state/action-types';
 
+import 'calypso/state/ui/init';
+
 export function setSection( section, options = {} ) {
 	const action = {
 		...options,

--- a/client/state/ui/selectors/get-section.js
+++ b/client/state/ui/selectors/get-section.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
+/**
  * Returns the current section.
  *
  * @param  {object}  state Global state tree

--- a/client/state/ui/selectors/get-selected-site-id.js
+++ b/client/state/ui/selectors/get-selected-site-id.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
+/**
  * Returns the currently selected site ID.
  *
  * @param  {object}  state Global state tree

--- a/client/state/ui/selectors/is-preview-showing.js
+++ b/client/state/ui/selectors/is-preview-showing.js
@@ -4,10 +4,15 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
+/**
  * Returns true if WebPreview is currently showing.
  *
  * @param  {object}  state Global state tree
- * @returns {bool}    True if currently showing WebPreview
+ * @returns {boolean}    True if currently showing WebPreview
  *
  * @see client/components/web-preview
  */

--- a/client/state/ui/selectors/is-section-loading.js
+++ b/client/state/ui/selectors/is-section-loading.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
+/**
  * Returns whether a section is loading.
  *
  * @param  {object}  state Global state tree

--- a/client/state/ui/selectors/masterbar-is-visible.js
+++ b/client/state/ui/selectors/masterbar-is-visible.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
 export default function masterbarIsVisible( state ) {
 	return state.ui.masterbarVisibility;
 }

--- a/client/state/ui/selectors/package.json
+++ b/client/state/ui/selectors/package.json
@@ -1,3 +1,0 @@
-{
-	"sideEffects": false
-}

--- a/client/state/ui/selectors/sidebar-visibility.js
+++ b/client/state/ui/selectors/sidebar-visibility.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/ui/init';
+
 export default function getSidebarIsCollapsed( state ) {
 	return state.ui.sidebarIsCollapsed;
 }


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles ui state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42486.

#### Changes proposed in this Pull Request

* Modularise ui state

#### Testing instructions

UI state is loaded pretty early on in Calypso, since the entire application depends on it. As such, there isn't really a good way of verifying the loading process.

For testing, please smoke-test basic UI functionality like navigation, and ensure that everything continues to work correctly.