### PR TITLE
Plugins: Remove unnecessary NOT_ALLOWED_TO_RECEIVE_PLUGINS flux action

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -1,13 +1,7 @@
 /**
- * External dependencies
- */
-import { defer } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import Dispatcher from 'calypso/dispatcher';
-import { userCan } from 'calypso/lib/site/utils';
 import wpcom from 'calypso/lib/wp';
 
 const PluginsActions = {
@@ -19,18 +13,6 @@ const PluginsActions = {
 	},
 
 	fetchSitePlugins: ( site ) => {
-		if ( ! userCan( 'manage_options', site ) || ! site.jetpack ) {
-			defer( () => {
-				Dispatcher.handleViewAction( {
-					type: 'NOT_ALLOWED_TO_RECEIVE_PLUGINS',
-					action: 'RECEIVE_PLUGINS',
-					site: site,
-				} );
-			} );
-
-			return;
-		}
-
 		const receivePluginsDispatcher = ( error, data ) => {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_PLUGINS',

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -271,12 +271,6 @@ PluginsStore.dispatchToken = Dispatcher.register( function ( { action } ) {
 			PluginsStore.emitChange();
 			break;
 
-		case 'NOT_ALLOWED_TO_RECEIVE_PLUGINS':
-			_fetching[ action.site.ID ] = false;
-			_pluginsBySite[ action.site.ID ] = {};
-			PluginsStore.emitChange();
-			break;
-
 		case 'UPDATE_PLUGIN':
 			PluginsStore.emitChange();
 			break;

--- a/client/lib/plugins/test/fixtures/actions.js
+++ b/client/lib/plugins/test/fixtures/actions.js
@@ -42,13 +42,6 @@ export default {
 		},
 	},
 
-	fetchedNotAllowed: {
-		type: 'NOT_ALLOWED_TO_RECEIVE_PLUGINS',
-		site: { ID: 123 },
-		data: undefined,
-		error: undefined,
-	},
-
 	// Update
 	updatePlugin: {
 		type: 'UPDATE_PLUGIN',

--- a/client/lib/plugins/test/store.js
+++ b/client/lib/plugins/test/store.js
@@ -181,18 +181,6 @@ describe( 'Plugins Store', () => {
 			} );
 			assert.lengthOf( UpdatedStore, 0 );
 		} );
-
-		test( 'Should not set value of the site if NOT_ALLOWED_TO_RECEIVE_PLUGINS errors', () => {
-			Dispatcher.handleServerAction( actions.fetchedNotAllowed );
-			const UpdatedStore = PluginsStore.getPlugins( { ID: 123 } );
-			assert.isDefined( UpdatedStore );
-			assert.lengthOf( UpdatedStore, 0 );
-		} );
-
-		test( 'Should not be set as "fetching" after NOT_ALLOWED_TO_RECEIVE_PLUGINS is triggered', () => {
-			Dispatcher.handleServerAction( actions.fetchedNotAllowed );
-			assert.isFalse( PluginsStore.isFetchingSite( { ID: 123 } ) );
-		} );
 	} );
 
 	describe( 'Fetch Plugins Again', () => {


### PR DESCRIPTION
Prior to #15482, we were doing some of the capability checks, whether the user can install plugins in the flux actions themselves. However, since #15482 landed, the primary components will prevent the unauthorized requests already, so the extra checks at the flux layer are no longer necessary.

Removing the arbitrary checks contributes to one less flux trait to reduxify, which makes it related to #24180 where we are reduxifying the rest of the plugins functionality.

#### Changes proposed in this Pull Request

* Plugins: Remove unnecessary `NOT_ALLOWED_TO_RECEIVE_PLUGINS` flux action

#### Testing instructions

* Login to WP.com as a user who is a contributor or author in a Jetpack site.
* Go to `/plugins/manage/:site`
* Verify there is no network request to `/sites/:siteId/plugins`, there are no errors, and you're still seeing the "Oops! You don't have permission to manage plugins." message.
* Go to `/plugins/manage/:site` as an administrator of the site, and verify things continue to work properly - plugins load, and there is a network request to `/sites/:siteId/plugins`.
