### PR TITLE
Coming soon: remove flag and permanently enable v2 for site settings

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -297,122 +297,6 @@ export class SiteSettingsFormGeneral extends Component {
 	visibilityOptionsComingSoon() {
 		const {
 			fields,
-			isRequestingSettings,
-			isWPForTeamsSite,
-			eventTracker,
-			siteIsJetpack,
-			siteIsAtomic,
-			translate,
-		} = this.props;
-		const blogPublic = parseInt( fields.blog_public, 10 );
-		const wpcomComingSoon = 1 === parseInt( fields.wpcom_coming_soon, 10 );
-		const isNonAtomicJetpackSite = siteIsJetpack && ! siteIsAtomic;
-
-		return (
-			<FormFieldset>
-				{ ! isNonAtomicJetpackSite && ! isWPForTeamsSite && (
-					<>
-						<FormLabel className="site-settings__visibility-label is-coming-soon">
-							<FormRadio
-								name="blog_public"
-								value="-1"
-								checked={ -1 === blogPublic && wpcomComingSoon }
-								onChange={ () =>
-									this.handleVisibilityOptionChange( {
-										blog_public: -1,
-										wpcom_coming_soon: 1,
-										wpcom_public_coming_soon: 0,
-									} )
-								}
-								disabled={ isRequestingSettings }
-								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-								label={ translate( 'Coming Soon' ) }
-							/>
-						</FormLabel>
-						<FormSettingExplanation>
-							{ translate(
-								'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
-							) }
-						</FormSettingExplanation>
-					</>
-				) }
-				{ ! isNonAtomicJetpackSite && (
-					<FormLabel className="site-settings__visibility-label is-public">
-						<FormRadio
-							name="blog_public"
-							value="1"
-							checked={ blogPublic === 0 || blogPublic === 1 }
-							onChange={ () =>
-								this.handleVisibilityOptionChange( {
-									blog_public: 1,
-									wpcom_coming_soon: 0,
-									wpcom_public_coming_soon: 0,
-								} )
-							}
-							disabled={ isRequestingSettings }
-							onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-							label={ translate( 'Public' ) }
-						/>
-					</FormLabel>
-				) }
-				<FormSettingExplanation>
-					{ translate( 'Your site is visible to everyone.' ) }
-				</FormSettingExplanation>
-				<FormLabel className="site-settings__visibility-label is-checkbox is-hidden">
-					<FormInputCheckbox
-						name="blog_public"
-						value="0"
-						checked={ 0 === blogPublic }
-						onChange={ () =>
-							this.handleVisibilityOptionChange( {
-								blog_public: blogPublic === 0 ? 1 : 0,
-								wpcom_coming_soon: 0,
-								wpcom_public_coming_soon: 0,
-							} )
-						}
-						disabled={ isRequestingSettings }
-						onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-					/>
-					<span>{ translate( 'Discourage search engines from indexing this site' ) }</span>
-					<FormSettingExplanation>
-						{ translate(
-							'This option does not block access to your site — it is up to search engines to honor your request.'
-						) }
-					</FormSettingExplanation>
-				</FormLabel>
-				{ ! isNonAtomicJetpackSite && (
-					<>
-						<FormLabel className="site-settings__visibility-label is-private">
-							<FormRadio
-								name="blog_public"
-								value="-1"
-								checked={ -1 === blogPublic && ! wpcomComingSoon }
-								onChange={ () =>
-									this.handleVisibilityOptionChange( {
-										blog_public: -1,
-										wpcom_coming_soon: 0,
-										wpcom_public_coming_soon: 0,
-									} )
-								}
-								disabled={ isRequestingSettings }
-								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-								label={ translate( 'Private' ) }
-							/>
-						</FormLabel>
-						<FormSettingExplanation>
-							{ translate(
-								'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-							) }
-						</FormSettingExplanation>
-					</>
-				) }
-			</FormFieldset>
-		);
-	}
-
-	visibilityOptionsComingSoonV2() {
-		const {
-			fields,
 			isAtomicAndEditingToolkitDeactivated,
 			isRequestingSettings,
 			isWPForTeamsSite,
@@ -685,10 +569,7 @@ export class SiteSettingsFormGeneral extends Component {
 					title={ translate( 'Privacy', { context: 'Privacy Settings header' } ) }
 				/>
 				<Card>
-					<form>
-						{ ! config.isEnabled( 'coming-soon-v2' ) && this.visibilityOptionsComingSoon() }
-						{ config.isEnabled( 'coming-soon-v2' ) && this.visibilityOptionsComingSoonV2() }
-					</form>
+					<form> { this.visibilityOptionsComingSoon() }</form>
 				</Card>
 			</>
 		);

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -50,11 +50,7 @@ import {
  * Internal dependencies
  */
 import { SiteSettingsFormGeneral } from '../form-general';
-import config from 'calypso/config';
 import moment from 'moment';
-
-const configMock = ( values ) => ( key ) => values[ key ];
-config.isEnabled.mockImplementation( configMock( { 'coming-soon-v2': false } ) );
 
 moment.tz = {
 	guess: () => moment(),
@@ -154,48 +150,6 @@ describe( 'SiteSettingsFormGeneral ', () => {
 			expect( container.querySelectorAll( '[name="blog_public"]' ).length ).toBe( 4 );
 		} );
 
-		describe( 'blog_public states (coming-soon-v1)', () => {
-			[
-				[
-					'Coming soon',
-					'Coming Soon',
-					1,
-					{ blog_public: -1, wpcom_coming_soon: 1, wpcom_public_coming_soon: 0 },
-				],
-				[
-					'Public',
-					'Public',
-					-1,
-					{ blog_public: 1, wpcom_coming_soon: 0, wpcom_public_coming_soon: 0 },
-				],
-				[
-					'Hidden',
-					'Discourage search engines from indexing this site',
-					-1,
-					{ blog_public: 0, wpcom_coming_soon: 0, wpcom_public_coming_soon: 0 },
-				],
-				[
-					'Private',
-					'Private',
-					1,
-					{ blog_public: -1, wpcom_coming_soon: 0, wpcom_public_coming_soon: 0 },
-				],
-			].forEach( ( [ name, text, initialBlogPublic, updatedFields ] ) => {
-				test( `${ name } option should be selectable`, () => {
-					config.isEnabled.mockImplementation( configMock( { 'coming-soon-v2': false } ) );
-					testProps.fields.blog_public = initialBlogPublic;
-					const { getByLabelText } = renderWithRedux(
-						<SiteSettingsFormGeneral { ...testProps } />
-					);
-
-					const radioButton = getByLabelText( text, { exact: false } );
-					expect( radioButton ).not.toBeChecked();
-					fireEvent.click( radioButton );
-					expect( testProps.updateFields ).toBeCalledWith( updatedFields );
-				} );
-			} );
-		} );
-
 		test( `Selecting Hidden should switch radio to Public`, () => {
 			testProps.fields.blog_public = -1;
 			const { getByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
@@ -236,7 +190,7 @@ describe( 'SiteSettingsFormGeneral ', () => {
 			} );
 		} );
 
-		describe( 'blog_public states (coming-soon-v2)', () => {
+		describe( 'blog_public states', () => {
 			[
 				[
 					'Coming soon',
@@ -264,7 +218,6 @@ describe( 'SiteSettingsFormGeneral ', () => {
 				],
 			].forEach( ( [ name, text, initialBlogPublic, updatedFields ] ) => {
 				test( `${ name } option should be selectable`, () => {
-					config.isEnabled.mockImplementation( configMock( { 'coming-soon-v2': true } ) );
 					testProps.fields.blog_public = initialBlogPublic;
 					const { getByLabelText } = renderWithRedux(
 						<SiteSettingsFormGeneral { ...testProps } />
@@ -275,6 +228,130 @@ describe( 'SiteSettingsFormGeneral ', () => {
 					fireEvent.click( radioButton );
 					expect( testProps.updateFields ).toBeCalledWith( updatedFields );
 				} );
+			} );
+
+			// We want to show the coming soon setting for existing coming soon v1 sites that have not migrated
+			describe( 'support existing coming soon v1 sites that have not migrated', () => {
+				test( 'Coming soon option should be selected when a site is private and unlaunched (coming soon mode v1 by default)', () => {
+					const newProps = {
+						...testProps,
+						fields: {
+							blog_public: -1,
+						},
+						isUnlaunchedSite: true,
+						// So renderLaunchSite() runs smoothly.
+						siteDomains: [ 'test.com' ],
+					};
+
+					const { getByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...newProps } /> );
+					const radioButton = getByLabelText( 'Coming soon', { exact: false } );
+					expect( radioButton ).toBeChecked();
+				} );
+
+				test( 'Should check private option when site is private, but not in coming soon v1 and not private and unlaunched', () => {
+					const newProps = {
+						...testProps,
+						fields: {
+							blog_public: -1,
+							wpcom_coming_soon: 0,
+						},
+					};
+
+					const { getByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...newProps } /> );
+					const radioButtonComingSoon = getByLabelText( 'Coming soon', { exact: false } );
+					expect( radioButtonComingSoon ).not.toBeChecked();
+
+					// Check that we're not displaying the site as private
+					const radioButtonPrivate = getByLabelText( 'Private', { exact: false } );
+					expect( radioButtonPrivate ).toBeChecked();
+				} );
+
+				test( 'Coming soon option should be selected when a site still has coming soon v1 enabled', () => {
+					const newProps = {
+						...testProps,
+						fields: {
+							wpcom_coming_soon: 1,
+						},
+					};
+
+					const { getByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...newProps } /> );
+					const radioButtonComingSoon = getByLabelText( 'Coming soon', { exact: false } );
+					expect( radioButtonComingSoon ).toBeChecked();
+
+					// Check that we're not displaying the site as private
+					const radioButtonPrivate = getByLabelText( 'Private', { exact: false } );
+					expect( radioButtonPrivate ).not.toBeChecked();
+				} );
+
+				test( 'Should check private option when site is in coming soon v1 mode but the etk plugin is disabled on atomic', () => {
+					const newProps = {
+						...testProps,
+						fields: {
+							wpcom_coming_soon: 1,
+						},
+						isAtomicAndEditingToolkitDeactivated: true,
+					};
+
+					const { getByLabelText, container } = renderWithRedux(
+						<SiteSettingsFormGeneral { ...newProps } />
+					);
+					expect(
+						container.querySelector( '.site-settings__visibility-label.is-coming-soon' )
+					).toBe( null );
+
+					// Check that we're not displaying the site as private
+					const radioButtonPrivate = getByLabelText( 'Private', { exact: false } );
+					expect( radioButtonPrivate ).toBeChecked();
+				} );
+			} );
+		} );
+
+		describe( 'Coming soon plugin availability', () => {
+			test( 'Should hide Coming Soon form element when the site is not atomic or the editing toolkit plugin is not disabled', () => {
+				const newProps = {
+					...props,
+					isAtomicAndEditingToolkitDeactivated: false,
+				};
+
+				const comp = shallow( <SiteSettingsFormGeneral { ...newProps } /> );
+				expect( comp.find( '.site-settings__visibility-label.is-coming-soon' ).length ).toBe( 1 );
+			} );
+
+			test( 'Should hide Coming Soon form element when the site is atomic and the editing toolkit plugin is disabled', () => {
+				const newProps = {
+					...props,
+					isAtomicAndEditingToolkitDeactivated: true,
+				};
+				const comp = shallow( <SiteSettingsFormGeneral { ...newProps } /> );
+				expect( comp.find( '.site-settings__visibility-label.is-coming-soon' ).length ).toBe( 0 );
+			} );
+
+			test( 'Should check public not indexed when coming soon plugin is not available', () => {
+				const newProps = {
+					...props,
+					fields: {
+						wpcom_public_coming_soon: 1,
+						blog_public: 0,
+					},
+					isAtomicAndEditingToolkitDeactivated: true,
+				};
+				const { getByLabelText, container } = renderWithRedux(
+					<SiteSettingsFormGeneral { ...newProps } />
+				);
+				expect( container.querySelector( '.site-settings__visibility-label.is-coming-soon' ) ).toBe(
+					null
+				);
+
+				const radioButtonPublic = getByLabelText( 'Public', { exact: false } );
+				expect( radioButtonPublic ).toBeChecked();
+
+				const hiddenCheckbox = getByLabelText(
+					'Discourage search engines from indexing this site',
+					{
+						exact: false,
+					}
+				);
+				expect( hiddenCheckbox ).toBeChecked();
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Changes proposed in this Pull Request

Coming Soon (public not-indexable by default) has been in production and running smoothly. By "smoothly" we mean no serious bug reports, user difficulties or cataclysmic events.

This PR will be one in a series that removes the coming-soon-v2 flag from Calypso and, eventually, removes the flag from the config files altogether. The consequence is that we are permanently excising v1 (private by default).

This PR removes the coming soon flag check for site settings, thereby removing the v1 private-by-default form fields. All new sites will therefore be able to toggle in an out of Coming Soon v2™️ mode!

The form will display the correct selection for existing Coming Soon v1 sites, that is, if the site is private and unlaunched or set to Coming Soon, the Coming Soon radio button will be checked.

When they toggle Coming Soon mode off and on however, they'll be migrated to Coming Soon v2.

### Testing instructions

Run the unit tests:

` npm run test-client client/my-sites/site-settings/test/form-general.jsx`

Toggle between public and private and coming soon

<img width="764" alt="Screen Shot 2020-11-30 at 12 11 24 pm" src="https://user-images.githubusercontent.com/6458278/100559070-390df080-3305-11eb-8dd0-727e4ddf7aa7.png">

After each toggle check that your site is in the corresponding mode in an incognito window.


