### PR TITLE
Focused launch: Try getting cart data using a resolver

### DIFF
--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -36,6 +36,7 @@
 		"@wordpress/api-fetch": "^3.18.0",
 		"@wordpress/data-controls": "^1.16.3",
 		"@wordpress/url": "^2.17.0",
+		"@automattic/shopping-cart": "^1.0.0",
 		"fast-json-stable-stringify": "^2.1.0",
 		"i18n-calypso": "^5.0.0",
 		"qs": "^6.9.1",

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { RequestCart, ResponseCart } from '@automattic/shopping-cart';
+
+/**
  * Internal dependencies
  */
 import type {
@@ -7,7 +12,6 @@ import type {
 	NewSiteSuccessResponse,
 	SiteDetails,
 	SiteError,
-	Cart,
 	Domain,
 } from './types';
 import type { WpcomClientCredentials } from '../shared-types';
@@ -116,7 +120,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		return true;
 	}
 
-	// TODO: move getCart and setCart to a 'cart' data-store
+	// @TODO: decide if we really need this; currently used for setting cart during launch flow
 	function* getCart( siteId: number ) {
 		const success = yield wpcomRequest( {
 			path: '/me/shopping-cart/' + siteId,
@@ -132,7 +136,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		domains,
 	} );
 
-	function* setCart( siteId: number, cartData: Cart ) {
+	// @TODO: setCart action and getCart selector & resolver to a 'cart' data-store
+	function* setCart( siteId: number, cartData: RequestCart ) {
 		const success = yield wpcomRequest( {
 			path: '/me/shopping-cart/' + siteId,
 			apiVersion: '1.1',
@@ -141,6 +146,12 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		} );
 		return success;
 	}
+
+	const receiveCart = ( siteId: number, cartData: ResponseCart ) => ( {
+		type: 'RECEIVE_CART' as const,
+		siteId,
+		cartData,
+	} );
 
 	function* saveSiteTitle( siteId: number, title: string | undefined ) {
 		try {
@@ -172,6 +183,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		launchSiteStart,
 		launchSiteComplete,
 		getCart,
+		receiveCart,
 		setCart,
 	};
 }
@@ -192,6 +204,7 @@ export type Action =
 			| ActionCreators[ 'resetNewSiteFailed' ]
 			| ActionCreators[ 'launchSiteStart' ]
 			| ActionCreators[ 'launchSiteComplete' ]
+			| ActionCreators[ 'receiveCart' ]
 	  >
 	// Type added so we can dispatch actions in tests, but has no runtime cost
 	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -3,6 +3,7 @@
  */
 import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -114,6 +115,16 @@ export const launchStatus: Reducer<
 	return state;
 };
 
+export const cartData: Reducer< { [ key: number ]: ResponseCart }, Action > = (
+	state = {},
+	action
+) => {
+	if ( action.type === 'RECEIVE_CART' ) {
+		return { ...state, [ action.siteId ]: action.cartData };
+	}
+	return state;
+};
+
 const newSite = combineReducers( {
 	data: newSiteData,
 	error: newSiteError,
@@ -126,6 +137,7 @@ const reducer = combineReducers( {
 	sites,
 	launchStatus,
 	sitesDomains,
+	cartData,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -44,3 +44,19 @@ export function* getSiteDomains( siteId: number ) {
 		yield dispatch( STORE_KEY ).receiveSiteDomains( siteId, result?.domains );
 	} catch ( e ) {}
 }
+
+/**
+ * Get all site domains
+ *
+ * @param siteId {number} The site id
+ */
+export function* getCart( siteId: number ) {
+	try {
+		const result = yield wpcomRequest( {
+			path: '/me/shopping-cart/' + siteId,
+			apiVersion: '1.1',
+			method: 'GET',
+		} );
+		yield dispatch( STORE_KEY ).receiveCart( siteId, result );
+	} catch ( e ) {}
+}

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { select } from '@wordpress/data';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -53,3 +54,7 @@ export const getSiteSubdomain = ( _: State, siteId: number ) =>
 	select( STORE_KEY )
 		.getSiteDomains( siteId )
 		?.find( ( domain ) => domain.is_subdomain );
+
+export const getCart = ( state: State, siteId: number ): ResponseCart => {
+	return state.cartData[ siteId ];
+};

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -93,37 +93,6 @@ export interface SiteError {
 
 export type SiteResponse = SiteDetails | SiteError;
 
-export interface Cart {
-	blog_id: number;
-	cart_key: number;
-	coupon: string;
-	coupon_discounts: unknown[];
-	coupon_discounts_integer: unknown[];
-	is_coupon_applied: boolean;
-	has_bundle_credit: boolean;
-	next_domain_is_free: boolean;
-	next_domain_condition: string;
-	products: unknown[];
-	total_cost: number;
-	currency: string;
-	total_cost_display: string;
-	total_cost_integer: number;
-	temporary: boolean;
-	tax: unknown;
-	sub_total: number;
-	sub_total_display: string;
-	sub_total_integer: number;
-	total_tax: number;
-	total_tax_display: string;
-	total_tax_integer: number;
-	credits: number;
-	credits_display: string;
-	credits_integer: number;
-	allowed_payment_methods: unknown[];
-	create_new_blog: boolean;
-	messages: Record< 'errors' | 'success', unknown >;
-}
-
 export interface Domain {
 	primary_domain: boolean;
 	blog_id: number;

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -34,5 +34,6 @@
 		"composite": true
 	},
 	"include": [ "src" ],
-	"exclude": [ "**/docs/*", "**/test/*" ]
+	"exclude": [ "**/docs/*", "**/test/*" ],
+	"references": [ { "path": "../shopping-cart" } ]
 }

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -38,6 +38,7 @@
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/plans-grid": "^1.0.0-alpha.0",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
+		"@automattic/shopping-cart": "^1.0.0",
 		"@wordpress/components": "^10.0.5",
 		"@wordpress/icons": "^2.4.0",
 		"@wordpress/url": "^2.17.0",

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -15,7 +15,7 @@ import DomainDetails from './domain-details';
 import PlanDetails from './plan-details';
 import Success from './success';
 import { LAUNCH_STORE } from '../stores';
-import { useDomainSuggestionFromCart } from '../hooks';
+import { useDomainSuggestionFromCart, usePlanFromCart } from '../hooks';
 
 import './style.scss';
 
@@ -38,6 +38,17 @@ const FocusedLaunch: React.FunctionComponent = () => {
 			setDomain( domainSuggestionFromCart );
 		}
 	}, [ selectedDomain, domainSuggestionFromCart, setDomain ] );
+
+	// If there is no selected plan, but there is a plan in cart,
+	// set the plan from cart as the selected plan.
+	const planFromCart = usePlanFromCart();
+	const selectedPlan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
+	const { setPlan } = useDispatch( LAUNCH_STORE );
+	React.useEffect( () => {
+		if ( ! selectedPlan && planFromCart ) {
+			setPlan( planFromCart );
+		}
+	}, [ selectedPlan, planFromCart, setPlan ] );
 
 	return (
 		<Router initialEntries={ [ FocusedLaunchRoute.Summary ] }>

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -3,6 +3,7 @@
  */
 import * as React from 'react';
 import { MemoryRouter as Router, Switch, Route, Redirect } from 'react-router-dom';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -13,6 +14,8 @@ import Summary from './summary';
 import DomainDetails from './domain-details';
 import PlanDetails from './plan-details';
 import Success from './success';
+import { LAUNCH_STORE } from '../stores';
+import { useDomainSuggestionFromCart } from '../hooks';
 
 import './style.scss';
 
@@ -24,6 +27,17 @@ const FocusedLaunch: React.FunctionComponent = () => {
 			document.body.classList.add( 'is-focused-launch-complete' );
 		}
 	}, [ isSiteLaunched, isSiteLaunching ] );
+
+	// If there is no selected domain, but there is a domain in cart,
+	// set the domain from cart as the selected domain.
+	const domainSuggestionFromCart = useDomainSuggestionFromCart();
+	const selectedDomain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
+	const { setDomain } = useDispatch( LAUNCH_STORE );
+	React.useEffect( () => {
+		if ( ! selectedDomain && domainSuggestionFromCart ) {
+			setDomain( domainSuggestionFromCart );
+		}
+	}, [ selectedDomain, domainSuggestionFromCart, setDomain ] );
 
 	return (
 		<Router initialEntries={ [ FocusedLaunchRoute.Summary ] }>

--- a/packages/launch/src/hooks/use-cart.ts
+++ b/packages/launch/src/hooks/use-cart.ts
@@ -3,13 +3,14 @@
  */
 import * as React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
 import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
 import LaunchContext from '../context';
-import { getPlanProduct, getDomainProduct } from '../utils';
+import { getPlanProduct, getDomainProduct, isPlanProduct, isDomainProduct } from '../utils';
 
 export function useCart(): { goToCheckout: () => Promise< void > } {
 	const { siteId, flow, openCheckout } = React.useContext( LaunchContext );
@@ -40,4 +41,17 @@ export function useCart(): { goToCheckout: () => Promise< void > } {
 	return {
 		goToCheckout,
 	};
+}
+
+export function useProductsFromCart(): ResponseCartProduct[] | undefined {
+	const { siteId } = React.useContext( LaunchContext );
+	return useSelect( ( select ) => select( SITE_STORE ).getCart( siteId )?.products );
+}
+
+export function usePlanProductFromCart(): ResponseCartProduct | undefined {
+	return useProductsFromCart()?.find( ( item ) => isPlanProduct( item ) );
+}
+
+export function useDomainProductFromCart(): ResponseCartProduct | undefined {
+	return useProductsFromCart()?.find( ( item ) => isDomainProduct( item ) );
 }

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -1,15 +1,62 @@
 /**
  * External dependencies
  */
+import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
  */
-import { LAUNCH_STORE } from '../stores';
+import { LAUNCH_STORE, SITE_STORE, DOMAIN_SUGGESTIONS_STORE } from '../stores';
+import LaunchContext from '../context';
+import { isDomainProduct } from '../utils';
+import type { Product, DomainProduct } from '../utils';
 
-export function useDomainSelection() {
+export function useDomainProductFromCart(): DomainProduct | undefined {
+	const { siteId } = React.useContext( LaunchContext );
+	const { getCart } = useDispatch( SITE_STORE );
+
+	const [ domainProductFromCart, setDomainProductFromCart ] = React.useState<
+		DomainProduct | undefined
+	>( undefined );
+
+	React.useEffect( () => {
+		( async function () {
+			const cart = await getCart( siteId );
+			const domainProduct = cart.products?.find( ( item: Product ) => isDomainProduct( item ) );
+			setDomainProductFromCart( domainProduct );
+		} )();
+	}, [ siteId, getCart, setDomainProductFromCart ] );
+
+	return domainProductFromCart;
+}
+
+export function useDomainSuggestionFromCart(): DomainSuggestions.DomainSuggestion | undefined {
+	const domainProductFromCart = useDomainProductFromCart();
+
+	const domainName = domainProductFromCart?.meta;
+
+	const domainSuggestion = useSelect( ( select ) =>
+		domainName
+			? select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( domainName, {
+					quantity: 1,
+					include_wordpressdotcom: false,
+					include_dotblogsubdomain: false,
+			  } )?.[ 0 ]
+			: undefined
+	);
+
+	return domainSuggestion;
+}
+
+type DomainSelection = {
+	onDomainSelect: ( suggestion: DomainSuggestions.DomainSuggestion ) => void;
+	onExistingSubdomainSelect: () => void;
+	selectedDomain: DomainSuggestions.DomainSuggestion | undefined;
+};
+
+export function useDomainSelection(): DomainSelection {
 	const { plan } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 	const { setDomain, unsetDomain, unsetPlan, confirmDomainSelection } = useDispatch( LAUNCH_STORE );
 	const { domain: selectedDomain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -1,36 +1,14 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
  */
-import { LAUNCH_STORE, SITE_STORE, DOMAIN_SUGGESTIONS_STORE } from '../stores';
-import LaunchContext from '../context';
-import { isDomainProduct } from '../utils';
-import type { Product, DomainProduct } from '../utils';
-
-export function useDomainProductFromCart(): DomainProduct | undefined {
-	const { siteId } = React.useContext( LaunchContext );
-	const { getCart } = useDispatch( SITE_STORE );
-
-	const [ domainProductFromCart, setDomainProductFromCart ] = React.useState<
-		DomainProduct | undefined
-	>( undefined );
-
-	React.useEffect( () => {
-		( async function () {
-			const cart = await getCart( siteId );
-			const domainProduct = cart.products?.find( ( item: Product ) => isDomainProduct( item ) );
-			setDomainProductFromCart( domainProduct );
-		} )();
-	}, [ siteId, getCart, setDomainProductFromCart ] );
-
-	return domainProductFromCart;
-}
+import { LAUNCH_STORE, DOMAIN_SUGGESTIONS_STORE } from '../stores';
+import { useDomainProductFromCart } from './use-cart';
 
 export function useDomainSuggestionFromCart(): DomainSuggestions.DomainSuggestion | undefined {
 	const domainProductFromCart = useDomainProductFromCart();

--- a/packages/launch/src/hooks/use-plans.tsx
+++ b/packages/launch/src/hooks/use-plans.tsx
@@ -1,18 +1,15 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useLocale } from '@automattic/i18n-utils';
 import type { Plans } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
  */
-import { PLANS_STORE, SITE_STORE } from '../stores';
-import LaunchContext from '../context';
-import { isPlanProduct } from '../utils';
-import type { Product, PlanProduct } from '../utils';
+import { PLANS_STORE } from '../stores';
+import { usePlanProductFromCart } from './use-cart';
 
 export function usePlans(): {
 	defaultPaidPlan: Plans.Plan;
@@ -30,25 +27,6 @@ export function usePlans(): {
 	const planPrices = useSelect( ( select ) => select( PLANS_STORE ).getPrices( '' ) );
 
 	return { defaultPaidPlan, defaultFreePlan, planPrices };
-}
-
-export function usePlanProductFromCart(): PlanProduct | undefined {
-	const { siteId } = React.useContext( LaunchContext );
-	const { getCart } = useDispatch( SITE_STORE );
-
-	const [ planProductFromCart, setPlanProductFromCart ] = React.useState< PlanProduct | undefined >(
-		undefined
-	);
-
-	React.useEffect( () => {
-		( async function () {
-			const cart = await getCart( siteId );
-			const planProduct = cart.products?.find( ( item: Product ) => isPlanProduct( item ) );
-			setPlanProductFromCart( planProduct );
-		} )();
-	}, [ siteId, getCart, setPlanProductFromCart ] );
-
-	return planProductFromCart;
 }
 
 export function usePlanFromCart(): Plans.Plan | undefined {

--- a/packages/launch/src/hooks/use-plans.tsx
+++ b/packages/launch/src/hooks/use-plans.tsx
@@ -1,15 +1,24 @@
 /**
  * External dependencies
  */
-import { useSelect } from '@wordpress/data';
+import * as React from 'react';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useLocale } from '@automattic/i18n-utils';
+import type { Plans } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
  */
-import { PLANS_STORE } from '../stores';
+import { PLANS_STORE, SITE_STORE } from '../stores';
+import LaunchContext from '../context';
+import { isPlanProduct } from '../utils';
+import type { Product, PlanProduct } from '../utils';
 
-export const usePlans = function usePlans() {
+export function usePlans(): {
+	defaultPaidPlan: Plans.Plan;
+	defaultFreePlan: Plans.Plan;
+	planPrices: Record< string, string >;
+} {
 	const locale = useLocale();
 
 	const defaultPaidPlan = useSelect( ( select ) =>
@@ -21,4 +30,35 @@ export const usePlans = function usePlans() {
 	const planPrices = useSelect( ( select ) => select( PLANS_STORE ).getPrices( '' ) );
 
 	return { defaultPaidPlan, defaultFreePlan, planPrices };
-};
+}
+
+export function usePlanProductFromCart(): PlanProduct | undefined {
+	const { siteId } = React.useContext( LaunchContext );
+	const { getCart } = useDispatch( SITE_STORE );
+
+	const [ planProductFromCart, setPlanProductFromCart ] = React.useState< PlanProduct | undefined >(
+		undefined
+	);
+
+	React.useEffect( () => {
+		( async function () {
+			const cart = await getCart( siteId );
+			const planProduct = cart.products?.find( ( item: Product ) => isPlanProduct( item ) );
+			setPlanProductFromCart( planProduct );
+		} )();
+	}, [ siteId, getCart, setPlanProductFromCart ] );
+
+	return planProductFromCart;
+}
+
+export function usePlanFromCart(): Plans.Plan | undefined {
+	const planProductFromCart = usePlanProductFromCart();
+
+	const planSlug = planProductFromCart?.product_slug;
+
+	const plan = useSelect( ( select ) =>
+		planSlug ? select( PLANS_STORE ).getPlanBySlug( planSlug ) : undefined
+	);
+
+	return plan;
+}

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-
 import type { Plans, DomainSuggestions } from '@automattic/data-stores';
+import { Plans as PlansStore } from '@automattic/data-stores';
 
 const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
 
@@ -21,7 +21,7 @@ export const isDefaultSiteTitle = ( {
 		? currentSiteTitle === DEFAULT_SITE_NAME
 		: new RegExp( DEFAULT_SITE_NAME, 'i' ).test( currentSiteTitle );
 
-type PlanProduct = {
+export type PlanProduct = {
 	product_id: number;
 	product_slug: string;
 	extra: {
@@ -62,9 +62,22 @@ export const getDomainProduct = (
 
 export type Product = {
 	product_id: number;
+	product_slug: string;
 };
 
 export const isDomainProduct = ( item: Product ): boolean => {
 	const DOMAIN_PRODUCT_ID = 148;
 	return item.product_id === DOMAIN_PRODUCT_ID;
+};
+
+export const isPlanProduct = ( item: Product ): boolean => {
+	return (
+		[
+			PlansStore.PLAN_FREE,
+			PlansStore.PLAN_PERSONAL,
+			PlansStore.PLAN_PREMIUM,
+			PlansStore.PLAN_BUSINESS,
+			PlansStore.PLAN_ECOMMERCE,
+		].indexOf( item.product_slug ) > -1
+	);
 };

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -2,8 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import type { Plans, DomainSuggestions } from '@automattic/data-stores';
 import { Plans as PlansStore } from '@automattic/data-stores';
+
+import type { Plans, DomainSuggestions } from '@automattic/data-stores';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 const DEFAULT_SITE_NAME = __( 'Site Title', __i18n_text_domain__ );
 
@@ -21,15 +23,10 @@ export const isDefaultSiteTitle = ( {
 		? currentSiteTitle === DEFAULT_SITE_NAME
 		: new RegExp( DEFAULT_SITE_NAME, 'i' ).test( currentSiteTitle );
 
-export type PlanProduct = {
-	product_id: number;
-	product_slug: string;
-	extra: {
-		source: string;
-	};
-};
-
-export const getPlanProduct = ( plan: Plans.Plan, flow: string ): PlanProduct => ( {
+export const getPlanProduct = (
+	plan: Plans.Plan,
+	flow: string
+): Partial< ResponseCartProduct > => ( {
 	product_id: plan.productId,
 	product_slug: plan.storeSlug,
 	extra: {
@@ -37,20 +34,10 @@ export const getPlanProduct = ( plan: Plans.Plan, flow: string ): PlanProduct =>
 	},
 } );
 
-export type DomainProduct = {
-	meta: string;
-	product_id: number;
-	extra: {
-		privacy_available: boolean;
-		privacy: boolean;
-		source: string;
-	};
-};
-
 export const getDomainProduct = (
 	domain: DomainSuggestions.DomainSuggestion,
 	flow: string
-): DomainProduct => ( {
+): Partial< ResponseCartProduct > => ( {
 	meta: domain?.domain_name,
 	product_id: domain?.product_id,
 	extra: {
@@ -60,17 +47,12 @@ export const getDomainProduct = (
 	},
 } );
 
-export type Product = {
-	product_id: number;
-	product_slug: string;
-};
-
-export const isDomainProduct = ( item: Product ): boolean => {
+export const isDomainProduct = ( item: ResponseCartProduct ): boolean => {
 	const DOMAIN_PRODUCT_ID = 148;
 	return item.product_id === DOMAIN_PRODUCT_ID;
 };
 
-export const isPlanProduct = ( item: Product ): boolean => {
+export const isPlanProduct = ( item: ResponseCartProduct ): boolean => {
 	return (
 		[
 			PlansStore.PLAN_FREE,

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -37,7 +37,7 @@ export const getPlanProduct = ( plan: Plans.Plan, flow: string ): PlanProduct =>
 	},
 } );
 
-type DomainProduct = {
+export type DomainProduct = {
 	meta: string;
 	product_id: number;
 	extra: {
@@ -59,3 +59,12 @@ export const getDomainProduct = (
 		source: flow,
 	},
 } );
+
+export type Product = {
+	product_id: number;
+};
+
+export const isDomainProduct = ( item: Product ): boolean => {
+	const DOMAIN_PRODUCT_ID = 148;
+	return item.product_id === DOMAIN_PRODUCT_ID;
+};

--- a/packages/launch/tsconfig.json
+++ b/packages/launch/tsconfig.json
@@ -40,6 +40,7 @@
 		{ "path": "../domain-picker" },
 		{ "path": "../plans-grid" },
 		{ "path": "../calypso-analytics" },
-		{ "path": "../i18n-utils" }
+		{ "path": "../i18n-utils" },
+		{ "path": "../shopping-cart" }
 	]
 }

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -167,6 +167,7 @@ export type ResponseCartProductExtra = {
 	purchaseType?: string;
 	includedDomain?: string;
 	privacy?: boolean;
+	privacy_available?: boolean;
 };
 
 export interface GSuiteProductUser {


### PR DESCRIPTION
**To Do:**
- [ ] Explore the alternative to use `useShoppingCart` hook from [@automattic/shopping-cart](https://github.com/Automattic/wp-calypso/tree/trunk/packages/shopping-cart) package.
- [ ] Explore `react-query` p4TIVU-9AF-p2

#### Changes proposed in this Pull Request
**Update `Site` data-store to get cart data.**
  * Add `getCart` selector and resolver
  * Add `cartData` reducer
  * Add `receiveCart` action creator

**Update focused launch to use `getCart` selector.**
  * Add hooks for fetching cart products in `use-cart`
  * Update `use-domain-selection` and `use-plans`
  * Cleanup `utils` and use `ResponseCartProduct` type from `shopping-cart` package

#### Testing instructions
Follow instructions in: 
* https://github.com/Automattic/wp-calypso/pull/47990
* https://github.com/Automattic/wp-calypso/pull/47987

All the functionality should be the same.