### PR TITLE
New onboarding: existing users non-en A/B test

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -130,7 +130,7 @@ export default {
 				// Assign to the experiment only logged-in users creating a site using 'onboarding' flow.
 				const existingUsersOnboardingVariant = getVariationForUser(
 					state,
-					'new_onboarding_existing_users_non_en'
+					'new_onboarding_existing_users_non_en_v2'
 				);
 
 				if (

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -43,6 +43,7 @@ import { requestGeoLocation } from 'calypso/state/data-getters';
 import { getDotBlogVerticalId } from './config/dotblog-verticals';
 import { abtest } from 'calypso/lib/abtest';
 import user from 'calypso/lib/user';
+import { getVariationForUser } from 'calypso/state/experiments/selectors';
 
 /**
  * Constants
@@ -123,7 +124,18 @@ export default {
 			const locale = getCurrentUserLocale( context.store.getState() );
 			const flowName = getFlowName( context.params );
 			const userLoggedIn = isUserLoggedIn( context.store.getState() );
-			if ( userLoggedIn && flowName === 'onboarding' && [ 'en', 'en-gb' ].includes( locale ) ) {
+
+			// Get the variant for "New Onboarding for existing users [non-EN]"" experiment
+			const existingUsersOnboardingVariant = getVariationForUser(
+				context.store.getState(),
+				'new_onboarding_existing_users_non_en'
+			);
+
+			if (
+				userLoggedIn &&
+				flowName === 'onboarding' &&
+				( existingUsersOnboardingVariant === 'treatment' || [ 'en', 'en-gb' ].includes( locale ) )
+			) {
 				gutenbergRedirect( context.params.flowName );
 				return;
 			}

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -121,23 +121,25 @@ export default {
 
 			next();
 		} else {
-			const locale = getCurrentUserLocale( context.store.getState() );
+			const state = context.store.getState();
+			const locale = getCurrentUserLocale( state );
 			const flowName = getFlowName( context.params );
-			const userLoggedIn = isUserLoggedIn( context.store.getState() );
+			const userLoggedIn = isUserLoggedIn( state );
 
-			// Get the variant for "New Onboarding for existing users [non-EN]"" experiment
-			const existingUsersOnboardingVariant = getVariationForUser(
-				context.store.getState(),
-				'new_onboarding_existing_users_non_en'
-			);
+			if ( userLoggedIn && flowName === 'onboarding' ) {
+				// Assign to the experiment only logged-in users creating a site using 'onboarding' flow.
+				const existingUsersOnboardingVariant = getVariationForUser(
+					state,
+					'new_onboarding_existing_users_non_en'
+				);
 
-			if (
-				userLoggedIn &&
-				flowName === 'onboarding' &&
-				( existingUsersOnboardingVariant === 'treatment' || [ 'en', 'en-gb' ].includes( locale ) )
-			) {
-				gutenbergRedirect( context.params.flowName );
-				return;
+				if (
+					existingUsersOnboardingVariant === 'treatment' ||
+					[ 'en', 'en-gb' ].includes( locale )
+				) {
+					gutenbergRedirect( context.params.flowName );
+					return;
+				}
 			}
 
 			waitForHttpData( () => ( { geo: requestGeoLocation() } ) )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add code for `new_onboarding_existing_users_non_en` experiment.

#### Testing instructions
* As a logged in user with any locale other than 'en' or 'en-gb' set in your account, try creating a site starting from Calypso or by navigating to `/start`.
  * if you are assigned to 'control' variation you will continue with the `/start` flow.
  * if you are assigned to 'treatment' variation you will continue with the `/new` flow.

#### Context
pbxNRc-vn-p2