### PR TITLE
Remove Old Experiment in Cancelation Flow

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
@@ -11,7 +11,6 @@ import {
 } from 'calypso/lib/plans/constants';
 import { findPlansKeys } from 'calypso/lib/plans';
 import { isPlan, includesProduct } from 'calypso/lib/products-values';
-import { abtest } from 'calypso/lib/abtest';
 import * as steps from './steps';
 
 const BUSINESS_PLANS = findPlansKeys( { group: GROUP_WPCOM, type: TYPE_BUSINESS } );
@@ -33,7 +32,7 @@ export default function stepsForProductAndSurvey(
 	downgradePossible
 ) {
 	if ( survey && survey.questionOneRadio === 'couldNotInstall' ) {
-		if ( includesProduct( BUSINESS_PLANS, product ) && abtest( 'ATPromptOnCancel' ) === 'show' ) {
+		if ( includesProduct( BUSINESS_PLANS, product ) ) {
 			return [ steps.INITIAL_STEP, steps.BUSINESS_AT_STEP, steps.FINAL_STEP ];
 		}
 

--- a/client/components/marketing-survey/cancel-purchase-form/test/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/steps-for-product-and-survey.js
@@ -8,9 +8,7 @@ import { expect } from 'chai';
  */
 import * as steps from '../steps';
 import stepsForProductAndSurvey from '../steps-for-product-and-survey';
-import { abtest } from 'calypso/lib/abtest';
 import * as plans from 'calypso/lib/plans/constants';
-jest.mock( 'lib/abtest', () => ( { abtest: require( 'sinon' ).stub() } ) );
 
 const PLAN_SURVEY_STEPS = [ steps.INITIAL_STEP, steps.FINAL_STEP ];
 const DEFAULT_STEPS_WITH_UPGRADE_AT_STEP = [
@@ -204,35 +202,17 @@ describe( 'stepsForProductAndSurvey', () => {
 			);
 		} );
 
-		test( 'should include business AT step if product is personal plan and abtest variant is show', () => {
+		test( 'should include business AT step if product is personal plan', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS };
-			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'show' );
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
 				DEFAULT_STEPS_WITH_BUSINESS_AT_STEP
 			);
 		} );
 
-		test( 'should include business AT step if product is personal plan and abtest variant is show (2y)', () => {
+		test( 'should include business AT step if product is personal plan (2y)', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
-			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'show' );
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
 				DEFAULT_STEPS_WITH_BUSINESS_AT_STEP
-			);
-		} );
-
-		test( 'should not include business AT step if product is business plan and abtest variant is hide', () => {
-			const product = { product_slug: plans.PLAN_BUSINESS };
-			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
-				PLAN_SURVEY_STEPS
-			);
-		} );
-
-		test( 'should not include business AT step if product is business plan and abtest variant is hide (2y)', () => {
-			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
-			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
-				PLAN_SURVEY_STEPS
 			);
 		} );
 	} );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -19,15 +19,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	ATPromptOnCancel: {
-		datestamp: '20170515',
-		variations: {
-			hide: 20,
-			show: 80,
-		},
-		defaultVariation: 'hide',
-		allowExistingUsers: true,
-	},
 	builderReferralThemesBanner: {
 		datestamp: '20181218',
 		variations: {


### PR DESCRIPTION
This test has been inconclusive for a really long time. I'm proposing to end it with variation winning because it actually makes sense to make sure people are aware that they have the feature for which they missed and decided to cancel because of it.

#### Changes proposed in this Pull Request

Remove the experiment with test selected as a winner while the data is insufficient.

#### Testing instructions

1. Make sure the test passes
2. Add Personal plan to an existing site. Go to /me/purchases and click cancel
3. In the cancelation survey, select that you couldn't install plugins or themes
4. The prompt to upgrade should appear:
<img width="610" alt="Screenshot 2020-12-04 at 15 58 11" src="https://user-images.githubusercontent.com/82778/101172710-359ea000-364a-11eb-9869-bf938fe123ad.png">

5. Repeat the steps with the Business plan
6. The prompt to upgrade should appear:
<img width="573" alt="Screenshot 2020-12-04 at 15 59 19" src="https://user-images.githubusercontent.com/82778/101172722-39322700-364a-11eb-9665-8b204ed808e7.png">

