### PR TITLE
Reader: always show lists in sidebar if list management is enabled for the environment

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -209,7 +209,7 @@ export class ReaderSidebar extends React.Component {
 					} ) }
 				/>
 
-				{ this.props.subscribedLists && this.props.subscribedLists.length > 0 && (
+				{ ( this.props.subscribedLists?.length > 0 || isEnabled( 'reader/list-management' ) ) && (
 					<ReaderSidebarLists
 						lists={ this.props.subscribedLists }
 						path={ path }

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -41,6 +41,7 @@ import QueryReaderOrganizations from 'calypso/components/data/query-reader-organ
 import { getReaderOrganizations } from 'calypso/state/reader/organizations/selectors';
 import ReaderSidebarFollowedSites from 'calypso/reader/sidebar/reader-sidebar-followed-sites';
 import SidebarSeparator from 'calypso/layout/sidebar/separator';
+import { isEnabled } from 'calypso/config';
 
 /**
  * Style dependencies
@@ -299,7 +300,7 @@ export class ReaderSidebar extends React.Component {
 					} ) }
 				/>
 
-				{ this.props.subscribedLists && this.props.subscribedLists.length > 0 && (
+				{ ( this.props.subscribedLists?.length > 0 || isEnabled( 'reader/list-management' ) ) && (
 					<ReaderSidebarLists
 						lists={ this.props.subscribedLists }
 						path={ path }

--- a/client/reader/sidebar/reader-sidebar-lists/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { localize } from 'i18n-calypso';
 import { identity, map } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -28,7 +27,7 @@ export class ReaderSidebarListsList extends React.Component {
 
 	renderItems() {
 		const { currentListOwner, currentListSlug, path } = this.props;
-		return map( this.props.lists, function ( list ) {
+		return map( this.props.lists, ( list ) => {
 			return (
 				<ListItem
 					key={ list.ID }
@@ -43,15 +42,6 @@ export class ReaderSidebarListsList extends React.Component {
 
 	render() {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		const { translate, lists } = this.props;
-		if ( ! lists || lists.length === 0 ) {
-			return (
-				<div key="empty" className="sidebar__menu-empty">
-					{ translate( 'Collect sites together by adding a list.' ) }
-				</div>
-			);
-		}
-
 		return (
 			<ul className="sidebar__menu-list">
 				{ this.renderItems() }
@@ -64,4 +54,4 @@ export class ReaderSidebarListsList extends React.Component {
 	}
 }
 
-export default localize( ReaderSidebarListsList );
+export default ReaderSidebarListsList;

--- a/client/reader/sidebar/reader-sidebar-lists/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import config from 'calypso/config';
+import { isEnabled } from 'calypso/config';
 import ListItem from './list-item';
 import ListItemCreateLink from './list-item-create-link';
 
@@ -55,7 +55,7 @@ export class ReaderSidebarListsList extends React.Component {
 		return (
 			<ul className="sidebar__menu-list">
 				{ this.renderItems() }
-				{ config.isEnabled( 'reader/list-management' ) && (
+				{ isEnabled( 'reader/list-management' ) && (
 					<ListItemCreateLink key="create-item-link" path={ this.props.path } />
 				) }
 			</ul>

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -108,6 +108,7 @@
 		"press-this": true,
 		"privacy-policy": true,
 		"reader": true,
+		"reader/list-management": true,
 		"reader/seen-posts": true,
 		"republicize": true,
 		"safari-idb-mitigation": true,

--- a/config/test.json
+++ b/config/test.json
@@ -91,6 +91,7 @@
 		"publicize-preview": true,
 		"reader": true,
 		"reader/full-errors": true,
+		"reader/list-management": true,
 		"reader/seen-posts": true,
 		"republicize": true,
 		"rum-tracking/logstash": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -129,6 +129,7 @@
 		"publicize-preview": true,
 		"reader": true,
 		"reader/full-errors": true,
+		"reader/list-management": true,
 		"reader/seen-posts": true,
 		"recommend-plugins": true,
 		"republicize": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

At the moment, the Lists sidebar menu only shows up for users who have subscribed to at least one list. This prevents new internal users from trying the lists feature.

This PR changes the logic so that the Lists sidebar menu is always shown if either:
- the user has subscribed to one or more lists;
- list management is enabled on the environment (currently enabled up to staging)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Using a user account that hasn't created or subscribed to any lists, ensure that the Lists sidebar menu shows up.
