### PR TITLE
Editing toolkit: Fixes missing block translation

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/index.php
@@ -37,6 +37,7 @@ function enqueue_script( $filename, $in_footer = false ) {
 		$asset['version'],
 		$in_footer
 	);
+	wp_set_script_translations( $filename, 'full-site-editing' );
 }
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/premium-content.php
@@ -79,6 +79,7 @@ function premium_content_block_enqueue_block_editor_assets() {
 		filemtime( PREMIUM_CONTENT__PLUGIN_DIR . '/' . $editor_css ),
 		false
 	);
+	wp_set_script_translations( 'premium-content-editor', 'full-site-editing' );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes the following missing translations:
- Block tooltips:
![image](https://user-images.githubusercontent.com/23708351/100872443-7eb7ee00-34aa-11eb-9b43-b67756fa4d83.png)

Some other keywords that trigger tooltips: `theme`, `css`, `plugin`, `header`.
- Premium content Block : 
![image](https://user-images.githubusercontent.com/23708351/100872540-a14a0700-34aa-11eb-8c81-0d77ed075c50.png)


#### Testing instructions
1. Checkout the diff mentioned below on your sandbox and sandbox a test website.
1. Change your account language to one of Mag-16.
1. Confirm that the tooltips and premium content block are now translated.