### PR TITLE
Modularise notices state

### DIFF
--- a/client/landing/login/store.js
+++ b/client/landing/login/store.js
@@ -15,7 +15,6 @@ import {
 } from 'calypso/state/data-layer/http-data';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
 import documentHead from 'calypso/state/document-head/reducer';
-import notices from 'calypso/state/notices/reducer';
 import i18n from 'calypso/state/i18n/reducer';
 import currentUser from 'calypso/state/current-user/reducer';
 
@@ -24,7 +23,6 @@ import currentUser from 'calypso/state/current-user/reducer';
 const rootReducer = combineReducers( {
 	documentHead,
 	httpData,
-	notices,
 	i18n,
 	currentUser,
 } );

--- a/client/state/http/README.md
+++ b/client/state/http/README.md
@@ -12,6 +12,7 @@ So, let's say you would like to do a `POST` request to <https://api.example.com>
 import { GET_EXAMPLE_DATA, EXAMPLE_DATA_ADD, NOTICE_CREATE } from 'calypso/state/action-types';
 import { dispatchRequest } from 'calypso/state/wpcom-http/utils';
 import { http } from 'calypso/state/http/actions';
+import { createNotice } from 'calypso/state/notices/actions';
 import { get } from 'lodash';
 
 const requestExampleData = ( action ) =>
@@ -32,12 +33,10 @@ const receivedExampleData = ( action, data ) => ( {
 	data,
 } );
 
-const receivedExampleDataError = ( action, error ) => ( {
-	type: NOTICE_CREATE,
-	notice: {
-		text: get( error, 'response.body.error', null ),
-	},
-} );
+const receivedExampleDataError = ( action, error ) => createNotice(
+	'is-error',
+	get( error, 'response.body.error', null )
+);
 
 export default {
 	[ GET_EXAMPLE_DATA ]: dispatchRequest( {

--- a/client/state/http/README.md
+++ b/client/state/http/README.md
@@ -9,7 +9,7 @@ It follows the same API as `wpcom-http`, the only difference from the user's per
 So, let's say you would like to do a `POST` request to <https://api.example.com> when the action `GET_EXAMPLE_DATA` is dispatched, later continuing with `EXAMPLE_DATA_ADD` for the data or `NOTICE_CREATE` for the error. You'll be able to do that with the following code (that could be located under `third-party`):
 
 ```js
-import { GET_EXAMPLE_DATA, EXAMPLE_DATA_ADD, NOTICE_CREATE } from 'calypso/state/action-types';
+import { GET_EXAMPLE_DATA, EXAMPLE_DATA_ADD } from 'calypso/state/action-types';
 import { dispatchRequest } from 'calypso/state/wpcom-http/utils';
 import { http } from 'calypso/state/http/actions';
 import { createNotice } from 'calypso/state/notices/actions';

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -2,13 +2,16 @@
  * External dependencies
  */
 import impureLodash from 'calypso/lib/impure-lodash';
-const { uniqueId } = impureLodash;
 
 /**
  * Internal dependencies
  */
 import { NOTICE_CREATE, NOTICE_REMOVE } from 'calypso/state/action-types';
 import { extendAction } from 'calypso/state/utils';
+
+import 'calypso/state/notices/init';
+
+const { uniqueId } = impureLodash;
 
 export function removeNotice( noticeId ) {
 	return {

--- a/client/state/notices/init.js
+++ b/client/state/notices/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'notices' ], reducer );

--- a/client/state/notices/package.json
+++ b/client/state/notices/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/notices/reducer.js
+++ b/client/state/notices/reducer.js
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-
 import { omit, reduce } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { NOTICE_CREATE, NOTICE_REMOVE, ROUTE_SET } from 'calypso/state/action-types';
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers, withoutPersistence, withStorageKey } from 'calypso/state/utils';
 
 export const items = withoutPersistence( ( state = {}, action ) => {
 	switch ( action.type ) {
@@ -68,7 +67,9 @@ export const lastTimeShown = withoutPersistence( ( state = {}, action ) => {
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	items,
 	lastTimeShown,
 } );
+
+export default withStorageKey( 'notices', combinedReducer );

--- a/client/state/notices/selectors.js
+++ b/client/state/notices/selectors.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { values } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'calypso/lib/create-selector';
+
+import 'calypso/state/notices/init';
 
 /**
  * Returns array value of notice item state

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -24,7 +24,6 @@ import importerNux from './importer-nux/reducer';
 import inlineSupportArticle from './inline-support-article/reducer';
 import jitm from './jitm/reducer';
 import mySites from './my-sites/reducer';
-import notices from './notices/reducer';
 import sites from './sites/reducer';
 import support from './support/reducer';
 import userSettings from './user-settings/reducer';
@@ -45,7 +44,6 @@ const reducers = {
 	inlineSupportArticle,
 	jitm,
 	mySites,
-	notices,
 	sites,
 	support,
 	userSettings,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles notices state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42460.

#### Changes proposed in this Pull Request

* Modularise notices state

#### Testing instructions

Unfortunately, `notices` state gets loaded pretty early on in the boot process, through the email verification page middleware. As such, it's not easy to test the automated loading process, but it should be enough to smoke-test notices functionality in order to ensure that it continues to work correctly. I did so with a cart notification, but there are probably easier methods.
