### PR TITLE
Focused launch: fix wrong number of domain items while loading

### DIFF
--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -177,7 +177,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 			( suggestion ) => suggestion.domain_name === currentDomain?.domain_name
 		);
 
-		if ( ! currentDomainIsInSuggestions ) {
+		if ( domainSuggestionsWithSubdomain?.length && ! currentDomainIsInSuggestions ) {
 			setPersistentSelectedDomain( currentDomain );
 		}
 	}, [ currentDomain, domainSuggestionsWithSubdomain ] );


### PR DESCRIPTION
**Note for ET release**: N/A (this PR is fixing a bug that hasn't been released yet)

#### Changes proposed in this Pull Request

* Domain picker should call `setPersistentSelectedDomain` only after `domainSuggestions` are loaded.

#### Testing instructions

* Open Focused Launch 
* Watch how domain suggestions are loading in both Domain step in Summary view and Domain Details view
* The placeholder items should match the rendered items as described in #47998

Fixes #47998
