### PR TITLE
Prevent null and DOM elements to trigger errors in Experiment component

### DIFF
--- a/client/components/experiment/index.tsx
+++ b/client/components/experiment/index.tsx
@@ -18,6 +18,11 @@ export { default as DefaultVariation } from './default-variation';
 export { default as LoadingVariations } from './loading-variations';
 
 /**
+ * Type Dependencies
+ */
+import { LoadingProps } from './loading-props';
+
+/**
  * The experiment component to display the experiment variations
  *
  * @param props The properties that describe the experiment
@@ -42,8 +47,19 @@ export const Experiment: FunctionComponent< ExperimentProps > = ( props ) => {
 	return (
 		<>
 			<QueryExperiments />
-			{ React.Children.map( children, ( elem ) => {
-				return React.cloneElement( elem, { variation, isLoading: loading } );
+			{ React.Children.map( children as JSX.Element[], ( elem ) => {
+				if ( elem ) {
+					const props: LoadingProps = { variation };
+
+					// Unless element is a DOM element
+					if ( 'string' !== typeof elem.type ) {
+						props.isLoading = loading;
+					}
+
+					return React.cloneElement( elem, props );
+				}
+
+				return null;
 			} ) }
 		</>
 	);
@@ -63,7 +79,7 @@ function mapStateToProps( state: AppState, ownProps?: ExperimentProps ): Experim
 	const { name: experimentName } = ownProps;
 	return {
 		isLoading: isLoading( state ),
-		variation: getVariationForUser( state, experimentName ),
+		variation: getVariationForUser( state, experimentName ) ?? undefined,
 		...ownProps,
 	};
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

The `Experiment` component (`client/components/experiment/index.tsx`) triggers a warning when one of its children is a DOM element (see capture below). It also throws an exception if one of its children is null. This PR fixes both cases.

Check #47971 for the implementation that pointed out these issues.

### Testing instructions

### Screenshots

_Warning for DOM element_
<img width="1555" alt="Screen Shot 2020-12-02 at 1 56 42 PM" src="https://user-images.githubusercontent.com/1620183/100933922-078b5580-34bc-11eb-9fbf-cee224c1c5ab.png">
