### PR TITLE
Refactor createSite() to take "named parameters" object

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-login.ts
+++ b/client/landing/gutenboarding/hooks/use-on-login.ts
@@ -30,7 +30,12 @@ export default function useOnLogin(): void {
 
 	React.useEffect( () => {
 		if ( ! isCreatingSite && ! newSite && currentUser && shouldTriggerCreate ) {
-			createSite( currentUser.username, locale, undefined, visibility );
+			createSite( {
+				username: currentUser.username,
+				languageSlug: locale,
+				bearerToken: undefined,
+				visibility,
+			} );
 		}
 	}, [
 		createSite,

--- a/client/landing/gutenboarding/hooks/use-on-signup.ts
+++ b/client/landing/gutenboarding/hooks/use-on-signup.ts
@@ -26,15 +26,20 @@ export default function useOnSignup() {
 	const visibility = useNewSiteVisibility();
 
 	const handleCreateSite = React.useCallback(
-		( username: string, bearerToken?: string, isPublicSite?: number ) => {
-			createSite( username, locale, bearerToken, isPublicSite );
+		( username: string, isPublicSite: number, bearerToken?: string ) => {
+			createSite( {
+				username,
+				languageSlug: locale,
+				bearerToken,
+				visibility: isPublicSite,
+			} );
 		},
 		[ createSite, locale ]
 	);
 
 	React.useEffect( () => {
 		if ( newUser && newUser.bearerToken && newUser.username && ! newSite ) {
-			handleCreateSite( newUser.username, newUser.bearerToken, visibility );
+			handleCreateSite( newUser.username, visibility, newUser.bearerToken );
 		}
 	}, [ newSite, newUser, locale, handleCreateSite, visibility ] );
 }

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -39,7 +39,12 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	const { onSignupDialogOpen } = useSignup();
 	const handleSiteCreation = () =>
 		currentUser
-			? createSite( currentUser.username, locale, undefined, newSiteVisibility )
+			? createSite( {
+					username: currentUser.username,
+					languageSlug: locale,
+					bearerToken: undefined,
+					visibility: newSiteVisibility,
+			  } )
 			: onSignupDialogOpen();
 
 	const currentStepIndex = steps.findIndex( ( step ) => step === Step[ currentStep ] );

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -37,14 +37,21 @@ export const addFeature = ( featureId: FeatureId ) => ( {
 	featureId,
 } );
 
-export function* createSite(
-	username: string,
-	languageSlug: string,
-	bearerToken?: string,
-	visibility: number = isEnabled( 'coming-soon-v2' )
+export interface CreateSiteActionParameters {
+	username: string;
+	languageSlug: string;
+	bearerToken?: string;
+	visibility: number;
+}
+
+export function* createSite( {
+	username,
+	languageSlug,
+	bearerToken = undefined,
+	visibility = isEnabled( 'coming-soon-v2' )
 		? Site.Visibility.PublicNotIndexed
-		: Site.Visibility.Private
-) {
+		: Site.Visibility.Private,
+}: CreateSiteActionParameters ) {
 	const {
 		domain,
 		selectedDesign,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* No functionality changes; site should work the same before and after.
* The `createSite()` action creator will now take one object parameter instead of 4 individual parameters.
  * Using a popular js/ts idiom to emulate named parameters.
    * For example, instead of `rectangleArea(5, 10)`, we call `rectangleArea({width: 5, height: 10})`.
  * This allows us to be a little bit more clear about what we're passing in to the function.
  * #47600 will probably add a 5th parameter for anchor; 5 parameters is starting to become too much, especially when one or two of them are undefined.  `function(aaa, bbb, undefined, ddd, undefined)` just isn't very clear.
* Steps taken:
  * New `CreateSiteActionParameters` interface created, with existing types pulled from `createSite()` arguments list.
  * `createSite()` arguments were changed to be an object of `CreateSiteActionParameters` type.
  * All call sites were updated to pass an object instead of 4 parameters (use-on-login, use-on-signup, use-step-navigation)
  * In the use-on-signup callsite, the `handleCreateSite` callback type was updated:
    * Old type: `( username: string, bearerToken?: string, isPublicSite?: number )`
    * New type: `( username: string, isPublicSite: number, bearerToken?: string )`
      * 1st Change: `isPublicSite?` changed to `isPublicSite`
        * visibility at `createSite` is required (`number`, not `number?`). This was causing a type error.
        * this ultimately comes from `useNewSiteVisibility()`, which is [guaranteed to return a number](https://github.com/Automattic/wp-calypso/blob/70ba68996256fb60ded4fa0ea35e6071de590487/client/landing/gutenboarding/hooks/use-selected-plan.ts#L54).
      * 2nd Change: Ordering change
        * Optional parameters must be last.
        * Single call site updated as well.

#### Testing instructions

* Manually: Visit http://calypso.localhost:3000/new in a private window and the gutenboarding flow should work as normal.
* Automated: e2e tests cover gutenboarding as well.
* Manual type check: `yarn && yarn start` in one window, then `yarn run tsc --project client/landing/gutenboarding` in another.  This also runs automatically in the PR as well.
