### PR TITLE
Onboarding: Flip the domain picker illustration in RTL languages

### DIFF
--- a/packages/domain-picker/src/domain-name-explanation/index.tsx
+++ b/packages/domain-picker/src/domain-name-explanation/index.tsx
@@ -23,19 +23,23 @@ export const DomainNameExplanationImage: FunctionComponent = () => {
 			<rect x="8" y="8" width="25" height="25" rx="5" fill="#fff" />
 			<rect x="40" y="8" width="25" height="25" rx="5" fill="#fff" />
 			<rect x="72" y="8" width="300" height="25" rx="5" fill="#fff" />
-			<g direction="ltr" transform={ isRTL() ? 'scale(-1,1) translate(-160,0)' : undefined }>
-				<text x="80" y="26" textAnchor={ isRTL() ? 'end' : 'start' }>
-					<tspan fill="#999">
-						<tspan>https://</tspan>
-					</tspan>
-					<tspan fill="#515151" dx="4.5">
-						{
-							/* translators: An example domain name. Used to describe what a domain name is. */
-							__( 'example.com', __i18n_text_domain__ )
-						}
-					</tspan>
-				</text>
-			</g>
+			<text
+				x="80"
+				y="26"
+				direction="ltr"
+				textAnchor={ isRTL() ? 'end' : 'start' }
+				transform={ isRTL() ? 'scale(-1,1) translate(-160,0)' : undefined }
+			>
+				<tspan fill="#999">
+					<tspan>https://</tspan>
+				</tspan>
+				<tspan fill="#515151" dx="4.5">
+					{
+						/* translators: An example domain name. Used to describe what a domain name is. */
+						__( 'example.com', __i18n_text_domain__ )
+					}
+				</tspan>
+			</text>
 		</svg>
 	);
 };

--- a/packages/domain-picker/src/domain-name-explanation/index.tsx
+++ b/packages/domain-picker/src/domain-name-explanation/index.tsx
@@ -2,9 +2,11 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 
 export const DomainNameExplanationImage: FunctionComponent = () => {
+	const { __, isRTL } = useI18n();
+
 	return (
 		<svg
 			version="1.1"
@@ -15,20 +17,23 @@ export const DomainNameExplanationImage: FunctionComponent = () => {
 			viewBox="0 0 300 40"
 			xmlSpace="preserve"
 			width="300"
+			transform={ isRTL() ? 'scale(-1,1)' : undefined }
 		>
 			<rect x="0" width="310" height="50" rx="10" fill="#D8D8D8" />
 			<rect x="8" y="8" width="25" height="25" rx="5" fill="#fff" />
 			<rect x="40" y="8" width="25" height="25" rx="5" fill="#fff" />
 			<rect x="72" y="8" width="300" height="25" rx="5" fill="#fff" />
-			<text x="80" y="26" fill="#999">
-				https://
-			</text>
-			<text x="133" y="26" fill="#515151">
-				{
-					/* translators: An example domain name. Used to describe what a domain name is. */
-					__( 'example.com', __i18n_text_domain__ )
-				}
-			</text>
+			<g direction="ltr" transform={ isRTL() ? 'scale(-1,1) translate(-305,0)' : undefined }>
+				<text x="80" y="26" fill="#999">
+					https://
+				</text>
+				<text x="133" y="26" fill="#515151">
+					{
+						/* translators: An example domain name. Used to describe what a domain name is. */
+						__( 'example.com', __i18n_text_domain__ )
+					}
+				</text>
+			</g>
 		</svg>
 	);
 };

--- a/packages/domain-picker/src/domain-name-explanation/index.tsx
+++ b/packages/domain-picker/src/domain-name-explanation/index.tsx
@@ -17,7 +17,7 @@ export const DomainNameExplanationImage: FunctionComponent = () => {
 			viewBox="0 0 300 40"
 			xmlSpace="preserve"
 			width="300"
-			transform={ isRTL() ? 'scale(-1,1)' : undefined }
+			style={ isRTL() ? { transform: 'scaleX(-1)' } : undefined }
 		>
 			<rect x="0" width="310" height="50" rx="10" fill="#D8D8D8" />
 			<rect x="8" y="8" width="25" height="25" rx="5" fill="#fff" />

--- a/packages/domain-picker/src/domain-name-explanation/index.tsx
+++ b/packages/domain-picker/src/domain-name-explanation/index.tsx
@@ -23,15 +23,17 @@ export const DomainNameExplanationImage: FunctionComponent = () => {
 			<rect x="8" y="8" width="25" height="25" rx="5" fill="#fff" />
 			<rect x="40" y="8" width="25" height="25" rx="5" fill="#fff" />
 			<rect x="72" y="8" width="300" height="25" rx="5" fill="#fff" />
-			<g direction="ltr" transform={ isRTL() ? 'scale(-1,1) translate(-305,0)' : undefined }>
-				<text x="80" y="26" fill="#999">
-					https://
-				</text>
-				<text x="133" y="26" fill="#515151">
-					{
-						/* translators: An example domain name. Used to describe what a domain name is. */
-						__( 'example.com', __i18n_text_domain__ )
-					}
+			<g direction="ltr" transform={ isRTL() ? 'scale(-1,1) translate(-160,0)' : undefined }>
+				<text x="80" y="26" textAnchor={ isRTL() ? 'end' : 'start' }>
+					<tspan fill="#999">
+						<tspan>https://</tspan>
+					</tspan>
+					<tspan fill="#515151" dx="4.5">
+						{
+							/* translators: An example domain name. Used to describe what a domain name is. */
+							__( 'example.com', __i18n_text_domain__ )
+						}
+					</tspan>
 				</text>
 			</g>
 		</svg>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The domain picker includes an illustration to help users who don't necessarily know what the term "domain" means.

* Flip the domain picker illustration when it's a RTL language
* Adjust how the text is displayed so it flows instead of being absolutely positioned (important if the translator changes the example domain to something longer)

**English**
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/1500769/100707174-1bc54900-340f-11eb-9eb1-d55f27c4c866.png">


**Hebrew**
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/1500769/100707181-21229380-340f-11eb-8ac7-69decdc808f6.png">


This is a screenshot of a Hebrew version of Chrome that I'm using as a guide (since the illustration is supposed to look a bit like the top bar of a web browser)
<img width="942" alt="Screenshot 2020-12-01 at 7 29 54 PM" src="https://user-images.githubusercontent.com/1500769/100707077-f6d0d600-340e-11eb-9393-7267bc6492fe.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/new/he` and advance to the domain step
* Clear the domain search box so that the illustration appears. It should look good in RTL.
* `/new/en` and compare the domain picker illustration to production to ensure there are no changes

Fixes #47490
