### PR TITLE
Jetpack Backup: Show the date's latest _good_ backup on 'latest backup' card

### DIFF
--- a/client/my-sites/backup/status/hooks.js
+++ b/client/my-sites/backup/status/hooks.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+
+/**
  * Internal dependencies
  */
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -116,6 +121,7 @@ export const useDailyBackupStatus = ( siteId, selectedDate ) => {
 		mostRecentBackupEver: mostRecentBackupEver.backupAttempt,
 		lastBackupBeforeDate: lastBackupBeforeDate.backupAttempt,
 		lastBackupAttemptOnDate: lastAttemptOnDate.backupAttempt,
+		lastSuccessfulBackupOnDate: successfulLastAttempt ? lastAttemptOnDate.backupAttempt : undefined,
 		deltas: backupDeltas.deltas,
 		rawDeltas: rawBackupDeltas.deltas,
 	};
@@ -138,10 +144,15 @@ export const useRealtimeBackupStatus = ( siteId, selectedDate ) => {
 		after: moment( selectedDate ).startOf( 'day' ).toISOString(),
 	} );
 
-	const backupAttemptsOnDate = activityLogs.filter(
-		( activity ) => isActivityBackup( activity ) || isSuccessfulRealtimeBackup( activity )
+	const backupAttemptsOnDate = useMemo(
+		() =>
+			activityLogs.filter(
+				( activity ) => isActivityBackup( activity ) || isSuccessfulRealtimeBackup( activity )
+			),
+		[ activityLogs ]
 	);
 	const lastBackupAttemptOnDate = backupAttemptsOnDate[ 0 ];
+	const lastSuccessfulBackupOnDate = backupAttemptsOnDate.filter( isSuccessfulRealtimeBackup )[ 0 ];
 
 	const hasPreviousBackup = ! lastBackupBeforeDate.isLoading && lastBackupBeforeDate.backupAttempt;
 	const successfulLastAttempt =
@@ -164,8 +175,9 @@ export const useRealtimeBackupStatus = ( siteId, selectedDate ) => {
 			rawDeltas.isLoading,
 		mostRecentBackupEver: mostRecentBackupEver.backupAttempt,
 		lastBackupBeforeDate: lastBackupBeforeDate.backupAttempt,
-		lastBackupAttemptOnDate: backupAttemptsOnDate[ 0 ],
-		earlierBackupAttemptsOnDate: backupAttemptsOnDate?.slice?.( 1 ) || [],
+		lastBackupAttemptOnDate,
+		lastSuccessfulBackupOnDate,
+		backupAttemptsOnDate,
 		rawDeltas: rawDeltas.deltas,
 	};
 };

--- a/client/my-sites/backup/status/index.jsx
+++ b/client/my-sites/backup/status/index.jsx
@@ -64,7 +64,8 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 		isLoading,
 		lastBackupBeforeDate,
 		lastBackupAttemptOnDate,
-		earlierBackupAttemptsOnDate,
+		lastSuccessfulBackupOnDate,
+		backupAttemptsOnDate,
 	} = useRealtimeBackupStatus( siteId, selectedDate );
 
 	// Eagerly cache requests for the days before and after our selected date, to make navigation smoother
@@ -86,14 +87,14 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 				{ ...{
 					selectedDate,
 					lastBackupDate,
-					backup: lastBackupAttemptOnDate,
+					backup: lastSuccessfulBackupOnDate || lastBackupAttemptOnDate,
 				} }
 			/>
 
 			{ lastBackupAttemptOnDate && (
 				<BackupDelta
 					{ ...{
-						realtimeBackups: earlierBackupAttemptsOnDate,
+						realtimeBackups: backupAttemptsOnDate,
 						isToday: moment().isSame( selectedDate, 'day' ),
 					} }
 				/>

--- a/client/my-sites/backup/status/simplified-i4.jsx
+++ b/client/my-sites/backup/status/simplified-i4.jsx
@@ -80,7 +80,8 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 		mostRecentBackupEver,
 		lastBackupBeforeDate,
 		lastBackupAttemptOnDate,
-		earlierBackupAttemptsOnDate,
+		lastSuccessfulBackupOnDate,
+		backupAttemptsOnDate,
 		rawDeltas,
 	} = useRealtimeBackupStatus( siteId, selectedDate );
 
@@ -117,14 +118,14 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 					{ ...{
 						selectedDate,
 						lastBackupDate,
-						backup: lastBackupAttemptOnDate,
+						backup: lastSuccessfulBackupOnDate || lastBackupAttemptOnDate,
 						isLatestBackup,
 						dailyDeltas,
 					} }
 				/>
 			</li>
 
-			{ earlierBackupAttemptsOnDate.map( ( activity ) => (
+			{ backupAttemptsOnDate.map( ( activity ) => (
 				<li key={ activity.activityId }>
 					<BackupCard activity={ activity } />
 				</li>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Alter the top-of-page backup status components to always show the last _good_ backup for any given date, whether or not it's truly the last backup of the day.
* Memoize the `backupAttemptsOnDate` property in the real-time backup status hook, to avoid unnecessary re-renders and update loops.

Partially fixes `1164141197617539-as-1199364778347733`.

#### Testing instructions

**Note:** You'll want to test this PR with both Backup Daily and Backup Real-time, but the focus is mostly on Backup Real-time, since it almost always creates multiple backups per day for sites that use it.

* Find and select a site and calendar date where the latest backup event is a failure, but at least one successful backup exists earlier in the day.
* Verify that the failed backup still exists in the date's list of activities, but the "Latest backup on this day" card shows the last *successful* backup for that day.

**Known issue:** If the latest backup is successful on any given date, that backup shows up in both places (i.e., the top card as well as the list of activities). We may revisit this later to cut down on redundancy, but for now we're focused on making sure the biggest/most obvious backup is usable for downloading and/or restoring.