### PR TITLE
Shopping cart: replace existing cart for renewals whenever any product is added

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -202,7 +202,6 @@ export default function CompositeCheckout( {
 
 	const {
 		productsForCart,
-		renewalsForCart,
 		isLoading: areCartProductsPreparing,
 		error: cartProductPrepError,
 	} = usePrepareProductsForCart( {
@@ -225,19 +224,16 @@ export default function CompositeCheckout( {
 		loadingError: cartLoadingError,
 		loadingErrorType: cartLoadingErrorType,
 		addProductsToCart,
-		replaceProductsInCart,
 	} = useShoppingCart();
 
 	const isInitialCartLoading = useAddProductsFromUrl( {
 		isLoadingCart,
 		isCartPendingUpdate,
 		productsForCart,
-		renewalsForCart,
 		areCartProductsPreparing,
 		couponCodeFromUrl,
 		applyCoupon,
 		addProductsToCart,
-		replaceProductsInCart,
 	} );
 
 	useRecordCartLoaded( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -3,7 +3,11 @@
  */
 import { useEffect, useRef, useState } from 'react';
 import debugFactory from 'debug';
-import type { RequestCartProduct } from '@automattic/shopping-cart';
+import type {
+	RequestCartProduct,
+	ApplyCouponToCart,
+	AddProductsToCart,
+} from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -16,22 +20,18 @@ export default function useAddProductsFromUrl( {
 	isLoadingCart,
 	isCartPendingUpdate,
 	productsForCart,
-	renewalsForCart,
 	areCartProductsPreparing,
 	couponCodeFromUrl,
 	applyCoupon,
 	addProductsToCart,
-	replaceProductsInCart,
 }: {
 	isLoadingCart: boolean;
 	isCartPendingUpdate: boolean;
 	productsForCart: RequestCartProduct[];
-	renewalsForCart: RequestCartProduct[];
 	areCartProductsPreparing: boolean;
 	couponCodeFromUrl: string | null | undefined;
-	applyCoupon: ( couponId: string ) => void;
-	addProductsToCart: ( products: RequestCartProduct[] ) => void;
-	replaceProductsInCart: ( products: RequestCartProduct[] ) => void;
+	applyCoupon: ApplyCouponToCart;
+	addProductsToCart: AddProductsToCart;
 } ): isPendingAddingProductsFromUrl {
 	const [ isLoading, setIsLoading ] = useState< boolean >( true );
 	const hasRequestedInitialProducts = useRef< boolean >( false );
@@ -45,7 +45,6 @@ export default function useAddProductsFromUrl( {
 		if (
 			! areCartProductsPreparing &&
 			productsForCart.length === 0 &&
-			renewalsForCart.length === 0 &&
 			! couponCodeFromUrl &&
 			! isLoadingCart &&
 			! isCartPendingUpdate
@@ -60,7 +59,6 @@ export default function useAddProductsFromUrl( {
 		isLoadingCart,
 		areCartProductsPreparing,
 		productsForCart.length,
-		renewalsForCart.length,
 		couponCodeFromUrl,
 	] );
 
@@ -94,16 +92,6 @@ export default function useAddProductsFromUrl( {
 		if ( productsForCart.length > 0 ) {
 			addProductsToCart( productsForCart );
 		}
-		debug( 'adding initial renewal products to cart', renewalsForCart );
-		if ( renewalsForCart.length > 0 ) {
-			if ( productsForCart.length > 0 ) {
-				throw new Error(
-					'Renewals and non-renewals cannot be added to the cart from the URL at the same time'
-				);
-			}
-			// Note that adding renewals replaces any existing products in the cart
-			replaceProductsInCart( renewalsForCart );
-		}
 		debug( 'adding initial coupon to cart', couponCodeFromUrl );
 		if ( couponCodeFromUrl ) {
 			applyCoupon( couponCodeFromUrl );
@@ -116,9 +104,7 @@ export default function useAddProductsFromUrl( {
 		couponCodeFromUrl,
 		applyCoupon,
 		productsForCart,
-		renewalsForCart,
 		addProductsToCart,
-		replaceProductsInCart,
 	] );
 
 	debug( 'useAddProductsFromUrl isLoading', isLoading );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -28,7 +28,6 @@ const debug = debugFactory( 'calypso:composite-checkout:use-prepare-products-for
 
 interface PreparedProductsForCart {
 	productsForCart: RequestCartProduct[];
-	renewalsForCart: RequestCartProduct[];
 	isLoading: boolean;
 	error: string | null;
 }
@@ -36,7 +35,6 @@ interface PreparedProductsForCart {
 const initialPreparedProductsState = {
 	isLoading: true,
 	productsForCart: [],
-	renewalsForCart: [],
 	error: null,
 };
 
@@ -106,18 +104,13 @@ function preparedProductsReducer(
 	action: PreparedProductsAction
 ): PreparedProductsForCart {
 	switch ( action.type ) {
+		case 'RENEWALS_ADD':
+		// fall through
 		case 'PRODUCTS_ADD':
 			if ( ! state.isLoading ) {
 				return state;
 			}
-			// Note that products and renewals are mutually exclusive; they cannot both be in the cart at the same time
-			return { ...state, productsForCart: action.products, renewalsForCart: [], isLoading: false };
-		case 'RENEWALS_ADD':
-			if ( ! state.isLoading ) {
-				return state;
-			}
-			// Note that products and renewals are mutually exclusive; they cannot both be in the cart at the same time
-			return { ...state, productsForCart: [], renewalsForCart: action.products, isLoading: false };
+			return { ...state, productsForCart: action.products, isLoading: false };
 		case 'PRODUCTS_ADD_ERROR':
 			if ( ! state.isLoading ) {
 				return state;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -384,6 +384,7 @@ function createRenewalItemToAddToCart(
 	};
 	return {
 		meta,
+		quantity: null,
 		volume: 1,
 		product_slug: productSlug,
 		product_id: parseInt( String( productId ), 10 ),

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -29,7 +29,7 @@ This is a React hook that can be used in any child component under [ShoppingCart
 
 The following actions are also properties. Each one returns a Promise that resolves when the cart is next valid (this may be after several queued actions are complete).
 
-- `addProductsToCart: ( products: RequestCartProduct[] ) => Promise<void>`. A function that requests adding new products to the cart.
+- `addProductsToCart: ( products: RequestCartProduct[] ) => Promise<void>`. A function that requests adding new products to the cart. May cause the cart to be replaced instead, depending on the RequestCartProducts (mostly renewals and non-renewals cannot co-exist in the cart at the same time).
 - `removeProductFromCart: ( uuidToRemove: string ) => Promise<void>`. A function that requests removing a product from the cart.
 - `applyCoupon: ( couponId: string ) => Promise<void>`. A function that requests applying a coupon to the cart (only one coupon can be applied at a time).
 - `removeCoupon: () => Promise<void>`. A function that requests removing a coupon to the cart.

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -184,10 +184,40 @@ function isRealProduct( serverCartItem: ResponseCartProduct ): boolean {
 	return true;
 }
 
+function shouldProductReplaceCart(
+	product: RequestCartProduct,
+	responseCart: TempResponseCart
+): boolean {
+	if ( product.extra?.purchaseType === 'renewal' && product.product_slug !== 'domain_redemption' ) {
+		// adding a renewal replaces the cart unless it is a privacy protection (comment copied from cartItemShouldReplaceCart; is domain_redemption really privacy protection?)
+		return true;
+	}
+
+	if (
+		product.extra?.purchaseType !== 'renewal' &&
+		responseCart.products.some( ( cartProduct ) => cartProduct.extra?.purchaseType === 'renewal' )
+	) {
+		// all items should replace the cart if the cart contains a renewal
+		return true;
+	}
+
+	return false;
+}
+
+function shouldProductsReplaceCart(
+	products: RequestCartProduct[],
+	responseCart: TempResponseCart
+): boolean {
+	return products.some( ( product ) => shouldProductReplaceCart( product, responseCart ) );
+}
+
 export function addItemsToResponseCart(
 	responseCart: TempResponseCart,
 	products: RequestCartProduct[]
 ): TempResponseCart {
+	if ( shouldProductsReplaceCart( products, responseCart ) ) {
+		return replaceAllItemsInResponseCart( responseCart, products );
+	}
 	return {
 		...responseCart,
 		products: [ ...responseCart.products, ...products ],

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+/**
  * Internal dependencies
  */
 import { getEmptyResponseCart } from './empty-carts';
@@ -11,6 +16,7 @@ import type {
 	ResponseCartProduct,
 } from './types';
 
+const debug = debugFactory( 'shopping-cart:cart-functions' );
 let lastUUID = 100;
 const emptyResponseCart = getEmptyResponseCart();
 
@@ -216,8 +222,10 @@ export function addItemsToResponseCart(
 	products: RequestCartProduct[]
 ): TempResponseCart {
 	if ( shouldProductsReplaceCart( products, responseCart ) ) {
+		debug( 'items should replace response cart', products );
 		return replaceAllItemsInResponseCart( responseCart, products );
 	}
+	debug( 'items should not replace response cart', products );
 	return {
 		...responseCart,
 		products: [ ...responseCart.products, ...products ],

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -194,15 +194,20 @@ function shouldProductReplaceCart(
 	product: RequestCartProduct,
 	responseCart: TempResponseCart
 ): boolean {
-	if ( product.extra?.purchaseType === 'renewal' && product.product_slug !== 'domain_redemption' ) {
+	const doesCartHaveRenewals = responseCart.products.some(
+		( cartProduct ) => cartProduct.extra?.purchaseType === 'renewal'
+	);
+
+	if (
+		! doesCartHaveRenewals &&
+		product.extra?.purchaseType === 'renewal' &&
+		product.product_slug !== 'domain_redemption'
+	) {
 		// adding a renewal replaces the cart unless it is a privacy protection (comment copied from cartItemShouldReplaceCart; is domain_redemption really privacy protection?)
 		return true;
 	}
 
-	if (
-		product.extra?.purchaseType !== 'renewal' &&
-		responseCart.products.some( ( cartProduct ) => cartProduct.extra?.purchaseType === 'renewal' )
-	) {
+	if ( doesCartHaveRenewals && product.extra?.purchaseType !== 'renewal' ) {
 		// all items should replace the cart if the cart contains a renewal
 		return true;
 	}

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -12,20 +12,20 @@ import { screen, act, render, waitFor, fireEvent } from '@testing-library/react'
  * Internal dependencies
  */
 import { useShoppingCart, ShoppingCartProvider } from '../index';
-import { emptyResponseCart } from '../src/empty-carts';
+import { getEmptyResponseCart } from '../src/empty-carts';
 import { RequestCartProduct, ResponseCartProduct, RequestCart, ResponseCart } from '../src/types';
 
-const planOne = {
+const planOne: ResponseCartProduct = {
 	product_name: 'WordPress.com Personal',
 	product_slug: 'personal-bundle',
 	currency: 'BRL',
 	extra: {
 		context: 'signup',
 	},
-	free_trial: false,
 	meta: '',
 	product_id: 1009,
 	volume: 1,
+	quantity: null,
 	item_original_cost_integer: 14400,
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
@@ -47,17 +47,17 @@ const planOne = {
 	included_domain_purchase_amount: 0,
 };
 
-const planTwo = {
+const planTwo: ResponseCartProduct = {
 	product_name: 'WordPress.com Business',
 	product_slug: 'business-bundle',
 	currency: 'BRL',
 	extra: {
 		context: 'signup',
 	},
-	free_trial: false,
 	meta: '',
 	product_id: 1010,
 	volume: 1,
+	quantity: null,
 	item_original_cost_integer: 14400,
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
@@ -80,6 +80,8 @@ const planTwo = {
 };
 
 const mainCartKey = '1';
+
+const emptyResponseCart = getEmptyResponseCart();
 
 async function getCart( cartKey: string ) {
 	if ( cartKey === mainCartKey ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously in https://github.com/Automattic/wp-calypso/pull/46248, code was added to `useAddProductsFromUrl` so that renewals would be added separately and would replace the cart. However, the logic we want is more complex than that (see https://github.com/Automattic/wp-calypso/issues/46624) and it would be nice to apply it to all uses of `addProductsToCart`, so here we remove those additions and leave it to `useShoppingCart` to handle when to replace the cart.

This copies over some of the logic (minus the Jetpack plans logic, which requires a lot of knowledge from calypso about jetpack plans and products) from `cartItemShouldReplaceCart`: if any item that would be added is a renewal (except for `domain_redemption` for some reason), then the cart is replaced entirely and if any item in the existing cart is a renewal and any item that would be added is not a renewal, then the cart is replaced entirely.

Fixes https://github.com/Automattic/wp-calypso/issues/46624 (mostly)

#### Testing instructions

1. Start with an empty cart.
1. Add a domain to your cart.
1. Visit checkout and verify that only the domain is present.
1. Leave checkout and add a plan to your cart (you must do it in this order because adding the domain does not use the new logic yet).
1. Visit checkout and verify that both the plan and the domain are present.
1. Leave checkout and add a renewal to your cart.
1. Visit checkout and verify that only the renewal is present (the domain and plan were removed).
1. Leave checkout and add a plan to your cart.
1. Visit checkout and verify that only the plan is present (the renewal was removed).