### PR TITLE
Modularise stored cards state

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -34,7 +34,6 @@ import selectedEditor from './selected-editor/reducer';
 import siteKeyrings from './site-keyrings/reducer';
 import siteRoles from './site-roles/reducer';
 import sites from './sites/reducer';
-import storedCards from './stored-cards/reducer';
 import support from './support/reducer';
 import ui from './ui/reducer';
 import userSettings from './user-settings/reducer';
@@ -65,7 +64,6 @@ const reducers = {
 	siteKeyrings,
 	siteRoles,
 	sites,
-	storedCards,
 	support,
 	ui,
 	userSettings,

--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -17,6 +17,8 @@ import {
 } from 'calypso/state/action-types';
 import wp from 'calypso/lib/wp';
 
+import 'calypso/state/stored-cards/init';
+
 export const addStoredCard = ( cardData ) => ( dispatch ) => {
 	return wp
 		.undocumented()

--- a/client/state/stored-cards/init.js
+++ b/client/state/stored-cards/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'storedCards' ], reducer );

--- a/client/state/stored-cards/package.json
+++ b/client/state/stored-cards/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/stored-cards/reducer.js
+++ b/client/state/stored-cards/reducer.js
@@ -11,7 +11,7 @@ import {
 	STORED_CARDS_DELETE_COMPLETED,
 	STORED_CARDS_DELETE_FAILED,
 } from 'calypso/state/action-types';
-import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation, withStorageKey } from 'calypso/state/utils';
 import { storedCardsSchema } from './schema';
 
 /**
@@ -106,9 +106,11 @@ export const isDeleting = ( state = {}, action ) => {
 	return state;
 };
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	hasLoadedFromServer,
 	isDeleting,
 	isFetching,
 	items,
 } );
+
+export default withStorageKey( 'storedCards', combinedReducer );

--- a/client/state/stored-cards/selectors.js
+++ b/client/state/stored-cards/selectors.js
@@ -8,6 +8,8 @@ import { groupBy } from 'lodash';
  */
 import { isPaymentAgreement, isCreditCard } from 'calypso/lib/checkout/payment-methods';
 
+import 'calypso/state/stored-cards/init';
+
 /**
  * Return user's stored cards from state object
  *


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles stored cards state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42483.

#### Changes proposed in this Pull Request

* Modularise stored cards state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/home` on the live branch or your local copy of this branch. Choose a business account with a custom domain.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `storedCards` key, even if you expand the list of keys. This indicates that the stored cards state hasn't been loaded yet.
* Add something to your card.
* Click to view your cart.
* Verify that a `storedCards` key is added with the stored cards state. This indicates that the stored cards state has now been loaded.