### PR TITLE
Focused-Launch: Fix styles for buttons on the Plan Details View

### DIFF
--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -228,6 +228,10 @@
 		color: var( --studio-gray-90 );
 		text-decoration: line-through;
 
+		span {
+			opacity: 0.5;
+		}
+
 		&:hover {
 			color: inherit;
 		}

--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -216,9 +216,36 @@
 	}
 }
 
-.plan-item__select-button.components-button.is-primary {
+.plan-item__select-button.components-button {
 	padding: 0 24px;
 	height: 40px;
+
+	&:hover {
+		color: inherit;
+	}
+
+	&:disabled {
+		color: var( --studio-gray-90 );
+		text-decoration: line-through;
+
+		&:hover {
+			color: inherit;
+		}
+	}
+}
+
+.plan-item__select-button.components-button.full-width {
+	width: 100%;
+	justify-content: center;
+	font-size: $font-body-small;
+	// stylelint-disable-next-line scales/radii
+	border-radius: 4px;
+	margin-top: 15px;
+	border: 1px solid var( --studio-gray-5 );
+}
+
+.plan-item__select-button.components-button.is-primary {
+	border: 0;
 
 	&:disabled {
 		opacity: 0.5;
@@ -227,20 +254,5 @@
 	svg {
 		margin-left: -8px;
 		margin-right: 10px;
-	}
-}
-
-.plan-item__select-button.full-width.components-button {
-	padding: 0 24px;
-	height: 40px;
-	width: 100%;
-	justify-content: center;
-	font-size: $font-body-small;
-	// stylelint-disable-next-line scales/radii
-	border-radius: 4px;
-	margin-top: 15px;
-
-	&:not( .is-primary ) {
-		border: 2px solid var( --studio-gray-5 );
 	}
 }

--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -220,14 +220,13 @@
 	padding: 0 24px;
 	height: 40px;
 
-	&:hover {
-		color: inherit;
-	}
-
 	&:disabled {
-		color: var( --studio-gray-90 );
 		text-decoration: line-through;
 		opacity: 0.5;
+	}
+
+	&:not( .is-primary ) {
+		color: var( --studio-gray-90 );
 
 		&:hover {
 			color: inherit;

--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -248,10 +248,6 @@
 .plan-item__select-button.components-button.is-primary {
 	border: 0;
 
-	&:disabled {
-		opacity: 0.5;
-	}
-
 	svg {
 		margin-left: -8px;
 		margin-right: 10px;

--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -227,10 +227,7 @@
 	&:disabled {
 		color: var( --studio-gray-90 );
 		text-decoration: line-through;
-
-		span {
-			opacity: 0.5;
-		}
+		opacity: 0.5;
 
 		&:hover {
 			color: inherit;


### PR DESCRIPTION
The current implementation does not match the design so we updated the disabled & hover state of unselected buttons to make it match again.

#### Testing instructions
1. Create a new site via `/start` and pick a free plan
2. Go to the block editor, append `?flags=create/focused-launch-flow` to the URL, and refresh the page
3. Click on the "Launch" button in the editor's header
4. Pick a premium domain
5. Click on "View all plans" to show the Plans grid
6. Open Dev Tools and check if:
   - [x] The disabled "Free Plan" button's text color is not changed when hovered;
   - [x] The disabled "Free Plan" button has an opacity of `0.5` when disabled;
   - [x] The disabled "Free Plan" button's text color is `gray 90`;
   - [x] The disabled "Free Plan" button's text has a strikethrough effect;
   - [x] The disabled and unselected buttons have a `1px` wide border
   - [x] The unselected buttons don't change text color when hovered

Note: copy and styles for the "Free Plan" card are spec'd separately in #47788 and solved in #47796

#### Context
Remember that the Plans Grid package is used in different places — namely:

  * New Onboarding
  * Focused Launch
  * Step by Step launch

**Please test in every environment!**

#### Expected result:

When user can select Free Plan:

![Screenshot 2020-11-25 at 13 37 59](https://user-images.githubusercontent.com/1083581/100228745-72201c80-2f23-11eb-8873-a02c1defe72b.png)

When Free plan is not selectable (because user has picked a premium domain)

<img width="1355" alt="Screenshot 2020-11-26 at 12 13 48" src="https://user-images.githubusercontent.com/1083581/100344386-04d2c100-2fe1-11eb-9f6e-74c9841612d2.png">


Fixes #47740 
