### PR TITLE
Use the standard <Notice> component for showing onboarding errors

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -91,15 +91,8 @@
 	}
 
 	.signup-form__error-notice {
-		@include onboarding-medium-text;
-		margin: 0;
-		border: none;
-		background: none;
-		color: var( --studio-red-60 );
-
-		@include break-mobile {
-			margin: 0 16px;
-		}
+		max-width: 400px;
+		margin: 10px auto;
 
 		.components-notice__content {
 			margin: 0;

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -4,7 +4,7 @@
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import { useSelect } from '@wordpress/data';
 import { noop, times } from 'lodash';
-import { Button, TextControl } from '@wordpress/components';
+import { Button, TextControl, Notice } from '@wordpress/components';
 import { Icon, search } from '@wordpress/icons';
 import { getNewRailcarId, recordTrainTracksRender } from '@automattic/calypso-analytics';
 import type { DomainSuggestions } from '@automattic/data-stores';
@@ -258,13 +258,13 @@ const DomainPicker: FunctionComponent< Props > = ( {
 				</div>
 			) }
 			{ showErrorMessage && (
-				<div className="domain-picker__error">
+				<Notice className="domain-picker__error" status="error" isDismissible={ false }>
 					<p className="domain-picker__error-message">
-						{ __(
-							'An error has occurred, please check your connection and retry.',
-							__i18n_text_domain__
-						) }
-						{ domainSuggestionErrorMessage && ` ${ domainSuggestionErrorMessage }` }
+						{ domainSuggestionErrorMessage ||
+							__(
+								'An error has occurred, please check your connection and retry.',
+								__i18n_text_domain__
+							) }
 					</p>
 					<Button
 						isPrimary
@@ -273,7 +273,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					>
 						{ __( 'Retry', __i18n_text_domain__ ) }
 					</Button>
-				</div>
+				</Notice>
 			) }
 			{ ( showDomainSuggestionsResults || areDependenciesLoading ) && (
 				<div className="domain-picker__body">

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -422,7 +422,9 @@ $accent-blue: #117ac9;
 }
 
 .domain-picker__error {
-	margin-top: 24px;
+	&.components-notice {
+		margin: 0;
+	}
 
 	#{&}-message {
 		@include onboarding-medium-text;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Login error `<Notice>` uses default GB styling
* Display domain search errors with `<Notice>`
* When error is returned by domain search, only show that error, don't prepend a generic message
* Only show generic domain search error when we know there was an error but the server returned no message

I wanted all the error notices in onboarding to use a consistent styling, and wanted to share the code for that styling. I initially tried to have the domain error use the same style as the existing login error, however `domain-picker` is in `packages/` so would need to do some clever things in order to share a component with onboarding. I was half way through some render-props type implementation when I realised I was really over-engineering this. Which is why I've just reverted back to the default `<Notice>` styling. The domain picker is used in the editor, so being consistent with the error notices displayed there makes sense.

##### Domain Search Before
<img width="836" alt="image" src="https://user-images.githubusercontent.com/1500769/101091017-6ff14880-361c-11eb-9507-cdc2eaa7586f.png">

##### Domain Search After
<img width="837" alt="image" src="https://user-images.githubusercontent.com/1500769/101090791-11c46580-361c-11eb-8b46-b9a6cdcfe852.png">

##### Signup Before
<img width="582" alt="image" src="https://user-images.githubusercontent.com/1500769/101090956-55b76a80-361c-11eb-80ae-3d86f4a25153.png">

##### Signup After
<img width="582" alt="image" src="https://user-images.githubusercontent.com/1500769/101090888-391b3280-361c-11eb-84a3-973313cff6f7.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use `/new` while logged out
* Generate some errors on the domain step
* Generate some errors on the signup step (try a short password or an email from an existing account)
* Try different browser window sizes

