### PR TITLE
Show new plans benefits in the Disconnect Site page

### DIFF
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -135,10 +135,7 @@ class DisconnectJetpack extends PureComponent {
 				)
 			);
 			features.push(
-				translate(
-					'{{icon/}} Daily automated malware scanning with automated resolution',
-					this.getIcon( 'spam' )
-				)
+				translate( '{{icon/}} Real-time automated malware scanning', this.getIcon( 'spam' ) )
 			);
 			features.push(
 				translate( '{{icon/}} Priority WordPress and security support', this.getIcon( 'chat' ) )

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -130,7 +130,7 @@ class DisconnectJetpack extends PureComponent {
 		) {
 			features.push(
 				translate(
-					'{{icon/}} Daily automated backups (unlimited storage)',
+					'{{icon/}} Real-time automated backups (unlimited storage)',
 					this.getIcon( 'history' )
 				)
 			);

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -81,77 +81,72 @@ class DisconnectJetpack extends PureComponent {
 	planFeatures() {
 		const { plan, translate } = this.props;
 		const features = [];
-		switch ( plan ) {
-			case 'is-free-plan':
-				features.push(
-					translate(
-						'{{icon/}} Site stats, related content, and sharing tools',
-						this.getIcon( 'stats-alt' )
-					)
-				);
-				features.push(
-					translate(
-						'{{icon/}} Brute force attack protection and downtime monitoring',
-						this.getIcon( 'lock' )
-					)
-				);
-				features.push(
-					translate( '{{icon/}} Unlimited, high-speed image hosting', this.getIcon( 'image' ) )
-				);
-				break;
 
-			case 'is-personal-plan':
-				features.push(
-					translate(
-						'{{icon/}} Daily automated backups (unlimited storage)',
-						this.getIcon( 'history' )
-					)
-				);
-				features.push(
-					translate( '{{icon/}} Priority WordPress and security support', this.getIcon( 'chat' ) )
-				);
-				features.push( translate( '{{icon/}} Spam filtering', this.getIcon( 'spam' ) ) );
-				break;
-
-			case 'is-premium-plan':
-				features.push(
-					translate(
-						'{{icon/}} Daily automated backups (unlimited storage)',
-						this.getIcon( 'history' )
-					)
-				);
-				features.push(
-					translate( '{{icon/}} Daily automated malware scanning', this.getIcon( 'spam' ) )
-				);
-				features.push(
-					translate( '{{icon/}} Priority WordPress and security support', this.getIcon( 'chat' ) )
-				);
-				features.push(
-					translate( '{{icon/}} 13GB of high-speed video hosting', this.getIcon( 'video' ) )
-				);
-				break;
-
-			case 'is-business-plan':
-				features.push(
-					translate(
-						'{{icon/}} Daily automated backups (unlimited storage)',
-						this.getIcon( 'history' )
-					)
-				);
-				features.push(
-					translate(
-						'{{icon/}} Daily automated malware scanning with automated resolution',
-						this.getIcon( 'spam' )
-					)
-				);
-				features.push(
-					translate( '{{icon/}} Priority WordPress and security support', this.getIcon( 'chat' ) )
-				);
-				features.push(
-					translate( '{{icon/}} Unlimited high-speed video hosting', this.getIcon( 'video' ) )
-				);
-				features.push( translate( '{{icon/}} SEO preview tools', this.getIcon( 'globe' ) ) );
-				break;
+		if ( plan === 'is-free-plan' ) {
+			features.push(
+				translate(
+					'{{icon/}} Site stats, related content, and sharing tools',
+					this.getIcon( 'stats-alt' )
+				)
+			);
+			features.push(
+				translate(
+					'{{icon/}} Brute force attack protection and downtime monitoring',
+					this.getIcon( 'lock' )
+				)
+			);
+			features.push(
+				translate( '{{icon/}} Unlimited, high-speed image hosting', this.getIcon( 'image' ) )
+			);
+		} else if ( plan === 'is-personal-plan' ) {
+			features.push(
+				translate(
+					'{{icon/}} Daily automated backups (unlimited storage)',
+					this.getIcon( 'history' )
+				)
+			);
+			features.push(
+				translate( '{{icon/}} Priority WordPress and security support', this.getIcon( 'chat' ) )
+			);
+			features.push( translate( '{{icon/}} Spam filtering', this.getIcon( 'spam' ) ) );
+		} else if ( [ 'is-premium-plan', 'is-daily-security-plan' ].includes( plan ) ) {
+			features.push(
+				translate(
+					'{{icon/}} Daily automated backups (unlimited storage)',
+					this.getIcon( 'history' )
+				)
+			);
+			features.push(
+				translate( '{{icon/}} Daily automated malware scanning', this.getIcon( 'spam' ) )
+			);
+			features.push(
+				translate( '{{icon/}} Priority WordPress and security support', this.getIcon( 'chat' ) )
+			);
+			features.push(
+				translate( '{{icon/}} 13GB of high-speed video hosting', this.getIcon( 'video' ) )
+			);
+		} else if (
+			[ 'is-business-plan', 'is-realtime-security-plan', 'is-complete-plan' ].includes( plan )
+		) {
+			features.push(
+				translate(
+					'{{icon/}} Daily automated backups (unlimited storage)',
+					this.getIcon( 'history' )
+				)
+			);
+			features.push(
+				translate(
+					'{{icon/}} Daily automated malware scanning with automated resolution',
+					this.getIcon( 'spam' )
+				)
+			);
+			features.push(
+				translate( '{{icon/}} Priority WordPress and security support', this.getIcon( 'chat' ) )
+			);
+			features.push(
+				translate( '{{icon/}} Unlimited high-speed video hosting', this.getIcon( 'video' ) )
+			);
+			features.push( translate( '{{icon/}} SEO preview tools', this.getIcon( 'globe' ) ) );
 		}
 
 		return features.map( ( freature, index ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Include Jetpack Security and Jetpack Complete plans in the algorithm that selects the list of benefits to display when a user is in the process of disconnecting a site.
* Mention real-time backups instead of daily backups in the case of Jetpack Security Real-time, Jetpack Complete, and Jetpack Professional (business).

#### Testing instructions

* Run this PR.
* Select a Jetpack site that has Jetpack Security Daily.
* Visit `settings/disconnect-site/confirm/:site?reason=troubleshooting`.
* Verify that you see these four benefits: `Daily automated backups (unlimited storage)`, `Daily automated malware scanning`, `Priority WordPress and security support`, and `13GB of high-speed video hosting`.

* Select a Jetpack site that has Jetpack Security Real-time or Jetpack Complete.
* Visit `settings/disconnect-site/confirm/:site?reason=troubleshooting`.
* Verify that you see these five benefits: `Real-time automated backups (unlimited storage)`, `Real-time automated malware scanning`, `Priority WordPress and security support`, `Unlimited high-speed video hosting`, and `SEO preview tools`.

Fixes 1164141197617539-as-1199490895109286

#### Demo

#### Before (all new plans)
![image](https://user-images.githubusercontent.com/3418513/100889167-9afd6000-3495-11eb-9243-4381891f86b2.png)

#### Jetpack Security Daily
![image](https://user-images.githubusercontent.com/3418513/100888860-51147a00-3495-11eb-805b-84308e54a78f.png)

#### Jetpack Security Real-time and Jetpack Complete
![image](https://user-images.githubusercontent.com/3418513/100888904-5b367880-3495-11eb-8a2d-082a9ed950d4.png)
