### PR TITLE
Checkout: fix apply button in coupon field

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/coupon.js
+++ b/client/my-sites/checkout/composite-checkout/components/coupon.js
@@ -106,8 +106,8 @@ const CouponWrapper = styled.form`
 
 const ApplyButton = styled( Button )`
 	position: absolute;
-	top: 5px;
-	right: 4px;
+	top: 3px;
+	right: 3px;
 	padding: 8px;
 	animation: ${ animateIn } 0.2s ease-out;
 	animation-fill-mode: backwards;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a spacing issue with the coupon field that was recently introduced when we [updated our fields](https://github.com/Automattic/wp-calypso/pull/47246). 

**Before**
![image](https://user-images.githubusercontent.com/6981253/100387894-26d73e00-2ff7-11eb-98d7-ca8233834b8e.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/100387856-11faaa80-2ff7-11eb-9a9a-eaff8ec2e5fc.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit checkout and click on "Add a coupon" link.


