### PR TITLE
When going through the business flow with promo code don't show the free domain option

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -502,8 +502,8 @@ class DomainsStep extends React.Component {
 				isDomainOnly={ this.props.isDomainOnly }
 				analyticsSection={ this.getAnalyticsSection() }
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-				includeWordPressDotCom={ includeWordPressDotCom }
-				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
+				includeWordPressDotCom={ trueNamePromoTlds ? false : includeWordPressDotCom }
+				includeDotBlogSubdomain={ trueNamePromoTlds ? false : this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
 				isPlanSelectionAvailableInFlow={ isPlanSelectionAvailableInFlow }
 				showExampleSuggestions={ showExampleSuggestions }


### PR DESCRIPTION
When going through the business flow with promo code don't show the free domain option

#### Changes proposed in this Pull Request

* When going through the business flow with promo code don't show the free domain option as the promo is only valid if the business plan is bundled with domain

#### Testing instructions

* from /start/business?coupon={promo_code} when you're on the domain step you should not see the free domain option.
