### PR TITLE
WIP: Implement hooks client for ExPlat

### DIFF
--- a/client/state/data-layer/wpcom/experiments/index.js
+++ b/client/state/data-layer/wpcom/experiments/index.js
@@ -42,7 +42,10 @@ export const handleFetchExperiments = ( action ) =>
 	);
 
 /**
- * Inform the data-layer to request new experiments from the API
+ * Inform the data-layer to request a experiment assignment from the API,
+ * initialising an assignment if necessary.
+ *
+ * Due to a temporary issue on the backend we have to get and assign all experiments at once.
  */
 export const fetchExperiments = () => ( {
 	type: EXPERIMENT_FETCH,

--- a/client/state/experiments/hooks.ts
+++ b/client/state/experiments/hooks.ts
@@ -18,7 +18,7 @@ import { getVariationForUser, isLoading, nextRefresh } from './selectors';
 let hasAnonIdGeneratingTracksEventFired = false;
 
 /**
- * Gets (and initialises if not yet initialised) a users assignment to an experiment.
+ * Gets (and initialises if not yet initialised) a user's assignment to an experiment.
  *
  * Usage tips:
  * - Account for loading state as assignment is now server-side.

--- a/client/state/experiments/hooks.ts
+++ b/client/state/experiments/hooks.ts
@@ -31,14 +31,6 @@ let hasAnonIdGeneratingTracksEventFired = false;
 export function useExperiment( experimentName: string ): [ boolean, string | null ] {
 	const dispatch = useDispatch();
 
-	if ( ! experimentName ) {
-		if ( ! process.env.NODE_ENV || process.env.NODE_ENV === 'development' ) {
-			throw 'Experiment name is not defined!';
-		}
-		return [ false, null ];
-	}
-	// TODO: LogStash if missing an experiment name
-
 	const { variation, isLoading: isVariationLoading, updateAfter } = useSelector( ( state ) => ( {
 		variation: getVariationForUser( state, experimentName ),
 		isLoading: isLoading( state ),
@@ -63,6 +55,14 @@ export function useExperiment( experimentName: string ): [ boolean, string | nul
 			dispatch( fetchExperiments() );
 		}
 	}, [ updateAfter ] );
+
+	if ( ! experimentName ) {
+		if ( ! process.env.NODE_ENV || process.env.NODE_ENV === 'development' ) {
+			throw 'Experiment name is not defined!';
+		}
+		// TODO: LogStash if missing an experiment name
+		return [ false, null ];
+	}
 
 	return [ isVariationLoading, variation ];
 }

--- a/client/state/experiments/hooks.ts
+++ b/client/state/experiments/hooks.ts
@@ -1,60 +1,68 @@
 /**
  * External Dependencies
  */
-import { useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
 /**
  * Internal Dependencies
  */
-import { getVariationForUser, isLoading, getAnonId, nextRefresh } from './selectors';
+import { fetchExperiments } from 'calypso/state/data-layer/wpcom/experiments';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getVariationForUser, isLoading, nextRefresh } from './selectors';
 
 /**
- * Returns true if the variations are loading for the current user
+ * Keeps track of whether an event has fired to generate an anonId
+ * Internal state not to be used anywhere else
  */
-export function useIsLoading(): boolean {
-	return useSelector( isLoading );
-}
+let hasAnonIdGeneratingTracksEventFired = false;
 
 /**
- * Returns the user's assigned variation for a given experiment
+ * Gets (and initialises if not yet initialised) a users assignment to an experiment.
  *
- * @param experiment The name of the experiment
- */
-export function useVariationForUser( experiment: string ): string | null {
-	return useSelector( ( state ) => getVariationForUser( state, experiment ) );
-}
-
-/**
- * Gets the anon id for the user, if set
- */
-export function useAnonId(): string | null {
-	return useSelector( getAnonId );
-}
-
-/**
- * Get the time for the next variation refresh
- */
-export function useNextRefresh(): number {
-	return useSelector( nextRefresh );
-}
-
-type ExperimentInfo = {
-	variation: string | null;
-	anonId: string | null;
-	nextRefresh: number;
-	isLoading: boolean;
-};
-
-/**
- * Get the information for a given experiment
+ * Usage tips:
+ * - Account for loading state as assignment is now server-side.
+ * - Account for null variations: Provide the fallback experience.
  *
- * @param experiment The name of the experiment
+ * @param experimentName The name of the experiment
+ *
+ * @returns [isVariationLoading, variation]
  */
-export function useExperiment( experiment: string ): ExperimentInfo {
-	return useSelector( ( state ) => ( {
-		variation: getVariationForUser( state, experiment ),
-		anonId: getAnonId( state ),
-		nextRefresh: nextRefresh( state ),
+export function useExperiment( experimentName: string ): [ boolean, string | null ] {
+	const dispatch = useDispatch();
+
+	if ( ! experimentName ) {
+		if ( ! process.env.NODE_ENV || process.env.NODE_ENV === 'development' ) {
+			throw 'Experiment name is not defined!';
+		}
+		return [ false, null ];
+	}
+	// TODO: LogStash if missing an experiment name
+
+	const { variation, isLoading: isVariationLoading, updateAfter } = useSelector( ( state ) => ( {
+		variation: getVariationForUser( state, experimentName ),
 		isLoading: isLoading( state ),
+		updateAfter: nextRefresh( state ),
 	} ) );
+
+	// HACK:
+	// Due to a temporary issue on the backend we have to get and assign all experiments at once.
+	//
+	// updateAfter is used to periodically refresh the assignments in the case of long running sessions.
+	// It is just the last fetch time + 1000
+	useEffect( () => {
+		// Due to how tracks works, we need to ensure that an event has been fired at least once to have an anonId.
+		if ( ! hasAnonIdGeneratingTracksEventFired ) {
+			recordTracksEvent( 'calypso_experiment_first_session_assignment', {
+				experiment_name: experimentName,
+			} );
+			hasAnonIdGeneratingTracksEventFired = true;
+		}
+
+		if ( updateAfter < Date.now() ) {
+			dispatch( fetchExperiments() );
+		}
+	}, [ updateAfter ] );
+
+	return [ isVariationLoading, variation ];
 }

--- a/client/state/experiments/hooks.ts
+++ b/client/state/experiments/hooks.ts
@@ -24,6 +24,8 @@ let hasAnonIdGeneratingTracksEventFired = false;
  * - Account for loading state as assignment is now server-side.
  * - Account for null variations: Provide the fallback experience.
  *
+ * See the README for more info
+ *
  * @param experimentName The name of the experiment
  *
  * @returns [isVariationLoading, variation]


### PR DESCRIPTION
**This PR adds a full hooks implementation for ExPlat**

The previous iteration of the hooks client just fetched the ExPlat store state, this iteration:
- Simplifies the API to just: `const [isLoadingVariation, variation] = useExperiment('experiment_name')`
- Initialises/fetches assignment as well - making it an entire client.

### Is this useful? Is this worth it?

**Benefits:**
- Simpler
- Similar to existing method

**Downsides:**
- Less controlled

On balance I think this implementation is an improvement over the component implementation, and this implementation can in fact underpin the component implementation when it is ready. We (the ExPlat team and Co) still plan to review experiments and although there will be less built-in control, a simpler interface might result in simpler code to review.

### Future: Going one step further

There is one step further than this - implementing a client in the `/lib` code as a  single function (non-hook) API which I think is possible and might be worthwhile. That implementation could eventually underpin this hooks implementation (which underpins the component implementation).

### Implementation plan

If we do go ahead with this I propose the following plan:
- [ ] Finalise the hook code, ensure it is separate to the component code.
- [ ] A/A test the hook code to ensure it is up to scratch.
- [ ] Change the code in `<Experiment>` to use it.
- [ ] Publish it as ready.
