### PR TITLE
Remove `jetpackConversionRateOptimization` experiment

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -192,16 +192,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: [ 'en' ],
 	},
-	jetpackConversionRateOptimization: {
-		datestamp: '20201115',
-		variations: {
-			'v1 - 3 cols layout': 0, // first Offer Reset iteration (3 layout columns + simpler cards)
-			'v2 - slide outs': 0, // second Offer Reset iteration (reorder & slide outs)
-			'i5 - Saas table design': 100, // third Offer Reset iteration (Saas table design)
-		},
-		defaultVariation: 'i5 - Saas table design',
-		allowExistingUsers: true,
-	},
 	secureYourBrand: {
 		datestamp: '20201124',
 		variations: {

--- a/client/my-sites/plans/jetpack-plans/abtest.ts
+++ b/client/my-sites/plans/jetpack-plans/abtest.ts
@@ -1,7 +1,10 @@
 /**
  * Internal dependencies
  */
-import { abtest } from 'calypso/lib/abtest';
+import { getUrlParts } from 'calypso/lib/url/url-parts';
+
+const VERSIONS = [ 'v1', 'v2', 'i5' ];
+const DEFAULT_VERSION = 'i5';
 
 /**
  * Returns the name of the Conversion Rate Optimization test that is currently active.
@@ -9,16 +12,17 @@ import { abtest } from 'calypso/lib/abtest';
  * @returns {string}  The name of the active test.
  */
 export const getJetpackCROActiveVersion = (): string => {
-	const currentVariant = abtest( 'jetpackConversionRateOptimization' );
+	let version;
 
-	switch ( currentVariant ) {
-		case 'v1 - 3 cols layout':
-			return 'v1';
-		case 'v2 - slide outs':
-			return 'v2';
-		case 'i5 - Saas table design':
-			return 'i5';
+	if ( 'undefined' !== typeof window ) {
+		const versionQuery = getUrlParts( window.location.href ).searchParams?.get(
+			'cloud-pricing-page'
+		);
+
+		if ( versionQuery && VERSIONS.includes( versionQuery ) ) {
+			version = versionQuery;
+		}
 	}
 
-	return 'v1';
+	return version || DEFAULT_VERSION;
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

The frontend library for a/b experiment `calypso-abtest` is deprecated and experiments implemented with this library are progressively removed from the codebase. This PR removes the `jetpackConversionRateOptimization` experiment.

### Implementation notes

- Removed experiment entry in `client/lib/abtest/active-tests.js`
- Hardcoded default version in `client/my-sites/plans/jetpack-plans/abtest.ts`
- Added the possibility to specify a version with the `cloud-pricing-page` query parameter

_This PR will be revisited with the implementation of the upcoming A/B experiments._

### Testing instructions

- Download this PR
- Run both Calypso and cloud concurrently
- Visit the plans/pricing page in both platforms and check that it looks like production
- Visit the same page and add the query parameter `cloud-pricing-page` (possible values: `v1`, `v2`, and `i5`) and check that you see the corresponding version