### PR TITLE
Plugins: Reduxify getNotInstalledSites

### DIFF
--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -233,23 +233,6 @@ const PluginsStore = {
 		return _fetching[ site.ID ];
 	},
 
-	// Array of sites without a particular plugin.
-	getNotInstalledSites: function ( sites, pluginSlug ) {
-		const installedOnSites = this.getSites( sites, pluginSlug ) || [];
-		return sites.filter( function ( site ) {
-			if ( ! site.visible ) {
-				return false;
-			}
-			if ( site.jetpack && site.isSecondaryNetworkSite ) {
-				return false;
-			}
-
-			return installedOnSites.every( function ( installedOnSite ) {
-				return installedOnSite.slug !== site.slug;
-			} );
-		} );
-	},
-
 	emitChange: function () {
 		this.emit( 'change' );
 	},

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -359,7 +359,7 @@ export default connect(
 		const sites = getSelectedOrAllSitesWithPlugins( state );
 
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-		const siteIds = uniq( sites ).map( ( site ) => site.ID );
+		const siteIds = uniq( sites.map( ( site ) => site.ID ) );
 
 		return {
 			wporgPlugin: getWporgPlugin( state, props.pluginSlug ),

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -41,6 +41,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import NoPermissionsError from './no-permissions-error';
 import getToursHistory from 'calypso/state/guided-tours/selectors/get-tours-history';
 import hasNavigated from 'calypso/state/selectors/has-navigated';
+import { getSitesWithoutPlugin } from 'calypso/state/plugins/installed/selectors';
 
 /* eslint-disable react/prefer-es6-class */
 
@@ -96,9 +97,13 @@ const SinglePlugin = createReactClass( {
 			sitePlugin
 		);
 
+		const notInstalledSites = props.sitesWithoutPlugin.map( ( siteId ) =>
+			sites.find( ( site ) => site.ID === siteId )
+		);
+
 		return {
 			sites: PluginsStore.getSites( sites, props.pluginSlug ) || [],
-			notInstalledSites: PluginsStore.getNotInstalledSites( sites, props.pluginSlug ) || [],
+			notInstalledSites,
 			plugin,
 		};
 	},
@@ -351,19 +356,24 @@ const SinglePlugin = createReactClass( {
 export default connect(
 	( state, props ) => {
 		const selectedSiteId = getSelectedSiteId( state );
+		const sites = getSelectedOrAllSitesWithPlugins( state );
+
+		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+		const siteIds = uniq( sites ).map( ( site ) => site.ID );
 
 		return {
 			wporgPlugin: getWporgPlugin( state, props.pluginSlug ),
 			wporgFetching: isWporgPluginFetching( state, props.pluginSlug ),
 			wporgFetched: isWporgPluginFetched( state, props.pluginSlug ),
 			selectedSite: getSelectedSite( state ),
+			sitesWithoutPlugin: getSitesWithoutPlugin( state, siteIds, props.pluginSlug ),
 			isAtomicSite: isSiteAutomatedTransfer( state, selectedSiteId ),
 			isJetpackSite: selectedSiteId && isJetpackSite( state, selectedSiteId ),
 			isRequestingSites: isRequestingSites( state ),
 			userCanManagePlugins: selectedSiteId
 				? canCurrentUser( state, selectedSiteId, 'manage_options' )
 				: canCurrentUserManagePlugins( state ),
-			sites: getSelectedOrAllSitesWithPlugins( state ),
+			sites,
 			toursHistory: getToursHistory( state ),
 			navigated: hasNavigated( state ),
 		};


### PR DESCRIPTION
This PR replaces any `PluginStore.getNotInstalledSites()` usage with its Redux counterpart, and removes the unused `getNotInstalledSites` method from the old plugins flux store.

This PR is part of the plugins reduxification effort in #24180.

#### Changes proposed in this Pull Request

* Plugins: Reduxify `PluginStore.getNotInstalledSites()`

#### Testing instructions

* Go to `/plugins/contact-form-7` or any other plugin of your choice.
* Make sure you have at least several sites that **don't** have that plugin installed.
* Verify the list of "Available sites" is the same as in production, and the "Install" button functions the same way.
