### PR TITLE
Focused Launch: Get selected plan from cart if available.

### DIFF
--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -46,6 +46,17 @@ const FocusedLaunch: React.FunctionComponent = () => {
 		}
 	}, [ selectedDomain, domainSuggestionFromCart, setDomain ] );
 
+	// If there is no selected domain, but there is a domain in cart,
+	// set the domain from cart as the selected domain.
+	const domainSuggestionFromCart = useDomainSuggestionFromCart();
+	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
+	const { setDomain } = useDispatch( LAUNCH_STORE );
+	React.useEffect( () => {
+		if ( ! selectedDomain && domainSuggestionFromCart ) {
+			setDomain( domainSuggestionFromCart );
+		}
+	}, [ selectedDomain, domainSuggestionFromCart, setDomain ] );
+
 	return (
 		<Router
 			initialEntries={ [ FocusedLaunchRoute.Summary, FocusedLaunchRoute.Success ] }

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -46,17 +46,6 @@ const FocusedLaunch: React.FunctionComponent = () => {
 		}
 	}, [ selectedDomain, domainSuggestionFromCart, setDomain ] );
 
-	// If there is no selected domain, but there is a domain in cart,
-	// set the domain from cart as the selected domain.
-	const domainSuggestionFromCart = useDomainSuggestionFromCart();
-	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
-	const { setDomain } = useDispatch( LAUNCH_STORE );
-	React.useEffect( () => {
-		if ( ! selectedDomain && domainSuggestionFromCart ) {
-			setDomain( domainSuggestionFromCart );
-		}
-	}, [ selectedDomain, domainSuggestionFromCart, setDomain ] );
-
 	// If there is no selected plan, but there is a plan in cart,
 	// set the plan from cart as the selected plan.
 	const planFromCart = usePlanFromCart();

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -15,7 +15,7 @@ import DomainDetails from './domain-details';
 import PlanDetails from './plan-details';
 import Success from './success';
 import { LAUNCH_STORE } from '../stores';
-import { useDomainSuggestionFromCart } from '../hooks';
+import { useDomainSuggestionFromCart, usePlanFromCart } from '../hooks';
 
 import './style.scss';
 
@@ -56,6 +56,17 @@ const FocusedLaunch: React.FunctionComponent = () => {
 			setDomain( domainSuggestionFromCart );
 		}
 	}, [ selectedDomain, domainSuggestionFromCart, setDomain ] );
+
+	// If there is no selected plan, but there is a plan in cart,
+	// set the plan from cart as the selected plan.
+	const planFromCart = usePlanFromCart();
+	const selectedPlan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
+	const { setPlan } = useDispatch( LAUNCH_STORE );
+	React.useEffect( () => {
+		if ( ! selectedPlan && planFromCart ) {
+			setPlan( planFromCart );
+		}
+	}, [ selectedPlan, planFromCart, setPlan ] );
 
 	return (
 		<Router

--- a/packages/launch/src/hooks/use-plans.tsx
+++ b/packages/launch/src/hooks/use-plans.tsx
@@ -1,15 +1,24 @@
 /**
  * External dependencies
  */
-import { useSelect } from '@wordpress/data';
+import * as React from 'react';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useLocale } from '@automattic/i18n-utils';
+import type { Plans } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
  */
-import { PLANS_STORE } from '../stores';
+import { PLANS_STORE, SITE_STORE } from '../stores';
+import LaunchContext from '../context';
+import { isPlanProduct } from '../utils';
+import type { Product, PlanProduct } from '../utils';
 
-export const usePlans = function usePlans() {
+export function usePlans(): {
+	defaultPaidPlan: Plans.Plan;
+	defaultFreePlan: Plans.Plan;
+	planPrices: Record< string, string >;
+} {
 	const locale = useLocale();
 
 	const defaultPaidPlan = useSelect( ( select ) =>
@@ -21,4 +30,35 @@ export const usePlans = function usePlans() {
 	const planPrices = useSelect( ( select ) => select( PLANS_STORE ).getPrices( '' ) );
 
 	return { defaultPaidPlan, defaultFreePlan, planPrices };
-};
+}
+
+export function usePlanProductFromCart(): PlanProduct | undefined {
+	const { siteId } = React.useContext( LaunchContext );
+	const { getCart } = useDispatch( SITE_STORE );
+
+	const [ planProductFromCart, setPlanProductFromCart ] = React.useState< PlanProduct | undefined >(
+		undefined
+	);
+
+	React.useEffect( () => {
+		( async function () {
+			const cart = await getCart( siteId );
+			const planProduct = cart.products?.find( ( item: Product ) => isPlanProduct( item ) );
+			setPlanProductFromCart( planProduct );
+		} )();
+	}, [ siteId, getCart, setPlanProductFromCart ] );
+
+	return planProductFromCart;
+}
+
+export function usePlanFromCart(): Plans.Plan | undefined {
+	const planProductFromCart = usePlanProductFromCart();
+
+	const planSlug = planProductFromCart?.product_slug;
+
+	const plan = useSelect( ( select ) =>
+		planSlug ? select( PLANS_STORE ).getPlanBySlug( planSlug ) : undefined
+	);
+
+	return plan;
+}

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-
 import type { Plans, DomainSuggestions } from '@automattic/data-stores';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
+import { Plans as PlansStore } from '@automattic/data-stores';
 
 const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
 
@@ -22,7 +22,7 @@ export const isDefaultSiteTitle = ( {
 		? currentSiteTitle === DEFAULT_SITE_NAME
 		: new RegExp( DEFAULT_SITE_NAME, 'i' ).test( currentSiteTitle );
 
-type PlanProduct = {
+export type PlanProduct = {
 	product_id: number;
 	product_slug: string;
 	extra: {
@@ -63,4 +63,16 @@ export const getDomainProduct = (
 
 export const isDomainProduct = ( item: ResponseCartProduct ): boolean => {
 	return !! item.is_domain_registration;
+};
+
+export const isPlanProduct = ( item: ResponseCartProduct ): boolean => {
+	return (
+		[
+			PlansStore.PLAN_FREE,
+			PlansStore.PLAN_PERSONAL,
+			PlansStore.PLAN_PREMIUM,
+			PlansStore.PLAN_BUSINESS,
+			PlansStore.PLAN_ECOMMERCE,
+		].indexOf( item.product_slug ) > -1
+	);
 };


### PR DESCRIPTION
Note: This PR is branched off https://github.com/Automattic/wp-calypso/pull/47987.

#### Changes proposed in this Pull Request

* If the user has previously added a plan to cart, Focused Launch's plan picker will use the plan from cart, provided that user hasn't selected a plan through the plan picker.

**Technical Changes:**
- Added `usePlanProductFromCart()` hook.
- Added `usePlanFromCart()` hook.
- Added `isPlanProduct()` util function.
- The type `PlanProduct` is now exported.
- The checking and assigning of `selectedPlan` from cart is done at `src/focused-launch/index.tsx`.

#### Testing instructions

* Create a free unlaunched site.
   * Let's say its called **http://test123_wordpress_dotcom**.
* Go to **http://calypso.localhost:3000/plans/test123_wordpress_dotcom**.
  * Add a plan to your cart, **just make sure it's not Premium** (to avoid confusion).
* Go to **http://calypso.localhost:3000/page/test123_wordpress_dotcom/home?fresh&flags=create/focused-launch-flow-calypso**.
  * You should see the plan that you added to your cart as the pre-selected choice.

Fixes part of #47233
