### PR TITLE
Jetpack Thank You modals: add state to control the modal appearance

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.tsx
@@ -13,22 +13,30 @@ import ThankYou, { ThankYouCtaType } from './thank-you';
 import versionCompare from 'calypso/lib/version-compare';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-const ThankYouCta: ThankYouCtaType = ( { jetpackVersion, recordThankYouClick, siteAdminUrl } ) => {
+const ThankYouCta: ThankYouCtaType = ( {
+	dismissUrl,
+	jetpackVersion,
+	recordThankYouClick,
+	siteAdminUrl,
+} ) => {
 	const translate = useTranslate();
 	return (
-		<Button
-			primary
-			href={
-				jetpackVersion && versionCompare( jetpackVersion, '8.4', '<' )
-					? siteAdminUrl + 'plugins.php'
-					: siteAdminUrl + 'customize.php?autofocus[section]=jetpack_search'
-			}
-			onClick={ () => recordThankYouClick( 'search', 'customizer' ) }
-		>
-			{ jetpackVersion && versionCompare( jetpackVersion, '8.4', '<' )
-				? translate( 'Update Jetpack' )
-				: translate( 'Try Search and customize it now' ) }
-		</Button>
+		<>
+			<Button
+				primary
+				href={
+					jetpackVersion && versionCompare( jetpackVersion, '8.4', '<' )
+						? siteAdminUrl + 'plugins.php'
+						: siteAdminUrl + 'customize.php?autofocus[section]=jetpack_search'
+				}
+				onClick={ () => recordThankYouClick( 'search', 'customizer' ) }
+			>
+				{ jetpackVersion && versionCompare( jetpackVersion, '8.4', '<' )
+					? translate( 'Update Jetpack' )
+					: translate( 'Try Search and customize it now' ) }
+			</Button>
+			<Button href={ dismissUrl }>{ translate( 'Close' ) }</Button>
+		</>
 	);
 };
 

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.tsx
@@ -35,7 +35,7 @@ const ThankYouCta: ThankYouCtaType = ( {
 					? translate( 'Update Jetpack' )
 					: translate( 'Try Search and customize it now' ) }
 			</Button>
-			<Button href={ dismissUrl }>{ translate( 'Close' ) }</Button>
+			<Button href={ dismissUrl }>{ translate( 'Skip for now' ) }</Button>
 		</>
 	);
 };

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -73,6 +73,10 @@ import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedu
 import './style.scss';
 
 class CurrentPlan extends Component {
+	state = {
+		hideThankYouModal: false,
+	};
+
 	static propTypes = {
 		selectedSiteId: PropTypes.number,
 		selectedSite: PropTypes.object,
@@ -104,6 +108,12 @@ class CurrentPlan extends Component {
 
 		return ! selectedSite || isRequestingPlans || null === scheduleId;
 	}
+
+	hideThankYouModalOnClose = () => {
+		this.setState( {
+			hideThankYouModal: true,
+		} );
+	};
 
 	renderThankYou() {
 		const { currentPlan, product, selectedSite } = this.props;
@@ -200,10 +210,11 @@ class CurrentPlan extends Component {
 				<QuerySitePurchases siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
-				{ showThankYou && (
+				{ showThankYou && ! this.state.hideThankYouModal && (
 					<Dialog
 						baseClassName="current-plan__dialog dialog__content dialog__backdrop"
 						isVisible={ showThankYou }
+						onClose={ this.hideThankYouModalOnClose }
 					>
 						{ this.renderThankYou() }
 					</Dialog>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add state to allow users to close the modal with the ESC key. We need the state because the appearance of the modal is controlled only by props.

#### Notes

* This change will allow users to close all thank you modals with the ESC key, not just the Jetpack Search's one.

#### Testing instructions

* Run this PR (Calypso Blue).
* Select a Jetpack site and visit `/plans/my-plan/:site?thank-you=true&product=jetpack_search`.
* Verify that you see the `SearchProductThankYou` modal component.
* Press the ESC key.
* Verify that the modal was closed and it's no longer visible.
* Visit `/plans/my-plan/:site?thank-you=true&product=jetpack_search` for a second time.
* Click the `Skip for now` button.
* Verify that the modal was closed and it's no longer visible.

Fixes 1164141197617539-as-1199517240372205

#### Demo
![image](https://user-images.githubusercontent.com/3418513/101666024-7290db00-3a2c-11eb-8854-4f50b3af648d.png)
