### PR TITLE
Purchases: Don't show pre-cancellation chat button for Jetpack products

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -33,7 +33,7 @@ import UpgradeATStep from './step-components/upgrade-at-step';
 import PrecancellationChatButton from './precancellation-chat-button';
 import DowngradeStep from './step-components/downgrade-step';
 import { getName, isRefundable } from 'calypso/lib/purchases';
-import { isGoogleApps } from 'calypso/lib/products-values';
+import { isGoogleApps, isJetpackPlanSlug, isJetpackProductSlug } from 'calypso/lib/products-values';
 import { radioOption } from './radio-option';
 import {
 	cancellationOptionsForPurchase,
@@ -74,6 +74,29 @@ class CancelPurchaseForm extends React.Component {
 		onInputChange: () => {},
 		showSurvey: true,
 		isVisible: false,
+	};
+
+	shouldShowChatButton = () => {
+		if ( ! config.isEnabled( 'upgrades/precancellation-chat' ) ) {
+			return false;
+		}
+
+		// Don't show a button to start Happychat
+		// if we're already in a chat session
+		const { surveyStep } = this.state;
+		if ( surveyStep === steps.HAPPYCHAT_STEP ) {
+			return false;
+		}
+
+		// Jetpack doesn't do Happychat support
+		const { purchase } = this.props;
+		const isJetpack =
+			isJetpackProductSlug( purchase.productSlug ) || isJetpackPlanSlug( purchase.productSlug );
+
+		// NOTE: The HappychatButton component may still decide not to render,
+		// based on agent availability and connection status.
+
+		return ! isJetpack;
 	};
 
 	getAllSurveySteps = () => {
@@ -709,10 +732,10 @@ class CancelPurchaseForm extends React.Component {
 			</Button>
 		);
 
-		const firstButtons =
-			config.isEnabled( 'upgrades/precancellation-chat' ) && surveyStep !== 'happychat_step'
-				? [ chat, close ]
-				: [ close ];
+		const firstButtons = [ close ];
+		if ( this.shouldShowChatButton() ) {
+			firstButtons.unshift( chat );
+		}
 
 		if ( surveyStep === steps.FINAL_STEP ) {
 			const stepsCount = this.getAllSurveySteps().length;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the **Need help? Chat with us** button from the pre-cancellation survey dialog if the purchase in question is a Jetpack product. (Jetpack doesn't do Happychat support.)

Fixes `1164141197617539-as-1193391635570025`.

#### Testing instructions

**Prerequisite:** At least one site with a cancellable Jetpack purchase, and at least one other site with a cancellable non-Jetpack purchase.

**Important:** The pre-cancellation Happychat button is only visible when Happychat agents are available to start a session and your browser has a connection to the Happychat server. To check your connection, inspect `state.happychat` in the Redux app state tree.

If Happychat isn't available for you *after clicking the button* to cancel a purchase, you can simulate an available state by sending the following action through Redux DevTools:

```js
{
  type: 'HAPPYCHAT_IO_RECEIVE_ACCEPT',
  isAvailable: true
}
```

##### Case 1: Site with a cancellable non-Jetpack product/plan purchase

* Attempt to remove/cancel the purchase (e.g., through the Billing page).
* In the pre-cancellation survey, verify that if a Happychat connection is available, you see a button at the bottom that says **Need help? Chat with us** and sends you to a new Happychat session if you click it.

##### Cases 2 & 3: Site with a cancellable Jetpack individual product (1) or plan (2) purchase

* Attempt to remove/cancel the purchase (e.g., through the Billing page).
* In the pre-cancellation survey, verify that even if a Happychat connection is available, no "chat" button is displayed.

#### Reference screenshots

##### Cancellation button

<img width="285" alt="Screen Shot 2020-12-04 at 11 01 59" src="https://user-images.githubusercontent.com/670067/101192287-7aaddc80-3620-11eb-8c94-68bc2bf9a123.png">

##### Pre-cancellation survey: chat button visible

<img width="542" alt="Screen Shot 2020-12-04 at 11 02 08" src="https://user-images.githubusercontent.com/670067/101192304-7f729080-3620-11eb-8a04-5adf65c5c7a9.png">

##### Pre-cancellation survey: chat button not visible

<img width="538" alt="Screen Shot 2020-12-04 at 11 04 46" src="https://user-images.githubusercontent.com/670067/101192346-8d281600-3620-11eb-87ac-36f695feb287.png">