### PR TITLE
Use new inclusive site settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -358,10 +358,6 @@ module.exports = {
 					// It's not likely that this will change
 					{ term: 'mastercard', allowPartialMatches: true },
 
-					// The next two are stored in a site's meta so would require a data migration of all sites to fix
-					'comment_whitelist',
-					'blacklist_keys',
-
 					// Depends on https://github.com/Automattic/jetpack/blob/3dae8f80e5020338e84bfc20bb41786f056a2eec/json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php#L38
 					'option_name_not_in_whitelist',
 

--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -220,7 +220,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 		authorUrl: get( comment, 'author.URL', '' ),
 		isAuthorBlocked: isAuthorsEmailBlocked( state, siteId, authorEmail ),
 		showBlockUser,
-		blockedCommentAuthorKeys: getSiteSetting( state, siteId, 'blacklist_keys' ),
+		blockedCommentAuthorKeys: getSiteSetting( state, siteId, 'disallowed_keys' ),
 		siteId,
 		siteSlug: getSelectedSiteSlug( state ),
 	};
@@ -240,7 +240,7 @@ const mapDispatchToProps = ( dispatch ) => ( {
 							: 'comment_author_unblocked'
 					)
 				),
-				saveSiteSettings( siteId, { blacklist_keys: blockedCommentAuthorKeys } )
+				saveSiteSettings( siteId, { disallowed_keys: blockedCommentAuthorKeys } )
 			)
 		),
 	trackAnonymousModeration: () =>

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -452,9 +452,9 @@ class SiteSettingsFormDiscussion extends Component {
 					{ translate( 'Comment must be manually approved' ) }
 				</FormToggle>
 				<FormToggle
-					checked={ !! fields.comment_whitelist }
+					checked={ !! fields.comment_previously_approved }
 					disabled={ isRequestingSettings || isSavingSettings }
-					onChange={ handleAutosavingToggle( 'comment_whitelist' ) }
+					onChange={ handleAutosavingToggle( 'comment_previously_approved' ) }
 				>
 					{ translate( 'Comment author must have a previously approved comment' ) }
 				</FormToggle>
@@ -535,8 +535,8 @@ class SiteSettingsFormDiscussion extends Component {
 				<FormTextarea
 					name="disallowed_comment_keys"
 					id="disallowed_comment_keys"
-					value={ fields.blacklist_keys }
-					onChange={ onChangeField( 'blacklist_keys' ) }
+					value={ fields.disallowed_keys }
+					onChange={ onChangeField( 'disallowed_keys' ) }
 					disabled={ isRequestingSettings || isSavingSettings }
 					autoCapitalize="none"
 					onClick={ eventTracker( 'Clicked Disallowed Comments Field' ) }
@@ -669,10 +669,10 @@ const getFormSettings = ( settings ) => {
 		'social_notifications_reblog',
 		'social_notifications_subscribe',
 		'comment_moderation',
-		'comment_whitelist',
+		'comment_previously_approved',
 		'comment_max_links',
 		'moderation_keys',
-		'blacklist_keys',
+		'disallowed_keys',
 		'highlander_comment_form_prompt',
 		'jetpack_comment_form_color_scheme',
 		'subscriptions',

--- a/client/state/selectors/is-authors-email-blocked.js
+++ b/client/state/selectors/is-authors-email-blocked.js
@@ -18,7 +18,7 @@ import getSiteSetting from 'calypso/state/selectors/get-site-setting';
  * @returns {boolean} If the email address is disallowed.
  */
 export const isAuthorsEmailBlocked = ( state, siteId, email = '' ) => {
-	const blocklist = getSiteSetting( state, siteId, 'blacklist_keys' ) || '';
+	const blocklist = getSiteSetting( state, siteId, 'disallowed_keys' ) || '';
 	return includes( blocklist.split( '\n' ), email );
 };
 

--- a/client/state/selectors/test/is-authors-email-blocked.js
+++ b/client/state/selectors/test/is-authors-email-blocked.js
@@ -14,13 +14,13 @@ const state = {
 	siteSettings: {
 		items: {
 			123: {
-				blacklist_keys: 'mail@mail.com\ntest@example.com\nfoo@bar.baz\nyadda@yadda.yadda',
+				disallowed_keys: 'mail@mail.com\ntest@example.com\nfoo@bar.baz\nyadda@yadda.yadda',
 			},
 			456: {
-				blacklist_keys: 'mail@mail.com\ntest@example.com\nyadda@yadda.yadda',
+				disallowed_keys: 'mail@mail.com\ntest@example.com\nyadda@yadda.yadda',
 			},
 			789: {
-				blacklist_keys: '',
+				disallowed_keys: '',
 			},
 		},
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The legacy non-inclusive site settings backed by the `comment_whitelist` and `blacklist_keys` blog options were migrated to `comment_previously_approved` and `disallowed_keys` respectively in WordPress 5.5 (https://core.trac.wordpress.org/changeset/48575).

The legacy options are no longer supported as valid settings in the site API endpoint as of Jetpack 9.2 (https://github.com/Automattic/jetpack/pull/17820), so this PR updates the settings name to use the new inclusive names.

Note that WP.com still uses the legacy options internally (D47633-code), but there are some compatibility hacks in place that makes possible to use the new names for getting/updating the value of the legacy settings.

#### Testing instructions

- Go to `/settings/discussion`.
- Select a Simple site.
- Toggle the "Comment author must have a previously approved comment" option.
- Add some words to the "Disallowed comments" field.
- Save the settings.
- Reload.
- Make sure the settings have been saved.
- Repeat with a Jetpack, Atomic, and VIP site.

Fixes https://github.com/Automattic/wp-calypso/issues/47840
Fixes https://github.com/Automattic/wp-calypso/issues/47844
