### PR TITLE
Hide Jetpack Search menu item in Jetpack Cloud

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -22,6 +22,7 @@ import ScanBadge from 'calypso/components/jetpack/scan-badge';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import { isEnabled } from 'calypso/config';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 	const translate = useTranslate();
@@ -87,17 +88,19 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 					<ScanBadge progress={ scanProgress } numberOfThreatsFound={ scanThreats?.length ?? 0 } />
 				</SidebarItem>
 			) }
-			<SidebarItem
-				tipTarget="jetpack-search"
-				icon={ showIcons ? 'search' : undefined }
-				label={ translate( 'Search', {
-					comment: 'Jetpack sidebar menu item',
-				} ) }
-				link={ `/jetpack-search/${ siteSlug }` }
-				onNavigate={ onNavigate( tracksEventNames.activityClicked ) }
-				selected={ currentPathMatches( `/jetpack-search/${ siteSlug }` ) }
-				expandSection={ expandSection }
-			/>
+			{ ! isJetpackCloud() && (
+				<SidebarItem
+					tipTarget="jetpack-search"
+					icon={ showIcons ? 'search' : undefined }
+					label={ translate( 'Search', {
+						comment: 'Jetpack sidebar menu item',
+					} ) }
+					link={ `/jetpack-search/${ siteSlug }` }
+					onNavigate={ onNavigate( tracksEventNames.activityClicked ) }
+					selected={ currentPathMatches( `/jetpack-search/${ siteSlug }` ) }
+					expandSection={ expandSection }
+				/>
+			) }
 		</>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Followup to #47607, where we added a "Jetpack Search" section to Calypso.

We weren't aware that when adding this item to the Calypso menu, it would also appear in Jetpack Cloud. This PR hides the "Search" item in Jetpack Cloud for the moment.

We'll aim to add this section to Jetpack Cloud in the future.

<img width="284" alt="Screen Shot 2020-12-01 at 10 59 42" src="https://user-images.githubusercontent.com/17325/100670877-6372b300-33c4-11eb-85ff-6c997fe9e3cc.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set up a local Docker environment and run `npm run docker-jetpack-cloud`. Point cloud.jetpack.com to 127.0.0.1 in your hosts file. 
2. Navigate to https://cloud.jetpack.com, choose a site, and verify that "Search" is not shown in the sidebar.

