### PR TITLE
Editing Toolkit: Update to 2.8.11

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.10
+ * Version: 2.8.11
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.10' );
+define( 'PLUGIN_VERSION', '2.8.11' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.10
+Stable tag: 2.8.11
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.11 =
+* Focused Launch: Add persistent success view after launch (https://github.com/Automattic/wp-calypso/pull/47808)
+* Focused Launch: Implement step highlighting logic (https://github.com/Automattic/wp-calypso/pull/#47503)
 
 = 2.8.10 =
 * Premium Content: Fix selection of payment plans (https://github.com/Automattic/wp-calypso/pull/47944)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -41,6 +41,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 2.8.11 =
+* Focused Launch: Render selected popular plan only once (https://github.com/Automattic/wp-calypso/pull/47913)
+* Patterns: fix PHP notice about undefined offset in can_register_pattern (https://github.com/Automattic/wp-calypso/pull/48025)
+* Focused Launch: Get selected domain and plan from cart if available (https://github.com/Automattic/wp-calypso/pull/47987)
 * Focused Launch: Add persistent success view after launch (https://github.com/Automattic/wp-calypso/pull/47808)
 * Focused Launch: Implement step highlighting logic (https://github.com/Automattic/wp-calypso/pull/#47503)
 

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.10",
+	"version": "2.8.11",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bumps version of Editing Toolkit to 2.8.11

#### [Changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)

* Patterns: fix PHP notice about undefined offset in can_register_pattern (#48025)
* Focused Launch: Implement step highlighting logic (#47503)
* Focused Launch: Add persistent success view after launch (#47808)
* Editing Toolkit: pin wp-env version (#47979)

#### Other [changes](https://github.com/Automattic/wp-calypso/commits/trunk/packages) included from the [imported @automattic packages](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/tsconfig.json#L37-L46) and their imports

* Focused launch: fix wrong number of domain items while loading (#48036)
* Focused launch: fix not selectable subdomain (#48035)
* Focused Launch: Render selected popular plan once (#47913)
* Focused Launch: Get selected domain from cart if available. (#47987)
* Shopping cart: replace existing cart for renewals whenever any product is added (#47978)
* Shopping Cart: Use import type where it should. (#48005)

#### Testing instructions

1. Load the diff on your sandbox (D53735-code) and confirm that the above changes work correctly
2. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.