### PR TITLE
Shopping cart: Update StaleCartItemsNotice to use useShoppingCart

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -22,6 +22,7 @@ import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { hasAllSitesList } from 'calypso/state/sites/selectors';
 import { expandSidebar } from 'calypso/state/ui/actions';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 /**
  * Style dependencies
@@ -112,10 +113,12 @@ class CurrentSite extends Component {
 						/>
 					) }
 					{ selectedSite && isEnabled( 'current-site/stale-cart-notice' ) && (
-						<AsyncLoad
-							require="calypso/my-sites/current-site/stale-cart-items-notice"
-							placeholder={ null }
-						/>
+						<CalypsoShoppingCartProvider>
+							<AsyncLoad
+								require="calypso/my-sites/current-site/stale-cart-items-notice"
+								placeholder={ null }
+							/>
+						</CalypsoShoppingCartProvider>
 					) }
 					{ selectedSite && isEnabled( 'current-site/notice' ) && (
 						<AsyncLoad


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove the deprecated `CartStore`, this PR updates the `StaleCartItemsNotice` component so that it now uses `useShoppingCart` (part of the `@automattic/shopping-cart` package).

#### Screenshots

<img width="553" alt="Screen Shot 2020-12-02 at 2 11 07 PM" src="https://user-images.githubusercontent.com/2036909/100919824-516a4080-34a8-11eb-99cd-a5d89448dd7a.png">

#### Testing instructions

- Visit the plans page for a site which has had items in its cart for more than 10 minutes.
- Verify that you see the above notice.
- Verify that clicking on the link in the notice opens the cart.
- Without reloading the page, return to the plans page (navigate to a different page first if you haven't already done so).
- Verify that the notice does not get displayed.