### PR TITLE
Plugins: Fix mass removal of plugins

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -31,6 +31,7 @@ import {
 	deactivatePlugin,
 	disableAutoupdatePlugin,
 	enableAutoupdatePlugin,
+	removePlugin,
 	updatePlugin,
 } from 'calypso/state/plugins/installed/actions';
 
@@ -417,7 +418,7 @@ export const PluginsList = createReactClass( {
 
 	removeSelected( accepted ) {
 		if ( accepted ) {
-			this.doActionOverSelected( 'removing', PluginsActions.removePlugin );
+			this.doActionOverSelected( 'removing', this.props.removePlugin, true );
 			this.recordEvent( 'Clicked Remove Plugin(s)', true );
 		}
 	},
@@ -577,6 +578,7 @@ export default connect(
 		disableAutoupdatePlugin,
 		enableAutoupdatePlugin,
 		recordGoogleEvent,
+		removePlugin,
 		updatePlugin,
 		warningNotice,
 	}


### PR DESCRIPTION
As reported by @flootr in https://github.com/Automattic/wp-calypso/pull/47860#issuecomment-737102959 #47860 caused a regression when mass removing plugins. Reason: we forgot to reduxify that bit 😞  This PR fixes that.

This is part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Fix mass removal of plugins

#### Testing instructions

* Go to `/plugins/manage/:site`
* Click "Edit All" and deselect all plugins
* Select one or more plugins, and attempt to remove them.
* Verify it works well and no errors are thrown.