### PR TITLE
Shopping Cart: Use import type where it should.

### DIFF
--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getEmptyResponseCart } from './empty-carts';
-import { TempResponseCart } from './shopping-cart-endpoint';
+import type { TempResponseCart } from './shopping-cart-endpoint';
 import type {
 	CartLocation,
 	RequestCart,

--- a/packages/shopping-cart/src/create-request-cart-product.ts
+++ b/packages/shopping-cart/src/create-request-cart-product.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { RequestCartProduct } from './shopping-cart-endpoint';
+import type { RequestCartProduct } from './shopping-cart-endpoint';
 
 export default function createRequestCartProduct(
 	properties: Partial< RequestCartProduct > &

--- a/packages/shopping-cart/src/shopping-cart-context.ts
+++ b/packages/shopping-cart/src/shopping-cart-context.ts
@@ -6,7 +6,7 @@ import { createContext } from 'react';
 /**
  * Internal dependencies
  */
-import { ShoppingCartManager } from './types';
+import type { ShoppingCartManager } from './types';
 
 const ShoppingCartContext = createContext< ShoppingCartManager | undefined >( undefined );
 export default ShoppingCartContext;

--- a/packages/shopping-cart/src/shopping-cart-provider.tsx
+++ b/packages/shopping-cart/src/shopping-cart-provider.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { RequestCart, ResponseCart } from './types';
+import type { RequestCart, ResponseCart } from './types';
 import useShoppingCartManager from './use-shopping-cart-manager';
 import ShoppingCartContext from './shopping-cart-context';
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
+import type {
 	TempResponseCart,
 	ResponseCart,
 	RequestCart,

--- a/packages/shopping-cart/src/use-cart-update-and-revalidate.ts
+++ b/packages/shopping-cart/src/use-cart-update-and-revalidate.ts
@@ -11,7 +11,7 @@ import {
 	convertResponseCartToRequestCart,
 	convertRawResponseCartToResponseCart,
 } from './cart-functions';
-import {
+import type {
 	TempResponseCart,
 	RequestCart,
 	ResponseCart,

--- a/packages/shopping-cart/src/use-initialize-cart-from-server.ts
+++ b/packages/shopping-cart/src/use-initialize-cart-from-server.ts
@@ -8,7 +8,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { convertRawResponseCartToResponseCart } from './cart-functions';
-import { ResponseCart, RequestCart, CacheStatus, ShoppingCartAction } from './types';
+import type { ResponseCart, RequestCart, CacheStatus, ShoppingCartAction } from './types';
 
 const debug = debugFactory( 'shopping-cart:use-initialize-cart-from-server' );
 

--- a/packages/shopping-cart/src/use-shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-reducer.ts
@@ -18,7 +18,7 @@ import {
 	doesCartLocationDifferFromResponseCartLocation,
 	doesResponseCartContainProductMatching,
 } from './cart-functions';
-import { ResponseCart, ShoppingCartState, ShoppingCartAction, CouponStatus } from './types';
+import type { ResponseCart, ShoppingCartState, ShoppingCartAction, CouponStatus } from './types';
 import { getEmptyResponseCart } from './empty-carts';
 
 const debug = debugFactory( 'shopping-cart:use-shopping-cart-reducer' );

--- a/packages/shopping-cart/src/use-shopping-cart.ts
+++ b/packages/shopping-cart/src/use-shopping-cart.ts
@@ -6,7 +6,7 @@ import { useContext } from 'react';
 /**
  * Internal dependencies
  */
-import { ShoppingCartManager } from './types';
+import type { ShoppingCartManager } from './types';
 import ShoppingCartContext from './shopping-cart-context';
 
 export default function useShoppingCart(): ShoppingCartManager {

--- a/packages/shopping-cart/tsconfig.json
+++ b/packages/shopping-cart/tsconfig.json
@@ -27,6 +27,7 @@
 		"typeRoots": [ "../../node_modules/@types" ],
 		"types": [],
 
+		"importsNotUsedAsValues": "error",
 		"importHelpers": true,
 		"composite": true,
 		"tsBuildInfoFile": "../../.tsc-cache/packages__shopping-cart"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `import type` where it should in `packages/shopping-cart`.
* Add `"importsNotUsedAsValues": "error"` to `packages/shoping-cart/tsconfig.json`.

**Some context:**
`packages/launch` has this `"importsNotUsedAsValues": "error"` configured in the `tsconfig.json`, and we're importing from `packages/shopping-cart`, and our compilation breaks when we do so.

![image](https://user-images.githubusercontent.com/1287077/101057983-5527c100-3595-11eb-82c4-3c4057c4f0aa.png)

#### Testing instructions

Run the following command:
* `cd packages/shopping-cart`
* `yarn build`
* It should not produce any TS compilation error.

Test if it breaks:
* Modify one of the files changes here by renaming `import type` back to `import`.
* Rerun the build command above.
* It should break.
