### PR TITLE
e2e: Update free plan selector to account for two versions

### DIFF
--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -48,7 +48,7 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 
 		if ( level === 'free' ) {
 			if ( ! ( await driverHelper.isElementPresent( this.driver, selector ) ) ) {
-				selector = By.css( '.plans-features-main__banner-content button' );
+				selector = By.css( '.plans-features-main__banner-content button, .formatted-header__subtitle button' );
 			}
 		}
 		await driverHelper.waitTillPresentAndDisplayed(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*This PR updates the selector for the free plan in signup because there are currently two different versions coming in and they aren't being set switched by the calypso config

#### Testing instructions

* make sure e2e tests pass