### PR TITLE
Reader: update client/reader components to use new recordReaderTracksEvent action - part one

### DIFF
--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -4,19 +4,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import Gridicon from 'calypso/components/gridicon';
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import { recordTrack } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
- * Image dependencies
+ * Asset dependencies
  */
 import charactersImage from 'calypso/assets/images/reader/reader-conversations-characters.svg';
 
@@ -52,11 +52,12 @@ class ConversationsIntro extends React.Component {
 
 	maybeRecordRenderTrack = ( props = this.props ) => {
 		if ( props.hasUsedConversations !== true ) {
-			recordTrack( 'calypso_reader_conversations_intro_render' );
+			this.props.recordReaderTracksEvent( 'calypso_reader_conversations_intro_render' );
 		}
 	};
 
 	dismiss = () => {
+		this.props.recordReaderTracksEvent( 'calypso_reader_conversations_intro_dismiss' );
 		this.props.dismiss( this.props.isInternal );
 	};
 
@@ -129,9 +130,9 @@ export default connect(
 	},
 	{
 		dismiss: ( isInternal ) => {
-			recordTrack( 'calypso_reader_conversations_intro_dismiss' );
 			const preferenceName = getPreferenceName( isInternal );
 			return savePreference( preferenceName, true );
 		},
+		recordReaderTracksEvent,
 	}
 )( localize( ConversationsIntro ) );

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -4,6 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import i18n, { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,7 +12,8 @@ import i18n, { localize } from 'i18n-calypso';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class FeedError extends React.Component {
 	static defaultProps = {
@@ -21,13 +23,13 @@ class FeedError extends React.Component {
 	recordAction = () => {
 		recordAction( 'clicked_search_on_404' );
 		recordGaEvent( 'Clicked Search on 404' );
-		recordTrack( 'calypso_reader_search_on_feed_error_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_search_on_feed_error_clicked' );
 	};
 
 	recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_404' );
 		recordGaEvent( 'Clicked Discover on 404' );
-		recordTrack( 'calypso_reader_discover_on_feed_error_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_discover_on_feed_error_clicked' );
 	};
 
 	render() {
@@ -74,4 +76,6 @@ FeedError.propTypes = {
 	sidebarTitle: PropTypes.string,
 };
 
-export default localize( FeedError );
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( localize( FeedError ) );

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -26,12 +26,6 @@ class FeedError extends React.Component {
 		this.props.recordReaderTracksEvent( 'calypso_reader_search_on_feed_error_clicked' );
 	};
 
-	recordSecondaryAction = () => {
-		recordAction( 'clicked_discover_on_404' );
-		recordGaEvent( 'Clicked Discover on 404' );
-		this.props.recordReaderTracksEvent( 'calypso_reader_discover_on_feed_error_clicked' );
-	};
-
 	render() {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		const action = (
@@ -43,15 +37,6 @@ class FeedError extends React.Component {
 				{ this.props.translate( 'Find sites to follow' ) }
 			</a>
 		);
-		const secondaryAction = (
-			<a
-				className="empty-content__action button"
-				onClick={ this.recordSecondaryAction }
-				href="/discover"
-			>
-				{ this.props.translate( 'Explore' ) }
-			</a>
-		);
 
 		return (
 			<ReaderMain>
@@ -61,7 +46,6 @@ class FeedError extends React.Component {
 
 				<EmptyContent
 					action={ action }
-					secondaryAction={ secondaryAction }
 					title={ this.props.message }
 					illustration={ '/calypso/images/illustrations/illustration-404.svg' }
 					illustrationWidth={ 500 }

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -19,12 +19,6 @@ class FeedEmptyContent extends React.PureComponent {
 		this.props.recordReaderTracksEvent( 'calypso_reader_search_on_empty_feed_clicked' );
 	};
 
-	recordSecondaryAction = () => {
-		recordAction( 'clicked_discover_on_empty' );
-		recordGaEvent( 'Clicked Discover on EmptyContent' );
-		this.props.recordReaderTracksEvent( 'calypso_reader_discover_on_empty_feed_clicked' );
-	};
-
 	render() {
 		const { translate } = this.props;
 		const action = (
@@ -36,22 +30,12 @@ class FeedEmptyContent extends React.PureComponent {
 				{ translate( 'Find sites to follow' ) }
 			</a>
 		);
-		const secondaryAction = (
-			<a
-				className="empty-content__action button" //eslint-disable-line
-				onClick={ this.recordSecondaryAction }
-				href="/discover"
-			>
-				{ translate( 'Explore' ) }
-			</a>
-		);
 
 		return (
 			<EmptyContent
 				title={ translate( 'No recent posts' ) }
 				line={ translate( 'This site has not posted anything recently.' ) }
 				action={ action }
-				secondaryAction={ secondaryAction }
 				illustration={ '/calypso/images/illustrations/illustration-empty-results.svg' }
 				illustrationWidth={ 500 }
 			/>

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -1,30 +1,32 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class FeedEmptyContent extends React.PureComponent {
 	recordAction = () => {
 		recordAction( 'clicked_search_on_empty' );
 		recordGaEvent( 'Clicked Search on EmptyContent' );
-		recordTrack( 'calypso_reader_search_on_empty_feed_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_search_on_empty_feed_clicked' );
 	};
 
 	recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty' );
 		recordGaEvent( 'Clicked Discover on EmptyContent' );
-		recordTrack( 'calypso_reader_discover_on_empty_feed_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_discover_on_empty_feed_clicked' );
 	};
 
 	render() {
-		const translate = this.props.translate;
+		const { translate } = this.props;
 		const action = (
 			<a
 				className="empty-content__action button is-primary" //eslint-disable-line
@@ -57,4 +59,6 @@ class FeedEmptyContent extends React.PureComponent {
 	}
 }
 
-export default localize( FeedEmptyContent );
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( localize( FeedEmptyContent ) );

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -27,7 +27,7 @@ import SidebarRegion from 'calypso/layout/sidebar/region';
 import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { getTagStreamUrl } from 'calypso/reader/route';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { getSubscribedLists } from 'calypso/state/reader/lists/selectors';
 import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
@@ -42,6 +42,7 @@ import { getReaderOrganizations } from 'calypso/state/reader/organizations/selec
 import ReaderSidebarFollowedSites from 'calypso/reader/sidebar/reader-sidebar-followed-sites';
 import SidebarSeparator from 'calypso/layout/sidebar/separator';
 import { isEnabled } from 'calypso/config';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Style dependencies
@@ -113,41 +114,41 @@ export class ReaderSidebar extends React.Component {
 		}
 	};
 
-	handleReaderSidebarFollowedSitesClicked() {
+	handleReaderSidebarFollowedSitesClicked = () => {
 		recordAction( 'clicked_reader_sidebar_followed_sites' );
 		recordGaEvent( 'Clicked Reader Sidebar Followed Sites' );
-		recordTrack( 'calypso_reader_sidebar_followed_sites_clicked' );
-	}
+		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_followed_sites_clicked' );
+	};
 
-	handleReaderSidebarConversationsClicked() {
+	handleReaderSidebarConversationsClicked = () => {
 		recordAction( 'clicked_reader_sidebar_conversations' );
 		recordGaEvent( 'Clicked Reader Sidebar Conversations' );
-		recordTrack( 'calypso_reader_sidebar_conversations_clicked' );
-	}
+		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_conversations_clicked' );
+	};
 
-	handleReaderSidebarA8cConversationsClicked() {
+	handleReaderSidebarA8cConversationsClicked = () => {
 		recordAction( 'clicked_reader_sidebar_a8c_conversations' );
 		recordGaEvent( 'Clicked Reader Sidebar A8C Conversations' );
-		recordTrack( 'calypso_reader_sidebar_automattic_conversations_clicked' );
-	}
+		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_automattic_conversations_clicked' );
+	};
 
-	handleReaderSidebarDiscoverClicked() {
+	handleReaderSidebarDiscoverClicked = () => {
 		recordAction( 'clicked_reader_sidebar_discover' );
 		recordGaEvent( 'Clicked Reader Sidebar Discover' );
-		recordTrack( 'calypso_reader_sidebar_discover_clicked' );
-	}
+		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_discover_clicked' );
+	};
 
-	handleReaderSidebarSearchClicked() {
+	handleReaderSidebarSearchClicked = () => {
 		recordAction( 'clicked_reader_sidebar_search' );
 		recordGaEvent( 'Clicked Reader Sidebar Search' );
-		recordTrack( 'calypso_reader_sidebar_search_clicked' );
-	}
+		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_search_clicked' );
+	};
 
-	handleReaderSidebarLikeActivityClicked() {
+	handleReaderSidebarLikeActivityClicked = () => {
 		recordAction( 'clicked_reader_sidebar_like_activity' );
 		recordGaEvent( 'Clicked Reader Sidebar Like Activity' );
-		recordTrack( 'calypso_reader_sidebar_like_activity_clicked' );
-	}
+		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_like_activity_clicked' );
+	};
 
 	renderForRegularUsers() {
 		const { path, translate } = this.props;
@@ -357,8 +358,9 @@ export default connect(
 		};
 	},
 	{
+		recordReaderTracksEvent,
+		setNextLayoutFocus,
 		toggleListsVisibility: toggleReaderSidebarLists,
 		toggleTagsVisibility: toggleReaderSidebarTags,
-		setNextLayoutFocus,
 	}
 )( localize( ReaderSidebar ) );

--- a/client/reader/sidebar/reader-sidebar-followed-sites/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-followed-sites/index.jsx
@@ -17,11 +17,12 @@ import { isFollowingOpen } from 'calypso/state/reader-ui/sidebar/selectors';
 import getReaderFollowedSites from 'calypso/state/reader/follows/selectors/get-reader-followed-sites';
 import ReaderSidebarHelper from 'calypso/reader/sidebar/helper';
 import SidebarItem from 'calypso/layout/sidebar/item';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import Count from 'calypso/components/count';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
- * Styles
+ * Style dependencies
  */
 import '../style.scss';
 
@@ -32,11 +33,11 @@ export class ReaderSidebarFollowedSites extends Component {
 		isFollowingOpen: PropTypes.bool,
 	};
 
-	handleReaderSidebarFollowedSitesClicked() {
+	handleReaderSidebarFollowedSitesClicked = () => {
 		recordAction( 'clicked_reader_sidebar_followed_sites' );
 		recordGaEvent( 'Clicked Reader Sidebar Followed Sites' );
-		recordTrack( 'calypso_reader_sidebar_followed_sites_clicked' );
-	}
+		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_followed_sites_clicked' );
+	};
 
 	renderAll() {
 		const { path, translate, sites } = this.props;
@@ -95,6 +96,7 @@ export default connect(
 		};
 	},
 	{
+		recordReaderTracksEvent,
 		toggleReaderSidebarFollowing,
 	}
 )( localize( ReaderSidebarFollowedSites ) );

--- a/client/reader/sidebar/reader-sidebar-followed-sites/item.jsx
+++ b/client/reader/sidebar/reader-sidebar-followed-sites/item.jsx
@@ -12,23 +12,23 @@ import Count from 'calypso/components/count';
 import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { useDispatch } from 'react-redux';
+import Favicon from 'calypso/reader/components/favicon';
 
 /**
  * Style dependencies
  */
 import '../style.scss';
-import Favicon from 'calypso/reader/components/favicon';
 
 const ReaderSidebarFollowingItem = ( props ) => {
 	const { site, path } = props;
 	const dispatch = useDispatch();
 
-	const handleSidebarClick = () => {
+	const handleSidebarClick = ( selectedSite ) => {
 		recordAction( 'clicked_reader_sidebar_following_item' );
 		recordGaEvent( 'Clicked Reader Sidebar Following Item' );
 		dispatch(
 			recordReaderTracksEvent( 'calypso_reader_sidebar_following_item_clicked', {
-				blog: decodeURIComponent( this.props.site ),
+				blog: decodeURIComponent( selectedSite.URL ),
 			} )
 		);
 	};
@@ -56,7 +56,7 @@ const ReaderSidebarFollowingItem = ( props ) => {
 			<a
 				className="sidebar__menu-link sidebar__menu-link-reader"
 				href={ streamLink }
-				onClick={ handleSidebarClick }
+				onClick={ () => handleSidebarClick( site ) }
 			>
 				<Favicon site={ site } className="sidebar__menu-item-siteicon" size={ 18 } />
 

--- a/client/reader/sidebar/reader-sidebar-followed-sites/item.jsx
+++ b/client/reader/sidebar/reader-sidebar-followed-sites/item.jsx
@@ -1,76 +1,73 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import ReaderSidebarHelper from '../helper';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import Count from 'calypso/components/count';
 import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { useDispatch } from 'react-redux';
 
 /**
- * Styles
+ * Style dependencies
  */
 import '../style.scss';
 import Favicon from 'calypso/reader/components/favicon';
 
-export class ReaderSidebarFollowingItem extends Component {
-	static propTypes = {
-		site: PropTypes.object,
-		path: PropTypes.string,
-	};
+const ReaderSidebarFollowingItem = ( props ) => {
+	const { site, path } = props;
+	const dispatch = useDispatch();
 
-	handleSidebarClick = () => {
+	const handleSidebarClick = () => {
 		recordAction( 'clicked_reader_sidebar_following_item' );
 		recordGaEvent( 'Clicked Reader Sidebar Following Item' );
-		recordTrack( 'calypso_reader_sidebar_following_item_clicked', {
-			blog: decodeURIComponent( this.props.site ),
-		} );
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_sidebar_following_item_clicked', {
+				blog: decodeURIComponent( this.props.site ),
+			} )
+		);
 	};
 
-	render() {
-		const { site, path } = this.props;
+	let streamLink;
 
-		let streamLink;
-
-		if ( site.feed_ID ) {
-			streamLink = `/read/feeds/${ site.feed_ID }`;
-		} else if ( site.blog_ID ) {
-			// If subscription is missing a feed ID, fallback to blog stream
-			streamLink = `/read/blogs/${ site.blog_ID }`;
-		} else {
-			// Skip it
-			return null;
-		}
-
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		return (
-			<li
-				key={ this.props.title }
-				className={ ReaderSidebarHelper.itemLinkClass( streamLink, path, {
-					'sidebar-dynamic-menu__blog': true,
-				} ) }
-			>
-				<a
-					className="sidebar__menu-link sidebar__menu-link-reader"
-					href={ streamLink }
-					onClick={ this.handleSidebarClick }
-				>
-					<Favicon site={ site } className="sidebar__menu-item-siteicon" size={ 18 } />
-
-					<span className="sidebar__menu-item-sitename">
-						{ site.name || formatUrlForDisplay( site.URL ) }
-					</span>
-					{ site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
-				</a>
-			</li>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	if ( site.feed_ID ) {
+		streamLink = `/read/feeds/${ site.feed_ID }`;
+	} else if ( site.blog_ID ) {
+		// If subscription is missing a feed ID, fallback to blog stream
+		streamLink = `/read/blogs/${ site.blog_ID }`;
+	} else {
+		// Skip it
+		return null;
 	}
-}
+
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<li
+			key={ props.title }
+			className={ ReaderSidebarHelper.itemLinkClass( streamLink, path, {
+				'sidebar-dynamic-menu__blog': true,
+			} ) }
+		>
+			<a
+				className="sidebar__menu-link sidebar__menu-link-reader"
+				href={ streamLink }
+				onClick={ handleSidebarClick }
+			>
+				<Favicon site={ site } className="sidebar__menu-item-siteicon" size={ 18 } />
+
+				<span className="sidebar__menu-item-sitename">
+					{ site.name || formatUrlForDisplay( site.URL ) }
+				</span>
+				{ site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
+			</a>
+		</li>
+	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+};
 
 export default ReaderSidebarFollowingItem;

--- a/client/reader/site-stream/empty.jsx
+++ b/client/reader/site-stream/empty.jsx
@@ -3,48 +3,27 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction as statRecordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
-import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
+import { recordAction as statRecordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 const SiteEmptyContent = ( { translate } ) => {
-	const recordAction = () => {
-		statRecordAction( 'clicked_discover_on_empty' );
-		recordGaEvent( 'Clicked Discover on EmptyContent' );
-		recordTrack( 'calypso_reader_discover_on_empty_site_stream_clicked' );
-	};
+	const dispatch = useDispatch();
 
-	const recordSecondaryAction = () => {
+	const recordAction = () => {
 		statRecordAction( 'clicked_search_on_empty' );
 		recordGaEvent( 'Clicked Search on EmptyContent' );
-		recordTrack( 'calypso_reader_search_on_empty_site_stream_clicked' );
+		dispatch( recordReaderTracksEvent( 'calypso_reader_search_on_empty_site_stream_clicked' ) );
 	};
 
-	let action;
-
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	if ( isDiscoverEnabled() ) {
-		action = (
-			<a
-				className="empty-content__action button is-primary"
-				onClick={ recordAction }
-				href="/discover"
-			>
-				{ translate( 'Explore' ) }
-			</a>
-		);
-	}
-
-	const secondaryAction = (
-		<a
-			className="empty-content__action button"
-			onClick={ recordSecondaryAction }
-			href="/read/search"
-		>
+	const action = (
+		<a className="empty-content__action button" onClick={ recordAction } href="/read/search">
 			{ translate( 'Find sites to follow' ) }
 		</a>
 	);
@@ -52,10 +31,9 @@ const SiteEmptyContent = ( { translate } ) => {
 
 	return (
 		<EmptyContent
-			title={ translate( 'No Posts' ) }
+			title={ translate( 'No posts' ) }
 			line={ translate( 'This site has not posted anything yet. Try back later.' ) }
 			action={ action }
-			secondaryAction={ secondaryAction }
 			illustration={ '/calypso/images/illustrations/illustration-empty-results.svg' }
 			illustrationWidth={ 500 }
 		/>

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -3,16 +3,18 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
- * Image dependencies
+ * Asset dependencies
  */
 import welcomeImage from 'calypso/assets/images/reader/reader-welcome-illustration.svg';
 
@@ -24,7 +26,7 @@ class FollowingEmptyContent extends React.Component {
 	recordAction = () => {
 		recordAction( 'clicked_search_on_empty' );
 		recordGaEvent( 'Clicked Search on EmptyContent' );
-		recordTrack( 'calypso_reader_search_on_empty_stream_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_search_on_empty_stream_clicked' );
 	};
 
 	render() {
@@ -55,4 +57,6 @@ class FollowingEmptyContent extends React.Component {
 	}
 }
 
-export default withPerformanceTrackerStop( localize( FollowingEmptyContent ) );
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( withPerformanceTrackerStop( localize( FollowingEmptyContent ) ) );

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -4,14 +4,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class TagEmptyContent extends React.Component {
 	static propTypes = {
@@ -25,13 +27,13 @@ class TagEmptyContent extends React.Component {
 	recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
-		recordTrack( 'calypso_reader_following_on_empty_tag_stream_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_following_on_empty_tag_stream_clicked' );
 	};
 
 	recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty' );
 		recordGaEvent( 'Clicked Discover on EmptyContent' );
-		recordTrack( 'calypso_reader_discover_on_empty_tag_stream_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_discover_on_empty_tag_stream_clicked' );
 	};
 
 	render() {
@@ -80,4 +82,6 @@ class TagEmptyContent extends React.Component {
 	}
 }
 
-export default withPerformanceTrackerStop( localize( TagEmptyContent ) );
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( withPerformanceTrackerStop( localize( TagEmptyContent ) ) );

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -14,13 +14,14 @@ import Stream from 'calypso/reader/stream';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from './empty';
 import TagStreamHeader from './header';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import HeaderBack from 'calypso/reader/header-back';
 import { getReaderTags, getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
 import QueryReaderFollowedTags from 'calypso/components/data/query-reader-followed-tags';
 import QueryReaderTag from 'calypso/components/data/query-reader-tag';
 import ReaderMain from 'calypso/reader/components/reader-main';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Style dependencies
@@ -89,7 +90,7 @@ class TagStream extends React.Component {
 			isFollowing ? 'Clicked Unfollow Topic' : 'Clicked Follow Topic',
 			decodedTagSlug
 		);
-		recordTrack(
+		this.props.recordReaderTracksEvent(
 			isFollowing ? 'calypso_reader_reader_tag_unfollowed' : 'calypso_reader_reader_tag_followed',
 			{
 				tag: decodedTagSlug,
@@ -134,7 +135,7 @@ class TagStream extends React.Component {
 				listName={ this.state.title }
 				emptyContent={ emptyContent }
 				showFollowInHeader={ true }
-				forcePlaceholders={ ! tag } // if tag hasn't loaded yet, then make everything a placeholder
+				forcePlaceholders={ ! tag } // if tag has not loaded yet, then make everything a placeholder
 			>
 				<QueryReaderFollowedTags />
 				<QueryReaderTag tag={ this.props.decodedTagSlug } />
@@ -165,6 +166,7 @@ export default connect(
 	} ),
 	{
 		followTag: requestFollowTag,
+		recordReaderTracksEvent,
 		unfollowTag: requestUnfollowTag,
 	}
 )( localize( TagStream ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request  

Following up on #47818, which added a new Redux thunk for recording Tracks events in Reader, replacing the old recordTrack() function.

This is part of an effort to remedy #14470. We want to send a subscription count with each event and that's currently broken.

This PR switches over any Reader blocks in the blocks directory to use the new recordReaderTracksEvent action.

### Testing instructions

Turn on Analytics logging in your console with:

`localStorage.setItem('debug', 'calypso:analytics*');`

Using the Reader, verify that you can fire the following Tracks events, and that they all include subscription_count:

- [x] calypso_reader_conversations_intro_render
- [x] calypso_reader_conversations_intro_dismiss
- [x] calypso_reader_search_on_feed_error_clicked
- [x] calypso_reader_search_on_empty_feed_clicked
- [x] calypso_reader_sidebar_followed_sites_clicked
- [x] calypso_reader_sidebar_conversations_clicked
- [x] calypso_reader_sidebar_automattic_conversations_clicked
- [x] calypso_reader_sidebar_search_clicked
- [x] calypso_reader_sidebar_like_activity_clicked
- [x] calypso_reader_sidebar_following_item_clicked
- [x] calypso_reader_search_on_empty_site_stream_clicked
- [x] calypso_reader_search_on_empty_stream_clicked
- [x] calypso_reader_following_on_empty_tag_stream_clicked
- [x] calypso_reader_reader_tag_unfollowed
- [x] calypso_reader_reader_tag_followed

See #14470.