### PR TITLE
Plugins: Untangle notices mixin from PluginsList and SinglePlugin

### DIFF
--- a/client/my-sites/plugins/plugin-activate-toggle/test/fixtures/index.js
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/fixtures/index.js
@@ -7,9 +7,5 @@ export default {
 	plugin: {
 		slug: 'test',
 	},
-	notices: {
-		completed: [],
-		errors: [],
-	},
 	action: function () {},
 };

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/test/fixtures/index.js
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/test/fixtures/index.js
@@ -8,10 +8,6 @@ export default {
 		jetpack: true,
 	},
 	plugin: { slug: 'test' },
-	notices: {
-		completed: [],
-		errors: [],
-	},
 	wporg: true,
 	action: function () {},
 };

--- a/client/my-sites/plugins/plugin-item/README.md
+++ b/client/my-sites/plugins/plugin-item/README.md
@@ -33,5 +33,4 @@ function render() {
 - `allowedActions`: an object of allowed plugin actions: `activation`, `autoupdate`. Used to display/hide plugin actions.
 - `isAutoManaged`: a boolean if the plugin is auto managed. If true it will dispaly an auto managed message. Defaults to false.
 - `progress`: an array of progress steps.
-- `notices`: an object of plugin notices: `completed`, `errors`, `inProgress`.
 - `hasUpdate`: a function to determine if a plugin has an update available. Defaults to a function returning false.

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -59,7 +59,7 @@ class PluginItem extends Component {
 		const { translate, progress } = this.props;
 		const log = progress[ 0 ];
 		const uniqLogs = uniqBy( progress, function ( uniqLog ) {
-			return uniqLog.site.ID;
+			return uniqLog.siteId;
 		} );
 		const translationArgs = {
 			args: { count: uniqLogs.length },

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -28,7 +28,6 @@ class PluginSiteJetpack extends React.Component {
 	static propTypes = {
 		site: PropTypes.object,
 		plugin: PropTypes.object,
-		notices: PropTypes.object,
 		allowedActions: PropTypes.shape( {
 			activation: PropTypes.bool,
 			autoupdate: PropTypes.bool,
@@ -89,7 +88,6 @@ class PluginSiteJetpack extends React.Component {
 					<PluginUpdateIndicator
 						site={ this.props.site }
 						plugin={ this.props.plugin }
-						notices={ this.props.notices }
 						expanded={ false }
 					/>
 				}
@@ -97,7 +95,6 @@ class PluginSiteJetpack extends React.Component {
 					<PluginUpdateIndicator
 						site={ this.props.site }
 						plugin={ this.props.plugin }
-						notices={ this.props.notices }
 						expanded={ true }
 					/>
 				}

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -23,7 +23,6 @@ import './style.scss';
 
 export class PluginSiteList extends Component {
 	static propTypes = {
-		notices: PropTypes.object,
 		plugin: PropTypes.object,
 		sites: PropTypes.array,
 		sitesWithSecondarySites: PropTypes.array,
@@ -45,7 +44,6 @@ export class PluginSiteList extends Component {
 				secondarySites={ this.getSecondaryPluginSites( site, secondarySites ) }
 				plugin={ this.props.plugin }
 				wporg={ this.props.wporg }
-				notices={ this.props.notices }
 			/>
 		);
 	}

--- a/client/my-sites/plugins/plugin-site-network/index.jsx
+++ b/client/my-sites/plugins/plugin-site-network/index.jsx
@@ -31,7 +31,6 @@ class PluginSiteNetwork extends React.Component {
 	static propTypes = {
 		site: PropTypes.object,
 		plugin: PropTypes.object,
-		notices: PropTypes.object,
 		secondarySites: PropTypes.array,
 	};
 
@@ -99,7 +98,6 @@ class PluginSiteNetwork extends React.Component {
 					<PluginUpdateIndicator
 						site={ this.props.site }
 						plugin={ this.props.plugin }
-						notices={ this.props.notices }
 						expanded={ false }
 					/>
 				}
@@ -107,7 +105,6 @@ class PluginSiteNetwork extends React.Component {
 					<PluginUpdateIndicator
 						site={ this.props.site }
 						plugin={ this.props.plugin }
-						notices={ this.props.notices }
 						expanded={ true }
 					/>
 				}

--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -12,8 +12,9 @@ import React from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import Gridicon from 'calypso/components/gridicon';
-import { updatePlugin } from 'calypso/state/plugins/installed/actions';
+import { getPluginStatusesByType } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
+import { updatePlugin } from 'calypso/state/plugins/installed/actions';
 
 /**
  * Style dependencies
@@ -29,7 +30,6 @@ class PluginSiteUpdateIndicator extends React.Component {
 			ID: PropTypes.number.isRequired,
 		} ),
 		plugin: PropTypes.shape( { slug: PropTypes.string } ),
-		notices: PropTypes.object.isRequired,
 		expanded: PropTypes.bool,
 	};
 
@@ -53,8 +53,9 @@ class PluginSiteUpdateIndicator extends React.Component {
 	};
 
 	getOngoingUpdates = () => {
-		return this.props.notices.inProgress.filter(
-			( log ) => log.site.ID === this.props.site.ID && log.action === 'UPDATE_PLUGIN'
+		return this.props.inProgressStatuses.filter(
+			( status ) =>
+				parseInt( status.siteId ) === this.props.site.ID && status.action === 'UPDATE_PLUGIN'
 		);
 	};
 
@@ -69,7 +70,7 @@ class PluginSiteUpdateIndicator extends React.Component {
 
 		if ( isUpdating ) {
 			message = this.props.translate( 'Updating to version %(version)s', {
-				args: { version: ongoingUpdates[ 0 ].plugin.update.new_version },
+				args: { version: this.props.site.plugin.update.new_version },
 			} );
 		} else {
 			message = this.props.translate( 'Update to %(version)s', {
@@ -115,6 +116,9 @@ class PluginSiteUpdateIndicator extends React.Component {
 	}
 }
 
-export default connect( null, { removePluginStatuses, updatePlugin } )(
-	localize( PluginSiteUpdateIndicator )
-);
+export default connect(
+	( state ) => ( {
+		inProgressStatuses: getPluginStatusesByType( state, 'inProgress' ),
+	} ),
+	{ removePluginStatuses, updatePlugin }
+)( localize( PluginSiteUpdateIndicator ) );

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -255,7 +255,6 @@ const SinglePlugin = createReactClass( {
 					} ) }
 					sites={ this.state.sites }
 					plugin={ plugin }
-					notices={ this.state.notices }
 				/>
 				{ plugin.wporg && (
 					<PluginSiteList
@@ -265,7 +264,6 @@ const SinglePlugin = createReactClass( {
 						} ) }
 						sites={ this.state.notInstalledSites }
 						plugin={ plugin }
-						notices={ this.state.notices }
 					/>
 				) }
 			</div>

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -33,6 +33,7 @@ import {
 	removePlugin,
 	updatePlugin,
 } from 'calypso/state/plugins/installed/actions';
+import { getPluginStatusesByType } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 
 /**
@@ -101,7 +102,8 @@ export const PluginsList = createReactClass( {
 		if ( ! isEqual( this.state.selectedPlugins, nextState.selectedPlugins ) ) {
 			return true;
 		}
-		if ( this.shouldComponentUpdateNotices( this.state.notices, nextState.notices ) ) {
+
+		if ( ! isEqual( this.props.inProgressStatuses, nextProps.inProgressStatuses ) ) {
 			return true;
 		}
 
@@ -426,7 +428,7 @@ export const PluginsList = createReactClass( {
 	showDisconnectDialog() {
 		const { translate } = this.props;
 
-		if ( this.state.disconnectJetpackDialog && ! this.state.notices.inProgress.length ) {
+		if ( this.state.disconnectJetpackDialog && ! this.props.inProgressStatuses.length ) {
 			this.setState( {
 				disconnectJetpackDialog: false,
 			} );
@@ -541,8 +543,8 @@ export const PluginsList = createReactClass( {
 				key={ plugin.slug }
 				plugin={ plugin }
 				sites={ plugin.sites }
-				progress={ this.state.notices.inProgress.filter(
-					( log ) => log.plugin.slug === plugin.slug
+				progress={ this.props.inProgressStatuses.filter(
+					( status ) => status.pluginId === plugin.id
 				) }
 				isSelected={ this.isSelected( plugin ) }
 				isSelectable={ isSelectable }
@@ -565,9 +567,11 @@ export const PluginsList = createReactClass( {
 export default connect(
 	( state ) => {
 		const selectedSite = getSelectedSite( state );
+
 		return {
 			selectedSite,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
+			inProgressStatuses: getPluginStatusesByType( state, 'inProgress' ),
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, get( selectedSite, 'ID' ) ),
 		};
 	},

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -49,6 +49,7 @@ describe( 'PluginsList', () => {
 				selectedSite: sites[ 0 ],
 				isPlaceholder: false,
 				pluginUpdateCount: plugins.length,
+				inProgressStatuses: [],
 			};
 		} );
 

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -6,6 +6,7 @@ import { every, filter, find, get, pick, reduce, some, sortBy, values } from 'lo
 /**
  * Internal dependencies
  */
+import createSelector from 'calypso/lib/create-selector';
 import {
 	getSite,
 	getSiteTitle,
@@ -185,3 +186,31 @@ export function isPluginActionStatus( state, siteId, pluginId, action, status ) 
 export function isPluginActionInProgress( state, siteId, pluginId, action ) {
 	return isPluginActionStatus( state, siteId, pluginId, action, 'inProgress' );
 }
+
+/**
+ * Retrieve all plugin statuses of a certain type.
+ *
+ * @param  {object} state    Global state tree
+ * @param  {string} status   Status of interest
+ * @returns {Array}          Array of plugin status objects
+ */
+export const getPluginStatusesByType = createSelector(
+	( state, status ) => {
+		const statuses = [];
+
+		Object.entries( state.plugins.installed.status ).map( ( [ siteId, siteStatuses ] ) => {
+			Object.entries( siteStatuses ).map( ( [ pluginId, pluginStatus ] ) => {
+				if ( pluginStatus.status === status ) {
+					statuses.push( {
+						...pluginStatus,
+						siteId,
+						pluginId,
+					} );
+				}
+			} );
+		} );
+
+		return statuses;
+	},
+	( state ) => state.plugins.installed.status
+);

--- a/client/state/plugins/installed/test/selectors.js
+++ b/client/state/plugins/installed/test/selectors.js
@@ -402,4 +402,21 @@ describe( 'Installed plugin selectors', () => {
 			).to.be.true;
 		} );
 	} );
+
+	describe( 'getPluginStatusesByType', () => {
+		test( 'Should return a list of all plugin statuses, and add siteId and pluginId to each status.', () => {
+			expect( selectors.getPluginStatusesByType( state, 'completed' ) ).to.deep.equal( [
+				{
+					siteId: 'site.one',
+					pluginId: 'jetpack/jetpack',
+					action: DEACTIVATE_PLUGIN,
+					status: 'completed',
+				},
+			] );
+		} );
+
+		test( 'Should return an empty array if there are no matching statuses of that type.', () => {
+			expect( selectors.getPluginStatusesByType( state, 'someOtherType' ) ).to.eql( [] );
+		} );
+	} );
 } );


### PR DESCRIPTION
`PluginsList` and `SinglePlugin` are currently using `createReactClass` and the only reason for that is that they're using the `PluginNotices` mixin. That mixin relies on both event emitter and flux patterns, so we have to remove it and refactor it to a component.

Converting the mixin to a composable component should be pretty trivial on its own, but first, we need to untangle any usage of mixin functionality in those 2 major components. Luckily, the mixin itself isn't directly used in a lot of places, and instead is being relied on mostly passively. 

So, this PR introduces a new `getPluginStatusesByType` selector that allows us to retrieve plugin statuses by a certain type (`success`, `error` or `inProgress`), which mostly mirrors what the mixin is currently providing. We're simplifying it, too - the mixin contains the entire site object and the entire plugin object, but in our new selector we only provide the site ID and plugin ID, to avoid any duplication and stale data. We're also adding some tests to this new selector.

Furthermore, we're untangling any `this.state.notices` and `this.shouldComponentUpdateNotices`, which are the only directly accessed mixin features. We're refactoring those to use the new selector and data from Redux instead.

As a next step, we'll be able to convert the plugin notices mixin to a component, and consequently, refactor `PluginsList` and `SinglePlugin` away from their `createReactClass` usage.

This PR is part of #24180.

#### Changes proposed in this Pull Request

* State: Introduce a `getPluginStatusesByType` selector
* Plugins: Untangle `PluginNotices` direct mixin usage from `PluginsList`
* Plugins: Untangle `PluginNotices` direct mixin usage from `SinglePlugin`

#### Testing instructions

* Get a Jetpack site with some plugins for testing.
* Compare against production and verify that global notices and inline notices in plugin items still work the same way when updating, installing, or removing plugins, as well as toggling auto-updates and enabling/disabling plugins:
  * `/plugins/:plugin/:site`
  * `/plugins/:plugin`
  * `/plugins`
  * `/plugins/manage/:site` - for a single plugin
  * `/plugins/manage/:site` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
* Make sure to specifically test this case:
  * `/plugins/:plugin` and make sure you have a site that's running an old version of the plugin. While updating it from the "Installed in" card, make sure that status is being reflected correctly and notices appear correctly.
* Verify all tests pass.

#### Notes

Linting errors are expected - there are a couple of them in a file we touched. I'm not fixing them here to avoid making the PR extra large.