### PR TITLE
Nav-unification - Sidebar Scroll: fix scrolling when content is shorter than sidebar.

### DIFF
--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -22,26 +22,26 @@ let pinnedSidebarBottom = false;
 let ticking = false; // Used for Scroll event throttling.
 
 export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
-	// Do not run until next requestAnimationFrame.
+	// Run only in browser context and for desktop viewports.
+	if ( typeof window === undefined || window.innerWidth <= 660 ) {
+		return;
+	}
+
+	// Do not run until next requestAnimationFrame or if running out of browser context.
 	if ( ticking ) {
 		return;
 	}
+
+	const windowHeight = window.innerHeight;
 	const content = document.getElementById( 'content' );
 	const contentHeight = document.getElementById( 'content' )?.scrollHeight;
 	const secondaryEl = document.getElementById( 'secondary' ); // Or referred as sidebar.
-	const windowHeight = window?.innerHeight;
 	const secondaryElHeight = secondaryEl?.scrollHeight;
 	const masterbarHeight = document.getElementById( 'header' )?.getBoundingClientRect().height;
 
 	// Check whether we need to adjust content height so that scroll events are triggered.
 	// Sidebar has overflow: initial and position:fixed, so content is our only chance for scroll events.
-	if (
-		content &&
-		contentHeight &&
-		masterbarHeight &&
-		secondaryElHeight &&
-		window.innerWidth > 660 // Run only for desktop viewports.
-	) {
+	if ( content && contentHeight && masterbarHeight && secondaryElHeight ) {
 		if ( contentHeight < secondaryElHeight ) {
 			// Adjust the content height so that it matches the sidebar + masterbar vertical scroll estate.
 			content.style.minHeight = secondaryElHeight + masterbarHeight + 'px';
@@ -57,12 +57,10 @@ export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
 	}
 
 	if (
-		typeof window !== undefined &&
 		secondaryEl !== undefined &&
 		secondaryEl !== null &&
 		secondaryElHeight !== undefined &&
 		masterbarHeight !== undefined &&
-		window.innerWidth > 660 && // Run only for desktop viewports.
 		( secondaryElHeight + masterbarHeight > windowHeight || 'resize' === event.type ) // Only run when sidebar & masterbar are taller than window height OR we have a resize event
 	) {
 		// Throttle scroll event

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -17,7 +17,7 @@ export function getShouldShowAppBanner( site: any ): boolean {
 
 let lastScrollPosition = 0; // Used for calculating scroll direction.
 let sidebarTop = 0; // Current sidebar top position.
-let pinnedSidebarTop = true;
+let pinnedSidebarTop = true; // We pin sidebar to the top by default.
 let pinnedSidebarBottom = false;
 let ticking = false; // Used for Scroll event throttling.
 

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -22,14 +22,39 @@ let pinnedSidebarBottom = false;
 let ticking = false; // Used for Scroll event throttling.
 
 export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
-	// Do not run until next requestAnimationFrame
+	// Do not run until next requestAnimationFrame.
 	if ( ticking ) {
 		return;
 	}
-	const secondaryEl = document.getElementById( 'secondary' );
+	const content = document.getElementById( 'content' );
+	const contentHeight = document.getElementById( 'content' )?.scrollHeight;
+	const secondaryEl = document.getElementById( 'secondary' ); // Or referred as sidebar.
 	const windowHeight = window?.innerHeight;
 	const secondaryElHeight = secondaryEl?.scrollHeight;
 	const masterbarHeight = document.getElementById( 'header' )?.getBoundingClientRect().height;
+
+	// Check whether we need to adjust content height so that scroll events are triggered.
+	// Sidebar has overflow: initial and position:fixed, so content is our only chance for scroll events.
+	if (
+		content &&
+		contentHeight &&
+		masterbarHeight &&
+		secondaryElHeight &&
+		window.innerWidth > 660 // Run only for desktop viewports.
+	) {
+		if ( contentHeight < secondaryElHeight ) {
+			// Adjust the content height so that it matches the sidebar + masterbar vertical scroll estate.
+			content.style.minHeight = secondaryElHeight + masterbarHeight + 'px';
+		}
+
+		if (
+			windowHeight >= secondaryElHeight + masterbarHeight &&
+			content.style.minHeight !== 'initial'
+		) {
+			// In case that window is taller than the sidebar we reinstate the content min-height. CSS code: client/layout/style.scss:30.
+			content.style.minHeight = 'initial';
+		}
+	}
 
 	if (
 		typeof window !== undefined &&
@@ -108,6 +133,12 @@ export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
 
 					// Calculate new offset position.
 					sidebarTop = scrollY + masterbarHeight - maxScroll;
+					if ( contentHeight === secondaryElHeight + masterbarHeight ) {
+						// When content is originally shorter than the sidebar and
+						// we have already made it equal to the sidebar + masterbar
+						// the offset will always be the masterbar height (top position).
+						sidebarTop = masterbarHeight;
+					}
 
 					secondaryEl.style.position = 'absolute';
 					secondaryEl.style.top = `${ sidebarTop }px`;

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -37,7 +37,7 @@ export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
 		secondaryEl !== null &&
 		secondaryElHeight !== undefined &&
 		masterbarHeight !== undefined &&
-		window.innerWidth > 660 && // Do not run when sidebar is fullscreen
+		window.innerWidth > 660 && // Run only for desktop viewports.
 		( secondaryElHeight + masterbarHeight > windowHeight || 'resize' === event.type ) // Only run when sidebar & masterbar are taller than window height OR we have a resize event
 	) {
 		// Throttle scroll event

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -46,6 +46,11 @@ $font-size: rem( 14px );
 }
 
 .is-nav-unification {
+	// client/layout/style.scss
+	.layout__content {
+		min-height: 101vh; // Hack to give JS the chance to trigger the scroll event when the content is short. JS code: client/layout/utils.ts:36.
+	}
+
 	// client/layout/sidebar/style.scss
 	.sidebar {
 		position: relative;
@@ -584,8 +589,13 @@ $font-size: rem( 14px );
 }
 
 @media screen and ( max-width: 660px ) {
-	// client/layout/sidebar/style.scss
 	.is-nav-unification {
+		// client/layout/style.scss
+		.layout__content {
+			min-height: initial;
+		}
+
+		// client/layout/sidebar/style.scss
 		.sidebar {
 			position: absolute;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The new sidebar scrolling experience that wp-admin has and we have adopted in calypso for the nav-unification project, didn't handle cases where the content was shorter than the sidebar

![](https://cln.sh/fdd7qo+)

In the cases pictured above, there was no scroll event triggered cause the content was smaller than the window and the sidebar is `position: fixed` with `overflow: initial`. There could potentially be another fix by **completely refactoring** the layout - sidebar code so that the sidebar in not fixed initially. I ended up using a trick ( making content slightly higher than the window ) so that the scroll event kicks in and adjusts the heights accordingly.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* make sure you assign yourself to the treatment variation ( paYJgx-1af-p2 ).
* in a high enough window load https://wordpress.com/posts/cpapfree.wordpress.com .
* you should not be able to scroll.
* adjust your window height to be shorter than the sidebar and taller than the content.
* now you should be able to scroll.

Fixes https://github.com/Automattic/wp-calypso/issues/48133
