### PR TITLE
Add Desktop Github Release Notes Script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -970,12 +970,16 @@ jobs:
             echo "Publishing draft release for wp-desktop $VERSION..."
             NAME="WP-Desktop ${VERSION#?}"
 
+            chmod +x desktop/bin/make-changelog.sh
+            ./desktop/bin/make-changelog.sh > desktop/CHANGELOG.md
+
             ghr \
               --token "${GH_TOKEN}" \
               --username "${CIRCLE_PROJECT_USERNAME}" \
               --repository "${CIRCLE_PROJECT_REPONAME}" \
               --commitish "${CIRCLE_SHA1}" \
               --name "${NAME}" \
+              --body "$(cat desktop/CHANGELOG.md)" \
               --delete \
               --draft \
               "${VERSION}" desktop/release/

--- a/desktop/bin/make-changelog.sh
+++ b/desktop/bin/make-changelog.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# desktop tags
+function get_desktop_tags() {
+  desktop_tags=""
+  declare -i x=0
+  for tag in $(git tag); do
+    # guard against stray v9.9.9 test tag that keeps being re-introduced to the repo! ಠ_ಠ
+    if [[ "$tag" == *"9.9.9" ]]; then
+      continue;
+    fi
+
+    if [[ $tag == v* ]]; then
+      if [ $x -gt 0 ]; then
+        desktop_tags="$desktop_tags"$'\n'"$tag"
+      else
+        desktop_tags="$tag"
+      fi
+    fi
+    x+=1
+  done
+  echo "$desktop_tags"
+}
+
+# fetch all tags in descending lexicographical order
+# (exclude current tag with `awk`)
+tags=$(get_desktop_tags | tr - \~ | sort -V -r | tr \~ - | awk '{if(NR>1)print}')
+
+# get tag for previous stable release from the sorted list
+# (first match without `-`, e.g. v1.2.3, not v1.2.3-alpha1)
+last_stable_tag=$(for tag in $tags; do if [[ ! "$tag" == *"-"* ]]; then
+  echo "$tag"
+  break
+fi; done)
+
+# get the current tag, fall back to HEAD
+current_tag=$VERSION
+if [ -z "$current_tag" ]; then
+  current_tag=HEAD
+fi
+
+# Include commit message (%s). Other elements such as
+# commit author (_%aN_) and commit short hash (%h) can
+# be included if desired.
+git_log_format="%s"
+
+echo "## What's Changed"
+echo ""
+
+# Fill and sort changelog (final sort in commit-date order)
+git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag...$current_tag -- desktop/ client/lib/desktop |
+  sort -s -k 1,1)
+
+echo "$git_log" | while IFS=$'\r' read change; do
+  awk '$0 !~ /([0-9])+\.([0-9])+\.([0-9])+/ {print "* " $0}' <<< $change
+done

--- a/desktop/bin/make-changelog.sh
+++ b/desktop/bin/make-changelog.sh
@@ -56,3 +56,5 @@ git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag..
 echo "$git_log" | while IFS=$'\r' read change; do
   awk '$0 !~ /([0-9])+\.([0-9])+\.([0-9])+/ {print "* " $0}' <<< $change
 done
+
+printf "\n"

--- a/desktop/bin/make-changelog.sh
+++ b/desktop/bin/make-changelog.sh
@@ -50,8 +50,7 @@ echo "## What's Changed"
 echo ""
 
 # Fill and sort changelog (final sort in commit-date order)
-git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag...$current_tag -- "$CALYPSO_DIR/desktop/" "$CALYPSO_DIR/client/lib/desktop" |
-  sort -s -k 1,1)
+git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag...$current_tag -- "$CALYPSO_DIR/desktop/" "$CALYPSO_DIR/client/lib/desktop")
 
 echo "$git_log" | while IFS=$'\r' read change; do
   # Don't include application version bump commits

--- a/desktop/bin/make-changelog.sh
+++ b/desktop/bin/make-changelog.sh
@@ -54,6 +54,7 @@ git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag..
   sort -s -k 1,1)
 
 echo "$git_log" | while IFS=$'\r' read change; do
+  # Don't include application version bump commits
   awk '$0 !~ /([0-9])+\.([0-9])+\.([0-9])+/ {print "* " $0}' <<< $change
 done
 

--- a/desktop/bin/make-changelog.sh
+++ b/desktop/bin/make-changelog.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CALYPSO_DIR=$(cd $(dirname $0)/../../ && pwd)
+
 # desktop tags
 function get_desktop_tags() {
   desktop_tags=""
@@ -48,7 +50,7 @@ echo "## What's Changed"
 echo ""
 
 # Fill and sort changelog (final sort in commit-date order)
-git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag...$current_tag -- desktop/ client/lib/desktop |
+git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag...$current_tag -- "$CALYPSO_DIR/desktop/" "$CALYPSO_DIR/client/lib/desktop" |
   sort -s -k 1,1)
 
 echo "$git_log" | while IFS=$'\r' read change; do


### PR DESCRIPTION
### Description

This PR adds a simplified version of the [release notes script](https://github.com/Automattic/wp-desktop/blob/develop/make-changelog.sh) that was used in the prior, separate wp-desktop repository.

Because we can no longer depend on consistent commit formatting, this script simply aggregates a list of changes since the last stable version under a generic "What's Changed" heading. It won't be as nicely-formatted or organized, but it's something. 🙂 

### Motivation

Prior experimentation with our release notes confirmed that having a readily-available list of changes with corresponding (hyperlinked) PRs is highly valuable to interested stakeholders.

Manually generating and maintaining this list of changes for each (beta and stable) release is time-consuming and this task can easily get dropped from one release to the next (for example if the developer isn't available or is unaware, or simply forgets).

The goal _is not_ to have a perfectly-edited list of release notes for end-users but to have _a reasonable first draft_ of all relevant changes gathered in one place. This ensures that a release can be generated at any time and internal stakeholders (like Platform) will always be able to inspect the relevant changeset via Github.

This "first draft" can also serve as a baseline for further editing (for example with amended formatting or descriptions). However, the most important value here is ensuring there is always _some_ available documentation of recent changes.

### To Test

Check out this branch and execute `./bin/desktop/make-changelog.sh` to get an idea of what the generated changelog might look like.