### PR TITLE
Modularise experiments state

### DIFF
--- a/client/state/experiments/actions.ts
+++ b/client/state/experiments/actions.ts
@@ -4,6 +4,8 @@
 import { EXPERIMENT_ASSIGN } from 'calypso/state/action-types';
 import { ExperimentResponse } from 'calypso/state/experiments/types';
 
+import 'calypso/state/experiments/init';
+
 /**
  * Assign the user to the specified experiments
  *

--- a/client/state/experiments/init.js
+++ b/client/state/experiments/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'experiments' ], reducer );

--- a/client/state/experiments/package.json
+++ b/client/state/experiments/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/experiments/reducer.ts
+++ b/client/state/experiments/reducer.ts
@@ -9,7 +9,7 @@ import { Action, Reducer } from 'redux';
 import { EXPERIMENT_FETCH, EXPERIMENT_ASSIGN } from 'calypso/state/action-types';
 import { ExperimentState, ExperimentAssign } from 'calypso/state/experiments/types';
 import { tracksAnonymousUserId } from 'calypso/lib/analytics/ad-tracking';
-import { withSchemaValidation } from 'calypso/state/utils';
+import { withSchemaValidation, withStorageKey } from 'calypso/state/utils';
 import { schema } from 'calypso/state/experiments/schema';
 
 /**
@@ -66,4 +66,6 @@ const reducer: Reducer< ExperimentState, HandledActions > = (
 	}
 };
 
-export default withSchemaValidation( schema, reducer );
+const validatedReducer = withSchemaValidation( schema, reducer );
+
+export default withStorageKey( 'experiments', validatedReducer );

--- a/client/state/experiments/selectors.ts
+++ b/client/state/experiments/selectors.ts
@@ -3,6 +3,8 @@
  */
 import type { AppState } from 'calypso/types';
 
+import 'calypso/state/experiments/init';
+
 /**
  * Returns the user's assigned variation for a given experiment
  *

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -18,7 +18,6 @@ import atomicTransfer from './atomic-transfer/reducer';
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import documentHead from './document-head/reducer';
-import experiments from './experiments/reducer';
 import happychat from './happychat/reducer';
 import i18n from './i18n/reducer';
 import immediateLogin from './immediate-login/reducer';
@@ -44,7 +43,6 @@ const reducers = {
 	currentUser,
 	dataRequests,
 	documentHead,
-	experiments,
 	happychat,
 	httpData,
 	i18n,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles experiments state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42434.

#### Changes proposed in this Pull Request

* Modularise experiments state

#### Testing instructions

Unfortunately, experiments state is loaded unconditionally pretty early in Calypso boot, at the `Layout` level, due to a currently running experiment. As such, it's not straightforward to verify the before/after on the automatic loading process, only that it does load.

To verify that everything continues working normally, please smoke-test that any experiment-related code continues to work correctly, by e.g. checking any of the currently-running experiments.