### PR TITLE
Plugins: Reduxify PluginSiteJetpack progress

### DIFF
--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -1,16 +1,15 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import FoldableCard from 'calypso/components/foldable-card';
-import PluginsLog from 'calypso/lib/plugins/log-store';
 import PluginActivateToggle from 'calypso/my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 import PluginUpdateIndicator from 'calypso/my-sites/plugins/plugin-site-update-indicator';
@@ -18,6 +17,7 @@ import PluginInstallButton from 'calypso/my-sites/plugins/plugin-install-button'
 import PluginRemoveButton from 'calypso/my-sites/plugins/plugin-remove-button';
 import Site from 'calypso/blocks/site';
 import { Button } from '@automattic/components';
+import { isPluginActionInProgress } from 'calypso/state/plugins/installed/selectors';
 
 /**
  * Style dependencies
@@ -47,18 +47,12 @@ class PluginSiteJetpack extends React.Component {
 	};
 
 	renderInstallButton = () => {
-		const installInProgress = PluginsLog.isInProgressAction(
-			this.props.site.ID,
-			this.props.plugin.slug,
-			'INSTALL_PLUGIN'
-		);
-
 		return (
 			<PluginInstallButton
 				isEmbed={ true }
 				selectedSite={ this.props.site }
 				plugin={ this.props.plugin }
-				isInstalling={ installInProgress }
+				isInstalling={ this.props.installInProgress }
 			/>
 		);
 	};
@@ -150,4 +144,6 @@ class PluginSiteJetpack extends React.Component {
 	}
 }
 
-export default localize( PluginSiteJetpack );
+export default connect( ( state, { site, plugin } ) => ( {
+	installInProgress: isPluginActionInProgress( state, site.ID, plugin.id, 'INSTALL_PLUGIN' ),
+} ) )( localize( PluginSiteJetpack ) );


### PR DESCRIPTION
This PR updates the `PluginSiteJetpack` component to use Redux for determining whether the plugin is being installed or not, instead of using the old `PluginsLog` store.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Reduxify `PluginSiteJetpack` progress

#### Testing instructions

* Go to `/plugins/hello-dolly`. If you have it installed for all sites, remove it from at least one.
* Click the "Install" button for one of your sites.
* Verify that while installing, you still get a "Installing..." message.
* Verify all tests still pass.

#### Note
* ~Do not merge just yet - this depends on #47951 and needs to be rebased when it's merged. Feel free to review it though - I've made sure that it's easier to review by basing it against #47951.~ Rebased after #47951 landed.
* We could be importing the notice actions from the plugins state constants file that defines them, but I'm leaving that for another PR as it affects other locations, too.