### PR TITLE
Focused-Launch: Refactor Plan Summary Items rendering

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -302,6 +302,12 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 			? onceSelectedPaidPlan?.current
 			: undefined;
 
+	const allAvailablePlans: ( Plan | undefined )[] = [
+		defaultPaidPlan,
+		nonDefaultPaidPlan && onceSelectedPaidPlan.current,
+		defaultFreePlan,
+	];
+
 	return (
 		<SummaryStep
 			highlighted={ !! highlighted }
@@ -369,80 +375,44 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 							</span>
 						</p>
 						<div>
-							<FocusedLaunchSummaryItem
-								isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
-								onClick={ () => defaultPaidPlan && setPlan( defaultPaidPlan ) }
-								isSelected={ isPlanSelected( defaultPaidPlan ) }
-							>
-								<LeadingContentSide
-									label={
-										/* translators: %s is WordPress.com plan name (eg: Premium Plan) */
-										sprintf( __( '%s Plan', __i18n_text_domain__ ), defaultPaidPlan?.title ?? '' )
-									}
-									badgeText={
-										defaultPaidPlan?.isPopular ? __( 'Popular', __i18n_text_domain__ ) : ''
-									}
-								/>
-								<TrailingContentSide nodeType="PRICE">
-									<span>{ defaultPaidPlan && planPrices[ defaultPaidPlan?.storeSlug ] }</span>
-									<span>
-										{
-											// translators: /mo is short for "per-month"
-											__( '/mo', __i18n_text_domain__ )
-										}
-									</span>
-								</TrailingContentSide>
-							</FocusedLaunchSummaryItem>
-
-							{ nonDefaultPaidPlan && (
-								<FocusedLaunchSummaryItem
-									onClick={ () => setPlan( nonDefaultPaidPlan ) }
-									isSelected={ isPlanSelected( nonDefaultPaidPlan ) }
-								>
-									<LeadingContentSide
-										label={
-											/* translators: %s is WordPress.com plan name (eg: Premium Plan) */
-											sprintf(
-												__( '%s Plan', __i18n_text_domain__ ),
-												nonDefaultPaidPlan.title ?? ''
-											)
-										}
-										badgeText={
-											nonDefaultPaidPlan.isPopular ? __( 'Popular', __i18n_text_domain__ ) : ''
-										}
-									/>
-									<TrailingContentSide nodeType="PRICE">
-										<span>{ planPrices[ nonDefaultPaidPlan?.storeSlug ] }</span>
-										<span>
-											{
-												// translators: /mo is short for "per-month"
-												__( '/mo', __i18n_text_domain__ )
-											}
-										</span>
-									</TrailingContentSide>
-								</FocusedLaunchSummaryItem>
+							{ allAvailablePlans.map(
+								( plan ) =>
+									plan && (
+										<FocusedLaunchSummaryItem
+											isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
+											onClick={ () => plan && setPlan( plan ) }
+											isSelected={ plan && isPlanSelected( plan ) }
+											readOnly={ plan.isFree && ( hasPaidDomain || selectedPaidDomain ) }
+										>
+											<LeadingContentSide
+												label={
+													/* translators: %s is WordPress.com plan name (eg: Premium Plan) */
+													sprintf( __( '%s Plan', __i18n_text_domain__ ), plan?.title ?? '' )
+												}
+												badgeText={ plan?.isPopular ? __( 'Popular', __i18n_text_domain__ ) : '' }
+											/>
+											{ plan.isFree ? (
+												<TrailingContentSide
+													nodeType={ hasPaidDomain || selectedPaidDomain ? 'WARNING' : 'PRICE' }
+												>
+													{ hasPaidDomain || selectedPaidDomain
+														? __( 'Not available with your domain selection', __i18n_text_domain__ )
+														: __( 'Free', __i18n_text_domain__ ) }
+												</TrailingContentSide>
+											) : (
+												<TrailingContentSide nodeType="PRICE">
+													<span>{ plan && planPrices[ plan?.storeSlug ] }</span>
+													<span>
+														{
+															// translators: /mo is short for "per-month"
+															__( '/mo', __i18n_text_domain__ )
+														}
+													</span>
+												</TrailingContentSide>
+											) }
+										</FocusedLaunchSummaryItem>
+									)
 							) }
-
-							<FocusedLaunchSummaryItem
-								isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
-								readOnly={ hasPaidDomain || selectedPaidDomain }
-								onClick={ () => defaultFreePlan && setPlan( defaultFreePlan ) }
-								isSelected={ ! ( hasPaidDomain || selectedPaidDomain ) && selectedPlan?.isFree }
-							>
-								<LeadingContentSide
-									label={
-										/* translators: %s is WordPress.com plan name (eg: Premium Plan) */
-										sprintf( __( '%s Plan', __i18n_text_domain__ ), defaultFreePlan?.title ?? '' )
-									}
-								/>
-								<TrailingContentSide
-									nodeType={ hasPaidDomain || selectedPaidDomain ? 'WARNING' : 'PRICE' }
-								>
-									{ hasPaidDomain || selectedPaidDomain
-										? __( 'Not available with your domain selection', __i18n_text_domain__ )
-										: __( 'Free', __i18n_text_domain__ ) }
-								</TrailingContentSide>
-							</FocusedLaunchSummaryItem>
 						</div>
 						<Link to={ Route.PlanDetails } className="focused-launch-summary__details-link">
 							{ __( 'View all plans', __i18n_text_domain__ ) }

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -376,10 +376,10 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 						</p>
 						<div>
 							{ allAvailablePlans.map(
-								( plan, idx ) =>
+								( plan ) =>
 									plan && (
 										<FocusedLaunchSummaryItem
-											key={ idx }
+											key={ plan.storeSlug }
 											isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
 											onClick={ () => setPlan( plan ) }
 											isSelected={ isPlanSelected( plan ) }

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -376,9 +376,10 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 						</p>
 						<div>
 							{ allAvailablePlans.map(
-								( plan ) =>
+								( plan, idx ) =>
 									plan && (
 										<FocusedLaunchSummaryItem
+											key={ idx }
 											isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
 											onClick={ () => setPlan( plan ) }
 											isSelected={ isPlanSelected( plan ) }

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -380,16 +380,16 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 									plan && (
 										<FocusedLaunchSummaryItem
 											isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
-											onClick={ () => plan && setPlan( plan ) }
-											isSelected={ plan && isPlanSelected( plan ) }
+											onClick={ () => setPlan( plan ) }
+											isSelected={ isPlanSelected( plan ) }
 											readOnly={ plan.isFree && ( hasPaidDomain || selectedPaidDomain ) }
 										>
 											<LeadingContentSide
 												label={
 													/* translators: %s is WordPress.com plan name (eg: Premium Plan) */
-													sprintf( __( '%s Plan', __i18n_text_domain__ ), plan?.title ?? '' )
+													sprintf( __( '%s Plan', __i18n_text_domain__ ), plan.title ?? '' )
 												}
-												badgeText={ plan?.isPopular ? __( 'Popular', __i18n_text_domain__ ) : '' }
+												badgeText={ plan.isPopular ? __( 'Popular', __i18n_text_domain__ ) : '' }
 											/>
 											{ plan.isFree ? (
 												<TrailingContentSide
@@ -401,7 +401,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 												</TrailingContentSide>
 											) : (
 												<TrailingContentSide nodeType="PRICE">
-													<span>{ plan && planPrices[ plan?.storeSlug ] }</span>
+													<span>{ planPrices[ plan.storeSlug ] }</span>
 													<span>
 														{
 															// translators: /mo is short for "per-month"


### PR DESCRIPTION
Currently, the items are rendered separately and in order to make the code DRY-er and more maintainable it makes more sense to collect them in an array and render them in a .map().

#### Testing instructions
* checkout this branch
* run `yarn` && `yarn start` in a terminal;
* go to the block editor, append `?flags=create/focused-launch-flow-calypso` to the URL, and refresh the page;
* compare the plans rendering behavior with production. They should match!

Fixes #47994
