### PR TITLE
Reader: update blocks to use new recordReaderTracksEvent action

### DIFF
--- a/client/blocks/comments/comment-likes.jsx
+++ b/client/blocks/comments/comment-likes.jsx
@@ -1,21 +1,20 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { get, pick } from 'lodash';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import LikeButton from 'calypso/blocks/like-button/button';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { likeComment, unlikeComment } from 'calypso/state/comments/actions';
 import { getCommentLike } from 'calypso/state/comments/selectors';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class CommentLikeButtonContainer extends React.Component {
 	constructor() {
@@ -32,10 +31,13 @@ class CommentLikeButtonContainer extends React.Component {
 
 		recordAction( liked ? 'liked_comment' : 'unliked_comment' );
 		recordGaEvent( liked ? 'Clicked Comment Like' : 'Clicked Comment Unlike' );
-		recordTrack( 'calypso_reader_' + ( liked ? 'liked' : 'unliked' ) + '_comment', {
-			blog_id: this.props.siteId,
-			comment_id: this.props.commentId,
-		} );
+		this.props.recordReaderTracksEvent(
+			'calypso_reader_' + ( liked ? 'liked' : 'unliked' ) + '_comment',
+			{
+				blog_id: this.props.siteId,
+				comment_id: this.props.commentId,
+			}
+		);
 	}
 
 	render() {
@@ -74,12 +76,5 @@ export default connect(
 	( state, props ) => ( {
 		commentLike: getCommentLike( state, props.siteId, props.postId, props.commentId ),
 	} ),
-	( dispatch ) =>
-		bindActionCreators(
-			{
-				likeComment,
-				unlikeComment,
-			},
-			dispatch
-		)
+	{ likeComment, unlikeComment, recordReaderTracksEvent }
 )( CommentLikeButtonContainer );

--- a/client/blocks/comments/comment-likes.jsx
+++ b/client/blocks/comments/comment-likes.jsx
@@ -76,5 +76,5 @@ export default connect(
 	( state, props ) => ( {
 		commentLike: getCommentLike( state, props.siteId, props.postId, props.commentId ),
 	} ),
-	{ likeComment, unlikeComment, recordReaderTracksEvent }
+	{ likeComment, recordReaderTracksEvent, unlikeComment }
 )( CommentLikeButtonContainer );

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -24,7 +24,7 @@ import {
 	setActiveReply,
 } from 'calypso/state/comments/actions';
 import { NUMBER_OF_COMMENTS_PER_FETCH } from 'calypso/state/comments/constants';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import PostComment from './post-comment';
 import PostCommentFormRoot from './form-root';
 import CommentCount from './comment-count';
@@ -34,6 +34,7 @@ import ConversationFollowButton from 'calypso/blocks/conversation-follow-button'
 import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Style dependencies
@@ -264,7 +265,7 @@ class PostCommentList extends React.Component {
 		this.setActiveReplyComment( commentId );
 		recordAction( 'comment_reply_click' );
 		recordGaEvent( 'Clicked Reply to Comment' );
-		recordTrack( 'calypso_reader_comment_reply_click', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_comment_reply_click', {
 			blog_id: this.props.post.site_ID,
 			comment_id: commentId,
 		} );
@@ -274,7 +275,7 @@ class PostCommentList extends React.Component {
 		this.setState( { commentText: null } );
 		recordAction( 'comment_reply_cancel_click' );
 		recordGaEvent( 'Clicked Cancel Reply to Comment' );
-		recordTrack( 'calypso_reader_comment_reply_cancel_click', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_comment_reply_cancel_click', {
 			blog_id: this.props.post.site_ID,
 			comment_id: this.state.activeReplyCommentId,
 		} );
@@ -550,5 +551,5 @@ export default connect(
 			} ),
 		};
 	},
-	{ requestPostComments, requestComment, setActiveReply }
+	{ recordReaderTracksEvent, requestPostComments, requestComment, setActiveReply }
 )( PostCommentList );

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -551,5 +551,5 @@ export default connect(
 			} ),
 		};
 	},
-	{ recordReaderTracksEvent, requestPostComments, requestComment, setActiveReply }
+	{ requestComment, requestPostComments, recordReaderTracksEvent, setActiveReply }
 )( PostCommentList );

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -16,12 +16,7 @@ import { isEnabled } from 'calypso/config';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import TimeSince from 'calypso/components/time-since';
 import Gravatar from 'calypso/components/gravatar';
-import {
-	recordAction,
-	recordGaEvent,
-	recordTrack,
-	recordPermalinkClick,
-} from 'calypso/reader/stats';
+import { recordAction, recordGaEvent, recordPermalinkClick } from 'calypso/reader/stats';
 import { getStreamUrl } from 'calypso/reader/route';
 import PostCommentContent from './post-comment-content';
 import PostCommentForm from './form';
@@ -35,6 +30,7 @@ import Emojify from 'calypso/components/emojify';
 import ConversationCaterpillar from 'calypso/blocks/conversation-caterpillar';
 import withDimensions from 'calypso/lib/with-dimensions';
 import { expandComments } from 'calypso/state/comments/actions';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Style dependencies
@@ -124,7 +120,7 @@ class PostComment extends React.PureComponent {
 	handleAuthorClick = ( event ) => {
 		recordAction( 'comment_author_click' );
 		recordGaEvent( 'Clicked Author Name' );
-		recordTrack( 'calypso_reader_comment_author_click', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_comment_author_click', {
 			blog_id: this.props.post.site_ID,
 			post_id: this.props.post.ID,
 			comment_id: this.props.commentId,
@@ -325,7 +321,7 @@ class PostComment extends React.PureComponent {
 			} );
 		recordAction( 'comment_read_more_click' );
 		recordGaEvent( 'Clicked Comment Read More' );
-		recordTrack( 'calypso_reader_comment_read_more_click', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_comment_read_more_click', {
 			blog_id: this.props.post.site_ID,
 			post_id: this.props.post.ID,
 			comment_id: this.props.commentId,
@@ -504,7 +500,7 @@ const ConnectedPostComment = connect(
 	( state ) => ( {
 		currentUser: getCurrentUser( state ),
 	} ),
-	{ expandComments }
+	{ expandComments, recordReaderTracksEvent }
 )( withDimensions( PostComment ) );
 
 export default ConnectedPostComment;

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -10,12 +10,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { getPostCommentsTree, getDateSortedPostComments } from 'calypso/state/comments/selectors';
 import { expandComments } from 'calypso/state/comments/actions';
 import { POST_COMMENT_DISPLAY_TYPES } from 'calypso/state/comments/constants';
 import { isAncestor } from 'calypso/blocks/comments/utils';
 import GravatarCaterpillar from 'calypso/components/gravatar-caterpillar';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Style dependencies
@@ -69,7 +70,7 @@ class ConversationCaterpillarComponent extends React.Component {
 		} );
 		recordAction( 'comment_caterpillar_click' );
 		recordGaEvent( 'Clicked Caterpillar' );
-		recordTrack( 'calypso_reader_comment_caterpillar_click', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_comment_caterpillar_click', {
 			blog_id: blogId,
 			post_id: postId,
 		} );
@@ -152,7 +153,7 @@ const ConnectedConversationCaterpillar = connect(
 			commentsTree: getPostCommentsTree( state, blogId, postId, 'all' ),
 		};
 	},
-	{ expandComments }
+	{ expandComments, recordReaderTracksEvent }
 )( ConversationCaterpillar );
 
 export default ConnectedConversationCaterpillar;

--- a/client/blocks/conversations/empty.jsx
+++ b/client/blocks/conversations/empty.jsx
@@ -3,16 +3,18 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
- * Image dependencies
+ * Asset dependencies
  */
 import charactersImage from 'calypso/assets/images/reader/reader-conversations-characters.svg';
 
@@ -24,7 +26,7 @@ class ConversationsEmptyContent extends React.Component {
 	recordAction = () => {
 		recordAction( 'clicked_search_on_empty' );
 		recordGaEvent( 'Clicked Search on EmptyContent' );
-		recordTrack( 'calypso_reader_search_on_empty_stream_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_search_on_empty_stream_clicked' );
 	};
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -58,4 +60,6 @@ class ConversationsEmptyContent extends React.Component {
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
-export default withPerformanceTrackerStop( localize( ConversationsEmptyContent ) );
+export default connect( null, { recordReaderTracksEvent } )(
+	withPerformanceTrackerStop( localize( ConversationsEmptyContent ) )
+);

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -21,7 +21,7 @@ import {
 	getPostCommentsTree,
 } from 'calypso/state/comments/selectors';
 import ConversationCaterpillar from 'calypso/blocks/conversation-caterpillar';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import PostCommentFormRoot from 'calypso/blocks/comments/form-root';
 import {
 	requestPostComments,
@@ -30,6 +30,7 @@ import {
 } from 'calypso/state/comments/actions';
 import { getErrorKey } from 'calypso/state/comments/utils';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Style dependencies
@@ -82,7 +83,7 @@ export class ConversationCommentList extends React.Component {
 		this.setActiveReplyComment( commentId );
 		recordAction( 'comment_reply_click' );
 		recordGaEvent( 'Clicked Reply to Comment' );
-		recordTrack( 'calypso_reader_comment_reply_click', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_comment_reply_click', {
 			blog_id: this.props.post.site_ID,
 			comment_id: commentId,
 		} );
@@ -92,7 +93,7 @@ export class ConversationCommentList extends React.Component {
 		this.setState( { commentText: null } );
 		recordAction( 'comment_reply_cancel_click' );
 		recordGaEvent( 'Clicked Cancel Reply to Comment' );
-		recordTrack( 'calypso_reader_comment_reply_cancel_click', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_comment_reply_cancel_click', {
 			blog_id: this.props.post.site_ID,
 			comment_id: this.props.activeReplyCommentId,
 		} );
@@ -303,7 +304,7 @@ const ConnectedConversationCommentList = connect(
 			commentErrors: getCommentErrors( state ),
 		};
 	},
-	{ requestPostComments, requestComment, setActiveReply }
+	{ recordReaderTracksEvent, requestPostComments, requestComment, setActiveReply }
 )( ConversationCommentList );
 
 export default ConnectedConversationCommentList;

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { Card } from '@automattic/components';
 import { getStreamUrl } from 'calypso/reader/route';
@@ -18,12 +18,12 @@ import ReaderCombinedCardPost from './post';
 import { keysAreEqual, keyForPost } from 'calypso/reader/post-key';
 import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
-import { recordTrack } from 'calypso/reader/stats';
 import { getSiteName } from 'calypso/reader/get-helpers';
 import FollowButton from 'calypso/reader/follow-button';
 import { getPostsByKeys } from 'calypso/state/reader/posts/selectors';
 import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
 import PostBlocked from 'calypso/blocks/reader-post-card/blocked';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Style dependencies
@@ -67,7 +67,7 @@ class ReaderCombinedCardComponent extends React.Component {
 	recordRenderTrack = () => {
 		const { postKey, posts } = this.props;
 
-		recordTrack( 'calypso_reader_combined_card_render', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_combined_card_render', {
 			blog_id: postKey.blogId,
 			feed_id: postKey.feedId,
 			post_count: size( posts ),
@@ -209,4 +209,4 @@ function mapStateToProps( st, ownProps ) {
 	};
 }
 
-export default connect( mapStateToProps )( ReaderCombinedCard );
+export default connect( mapStateToProps, { recordReaderTracksEvent } )( ReaderCombinedCard );

--- a/client/blocks/reader-list-item/index.jsx
+++ b/client/blocks/reader-list-item/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import classnames from 'classnames';
 import { flowRight as compose, isEmpty, get } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -21,10 +22,11 @@ import {
 	getSiteUrl,
 } from 'calypso/reader/get-helpers';
 import ReaderListItemPlaceholder from 'calypso/blocks/reader-list-item/placeholder';
-import { recordTrack, recordTrackWithRailcar } from 'calypso/reader/stats';
+import { recordRailcar } from 'calypso/reader/stats';
 import ExternalLink from 'calypso/components/external-link';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Style dependencies
@@ -57,23 +59,25 @@ function ReaderListItem( {
 	const siteUrl = getSiteUrl( { feed, site } );
 	const isMultiAuthor = get( site, 'is_multi_author', false );
 	const preferGravatar = ! isMultiAuthor;
+	const dispatch = useDispatch();
 
 	if ( ! site && ! feed ) {
 		return <ReaderListItemPlaceholder />;
 	}
 
-	function recordEvent( name ) {
-		const props = {
+	const recordEvent = ( eventName ) => {
+		const eventProps = {
 			blog_id: siteId,
 			feed_id: feedId,
 			source: followSource,
 		};
+
+		dispatch( recordReaderTracksEvent( eventName, eventProps ) );
+
 		if ( railcar ) {
-			recordTrackWithRailcar( name, railcar, props );
-		} else {
-			recordTrack( name, props );
+			recordRailcar( eventName, railcar, eventProps );
 		}
-	}
+	};
 
 	const recordTitleClick = () => recordEvent( 'calypso_reader_feed_link_clicked' );
 	const recordAuthorClick = () => recordEvent( 'calypso_reader_author_link_clicked' );

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -1,11 +1,11 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { assign, partial, pick } from 'lodash';
 import debugFactory from 'debug';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
@@ -102,6 +102,8 @@ function getLocation( path ) {
  *   recordTrack after changing windows and would result in a `ui_algo: single_post`
  *   regardless of the stream the post was opened. This now allows the article_opened
  *   Tracks event to correctly specify which stream the post was opened.
+ *
+ * @deprecated Use the recordReaderTracksEvent action instead.
  */
 export function recordTrack( eventName, eventProperties, { pathnameOverride } = {} ) {
 	debug( 'reader track', ...arguments );
@@ -158,6 +160,7 @@ export const recordTracksRailcarRender = partial(
 	recordTracksRailcar,
 	'calypso_traintracks_render'
 );
+
 export const recordTracksRailcarInteract = partial(
 	recordTracksRailcar,
 	'calypso_traintracks_interact'
@@ -187,13 +190,17 @@ export function getTracksPropertiesForPost( post = {} ) {
 	};
 }
 
-export function recordTrackWithRailcar( eventName, railcar, eventProperties ) {
-	recordTrack( eventName, eventProperties );
+export function recordRailcar( eventName, railcar, eventProperties ) {
 	recordTracksRailcarInteract(
 		eventName,
 		railcar,
 		pick( eventProperties, [ 'ui_position', 'ui_algo' ] )
 	);
+}
+
+export function recordTrackWithRailcar( eventName, railcar, eventProperties ) {
+	recordTrack( eventName, eventProperties );
+	recordRailcar( eventName, railcar, eventProperties );
 }
 
 export function pageViewForPost( blogId, blogUrl, postId, isPrivate ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following up on https://github.com/Automattic/wp-calypso/pull/47818, which added a new Redux thunk for recording Tracks events in Reader, replacing the old `recordTrack()` function.

This is part of an effort to remedy https://github.com/Automattic/wp-calypso/issues/14470. We want to send a subscription count with each event and that's currently broken.

This PR switches over any Reader blocks in the `blocks` directory to use the new `recordReaderTracksEvent` action.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Turn on Analytics logging in your console with:

`localStorage.setItem('debug', 'calypso:analytics*');`

Using the Reader, verify that you can fire the following Tracks events, and that they all include `subscription_count`:

* calypso_reader_liked_comment
* calypso_reader_unliked_comment
* calypso_reader_comment_reply_click
* calypso_reader_comment_reply_cancel_click
* calypso_reader_comment_author_click
* calypso_reader_comment_read_more_click
* calypso_reader_comment_caterpillar_click
* calypso_reader_search_on_empty_stream_clicked (appears on an empty Conversations stream - try with a fresh test account)
* calypso_reader_combined_card_render (try looking for this after loading your Following Stream)
* calypso_reader_feed_link_clicked (Recommended Sites - try under search on Following Manage)
* calypso_reader_site_url_clicked (Recommended Sites)
* calypso_reader_avatar_clicked (Recommended Sites)

It's easiest to test the comment events in Reader Conversations.

See https://github.com/Automattic/wp-calypso/issues/14470.