### PR TITLE
Coming Soon: show Coming Soon page on blog post pages

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -13,7 +13,7 @@ namespace A8C\FSE\Coming_soon;
  * @return boolean
  */
 function should_show_coming_soon_page() {
-	if ( ! is_singular() && ! is_archive() && ! is_search() && ! is_front_page() ) {
+	if ( ! is_singular() && ! is_archive() && ! is_search() && ! is_front_page() && ! is_home() ) {
 		return false;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds an `is_home` to check for blog pages that are not set as front pages. It catches the situation in which blog roll pages aren't set as the homepage.

From the [WordPress.org docs](https://codex.wordpress.org/Conditional_Tags#The_Blog_Page):

> You have to use both is_home() and is_front_page() to detect this page, but those functions can be misused. In fact, a user can define a static page for the homepage, and another page to display the blog. This one will return true with is_home() function, even if it's not the homepage. 

We're also preventing the "The Neverending Home Page" MU plugin from loading. 

Props to @andrewserong for catching ~this one~ both scenarios! 🙇 

### Testing instructions

#### is_home

1. Create a new coming soon v2 blog over at `/new` (the Bowen design has a blog)
2. Check that your homepage shows the Coming Soon page in an incognito browser
3. Check that your `/blog` page shows the Coming Soon page in an incognito browser
4. In the site **Customizer > Homepage settings**, change your site home page to show a list of latest posts
5. Check that your homepage shows the Coming Soon page in an incognito browser

#### Infinity homepage

1. Switch your theme to Hemingway Rewritten
2. Check that the Infinity homepage isn't displayed on your Coming Soon page in an incognito browser See: https://github.com/Automattic/wp-calypso/pull/47853#issuecomment-735514136
