### PR TITLE
Plugins: Cleanup unused notices prop and shouldComponentUpdate

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -3,9 +3,8 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { flowRight as compose, isEqual, uniqBy } from 'lodash';
+import { flowRight as compose, uniqBy } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -19,26 +18,11 @@ import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-t
 import Count from 'calypso/components/count';
 import Notice from 'calypso/components/notice';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import PluginNotices from 'calypso/lib/plugins/notices';
-import { errorNotice } from 'calypso/state/notices/actions';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-function checkPropsChange( nextProps, propArr ) {
-	let i;
-
-	for ( i = 0; i < propArr.length; i++ ) {
-		const prop = propArr[ i ];
-
-		if ( ! isEqual( nextProps[ prop ], this.props[ prop ] ) ) {
-			return true;
-		}
-	}
-	return false;
-}
 
 class PluginItem extends Component {
 	static propTypes = {
@@ -54,11 +38,6 @@ class PluginItem extends Component {
 		} ),
 		isAutoManaged: PropTypes.bool,
 		progress: PropTypes.array,
-		notices: PropTypes.shape( {
-			completed: PropTypes.array,
-			errors: PropTypes.array,
-			inProgress: PropTypes.array,
-		} ),
 		hasUpdate: PropTypes.func,
 	};
 
@@ -71,29 +50,6 @@ class PluginItem extends Component {
 		isAutoManaged: false,
 		hasUpdate: () => false,
 	};
-
-	shouldComponentUpdate( nextProps ) {
-		const propsToCheck = [
-			'plugin',
-			'sites',
-			'selectedSite',
-			'isMock',
-			'isSelectable',
-			'isSelected',
-		];
-		if ( checkPropsChange.call( this, nextProps, propsToCheck ) ) {
-			return true;
-		}
-
-		if (
-			this.props.notices &&
-			PluginNotices.shouldComponentUpdateNotices( this.props.notices, nextProps.notices )
-		) {
-			return true;
-		}
-
-		return false;
-	}
 
 	ago( date ) {
 		return this.props.moment.utc( date, 'YYYY-MM-DD hh:mma' ).fromNow();
@@ -260,7 +216,6 @@ class PluginItem extends Component {
 						plugin={ this.props.plugin }
 						disabled={ this.props.isSelectable }
 						site={ this.props.selectedSite }
-						notices={ this.props.notices }
 					/>
 				) }
 				{ canToggleAutoupdate && (
@@ -269,7 +224,6 @@ class PluginItem extends Component {
 						plugin={ this.props.plugin }
 						disabled={ this.props.isSelectable }
 						site={ this.props.selectedSite }
-						notices={ this.props.notices }
 						wporg={ !! this.props.plugin.wporg }
 					/>
 				) }
@@ -357,8 +311,4 @@ class PluginItem extends Component {
 	}
 }
 
-export default compose(
-	connect( null, { errorNotice } ),
-	localize,
-	withLocalizedMoment
-)( PluginItem );
+export default compose( localize, withLocalizedMoment )( PluginItem );

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { flowRight as compose, uniqBy } from 'lodash';
+import { uniqBy } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -311,4 +311,4 @@ class PluginItem extends Component {
 	}
 }
 
-export default compose( localize, withLocalizedMoment )( PluginItem );
+export default localize( withLocalizedMoment( PluginItem ) );

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -544,7 +544,6 @@ export const PluginsList = createReactClass( {
 				progress={ this.state.notices.inProgress.filter(
 					( log ) => log.plugin.slug === plugin.slug
 				) }
-				notices={ this.state.notices }
 				isSelected={ this.isSelected( plugin ) }
 				isSelectable={ isSelectable }
 				onClick={ selectThisPlugin }


### PR DESCRIPTION
Currently, in the `PluginItem` component we're using an unnecessary `shouldComponentUpdate`. It was introduced [here](https://github.com/Automattic/wp-calypso/commit/da5a71e00f6a59994eb2417252aca7f34a091d70) together with a `PureRenderMixin`, but when the `PureRenderMixin` was removed, the `shouldComponentUpdate` wasn't removed.  This PR removes that unnecessary `shouldComponentUpdate`.

Furthermore, we're passing down the `notices` prop but it's not used at all. This PR removes that prop from components that don't need it.

With this PR, we're paving the way for reduxifying `PluginNotices`.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Cleanup unused notices prop and shouldComponentUpdate

#### Testing instructions

* Go to `/plugins/manage/:site` where `:site` is a Jetpack site with plugins.
* Try single and mass activation, deactivation, autoupdate activation and deactivation, install, remove, update and verify notices are still appearing properly and there are no visual, behavioral or functional changes related to the notes or the plugin items.
* Verify there are no `notices` props passed down to `PluginItem` anymore.