### PR TITLE
Fix `/plans` route not rendering in Jetpack cloud

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -631,7 +631,8 @@ export default function pages() {
 
 		app.get( '/plans', function ( req, res, next ) {
 			if ( ! req.context.isLoggedIn ) {
-				const queryFor = req.query && req.query.for;
+				const queryFor = req.query?.for;
+
 				if ( queryFor && 'jetpack' === queryFor ) {
 					res.redirect(
 						'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans'
@@ -639,9 +640,9 @@ export default function pages() {
 				} else if ( ! config.isEnabled( 'jetpack-cloud/connect' ) ) {
 					res.redirect( 'https://wordpress.com/pricing' );
 				}
-			} else {
-				next();
 			}
+
+			next();
 		} );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes the `/plans` route not rendering in staging.

### Testing instructions

- Download the PR
- In `client/server/pages/index.js`,  update the condition at line 614 to `process.env.NODE_ENV === 'development'` in order to test the fix locally
- Run cloud
- Visit `/plans` and check that the pricing page is rendered