### PR TITLE
Coming Soon: check for coming soon mode on 404

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -13,7 +13,7 @@ namespace A8C\FSE\Coming_soon;
  * @return boolean
  */
 function should_show_coming_soon_page() {
-	if ( ! is_singular() && ! is_archive() && ! is_search() && ! is_front_page() && ! is_home() ) {
+	if ( ! is_singular() && ! is_archive() && ! is_search() && ! is_front_page() && ! is_home() && ! is_404() ) {
 		return false;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Hi!

In this PR we are adding an `is404()`, after which we'll decide whether to show the coming soon page.

This primarily captures the case where the user edits the post's visibility in the editor by switching the post status to private. 

Individual private posts are not available at all to the public and will 404. 

<img width="811" alt="Screen Shot 2020-12-02 at 2 06 25 pm" src="https://user-images.githubusercontent.com/6458278/100823809-056bcb80-34a9-11eb-8b94-f755241c0beb.png">

More information: https://wordpress.org/support/article/content-visibility/

Props to @charliescheer and @katiebethbrown for alerting us to this! 

### Testing instructions

Checkout this branch

Run `yarn dev --sync` in `apps/editing-toolkit` 

Sandbox a test site. Ensure that site is launched.

Enable Coming Soon mode over at `/settings/general/{your_site}`

<img width="755" alt="Screen Shot 2020-12-02 at 2 06 29 pm" src="https://user-images.githubusercontent.com/6458278/100823744-e705d000-34a8-11eb-98dc-d4780f1497f6.png">

Now head to any post or page, and make that individual post/page private

<img width="419" alt="Screen Shot 2020-12-02 at 2 11 53 pm" src="https://user-images.githubusercontent.com/6458278/100823727-e2411c00-34a8-11eb-991e-6d3b6faf3118.png">

Visit this page in an incognito browser

You should see the Coming Soon page

<img width="1072" alt="coming-soon-v2-is-here" src="https://user-images.githubusercontent.com/6458278/100823792-fe44bd80-34a8-11eb-8bd7-18fc6ea2e8e3.png">


