### PR TITLE
Plugins: Reduxify PluginSiteNetwork progress

### DIFF
--- a/client/my-sites/plugins/plugin-site-network/index.jsx
+++ b/client/my-sites/plugins/plugin-site-network/index.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
 import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -12,13 +12,13 @@ import React from 'react';
 import FoldableCard from 'calypso/components/foldable-card';
 import { CompactCard } from '@automattic/components';
 import AllSites from 'calypso/blocks/all-sites';
-import PluginsLog from 'calypso/lib/plugins/log-store';
 import PluginActivateToggle from 'calypso/my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 import PluginUpdateIndicator from 'calypso/my-sites/plugins/plugin-site-update-indicator';
 import PluginInstallButton from 'calypso/my-sites/plugins/plugin-install-button';
 import PluginRemoveButton from 'calypso/my-sites/plugins/plugin-remove-button';
 import Site from 'calypso/blocks/site';
+import { isPluginActionInProgress } from 'calypso/state/plugins/installed/selectors';
 
 /**
  * Style dependencies
@@ -36,18 +36,12 @@ class PluginSiteNetwork extends React.Component {
 	};
 
 	renderInstallButton = () => {
-		const installInProgress = PluginsLog.isInProgressAction(
-			this.props.site.ID,
-			this.props.plugin.slug,
-			'INSTALL_PLUGIN'
-		);
-
 		return (
 			<PluginInstallButton
 				isEmbed={ true }
 				selectedSite={ this.props.site }
 				plugin={ this.props.plugin }
-				isInstalling={ installInProgress }
+				isInstalling={ this.props.installInProgress }
 			/>
 		);
 	};
@@ -162,4 +156,6 @@ class PluginSiteNetwork extends React.Component {
 	}
 }
 
-export default localize( PluginSiteNetwork );
+export default connect( ( state, { site, plugin } ) => ( {
+	installInProgress: isPluginActionInProgress( state, site.ID, plugin.id, 'INSTALL_PLUGIN' ),
+} ) )( localize( PluginSiteNetwork ) );


### PR DESCRIPTION
This PR updates the `PluginSiteNetwork` component to use Redux for determining whether the plugin is being installed or not, instead of using the old `PluginsLog` store.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Reduxify `PluginSiteNetwork` progress

#### Testing instructions

* Go to `/plugins/hello-dolly`. If you have it installed for all multisite networks, remove it from at least one.
* Click the "Install" button for one of your multisite networks that doesn't have it installed yet.
* Verify that while installing, you still get a "Installing..." message.
* Verify all tests still pass.

#### Note
* ~Do not merge just yet - this depends on #47951 and needs to be rebased when it's merged. Feel free to review it though - I've made sure that it's easier to review by basing it against #47951.~ Rebased after #47951 landed.
* We could be importing the notice actions from the plugins state constants file that defines them, but I'm leaving that for another PR as it affects other locations, too.