### PR TITLE
New Onboarding: Localize help contact url in Step-by-step launch flow

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -10,6 +10,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Button, Tip } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import { useSiteDomains, useDomainSuggestion, useDomainSearch, useTitle } from '@automattic/launch';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
 import {
 	CheckoutStepBody,
@@ -60,6 +61,8 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 	const { domainSearch } = useDomainSearch();
 
 	const { setStep } = useDispatch( LAUNCH_STORE );
+
+	const localizeUrl = useLocalizeUrl();
 
 	const nameSummary = (
 		<div className="nux-launch__summary-item">
@@ -200,7 +203,11 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 									</ul>
 									<p>
 										{ __( 'Questions?', 'full-site-editing' ) }{ ' ' }
-										<Button isLink href="https://wordpress.com/help/contact" target="_blank">
+										<Button
+											isLink
+											href={ localizeUrl( 'https://wordpress.com/help/contact' ) }
+											target="_blank"
+										>
 											{ __( 'Ask a Happiness Engineer', 'full-site-editing' ) }
 										</Button>
 									</p>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -205,7 +205,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 										{ __( 'Questions?', 'full-site-editing' ) }{ ' ' }
 										<Button
 											isLink
-											href={ localizeUrl( 'https://wordpress.com/help/contact' ) }
+											href={ localizeUrl( 'https://wordpress.com/help/contact', null, window.currentUser ) }
 											target="_blank"
 										>
 											{ __( 'Ask a Happiness Engineer', 'full-site-editing' ) }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -205,7 +205,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 										{ __( 'Questions?', 'full-site-editing' ) }{ ' ' }
 										<Button
 											isLink
-											href={ localizeUrl( 'https://wordpress.com/help/contact', null, window.currentUser ) }
+											href={ localizeUrl( 'https://wordpress.com/help/contact', locale ) }
 											target="_blank"
 										>
 											{ __( 'Ask a Happiness Engineer', 'full-site-editing' ) }


### PR DESCRIPTION
Currently blocked by: https://github.com/Automattic/wp-calypso/issues/48033 - we need to wait until the logged out localized url is accessible before we localize this url. Logged in users already receive a localized experience.

#### Changes proposed in this Pull Request

* Wraps https://wordpress.com/help/contact link with `localizeUrl` in the etk launch flow.

#### Testing instructions

* Create a new site at /new
* Go through the launch flow from the editor and check the link is localized here: 
![Screen Shot on 2020-12-04 at 10:20:36](https://user-images.githubusercontent.com/1500769/101089723-6ff04900-361a-11eb-9b6b-35c6d3b27223.png)

Partial #37665
