### PR TITLE
Jetpack connect: enable `/plans/` route in Jetpack cloud

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -128,11 +128,11 @@ const oauthTokenMiddleware = () => {
 		];
 
 		if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
-			loggedOutRoutes.push( '/jetpack/connect' );
+			loggedOutRoutes.push( '/jetpack/connect', '/plans' );
 		}
 
 		if ( isJetpackCloud() && config.isEnabled( 'jetpack/pricing-page' ) ) {
-			loggedOutRoutes.push( '/pricing', '/plans' );
+			loggedOutRoutes.push( '/pricing' );
 			getLanguageSlugs().forEach( ( slug ) => loggedOutRoutes.push( `/${ slug }/pricing` ) );
 		}
 
@@ -348,7 +348,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 		// Dead-end the sections the user can't access when logged out
 		page( '*', function ( context, next ) {
 			//see server/pages/index for prod redirect
-			if ( ! isJetpackCloud() && '/plans' === context.pathname ) {
+			if ( ! config.isEnabled( 'jetpack-cloud/connect' ) && '/plans' === context.pathname ) {
 				const queryFor = context.query && context.query.for;
 				if ( queryFor && 'jetpack' === queryFor ) {
 					window.location =

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -348,7 +348,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 		// Dead-end the sections the user can't access when logged out
 		page( '*', function ( context, next ) {
 			//see server/pages/index for prod redirect
-			if ( '/plans' === context.pathname ) {
+			if ( ! isJetpackCloud() && '/plans' === context.pathname ) {
 				const queryFor = context.query && context.query.for;
 				if ( queryFor && 'jetpack' === queryFor ) {
 					window.location =

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -132,7 +132,7 @@ const oauthTokenMiddleware = () => {
 		}
 
 		if ( isJetpackCloud() && config.isEnabled( 'jetpack/pricing-page' ) ) {
-			loggedOutRoutes.push( '/pricing' );
+			loggedOutRoutes.push( '/pricing', '/plans' );
 			getLanguageSlugs().forEach( ( slug ) => loggedOutRoutes.push( `/${ slug }/pricing` ) );
 		}
 

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -13,7 +13,7 @@ import JetpackComFooter from './jpcom-footer';
 import { setLocale } from 'calypso/state/ui/language/actions';
 import { addQueryArgs } from 'calypso/lib/route';
 
-export function jetpackPricingContext( context: PageJS.Context, next: () => any ) {
+export function jetpackPricingContext( context: PageJS.Context, next: () => void ): void {
 	const urlQueryArgs = context.query;
 	const { locale } = context.params;
 

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import config from 'calypso/config';
 import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 import * as controller from './controller';
 
@@ -12,5 +13,8 @@ import './style.scss';
 export default function (): void {
 	jetpackPlans( `/:locale/pricing`, controller.jetpackPricingContext );
 	jetpackPlans( `/pricing`, controller.jetpackPricingContext );
-	jetpackPlans( `/plans`, controller.jetpackPricingContext );
+
+	if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
+		jetpackPlans( `/plans`, controller.jetpackPricingContext );
+	}
 }

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -9,7 +9,8 @@ import * as controller from './controller';
  */
 import './style.scss';
 
-export default function () {
+export default function (): void {
 	jetpackPlans( `/:locale/pricing`, controller.jetpackPricingContext );
 	jetpackPlans( `/pricing`, controller.jetpackPricingContext );
+	jetpackPlans( `/plans`, controller.jetpackPricingContext );
 }

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -19,7 +19,6 @@ import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/c
 import { noSite, siteSelection } from 'calypso/my-sites/controller';
 import config from 'calypso/config';
 import userFactory from 'calypso/lib/user';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 export default function () {
 	SiftScience.recordUser();
@@ -157,7 +156,7 @@ export default function () {
 	);
 
 	// Visiting /checkout without a plan or product should be redirected to /plans
-	page( '/checkout', isJetpackCloud() ? '/pricing' : '/plans' );
+	page( '/checkout', '/plans' );
 
 	page(
 		'/checkout/:site/offer-plan-upgrade/:upgradeItem/:receiptId?',

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -156,7 +156,7 @@ export default function () {
 	);
 
 	// Visiting /checkout without a plan or product should be redirected to /plans
-	page( '/checkout', '/plans' );
+	page( '/checkout', config.isEnabled( 'jetpack-cloud/connect' ) ? '/plans' : '/pricing' );
 
 	page(
 		'/checkout/:site/offer-plan-upgrade/:upgradeItem/:receiptId?',

--- a/client/sections.js
+++ b/client/sections.js
@@ -449,7 +449,7 @@ const sections = [
 	},
 	{
 		name: 'jetpack-cloud-pricing',
-		paths: [ '/pricing', '/[^\\/]+/pricing' ],
+		paths: [ '/pricing', '/plans', '/[^\\/]+/pricing' ],
 		module: 'calypso/jetpack-cloud/sections/pricing',
 		group: 'jetpack-cloud',
 		enableLoggedOut: true,

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -45,7 +45,6 @@ import { logSectionResponse } from './analytics';
 import analytics from 'calypso/server/lib/analytics';
 import { getLanguage, filterLanguageRevisions } from 'calypso/lib/i18n-utils';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { GUTENBOARDING_SECTION_DEFINITION } from 'calypso/landing/gutenboarding/section';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 
@@ -637,7 +636,7 @@ export default function pages() {
 					res.redirect(
 						'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans'
 					);
-				} else if ( ! isJetpackCloud() ) {
+				} else if ( ! config.isEnabled( 'jetpack-cloud/connect' ) ) {
 					res.redirect( 'https://wordpress.com/pricing' );
 				}
 			} else {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -45,6 +45,7 @@ import { logSectionResponse } from './analytics';
 import analytics from 'calypso/server/lib/analytics';
 import { getLanguage, filterLanguageRevisions } from 'calypso/lib/i18n-utils';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { GUTENBOARDING_SECTION_DEFINITION } from 'calypso/landing/gutenboarding/section';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 
@@ -636,7 +637,7 @@ export default function pages() {
 					res.redirect(
 						'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans'
 					);
-				} else {
+				} else if ( ! isJetpackCloud() ) {
 					res.redirect( 'https://wordpress.com/pricing' );
 				}
 			} else {


### PR DESCRIPTION
### Changes proposed in this Pull Request

The Jetpack plans are currently available in Jetpack cloud at `/pricing`. This PR makes them accessible at `/plans` as well. This is necessary to port the connection flow to Jetpack cloud as many redirects to `/plans` occur in the flow.

It also redirects `/checkout` to `/plans` in Jetpack cloud to match Calypo's behaviour.

### Implementation notes

Usually, we'd add a section by adding an entry in the `section` value of an environment config file. This doesn't work in our case though, since the section would mirror the Plans section in Calypso exactly (with the navigation, tab, etc.), which we don't want for now.

Note: `/plans` is available only when config `jetpack-cloud/connect` is enabled (i.e. not in prod).

### Testing instructions

- Download this PR
- Run Jetpack cloud (and **not** Calypso and cloud concurrently)
- Visit `/plans` and `/plans/:site`, logged in then logged out, and check that the page looks like the page at `/pricing`
- Visit `/checkout` (logged in) and check that it redirects to `/plans` (instead of `/pricing`)
