### PR TITLE
Jetpack Backup: Allow download/restore for non-rewindable activities with rewindable streams

### DIFF
--- a/client/components/activity-card/index.jsx
+++ b/client/components/activity-card/index.jsx
@@ -170,6 +170,13 @@ class ActivityCard extends Component {
 			? this.state.showTopPopoverMenu
 			: this.state.showBottomPopoverMenu;
 
+		// The activity itself may not be rewindable, but at least one of the
+		// streams should be; if this is the case, make sure we send the user
+		// to a valid restore/download point when they click an action button
+		const actionableRewindId = activity.activityIsRewindable
+			? activity.rewindId
+			: activity.streams.find( ( s ) => s.activityIsRewindable )?.rewindId;
+
 		return (
 			<>
 				<Button
@@ -191,7 +198,9 @@ class ActivityCard extends Component {
 					className="activity-card__popover"
 				>
 					<Button
-						href={ ! doesRewindNeedCredentials && backupRestorePath( siteSlug, activity.rewindId ) }
+						href={
+							! doesRewindNeedCredentials && backupRestorePath( siteSlug, actionableRewindId )
+						}
 						className="activity-card__restore-button"
 						disabled={ doesRewindNeedCredentials }
 					>
@@ -216,7 +225,7 @@ class ActivityCard extends Component {
 						borderless
 						compact
 						isPrimary={ false }
-						href={ backupDownloadPath( siteSlug, activity.rewindId ) }
+						href={ backupDownloadPath( siteSlug, actionableRewindId ) }
 						className="activity-card__download-button"
 					>
 						<img

--- a/client/components/activity-card/index.jsx
+++ b/client/components/activity-card/index.jsx
@@ -25,6 +25,7 @@ import Button from 'calypso/components/forms/form-button';
 import ExternalLink from 'calypso/components/external-link';
 import getAllowRestore from 'calypso/state/selectors/get-allow-restore';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
+import { getActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id';
 import Gridicon from 'calypso/components/gridicon';
 import PopoverMenu from 'calypso/components/popover/menu';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
@@ -173,9 +174,7 @@ class ActivityCard extends Component {
 		// The activity itself may not be rewindable, but at least one of the
 		// streams should be; if this is the case, make sure we send the user
 		// to a valid restore/download point when they click an action button
-		const actionableRewindId = activity.activityIsRewindable
-			? activity.rewindId
-			: activity.streams.find( ( s ) => s.activityIsRewindable )?.rewindId;
+		const actionableRewindId = getActionableRewindId( activity );
 
 		return (
 			<>

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -16,6 +16,7 @@ import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-valu
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
 import ActivityCard from 'calypso/components/activity-card';
+import { useActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id';
 import ActionButtons from '../action-buttons';
 import BackupChanges from '../backup-changes';
 import useGetDisplayDate from '../use-get-display-date';
@@ -56,11 +57,7 @@ const BackupSuccessful = ( { backup, deltas, selectedDate } ) => {
 		( 'rewind__backup_complete_full' !== backup.activityName ||
 			'rewind__backup_only_complete_full' !== backup.activityName );
 
-	// If the activity isn't rewindable but has streams that are,
-	// use one of the streams' rewind ID as the download or restore point
-	const actionableRewindId = backup.activityIsRewindable
-		? backup.rewindId
-		: backup.streams?.find?.( ( a ) => a.activityIsRewindable )?.rewindId;
+	const actionableRewindId = useActionableRewindId( backup );
 
 	return (
 		<>

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -56,6 +56,12 @@ const BackupSuccessful = ( { backup, deltas, selectedDate } ) => {
 		( 'rewind__backup_complete_full' !== backup.activityName ||
 			'rewind__backup_only_complete_full' !== backup.activityName );
 
+	// If the activity isn't rewindable but has streams that are,
+	// use one of the streams' rewind ID as the download or restore point
+	const actionableRewindId = backup.activityIsRewindable
+		? backup.rewindId
+		: backup.streams?.find?.( ( a ) => a.activityIsRewindable )?.rewindId;
+
 	return (
 		<>
 			<div className="status-card__message-head">
@@ -71,7 +77,7 @@ const BackupSuccessful = ( { backup, deltas, selectedDate } ) => {
 				<div className="status-card__title">{ displayDateNoLatest }</div>
 			</div>
 			<div className="status-card__meta">{ meta }</div>
-			<ActionButtons rewindId={ backup.rewindId } />
+			<ActionButtons rewindId={ actionableRewindId } />
 			{ showBackupDetails && (
 				<div className="status-card__realtime-details">
 					<div className="status-card__realtime-details-card">

--- a/client/lib/jetpack/actionable-rewind-id.ts
+++ b/client/lib/jetpack/actionable-rewind-id.ts
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+
+type Activity = {
+	activityIsRewindable: boolean;
+	rewindId?: string;
+	streams?: Activity[];
+};
+
+type Hook = ( activity: Activity ) => string | null | undefined;
+
+// NOTE: Use the hook version if at all possible! This method exists mainly to
+//       allow for finding an actionable rewind ID in places that don't
+//       support hooks; e.g., class components.
+//
+// If the activity isn't rewindable but has streams that are,
+// use one of the streams' rewind ID as the download or restore point
+export const getActionableRewindId: Hook = ( activity ) =>
+	activity.activityIsRewindable
+		? activity.rewindId
+		: activity.streams?.find?.( ( a ) => a.activityIsRewindable )?.rewindId;
+
+export const useActionableRewindId: Hook = ( activity ) =>
+	useMemo( () => getActionableRewindId( activity ), [ activity ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the `ActivityCard` component, if the activity itself isn't rewindable but has rewindable streams, use the stream's rewind ID in links to download or restore.
* Do the same for the `BackupSuccessful` component, so that people can more consistently restore from the latest backup.

Partially fixes `1164141197617539-as-1199364778347733`.

#### Testing instructions

**Prerequisite:** Select a site that has Backup Real-time and at least one backup that contains one or more streams (e.g., media uploads).

* Find a day where the last successful backup contains streams, and a day where at least one other backup contains streams.
* For the "last successful backup" example, open React DevTools and go through the cases below while examining the `BackupSuccessful` page component. Note the `backup` property's `rewindId`, `activityIsRewindable`, and `streams` values.
* For the "other backup" example, open React DevTools and go through the cases below while examining the properties of the corresponding `ActivityCard` component.

##### Case 1: Activity is rewindable

* If `activityIsRewindable` is false for the main backup/activity property, modify it to make it true.
* Verify that the **Download backup** and **Restore to this point** buttons point to `/backup/:site_id/download/:rewind_id` or `/backup/:site_id/restore/:rewind_id`, respectively, and that the referenced Rewind ID matches the one in the backup you noted above. **NOTE**: The rewind ID of the main backup/activity may be the same as one of its rewindable streams; feel free to modify either of these values so that you can tell them apart.

##### Case 2: Activity is *not* rewindable, but its streams are

* If `activityIsRewindable` is true for the main backup/activity property, modify it to make it false.
* Note in the `streams` property that at least one of the main activity's streams has its own `rewindId` value and `activityIsRewindable` set to true.
* Verify that the **Download backup** and **Restore to this point** buttons point to the download or restore path for one of the stream IDs that's rewindable, as in Case 1. **NOTE**: The rewind ID of the main backup/activity may be the same as one of its rewindable streams; feel free to modify either of these values so that you can tell them apart.

#### Reference screenshots

##### Latest backup

<img width="350" src="https://user-images.githubusercontent.com/670067/100905418-a8165100-348d-11eb-8964-7ebb17d53a14.png"> <img width="350" alt="image" src="https://user-images.githubusercontent.com/670067/100905837-21ae3f00-348e-11eb-8898-149e67768d12.png">

##### Activity card

![image](https://user-images.githubusercontent.com/670067/100906213-8c5f7a80-348e-11eb-8b42-10edf3a150ac.png)
![image](https://user-images.githubusercontent.com/670067/100906708-160f4800-348f-11eb-88b3-4413282c709d.png)
