### PR TITLE
Focused launch: Highlight flow steps [part 2]

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -14,20 +14,20 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
  */
 import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
 import { LAUNCH_STORE } from '../../stores';
-import { useSite, useDomainSearch } from '@automattic/launch';
+import { useDomainSelection, useSiteDomains, useDomainSearch } from '@automattic/launch';
 
 import { FLOW_ID } from '../../constants';
 import './styles.scss';
 
 const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
-	const { plan, domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
-	const { currentDomainName } = useSite();
+	const { plan } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+	const { currentDomain } = useDomainSelection();
+	const { siteSubdomain } = useSiteDomains();
 	const { domainSearch, setDomainSearch } = useDomainSearch();
 
 	const { setDomain, unsetDomain, unsetPlan, confirmDomainSelection } = useDispatch( LAUNCH_STORE );
 
 	const handleNext = () => {
-		confirmDomainSelection();
 		onNextStep?.();
 	};
 
@@ -74,8 +74,8 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 					initialDomainSearch={ domainSearch }
 					onSetDomainSearch={ setDomainSearch }
 					onDomainSearchBlur={ trackDomainSearchInteraction }
-					currentDomain={ domain || mockDomainSuggestion( currentDomainName ) }
-					existingSubdomain={ mockDomainSuggestion( currentDomainName ) }
+					currentDomain={ currentDomain }
+					existingSubdomain={ mockDomainSuggestion( siteSubdomain?.domain ) }
 					onDomainSelect={ handleDomainSelect }
 					onExistingSubdomainSelect={ handleExistingSubdomainSelect }
 					analyticsUiAlgo="editor_domain_modal"

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Button, Tip } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
-import { useSite, useDomainSuggestion, useDomainSearch, useTitle } from '@automattic/launch';
+import { useSiteDomains, useDomainSuggestion, useDomainSearch, useTitle } from '@automattic/launch';
 import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
 import {
 	CheckoutStepBody,
@@ -43,7 +43,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 	const isFlowCompleted = useSelect( ( select ) => select( LAUNCH_STORE ).isFlowCompleted() );
 
 	const { title } = useTitle();
-	const { currentDomainName } = useSite();
+	const { siteSubdomain } = useSiteDomains();
 	const domainSuggestion = useDomainSuggestion();
 	const { domainSearch } = useDomainSearch();
 
@@ -66,7 +66,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 			) : (
 				<>
 					<p>
-						{ __( 'Free site address', 'full-site-editing' ) }: { currentDomainName }
+						{ __( 'Free site address', 'full-site-editing' ) }: { siteSubdomain?.domain }
 					</p>
 					<Tip>
 						{ domainSearch

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -120,7 +120,7 @@ export interface DomainSuggestion {
 	/**
 	 * Whether the domain is free
 	 */
-	is_free?: true;
+	is_free?: boolean;
 
 	/**
 	 * Whether the domain requies HSTS

--- a/packages/launch/src/focused-launch/domain-details/index.tsx
+++ b/packages/launch/src/focused-launch/domain-details/index.tsx
@@ -16,7 +16,7 @@ import { useLocale } from '@automattic/i18n-utils';
 /**
  * Internal dependencies
  */
-import { useSite, useDomainSearch, useDomainSelection } from '../../hooks';
+import { useDomainSearch, useDomainSelection, useSiteDomains } from '../../hooks';
 import { FOCUSED_LAUNCH_FLOW_ID } from '../../constants';
 import GoBackButton from '../go-back-button';
 
@@ -27,9 +27,9 @@ const ANALYTICS_UI_LOCATION = 'domain_step';
 const DomainDetails: React.FunctionComponent = () => {
 	const locale = useLocale();
 
-	const { currentDomainName } = useSite();
+	const { siteSubdomain } = useSiteDomains();
 	const { domainSearch, setDomainSearch } = useDomainSearch();
-	const { onDomainSelect, onExistingSubdomainSelect, selectedDomain } = useDomainSelection();
+	const { onDomainSelect, onExistingSubdomainSelect, currentDomain } = useDomainSelection();
 	const history = useHistory();
 
 	const goBack = () => {
@@ -65,8 +65,8 @@ const DomainDetails: React.FunctionComponent = () => {
 					initialDomainSearch={ domainSearch }
 					onSetDomainSearch={ setDomainSearch }
 					onDomainSearchBlur={ trackDomainSearchInteraction }
-					currentDomain={ selectedDomain || mockDomainSuggestion( currentDomainName ) }
-					existingSubdomain={ mockDomainSuggestion( currentDomainName ) }
+					currentDomain={ currentDomain }
+					existingSubdomain={ mockDomainSuggestion( siteSubdomain?.domain ) }
 					onDomainSelect={ handleSelect }
 					onExistingSubdomainSelect={ onExistingSubdomainSelect }
 					analyticsFlowId={ FOCUSED_LAUNCH_FLOW_ID }

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -34,7 +34,7 @@ import FocusedLaunchSummaryItem, {
 } from './focused-launch-summary-item';
 import { LAUNCH_STORE, SITE_STORE, Plan } from '../../stores';
 import LaunchContext from '../../context';
-import { isDefaultSiteTitle } from '../../utils';
+import { isValidSiteTitle } from '../../utils';
 import { FOCUSED_LAUNCH_FLOW_ID } from '../../constants';
 
 import './style.scss';
@@ -135,7 +135,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 
 	return (
 		<SummaryStep
-			highlighted={ !! title }
+			highlighted={ isValidSiteTitle( title ) }
 			input={
 				hasPaidDomain ? (
 					<>
@@ -524,8 +524,8 @@ const Summary: React.FunctionComponent = () => {
 	const { setModalDismissible, showModalTitle } = useDispatch( LAUNCH_STORE );
 
 	const { title, updateTitle, saveTitle, isSiteTitleStepVisible, showSiteTitleStep } = useTitle();
-	const { sitePrimaryDomain, siteSubdomain, hasPaidDomain } = useSiteDomains();
-	const { onDomainSelect, onExistingSubdomainSelect } = useDomainSelection();
+	const { siteSubdomain, hasPaidDomain } = useSiteDomains();
+	const { onDomainSelect, onExistingSubdomainSelect, currentDomain } = useDomainSelection();
 	const { domainSearch, isLoading } = useDomainSearch();
 	const { isPaidPlan: hasPaidPlan } = useSite();
 
@@ -544,10 +544,7 @@ const Summary: React.FunctionComponent = () => {
 	// step to the user when in this launch flow.
 	// Allow changing site title when it's the default value or when it's an empty string.
 	React.useEffect( () => {
-		if (
-			! isSiteTitleStepVisible &&
-			( title === '' || isDefaultSiteTitle( { currentSiteTitle: title } ) )
-		) {
+		if ( ! isSiteTitleStepVisible && ! isValidSiteTitle( title ) ) {
 			showSiteTitleStep();
 		}
 	}, [ title, showSiteTitleStep, isSiteTitleStepVisible ] );
@@ -586,7 +583,7 @@ const Summary: React.FunctionComponent = () => {
 			stepIndex={ forwardStepIndex ? stepIndex : undefined }
 			key={ stepIndex }
 			existingSubdomain={ mockDomainSuggestion( siteSubdomain?.domain ) }
-			currentDomain={ selectedDomain ?? mockDomainSuggestion( sitePrimaryDomain?.domain ) }
+			currentDomain={ currentDomain }
 			initialDomainSearch={ domainSearch }
 			hasPaidDomain={ hasPaidDomain }
 			isLoading={ isLoading }

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -166,7 +166,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							</p>
 						</label>
 						<FocusedLaunchSummaryItem readOnly>
-							<LeadingContentSide label={ currentDomain || '' } />
+							<LeadingContentSide label={ currentDomain?.domain_name || '' } />
 							<TrailingContentSide nodeType="PRICE">
 								<Icon icon={ check } size={ 18 } /> { __( 'Purchased', __i18n_text_domain__ ) }
 							</TrailingContentSide>

--- a/packages/launch/src/hooks/use-domain-search.ts
+++ b/packages/launch/src/hooks/use-domain-search.ts
@@ -9,6 +9,7 @@ import { useDispatch } from '@wordpress/data';
 import { LAUNCH_STORE } from '../stores';
 import { useSite, useTitle } from './';
 import { isDefaultSiteTitle } from '../utils';
+import { useSiteDomains } from './use-site-domains';
 
 export function useDomainSearch(): {
 	domainSearch: string;
@@ -17,13 +18,15 @@ export function useDomainSearch(): {
 } {
 	const { domainSearch } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 	const { title } = useTitle();
-	const { currentDomainName, isLoadingSite } = useSite();
+	const { isLoadingSite } = useSite();
+	const { siteSubdomain } = useSiteDomains();
+
 	const { setDomainSearch } = useDispatch( LAUNCH_STORE );
 
 	let search = domainSearch.trim() || title;
 
 	if ( ! search || isDefaultSiteTitle( { currentSiteTitle: search, exact: true } ) ) {
-		search = currentDomainName?.split( '.' )[ 0 ] ?? '';
+		search = siteSubdomain?.domain?.split( '.' )[ 0 ] ?? '';
 	}
 
 	return {

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -3,16 +3,20 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import type { DomainSuggestions } from '@automattic/data-stores';
+import { mockDomainSuggestion } from '@automattic/domain-picker';
 
 /**
  * Internal dependencies
  */
 import { LAUNCH_STORE } from '../stores';
+import { useSiteDomains } from './use-site-domains';
 
 export function useDomainSelection() {
-	const { plan } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 	const { setDomain, unsetDomain, unsetPlan, confirmDomainSelection } = useDispatch( LAUNCH_STORE );
-	const { domain: selectedDomain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+	const { domain: selectedDomain, plan, confirmedDomainSelection } = useSelect( ( select ) =>
+		select( LAUNCH_STORE ).getState()
+	);
+	const { siteSubdomain } = useSiteDomains();
 
 	function onDomainSelect( suggestion: DomainSuggestions.DomainSuggestion ) {
 		confirmDomainSelection();
@@ -30,5 +34,9 @@ export function useDomainSelection() {
 		onDomainSelect,
 		onExistingSubdomainSelect,
 		selectedDomain,
+		currentDomain:
+			selectedDomain || confirmedDomainSelection
+				? mockDomainSuggestion( siteSubdomain?.domain )
+				: undefined,
 	};
 }

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -27,6 +27,7 @@ export function useDomainSelection() {
 	}
 
 	function onExistingSubdomainSelect() {
+		confirmDomainSelection();
 		unsetDomain();
 	}
 

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -31,13 +31,19 @@ export function useDomainSelection() {
 		unsetDomain();
 	}
 
+	let currentDomain: DomainSuggestions.DomainSuggestion | undefined = undefined;
+
+	if ( selectedDomain ) {
+		currentDomain = selectedDomain;
+	} else if ( confirmedDomainSelection ) {
+		// in the scenario where confirmedDomainSelection is true and selectedDomain is falsey we can assume they've selected the sub-domain
+		currentDomain = mockDomainSuggestion( siteSubdomain?.domain );
+	}
+
 	return {
 		onDomainSelect,
 		onExistingSubdomainSelect,
 		selectedDomain,
-		currentDomain:
-			selectedDomain || confirmedDomainSelection
-				? mockDomainSuggestion( siteSubdomain?.domain )
-				: undefined,
+		currentDomain,
 	};
 }

--- a/packages/launch/src/hooks/use-site.ts
+++ b/packages/launch/src/hooks/use-site.ts
@@ -22,7 +22,6 @@ export function useSite() {
 		isPaidPlan: site && ! site.plan?.is_free, // sometimes plan will not be available: https://github.com/Automattic/wp-calypso/pull/44895
 		isSiteLaunched,
 		isSiteLaunching,
-		currentDomainName: site?.URL && new URL( site?.URL ).hostname,
 		selectedFeatures: site?.options?.selected_features,
 		isLoadingSite: !! isLoading,
 	};

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -21,6 +21,9 @@ export const isDefaultSiteTitle = ( {
 		? currentSiteTitle === DEFAULT_SITE_NAME
 		: new RegExp( DEFAULT_SITE_NAME, 'i' ).test( currentSiteTitle );
 
+export const isValidSiteTitle = ( title?: string ): boolean =>
+	title !== '' && ! isDefaultSiteTitle( { currentSiteTitle: title } );
+
 type PlanProduct = {
 	product_id: number;
 	product_slug: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't preselect subdomain anymore. An explicit selection is now needed in order for Plans step to be highlighted.
* Highlight domain step only if title has a value and is not the default title

**Demo:** https://cloudup.com/cdwclxj2aXA

#### Testing instructions

* same as https://github.com/Automattic/wp-calypso/pull/47503

Fixes #47743
