### PR TITLE
Nav Unification: use new experiment for internal testing

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -325,7 +325,7 @@ export default compose(
 			shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
 			isNewLaunchFlow,
 			isCheckoutFromGutenboarding,
-			navUnificationVariation: getVariationForUser( state, 'nav_unification' ),
+			navUnificationVariation: getVariationForUser( state, 'nav_unification_v2' ),
 		};
 	} )
 )( Layout );


### PR DESCRIPTION
After a failed first attempt to enable the feature for internal testing p58i-9Mc-p2, the data folks have followed up with cloning the experiment and disabling the "Run" button https://github.com/Automattic/abacus/pull/418 so that it cannot be run accidentally. We can now update the experiment name both in calypso and wpcom and restart the internal testing.

#### Changes proposed in this Pull Request

* Change experiment to `nav_unification_v2`

Please also apply D53704-code to your sandbox.
 
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load calypso and wp-admin and make sure you are not served the new UI / UX