### PR TITLE
State: Modularize post formats state

### DIFF
--- a/client/state/post-formats/actions.js
+++ b/client/state/post-formats/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'calypso/lib/wp';
 import {
 	POST_FORMATS_RECEIVE,
@@ -9,6 +8,8 @@ import {
 	POST_FORMATS_REQUEST_SUCCESS,
 	POST_FORMATS_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
+
+import 'calypso/state/post-formats/init';
 
 /**
  * Returns an action thunk which, when invoked, triggers a network request to

--- a/client/state/post-formats/init.js
+++ b/client/state/post-formats/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'postFormats' ], reducer );

--- a/client/state/post-formats/package.json
+++ b/client/state/post-formats/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/post-formats/reducer.js
+++ b/client/state/post-formats/reducer.js
@@ -2,7 +2,12 @@
  * Internal dependencies
  */
 import { postFormatsItemsSchema } from './schema';
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'calypso/state/utils';
+import {
+	combineReducers,
+	withSchemaValidation,
+	withStorageKey,
+	withoutPersistence,
+} from 'calypso/state/utils';
 import {
 	POST_FORMATS_RECEIVE,
 	POST_FORMATS_REQUEST,
@@ -56,7 +61,10 @@ export const items = withSchemaValidation( postFormatsItemsSchema, ( state = {},
 	return state;
 } );
 
-export default combineReducers( {
-	requesting,
-	items,
-} );
+export default withStorageKey(
+	'postFormats',
+	combineReducers( {
+		requesting,
+		items,
+	} )
+);

--- a/client/state/post-formats/selectors.js
+++ b/client/state/post-formats/selectors.js
@@ -1,12 +1,16 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/post-formats/init';
+
+/**
  * Returns true if currently requesting post formats for the specified site ID, or
  * false otherwise.
  *
- *
+ * @param {object}  state  Global state tree
  * @param {number}  siteId Site ID
  * @returns {boolean}        Whether post formats are being requested
  */
-
 export function isRequestingPostFormats( state, siteId ) {
 	return !! state.postFormats.requesting[ siteId ];
 }

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -30,7 +30,6 @@ import media from './media/reducer';
 import mySites from './my-sites/reducer';
 import notices from './notices/reducer';
 import { unseenCount as notificationsUnseenCount } from './notifications';
-import postFormats from './post-formats/reducer';
 import selectedEditor from './selected-editor/reducer';
 import siteKeyrings from './site-keyrings/reducer';
 import siteRoles from './site-roles/reducer';
@@ -63,7 +62,6 @@ const reducers = {
 	mySites,
 	notices,
 	notificationsUnseenCount,
-	postFormats,
 	selectedEditor,
 	siteKeyrings,
 	siteRoles,


### PR DESCRIPTION
This PR is one of many working on the modularizing state in Calypso. This one handles post formats state.

For more details on state modularization, see the [modularized state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42468.

#### Changes proposed in this Pull Request

* Modularize post formats state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en) if you haven't yet.
* Open DevTools and switch to the Redux tab.
* Open Home on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `postFormats` key, even if you expand the list of keys. This indicates that the post formats state hasn't been loaded yet.
* Go to `/settings/writing/:site` where `:site` is one of your Jetpack sites.
* Verify that a `postFormats` key is added with the post formats state. This indicates that the post formats state has now been loaded.
* Tinker with the "Default Post Format" setting and verify everything works as it did before.

#### Note

Linting errors are expected - they're coming from the non-modularized reducer, and will disappear once we modularize all of it.