### PR TITLE
Focused Launch: Add persistent success view after launch

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -20,10 +20,17 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 	render: function LaunchSidebar() {
 		const currentSiteId = window._currentSiteId;
 
-		const [ isFocusedLaunchOpen, isSiteLaunched ] = useSelect( ( select ) => [
-			select( LAUNCH_STORE ).isFocusedLaunchOpen(),
-			select( SITE_STORE ).isSiteLaunched( currentSiteId ),
-		] );
+		const [ isFocusedLaunchOpen, shouldDisplaySuccessView, isSiteLaunched ] = useSelect(
+			( select ) => {
+				const { isFocusedLaunchOpen, shouldDisplaySuccessView } = select( LAUNCH_STORE ).getState();
+
+				return [
+					isFocusedLaunchOpen,
+					shouldDisplaySuccessView,
+					select( SITE_STORE ).isSiteLaunched( currentSiteId ),
+				];
+			}
+		);
 
 		// Add a class to hide the Launch button from editor bar when site is launched
 		React.useEffect( () => {
@@ -32,17 +39,13 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 			}
 		}, [ isSiteLaunched ] );
 
-		if ( ! isFocusedLaunchOpen ) {
-			return null;
-		}
-
-		return (
+		return isFocusedLaunchOpen || shouldDisplaySuccessView ? (
 			<FocusedLaunchModal
 				locale={ window.wpcomEditorSiteLaunch?.locale }
 				openCheckout={ openCheckout }
 				redirectTo={ redirectToWpcomPath }
 				siteId={ currentSiteId }
 			/>
-		);
+		) : null;
 	},
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -9,7 +9,7 @@ import FocusedLaunchModal from '@automattic/launch';
 /**
  * Internal dependencies
  */
-import { LAUNCH_STORE } from './stores';
+import { LAUNCH_STORE, SITE_STORE } from './stores';
 import { openCheckout, redirectToWpcomPath } from './utils';
 
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
@@ -20,9 +20,17 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 	render: function LaunchSidebar() {
 		const currentSiteId = window._currentSiteId;
 
-		const isFocusedLaunchOpen = useSelect( ( select ) =>
-			select( LAUNCH_STORE ).isFocusedLaunchOpen()
-		);
+		const [ isFocusedLaunchOpen, isSiteLaunched ] = useSelect( ( select ) => [
+			select( LAUNCH_STORE ).isFocusedLaunchOpen(),
+			select( SITE_STORE ).isSiteLaunched( currentSiteId ),
+		] );
+
+		// Add a class to hide the Launch button from editor bar when site is launched
+		React.useEffect( () => {
+			if ( isSiteLaunched ) {
+				document.body.classList.add( 'is-focused-launch-complete' );
+			}
+		}, [ isSiteLaunched ] );
 
 		if ( ! isFocusedLaunchOpen ) {
 			return null;

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -116,14 +116,14 @@ export const hideModalTitle = () =>
 		type: 'HIDE_MODAL_TITLE',
 	} as const );
 
-export const showSuccessView = () =>
+export const enablePersistentSuccessView = () =>
 	( {
-		type: 'SHOW_SUCCESS_VIEW',
+		type: 'ENABLE_SUCCESS_VIEW',
 	} as const );
 
-export const hideSuccessView = () =>
+export const disablePersistentSuccessView = () =>
 	( {
-		type: 'HIDE_SUCCESS_VIEW',
+		type: 'DISABLE_SUCCESS_VIEW',
 	} as const );
 
 export type LaunchAction = ReturnType<
@@ -146,6 +146,6 @@ export type LaunchAction = ReturnType<
 	| typeof unsetModalDismissible
 	| typeof showModalTitle
 	| typeof hideModalTitle
-	| typeof showSuccessView
-	| typeof hideSuccessView
+	| typeof enablePersistentSuccessView
+	| typeof disablePersistentSuccessView
 >;

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -116,6 +116,16 @@ export const hideModalTitle = () =>
 		type: 'HIDE_MODAL_TITLE',
 	} as const );
 
+export const showSuccessView = () =>
+	( {
+		type: 'SHOW_SUCCESS_VIEW',
+	} as const );
+
+export const hideSuccessView = () =>
+	( {
+		type: 'HIDE_SUCCESS_VIEW',
+	} as const );
+
 export type LaunchAction = ReturnType<
 	| typeof unsetDomain
 	| typeof setStep
@@ -136,4 +146,6 @@ export type LaunchAction = ReturnType<
 	| typeof unsetModalDismissible
 	| typeof showModalTitle
 	| typeof hideModalTitle
+	| typeof showSuccessView
+	| typeof hideSuccessView
 >;

--- a/packages/data-stores/src/launch/index.ts
+++ b/packages/data-stores/src/launch/index.ts
@@ -36,6 +36,7 @@ export function register(): typeof STORE_KEY {
 				'confirmedDomainSelection',
 				'isExperimental',
 				'isSiteTitleStepVisible',
+				'shouldDisplaySuccessView',
 			],
 		} );
 	}

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -144,11 +144,11 @@ const isModalTitleVisible: Reducer< boolean, LaunchAction > = ( state = true, ac
 };
 
 const shouldDisplaySuccessView: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
-	if ( action.type === 'SHOW_SUCCESS_VIEW' ) {
+	if ( action.type === 'ENABLE_SUCCESS_VIEW' ) {
 		return true;
 	}
 
-	if ( action.type === 'HIDE_SUCCESS_VIEW' ) {
+	if ( action.type === 'DISABLE_SUCCESS_VIEW' ) {
 		return false;
 	}
 

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -71,6 +71,7 @@ const paidPlan: Reducer< Plans.Plan | undefined, LaunchAction > = ( state, actio
 	return state;
 };
 
+// Check if focused launch modal is open
 const isFocusedLaunchOpen: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
 	if ( action.type === 'OPEN_FOCUSED_LAUNCH' ) {
 		return true;
@@ -82,6 +83,7 @@ const isFocusedLaunchOpen: Reducer< boolean, LaunchAction > = ( state = false, a
 	return state;
 };
 
+// Check if step-by-step launch modal is open
 const isSidebarOpen: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
 	if ( action.type === 'OPEN_SIDEBAR' ) {
 		return true;
@@ -93,6 +95,7 @@ const isSidebarOpen: Reducer< boolean, LaunchAction > = ( state = false, action 
 	return state;
 };
 
+// Check if step-by-step launch modal is full screen
 const isSidebarFullscreen: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
 	if ( action.type === 'SET_SIDEBAR_FULLSCREEN' ) {
 		return true;
@@ -111,6 +114,7 @@ const isExperimental: Reducer< boolean, LaunchAction > = ( state = false, action
 	return state;
 };
 
+// Check if site title step should be displayed
 const isSiteTitleStepVisible: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
 	if ( action.type === 'SHOW_SITE_TITLE_STEP' ) {
 		return true;
@@ -119,6 +123,7 @@ const isSiteTitleStepVisible: Reducer< boolean, LaunchAction > = ( state = false
 	return state;
 };
 
+// Check if launch modal can be dismissed
 const isModalDismissible: Reducer< boolean, LaunchAction > = ( state = true, action ) => {
 	if ( action.type === 'SET_MODAL_DISMISSIBLE' ) {
 		return true;
@@ -131,6 +136,7 @@ const isModalDismissible: Reducer< boolean, LaunchAction > = ( state = true, act
 	return state;
 };
 
+// Check if launch modal title should be visible
 const isModalTitleVisible: Reducer< boolean, LaunchAction > = ( state = true, action ) => {
 	if ( action.type === 'SHOW_MODAL_TITLE' ) {
 		return true;
@@ -143,6 +149,7 @@ const isModalTitleVisible: Reducer< boolean, LaunchAction > = ( state = true, ac
 	return state;
 };
 
+// Check if launch Success view should be displayed (user didn't dismissed the Success View modal)
 const shouldDisplaySuccessView: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
 	if ( action.type === 'ENABLE_SUCCESS_VIEW' ) {
 		return true;

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -143,6 +143,18 @@ const isModalTitleVisible: Reducer< boolean, LaunchAction > = ( state = true, ac
 	return state;
 };
 
+const shouldDisplaySuccessView: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
+	if ( action.type === 'SHOW_SUCCESS_VIEW' ) {
+		return true;
+	}
+
+	if ( action.type === 'HIDE_SUCCESS_VIEW' ) {
+		return false;
+	}
+
+	return state;
+};
+
 const reducer = combineReducers( {
 	step,
 	domain,
@@ -157,6 +169,7 @@ const reducer = combineReducers( {
 	isSiteTitleStepVisible,
 	isModalDismissible,
 	isModalTitleVisible,
+	shouldDisplaySuccessView,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -84,5 +84,9 @@ export const isModalDismissible = ( state: State ): boolean => state.isModalDism
 // Check if launch modal title should be visible
 export const isModalTitleVisible = ( state: State ): boolean => state.isModalTitleVisible;
 
+// Check if launch Success view should be displayed (user didn't dismissed the Success View modal)
+export const shouldDisplaySuccessView = ( state: State ): boolean => state.shouldDisplaySuccessView;
+
 // Check if launch modal can be dismissed
-export const isFocusedLaunchOpen = ( state: State ): boolean => state.isFocusedLaunchOpen;
+export const isFocusedLaunchOpen = ( state: State ): boolean =>
+	state.isFocusedLaunchOpen || select( LAUNCH_STORE ).shouldDisplaySuccessView();

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -74,19 +74,3 @@ export const isFlowStarted = ( state: State ): boolean =>
 // Get first incomplete step
 export const getFirstIncompleteStep = ( state: State ): LaunchStepType | undefined =>
 	LaunchSequence.find( ( step ) => ! isStepCompleted( state, step ) );
-
-// Check if site title step should be displayed
-export const isSiteTitleStepVisible = ( state: State ): boolean => state.isSiteTitleStepVisible;
-
-// Check if launch modal can be dismissed
-export const isModalDismissible = ( state: State ): boolean => state.isModalDismissible;
-
-// Check if launch modal title should be visible
-export const isModalTitleVisible = ( state: State ): boolean => state.isModalTitleVisible;
-
-// Check if launch Success view should be displayed (user didn't dismissed the Success View modal)
-export const shouldDisplaySuccessView = ( state: State ): boolean => state.shouldDisplaySuccessView;
-
-// Check if launch modal can be dismissed
-export const isFocusedLaunchOpen = ( state: State ): boolean =>
-	state.isFocusedLaunchOpen || select( LAUNCH_STORE ).shouldDisplaySuccessView();

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -19,9 +19,7 @@ import { LAUNCH_STORE } from '../stores';
 import './style.scss';
 
 const FocusedLaunch: React.FunctionComponent = () => {
-	const shouldDisplaySuccessView = useSelect( ( select ) =>
-		select( LAUNCH_STORE ).shouldDisplaySuccessView()
-	);
+	const { shouldDisplaySuccessView } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 
 	const { isSiteLaunched, isSiteLaunching } = useSite();
 

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -3,6 +3,7 @@
  */
 import * as React from 'react';
 import { MemoryRouter as Router, Switch, Route, Redirect } from 'react-router-dom';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -13,20 +14,33 @@ import Summary from './summary';
 import DomainDetails from './domain-details';
 import PlanDetails from './plan-details';
 import Success from './success';
+import { LAUNCH_STORE } from '../stores';
 
 import './style.scss';
 
 const FocusedLaunch: React.FunctionComponent = () => {
+	const shouldDisplaySuccessView = useSelect( ( select ) =>
+		select( LAUNCH_STORE ).shouldDisplaySuccessView()
+	);
+
 	const { isSiteLaunched, isSiteLaunching } = useSite();
 
+	const { showSuccessView } = useDispatch( LAUNCH_STORE );
+
 	React.useEffect( () => {
+		if ( isSiteLaunched ) {
+			showSuccessView();
+		}
 		if ( isSiteLaunched || isSiteLaunching ) {
 			document.body.classList.add( 'is-focused-launch-complete' );
 		}
-	}, [ isSiteLaunched, isSiteLaunching ] );
+	}, [ isSiteLaunched, isSiteLaunching, showSuccessView ] );
 
 	return (
-		<Router initialEntries={ [ FocusedLaunchRoute.Summary ] }>
+		<Router
+			initialEntries={ [ FocusedLaunchRoute.Summary, FocusedLaunchRoute.Success ] }
+			initialIndex={ shouldDisplaySuccessView ? 1 : 0 }
+		>
 			{ ( isSiteLaunched || isSiteLaunching ) && <Redirect to={ FocusedLaunchRoute.Success } /> }
 			<Switch>
 				<Route path={ FocusedLaunchRoute.DomainDetails }>

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -25,16 +25,16 @@ const FocusedLaunch: React.FunctionComponent = () => {
 
 	const { isSiteLaunched, isSiteLaunching } = useSite();
 
-	const { showSuccessView } = useDispatch( LAUNCH_STORE );
+	const { enablePersistentSuccessView } = useDispatch( LAUNCH_STORE );
 
 	React.useEffect( () => {
 		if ( isSiteLaunched ) {
-			showSuccessView();
+			enablePersistentSuccessView();
 		}
 		if ( isSiteLaunched || isSiteLaunching ) {
 			document.body.classList.add( 'is-focused-launch-complete' );
 		}
-	}, [ isSiteLaunched, isSiteLaunching, showSuccessView ] );
+	}, [ isSiteLaunched, isSiteLaunching, enablePersistentSuccessView ] );
 
 	return (
 		<Router

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -27,14 +27,25 @@ const FocusedLaunch: React.FunctionComponent = () => {
 
 	const { enablePersistentSuccessView } = useDispatch( LAUNCH_STORE );
 
+	// Force Success view to be the default view when opening Focused Launch modal.
+	// This is used in case the user opens the Focused Launch modal after launching
+	// the site (e.g. when redirected back after the checkout screen)
 	React.useEffect( () => {
 		if ( isSiteLaunched ) {
 			enablePersistentSuccessView();
 		}
+	}, [ isSiteLaunched, enablePersistentSuccessView ] );
+
+	// This class is used to hide the "Launch" button from the block editor's header
+	// @TODO:
+	//   - if this is a block editor specific feature, move to the LaunchContext
+	//     and only specify when including Focused Launch thorugh Editing Toolkit
+	//   - think about a less hacky way to achieve this (e.g. @wordpress/hooks?)
+	React.useEffect( () => {
 		if ( isSiteLaunched || isSiteLaunching ) {
 			document.body.classList.add( 'is-focused-launch-complete' );
 		}
-	}, [ isSiteLaunched, isSiteLaunching, enablePersistentSuccessView ] );
+	}, [ isSiteLaunched, isSiteLaunching ] );
 
 	return (
 		<Router

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -36,17 +36,6 @@ const FocusedLaunch: React.FunctionComponent = () => {
 		}
 	}, [ isSiteLaunched, enablePersistentSuccessView ] );
 
-	// This class is used to hide the "Launch" button from the block editor's header
-	// @TODO:
-	//   - if this is a block editor specific feature, move to the LaunchContext
-	//     and only specify when including Focused Launch thorugh Editing Toolkit
-	//   - think about a less hacky way to achieve this (e.g. @wordpress/hooks?)
-	React.useEffect( () => {
-		if ( isSiteLaunched || isSiteLaunching ) {
-			document.body.classList.add( 'is-focused-launch-complete' );
-		}
-	}, [ isSiteLaunched, isSiteLaunching ] );
-
 	return (
 		<Router
 			initialEntries={ [ FocusedLaunchRoute.Summary, FocusedLaunchRoute.Success ] }

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -27,7 +27,12 @@ const Success: React.FunctionComponent = () => {
 
 	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
 
-	const { unsetModalDismissible, hideModalTitle, closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
+	const {
+		unsetModalDismissible,
+		hideModalTitle,
+		closeFocusedLaunch,
+		hideSuccessView,
+	} = useDispatch( LAUNCH_STORE );
 
 	const { siteSubdomain, sitePrimaryDomain } = useSiteDomains();
 
@@ -45,7 +50,13 @@ const Success: React.FunctionComponent = () => {
 		hideModalTitle();
 	}, [ unsetModalDismissible, hideModalTitle ] );
 
+	const continueEditing = () => {
+		hideSuccessView();
+		closeFocusedLaunch();
+	};
+
 	const redirectToHome = () => {
+		hideSuccessView();
 		redirectTo( `/home/${ siteSubdomain?.domain }` );
 	};
 
@@ -89,7 +100,7 @@ const Success: React.FunctionComponent = () => {
 
 					{ /* @TODO: at the moment this only works when the modal is in the block editor. */ }
 					<NextButton
-						onClick={ closeFocusedLaunch }
+						onClick={ continueEditing }
 						className="focused-launch-success__continue-editing-button"
 					>
 						{ __( 'Continue Editing', __i18n_text_domain__ ) }

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -31,7 +31,7 @@ const Success: React.FunctionComponent = () => {
 		unsetModalDismissible,
 		hideModalTitle,
 		closeFocusedLaunch,
-		hideSuccessView,
+		disablePersistentSuccessView,
 	} = useDispatch( LAUNCH_STORE );
 
 	const { siteSubdomain, sitePrimaryDomain } = useSiteDomains();
@@ -51,12 +51,12 @@ const Success: React.FunctionComponent = () => {
 	}, [ unsetModalDismissible, hideModalTitle ] );
 
 	const continueEditing = () => {
-		hideSuccessView();
+		disablePersistentSuccessView();
 		closeFocusedLaunch();
 	};
 
 	const redirectToHome = () => {
-		hideSuccessView();
+		disablePersistentSuccessView();
 		redirectTo( `/home/${ siteSubdomain?.domain }` );
 	};
 

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -504,14 +504,18 @@ type StepIndexRenderFunction = ( renderOptions: {
 } ) => React.ReactNode;
 
 const Summary: React.FunctionComponent = () => {
-	const hasSelectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).hasSelectedDomain() );
-	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
-	const selectedPlan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
+	const [ hasSelectedDomain, isSiteTitleStepVisible, selectedDomain, selectedPlan ] = useSelect(
+		( select ) => {
+			const { isSiteTitleStepVisible, domain, plan } = select( LAUNCH_STORE ).getState();
+
+			return [ select( LAUNCH_STORE ).hasSelectedDomain(), isSiteTitleStepVisible, domain, plan ];
+		}
+	);
 
 	const { launchSite } = useDispatch( SITE_STORE );
-	const { setModalDismissible, showModalTitle } = useDispatch( LAUNCH_STORE );
+	const { setModalDismissible, showModalTitle, showSiteTitleStep } = useDispatch( LAUNCH_STORE );
 
-	const { title, updateTitle, saveTitle, isSiteTitleStepVisible, showSiteTitleStep } = useTitle();
+	const { title, updateTitle, saveTitle } = useTitle();
 	const { sitePrimaryDomain, siteSubdomain, hasPaidDomain } = useSiteDomains();
 	const { onDomainSelect, onExistingSubdomainSelect } = useDomainSelection();
 	const { domainSearch, isLoading } = useDomainSearch();

--- a/packages/launch/src/hooks/use-title.ts
+++ b/packages/launch/src/hooks/use-title.ts
@@ -7,7 +7,7 @@ import { useContext, useEffect, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { SITE_STORE, LAUNCH_STORE } from '../stores';
+import { SITE_STORE } from '../stores';
 import LaunchContext from '../context';
 
 export function useTitle() {
@@ -21,12 +21,6 @@ export function useTitle() {
 
 	const saveSiteTitle = useDispatch( SITE_STORE ).saveSiteTitle;
 
-	const isSiteTitleStepVisible = useSelect( ( select ) =>
-		select( LAUNCH_STORE ).isSiteTitleStepVisible()
-	);
-
-	const showSiteTitleStep = useDispatch( LAUNCH_STORE ).showSiteTitleStep;
-
 	return {
 		title: localStateTitle,
 		updateTitle: setLocalStateTitle,
@@ -38,7 +32,5 @@ export function useTitle() {
 			}
 			saveSiteTitle( siteId, localStateTitle );
 		},
-		isSiteTitleStepVisible,
-		showSiteTitleStep,
 	};
 }

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -35,6 +35,9 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
 	const isModalTitleVisible = useSelect( ( select ) =>
 		select( LAUNCH_STORE ).isModalTitleVisible()
 	);
+	const shouldDisplaySuccessView = useSelect( ( select ) =>
+		select( LAUNCH_STORE ).shouldDisplaySuccessView()
+	);
 
 	const { closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
 
@@ -45,7 +48,9 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
 				className={ classNames( 'launch__focused-modal', {
 					'launch__focused-modal--hide-title': ! isModalTitleVisible,
 				} ) }
-				overlayClassName="launch__focused-modal-overlay"
+				overlayClassName={ classNames( 'launch__focused-modal-overlay', {
+					'launch__focused-modal-overlay--delay-animation-in': shouldDisplaySuccessView,
+				} ) }
 				bodyOpenClassName="has-focused-launch-modal"
 				onRequestClose={ closeFocusedLaunch }
 				title={ __( 'Complete setup', __i18n_text_domain__ ) }

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -31,13 +31,11 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
 	openCheckout,
 	redirectTo,
 } ) => {
-	const isModalDismissible = useSelect( ( select ) => select( LAUNCH_STORE ).isModalDismissible() );
-	const isModalTitleVisible = useSelect( ( select ) =>
-		select( LAUNCH_STORE ).isModalTitleVisible()
-	);
-	const shouldDisplaySuccessView = useSelect( ( select ) =>
-		select( LAUNCH_STORE ).shouldDisplaySuccessView()
-	);
+	const {
+		isModalDismissible,
+		isModalTitleVisible,
+		shouldDisplaySuccessView,
+	} = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 
 	const { closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
 

--- a/packages/launch/src/launch/styles.scss
+++ b/packages/launch/src/launch/styles.scss
@@ -20,12 +20,14 @@ body.has-focused-launch-modal {
 		animation-delay: 1s;
 		// "fill-mode: both" keeps the modal invisible until the animation starts
 		animation-fill-mode: both;
+
+		.launch__focused-modal {
+			animation-delay: inherit;
+		}
 	}
 }
 
 .launch__focused-modal {
-	animation-delay: inherit;
-
 	&.components-modal__frame {
 		transform: none;
 	}

--- a/packages/launch/src/launch/styles.scss
+++ b/packages/launch/src/launch/styles.scss
@@ -15,7 +15,17 @@ body.has-focused-launch-modal {
 	overflow: hidden;
 }
 
+.launch__focused-modal-overlay {
+	&.launch__focused-modal-overlay--delay-animation-in {
+		animation-delay: 1s;
+		// "fill-mode: both" keeps the modal invisible until the animation starts
+		animation-fill-mode: both;
+	}
+}
+
 .launch__focused-modal {
+	animation-delay: inherit;
+
 	&.components-modal__frame {
 		transform: none;
 	}


### PR DESCRIPTION
## Changes proposed in this Pull Request

There are two special cases after launching a site from the editor using Focused Launch:
* the user completes a purchase (eg: Premium plan) and they get redirected to _Thank you_ page
* the user navigates away from the editor without dismissing the Success View by pressing one of the action buttons.

In these cases, when returning to the editor, Success View is displayed.

## Testing instructions

#### Run the project locally

- Make sure you're connected to your sandbox, and that your sandbox is clean and up to date
- Check out the branch on your machine and run in two parallel terminal windows:
   - `yarn && yarn start`
   - `cd apps/editing-toolkit && yarn dev --sync`

#### Open the Focused Launch modal

1. Add a new, _unlaunched_ site created with `/start` to your sandbox (for convenience, `SITE_ID`)
2. Visit `calypso.localhost:3000/page/SITE_ID/home?flags=create/focused-launch-flow` and click on the "Launch" button. The Focused Launch modal should appear.

#### Focused launch — selecting the free options

1. Follow instructions from the previous `Run the project locally` and `Open the Focused Launch modal` sections
2. Select free domain and plan and click "Launch your site" at the bottom
   - [x] The loading view and then Success view should appear.

#### Focused launch — selecting paid options, but exiting checkout without paying

1. Follow instructions from the previous `Run the project locally` and `Open the Focused Launch modal` sections
2. Select a paid domain and a paid plan
   - [x] The loading view and then checkout overlay should be displayed
3. Close the checkout overlay without completing the purchase
   - [x] The Success view should be shown, giving you the option to continue editing (no redirect)

#### Focused launch —  selecting paid options, with successful payment

1. Follow instructions from the previous `Run the project locally` and `Open the Focused Launch modal` sections
2. Select a paid domain and a paid plan
   - [x] The loading view and then checkout overlay should be displayed
3. Complete the plan purchase
   - [x] You should be redirected to _Thank you_ page (depending on the plan)
   - [x] After skipping the upsell you should be redirected back to block editor. The Focused Launch modal should open automatically and show the Success view (with some delay, as discussed in [this comment](https://github.com/Automattic/wp-calypso/pull/47808#issuecomment-734625847))

Fixes #47392

(it fixes #47392 only partially, but it is the last spec left in that issue)