### PR TITLE
Help: Add a support session card to the help screen

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -23,6 +23,9 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import SectionHeader from 'calypso/components/section-header';
 import { getCurrentUserId, isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
+import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
+import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id.js';
+import getConciergeNextAppointment from 'calypso/state/selectors/get-concierge-next-appointment';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { getUserPurchases, isFetchingUserPurchases } from 'calypso/state/purchases/selectors';
 import { planHasFeature } from 'calypso/lib/plans';
@@ -227,7 +230,12 @@ class Help extends React.PureComponent {
 	};
 
 	supportSessionCard = () => {
-		const { translate } = this.props;
+		const { translate, hasAppointment, scheduleId } = this.props;
+
+		//If we already have an appointment or the scheduleId has not been loaded, bail
+		if ( hasAppointment || null === scheduleId ) {
+			return;
+		}
 
 		return (
 			<Card className="help__support-session-card">
@@ -306,6 +314,7 @@ class Help extends React.PureComponent {
 				{ this.getHelpfulArticles() }
 				{ this.getSupportLinks() }
 				<HappinessEngineers />
+				<QueryConciergeInitial />
 				<QueryUserPurchases userId={ userId } />
 			</Main>
 		);
@@ -323,6 +332,8 @@ export const mapStateToProps = ( state, ownProps ) => {
 	const isLoading = isFetchingUserPurchases( state );
 	const isBusinessPlanUser = some( purchases, planHasOnboarding );
 	const showCoursesTeaser = ownProps.isCoursesEnabled && isBusinessPlanUser;
+	const hasAppointment = getConciergeNextAppointment( state );
+	const scheduleId = getConciergeScheduleId( state );
 
 	return {
 		userId,
@@ -330,6 +341,8 @@ export const mapStateToProps = ( state, ownProps ) => {
 		showCoursesTeaser,
 		isLoading,
 		isEmailVerified,
+		hasAppointment,
+		scheduleId,
 	};
 };
 

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -245,7 +245,7 @@ class Help extends React.PureComponent {
 							className="help__support-session-action"
 							primary
 							href={ localizeUrl( 'https://wordpress.com/checkout/offer-quickstart-session/' ) }
-							onClick={ this.trackSupportSessionButtonClick() }
+							onClick={ this.trackSupportSessionButtonClick }
 						>
 							{ translate( 'Schedule a session' ) }
 						</Button>
@@ -266,7 +266,7 @@ class Help extends React.PureComponent {
 	};
 
 	trackSupportSessionButtonClick = () => {
-		//@TODO: What information do we want to track?
+		recordTracksEvent( 'calypso_help_support_session_card_click' );
 	};
 
 	trackCoursesButtonClick = () => {

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -243,14 +243,14 @@ class Help extends React.PureComponent {
 							href={ localizeUrl( 'https://wordpress.com/checkout/offer-quickstart-session/' ) }
 							onClick={ this.trackSupportSessionButtonClick() }
 						>
-							Schedule a session
+							{ this.props.translate( 'Schedule a session' ) }
 						</Button>
 						<Button
 							className="help__support-session-action is-link"
 							borderless
 							href={ localizeUrl( 'https://wordpress.com/support/quickstart-support/' ) }
 						>
-							Learn more
+							{ this.props.translate( 'Learn more' ) }
 						</Button>
 					</div>
 				</div>

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -11,7 +11,7 @@ import { some } from 'lodash';
  * Internal dependencies
  */
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { Button, CompactCard } from '@automattic/components';
+import { Button, CompactCard, Card } from '@automattic/components';
 import HappinessEngineers from 'calypso/me/help/help-happiness-engineers';
 import HelpResult from './help-results/item';
 import HelpSearch from './help-search';
@@ -32,6 +32,11 @@ import { FEATURE_BUSINESS_ONBOARDING } from 'calypso/lib/plans/constants';
  * Style dependencies
  */
 import './style.scss';
+
+/**
+ * Images
+ */
+import supportSession from 'calypso/assets/images/customer-home/illustration-webinars.svg';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -219,6 +224,51 @@ class Help extends React.PureComponent {
 		);
 	};
 
+	supportSessionCard = () => {
+		return (
+			<Card className="help__support-session-card">
+				<div className="help__support-session-text">
+					<h2 className="help__support-session-title">
+						{ this.props.translate( 'Schedule a support session' ) }
+					</h2>
+					<p className="help__support-session-description">
+						{ this.props.translate(
+							'Quick Start Support Sessions give you a way to talk to one of our Happiness Engineers via a screen share with audio.'
+						) }
+					</p>
+					<div className="help__support-session-actions">
+						<Button
+							className="help__support-session-action"
+							primary
+							href={ localizeUrl( 'https://wordpress.com/checkout/offer-quickstart-session/' ) }
+							onClick={ this.trackSupportSessionButtonClick() }
+						>
+							Schedule a session
+						</Button>
+						<Button
+							className="help__support-session-action is-link"
+							borderless
+							href={ localizeUrl( 'https://wordpress.com/support/quickstart-support/' ) }
+						>
+							Learn more
+						</Button>
+					</div>
+				</div>
+				<div className="help__support-session-illustration">
+					<img src={ supportSession } alt="" />
+				</div>
+			</Card>
+		);
+	};
+
+	trackSupportSessionButtonClick = () => {
+		//@TODO: What information do we want to track here?
+		const { isBusinessPlanUser } = this.props;
+		recordTracksEvent( 'calypso_help_support_session_card_click', {
+			is_business_plan_user: isBusinessPlanUser,
+		} );
+	};
+
 	trackCoursesButtonClick = () => {
 		const { isBusinessPlanUser } = this.props;
 		recordTracksEvent( 'calypso_help_courses_click', {
@@ -228,7 +278,7 @@ class Help extends React.PureComponent {
 
 	getPlaceholders = () => {
 		return (
-			<Main className="help">
+			<Main className="help" wideLayout>
 				<MeSidebarNavigation />
 				<div className="help-search is-placeholder" />
 				<div className="help__help-teaser-button is-placeholder" />
@@ -246,12 +296,13 @@ class Help extends React.PureComponent {
 		}
 
 		return (
-			<Main className="help">
+			<Main className="help" wideLayout>
 				<PageViewTracker path="/help" title="Help" />
 				<MeSidebarNavigation />
 				<HelpSearch />
 				{ ! isEmailVerified && <HelpUnverifiedWarning /> }
 				{ this.getCoursesTeaser() }
+				{ this.supportSessionCard() }
 				{ this.getHelpfulArticles() }
 				{ this.getSupportLinks() }
 				<HappinessEngineers />

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -207,6 +207,8 @@ class Help extends React.PureComponent {
 	};
 
 	getCoursesTeaser = () => {
+		const { translate } = this.props;
+
 		if ( ! this.props.showCoursesTeaser ) {
 			return null;
 		}
@@ -216,8 +218,8 @@ class Help extends React.PureComponent {
 				onClick={ this.trackCoursesButtonClick }
 				href="https://wordpress.com/webinars"
 				target="_blank"
-				title={ this.props.translate( 'Courses' ) }
-				description={ this.props.translate(
+				title={ translate( 'Courses' ) }
+				description={ translate(
 					'Learn how to make the most of your site with these courses and webinars'
 				) }
 			/>
@@ -225,14 +227,16 @@ class Help extends React.PureComponent {
 	};
 
 	supportSessionCard = () => {
+		const { translate } = this.props;
+
 		return (
 			<Card className="help__support-session-card">
 				<div className="help__support-session-text">
 					<h2 className="help__support-session-title">
-						{ this.props.translate( 'Schedule a support session' ) }
+						{ translate( 'Schedule a support session' ) }
 					</h2>
 					<p className="help__support-session-description">
-						{ this.props.translate(
+						{ translate(
 							'Quick Start Support Sessions give you a way to talk to one of our Happiness Engineers via a screen share with audio.'
 						) }
 					</p>
@@ -243,14 +247,14 @@ class Help extends React.PureComponent {
 							href={ localizeUrl( 'https://wordpress.com/checkout/offer-quickstart-session/' ) }
 							onClick={ this.trackSupportSessionButtonClick() }
 						>
-							{ this.props.translate( 'Schedule a session' ) }
+							{ translate( 'Schedule a session' ) }
 						</Button>
 						<Button
 							className="help__support-session-action is-link"
 							borderless
 							href={ localizeUrl( 'https://wordpress.com/support/quickstart-support/' ) }
 						>
-							{ this.props.translate( 'Learn more' ) }
+							{ translate( 'Learn more' ) }
 						</Button>
 					</div>
 				</div>
@@ -262,11 +266,7 @@ class Help extends React.PureComponent {
 	};
 
 	trackSupportSessionButtonClick = () => {
-		//@TODO: What information do we want to track here?
-		const { isBusinessPlanUser } = this.props;
-		recordTracksEvent( 'calypso_help_support_session_card_click', {
-			is_business_plan_user: isBusinessPlanUser,
-		} );
+		//@TODO: What information do we want to track?
 	};
 
 	trackCoursesButtonClick = () => {

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -1,7 +1,10 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .help .upwork-banner {
 	margin: 10px 10px 20px;
 
-	@include breakpoint-deprecated( '>660px' ) {
+	@include break-small {
 		margin: 0 0 24px;
 	}
 }
@@ -46,7 +49,7 @@
 .help__support-link-title {
 	font-size: $font-body;
 	color: var( --color-primary );
-	@include breakpoint-deprecated( '>660px' ) {
+	@include break-small {
 		font-size: $font-title-small;
 	}
 }
@@ -87,7 +90,7 @@
 		box-sizing: border-box;
 		padding: 24px;
 
-		@include breakpoint-deprecated( '>1040px' ) {
+		@include break-huge {
 			padding: 32px;
 		}
 	}
@@ -99,11 +102,16 @@
 	}
 
 	.help__support-session-illustration {
+		display: none;
 		width: 33.33%;
 		align-self: center;
 		flex-shrink: 0;
 		margin-left: auto;
 		text-align: center;
+
+		@include break-large {
+			display: block;
+		}
 	}
 
 	.help__support-session-title {
@@ -112,7 +120,7 @@
 		line-height: 36px;
 		margin-bottom: 4px;
 
-		@include breakpoint-deprecated( '>800px' ) {
+		@include break-medium {
 			line-height: 40px;
 		}
 	}
@@ -123,7 +131,7 @@
 		line-height: 24px;
 		color: var( --color-text );
 
-		@include breakpoint-deprecated( '>800px' ) {
+		@include break-medium {
 			line-height: 28px;
 			margin-bottom: 32px;
 		}

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -74,3 +74,70 @@
 	height: 380px;
 	margin-bottom: 15px;
 }
+
+.help__support-session-card {
+	display: flex;
+	background: var( --color-surface );
+	box-shadow: 0 0 0 1px var( --color-border-subtle );
+	padding: 0;
+	position: relative;
+
+	.help__support-session-text,
+	.help__support-session-illustration {
+		box-sizing: border-box;
+		padding: 24px;
+
+		@include breakpoint-deprecated( '>1040px' ) {
+			padding: 32px;
+		}
+	}
+
+	.help__support-session-text {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.help__support-session-illustration {
+		width: 33.33%;
+		align-self: center;
+		flex-shrink: 0;
+		margin-left: auto;
+		text-align: center;
+	}
+
+	.help__support-session-title {
+		@extend .wp-brand-font;
+		font-size: $font-title-large;
+		line-height: 36px;
+		margin-bottom: 4px;
+
+		@include breakpoint-deprecated( '>800px' ) {
+			line-height: 40px;
+		}
+	}
+
+	.help__support-session-description {
+		margin-bottom: 24px;
+		font-size: $font-body;
+		line-height: 24px;
+		color: var( --color-text );
+
+		@include breakpoint-deprecated( '>800px' ) {
+			line-height: 28px;
+			margin-bottom: 32px;
+		}
+	}
+
+	.help__support-session-actions {
+		display: flex;
+		align-items: center;
+		padding-top: 0;
+		margin-top: auto;
+		font-size: $font-body-small;
+	}
+
+	.help__support-session-action {
+		margin-right: 16px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* See #40870
* Widens the layout on the `/help` screen and adds a Support session card at the top
* If you already have a support session scheduled, you will not see the card prompt

**Before**

<img width="1680" alt="Screen Shot 2020-12-02 at 4 42 24 PM" src="https://user-images.githubusercontent.com/2124984/100934878-5dacc880-34bd-11eb-82d7-aa86c0537c38.png">

**After**

<img width="1678" alt="Screen Shot 2020-12-02 at 4 42 13 PM" src="https://user-images.githubusercontent.com/2124984/100934894-656c6d00-34bd-11eb-82b4-9a18829a7151.png">

No card prompt when support session has already been scheduled:

<img width="1092" alt="Screen Shot 2020-12-04 at 12 53 19 PM" src="https://user-images.githubusercontent.com/2124984/101197274-e51a4900-362f-11eb-8a3c-90ffd32eb9bd.png">


#### Testing instructions

* Switch to this PR and navigate to `/help`
* Note the visual layout changes and make sure there are no regressions
* Make sure the buttons on the support card work
* Check that the Tracks event is firing properly for the primary CTA
* Sign up for a Concierge support session at `/me/concierge` (make sure you note it's a test in the description).
* Look at `/help` again. You should not see a prompt to schedule a session.
* Don't forget to cancel the Concierge session. :)