### PR TITLE
Editing Toolkit: Update to 2.8.9

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.8
+ * Version: 2.8.9
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.8' );
+define( 'PLUGIN_VERSION', '2.8.9' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.8
+Stable tag: 2.8.9
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.9 =
+* Domain Picker: Persistent Domain (https://github.com/Automattic/wp-calypso/pull/47633)
+* Focused Launch: Add Launch your site button (https://github.com/Automattic/wp-calypso/pull/47601)
 
 = 2.8.8 =
 * Coming soon: Show coming soon page when showing posts on front (https://github.com/Automattic/wp-calypso/pull/47661)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.8",
+	"version": "2.8.9",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bumps version of Editing Toolkit to 2.8.9

#### [Changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)

* Domain Picker: Persistent Domain (https://github.com/Automattic/wp-calypso/pull/47633)
* Focused Launch: Add Launch your site button (https://github.com/Automattic/wp-calypso/pull/47601)
* Composer: Upgrade deps for composer 2 (https://github.com/Automattic/wp-calypso/pull/47498)
* fix(deps): update babel monorepo (https://github.com/Automattic/wp-calypso/pull/46265)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load the diff (D53489-code) on your sandbox and confirm that the above changes work correctly
2. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.