### PR TITLE
Pass through Anchor params into the Block Editor iframe

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -77,7 +77,11 @@ interface Props {
 	postType: T.PostType;
 	editorType: 'site' | 'post'; // Note: a page or other CPT is a type of post.
 	pressThis: any;
-	anchorFmData: any;
+	anchorFmData: {
+		anchor_podcast: string | undefined;
+		anchor_episode: string | undefined;
+		spotify_show_url: string | undefined;
+	};
 	siteAdminUrl: T.URL | null;
 	fseParentPageId: T.PostId;
 	parentPostId: T.PostId;

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -77,6 +77,7 @@ interface Props {
 	postType: T.PostType;
 	editorType: 'site' | 'post'; // Note: a page or other CPT is a type of post.
 	pressThis: any;
+	anchorFmData: any;
 	siteAdminUrl: T.URL | null;
 	fseParentPageId: T.PostId;
 	parentPostId: T.PostId;
@@ -779,6 +780,7 @@ const mapStateToProps = (
 		creatingNewHomepage,
 		editorType = 'post',
 		stripeConnectSuccess,
+		anchorFmData,
 	}: Props
 ) => {
 	const siteId = getSelectedSiteId( state );
@@ -801,6 +803,7 @@ const mapStateToProps = (
 		'environment-id': config( 'env_id' ),
 		'new-homepage': creatingNewHomepage,
 		...( !! stripeConnectSuccess && { stripe_connect_success: stripeConnectSuccess } ),
+		...anchorFmData,
 	} );
 
 	// needed for loading the editor in SU sessions

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -198,6 +198,11 @@ function getPressThisData( query ) {
 	return url ? { text, url, title, image, embed } : null;
 }
 
+function getAnchorFmData( query ) {
+	const { anchor_podcast, anchor_episode } = query;
+	return anchor_podcast && anchor_episode ? { anchor_podcast, anchor_episode } : null;
+}
+
 export const post = ( context, next ) => {
 	// See post-editor/controller.js for reference.
 
@@ -211,6 +216,7 @@ export const post = ( context, next ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	const pressThis = getPressThisData( context.query );
+	const anchorFmData = getAnchorFmData( context.query );
 	const fseParentPageId = parseInt( context.query.fse_parent_post, 10 ) || null;
 	const parentPostId = parseInt( context.query.parent_post, 10 ) || null;
 
@@ -227,6 +233,7 @@ export const post = ( context, next ) => {
 			postType={ postType }
 			duplicatePostId={ duplicatePostId }
 			pressThis={ pressThis }
+			anchorFmData={ anchorFmData }
 			fseParentPageId={ fseParentPageId }
 			parentPostId={ parentPostId }
 			creatingNewHomepage={ postType === 'page' && has( context, 'query.new-homepage' ) }

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -199,8 +199,8 @@ function getPressThisData( query ) {
 }
 
 function getAnchorFmData( query ) {
-	const { anchor_podcast, anchor_episode } = query;
-	return anchor_podcast && anchor_episode ? { anchor_podcast, anchor_episode } : null;
+	const { anchor_podcast, anchor_episode, spotify_show_url } = query;
+	return { anchor_podcast, anchor_episode, spotify_show_url };
 }
 
 export const post = ( context, next ) => {


### PR DESCRIPTION
Fixes 315-gh-Automattic/dotcom-manage

#### Changes proposed in this Pull Request

* takes GET params from the post edit route in calypso and passes them as GET params to the `post(-new).php` which is loaded in an iframe (and read by our Anchor extension in https://github.com/Automattic/jetpack/pull/17936)
* allowed params are `anchor_podcast`, `anchor_episode` and `spotify_show_url`

#### Testing instructions
* using this branch, on literally any site, click "Write" to start a new post and manually edit the URL to add the three params
* for example `http://calypso.localhost:3000/post/example.com?anchor_podcast=test&anchor_episode=test&spotify_show_url=test`
* wait for the editor to load
* inspect the page and find the iframe with the block editor loaded
* confim its URL contains both GET params with values you've added to the calypso URL
* expect no functionality/visual change. These params are not handled as of now but we need them to be passed through for later