### PR TITLE
Patterns: fix PHP notice about undefined offset in can_register_pattern

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -173,7 +173,7 @@ class Block_Patterns_From_API {
 			$split_slug = preg_split( '/^requires-/', $tag_slug );
 
 			// If the theme does not support the matched feature, then skip registering the pattern.
-			if ( $split_slug[1] && false === get_theme_support( $split_slug[1] ) ) {
+			if ( isset( $split_slug[1] ) && false === get_theme_support( $split_slug[1] ) ) {
 				return false;
 			}
 		}


### PR DESCRIPTION


#### Changes proposed in this Pull Request

* Add `isset` check before attempting to access the index on `$split_slug` in `can_register_pattern` to prevent a `PHP Notice: Undefined offset`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the diff associated with this PR and check that the "5am, the beach" pattern is still hidden on sites with the Hemingway Rewritten theme activated (testing steps in #47571)

Fixes a PHP notice introduced in #47571 
