### PR TITLE
Plugins: Reduxify PluginAutoUpdateToggle progress

### DIFF
--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -10,12 +10,14 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PluginsActions from 'calypso/lib/plugins/actions';
-import PluginsLog from 'calypso/lib/plugins/log-store';
 import PluginAction from 'calypso/my-sites/plugins/plugin-action/plugin-action';
 import ExternalLink from 'calypso/components/external-link';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSiteFileModDisableReason, isMainNetworkSite } from 'calypso/lib/site/utils';
+import { getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
 import { togglePluginAutoUpdate } from 'calypso/state/plugins/installed/actions';
+
+const autoUpdateActions = [ 'ENABLE_AUTOUPDATE_PLUGIN', 'DISABLE_AUTOUPDATE_PLUGIN' ];
 
 export class PluginAutoUpdateToggle extends Component {
 	toggleAutoUpdates = () => {
@@ -137,15 +139,11 @@ export class PluginAutoUpdateToggle extends Component {
 	}
 
 	render() {
-		const { site, plugin, translate, disabled } = this.props;
+		const { inProgress, site, plugin, translate, disabled } = this.props;
 		if ( ! site.jetpack ) {
 			return null;
 		}
 
-		const inProgress = PluginsLog.isInProgressAction( site.ID, plugin.slug, [
-			'ENABLE_AUTOUPDATE_PLUGIN',
-			'DISABLE_AUTOUPDATE_PLUGIN',
-		] );
 		const getDisabledInfo = this.getDisabledInfo();
 		const label = translate( 'Autoupdates', {
 			comment:
@@ -179,8 +177,19 @@ PluginAutoUpdateToggle.defaultProps = {
 	disabled: false,
 };
 
-export default connect( null, {
-	recordGoogleEvent,
-	recordTracksEvent,
-	togglePluginAutoUpdate,
-} )( localize( PluginAutoUpdateToggle ) );
+export default connect(
+	( state, { site, plugin } ) => {
+		const pluginStatus = getStatusForPlugin( state, site.ID, plugin.id );
+		const inProgress =
+			autoUpdateActions.includes( pluginStatus?.action ) && 'inProgress' === pluginStatus?.status;
+
+		return {
+			inProgress,
+		};
+	},
+	{
+		recordGoogleEvent,
+		recordTracksEvent,
+		togglePluginAutoUpdate,
+	}
+)( localize( PluginAutoUpdateToggle ) );


### PR DESCRIPTION
This PR updates the `PluginAutoUpdateToggle` component to use Redux for determining whether the plugin auto-update functionality is being enabled/disabled or not, instead of using the old `PluginsLog` store.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Reduxify `PluginAutoUpdateToggle` progress

#### Testing instructions

* Get a Jetpack site for testing.
* Go to `/plugins/hello-dolly/:site` and install the plugin if it's not installed.
* Enable and disable the plugin's autoupdate toggle.
* Verify that while enabling and disabling the auto-update setting, the toggle gets disabled.
* Verify all tests still pass.

#### Note

We could be importing the notice actions from the plugins state constants file that defines them, but I'm leaving that for another PR as it affects other locations, too.