### PR TITLE
Nav unification: update Sunset color scheme to be compatible with Nav Unification

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunset.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunset.scss
@@ -120,4 +120,10 @@
 	--color-sidebar-menu-hover-background: var( --studio-red-80 );
 	--color-sidebar-menu-hover-background-rgb: var( --studio-red-80-rgb );
 	--color-sidebar-menu-hover-text: var( --studio-white );
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: var( --studio-red-60 );
+	--color-sidebar-submenu-text: var( --studio-white );
+	--color-sidebar-submenu-hover-text: var( --studio-yellow-20 );
+	--color-sidebar-submenu-selected-text: var( --studio-white );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update Sunset color scheme to be compatible with Nav Unification

While working on porting Sunset to wp-admin in Automattic/jetpack#17828, I noticed we will need a few more changes to the color scheme in Calypso to work with Nav Unification.

|Before|After|
|-|-|
|<img width="463" alt="Screenshot 2020-11-26 at 10 34 33" src="https://user-images.githubusercontent.com/1562646/100335609-773da400-2fd5-11eb-868d-e4f9feb98b98.png">|<img width="462" alt="Screenshot 2020-11-26 at 10 48 09" src="https://user-images.githubusercontent.com/1562646/100335622-799ffe00-2fd5-11eb-862b-23bfdce58933.png">|

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /me/account in production and select the color scheme
* Check out this branch, run `yarn && yarn start`, visit http://calypso.localhost:3000/
* Add your user to `Treatment Variation` in Experiment (see paYJgx-1af-p2) to enable nav unification
* Compare against nav unification without this branch
