### PR TITLE
Modularise immediate login state

### DIFF
--- a/client/state/immediate-login/actions.js
+++ b/client/state/immediate-login/actions.js
@@ -1,16 +1,14 @@
 /**
- * External dependencies
- */
-
-/**
  * Internal dependencies
  */
 import { IMMEDIATE_LOGIN_SAVE_INFO } from 'calypso/state/action-types';
 
+import 'calypso/state/immediate-login/init';
+
 /**
  * Stores immediate link-related information in state so it can be reused later
  *
- * @param {bool} success - Whether the immediate login attempt was successful.
+ * @param {boolean} success - Whether the immediate login attempt was successful.
  * @param {string} reason - Reason for this immediate login, if known.
  * @param {string} email - Email address used for the immediate login attempt,
  *                         if known.

--- a/client/state/immediate-login/init.js
+++ b/client/state/immediate-login/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'immediateLogin' ], reducer );

--- a/client/state/immediate-login/package.json
+++ b/client/state/immediate-login/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/immediate-login/reducer.js
+++ b/client/state/immediate-login/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import { withoutPersistence } from 'calypso/state/utils';
+import { withoutPersistence, withStorageKey } from 'calypso/state/utils';
 import { IMMEDIATE_LOGIN_SAVE_INFO } from 'calypso/state/action-types';
 
 const initialState = {
@@ -13,7 +13,7 @@ const initialState = {
 	locale: null,
 };
 
-export default withoutPersistence( ( state = initialState, action ) => {
+const reducer = withoutPersistence( ( state = initialState, action ) => {
 	switch ( action.type ) {
 		case IMMEDIATE_LOGIN_SAVE_INFO: {
 			const { success, reason, email, locale } = action;
@@ -30,3 +30,5 @@ export default withoutPersistence( ( state = initialState, action ) => {
 
 	return state;
 } );
+
+export default withStorageKey( 'immediateLogin', reducer );

--- a/client/state/immediate-login/selectors.js
+++ b/client/state/immediate-login/selectors.js
@@ -8,12 +8,14 @@ import { get, includes } from 'lodash';
  */
 import { REASONS_FOR_MANUAL_RENEWAL } from './constants';
 
+import 'calypso/state/immediate-login/init';
+
 /**
  * Retrieves information about whether an immediate login attempt was made for
  * the current instance of Calypso.
  *
  * @param  {object} state - Global state tree
- * @returns {bool} - Whether the client request indicates that an immediate
+ * @returns {boolean} - Whether the client request indicates that an immediate
  *                  login attempt was made
  */
 export const wasImmediateLoginAttempted = ( state ) => {
@@ -31,8 +33,8 @@ export const wasImmediateLoginAttempted = ( state ) => {
  * use it to make user interface improvements for the immediate login scenario.
  *
  * @param {object} state - Global state tree
- * @returns {bool} - Whether the client request indicates that an immediate
- *                  login attempt was successful
+ * @returns {boolean} - Whether the client request indicates that an immediate
+ *                      login attempt was successful
  */
 export const wasImmediateLoginSuccessfulAccordingToClient = ( state ) => {
 	return get( state, 'immediateLogin.success', false );
@@ -80,8 +82,8 @@ export const getImmediateLoginLocale = ( state ) => {
  * current instance of Calypso.
  *
  * @param {object} state - Global state tree
- * @returns {bool} - Whether the client request indicates that an immediate
- *                  login attempt was made from a manual renewal email
+ * @returns {boolean} - Whether the client request indicates that an immediate
+ *                      login attempt was made from a manual renewal email
  */
 export const wasManualRenewalImmediateLoginAttempted = ( state ) => {
 	return includes( REASONS_FOR_MANUAL_RENEWAL, getImmediateLoginReason( state ) );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -20,7 +20,6 @@ import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import documentHead from './document-head/reducer';
 import happychat from './happychat/reducer';
 import i18n from './i18n/reducer';
-import immediateLogin from './immediate-login/reducer';
 import importerNux from './importer-nux/reducer';
 import inlineSupportArticle from './inline-support-article/reducer';
 import jitm from './jitm/reducer';
@@ -45,7 +44,6 @@ const reducers = {
 	happychat,
 	httpData,
 	i18n,
-	immediateLogin,
 	importerNux,
 	inlineSupportArticle,
 	jitm,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles immediate login state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42445.

#### Changes proposed in this Pull Request

* Modularise immediate login state

#### Testing instructions

Unfortunately, immediate login state is loaded unconditionally pretty early in Calypso boot, due to some middleware. As such, it's not straightforward to verify the before/after on the automatic loading process, only that it does load.

I'm not entirely sure how to test immediate login, but I'm hoping that a simple smoke-test of that functionality is enough to validate that it continues working correctly after this change.