### PR TITLE
Modularise notificationsUnseenCount state

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -32,7 +32,7 @@ import config from 'calypso/config';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentLocaleVariant from 'calypso/state/selectors/get-current-locale-variant';
-import { setUnseenCount } from 'calypso/state/notifications';
+import { setUnseenCount } from 'calypso/state/notifications/actions';
 import { shouldForceRefresh } from 'calypso/state/notifications-panel/selectors';
 import { didForceRefresh } from 'calypso/state/notifications-panel/actions';
 

--- a/client/state/notifications/actions.js
+++ b/client/state/notifications/actions.js
@@ -3,8 +3,7 @@
  */
 import { NOTIFICATIONS_UNSEEN_COUNT_SET } from 'calypso/state/action-types';
 
-export const unseenCount = ( state = null, action ) =>
-	NOTIFICATIONS_UNSEEN_COUNT_SET === action.type ? action.unseenCount : state;
+import 'calypso/state/notifications/init';
 
 export const setUnseenCount = ( count ) => ( {
 	type: NOTIFICATIONS_UNSEEN_COUNT_SET,

--- a/client/state/notifications/init.js
+++ b/client/state/notifications/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'notificationsUnseenCount' ], reducer );

--- a/client/state/notifications/package.json
+++ b/client/state/notifications/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/notifications/reducer.js
+++ b/client/state/notifications/reducer.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { NOTIFICATIONS_UNSEEN_COUNT_SET } from 'calypso/state/action-types';
+import { withStorageKey } from 'calypso/state/utils';
+
+const unseenCount = ( state = null, action ) =>
+	NOTIFICATIONS_UNSEEN_COUNT_SET === action.type ? action.unseenCount : state;
+
+export default withStorageKey( 'notificationsUnseenCount', unseenCount );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -25,7 +25,6 @@ import inlineSupportArticle from './inline-support-article/reducer';
 import jitm from './jitm/reducer';
 import mySites from './my-sites/reducer';
 import notices from './notices/reducer';
-import { unseenCount as notificationsUnseenCount } from './notifications';
 import selectedEditor from './selected-editor/reducer';
 import sites from './sites/reducer';
 import support from './support/reducer';
@@ -48,7 +47,6 @@ const reducers = {
 	jitm,
 	mySites,
 	notices,
-	notificationsUnseenCount,
 	selectedEditor,
 	sites,
 	support,

--- a/client/state/selectors/get-notification-unseen-count.js
+++ b/client/state/selectors/get-notification-unseen-count.js
@@ -1,2 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/notifications/init';
+
 export default ( state ) =>
 	undefined === state.notificationsUnseenCount ? null : state.notificationsUnseenCount;


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles notifications (unseen count) state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42462.

#### Changes proposed in this Pull Request

* Modularise notifications state
* Refactor notifications state into separate files for reducer and action creator

#### Testing instructions

Unfortunately, `notificationsUnseenCount` state gets loaded pretty early on in the boot process, through `Layout`. As such, it's not easy to test the automated loading process, but it should be enough to smoke-test notification functionality in order to ensure that it continues to work correctly.
