### PR TITLE
Removes the coming-soon-v2 flag so we can rollback the feature

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -22,7 +22,6 @@
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,
-		"coming-soon-v2": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -18,7 +18,6 @@
 		"async-payments": false,
 		"blogger-plan": false,
 		"catch-js-errors": false,
-		"coming-soon-v2": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,

--- a/config/development.json
+++ b/config/development.json
@@ -34,7 +34,6 @@
 		"automated-transfer": true,
 		"blogger-plan": true,
 		"calypsoify/plugins": true,
-		"coming-soon-v2": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,7 +21,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"coming-soon-v2": true,
 		"composite-checkout-testing": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,

--- a/config/production.json
+++ b/config/production.json
@@ -21,7 +21,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"coming-soon-v2": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -22,7 +22,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"coming-soon-v2": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -31,7 +31,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
-		"coming-soon-v2": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,7 +24,6 @@
 		"comments/management/threaded-view": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"coming-soon-v2": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/47401 we released Coming Soon v2 (pbAok1-1gI-p2)

This is a preparatory rollback PR just in case things go pear-shaped.

#### Testing instructions

Make sure that, when you create a site, we pass `wpcom_coming_soon: 1` to `sites/new` and not `wpcom_public_coming_soon`

Setting the site to Coming Soon on the site settings page should switch on the private version.

The low-tech way of checking is to look at the HTML source of the Coming Soon page itself. The new one has an HTML comment just before the closing body tag:

<!-- WordPress.com Editing Toolkit Plugin - Coming Soon -->

The v1 one does not.


