### PR TITLE
Activity Log: ask for credentials only if we don't have them

### DIFF
--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -243,6 +243,7 @@ class ActivityLogItem extends Component {
 			createRewind,
 			disableRestore,
 			disableBackup,
+			missingRewindCredentials,
 			siteId,
 			siteSlug,
 			trackAddCreds,
@@ -260,7 +261,7 @@ class ActivityLogItem extends Component {
 						{ translate( 'Restore to this point' ) }
 					</PopoverMenuItem>
 
-					{ disableRestore && (
+					{ disableRestore && missingRewindCredentials && (
 						<PopoverMenuItem
 							icon="plus"
 							href={
@@ -430,6 +431,7 @@ const mapStateToProps = ( state, { activity, siteId } ) => {
 		timezone: getSiteTimezoneValue( state, siteId ),
 		siteSlug: site.slug,
 		rewindIsActive: 'active' === rewindState.state || 'provisioning' === rewindState.state,
+		missingRewindCredentials: rewindState.state === 'awaitingCredentials',
 		canAutoconfigure: rewindState.canAutoconfigure,
 		site,
 	};


### PR DESCRIPTION
#### The problem

Fixes 1164141197617539-as-1199377862002819

When a restore point is disabled, we always show the "Add server credentials to enable restoring" message regardless of the reason why the restore point is disabled. This is particularly wrong in the case of Atomic sites since we have their credentials by default.

#### Changes proposed in this Pull Request

* Only show the "Add server credentials to enable restoring" message when rewind's state is `awaitingCredentials`.

#### Testing instructions

**Prerequisite:** Jetpack site with a paid plan (we need to have restore points in the Activity Log).


* Run this PR _locally_. We are going to need to interact with the app's state.
* Visit the Activity Log in `/activity-log/:site`.
* Open the `Components` panel that comes with React dev tools extension.
* Search for `ActivityLogItem`. Make sure to select one that is rewindable (see capture below).
* Set the `disableRestore` prop to `true` and `missingRewindCredentials` to `false`.
* Verify that the "Add server credentials to enable restoring" is _not visible_.
* Set `missingRewindCredentials` to `true`.
* Verify that the "Add server credentials to enable restoring" is _visible_.
* Set both props to `false`.
* Make sure that the restore point is enabled.

![image](https://user-images.githubusercontent.com/3418513/100476906-974c9080-30c5-11eb-84fa-f0e1427aaf7e.png)

#### Demo

#### Disabled _with_ credentials
![image](https://user-images.githubusercontent.com/3418513/100477312-bac40b00-30c6-11eb-8d3b-c373631cdfe9.png)

#### Disabled _without_ credentials
![image](https://user-images.githubusercontent.com/3418513/100477322-bf88bf00-30c6-11eb-8d3f-1dd3847f4841.png)
