### PR TITLE
Move is_anchor attribute on gutenboard designs to feature array

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -12,7 +12,7 @@
 			"categories": [ "featured" ],
 			"is_premium": false,
 			"is_fse": true,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Twenty Twenty One",
@@ -26,7 +26,7 @@
 			"categories": [ "featured" ],
 			"is_premium": false,
 			"is_fse": true,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Cassel",
@@ -39,7 +39,7 @@
 			},
 			"categories": [ "featured", "blog" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Edison",
@@ -52,7 +52,7 @@
 			},
 			"categories": [ "featured", "blog" ],
 			"is_premium": true,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Vesta",
@@ -65,7 +65,7 @@
 			},
 			"categories": [ "featured", "portfolio" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Doyle",
@@ -78,7 +78,7 @@
 			},
 			"categories": [ "featured", "business" ],
 			"is_premium": true,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Bowen",
@@ -91,7 +91,7 @@
 			},
 			"categories": [ "featured", "blog" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Easley",
@@ -104,7 +104,7 @@
 			},
 			"categories": [ "featured", "portfolio" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Camdem",
@@ -117,7 +117,7 @@
 			},
 			"categories": [ "featured", "portfolio" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Reynolds",
@@ -130,7 +130,7 @@
 			},
 			"categories": [ "featured", "portfolio" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Overton",
@@ -143,7 +143,7 @@
 			},
 			"categories": [ "featured", "business" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Brice",
@@ -156,7 +156,7 @@
 			},
 			"categories": [ "featured", "charity", "non-profit" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Barnsbury",
@@ -169,7 +169,7 @@
 			},
 			"categories": [ "featured", "business" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Alves",
@@ -182,7 +182,7 @@
 			},
 			"categories": [ "featured", "non-profit", "charity" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Mayland",
@@ -195,7 +195,7 @@
 			},
 			"categories": [ "featured", "portfolio" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Rivington",
@@ -208,7 +208,7 @@
 			},
 			"categories": [ "featured", "real estate listing" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Maywood",
@@ -221,7 +221,7 @@
 			},
 			"categories": [ "featured", "restaurant, small business" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Balasana",
@@ -234,7 +234,7 @@
 			},
 			"categories": [ "featured", "restaurant, small business" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Stratford",
@@ -247,7 +247,7 @@
 			},
 			"categories": [ "featured", "school" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Rockfield",
@@ -260,7 +260,7 @@
 			},
 			"categories": [ "featured", "restaurant", "small business" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Coutoire",
@@ -273,7 +273,7 @@
 			},
 			"categories": [ "featured", "portfolio" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Leven",
@@ -286,7 +286,7 @@
 			},
 			"categories": [ "featured", "portfolio", "small business" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Gibbs",
@@ -299,7 +299,7 @@
 			},
 			"categories": [ "featured", "restaurant", "small business" ],
 			"is_premium": false,
-			"is_anchorfm": false
+			"features": []
 		},
 		{
 			"title": "Leven (Anchor Placeholder, to be removed)",
@@ -312,7 +312,7 @@
 			},
 			"categories": [ "featured", "portfolio", "small business" ],
 			"is_premium": false,
-			"is_anchorfm": true
+			"features": [ "anchorfm" ]
 		},
 		{
 			"title": "Gibbs (Anchor Placeholder, to be removed)",
@@ -325,7 +325,7 @@
 			},
 			"categories": [ "featured", "restaurant", "small business" ],
 			"is_premium": false,
-			"is_anchorfm": true
+			"features": [ "anchorfm" ]
 		}
 	]
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -68,7 +68,7 @@ const DesignSelector: React.FunctionComponent = () => {
 							( design ) =>
 								// TODO Add finalized design templates to client/landing/gutenboarding/available-designs-config.json
 								// along with is_anchorfm prop
-								isAnchorFmSignup === ( design.is_anchorfm ?? false )
+								isAnchorFmSignup === design.features.includes( 'anchorfm' )
 						)
 						.map( ( design ) => (
 							<button

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -29,11 +29,12 @@ export interface SiteVertical {
 	slug?: string;
 }
 
+export type DesignFeatures = 'anchorfm'; // For additional features, = 'anchorfm' | 'feature2' | 'feature3'
+
 export interface Design {
 	categories: Array< string >;
 	fonts: FontPair;
 	is_alpha?: boolean;
-	is_anchorfm?: boolean;
 	is_fse?: boolean;
 	is_premium: boolean;
 	slug: string;
@@ -41,4 +42,5 @@ export interface Design {
 	template: string;
 	theme: string;
 	title: string;
+	features: Array< DesignFeatures >;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the `.is_anchor` attribute on gutenboarding designs to a `features` array
  * Trying to address the feedback from #47600 that there are too many ".is_XYZ" fields being added to gutenboarding designs.  Later, we can add other non-anchor fields.

#### Testing instructions

* Visit http://calypso.localhost:3000/new?anchor_podcast=cafef00d in a private window
  * You should only see the two anchor designs on the design step
* Visit http://calypso.localhost:3000/new? in a private window
  * You should see the regular designs, but not the anchor designs