### PR TITLE
Pricing page: make copy translatable

### DIFF
--- a/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
+++ b/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
@@ -44,7 +44,7 @@ const JetpackFAQi5: React.FC = () => {
 	return (
 		<>
 			<section className="jetpack-faq-i5">
-				<h2 className="jetpack-faq-i5__heading">Frequently Asked Questions</h2>
+				<h2 className="jetpack-faq-i5__heading">{ translate( 'Frequently Asked Questions' ) }</h2>
 
 				<FoldableFAQ
 					id="faq-1"

--- a/client/my-sites/plans/jetpack-plans/plans-filter-bar-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-filter-bar-i5/index.tsx
@@ -87,6 +87,7 @@ const PlansFilterBarI5: React.FC< FilterBarProps > = ( {
 	duration,
 	onDurationChange,
 } ) => {
+	const translate = useTranslate();
 	const isInConnectStore = useMemo( isConnectStore, [] );
 	const isInJetpackCloud = useMemo( isJetpackCloud, [] );
 	const windowBoundaryOffset =
@@ -109,13 +110,15 @@ const PlansFilterBarI5: React.FC< FilterBarProps > = ( {
 					checked: durationChecked,
 				} ) }
 			>
-				<span className="plans-filter-bar-i5__toggle-off-label">Bill monthly</span>
+				<span className="plans-filter-bar-i5__toggle-off-label">
+					{ translate( 'Bill monthly' ) }
+				</span>
 				<ToggleControl
 					className="plans-filter-bar-i5__toggle-control"
 					checked={ durationChecked }
 					onChange={ () => setDurationChecked( ( prevState ) => ! prevState ) }
 				/>
-				<span className="plans-filter-bar-i5__toggle-on-label">Bill yearly</span>
+				<span className="plans-filter-bar-i5__toggle-on-label">{ translate( 'Bill yearly' ) }</span>
 			</div>
 			{ showDiscountMessage && <DiscountMessage primary={ durationChecked } /> }
 		</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR wraps a couple of strings that we forgot in a `translate` call in the pricing page.

### Testing instructions

- Download this PR or visit the live link
- Run Calypso or cloud
- Visit the pricing page
- Verify that it looks like production
- Check in `client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx` and `client/my-sites/plans/jetpack-plans/plans-filter-bar-i5/index.tsx` that all copy strings are wrapped in a `translate` call

### Catpures

![screenshot](https://user-images.githubusercontent.com/1620183/100664688-fe688000-3325-11eb-871e-4c9e4499cc48.png)
![screenshot (1)](https://user-images.githubusercontent.com/1620183/100664716-0b856f00-3326-11eb-872a-d6aa7b2f4d37.png)
