### PR TITLE
Focused-Launch: Hide mobile value proposition quotes on desktop

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -139,7 +139,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							>
 								<span>{ info }</span>
 							</Tooltip>
-							<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
+							<p className="focused-launch-summary__mobile-commentary">
 								<Icon icon={ bulb } />
 								<span>
 									{ createInterpolateElement(
@@ -170,7 +170,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 										{ stepIndex && `${ stepIndex }. ` }
 										{ __( 'Confirm your domain', __i18n_text_domain__ ) }
 									</label>
-									<p className="focused-launch-summary__mobile-commentary focused-launch-summary__mobile-only">
+									<p className="focused-launch-summary__mobile-commentary">
 										<Icon icon={ bulb } />
 										<span>
 											{ createInterpolateElement(

--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -23,17 +23,12 @@ $commentary-column-gap-wide: 100px;
 	}
 }
 
-.focused-launch-summary__mobile-only {
-	@include break-medium {
-		display: none;
-	}
-}
-
 .focused-launch-summary__mobile-commentary {
-	font-size: 0.875rem;
-	color: var( --studio-gray-60 );
 	display: flex;
 	align-items: flex-start;
+	font-size: $font-body-small;
+	color: var( --studio-gray-60 );
+
 	svg {
 		vertical-align: bottom;
 		fill: var( --studio-gray-20 );
@@ -41,6 +36,10 @@ $commentary-column-gap-wide: 100px;
 
 		// compensate for the gap in the svg top
 		margin-top: -1px;
+	}
+
+	@include break-medium {
+		display: none;
 	}
 }
 


### PR DESCRIPTION
Since propositions are already displayed in the sidebar (on desktop) there is no use to display inline propositions as well. In other words: They only have to be visible on mobile. This PR updates CSS rules to enable this. It is a mobile-first approach, which might change to desktop-first in a follow-up commit since we have to align development preferences.

#### Changes proposed in this Pull Request

* Show inline propositions on mobile only.

#### Testing instructions
* Check out this branch and run `yarn && yarn start`;
* Go to the block editor, append `?flags=create/focused-launch-flow` to the URL, and refresh the page;
* Click on the "Launch" button in the editor's header:
   * [x] Inline propositions are invisible;
* Open DevTools and switch to a mobile device:
   * [x] Inline propositions are visible;
   * [x] Sidebar propositions are invisible;

#### Expected view on desktop
<img width="1002" alt="Screenshot 2020-11-27 at 08 40 52" src="https://user-images.githubusercontent.com/12104589/100423448-4a989380-308c-11eb-8e2f-4a3e0287f7fe.png">

#### Expected view on mobile
<img width="360" alt="Screenshot 2020-11-27 at 08 44 36" src="https://user-images.githubusercontent.com/12104589/100423762-d27e9d80-308c-11eb-96e9-063f4f7f368c.png">

#### Context / Source
Remember to test changes in:
* New Onboarding
* Focused Launch


Fixes #47785
