### PR TITLE
Focused launch: fix persisted selected plan in Summary view

### DIFF
--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -57,20 +57,6 @@ const plan: Reducer< Plans.Plan | undefined, LaunchAction > = ( state, action ) 
 	return state;
 };
 
-/**
- * To keep track of the last paid plan the user has picked
- * This is useful information as this paid plan can be suggested later
- *
- * @param state the state
- * @param action the action
- */
-const paidPlan: Reducer< Plans.Plan | undefined, LaunchAction > = ( state, action ) => {
-	if ( action.type === 'SET_PLAN' && ! action.plan?.isFree ) {
-		return action.plan;
-	}
-	return state;
-};
-
 const isFocusedLaunchOpen: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
 	if ( action.type === 'OPEN_FOCUSED_LAUNCH' ) {
 		return true;
@@ -149,7 +135,6 @@ const reducer = combineReducers( {
 	confirmedDomainSelection,
 	domainSearch,
 	plan,
-	paidPlan,
 	isSidebarOpen,
 	isSidebarFullscreen,
 	isExperimental,

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -35,7 +35,8 @@ export const getSelectedPlan = ( state: State ): Plans.Plan | undefined => state
  *
  * @param state State
  */
-export const getPaidPlan = ( state: State ): Plans.Plan | undefined => state.paidPlan;
+export const getPaidPlan = ( state: State ): Plans.Plan | undefined =>
+	state.plan && ! state.plan?.isFree ? state.plan : undefined;
 
 // Check if a domain has been explicitly selected (including free subdomain)
 export const hasSelectedDomain = ( state: State ): boolean =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Cleanup unnecessary useEffect usage in Summary
* Remove paidPlan reducer
* Update getPaidPlan selector

#### Testing instructions

* Same as #47913

Fixes #47544
Fixed #47913
