### PR TITLE
Remove football as the default vertical

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -71,7 +71,7 @@ export function* createSite(
 			// so we can match directories in
 			// https://github.com/Automattic/wp-calypso/tree/HEAD/static/page-templates/verticals
 			// TODO: determine default vertical should user input match no official vertical
-			site_vertical_slug: siteVertical?.slug || 'football',
+			site_vertical_slug: siteVertical?.slug,
 			site_information: {
 				title: blogTitle,
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're not using verticals right now in signup. The default 'football' isn't relevant to any code or feature. Let's get rid of it.

#### Testing instructions

Create a site over at `/new`

You should be able to create a site
