### PR TITLE
Coming Soon private by default: pass wpcom_coming_soon to sites/new 

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -87,6 +87,10 @@ export function* createSite(
 			} ),
 			use_patterns: true,
 			selected_features: selectedFeatures,
+			...( ! isEnabled( 'coming-soon-v2' ) &&
+				visibility === Site.Visibility.Private && {
+					wpcom_coming_soon: 1,
+				} ),
 			...( isEnabled( 'coming-soon-v2' ) &&
 				visibility === Site.Visibility.PublicNotIndexed && {
 					wpcom_public_coming_soon: 1,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This commit makes the onboarding flow `/new` consistent with `/start/domains` by setting the v1 coming soon option for Gutenboarding to `1`.

There should be no side effects. 

#### Testing instructions

Create a new site via `/new`
It should be in private coming soon mode
Check in the console that we're sending `wpcom_coming_soon: 1` to `site/new` in the option object
<img width="391" alt="Screen Shot 2020-11-26 at 10 29 09 am" src="https://user-images.githubusercontent.com/6458278/100291568-3d1ed300-2fd2-11eb-8169-41ba0b17d2ef.png">
Launch the site
It should be public

Create a new site via `/start/domains`
It should be in private coming soon mode
Launch the site
It should be public

