### PR TITLE
Modularise selected editor state

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -25,7 +25,6 @@ import inlineSupportArticle from './inline-support-article/reducer';
 import jitm from './jitm/reducer';
 import mySites from './my-sites/reducer';
 import notices from './notices/reducer';
-import selectedEditor from './selected-editor/reducer';
 import sites from './sites/reducer';
 import support from './support/reducer';
 import userSettings from './user-settings/reducer';
@@ -47,7 +46,6 @@ const reducers = {
 	jitm,
 	mySites,
 	notices,
-	selectedEditor,
 	sites,
 	support,
 	userSettings,

--- a/client/state/selected-editor/actions.js
+++ b/client/state/selected-editor/actions.js
@@ -1,12 +1,10 @@
 /**
- * External dependencies
- */
-
-/**
  * Internal dependencies
  */
 import { EDITOR_TYPE_REQUEST, EDITOR_TYPE_UPDATE } from 'calypso/state/action-types';
+
 import 'calypso/state/data-layer/wpcom/sites/gutenberg';
+import 'calypso/state/selected-editor/init';
 
 export const requestSelectedEditor = ( siteId ) => ( {
 	type: EDITOR_TYPE_REQUEST,

--- a/client/state/selected-editor/init.js
+++ b/client/state/selected-editor/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import readerReducer from './reducer';
+
+registerReducer( [ 'selectedEditor' ], readerReducer );

--- a/client/state/selected-editor/init.js
+++ b/client/state/selected-editor/init.js
@@ -2,6 +2,6 @@
  * Internal dependencies
  */
 import { registerReducer } from 'calypso/state/redux-store';
-import readerReducer from './reducer';
+import reducer from './reducer';
 
-registerReducer( [ 'selectedEditor' ], readerReducer );
+registerReducer( [ 'selectedEditor' ], reducer );

--- a/client/state/selected-editor/package.json
+++ b/client/state/selected-editor/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/selected-editor/reducer.js
+++ b/client/state/selected-editor/reducer.js
@@ -1,14 +1,10 @@
 /**
- * External dependencies
- */
-
-/**
  * Internal dependencies
  */
 import { EDITOR_TYPE_SET } from 'calypso/state/action-types';
-import { keyedReducer } from 'calypso/state/utils';
+import { keyedReducer, withStorageKey } from 'calypso/state/utils';
 
 export const selectedEditor = ( state, { type, editor } ) =>
 	type === EDITOR_TYPE_SET ? editor : state;
 
-export default keyedReducer( 'siteId', selectedEditor );
+export default withStorageKey( 'selectedEditor', keyedReducer( 'siteId', selectedEditor ) );

--- a/client/state/selectors/get-selected-editor.js
+++ b/client/state/selectors/get-selected-editor.js
@@ -8,6 +8,8 @@ import { get } from 'lodash';
  */
 import isClassicEditorForced from 'calypso/state/selectors/is-classic-editor-forced';
 
+import 'calypso/state/selected-editor/init';
+
 /**
  * Returns the editor of the selected site
  *

--- a/client/state/selectors/is-classic-editor-forced.js
+++ b/client/state/selectors/is-classic-editor-forced.js
@@ -9,6 +9,8 @@ import { isEnabled } from 'calypso/config';
  */
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 
+import 'calypso/state/selected-editor/init';
+
 /**
  * Indicates if the classic editor should be always loaded even if the selected editor for the given site is Gutenberg.
  *


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles selected editor state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42474.

#### Changes proposed in this Pull Request

* Modularise selected editor state

#### Testing instructions

Unfortunately, `selectedEditor` state gets loaded pretty early on in the boot process, through the editor controller. As such, it's not easy to test the automated loading process, but it should be enough to smoke-test editor selection functionality in order to ensure that it continues to work correctly.
