### PR TITLE
Stores redirect initialization state to prevent additional redirects

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -113,6 +113,10 @@ export class JetpackAuthorize extends Component {
 	redirecting = false;
 	retryingAuth = false;
 
+	state = {
+		isRedirecting: false,
+	};
+
 	UNSAFE_componentWillMount() {
 		const { recordTracksEvent, isMobileAppFlow } = this.props;
 
@@ -202,6 +206,11 @@ export class JetpackAuthorize extends Component {
 	redirect() {
 		const { isMobileAppFlow, mobileAppRedirect } = this.props;
 		const { from, redirectAfterAuth, scope } = this.props.authQuery;
+		const { isRedirecting } = this.state;
+
+		if ( isRedirecting ) {
+			return;
+		}
 
 		if ( isMobileAppFlow ) {
 			debug( `Redirecting to mobile app ${ mobileAppRedirect }` );
@@ -228,6 +237,8 @@ export class JetpackAuthorize extends Component {
 		} else {
 			page.redirect( this.getRedirectionTarget() );
 		}
+
+		this.setState( { isRedirecting: true } );
 	}
 
 	redirectToXmlRpcErrorFallbackUrl() {
@@ -608,7 +619,7 @@ export class JetpackAuthorize extends Component {
 
 	getRedirectionTarget() {
 		const { clientId, homeUrl, redirectAfterAuth } = this.props.authQuery;
-		const { partnerSlug } = this.props;
+		const { partnerSlug, selectedPlanSlug } = this.props;
 
 		// Redirect sites hosted on Pressable with a partner plan to some URL.
 		if (
@@ -622,11 +633,11 @@ export class JetpackAuthorize extends Component {
 		const jetpackCheckoutSlugs = OFFER_RESET_FLOW_TYPES.filter( ( productSlug ) =>
 			productSlug.includes( 'jetpack' )
 		);
-		if ( jetpackCheckoutSlugs.includes( this.props.selectedPlanSlug ) ) {
+		if ( jetpackCheckoutSlugs.includes( selectedPlanSlug ) ) {
 			// Once we decide we want to redirect the user to the checkout page and that there is a
 			// valid plan, we can safely remove it from the session storage
 			clearPlan();
-			return '/checkout/' + urlToSlug( homeUrl ) + '/' + this.props.selectedPlanSlug;
+			return `/checkout/${ urlToSlug( homeUrl ) }/${ selectedPlanSlug }`;
 		}
 
 		return addQueryArgs(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds state to the JP connect component to track whether a redirect has been started, as redirects are async. This resolves an issue where the code clears the chosen product and then runs the redirect code again, this time sending the user elsewhere.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site that is not connected to JP.
* Visit `/plans` and choose a plan while logged in.
* Enter the URL for the site and continue.
* Observe where the browser ends up.

Before: The browser ends on the plans page again.
After: The browser correctly goes to the checkout page.

Fixes 1199166334111093-as-1199403302392655.