### PR TITLE
Modularise happychat state

### DIFF
--- a/client/state/happychat/connection/actions.js
+++ b/client/state/happychat/connection/actions.js
@@ -31,6 +31,8 @@ import {
 } from 'calypso/state/action-types';
 import { HAPPYCHAT_MESSAGE_TYPES } from 'calypso/state/happychat/constants';
 
+import 'calypso/state/happychat/init';
+
 /**
  * Returns an action object indicating that the connection is being stablished.
  *
@@ -154,6 +156,8 @@ export const receiveError = ( error ) => ( { type: HAPPYCHAT_IO_RECEIVE_ERROR, e
  * Returns an action object for the transcript reception.
  *
  * @param {object} result An object with {messages, timestamp} props
+ * @param {Array} result.messages An array of message objects
+ * @param {number} result.timestamp The transcript reception timestamp
  * @returns {object} Action object
  */
 export const receiveTranscript = ( { messages, timestamp } ) => ( {

--- a/client/state/happychat/connection/actions.js
+++ b/client/state/happychat/connection/actions.js
@@ -155,8 +155,8 @@ export const receiveError = ( error ) => ( { type: HAPPYCHAT_IO_RECEIVE_ERROR, e
 /**
  * Returns an action object for the transcript reception.
  *
- * @param {object} result An object with {messages, timestamp} props
- * @param {Array} result.messages An array of message objects
+ * @param {object} result           An object with {messages, timestamp} props
+ * @param {Array}  result.messages  An array of message objects
  * @param {number} result.timestamp The transcript reception timestamp
  * @returns {object} Action object
  */

--- a/client/state/happychat/init.js
+++ b/client/state/happychat/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'happychat' ], reducer );

--- a/client/state/happychat/package.json
+++ b/client/state/happychat/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -1,15 +1,17 @@
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'calypso/state/utils';
+import { combineReducers, withStorageKey } from 'calypso/state/utils';
 import chat from './chat/reducer';
 import connection from './connection/reducer';
 import ui from './ui/reducer';
 import user from './user/reducer';
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	chat,
 	connection,
 	ui,
 	user,
 } );
+
+export default withStorageKey( 'happychat', combinedReducer );

--- a/client/state/happychat/selectors/get-geolocation.js
+++ b/client/state/happychat/selectors/get-geolocation.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/happychat/init';
+
+/**
  * Returns the geo location of the current user, based happychat session initiation (on ip)
  *
  * @param {object}  state  Global state tree

--- a/client/state/happychat/selectors/get-happychat-chat-status.js
+++ b/client/state/happychat/selectors/get-happychat-chat-status.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/happychat/init';
+
+/**
  * Gets the current happychat chat status
  *
  * @param {object} state - global redux state

--- a/client/state/happychat/selectors/get-happychat-connection-status.js
+++ b/client/state/happychat/selectors/get-happychat-connection-status.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/happychat/init';
+
+/**
  * Gets the current happychat connection status
  *
  * @param {object} state - global redux state

--- a/client/state/happychat/selectors/get-happychat-current-message.js
+++ b/client/state/happychat/selectors/get-happychat-current-message.js
@@ -3,4 +3,9 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/happychat/init';
+
 export default ( state ) => get( state, 'happychat.ui.currentMessage' );

--- a/client/state/happychat/selectors/get-happychat-lastactivitytimestamp.js
+++ b/client/state/happychat/selectors/get-happychat-lastactivitytimestamp.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/happychat/init';
+
+/**
  * Gets the lastActivityTimestamp
  *
  * @param {object} state - global redux state

--- a/client/state/happychat/selectors/get-happychat-timeline.js
+++ b/client/state/happychat/selectors/get-happychat-timeline.js
@@ -8,6 +8,8 @@ import { map } from 'lodash';
  */
 import createSelector from 'calypso/lib/create-selector';
 
+import 'calypso/state/happychat/init';
+
 /**
  * Gets timeline chat events from the happychat state
  *

--- a/client/state/happychat/selectors/get-lostfocus-timestamp.js
+++ b/client/state/happychat/selectors/get-lostfocus-timestamp.js
@@ -3,4 +3,9 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/happychat/init';
+
 export default ( state ) => get( state, 'happychat.ui.lostFocusAt' );

--- a/client/state/happychat/selectors/has-active-happychat-session.js
+++ b/client/state/happychat/selectors/has-active-happychat-session.js
@@ -14,6 +14,8 @@ import {
 } from 'calypso/state/happychat/constants';
 import createSelector from 'calypso/lib/create-selector';
 
+import 'calypso/state/happychat/init';
+
 /**
  * Returns true if there's an active chat session in-progress. Chat sessions with
  * the status `new`, `default`, or `closed` are considered inactive, as the session

--- a/client/state/happychat/selectors/has-happychat-localized-support.js
+++ b/client/state/happychat/selectors/has-happychat-localized-support.js
@@ -8,6 +8,8 @@ import { get } from 'lodash';
  */
 import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-happychat-client-connected';
 
+import 'calypso/state/happychat/init';
+
 /**
  * Returns true if Happychat client is connected and server is available to take new localized chats
  *

--- a/client/state/happychat/selectors/is-happychat-available.js
+++ b/client/state/happychat/selectors/is-happychat-available.js
@@ -8,6 +8,8 @@ import { get } from 'lodash';
  */
 import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-happychat-client-connected';
 
+import 'calypso/state/happychat/init';
+
 /**
  * Returns true if Happychat client is connected and server is available to take new chats
  *

--- a/client/state/happychat/selectors/is-happychat-chat-assigned.js
+++ b/client/state/happychat/selectors/is-happychat-chat-assigned.js
@@ -8,5 +8,7 @@ import { get } from 'lodash';
  */
 import { HAPPYCHAT_CHAT_STATUS_ASSIGNED } from 'calypso/state/happychat/constants';
 
+import 'calypso/state/happychat/init';
+
 export default ( state ) =>
 	get( state, 'happychat.chat.status' ) === HAPPYCHAT_CHAT_STATUS_ASSIGNED;

--- a/client/state/happychat/selectors/is-happychat-minimizing.js
+++ b/client/state/happychat/selectors/is-happychat-minimizing.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/happychat/init';
+
+/**
  * Gets the current happychat minimizing status
  *
  * @param {object} state - global redux state

--- a/client/state/happychat/selectors/is-happychat-open.js
+++ b/client/state/happychat/selectors/is-happychat-open.js
@@ -4,6 +4,8 @@
 import createSelector from 'calypso/lib/create-selector';
 import { getSectionName } from 'calypso/state/ui/selectors';
 
+import 'calypso/state/happychat/init';
+
 /**
  * Returns whether the docked happychat client UI should be displayed
  * The docked UI should not be displayed when viewing the happychat section

--- a/client/state/happychat/selectors/is-happychat-server-reachable.js
+++ b/client/state/happychat/selectors/is-happychat-server-reachable.js
@@ -8,6 +8,8 @@ import { get } from 'lodash';
  */
 import { HAPPYCHAT_CONNECTION_ERROR_PING_TIMEOUT } from 'calypso/state/happychat/constants';
 
+import 'calypso/state/happychat/init';
+
 /**
  * Returns true if Happychat server is reachable
  *

--- a/client/state/happychat/selectors/is-happychat-user-eligible.js
+++ b/client/state/happychat/selectors/is-happychat-user-eligible.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/happychat/init';
+
+/**
  * @param {object} state - global redux state
  * @returns {boolean?} Whether the user is eligible for Happychat. `null` if the
  * eligibility status is unknown (i.e., not fetched from server yet)

--- a/client/state/happychat/selectors/is-precancellation-chat-available.js
+++ b/client/state/happychat/selectors/is-precancellation-chat-available.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/happychat/init';
+
+/**
  * Returns if precancellation chat is available.
  *
  * @param   {object}  state  Global state tree

--- a/client/state/happychat/selectors/is-presales-chat-available.js
+++ b/client/state/happychat/selectors/is-presales-chat-available.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/happychat/init';
+
+/**
  * Returns if presales chat is available.
  *
  * @param   {object}  state  Global state tree

--- a/client/state/happychat/ui/actions.js
+++ b/client/state/happychat/ui/actions.js
@@ -9,6 +9,8 @@ import {
 	HAPPYCHAT_SET_CURRENT_MESSAGE,
 } from 'calypso/state/action-types';
 
+import 'calypso/state/happychat/init';
+
 const setChatOpen = ( isOpen ) => ( { type: HAPPYCHAT_OPEN, isOpen } );
 const setChatMinimizing = ( isMinimizing ) => ( { type: HAPPYCHAT_MINIMIZING, isMinimizing } );
 

--- a/client/state/happychat/user/actions.js
+++ b/client/state/happychat/user/actions.js
@@ -10,6 +10,8 @@ import {
 import { errorNotice } from 'calypso/state/notices/actions';
 import { setSupportLevel } from 'calypso/state/help/actions';
 
+import 'calypso/state/happychat/init';
+
 export const setHappyChatEligibility = ( isEligible ) => ( {
 	type: HAPPYCHAT_ELIGIBILITY_SET,
 	isEligible,

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -18,7 +18,6 @@ import atomicTransfer from './atomic-transfer/reducer';
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import documentHead from './document-head/reducer';
-import happychat from './happychat/reducer';
 import i18n from './i18n/reducer';
 import importerNux from './importer-nux/reducer';
 import inlineSupportArticle from './inline-support-article/reducer';
@@ -39,7 +38,6 @@ const reducers = {
 	currentUser,
 	dataRequests,
 	documentHead,
-	happychat,
 	httpData,
 	i18n,
 	importerNux,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles happychat state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42440.

#### Changes proposed in this Pull Request

* Modularise happychat state

#### Testing instructions

Unfortunately, `happychat` state gets loaded pretty early on in the boot process, through the happychat middleware. As such, it's not easy to test the automated loading process, but it should be enough to smoke-test happychat functionality in order to ensure that it continues to work correctly.
