### PR TITLE
Coming soon: remove flag and permanently enable v2 for the site badge

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -119,7 +119,7 @@ class Site extends React.Component {
 
 		// We show public coming soon badge only when the site is not private and the editing toolkit is available.
 		// Check for `! site.is_private` to ensure two Coming Soon badges don't appear while we introduce public coming soon.
-		const shouldPublicShowComingSoonSiteBadge =
+		const shouldShowPublicComingSoonSiteBadge =
 			! site.is_private && this.props.site.is_coming_soon && ! isAtomicAndEditingToolkitDeactivated;
 
 		// Cover the coming Soon v1 cases for sites still unlaunched and/or in Coming Soon private by default.
@@ -175,7 +175,7 @@ class Site extends React.Component {
 									: translate( 'Private' ) }
 							</span>
 						) }
-						{ shouldPublicShowComingSoonSiteBadge && (
+						{ shouldShowPublicComingSoonSiteBadge && (
 							<span className="site__badge site__badge-coming-soon">
 								{ translate( 'Coming Soon' ) }
 							</span>

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -117,11 +117,17 @@ class Site extends React.Component {
 			'is-compact': this.props.compact,
 		} );
 
-		// To ensure two Coming Soon badges don't appear while we introduce public coming soon
-		const isPublicComingSoon =
-			isEnabled( 'coming-soon-v2' ) && ! site.is_private && this.props.site.is_coming_soon;
+		// We show public coming soon badge only when the site is not private and the editing toolkit is available.
+		// Check for `! site.is_private` to ensure two Coming Soon badges don't appear while we introduce public coming soon.
+		const shouldPublicShowComingSoonSiteBadge =
+			! site.is_private && this.props.site.is_coming_soon && ! isAtomicAndEditingToolkitDeactivated;
+
+		// Cover the coming Soon v1 cases for sites still unlaunched and/or in Coming Soon private by default.
 		// isPrivateAndUnlaunched means it is an unlaunched coming soon v1 site
 		const isPrivateAndUnlaunched = site.is_private && isSiteUnlaunched;
+		const shouldShowPrivateByDefaultComingSoonBadge =
+			( this.props.site.is_coming_soon || isPrivateAndUnlaunched ) &&
+			! isAtomicAndEditingToolkitDeactivated;
 
 		return (
 			<div className={ siteClass }>
@@ -162,15 +168,14 @@ class Site extends React.Component {
 								: site.domain }
 						</div>
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-						{ this.props.site.is_private && ( // Coming Soon v1
+						{ this.props.site.is_private && (
 							<span className="site__badge site__badge-private">
-								{ ( this.props.site.is_coming_soon || isPrivateAndUnlaunched ) &&
-								! isAtomicAndEditingToolkitDeactivated
+								{ shouldShowPrivateByDefaultComingSoonBadge
 									? translate( 'Coming Soon' )
 									: translate( 'Private' ) }
 							</span>
 						) }
-						{ isPublicComingSoon && ! isAtomicAndEditingToolkitDeactivated && (
+						{ shouldPublicShowComingSoonSiteBadge && (
 							<span className="site__badge site__badge-coming-soon">
 								{ translate( 'Coming Soon' ) }
 							</span>


### PR DESCRIPTION
### Changes proposed in this Pull Request

Coming Soon (public not-indexable by default) has been in production and running smoothly. By "smoothly" we mean no serious bug reports, user difficulties or galactic anomalies. 

This PR will be one in a series that removes the `coming-soon-v2` flag from Calypso and, eventually, removes the flag from the config files altogether. The consequence is that we are permanently excising v2 (private by default).

**This PR removes the coming soon v2 flag for the site badge component. It preserves the Coming Soon v1 badge for existing, unlaunched private-by-default sites.**

### Testing instructions
1. Toggle the visibility settings over at `/settings/general/{your_sweet_site}` between Coming Soon, Public and Private
2. The site badge should reflect your Coming Soon and Private statuses (There is no badge for public sites)

<img width="962" alt="Screen Shot 2020-11-30 at 11 48 32 am" src="https://user-images.githubusercontent.com/6458278/100558533-f4815580-3302-11eb-9c0e-f6abf8b5a673.png">

