### PR TITLE
Plugin Browser: Move the manage and install buttons

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -387,7 +387,7 @@ export class PluginsMain extends Component {
 				href={ browserUrl }
 				onClick={ this.handleAddPluginButtonClick }
 			>
-				<span className="plugins__button-text">{ translate( 'Add plugin' ) }</span>
+				<span className="plugins__button-text">{ translate( 'Browse plugins' ) }</span>
 			</Button>
 		);
 	}

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -6,7 +6,6 @@ import page from 'page';
 import { connect } from 'react-redux';
 import { capitalize, find, flow, isEmpty, some } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
@@ -14,6 +13,7 @@ import Gridicon from 'calypso/components/gridicon';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
 import SectionNav from 'calypso/components/section-nav';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import NavItem from 'calypso/components/section-nav/item';
@@ -356,6 +356,7 @@ export class PluginsMain extends Component {
 		const suggestedPluginsList = showSuggestedPluginsList && (
 			<PluginsBrowser
 				hideSearchForm
+				hideHeader
 				path={ this.props.context.path }
 				search={ search }
 				searchTitle={ searchTitle }
@@ -383,12 +384,10 @@ export class PluginsMain extends Component {
 		return (
 			<Button
 				className="plugins__button"
-				compact
 				href={ browserUrl }
 				onClick={ this.handleAddPluginButtonClick }
 			>
-				<Gridicon icon="plus" />
-				<span className="plugins__button-text">{ translate( 'Add Plugin' ) }</span>
+				<span className="plugins__button-text">{ translate( 'Add plugin' ) }</span>
 			</Button>
 		);
 	}
@@ -409,11 +408,9 @@ export class PluginsMain extends Component {
 		return (
 			<Button
 				className="plugins__button"
-				compact
 				href={ uploadUrl }
 				onClick={ this.handleUploadPluginButtonClick }
 			>
-				<Gridicon icon="cloud-upload" />
 				<span className="plugins__button-text">{ translate( 'Install plugin' ) }</span>
 			</Button>
 		);
@@ -447,6 +444,21 @@ export class PluginsMain extends Component {
 				{ this.renderPageViewTracking() }
 				<SidebarNavigation />
 				<div className="plugins__main">
+					<div className="plugins__header">
+						<FormattedHeader
+							brandFont
+							className="plugins__page-heading"
+							headerText={ this.props.translate( 'Plugins' ) }
+							align="left"
+							subHeaderText={ this.props.translate(
+								'Plugins are extensions that add useful features to your site.'
+							) }
+						/>
+						<div className="plugins__main-buttons">
+							{ this.renderAddPluginButton() }
+							{ this.renderUploadPluginButton() }
+						</div>
+					</div>
 					<div className="plugins__main-header">
 						<SectionNav selectedText={ this.getSelectedText() }>
 							<NavTabs>{ navItems }</NavTabs>
@@ -460,10 +472,6 @@ export class PluginsMain extends Component {
 								placeholder={ this.getSearchPlaceholder() }
 							/>
 						</SectionNav>
-					</div>
-					<div className="plugins__main-buttons">
-						{ this.renderAddPluginButton() }
-						{ this.renderUploadPluginButton() }
 					</div>
 				</div>
 				{ this.renderPluginsContent() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -452,7 +452,7 @@ export class PluginsBrowser extends Component {
 		const site = siteSlug ? '/' + siteSlug : '';
 
 		return (
-			<Button className="plugins-browser__button" compact href={ '/plugins/manage' + site }>
+			<Button className="plugins-browser__button" href={ '/plugins/manage' + site }>
 				<Gridicon icon="cog" />
 				<span className="plugins-browser__button-text">{ translate( 'Manage plugins' ) }</span>
 			</Button>
@@ -475,7 +475,6 @@ export class PluginsBrowser extends Component {
 		return (
 			<Button
 				className="plugins-browser__button"
-				compact
 				onClick={ this.handleUploadPluginButtonClick }
 				href={ uploadUrl }
 			>
@@ -497,10 +496,6 @@ export class PluginsBrowser extends Component {
 			<div className="plugins-browser__main">
 				<div className="plugins-browser__main-header">
 					<div className="plugins__header-navigation">{ navigation }</div>
-				</div>
-				<div className="plugins-browser__main-buttons">
-					{ this.renderManageButton() }
-					{ this.renderUploadPluginButton() }
 				</div>
 			</div>
 		);
@@ -571,12 +566,21 @@ export class PluginsBrowser extends Component {
 				{ this.renderPageViewTracker() }
 				<DocumentHead title={ this.props.translate( 'Plugin Browser', { textOnly: true } ) } />
 				<SidebarNavigation />
-				<FormattedHeader
-					brandFont
-					className="plugins-browser__page-heading"
-					headerText={ this.props.translate( 'Plugin Browser' ) }
-					align="left"
-				/>
+				<div className="plugins-browser__header">
+					<FormattedHeader
+						brandFont
+						className="plugins-browser__page-heading"
+						headerText={ this.props.translate( 'Plugin Browser' ) }
+						align="left"
+						subHeaderText={ this.props.translate(
+							'Plugins are extensions that add useful features to your site.'
+						) }
+					/>
+					<div className="plugins-browser__main-buttons">
+						{ this.renderManageButton() }
+						{ this.renderUploadPluginButton() }
+					</div>
+				</div>
 				{ this.renderUpgradeNudge() }
 				{ this.getPageHeaderView() }
 				{ this.getPluginBrowserContent() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { concat, find, flow, get, flatMap, includes } from 'lodash';
 import PropTypes from 'prop-types';
-import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
@@ -453,7 +452,6 @@ export class PluginsBrowser extends Component {
 
 		return (
 			<Button className="plugins-browser__button" href={ '/plugins/manage' + site }>
-				<Gridicon icon="cog" />
 				<span className="plugins-browser__button-text">{ translate( 'Manage plugins' ) }</span>
 			</Button>
 		);
@@ -478,7 +476,6 @@ export class PluginsBrowser extends Component {
 				onClick={ this.handleUploadPluginButtonClick }
 				href={ uploadUrl }
 			>
-				<Gridicon icon="cloud-upload" />
 				<span className="plugins-browser__button-text">{ translate( 'Install plugin' ) }</span>
 			</Button>
 		);

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -67,6 +67,7 @@ export class PluginsBrowser extends Component {
 		recommendedPlugins: PropTypes.arrayOf( PropTypes.object ),
 		selectedSite: PropTypes.object,
 		trackPageView: PropTypes.bool,
+		hideHeader: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -548,11 +549,7 @@ export class PluginsBrowser extends Component {
 
 	render() {
 		if ( ! this.props.isRequestingSites && this.props.noPermissionsError ) {
-			return (
-				<NoPermissionsError
-					title={ this.props.translate( 'Plugin Browser', { textOnly: true } ) }
-				/>
-			);
+			return <NoPermissionsError title={ this.props.translate( 'Plugins', { textOnly: true } ) } />;
 		}
 
 		return (
@@ -561,23 +558,25 @@ export class PluginsBrowser extends Component {
 					<QuerySiteRecommendedPlugins siteId={ this.props.selectedSiteId } />
 				) }
 				{ this.renderPageViewTracker() }
-				<DocumentHead title={ this.props.translate( 'Plugin Browser', { textOnly: true } ) } />
+				<DocumentHead title={ this.props.translate( 'Plugins', { textOnly: true } ) } />
 				<SidebarNavigation />
-				<div className="plugins-browser__header">
-					<FormattedHeader
-						brandFont
-						className="plugins-browser__page-heading"
-						headerText={ this.props.translate( 'Plugin Browser' ) }
-						align="left"
-						subHeaderText={ this.props.translate(
-							'Plugins are extensions that add useful features to your site.'
-						) }
-					/>
-					<div className="plugins-browser__main-buttons">
-						{ this.renderManageButton() }
-						{ this.renderUploadPluginButton() }
+				{ ! this.props.hideHeader && (
+					<div className="plugins-browser__header">
+						<FormattedHeader
+							brandFont
+							className="plugins-browser__page-heading"
+							headerText={ this.props.translate( 'Plugins' ) }
+							align="left"
+							subHeaderText={ this.props.translate(
+								'Plugins are extensions that add useful features to your site.'
+							) }
+						/>
+						<div className="plugins-browser__main-buttons">
+							{ this.renderManageButton() }
+							{ this.renderUploadPluginButton() }
+						</div>
 					</div>
-				</div>
+				) }
 				{ this.renderUpgradeNudge() }
 				{ this.getPageHeaderView() }
 				{ this.getPluginBrowserContent() }

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -1,3 +1,14 @@
+.plugins-browser__header {
+	display: flex;
+	flex: 1 1 auto;
+	justify-content: flex-start;
+	align-items: center;
+
+	.plugins-browser__page-heading {
+		width: 100%;
+	}
+}
+
 .plugins-browser__main-header {
 	background: var( --color-surface );
 	flex-direction: column;

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -47,19 +47,5 @@
 				margin-right: 15px;
 			}
 		}
-
-		.gridicon {
-			margin-right: 0;
-			@include breakpoint-deprecated( '>480px' ) {
-				margin-right: 4px;
-			}
-		}
-
-		.plugins-browser__button-text {
-			display: none;
-			@include breakpoint-deprecated( '>480px' ) {
-				display: inline-block;
-			}
-		}
 	}
 }

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -21,6 +21,10 @@
 	}
 }
 
+.plugins-browser__page-heading .formatted-header__subtitle {
+	margin: 0;
+}
+
 .plugins-browser__main-header .section-nav {
 	box-shadow: none;
 	flex: auto;
@@ -29,22 +33,28 @@
 
 .plugins-browser__main-buttons {
 	display: flex;
+	flex-direction: column;
 	justify-content: flex-end;
-	margin-bottom: 9px;
-	width: 100%;
+	align-items: stretch;
+	margin: auto;
+	margin-right: 15px;
 
 	@include breakpoint-deprecated( '>480px' ) {
+		flex-direction: row;
+		align-items: flex-end;
+		margin-right: 0;
 		margin-bottom: 17px;
 	}
 
 	.plugins-browser__button {
-		&:not( :last-child ) {
-			margin-right: 10px;
-		}
+		white-space: nowrap;
 
-		&:last-child {
-			@include breakpoint-deprecated( '<660px' ) {
-				margin-right: 15px;
+		&:not( :last-child ) {
+			margin-bottom: 8px;
+
+			@include breakpoint-deprecated( '>480px' ) {
+				margin-bottom: 0;
+				margin-right: 10px;
 			}
 		}
 	}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -6,6 +6,17 @@
 	white-space: nowrap;
 }
 
+.plugins__header {
+	display: flex;
+	flex: 1 1 auto;
+	justify-content: flex-start;
+	align-items: center;
+
+	.plugins__page-heading {
+		width: 100%;
+	}
+}
+
 .plugins__main-header {
 	background: var( --color-surface );
 	flex-direction: column;
@@ -51,24 +62,6 @@
 		&:last-child {
 			@include breakpoint-deprecated( '<660px' ) {
 				margin-right: 15px;
-			}
-		}
-
-		.gridicon {
-			margin-right: 0;
-			@include breakpoint-deprecated( '>480px' ) {
-				margin-right: 4px;
-			}
-		}
-
-		@include breakpoint-deprecated( '>480px' ) {
-			flex: none;
-		}
-
-		.plugins__button-text {
-			display: none;
-			@include breakpoint-deprecated( '>480px' ) {
-				display: inline-block;
 			}
 		}
 	}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -44,24 +44,34 @@
 	margin-bottom: 1px;
 }
 
+.plugins__page-heading .formatted-header__subtitle {
+	margin: 0;
+}
+
 .plugins__main-buttons {
 	display: flex;
+	flex-direction: column;
 	justify-content: flex-end;
-	margin-bottom: 9px;
-	width: 100%;
+	align-items: stretch;
+	margin: auto;
+	margin-right: 15px;
 
 	@include breakpoint-deprecated( '>480px' ) {
+		flex-direction: row;
+		align-items: flex-end;
+		margin-right: 0;
 		margin-bottom: 17px;
 	}
 
 	.plugins__button {
-		&:not( :last-child ) {
-			margin-right: 10px;
-		}
+		white-space: nowrap;
 
-		&:last-child {
-			@include breakpoint-deprecated( '<660px' ) {
-				margin-right: 15px;
+		&:not( :last-child ) {
+			margin-bottom: 8px;
+
+			@include breakpoint-deprecated( '>480px' ) {
+				margin-bottom: 0;
+				margin-right: 10px;
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're going to start slowly aligning the current plugin browser experience with new designs as much as we can; my thought is to do this in incremental PRs.
* This PR moves the Install and Manage buttons up next to the page heading, as we do on My Home.
* Adds a subheading to the FormattedHeader (my copy probably needs polish!)
* Updates the title of the page to "Plugins" from "Plugin Browser" which allows us to match the wording in the sidebar and keep the same heading at the top of the screen regardless of whether we're browsing for new plugins or managing existing plugins.

**Before**

<img width="1678" alt="Screen Shot 2020-12-01 at 2 05 55 PM" src="https://user-images.githubusercontent.com/2124984/100785218-582c8100-33de-11eb-93d0-e6e67246fb91.png">

Jetpack (Manage screen)

<img width="1665" alt="Screen Shot 2020-12-02 at 3 35 48 PM" src="https://user-images.githubusercontent.com/2124984/100929329-774a1200-34b5-11eb-8db6-09912e8389a0.png">

**After**

<img width="1664" alt="Screen Shot 2020-12-02 at 3 48 12 PM" src="https://user-images.githubusercontent.com/2124984/100929563-d60f8b80-34b5-11eb-946d-4d95852feea6.png">

Jetpack

<img width="1098" alt="Screen Shot 2020-12-03 at 10 18 22 AM" src="https://user-images.githubusercontent.com/2124984/101048780-ecb6f080-3550-11eb-8795-b22bf01184a9.png">

Also pinging Jetpack design to get their thoughts.

#### Testing instructions

* Switch to this PR 
* Check out `/plugins` on a simple site, and on a Jetpack site, and on an Atomic site
* Note visual differences. Make sure the buttons still work! :) 
* Check on mobile device/small screens to make sure there are no visual issues with having the buttons in the header area
