### PR TITLE
Pricing page: implement jetpack_pricing_switch_plan_sides experiment

### DIFF
--- a/client/my-sites/plans/jetpack-plans/experiments.ts
+++ b/client/my-sites/plans/jetpack-plans/experiments.ts
@@ -1,0 +1,6 @@
+/**
+ * Experiment: jetpack_pricing_switch_plan_sides
+ */
+export const SWITCH_PLAN_SIDES_EXPERIMENT = 'jetpack_pricing_switch_plan_sides';
+export const SWITCH_PLAN_SIDES_CONTROL = 'control';
+export const SWITCH_PLAN_SIDES_TREATMENT = 'treatment';

--- a/client/my-sites/plans/jetpack-plans/experiments.ts
+++ b/client/my-sites/plans/jetpack-plans/experiments.ts
@@ -1,6 +1,6 @@
 /**
  * Experiment: jetpack_pricing_switch_plan_sides
  */
-export const SWITCH_PLAN_SIDES_EXPERIMENT = 'jetpack_pricing_switch_plan_sides';
+export const SWITCH_PLAN_SIDES_EXPERIMENT = 'jetpack_pricing_switch_plan_sides2';
 export const SWITCH_PLAN_SIDES_CONTROL = 'control';
 export const SWITCH_PLAN_SIDES_TREATMENT = 'treatment';

--- a/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { SWITCH_PLAN_SIDES_TREATMENT } from '../experiments';
 import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 import {
 	PLAN_JETPACK_SECURITY_DAILY,
@@ -53,7 +54,7 @@ const PRODUCT_POSITION_IN_GRID_V2: Record< string, number > = {
 	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 60 ),
 };
 
-const PRODUCT_POSITION_IN_GRID_I5: Record< string, number > = {
+const PRODUCT_POSITION_IN_GRID_I5_CONTROL: Record< string, number > = {
 	// Plans
 	...setProductsInPosition( JETPACK_COMPLETE_PLANS, 1 ),
 	[ PLAN_JETPACK_SECURITY_REALTIME ]: 10,
@@ -71,14 +72,37 @@ const PRODUCT_POSITION_IN_GRID_I5: Record< string, number > = {
 	...setProductsInPosition( JETPACK_CRM_PRODUCTS, 80 ),
 };
 
-export function getProductPosition( slug: JetpackPlanSlugs | JetpackProductSlug ): number {
+const PRODUCT_POSITION_IN_GRID_I5_TREATMENT: Record< string, number > = {
+	// Plans
+	[ PLAN_JETPACK_SECURITY_DAILY ]: 1,
+	[ PLAN_JETPACK_SECURITY_DAILY_MONTHLY ]: 1,
+	[ PLAN_JETPACK_SECURITY_REALTIME ]: 10,
+	[ PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ]: 10,
+	...setProductsInPosition( JETPACK_COMPLETE_PLANS, 20 ),
+	// Products
+	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: 30,
+	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: 30,
+	[ PRODUCT_JETPACK_BACKUP_DAILY ]: 40,
+	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: 40,
+	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 50 ),
+	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 60 ),
+	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 70 ),
+	...setProductsInPosition( JETPACK_CRM_PRODUCTS, 80 ),
+};
+
+export function getProductPosition(
+	slug: JetpackPlanSlugs | JetpackProductSlug,
+	variation?: string
+): number {
 	switch ( getJetpackCROActiveVersion() ) {
 		case 'v1':
 			return PRODUCT_POSITION_IN_GRID_V1[ slug ];
 		case 'v2':
 			return PRODUCT_POSITION_IN_GRID_V2[ slug ];
 		case 'i5':
-			return PRODUCT_POSITION_IN_GRID_I5[ slug ];
+			return SWITCH_PLAN_SIDES_TREATMENT === variation
+				? PRODUCT_POSITION_IN_GRID_I5_TREATMENT[ slug ]
+				: PRODUCT_POSITION_IN_GRID_I5_CONTROL[ slug ];
 		default:
 			return 100;
 	}

--- a/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
@@ -10,12 +10,13 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-
+import { SWITCH_PLAN_SIDES_EXPERIMENT } from '../experiments';
 import PlansFilterBarI5 from '../plans-filter-bar-i5';
 import ProductCardI5 from '../product-card-i5';
 import { getProductPosition } from '../product-grid/products-order';
 import { getPlansToDisplay, getProductsToDisplay, isConnectionFlow } from '../product-grid/utils';
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
+import Experiment from 'calypso/components/experiment';
 import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card-i5';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
@@ -23,6 +24,7 @@ import {
 	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
 } from 'calypso/lib/plans/constants';
 import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import { getVariationForUser, isLoading } from 'calypso/state/experiments/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import MoreInfoBox from '../more-info-box';
@@ -56,6 +58,9 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const currentPlanSlug =
 		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
+	const variation =
+		useSelector( ( state ) => getVariationForUser( state, SWITCH_PLAN_SIDES_EXPERIMENT ) ) || '';
+	const isVariationLoading = useSelector( isLoading );
 
 	const { availableProducts, purchasedProducts, includedInPlanProducts } = useGetPlansGridProducts(
 		siteId
@@ -66,9 +71,9 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 	const sortedPlans = useMemo(
 		() =>
 			sortBy( getPlansToDisplay( { duration, currentPlanSlug } ), ( item ) =>
-				getProductPosition( item.productSlug as JetpackPlanSlugs )
+				getProductPosition( item.productSlug as JetpackPlanSlugs, variation )
 			),
-		[ duration, currentPlanSlug ]
+		[ duration, currentPlanSlug, variation ]
 	);
 	const sortedProducts = useMemo(
 		() =>
@@ -79,9 +84,9 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 					purchasedProducts,
 					includedInPlanProducts,
 				} ),
-				( item ) => getProductPosition( item.productSlug as JetpackProductSlug )
+				( item ) => getProductPosition( item.productSlug as JetpackProductSlug, variation )
 			),
-		[ duration, availableProducts, includedInPlanProducts, purchasedProducts ]
+		[ duration, availableProducts, includedInPlanProducts, purchasedProducts, variation ]
 	);
 
 	const scrollToComparison = () => {
@@ -116,7 +121,7 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 	}, [ onResize ] );
 
 	return (
-		<>
+		<Experiment name={ SWITCH_PLAN_SIDES_EXPERIMENT }>
 			<section className="products-grid-i5__section">
 				<h2 className="products-grid-i5__section-title">{ translate( 'Product Bundles' ) }</h2>
 				<div className="products-grid-i5__filter-bar">
@@ -126,67 +131,70 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 						duration={ duration }
 					/>
 				</div>
-				<ul
-					className={ classNames( 'products-grid-i5__plan-grid', {
-						'is-wrapping': isPlanRowWrapping,
-					} ) }
-					ref={ planGridRef }
-				>
-					{ sortedPlans.map( ( product ) => (
-						<li key={ product.iconSlug }>
-							<ProductCardI5
-								item={ product }
-								onClick={ onSelectProduct }
-								siteId={ siteId }
-								currencyCode={ currencyCode }
-								selectedTerm={ duration }
-								isAligned={ ! isPlanRowWrapping }
-								featuredPlans={ [
-									PLAN_JETPACK_SECURITY_REALTIME,
-									PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
-								] }
+				{ ! isVariationLoading && (
+					<>
+						<ul
+							className={ classNames( 'products-grid-i5__plan-grid', {
+								'is-wrapping': isPlanRowWrapping,
+							} ) }
+							ref={ planGridRef }
+						>
+							{ sortedPlans.map( ( product ) => (
+								<li key={ product.iconSlug }>
+									<ProductCardI5
+										item={ product }
+										onClick={ onSelectProduct }
+										siteId={ siteId }
+										currencyCode={ currencyCode }
+										selectedTerm={ duration }
+										isAligned={ ! isPlanRowWrapping }
+										featuredPlans={ [
+											PLAN_JETPACK_SECURITY_REALTIME,
+											PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+										] }
+									/>
+								</li>
+							) ) }
+						</ul>
+						<div
+							className={ classNames( 'products-grid-i5__more', {
+								'is-detached': isPlanRowWrapping,
+							} ) }
+						>
+							<MoreInfoBox
+								headline={ translate( 'Need more info?' ) }
+								buttonLabel={ translate( 'Compare all product bundles' ) }
+								onButtonClick={ scrollToComparison }
 							/>
-						</li>
-					) ) }
-				</ul>
-				<div
-					className={ classNames( 'products-grid-i5__more', {
-						'is-detached': isPlanRowWrapping,
-					} ) }
-				>
-					<MoreInfoBox
-						headline={ translate( 'Need more info?' ) }
-						buttonLabel={ translate( 'Compare all product bundles' ) }
-						onButtonClick={ scrollToComparison }
-					/>
-				</div>
+						</div>
+					</>
+				) }
 			</section>
 			<section className="products-grid-i5__section">
 				<h2 className="products-grid-i5__section-title">{ translate( 'Individual Products' ) }</h2>
-				<ul className="products-grid-i5__product-grid">
-					{ sortedProducts.map( ( product ) => (
-						<li key={ product.iconSlug }>
-							<ProductCardI5
-								item={ product }
-								onClick={ onSelectProduct }
-								siteId={ siteId }
-								currencyCode={ currencyCode }
-								selectedTerm={ duration }
-							/>
-						</li>
-					) ) }
-				</ul>
+				{ ! isVariationLoading && (
+					<ul className="products-grid-i5__product-grid">
+						{ sortedProducts.map( ( product ) => (
+							<li key={ product.iconSlug }>
+								<ProductCardI5
+									item={ product }
+									onClick={ onSelectProduct }
+									siteId={ siteId }
+									currencyCode={ currencyCode }
+									selectedTerm={ duration }
+								/>
+							</li>
+						) ) }
+					</ul>
+				) }
 				<div className="products-grid-i5__free">
 					{ ( isInConnectFlow || isInJetpackCloud ) && (
 						<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
 					) }
 				</div>
 			</section>
-			{ /* <section ref={ bundleComparisonRef } className="products-grid-i5__section">
-				<h2 className="products-grid-i5__section-title">{ translate( 'Bundle Comparison' ) }</h2>
-			</section> */ }
 			{ ! isJetpackCloud() && <StoreFooter /> }
-		</>
+		</Experiment>
 	);
 };
 

--- a/client/state/data-layer/wpcom/experiments/index.js
+++ b/client/state/data-layer/wpcom/experiments/index.js
@@ -31,9 +31,9 @@ const transformApiRequest = ( data ) => ( {
 export const handleFetchExperiments = ( action ) =>
 	http(
 		{
-			apiNamespace: 'wpcom',
+			apiNamespace: 'wpcom/v2',
 			method: 'GET',
-			path: '/v2/experiments/0.1.0/assignments/calypso',
+			path: '/experiments/0.1.0/assignments/calypso',
 			query: {
 				anon_id: action.anonId,
 			},

--- a/client/state/data-layer/wpcom/experiments/test/index.js
+++ b/client/state/data-layer/wpcom/experiments/test/index.js
@@ -16,9 +16,9 @@ describe( 'wpcom-api', () => {
 				expect( handleFetchExperiments( action ) ).toEqual(
 					http(
 						{
-							apiNamespace: 'wpcom',
+							apiNamespace: 'wpcom/v2',
 							method: 'GET',
-							path: '/v2/experiments/0.1.0/assignments/calypso',
+							path: '/experiments/0.1.0/assignments/calypso',
 							query: {
 								anon_id: 'abc',
 							},

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -32,6 +32,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
+		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
 		"jetpack-cloud/connect": true,
 		"jetpack/backups-date-picker": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -29,6 +29,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
+		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
 		"jetpack-cloud/connect": true,
 		"jetpack/backups-date-picker": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -31,6 +31,7 @@
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
 		"i18n/community-translator": false,
+		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
 		"jetpack-cloud/connect": false,
 		"jetpack/backups-date-picker": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -30,6 +30,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
+		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
 		"jetpack-cloud/connect": true,
 		"jetpack/backups-date-picker": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR implements the experiment `jetpack_pricing_switch_plan_sides`.

> Hypothesis: Swapping the position of Jetpack Complete with Jetpack Security Daily will increase purchases of one or more plans.

See experiment link in 1196108640073826-as-1199394984333679

### Testing instructions

_Prerequisites: visit the experiment page and add the bookmarks that allow you to switch between the control and treatment variations_
<img width="625" alt="Screen Shot 2020-12-02 at 2 12 15 PM" src="https://user-images.githubusercontent.com/1620183/100919904-6941c480-34a8-11eb-9da0-756165fb9e8d.png">


- Download the PR
- Run Calypso (`yarn start`) and Jetpack cloud concurrently (`yarn start-jetpack-cloud-p`, once Calypso is running)
- Select a self-hosted Jetpack site in Calypso
- Visit the pricing page in both platforms: `http://calypso.localhost:3000/plans/:site` and `http://jetpack.cloud.localhost:3001/pricing`
- Verify that you see the `control` variation (see capture)
- Click on the bookmark that activates the `treatment` variation and refresh the page
- Verify that you see the `treatment` variation (see capture)

_The result of the endpoint seems to be cached for a couple of seconds, so make sure that the call to `/experiments/0.1.0/assignments/calypso` is made in the Network panel as you test._

### Screenshots

#### Control
<img width="1056" alt="Screen Shot 2020-12-02 at 2 05 46 PM" src="https://user-images.githubusercontent.com/1620183/100919435-cab56380-34a7-11eb-8a8b-d7eec3c808e4.png">


#### Treatment
<img width="1056" alt="Screen Shot 2020-12-02 at 2 06 29 PM" src="https://user-images.githubusercontent.com/1620183/100919452-d0ab4480-34a7-11eb-8e8b-38aeb1b07f51.png">
