### PR TITLE
AnchorFM: Podcasting Redirect Link

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/podcasting/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/podcasting/index.jsx
@@ -21,8 +21,7 @@ const Podcasting = () => {
 				`Easily turn your blog into a podcast with Anchor — the world's biggest podcasting platform.`
 			) }
 			actionText={ translate( 'Create an Anchor account' ) }
-			// TODO replace with more appropriate URL as discussed in 320-gh-dotcom-manage
-			actionUrl={ `https://anchor.fm` }
+			actionUrl={ `https://anchor.fm/wordpress` }
 			illustration={ podcastingIllustration }
 			taskId={ TASK_PODCASTING }
 		/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Updated the redirect link to "Create an Anchor Account" for starting a podcast website with Anchor.fm

**DO NOT MERGE UNTIL CONFIRMED IN THIS SLACK THREAD**: p1606777886050200-slack-C017FUZGVAL

#### Testing instructions

1. Use the Calypso Live link
2. On your site https://wordpress.com/home/{site}, where you've already gone through the introductory set-up tasks, dismiss the cards at the top until you see the podcast card.
3. Click on "Create an Anchor Account". This should take you to https://anchor.fm/wordpress.

#### Screenshots

<img width="1230" alt="Screen Shot 2020-12-01 at 6 29 02 PM" src="https://user-images.githubusercontent.com/66652282/100809255-b9b31680-3403-11eb-8ff4-3d49ed4d0bf3.png">

Fixes 328-gh-Automattic/dotcom-manage