### PR TITLE
Purchases: Update billing history search

### DIFF
--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -16,9 +16,8 @@ import { CompactCard } from '@automattic/components';
 import Pagination from 'calypso/components/pagination';
 import TransactionsHeader from './transactions-header';
 import { groupDomainProducts, renderTransactionAmount } from './utils';
-import SearchCard from 'calypso/components/search-card';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { setPage, setQuery } from 'calypso/state/billing-transactions/ui/actions';
+import { setPage } from 'calypso/state/billing-transactions/ui/actions';
 import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
 import getFilteredBillingTransactions from 'calypso/state/selectors/get-filtered-billing-transactions';
 import { getPlanTermLabel } from 'calypso/lib/plans';
@@ -32,10 +31,6 @@ class TransactionsTable extends React.Component {
 
 	onPageClick = ( page ) => {
 		this.props.setPage( this.props.transactionType, page );
-	};
-
-	onSearch = ( terms ) => {
-		this.props.setQuery( this.props.transactionType, terms );
 	};
 
 	render() {
@@ -52,10 +47,6 @@ class TransactionsTable extends React.Component {
 
 		return (
 			<div>
-				<SearchCard
-					placeholder={ this.props.translate( 'Search all receipts…', { textOnly: true } ) }
-					onSearch={ this.onSearch }
-				/>
 				<table className="billing-history__transactions">
 					{ header }
 					<tbody>{ this.renderRows() }</tbody>
@@ -229,6 +220,5 @@ export default connect(
 	},
 	{
 		setPage,
-		setQuery,
 	}
 )( localize( withLocalizedMoment( TransactionsTable ) ) );

--- a/client/me/pending-payments/test/index.js
+++ b/client/me/pending-payments/test/index.js
@@ -39,7 +39,7 @@ describe( 'PendingPayments', () => {
 
 		const rules = [
 			'Main.pending-payments Connect(MeSidebarNavigation)',
-			'Main.pending-payments Connect(Localized(PurchasesHeader))[section="pending"]',
+			'Main.pending-payments PurchasesHeader[section="pending"]',
 			'Connect(PurchasesSite)[isPlaceholder=true]',
 		];
 
@@ -57,7 +57,7 @@ describe( 'PendingPayments', () => {
 
 		const rules = [
 			'Main.pending-payments Connect(MeSidebarNavigation)',
-			'Main.pending-payments Connect(Localized(PurchasesHeader))[section="pending"]',
+			'Main.pending-payments PurchasesHeader[section="pending"]',
 			'.pending-payments .pending-payments__no-content EmptyContent',
 		];
 
@@ -82,7 +82,7 @@ describe( 'PendingPayments', () => {
 
 		const rules = [
 			'Main.pending-payments Connect(MeSidebarNavigation)',
-			'Main.pending-payments Connect(Localized(PurchasesHeader))[section="pending"]',
+			'Main.pending-payments PurchasesHeader[section="pending"]',
 			'Main.pending-payments Connect(PendingListItem)',
 		];
 

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -22,8 +22,9 @@ import SectionNav from 'calypso/components/section-nav';
 import { isEnabled } from 'calypso/config';
 import Search from 'calypso/components/search';
 import { setQuery } from 'calypso/state/billing-transactions/ui/actions';
+import getPastBillingTransactions from 'calypso/state/selectors/get-past-billing-transactions';
 
-export default function PurchasesHeader( { section } ) {
+const PurchasesHeader = ( { section } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	let text = translate( 'Billing History' );
@@ -71,8 +72,12 @@ export default function PurchasesHeader( { section } ) {
 			) }
 		</SectionNav>
 	);
-}
+};
 
 PurchasesHeader.propTypes = {
 	section: PropTypes.string.isRequired,
 };
+
+export default connect( ( state ) => ( {
+	pastTransactions: getPastBillingTransactions( state ),
+} ) )( PurchasesHeader );

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-import { connect, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -22,9 +21,8 @@ import SectionNav from 'calypso/components/section-nav';
 import { isEnabled } from 'calypso/config';
 import Search from 'calypso/components/search';
 import { setQuery } from 'calypso/state/billing-transactions/ui/actions';
-import getPastBillingTransactions from 'calypso/state/selectors/get-past-billing-transactions';
 
-const PurchasesHeader = ( { section } ) => {
+export default function PurchasesHeader( { section } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	let text = translate( 'Billing History' );
@@ -72,12 +70,8 @@ const PurchasesHeader = ( { section } ) => {
 			) }
 		</SectionNav>
 	);
-};
+}
 
 PurchasesHeader.propTypes = {
 	section: PropTypes.string.isRequired,
 };
-
-export default connect( ( state ) => ( {
-	pastTransactions: getPastBillingTransactions( state ),
-} ) )( PurchasesHeader );

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -65,7 +65,6 @@ export default function PurchasesHeader( { section } ) {
 					onSearch={ ( term ) => {
 						dispatch( setQuery( 'past', term ) );
 					} }
-					initialValue={ null }
 					placeholder={ translate( 'Search all receipts…' ) }
 					analyticsGroup="Billing"
 				/>

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -4,20 +4,28 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import { billingHistory, paymentMethods, pendingPayments, purchasesRoot } from '../../paths.js';
+import {
+	billingHistory,
+	paymentMethods,
+	pendingPayments,
+	purchasesRoot,
+} from 'calypso/me/purchases/paths.js';
 import SectionNav from 'calypso/components/section-nav';
-import config from 'calypso/config';
-import getPastBillingTransactions from 'calypso/state/selectors/get-past-billing-transactions';
+import { isEnabled } from 'calypso/config';
+import Search from 'calypso/components/search';
+import { setQuery } from 'calypso/state/billing-transactions/ui/actions';
 
-const PurchasesHeader = ( { section, translate } ) => {
+export default function PurchasesHeader( { section } ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
 	let text = translate( 'Billing History' );
 
 	if ( section === 'purchases' ) {
@@ -43,20 +51,29 @@ const PurchasesHeader = ( { section, translate } ) => {
 					{ translate( 'Payment Methods' ) }
 				</NavItem>
 
-				{ config.isEnabled( 'async-payments' ) && (
+				{ isEnabled( 'async-payments' ) && (
 					<NavItem path={ pendingPayments } selected={ section === 'pending' }>
 						{ translate( 'Pending Payments' ) }
 					</NavItem>
 				) }
 			</NavTabs>
+
+			{ section === 'billing' && (
+				<Search
+					pinned
+					fitsContainer
+					onSearch={ ( term ) => {
+						dispatch( setQuery( 'past', term ) );
+					} }
+					initialValue={ null }
+					placeholder={ translate( 'Search all receipts…' ) }
+					analyticsGroup="Billing"
+				/>
+			) }
 		</SectionNav>
 	);
-};
+}
 
 PurchasesHeader.propTypes = {
 	section: PropTypes.string.isRequired,
 };
-
-export default connect( ( state ) => ( {
-	pastTransactions: getPastBillingTransactions( state ),
-} ) )( localize( PurchasesHeader ) );

--- a/client/my-sites/purchases/navigation.tsx
+++ b/client/my-sites/purchases/navigation.tsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -10,6 +11,8 @@ import { useTranslate } from 'i18n-calypso';
 import SectionNav from 'calypso/components/section-nav';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import NavItem from 'calypso/components/section-nav/item';
+import Search from 'calypso/components/search';
+import { setQuery } from 'calypso/state/billing-transactions/ui/actions';
 
 export default function PurchasesNavigation( {
 	sectionTitle,
@@ -19,6 +22,7 @@ export default function PurchasesNavigation( {
 	siteSlug: string | null;
 } ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	return (
 		<SectionNav selectedText={ sectionTitle }>
@@ -42,6 +46,19 @@ export default function PurchasesNavigation( {
 					{ translate( 'Payment Methods' ) }
 				</NavItem>
 			</NavTabs>
+
+			{ sectionTitle === 'Billing History' && (
+				<Search
+					pinned
+					fitsContainer
+					onSearch={ ( term ) => {
+						dispatch( setQuery( 'past', term ) );
+					} }
+					initialValue={ null }
+					placeholder={ translate( 'Search all receipts…' ) }
+					analyticsGroup="Billing"
+				/>
+			) }
 		</SectionNav>
 	);
 }

--- a/client/my-sites/purchases/navigation.tsx
+++ b/client/my-sites/purchases/navigation.tsx
@@ -54,7 +54,6 @@ export default function PurchasesNavigation( {
 					onSearch={ ( term ) => {
 						dispatch( setQuery( 'past', term ) );
 					} }
-					initialValue={ null }
 					placeholder={ translate( 'Search all receipts…' ) }
 					analyticsGroup="Billing"
 				/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the search on the billing history screen so that it appears in the navigation bar like it does for a number of our other screens like pages and posts.

**Before**
![image](https://user-images.githubusercontent.com/6981253/101041755-80d18980-354a-11eb-9ff8-9cfaa2565aaa.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/101041598-74e5c780-354a-11eb-82e0-b6e4a1d192e5.png)


#### Testing instructions

* Visit the billing history screen at the site and account level
* Perform some searches and compare it to what's on production.
