### PR TITLE
State: Modularize inline support article

### DIFF
--- a/client/state/inline-support-article/actions.js
+++ b/client/state/inline-support-article/actions.js
@@ -6,12 +6,16 @@ import {
 	SUPPORT_ARTICLE_DIALOG_CLOSE,
 } from 'calypso/state/action-types';
 
+import 'calypso/state/inline-support-article/init';
+
 /**
  * Shows the given support article (by postId) in a dialog.
  *
- * @param {object} options - action options
- * 	{number} postId 	The id of the support article
- *  {string} postUrl	The URL of the support article
+ * @param {object} options             Action options
+ * @param {number} options.postId      The id of the support article
+ * @param {string} options.postUrl     The URL of the support article
+ * @param {string} options.actionLabel Label of the action
+ * @param {string} options.actionUrl   URL of the action
  *
  * @returns {object}		Action
  */

--- a/client/state/inline-support-article/init.js
+++ b/client/state/inline-support-article/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'inlineSupportArticle' ], reducer );

--- a/client/state/inline-support-article/package.json
+++ b/client/state/inline-support-article/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/inline-support-article/reducer.js
+++ b/client/state/inline-support-article/reducer.js
@@ -1,40 +1,43 @@
 /**
  * Internal dependencies
  */
-import { withoutPersistence } from 'calypso/state/utils';
+import { withoutPersistence, withStorageKey } from 'calypso/state/utils';
 import {
 	SUPPORT_ARTICLE_DIALOG_OPEN,
 	SUPPORT_ARTICLE_DIALOG_CLOSE,
 } from 'calypso/state/action-types';
 
-export default withoutPersistence(
-	(
-		state = {
-			postId: null,
-			postUrl: null,
-			isVisible: false,
-		},
-		action
-	) => {
-		switch ( action.type ) {
-			case SUPPORT_ARTICLE_DIALOG_OPEN: {
-				const { postId, postUrl = null, actionLabel = null, actionUrl = null } = action;
+export default withStorageKey(
+	'inlineSupportArticle',
+	withoutPersistence(
+		(
+			state = {
+				postId: null,
+				postUrl: null,
+				isVisible: false,
+			},
+			action
+		) => {
+			switch ( action.type ) {
+				case SUPPORT_ARTICLE_DIALOG_OPEN: {
+					const { postId, postUrl = null, actionLabel = null, actionUrl = null } = action;
 
-				return {
-					postUrl,
-					postId,
-					isVisible: true,
-					actionLabel,
-					actionUrl,
-				};
+					return {
+						postUrl,
+						postId,
+						isVisible: true,
+						actionLabel,
+						actionUrl,
+					};
+				}
+				case SUPPORT_ARTICLE_DIALOG_CLOSE:
+					return {
+						...state,
+						isVisible: false,
+					};
 			}
-			case SUPPORT_ARTICLE_DIALOG_CLOSE:
-				return {
-					...state,
-					isVisible: false,
-				};
-		}
 
-		return state;
-	}
+			return state;
+		}
+	)
 );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -21,7 +21,6 @@ import documentHead from './document-head/reducer';
 import happychat from './happychat/reducer';
 import i18n from './i18n/reducer';
 import importerNux from './importer-nux/reducer';
-import inlineSupportArticle from './inline-support-article/reducer';
 import jitm from './jitm/reducer';
 import mySites from './my-sites/reducer';
 import notices from './notices/reducer';
@@ -44,7 +43,6 @@ const reducers = {
 	httpData,
 	i18n,
 	importerNux,
-	inlineSupportArticle,
 	jitm,
 	mySites,
 	notices,

--- a/client/state/selectors/get-inline-support-article-action-is-external.js
+++ b/client/state/selectors/get-inline-support-article-action-is-external.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/inline-support-article/init';
+
+/**
  * @param {object} state Global app state
  * @returns {object} ...
  */

--- a/client/state/selectors/get-inline-support-article-action-label.js
+++ b/client/state/selectors/get-inline-support-article-action-label.js
@@ -4,6 +4,11 @@
 import { translate } from 'i18n-calypso';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/inline-support-article/init';
+
+/**
  * @param {object} state Global app state
  * @returns {object} ...
  */

--- a/client/state/selectors/get-inline-support-article-action-url.js
+++ b/client/state/selectors/get-inline-support-article-action-url.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/inline-support-article/init';
+
+/**
  * @param {object} state Global app state
  * @returns {object} ...
  */

--- a/client/state/selectors/get-inline-support-article-post-id.js
+++ b/client/state/selectors/get-inline-support-article-post-id.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/inline-support-article/init';
+
+/**
  * External dependencies
  */
 import { get } from 'lodash';

--- a/client/state/selectors/is-inline-support-article-visible.js
+++ b/client/state/selectors/is-inline-support-article-visible.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/inline-support-article/init';
+
+/**
  * @param {object} state Global app state
  * @returns {object} ...
  */


### PR DESCRIPTION
This PR is one of many working on the modularizing state in Calypso. This one handles inline support article state.

For more details on state modularization, see the [modularized state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42449.

#### Changes proposed in this Pull Request

* Modularize inline support article state

#### Testing instructions

Unfortunately, the inline support article state is loaded unconditionally pretty early in Calypso's `<Layout />`. As such, it's not straightforward to verify the before/after on the automatic loading process, only that it does load.

You can also test whether it still works as expected:

* Go to `/home/:site` where `:site` is one of your WP.com simple sites.
* Scroll down and in the "Get Help" card, click on an article.
* Verify it properly opens in a dialog with no errors in the console.

#### Note

Linting errors are expected - they're coming from the non-modularized reducer, and will disappear once we modularize all of it.