### PR TITLE
Focused Launch: Get selected domain from cart if available.

### DIFF
--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -38,6 +38,7 @@
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/plans-grid": "^1.0.0-alpha.0",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
+		"@automattic/shopping-cart": "^1.0.0",
 		"@wordpress/components": "^10.0.5",
 		"@wordpress/icons": "^2.4.0",
 		"@wordpress/url": "^2.17.0",

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -15,7 +15,7 @@ import DomainDetails from './domain-details';
 import PlanDetails from './plan-details';
 import Success from './success';
 import { LAUNCH_STORE } from '../stores';
-import { useDomainSuggestionFromCart } from '../hooks';
+import { useDomainSuggestionFromCart, usePlanFromCart } from '../hooks';
 
 import './style.scss';
 
@@ -45,6 +45,17 @@ const FocusedLaunch: React.FunctionComponent = () => {
 			setDomain( domainSuggestionFromCart );
 		}
 	}, [ selectedDomain, domainSuggestionFromCart, setDomain ] );
+
+	// If there is no selected plan, but there is a plan in cart,
+	// set the plan from cart as the selected plan.
+	const planFromCart = usePlanFromCart();
+	const selectedPlan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
+	const { setPlan } = useDispatch( LAUNCH_STORE );
+	React.useEffect( () => {
+		if ( ! selectedPlan && planFromCart ) {
+			setPlan( planFromCart );
+		}
+	}, [ selectedPlan, planFromCart, setPlan ] );
 
 	return (
 		<Router

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -15,6 +15,7 @@ import DomainDetails from './domain-details';
 import PlanDetails from './plan-details';
 import Success from './success';
 import { LAUNCH_STORE } from '../stores';
+import { useDomainSuggestionFromCart } from '../hooks';
 
 import './style.scss';
 
@@ -33,6 +34,17 @@ const FocusedLaunch: React.FunctionComponent = () => {
 			enablePersistentSuccessView();
 		}
 	}, [ isSiteLaunched, enablePersistentSuccessView ] );
+
+	// If there is no selected domain, but there is a domain in cart,
+	// set the domain from cart as the selected domain.
+	const domainSuggestionFromCart = useDomainSuggestionFromCart();
+	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
+	const { setDomain } = useDispatch( LAUNCH_STORE );
+	React.useEffect( () => {
+		if ( ! selectedDomain && domainSuggestionFromCart ) {
+			setDomain( domainSuggestionFromCart );
+		}
+	}, [ selectedDomain, domainSuggestionFromCart, setDomain ] );
 
 	return (
 		<Router

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -39,14 +39,16 @@ export function useDomainSuggestionFromCart(): DomainSuggestions.DomainSuggestio
 
 	const domainName = domainProductFromCart?.meta;
 
-	const domainSuggestion = useSelect( ( select ) =>
-		domainName
-			? select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( domainName, {
+	const domainSuggestion = useSelect(
+		( select ) =>
+			void (
+				domainName &&
+				select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( domainName, {
 					quantity: 1,
 					include_wordpressdotcom: false,
 					include_dotblogsubdomain: false,
-			  } )?.[ 0 ]
-			: undefined
+				} )?.[ 0 ]
+			)
 	);
 
 	return domainSuggestion;

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -39,16 +39,14 @@ export function useDomainSuggestionFromCart(): DomainSuggestions.DomainSuggestio
 
 	const domainName = domainProductFromCart?.meta;
 
-	const domainSuggestion = useSelect(
-		( select ) =>
-			void (
-				domainName &&
-				select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( domainName, {
+	const domainSuggestion = useSelect( ( select ) =>
+		domainName
+			? select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( domainName, {
 					quantity: 1,
 					include_wordpressdotcom: false,
 					include_dotblogsubdomain: false,
-				} )?.[ 0 ]
-			)
+			  } )?.[ 0 ]
+			: undefined
 	);
 
 	return domainSuggestion;

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import type { DomainSuggestions } from '@automattic/data-stores';
 import { mockDomainSuggestion } from '@automattic/domain-picker';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ import { mockDomainSuggestion } from '@automattic/domain-picker';
 import { LAUNCH_STORE, SITE_STORE, DOMAIN_SUGGESTIONS_STORE } from '../stores';
 import LaunchContext from '../context';
 import { isDomainProduct } from '../utils';
-import type { Product, DomainProduct } from '../utils';
+import type { DomainProduct } from '../utils';
 import { useSiteDomains } from './use-site-domains';
 
 export function useDomainProductFromCart(): DomainProduct | undefined {
@@ -26,7 +27,9 @@ export function useDomainProductFromCart(): DomainProduct | undefined {
 	React.useEffect( () => {
 		( async function () {
 			const cart = await getCart( siteId );
-			const domainProduct = cart.products?.find( ( item: Product ) => isDomainProduct( item ) );
+			const domainProduct = cart.products?.find( ( item: ResponseCartProduct ) =>
+				isDomainProduct( item )
+			);
 			setDomainProductFromCart( domainProduct );
 		} )();
 	}, [ siteId, getCart, setDomainProductFromCart ] );

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import type { DomainSuggestions } from '@automattic/data-stores';
 import { mockDomainSuggestion } from '@automattic/domain-picker';
@@ -8,10 +9,57 @@ import { mockDomainSuggestion } from '@automattic/domain-picker';
 /**
  * Internal dependencies
  */
-import { LAUNCH_STORE } from '../stores';
+import { LAUNCH_STORE, SITE_STORE, DOMAIN_SUGGESTIONS_STORE } from '../stores';
+import LaunchContext from '../context';
+import { isDomainProduct } from '../utils';
+import type { Product, DomainProduct } from '../utils';
 import { useSiteDomains } from './use-site-domains';
 
-export function useDomainSelection() {
+export function useDomainProductFromCart(): DomainProduct | undefined {
+	const { siteId } = React.useContext( LaunchContext );
+	const { getCart } = useDispatch( SITE_STORE );
+
+	const [ domainProductFromCart, setDomainProductFromCart ] = React.useState<
+		DomainProduct | undefined
+	>( undefined );
+
+	React.useEffect( () => {
+		( async function () {
+			const cart = await getCart( siteId );
+			const domainProduct = cart.products?.find( ( item: Product ) => isDomainProduct( item ) );
+			setDomainProductFromCart( domainProduct );
+		} )();
+	}, [ siteId, getCart, setDomainProductFromCart ] );
+
+	return domainProductFromCart;
+}
+
+export function useDomainSuggestionFromCart(): DomainSuggestions.DomainSuggestion | undefined {
+	const domainProductFromCart = useDomainProductFromCart();
+
+	const domainName = domainProductFromCart?.meta;
+
+	const domainSuggestion = useSelect( ( select ) =>
+		domainName
+			? select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( domainName, {
+					quantity: 1,
+					include_wordpressdotcom: false,
+					include_dotblogsubdomain: false,
+			  } )?.[ 0 ]
+			: undefined
+	);
+
+	return domainSuggestion;
+}
+
+type DomainSelection = {
+	onDomainSelect: ( suggestion: DomainSuggestions.DomainSuggestion ) => void;
+	onExistingSubdomainSelect: () => void;
+	selectedDomain: DomainSuggestions.DomainSuggestion | undefined;
+	currentDomain: DomainSuggestions.DomainSuggestion | undefined;
+};
+
+export function useDomainSelection(): DomainSelection {
 	const { setDomain, unsetDomain, unsetPlan, confirmDomainSelection } = useDispatch( LAUNCH_STORE );
 	const { domain: selectedDomain, plan, confirmedDomainSelection } = useSelect( ( select ) =>
 		select( LAUNCH_STORE ).getState()

--- a/packages/launch/src/hooks/use-plans.tsx
+++ b/packages/launch/src/hooks/use-plans.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useLocale } from '@automattic/i18n-utils';
 import type { Plans } from '@automattic/data-stores';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ import type { Plans } from '@automattic/data-stores';
 import { PLANS_STORE, SITE_STORE } from '../stores';
 import LaunchContext from '../context';
 import { isPlanProduct } from '../utils';
-import type { Product, PlanProduct } from '../utils';
+import type { PlanProduct } from '../utils';
 
 export function usePlans(): {
 	defaultPaidPlan: Plans.Plan;
@@ -43,7 +44,9 @@ export function usePlanProductFromCart(): PlanProduct | undefined {
 	React.useEffect( () => {
 		( async function () {
 			const cart = await getCart( siteId );
-			const planProduct = cart.products?.find( ( item: Product ) => isPlanProduct( item ) );
+			const planProduct = cart.products?.find( ( item: ResponseCartProduct ) =>
+				isPlanProduct( item )
+			);
 			setPlanProductFromCart( planProduct );
 		} )();
 	}, [ siteId, getCart, setPlanProductFromCart ] );

--- a/packages/launch/src/hooks/use-plans.tsx
+++ b/packages/launch/src/hooks/use-plans.tsx
@@ -1,15 +1,24 @@
 /**
  * External dependencies
  */
-import { useSelect } from '@wordpress/data';
+import * as React from 'react';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useLocale } from '@automattic/i18n-utils';
+import type { Plans } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
  */
-import { PLANS_STORE } from '../stores';
+import { PLANS_STORE, SITE_STORE } from '../stores';
+import LaunchContext from '../context';
+import { isPlanProduct } from '../utils';
+import type { Product, PlanProduct } from '../utils';
 
-export const usePlans = function usePlans() {
+export function usePlans(): {
+	defaultPaidPlan: Plans.Plan;
+	defaultFreePlan: Plans.Plan;
+	planPrices: Record< string, string >;
+} {
 	const locale = useLocale();
 
 	const defaultPaidPlan = useSelect( ( select ) =>
@@ -21,4 +30,35 @@ export const usePlans = function usePlans() {
 	const planPrices = useSelect( ( select ) => select( PLANS_STORE ).getPrices( '' ) );
 
 	return { defaultPaidPlan, defaultFreePlan, planPrices };
-};
+}
+
+export function usePlanProductFromCart(): PlanProduct | undefined {
+	const { siteId } = React.useContext( LaunchContext );
+	const { getCart } = useDispatch( SITE_STORE );
+
+	const [ planProductFromCart, setPlanProductFromCart ] = React.useState< PlanProduct | undefined >(
+		undefined
+	);
+
+	React.useEffect( () => {
+		( async function () {
+			const cart = await getCart( siteId );
+			const planProduct = cart.products?.find( ( item: Product ) => isPlanProduct( item ) );
+			setPlanProductFromCart( planProduct );
+		} )();
+	}, [ siteId, getCart, setPlanProductFromCart ] );
+
+	return planProductFromCart;
+}
+
+export function usePlanFromCart(): Plans.Plan | undefined {
+	const planProductFromCart = usePlanProductFromCart();
+
+	const planSlug = planProductFromCart?.product_slug;
+
+	const plan = useSelect( ( select ) =>
+		planSlug ? select( PLANS_STORE ).getPlanBySlug( planSlug ) : undefined
+	);
+
+	return plan;
+}

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 
 import type { Plans, DomainSuggestions } from '@automattic/data-stores';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
 
@@ -35,7 +36,6 @@ export const getPlanProduct = ( plan: Plans.Plan, flow: string ): PlanProduct =>
 export type DomainProduct = {
 	meta: string;
 	product_id: number;
-	is_domain_registration: true;
 	extra: {
 		privacy_available: boolean;
 		privacy: boolean;
@@ -49,7 +49,6 @@ export const getDomainProduct = (
 ): DomainProduct => ( {
 	meta: domain?.domain_name,
 	product_id: domain?.product_id,
-	is_domain_registration: true,
 	extra: {
 		privacy_available: domain?.supports_privacy,
 		privacy: domain?.supports_privacy,
@@ -57,11 +56,6 @@ export const getDomainProduct = (
 	},
 } );
 
-export type Product = {
-	product_id: number;
-	is_domain_registration?: boolean;
-};
-
-export const isDomainProduct = ( item: Product ): boolean => {
+export const isDomainProduct = ( item: ResponseCartProduct ): boolean => {
 	return !! item.is_domain_registration;
 };

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -32,7 +32,7 @@ export const getPlanProduct = ( plan: Plans.Plan, flow: string ): PlanProduct =>
 	},
 } );
 
-type DomainProduct = {
+export type DomainProduct = {
 	meta: string;
 	product_id: number;
 	extra: {
@@ -54,3 +54,12 @@ export const getDomainProduct = (
 		source: flow,
 	},
 } );
+
+export type Product = {
+	product_id: number;
+};
+
+export const isDomainProduct = ( item: Product ): boolean => {
+	const DOMAIN_PRODUCT_ID = 148;
+	return item.product_id === DOMAIN_PRODUCT_ID;
+};

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -35,6 +35,7 @@ export const getPlanProduct = ( plan: Plans.Plan, flow: string ): PlanProduct =>
 export type DomainProduct = {
 	meta: string;
 	product_id: number;
+	is_domain_registration: true;
 	extra: {
 		privacy_available: boolean;
 		privacy: boolean;
@@ -48,6 +49,7 @@ export const getDomainProduct = (
 ): DomainProduct => ( {
 	meta: domain?.domain_name,
 	product_id: domain?.product_id,
+	is_domain_registration: true,
 	extra: {
 		privacy_available: domain?.supports_privacy,
 		privacy: domain?.supports_privacy,
@@ -57,9 +59,9 @@ export const getDomainProduct = (
 
 export type Product = {
 	product_id: number;
+	is_domain_registration?: boolean;
 };
 
 export const isDomainProduct = ( item: Product ): boolean => {
-	const DOMAIN_PRODUCT_ID = 148;
-	return item.product_id === DOMAIN_PRODUCT_ID;
+	return !! item.is_domain_registration;
 };

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-
 import type { Plans, DomainSuggestions } from '@automattic/data-stores';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
+import { Plans as PlansStore } from '@automattic/data-stores';
 
 const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
 
@@ -17,7 +17,7 @@ export const isDefaultSiteTitle = ( {
 export const isValidSiteTitle = ( title?: string ): boolean =>
 	title !== '' && ! isDefaultSiteTitle( { currentSiteTitle: title } );
 
-type PlanProduct = {
+export type PlanProduct = {
 	product_id: number;
 	product_slug: string;
 	extra: {
@@ -58,4 +58,16 @@ export const getDomainProduct = (
 
 export const isDomainProduct = ( item: ResponseCartProduct ): boolean => {
 	return !! item.is_domain_registration;
+};
+
+export const isPlanProduct = ( item: ResponseCartProduct ): boolean => {
+	return (
+		[
+			PlansStore.PLAN_FREE,
+			PlansStore.PLAN_PERSONAL,
+			PlansStore.PLAN_PREMIUM,
+			PlansStore.PLAN_BUSINESS,
+			PlansStore.PLAN_ECOMMERCE,
+		].indexOf( item.product_slug ) > -1
+	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If the user has previously added a domain to cart, Focused Launch's domain picker will use the domain from cart, provided that user hasn't selected a domain through the domain picker.

**Technical Changes:**
- Added `useDomainProductFromCart()` hook.
- Added `useDomainSuggestionFromCart()` hook.
- Added `isDomainProduct()` util function.
- The type `DomainProduct` is now exported.
- The checking and assigning of `selectedDomain` from cart is done at `src/focused-launch/index.tsx`.

#### Testing instructions

* Create a free unlaunched site.
   * Let's say its called **http://test123_wordpress_dotcom**.
* Go to **http://calypso.localhost:3000/domains/add/test123_wordpress_dotcom**.
  * Add a domain to your cart.
* Go to **http://calypso.localhost:3000/page/test123_wordpress_dotcom/home?fresh&flags=create/focused-launch-flow-calypso**.
  * You should see the domain that you added to your cart as the pre-selected choice.
* Click on **View All Domain**.
  * It should also be the pre-selected choice 

Fixes #47233
