### PR TITLE
Checkout: redirect to Calypso checkout in Jetpack cloud

### DIFF
--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -67,7 +67,6 @@ import { getJetpackProductTagline } from 'calypso/lib/products-values/get-jetpac
 import { getJetpackProductCallToAction } from 'calypso/lib/products-values/get-jetpack-product-call-to-action';
 import { getJetpackProductDescription } from 'calypso/lib/products-values/get-jetpack-product-description';
 import { getJetpackProductShortName } from 'calypso/lib/products-values/get-jetpack-product-short-name';
-import config from 'calypso/config';
 import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 import { MORE_FEATURES_LINK } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -689,13 +688,12 @@ export function checkout(
 	if ( ! siteSlug ) {
 		path = `/jetpack/connect/${ productsString }`;
 	} else {
-		path =
-			isJetpackCloud() && ! config.isEnabled( 'jetpack-cloud/connect' )
-				? `/checkout/${ siteSlug }/${ productsString }`
-				: `/checkout/${ siteSlug }`;
+		path = isJetpackCloud()
+			? `/checkout/${ siteSlug }/${ productsString }`
+			: `/checkout/${ siteSlug }`;
 	}
 
-	if ( isJetpackCloud() && ! config.isEnabled( 'jetpack-cloud/connect' ) ) {
+	if ( isJetpackCloud() ) {
 		window.location.href = addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` );
 	} else {
 		addItems( productsArray.map( jetpackProductItem ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request

In the pricing page in Jetpack cloud, selecting a product redirects you to a ever loading checkout (not in production). This PR temporarily redirects user to the checkout page in Calypso.

### Testing instructions

- Run Jetpack cloud
- Visit `/pricing` and select a product
- Notice you're redirected to the checkout page in Calypso
