### PR TITLE
Fix "Build base images" build

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -269,6 +269,7 @@ object RunAllUnitTests : BuildType({
 				export npm_config_cache=${'$'}(yarn cache dir)
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Install modules
@@ -292,6 +293,7 @@ object RunAllUnitTests : BuildType({
 				export NODE_ENV="test"
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Prevent uncommited changes
@@ -321,6 +323,7 @@ object RunAllUnitTests : BuildType({
 				export NODE_ENV="test"
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Run type checks
@@ -347,6 +350,7 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Run client tests
@@ -373,6 +377,7 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Run server tests
@@ -399,6 +404,7 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Run packages tests
@@ -425,6 +431,7 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Run build-tools tests
@@ -451,6 +458,7 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Run Editing Toolkit tests
@@ -475,6 +483,7 @@ object RunAllUnitTests : BuildType({
 				export NODE_ENV="production"
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Build o2-blocks
@@ -504,6 +513,7 @@ object RunAllUnitTests : BuildType({
 				export NODE_ENV="production"
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				yarn components:storybook:start --ci --smoke-test
@@ -526,6 +536,7 @@ object RunAllUnitTests : BuildType({
 				export NODE_ENV="production"
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				yarn search:storybook:start --ci --smoke-test
@@ -631,6 +642,7 @@ object CheckCodeStyle : BuildType({
 				export npm_config_cache=${'$'}(yarn cache dir)
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Install modules
@@ -654,6 +666,7 @@ object CheckCodeStyle : BuildType({
 				export NODE_ENV="test"
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Find files to lint
@@ -773,6 +786,7 @@ object WpDesktop_DesktopE2ETests : BuildType({
 				export PUPPETEER_SKIP_DOWNLOAD=true
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Restore mtime to maximize cache hits
@@ -800,6 +814,7 @@ object WpDesktop_DesktopE2ETests : BuildType({
 				set -o pipefail
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Build desktop
@@ -823,6 +838,7 @@ object WpDesktop_DesktopE2ETests : BuildType({
 				export USE_HARD_LINKS=false
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Build app
@@ -848,6 +864,7 @@ object WpDesktop_DesktopE2ETests : BuildType({
 				export CI=true
 
 				# Update node
+				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Start framebuffer

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -36,7 +36,7 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 'Debug' option is available in the context menu for the task.
 */
 
-version = "2020.1"
+version = "2020.2"
 
 project {
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -617,6 +617,12 @@ object CheckCodeStyle : BuildType({
 				set -o errexit
 				set -o nounset
 				set -o pipefail
+				set -x
+
+				echo $PATH
+				set
+				ls /calpyso/.bashrc
+				cat /calpyso/.bashrc
 
 				export HOME="/calypso"
 				export NODE_ENV="test"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -262,11 +262,7 @@ object RunAllUnitTests : BuildType({
 				set -o nounset
 				set -o pipefail
 
-				export HOME="/calypso"
 				export NODE_ENV="test"
-				export CHROMEDRIVER_SKIP_DOWNLOAD=true
-				export PUPPETEER_SKIP_DOWNLOAD=true
-				export npm_config_cache=${'$'}(yarn cache dir)
 
 				# Update node
 				. "${'$'}NVM_DIR/nvm.sh" --no-use
@@ -289,7 +285,6 @@ object RunAllUnitTests : BuildType({
 				set -o nounset
 				set -o pipefail
 
-				export HOME="/calypso"
 				export NODE_ENV="test"
 
 				# Update node
@@ -319,7 +314,6 @@ object RunAllUnitTests : BuildType({
 				set -o nounset
 				set -o pipefail
 
-				export HOME="/calypso"
 				export NODE_ENV="test"
 
 				# Update node
@@ -344,7 +338,6 @@ object RunAllUnitTests : BuildType({
 				set -o pipefail
 
 				export JEST_JUNIT_OUTPUT_NAME="results.xml"
-				export HOME="/calypso"
 
 				unset NODE_ENV
 				unset CALYPSO_ENV
@@ -371,7 +364,6 @@ object RunAllUnitTests : BuildType({
 				set -o pipefail
 
 				export JEST_JUNIT_OUTPUT_NAME="results.xml"
-				export HOME="/calypso"
 
 				unset NODE_ENV
 				unset CALYPSO_ENV
@@ -398,7 +390,6 @@ object RunAllUnitTests : BuildType({
 				set -o pipefail
 
 				export JEST_JUNIT_OUTPUT_NAME="results.xml"
-				export HOME="/calypso"
 
 				unset NODE_ENV
 				unset CALYPSO_ENV
@@ -425,7 +416,6 @@ object RunAllUnitTests : BuildType({
 				set -o pipefail
 
 				export JEST_JUNIT_OUTPUT_NAME="results.xml"
-				export HOME="/calypso"
 
 				unset NODE_ENV
 				unset CALYPSO_ENV
@@ -452,7 +442,6 @@ object RunAllUnitTests : BuildType({
 				set -o pipefail
 
 				export JEST_JUNIT_OUTPUT_NAME="results.xml"
-				export HOME="/calypso"
 
 				unset NODE_ENV
 				unset CALYPSO_ENV
@@ -479,7 +468,6 @@ object RunAllUnitTests : BuildType({
 				set -o nounset
 				set -o pipefail
 
-				export HOME="/calypso"
 				export NODE_ENV="production"
 
 				# Update node
@@ -509,7 +497,6 @@ object RunAllUnitTests : BuildType({
 				set -o nounset
 				set -o pipefail
 
-				export HOME="/calypso"
 				export NODE_ENV="production"
 
 				# Update node
@@ -532,7 +519,6 @@ object RunAllUnitTests : BuildType({
 				set -o nounset
 				set -o pipefail
 
-				export HOME="/calypso"
 				export NODE_ENV="production"
 
 				# Update node
@@ -628,18 +614,8 @@ object CheckCodeStyle : BuildType({
 				set -o errexit
 				set -o nounset
 				set -o pipefail
-				set -x
 
-				echo ${'$'}PATH
-				set
-				ls /calpyso/.bashrc
-				cat /calpyso/.bashrc
-
-				export HOME="/calypso"
 				export NODE_ENV="test"
-				export CHROMEDRIVER_SKIP_DOWNLOAD=true
-				export PUPPETEER_SKIP_DOWNLOAD=true
-				export npm_config_cache=${'$'}(yarn cache dir)
 
 				# Update node
 				. "${'$'}NVM_DIR/nvm.sh" --no-use
@@ -662,7 +638,6 @@ object CheckCodeStyle : BuildType({
 				set -o nounset
 				set -o pipefail
 
-				export HOME="/calypso"
 				export NODE_ENV="test"
 
 				# Update node
@@ -782,9 +757,6 @@ object WpDesktop_DesktopE2ETests : BuildType({
 				set -o nounset
 				set -o pipefail
 
-				export CHROMEDRIVER_SKIP_DOWNLOAD=true
-				export PUPPETEER_SKIP_DOWNLOAD=true
-
 				# Update node
 				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
@@ -860,7 +832,6 @@ object WpDesktop_DesktopE2ETests : BuildType({
 
 				export E2EGUTENBERGUSER="%E2EGUTENBERGUSER%"
 				export E2EPASSWORD="%E2EPASSWORD%"
-				export DISPLAY=:99
 				export CI=true
 
 				# Update node

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -619,7 +619,7 @@ object CheckCodeStyle : BuildType({
 				set -o pipefail
 				set -x
 
-				echo $PATH
+				echo ${'$'}PATH
 				set
 				ls /calpyso/.bashrc
 				cat /calpyso/.bashrc

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -99,7 +99,7 @@ object BuildBaseImages : BuildType({
 				VERSION="%build.number%"
 				REGISTRY="registry.a8c.com/calypso"
 
-				build() {
+				function build {
 					imageName="${'$'}1"
 					buildArgs="${'$'}2"
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -90,77 +90,75 @@ object BuildBaseImages : BuildType({
 	}
 
 	steps {
-		steps {
-			dockerCommand {
-				name = "Build base image"
-				commandType = build {
-					source = file {
-						path = "Dockerfile.base"
-					}
-					namesAndTags = """
-						registry.a8c.com/calypso/base:latest
-						registry.a8c.com/calypso/base:%build.number%
-					""".trimIndent()
-					commandArgs = "--no-cache --target builder"
+		dockerCommand {
+			name = "Build base image"
+			commandType = build {
+				source = file {
+					path = "Dockerfile.base"
 				}
-				param("dockerImage.platform", "linux")
+				namesAndTags = """
+					registry.a8c.com/calypso/base:latest
+					registry.a8c.com/calypso/base:%build.number%
+				""".trimIndent()
+				commandArgs = "--no-cache --target builder"
 			}
-			dockerCommand {
-				name = "Build CI image"
-				commandType = build {
-					source = file {
-						path = "Dockerfile.base"
-					}
-					namesAndTags = """
-						registry.a8c.com/calypso/ci:latest
-						registry.a8c.com/calypso/ci:%build.number%
-					""".trimIndent()
-					commandArgs = "--target ci"
+			param("dockerImage.platform", "linux")
+		}
+		dockerCommand {
+			name = "Build CI image"
+			commandType = build {
+				source = file {
+					path = "Dockerfile.base"
 				}
-				param("dockerImage.platform", "linux")
+				namesAndTags = """
+					registry.a8c.com/calypso/ci:latest
+					registry.a8c.com/calypso/ci:%build.number%
+				""".trimIndent()
+				commandArgs = "--target ci"
 			}
-			dockerCommand {
-				name = "Build CI Desktop image"
-				commandType = build {
-					source = file {
-						path = "Dockerfile.base"
-					}
-					namesAndTags = """
-						registry.a8c.com/calypso/ci-desktop:latest
-						registry.a8c.com/calypso/ci-desktop:%build.number%
-					""".trimIndent()
-					commandArgs = "--target ci-desktop"
+			param("dockerImage.platform", "linux")
+		}
+		dockerCommand {
+			name = "Build CI Desktop image"
+			commandType = build {
+				source = file {
+					path = "Dockerfile.base"
 				}
-				param("dockerImage.platform", "linux")
+				namesAndTags = """
+					registry.a8c.com/calypso/ci-desktop:latest
+					registry.a8c.com/calypso/ci-desktop:%build.number%
+				""".trimIndent()
+				commandArgs = "--target ci-desktop"
 			}
-			dockerCommand {
-				name = "Build CI e2e image"
-				commandType = build {
-					source = file {
-						path = "Dockerfile.base"
-					}
-					namesAndTags = """
-						registry.a8c.com/calypso/ci-e2e:latest
-						registry.a8c.com/calypso/ci-e2e:%build.number%
-					""".trimIndent()
-					commandArgs = "--target ci-e2e"
+			param("dockerImage.platform", "linux")
+		}
+		dockerCommand {
+			name = "Build CI e2e image"
+			commandType = build {
+				source = file {
+					path = "Dockerfile.base"
 				}
-				param("dockerImage.platform", "linux")
+				namesAndTags = """
+					registry.a8c.com/calypso/ci-e2e:latest
+					registry.a8c.com/calypso/ci-e2e:%build.number%
+				""".trimIndent()
+				commandArgs = "--target ci-e2e"
 			}
-			dockerCommand {
-				name = "Push images"
-				commandType = push {
-					namesAndTags = """
-						registry.a8c.com/calypso/base:latest
-						registry.a8c.com/calypso/base:%build.number%
-						registry.a8c.com/calypso/ci:latest
-						registry.a8c.com/calypso/ci:%build.number%
-						registry.a8c.com/calypso/ci-desktop:latest
-						registry.a8c.com/calypso/ci-desktop:%build.number%
-						registry.a8c.com/calypso/ci-e2e:latest
-						registry.a8c.com/calypso/ci-e2e:%build.number%
-					""".trimIndent()
-				}
+			param("dockerImage.platform", "linux")
+		}
+		dockerCommand {
+			name = "Push images"
+			commandType = push {
+				namesAndTags = """
+					registry.a8c.com/calypso/base:latest
+					registry.a8c.com/calypso/base:%build.number%
+					registry.a8c.com/calypso/ci:latest
+					registry.a8c.com/calypso/ci:%build.number%
+					registry.a8c.com/calypso/ci-desktop:latest
+					registry.a8c.com/calypso/ci-desktop:%build.number%
+					registry.a8c.com/calypso/ci-e2e:latest
+					registry.a8c.com/calypso/ci-e2e:%build.number%
+				""".trimIndent()
 			}
 		}
 	}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -99,7 +99,7 @@ object BuildBaseImages : BuildType({
 				VERSION="%build.number%"
 				REGISTRY="registry.a8c.com/calypso"
 
-				function build {
+				build() {
 					imageName="${'$'}1"
 					buildArgs="${'$'}2"
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -217,7 +217,11 @@ object RunAllUnitTests : BuildType({
 		script {
 			name = "Prepare environment"
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export HOME="/calypso"
 				export NODE_ENV="test"
 				export CHROMEDRIVER_SKIP_DOWNLOAD=true
@@ -225,7 +229,6 @@ object RunAllUnitTests : BuildType({
 				export npm_config_cache=${'$'}(yarn cache dir)
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Install modules
@@ -240,13 +243,15 @@ object RunAllUnitTests : BuildType({
 			name = "Prevent uncommited changes"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				set -e
-				set -x
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export HOME="/calypso"
 				export NODE_ENV="test"
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Prevent uncommited changes
@@ -267,12 +272,15 @@ object RunAllUnitTests : BuildType({
 			name = "Run type checks"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export HOME="/calypso"
 				export NODE_ENV="test"
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Run type checks
@@ -287,7 +295,11 @@ object RunAllUnitTests : BuildType({
 			name = "Run unit tests for client"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export JEST_JUNIT_OUTPUT_NAME="results.xml"
 				export HOME="/calypso"
 
@@ -295,7 +307,6 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Run client tests
@@ -310,7 +321,11 @@ object RunAllUnitTests : BuildType({
 			name = "Run unit tests for server"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export JEST_JUNIT_OUTPUT_NAME="results.xml"
 				export HOME="/calypso"
 
@@ -318,7 +333,6 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Run server tests
@@ -333,7 +347,11 @@ object RunAllUnitTests : BuildType({
 			name = "Run unit tests for packages"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export JEST_JUNIT_OUTPUT_NAME="results.xml"
 				export HOME="/calypso"
 
@@ -341,7 +359,6 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Run packages tests
@@ -356,7 +373,11 @@ object RunAllUnitTests : BuildType({
 			name = "Run unit tests for build tools"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export JEST_JUNIT_OUTPUT_NAME="results.xml"
 				export HOME="/calypso"
 
@@ -364,7 +385,6 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Run build-tools tests
@@ -379,7 +399,11 @@ object RunAllUnitTests : BuildType({
 			name = "Run unit tests for Editing Toolkit"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export JEST_JUNIT_OUTPUT_NAME="results.xml"
 				export HOME="/calypso"
 
@@ -387,7 +411,6 @@ object RunAllUnitTests : BuildType({
 				unset CALYPSO_ENV
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Run Editing Toolkit tests
@@ -403,12 +426,15 @@ object RunAllUnitTests : BuildType({
 			name = "Build artifacts"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export HOME="/calypso"
 				export NODE_ENV="production"
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Build o2-blocks
@@ -429,12 +455,15 @@ object RunAllUnitTests : BuildType({
 			name = "Build components storybook"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export HOME="/calypso"
 				export NODE_ENV="production"
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				yarn components:storybook:start --ci --smoke-test
@@ -448,12 +477,15 @@ object RunAllUnitTests : BuildType({
 			name = "Build search storybook"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export HOME="/calypso"
 				export NODE_ENV="production"
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				yarn search:storybook:start --ci --smoke-test
@@ -541,7 +573,11 @@ object CheckCodeStyle : BuildType({
 		script {
 			name = "Prepare environment"
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export HOME="/calypso"
 				export NODE_ENV="test"
 				export CHROMEDRIVER_SKIP_DOWNLOAD=true
@@ -549,7 +585,6 @@ object CheckCodeStyle : BuildType({
 				export npm_config_cache=${'$'}(yarn cache dir)
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Install modules
@@ -564,12 +599,15 @@ object CheckCodeStyle : BuildType({
 			name = "Run linters"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
+
 				export HOME="/calypso"
 				export NODE_ENV="test"
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Find files to lint
@@ -680,13 +718,15 @@ object WpDesktop_DesktopE2ETests : BuildType({
 		script {
 			name = "Prepare environment"
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
 
 				export CHROMEDRIVER_SKIP_DOWNLOAD=true
 				export PUPPETEER_SKIP_DOWNLOAD=true
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Restore mtime to maximize cache hits
@@ -708,10 +748,12 @@ object WpDesktop_DesktopE2ETests : BuildType({
 		script {
 			name = "Build Calypso source"
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Build desktop
@@ -726,13 +768,15 @@ object WpDesktop_DesktopE2ETests : BuildType({
 		script {
 			name = "Build app (linux)"
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
 
 				export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
 				export USE_HARD_LINKS=false
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Build app
@@ -747,7 +791,10 @@ object WpDesktop_DesktopE2ETests : BuildType({
 		script {
 			name = "Run tests (linux)"
 			scriptContent = """
-				set -e
+				#!/bin/bash
+				set -o errexit
+				set -o nounset
+				set -o pipefail
 
 				export E2EGUTENBERGUSER="%E2EGUTENBERGUSER%"
 				export E2EPASSWORD="%E2EPASSWORD%"
@@ -755,7 +802,6 @@ object WpDesktop_DesktopE2ETests : BuildType({
 				export CI=true
 
 				# Update node
-				. "${'$'}NVM_DIR/nvm.sh" --no-use
 				nvm install
 
 				# Start framebuffer


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Be explicit about using `bash` so we can use bash syntax in scripts
* Update settings version to latest TeamCity
* Use "native" docker commands to build and publish images instead of a custom bash script.
* Delete ENV vars that are already defined in the [Docker image](https://github.com/Automattic/wp-calypso/blob/trunk/Dockerfile.base#L6) 
* Label the images, will be used to filter out images in `calypso.live`
 
#### Testing instructions

* Check TeamCity passes for this branch.
