### PR TITLE
Add __experimentalBlockPatterns tests

### DIFF
--- a/test/e2e/specs/wp-gutenberg-experimental-data-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-data-spec.js
@@ -36,11 +36,11 @@ describe( `[${ host }] Experimental data we depend on is available (${ screenSiz
 	step(
 		`is iterable: wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns`,
 		async function () {
-			const __experimentalBlockPatternsArePresent = await driver.executeScript(
+			const __experimentalBlockPatternsAreIterable = await driver.executeScript(
 				`return Array.isArray( window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns )`
 			);
 			assert(
-				__experimentalBlockPatternsArePresent,
+				__experimentalBlockPatternsAreIterable,
 				'__experimentalBlockPatterns was not iterable, please contact #team-ganon to update premium pattern highlighting'
 			);
 		}

--- a/test/e2e/specs/wp-gutenberg-experimental-data-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-data-spec.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import assert from 'assert';
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import LoginFlow from '../lib/flows/login-flow.js';
+import * as driverManager from '../lib/driver-manager';
+import * as dataHelper from '../lib/data-helper';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+const gutenbergUser =
+	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
+
+let driver;
+
+before( async function () {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+} );
+
+describe( `[${ host }] Experimental data we depend on is available (${ screenSize })`, function () {
+	this.timeout( mochaTimeOut );
+
+	step( 'Can log in', async function () {
+		this.loginFlow = new LoginFlow( driver, gutenbergUser );
+		return await this.loginFlow.loginAndStartNewPost( null, true );
+	} );
+
+	step(
+		`is iterable: wp.data.select( 'core/editor' ).getEditorSettings().__missingExperimentalBlockPatterns exists`,
+		async function () {
+			const __missingExperimentalBlockPatternsArePresent = await driver.executeScript(
+				`return Array.isArray( window.wp.data.select( 'core/editor' ).getEditorSettings().___missingExperimentalBlockPatterns )`
+			);
+			assert(
+				__missingExperimentalBlockPatternsArePresent,
+				'___missingExperimentalBlockPatterns was not iterable, please contact #team-ganon to update premium pattern highlighting'
+			);
+		}
+	);
+
+	step(
+		`is iterable: wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns`,
+		async function () {
+			const __experimentalBlockPatternsArePresent = await driver.executeScript(
+				`return Array.isArray( window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns )`
+			);
+			assert(
+				__experimentalBlockPatternsArePresent,
+				'__experimentalBlockPatterns was not iterable, please contact #team-ganon to update premium pattern highlighting'
+			);
+		}
+	);
+
+	after( async () => {
+		return await driver.switchTo().defaultContent();
+	} );
+} );

--- a/test/e2e/specs/wp-gutenberg-experimental-data-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-data-spec.js
@@ -25,7 +25,7 @@ before( async function () {
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] Experimental data we depend on is available (${ screenSize })`, function () {
+describe( `[${ host }] Experimental data we depend on is available (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	step( 'Can log in', async function () {

--- a/test/e2e/specs/wp-gutenberg-experimental-data-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-data-spec.js
@@ -34,19 +34,6 @@ describe( `[${ host }] Experimental data we depend on is available (${ screenSiz
 	} );
 
 	step(
-		`is iterable: wp.data.select( 'core/editor' ).getEditorSettings().__missingExperimentalBlockPatterns exists`,
-		async function () {
-			const __missingExperimentalBlockPatternsArePresent = await driver.executeScript(
-				`return Array.isArray( window.wp.data.select( 'core/editor' ).getEditorSettings().___missingExperimentalBlockPatterns )`
-			);
-			assert(
-				__missingExperimentalBlockPatternsArePresent,
-				'___missingExperimentalBlockPatterns was not iterable, please contact #team-ganon to update premium pattern highlighting'
-			);
-		}
-	);
-
-	step(
 		`is iterable: wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns`,
 		async function () {
 			const __experimentalBlockPatternsArePresent = await driver.executeScript(


### PR DESCRIPTION
This PR adds tests to protect us from changes in the `__experimentalBlockPatterns` property in the `core/block-editor` store.

#### Testing instructions

Confirm that the "Experimental data we depend on is available" test runs in CircleCI. You might need to check the different parallel instances - it ran in instance 0 instance for me in https://app.circleci.com/pipelines/github/Automattic/wp-e2e-tests-for-branches/50269/workflows/dec8f9c0-6d24-4cf8-a605-08ccf417ba31/jobs/125866/parallel-runs/0?filterBy=ALL

If you want to re-trigger the tests, you can try removing and then re-adding the `Needs e2e Testing` or `Needs Review` labels - I think either will work.

Part of  #47896
