### PR TITLE
Modularise GSuite users state

### DIFF
--- a/client/state/gsuite-users/actions.js
+++ b/client/state/gsuite-users/actions.js
@@ -8,6 +8,7 @@ import {
 } from 'calypso/state/action-types';
 
 import 'calypso/state/data-layer/wpcom/gsuite-users';
+import 'calypso/state/gsuite-users/init';
 
 export const getGSuiteUsers = ( siteId ) => {
 	return {

--- a/client/state/gsuite-users/init.js
+++ b/client/state/gsuite-users/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'gsuiteUsers' ], reducer );

--- a/client/state/gsuite-users/package.json
+++ b/client/state/gsuite-users/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/gsuite-users/reducer.js
+++ b/client/state/gsuite-users/reducer.js
@@ -4,8 +4,9 @@
 import {
 	combineReducers,
 	keyedReducer,
-	withSchemaValidation,
 	withoutPersistence,
+	withSchemaValidation,
+	withStorageKey,
 } from 'calypso/state/utils';
 import {
 	GSUITE_USERS_REQUEST,
@@ -61,7 +62,7 @@ export const requestingReducer = withoutPersistence( ( state = false, action ) =
 	return state;
 } );
 
-export default keyedReducer(
+const combinedReducer = keyedReducer(
 	'siteId',
 	combineReducers( {
 		users: usersReducer,
@@ -69,3 +70,5 @@ export default keyedReducer(
 		requestError: requestErrorReducer,
 	} )
 );
+
+export default withStorageKey( 'gsuiteUsers', combinedReducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -19,7 +19,6 @@ import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import documentHead from './document-head/reducer';
 import experiments from './experiments/reducer';
-import gsuiteUsers from './gsuite-users/reducer';
 import happychat from './happychat/reducer';
 import i18n from './i18n/reducer';
 import immediateLogin from './immediate-login/reducer';
@@ -49,7 +48,6 @@ const reducers = {
 	dataRequests,
 	documentHead,
 	experiments,
-	gsuiteUsers,
 	happychat,
 	httpData,
 	i18n,

--- a/client/state/selectors/get-gsuite-users.js
+++ b/client/state/selectors/get-gsuite-users.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/gsuite-users/init';
+
+/**
  * Retrieves the list of G Suite users for the specified site.
  *
  * @param {object} state - global state tree

--- a/client/state/selectors/is-requesting-gsuite-users.js
+++ b/client/state/selectors/is-requesting-gsuite-users.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/gsuite-users/init';
+
+/**
  * Determines whether the list of G Suite users is being requested.
  *
  * @param {object} state - global state tree


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles GSuite users state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42437.

#### Changes proposed in this Pull Request

* Modularise GSuite users state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/home` on the live branch or your local copy of this branch. Choose a business account with a custom domain.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `gsuiteUsers` key, even if you expand the list of keys. This indicates that the GSuite users state hasn't been loaded yet.
* Click `Manage` followed by `Domains` on the side bar.
* Click `Add` under `Email` for one of the domains on the right side.
* Verify that a `gsuiteUsers` key is added with the GSuite users state. This indicates that the GSuite users state has now been loaded.