### PR TITLE
Signup: remove the unused `skippableDomainStep` AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -77,15 +77,6 @@ export default {
 		defaultVariation: 'noOffer',
 		allowExistingUsers: true,
 	},
-	skippableDomainStep: {
-		datestamp: '20290717',
-		variations: {
-			skippable: 0,
-			notSkippable: 100,
-		},
-		defaultVariation: 'notSkippable',
-		allowExistingUsers: true,
-	},
 	passwordlessSignup: {
 		datestamp: '20291029',
 		variations: {

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -24,7 +24,6 @@ import {
 	maybeRemoveStepForUserlessCheckout,
 	isSecureYourBrandFulfilled,
 } from 'calypso/lib/signup/step-actions';
-import { abtest } from 'calypso/lib/abtest';
 import { generateSteps } from './steps-pure';
 
 export default generateSteps( {
@@ -47,8 +46,5 @@ export default generateSteps( {
 } );
 
 export function isDomainStepSkippable( flowName ) {
-	return (
-		flowName === 'test-fse' ||
-		( flowName === 'onboarding' && abtest( 'skippableDomainStep' ) === 'skippable' )
-	);
+	return flowName === 'test-fse';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Cleaning up old ab test. Context: pbmo2S-Bv-p2

* Remove `skippableDomainStep` test

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run through onboarding from `/start` and make sure it works as expected
* Try another onboarding flow, like `/start/premium`
