### PR TITLE
Jetpack Plans: always add products to cart by URL

### DIFF
--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -25,8 +25,6 @@ import {
 	SUBTYPE_TO_OPTION,
 } from './constants';
 import RecordsDetails from './records-details';
-import { addItems } from 'calypso/lib/cart/actions';
-import { jetpackProductItem } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	TERM_ANNUALLY,
@@ -604,20 +602,13 @@ export function checkout(
 	// If there is not siteSlug, we need to redirect the user to the site selection
 	// step of the flow. Since purchases of multiple products are allowed, we need
 	// to pass all products separated by comma in the URL.
-	let path;
-	if ( ! siteSlug ) {
-		path = `/jetpack/connect/${ productsString }`;
-	} else {
-		path =
-			isJetpackCloud() && ! config.isEnabled( 'jetpack-cloud/connect' )
-				? `/checkout/${ siteSlug }/${ productsString }`
-				: `/checkout/${ siteSlug }`;
-	}
+	const path = siteSlug
+		? `/checkout/${ siteSlug }/${ productsString }`
+		: `/jetpack/connect/${ productsString }`;
 
 	if ( isJetpackCloud() && ! config.isEnabled( 'jetpack-cloud/connect' ) ) {
 		window.location.href = addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` );
 	} else {
-		addItems( productsArray.map( jetpackProductItem ) );
 		page.redirect( addQueryArgs( urlQueryArgs, path ) );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 1164141197617539-as-1199515021864517

* Instead of dispatching an HTTP request to update the cart before redirecting the user to checkout, pass the product(s) slug itself by URL. In this way, the Composite Checkout will be in charge of adding the product(s) to the cart in the backend.

#### Notes

If I recall correctly, we decided to use `addItems` action to add items to the cart because at that time it was the only way to add more than one product. Now we can do it by URL so it's no longer needed.

#### Testing instructions

**How to replicate the issue**
* Visit `wordpress.com/plans/:site` with a Jetpack site.
* Immediately select any product from the first row.
* Verify that you see the checkout and then that you are redirected back to the Plans page.
* Repeat the process until you see the issue (it might take you a couple of attempts).

**The solution**
* Run this PR (horizon is enough).
* Visit `/plans/:site` with a Jetpack site.
* Immediately select any plan/product from the first row.
* Verify that you see the checkout and that the selected product is in the cart.
* Verify that the URL contains at the end the slug of the selected product.
* Repeat the exercise several times.

#### Demo before
![Kapture 2020-12-03 at 10 49 13](https://user-images.githubusercontent.com/3418513/101026602-dfe8cb80-3555-11eb-8a50-f990beec7641.gif)

#### Demo after
![Kapture 2020-12-03 at 10 47 41](https://user-images.githubusercontent.com/3418513/101026609-e1b28f00-3555-11eb-9241-a3deb075696f.gif)

