### PR TITLE
Nav unification: update Sakura color scheme to be compatible with Nav Unification

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sakura.scss
@@ -120,4 +120,10 @@
 	--color-sidebar-menu-hover-background: var( --studio-pink-10 );
 	--color-sidebar-menu-hover-background-rgb: var( --studio-pink-10-rgb );
 	--color-sidebar-menu-hover-text: var( --studio-pink-90 );
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: var( --studio-pink-90 );
+	--color-sidebar-submenu-text: var( --studio-pink-0 );
+	--color-sidebar-submenu-hover-text: var( --studio-blue-20 );
+	--color-sidebar-submenu-selected-text: var( --studio-pink-0 );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update Sakura color scheme to be compatible with Nav Unification

While working on porting Sakura to wp-admin in Automattic/jetpack#17828, I noticed we will need a few more changes to the color scheme in Calypso to work with Nav Unification.

|Before|After|
|-|-|
|<img width="461" alt="Screenshot 2020-11-26 at 08 53 44" src="https://user-images.githubusercontent.com/1562646/100326804-badee080-2fca-11eb-8809-478177c77df7.png">|<img width="464" alt="Screenshot 2020-11-26 at 09 31 27" src="https://user-images.githubusercontent.com/1562646/100326813-bd413a80-2fca-11eb-8f10-45b55348252f.png">|
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /me/account in production and select the color scheme
* Check out this branch, run `yarn && yarn start`, visit http://calypso.localhost:3000/
* Add your user to `Treatment Variation` in Experiment (see paYJgx-1af-p2) to enable nav unification
* Compare against nav unification without this branch
