### PR TITLE
Add launch-only flow that skips domain and plans steps

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -395,7 +395,7 @@ export function generateFlows( {
 		steps: [ 'launch' ],
 		destination: getLaunchDestination,
 		description:
-			'Launch flow without domain or plan selected, used for sites that already have a paid plan and domain',
+			'Launch flow without domain or plan selected, used for sites that already have a paid plan and domain (e.g. via the launch banner in the site preview)',
 		lastModified: '2020-11-30',
 		pageTitle: translate( 'Launch your site' ),
 		providesDependenciesInQuery: [ 'siteSlug' ],

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -391,6 +391,16 @@ export function generateFlows( {
 		providesDependenciesInQuery: [ 'siteSlug', 'source' ],
 	};
 
+	flows[ 'launch-only' ] = {
+		steps: [ 'launch' ],
+		destination: getLaunchDestination,
+		description:
+			'Launch flow without domain or plan selected, used for sites that already have a paid plan and domain',
+		lastModified: '2020-11-30',
+		pageTitle: translate( 'Launch your site' ),
+		providesDependenciesInQuery: [ 'siteSlug' ],
+	};
+
 	return flows;
 }
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -98,6 +98,7 @@ export default {
 			context.pathname.indexOf( 'onboarding-registrationless' ) >= 0 ||
 			context.pathname.indexOf( 'wpcc' ) >= 0 ||
 			context.pathname.indexOf( 'launch-site' ) >= 0 ||
+			context.pathname.indexOf( 'launch-only' ) >= 0 ||
 			context.params.flowName === 'user' ||
 			context.params.flowName === 'account' ||
 			context.params.flowName === 'crowdsignal' ||


### PR DESCRIPTION
This PR adds in an additional launch flow, that skips domains and plans steps and goes directly to launching the site. The use case is to be able to direct link to launching a site from non-Calypso links such as a persistent launch banner that's generated via PHP.

For example, a site that already has a paid plan and a custom domain, will not need the domains and plans steps, so it might be clearer to direct to a flow that doesn't use those steps.

#### Changes proposed in this Pull Request

* Add a `launch-only` flow that does not include a domains or plans step.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a test site at `/new`.
* Once the site is created, manually enter the following into the address bar: `/start/launch-only?siteSlug=` followed by the domain for your site.
* Check that your site has been launched and is now public.

Part of addressing #47729 

Note: D53403-code depends on this PR.