### PR TITLE
Modularise support state

### DIFF
--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -9,7 +9,6 @@ import debugModule from 'debug';
 import wpcom from 'calypso/lib/wp';
 import config from '@automattic/calypso-config';
 import { bypassPersistentStorage } from 'calypso/lib/browser-storage';
-import { supportSessionActivate } from 'calypso/state/support/actions';
 import localStorageBypass from 'calypso/lib/local-storage-bypass';
 
 /**
@@ -130,6 +129,9 @@ export async function supportUserBoot() {
 
 	wpcom.setSupportUserToken( user, token, onTokenError );
 
+	// This needs to be a dynamic import in order to avoid boot race conditions.
+	const { supportSessionActivate } = await import( 'calypso/state/support/actions' );
+
 	// the boot is performed before the Redux store is created, so we need to wait for a promise
 	const reduxStore = await reduxStoreReady;
 	reduxStore.dispatch( supportSessionActivate() );
@@ -146,6 +148,9 @@ export async function supportNextBoot() {
 	// they are safe to share across user sessions.
 	const allowedKeys = [ 'debug' ];
 	localStorageBypass( allowedKeys );
+
+	// This needs to be a dynamic import in order to avoid boot race conditions.
+	const { supportSessionActivate } = await import( 'calypso/state/support/actions' );
 
 	// the boot is performed before the Redux store is created, so we need to wait for a promise
 	const reduxStore = await reduxStoreReady;

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -21,7 +21,6 @@ import documentHead from './document-head/reducer';
 import i18n from './i18n/reducer';
 import importerNux from './importer-nux/reducer';
 import sites from './sites/reducer';
-import support from './support/reducer';
 import userSettings from './user-settings/reducer';
 
 // Legacy reducers
@@ -36,7 +35,6 @@ const reducers = {
 	i18n,
 	importerNux,
 	sites,
-	support,
 	userSettings,
 };
 

--- a/client/state/support/actions.js
+++ b/client/state/support/actions.js
@@ -1,9 +1,10 @@
 /**
  * Internal dependencies
  */
-
 import { SUPPORT_SESSION_TRANSITION } from 'calypso/state/action-types';
-import { SESSION_ACTIVE, SESSION_EXPIRED } from './reducer';
+import { SESSION_ACTIVE, SESSION_EXPIRED } from './constants';
+
+import 'calypso/state/support/init';
 
 export function supportSessionActivate() {
 	return {

--- a/client/state/support/constants.js
+++ b/client/state/support/constants.js
@@ -1,0 +1,3 @@
+export const SESSION_NONE = 'none';
+export const SESSION_ACTIVE = 'active';
+export const SESSION_EXPIRED = 'expired';

--- a/client/state/support/init.js
+++ b/client/state/support/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'support' ], reducer );

--- a/client/state/support/package.json
+++ b/client/state/support/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/support/reducer.js
+++ b/client/state/support/reducer.js
@@ -7,14 +7,12 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { SUPPORT_SESSION_TRANSITION } from 'calypso/state/action-types';
+import { withStorageKey } from 'calypso/state/utils';
+import { SESSION_ACTIVE, SESSION_EXPIRED, SESSION_NONE } from './constants';
 
 const debug = debugFactory( 'calypso:state:support:actions' );
 
-export const SESSION_NONE = 'none';
-export const SESSION_ACTIVE = 'active';
-export const SESSION_EXPIRED = 'expired';
-
-export default function supportSession( state = SESSION_NONE, { type, nextState } ) {
+function supportSession( state = SESSION_NONE, { type, nextState } ) {
 	switch ( type ) {
 		case SUPPORT_SESSION_TRANSITION:
 			if (
@@ -31,3 +29,5 @@ export default function supportSession( state = SESSION_NONE, { type, nextState 
 			return state;
 	}
 }
+
+export default withStorageKey( 'support', supportSession );

--- a/client/state/support/reducer.js
+++ b/client/state/support/reducer.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import debugFactory from 'debug';
+import { withStorageKey } from '@automattic/state-utils';
 
 /**
  * Internal dependencies
  */
 import { SUPPORT_SESSION_TRANSITION } from 'calypso/state/action-types';
-import { withStorageKey } from 'calypso/state/utils';
 import { SESSION_ACTIVE, SESSION_EXPIRED, SESSION_NONE } from './constants';
 
 const debug = debugFactory( 'calypso:state:support:actions' );

--- a/client/state/support/selectors.js
+++ b/client/state/support/selectors.js
@@ -1,7 +1,9 @@
 /**
  * Internal dependencies
  */
-import { SESSION_ACTIVE, SESSION_EXPIRED } from './reducer';
+import { SESSION_ACTIVE, SESSION_EXPIRED } from './constants';
+
+import 'calypso/state/support/init';
 
 export function isSupportSession( { support } ) {
 	return support === SESSION_ACTIVE || support === SESSION_EXPIRED;

--- a/client/state/support/test/reducer.js
+++ b/client/state/support/test/reducer.js
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import reducer, { SESSION_NONE, SESSION_ACTIVE, SESSION_EXPIRED } from '../reducer';
+import reducer from '../reducer';
+import { SESSION_NONE, SESSION_ACTIVE, SESSION_EXPIRED } from '../constants';
 import { SUPPORT_SESSION_TRANSITION } from 'calypso/state/action-types';
 
 describe( 'reducer', () => {


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles support state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42484.

#### Changes proposed in this Pull Request

* Modularise support state
* Move support constants out of the reducer, to their own constants file

#### Testing instructions

Unfortunately, `support` state gets loaded pretty early on in the boot process, through `Layout`. As such, it's not easy to test the automated loading process, but it should be enough to smoke-test support session functionality in order to ensure that it continues to work correctly.
