### PR TITLE
Onboarding: Add RTL support to domain picker

### DIFF
--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -253,6 +253,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 						onChange={ handleInputChange }
 						onBlur={ onDomainSearchBlurValue }
 						value={ domainSearch }
+						dir="ltr"
 					/>
 				</div>
 			) }

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -226,7 +226,7 @@ $accent-blue: #117ac9;
 		flex-wrap: wrap;
 	}
 
-	.domain-picker__domain-name {
+	.domain-picker__sub-domain {
 		word-break: break-word; // use hyphens if any to break domain name
 	}
 
@@ -246,6 +246,14 @@ $accent-blue: #117ac9;
 .domain-picker__domain-tld {
 	color: var( --studio-blue-40 );
 
+	.domain-picker__suggestion-item.is-unavailable & {
+		color: var( --studio-gray-40 );
+	}
+}
+
+.domain-picker__domain-wrapper {
+	direction: ltr;
+
 	&.with-margin {
 		// margin for recommended badge. this margin shouldn't
 		// be placed on the badge because if the badge falls
@@ -253,10 +261,6 @@ $accent-blue: #117ac9;
 		// margin isnt applied if hstsRequired is truthy as InfoTooltip component
 		// provides equal spacing between this and the recommended badge.
 		margin-right: 10px;
-	}
-
-	.domain-picker__suggestion-item.is-unavailable & {
-		color: var( --studio-gray-40 );
 	}
 }
 

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -137,13 +137,13 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 				) ) }
 			<div className="domain-picker__suggestion-item-name">
 				<div className="domain-picker__suggestion-item-name-inner">
-					<span className="domain-picker__domain-name">{ domainName }</span>
 					<span
-						className={ classnames( 'domain-picker__domain-tld', {
+						className={ classnames( 'domain-picker__domain-wrapper', {
 							'with-margin': ! hstsRequired,
 						} ) }
 					>
-						{ domainTld }
+						<span className="domain-picker__domain-sub-domain">{ domainName }</span>
+						<span className="domain-picker__domain-tld">{ domainTld }</span>
 					</span>
 					{ hstsRequired && (
 						<InfoTooltip


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The sub-parts of a domain are always shown in a LTR fashion, even in a RTL language. These changes fixes the domain picker so that domains are always shown the correct way even when we do special things like split domain parts into different DOM elements.

* The domain search box is always displayed LTR
* The domains in the search results are displayed correctly (i.e. the tld part is shown to the right of the subdomain part)

**Before**
<img width="1081" alt="image" src="https://user-images.githubusercontent.com/1500769/100694837-bebc9980-33f4-11eb-94aa-75e28387a227.png">

**After**
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/1500769/100694940-0511f880-33f5-11eb-8f0d-ad066882729c.png">


**The old domain picker for reference**
<img width="991" alt="image" src="https://user-images.githubusercontent.com/1500769/100694880-db58d180-33f4-11eb-83c5-e8ddfb578c0d.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start onboarding at `/new/he` and go to the domain picker
* Test it out, resize the window etc. etc.
* Search for a `.dev` domain and verify that the tooltip margin is correct
* ~~Make sure the domain picker in the launch flow works too~~ actually we should do ETK stuff in another PR, it doesn't look like ETK's css is being run through auto-rtl processing yet, so we should get that going first.

Fixes #47885 