### PR TITLE
Add P2 all section

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -297,6 +297,41 @@ const exported = {
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 		next();
 	},
+
+	readFollowingP2( context, next ) {
+		const basePath = sectionify( context.path );
+		const fullAnalyticsPageTitle = analyticsPageTitle + ' > P2';
+		const mcKey = 'p2';
+		const streamKey = 'p2';
+		const startDate = getStartDate( context );
+
+		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+
+		setPageTitle( context, 'P2' );
+
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		context.primary = (
+			<AsyncLoad
+				require="calypso/reader/p2/main"
+				key="read-p2"
+				listName="P2"
+				streamKey={ streamKey }
+				startDate={ startDate }
+				trackScrollPage={ trackScrollPage.bind(
+					null,
+					basePath,
+					fullAnalyticsPageTitle,
+					analyticsPageTitle,
+					mcKey
+				) }
+				showPrimaryFollowButtonOnCards={ false }
+				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+				placeholder={ null }
+			/>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+		next();
+	},
 };
 
 export const {
@@ -312,4 +347,5 @@ export const {
 	feedListing,
 	blogListing,
 	readA8C,
+	readFollowingP2,
 } = exported;

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -16,6 +16,7 @@ import {
 	legacyRedirects,
 	prettyRedirects,
 	readA8C,
+	readFollowingP2,
 	sidebar,
 	updateLastRoute,
 } from './controller';
@@ -95,4 +96,7 @@ export default async function () {
 
 	// Automattic Employee Posts
 	page( '/read/a8c', updateLastRoute, sidebar, forceTeamA8C, readA8C, makeLayout, clientRender );
+
+	// new P2 Posts
+	page( '/read/p2', updateLastRoute, sidebar, readFollowingP2, makeLayout, clientRender );
 }

--- a/client/reader/p2/main.jsx
+++ b/client/reader/p2/main.jsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { connect, useDispatch } from 'react-redux';
+import config from 'calypso/config';
+
+/**
+ * Internal dependencies
+ */
+import Stream from 'calypso/reader/stream';
+import { Button } from '@automattic/components';
+import SectionHeader from 'calypso/components/section-header';
+import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
+import { SECTION_P2_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
+import { P2_ORG_ID } from 'calypso/state/reader/organizations/constants';
+import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizations/selectors';
+
+const P2Following = ( props ) => {
+	const { translate } = props;
+	const dispatch = useDispatch();
+
+	const markAllAsSeen = ( feedsInfo ) => {
+		const { feedIds, feedUrls } = feedsInfo;
+		dispatch( requestMarkAllAsSeen( { identifier: SECTION_P2_FOLLOWING, feedIds, feedUrls } ) );
+	};
+
+	return (
+		<Stream { ...props } shouldCombineCards={ false }>
+			<SectionHeader label={ translate( 'Followed P2 Sites' ) }>
+				{ config.isEnabled( 'reader/seen-posts' ) && (
+					<Button
+						compact
+						onClick={ () => markAllAsSeen( props.feedsInfo ) }
+						disabled={ ! props.feedsInfo.unseenCount }
+					>
+						{ translate( 'Mark all as seen' ) }
+					</Button>
+				) }
+			</SectionHeader>
+		</Stream>
+	);
+};
+
+export default connect( ( state ) => ( {
+	feedsInfo: getReaderOrganizationFeedsInfo( state, P2_ORG_ID ),
+} ) )( localize( P2Following ) );

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -50,28 +50,25 @@ export class ReaderSidebarOrganizationsList extends Component {
 
 	renderAll() {
 		const { translate, organization, path, sites } = this.props;
-		if ( organization.id === AUTOMATTIC_ORG_ID ) {
-			// have a selector
-			const sum = sites.reduce( ( acc, item ) => {
-				acc = acc + item.unseen_count;
-				return acc;
-			}, 0 );
-			return (
-				<>
-					<SidebarItem
-						link={ '/read/' + organization.slug }
-						key={ translate( 'All' ) }
-						label={ translate( 'All' ) }
-						className={ ReaderSidebarHelper.itemLinkClass( '/read/' + organization.slug, path, {
-							'sidebar-streams__all': true,
-						} ) }
-					>
-						{ sum > 0 && <Count count={ sum } compact /> }
-					</SidebarItem>
-				</>
-			);
-		}
-		return null;
+		// have a selector
+		const sum = sites.reduce( ( acc, item ) => {
+			acc = acc + item.unseen_count;
+			return acc;
+		}, 0 );
+		return (
+			<>
+				<SidebarItem
+					link={ '/read/' + organization.slug }
+					key={ translate( 'All' ) }
+					label={ translate( 'All' ) }
+					className={ ReaderSidebarHelper.itemLinkClass( '/read/' + organization.slug, path, {
+						'sidebar-streams__all': true,
+					} ) }
+				>
+					{ sum > 0 && <Count count={ sum } compact /> }
+				</SidebarItem>
+			</>
+		);
 	}
 
 	renderSites() {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -51,6 +51,9 @@ function getLocation( path ) {
 	if ( path.indexOf( '/read/a8c' ) === 0 ) {
 		return 'following_a8c';
 	}
+	if ( path.indexOf( '/read/p2' ) === 0 ) {
+		return 'following_p2';
+	}
 	if ( path.indexOf( '/tag/' ) === 0 ) {
 		return 'topic_page';
 	}

--- a/client/sections.js
+++ b/client/sections.js
@@ -270,7 +270,13 @@ const sections = [
 	},
 	{
 		name: 'reader',
-		paths: [ '/read/feeds/[^\\/]+', '/read/blogs/[^\\/]+', '/read/a8c', '/recommendations' ],
+		paths: [
+			'/read/feeds/[^\\/]+',
+			'/read/blogs/[^\\/]+',
+			'/read/a8c',
+			'/read/p2',
+			'/recommendations',
+		],
 		module: 'calypso/reader',
 		group: 'reader',
 		trackLoadPerformance: true,

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -118,6 +118,10 @@ const streamApis = {
 		path: ( { streamKey } ) => `/read/sites/${ streamKeySuffix( streamKey ) }/featured`,
 		dateProperty: 'date',
 	},
+	p2: {
+		path: () => '/read/following/p2',
+		dateProperty: 'date',
+	},
 	a8c: {
 		path: () => '/read/a8c',
 		dateProperty: 'date',

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -197,6 +197,7 @@ export function requestPage( action ) {
 		: {};
 
 	const fetchCount = pageHandle ? PER_FETCH : INITIAL_FETCH;
+	// eslint-disable-next-line no-extra-boolean-cast
 	const number = !! gap ? PER_GAP : fetchCount;
 
 	return http( {

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -87,6 +87,15 @@ describe( 'streams', () => {
 					},
 				},
 				{
+					stream: 'p2',
+					expected: {
+						method: 'GET',
+						path: '/read/following/p2',
+						apiVersion: '1.2',
+						query,
+					},
+				},
+				{
 					stream: 'conversations',
 					expected: {
 						method: 'GET',

--- a/client/state/reader/seen-posts/constants.js
+++ b/client/state/reader/seen-posts/constants.js
@@ -3,3 +3,4 @@ export const SOURCE_READER_WEB = 'reader-web';
 // current reader sections
 export const SECTION_FOLLOWING = 'following';
 export const SECTION_A8C_FOLLOWING = 'a8c';
+export const SECTION_P2_FOLLOWING = 'p2';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add an `All` subsection for the Reader / P2 section, it should contain posts from your followed non-a8c P2s.

![Markup on 2020-11-26 at 12:20:33 PM](https://user-images.githubusercontent.com/2129455/100339024-fe911480-2fe1-11eb-9b65-c055af7ff008.png)

#### Known Issues
At the moment Reader / Followed Sites / All would include also posts from the P2 section, that should be fixed after is deployed and the 24 hours cache gets busted.

#### Testing instructions

- Apply D53355-code
- Go to Reader / P2 / All
- Marking the whole section as seen should work as expected
- Refreshing the page should work as expected
- Unseen counts should sum all the unseen items for all P2 sites