### PR TITLE
Fix broken mobile arrow scroll of the plans page in Safari desktop and mobile

### DIFF
--- a/client/my-sites/plan-features/scroller.jsx
+++ b/client/my-sites/plan-features/scroller.jsx
@@ -111,7 +111,7 @@ export default class PlanFeaturesScroller extends PureComponent {
 				nextPos = step < 0 ? Math.max( nextPos, to ) : Math.min( nextPos, to );
 				this.scrollWrapperDOM.scrollLeft = nextPos;
 
-				if ( nextPos !== to ) {
+				if ( Math.abs( to - nextPos ) > 50 ) {
 					window.requestAnimationFrame( animate );
 				} else {
 					window.requestAnimationFrame( resolve );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The arrow scroll is broken in safari browsers for the plans page. Hence, the user is not able to switch to other plans when on safari-mobile using arrows (Swipe works).
* Used an inequality to decide on whether to calculate the final animation frame

#### Testing instructions

* Go to plans page on the mobile resolution in the Safari web browser and check whether arrow keys properly work when scrolling

