### PR TITLE
State: Modularize profile links

### DIFF
--- a/client/state/data-layer/wpcom/me/settings/profile-links/delete/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/delete/index.js
@@ -8,8 +8,9 @@ import {
 	deleteUserProfileLinkError,
 	deleteUserProfileLinkSuccess,
 } from 'calypso/state/profile-links/actions';
-
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+import 'calypso/state/profile-links/init';
 
 /**
  * Dispatches a request to delete a profile link for the current user
@@ -30,7 +31,8 @@ export const deleteUserProfileLink = ( action ) =>
 /**
  * Dispatches a user profile links deletion success action when the request succeeded.
  *
- * @param   {object} action Redux action
+ * @param   {object} action          Redux action
+ * @param   {string} action.linkSlug Slug of the link
  * @returns {object} Dispatched user profile links delete success action
  */
 export const handleDeleteSuccess = ( { linkSlug } ) => deleteUserProfileLinkSuccess( linkSlug );
@@ -38,8 +40,9 @@ export const handleDeleteSuccess = ( { linkSlug } ) => deleteUserProfileLinkSucc
 /**
  * Dispatches a user profile links deletion error action when the request failed.
  *
- * @param   {object} action Redux action
- * @param   {object} error  Error returned
+ * @param   {object} action          Redux action
+ * @param   {string} action.linkSlug Slug of the link
+ * @param   {object} error           Error returned
  * @returns {object} Dispatched user profile links delete error action
  */
 export const handleDeleteError = ( { linkSlug }, error ) =>

--- a/client/state/data-layer/wpcom/me/settings/profile-links/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/index.js
@@ -10,8 +10,9 @@ import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { USER_PROFILE_LINKS_REQUEST } from 'calypso/state/action-types';
 import { receiveUserProfileLinks } from 'calypso/state/profile-links/actions';
-
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+import 'calypso/state/profile-links/init';
 
 /**
  * Dispatches a request to fetch profile links of the current user
@@ -32,8 +33,9 @@ export const requestUserProfileLinks = ( action ) =>
 /**
  * Dispatches a user profile links receive action when the request succeeded.
  *
- * @param   {object} action Redux action
- * @param   {Array}  data   Response from the endpoint
+ * @param   {object} action             Redux action
+ * @param   {Array}  data               Response from the endpoint
+ * @param   {object} data.profile_links Profile links
  * @returns {object} Dispatched user profile links receive action
  */
 export const handleRequestSuccess = ( action, { profile_links } ) =>

--- a/client/state/data-layer/wpcom/me/settings/profile-links/new/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/new/index.js
@@ -11,8 +11,9 @@ import {
 	addUserProfileLinksSuccess,
 	receiveUserProfileLinks,
 } from 'calypso/state/profile-links/actions';
-
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+
+import 'calypso/state/profile-links/init';
 
 /**
  * Dispatches a request to add profile links for the current user
@@ -60,8 +61,9 @@ export const handleAddSuccess = ( action, data ) => {
 /**
  * Dispatches a user profile links add error action when the request failed.
  *
- * @param   {object} action Redux action
- * @param   {object} error  Error returned
+ * @param   {object} action              Redux action
+ * @param   {object} action.profileLinks Profile links
+ * @param   {object} error               Error returned
  * @returns {object} Dispatched user profile links add error action
  */
 export const handleAddError = ( { profileLinks }, error ) =>

--- a/client/state/profile-links/actions.js
+++ b/client/state/profile-links/actions.js
@@ -15,6 +15,8 @@ import {
 	USER_PROFILE_LINKS_RESET_ERRORS,
 } from 'calypso/state/action-types';
 
+import 'calypso/state/profile-links/init';
+
 import 'calypso/state/data-layer/wpcom/me/settings/profile-links';
 import 'calypso/state/data-layer/wpcom/me/settings/profile-links/delete';
 import 'calypso/state/data-layer/wpcom/me/settings/profile-links/new';

--- a/client/state/profile-links/init.js
+++ b/client/state/profile-links/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'userProfileLinks' ], reducer );

--- a/client/state/profile-links/package.json
+++ b/client/state/profile-links/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/profile-links/reducer.js
+++ b/client/state/profile-links/reducer.js
@@ -6,7 +6,7 @@ import { reject } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withoutPersistence, withStorageKey } from 'calypso/state/utils';
 import {
 	USER_PROFILE_LINKS_ADD_DUPLICATE,
 	USER_PROFILE_LINKS_ADD_FAILURE,
@@ -68,7 +68,10 @@ export const errors = withoutPersistence( ( state = {}, action ) => {
 	return state;
 } );
 
-export default combineReducers( {
-	items,
-	errors,
-} );
+export default withStorageKey(
+	'userProfileLinks',
+	combineReducers( {
+		items,
+		errors,
+	} )
+);

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -38,7 +38,6 @@ import sites from './sites/reducer';
 import storedCards from './stored-cards/reducer';
 import support from './support/reducer';
 import ui from './ui/reducer';
-import userProfileLinks from './profile-links/reducer';
 import userSettings from './user-settings/reducer';
 import users from './users/reducer';
 
@@ -71,7 +70,6 @@ const reducers = {
 	storedCards,
 	support,
 	ui,
-	userProfileLinks,
 	userSettings,
 	users,
 };

--- a/client/state/selectors/get-profile-links-error-type.js
+++ b/client/state/selectors/get-profile-links-error-type.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/profile-links/init';
+
+/**
  * Returns the type of the last profile links request error, or null if there's no error.
  * Can be one of 'duplicate', 'malformed', 'other' or `null`.
  *

--- a/client/state/selectors/get-profile-links.js
+++ b/client/state/selectors/get-profile-links.js
@@ -1,9 +1,14 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/profile-links/init';
+
+/**
  * Returns all profile links of the current user.
  *
  * @param {object}  state  Global state tree
  * @returns {?Array}        Profile links
  */
 export default function getProfileLinks( state ) {
-	return state.userProfileLinks.items;
+	return state.userProfileLinks?.items;
 }


### PR DESCRIPTION
This PR is one of many working on the modularizing state in Calypso. This one handles profile links state.

For more details on state modularization, see the [modularized state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42489.

#### Changes proposed in this Pull Request

* Modularize profile links state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en) if you haven't yet.
* Open DevTools and switch to the Redux tab.
* Open Home on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `userProfileLinks` key, even if you expand the list of keys. This indicates that the profile links state hasn't been loaded yet.
* Go to `/me`.
* Verify that a `userProfileLinks` key is added with the profile links state. This indicates that the profile links state has now been loaded.
* Try adding a new profile link (a WP site and a custom URL) and deleting existing ones and verify everything works as it did before.

#### Note

Linting errors are expected - they're coming from the non-modularized reducer, and will disappear once we modularize all of it.