### PR TITLE
StickyPanel: don't fail when header is not present, remove unneeded top margin

### DIFF
--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -31,8 +31,9 @@ const commonDefaultProps = {
 };
 
 export function calculateOffset() {
-	// Offset to account for Master Bar
-	return document.getElementById( 'header' ).getBoundingClientRect().height;
+	// Offset to account for Masterbar
+	const headerEl = document.getElementById( 'header' );
+	return headerEl ? headerEl.getBoundingClientRect().height : 0;
 }
 
 export function getBlockStyle( state ) {

--- a/client/components/sticky-panel/style.scss
+++ b/client/components/sticky-panel/style.scss
@@ -16,9 +16,3 @@
 	position: fixed;
 	z-index: z-index( 'root', '.sticky-panel.is-sticky .sticky-panel__content' );
 }
-
-@include breakpoint-deprecated( '<960px' ) {
-	.sticky-panel.is-sticky .sticky-panel__content {
-		margin-top: 8px;
-	}
-}


### PR DESCRIPTION
Before closing an experimental #32927 PR, I'd like to merge one of its valuable improvements.

The `StickyPanel` component crashes when it cannot find a `#header` element in the DOM, i.e., if there is no Masterbar (btw do we have plans to rename this component?).

This PR fixes that by returning a 0 offset if there's no `#header` element. Currently there's no place in Calypso where this would actually crash, but in my experimental PR I indeed had no Masterbar. Let's prevent surprises for future users.

Another bugfix I discovered when testing: there's an unneeded top 8px margin on the Sticky Panel element when the viewport is narrower than 960px:

<img width="564" alt="Screenshot 2020-12-04 at 10 55 26" src="https://user-images.githubusercontent.com/664258/101152503-78994d00-3623-11eb-8c84-a810101ce41e.png">

This margin comes from a very old, Classic Editor issue that's no longer relevant today: https://github.com/Automattic/wp-calypso/issues/1090

**How to test:**
Check usages of `StickyPanel`, e.g., when scrolling in Stats, and verify things are OK.