### PR TITLE
Framework: Remove usages of lodash forIn()

### DIFF
--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { equal, ok, deepStrictEqual } from 'assert';
-import { groupBy, pickBy, forIn } from 'lodash';
+import { groupBy, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ describe( 'metadata:', () => {
 		);
 
 		describe( 'countries sharing dial code should have priority data', () => {
-			forIn( countriesShareDialCode, ( countriesWithDialCode, dialCode ) => {
+			Object.entries( countriesShareDialCode ).map( ( [ dialCode, countriesWithDialCode ] ) => {
 				describe( 'Dialcode: ' + dialCode, () => {
 					countriesWithDialCode.forEach( ( country ) =>
 						test( country.isoCode, () =>

--- a/client/state/themes/selectors/get-theme-filter-terms-table.js
+++ b/client/state/themes/selectors/get-theme-filter-terms-table.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forIn, keys, mapValues } from 'lodash';
+import { keys, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,7 +23,7 @@ export const getThemeFilterTermsTable = createSelector(
 	( state ) => {
 		const termTable = {};
 		const taxonomies = mapValues( getThemeFilters( state ), keys );
-		forIn( taxonomies, ( terms, taxonomy ) => {
+		Object.entries( taxonomies ).map( ( [ taxonomy, terms ] ) => {
 			terms.forEach( ( term ) => {
 				const key = isAmbiguousThemeFilterTerm( state, term ) ? `${ taxonomy }:${ term }` : term;
 				termTable[ key ] = taxonomy;

--- a/client/state/themes/selectors/get-theme-filter-to-term-table.js
+++ b/client/state/themes/selectors/get-theme-filter-to-term-table.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forIn, keys, mapValues } from 'lodash';
+import { keys, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,7 +23,7 @@ export const getThemeFilterToTermTable = createSelector(
 	( state ) => {
 		const result = {};
 		const taxonomies = mapValues( getThemeFilters( state ), keys );
-		forIn( taxonomies, ( terms, taxonomy ) => {
+		Object.entries( taxonomies ).map( ( [ taxonomy, terms ] ) => {
 			terms.forEach( ( term ) => {
 				const key = `${ taxonomy }:${ term }`;
 				result[ key ] = getThemeFilterTermFromString( state, key );


### PR DESCRIPTION
We have only a couple usages of lodash's `forIn()` method. They can be refactored to use native methods. This PR removes them, in order to make us a bit less dependent on lodash.

This PR should not offer any visual or functional changes.

#### Changes proposed in this Pull Request

* Framework: Remove usages of lodash `forIn()`

#### Testing instructions

* Verify all tests pass - all changes here have corresponding tests.