### PR TITLE
Jetpack: reset AL's filter selection when entering the Backup section

### DIFF
--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import Debug from 'debug';
 
 /**
  * Internal dependencies
@@ -24,7 +25,11 @@ import { isJetpackBackupSlug } from 'calypso/lib/products-values';
 import HasVaultPressSwitch from 'calypso/components/jetpack/has-vaultpress-switch';
 import IsJetpackDisconnectedSwitch from 'calypso/components/jetpack/is-jetpack-disconnected-switch';
 
+const debug = new Debug( 'calypso:my-sites:backup:controller' );
+
 export function showUpsellIfNoBackup( context, next ) {
+	debug( 'controller: showUpsellIfNoBackup', context.params );
+
 	const UpsellComponent = isJetpackCloud() ? BackupUpsell : WPCOMBackupUpsell;
 	context.primary = (
 		<>
@@ -50,6 +55,8 @@ export function showUpsellIfNoBackup( context, next ) {
 }
 
 export function showJetpackIsDisconnected( context, next ) {
+	debug( 'controller: showJetpackIsDisconnected', context.params );
+
 	const JetpackConnectionFailed = isJetpackCloud() ? (
 		<BackupUpsell reason="no_connected_jetpack" />
 	) : (
@@ -65,6 +72,8 @@ export function showJetpackIsDisconnected( context, next ) {
 }
 
 export function showUnavailableForVaultPressSites( context, next ) {
+	debug( 'controller: showUnavailableForVaultPressSites', context.params );
+
 	const message = isJetpackCloud() ? (
 		<BackupUpsell reason="vp_active_on_site" />
 	) : (
@@ -79,6 +88,8 @@ export function showUnavailableForVaultPressSites( context, next ) {
 }
 
 export function showUnavailableForMultisites( context, next ) {
+	debug( 'controller: showUnavailableForMultisites', context.params );
+
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	if ( isJetpackSiteMultiSite( state, siteId ) ) {
@@ -94,6 +105,8 @@ export function showUnavailableForMultisites( context, next ) {
 
 /* handles /backup/:site, see `backupMainPath` */
 export function backups( context, next ) {
+	debug( 'controller: backups', context.params );
+
 	// When a user visits `/backup`, we don't want to carry over any filter
 	// selection that could've happened in the Activity Log, otherwise,
 	// the app will render the `SearchResults` component instead of the
@@ -113,6 +126,8 @@ export function backups( context, next ) {
 
 /* handles /backup/:site/download/:rewindId, see `backupDownloadPath` */
 export function backupDownload( context, next ) {
+	debug( 'controller: backupDownload', context.params );
+
 	context.primary = (
 		<BackupRewindFlow rewindId={ context.params.rewindId } purpose={ RewindFlowPurpose.DOWNLOAD } />
 	);
@@ -121,6 +136,8 @@ export function backupDownload( context, next ) {
 
 /* handles /backup/:site/restore/:rewindId, see `backupRestorePath` */
 export function backupRestore( context, next ) {
+	debug( 'controller: backupRestore', context.params );
+
 	context.primary = (
 		<BackupRewindFlow rewindId={ context.params.rewindId } purpose={ RewindFlowPurpose.RESTORE } />
 	);

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -14,6 +14,7 @@ import WPCOMBackupUpsell from './wpcom-backup-upsell';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import FormattedHeader from 'calypso/components/formatted-header';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import { setFilter } from 'calypso/state/activity-log/actions';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
@@ -93,6 +94,17 @@ export function showUnavailableForMultisites( context, next ) {
 
 /* handles /backup/:site, see `backupMainPath` */
 export function backups( context, next ) {
+	// When a user visits `/backup`, we don't want to carry over any filter
+	// selection that could've happened in the Activity Log, otherwise,
+	// the app will render the `SearchResults` component instead of the
+	// `BackupStatus`.
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	context.store.dispatch( {
+		...setFilter( siteId, {} ),
+		meta: { skipUrlUpdate: true },
+	} );
+
 	const { date } = context.query;
 
 	context.primary = <BackupsPage queryDate={ date } />;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reset the Activity Log's filter selection when a user enters the Backup section. Without this, having an active filter selection makes the Backup section display the `SearchResults` component instead of the `BackupStatus` one which negatively affects the UX (see the demo section for graphical representation of the problem).

#### Testing instructions

**Prerequisite: a Jetpack site with a paid plan**

**Issue replication**
* Follow the next steps in wordpress.com and cloud.jetpack.com.
* Visit the `/activity-log` section.
* From the pagination component, select any page.
* Visit the `/backup` section.
* Verify that you still see the search results from the AL page.

**Testing the fix**

* Download this PR and build both Calypsos.
* Repeat the next steps in both environments.
* Visit the `/activity-log` section.
* From the pagination component, select any page.
* Visit the `/backup` section.
* Verify that you see the latest backup status.

Fixes 1164141197617539-as-1199363383067093

#### Demo

#### Calypso Blue – before
![Kapture 2020-11-25 at 17 45 45](https://user-images.githubusercontent.com/3418513/100279878-17e48300-2f46-11eb-8de8-fc11b7daaec2.gif)

#### Calypso Blue – after
![Kapture 2020-11-25 at 17 47 12](https://user-images.githubusercontent.com/3418513/100280029-4b271200-2f46-11eb-939f-d06ae971595d.gif)

#### Calypso Green – before
![Kapture 2020-11-25 at 17 48 08](https://user-images.githubusercontent.com/3418513/100280103-685be080-2f46-11eb-8254-0b2c3ce7ea6a.gif)

#### Calypso Green – after
![Kapture 2020-11-25 at 17 49 05](https://user-images.githubusercontent.com/3418513/100280229-950ff800-2f46-11eb-8beb-d0045dc494e9.gif)
