### PR TITLE
Adds settings URL for backup timezone mismatch notice

### DIFF
--- a/client/blocks/time-mismatch-warning/docs/example.tsx
+++ b/client/blocks/time-mismatch-warning/docs/example.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { TimeMismatchWarning } from 'calypso/blocks/time-mismatch-warning';
 
 const TimeMismatchWarningExample = () => {
-	return <TimeMismatchWarning siteId={ 1 } />;
+	return <TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" />;
 };
 TimeMismatchWarningExample.displayName = 'TimeMismatchWarning';
 

--- a/client/blocks/time-mismatch-warning/index.tsx
+++ b/client/blocks/time-mismatch-warning/index.tsx
@@ -17,13 +17,13 @@ import { savePreference } from 'calypso/state/preferences/actions';
 interface ExternalProps {
 	status?: string;
 	siteId: number | null;
-	settingsUrl?: string;
+	settingsUrl: string;
 }
 
 export const TimeMismatchWarning: FC< ExternalProps > = ( {
 	status = 'is-warning',
 	siteId,
-	settingsUrl = '#',
+	settingsUrl,
 }: ExternalProps ) => {
 	const dismissPreference = `time-mismatch-warning-${ siteId }`;
 
@@ -39,6 +39,7 @@ export const TimeMismatchWarning: FC< ExternalProps > = ( {
 	if (
 		! siteId ||
 		! hasPreferences ||
+		! settingsUrl ||
 		isDismissed ||
 		siteOffset === null ||
 		userOffset === siteOffset

--- a/client/blocks/time-mismatch-warning/test/index.jsx
+++ b/client/blocks/time-mismatch-warning/test/index.jsx
@@ -45,25 +45,36 @@ describe( 'TimeMismatchWarning', () => {
 	} );
 
 	test( 'to render nothing if no site ID is provided', () => {
-		const wrapper = shallow( <TimeMismatchWarning /> );
+		const wrapper = shallow( <TimeMismatchWarning settingsUrl="https://example.com" /> );
+		expect( wrapper.isEmptyRender() ).toBeTruthy();
+	} );
+
+	test( 'to render nothing if no settings URL is provided', () => {
+		const wrapper = shallow( <TimeMismatchWarning siteId={ 1 } /> );
 		expect( wrapper.isEmptyRender() ).toBeTruthy();
 	} );
 
 	test( 'to render nothing if times match', () => {
-		const wrapper = shallow( <TimeMismatchWarning siteId={ 1 } /> );
+		const wrapper = shallow(
+			<TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" />
+		);
 		expect( wrapper.isEmptyRender() ).toBeTruthy();
 	} );
 
 	test( 'to render nothing if the user preference is dismissed', () => {
 		getSiteGmtOffset.mockReturnValueOnce( 10 );
 		getPreference.mockReturnValueOnce( () => true );
-		const wrapper = shallow( <TimeMismatchWarning siteId={ 1 } /> );
+		const wrapper = shallow(
+			<TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" />
+		);
 		expect( wrapper.isEmptyRender() ).toBeTruthy();
 	} );
 
 	test( 'to render if GMT offsets do not match', () => {
 		getSiteGmtOffset.mockReturnValueOnce( 10 );
-		const wrapper = shallow( <TimeMismatchWarning siteId={ 1 } /> );
+		const wrapper = shallow(
+			<TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" />
+		);
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
@@ -77,7 +88,9 @@ describe( 'TimeMismatchWarning', () => {
 
 	test( 'to render the status if set', () => {
 		getSiteGmtOffset.mockReturnValueOnce( 10 );
-		const wrapper = shallow( <TimeMismatchWarning siteId={ 1 } status="is-error" /> );
+		const wrapper = shallow(
+			<TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" status="is-error" />
+		);
 		expect( wrapper.dive().prop( 'className' ) ).toEqual( 'is-error' );
 	} );
 
@@ -85,7 +98,9 @@ describe( 'TimeMismatchWarning', () => {
 		const dispatch = jest.fn( () => null );
 		useDispatch.mockReturnValueOnce( dispatch );
 		getSiteGmtOffset.mockReturnValueOnce( 10 );
-		const wrapper = shallow( <TimeMismatchWarning siteId={ 1 } /> );
+		const wrapper = shallow(
+			<TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" />
+		);
 		const onDismissClick = wrapper.prop( 'onDismissClick' );
 		onDismissClick();
 		expect( dispatch ).toHaveBeenCalled();

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -18,6 +18,7 @@ import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
+import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryRewindCapabilities from 'calypso/components/data/query-rewind-capabilities';
@@ -46,6 +47,7 @@ import './style.scss';
 
 const BackupPage = ( { queryDate } ) => {
 	const siteId = useSelector( getSelectedSiteId );
+	const siteSettingsUrl = useSelector( ( state ) => getSettingsUrl( state, siteId, 'general' ) );
 
 	const moment = useLocalizedMoment();
 	const parsedQueryDate = queryDate ? moment( queryDate, INDEX_FORMAT ) : moment();
@@ -63,7 +65,7 @@ const BackupPage = ( { queryDate } ) => {
 				} ) }
 			>
 				<SidebarNavigation />
-				<TimeMismatchWarning siteId={ siteId } />
+				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
 				{ ! isJetpackCloud() && (
 					<FormattedHeader headerText="Jetpack Backup" align="left" brandFont />
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the correct settings link for timezone mismatch notice in the backups page.
* Makes settings URL prop not optional going forward. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get a site with backups.
* Change the timezone to different from yours.
* Go to backups page in Calypso (blue or green).
* Check whether link in notice goes anywhere.

Fixes 1164141197617539-as-1199518262884253.