### PR TITLE
Upgrade to wp-prettier 2.2.1

### DIFF
--- a/client/desktop/window-handlers/failed-to-load/index.js
+++ b/client/desktop/window-handlers/failed-to-load/index.js
@@ -71,25 +71,24 @@ function failedToLoadError( mainWindow ) {
 // @adlk: Keep in mind that every request, even the ones we do not control (e.g. atomic- or self hosted sites), might cause the app to "soft-crash" even though the user experience might not be affected directly by some requests that fail.
 module.exports = function ( mainWindow ) {
 	// This attempts to catch some network errors and display an error screen in order to avoid a blank white page
-	mainWindow.webContents.on( 'did-fail-load', async function (
-		event,
-		errorCode,
-		errorDescription
-	) {
-		if ( ERRORS_TO_IGNORE.indexOf( errorCode ) === -1 ) {
-			if ( isErrorPage( event.sender ) ) {
-				failedToLoadError( mainWindow );
-			} else {
-				log.error(
-					'Failed to load from server, showing fallback page: code=' +
-						errorCode +
-						' ' +
-						errorDescription
-				);
+	mainWindow.webContents.on(
+		'did-fail-load',
+		async function ( event, errorCode, errorDescription ) {
+			if ( ERRORS_TO_IGNORE.indexOf( errorCode ) === -1 ) {
+				if ( isErrorPage( event.sender ) ) {
+					failedToLoadError( mainWindow );
+				} else {
+					log.error(
+						'Failed to load from server, showing fallback page: code=' +
+							errorCode +
+							' ' +
+							errorDescription
+					);
 
-				await mainWindow.webContents.session.setProxy( { proxyRules: 'direct://' } );
-				mainWindow.loadURL( FAILED_FILE + '#' + errorCode );
+					await mainWindow.webContents.session.setProxy( { proxyRules: 'direct://' } );
+					mainWindow.loadURL( FAILED_FILE + '#' + errorCode );
+				}
 			}
 		}
-	} );
+	);
 };

--- a/client/lib/cart/store/cart-synchronizer.js
+++ b/client/lib/cart/store/cart-synchronizer.js
@@ -142,17 +142,18 @@ CartSynchronizer.prototype._processQueuedChanges = function () {
 };
 
 CartSynchronizer.prototype._postToServer = function ( callback ) {
-	this._wpcom.setCart( this._cartKey, preprocessCartForServer( this._latestValue ), function (
-		error,
-		newValue
-	) {
-		if ( error ) {
-			callback( error );
-			return;
-		}
+	this._wpcom.setCart(
+		this._cartKey,
+		preprocessCartForServer( this._latestValue ),
+		function ( error, newValue ) {
+			if ( error ) {
+				callback( error );
+				return;
+			}
 
-		callback( null, preprocessCartFromServer( newValue ) );
-	} );
+			callback( null, preprocessCartFromServer( newValue ) );
+		}
+	);
 };
 
 CartSynchronizer.prototype._poll = function () {

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -77,14 +77,14 @@ export function formatExcerpt( content ) {
 	stripLeadingBreaklines( dom );
 
 	// now limit it to the first three elements
-	forEach( dom.querySelectorAll( '#__better_excerpt__ > p, #__better_excerpt__ > br' ), function (
-		element,
-		index
-	) {
-		if ( index >= 3 ) {
-			element.parentNode && element.parentNode.removeChild( element );
+	forEach(
+		dom.querySelectorAll( '#__better_excerpt__ > p, #__better_excerpt__ > br' ),
+		function ( element, index ) {
+			if ( index >= 3 ) {
+				element.parentNode && element.parentNode.removeChild( element );
+			}
 		}
-	} );
+	);
 
 	// trim and replace &nbsp; entities
 	const betterExcerpt = trim( dom.innerHTML.replace( /&nbsp;/g, ' ' ) );

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -11,15 +11,19 @@ import { trim, toArray, forEach } from 'lodash';
 import { domForHtml } from './utils';
 
 /**
- *  removes an html element from the dom
+ * Removes an HTML element from the DOM
+ *
+ * @param {Node} element DOM element to remove
  */
 function removeElement( element ) {
 	element.parentNode && element.parentNode.removeChild( element );
 }
 
 /**
- *  Trims any empty starting br tags.  Recurses into non-empty tags.
- *  will remove all of the leading brs it can find.
+ *  Trims any empty starting `br` tags.  Recurses into non-empty tags.
+ *  will remove all of the leading `br`s it can find.
+ *
+ * @param {Node} dom DOM element to remove br tags from.
  */
 function stripLeadingBreaklines( dom ) {
 	if ( ! dom ) {
@@ -33,8 +37,10 @@ function stripLeadingBreaklines( dom ) {
 }
 
 /**
- *  Returns the node if first element ( checking nested ) is a br
+ *  Returns the node if first element ( checking nested ) is a `br`
  *  else returns falsy
+ *
+ * @param {Node} dom DOM element to check
  */
 function firstElementIsBreakline( dom ) {
 	if ( dom.childNodes.length === 0 ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2410,17 +2410,17 @@ Undocumented.prototype.updateSiteAddress = function (
 };
 
 Undocumented.prototype.requestGdprConsentManagementLink = function ( domain, callback ) {
-	return this.wpcom.req.get( `/domains/${ domain }/request-gdpr-consent-management-link`, function (
-		error,
-		response
-	) {
-		if ( error ) {
-			callback( error );
-			return;
-		}
+	return this.wpcom.req.get(
+		`/domains/${ domain }/request-gdpr-consent-management-link`,
+		function ( error, response ) {
+			if ( error ) {
+				callback( error );
+				return;
+			}
 
-		callback( null, response );
-	} );
+			callback( null, response );
+		}
+	);
 };
 
 Undocumented.prototype.getDomainConnectSyncUxUrl = function (

--- a/client/my-sites/purchases/site-level-purchases-error-boundary.tsx
+++ b/client/my-sites/purchases/site-level-purchases-error-boundary.tsx
@@ -7,9 +7,7 @@ import styled from '@emotion/styled';
 
 const debug = debugFactory( 'calypso:site-level-purchases-error-boundary' );
 
-export default class SiteLevelPurchasesErrorBoundary extends React.Component<
-	SiteLevelPurchasesErrorBoundaryProps
-> {
+export default class SiteLevelPurchasesErrorBoundary extends React.Component< SiteLevelPurchasesErrorBoundaryProps > {
 	constructor( props: SiteLevelPurchasesErrorBoundaryProps ) {
 		super( props );
 	}

--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
 		"photon": "^3.0.0",
 		"postcss-cli": "^6.1.3",
 		"postcss-custom-properties": "^9.1.1",
-		"prettier": "npm:wp-prettier@2.1.1-beta-1",
+		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"qs": "^6.9.1",
 		"react": "^16.12.0",
 		"react-dom": "^16.12.0",

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -863,8 +863,7 @@ const StepNumber = styled.div< StepNumberProps & React.HTMLAttributes< HTMLDivEl
 	// Reason: The IE media query needs to not have spaces within brackets otherwise ie11 doesn't read them
 	// prettier-ignore
 	@media all and (-ms-high-contrast:none), (-ms-high-contrast:active) {
-		z-index: ${ ( props ) =>
-		props.isComplete ? '0' : '1' };
+		z-index: ${ ( props ) => ( props.isComplete ? '0' : '1' ) };
 	}
 `;
 
@@ -880,9 +879,7 @@ const StepNumberCompleted = styled( StepNumber )`
 	// prettier-ignore
 	@media all and (-ms-high-contrast:none), (-ms-high-contrast:active) {
 		backface-visibility: visible;
-		z-index: ${ (
-		props
-	) => ( props.isComplete ? '1' : '0' ) };
+		z-index: ${ ( props ) => ( props.isComplete ? '1' : '0' ) };
 	}
 
 	svg {

--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -48,7 +48,9 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 
 		if ( level === 'free' ) {
 			if ( ! ( await driverHelper.isElementPresent( this.driver, selector ) ) ) {
-				selector = By.css( '.plans-features-main__banner-content button, .formatted-header__subtitle button' );
+				selector = By.css(
+					'.plans-features-main__banner-content button, .formatted-header__subtitle button'
+				);
 			}
 		}
 		await driverHelper.waitTillPresentAndDisplayed(

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -52,7 +52,7 @@
 		"mocha-steps": "^1.3.0",
 		"node-slack-upload": "^1.2.1",
 		"png-itxt": "^1.3.0",
-		"prettier": "npm:wp-prettier@2.1.1-beta-1",
+		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"push-receiver": "^2.0.0",
 		"request": "^2.88.2",
 		"request-promise": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22601,10 +22601,10 @@ prettier-linter-helpers@^1.0.0:
   resolved "https://registry.yarnpkg.com/wp-prettier/-/wp-prettier-2.0.5.tgz#1aeff6000142d61bfbd7cc35a3d561551b25399f"
   integrity sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==
 
-"prettier@npm:wp-prettier@2.1.1-beta-1":
-  version "2.1.1-beta-1"
-  resolved "https://registry.yarnpkg.com/wp-prettier/-/wp-prettier-2.1.1-beta-1.tgz#16bd95101f80eb7e78ecf6dff2b4f473979ab330"
-  integrity sha512-3geX4uqArYAb/Yuu2eFcwuntI9bjoc/bBJOUQBtssmWJpM3DjG+v3zEn9JMnwi2/hfRNgBAXeDkHxVlzMlCvRg==
+"prettier@npm:wp-prettier@2.2.1-beta-1":
+  version "2.2.1-beta-1"
+  resolved "https://registry.yarnpkg.com/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz#8afb761f83426bde870f692edc49adbd3e265118"
+  integrity sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==
 
 pretty-error@^2.0.2, pretty-error@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
This is how Calypso codebase gets reformatted after upgrade to `wp-prettier@2.2.1`. I was originally testing with a local build, so the PR contained only the formatting changes and not the package upgrade. Later after verifying the upgrade both with Calypso and Gutenberg, I published `wp-prettier@2.2.1-beta-§` to NPM and updated our `package.json` accordingly.

**Notable changes:**
```js
a( b, (
  c,
  d
) => {
  e();
} );
```
no longer breaks the argument list of the inline arrow function and formats the code more nicely:
```js
a(
  b,
  ( c, d ) => {
    e();
  }
);
```
This is an expected change that's been [announced in Prettier 2.2.0 changelog](https://prettier.io/blog/2020/11/20/2.2.0.html#flatten-function-expression-parameters-in-hugged-last-argument-9662httpsgithubcomprettierprettierpull9662-by-thorn0httpsgithubcomthorn0).

Then there's fixed arrow function formatting inside Styled Components template literal:
```js
styled(A)`
  @media (aaaaaaaaaaaaa) {
	z-index: ${(props) => (props.isComplete ? '1' : '0')};
  }
`;
```
Also expected, it's a bug fixed in 2.1.2 (https://github.com/prettier/prettier/pull/9136) after our report.

Finally, Prettier stopped breaking type parameters in long `class ... extends` statements.

Before:
```js
export default class SiteLevelPurchasesErrorBoundary extends React.Component<
  SiteLevelPurchasesErrorBoundaryProps
>
```
After:
```js
export default class SiteLevelPurchasesErrorBoundary extends React.Component< SiteLevelPurchasesErrorBoundaryProps >
```
