### PR TITLE
Fix Jetpack Cloud infinite loop (non-Jetpack sites bug)

### DIFF
--- a/client/jetpack-cloud/index.js
+++ b/client/jetpack-cloud/index.js
@@ -14,6 +14,7 @@ import { siteSelection, sites } from 'calypso/my-sites/controller';
 import { startJetpackCloudOAuthOverride } from 'calypso/lib/jetpack/oauth-override';
 import { translate } from 'i18n-calypso';
 import Landing from './sections/landing';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 
 const debug = new Debug( 'calypso:jetpack-cloud:controller' );
 
@@ -34,7 +35,9 @@ const redirectToPrimarySiteLanding = ( context ) => {
 	const state = context.store.getState();
 	const currentUser = getCurrentUser( state );
 
-	page( `/landing/${ currentUser?.primarySiteSlug ?? '' }` );
+	isJetpackSite( state, currentUser.primary_blog )
+		? page( `/landing/${ currentUser.primarySiteSlug }` )
+		: page( `/landing` );
 };
 
 const landingController = ( context, next ) => {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -336,7 +336,7 @@ export function noSite( context, next ) {
  */
 export function siteSelection( context, next ) {
 	const { getState, dispatch } = getStore( context );
-	const siteFragment = context.params.site || context.query.site || getSiteFragment( context.path );
+	const siteFragment = context.params.site || getSiteFragment( context.path );
 	const basePath = sectionify( context.path, siteFragment );
 	const currentUser = getCurrentUser( getState() );
 	const hasOneSite = currentUser && currentUser.visible_site_count === 1;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the `redirectToPrimarySiteLanding` verify that the user's primary site is a Jetpack site before using it for a redirection.
* Revert change https://github.com/Automattic/wp-calypso/pull/47870/files#diff-18e8c98551ffdb30f512920db2f0637cbe65e6ac35b2a7d7cbb6164ff81b621eR339 made to the `siteSelection` controller.

#### Testing instructions

* Run this PR (Calypso Blue and Green).

**Calypso Green**
* Make sure your primary site is not a Jetpack site.
* Visit `http://jetpack.cloud.localhost:3001/`.
* Verify that you see the Site Selector prompt component.
* Visit `http://jetpack.cloud.localhost:3001/backup/fakesite`.
* Verify that you see the Site Selector prompt component.

**Calypso Blue**
* Visit `http://calypso.localhost:3000/backup/fakesite`.
* Verify that you see the Site Selector prompt component.

Repeat the exercise with a Jetpack site and any other type of site you can think of.

Fixes 1164141197617539-as-1199400895793101