### PR TITLE
Billing: Fix - Purchase plan details stuck in loading state.

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -25,6 +25,7 @@ import {
 import { isDataLoading } from 'calypso/me/purchases/utils';
 import {
 	getByPurchaseId,
+	hasLoadedSitePurchasesFromServer,
 	hasLoadedUserPurchasesFromServer,
 	getIncludedDomainPurchase,
 } from 'calypso/state/purchases/selectors';
@@ -238,9 +239,12 @@ class CancelPurchase extends React.Component {
 
 export default connect( ( state, props ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
+	const siteId = purchase ? purchase.siteId : null;
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
-		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+		hasLoadedPurchasesFromServer: siteId
+			? hasLoadedSitePurchasesFromServer( state )
+			: hasLoadedUserPurchasesFromServer( state ),
 		purchase,
 		includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
 		site: getSite( state, purchase ? purchase.siteId : null ),

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -41,7 +41,7 @@ export class PurchasePlanDetails extends Component {
 		// Connected props
 		purchase: PropTypes.object,
 		hasLoadedSites: PropTypes.bool,
-		hasLoadedUserPurchasesFromServer: PropTypes.bool,
+		hasLoadedPurchasesFromServer: PropTypes.bool,
 		pluginList: PropTypes.arrayOf(
 			PropTypes.shape( {
 				slug: PropTypes.string.isRequired,

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -19,6 +19,7 @@ import PlanBillingPeriod from './billing-period';
 import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
 import {
 	getByPurchaseId,
+	hasLoadedSitePurchasesFromServer,
 	hasLoadedUserPurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
 import { isDataLoading } from 'calypso/me/purchases/utils';
@@ -123,14 +124,16 @@ export class PurchasePlanDetails extends Component {
 	}
 }
 
-// hasLoadedSites & hasLoadedUserPurchasesFromServer are used in isDataLoading
+// hasLoadedSites & hasLoadedPurchasesFromServer are used in isDataLoading
 export default connect( ( state, props ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
 	const siteId = purchase ? purchase.siteId : null;
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
 		site: purchase ? getSite( state, purchase.siteId ) : null,
-		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+		hasLoadedPurchasesFromServer: siteId
+			? hasLoadedSitePurchasesFromServer( state )
+			: hasLoadedUserPurchasesFromServer( state ),
 		purchase,
 		pluginList: getPluginsForSite( state, siteId ),
 		siteId,

--- a/client/me/purchases/manage-purchase/plan-details/test/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/index.jsx
@@ -23,7 +23,7 @@ const props = {
 		expiryStatus: 'active',
 	},
 	hasLoadedSites: true,
-	hasLoadedUserPurchasesFromServer: true,
+	hasLoadedPurchasesFromServer: true,
 	pluginList: [
 		{
 			slug: 'vaultpress',

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -11,7 +11,7 @@ import {
 import { isDomainTransfer } from 'calypso/lib/products-values';
 
 function isDataLoading( props ) {
-	return ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;
+	return ! props.hasLoadedSites || ! props.hasLoadedPurchasesFromServer;
 }
 
 function canEditPaymentDetails( purchase ) {


### PR DESCRIPTION
Fixed logic making the PurchasePlanDetails component (billing expiration info) unable to load, therefore always showing loading placeholder.  (see screenshot)

![Markup 2020-12-02 at 15 41 01](https://user-images.githubusercontent.com/11078128/100945569-5635f100-34b6-11eb-82d8-8059b83b1281.png)

Fixes 1164141197617539-as-1199504839490770

### Testing instructions

**To view the issue:**
1. Go to wordpress.com staging, (logged in)
2. Select any site with a purchased plan (not a Jetpack Free site)
3. Go to Plans --> Billing --> click/select the Plan (to open the plan details/settings)
4. You should see the plan purchase details area is stuck in a never ending loading state (See screenshot above)

**To test the issue is fixed:**
1. Checkout and run this PR or open the live link.
2. Select any site with a purchased plan (not a Jetpack Free site)
3. Go to Plans --> Billing --> click/select the Plan (to open the plan details/settings)
4. Verify that the PurchasePlanDetails component (billing expiration info) is showing and that it is no longer stuck in a loading state. (see screenshot)

**Fixed. Billing period is now showing:**
![Markup 2020-12-02 at 15 42 15](https://user-images.githubusercontent.com/11078128/100946212-b7aa8f80-34b7-11eb-9a28-34b01fc18fc1.png)
