### PR TITLE
Plugins: Introduce and use new plugin actions status selectors

### DIFF
--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -15,7 +15,7 @@ import PluginsActions from 'calypso/lib/plugins/actions';
 import PluginAction from 'calypso/my-sites/plugins/plugin-action/plugin-action';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { togglePluginActivation } from 'calypso/state/plugins/installed/actions';
-import { getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
+import { isPluginActionInProgress } from 'calypso/state/plugins/installed/selectors';
 
 /**
  * Style dependencies
@@ -144,15 +144,9 @@ PluginActivateToggle.defaultProps = {
 };
 
 export default connect(
-	( state, { site, plugin } ) => {
-		const pluginStatus = getStatusForPlugin( state, site.ID, plugin.id );
-		const inProgress =
-			activationActions.includes( pluginStatus?.action ) && 'inProgress' === pluginStatus?.status;
-
-		return {
-			inProgress,
-		};
-	},
+	( state, { site, plugin } ) => ( {
+		inProgress: isPluginActionInProgress( state, site.ID, plugin.id, activationActions ),
+	} ),
 	{
 		recordGoogleEvent,
 		recordTracksEvent,

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -14,7 +14,7 @@ import PluginAction from 'calypso/my-sites/plugins/plugin-action/plugin-action';
 import ExternalLink from 'calypso/components/external-link';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSiteFileModDisableReason, isMainNetworkSite } from 'calypso/lib/site/utils';
-import { getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
+import { isPluginActionInProgress } from 'calypso/state/plugins/installed/selectors';
 import { togglePluginAutoUpdate } from 'calypso/state/plugins/installed/actions';
 
 const autoUpdateActions = [ 'ENABLE_AUTOUPDATE_PLUGIN', 'DISABLE_AUTOUPDATE_PLUGIN' ];
@@ -178,15 +178,9 @@ PluginAutoUpdateToggle.defaultProps = {
 };
 
 export default connect(
-	( state, { site, plugin } ) => {
-		const pluginStatus = getStatusForPlugin( state, site.ID, plugin.id );
-		const inProgress =
-			autoUpdateActions.includes( pluginStatus?.action ) && 'inProgress' === pluginStatus?.status;
-
-		return {
-			inProgress,
-		};
-	},
+	( state, { site, plugin } ) => ( {
+		inProgress: isPluginActionInProgress( state, site.ID, plugin.id, autoUpdateActions ),
+	} ),
 	{
 		recordGoogleEvent,
 		recordTracksEvent,

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -152,3 +152,36 @@ export function isPluginDoingAction( state, siteId, pluginId ) {
 	const status = getStatusForPlugin( state, siteId, pluginId );
 	return !! status && 'inProgress' === status.status;
 }
+
+/**
+ * Whether the plugin's status for one or more recent actions matches a specified status.
+ *
+ * @param  {object}       state    Global state tree
+ * @param  {number}       siteId   ID of the site
+ * @param  {string}       pluginId ID of the plugin
+ * @param  {string|Array} action   Action, or array of actions of interest
+ * @param  {string}       status   Status to check against
+ * @returns {boolean}              True if status is the specified one for one or more actions, false otherwise.
+ */
+export function isPluginActionStatus( state, siteId, pluginId, action, status ) {
+	const pluginStatus = getStatusForPlugin( state, siteId, pluginId );
+	if ( ! pluginStatus ) {
+		return false;
+	}
+
+	const actions = Array.isArray( action ) ? action : [ action ];
+	return actions.includes( pluginStatus.action ) && status === pluginStatus.status;
+}
+
+/**
+ * Whether the plugin's status for one or more recent actions is in progress.
+ *
+ * @param  {object}       state    Global state tree
+ * @param  {number}       siteId   ID of the site
+ * @param  {string}       pluginId ID of the plugin
+ * @param  {string|Array} action   Action, or array of actions of interest
+ * @returns {boolean}              True if one or more specified actions are in progress, false otherwise.
+ */
+export function isPluginActionInProgress( state, siteId, pluginId, action ) {
+	return isPluginActionStatus( state, siteId, pluginId, action, 'inProgress' );
+}

--- a/client/state/plugins/installed/test/selectors.js
+++ b/client/state/plugins/installed/test/selectors.js
@@ -304,4 +304,102 @@ describe( 'Installed plugin selectors', () => {
 			expect( selectors.isPluginDoingAction( state, 'site.two', 'akismet/akismet' ) ).to.be.false;
 		} );
 	} );
+
+	describe( 'isPluginActionStatus', () => {
+		test( 'Should get `false` if the requested site is not in the current state', () => {
+			expect(
+				selectors.isPluginActionStatus(
+					state,
+					'no.site',
+					'jetpack/jetpack',
+					DEACTIVATE_PLUGIN,
+					'completed'
+				)
+			).to.be.false;
+		} );
+
+		test( 'Should get `false` if the plugin status for the action does not exist.', () => {
+			expect(
+				selectors.isPluginActionStatus(
+					state,
+					'site.one',
+					'jetpack/jetpack',
+					INSTALL_PLUGIN,
+					'completed'
+				)
+			).to.be.false;
+		} );
+
+		test( 'Should get `false` if the plugin status for the action does not match the status.', () => {
+			expect(
+				selectors.isPluginActionStatus(
+					state,
+					'site.one',
+					'jetpack/jetpack',
+					DEACTIVATE_PLUGIN,
+					'inProgress'
+				)
+			).to.be.false;
+		} );
+
+		test( 'Should get `false` if the plugin status for none of the actions matches the status.', () => {
+			expect(
+				selectors.isPluginActionStatus(
+					state,
+					'site.one',
+					'jetpack/jetpack',
+					[ INSTALL_PLUGIN, ENABLE_AUTOUPDATE_PLUGIN ],
+					'completed'
+				)
+			).to.be.false;
+		} );
+
+		test( 'Should get `true` if the plugin status for the action matches the status.', () => {
+			expect(
+				selectors.isPluginActionStatus(
+					state,
+					'site.one',
+					'jetpack/jetpack',
+					DEACTIVATE_PLUGIN,
+					'completed'
+				)
+			).to.be.true;
+		} );
+
+		test( 'Should get `true` if the plugin status for one of the actions matches the status.', () => {
+			expect(
+				selectors.isPluginActionStatus(
+					state,
+					'site.one',
+					'jetpack/jetpack',
+					[ INSTALL_PLUGIN, DEACTIVATE_PLUGIN ],
+					'completed'
+				)
+			).to.be.true;
+		} );
+	} );
+
+	describe( 'isPluginActionInProgress', () => {
+		test( 'Should get `false` if the plugin status for the action is not "inProgress".', () => {
+			expect(
+				selectors.isPluginActionInProgress(
+					state,
+					'site.one',
+					'jetpack/jetpack',
+					DEACTIVATE_PLUGIN
+				)
+			).to.be.false;
+		} );
+
+		test( 'Should get `true` if the plugin status for the action is "inProgress".', () => {
+			expect(
+				selectors.isPluginActionInProgress(
+					state,
+					'site.one',
+					'akismet/akismet',
+					ENABLE_AUTOUPDATE_PLUGIN
+				)
+			).to.be.true;
+		} );
+	} );
 } );


### PR DESCRIPTION
This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/47920#discussion_r533964859 and https://github.com/Automattic/wp-calypso/pull/47921#discussion_r533966507 where @flootr suggested that we introduce a selector for the common "is plugin status for one or more actions the specified one" functionality. 

In this PR we introduce the selectors and update the existing use cases.

Part of #24180.

#### Changes proposed in this Pull Request

* State: Introduce new `isPluginActionStatus` and `isPluginActionInProgress` selectors with tests.
* Plugins: Update `PluginActivateToggle` to use the `isPluginActionInProgress` selector.
* Plugins: Update `PluginAutoUpdateToggle` to use the `isPluginActionInProgress` selector.

#### Testing instructions

* Get a Jetpack site for testing.
* Go to `/plugins/hello-dolly/:site` and install the plugin if it's not installed.
* Activate and deactivate the plugin from the toggle.
* Verify that while (de)activating, the toggle gets disabled.
* Enable and disable the plugin's auto-update toggle.
* Verify that while enabling and disabling the auto-update setting, the toggle gets disabled.
* Verify all tests pass.
