### PR TITLE
Modularise site keyrings state

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -31,7 +31,6 @@ import mySites from './my-sites/reducer';
 import notices from './notices/reducer';
 import { unseenCount as notificationsUnseenCount } from './notifications';
 import selectedEditor from './selected-editor/reducer';
-import siteKeyrings from './site-keyrings/reducer';
 import siteRoles from './site-roles/reducer';
 import sites from './sites/reducer';
 import storedCards from './stored-cards/reducer';
@@ -62,7 +61,6 @@ const reducers = {
 	notices,
 	notificationsUnseenCount,
 	selectedEditor,
-	siteKeyrings,
 	siteRoles,
 	sites,
 	storedCards,

--- a/client/state/selectors/is-google-my-business-location-connected.js
+++ b/client/state/selectors/is-google-my-business-location-connected.js
@@ -3,6 +3,8 @@
  */
 import { getKeyringConnectionsByName } from 'calypso/state/sharing/keyring/selectors';
 
+import 'calypso/state/site-keyrings/init';
+
 export default function isGoogleMyBusinessLocationConnected( state, siteId ) {
 	const siteKeyrings = state.siteKeyrings.items[ siteId ] ?? [];
 	const googleMyBusinessSiteKeyring = siteKeyrings.find(

--- a/client/state/site-keyrings/actions.js
+++ b/client/state/site-keyrings/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'calypso/lib/wp';
 import {
 	SITE_KEYRINGS_REQUEST,
@@ -17,6 +16,8 @@ import {
 	SITE_KEYRINGS_UPDATE_SUCCESS,
 	SITE_KEYRINGS_UPDATE_FAILURE,
 } from 'calypso/state/action-types';
+
+import 'calypso/state/site-keyrings/init';
 
 /**
  * Returns an action thunk which, when invoked, triggers a network request to

--- a/client/state/site-keyrings/init.js
+++ b/client/state/site-keyrings/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'siteKeyrings' ], reducer );

--- a/client/state/site-keyrings/package.json
+++ b/client/state/site-keyrings/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/site-keyrings/reducer.js
+++ b/client/state/site-keyrings/reducer.js
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'calypso/state/utils';
+import {
+	combineReducers,
+	withoutPersistence,
+	withSchemaValidation,
+	withStorageKey,
+} from 'calypso/state/utils';
 import { siteKeyrings as siteKeyringsSchema } from './schema';
 import {
 	SITE_KEYRINGS_REQUEST,
@@ -137,8 +142,10 @@ const items = withSchemaValidation( siteKeyringsSchema, ( state = {}, action ) =
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	items,
 	requesting,
 	saveRequests,
 } );
+
+export default withStorageKey( 'siteKeyrings', combinedReducer );

--- a/client/state/site-keyrings/selectors.js
+++ b/client/state/site-keyrings/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get, filter, find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/site-keyrings/init';
 
 /**
  * Returns true if we are requesting keyrings for the specified site ID, false otherwise.


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles site keyrings state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42479.

#### Changes proposed in this Pull Request

* Modularise site keyrings state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/home` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `siteKeyrings` key, even if you expand the list of keys. This indicates that the site keyrings state hasn't been loaded yet.
* Click `Tools` followed by `Marketing` on the side bar.
* Verify that a `siteKeyrings` key is added with the site keyrings state. This indicates that the site keyrings state has now been loaded.
* Verify that Google My Business functionality continues to work correctly.