### PR TITLE
Use strengthened key in accept invite API call

### DIFF
--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -76,6 +76,10 @@ class InviteAccept extends React.Component {
 				authKey: this.props.authKey,
 			};
 
+			// Replace the plain invite key with the strengthened key
+			// from the url: invite key + secret
+			invite.inviteKey = this.props.inviteKey;
+
 			this.handleFetchInvite( false, invite );
 		} catch ( error ) {
 			this.handleFetchInvite( error );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change is required by D53304-code, which addresses an H1 report on invites-related security issues. See H1 report no. 1040047 more context.
* Change: use the `inviteKey` in the `accept-invite` URL when sending the `accept` API request, which is the strengthened version of the original invite key. Older keys should not be affected and previously sent invites should still work even with this change.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Email Invites**
* Go to Manage > People > Invite.
* Send an email invite to User B.
* As User B, accept the invite by clicking on the email link. You will be redirected to the invite page. 
* Change the URL's host to your Calypso dev local. 
* You should be able to join the blog without any issues.

**Group Invites**
* Go to Manage > People > Invite for a P2 site.
* Generate Invite Links if there are none.
* As another user, use one of the invite inks to join the blog, again first changing the link's host to your Calypso dev local.
* You should be able to join the blog without any issues.

(Optional) Apply D53304-code and repeat the tests above.
 
Fixes H1 1040047
