### PR TITLE
Coming soon: remove flag and permanently enable v2 for seo settings notice

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -56,7 +56,6 @@ import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import { requestSiteSettings, saveSiteSettings } from 'calypso/state/site-settings/actions';
 import WebPreview from 'calypso/components/web-preview';
 import { getFirstConflictingPlugin } from 'calypso/lib/seo';
-import { isEnabled } from 'calypso/config';
 
 /**
  * Style dependencies
@@ -319,8 +318,9 @@ export class SeoForm extends React.Component {
 							type: TYPE_BUSINESS,
 						} ),
 			  };
-		// To ensure two Coming Soon badges don't appear while we introduce public coming soon
-		const isPublicComingSoon = isEnabled( 'coming-soon-v2' ) && ! isSitePrivate && siteIsComingSoon;
+
+		// To ensure two Coming Soon badges don't appear while sites with Coming Soon v1 (isSitePrivate && siteIsComingSoon) still exist.
+		const isPublicComingSoon = ! isSitePrivate && siteIsComingSoon;
 
 		return (
 			<div>
@@ -333,12 +333,6 @@ export class SeoForm extends React.Component {
 						showDismiss={ false }
 						text={ ( function () {
 							if ( isSitePrivate ) {
-								if ( siteIsComingSoon ) {
-									return translate(
-										"SEO settings aren't recognized by search engines while your site is Coming Soon."
-									);
-								}
-
 								return translate(
 									"SEO settings aren't recognized by search engines while your site is Private."
 								);


### PR DESCRIPTION
### Changes proposed in this Pull Request

Coming Soon (public not-indexable by default) has been in production and running smoothly. By "smoothly" we mean no serious bug reports, user difficulties or galactic anomalies. 

This PR will be one in a series that removes the `coming-soon-v2` flag from Calypso and, eventually, removes the flag from the config files altogether. The consequence is that we are permanently excising v1 (private by default).

**This PR removes the coming soon v2 flag for the SEO settings notice. Coming Soon v2 sites will show a Coming Soon-related notice.**

### Testing instructions


Create a new site at `/new`

Upgrade to a business plan

Head over to `/marketing/traffic/{your_site_wordpress_com}`

Make sure the banner mentions **Coming Soon**

<img width="1058" alt="Screen Shot 2020-11-04 at 2 19 14 pm" src="https://user-images.githubusercontent.com/6458278/98066066-06114200-1eaa-11eb-9b65-1ecca9ef634f.png">

Toggle your site to Private in the site settings `/settings/general/{your_site_wordpress_com}`

Make sure the banner mentions **Private** 

<img width="1064" alt="Screen Shot 2020-11-04 at 2 17 58 pm" src="https://user-images.githubusercontent.com/6458278/98066070-090c3280-1eaa-11eb-9bc7-2861e848ca1f.png">

Now go to the site settings `/settings/general/{your_site_wordpress_com}`

Change the site to public and check `'Discourage search engines from indexing this site'`

<img width="761" alt="Screen Shot 2020-11-04 at 2 33 18 pm" src="https://user-images.githubusercontent.com/6458278/98066412-01995900-1eab-11eb-8b38-71ac16923212.png">

Back at `/marketing/traffic/{your_site_wordpress_com}` check that the banner mentions **Hidden** 

<img width="1077" alt="Screen Shot 2020-11-04 at 2 33 36 pm" src="https://user-images.githubusercontent.com/6458278/98066419-052ce000-1eab-11eb-8aa5-184232d82492.png">


