### PR TITLE
Removes a no longer used AB test

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -39,7 +39,6 @@ import {
 	getThemeShowcaseTitle,
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
-import UpworkBanner from 'calypso/blocks/upwork-banner';
 import RecommendedThemes from './recommended-themes';
 
 /**

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -32,7 +32,6 @@ import {
 import ThemesSearchCard from './themes-magic-search-card';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
 import {
-	getActiveTheme,
 	getThemeFilterTerms,
 	getThemeFilterToTermTable,
 	getThemeShowcaseDescription,
@@ -85,7 +84,6 @@ class ThemeShowcase extends React.Component {
 	}
 
 	static propTypes = {
-		currentThemeId: PropTypes.string,
 		emptyContent: PropTypes.element,
 		tier: PropTypes.oneOf( [ '', 'free', 'premium' ] ),
 		search: PropTypes.string,
@@ -220,7 +218,6 @@ class ThemeShowcase extends React.Component {
 
 	render() {
 		const {
-			currentThemeId,
 			siteId,
 			options,
 			getScreenshotOption,
@@ -268,8 +265,6 @@ class ThemeShowcase extends React.Component {
 				.filter( ( icon ) => !! icon )
 				.sort( ( a, b ) => a.order - b.order )
 		);
-
-		const showBanners = currentThemeId || ! siteId || ! isLoggedIn;
 
 		const { isShowcaseOpen } = this.state;
 		const isQueried = this.props.search || this.props.filter || this.props.tier;
@@ -430,7 +425,6 @@ class ThemeShowcase extends React.Component {
 }
 
 const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
-	currentThemeId: getActiveTheme( state, siteId ),
 	isLoggedIn: !! getCurrentUserId( state ),
 	siteSlug: getSiteSlug( state, siteId ),
 	description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the AB test added here to display the hire a builder banner on themes https://github.com/Automattic/wp-calypso/pull/29681

#### Testing instructions

* Does the banner appear?

A follow up to this PR should remove the remainder of the banner and the associated code.
