### PR TITLE
Onboarding: Add support for RTL site launch stylesheet to ETK

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/index.php
@@ -43,9 +43,13 @@ function enqueue_script_and_style() {
 		)
 	);
 
+	$style_file = is_rtl()
+		? 'editor-site-launch.rtl.css'
+		: 'editor-site-launch.css';
+
 	wp_enqueue_style(
 		'a8c-fse-editor-site-launch-style',
-		plugins_url( 'dist/editor-site-launch.css', __FILE__ ),
+		plugins_url( 'dist/' . $style_file, __FILE__ ),
 		array(),
 		$style_version
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enqueue the RTL stylesheet when `is_rtl()`

Copying prior art for how this is done in the ETK plugin:
- https://github.com/Automattic/wp-calypso/blob/961a9bdc22c84d8d714c35a90174434c7c47369b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/class-full-site-editing.php#L139
- https://github.com/Automattic/wp-calypso/blob/961a9bdc22c84d8d714c35a90174434c7c47369b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php#L131

**Before**
(see how the margins are all strange)
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/1500769/100698175-b4060280-33fc-11eb-9a93-ca171bd30ad1.png">

**After**
(also includes the fix from #47889)
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/1500769/100698088-828d3700-33fc-11eb-8d70-b2bccdd8a048.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn dev --sync` and sandbox an un-launched site
* Open the launch flow and see that the margins are all looking correct now
* Open the network tab and see that `editor-site-launch.rtl.css` is being loaded and the non-rtl file isn't