### PR TITLE
Rename main function inside use-on-login.ts to useOnLogin

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-login.ts
+++ b/client/landing/gutenboarding/hooks/use-on-login.ts
@@ -18,7 +18,7 @@ import { useNewQueryParam } from '../path';
  * After signup a site is automatically created using the username and bearerToken
  **/
 
-export default function useOnSignup() {
+export default function useOnLogin(): void {
 	const locale = useLocale();
 	const { createSite } = useDispatch( ONBOARD_STORE );
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* **No functional changes.**  Site should act exactly the same before and after.
* **Rename the default export function inside `use-on-login.ts` to `useOnLogin()`**
  - It looks like `use-on-login.ts` was copied from `use-on-signup.ts`, so the main function is still called `useOnSignup()`.
  - It only has one call site, which simply uses the default export name, so the caller does not need to be changed.
* Also added TS return type hint to prevent eslint warning

Lines 26+35 in gutenboard.tsx, the only call site, which doesn't need to be changed:

https://github.com/Automattic/wp-calypso/blob/25a25e3921058f04433ff7bc60327259dd19d96e/client/landing/gutenboarding/gutenboard.tsx#L25-L36


#### Testing instructions

* Manually: Visit http://calypso.localhost:3000/new in a private window and the gutenboarding flow should work as normal.
* Automated: e2e tests cover gutenboarding as well.
