### PR TITLE
Checkout: fix ever loading checkout screen in Jetpack cloud

### DIFF
--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -12,7 +12,7 @@ import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 import './style.scss';
 
 export default function (): void {
-	jetpackPlans( `/:locale/pricing/:site?`, siteSelection, controller.jetpackPricingContext );
+	jetpackPlans( `/:locale/pricing`, controller.jetpackPricingContext );
 	jetpackPlans( `/pricing/:site?`, siteSelection, controller.jetpackPricingContext );
 
 	if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-import * as controller from './controller';
+import { jetpackPricingContext } from './controller';
 import config from 'calypso/config';
+import userFactory from 'calypso/lib/user';
 import { siteSelection } from 'calypso/my-sites/controller';
 import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 
@@ -12,10 +13,22 @@ import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 import './style.scss';
 
 export default function (): void {
-	jetpackPlans( `/:locale/pricing`, controller.jetpackPricingContext );
-	jetpackPlans( `/pricing/:site?`, siteSelection, controller.jetpackPricingContext );
+	const user = userFactory();
+	const isLoggedOut = ! user.get();
 
-	if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
-		jetpackPlans( `/plans/:site?`, siteSelection, controller.jetpackPricingContext );
+	jetpackPlans( `/:locale/pricing`, jetpackPricingContext );
+
+	if ( isLoggedOut ) {
+		jetpackPlans( `/pricing`, jetpackPricingContext );
+
+		if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
+			jetpackPlans( `/plans`, jetpackPricingContext );
+		}
+	} else {
+		jetpackPlans( `/pricing/:site?`, siteSelection, jetpackPricingContext );
+
+		if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
+			jetpackPlans( `/plans/:site?`, siteSelection, jetpackPricingContext );
+		}
 	}
 }

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -1,9 +1,10 @@
 /**
  * Internal dependencies
  */
-import config from 'calypso/config';
-import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 import * as controller from './controller';
+import config from 'calypso/config';
+import { siteSelection } from 'calypso/my-sites/controller';
+import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 
 /**
  * Style dependencies
@@ -11,10 +12,10 @@ import * as controller from './controller';
 import './style.scss';
 
 export default function (): void {
-	jetpackPlans( `/:locale/pricing`, controller.jetpackPricingContext );
-	jetpackPlans( `/pricing`, controller.jetpackPricingContext );
+	jetpackPlans( `/:locale/pricing/:site?`, siteSelection, controller.jetpackPricingContext );
+	jetpackPlans( `/pricing/:site?`, siteSelection, controller.jetpackPricingContext );
 
 	if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
-		jetpackPlans( `/plans`, controller.jetpackPricingContext );
+		jetpackPlans( `/plans/:site?`, siteSelection, controller.jetpackPricingContext );
 	}
 }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -336,7 +336,7 @@ export function noSite( context, next ) {
  */
 export function siteSelection( context, next ) {
 	const { getState, dispatch } = getStore( context );
-	const siteFragment = context.params.site || getSiteFragment( context.path );
+	const siteFragment = context.params.site || context.query.site || getSiteFragment( context.path );
 	const basePath = sectionify( context.path, siteFragment );
 	const currentUser = getCurrentUser( getState() );
 	const hasOneSite = currentUser && currentUser.visible_site_count === 1;

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -59,6 +59,7 @@ import { getJetpackProductTagline } from 'calypso/lib/products-values/get-jetpac
 import { getJetpackProductCallToAction } from 'calypso/lib/products-values/get-jetpack-product-call-to-action';
 import { getJetpackProductDescription } from 'calypso/lib/products-values/get-jetpack-product-description';
 import { getJetpackProductShortName } from 'calypso/lib/products-values/get-jetpack-product-short-name';
+import config from 'calypso/config';
 import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 import { MORE_FEATURES_LINK } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -607,12 +608,13 @@ export function checkout(
 	if ( ! siteSlug ) {
 		path = `/jetpack/connect/${ productsString }`;
 	} else {
-		path = isJetpackCloud()
-			? `/checkout/${ siteSlug }/${ productsString }`
-			: `/checkout/${ siteSlug }`;
+		path =
+			isJetpackCloud() && ! config.isEnabled( 'jetpack-cloud/connect' )
+				? `/checkout/${ siteSlug }/${ productsString }`
+				: `/checkout/${ siteSlug }`;
 	}
 
-	if ( isJetpackCloud() ) {
+	if ( isJetpackCloud() && ! config.isEnabled( 'jetpack-cloud/connect' ) ) {
 		window.location.href = addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` );
 	} else {
 		addItems( productsArray.map( jetpackProductItem ) );

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -51,7 +51,8 @@
 		"oauth": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"support-user": true
+		"support-user": true,
+		"upgrades/redirect-payments": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -47,7 +47,8 @@
 		"layout/support-article-dialog": false,
 		"oauth": false,
 		"site-indicator": false,
-		"support-user": true
+		"support-user": true,
+		"upgrades/redirect-payments": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -46,7 +46,8 @@
 		"oauth": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"support-user": true
+		"support-user": true,
+		"upgrades/redirect-payments": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -49,7 +49,8 @@
 		"oauth": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"support-user": true
+		"support-user": true,
+		"upgrades/redirect-payments": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
### Changes proposed in this Pull Request

Checkout in Jetpack cloud works if the purchased product is passed directly in the URL. However, when a user select a product from the plans page, they see a checkout page that doesn't seem to load. This PR fixes it.

### Implementation notes

When selecting a product in the pricing page, the product is added to the cart before redirecting the user to the checkout page. The cart requires the site id in order to be synchronized across pages.

- Reverted the temporary redirection to Calypso (#47811)
- Enabled the `upgrades/redirect-payments` feature flag (except in prod)
- Added `siteSelection` to the chain of middlewares in the pricing page

### Testing instructions

- Download the PR
- Run both Calypso and cloud locally

**Cloud**
- Visit `/pricing?site=:site` while authenticated and select any product
- Check that you land in the checkout page with the product in the cart
- Remove the product from the cart
- Test again with `/pricing/:site`, `/plans/:site`, and `/checkout/:product/:site`

**Calypso**
- Test that you can still purchase any product from the plans page

### Screenshots

_Broken checkout page_
<img width="612" alt="Screen Shot 2020-11-30 at 9 54 22 AM" src="https://user-images.githubusercontent.com/1620183/100625029-10303000-32f2-11eb-9ec6-270dbcf4aab9.png">
