### PR TITLE
Jetpack plans: add 'Downgrade to another plan' as a new cancellation reason

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -318,6 +318,12 @@ class CancelPurchaseForm extends React.Component {
 		);
 
 		appendRadioOption(
+			'downgradeToAnotherPlan',
+			translate( "I'd like to downgrade to another plan." ),
+			translate( 'Mind telling us which one?' )
+		);
+
+		appendRadioOption(
 			'onlyNeedFree',
 			translate( 'The plan was too expensive.' ),
 			translate( 'How can we improve our upgrades?' )

--- a/client/components/marketing-survey/cancel-purchase-form/options-for-product.js
+++ b/client/components/marketing-survey/cancel-purchase-form/options-for-product.js
@@ -6,7 +6,7 @@ import { isDomainTransfer, isJetpackPlan } from 'calypso/lib/products-values';
 
 export const cancellationOptionsForPurchase = ( purchase ) => {
 	if ( isJetpackPlan( purchase ) ) {
-		return [ 'couldNotActivate', 'didNotInclude', 'onlyNeedFree' ];
+		return [ 'couldNotActivate', 'didNotInclude', 'downgradeToAnotherPlan', 'onlyNeedFree' ];
 	}
 
 	if ( isDomainTransfer( purchase ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 1164141197617539-as-1182228962974270 (read 5058-gh-Automattic/jpop-issues for more context).

* Add a new cancellation survey option for users that decided they want to downgrade to another Jetpack plan.

#### Testing instructions

* Run this PR (Calypso Blue).
* Select a Jetpack site that has a paid plan.
* Go to the Billing section located at `/purchases/subscriptions/:site`.
* Select the site's plan.
* Click on the `[Remove :planName]` button at the bottom of the section.
* Verify that you see an option labeled as `I'd like to downgrade to another plan`.
* Click that option.
* Verify that the input box placeholder text is `Mind telling us which one?`.

#### Demo
![image](https://user-images.githubusercontent.com/3418513/100920755-5506c300-34ba-11eb-855f-34775c76d0fd.png)
