### PR TITLE
Coming soon: remove flag and permanently enable v2 for viewers tab

### DIFF
--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -13,7 +13,6 @@ import SectionNav from 'calypso/components/section-nav';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import NavItem from 'calypso/components/section-nav/item';
 import PeopleSearch from 'calypso/my-sites/people/people-section-nav/people-search';
-import config from 'calypso/config';
 
 class PeopleNavTabs extends React.Component {
 	static displayName = 'PeopleNavTabs';
@@ -105,8 +104,7 @@ class PeopleSectionNav extends Component {
 			return false;
 		}
 
-		const wpcomPublicComingSoon = config.isEnabled( 'coming-soon-v2' ) && this.props.isComingSoon;
-		const isPrivateOrPublicComingSoon = this.props.isPrivate || wpcomPublicComingSoon;
+		const isPrivateOrPublicComingSoon = this.props.isPrivate || this.props.isComingSoon;
 
 		if (
 			'viewers' === this.props.filter ||


### PR DESCRIPTION
### Changes proposed in this Pull Request

Coming Soon (public not-indexable by default) has been in production and running smoothly. By "smoothly" we mean no serious bug reports, user difficulties or galactic anomalies. 

This PR will be one in a series that removes the `coming-soon-v2` flag from Calypso and, eventually, removes the flag from the config files altogether. The consequence is that we are permanently excising v1 (private by default).

**This PR removes the coming-soon-v2 flag so that we show the viewers tab for both private and coming soon modes. This enables users to see who can see their site in both modes.**

### Testing instructions

See: https://github.com/Automattic/wp-calypso/pull/47851


