### PR TITLE
Allow one click upsell for the plan upgrade nudge

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -17,6 +17,14 @@ import CheckoutContainer from './checkout/checkout-container';
 import CheckoutSystemDecider from './checkout-system-decider';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
+<<<<<<< HEAD
+=======
+import UpsellNudge, {
+	PLAN_UPGRADE_UPSELL,
+	CONCIERGE_SUPPORT_SESSION,
+	CONCIERGE_QUICKSTART_SESSION,
+} from './upsell-nudge';
+>>>>>>> Dynamically resolve product slug based on the upsell type and upgraded item if applicable
 import { canUserPurchaseGSuite } from 'calypso/lib/gsuite';
 import { getRememberedCoupon } from 'calypso/lib/cart/actions';
 import { setSectionMiddleware } from 'calypso/controller';

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -17,14 +17,6 @@ import CheckoutContainer from './checkout/checkout-container';
 import CheckoutSystemDecider from './checkout-system-decider';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
-<<<<<<< HEAD
-=======
-import UpsellNudge, {
-	PLAN_UPGRADE_UPSELL,
-	CONCIERGE_SUPPORT_SESSION,
-	CONCIERGE_QUICKSTART_SESSION,
-} from './upsell-nudge';
->>>>>>> Dynamically resolve product slug based on the upsell type and upgraded item if applicable
 import { canUserPurchaseGSuite } from 'calypso/lib/gsuite';
 import { getRememberedCoupon } from 'calypso/lib/cart/actions';
 import { setSectionMiddleware } from 'calypso/controller';

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -250,6 +250,7 @@ export class UpsellNudge extends React.Component {
 
 		return true;
 	};
+	
 
 	handleOneClickUpsellComplete = () => {
 		this.props.handleCheckoutCompleteRedirect( true );

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -252,8 +252,8 @@ export class UpsellNudge extends React.Component {
 		return true;
 	};
 
-	handleOneClickUpsellComplete = () => {
-		this.props.handleCheckoutCompleteRedirect( true );
+	handleOneClickUpsellComplete = ( currentRecieptId ) => {
+		this.props.handleCheckoutCompleteRedirect( true, currentRecieptId );
 	};
 
 	renderPurchaseModal = () => {

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -48,14 +48,15 @@ import { getPlanByPathSlug } from 'calypso/lib/plans';
  * Style dependencies
  */
 import './style.scss';
+import { getPlanByPathSlug } from 'calypso/lib/plans';
 
 /**
  * Upsell Types
  */
 export const CONCIERGE_QUICKSTART_SESSION = 'concierge-quickstart-session';
 export const CONCIERGE_SUPPORT_SESSION = 'concierge-support-session';
-export const PREMIUM_PLAN_UPGRADE_UPSELL = 'premium-plan-upgrade-upsell';
-export const BUSINESS_PLAN_UPGRADE_UPSELL = 'business-plan-upgrade-upsell';
+export const PREMIUM_PLAN_UPGRADE_UPSELL = 'plan-upgrade-upsell';
+export const BUSINESS_PLAN_UPGRADE_UPSELL = 'plan-upgrade-upsell';
 
 export class UpsellNudge extends React.Component {
 	static propTypes = {
@@ -233,8 +234,8 @@ export class UpsellNudge extends React.Component {
 
 	isEligibleForOneClickUpsell = ( buttonAction ) => {
 		const { cards, siteSlug, upsellType } = this.props;
-		const supportedUpsellTypes = [ 'concierge-quickstart-session', 'premium-plan-upgrade-upsell' ];
 
+		const supportedUpsellTypes = [ CONCIERGE_QUICKSTART_SESSION, PREMIUM_PLAN_UPGRADE_UPSELL, BUSINESS_PLAN_UPGRADE_UPSELL ];
 		if ( 'accept' !== buttonAction || ! supportedUpsellTypes.includes( upsellType ) ) {
 			return false;
 		}
@@ -250,7 +251,6 @@ export class UpsellNudge extends React.Component {
 
 		return true;
 	};
-	
 
 	handleOneClickUpsellComplete = () => {
 		this.props.handleCheckoutCompleteRedirect( true );
@@ -315,6 +315,7 @@ export default connect(
 		const annualPrice = getSitePlanRawPrice( state, selectedSiteId, planSlug, {
 			isMonthly: false,
 		} );
+		const productSlug = resolveProductSlug( upsellType, upgradeItem );
 
 		const productSlug = resolveProductSlug( upsellType, upgradeItem );
 

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -48,15 +48,14 @@ import { getPlanByPathSlug } from 'calypso/lib/plans';
  * Style dependencies
  */
 import './style.scss';
-import { getPlanByPathSlug } from 'calypso/lib/plans';
 
 /**
  * Upsell Types
  */
 export const CONCIERGE_QUICKSTART_SESSION = 'concierge-quickstart-session';
 export const CONCIERGE_SUPPORT_SESSION = 'concierge-support-session';
-export const PREMIUM_PLAN_UPGRADE_UPSELL = 'plan-upgrade-upsell';
-export const BUSINESS_PLAN_UPGRADE_UPSELL = 'plan-upgrade-upsell';
+export const PREMIUM_PLAN_UPGRADE_UPSELL = 'premium-plan-upgrade-upsell';
+export const BUSINESS_PLAN_UPGRADE_UPSELL = 'business-plan-upgrade-upsell';
 
 export class UpsellNudge extends React.Component {
 	static propTypes = {
@@ -235,7 +234,11 @@ export class UpsellNudge extends React.Component {
 	isEligibleForOneClickUpsell = ( buttonAction ) => {
 		const { cards, siteSlug, upsellType } = this.props;
 
-		const supportedUpsellTypes = [ CONCIERGE_QUICKSTART_SESSION, PREMIUM_PLAN_UPGRADE_UPSELL, BUSINESS_PLAN_UPGRADE_UPSELL ];
+		const supportedUpsellTypes = [
+			CONCIERGE_QUICKSTART_SESSION,
+			PREMIUM_PLAN_UPGRADE_UPSELL,
+			BUSINESS_PLAN_UPGRADE_UPSELL,
+		];
 		if ( 'accept' !== buttonAction || ! supportedUpsellTypes.includes( upsellType ) ) {
 			return false;
 		}
@@ -315,7 +318,6 @@ export default connect(
 		const annualPrice = getSitePlanRawPrice( state, selectedSiteId, planSlug, {
 			isMonthly: false,
 		} );
-		const productSlug = resolveProductSlug( upsellType, upgradeItem );
 
 		const productSlug = resolveProductSlug( upsellType, upgradeItem );
 

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
@@ -68,7 +68,7 @@ export function useSubmitTransaction( {
 					persistent: true,
 				} );
 				recordTracksEvent( 'calypso_oneclick_upsell_payment_success', {} );
-				onComplete?.();
+				onComplete?.( data?.receipt_id );
 			}
 		} );
 	}, [ cart, storedCard, setStep, onClose, onComplete, successMessage ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Support feature provided in #45350 for plan upgrade upsell nudge.

#### Testing instructions
1-Register new site by going to http://calypso.localhost:3000/start/domains
2-Select the premium plan in the plans step
3-Complete purchase on checkout using a credit card
3-In the up-sell nudge click on Yes, I need plugins for my site!
4-The following modal should appear
![image](https://user-images.githubusercontent.com/3422709/100444549-97eb2400-30d1-11eb-9f91-d609e2a11b94.png)

