### PR TITLE
Add ability to redirect when completing a purchase triggered by ManagePurchase

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -132,9 +132,11 @@ function getSubscriptionEndDate( purchase ) {
  *
  * @param {object} purchase - the purchase to be renewed
  * @param {string} siteSlug - the site slug to renew the purchase for
- * @param {object} tracksProps - where was the renew button clicked from
+ * @param {object} [options] - optional information
+ * @param {string} [options.redirectTo] - Passed as redirect_to in checkout
+ * @param {object} [options.tracksProps] - where was the renew button clicked from
  */
-function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
+function handleRenewNowClick( purchase, siteSlug, options = {} ) {
 	const renewItem = getRenewalItemFromProduct( purchase, {
 		domain: purchase.meta,
 	} );
@@ -142,7 +144,7 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 	// Track the renew now submit.
 	recordTracksEvent( 'calypso_purchases_renew_now_click', {
 		product_slug: purchase.productSlug,
-		...tracksProps,
+		...options.tracksProps,
 	} );
 
 	if ( ! renewItem.extra.purchaseId ) {
@@ -155,9 +157,12 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 	}
 	const { productSlugs, purchaseIds } = getProductSlugsAndPurchaseIds( [ renewItem ] );
 
-	const renewalUrl = `/checkout/${ productSlugs[ 0 ] }/renew/${ purchaseIds[ 0 ] }/${
+	let renewalUrl = `/checkout/${ productSlugs[ 0 ] }/renew/${ purchaseIds[ 0 ] }/${
 		siteSlug || renewItem.extra.purchaseDomain || ''
 	}`;
+	if ( options.redirectTo ) {
+		renewalUrl += '?redirect_to=' + encodeURIComponent( options.redirectTo );
+	}
 	debug( 'handling renewal click', purchase, siteSlug, renewItem, renewalUrl );
 
 	page( renewalUrl );
@@ -168,14 +173,16 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
  *
  * @param {Array} purchases - the purchases to be renewed
  * @param {string} siteSlug - the site slug to renew the purchase for
- * @param {object} tracksProps - where was the renew button clicked from
+ * @param {object} [options] - optional information
+ * @param {string} [options.redirectTo] - Passed as redirect_to in checkout
+ * @param {object} [options.tracksProps] - where was the renew button clicked from
  */
-function handleRenewMultiplePurchasesClick( purchases, siteSlug, tracksProps = {} ) {
+function handleRenewMultiplePurchasesClick( purchases, siteSlug, options = {} ) {
 	purchases.forEach( ( purchase ) => {
 		// Track the renew now submit.
 		recordTracksEvent( 'calypso_purchases_renew_multiple_click', {
 			product_slug: purchase.productSlug,
-			...tracksProps,
+			...options.tracksProps,
 		} );
 	} );
 
@@ -191,9 +198,12 @@ function handleRenewMultiplePurchasesClick( purchases, siteSlug, tracksProps = {
 		throw new Error( 'Could not find product slug or purchase id for renewal.' );
 	}
 
-	const renewalUrl = `/checkout/${ productSlugs.join( ',' ) }/renew/${ purchaseIds.join( ',' ) }/${
+	let renewalUrl = `/checkout/${ productSlugs.join( ',' ) }/renew/${ purchaseIds.join( ',' ) }/${
 		siteSlug || renewItems[ 0 ].extra.purchaseDomain || ''
 	}`;
+	if ( options.redirectTo ) {
+		renewalUrl += '?redirect_to=' + encodeURIComponent( options.redirectTo );
+	}
 	debug( 'handling renewal click', purchases, siteSlug, renewItems, renewalUrl );
 
 	page( renewalUrl );

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -225,6 +225,13 @@ describe( 'index', () => {
 			);
 		} );
 
+		test( 'should redirect to the checkout page with ?redirect_to', () => {
+			handleRenewNowClick( purchase, siteSlug, { redirectTo: '/me/purchases' } );
+			expect( page ).toHaveBeenCalledWith(
+				'/checkout/personal-bundle/renew/1/my-site.wordpress.com?redirect_to=%2Fme%2Fpurchases'
+			);
+		} );
+
 		test( 'should send the tracks events', () => {
 			const tracksProps = { extra: 'extra' };
 			handleRenewNowClick( purchase, siteSlug, { tracksProps } );

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -226,8 +226,8 @@ describe( 'index', () => {
 		} );
 
 		test( 'should send the tracks events', () => {
-			const trackProps = { extra: 'extra' };
-			handleRenewNowClick( purchase, siteSlug, trackProps );
+			const tracksProps = { extra: 'extra' };
+			handleRenewNowClick( purchase, siteSlug, { tracksProps } );
 			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_purchases_renew_now_click', {
 				product_slug: 'personal-bundle',
 				extra: 'extra',

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -122,6 +122,7 @@ class ManagePurchase extends Component {
 		purchase: PropTypes.object,
 		purchaseAttachedTo: PropTypes.object,
 		purchaseListUrl: PropTypes.string,
+		redirectTo: PropTypes.string,
 		showHeader: PropTypes.bool,
 		site: PropTypes.object,
 		siteId: PropTypes.number,
@@ -183,11 +184,15 @@ class ManagePurchase extends Component {
 	}
 
 	handleRenew = () => {
-		handleRenewNowClick( this.props.purchase, this.props.siteSlug );
+		const { purchase, siteSlug, redirectTo } = this.props;
+		const options = redirectTo ? { redirectTo } : undefined;
+		handleRenewNowClick( purchase, siteSlug, options );
 	};
 
 	handleRenewMultiplePurchases = ( purchases ) => {
-		handleRenewMultiplePurchasesClick( purchases, this.props.siteSlug );
+		const { siteSlug, redirectTo } = this.props;
+		const options = redirectTo ? { redirectTo } : undefined;
+		handleRenewMultiplePurchasesClick( purchases, siteSlug, options );
 	};
 
 	shouldShowNonPrimaryDomainWarning() {

--- a/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
@@ -36,11 +36,9 @@ class RenewButton extends React.Component {
 	};
 
 	handleRenew = () => {
-		handleRenewNowClick(
-			this.props.purchase,
-			this.props.selectedSite.slug,
-			this.props.tracksProps
-		);
+		handleRenewNowClick( this.props.purchase, this.props.selectedSite.slug, {
+			tracksProps: this.props.tracksProps,
+		} );
 	};
 
 	render() {

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -116,6 +116,7 @@ export function PurchaseDetails( {
 					siteSlug={ siteSlug }
 					showHeader={ false }
 					purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
+					redirectTo={ getManagePurchaseUrlFor( siteSlug, purchaseId ) }
 					getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
 					getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
 					getEditPaymentMethodUrlFor={ getEditOrAddPaymentMethodUrlFor }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Turn the third parameter in `handleRenewNowClick` and `handleRenewMultiplePurchasesClick` into an object
* Add `redirectTo` to the new options object, appending to the URL as `redirect_to`
* Create a test for the `redirectTo` option
* Add `redirectTo` as a prop to ManagePurchase and pass to `handleRenew*` calls
* Pass `redirectTo` from site-level component

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click "Renew now" from a site-level purchase and confirm it returns you to the site-level purchase page after completing checkout
* Click "Renew now" from a user-level purchase and confirm it returns you to the user-level purchase page after completing checkout

Fixes #46335 
