### PR TITLE
People: Fix Invite button for sites on subdirectories

### DIFF
--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -122,7 +122,7 @@ class Followers extends Component {
 		const { site, translate } = this.props;
 
 		return (
-			<Button primary={ isPrimary } href={ `/people/new/${ site.domain }` }>
+			<Button primary={ isPrimary } href={ `/people/new/${ site.slug }` }>
 				<Gridicon icon="user-add" />
 				<span>{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }</span>
 			</Button>


### PR DESCRIPTION
Usually, even though they're technically different, the site's domain and the site's slug are often the same. However, that's not the case for sites that are installed in subdirectories. 

For example, for the site `https://yourjetpack.blog/subdir`, the domain would be `yourjetpack.blog` but the slug will be `yourjetpack.blog::subdir` (note that we're encoding the forward slashes to `::` for technical reasons).

So, because we were using `domain` instead of `slug` in the people pages when a site has no followers, the "Invite" button to invite followers had a wrong URL, leading to odd errors when clicking the button.

This PR updates the `domain` to `slug`, and that resolves the problem

#### Changes proposed in this Pull Request

*  People: Fix Invite button for sites on subdirectories.

#### Testing instructions

* Go to `/people/email-followers/domain::subdir` where `domain::subdir` is the slug of a Jetpack site that is installed in a subdirectory. Make sure that the site doesn't have any email followers yet.
* Click the "Invite" button.
* Verify it leads you to the form for inviting users and no errors are thrown anymore.
