### PR TITLE
Updating name of feature flag for anchor.fm project

### DIFF
--- a/client/lib/features-helper/feature-list.js
+++ b/client/lib/features-helper/feature-list.js
@@ -15,7 +15,7 @@ const enabledClass = 'features-helper__feature-item-enabled';
 const disabledClass = 'features-helper__feature-item-disabled';
 
 export const FeatureList = React.memo( () => {
-	const currentXLProjects = [ 'anchor-fm', 'nav-unification' ];
+	const currentXLProjects = [ 'anchor-fm-dev', 'nav-unification' ];
 	const enabledFeatures = config.enabledFeatures();
 	return (
 		<>

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -18,7 +18,7 @@
 	"features": {
 		"ad-tracking": true,
 		"always_use_logout_url": true,
-		"anchor-fm": false,
+		"anchor-fm-dev": false,
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -14,7 +14,7 @@
 	"features": {
 		"ad-tracking": true,
 		"always_use_logout_url": true,
-		"anchor-fm": false,
+		"anchor-fm-dev": false,
 		"async-payments": false,
 		"blogger-plan": false,
 		"catch-js-errors": false,

--- a/config/development.json
+++ b/config/development.json
@@ -29,7 +29,7 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
-		"anchor-fm": true,
+		"anchor-fm-dev": true,
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -14,7 +14,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"anchor-fm": false,
+		"anchor-fm-dev": false,
 		"automated-transfer": true,
 		"async-payments": false,
 		"ad-tracking": false,

--- a/config/production.json
+++ b/config/production.json
@@ -15,7 +15,7 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": true,
-		"anchor-fm": false,
+		"anchor-fm-dev": false,
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -16,7 +16,7 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
-		"anchor-fm": false,
+		"anchor-fm-dev": false,
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,

--- a/config/test.json
+++ b/config/test.json
@@ -26,7 +26,7 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
-		"anchor-fm": false,
+		"anchor-fm-dev": false,
 		"async-payments": false,
 		"blogger-plan": false,
 		"calypsoify/plugins": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -17,7 +17,7 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
-		"anchor-fm": false,
+		"anchor-fm-dev": false,
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates references to the `anchor-fm` feature flag to be called `anchor-fm-dev` instead, so we can use the `anchor-fm` sticker as a indicator of real users of the feature in future. (See discussion in 345-gh-Automattic/dotcom-manage)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A