### PR TITLE
Editing Toolkit: Update to 2.8.10

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.9
+ * Version: 2.8.10
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.9' );
+define( 'PLUGIN_VERSION', '2.8.10' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.9
+Stable tag: 2.8.10
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,12 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.10 =
+* Premium Content: Fix selection of payment plans (https://github.com/Automattic/wp-calypso/pull/47944)
+* Coming soon: Check for coming soon mode on 404 (https://github.com/Automattic/wp-calypso/pull/47945)
+* Onboarding: Add support for RTL site launch stylesheet (https://github.com/Automattic/wp-calypso/pull/47890)
+* Coming soon: Show Coming Soon on blog post pages (https://github.com/Automattic/wp-calypso/pull/47853)
 
 = 2.8.9 =
 * Domain Picker: Persistent Domain (https://github.com/Automattic/wp-calypso/pull/47633)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.9",
+	"version": "2.8.10",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bumps version of Editing Toolkit to 2.8.10

#### [Changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)

* Premium Content: Fix selection of payment plans (https://github.com/Automattic/wp-calypso/pull/47944)
* Coming Soon: Check for coming soon mode on 404 (https://github.com/Automattic/wp-calypso/pull/47945)
* Onboarding: Add support for RTL site launch stylesheet (https://github.com/Automattic/wp-calypso/pull/47890)
* Update to node 12.19.1 (https://github.com/Automattic/wp-calypso/pull/47866)
* Coming soon: Show Coming Soon on blog post pages (https://github.com/Automattic/wp-calypso/pull/47853)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load the diff on your sandbox (D53662-code) and confirm that the above changes work correctly
2. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.

