### PR TITLE
Changes:

### DIFF
--- a/test/e2e/lib/components/sidebar-component-playwright.js
+++ b/test/e2e/lib/components/sidebar-component-playwright.js
@@ -18,13 +18,11 @@ export default class SidebarComponent {
 		// In a production system, itemName should be subjected to sanitization
 		// to prevent case errors from breaking the test.
 
-		// Note this selector is plural - the intention is to select all matching
-		// selectors, then iterate through each item and check its innerText attribute.
-		const sidebarMenuSelectors = 'css=.sidebar >> css=.is-togglable';
+		const sidebarMenuSelector = 'css=.sidebar >> css=.is-togglable';
 		// Once drawer is toggled, this CSS class is added.
-		const drawerOpen = 'is-toggle-open';
+		const drawerOpen = '.is-toggle-open';
 
-		const handles = await this.page.$$( sidebarMenuSelectors );
+		const handles = await this.page.$$( sidebarMenuSelector );
 
 		for ( const h of handles ) {
 			// Yay, there was a match. Let's click on the element to expand it.
@@ -36,15 +34,21 @@ export default class SidebarComponent {
 		}
 	}
 
+	async selectMyHome() {
+		this.page.waitForNavigation();
+
+		return await this.page.click( '.myhome' );
+	}
+
 	async selectMarketing() {
-		this.expandDrawerItem( 'Tools' );
+		await this.expandDrawerItem( 'Tools' );
 		// Promise that will resolve on page navigation event firing.
 		this.page.waitForNavigation();
 		return await this.page.click( '.marketing' );
 	}
 
 	async selectSettings() {
-		this.expandDrawerItem( 'Manage' );
+		await this.expandDrawerItem( 'Manage' );
 		// Promise that will resolve on page navigation event firing.
 		this.page.waitForNavigation();
 		return await this.page.click( '.settings' );

--- a/test/e2e/lib/components/sidebar-component-playwright.js
+++ b/test/e2e/lib/components/sidebar-component-playwright.js
@@ -4,7 +4,7 @@ export default class SidebarComponent {
 		this.sidebarSelector = '.sidebar';
 
 		this.page = page;
-		
+
 		this._init();
 	}
 
@@ -21,18 +21,17 @@ export default class SidebarComponent {
 		// Note this selector is plural - the intention is to select all matching
 		// selectors, then iterate through each item and check its innerText attribute.
 		const sidebarMenuSelectors = 'css=.sidebar >> css=.is-togglable';
-		// Once drawer is toggled, this CSS class is added. 
+		// Once drawer is toggled, this CSS class is added.
 		const drawerOpen = 'is-toggle-open';
 
 		const handles = await this.page.$$( sidebarMenuSelectors );
 
-		for (const h of handles) {
+		for ( const h of handles ) {
 			// Yay, there was a match. Let's click on the element to expand it.
-			if ( await h.innerText() === itemName ) {
+			if ( ( await h.innerText() ) === itemName ) {
 				await h.click();
 				// Ensure we were actually successful in toggling open the drawer.
 				return await this.page.waitForSelector( drawerOpen );
-				
 			}
 		}
 	}
@@ -42,5 +41,12 @@ export default class SidebarComponent {
 		// Promise that will resolve on page navigation event firing.
 		this.page.waitForNavigation();
 		return await this.page.click( '.marketing' );
+	}
+
+	async selectSettings() {
+		this.expandDrawerItem( 'Manage' );
+		// Promise that will resolve on page navigation event firing.
+		this.page.waitForNavigation();
+		return await this.page.click( '.settings' );
 	}
 }

--- a/test/e2e/lib/components/sidebar-component-playwright.js
+++ b/test/e2e/lib/components/sidebar-component-playwright.js
@@ -35,22 +35,18 @@ export default class SidebarComponent {
 	}
 
 	async selectMyHome() {
-		this.page.waitForNavigation();
-
-		return await this.page.click( '.myhome' );
+		return await Promise.all( [ this.page.waitForNavigation(), this.page.click( '.myhome' ) ] );
 	}
 
 	async selectMarketing() {
 		await this.expandDrawerItem( 'Tools' );
-		// Promise that will resolve on page navigation event firing.
-		this.page.waitForNavigation();
-		return await this.page.click( '.marketing' );
+
+		return await Promise.all( [ this.page.waitForNavigation(), this.page.click( '.marketing' ) ] );
 	}
 
 	async selectSettings() {
 		await this.expandDrawerItem( 'Manage' );
-		// Promise that will resolve on page navigation event firing.
-		this.page.waitForNavigation();
-		return await this.page.click( '.settings' );
+
+		return await Promise.all( [ this.page.waitForNavigation(), this.page.click( '.settings' ) ] );
 	}
 }

--- a/test/e2e/lib/components/sidebar-component-playwright.js
+++ b/test/e2e/lib/components/sidebar-component-playwright.js
@@ -1,0 +1,46 @@
+export default class SidebarComponent {
+	constructor( page ) {
+		// Selectors
+		this.sidebarSelector = '.sidebar';
+
+		this.page = page;
+		
+		this._init();
+	}
+
+	async _init() {
+		return await this.page.waitForSelector( this.sidebarSelector );
+	}
+
+	async expandDrawerItem( itemName ) {
+		// itemName should reflect the text as rendered for the side pane item
+		// that should be clicked.
+		// In a production system, itemName should be subjected to sanitization
+		// to prevent case errors from breaking the test.
+
+		// Note this selector is plural - the intention is to select all matching
+		// selectors, then iterate through each item and check its innerText attribute.
+		const sidebarMenuSelectors = 'css=.sidebar >> css=.is-togglable';
+		// Once drawer is toggled, this CSS class is added. 
+		const drawerOpen = 'is-toggle-open';
+
+		const handles = await this.page.$$( sidebarMenuSelectors );
+
+		for (const h of handles) {
+			// Yay, there was a match. Let's click on the element to expand it.
+			if ( await h.innerText() === itemName ) {
+				await h.click();
+				// Ensure we were actually successful in toggling open the drawer.
+				return await this.page.waitForSelector( drawerOpen );
+				
+			}
+		}
+	}
+
+	async selectMarketing() {
+		this.expandDrawerItem( 'Tools' );
+		// Promise that will resolve on page navigation event firing.
+		this.page.waitForNavigation();
+		return await this.page.click( '.marketing' );
+	}
+}

--- a/test/e2e/lib/flows/login-flow-playwright.js
+++ b/test/e2e/lib/flows/login-flow-playwright.js
@@ -82,6 +82,7 @@ export default class LoginFlow {
 
         await page.waitForSelector( newPostButton );
         await page.click( newPostButton );
+        // Editor is loaded once the iframe shows.
         return await page.waitForSelector( iframe );
     }
 }

--- a/test/e2e/lib/flows/login-flow-playwright.js
+++ b/test/e2e/lib/flows/login-flow-playwright.js
@@ -1,96 +1,103 @@
 /**
- * External dependencies
- */
-import playwright from 'playwright';
-
-/**
  * Internal dependencies
  */
 import LoginPage from '../pages/login-page-playwright.js';
 
+import SidebarComponent from '../components/sidebar-component-playwright.js';
+
 import * as dataHelper from '../data-helper';
 
 export default class LoginFlow {
-    constructor( context, accountOrFeatures ) {
-        // This setup runs all tests in different (new) tabs in within the same window.
-        // This can easily be changed to launch a new incognito browser window each time,
-        // further isolating tests.
-        this.context = context;
+	constructor( context, accountOrFeatures ) {
+		// This setup runs all tests in different (new) tabs in within the same window.
+		// This can easily be changed to launch a new incognito browser window each time,
+		// further isolating tests.
+		this.context = context;
 
-        // The following piece is a simplified one from the original LoginFlow file.
-        const legacyConfig = dataHelper.getAccountConfig(accountOrFeatures);
-        if (!legacyConfig) {
-            throw new Error(`Account key '${accountOrFeatures}' not found in the configuration`);
-        }
+		// The following piece is a simplified one from the original LoginFlow file.
+		const legacyConfig = dataHelper.getAccountConfig( accountOrFeatures );
+		if ( ! legacyConfig ) {
+			throw new Error( `Account key '${ accountOrFeatures }' not found in the configuration` );
+		}
 
-        this.account = {
-            email: legacyConfig[0],
-            username: legacyConfig[0],
-            password: legacyConfig[1],
-            loginURL: legacyConfig[2],
-            legacyAccountName: accountOrFeatures,
-        };
-    }   
+		this.account = {
+			email: legacyConfig[ 0 ],
+			username: legacyConfig[ 0 ],
+			password: legacyConfig[ 1 ],
+			loginURL: legacyConfig[ 2 ],
+			legacyAccountName: accountOrFeatures,
+		};
+	}
 
-    async login() {
-        /* This will be the base method that performs the logins.
+	async login() {
+		/* This will be the base method that performs the logins.
         Functions that perform additional actions on top of logging in
         such as new post, new page, select people, etc. will call this method
         as the first call. */
 
-        console.log( 'Logging in as ' + this.account.username );
+		console.log( 'Logging in as ' + this.account.username );
 
-        // Retrieve the browser context stored in this object.
-        const context = this.context;
-        // Launch a new page/tab in the context.
-        const page = await context.newPage();
+		// Retrieve the browser context stored in this object.
+		const context = this.context;
+		// Launch a new page/tab in the context.
+		const page = await context.newPage();
 
-        // Initialize the LoginPage page object with the current (empty) page.
-        let loginPage;
-        loginPage = new LoginPage( page );
+		// Initialize the LoginPage page object with the current (empty) page.
+		const loginPage = new LoginPage( page );
 
-        // Navigate to the login URL.
-        await page.goto( loginPage.url );
-        // Perform the login action.
-        await loginPage.login( this.account.email || this.account.username, this.account.password );
+		// Navigate to the login URL.
+		await page.goto( loginPage.url );
+		// Perform the login action.
+		await loginPage.login( this.account.email || this.account.username, this.account.password );
 
-        // Upon successful login, assign page as class property.
-        // this.page = page;
-        return await page;
-    }
+		// Upon successful login, assign page as class property.
+		// this.page = page;
+		return await page;
+	}
 
-    async loginAndStartNewPost() {
-        const newPostButton = 'a.masterbar__item-new';
-        const iframe = '.main > iframe:nth-child(1)';
+	async loginAndStartNewPost() {
+		const newPostButton = 'a.masterbar__item-new';
+		const iframe = '.main > iframe:nth-child(1)';
 
-        // Call the login() function to perform the login steps and to obtain the page object.
-        let page = await this.login();
-        
-        console.log( 'Starting new post' );
+		// Call the login() function to perform the login steps and to obtain the page object.
+		const page = await this.login();
 
-        await page.waitForSelector( newPostButton );
-        await page.click( newPostButton );
-        // Editor is loaded once the iframe shows.
-        await page.waitForSelector( iframe );
-        // Return the page object to the caller for further operations.
-        return page;
-    }
+		console.log( 'Starting new post' );
 
-    async loginAndSelectMySites() {
-        const navBarSelector = '.masterbar';
-        const mySitesSelector = 'header.masterbar a.masterbar__item';
+		await page.waitForSelector( newPostButton );
+		await page.click( newPostButton );
+		// Editor is loaded once the iframe shows.
+		await page.waitForSelector( iframe );
+		// Return the page object to the caller for further operations.
+		return page;
+	}
 
-        let page = await this.login();
+	async loginAndSelectMySites() {
+		const navBarSelector = '.masterbar';
+		const mySitesSelector = 'header.masterbar a.masterbar__item';
 
-        console.log( 'Selecting My Sites' );
+		const page = await this.login();
 
-        await page.waitForSelector( navBarSelector );
-        await page.waitForSelector( mySitesSelector );
-        
-        page.waitForNavigation();
-        await page.click(mySitesSelector);
-        // Return page once navigation is complete.
+		console.log( 'Selecting My Sites' );
 
-        return page;
-    }
+		await page.waitForSelector( navBarSelector );
+		await page.waitForSelector( mySitesSelector );
+
+		page.waitForNavigation();
+		await page.click( mySitesSelector );
+		// Return page once navigation is complete.
+
+		return page;
+	}
+
+	async loginAndSelectSettings() {
+		const page = await this.login();
+
+		console.log( 'Selecting settings' );
+
+		const sidebarComponent = new SidebarComponent( page );
+		await sidebarComponent.selectSettings();
+
+		return page;
+	}
 }

--- a/test/e2e/lib/flows/login-flow-playwright.js
+++ b/test/e2e/lib/flows/login-flow-playwright.js
@@ -74,7 +74,7 @@ export default class LoginFlow {
 
     async loginAndStartNewPost() {
         const newPostButton = 'a.masterbar__item-new';
-        const iframe = '.main > iframe:nth-child(1)'
+        const iframe = '.main > iframe:nth-child(1)';
 
         // Call the login() function to perform the login steps,
         // and to obtain the page object.
@@ -88,5 +88,20 @@ export default class LoginFlow {
         await page.click( newPostButton );
         // Editor is loaded once the iframe shows.
         return await page.waitForSelector( iframe );
+    }
+
+    async loginAndSelectMySites() {
+        const navBarSelector = '.masterbar';
+        const mySitesSelector = 'header.masterbar a.masterbar__item';
+        
+        await this.login();
+
+        const page = this.page;
+
+        console.log( 'Selecting My Sites' );
+
+        await page.waitForSelector( navBarSelector );
+        await page.waitForSelector( mySitesSelector );
+        return await page.click( mySitesSelector );
     }
 }

--- a/test/e2e/lib/flows/login-flow-playwright.js
+++ b/test/e2e/lib/flows/login-flow-playwright.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import playwright from 'playwright';
+
+/**
+ * Internal dependencies
+ */
+import LoginPage from '../pages/login-page-playwright.js';
+
+import * as dataHelper from '../data-helper';
+
+const host = dataHelper.getJetpackHost();
+
+export default class LoginFlow {
+    constructor( browser, accountOrFeatures) {
+        this.browser = browser;
+
+        // The following if/else is essentially carried over from the
+        // original file.
+        accountOrFeatures = accountOrFeatures || 'defaultUser';
+        if ( typeof accountOrFeatures === 'string' ) {
+            const legacyConfig = dataHelper.getAccountConfig( accountOrFeatures );
+            if ( ! legacyConfig ) {
+				throw new Error( `Account key '${ accountOrFeatures }' not found in the configuration` );
+            }
+            
+			this.account = {
+				email: legacyConfig[ 0 ],
+				username: legacyConfig[ 0 ],
+				password: legacyConfig[ 1 ],
+				loginURL: legacyConfig[ 2 ],
+				legacyAccountName: accountOrFeatures,
+			};
+		} else {
+			this.account = dataHelper.pickRandomAccountWithFeatures( accountOrFeatures );
+			if ( ! this.account ) {
+				throw new Error(
+					`Could not find any account matching features '${ accountOrFeatures.toString() }'`
+				);
+			}
+		}
+    }   
+
+    async login() {
+        console.log( 'Logging in as ' + this.account.username );
+
+        const browser = this.browser;
+        const context = await browser.newContext();
+        const page = await context.newPage();
+
+        // Initialize the LoginPage page object.
+        let loginPage;
+        loginPage = new LoginPage( page );
+
+        // Navigate to the login URL.
+        await page.goto(loginPage.url);
+        return await loginPage.login( this.account.email || this.account.username, this.account.password );
+    }
+}

--- a/test/e2e/lib/flows/login-flow-playwright.js
+++ b/test/e2e/lib/flows/login-flow-playwright.js
@@ -47,15 +47,19 @@ export default class LoginFlow {
     }   
 
     async login() {
+        /* This will be the base method that performs the logins.
+        Functions that perform additional actions on top of logging in
+        such as new post, new page, select people, etc. will call this method
+        as the first call. */
+
         console.log( 'Logging in as ' + this.account.username );
 
-        // Retrieve the context created in the constructor.
+        // Retrieve the browser context (session).
         const context = await this.context;
         // Launch a new page/tab in the context.
         const page = await context.newPage();
 
-        // Initialize the LoginPage page object with the current page
-        // as the parameter.
+        // Initialize the LoginPage page object with the current (empty) page.
         let loginPage;
         loginPage = new LoginPage( page );
 

--- a/test/e2e/lib/flows/login-flow-playwright.js
+++ b/test/e2e/lib/flows/login-flow-playwright.js
@@ -50,9 +50,8 @@ export default class LoginFlow {
 		// Perform the login action.
 		await loginPage.login( this.account.email || this.account.username, this.account.password );
 
-		// Upon successful login, assign page as class property.
-		// this.page = page;
-		return await page;
+		// Upon successful login, return the page object to the caller for additional steps.
+		return page;
 	}
 
 	async loginAndStartNewPost() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component-playwright.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component-playwright.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import { kebabCase } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import * as dataHelper from '../data-helper';
+
+export default class GutenbergEditorComponent {
+    constructor( page ) {
+        // Selectors
+        this.editorFrame = '.main > iframe:nth-child(1)';
+        this.toggleBlockInserter = '.edit-post-header .edit-post-header-toolbar__inserter-toggle';
+
+        this.page = page;
+        // Tries the best to make sure the editor iframe is loaded and able to be selected
+        // prior to continuing the tests.
+        this._init();
+    }
+
+    async _init() {
+        const page = this.page;
+
+        await page.waitForSelector( this.editorFrame );
+        const handle = await page.$( this.editorFrame );
+        this.frame = await handle.contentFrame();
+    }
+
+    async openBlockInserter() {
+        const frame = this.frame;
+    
+        await frame.waitForSelector( this.toggleBlockInserter );
+        return await frame.click( this.toggleBlockInserter );
+    }
+
+    async searchBlock( blockName ) {
+        const frame = this.frame;
+        const inserterBlockSearch = 'input.block-editor-inserter__search-input';
+
+        await frame.waitForSelector( inserterBlockSearch );
+        await frame.focus( inserterBlockSearch );
+        return await frame.fill( inserterBlockSearch, blockName );
+    }
+
+    async addBlock( blockName ) {
+        const frame = this.frame;
+        const blockSelector = `text="${ blockName }"`;
+
+        await frame.waitForSelector( blockSelector );
+        return await frame.click( blockSelector );
+    }
+
+    async fillText( blockSelector, text ) {
+        const frame = this.frame;
+
+        await frame.waitForSelector( blockSelector );
+        await frame.focus( blockSelector );
+        return await frame.fill( blockSelector, text );
+    }
+
+    async uploadFile( blockSelector, fileInputSelector, file ) {
+        const frame = this.frame;
+
+        await frame.waitForSelector( blockSelector );
+        return await frame.setInputFiles( fileInputSelector, file );
+    }
+
+    async saveDraft() {
+        const frame = this.frame;
+        const saveDraftButton = '.editor-post-save-draft';
+        const savedConfirmSelector = 'span.is-saved';
+
+        await frame.waitForSelector( saveDraftButton );
+        await frame.click( saveDraftButton );
+        return await frame.waitForSelector( savedConfirmSelector );
+    }
+
+    async publishPost() {
+        const frame = this.frame;
+        const prePublishButtonSelector = '.editor-post-publish-panel__toggle';
+        const publishSelector = '.editor-post-publish-panel__header-publish-button button.editor-post-publish-button';
+
+        await frame.waitForSelector( prePublishButtonSelector );
+        await frame.click( prePublishButtonSelector );
+        await frame.waitForSelector( publishSelector );
+        return await frame.click( publishSelector );
+    }
+
+    async confirmPostPublished() {
+        const frame = this.frame;
+        const snackBarNotice = '.components-snackbar';
+        
+        await frame.waitForSelector( snackBarNotice );
+    }
+
+    async visitPublishedPost() {
+        const page = this.page;
+        const frame = this.frame;
+        const snackBarNoticeLinkSelector = '.components-snackbar__content a';
+
+        // page.waitForNavigation will resolve if a new URL is loaded.
+        page.waitForNavigation();
+        return await frame.click( snackBarNoticeLinkSelector );
+    }
+}

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component-playwright.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component-playwright.js
@@ -11,33 +11,35 @@ export default class GutenbergEditorComponent {
     }
 
     async _init() {
+        // Completes the initialization of the GutenbergEditorComponent class.
+        // This is a workaround since constructors do not permit async calls, but the 
+        // editor frame needs to finish loading in order for the selectors to function.
         await this.page.waitForSelector( this.editorFrame );
         const handle = await this.page.$( this.editorFrame );
+        // Selects the editor block iframe, with which all block related operations are
+        // called from.
+        // To avoid this, it is possible to call page.frame(name or url) instead.
         this.frame = await handle.contentFrame();
     }
 
-    async openBlockInserter() {
-        const frame = this.frame;
-    
-        await frame.waitForSelector( this.toggleBlockInserter );
-        return await frame.click( this.toggleBlockInserter );
+    async openBlockInserter() {    
+        await this.frame.waitForSelector( this.toggleBlockInserter );
+        return await this.frame.click( this.toggleBlockInserter );
     }
 
     async searchBlock( blockName ) {
-        const frame = this.frame;
         const inserterBlockSearch = 'input.block-editor-inserter__search-input';
 
-        await frame.waitForSelector( inserterBlockSearch );
-        await frame.focus( inserterBlockSearch );
-        return await frame.fill( inserterBlockSearch, blockName );
+        await this.frame.waitForSelector( inserterBlockSearch );
+        await this.frame.focus( inserterBlockSearch );
+        return await this.frame.fill( inserterBlockSearch, blockName );
     }
 
     async addBlock( blockName ) {
-        const frame = this.frame;
         const blockSelector = `text="${ blockName }"`;
 
-        await frame.waitForSelector( blockSelector );
-        return await frame.click( blockSelector );
+        await this.frame.waitForSelector( blockSelector );
+        return await this.frame.click( blockSelector );
     }
 
     async fillText( blockSelector, text ) {
@@ -49,10 +51,8 @@ export default class GutenbergEditorComponent {
     }
 
     async uploadFile( blockSelector, fileInputSelector, file ) {
-        const frame = this.frame;
-
-        await frame.waitForSelector( blockSelector );
-        return await frame.setInputFiles( fileInputSelector, file );
+        await this.frame.waitForSelector( blockSelector );
+        return await this.frame.setInputFiles( fileInputSelector, file );
     }
 
     async saveDraft() {
@@ -77,19 +77,16 @@ export default class GutenbergEditorComponent {
     }
 
     async confirmPostPublished() {
-        const frame = this.frame;
         const snackBarNotice = '.components-snackbar';
         
-        await frame.waitForSelector( snackBarNotice );
+        await this.frame.waitForSelector( snackBarNotice );
     }
 
     async visitPublishedPost() {
-        const page = this.page;
-        const frame = this.frame;
         const snackBarNoticeLinkSelector = '.components-snackbar__content a';
 
         // page.waitForNavigation will resolve if a new URL is loaded.
-        page.waitForNavigation();
-        return await frame.click( snackBarNoticeLinkSelector );
+        this.page.waitForNavigation();
+        return await this.frame.click( snackBarNoticeLinkSelector );
     }
 }

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component-playwright.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component-playwright.js
@@ -1,13 +1,3 @@
-/**
- * External dependencies
- */
-import { kebabCase } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import * as dataHelper from '../data-helper';
-
 export default class GutenbergEditorComponent {
     constructor( page ) {
         // Selectors
@@ -21,10 +11,8 @@ export default class GutenbergEditorComponent {
     }
 
     async _init() {
-        const page = this.page;
-
-        await page.waitForSelector( this.editorFrame );
-        const handle = await page.$( this.editorFrame );
+        await this.page.waitForSelector( this.editorFrame );
+        const handle = await this.page.$( this.editorFrame );
         this.frame = await handle.contentFrame();
     }
 

--- a/test/e2e/lib/pages/login-page-playwright.js
+++ b/test/e2e/lib/pages/login-page-playwright.js
@@ -6,49 +6,49 @@ import * as dataHelper from '../data-helper';
 // This is the Calypso WordPress.com login page
 // For the wp-admin login page see /wp-admin/wp-admin-logon-page
 export default class LoginPage {
-    constructor( page ) {
-        // Accepts an instance of a page object.
-        this.page = page;
-        // Set the login URL as an attribute of this page.
-        this.url = LoginPage.getLoginURL();
-    }
+	constructor( page ) {
+		// Accepts an instance of a page object.
+		this.page = page;
+		// Set the login URL as an attribute of this page.
+		this.url = LoginPage.getLoginURL();
+	}
 
-    async login( username, password ) {
-        // Establish CSS class selectors.
-        const userNameSelector = "#usernameOrEmail";
-        const passwordSelector = "#password";
-        const loginContainer = ".wp-login__container";
-        const changeAccountSelector = "#loginAsAnotherUser";
-        
-        // Retrive the page object.
-        const page = this.page;
+	async login( username, password ) {
+		// Establish CSS class selectors.
+		const userNameSelector = '#usernameOrEmail';
+		const passwordSelector = '#password';
+		const loginContainer = '.wp-login__container';
+		const changeAccountSelector = '#loginAsAnotherUser';
 
-        // If there is already a logged in session.
-        const alredyLoggedIn = await page.$( changeAccountSelector );
-        if ( alredyLoggedIn ) {
-            await page.click( changeAccountSelector );
-        }
-        
-        // Begin the process of logging in.
-        await page.waitForSelector( loginContainer );
-        await page.waitForSelector( userNameSelector );
+		// Retrive the page object.
+		const page = this.page;
 
-        await page.fill( userNameSelector, username );
-        await page.keyboard.press("Enter")
-        
-        await page.waitForSelector( passwordSelector) ;
-        await page.fill( passwordSelector, password );
-        await page.keyboard.press("Enter");
+		// If there is already a logged in session.
+		const alredyLoggedIn = await page.$( changeAccountSelector );
+		if ( alredyLoggedIn ) {
+			await page.click( changeAccountSelector );
+		}
 
-        // Check if My Home header appears to verify that login was successful.
-        // Note, I am not fond of this method, as the page element specified does not
-        // belong to the Login Page and therefore should have no business being here.
-        // Alternatively it may be better to check for lack of an element that should be 
-        // present at login page or check that URL string no longer contains wp-login.
-        return await page.waitForSelector( ".customer-home__heading", { visible: true } );
-    }
+		// Begin the process of logging in.
+		await page.waitForSelector( loginContainer );
+		await page.waitForSelector( userNameSelector );
 
-    static getLoginURL() {
+		await page.fill( userNameSelector, username );
+		await page.keyboard.press( 'Enter' );
+
+		await page.waitForSelector( passwordSelector );
+		await page.fill( passwordSelector, password );
+
+		// Wait for the sidebar to be loaded in the dashbaord before resolving the promise.
+		return await Promise.all( [
+			page.waitForResponse(
+				'https://wordpress.com/calypso/evergreen/async-load-calypso-my-sites-sidebar**'
+			),
+			page.keyboard.press( 'Enter' ),
+		] );
+	}
+
+	static getLoginURL() {
 		return dataHelper.getCalypsoURL( 'log-in' );
 	}
 }

--- a/test/e2e/lib/pages/login-page-playwright.js
+++ b/test/e2e/lib/pages/login-page-playwright.js
@@ -6,21 +6,28 @@ import * as dataHelper from '../data-helper';
 // This is the Calypso WordPress.com login page
 // For the wp-admin login page see /wp-admin/wp-admin-logon-page
 export default class LoginPage {
-    constructor(page) {
+    constructor( page ) {
         // Accepts an instance of a page object.
         this.page = page;
         // Set the login URL as an attribute of this page.
         this.url = LoginPage.getLoginURL();
     }
 
-    async login( username, password, emailSSO = false ) {
+    async login( username, password ) {
         // Establish CSS class selectors.
         const userNameSelector = "#usernameOrEmail";
         const passwordSelector = "#password";
         const loginContainer = ".wp-login__container";
+        const changeAccountSelector = "#loginAsAnotherUser";
         
         // Retrive the page object.
         const page = this.page;
+
+        // If there is already a logged in session.
+        const alredyLoggedIn = await page.$( changeAccountSelector );
+        if ( alredyLoggedIn ) {
+            await page.click( changeAccountSelector );
+        }
         
         // Begin the process of logging in.
         await page.waitForSelector( loginContainer );

--- a/test/e2e/lib/pages/login-page-playwright.js
+++ b/test/e2e/lib/pages/login-page-playwright.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import playwright from 'playwright';
+
+/**
+ * Internal dependencies
+ */
+import * as dataHelper from '../data-helper';
+
+// This is the Calypso WordPress.com login page
+// For the wp-admin login page see /wp-admin/wp-admin-logon-page
+export default class LoginPage {
+    constructor(page) {
+        // Accepts an instance of a page object.
+        this.page = page;
+        // Instead of passing the URL as parameter to the parent class,
+        // simply set it as an attribute of this class instance.
+        this.url = LoginPage.getLoginURL();
+    }
+
+    async login( username, password, emailSSO = false ) {
+        // Establish CSS class selectors.
+        const userNameSelector = "#usernameOrEmail";
+        const passwordSelector = "#password";
+        const loginContainer = ".wp-login__container";
+        
+        const page = this.page;
+        
+        await page.waitForSelector( loginContainer );
+        await page.waitForSelector( userNameSelector );
+
+        await page.fill( userNameSelector, username );
+        await page.keyboard.press("Enter")
+        
+        await page.waitForSelector( passwordSelector) ;
+        await page.fill( passwordSelector, password );
+        await page.keyboard.press("Enter");
+
+        // Check if My Home header appears.
+        // Note, I am not fond of this method, as the element does not belong to LoginPage object.
+        // It would be better to check for lack of an element that should be present at 
+        // login page or check that URL string no longer contains wp-login.
+        return await page.waitForSelector( ".customer-home__heading", {visible: true} );
+    }
+
+    static getLoginURL() {
+		return dataHelper.getCalypsoURL( 'log-in' );
+	}
+}

--- a/test/e2e/lib/pages/login-page-playwright.js
+++ b/test/e2e/lib/pages/login-page-playwright.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import playwright from 'playwright';
-
-/**
  * Internal dependencies
  */
 import * as dataHelper from '../data-helper';
@@ -25,8 +20,10 @@ export default class LoginPage {
         const passwordSelector = "#password";
         const loginContainer = ".wp-login__container";
         
+        // Retrive the page object.
         const page = this.page;
         
+        // Begin the process of logging in.
         await page.waitForSelector( loginContainer );
         await page.waitForSelector( userNameSelector );
 
@@ -37,11 +34,12 @@ export default class LoginPage {
         await page.fill( passwordSelector, password );
         await page.keyboard.press("Enter");
 
-        // Check if My Home header appears.
-        // Note, I am not fond of this method, as the element does not belong to LoginPage object.
-        // It would be better to check for lack of an element that should be present at 
-        // login page or check that URL string no longer contains wp-login.
-        return await page.waitForSelector( ".customer-home__heading", {visible: true} );
+        // Check if My Home header appears to verify that login was successful.
+        // Note, I am not fond of this method, as the page element specified does not
+        // belong to the Login Page and therefore should have no business being here.
+        // Alternatively it may be better to check for lack of an element that should be 
+        // present at login page or check that URL string no longer contains wp-login.
+        return await page.waitForSelector( ".customer-home__heading", { visible: true } );
     }
 
     static getLoginURL() {

--- a/test/e2e/lib/pages/login-page-playwright.js
+++ b/test/e2e/lib/pages/login-page-playwright.js
@@ -9,8 +9,7 @@ export default class LoginPage {
     constructor(page) {
         // Accepts an instance of a page object.
         this.page = page;
-        // Instead of passing the URL as parameter to the parent class,
-        // simply set it as an attribute of this class instance.
+        // Set the login URL as an attribute of this page.
         this.url = LoginPage.getLoginURL();
     }
 

--- a/test/e2e/lib/pages/support-page-playwright.js
+++ b/test/e2e/lib/pages/support-page-playwright.js
@@ -37,26 +37,20 @@ export default class SupportPage {
 		return visible !== null;
 	}
 
-	async getDefaultResults() {
-		const defaultResultsSelector = '.inline-help__results-cell';
-
-		return this.page.$$( defaultResultsSelector );
+	async getResults( selector ) {
+		await this.page.waitForLoadState( 'networkidle' );
+		await this.page.waitForSelector( selector );
+		return await this.page.$$( selector );
 	}
 
 	async getDefaultResultCount() {
-		const results = await this.getDefaultResults();
+		const results = await this.getResults( '.inline-help__results-cell' );
 
 		return results.length;
 	}
 
-	async getResults() {
-		const searchResults = '[aria-labelledby="inline-search--api_help"]';
-
-		return await this.page.$$( searchResults );
-	}
-
 	async getResultCount() {
-		const results = await this.getResults();
+		const results = await this.getResults( '[aria-labelledby="inline-search--api_help"]' );
 
 		return results.length;
 	}

--- a/test/e2e/lib/pages/support-page-playwright.js
+++ b/test/e2e/lib/pages/support-page-playwright.js
@@ -1,0 +1,103 @@
+export default class SupportPage {
+	constructor( page ) {
+		// Selectors
+		this.inlineHelpButton = '.inline-help__button';
+		this.inlineHelpPopover = '.inline-help__popover';
+
+		this.page = page;
+	}
+
+	async openInlineHelp() {
+		const inlineHelpOpen = await this.inlineHelpPopoverVisible();
+		// If the in-line help popover is not visible, let's click it.
+		if ( ! inlineHelpOpen ) {
+			await this.inlineHelpButtonVisible();
+			await this.page.click( this.inlineHelpButton );
+			return await this.inlineHelpPopoverVisible();
+		}
+	}
+
+	async closeInlineHelp() {
+		const inlineHelpOpen = await this.inlineHelpPopoverVisible();
+		if ( inlineHelpOpen ) {
+			await this.inlineHelpButtonVisible();
+			return await this.page.click( this.inlineHelpButton );
+		}
+	}
+
+	async inlineHelpButtonVisible() {
+		await this.page.waitForLoadState( 'networkidle' );
+		const visible = await this.page.$( this.inlineHelpButton );
+		return visible !== null;
+	}
+
+	async inlineHelpPopoverVisible() {
+		await this.page.waitForLoadState( 'networkidle' );
+		const visible = await this.page.$( this.inlineHelpPopover );
+		return visible !== null;
+	}
+
+	async getDefaultResults() {
+		const defaultResultsSelector = '.inline-help__results-cell';
+
+		return this.page.$$( defaultResultsSelector );
+	}
+
+	async getDefaultResultCount() {
+		const results = await this.getDefaultResults();
+
+		return results.length;
+	}
+
+	async getResults() {
+		const searchResults = '[aria-labelledby="inline-search--api_help"]';
+
+		return await this.page.$$( searchResults );
+	}
+
+	async getResultCount() {
+		const results = await this.getResults();
+
+		return results.length;
+	}
+
+	async searchForQuery( searchTerm ) {
+		const page = this.page;
+		const inlineHelpSearchInput = '.form-text-input.search__input';
+
+		await this.openInlineHelp();
+
+		await page.waitForSelector( this.inlineHelpPopover );
+		await page.waitForSelector( inlineHelpSearchInput );
+
+		if ( searchTerm.trim() === '' ) {
+			// An otherwise empty search query won't trigger a HTTP GET request.
+			// This clause will catch this specific condition so that the waitForResponse call does not
+			// hang forever.
+			return await page.waitForLoadState( 'domcontentloaded' );
+		}
+		// For a test scenario where a valid search query is given, the most reliable way that works
+		// is to check for the HTTP 200 response of the GET request against the search API and resolve
+		// the promise once all requests are complete.
+		return await Promise.all( [
+			page.waitForResponse( 'https://public-api.wordpress.com/rest/v1.1/help/search**' ),
+			page.fill( inlineHelpSearchInput, searchTerm ),
+		] );
+	}
+
+	async clearSearchField() {
+		const inlineHelpSearchInput = '.form-text-input.search__input';
+
+		// With Playwright, clearing the search field is as easy as filling it with empty string.
+		return await this.page.fill( inlineHelpSearchInput, '' );
+	}
+
+	async searchReturnedNoResultsMessage() {
+		const noResultsMessageSelector = '.inline-help__empty-results';
+
+		// As per documentation, returns a null if no element with such selector is found.
+		// Therefore if the returned value is not null, the element in question has been found.
+		const noResults = await this.page.$( noResultsMessageSelector );
+		return noResults !== null;
+	}
+}

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -51,6 +51,7 @@
 		"mocha-multi-reporters": "^1.1.7",
 		"mocha-steps": "^1.3.0",
 		"node-slack-upload": "^1.2.1",
+		"playwright": "^1.6.2",
 		"png-itxt": "^1.3.0",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"push-receiver": "^2.0.0",

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
@@ -41,7 +41,6 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
 
         // Retrieve the page object.
         const page = await this.LoginFlow.page;
-        await page.waitForSelector( iframe );
 
         // Obtain the main block editor window iframe.
         const handle = await page.$( iframe );
@@ -102,15 +101,9 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
 
         // Look for snackbar/toast that appears on successful publishing.
         // Visit the site from that link.
-        // const editorURL = await page.url();
         await frame.waitForSelector( snackBarNotice );
         page.waitForNavigation();
         return await frame.click( snackBarNoticeLinkSelector );
-
-        // const publishedURL = await page.url();
-
-        // Wait for the site-content div to load.
-        // return await page.waitForSelector( 'site-content' );
     });
 
     it( `Can see the Click to Tweet block in our published post`, async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+
+import playwright from 'playwright';
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import LoginFlow from '../lib/flows/login-flow-playwright.js';
+
+import * as driverManager from '../lib/driver-manager';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const gutenbergUser =
+    process.env.COBLOCKS_EDGE === 'true' ? 'coBlocksSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
+
+describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
+    this.timeout( mochaTimeOut );
+
+    let browser;
+
+    before( async function() {
+        browser = await playwright.chromium.launch({headless: false});
+    });
+
+    it( `Can log in`, async function() {
+        this.LoginFlow = new LoginFlow( browser, gutenbergUser );
+        return await this.LoginFlow.login();
+    });
+
+    it( `Can insert the Click to Tweet block`, async function() {
+        // steps    
+    })
+
+    after( async function() {
+        await browser.close()
+    })
+
+})

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
@@ -9,113 +9,186 @@ import config from 'config';
  */
 import LoginFlow from '../lib/flows/login-flow-playwright.js';
 
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component-playwright.js';
+
 import * as driverManager from '../lib/driver-manager';
+import * as mediaHelper from '../lib/media-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const gutenbergUser =
     process.env.COBLOCKS_EDGE === 'true' ? 'coBlocksSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
 
+let browser;
+
+before( async function() {
+    browser = await playwright.chromium.launch({headless: false, devtools: false });
+});
+
 describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
     this.timeout( mochaTimeOut );
 
-    let browser;
-
-    before( async function() {
-        browser = await playwright.chromium.launch({headless: false, devtools: true });
-    });
-
-    it( `Can log in`, async function() {
-        this.LoginFlow = new LoginFlow( browser, gutenbergUser );
-        return await this.LoginFlow.loginAndStartNewPost();
-    });
-
-    it( `Can insert the Click to Tweet block`, async function() {
-        // The block editor is within an iframe and puppeteer/playwright cannot see such elements
-        // without selecting the iframe.
-        const iframe = '.main > iframe:nth-child(1)'
-        const toggleBlockInserter = '.edit-post-header .edit-post-header-toolbar__inserter-toggle';
-        const inserterBlockSearch = 'input.block-editor-inserter__search-input';
-        const insertClickToTweetButton = '.edit-post-layout__inserter-panel .block-editor-inserter__block-list button.editor-block-list-item-coblocks-click-to-tweet';
-        const clickToTweetBlock = '.wp-block-coblocks-click-to-tweet';
-
-        // Retrieve the page object.
-        const page = await this.LoginFlow.page;
-
-        // Obtain the main block editor window iframe.
-        const handle = await page.$( iframe );
-        const frame = await handle.contentFrame();
-
-        // From this point on, interact with the frame.
-        await frame.waitForSelector( toggleBlockInserter );
-        await frame.click( toggleBlockInserter );
-        await frame.waitForSelector( inserterBlockSearch );
-        await frame.focus( inserterBlockSearch );
-        await frame.fill( inserterBlockSearch, 'Click to tweet' );
-        await frame.waitForSelector( insertClickToTweetButton );
-        await frame.click( insertClickToTweetButton );
-
-        return await frame.waitForSelector( clickToTweetBlock );
-    });
-
-    it( `Can enter text to tweet`, async function () {
-        const iframe = '.main > iframe:nth-child(1)'
-        const clickToTweetTextInput = '.wp-block-coblocks-click-to-tweet__text';
-        const tweetContent = 'The foolish man seeks happiness in the distance. The wise grows it under his feet. — James Oppenheim';
-        
-        const page = await this.LoginFlow.page;
-        const handle = await page.$( iframe );
-        const frame = await handle.contentFrame();
-
-        await frame.waitForSelector( clickToTweetTextInput );
-        await frame.focus( clickToTweetTextInput );
-        return await frame.fill( clickToTweetTextInput, tweetContent);
-    });
-
-    it( `Can publish and view content`, async function () {
-        const iframe = '.main > iframe:nth-child(1)'
-        const saveDraftButton = '.editor-post-save-draft';
-        const savedSelector = 'span.is-saved';
-        const snackBarNotice = '.components-snackbar';
-        const snackBarNoticeLinkSelector = '.components-snackbar__content a';
-        const prePublishButtonSelector = '.editor-post-publish-panel__toggle';
-        const publishSelector = '.editor-post-publish-panel__header-publish-button button.editor-post-publish-button';
-        const viewPublishedPostButton = 'text="View Post"';
-
-        const page = await this.LoginFlow.page;
-        const handle = await page.$( iframe );
-        const frame = await handle.contentFrame();
-
-        // Save as draft.
-        await frame.waitForSelector( saveDraftButton );
-        await frame.click( saveDraftButton );
-        await frame.waitForSelector( savedSelector );
-
-        // Publish post.
-        await frame.waitForSelector( prePublishButtonSelector );
-        await frame.click( prePublishButtonSelector );
-
-        // Choose to publish post.
-        await frame.waitForSelector( publishSelector );
-        await frame.click( publishSelector );
-
-        // Look for snackbar/toast that appears on successful publishing.
-        // Visit the site from that link.
-        await frame.waitForSelector( snackBarNotice );
-        page.waitForNavigation();
-        return await frame.click( snackBarNoticeLinkSelector );
-    });
-
-    it( `Can see the Click to Tweet block in our published post`, async function () {
-        const clickToTweetBlock = '.entry-content .wp-block-coblocks-click-to-tweet';
-
-        const page = this.LoginFlow.page;
-
-        return await page.waitForSelector( clickToTweetBlock );
-    });
-
-    after( async function() {
-        await browser.close();
+    describe( `Insert a Click to Tweet block`, function () {
+        it( `Can log in and start a new post`, async function() {
+            this.LoginFlow = new LoginFlow( browser, gutenbergUser );
+            await this.LoginFlow.loginAndStartNewPost();
+            this.GutenbergEditorComponent = new GutenbergEditorComponent( this.LoginFlow.page );
+            // Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
+            await this.GutenbergEditorComponent._init();
+        });
+    
+        it( `Can insert the Click to Tweet block`, async function() {
+            const editor = await this.GutenbergEditorComponent;
+            const blockName = 'Click to Tweet';
+            
+            await editor.openBlockInserter();
+            await editor.searchBlock( blockName );
+            return await editor.addBlock( blockName );    
+        });
+    
+        it( `Can enter text to tweet`, async function () {
+            const editor = await this.GutenbergEditorComponent;
+            const blockSelector = '.wp-block-coblocks-click-to-tweet__text';
+            const tweetContent = 'The foolish man seeks happiness in the distance. The wise grows it under his feet. — James Oppenheim';
+    
+            return await editor.fillText( blockSelector, tweetContent );
+        });
+    
+        it( `Can publish and view content`, async function () {
+            const editor = this.GutenbergEditorComponent;
+    
+            await editor.saveDraft();
+            await editor.publishPost();
+            await editor.confirmPostPublished();
+            return await editor.visitPublishedPost();
+        });
+    
+        it( `Can see the Click to Tweet block in our published post`, async function () {
+            const clickToTweetBlock = '.entry-content .wp-block-coblocks-click-to-tweet';
+            const page = this.LoginFlow.page;
+    
+            return await page.waitForSelector( clickToTweetBlock );
+        });
     })
 
+    describe( `Insert a Dynamic HR block`, function () {
+        it( `Can log in and start a new post`, async function() {
+            this.LoginFlow = new LoginFlow( browser, gutenbergUser );
+            await this.LoginFlow.loginAndStartNewPost();
+            this.GutenbergEditorComponent = new GutenbergEditorComponent( this.LoginFlow.page );
+            // Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
+            await this.GutenbergEditorComponent._init();
+        });
+
+        it( 'Can insert the Dynamic HR block', async function () {
+            const editor = this.GutenbergEditorComponent;
+            const blockName = 'Dynamic HR';
+
+            await editor.openBlockInserter();
+            await editor.searchBlock( blockName );
+            return await editor.addBlock( blockName );
+        });
+
+        it( `Can publish and view content`, async function () {
+            const editor = this.GutenbergEditorComponent;
+    
+            await editor.publishPost();
+            await editor.confirmPostPublished();
+            return await editor.visitPublishedPost();
+        });
+
+        it( `Can see the Dynamic HR block in our published post`, async function () {
+            const dynamicHRBlock = '.entry-content .wp-block-coblocks-dynamic-separator';
+            const page = this.LoginFlow.page;
+    
+            return await page.waitForSelector( dynamicHRBlock );
+        });
+    })
+
+    describe( `Insert a Hero block`, function() {
+        it( `Can log in and start a new post`, async function() {
+            this.LoginFlow = new LoginFlow( browser, gutenbergUser );
+            await this.LoginFlow.loginAndStartNewPost();
+            this.GutenbergEditorComponent = new GutenbergEditorComponent( this.LoginFlow.page );
+            // Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
+            await this.GutenbergEditorComponent._init();
+        });
+
+        it( 'Can insert the Hero block', async function () {
+            const editor = this.GutenbergEditorComponent;
+            const blockName = 'Hero';
+
+            await editor.openBlockInserter();
+            await editor.searchBlock( blockName );
+            return await editor.addBlock( blockName );
+        });
+
+        it( `Can publish and view content`, async function () {
+            const editor = this.GutenbergEditorComponent;
+    
+            await editor.publishPost();
+            await editor.confirmPostPublished();
+            return await editor.visitPublishedPost();
+        });
+
+        it( `Can see the Hero block in our published post`, async function () {
+            const heroBlock = '.entry-content .wp-block-coblocks-hero';
+            const page = this.LoginFlow.page;
+    
+            return await page.waitForSelector( heroBlock );
+        });
+    })
+
+    describe( `Insert a Logos block`, function() {
+        let fileDetails;
+
+        // Create image file for upload
+		before( async function () {
+			fileDetails = await mediaHelper.createFile();
+			return fileDetails;
+		});
+
+        it( `Can log in and start a new post`, async function() {
+            this.LoginFlow = new LoginFlow( browser, gutenbergUser );
+            await this.LoginFlow.loginAndStartNewPost();
+            this.GutenbergEditorComponent = new GutenbergEditorComponent( this.LoginFlow.page );
+            // Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
+            await this.GutenbergEditorComponent._init();
+        });
+
+        it( 'Can insert the Logos block', async function () {
+            const editor = this.GutenbergEditorComponent;
+            const blockName = 'Logos';
+
+            await editor.openBlockInserter();
+            await editor.searchBlock( blockName );
+            return await editor.addBlock( blockName );
+        });
+
+        it( `Can select an image as a logo`, async function () {
+            const editor = this.GutenbergEditorComponent;
+            const fileInputSelector = '.components-form-file-upload input[type="file"]';
+            
+            return await editor.uploadFile( '.block-editor-media-placeholder', fileInputSelector, fileDetails.file );
+        });
+
+        it( `Can publish and view content`, async function () {
+            const editor = this.GutenbergEditorComponent;
+    
+            await editor.publishPost();
+            await editor.confirmPostPublished();
+            return await editor.visitPublishedPost();
+        });
+
+        it( `Can see the Hero block in our published post`, async function () {
+            const logosBlock = '.entry-content .wp-block-coblocks-logos'
+            const page = this.LoginFlow.page;
+    
+            return await page.waitForSelector( logosBlock );
+        });
+    })
+})
+
+after( async function() {
+    await browser.close();
 })

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
@@ -20,214 +20,220 @@ const gutenbergUser = 'gutenbergSimpleSiteUser';
 
 // The intention here is to launch exactly one instance of the browser
 // and context. Playwright launches browsers in incognito mode to ensure a clean context (session).
-let browser, context;
+let browser;
+let browserContext;
 
-before( async function() {
-    browser = await playwright.chromium.launch({headless: false, devtools: false });
-    context = await browser.newContext();
-});
+before( async function () {
+	browser = await playwright.chromium.launch( { headless: false, devtools: false } );
+	browserContext = await browser.newContext();
+} );
 
 describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
-    this.timeout( mochaTimeOut );
+	this.timeout( mochaTimeOut );
 
-    describe( `Insert a Click to Tweet block`, function () {
-        let page;
+	describe( `Insert a Click to Tweet block`, function () {
+		let page;
 
-        it( `Can log in and start a new post`, async function() {
-            this.LoginFlow = new LoginFlow( context, gutenbergUser );
-            page = await this.LoginFlow.loginAndStartNewPost();
-            // Initialize an instance of GutenbergEditorComponent with reference to the current page.
-            this.GutenbergEditorComponent = new GutenbergEditorComponent( page );
-            // Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
-            await this.GutenbergEditorComponent._init(); 
-        });
-    
-        it( `Can insert the Click to Tweet block`, async function() {
-            const editor = await this.GutenbergEditorComponent;
-            const blockName = 'Click to Tweet';
-            
-            await editor.openBlockInserter();
-            await editor.searchBlock( blockName );
-            return await editor.addBlock( blockName );    
-        });
-    
-        it( `Can enter text to tweet`, async function () {
-            const editor = await this.GutenbergEditorComponent;
-            const blockSelector = '.wp-block-coblocks-click-to-tweet__text';
-            const tweetContent = 'The foolish man seeks happiness in the distance. The wise grows it under his feet. — James Oppenheim';
-    
-            return await editor.fillText( blockSelector, tweetContent );
-        });
-    
-        it( `Can publish and view content`, async function () {
-            const editor = this.GutenbergEditorComponent;
-    
-            await editor.saveDraft();
-            await editor.publishPost();
-            await editor.confirmPostPublished();
-            return await editor.visitPublishedPost();
-        });
-    
-        it( `Can see the Click to Tweet block in our published post`, async function () {
-            const clickToTweetBlock = '.entry-content .wp-block-coblocks-click-to-tweet';
-    
-            return await page.waitForSelector( clickToTweetBlock );
-        });
-    })
+		it( `Can log in and start a new post`, async function () {
+			this.LoginFlow = new LoginFlow( browserContext, gutenbergUser );
+			page = await this.LoginFlow.loginAndStartNewPost();
+			// Initialize an instance of GutenbergEditorComponent with reference to the current page.
+			this.GutenbergEditorComponent = new GutenbergEditorComponent( page );
+			// Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
+			await this.GutenbergEditorComponent._init();
+		} );
 
-    describe( `Insert a Dynamic HR block`, function () {
-        let page;
+		it( `Can insert the Click to Tweet block`, async function () {
+			const editor = await this.GutenbergEditorComponent;
+			const blockName = 'Click to Tweet';
 
-        it( `Can log in and start a new post`, async function() {
-            this.LoginFlow = new LoginFlow(context, gutenbergUser);
-            page = await this.LoginFlow.loginAndStartNewPost();
-            this.GutenbergEditorComponent = new GutenbergEditorComponent(page);
-            await this.GutenbergEditorComponent._init();
-        });
+			await editor.openBlockInserter();
+			await editor.searchBlock( blockName );
+			return await editor.addBlock( blockName );
+		} );
 
-        it( `Can insert the Dynamic HR block`, async function () {
-            const editor = this.GutenbergEditorComponent;
-            const blockName = 'Dynamic HR';
+		it( `Can enter text to tweet`, async function () {
+			const editor = await this.GutenbergEditorComponent;
+			const blockSelector = '.wp-block-coblocks-click-to-tweet__text';
+			const tweetContent =
+				'The foolish man seeks happiness in the distance. The wise grows it under his feet. — James Oppenheim';
 
-            await editor.openBlockInserter();
-            await editor.searchBlock( blockName );
-            return await editor.addBlock( blockName );
-        });
+			return await editor.fillText( blockSelector, tweetContent );
+		} );
 
-        it( `Can publish and view content`, async function () {
-            const editor = this.GutenbergEditorComponent;
-    
-            await editor.publishPost();
-            await editor.confirmPostPublished();
-            return await editor.visitPublishedPost();
-        });
+		it( `Can publish and view content`, async function () {
+			const editor = this.GutenbergEditorComponent;
 
-        it( `Can see the Dynamic HR block in our published post`, async function () {
-            const dynamicHRBlock = '.entry-content .wp-block-coblocks-dynamic-separator';
-    
-            return await page.waitForSelector( dynamicHRBlock );
-        });
-    })
+			await editor.saveDraft();
+			await editor.publishPost();
+			await editor.confirmPostPublished();
+			return await editor.visitPublishedPost();
+		} );
 
-    describe( `Insert a Hero block`, function() {
-        let page;
+		it( `Can see the Click to Tweet block in our published post`, async function () {
+			const clickToTweetBlock = '.entry-content .wp-block-coblocks-click-to-tweet';
 
-        it( `Can log in and start a new post`, async function() {
-            this.LoginFlow = new LoginFlow(context, gutenbergUser);
-            page = await this.LoginFlow.loginAndStartNewPost();
-            this.GutenbergEditorComponent = new GutenbergEditorComponent(page);
-            await this.GutenbergEditorComponent._init();
-        });
+			return await page.waitForSelector( clickToTweetBlock );
+		} );
+	} );
 
-        it( `Can insert the Hero block`, async function () {
-            const editor = this.GutenbergEditorComponent;
-            const blockName = 'Hero';
+	describe( `Insert a Dynamic HR block`, function () {
+		let page;
 
-            await editor.openBlockInserter();
-            await editor.searchBlock( blockName );
-            return await editor.addBlock( blockName );
-        });
+		it( `Can log in and start a new post`, async function () {
+			this.LoginFlow = new LoginFlow( browserContext, gutenbergUser );
+			page = await this.LoginFlow.loginAndStartNewPost();
+			this.GutenbergEditorComponent = new GutenbergEditorComponent( page );
+			await this.GutenbergEditorComponent._init();
+		} );
 
-        it( `Can publish and view content`, async function () {
-            const editor = this.GutenbergEditorComponent;
-    
-            await editor.publishPost();
-            await editor.confirmPostPublished();
-            return await editor.visitPublishedPost();
-        });
+		it( `Can insert the Dynamic HR block`, async function () {
+			const editor = this.GutenbergEditorComponent;
+			const blockName = 'Dynamic HR';
 
-        it( `Can see the Hero block in our published post`, async function () {
-            const heroBlock = '.entry-content .wp-block-coblocks-hero';
-    
-            return await page.waitForSelector( heroBlock );
-        });
-    })
+			await editor.openBlockInserter();
+			await editor.searchBlock( blockName );
+			return await editor.addBlock( blockName );
+		} );
 
-    describe( `Insert a Logos block`, function() {
-        let page;
-        let fileDetails;
+		it( `Can publish and view content`, async function () {
+			const editor = this.GutenbergEditorComponent;
 
-        // Create image file for upload
+			await editor.publishPost();
+			await editor.confirmPostPublished();
+			return await editor.visitPublishedPost();
+		} );
+
+		it( `Can see the Dynamic HR block in our published post`, async function () {
+			const dynamicHRBlock = '.entry-content .wp-block-coblocks-dynamic-separator';
+
+			return await page.waitForSelector( dynamicHRBlock );
+		} );
+	} );
+
+	describe( `Insert a Hero block`, function () {
+		let page;
+
+		it( `Can log in and start a new post`, async function () {
+			this.LoginFlow = new LoginFlow( browserContext, gutenbergUser );
+			page = await this.LoginFlow.loginAndStartNewPost();
+			this.GutenbergEditorComponent = new GutenbergEditorComponent( page );
+			await this.GutenbergEditorComponent._init();
+		} );
+
+		it( `Can insert the Hero block`, async function () {
+			const editor = this.GutenbergEditorComponent;
+			const blockName = 'Hero';
+
+			await editor.openBlockInserter();
+			await editor.searchBlock( blockName );
+			return await editor.addBlock( blockName );
+		} );
+
+		it( `Can publish and view content`, async function () {
+			const editor = this.GutenbergEditorComponent;
+
+			await editor.publishPost();
+			await editor.confirmPostPublished();
+			return await editor.visitPublishedPost();
+		} );
+
+		it( `Can see the Hero block in our published post`, async function () {
+			const heroBlock = '.entry-content .wp-block-coblocks-hero';
+
+			return await page.waitForSelector( heroBlock );
+		} );
+	} );
+
+	describe( `Insert a Logos block`, function () {
+		let page;
+		let fileDetails;
+
+		// Create image file for upload
 		before( async function () {
 			fileDetails = mediaHelper.createFile();
 			return fileDetails;
-		});
+		} );
 
-        it( `Can log in and start a new post`, async function() {
-            this.LoginFlow = new LoginFlow(context, gutenbergUser);
-            page = await this.LoginFlow.loginAndStartNewPost();
-            // Initialize an instance of GutenbergEditorComponent with reference to the current page.
-            this.GutenbergEditorComponent = new GutenbergEditorComponent(page);
-            // Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
-            await this.GutenbergEditorComponent._init();
-        });
+		it( `Can log in and start a new post`, async function () {
+			this.LoginFlow = new LoginFlow( browserContext, gutenbergUser );
+			page = await this.LoginFlow.loginAndStartNewPost();
+			// Initialize an instance of GutenbergEditorComponent with reference to the current page.
+			this.GutenbergEditorComponent = new GutenbergEditorComponent( page );
+			// Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
+			await this.GutenbergEditorComponent._init();
+		} );
 
-        it( `Can insert the Logos block`, async function () {
-            const editor = this.GutenbergEditorComponent;
-            const blockName = 'Logos';
+		it( `Can insert the Logos block`, async function () {
+			const editor = this.GutenbergEditorComponent;
+			const blockName = 'Logos';
 
-            await editor.openBlockInserter();
-            await editor.searchBlock( blockName );
-            return await editor.addBlock( blockName );
-        });
+			await editor.openBlockInserter();
+			await editor.searchBlock( blockName );
+			return await editor.addBlock( blockName );
+		} );
 
-        it( `Can select an image as a logo`, async function () {
-            const editor = this.GutenbergEditorComponent;
-            const fileInputSelector = '.components-form-file-upload input[type="file"]';
-            
-            return await editor.uploadFile( '.block-editor-media-placeholder', fileInputSelector, fileDetails.file );
-        });
+		it( `Can select an image as a logo`, async function () {
+			const editor = this.GutenbergEditorComponent;
+			const fileInputSelector = '.components-form-file-upload input[type="file"]';
 
-        it( `Can publish and view content`, async function () {
-            const editor = this.GutenbergEditorComponent;
-    
-            await editor.publishPost();
-            await editor.confirmPostPublished();
-            return await editor.visitPublishedPost();
-        });
+			return await editor.uploadFile(
+				'.block-editor-media-placeholder',
+				fileInputSelector,
+				fileDetails.file
+			);
+		} );
 
-        it( `Can see the Logo block in our published post`, async function () {
-            const logosBlock = '.entry-content .wp-block-coblocks-logos';
-    
-            return await page.waitForSelector( logosBlock );
-        });
-    })
+		it( `Can publish and view content`, async function () {
+			const editor = this.GutenbergEditorComponent;
 
-    describe( `Insert a Pricing Table block`, async function() {
-        let page;
+			await editor.publishPost();
+			await editor.confirmPostPublished();
+			return await editor.visitPublishedPost();
+		} );
 
-        it( `Can log in and start a new post` , async function () {
-            this.LoginFlow = new LoginFlow(context, gutenbergUser);
-            page = await this.LoginFlow.loginAndStartNewPost();
-            this.GutenbergEditorComponent = new GutenbergEditorComponent(page);
-            await this.GutenbergEditorComponent._init();
-        });
+		it( `Can see the Logo block in our published post`, async function () {
+			const logosBlock = '.entry-content .wp-block-coblocks-logos';
 
-        it( `Can insert the Pricing Table block`, async function () {
-            const editor = this.GutenbergEditorComponent;
-            const blockName = 'Pricing Table';
+			return await page.waitForSelector( logosBlock );
+		} );
+	} );
 
-            await editor.openBlockInserter();
-            await editor.searchBlock( blockName );
-            return await editor.addBlock( blockName );
-        });
+	describe( `Insert a Pricing Table block`, async function () {
+		let page;
 
-        it( `Can publish and view content`, async function () {
-            const editor = this.GutenbergEditorComponent;
+		it( `Can log in and start a new post`, async function () {
+			this.LoginFlow = new LoginFlow( browserContext, gutenbergUser );
+			page = await this.LoginFlow.loginAndStartNewPost();
+			this.GutenbergEditorComponent = new GutenbergEditorComponent( page );
+			await this.GutenbergEditorComponent._init();
+		} );
 
-            await editor.publishPost();
-            await editor.confirmPostPublished();
-            return await editor.visitPublishedPost();
-        });
+		it( `Can insert the Pricing Table block`, async function () {
+			const editor = this.GutenbergEditorComponent;
+			const blockName = 'Pricing Table';
 
-        it( `Can see the Pricing Table block in our published post`, async function () {
-            const pricingTableBlock = '.entry-content .wp-block-coblocks-pricing-table';
+			await editor.openBlockInserter();
+			await editor.searchBlock( blockName );
+			return await editor.addBlock( blockName );
+		} );
 
-            return await page.waitForSelector( pricingTableBlock );
-        });
-    })
-})
+		it( `Can publish and view content`, async function () {
+			const editor = this.GutenbergEditorComponent;
 
-after( async function() {
-    await browser.close();
-});
+			await editor.publishPost();
+			await editor.confirmPostPublished();
+			return await editor.visitPublishedPost();
+		} );
+
+		it( `Can see the Pricing Table block in our published post`, async function () {
+			const pricingTableBlock = '.entry-content .wp-block-coblocks-pricing-table';
+
+			return await page.waitForSelector( pricingTableBlock );
+		} );
+	} );
+} );
+
+after( async function () {
+	await browser.close();
+} );

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
@@ -16,25 +16,30 @@ import * as mediaHelper from '../lib/media-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
-const gutenbergUser =
-    process.env.COBLOCKS_EDGE === 'true' ? 'coBlocksSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
+const gutenbergUser = 'gutenbergSimpleSiteUser';
 
-let browser;
+// The intention here is to launch exactly one instance of the browser
+// and context. Playwright launches browsers in incognito mode to ensure a clean context (session).
+let browser, context;
 
 before( async function() {
     browser = await playwright.chromium.launch({headless: false, devtools: false });
+    context = await browser.newContext();
 });
 
 describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
     this.timeout( mochaTimeOut );
 
     describe( `Insert a Click to Tweet block`, function () {
+        let page;
+
         it( `Can log in and start a new post`, async function() {
-            this.LoginFlow = new LoginFlow( browser, gutenbergUser );
-            await this.LoginFlow.loginAndStartNewPost();
-            this.GutenbergEditorComponent = new GutenbergEditorComponent( this.LoginFlow.page );
+            this.LoginFlow = new LoginFlow( context, gutenbergUser );
+            page = await this.LoginFlow.loginAndStartNewPost();
+            // Initialize an instance of GutenbergEditorComponent with reference to the current page.
+            this.GutenbergEditorComponent = new GutenbergEditorComponent( page );
             // Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
-            await this.GutenbergEditorComponent._init();
+            await this.GutenbergEditorComponent._init(); 
         });
     
         it( `Can insert the Click to Tweet block`, async function() {
@@ -65,18 +70,18 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
     
         it( `Can see the Click to Tweet block in our published post`, async function () {
             const clickToTweetBlock = '.entry-content .wp-block-coblocks-click-to-tweet';
-            const page = this.LoginFlow.page;
     
             return await page.waitForSelector( clickToTweetBlock );
         });
     })
 
     describe( `Insert a Dynamic HR block`, function () {
+        let page;
+
         it( `Can log in and start a new post`, async function() {
-            this.LoginFlow = new LoginFlow( browser, gutenbergUser );
-            await this.LoginFlow.loginAndStartNewPost();
-            this.GutenbergEditorComponent = new GutenbergEditorComponent( this.LoginFlow.page );
-            // Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
+            this.LoginFlow = new LoginFlow(context, gutenbergUser);
+            page = await this.LoginFlow.loginAndStartNewPost();
+            this.GutenbergEditorComponent = new GutenbergEditorComponent(page);
             await this.GutenbergEditorComponent._init();
         });
 
@@ -99,18 +104,18 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
 
         it( `Can see the Dynamic HR block in our published post`, async function () {
             const dynamicHRBlock = '.entry-content .wp-block-coblocks-dynamic-separator';
-            const page = this.LoginFlow.page;
     
             return await page.waitForSelector( dynamicHRBlock );
         });
     })
 
     describe( `Insert a Hero block`, function() {
+        let page;
+
         it( `Can log in and start a new post`, async function() {
-            this.LoginFlow = new LoginFlow( browser, gutenbergUser );
-            await this.LoginFlow.loginAndStartNewPost();
-            this.GutenbergEditorComponent = new GutenbergEditorComponent( this.LoginFlow.page );
-            // Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
+            this.LoginFlow = new LoginFlow(context, gutenbergUser);
+            page = await this.LoginFlow.loginAndStartNewPost();
+            this.GutenbergEditorComponent = new GutenbergEditorComponent(page);
             await this.GutenbergEditorComponent._init();
         });
 
@@ -133,25 +138,26 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
 
         it( `Can see the Hero block in our published post`, async function () {
             const heroBlock = '.entry-content .wp-block-coblocks-hero';
-            const page = this.LoginFlow.page;
     
             return await page.waitForSelector( heroBlock );
         });
     })
 
     describe( `Insert a Logos block`, function() {
+        let page;
         let fileDetails;
 
         // Create image file for upload
 		before( async function () {
-			fileDetails = await mediaHelper.createFile();
+			fileDetails = mediaHelper.createFile();
 			return fileDetails;
 		});
 
         it( `Can log in and start a new post`, async function() {
-            this.LoginFlow = new LoginFlow( browser, gutenbergUser );
-            await this.LoginFlow.loginAndStartNewPost();
-            this.GutenbergEditorComponent = new GutenbergEditorComponent( this.LoginFlow.page );
+            this.LoginFlow = new LoginFlow(context, gutenbergUser);
+            page = await this.LoginFlow.loginAndStartNewPost();
+            // Initialize an instance of GutenbergEditorComponent with reference to the current page.
+            this.GutenbergEditorComponent = new GutenbergEditorComponent(page);
             // Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
             await this.GutenbergEditorComponent._init();
         });
@@ -182,18 +188,18 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
 
         it( `Can see the Logo block in our published post`, async function () {
             const logosBlock = '.entry-content .wp-block-coblocks-logos';
-            const page = this.LoginFlow.page;
     
             return await page.waitForSelector( logosBlock );
         });
     })
 
     describe( `Insert a Pricing Table block`, async function() {
+        let page;
+
         it( `Can log in and start a new post` , async function () {
-            this.LoginFlow = new LoginFlow( browser, gutenbergUser );
-            await this.LoginFlow.loginAndStartNewPost();
-            this.GutenbergEditorComponent = new GutenbergEditorComponent( this.LoginFlow.page );
-            // Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
+            this.LoginFlow = new LoginFlow(context, gutenbergUser);
+            page = await this.LoginFlow.loginAndStartNewPost();
+            this.GutenbergEditorComponent = new GutenbergEditorComponent(page);
             await this.GutenbergEditorComponent._init();
         });
 
@@ -216,7 +222,6 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
 
         it( `Can see the Pricing Table block in our published post`, async function () {
             const pricingTableBlock = '.entry-content .wp-block-coblocks-pricing-table';
-            const page = this.LoginFlow.page;
 
             return await page.waitForSelector( pricingTableBlock );
         });

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
@@ -225,4 +225,4 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
 
 after( async function() {
     await browser.close();
-})
+});

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import playwright from 'playwright';
 import config from 'config';
 
@@ -23,20 +22,107 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
     let browser;
 
     before( async function() {
-        browser = await playwright.chromium.launch({headless: false});
+        browser = await playwright.chromium.launch({headless: false, devtools: true });
     });
 
     it( `Can log in`, async function() {
         this.LoginFlow = new LoginFlow( browser, gutenbergUser );
-        return await this.LoginFlow.login();
+        return await this.LoginFlow.loginAndStartNewPost();
     });
 
     it( `Can insert the Click to Tweet block`, async function() {
-        // steps    
-    })
+        // The block editor is within an iframe and puppeteer/playwright cannot see such elements
+        // without selecting the iframe.
+        const iframe = '.main > iframe:nth-child(1)'
+        const toggleBlockInserter = '.edit-post-header .edit-post-header-toolbar__inserter-toggle';
+        const inserterBlockSearch = 'input.block-editor-inserter__search-input';
+        const insertClickToTweetButton = '.edit-post-layout__inserter-panel .block-editor-inserter__block-list button.editor-block-list-item-coblocks-click-to-tweet';
+        const clickToTweetBlock = '.wp-block-coblocks-click-to-tweet';
+
+        // Retrieve the page object.
+        const page = await this.LoginFlow.page;
+        await page.waitForSelector( iframe );
+
+        // Obtain the main block editor window iframe.
+        const handle = await page.$( iframe );
+        const frame = await handle.contentFrame();
+
+        // From this point on, interact with the frame.
+        await frame.waitForSelector( toggleBlockInserter );
+        await frame.click( toggleBlockInserter );
+        await frame.waitForSelector( inserterBlockSearch );
+        await frame.focus( inserterBlockSearch );
+        await frame.fill( inserterBlockSearch, 'Click to tweet' );
+        await frame.waitForSelector( insertClickToTweetButton );
+        await frame.click( insertClickToTweetButton );
+
+        return await frame.waitForSelector( clickToTweetBlock );
+    });
+
+    it( `Can enter text to tweet`, async function () {
+        const iframe = '.main > iframe:nth-child(1)'
+        const clickToTweetTextInput = '.wp-block-coblocks-click-to-tweet__text';
+        const tweetContent = 'The foolish man seeks happiness in the distance. The wise grows it under his feet. — James Oppenheim';
+        
+        const page = await this.LoginFlow.page;
+        const handle = await page.$( iframe );
+        const frame = await handle.contentFrame();
+
+        await frame.waitForSelector( clickToTweetTextInput );
+        await frame.focus( clickToTweetTextInput );
+        return await frame.fill( clickToTweetTextInput, tweetContent);
+    });
+
+    it( `Can publish and view content`, async function () {
+        const iframe = '.main > iframe:nth-child(1)'
+        const saveDraftButton = '.editor-post-save-draft';
+        const savedSelector = 'span.is-saved';
+        const snackBarNotice = '.components-snackbar';
+        const snackBarNoticeLinkSelector = '.components-snackbar__content a';
+        const prePublishButtonSelector = '.editor-post-publish-panel__toggle';
+        const publishSelector = '.editor-post-publish-panel__header-publish-button button.editor-post-publish-button';
+        const viewPublishedPostButton = 'text="View Post"';
+
+        const page = await this.LoginFlow.page;
+        const handle = await page.$( iframe );
+        const frame = await handle.contentFrame();
+
+        // Save as draft.
+        await frame.waitForSelector( saveDraftButton );
+        await frame.click( saveDraftButton );
+        await frame.waitForSelector( savedSelector );
+
+        // Publish post.
+        await frame.waitForSelector( prePublishButtonSelector );
+        await frame.click( prePublishButtonSelector );
+
+        // Choose to publish post.
+        await frame.waitForSelector( publishSelector );
+        await frame.click( publishSelector );
+
+        // Look for snackbar/toast that appears on successful publishing.
+        // Visit the site from that link.
+        // const editorURL = await page.url();
+        await frame.waitForSelector( snackBarNotice );
+        page.waitForNavigation();
+        return await frame.click( snackBarNoticeLinkSelector );
+
+        // const publishedURL = await page.url();
+
+        // Wait for the site-content div to load.
+        // return await page.waitForSelector( 'site-content' );
+    });
+
+    it( `Can see the Click to Tweet block in our published post`, async function () {
+        const clickToTweetBlock = '.entry-content .wp-block-coblocks-click-to-tweet';
+
+        const page = this.LoginFlow.page;
+
+        return await page.waitForSelector( clickToTweetBlock );
+    });
 
     after( async function() {
-        await browser.close()
+        await browser.close();
     })
 
 })

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-playwright.js
@@ -80,7 +80,7 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
             await this.GutenbergEditorComponent._init();
         });
 
-        it( 'Can insert the Dynamic HR block', async function () {
+        it( `Can insert the Dynamic HR block`, async function () {
             const editor = this.GutenbergEditorComponent;
             const blockName = 'Dynamic HR';
 
@@ -114,7 +114,7 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
             await this.GutenbergEditorComponent._init();
         });
 
-        it( 'Can insert the Hero block', async function () {
+        it( `Can insert the Hero block`, async function () {
             const editor = this.GutenbergEditorComponent;
             const blockName = 'Hero';
 
@@ -156,7 +156,7 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
             await this.GutenbergEditorComponent._init();
         });
 
-        it( 'Can insert the Logos block', async function () {
+        it( `Can insert the Logos block`, async function () {
             const editor = this.GutenbergEditorComponent;
             const blockName = 'Logos';
 
@@ -180,11 +180,45 @@ describe( `Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function () {
             return await editor.visitPublishedPost();
         });
 
-        it( `Can see the Hero block in our published post`, async function () {
-            const logosBlock = '.entry-content .wp-block-coblocks-logos'
+        it( `Can see the Logo block in our published post`, async function () {
+            const logosBlock = '.entry-content .wp-block-coblocks-logos';
             const page = this.LoginFlow.page;
     
             return await page.waitForSelector( logosBlock );
+        });
+    })
+
+    describe( `Insert a Pricing Table block`, async function() {
+        it( `Can log in and start a new post` , async function () {
+            this.LoginFlow = new LoginFlow( browser, gutenbergUser );
+            await this.LoginFlow.loginAndStartNewPost();
+            this.GutenbergEditorComponent = new GutenbergEditorComponent( this.LoginFlow.page );
+            // Fulfills a similar role to the GutenbergEditorComponent.Expect() call of the in-repo file.
+            await this.GutenbergEditorComponent._init();
+        });
+
+        it( `Can insert the Pricing Table block`, async function () {
+            const editor = this.GutenbergEditorComponent;
+            const blockName = 'Pricing Table';
+
+            await editor.openBlockInserter();
+            await editor.searchBlock( blockName );
+            return await editor.addBlock( blockName );
+        });
+
+        it( `Can publish and view content`, async function () {
+            const editor = this.GutenbergEditorComponent;
+
+            await editor.publishPost();
+            await editor.confirmPostPublished();
+            return await editor.visitPublishedPost();
+        });
+
+        it( `Can see the Pricing Table block in our published post`, async function () {
+            const pricingTableBlock = '.entry-content .wp-block-coblocks-pricing-table';
+            const page = this.LoginFlow.page;
+
+            return await page.waitForSelector( pricingTableBlock );
         });
     })
 })

--- a/test/e2e/specs/wp-calypso-seo-preview-playwright.js
+++ b/test/e2e/specs/wp-calypso-seo-preview-playwright.js
@@ -15,62 +15,63 @@ import LoginFlow from '../lib/flows/login-flow-playwright.js';
 
 import SidebarComponent from '../lib/components/sidebar-component-playwright.js';
 
-const mochaTimeOut = config.get('mochaTimeoutMS');
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
-let browser, context;
+let browser;
+let context;
 
-before(async function () {
-    browser = await playwright.chromium.launch({ headless: false, devtools: false });
-    context = await browser.newContext();
-});
+before( async function () {
+	browser = await playwright.chromium.launch( { headless: false, devtools: false } );
+	context = await browser.newContext();
+} );
 
 describe( `[${ host }] SEO Preview page: (${ screenSize })`, function () {
-    this.timeout( mochaTimeOut );
+	this.timeout( mochaTimeOut );
 
-    // Login as Business plan user and open the sidebar
-    describe( `SEO Preview page:`, function () {
-        let page;
+	// Login as Business plan user and open the sidebar
+	describe( `SEO Preview page:`, function () {
+		let page;
 
-        it( `Can log in`, async function () {
-            this.LoginFlow = new LoginFlow( context, 'wooCommerceUser' );
-            page = await this.LoginFlow.loginAndSelectMySites();
-            this.sidebarComponent = new SidebarComponent( page );
-            return await this.sidebarComponent._init();
-        });
+		it( `Can log in`, async function () {
+			this.LoginFlow = new LoginFlow( context, 'wooCommerceUser' );
+			page = await this.LoginFlow.loginAndSelectMySites();
+			this.sidebarComponent = new SidebarComponent( page );
+			return await this.sidebarComponent._init();
+		} );
 
-        it( `Open the marketing page`, async function () {
-            return await this.sidebarComponent.selectMarketing();
-        });
+		it( `Open the marketing page`, async function () {
+			return await this.sidebarComponent.selectMarketing();
+		} );
 
-        it( `Enter front page meta description and click preview button`, async function () {
-            // In a production system, these should have its own page object, like the current in-repo
-            // tests do.
-            const trafficTabSelector = '.section-nav-tab__link[href*="/marketing/traffic/"]';
-            const frontPageMetaDescriptionSelector = '#advanced_seo_front_page_description';
-            const frontPageMetaDescriptionPreviewButton = '.seo-settings__preview-button';
+		it( `Enter front page meta description and click preview button`, async function () {
+			// In a production system, these should have its own page object, like the current in-repo
+			// tests do.
+			const trafficTabSelector = '.section-nav-tab__link[href*="/marketing/traffic/"]';
+			const frontPageMetaDescriptionSelector = '#advanced_seo_front_page_description';
+			const frontPageMetaDescriptionPreviewButton = '.seo-settings__preview-button';
 
-            await page.waitForSelector( trafficTabSelector );
-            await page.click( trafficTabSelector );
-            await page.waitForSelector( frontPageMetaDescriptionSelector );
-            await page.fill( frontPageMetaDescriptionSelector, 'test text' );
-            return await page.click( frontPageMetaDescriptionPreviewButton );
-        });
+			await page.waitForSelector( trafficTabSelector );
+			await page.click( trafficTabSelector );
+			await page.waitForSelector( frontPageMetaDescriptionSelector );
+			await page.fill( frontPageMetaDescriptionSelector, 'test text' );
+			return await page.click( frontPageMetaDescriptionPreviewButton );
+		} );
 
-        it( `Ensure site preview stays open for 10 seconds`, async function () {
-            const seoPreview = '.web-preview.is-seo';
-            
-            await page.waitForSelector( seoPreview );
-            await page.waitForTimeout( 10000 );
+		it( `Ensure site preview stays open for 10 seconds`, async function () {
+			const seoPreview = '.web-preview.is-seo';
 
-            // To test this, try closing the preview manually. It will fail the assertion.
-            let previewIsOpen = await page.$$( seoPreview );
-            assert( previewIsOpen.length > 0, 'The site preview component has been closed.');
-        });
-    })
-});
+			await page.waitForSelector( seoPreview );
+			await page.waitForTimeout( 10000 );
+
+			// To test this, try closing the preview manually. It will fail the assertion.
+			const previewIsOpen = await page.$$( seoPreview );
+			assert( previewIsOpen.length > 0, 'The site preview component has been closed.' );
+		} );
+	} );
+} );
 
 after( async function () {
-    await browser.close();
-});
+	await browser.close();
+} );

--- a/test/e2e/specs/wp-calypso-seo-preview-playwright.js
+++ b/test/e2e/specs/wp-calypso-seo-preview-playwright.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import assert from 'assert';
+import config from 'config';
+import playwright from 'playwright';
+
+/**
+ * Internal dependencies
+ */
+import * as dataHelper from '../lib/data-helper';
+import * as driverManager from '../lib/driver-manager';
+
+import LoginFlow from '../lib/flows/login-flow-playwright.js';
+
+import SidebarComponent from '../lib/components/sidebar-component-playwright.js';
+
+const mochaTimeOut = config.get('mochaTimeoutMS');
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+
+let browser;
+
+before( async function () {
+    browser = await playwright.chromium.launch({ headless: false, devtools: true });
+});
+
+describe( `[${ host }] SEO Preview page: (${ screenSize })`, function () {
+    this.timeout( mochaTimeOut );
+
+    // Login as Business plan user and open the sidebar
+    describe( `SEO Preview page:`, function () {
+        it( `Can log in`, async function () {
+            this.LoginFlow = new LoginFlow( browser, 'wooCommerceUser' );
+            await this.LoginFlow.loginAndSelectMySites();
+            this.sidebarComponent = new SidebarComponent( this.LoginFlow.page );
+            return await this.sidebarComponent._init();
+        });
+
+        it( `Open the marketing page`, async function () {
+            return await this.sidebarComponent.selectMarketing();
+        });
+
+        it( `Enter front page meta description and click preview button`, async function () {
+            // In a production system, these should have its own page object, like the current in-repo
+            // tests do.
+            const trafficTabSelector = '.section-nav-tab__link[href*="/marketing/traffic/"]';
+            const frontPageMetaDescriptionSelector = '#advanced_seo_front_page_description';
+            const frontPageMetaDescriptionPreviewButton = '.seo-settings__preview-button';
+            const page = this.LoginFlow.page;
+
+            await page.waitForSelector( trafficTabSelector );
+            await page.click( trafficTabSelector );
+            await page.waitForSelector( frontPageMetaDescriptionSelector );
+            await page.fill( frontPageMetaDescriptionSelector, 'test text' );
+            return await page.click( frontPageMetaDescriptionPreviewButton );
+        });
+
+        it( `Ensure site preview stays open for 10 seconds`, async function () {
+            const seoPreview = '.web-preview.is-seo';
+            const page = this.LoginFlow.page;
+            
+            await page.waitForSelector( seoPreview );
+            await page.waitForTimeout( 10000 );
+
+            assert( await page.$$( seoPreview ).length > 0, 'The site preview component has been closed.');
+        });
+    })
+});
+
+after( async function () {
+    await browser.close();
+});

--- a/test/e2e/specs/wp-inline-help-support-search-spec-playwright.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec-playwright.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import playwright from 'playwright';
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import * as dataHelper from '../lib/data-helper';
+import * as driverManager from '../lib/driver-manager';
+
+import LoginFlow from '../lib/flows/login-flow-playwright.js';
+
+import SidebarComponent from '../lib/components/sidebar-component-playwright.js';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+const gutenbergUser = 'gutenbergSimpleSiteUser';
+
+let browser;
+let context;
+
+before( async function () {
+	browser = await playwright.chromium.launch( { headless: false, devtools: false } );
+	context = await browser.newContext();
+} );
+
+describe( `[${ host }] Inline Help: (${ screenSize })`, function () {
+	this.timeout( mochaTimeOut );
+	let page;
+
+	it( `Login and select Settings`, async function () {
+		this.LoginFlow = new LoginFlow( context, gutenbergUser );
+		page = await this.LoginFlow.loginAndSelectSettings();
+		this.sidebarComponent = new SidebarComponent( page );
+		return await this.sidebarComponent._init();
+	} );
+} );
+
+after( async function () {
+	await browser.close();
+} );

--- a/test/e2e/specs/wp-inline-help-support-search-spec-playwright.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec-playwright.js
@@ -3,6 +3,7 @@
  */
 import playwright from 'playwright';
 import config from 'config';
+import assert from 'assert';
 
 /**
  * Internal dependencies
@@ -11,6 +12,8 @@ import * as dataHelper from '../lib/data-helper';
 import * as driverManager from '../lib/driver-manager';
 
 import LoginFlow from '../lib/flows/login-flow-playwright.js';
+
+import SupportPage from '../lib/pages/support-page-playwright.js';
 
 import SidebarComponent from '../lib/components/sidebar-component-playwright.js';
 
@@ -23,19 +26,109 @@ let browser;
 let context;
 
 before( async function () {
-	browser = await playwright.chromium.launch( { headless: false, devtools: false } );
+	browser = await playwright.chromium.launch( { headless: false, devtools: true, slowMo: 100 } );
 	context = await browser.newContext();
 } );
 
 describe( `[${ host }] Inline Help: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
+
 	let page;
 
 	it( `Login and select Settings`, async function () {
 		this.LoginFlow = new LoginFlow( context, gutenbergUser );
 		page = await this.LoginFlow.loginAndSelectSettings();
+		this.supportPage = new SupportPage( page );
 		this.sidebarComponent = new SidebarComponent( page );
 		return await this.sidebarComponent._init();
+	} );
+
+	describe( `Popover UI visibility`, function () {
+		it( `Check help toggle is not visible on My Home Page`, async function () {
+			await this.sidebarComponent.selectMyHome();
+			const visible = await this.supportPage.inlineHelpButtonVisible();
+			assert.strictEqual(
+				visible,
+				false,
+				'Inline Help button unexpectedly visisble on My Home Page.'
+			);
+		} );
+
+		it( `Check help toggle is visible on Settings page`, async function () {
+			await this.sidebarComponent.selectSettings();
+			const visible = await this.supportPage.inlineHelpButtonVisible();
+			assert.strictEqual(
+				visible,
+				true,
+				'Inline Help button unexpectedly not visible on Settings page.'
+			);
+		} );
+	} );
+
+	describe( `Performing searches`, function () {
+		it( `Open Inline Help popover`, async function () {
+			await this.supportPage.openInlineHelp();
+			return await this.supportPage.inlineHelpPopoverVisible();
+		} );
+
+		it( `Displays contextual search results by default`, async function () {
+			await this.supportPage.openInlineHelp();
+			const defaultHelpResults = await this.supportPage.getDefaultResultCount();
+			assert.strictEqual( defaultHelpResults, 6, 'There are no contextual results displayed' );
+		} );
+
+		it( `Returns search results for valid search query`, async function () {
+			await this.supportPage.searchForQuery( 'Podcast' );
+			const resultCount = await this.supportPage.getResultCount();
+			assert.strictEqual(
+				resultCount <= 5,
+				true,
+				'Too many search results displayed. Should be less than or equal to 5.'
+			);
+			assert.strictEqual(
+				resultCount >= 1,
+				true,
+				'Too few search results displayed. Should be more than or equal to 1.'
+			);
+		} );
+
+		it( `Resets search UI to default state when search input is cleared`, async function () {
+			await this.supportPage.clearSearchField();
+
+			const defaultHelpResults = await this.supportPage.getDefaultResultCount();
+			assert.strictEqual( defaultHelpResults, 6, 'There are no contextual results displayed.' );
+		} );
+
+		it( `Shows "No results" indicator and re-displays contextual results for search queries which return no results`, async function () {
+			await this.supportPage.searchForQuery( ';;;ppp;;;' );
+
+			const noResultsMessage = await this.supportPage.searchReturnedNoResultsMessage();
+			const resultCount = await this.supportPage.getDefaultResultCount();
+
+			assert.strictEqual( noResultsMessage, true, 'The "No results" message was not displayed.' );
+			assert.strictEqual( resultCount, 6, 'There are no contextual results displayed.' );
+		} );
+
+		it( `Does not request search results for empty search queries`, async function () {
+			await this.supportPage.clearSearchField();
+			await this.supportPage.searchForQuery( '         ' );
+
+			const noResultsMessage = await this.supportPage.searchReturnedNoResultsMessage();
+			const resultCount = await this.supportPage.getDefaultResultCount();
+
+			assert.strictEqual(
+				noResultsMessage,
+				false,
+				'The "No Results" message was unexpectedly displayed.'
+			);
+			assert.strictEqual( resultCount, 6, 'There are no contextual results displayed.' );
+		} );
+
+		it( `Close Inline Help popover`, async function () {
+			await this.supportPage.closeInlineHelp();
+			const visible = await this.supportPage.inlineHelpPopoverVisible();
+			assert.strictEqual( visible, false, 'The Inline Help popover was not closed correctly.' );
+		} );
 	} );
 } );
 

--- a/test/e2e/specs/wp-inline-help-support-search-spec-playwright.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec-playwright.js
@@ -26,7 +26,7 @@ let browser;
 let context;
 
 before( async function () {
-	browser = await playwright.chromium.launch( { headless: false, devtools: true, slowMo: 100 } );
+	browser = await playwright.chromium.launch( { headless: false, devtools: false } );
 	context = await browser.newContext();
 } );
 
@@ -67,8 +67,8 @@ describe( `[${ host }] Inline Help: (${ screenSize })`, function () {
 
 	describe( `Performing searches`, function () {
 		it( `Open Inline Help popover`, async function () {
-			await this.supportPage.openInlineHelp();
-			return await this.supportPage.inlineHelpPopoverVisible();
+			const inlineHelpVisible = await this.supportPage.openInlineHelp();
+			assert.strictEqual( inlineHelpVisible, true, 'Inline Help popover could not be opened.' );
 		} );
 
 		it( `Displays contextual search results by default`, async function () {
@@ -125,9 +125,8 @@ describe( `[${ host }] Inline Help: (${ screenSize })`, function () {
 		} );
 
 		it( `Close Inline Help popover`, async function () {
-			await this.supportPage.closeInlineHelp();
-			const visible = await this.supportPage.inlineHelpPopoverVisible();
-			assert.strictEqual( visible, false, 'The Inline Help popover was not closed correctly.' );
+			const closed = await this.supportPage.closeInlineHelp();
+			assert.strictEqual( closed, true, 'The Inline Help popover was not closed correctly.' );
 		} );
 	} );
 } );

--- a/yarn.lock
+++ b/yarn.lock
@@ -17517,6 +17517,11 @@ jest@^26.4.0:
     import-local "^3.0.2"
     jest-cli "^26.4.0"
 
+jpeg-js@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.2.tgz#8b345b1ae4abde64c2da2fe67ea216a114ac279d"
+  integrity sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==
+
 jquery@^1.12.3:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.3.tgz#1298b88b908e7c7f7501eb8c1a61f1ac8337b531"
@@ -19305,6 +19310,11 @@ mime@^2.0.3, mime@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
+
+mime@^2.4.6:
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
+  integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
 
 mime@~1.2.11, mime@~1.2.9:
   version "1.2.11"
@@ -21574,6 +21584,23 @@ pkg-up@3.1.0, pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
+playwright@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.6.2.tgz#8631aec4d16b081d8ac414637b006099814a69d1"
+  integrity sha512-KiMmQuANG4O/ozpwxP8EwBBap0/liS3+wwkGo6nBJ4O4951y4ZsRPR1dqwsMOUD9wjsWf3ER+bAmQH5XmEO4Ig==
+  dependencies:
+    debug "^4.1.1"
+    extract-zip "^2.0.1"
+    https-proxy-agent "^5.0.0"
+    jpeg-js "^0.4.2"
+    mime "^2.4.6"
+    pngjs "^5.0.0"
+    progress "^2.0.3"
+    proper-lockfile "^4.1.1"
+    proxy-from-env "^1.1.0"
+    rimraf "^3.0.2"
+    ws "^7.3.1"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -21628,6 +21655,11 @@ png-itxt@^1.3.0:
     duplexer "^0.1.1"
     png-chunk-stream "^1.0.1"
     through2 "^0.6.1"
+
+pngjs@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
+  integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
 
 pnp-webpack-plugin@1.6.4:
   version "1.6.4"
@@ -22631,7 +22663,7 @@ progress-event@^1.0.0:
   resolved "https://registry.yarnpkg.com/progress-event/-/progress-event-1.0.0.tgz#1146df4b61849ddbe93ee81f9365af91b8901c51"
   integrity sha1-EUbfS2GEndvpPugfk2WvkbiQHFE=
 
-progress@^2.0.0, progress@^2.0.1:
+progress@^2.0.0, progress@^2.0.1, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -22733,6 +22765,15 @@ propagate@^2.0.0:
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
+proper-lockfile@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.1.tgz#284cf9db9e30a90e647afad69deb7cb06881262c"
+  integrity sha512-1w6rxXodisVpn7QYvLk706mzprPTAPCYAqxMvctmPN3ekuRk/kuGkGc82pangZiAt4R3lwSuUzheTTn0/Yb7Zg==
+  dependencies:
+    graceful-fs "^4.1.11"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
+
 property-information@^5.0.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.4.0.tgz#16e08f13f4e5c4a7be2e4ec431c01c4f8dba869a"
@@ -22784,7 +22825,7 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.0"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@^1.0.0, proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As of 2020-12-06, this description is **UP TO DATE**.

## Overview
Incorporates Playwright to the e2e specs.

### Major components
#### Login
Converts Login-related files (`login-page-playwright.js`, `login-flow-playwright.js`) to Playwright.
* for `login-flow-playwright.js`, the happy path has been converted to Playwright for the purpose of this demo.
* for `login-page-playwright.js`, remove dependency on `async-base-container`.
* the overall flow of the Login process has been retained from the original files.

#### Specs
Migrate three test files to Playwright-based tests.
* `wp-calypso-gutenberg-coblocks-playwright.js` is complete; one bug found during migration. #48093 
* `wp-calypso-seo-preview-playwright.js` is complete.
* `wp-inline-help-support-search-spec-playwright.js` is complete.

#### Components and Pages
Supporting component and page files were created where I deemed necessary.
* `sidebar-component-playwright.js` represents the sidebar present in the dashboard.
* `support-page-playwright.js` represents the inline help popover present in certain pages of the dashboard.
* `gutenberg-editor-component-playwright.js` represents the block editing `iframe` where coblock tests run.
* `login-page-playwright.js` is as described above.

#### Work in progress
* checking for any edge cases or bugs.

### Thoughts
Playwright is quite pleasant to use. Not having to explicitly state a wait time, driver sleep or even having to specify a selector to be used is refreshing. I certainly wish I had these advanced capabilities years ago when I worked with Python + Selenium and Nightwatch.js as these were all factors that led to a nightmarish frontend test suite.

In particular, note that `async-base-container.js` is no longer necessary because Playwright is able to smartly wait for elements. This will help remove code from the repository and lead to reduced maintenance overheads and less flakey tests.

Although my last dabble with JS was more than three years ago, I was able to quickly pick it up again to efficiently execute the demo migration. It is partially attributable to Playwright's ease of setup and use.

If this project was to be undertaken on production, I have identified some areas of improvement:
* rethinking login - the Login process is being tested at least `n` times in these specs. What if we refactor the specs to log in just once? Would that save time? Would it cause unexpected interactions?
* parametrizing - in `pytest`, there is notion of running the same test block with `x` different inputs. Could something like that be applied to coblocks tests? 

#### Testing instructions

* pull repository
* decrypt secrets
* install dependencies if required
* navigate to `test/e2e`
* run `./node_modules/.bin/mocha specs/<file>` where file is any one of the three files migrated.