### PR TITLE
New onboarding: cleanup abtest slug for existing users A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -82,16 +82,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
-	existingUsersGutenbergOnboard: {
-		datestamp: '20201015',
-		variations: {
-			gutenberg: 100,
-			control: 0,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-		localeTargets: [ 'en' ],
-	},
 	secureYourBrand: {
 		datestamp: '20201124',
 		variations: {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -123,11 +123,7 @@ export default {
 			const locale = getCurrentUserLocale( context.store.getState() );
 			const flowName = getFlowName( context.params );
 			const userLoggedIn = isUserLoggedIn( context.store.getState() );
-			if (
-				userLoggedIn &&
-				flowName === 'onboarding' &&
-				[ 'en', 'en-gb', 'en-us', 'en-au' ].indexOf( locale ) !== -1
-			) {
+			if ( userLoggedIn && flowName === 'onboarding' && [ 'en', 'en-gb' ].includes( locale ) ) {
 				gutenbergRedirect( context.params.flowName );
 				return;
 			}

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -27,7 +27,7 @@ import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import store from 'store';
 import { setCurrentFlowName } from 'calypso/state/signup/flow/actions';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
 import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
 import {
@@ -120,12 +120,13 @@ export default {
 
 			next();
 		} else {
+			const locale = getCurrentUserLocale( context.store.getState() );
 			const flowName = getFlowName( context.params );
 			const userLoggedIn = isUserLoggedIn( context.store.getState() );
 			if (
 				userLoggedIn &&
 				flowName === 'onboarding' &&
-				'gutenberg' === abtest( 'existingUsersGutenbergOnboard' )
+				[ 'en', 'en-gb', 'en-us', 'en-au' ].indexOf( locale ) !== -1
 			) {
 				gutenbergRedirect( context.params.flowName );
 				return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Cleanup `existingUsersGutenbergOnboard` after the corresponding experiment has ended.
* Since 'gutenberg' version has been rolled out for 'en' locale, we are adding a redirect in code instead of using the abtest framework.

#### Testing instructions
* As a logged in user with 'en' or 'en-gb' locale set in your account, try creating a site starting from Calypso or navigating to `/start` => you should be redirected to `/new`.
* As a logged in user with any other locale set in your account, try creating a site starting from Calypso or navigating to `/start` => you will continue with the `/start` flow. 