### PR TITLE
Plugins: Reduxify removePluginUpdateInfo flux action

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -47,14 +47,6 @@ const PluginsActions = {
 			wpcom.site( site.ID ).wpcomPluginsList( receivePluginsDispatcher );
 		}
 	},
-
-	removePluginUpdateInfo: ( site, plugin ) => {
-		Dispatcher.handleViewAction( {
-			type: 'REMOVE_PLUGINS_UPDATE_INFO',
-			site: site,
-			plugin: plugin,
-		} );
-	},
 };
 
 export default PluginsActions;

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -23,9 +23,6 @@ const debug = debugFactory( 'calypso:sites-plugins:sites-plugins-store' );
 /*
  * Constants
  */
-// time to wait until a plugin recentlyUpdate flag is cleared once it's updated
-const _UPDATED_PLUGIN_INFO_TIME_TO_LIVE = 10 * 1000;
-
 // Stores the plugins of each site.
 const _fetching = {};
 const _pluginsBySite = {};
@@ -304,10 +301,6 @@ PluginsStore.dispatchToken = Dispatcher.register( function ( { action } ) {
 					Object.assign( { update: { recentlyUpdated: true } }, action.data )
 				);
 				reduxDispatch( sitePluginUpdated( action.site.ID ) );
-				setTimeout(
-					PluginsActions.removePluginUpdateInfo.bind( PluginsActions, action.site, action.plugin ),
-					_UPDATED_PLUGIN_INFO_TIME_TO_LIVE
-				);
 			}
 			PluginsStore.emitChange();
 			break;

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -302,6 +302,13 @@ export function updatePlugin( siteId, plugin ) {
 		const successCallback = ( data ) => {
 			dispatch( { ...defaultAction, type: PLUGIN_UPDATE_REQUEST_SUCCESS, data } );
 			afterUpdateCallback( undefined, data );
+
+			// @TODO: Remove when this flux action is completely reduxified
+			Dispatcher.handleViewAction( {
+				type: 'REMOVE_PLUGINS_UPDATE_INFO',
+				site,
+				plugin,
+			} );
 		};
 
 		const errorCallback = ( error ) => {


### PR DESCRIPTION
We have several plugins stores, and they're pretty tightly coupled with a lot of functionality. They're also some of the most complex flux stores that remain. In #24180 we're working on reduxifying them step by step. This incremental approach is required because migration in a single PR is not a feasible task.

This PR reduxifies the plugin `removePluginUpdateInfo` action. In order to keep the store and only reduxify the flux actions, it updates the redux action creators to also dispatch the corresponding flux actions and updates all the component flux action usage with redux.

As a next step, we can start reduxifying the corresponding flux store functionality.

See #47742 for similar work we did for plugin updates and autoupdates.

This is part of #24180.

#### Changes proposed in this Pull Request

* Trigger `REMOVE_PLUGINS_UPDATE_INFO` flux action from Redux instead of using the flux action.
* Remove the unnecessary 10 second timeout. 
* Plugins: Delete obsolete `removePluginUpdateInfo` flux action.

#### Testing instructions

* Get a Jetpack site with some plugins for testing.
* Install an older version of a plugin.
* Visit the plugin page: `/plugins/:plugin/:site`
* You'll see a notice that the plugin needs an update. Click the button to update it.
* Verify that the "needs update" notice gets removed and a success notice is displayed only after a successful update.
* Verify all tests still pass.

#### Notes
* The initial 10-second timeout was introduced because we were displaying a success message immediately (see #1934). I don't think this is the case anymore, so this timeout should be easy to remove.
* To download an old version of a plugin, head to its page on https://wordpress.org/plugins/ then copy its link from the download button, and replace the latest tag with an older one (you can see those in the development log of every plugin - https://plugins.trac.wordpress.org/log/:plugin_slug).