### PR TITLE
Revert "Billing: Fix - Purchase plan details stuck in loading state."

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -25,7 +25,6 @@ import {
 import { isDataLoading } from 'calypso/me/purchases/utils';
 import {
 	getByPurchaseId,
-	hasLoadedSitePurchasesFromServer,
 	hasLoadedUserPurchasesFromServer,
 	getIncludedDomainPurchase,
 } from 'calypso/state/purchases/selectors';
@@ -239,12 +238,9 @@ class CancelPurchase extends React.Component {
 
 export default connect( ( state, props ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
-	const siteId = purchase ? purchase.siteId : null;
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
-		hasLoadedPurchasesFromServer: siteId
-			? hasLoadedSitePurchasesFromServer( state )
-			: hasLoadedUserPurchasesFromServer( state ),
+		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		purchase,
 		includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
 		site: getSite( state, purchase ? purchase.siteId : null ),

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -19,7 +19,6 @@ import PlanBillingPeriod from './billing-period';
 import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
 import {
 	getByPurchaseId,
-	hasLoadedSitePurchasesFromServer,
 	hasLoadedUserPurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
 import { isDataLoading } from 'calypso/me/purchases/utils';
@@ -41,7 +40,7 @@ export class PurchasePlanDetails extends Component {
 		// Connected props
 		purchase: PropTypes.object,
 		hasLoadedSites: PropTypes.bool,
-		hasLoadedPurchasesFromServer: PropTypes.bool,
+		hasLoadedUserPurchasesFromServer: PropTypes.bool,
 		pluginList: PropTypes.arrayOf(
 			PropTypes.shape( {
 				slug: PropTypes.string.isRequired,
@@ -124,16 +123,14 @@ export class PurchasePlanDetails extends Component {
 	}
 }
 
-// hasLoadedSites & hasLoadedPurchasesFromServer are used in isDataLoading
+// hasLoadedSites & hasLoadedUserPurchasesFromServer are used in isDataLoading
 export default connect( ( state, props ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
 	const siteId = purchase ? purchase.siteId : null;
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
 		site: purchase ? getSite( state, purchase.siteId ) : null,
-		hasLoadedPurchasesFromServer: siteId
-			? hasLoadedSitePurchasesFromServer( state )
-			: hasLoadedUserPurchasesFromServer( state ),
+		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		purchase,
 		pluginList: getPluginsForSite( state, siteId ),
 		siteId,

--- a/client/me/purchases/manage-purchase/plan-details/test/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/index.jsx
@@ -23,7 +23,7 @@ const props = {
 		expiryStatus: 'active',
 	},
 	hasLoadedSites: true,
-	hasLoadedPurchasesFromServer: true,
+	hasLoadedUserPurchasesFromServer: true,
 	pluginList: [
 		{
 			slug: 'vaultpress',

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -11,7 +11,7 @@ import {
 import { isDomainTransfer } from 'calypso/lib/products-values';
 
 function isDataLoading( props ) {
-	return ! props.hasLoadedSites || ! props.hasLoadedPurchasesFromServer;
+	return ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;
 }
 
 function canEditPaymentDetails( purchase ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#47982

This prevents cancelling domains.

1. Buy a domain.
1. Go to Manage Purchases and click through to cancel/refund.
1. Screen hangs (and it looks like Calypso isn't even sending off any API requests to do the cancellation).

Fixes https://github.com/Automattic/wp-calypso/issues/48021