### PR TITLE
Plugins: Reduxify plugin fetching

### DIFF
--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -128,7 +128,7 @@ Actions get triggered by views and stores.
 
 Triggers api call to fetch the site data.
 
-#### PluginsActions.fetchSitePlugins( site );
+This action has been migrated to Redux. Please use the `fetchSitePlugins` Redux action.
 
 ---
 

--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import Dispatcher from 'calypso/dispatcher';
-import wpcom from 'calypso/lib/wp';
 
 const PluginsActions = {
 	removePluginsNotices: ( ...logs ) => {
@@ -10,24 +9,6 @@ const PluginsActions = {
 			type: 'REMOVE_PLUGINS_NOTICES',
 			logs: logs,
 		} );
-	},
-
-	fetchSitePlugins: ( site ) => {
-		const receivePluginsDispatcher = ( error, data ) => {
-			Dispatcher.handleServerAction( {
-				type: 'RECEIVE_PLUGINS',
-				action: 'RECEIVE_PLUGINS',
-				site: site,
-				data: data,
-				error: error,
-			} );
-		};
-
-		if ( site.jetpack ) {
-			wpcom.site( site.ID ).pluginsList( receivePluginsDispatcher );
-		} else {
-			wpcom.site( site.ID ).wpcomPluginsList( receivePluginsDispatcher );
-		}
 	},
 };
 

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -17,6 +17,7 @@ import { reduxDispatch, reduxGetState } from 'calypso/lib/redux-bridge';
 import getNetworkSites from 'calypso/state/selectors/get-network-sites';
 import { getSite } from 'calypso/state/sites/selectors';
 import { sitePluginUpdated } from 'calypso/state/sites/actions';
+import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 
 const debug = debugFactory( 'calypso:sites-plugins:sites-plugins-store' );
 
@@ -56,7 +57,7 @@ const _filters = {
 function refreshNetworkSites( site ) {
 	const networkSites = getNetworkSites( reduxGetState(), site.ID );
 	if ( networkSites ) {
-		networkSites.forEach( PluginsActions.fetchSitePlugins );
+		networkSites.forEach( ( networkSite ) => reduxDispatch( fetchSitePlugins( networkSite.ID ) ) );
 	}
 }
 
@@ -185,7 +186,7 @@ const PluginsStore = {
 			return [];
 		}
 		if ( ! _pluginsBySite[ site.ID ] && ! _fetching[ site.ID ] ) {
-			PluginsActions.fetchSitePlugins( site );
+			reduxDispatch( fetchSitePlugins( site.ID ) );
 			_fetching[ site.ID ] = true;
 		}
 		if ( ! _pluginsBySite[ site.ID ] ) {

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -10,7 +10,6 @@ import { assign, clone, isArray, sortBy, values, find } from 'lodash';
 import Dispatcher from 'calypso/dispatcher';
 import emitter from 'calypso/lib/mixins/emitter';
 /* eslint-enable no-restricted-imports */
-import PluginsActions from 'calypso/lib/plugins/actions';
 import versionCompare from 'calypso/lib/version-compare';
 import { normalizePluginData } from 'calypso/lib/plugins/utils';
 import { reduxDispatch, reduxGetState } from 'calypso/lib/redux-bridge';

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -617,6 +617,14 @@ export function removePlugin( siteId, plugin ) {
 	};
 }
 
+export function receivePlugins( siteId, plugins ) {
+	return {
+		type: PLUGINS_RECEIVE,
+		data: plugins,
+		siteId,
+	};
+}
+
 export function fetchPlugins( siteIds ) {
 	return ( dispatch, getState ) => {
 		return siteIds.map( ( siteId ) => {
@@ -626,7 +634,7 @@ export function fetchPlugins( siteIds ) {
 			dispatch( { ...defaultAction, type: PLUGINS_REQUEST } );
 
 			const receivePluginsDispatchSuccess = ( data ) => {
-				dispatch( { ...defaultAction, type: PLUGINS_RECEIVE, data: data.plugins } );
+				dispatch( receivePlugins( siteId, data.plugins ) );
 				dispatch( { ...defaultAction, type: PLUGINS_REQUEST_SUCCESS } );
 
 				data.plugins.map( ( plugin ) => {

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -617,7 +617,7 @@ export function removePlugin( siteId, plugin ) {
 	};
 }
 
-export function receivePlugins( siteId, plugins ) {
+export function receiveSitePlugins( siteId, plugins ) {
 	return {
 		type: PLUGINS_RECEIVE,
 		data: plugins,
@@ -625,34 +625,36 @@ export function receivePlugins( siteId, plugins ) {
 	};
 }
 
-export function fetchPlugins( siteIds ) {
+export function fetchSitePlugins( siteId ) {
 	return ( dispatch, getState ) => {
-		return siteIds.map( ( siteId ) => {
-			const defaultAction = {
-				siteId,
-			};
-			dispatch( { ...defaultAction, type: PLUGINS_REQUEST } );
+		const defaultAction = {
+			siteId,
+		};
+		dispatch( { ...defaultAction, type: PLUGINS_REQUEST } );
 
-			const receivePluginsDispatchSuccess = ( data ) => {
-				dispatch( receivePlugins( siteId, data.plugins ) );
-				dispatch( { ...defaultAction, type: PLUGINS_REQUEST_SUCCESS } );
+		const receivePluginsDispatchSuccess = ( data ) => {
+			dispatch( receiveSitePlugins( siteId, data.plugins ) );
+			dispatch( { ...defaultAction, type: PLUGINS_REQUEST_SUCCESS } );
 
-				data.plugins.map( ( plugin ) => {
-					if ( plugin.update && plugin.autoupdate ) {
-						updatePlugin( siteId, plugin )( dispatch, getState );
-					}
-				} );
-			};
+			data.plugins.map( ( plugin ) => {
+				if ( plugin.update && plugin.autoupdate ) {
+					updatePlugin( siteId, plugin )( dispatch, getState );
+				}
+			} );
+		};
 
-			const receivePluginsDispatchFail = ( error ) => {
-				dispatch( { ...defaultAction, type: PLUGINS_REQUEST_FAILURE, error } );
-			};
+		const receivePluginsDispatchFail = ( error ) => {
+			dispatch( { ...defaultAction, type: PLUGINS_REQUEST_FAILURE, error } );
+		};
 
-			return wpcom
-				.site( siteId )
-				.pluginsList()
-				.then( receivePluginsDispatchSuccess )
-				.catch( receivePluginsDispatchFail );
-		} );
+		return wpcom
+			.site( siteId )
+			.pluginsList()
+			.then( receivePluginsDispatchSuccess )
+			.catch( receivePluginsDispatchFail );
 	};
+}
+
+export function fetchPlugins( siteIds ) {
+	return ( dispatch ) => siteIds.map( ( siteId ) => dispatch( fetchSitePlugins( siteId ) ) );
 }

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -627,13 +627,27 @@ export function receiveSitePlugins( siteId, plugins ) {
 
 export function fetchSitePlugins( siteId ) {
 	return ( dispatch, getState ) => {
+		const state = getState();
+		const site = getSite( state, siteId );
 		const defaultAction = {
 			siteId,
 		};
 		dispatch( { ...defaultAction, type: PLUGINS_REQUEST } );
 
+		const afterFetchCallback = ( error, data ) => {
+			// @TODO: Remove when this flux action is completely reduxified
+			Dispatcher.handleServerAction( {
+				type: 'RECEIVE_PLUGINS',
+				action: 'RECEIVE_PLUGINS',
+				site,
+				data,
+				error,
+			} );
+		};
+
 		const receivePluginsDispatchSuccess = ( data ) => {
 			dispatch( receiveSitePlugins( siteId, data.plugins ) );
+			afterFetchCallback( undefined, data );
 			dispatch( { ...defaultAction, type: PLUGINS_REQUEST_SUCCESS } );
 
 			data.plugins.map( ( plugin ) => {
@@ -645,6 +659,7 @@ export function fetchSitePlugins( siteId ) {
 
 		const receivePluginsDispatchFail = ( error ) => {
 			dispatch( { ...defaultAction, type: PLUGINS_REQUEST_FAILURE, error } );
+			afterFetchCallback( error, undefined );
 		};
 
 		return wpcom

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -8,7 +8,7 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import {
-	fetchPlugins,
+	fetchSitePlugins,
 	activatePlugin,
 	deactivatePlugin,
 	updatePlugin,
@@ -81,7 +81,7 @@ describe( 'actions', () => {
 		},
 	} );
 
-	describe( '#fetchPlugins()', () => {
+	describe( '#fetchSitePlugins()', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
@@ -99,7 +99,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch fetch action when triggered', () => {
-			fetchPlugins( [ 2916284 ] )( spy, getState );
+			fetchSitePlugins( 2916284 )( spy, getState );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: PLUGINS_REQUEST,
@@ -108,8 +108,8 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch plugins receive action when request completes', () => {
-			const responses = fetchPlugins( [ 2916284 ] )( spy, getState );
-			return Promise.all( responses ).then( () => {
+			const response = fetchSitePlugins( 2916284 )( spy, getState );
+			return response.then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PLUGINS_RECEIVE,
 					siteId: 2916284,
@@ -119,8 +119,8 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch plugin request success action when request completes', () => {
-			const responses = fetchPlugins( [ 2916284 ] )( spy, getState );
-			return Promise.all( responses ).then( () => {
+			const response = fetchSitePlugins( 2916284 )( spy, getState );
+			return response.then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PLUGINS_REQUEST_SUCCESS,
 					siteId: 2916284,
@@ -129,8 +129,8 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch fail action when request fails', () => {
-			const responses = fetchPlugins( [ 77203074 ] )( spy, getState );
-			return Promise.all( responses ).then( () => {
+			const response = fetchSitePlugins( 77203074 )( spy, getState );
+			return response.then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PLUGINS_REQUEST_FAILURE,
 					siteId: 77203074,
@@ -142,8 +142,8 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch plugin update request if any site plugins need updating', () => {
-			const responses = fetchPlugins( [ 2916284 ] )( spy, getState );
-			return Promise.all( responses ).then( () => {
+			const response = fetchSitePlugins( 2916284 )( spy, getState );
+			return response.then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PLUGIN_UPDATE_REQUEST,
 					action: UPDATE_PLUGIN,


### PR DESCRIPTION
We have several plugins stores, and they're pretty tightly coupled with a lot of functionality. They're also some of the most complex flux stores that remain. In #24180 we're working on reduxifying them step by step. This incremental approach is required because migration in a single PR is not a feasible task.

This PR reduxifies plugin the fetching flux action. In order to keep the store and only reduxify the flux action, it updates the redux action creator to also dispatch the corresponding flux action and updates all the existing flux action usage with Redux. Additionally, it separates the existing Redux action creator site plugins functionality to separate action creators, because that's needed separately in another instance of the code.

As a next step, we can start reduxifying the corresponding flux store functionality that relies on plugin fetching.

See #47711 for similar work we did for plugin activation and deactivation, #47742 for updates and auto-updates, and #47860 for installation and uninstallation.

This PR is part of #24180.

#### Changes proposed in this Pull Request

* Move site plugins receiving to a separate action creator
* Move site plugin fetching to a separate action creator
* Dispatch flux plugins fetch action in the corresponding Redux action
* Use Redux instead of flux for fetching plugins
* Remove unused `fetchSitePlugins` flux action
* Add deprecation notice for the `fetchSitePlugins` flux action
* Update tests accordingly to reflect the new action creator structure

#### Testing instructions

* Get a Jetpack site with some plugins for testing.
* Verify initial fetching of plugins, fetching after updating, and fetching after installing or uninstalling a plugin still works everywhere:
  * `/plugins/:plugin/:site`
  * `/plugins/:plugin`
  * `/plugins`
  * `/plugins/manage/:site` - for a single plugin
  * `/plugins/manage/:site` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
* Install "All in One SEO Pack".
* Go to `/marketing/traffic/:site`.
* Verify that under "Search Engine Optimization" you're still seeing the "Your SEO settings are managed by the following plugin: All In One SEO Pack" notice.
* Verify all tests still pass.

#### Notes
* ~Do not merge just yet - this depends on #47911 and needs to be rebased when it's merged. Feel free to review it though - I've made sure that it's easier to review by basing it against #47911.~
* To download an old version of a plugin, head to its page on https://wordpress.org/plugins/ then copy its link from the download button, and replace the latest tag with an older one (you can see those in the development log of every plugin - https://plugins.trac.wordpress.org/log/:plugin_slug).