### PR TITLE
Jetpack Settings: Removes chat and updates help link

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -7,13 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
-import { getHappychatAuth } from 'calypso/state/happychat/utils';
-import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
-import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
-import isHappychatConnectionUninitialized from 'calypso/state/happychat/selectors/is-happychat-connection-uninitialized';
-import { initConnection, sendEvent } from 'calypso/state/happychat/connection/actions';
-import { openChat } from 'calypso/state/happychat/ui/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import {
@@ -23,33 +17,22 @@ import {
 	JETPACK_CREDENTIALS_STORE,
 	REWIND_STATE_UPDATE,
 } from 'calypso/state/action-types';
-import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { successNotice, errorNotice, infoNotice } from 'calypso/state/notices/actions';
 import { transformApi } from 'calypso/state/data-layer/wpcom/sites/rewind/api-transformer';
-
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
+import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
+import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
 
 const navigateTo =
 	undefined !== typeof window
 		? ( path ) => window.open( path, '_blank' )
 		: ( path ) => page( path );
 
-/**
- * Makes sure that we can initialize a connection
- * to HappyChat. We'll need this on the API response
- *
- * @param {object} args Redux dispatcher, getState
- */
-export const primeHappychat = ( { dispatch, getState } ) => {
-	const state = getState();
-	const getAuth = getHappychatAuth( state );
-
-	if ( isHappychatConnectionUninitialized( state ) ) {
-		dispatch( initConnection( getAuth() ) );
-	}
-};
-
 export const request = ( action ) => {
-	const notice = successNotice( i18n.translate( 'Testing connection…' ), { duration: 30000 } );
+	const notice = infoNotice( i18n.translate( 'Testing connection…' ), {
+		duration: 30000,
+		showDismiss: false,
+	} );
 	const {
 		notice: { noticeId },
 	} = notice;
@@ -119,20 +102,15 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 		siteId: action.siteId,
 	} );
 
-	const getHelp = () => {
-		const state = getState();
-		const canChat = isHappychatAvailable( state ) || hasActiveHappychatSession( state );
-
-		return canChat ? dispatch( openChat() ) : navigateTo( '/help' );
-	};
+	const getHelp = () => navigateTo( contactSupportUrl( getSelectedSiteSlug( getState() ) ) );
 
 	const baseOptions = { duration: 10000, id: action.noticeId };
 
-	const announce = ( message, options ) =>
-		dispatch( errorNotice( message, options ? { ...baseOptions, ...options } : baseOptions ) );
+	const announce = ( message, options = {} ) =>
+		dispatch( errorNotice( message, { ...baseOptions, ...options } ) );
 
-	const spreadHappiness = ( message ) => {
-		const tracksEvent = recordTracksEvent( 'calypso_rewind_creds_update_failure', {
+	dispatch(
+		recordTracksEvent( 'calypso_rewind_creds_update_failure', {
 			site_id: action.siteId,
 			error: error.code,
 			error_message: error.message,
@@ -144,25 +122,18 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 			port: action.credentials.port,
 			protocol: action.credentials.protocol,
 			user: action.credentials.user,
-		} );
-
-		dispatch(
-			hasActiveHappychatSession( getState() )
-				? withAnalytics( tracksEvent, sendEvent( message ) )
-				: tracksEvent
-		);
-	};
+		} )
+	);
 
 	switch ( error.code ) {
 		case 'service_unavailable':
 			announce(
 				i18n.translate(
-					'A error occurred when we were trying to validate your site information. Please make sure your credentials and host URL are correct and try again. If you need help, please click on the support chat link.'
+					'A error occurred when we were trying to validate your site information. ' +
+						'Please make sure your credentials and host URL are correct and try again. ' +
+						'If you need help, please click on the support link.'
 				),
-				{ button: i18n.translate( 'Support chat' ), onClick: getHelp }
-			);
-			spreadHappiness(
-				'Restore Credentials: update request failed on timeout (could be us or remote site)'
+				{ button: i18n.translate( 'Get help' ), onClick: getHelp }
 			);
 			break;
 
@@ -170,7 +141,6 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 			announce(
 				i18n.translate( 'Something seems to be missing — please fill out all the required fields.' )
 			);
-			spreadHappiness( 'Restore Credentials: missing API args (contact a dev)' );
 			break;
 
 		case 'invalid_args':
@@ -180,7 +150,6 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 						'another look to ensure everything is in the right place.'
 				)
 			);
-			spreadHappiness( 'Restore Credentials: invalid API args (contact a dev)' );
 			break;
 
 		case 'invalid_credentials':
@@ -189,7 +158,6 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 					"We couldn't connect to your site. Please verify your credentials and give it another try."
 				)
 			);
-			spreadHappiness( 'Restore Credentials: invalid credentials' );
 			break;
 
 		case 'invalid_wordpress_path':
@@ -200,7 +168,6 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 				),
 				{ button: i18n.translate( 'Get help' ), onClick: getHelp }
 			);
-			spreadHappiness( "Restore Credentials: can't find WordPress installation files" );
 			break;
 
 		case 'read_only_install':
@@ -211,7 +178,6 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 				),
 				{ button: i18n.translate( 'Get help' ), onClick: getHelp }
 			);
-			spreadHappiness( 'Restore Credentials: creds only seem to provide read-only access' );
 			break;
 
 		case 'unreachable_path':
@@ -221,18 +187,15 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 						"but it didn't work. Please make sure the directory is accessible and try again."
 				)
 			);
-			spreadHappiness( 'Restore Credentials: creds might be for wrong site on right server' );
 			break;
 
 		default:
 			announce( i18n.translate( 'Error saving. Please check your credentials and try again.' ) );
-			spreadHappiness( 'Restore Credentials: unknown failure saving credentials' );
 	}
 };
 
 registerHandlers( 'state/data-layer/wpcom/activity-log/update-credentials/index.js', {
 	[ JETPACK_CREDENTIALS_UPDATE ]: [
-		primeHappychat,
 		dispatchRequest( {
 			fetch: request,
 			onSuccess: success,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR does the following:

* Removes loading Happychat for Jetpack credentials.
* Fixes broken help link to point to the Jetpack support form with current site.
* Changes icon for testing connection notice to be info instead of success to reduce confusion.

#### Screenshots

Here is an example message where the link was fixed:
<img width="878" alt="Screen Shot 2020-12-04 at 11 19 08 AM" src="https://user-images.githubusercontent.com/1760168/101189327-e3975380-3624-11eb-8b2c-7a8adf3baf0e.png">

Testing connection notification **before**:
<img width="290" alt="Screen Shot 2020-12-04 at 11 37 44 AM" src="https://user-images.githubusercontent.com/1760168/101189499-22c5a480-3625-11eb-8631-e1eb16544718.png">

After:
<img width="238" alt="Screen Shot 2020-12-04 at 11 28 49 AM" src="https://user-images.githubusercontent.com/1760168/101189370-f742ba00-3624-11eb-9982-b947f547471a.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set up a site with a plan that allows credential input.
2. Put in correct login info except for incorrect WP path and hit save.
3. Observe notice for testing.
4. Observe error message and click link for Get Help.

* Testing notice should match screenshot.
* Error message link should go to: `https://jetpack.com/contact-support/?rel=support&url=[site slug]`

**Note:** Currently there is a redirect from jetpack.com to jetpackme.wordpress.com. That is unrelated to this PR. You can observe network traffic to see the 301.

Fixes 1143508703416848-as-1199518262884263.