### PR TITLE
Focus Launch: Fix Tooltip in Summary view

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -137,7 +137,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 									__i18n_text_domain__
 								) }
 							>
-								{ info }
+								<span>{ info }</span>
 							</Tooltip>
 							<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
 								<Icon icon={ bulb } />
@@ -313,7 +313,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 									__i18n_text_domain__
 								) }
 							>
-								{ info }
+								<span>{ info }</span>
 							</Tooltip>
 							<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
 								<Icon icon={ bulb } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wrap Tooltip icons in Summary View in `<span>` to fix missing tooltips. This is needed as Tooltip appends the tooltip message element inside the SVG element otherwise, which isn't valid markup and makes it not visible to the user.

#### Testing instructions

The easiest way to test this would be:

* Checkout this branch
* In file `packages/launch/src/focused-launch/summary/index.tsx` set the variable `hasPaidDomain` to `true`
* Visit `/page/UNLAUNCHED_SITE_ID/home?flags=create/focused-launch-flow-calypso`
* Hover over the information icon next to the "Your domain" sub-title on the domains step in the Summary view to reveal the tooltip which should look like the screenshot below

![Screenshot 2020-11-26 at 12 08 30](https://user-images.githubusercontent.com/8639742/100349371-3dbe6600-2fe0-11eb-9d46-b4541cfde316.png)

Fixes https://github.com/Automattic/wp-calypso/issues/47279
