### PR TITLE
Add search to onboarding language picker

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/language/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/language/index.tsx
@@ -25,10 +25,10 @@ import languages from '@automattic/languages';
 import './style.scss';
 
 const LanguageStep: React.FunctionComponent = () => {
-	const { __ } = useI18n();
+	const { __, i18nLocale } = useI18n();
 
 	const localizedLanguageNames = useSelect( ( select ) =>
-		select( I18N_STORE ).getLocalizedLanguageNames()
+		select( I18N_STORE ).getLocalizedLanguageNames( i18nLocale )
 	);
 
 	const history = useHistory();

--- a/client/landing/gutenboarding/onboarding-block/language/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/language/index.tsx
@@ -7,6 +7,7 @@ import { useI18n } from '@automattic/react-i18n';
 import { ActionButtons, BackButton } from '@automattic/onboarding';
 import LanguagePicker, { createLanguageGroups } from '@automattic/language-picker';
 import { I18N_STORE } from '../../stores/i18n';
+import { USER_STORE } from '../../stores/user';
 
 /**
  * WordPress dependencies
@@ -24,11 +25,17 @@ import languages from '@automattic/languages';
  */
 import './style.scss';
 
+const LOCALIZED_LANGUAGE_NAMES_FALLBACK_LOCALE = 'en';
+
 const LanguageStep: React.FunctionComponent = () => {
-	const { __, i18nLocale } = useI18n();
+	const { __ } = useI18n();
+
+	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 
 	const localizedLanguageNames = useSelect( ( select ) =>
-		select( I18N_STORE ).getLocalizedLanguageNames( i18nLocale )
+		select( I18N_STORE ).getLocalizedLanguageNames(
+			currentUser?.language ?? LOCALIZED_LANGUAGE_NAMES_FALLBACK_LOCALE
+		)
 	);
 
 	const history = useHistory();

--- a/client/landing/gutenboarding/onboarding-block/language/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/language/index.tsx
@@ -4,8 +4,14 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useI18n } from '@automattic/react-i18n';
-import { ActionButtons, BackButton, Title } from '@automattic/onboarding';
+import { ActionButtons, BackButton } from '@automattic/onboarding';
 import LanguagePicker, { createLanguageGroups } from '@automattic/language-picker';
+import { I18N_STORE } from '../../stores/i18n';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -21,6 +27,10 @@ import './style.scss';
 const LanguageStep: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 
+	const localizedLanguageNames = useSelect( ( select ) =>
+		select( I18N_STORE ).getLocalizedLanguageNames()
+	);
+
 	const history = useHistory();
 
 	const goBack = () => {
@@ -31,19 +41,20 @@ const LanguageStep: React.FunctionComponent = () => {
 		<ChangeLocaleContextConsumer>
 			{ ( changeLocale ) => (
 				<div className="gutenboarding-page language">
-					<div className="language__heading">
-						<Title>{ __( 'Select your site language' ) }</Title>
-						<ActionButtons>
-							<BackButton onClick={ goBack } />
-						</ActionButtons>
-					</div>
 					<LanguagePicker
+						headingTitle={ __( 'Select your site language' ) }
+						headingButtons={
+							<ActionButtons>
+								<BackButton onClick={ goBack } />
+							</ActionButtons>
+						}
 						languageGroups={ createLanguageGroups( __ ) }
 						languages={ languages }
 						onSelectLanguage={ ( language ) => {
 							changeLocale( language.langSlug );
 							goBack();
 						} }
+						localizedLanguageNames={ localizedLanguageNames }
 					/>
 				</div>
 			) }

--- a/client/landing/gutenboarding/onboarding-block/language/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/language/style.scss
@@ -1,5 +1,3 @@
-.language__heading {
-	margin: 64px 0 80px;
-	display: flex;
-	justify-content: space-between;
+.gutenboarding-page.language .language-picker-component__heading {
+	margin: 64px 0;
 }

--- a/client/landing/gutenboarding/stores/i18n/index.ts
+++ b/client/landing/gutenboarding/stores/i18n/index.ts
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import { I18n } from '@automattic/data-stores';
+
+export const I18N_STORE = I18n.register();

--- a/packages/language-picker/package.json
+++ b/packages/language-picker/package.json
@@ -35,7 +35,6 @@
 		"@wordpress/base-styles": "^2.0.1",
 		"@wordpress/components": "^10.0.5",
 		"@wordpress/i18n": "^3.14.0",
-		"lodash": "^4.17.20",
 		"tslib": "^1.10.0"
 	},
 	"peerDependencies": {

--- a/packages/language-picker/package.json
+++ b/packages/language-picker/package.json
@@ -30,10 +30,12 @@
 	"types": "dist/types",
 	"dependencies": {
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
+		"@automattic/search": "^1.0.0",
 		"@babel/runtime": "^7.12.5",
 		"@wordpress/base-styles": "^2.0.1",
 		"@wordpress/components": "^10.0.5",
 		"@wordpress/i18n": "^3.14.0",
+		"lodash": "4.17.20",
 		"tslib": "^1.10.0"
 	},
 	"peerDependencies": {

--- a/packages/language-picker/package.json
+++ b/packages/language-picker/package.json
@@ -35,7 +35,7 @@
 		"@wordpress/base-styles": "^2.0.1",
 		"@wordpress/components": "^10.0.5",
 		"@wordpress/i18n": "^3.14.0",
-		"lodash": "4.17.20",
+		"lodash": "^4.17.20",
 		"tslib": "^1.10.0"
 	},
 	"peerDependencies": {

--- a/packages/language-picker/src/Language.ts
+++ b/packages/language-picker/src/Language.ts
@@ -1,0 +1,24 @@
+export type LanguageGroup = {
+	id: string;
+	name: () => string;
+	subTerritories?: string[];
+	countries?: string[];
+	default?: boolean;
+};
+
+type LanguageSlug = string;
+type WPLocale = string;
+
+type BaseLanguage = {
+	langSlug: LanguageSlug;
+	name: string;
+	popular?: number;
+	rtl?: boolean;
+	territories: string[];
+	value: number;
+	wpLocale: WPLocale | '';
+};
+
+type SubLanguage = BaseLanguage & { parentLangSlug: string };
+
+export type Language = BaseLanguage | SubLanguage;

--- a/packages/language-picker/src/constants.ts
+++ b/packages/language-picker/src/constants.ts
@@ -1,17 +1,17 @@
 /**
  * Internal dependencies
  */
-import { LanguageGroup } from './language-picker';
+import { LanguageGroup } from './Language';
 import { I18nReact } from '@automattic/react-i18n';
 
 export const createLanguageGroups = ( __: I18nReact[ '__' ] ): LanguageGroup[] => [
 	{
 		id: 'popular',
-		name: () => __( 'Popular languages' ),
+		name: () => __( 'Popular languages', __i18n_text_domain__ ),
 	},
 	{
 		id: 'africa-middle-east',
-		name: () => __( 'Africa and Middle East' ),
+		name: () => __( 'Africa and Middle East', __i18n_text_domain__ ),
 		subTerritories: [ '145', '002' ],
 		countries: [
 			'AE',
@@ -96,7 +96,7 @@ export const createLanguageGroups = ( __: I18nReact[ '__' ] ): LanguageGroup[] =
 	},
 	{
 		id: 'americas',
-		name: () => __( 'Americas' ),
+		name: () => __( 'Americas', __i18n_text_domain__ ),
 		subTerritories: [ '019' ],
 		countries: [
 			'AG',
@@ -159,7 +159,7 @@ export const createLanguageGroups = ( __: I18nReact[ '__' ] ): LanguageGroup[] =
 	{
 		id: 'asia-pacific',
 		default: true,
-		name: () => __( 'Asia-Pacific' ),
+		name: () => __( 'Asia-Pacific', __i18n_text_domain__ ),
 		subTerritories: [ '143', '009', '030', '034', '035' ],
 		countries: [
 			'AC',
@@ -238,13 +238,13 @@ export const createLanguageGroups = ( __: I18nReact[ '__' ] ): LanguageGroup[] =
 	},
 	{
 		id: 'eastern-europe',
-		name: () => __( 'Eastern Europe' ),
+		name: () => __( 'Eastern Europe', __i18n_text_domain__ ),
 		subTerritories: [ '151' ],
 		countries: [ 'BG', 'BY', 'CZ', 'HU', 'MD', 'PL', 'RO', 'RU', 'SK', 'UA' ],
 	},
 	{
 		id: 'western-europe',
-		name: () => __( 'Western Europe' ),
+		name: () => __( 'Western Europe', __i18n_text_domain__ ),
 		subTerritories: [ '154', '155', '039' ],
 		countries: [
 			'AD',

--- a/packages/language-picker/src/index.ts
+++ b/packages/language-picker/src/index.ts
@@ -1,3 +1,4 @@
-export * from './language-picker';
+export * from './Language';
 export { default } from './language-picker';
 export * from './constants';
+export * from './search';

--- a/packages/language-picker/src/language-picker.tsx
+++ b/packages/language-picker/src/language-picker.tsx
@@ -3,52 +3,88 @@
  * External dependencies
  */
 import React, { useState } from 'react';
+import type { ReactNode } from 'react';
 import { useI18n } from '@automattic/react-i18n';
+import { intersection } from 'lodash';
+import Search from '@automattic/search';
 
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, CustomSelectControl, Flex, FlexBlock, FlexItem } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { Language, LanguageGroup } from './Language';
+import { getSearchedLanguages, LocalizedLanguageNames } from './search';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-export type LanguageGroup = {
-	id: string;
-	name: () => string;
-	subTerritories?: string[];
-	countries?: string[];
-	default?: boolean;
-};
-
-type LanguageSlug = string;
-type WPLocale = string;
-
-type BaseLanguage = {
-	langSlug: LanguageSlug;
-	name: string;
-	popular?: number;
-	rtl?: boolean;
-	territories: string[];
-	value: number;
-	wpLocale: WPLocale | '';
-};
-
-type SubLanguage = BaseLanguage & { parentLangSlug: string };
-
-export type Language = BaseLanguage | SubLanguage;
-
-type Props = {
-	onSelectLanguage: ( language: Language ) => void;
-	languages: Language[];
+type Props< TLanguage extends Language > = {
+	onSelectLanguage: ( language: TLanguage ) => void;
+	languages: TLanguage[];
 	languageGroups: LanguageGroup[];
+	selectedLanguage?: TLanguage;
+	localizedLanguageNames?: LocalizedLanguageNames;
+	headingButtons?: ReactNode;
+	headingTitle?: ReactNode;
 };
 
-const LanguagePicker = ( { onSelectLanguage, languages, languageGroups }: Props ) => {
+/**
+ * Pick the first language group that includes the currently selected language.
+ * If no language is currently selected then just use the default. Similarly,
+ * if no language group can be found with the current language in it, use the default.
+ *
+ * @param selectedLanguage The currently selected language, if one exists.
+ * @param languageGroups The language groups to choose from.
+ * @param defaultLananguageGroupId The default language group to use when a language isn't picked or when the selected language isn't found in any of the groups.
+ * @returns The best default language group id.
+ */
+const findBestDefaultLanguageGroupId = (
+	selectedLanguage: Language | undefined,
+	languageGroups: LanguageGroup[],
+	defaultLananguageGroupId: string
+): string => {
+	if ( ! selectedLanguage ) {
+		return defaultLananguageGroupId;
+	}
+
+	if ( selectedLanguage.popular ) {
+		return 'popular';
+	}
+
+	return (
+		languageGroups.find( ( lg ) => {
+			const sharedTerritories = intersection( lg.subTerritories, selectedLanguage.territories );
+
+			if ( sharedTerritories.length > 0 ) {
+				return lg;
+			}
+
+			return false;
+		} )?.id ?? defaultLananguageGroupId
+	);
+};
+
+function LanguagePicker< TLanguage extends Language >( {
+	onSelectLanguage,
+	languages,
+	languageGroups,
+	selectedLanguage,
+	localizedLanguageNames,
+	headingTitle,
+	headingButtons,
+}: Props< TLanguage > ): JSX.Element {
 	const { __ } = useI18n();
-	const [ filter, setFilter ] = useState( languageGroups[ 0 ].id );
+	const [ filter, setFilter ] = useState(
+		findBestDefaultLanguageGroupId( selectedLanguage, languageGroups, languageGroups[ 0 ].id )
+	);
+
+	const [ search, setSearch ] = useState( '' );
 
 	const getFilteredLanguages = () => {
 		switch ( filter ) {
@@ -77,27 +113,96 @@ const LanguagePicker = ( { onSelectLanguage, languages, languageGroups }: Props 
 			};
 
 			return (
-				<div key={ languageGroup.id }>
-					<Button onClick={ onClick } className="language-picker-component__language-group">
-						<span className={ isSelected ? 'is-selected' : '' }>{ languageGroup.name() }</span>
-					</Button>
-				</div>
+				<Button
+					key={ languageGroup.id }
+					onClick={ onClick }
+					className="language-picker-component__language-group"
+				>
+					<span className={ isSelected ? 'is-selected' : '' }>{ languageGroup.name() }</span>
+				</Button>
 			);
 		} );
 	};
 
+	const shouldDisplayRegions = ! search;
+
+	const languagesToRender = search
+		? getSearchedLanguages( languages, search, localizedLanguageNames )
+		: getFilteredLanguages();
+
+	const selectControlOptions = languageGroups.map( ( lg ) => ( { key: lg.id, name: lg.name() } ) );
+
 	return (
-		<div className="language-picker-component">
-			<div className="language-picker-component__regions-label">
-				{ __( 'regions', __i18n_text_domain__ ) }
-			</div>
-			<div className="language-picker-component__content">
-				<div className="language-picker-component__category-filters">
-					{ renderCategoryButtons() }
+		<Flex className="language-picker-component" align="left">
+			<FlexBlock className="language-picker-component__heading">
+				<Flex justify="space-between" align="left">
+					<FlexItem className="language-picker-component__title wp-brand-font">
+						{ headingTitle || __( 'Select a language', __i18n_text_domain__ ) }
+					</FlexItem>
+					{ headingButtons && (
+						<FlexItem className="language-picker-component__heading-buttons">
+							{ headingButtons }
+						</FlexItem>
+					) }
+				</Flex>
+			</FlexBlock>
+			<FlexBlock className="language-picker-component__search">
+				<CustomSelectControl
+					label={ __( 'regions' ) }
+					hideLabelFromVision
+					value={ selectControlOptions.find( ( option ) => option.key === filter ) }
+					options={ selectControlOptions }
+					onChange={ ( { selectedItem } ) => selectedItem && setFilter( selectedItem.key ) }
+				/>
+				<div className="language-picker-component__search-mobile">
+					<Search
+						onSearch={ setSearch }
+						pinned
+						fitsContainer
+						placeholder={ __( 'Search languages…' ) }
+						onSearchClose={ () =>
+							setFilter(
+								findBestDefaultLanguageGroupId( selectedLanguage, languageGroups, filter )
+							)
+						}
+					/>
 				</div>
+				<div className="language-picker-component__search-desktop">
+					<Search
+						openIconSide="right"
+						onSearch={ setSearch }
+						compact
+						placeholder={ __( 'Search languages…' ) }
+						onSearchClose={ () =>
+							setFilter(
+								findBestDefaultLanguageGroupId( selectedLanguage, languageGroups, filter )
+							)
+						}
+					/>
+				</div>
+			</FlexBlock>
+			<FlexBlock className="language-picker-component__labels">
+				{ shouldDisplayRegions ? (
+					<>
+						<div className="language-picker-component__regions-label">{ __( 'regions' ) }</div>
+						<div className="language-picker-component__languages-label">{ __( 'languages' ) }</div>
+					</>
+				) : (
+					<div className="language-picker-component__search-results-label">
+						{ __( 'Search results' ) }
+					</div>
+				) }
+			</FlexBlock>
+			<FlexBlock className="language-picker-component__content">
+				{ shouldDisplayRegions && (
+					<div className="language-picker-component__category-filters">
+						{ renderCategoryButtons() }
+					</div>
+				) }
 				<div className="language-picker-component__language-buttons">
-					{ getFilteredLanguages().map( ( language ) => (
+					{ languagesToRender.map( ( language ) => (
 						<Button
+							isPrimary={ selectedLanguage && language.langSlug === selectedLanguage.langSlug }
 							className="language-picker-component__language-button"
 							key={ language.langSlug }
 							onClick={ () => onSelectLanguage( language ) }
@@ -107,9 +212,9 @@ const LanguagePicker = ( { onSelectLanguage, languages, languageGroups }: Props 
 						</Button>
 					) ) }
 				</div>
-			</div>
-		</div>
+			</FlexBlock>
+		</Flex>
 	);
-};
+}
 
 export default LanguagePicker;

--- a/packages/language-picker/src/language-picker.tsx
+++ b/packages/language-picker/src/language-picker.tsx
@@ -62,7 +62,7 @@ const findBestDefaultLanguageGroupId = (
 			const sharedTerritories = intersection( lg.subTerritories, selectedLanguage.territories );
 
 			if ( sharedTerritories.length > 0 ) {
-				return lg;
+				return true;
 			}
 
 			return false;
@@ -132,6 +132,12 @@ function LanguagePicker< TLanguage extends Language >( {
 
 	const selectControlOptions = languageGroups.map( ( lg ) => ( { key: lg.id, name: lg.name() } ) );
 
+	const handleSearchClose = React.useCallback( () => {
+		setFilter( findBestDefaultLanguageGroupId( selectedLanguage, languageGroups, filter ) );
+	}, [ selectedLanguage, languageGroups, filter ] );
+
+	const searchPlaceholder = __( 'Search languages…' );
+
 	return (
 		<Flex className="language-picker-component" align="left">
 			<FlexBlock className="language-picker-component__heading">
@@ -159,12 +165,8 @@ function LanguagePicker< TLanguage extends Language >( {
 						onSearch={ setSearch }
 						pinned
 						fitsContainer
-						placeholder={ __( 'Search languages…' ) }
-						onSearchClose={ () =>
-							setFilter(
-								findBestDefaultLanguageGroupId( selectedLanguage, languageGroups, filter )
-							)
-						}
+						placeholder={ searchPlaceholder }
+						onSearchClose={ handleSearchClose }
 					/>
 				</div>
 				<div className="language-picker-component__search-desktop">
@@ -172,12 +174,8 @@ function LanguagePicker< TLanguage extends Language >( {
 						openIconSide="right"
 						onSearch={ setSearch }
 						compact
-						placeholder={ __( 'Search languages…' ) }
-						onSearchClose={ () =>
-							setFilter(
-								findBestDefaultLanguageGroupId( selectedLanguage, languageGroups, filter )
-							)
-						}
+						placeholder={ searchPlaceholder }
+						onSearchClose={ handleSearchClose }
 					/>
 				</div>
 			</FlexBlock>

--- a/packages/language-picker/src/language-picker.tsx
+++ b/packages/language-picker/src/language-picker.tsx
@@ -5,7 +5,6 @@
 import React, { useState } from 'react';
 import type { ReactNode } from 'react';
 import { useI18n } from '@automattic/react-i18n';
-import { intersection } from 'lodash';
 import Search from '@automattic/search';
 
 /**
@@ -59,7 +58,10 @@ const findBestDefaultLanguageGroupId = (
 
 	return (
 		languageGroups.find( ( lg ) => {
-			const sharedTerritories = intersection( lg.subTerritories, selectedLanguage.territories );
+			const sharedTerritories =
+				lg.subTerritories?.filter( ( territory ) =>
+					selectedLanguage.territories.includes( territory )
+				) ?? [];
 
 			if ( sharedTerritories.length > 0 ) {
 				return true;

--- a/packages/language-picker/src/search.ts
+++ b/packages/language-picker/src/search.ts
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { deburr } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { Language } from './Language';
+
+type SearchableFields = string[];
+export type LocalizedLanguageNames = { [ slug: string ]: { localized: string; en: string } };
+
+const getSearchableFields = < TLanguage extends Language >(
+	language: TLanguage,
+	localizedLanguageNames?: LocalizedLanguageNames
+): SearchableFields =>
+	[
+		deburr( language.name ),
+		language.langSlug,
+		deburr( localizedLanguageNames?.[ language.langSlug ]?.localized ),
+		deburr( localizedLanguageNames?.[ language.langSlug ]?.en ),
+	].map( ( s ) => s.toLowerCase() );
+
+export const getSearchedLanguages = < TLanguage extends Language >(
+	languages: TLanguage[],
+	search: string,
+	localizedLanguageNames?: LocalizedLanguageNames
+): TLanguage[] => {
+	const searchString = deburr( search ).toLowerCase();
+	return languages.filter( ( language ) =>
+		getSearchableFields( language, localizedLanguageNames ).some( ( name ) =>
+			name.includes( searchString )
+		)
+	);
+};

--- a/packages/language-picker/src/search.ts
+++ b/packages/language-picker/src/search.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { deburr } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { Language } from './Language';
@@ -11,16 +6,21 @@ import { Language } from './Language';
 type SearchableFields = string[];
 export type LocalizedLanguageNames = { [ slug: string ]: { localized: string; en: string } };
 
+const deburr = ( str?: string ) => str?.normalize( 'NFD' ).replace( /[\u0300-\u036f]/g, '' ) ?? '';
+const toLowerCase = ( str: string ) => str.toLowerCase();
+
 const getSearchableFields = < TLanguage extends Language >(
 	language: TLanguage,
 	localizedLanguageNames?: LocalizedLanguageNames
 ): SearchableFields =>
 	[
-		deburr( language.name ),
+		language.name,
 		language.langSlug,
-		deburr( localizedLanguageNames?.[ language.langSlug ]?.localized ),
-		deburr( localizedLanguageNames?.[ language.langSlug ]?.en ),
-	].map( ( s ) => s.toLowerCase() );
+		localizedLanguageNames?.[ language.langSlug ]?.localized,
+		localizedLanguageNames?.[ language.langSlug ]?.en,
+	]
+		.map( deburr )
+		.map( toLowerCase );
 
 export const getSearchedLanguages = < TLanguage extends Language >(
 	languages: TLanguage[],

--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -17,7 +17,6 @@
 
 	.language-picker-component__title {
 		font-size: 2rem;
-		white-space: nowrap;
 		padding: 0 10px 12px;
 
 		@include break-small() {
@@ -62,17 +61,18 @@
 			}
 		}
 
-		&-desktop {
-			.search-component {
+		.search-component.is-open {
+			border-radius: 2px;
+			box-shadow: 0 0 0 1px var( --color-primary );
+
+			.search-component__input {
 				border-radius: 2px;
-				box-shadow: 0 0 0 1px var( --color-primary );
-
-				.search-component__input {
-					border-radius: 2px;
-				}
 			}
+		}
 
+		&-desktop {
 			display: none;
+
 			@include break-small() {
 				display: block;
 				width: 240px;

--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -3,10 +3,93 @@
 @import '~@wordpress/base-styles/variables';
 
 .language-picker-component {
-	.language-picker-component__language-group {
-		width: 100%;
+	flex-direction: column;
+
+	.language-picker-component__heading {
+		margin: 0;
+
+		@include break-small() {
+			margin: 6px 12px 24px;
+			flex-direction: row;
+			align-items: center;
+		}
 	}
-	
+
+	.language-picker-component__title {
+		font-size: 2rem;
+		white-space: nowrap;
+		padding: 0 10px 12px;
+
+		@include break-small() {
+			padding: initial;
+		}
+	}
+
+	.components-custom-select-control {
+		width: 100%;
+		height: 100%;
+
+		.components-custom-select-control__button {
+			width: 85%;
+			height: 100%;
+			font-size: 0.875rem;
+		}
+
+		.components-custom-select-control__menu {
+			margin: 5px 0 0;
+
+			.components-custom-select-control__item {
+				font-size: 0.875rem;
+			}
+		}
+
+		@include break-small() {
+			display: none;
+		}
+	}
+
+	.language-picker-component__search {
+		position: relative;
+		height: 34px;
+		flex: 1 1 auto;
+		margin-bottom: 12px;
+
+		.search-component__input[type='search'] {
+			font-size: 0.875rem;
+
+			@include break-small() {
+				padding-left: 12px;
+			}
+		}
+
+		&-desktop {
+			.search-component {
+				border-radius: 2px;
+				box-shadow: 0 0 0 1px var( --color-primary );
+
+				.search-component__input {
+					border-radius: 2px;
+				}
+			}
+
+			display: none;
+			@include break-small() {
+				display: block;
+				width: 240px;
+			}
+		}
+
+		&-mobile {
+			@include break-small() {
+				display: none;
+			}
+		}
+	}
+
+	.language-picker-component__language-group {
+		width: 230px;
+	}
+
 	.language-picker-component__language-group > span {
 		padding-bottom: 4px;
 		&.is-selected {
@@ -14,36 +97,58 @@
 			border-bottom: 2px solid #3582c4;
 		}
 	}
-	
-	.language-picker-component__regions-label {
+
+	.language-picker-component__labels {
+		display: none;
+
+		@include break-small() {
+			display: flex;
+		}
+
+		flex-direction: row;
+		flex-wrap: nowrap;
 		font-family: $default-font;
 		margin: 6px 12px;
 		color: $gray-600;
 		/* stylelint-disable-next-line scales/font-size */
-		font-size: 13px;
+		font-size: 0.875rem;
 		text-transform: uppercase;
 	}
-	
+
 	.language-picker-component__content {
 		display: flex;
 	}
-	
+
+	.language-picker-component__labels > div,
 	.language-picker-component__category-filters {
-		min-width: 170px;
-	
-		@include break-small {
-			min-width: 220px;
-			margin-right: 60px;
+		@include break-small() {
+			width: 230px;
 		}
 	}
-	
+
+	.language-picker-component__category-filters {
+		display: none;
+
+		@include break-small() {
+			display: initial;
+		}
+	}
+
 	.language-picker-component__language-buttons {
 		display: flex;
 		flex-wrap: wrap;
 		align-content: flex-start;
+		width: 100%;
+
+		@include break-small() {
+			width: initial;
+		}
 	}
-	
+
 	.language-picker-component__language-button {
-		width: 165px;
+		width: 100%;
+		@include break-small() {
+			width: 165px;
+		}
 	}
 }

--- a/packages/language-picker/tsconfig.json
+++ b/packages/language-picker/tsconfig.json
@@ -30,5 +30,6 @@
 
 		"composite": true
 	},
-	"include": [ "src" ]
+	"include": [ "src" ],
+	"references": [ { "path": "../search" } ]
 }

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -4,7 +4,7 @@
  */
 import classNames from 'classnames';
 import React, { ChangeEvent, FocusEvent, FormEvent, KeyboardEvent, MouseEvent } from 'react';
-import { debounce, noop, uniqueId } from 'lodash';
+import { debounce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,6 +22,8 @@ import './style.scss';
  * Internal variables
  */
 const SEARCH_DEBOUNCE_MS = 300;
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {};
 
 const keyListener = (
 	methodToCall: (
@@ -112,7 +114,12 @@ class Search extends React.Component< Props, State > {
 		searching: false,
 	};
 
-	instanceId = uniqueId();
+	static currentId = 0;
+	static getUniqueId = (): number => {
+		return Search.currentId++;
+	};
+
+	instanceId = Search.getUniqueId();
 	searchInput = React.createRef< HTMLInputElement >();
 	openIcon = React.createRef< HTMLButtonElement >();
 	overlay = React.createRef< HTMLDivElement >();

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -22,6 +22,7 @@ $input-z-index: 20;
 	transition: all 0.15s ease-in-out;
 
 	input.search-component__input[type='search'] {
+		width: 0;
 		flex: 1 1 auto;
 		z-index: $input-z-index;
 		top: 0;
@@ -71,6 +72,7 @@ $input-z-index: 20;
 		top: 1px;
 		left: 0;
 		z-index: $input-z-index + 1;
+		padding-left: 5px;
 	}
 
 	&__icon-navigation {
@@ -124,7 +126,6 @@ $input-z-index: 20;
 		position: absolute;
 		display: flex;
 		height: 100%;
-		width: 50px;
 		top: 0;
 		right: 0;
 	
@@ -177,6 +178,7 @@ $input-z-index: 20;
 	}
 
 	&.is-open {
+		background-color: $white;
 		width: 100%;
 	
 		.search-component__open-icon {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18461,25 +18461,15 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@*, lodash@^4.0.0, lodash@^4.1.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.5.1, lodash@^4.6.1, lodash@~4.17.10, lodash@~4.17.12, lodash@~4.17.5:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@*, lodash@4.17.20, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.5.1, lodash@^4.6.1, lodash@~4.17.10, lodash@~4.17.12, lodash@~4.17.5:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 lodash@^3.6.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
-
-lodash@^4.0.1, lodash@^4.16.4, lodash@^4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@^4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@4.0.0, log-symbols@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18461,7 +18461,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@*, lodash@4.17.20, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.5.1, lodash@^4.6.1, lodash@~4.17.10, lodash@~4.17.12, lodash@~4.17.5:
+lodash@*, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.5.1, lodash@^4.6.1, lodash@~4.17.10, lodash@~4.17.12, lodash@~4.17.5:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -18461,15 +18461,25 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@*, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.5.1, lodash@^4.6.1, lodash@~4.17.10, lodash@~4.17.12, lodash@~4.17.5:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+lodash@*, lodash@^4.0.0, lodash@^4.1.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.5.1, lodash@^4.6.1, lodash@~4.17.10, lodash@~4.17.12, lodash@~4.17.5:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 lodash@^3.6.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
+
+lodash@^4.0.1, lodash@^4.16.4, lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@4.0.0, log-symbols@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds search to the language picker
* Updates the onboarding language picker to use search

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that `/new?flags=gutenboarding/language-picker` (click the language picker in the upper right-hand corner) matches the spec from @olaolusoga and @ollierozdarz here: p9oQ9f-kT-p2
* Verify that search works as expected (it should filter exactly the same as the previous search implementation from the Calypso language picker)
    * You should be able to search in English for any language
    * You should be able to search for any language in the language that you have selected
* Verify that selecting a new language and saving works
* Verify that selecting a new language and dismissing the modal without apply changes does not save the new language selection
