### PR TITLE
Framework: Remove usages of lodash trimStart()

### DIFF
--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { sortBy, trimStart, isEmpty } from 'lodash';
+import { sortBy, isEmpty } from 'lodash';
 import page from 'page';
 import classnames from 'classnames';
 
@@ -44,7 +44,7 @@ class FollowingManageSubscriptions extends Component {
 				const feed = follow.feed;
 				const site = follow.site;
 				const displayUrl = formatUrlForDisplay( follow.URL );
-				return trimStart( getFeedTitle( site, feed, displayUrl ).toLowerCase() );
+				return getFeedTitle( site, feed, displayUrl ).toLowerCase().trimStart();
 			} );
 		}
 

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, includes, mapValues, trimStart } from 'lodash';
+import { filter, includes, mapValues } from 'lodash';
 
 function validateAllFields( fieldValues, domainName ) {
 	return mapValues( fieldValues, ( value, fieldName ) => {
@@ -84,7 +84,7 @@ function getNormalizedData( record, selectedDomainName ) {
 	// The leading '_' in SRV's service field is a convention
 	// The record itself should not contain it
 	if ( record.service ) {
-		normalizedRecord.service = trimStart( record.service, '_' );
+		normalizedRecord.service = record.service.replace( /^_+/, '' );
 	}
 
 	return normalizedRecord;


### PR DESCRIPTION
We have only a couple usages of lodash's `trimStart()` method. They can be refactored to use native methods. This PR removes them, in order to make us a bit less dependent on lodash.

This PR should not offer any visual or functional changes.

#### Changes proposed in this Pull Request

* Framework: Remove usages of lodash `trimStart()`

#### Testing instructions

* Verify changes make sense - they should be pretty straightforward to review.