### PR TITLE
Correctly sync planId between PremiumContent and Payments block

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/buttons/edit.js
@@ -101,7 +101,7 @@ export default compose( [
 			.getBlock( props.clientId )
 			.innerBlocks.find( ( block ) => block.name === 'jetpack/recurring-payments' );
 
-		return subscribeButton;
+		return { subscribeButton };
 	} ),
 	withDispatch( ( dispatch, props ) => ( {
 		/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There was a syntax error causing the subscribeButton to not be passed in correctly as a prop to the Premium Content's `Buttons` block. This caused the `planId` to not sync correctly between the two. As a consequence, if the user updated the plan on their Premium Content block from the default, it was not being updated on the Payments button, which would continue pointing to a url for subscribing to the default plan.

This PR correctly passes the subscribeButton in through props, allowing the syncing to function correctly again.

#### Testing instructions

* Create a post and insert a premium content block
* Preview the post and inspect the subscribe button. Note the planId in the url:
<img width="565" alt="Screen Shot 2020-12-01 at 5 04 51 PM" src="https://user-images.githubusercontent.com/63313398/100814870-7f437c80-33f7-11eb-8fa0-69ab2d85be64.png">
* Return to the editor and select a different plan for the premium content block (for example, change from $5/month to $10/month)
* Preview the post again and inspect the subscribe button. Verify that the planId in the url has changed.

Fixes #47939
