### PR TITLE
Modularise site roles state

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -30,7 +30,6 @@ import mySites from './my-sites/reducer';
 import notices from './notices/reducer';
 import { unseenCount as notificationsUnseenCount } from './notifications';
 import selectedEditor from './selected-editor/reducer';
-import siteRoles from './site-roles/reducer';
 import sites from './sites/reducer';
 import support from './support/reducer';
 import userSettings from './user-settings/reducer';
@@ -57,7 +56,6 @@ const reducers = {
 	notices,
 	notificationsUnseenCount,
 	selectedEditor,
-	siteRoles,
 	sites,
 	support,
 	userSettings,

--- a/client/state/site-roles/actions.js
+++ b/client/state/site-roles/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'calypso/lib/wp';
 import {
 	SITE_ROLES_RECEIVE,
@@ -9,6 +8,8 @@ import {
 	SITE_ROLES_REQUEST_FAILURE,
 	SITE_ROLES_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
+
+import 'calypso/state/site-roles/init';
 
 export function requestSiteRoles( siteId ) {
 	return ( dispatch ) => {

--- a/client/state/site-roles/init.js
+++ b/client/state/site-roles/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'siteRoles' ], reducer );

--- a/client/state/site-roles/package.json
+++ b/client/state/site-roles/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/site-roles/reducer.js
+++ b/client/state/site-roles/reducer.js
@@ -2,7 +2,12 @@
  * Internal dependencies
  */
 import { siteRolesSchema } from './schema';
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'calypso/state/utils';
+import {
+	combineReducers,
+	withoutPersistence,
+	withSchemaValidation,
+	withStorageKey,
+} from 'calypso/state/utils';
 import {
 	SITE_ROLES_RECEIVE,
 	SITE_ROLES_REQUEST,
@@ -57,7 +62,9 @@ export const items = withSchemaValidation( siteRolesSchema, ( state = {}, action
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	requesting,
 	items,
 } );
+
+export default withStorageKey( 'siteRoles', combinedReducer );

--- a/client/state/site-roles/selectors.js
+++ b/client/state/site-roles/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 import { translate } from 'i18n-calypso';
 
@@ -9,6 +8,8 @@ import { translate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import { getSite } from 'calypso/state/sites/selectors';
+
+import 'calypso/state/site-roles/init';
 
 /**
  * Returns true if currently requesting roles for the specified site ID, or


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles site roles state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42480.

#### Changes proposed in this Pull Request

* Modularise site roles state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/home` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `siteRoles` key, even if you expand the list of keys. This indicates that the site roles state hasn't been loaded yet.
* Click `Manage` followed by `People` on the side bar.
* Verify that a `siteRoles` key is added with the site roles empty state. This indicates that the site roles state has now been loaded.
* Click the `Invite` button
* Ensure that the list of roles for that site is displayed correctly