### PR TITLE
Remove lodash from login selectors

### DIFF
--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -123,7 +123,7 @@ export const redirectTo = combineReducers( {
 	} ),
 } );
 
-export const isFormDisabled = withoutPersistence( ( state = null, action ) => {
+export const isFormDisabled = withoutPersistence( ( state = false, action ) => {
 	switch ( action.type ) {
 		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
 			return true;

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get, isEmpty } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import 'calypso/state/login/init';
@@ -16,7 +11,7 @@ import 'calypso/state/login/init';
  * @returns {?number}         The user ID.
  */
 export const getTwoFactorUserId = ( state ) => {
-	return get( state, 'login.twoFactorAuth.user_id', null );
+	return state.login.twoFactorAuth?.user_id ?? null;
 };
 
 /**
@@ -39,7 +34,7 @@ export const getTwoFactorAuthNonce = ( state, nonceType ) => {
  * @returns {?string}         The type of 2FA notification. enum: 'sms', 'push', 'none'.
  */
 export const getTwoFactorNotificationSent = ( state ) => {
-	return get( state, 'login.twoFactorAuth.two_step_notification_sent', null );
+	return state.login.twoFactorAuth?.two_step_notification_sent ?? null;
 };
 
 /**
@@ -48,8 +43,7 @@ export const getTwoFactorNotificationSent = ( state ) => {
  * @param  {object}   state  Global state tree
  * @returns {?string}         Push notification token to be used for polling auth state
  */
-export const getTwoFactorPushToken = ( state ) =>
-	get( state, 'login.twoFactorAuth.push_web_token', null );
+export const getTwoFactorPushToken = ( state ) => state.login.twoFactorAuth?.push_web_token ?? null;
 
 /**
  * Retrieve the progress status of polling for push authentication
@@ -58,7 +52,7 @@ export const getTwoFactorPushToken = ( state ) =>
  * @returns {boolean}         Whether the polling for push authentication is in progress
  */
 export const getTwoFactorPushPollInProgress = ( state ) =>
-	get( state, 'login.twoFactorAuthPushPoll.inProgress', false );
+	state.login.twoFactorAuthPushPoll?.inProgress ?? false;
 
 /**
  * Get whether user logged in successfully via push auth
@@ -67,7 +61,7 @@ export const getTwoFactorPushPollInProgress = ( state ) =>
  * @returns {boolean}         Whether the polling for push authentication completed successfully
  */
 export const getTwoFactorPushPollSuccess = ( state ) =>
-	get( state, 'login.twoFactorAuthPushPoll.success', false );
+	state.login.twoFactorAuthPushPoll?.success ?? false;
 
 /**
  * Determines whether two factor authentication is enabled for the logging in user.
@@ -76,9 +70,9 @@ export const getTwoFactorPushPollSuccess = ( state ) =>
  * @returns {boolean}        Whether 2FA is enabled
  */
 export const isTwoFactorEnabled = ( state ) => {
-	const twoFactorAuth = get( state, 'login.twoFactorAuth' );
+	const twoFactorAuth = state.login.twoFactorAuth;
 
-	return ! isEmpty( twoFactorAuth );
+	return !! ( twoFactorAuth && Object.keys( twoFactorAuth ).length );
 };
 
 /**
@@ -88,7 +82,7 @@ export const isTwoFactorEnabled = ( state ) => {
  * @returns {boolean}         Whether a request to authenticate 2FA is being made.
  */
 export const isRequestingTwoFactorAuth = ( state ) => {
-	return get( state, 'login.isRequestingTwoFactorAuth', false );
+	return state.login.isRequestingTwoFactorAuth ?? false;
 };
 
 /**
@@ -98,7 +92,7 @@ export const isRequestingTwoFactorAuth = ( state ) => {
  * @returns {?string}         Error for the request.
  */
 export const getTwoFactorAuthRequestError = ( state ) => {
-	return get( state, 'login.twoFactorAuthRequestError', null );
+	return state.login.twoFactorAuthRequestError ?? null;
 };
 
 /**
@@ -109,7 +103,7 @@ export const getTwoFactorAuthRequestError = ( state ) => {
  * @returns {?Array}          The supported auth types (of `authenticator`, `sms`, `push` ).
  */
 export const getTwoFactorSupportedAuthTypes = ( state ) => {
-	return get( state, 'login.twoFactorAuth.two_step_supported_auth_types', null );
+	return state.login.twoFactorAuth?.two_step_supported_auth_types ?? null;
 };
 
 /**
@@ -132,7 +126,7 @@ export const isTwoFactorAuthTypeSupported = ( state, type ) => {
  * @returns {boolean}         Whether a login request is in-progress.
  */
 export const isRequesting = ( state ) => {
-	return get( state, 'login.isRequesting', false );
+	return state.login.isRequesting ?? false;
 };
 
 /**
@@ -142,7 +136,7 @@ export const isRequesting = ( state ) => {
  * @returns {?object}         Error for the request.
  */
 export const getRequestError = ( state ) => {
-	return get( state, 'login.requestError', null );
+	return state.login.requestError ?? null;
 };
 
 /**
@@ -152,7 +146,7 @@ export const getRequestError = ( state ) => {
  * @returns {?object}         Notice for the request.
  */
 export const getRequestNotice = ( state ) => {
-	return get( state, 'login.requestNotice', null );
+	return state.login.requestNotice ?? null;
 };
 
 /**
@@ -164,7 +158,7 @@ export const getRequestNotice = ( state ) => {
  * @see getRedirectToSanitized for the sanitized version
  */
 export const getRedirectToOriginal = ( state ) => {
-	return get( state, 'login.redirectTo.original', null );
+	return state.login.redirectTo?.original ?? null;
 };
 
 /**
@@ -175,7 +169,7 @@ export const getRedirectToOriginal = ( state ) => {
  * @returns {?string}         Url to redirect the user to upon successful login
  */
 export const getRedirectToSanitized = ( state ) => {
-	return get( state, 'login.redirectTo.sanitized', null );
+	return state.login.redirectTo?.sanitized ?? null;
 };
 
 /**
@@ -185,7 +179,7 @@ export const getRedirectToSanitized = ( state ) => {
  * @returns {boolean}         Login form disabled flag
  */
 export const isFormDisabled = ( state ) => {
-	return get( state, 'login.isFormDisabled', false );
+	return state.login.isFormDisabled ?? false;
 };
 
 /**
@@ -195,7 +189,7 @@ export const isFormDisabled = ( state ) => {
  * @returns {?string}        Authentication account type (e.g. 'regular', 'passwordless' ...)
  */
 export const getAuthAccountType = ( state ) => {
-	return get( state, 'login.authAccountType', null );
+	return state.login.authAccountType ?? null;
 };
 
 /**
@@ -204,8 +198,7 @@ export const getAuthAccountType = ( state ) => {
  * @param  {object}   state  Global state tree
  * @returns {?boolean}         Error for the request.
  */
-export const isSocialAccountCreating = ( state ) =>
-	get( state, 'login.socialAccount.isCreating', null );
+export const isSocialAccountCreating = ( state ) => state.login.socialAccount?.isCreating ?? null;
 
 /**
  * Gets Username of the created social account
@@ -214,7 +207,7 @@ export const isSocialAccountCreating = ( state ) =>
  * @returns {?string}         Username of the created social account
  */
 export const getCreatedSocialAccountUsername = ( state ) =>
-	get( state, 'login.socialAccount.username', null );
+	state.login.socialAccount?.username ?? null;
 
 /**
  * Gets Bearer token of the created social account
@@ -223,7 +216,7 @@ export const getCreatedSocialAccountUsername = ( state ) =>
  * @returns {?string}         Bearer token of the created social account
  */
 export const getCreatedSocialAccountBearerToken = ( state ) =>
-	get( state, 'login.socialAccount.bearerToken', null );
+	state.login.socialAccount?.bearerToken ?? null;
 
 /**
  * Gets error for the create social account request.
@@ -232,7 +225,7 @@ export const getCreatedSocialAccountBearerToken = ( state ) =>
  * @returns {?object}         Error for the create social account request.
  */
 export const getCreateSocialAccountError = ( state ) =>
-	get( state, 'login.socialAccount.createError', null );
+	state.login.socialAccount?.createError ?? null;
 
 /**
  * Gets error for the get social account request.
@@ -241,7 +234,7 @@ export const getCreateSocialAccountError = ( state ) =>
  * @returns {?object}         Error for the get social account request.
  */
 export const getRequestSocialAccountError = ( state ) =>
-	get( state, 'login.socialAccount.requestError', null );
+	state.login.socialAccount?.requestError ?? null;
 
 /**
  * Gets social account linking status
@@ -250,7 +243,7 @@ export const getRequestSocialAccountError = ( state ) =>
  * @returns {?boolean}         Boolean describing social account linking status
  */
 export const getSocialAccountIsLinking = ( state ) =>
-	get( state, 'login.socialAccountLink.isLinking', null );
+	state.login.socialAccountLink?.isLinking ?? null;
 
 /**
  * Gets social account linking email
@@ -258,8 +251,7 @@ export const getSocialAccountIsLinking = ( state ) =>
  * @param  {object}   state  Global state tree
  * @returns {?string}         wpcom email that is being linked
  */
-export const getSocialAccountLinkEmail = ( state ) =>
-	get( state, 'login.socialAccountLink.email', null );
+export const getSocialAccountLinkEmail = ( state ) => state.login.socialAccountLink?.email ?? null;
 
 /**
  * Gets social account linking service
@@ -268,7 +260,7 @@ export const getSocialAccountLinkEmail = ( state ) =>
  * @returns {?string}         service name that is being linked
  */
 export const getSocialAccountLinkService = ( state ) =>
-	get( state, 'login.socialAccountLink.authInfo.service', null );
+	state.login.socialAccountLink?.authInfo?.service ?? null;
 
 /**
  * Gets the auth information of the social account to be linked.
@@ -277,7 +269,7 @@ export const getSocialAccountLinkService = ( state ) =>
  * @returns {?string}         Email address of the social account.
  */
 export const getSocialAccountLinkAuthInfo = ( state ) =>
-	get( state, 'login.socialAccountLink.authInfo', null );
+	state.login.socialAccountLink?.authInfo ?? null;
 
 /**
  * Gets the last username/email that was checked.
@@ -286,4 +278,4 @@ export const getSocialAccountLinkAuthInfo = ( state ) =>
  * @returns {?string}         Email address or username.
  */
 export const getLastCheckedUsernameOrEmail = ( state ) =>
-	get( state, 'login.lastCheckedUsernameOrEmail', null );
+	state.login.lastCheckedUsernameOrEmail ?? null;

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -77,7 +77,7 @@ export const isTwoFactorEnabled = ( state ) => state.login.twoFactorAuth != null
  * @returns {boolean}         Whether a request to authenticate 2FA is being made.
  */
 export const isRequestingTwoFactorAuth = ( state ) => {
-	return state.login.isRequestingTwoFactorAuth ?? false;
+	return state.login.isRequestingTwoFactorAuth;
 };
 
 /**

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -52,7 +52,7 @@ export const getTwoFactorPushToken = ( state ) => state.login.twoFactorAuth?.pus
  * @returns {boolean}         Whether the polling for push authentication is in progress
  */
 export const getTwoFactorPushPollInProgress = ( state ) =>
-	state.login.twoFactorAuthPushPoll?.inProgress ?? false;
+	state.login.twoFactorAuthPushPoll.inProgress;
 
 /**
  * Get whether user logged in successfully via push auth
@@ -60,8 +60,7 @@ export const getTwoFactorPushPollInProgress = ( state ) =>
  * @param  {object}   state  Global state tree
  * @returns {boolean}         Whether the polling for push authentication completed successfully
  */
-export const getTwoFactorPushPollSuccess = ( state ) =>
-	state.login.twoFactorAuthPushPoll?.success ?? false;
+export const getTwoFactorPushPollSuccess = ( state ) => state.login.twoFactorAuthPushPoll.success;
 
 /**
  * Determines whether two factor authentication is enabled for the logging in user.

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -193,7 +193,7 @@ export const getAuthAccountType = ( state ) => {
  * @param  {object}   state  Global state tree
  * @returns {?boolean}         Error for the request.
  */
-export const isSocialAccountCreating = ( state ) => state.login.socialAccount?.isCreating ?? null;
+export const isSocialAccountCreating = ( state ) => state.login.socialAccount.isCreating;
 
 /**
  * Gets Username of the created social account
@@ -202,7 +202,7 @@ export const isSocialAccountCreating = ( state ) => state.login.socialAccount?.i
  * @returns {?string}         Username of the created social account
  */
 export const getCreatedSocialAccountUsername = ( state ) =>
-	state.login.socialAccount?.username ?? null;
+	state.login.socialAccount.username ?? null;
 
 /**
  * Gets Bearer token of the created social account
@@ -211,7 +211,7 @@ export const getCreatedSocialAccountUsername = ( state ) =>
  * @returns {?string}         Bearer token of the created social account
  */
 export const getCreatedSocialAccountBearerToken = ( state ) =>
-	state.login.socialAccount?.bearerToken ?? null;
+	state.login.socialAccount.bearerToken ?? null;
 
 /**
  * Gets error for the create social account request.
@@ -220,7 +220,7 @@ export const getCreatedSocialAccountBearerToken = ( state ) =>
  * @returns {?object}         Error for the create social account request.
  */
 export const getCreateSocialAccountError = ( state ) =>
-	state.login.socialAccount?.createError ?? null;
+	state.login.socialAccount.createError ?? null;
 
 /**
  * Gets error for the get social account request.
@@ -229,7 +229,7 @@ export const getCreateSocialAccountError = ( state ) =>
  * @returns {?object}         Error for the get social account request.
  */
 export const getRequestSocialAccountError = ( state ) =>
-	state.login.socialAccount?.requestError ?? null;
+	state.login.socialAccount.requestError ?? null;
 
 /**
  * Gets social account linking status

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -237,8 +237,7 @@ export const getRequestSocialAccountError = ( state ) =>
  * @param  {object}   state  Global state tree
  * @returns {?boolean}         Boolean describing social account linking status
  */
-export const getSocialAccountIsLinking = ( state ) =>
-	state.login.socialAccountLink?.isLinking ?? null;
+export const getSocialAccountIsLinking = ( state ) => state.login.socialAccountLink.isLinking;
 
 /**
  * Gets social account linking email
@@ -246,7 +245,7 @@ export const getSocialAccountIsLinking = ( state ) =>
  * @param  {object}   state  Global state tree
  * @returns {?string}         wpcom email that is being linked
  */
-export const getSocialAccountLinkEmail = ( state ) => state.login.socialAccountLink?.email ?? null;
+export const getSocialAccountLinkEmail = ( state ) => state.login.socialAccountLink.email ?? null;
 
 /**
  * Gets social account linking service
@@ -255,7 +254,7 @@ export const getSocialAccountLinkEmail = ( state ) => state.login.socialAccountL
  * @returns {?string}         service name that is being linked
  */
 export const getSocialAccountLinkService = ( state ) =>
-	state.login.socialAccountLink?.authInfo?.service ?? null;
+	state.login.socialAccountLink.authInfo?.service ?? null;
 
 /**
  * Gets the auth information of the social account to be linked.
@@ -264,7 +263,7 @@ export const getSocialAccountLinkService = ( state ) =>
  * @returns {?string}         Email address of the social account.
  */
 export const getSocialAccountLinkAuthInfo = ( state ) =>
-	state.login.socialAccountLink?.authInfo ?? null;
+	state.login.socialAccountLink.authInfo ?? null;
 
 /**
  * Gets the last username/email that was checked.

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -88,7 +88,7 @@ export const isRequestingTwoFactorAuth = ( state ) => {
  * @returns {?string}         Error for the request.
  */
 export const getTwoFactorAuthRequestError = ( state ) => {
-	return state.login.twoFactorAuthRequestError ?? null;
+	return state.login.twoFactorAuthRequestError;
 };
 
 /**

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -153,7 +153,7 @@ export const getRequestNotice = ( state ) => {
  * @see getRedirectToSanitized for the sanitized version
  */
 export const getRedirectToOriginal = ( state ) => {
-	return state.login.redirectTo?.original ?? null;
+	return state.login.redirectTo.original ?? null;
 };
 
 /**
@@ -164,7 +164,7 @@ export const getRedirectToOriginal = ( state ) => {
  * @returns {?string}         Url to redirect the user to upon successful login
  */
 export const getRedirectToSanitized = ( state ) => {
-	return state.login.redirectTo?.sanitized ?? null;
+	return state.login.redirectTo.sanitized ?? null;
 };
 
 /**

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -131,7 +131,7 @@ export const isRequesting = ( state ) => {
  * @returns {?object}         Error for the request.
  */
 export const getRequestError = ( state ) => {
-	return state.login.requestError ?? null;
+	return state.login.requestError;
 };
 
 /**

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -174,7 +174,7 @@ export const getRedirectToSanitized = ( state ) => {
  * @returns {boolean}         Login form disabled flag
  */
 export const isFormDisabled = ( state ) => {
-	return state.login.isFormDisabled ?? false;
+	return state.login.isFormDisabled;
 };
 
 /**

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -184,7 +184,7 @@ export const isFormDisabled = ( state ) => {
  * @returns {?string}        Authentication account type (e.g. 'regular', 'passwordless' ...)
  */
 export const getAuthAccountType = ( state ) => {
-	return state.login.authAccountType ?? null;
+	return state.login.authAccountType;
 };
 
 /**

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -21,7 +21,7 @@ export const getTwoFactorUserId = ( state ) => state.login.twoFactorAuth?.user_i
  * @returns {?string}         The nonce.
  */
 export const getTwoFactorAuthNonce = ( state, nonceType ) =>
-	state.login.twoFactorAuth[ `two_step_nonce_${ nonceType }` ] ?? null;
+	state.login.twoFactorAuth?.[ `two_step_nonce_${ nonceType }` ] ?? null;
 
 /**
  * Retrieve the type of notification sent for the two factor authentication process.

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -271,5 +271,4 @@ export const getSocialAccountLinkAuthInfo = ( state ) =>
  * @param  {object}   state  Global state tree
  * @returns {?string}         Email address or username.
  */
-export const getLastCheckedUsernameOrEmail = ( state ) =>
-	state.login.lastCheckedUsernameOrEmail ?? null;
+export const getLastCheckedUsernameOrEmail = ( state ) => state.login.lastCheckedUsernameOrEmail;

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -121,7 +121,7 @@ export const isTwoFactorAuthTypeSupported = ( state, type ) => {
  * @returns {boolean}         Whether a login request is in-progress.
  */
 export const isRequesting = ( state ) => {
-	return state.login.isRequesting ?? false;
+	return state.login.isRequesting;
 };
 
 /**

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -69,11 +69,7 @@ export const getTwoFactorPushPollSuccess = ( state ) =>
  * @param  {object}   state  Global state tree
  * @returns {boolean}        Whether 2FA is enabled
  */
-export const isTwoFactorEnabled = ( state ) => {
-	const twoFactorAuth = state.login.twoFactorAuth;
-
-	return !! ( twoFactorAuth && Object.keys( twoFactorAuth ).length );
-};
+export const isTwoFactorEnabled = ( state ) => state.login.twoFactorAuth != null;
 
 /**
  * Determines whether a request to authenticate 2FA is being made.

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -10,9 +10,7 @@ import 'calypso/state/login/init';
  * @param  {object}   state  Global state tree
  * @returns {?number}         The user ID.
  */
-export const getTwoFactorUserId = ( state ) => {
-	return state.login.twoFactorAuth?.user_id ?? null;
-};
+export const getTwoFactorUserId = ( state ) => state.login.twoFactorAuth?.user_id ?? null;
 
 /**
  * Retrieve the actual nonce for the two factor authentication process.
@@ -22,9 +20,8 @@ export const getTwoFactorUserId = ( state ) => {
  * @param	{string}	nonceType nonce's type
  * @returns {?string}         The nonce.
  */
-export const getTwoFactorAuthNonce = ( state, nonceType ) => {
-	return state.login.twoFactorAuth[ `two_step_nonce_${ nonceType }` ] ?? null;
-};
+export const getTwoFactorAuthNonce = ( state, nonceType ) =>
+	state.login.twoFactorAuth[ `two_step_nonce_${ nonceType }` ] ?? null;
 
 /**
  * Retrieve the type of notification sent for the two factor authentication process.
@@ -33,9 +30,8 @@ export const getTwoFactorAuthNonce = ( state, nonceType ) => {
  * @param  {object}   state  Global state tree
  * @returns {?string}         The type of 2FA notification. enum: 'sms', 'push', 'none'.
  */
-export const getTwoFactorNotificationSent = ( state ) => {
-	return state.login.twoFactorAuth?.two_step_notification_sent ?? null;
-};
+export const getTwoFactorNotificationSent = ( state ) =>
+	state.login.twoFactorAuth?.two_step_notification_sent ?? null;
 
 /**
  * Retrieve a token to be used for push notification auth polling
@@ -76,9 +72,7 @@ export const isTwoFactorEnabled = ( state ) => state.login.twoFactorAuth != null
  * @param  {object}   state  Global state tree
  * @returns {boolean}         Whether a request to authenticate 2FA is being made.
  */
-export const isRequestingTwoFactorAuth = ( state ) => {
-	return state.login.isRequestingTwoFactorAuth;
-};
+export const isRequestingTwoFactorAuth = ( state ) => state.login.isRequestingTwoFactorAuth;
 
 /**
  * Returns the error for a request to authenticate 2FA.
@@ -86,9 +80,7 @@ export const isRequestingTwoFactorAuth = ( state ) => {
  * @param  {object}   state  Global state tree
  * @returns {?string}         Error for the request.
  */
-export const getTwoFactorAuthRequestError = ( state ) => {
-	return state.login.twoFactorAuthRequestError;
-};
+export const getTwoFactorAuthRequestError = ( state ) => state.login.twoFactorAuthRequestError;
 
 /**
  * Retrieves the supported auth types for the current login.
@@ -97,9 +89,8 @@ export const getTwoFactorAuthRequestError = ( state ) => {
  * @param  {object}   state  Global state tree
  * @returns {?Array}          The supported auth types (of `authenticator`, `sms`, `push` ).
  */
-export const getTwoFactorSupportedAuthTypes = ( state ) => {
-	return state.login.twoFactorAuth?.two_step_supported_auth_types ?? null;
-};
+export const getTwoFactorSupportedAuthTypes = ( state ) =>
+	state.login.twoFactorAuth?.two_step_supported_auth_types ?? null;
 
 /**
  * Determines whether an auth type is supported for the current login.
@@ -120,9 +111,7 @@ export const isTwoFactorAuthTypeSupported = ( state, type ) => {
  * @param  {object}   state  Global state tree
  * @returns {boolean}         Whether a login request is in-progress.
  */
-export const isRequesting = ( state ) => {
-	return state.login.isRequesting;
-};
+export const isRequesting = ( state ) => state.login.isRequesting;
 
 /**
  * Returns the error for a login request.
@@ -130,9 +119,7 @@ export const isRequesting = ( state ) => {
  * @param  {object}   state  Global state tree
  * @returns {?object}         Error for the request.
  */
-export const getRequestError = ( state ) => {
-	return state.login.requestError;
-};
+export const getRequestError = ( state ) => state.login.requestError;
 
 /**
  * Returns the notice for a login request.
@@ -140,9 +127,7 @@ export const getRequestError = ( state ) => {
  * @param  {object}   state  Global state tree
  * @returns {?object}         Notice for the request.
  */
-export const getRequestNotice = ( state ) => {
-	return state.login.requestNotice;
-};
+export const getRequestNotice = ( state ) => state.login.requestNotice;
 
 /**
  * Retrieves the last redirect url provided in the query parameters of any login page. This url must be sanitized by the
@@ -152,9 +137,7 @@ export const getRequestNotice = ( state ) => {
  * @returns {?string}         Url to redirect the user to upon successful login
  * @see getRedirectToSanitized for the sanitized version
  */
-export const getRedirectToOriginal = ( state ) => {
-	return state.login.redirectTo.original ?? null;
-};
+export const getRedirectToOriginal = ( state ) => state.login.redirectTo.original ?? null;
 
 /**
  * Retrieves the last redirect url provided in the query parameters of any login page that was sanitized by the API
@@ -163,9 +146,7 @@ export const getRedirectToOriginal = ( state ) => {
  * @param  {object}   state  Global state tree
  * @returns {?string}         Url to redirect the user to upon successful login
  */
-export const getRedirectToSanitized = ( state ) => {
-	return state.login.redirectTo.sanitized ?? null;
-};
+export const getRedirectToSanitized = ( state ) => state.login.redirectTo.sanitized ?? null;
 
 /**
  * Retrieves whether the login form should be disabled due to actions.
@@ -173,9 +154,7 @@ export const getRedirectToSanitized = ( state ) => {
  * @param  {object}   state  Global state tree
  * @returns {boolean}         Login form disabled flag
  */
-export const isFormDisabled = ( state ) => {
-	return state.login.isFormDisabled;
-};
+export const isFormDisabled = ( state ) => state.login.isFormDisabled;
 
 /**
  * Retrieves the authentication account type.
@@ -183,9 +162,7 @@ export const isFormDisabled = ( state ) => {
  * @param  {object}   state  Global state tree
  * @returns {?string}        Authentication account type (e.g. 'regular', 'passwordless' ...)
  */
-export const getAuthAccountType = ( state ) => {
-	return state.login.authAccountType;
-};
+export const getAuthAccountType = ( state ) => state.login.authAccountType;
 
 /**
  * Tells us if we're in a process of creating a social account

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -141,7 +141,7 @@ export const getRequestError = ( state ) => {
  * @returns {?object}         Notice for the request.
  */
 export const getRequestNotice = ( state ) => {
-	return state.login.requestNotice ?? null;
+	return state.login.requestNotice;
 };
 
 /**

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -28,10 +28,14 @@ import {
 	getSocialAccountLinkService,
 } from '../selectors';
 
+const EMPTY_STATE = {
+	login: {},
+};
+
 describe( 'selectors', () => {
 	describe( 'getTwoFactorUserId()', () => {
 		test( 'should return null if there is no information yet', () => {
-			const id = getTwoFactorUserId( undefined );
+			const id = getTwoFactorUserId( EMPTY_STATE );
 
 			expect( id ).to.be.null;
 		} );
@@ -51,7 +55,7 @@ describe( 'selectors', () => {
 
 	describe( 'getTwoFactorAuthNonce()', () => {
 		test( 'should return null if there is no information yet', () => {
-			const id = getTwoFactorUserId( undefined );
+			const id = getTwoFactorUserId( EMPTY_STATE );
 
 			expect( id ).to.be.null;
 		} );
@@ -89,7 +93,7 @@ describe( 'selectors', () => {
 
 	describe( 'isRequestingTwoFactorAuth', () => {
 		test( 'should return false by default', () => {
-			expect( isRequestingTwoFactorAuth( undefined ) ).to.be.false;
+			expect( isRequestingTwoFactorAuth( EMPTY_STATE ) ).to.be.false;
 		} );
 
 		test( 'should return true if the request is in progress', () => {
@@ -115,7 +119,7 @@ describe( 'selectors', () => {
 
 	describe( 'getRequestError', () => {
 		test( 'should return null by default', () => {
-			expect( getRequestError( undefined ) ).to.be.null;
+			expect( getRequestError( EMPTY_STATE ) ).to.be.null;
 		} );
 
 		test( 'should return null if there is no error', () => {
@@ -141,7 +145,7 @@ describe( 'selectors', () => {
 
 	describe( 'getTwoFactorAuthRequestError', () => {
 		test( 'should return null by default', () => {
-			expect( getTwoFactorAuthRequestError( undefined ) ).to.be.null;
+			expect( getTwoFactorAuthRequestError( EMPTY_STATE ) ).to.be.null;
 		} );
 
 		test( 'should return null if there is no error', () => {
@@ -167,7 +171,7 @@ describe( 'selectors', () => {
 
 	describe( 'isRequesting()', () => {
 		test( 'should return false if there is no information yet', () => {
-			expect( isRequesting( undefined ) ).to.be.false;
+			expect( isRequesting( EMPTY_STATE ) ).to.be.false;
 		} );
 
 		test( 'should return true/false depending on the state of the request', () => {
@@ -178,7 +182,7 @@ describe( 'selectors', () => {
 
 	describe( 'isFormDisabled()', () => {
 		test( 'should return false if there is no information yet', () => {
-			expect( isFormDisabled( undefined ) ).to.be.false;
+			expect( isFormDisabled( EMPTY_STATE ) ).to.be.false;
 		} );
 
 		test( 'should return true/false depending on the state of the request', () => {
@@ -189,7 +193,7 @@ describe( 'selectors', () => {
 
 	describe( 'isTwoFactorEnabled()', () => {
 		test( 'should return false if there is no two factor information yet', () => {
-			const twoFactorEnabled = isTwoFactorEnabled( undefined );
+			const twoFactorEnabled = isTwoFactorEnabled( EMPTY_STATE );
 
 			expect( twoFactorEnabled ).to.be.false;
 		} );
@@ -210,7 +214,7 @@ describe( 'selectors', () => {
 
 	describe( 'getTwoFactorSupportedAuthTypes', () => {
 		test( 'should return null if there is no information yet', () => {
-			expect( getTwoFactorSupportedAuthTypes( undefined ) ).to.be.null;
+			expect( getTwoFactorSupportedAuthTypes( EMPTY_STATE ) ).to.be.null;
 		} );
 
 		test( 'should return the supported auth types if they exist in state', () => {
@@ -236,7 +240,7 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return null when the state is not there yet', () => {
-			expect( isTwoFactorAuthTypeSupported( null, 'sms' ) ).to.be.null;
+			expect( isTwoFactorAuthTypeSupported( EMPTY_STATE, 'sms' ) ).to.be.null;
 		} );
 
 		test( 'should return false when the supported auth type does not exist in the state', () => {
@@ -250,7 +254,7 @@ describe( 'selectors', () => {
 
 	describe( 'getTwoFactorPushToken()', () => {
 		test( 'should return null by default', () => {
-			expect( getTwoFactorPushToken( undefined ) ).to.be.null;
+			expect( getTwoFactorPushToken( EMPTY_STATE ) ).to.be.null;
 		} );
 
 		test( "should return push token when it's set", () => {
@@ -269,7 +273,7 @@ describe( 'selectors', () => {
 
 	describe( 'getTwoFactorPushPollInProgress()', () => {
 		test( 'should return false by default', () => {
-			expect( getTwoFactorPushPollInProgress( undefined ) ).to.be.false;
+			expect( getTwoFactorPushPollInProgress( EMPTY_STATE ) ).to.be.false;
 		} );
 
 		test( 'should return polling progresss status', () => {
@@ -288,7 +292,7 @@ describe( 'selectors', () => {
 
 	describe( 'getTwoFactorPushPollSuccess()', () => {
 		test( 'should return false by default', () => {
-			expect( getTwoFactorPushPollSuccess( undefined ) ).to.be.false;
+			expect( getTwoFactorPushPollSuccess( EMPTY_STATE ) ).to.be.false;
 		} );
 
 		test( 'should return push polling success status', () => {
@@ -307,7 +311,7 @@ describe( 'selectors', () => {
 
 	describe( 'getSocialAccountLinkAuthInfo()', () => {
 		test( 'should return null if there is no information yet', () => {
-			expect( getSocialAccountLinkAuthInfo( undefined ) ).to.be.null;
+			expect( getSocialAccountLinkAuthInfo( EMPTY_STATE ) ).to.be.null;
 		} );
 
 		test( 'should return the social account authentication information when available', () => {

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -26,9 +26,11 @@ import {
 	getSocialAccountLinkEmail,
 	getSocialAccountLinkService,
 } from '../selectors';
+import reducer from '../reducer';
 
+// Initialize empty state from a missing previous state and a no-op.
 const EMPTY_STATE = {
-	login: {},
+	login: reducer( undefined, { type: 'NOOP' } ),
 };
 
 describe( 'selectors', () => {

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -37,7 +36,7 @@ describe( 'selectors', () => {
 		test( 'should return null if there is no information yet', () => {
 			const id = getTwoFactorUserId( EMPTY_STATE );
 
-			expect( id ).to.be.null;
+			expect( id ).toBeNull();
 		} );
 
 		test( 'should return the two factor auth ID if there is such', () => {
@@ -49,7 +48,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( id ).to.equal( 123456 );
+			expect( id ).toStrictEqual( 123456 );
 		} );
 	} );
 
@@ -57,7 +56,7 @@ describe( 'selectors', () => {
 		test( 'should return null if there is no information yet', () => {
 			const id = getTwoFactorUserId( EMPTY_STATE );
 
-			expect( id ).to.be.null;
+			expect( id ).toBeNull();
 		} );
 
 		test( 'should return the two factor auth nonce for push if there is such', () => {
@@ -72,7 +71,7 @@ describe( 'selectors', () => {
 				'push'
 			);
 
-			expect( nonce ).to.equal( 'abcdef123456' );
+			expect( nonce ).toStrictEqual( 'abcdef123456' );
 		} );
 
 		test( 'should return the two factor auth nonce for sms if there is such', () => {
@@ -87,13 +86,13 @@ describe( 'selectors', () => {
 				'sms'
 			);
 
-			expect( nonce ).to.equal( 'abcdef123456' );
+			expect( nonce ).toStrictEqual( 'abcdef123456' );
 		} );
 	} );
 
 	describe( 'isRequestingTwoFactorAuth', () => {
 		test( 'should return false by default', () => {
-			expect( isRequestingTwoFactorAuth( EMPTY_STATE ) ).to.be.false;
+			expect( isRequestingTwoFactorAuth( EMPTY_STATE ) ).toBeFalsy();
 		} );
 
 		test( 'should return true if the request is in progress', () => {
@@ -103,7 +102,7 @@ describe( 'selectors', () => {
 						isRequestingTwoFactorAuth: true,
 					},
 				} )
-			).to.be.true;
+			).toBeTruthy();
 		} );
 
 		test( 'should return false if the request is not in progress', () => {
@@ -113,13 +112,13 @@ describe( 'selectors', () => {
 						isRequestingTwoFactorAuth: false,
 					},
 				} )
-			).to.be.false;
+			).toBeFalsy();
 		} );
 	} );
 
 	describe( 'getRequestError', () => {
 		test( 'should return null by default', () => {
-			expect( getRequestError( EMPTY_STATE ) ).to.be.null;
+			expect( getRequestError( EMPTY_STATE ) ).toBeNull();
 		} );
 
 		test( 'should return null if there is no error', () => {
@@ -129,7 +128,7 @@ describe( 'selectors', () => {
 						requestError: null,
 					},
 				} )
-			).to.be.null;
+			).toBeNull();
 		} );
 
 		test( 'should return an error object for the request if there is an error', () => {
@@ -139,13 +138,13 @@ describe( 'selectors', () => {
 						requestError: { message: 'some error' },
 					},
 				} )
-			).to.eql( { message: 'some error' } );
+			).toEqual( { message: 'some error' } );
 		} );
 	} );
 
 	describe( 'getTwoFactorAuthRequestError', () => {
 		test( 'should return null by default', () => {
-			expect( getTwoFactorAuthRequestError( EMPTY_STATE ) ).to.be.null;
+			expect( getTwoFactorAuthRequestError( EMPTY_STATE ) ).toBeNull();
 		} );
 
 		test( 'should return null if there is no error', () => {
@@ -155,7 +154,7 @@ describe( 'selectors', () => {
 						twoFactorAuthRequestError: null,
 					},
 				} )
-			).to.be.null;
+			).toBeNull();
 		} );
 
 		test( 'should return an error for the request if there is an error', () => {
@@ -165,29 +164,29 @@ describe( 'selectors', () => {
 						twoFactorAuthRequestError: 'some error',
 					},
 				} )
-			).to.equal( 'some error' );
+			).toStrictEqual( 'some error' );
 		} );
 	} );
 
 	describe( 'isRequesting()', () => {
 		test( 'should return false if there is no information yet', () => {
-			expect( isRequesting( EMPTY_STATE ) ).to.be.false;
+			expect( isRequesting( EMPTY_STATE ) ).toBeFalsy();
 		} );
 
 		test( 'should return true/false depending on the state of the request', () => {
-			expect( isRequesting( { login: { isRequesting: false } } ) ).to.be.false;
-			expect( isRequesting( { login: { isRequesting: true } } ) ).to.be.true;
+			expect( isRequesting( { login: { isRequesting: false } } ) ).toBeFalsy();
+			expect( isRequesting( { login: { isRequesting: true } } ) ).toBeTruthy();
 		} );
 	} );
 
 	describe( 'isFormDisabled()', () => {
 		test( 'should return false if there is no information yet', () => {
-			expect( isFormDisabled( EMPTY_STATE ) ).to.be.false;
+			expect( isFormDisabled( EMPTY_STATE ) ).toBeFalsy();
 		} );
 
 		test( 'should return true/false depending on the state of the request', () => {
-			expect( isFormDisabled( { login: { isFormDisabled: false } } ) ).to.be.false;
-			expect( isFormDisabled( { login: { isFormDisabled: true } } ) ).to.be.true;
+			expect( isFormDisabled( { login: { isFormDisabled: false } } ) ).toBeFalsy();
+			expect( isFormDisabled( { login: { isFormDisabled: true } } ) ).toBeTruthy();
 		} );
 	} );
 
@@ -195,7 +194,7 @@ describe( 'selectors', () => {
 		test( 'should return false if there is no two factor information yet', () => {
 			const twoFactorEnabled = isTwoFactorEnabled( EMPTY_STATE );
 
-			expect( twoFactorEnabled ).to.be.false;
+			expect( twoFactorEnabled ).toBeFalsy();
 		} );
 
 		test( 'should return true if the request was successful and two-factor auth is enabled', () => {
@@ -208,13 +207,13 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( twoFactorEnabled ).to.be.true;
+			expect( twoFactorEnabled ).toBeTruthy();
 		} );
 	} );
 
 	describe( 'getTwoFactorSupportedAuthTypes', () => {
 		test( 'should return null if there is no information yet', () => {
-			expect( getTwoFactorSupportedAuthTypes( EMPTY_STATE ) ).to.be.null;
+			expect( getTwoFactorSupportedAuthTypes( EMPTY_STATE ) ).toBeNull();
 		} );
 
 		test( 'should return the supported auth types if they exist in state', () => {
@@ -226,7 +225,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( authTypes ).to.eql( [ 'authenticator', 'sms' ] );
+			expect( authTypes ).toEqual( [ 'authenticator', 'sms' ] );
 		} );
 	} );
 
@@ -240,21 +239,21 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return null when the state is not there yet', () => {
-			expect( isTwoFactorAuthTypeSupported( EMPTY_STATE, 'sms' ) ).to.be.null;
+			expect( isTwoFactorAuthTypeSupported( EMPTY_STATE, 'sms' ) ).toBeNull();
 		} );
 
 		test( 'should return false when the supported auth type does not exist in the state', () => {
-			expect( isTwoFactorAuthTypeSupported( state, 'unknown' ) ).to.be.false;
+			expect( isTwoFactorAuthTypeSupported( state, 'unknown' ) ).toBeFalsy();
 		} );
 
 		test( 'should return true when the supported auth type exists in the state', () => {
-			expect( isTwoFactorAuthTypeSupported( state, 'sms' ) ).to.be.true;
+			expect( isTwoFactorAuthTypeSupported( state, 'sms' ) ).toBeTruthy();
 		} );
 	} );
 
 	describe( 'getTwoFactorPushToken()', () => {
 		test( 'should return null by default', () => {
-			expect( getTwoFactorPushToken( EMPTY_STATE ) ).to.be.null;
+			expect( getTwoFactorPushToken( EMPTY_STATE ) ).toBeNull();
 		} );
 
 		test( "should return push token when it's set", () => {
@@ -267,13 +266,13 @@ describe( 'selectors', () => {
 						},
 					},
 				} )
-			).to.eql( token );
+			).toEqual( token );
 		} );
 	} );
 
 	describe( 'getTwoFactorPushPollInProgress()', () => {
 		test( 'should return false by default', () => {
-			expect( getTwoFactorPushPollInProgress( EMPTY_STATE ) ).to.be.false;
+			expect( getTwoFactorPushPollInProgress( EMPTY_STATE ) ).toBeFalsy();
 		} );
 
 		test( 'should return polling progresss status', () => {
@@ -286,13 +285,13 @@ describe( 'selectors', () => {
 						},
 					},
 				} )
-			).to.eql( inProgress );
+			).toEqual( inProgress );
 		} );
 	} );
 
 	describe( 'getTwoFactorPushPollSuccess()', () => {
 		test( 'should return false by default', () => {
-			expect( getTwoFactorPushPollSuccess( EMPTY_STATE ) ).to.be.false;
+			expect( getTwoFactorPushPollSuccess( EMPTY_STATE ) ).toBeFalsy();
 		} );
 
 		test( 'should return push polling success status', () => {
@@ -305,13 +304,13 @@ describe( 'selectors', () => {
 						},
 					},
 				} )
-			).to.eql( success );
+			).toEqual( success );
 		} );
 	} );
 
 	describe( 'getSocialAccountLinkAuthInfo()', () => {
 		test( 'should return null if there is no information yet', () => {
-			expect( getSocialAccountLinkAuthInfo( EMPTY_STATE ) ).to.be.null;
+			expect( getSocialAccountLinkAuthInfo( EMPTY_STATE ) ).toBeNull();
 		} );
 
 		test( 'should return the social account authentication information when available', () => {
@@ -328,7 +327,7 @@ describe( 'selectors', () => {
 						},
 					},
 				} )
-			).to.deep.eql( socialAccountInfo );
+			).toEqual( socialAccountInfo );
 		} );
 	} );
 
@@ -340,7 +339,7 @@ describe( 'selectors', () => {
 						socialAccount: {},
 					},
 				} )
-			).to.be.null;
+			).toBeNull();
 		} );
 
 		test( 'return error object if create error is set', () => {
@@ -354,7 +353,7 @@ describe( 'selectors', () => {
 						},
 					},
 				} )
-			).to.eql( createError );
+			).toEqual( createError );
 		} );
 	} );
 
@@ -368,7 +367,7 @@ describe( 'selectors', () => {
 						socialAccountLink,
 					},
 				} )
-			).to.eql( true );
+			).toEqual( true );
 		} );
 	} );
 
@@ -382,7 +381,7 @@ describe( 'selectors', () => {
 						socialAccountLink,
 					},
 				} )
-			).to.eql( 'test@hello.world' );
+			).toEqual( 'test@hello.world' );
 		} );
 	} );
 
@@ -396,7 +395,7 @@ describe( 'selectors', () => {
 						socialAccountLink,
 					},
 				} )
-			).to.eql( 'google' );
+			).toEqual( 'google' );
 		} );
 	} );
 } );

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -50,7 +50,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( id ).toStrictEqual( 123456 );
+			expect( id ).toBe( 123456 );
 		} );
 	} );
 
@@ -73,7 +73,7 @@ describe( 'selectors', () => {
 				'push'
 			);
 
-			expect( nonce ).toStrictEqual( 'abcdef123456' );
+			expect( nonce ).toBe( 'abcdef123456' );
 		} );
 
 		test( 'should return the two factor auth nonce for sms if there is such', () => {
@@ -88,13 +88,13 @@ describe( 'selectors', () => {
 				'sms'
 			);
 
-			expect( nonce ).toStrictEqual( 'abcdef123456' );
+			expect( nonce ).toBe( 'abcdef123456' );
 		} );
 	} );
 
 	describe( 'isRequestingTwoFactorAuth', () => {
 		test( 'should return false by default', () => {
-			expect( isRequestingTwoFactorAuth( EMPTY_STATE ) ).toBeFalsy();
+			expect( isRequestingTwoFactorAuth( EMPTY_STATE ) ).toBe( false );
 		} );
 
 		test( 'should return true if the request is in progress', () => {
@@ -104,7 +104,7 @@ describe( 'selectors', () => {
 						isRequestingTwoFactorAuth: true,
 					},
 				} )
-			).toBeTruthy();
+			).toBe( true );
 		} );
 
 		test( 'should return false if the request is not in progress', () => {
@@ -114,7 +114,7 @@ describe( 'selectors', () => {
 						isRequestingTwoFactorAuth: false,
 					},
 				} )
-			).toBeFalsy();
+			).toBe( false );
 		} );
 	} );
 
@@ -166,29 +166,29 @@ describe( 'selectors', () => {
 						twoFactorAuthRequestError: 'some error',
 					},
 				} )
-			).toStrictEqual( 'some error' );
+			).toBe( 'some error' );
 		} );
 	} );
 
 	describe( 'isRequesting()', () => {
 		test( 'should return false if there is no information yet', () => {
-			expect( isRequesting( EMPTY_STATE ) ).toBeFalsy();
+			expect( isRequesting( EMPTY_STATE ) ).toBe( false );
 		} );
 
 		test( 'should return true/false depending on the state of the request', () => {
-			expect( isRequesting( { login: { isRequesting: false } } ) ).toBeFalsy();
-			expect( isRequesting( { login: { isRequesting: true } } ) ).toBeTruthy();
+			expect( isRequesting( { login: { isRequesting: false } } ) ).toBe( false );
+			expect( isRequesting( { login: { isRequesting: true } } ) ).toBe( true );
 		} );
 	} );
 
 	describe( 'isFormDisabled()', () => {
 		test( 'should return false if there is no information yet', () => {
-			expect( isFormDisabled( EMPTY_STATE ) ).toBeFalsy();
+			expect( isFormDisabled( EMPTY_STATE ) ).toBe( false );
 		} );
 
 		test( 'should return true/false depending on the state of the request', () => {
-			expect( isFormDisabled( { login: { isFormDisabled: false } } ) ).toBeFalsy();
-			expect( isFormDisabled( { login: { isFormDisabled: true } } ) ).toBeTruthy();
+			expect( isFormDisabled( { login: { isFormDisabled: false } } ) ).toBe( false );
+			expect( isFormDisabled( { login: { isFormDisabled: true } } ) ).toBe( true );
 		} );
 	} );
 
@@ -196,7 +196,7 @@ describe( 'selectors', () => {
 		test( 'should return false if there is no two factor information yet', () => {
 			const twoFactorEnabled = isTwoFactorEnabled( EMPTY_STATE );
 
-			expect( twoFactorEnabled ).toBeFalsy();
+			expect( twoFactorEnabled ).toBe( false );
 		} );
 
 		test( 'should return true if the request was successful and two-factor auth is enabled', () => {
@@ -209,7 +209,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( twoFactorEnabled ).toBeTruthy();
+			expect( twoFactorEnabled ).toBe( true );
 		} );
 	} );
 
@@ -245,11 +245,11 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return false when the supported auth type does not exist in the state', () => {
-			expect( isTwoFactorAuthTypeSupported( state, 'unknown' ) ).toBeFalsy();
+			expect( isTwoFactorAuthTypeSupported( state, 'unknown' ) ).toBe( false );
 		} );
 
 		test( 'should return true when the supported auth type exists in the state', () => {
-			expect( isTwoFactorAuthTypeSupported( state, 'sms' ) ).toBeTruthy();
+			expect( isTwoFactorAuthTypeSupported( state, 'sms' ) ).toBe( true );
 		} );
 	} );
 
@@ -268,13 +268,13 @@ describe( 'selectors', () => {
 						},
 					},
 				} )
-			).toEqual( token );
+			).toBe( token );
 		} );
 	} );
 
 	describe( 'getTwoFactorPushPollInProgress()', () => {
 		test( 'should return false by default', () => {
-			expect( getTwoFactorPushPollInProgress( EMPTY_STATE ) ).toBeFalsy();
+			expect( getTwoFactorPushPollInProgress( EMPTY_STATE ) ).toBe( false );
 		} );
 
 		test( 'should return polling progresss status', () => {
@@ -287,13 +287,13 @@ describe( 'selectors', () => {
 						},
 					},
 				} )
-			).toEqual( inProgress );
+			).toBe( inProgress );
 		} );
 	} );
 
 	describe( 'getTwoFactorPushPollSuccess()', () => {
 		test( 'should return false by default', () => {
-			expect( getTwoFactorPushPollSuccess( EMPTY_STATE ) ).toBeFalsy();
+			expect( getTwoFactorPushPollSuccess( EMPTY_STATE ) ).toBe( false );
 		} );
 
 		test( 'should return push polling success status', () => {
@@ -306,7 +306,7 @@ describe( 'selectors', () => {
 						},
 					},
 				} )
-			).toEqual( success );
+			).toBe( success );
 		} );
 	} );
 
@@ -369,7 +369,7 @@ describe( 'selectors', () => {
 						socialAccountLink,
 					},
 				} )
-			).toEqual( true );
+			).toBe( true );
 		} );
 	} );
 
@@ -383,7 +383,7 @@ describe( 'selectors', () => {
 						socialAccountLink,
 					},
 				} )
-			).toEqual( 'test@hello.world' );
+			).toBe( 'test@hello.world' );
 		} );
 	} );
 
@@ -397,7 +397,7 @@ describe( 'selectors', () => {
 						socialAccountLink,
 					},
 				} )
-			).toEqual( 'google' );
+			).toBe( 'google' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Removing `lodash` from state, particularly `_.get`, will require some level of understanding of each portion of state, so that we avoid falling into the trap of using `?.` everywhere instead of just where it's needed.

I prepared this small PR to get some feedback on my approach, and whether you think it's the right one.

For example, for `login` state, I decided that selectors shouldn't need to able to work with `undefined` state, but rather can expect for state to have been initialised by the base reducer, such that `state.login` is always present and is an object. Is this the right approach?

#### Changes proposed in this Pull Request

* Remove `lodash`, particularly `_.get`, from the login selectors

#### Testing instructions

* Ensure that the login selector tests pass
* Smoke-test login and ensure it continues to work correctly
