### PR TITLE
Focused Launch: Render selected popular plan once

### DIFF
--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -57,20 +57,6 @@ const plan: Reducer< Plans.Plan | undefined, LaunchAction > = ( state, action ) 
 	return state;
 };
 
-/**
- * To keep track of the last paid plan the user has picked
- * This is useful information as this paid plan can be suggested later
- *
- * @param state the state
- * @param action the action
- */
-const paidPlan: Reducer< Plans.Plan | undefined, LaunchAction > = ( state, action ) => {
-	if ( action.type === 'SET_PLAN' && ! action.plan?.isFree ) {
-		return action.plan;
-	}
-	return state;
-};
-
 // Check if focused launch modal is open
 const isFocusedLaunchOpen: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
 	if ( action.type === 'OPEN_FOCUSED_LAUNCH' ) {
@@ -168,7 +154,6 @@ const reducer = combineReducers( {
 	confirmedDomainSelection,
 	domainSearch,
 	plan,
-	paidPlan,
 	isSidebarOpen,
 	isSidebarFullscreen,
 	isExperimental,

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -35,7 +35,9 @@ export const getSelectedPlan = ( state: State ): Plans.Plan | undefined => state
  *
  * @param state State
  */
-export const getPaidPlan = ( state: State ): Plans.Plan | undefined => state.paidPlan;
+export const getPaidPlan = ( state: State ): Plans.Plan | undefined =>
+	state.plan && ! state.plan?.isFree ? state.plan : undefined;
+
 // Check if a domain has been explicitly selected (including free subdomain)
 
 /**

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -307,7 +307,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 	// this allows us to keep showing it when they change their mind, we don't want
 	// it to disappear once they pick the default paid plan
 	React.useEffect( () => {
-		if ( onceSelectedPaidPlan !== defaultPaidPlan ) {
+		if ( defaultPaidPlan && onceSelectedPaidPlan !== defaultPaidPlan ) {
 			setNonDefaultPaidPlan( onceSelectedPaidPlan );
 		}
 	}, [ onceSelectedPaidPlan, defaultPaidPlan ] );

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -280,37 +280,27 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 	hasPaidDomain = false,
 	selectedPaidDomain = false,
 } ) => {
-	const { setPlan, unsetPlan } = useDispatch( LAUNCH_STORE );
+	const { setPlan } = useDispatch( LAUNCH_STORE );
 
 	const selectedPlan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
 
-	const onceSelectedPaidPlan = useSelect( ( select ) => select( LAUNCH_STORE ).getPaidPlan() );
+	const selectedPaidPlan = useSelect( ( select ) => select( LAUNCH_STORE ).getPaidPlan() );
 
 	const { defaultPaidPlan, defaultFreePlan, planPrices } = usePlans();
 
-	const [ nonDefaultPaidPlan, setNonDefaultPaidPlan ] = React.useState< Plan | undefined >();
+	// persist selected plan if it's paid in order to keep displaying it in the
+	const onceSelectedPaidPlan = React.useRef( selectedPaidPlan );
 
 	const isPlanSelected = ( plan: Plan ) => plan && plan.storeSlug === selectedPlan?.storeSlug;
 
-	const sitePlan = useSite().sitePlan;
+	const { sitePlan } = useSite();
 
-	React.useEffect( () => {
-		// To keep the launch store state valid,
-		// unselect the free plan if the user selected a paid domain.
-		// free plans don't support paid domains.
-		if ( selectedPaidDomain && selectedPlan && selectedPlan.isFree ) {
-			unsetPlan();
-		}
-	}, [ selectedPaidDomain, selectedPlan, unsetPlan ] );
-
-	// if the user picks a non-default paid plan, we need to keep track of it
-	// this allows us to keep showing it when they change their mind, we don't want
-	// it to disappear once they pick the default paid plan
-	React.useEffect( () => {
-		if ( defaultPaidPlan && onceSelectedPaidPlan !== defaultPaidPlan ) {
-			setNonDefaultPaidPlan( onceSelectedPaidPlan );
-		}
-	}, [ onceSelectedPaidPlan, defaultPaidPlan ] );
+	const nonDefaultPaidPlan =
+		onceSelectedPaidPlan?.current &&
+		defaultPaidPlan &&
+		onceSelectedPaidPlan?.current?.storeSlug !== defaultPaidPlan?.storeSlug
+			? onceSelectedPaidPlan?.current
+			: undefined;
 
 	return (
 		<SummaryStep
@@ -406,8 +396,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 
 							{ nonDefaultPaidPlan && (
 								<FocusedLaunchSummaryItem
-									isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
-									onClick={ () => nonDefaultPaidPlan && setPlan( nonDefaultPaidPlan ) }
+									onClick={ () => setPlan( nonDefaultPaidPlan ) }
 									isSelected={ isPlanSelected( nonDefaultPaidPlan ) }
 								>
 									<LeadingContentSide
@@ -415,17 +404,15 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 											/* translators: %s is WordPress.com plan name (eg: Premium Plan) */
 											sprintf(
 												__( '%s Plan', __i18n_text_domain__ ),
-												nonDefaultPaidPlan?.title ?? ''
+												nonDefaultPaidPlan.title ?? ''
 											)
 										}
 										badgeText={
-											nonDefaultPaidPlan?.isPopular ? __( 'Popular', __i18n_text_domain__ ) : ''
+											nonDefaultPaidPlan.isPopular ? __( 'Popular', __i18n_text_domain__ ) : ''
 										}
 									/>
 									<TrailingContentSide nodeType="PRICE">
-										<span>
-											{ nonDefaultPaidPlan && planPrices[ nonDefaultPaidPlan?.storeSlug ] }
-										</span>
+										<span>{ planPrices[ nonDefaultPaidPlan?.storeSlug ] }</span>
 										<span>
 											{
 												// translators: /mo is short for "per-month"


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Check that `defaultPaidPlan` is not `undefined` to avoid that the popular plan renders twice. 

#### Testing instructions

* checkout this branch
* open `packages/launch/src/focused-launch/summary/index.tsx` and set `defaultPaidPlan` to `undefined`.
* run `yarn` && `yarn start` in a terminal;
* go to the block editor, append ?flags=create/focused-launch-flow-calypso to the URL, and refresh the page;
* click on "View all plans";
* select the Premium Plan and go back to the summary;
   * [ ] only the Premium Plan & Free Plan should be visible;
* click on "View all plans" again;
* select the eCommerce plan and go back to the summary;
   * [ ] the Premium, eCommerce & Free plans should be visible 

Fixes #47789
Fixes #47544