### PR TITLE
Billing Page: Remove "Upgrade Now" option for Jetpack Complete plan subscription

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -59,6 +59,7 @@ import {
 	isBusiness,
 	isEcommerce,
 	isPlan,
+	isComplete,
 	isDomainProduct,
 	isDomainRegistration,
 	isDomainMapping,
@@ -259,7 +260,7 @@ class ManagePurchase extends Component {
 			? translate( 'Pick Another Plan' )
 			: translate( 'Upgrade Plan' );
 
-		if ( ! isPlan( purchase ) || isEcommerce( purchase ) ) {
+		if ( ! isPlan( purchase ) || isEcommerce( purchase ) || isComplete( purchase ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Given that Jetpack Complete is the highest tier of all the Jetpack plans it therefore cannot be upgraded to a higher tier plan. This PR removes the "Upgrade Now" button on the Billing page for the Jetpack Complete plan subscription.

Fixes: 1164141197617539-as-1199365241025325

### Testing instructions

First, to view the issue:
1. Open Calypso - (wordpress.com)
2. Select a site with **_Jetpack Complete_** plan.
3. Go to Plan --> Billing --> Purchases tab.
4. Select the "Jetpack Complete" plan. (this will open the Purchase Settings)
5. Verify that you see the "Upgrade Now" button toward the bottom of the page.  This is the issue.  Jetpack Complete is not upgradable so this button should not be displayed to the user. (see screenshot)
![Markup 2020-11-30 at 09 27 16](https://user-images.githubusercontent.com/11078128/100643150-89c61f00-32ee-11eb-8c06-4fc360197ef5.png)


Next, verify the issue is fixed:
1. Checkout and run this PR
2. Select a site with _**Jetpack Complete**_ plan.
3. Go to Plan --> Billing --> Purchases tab.
4. Select the "Jetpack Complete" plan. (this will open the Purchase Settings)
5. Verify that the "Upgrade Now" is no longer showing. (see screenshot below)
6. Select a site with a plan **_other than_** Jetpack Complete and verify that the "Upgrade Now" button **_is_** available

![Screenshot on 2020-11-30 at 09-27-42](https://user-images.githubusercontent.com/11078128/100643222-9ea2b280-32ee-11eb-906e-d3f1bb179ef1.png)
