### PR TITLE
Plugins: Remove old autoupdate flux action types

### DIFF
--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -280,7 +280,6 @@ PluginsStore.dispatchToken = Dispatcher.register( function ( { action } ) {
 			PluginsStore.emitChange();
 			break;
 
-		case 'AUTOUPDATE_PLUGIN':
 		case 'UPDATE_PLUGIN':
 			PluginsStore.emitChange();
 			break;
@@ -290,7 +289,6 @@ PluginsStore.dispatchToken = Dispatcher.register( function ( { action } ) {
 			PluginsStore.emitChange();
 			break;
 
-		case 'RECEIVE_AUTOUPDATE_PLUGIN':
 		case 'RECEIVE_UPDATED_PLUGIN':
 			if ( action.error ) {
 				debug( 'plugin updating error', action.error );


### PR DESCRIPTION
We're currently in the process of reduxifying the plugins, and I stumbled upon a couple of old flux action types that are no longer in use since https://github.com/Automattic/wp-calypso/pull/16771 and can be removed. 

This PR removes them, leaving a couple of fewer action types to reduxify. 😉 

This PR is part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Remove old autoupdate flux action types

#### Testing instructions

* Verify the removed action types aren't in use.
