### PR TITLE
Onboarding: Don't use site title as default domain query if it'll just error

### DIFF
--- a/client/landing/gutenboarding/lib/is-good-default-domain-query.ts
+++ b/client/landing/gutenboarding/lib/is-good-default-domain-query.ts
@@ -1,0 +1,19 @@
+/**
+ * The domain search API will return an error for certain queries. This helper
+ * pre-emptively guesses whether a given string will return an error result.
+ * Useful for deciding whether a string is a good default domain query.
+ *
+ * @param domainQuery string to check
+ */
+export function isGoodDefaultDomainQuery( domainQuery: string ): boolean {
+	if ( typeof domainQuery.normalize === 'undefined' ) {
+		// If the browser doesn't support String.prototype.normalize then
+		// play it safe and assume this isn't a safe domain query.
+		return false;
+	}
+
+	return !! domainQuery
+		.normalize( 'NFD' ) // Encode diacritics in a consistent way so we can remove them
+		.replace( /[\u0300-\u036f]/g, '' )
+		.match( /[a-z0-9-.\s]/i );
+}

--- a/client/landing/gutenboarding/lib/test/is-good-default-domain-query.ts
+++ b/client/landing/gutenboarding/lib/test/is-good-default-domain-query.ts
@@ -1,0 +1,38 @@
+/**
+ * Internal dependencies
+ */
+import { isGoodDefaultDomainQuery } from '../is-good-default-domain-query';
+
+describe( 'isValidDomainQuery', () => {
+	it( 'rejects empty queries', () => {
+		expect( isGoodDefaultDomainQuery( '' ) ).toBe( false );
+	} );
+
+	it( 'accepts an English domain name', () => {
+		expect( isGoodDefaultDomainQuery( 'example.com' ) ).toBe( true );
+	} );
+
+	it( 'accepts an uppercase English domain name', () => {
+		expect( isGoodDefaultDomainQuery( 'EXAMPLE.COM' ) ).toBe( true );
+	} );
+
+	it( 'accepts a query with only letters that have diacritics that the server will strip', () => {
+		expect( isGoodDefaultDomainQuery( 'Ďîàçŕïţíćś ôñłÿ' ) ).toBe( true );
+	} );
+
+	it( 'accepts all "latin" characters with one letter having a diacritic', () => {
+		expect( isGoodDefaultDomainQuery( 'tohutō' ) ).toBe( true );
+	} );
+
+	it( 'rejects query with all Arabic characters', () => {
+		expect( isGoodDefaultDomainQuery( 'الأبجدية' ) ).toBe( false );
+	} );
+
+	it( 'accepts a query with half latin and half Arabic characters', () => {
+		expect( isGoodDefaultDomainQuery( 'half english and half عربى' ) ).toBe( true );
+	} );
+
+	it( 'rejects emoji', () => {
+		expect( isGoodDefaultDomainQuery( '🐢' ) ).toBe( false );
+	} );
+} );

--- a/client/landing/gutenboarding/lib/test/is-good-default-domain-query.ts
+++ b/client/landing/gutenboarding/lib/test/is-good-default-domain-query.ts
@@ -17,7 +17,7 @@ describe( 'isValidDomainQuery', () => {
 	} );
 
 	it( 'accepts a query with only letters that have diacritics that the server will strip', () => {
-		expect( isGoodDefaultDomainQuery( 'Ďîàçŕïţíćś ôñłÿ' ) ).toBe( true );
+		expect( isGoodDefaultDomainQuery( 'Ďîàçŕïţíćś' ) ).toBe( true );
 	} );
 
 	it( 'accepts all "latin" characters with one letter having a diacritic', () => {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -18,6 +18,7 @@ import { useTrackStep } from '../../hooks/use-track-step';
 import useStepNavigation from '../../hooks/use-step-navigation';
 import { recordVerticalSkip, recordSiteTitleSkip } from '../../lib/analytics';
 import Arrow from './arrow';
+import { isGoodDefaultDomainQuery } from '../../lib/is-good-default-domain-query';
 
 /**
  * Style dependencies
@@ -70,7 +71,7 @@ const AcquireIntent: React.FunctionComponent = () => {
 	};
 
 	const handleSiteTitleSubmit = () => {
-		if ( hasSiteTitle() ) {
+		if ( hasSiteTitle() && isGoodDefaultDomainQuery( getSelectedSiteTitle() ) ) {
 			setDomainSearch( getSelectedSiteTitle() );
 		}
 		goNext();

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import type { State } from './reducer';
+import { isGoodDefaultDomainQuery } from '../../lib/is-good-default-domain-query';
 
 export const getIsRedirecting = ( state: State ) => state.isRedirecting;
 export const getPlan = ( state: State ) => state.plan;
@@ -31,4 +32,6 @@ export const wasVerticalSkipped = ( state: State ): boolean => state.wasVertical
 
 // Selectors dependent on other selectors (cannot be put in alphabetical order)
 export const getDomainSearch = ( state: State ) =>
-	state.domainSearch || getSelectedSiteTitle( state ) || getSelectedVertical( state )?.label;
+	state.domainSearch ||
+	( isGoodDefaultDomainQuery( getSelectedSiteTitle( state ) ) && getSelectedSiteTitle( state ) ) ||
+	getSelectedVertical( state )?.label;


### PR DESCRIPTION

We've been defaulting the domain query to the site title since it seems like a good place to start when looking for a domain. However the domain API returns an error for queries that only include "non-latin" characters, so if a site title is Japanese then the domain step will be in an error state as soon as the user navigates there.

An example of what the user might see when they navigate to the domain step:
<img width="909" alt="image" src="https://user-images.githubusercontent.com/1500769/101119783-f58eeb80-3650-11eb-8c33-2aaeefa0b6a4.png">
(also working on the incorrect network error here: #47985)

By not defaulting to the site title in this case the user will either:
- Type the site title themselves into the search box, in which case they'll get an error, but it'll make more sense given they've triggered it themselves
- Maybe they're going to try a traditional "latin-only" domain name anyway

#### Changes proposed in this Pull Request

* Add `isGoodDefaultDomainQuery` helper function
* Don't auto fill domain query with the site title if `isGoodDefaultDomainQuery` returns false

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the `/new` flow and experiment using the flow with and without valid site titles and seeing how the domain picker responds to this.
* We also have a domain picker in the in-editor launch flow, so make sure we don't have the same issue there

Partial #37665
