### PR TITLE
Checkout: Decouple existingCardProcessor from checkout

### DIFF
--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -183,7 +183,7 @@ function ChangePaymentMethodList( {
 	const currentlyAssignedPaymentMethodId = 'existingCard-' + currentPaymentMethod.stored_details_id; // TODO: make this work for paypal.
 
 	const translate = useTranslate();
-	const { isStripeLoading } = useStripe();
+	const { isStripeLoading, stripe, stripeConfiguration } = useStripe();
 	const paymentMethods = useAssignablePaymentMethods();
 
 	const showErrorMessage = useCallback( ( error ) => {
@@ -218,7 +218,10 @@ function ChangePaymentMethodList( {
 			paymentProcessors={ {
 				'existing-card': ( data ) => assignExistingCardProcessor( purchase, data ),
 				card: ( data ) =>
-					assignNewCardProcessor( { purchase, translate, siteSlug, apiParams }, data ),
+					assignNewCardProcessor(
+						{ purchase, translate, siteSlug, apiParams, stripe, stripeConfiguration },
+						data
+					),
 			} }
 			isLoading={ isStripeLoading }
 			initiallySelectedPaymentMethodId={ currentlyAssignedPaymentMethodId }
@@ -252,8 +255,8 @@ async function assignExistingCardProcessor( purchase, { storedDetailsId } ) {
 }
 
 async function assignNewCardProcessor(
-	{ purchase, translate, siteSlug, apiParams },
-	{ stripe, stripeConfiguration, name, countryCode, postalCode }
+	{ purchase, translate, siteSlug, apiParams, stripe, stripeConfiguration },
+	{ name, countryCode, postalCode }
 ) {
 	const createStripeSetupIntentAsync = async ( paymentDetails ) => {
 		const { country, 'postal-code': zip } = paymentDetails;

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -422,17 +422,23 @@ export default function CompositeCheckout( {
 			includeGSuiteDetails,
 			recordEvent,
 			createUserAndSiteBeforeTransaction,
+			stripeConfiguration,
 		} ),
-		[ includeDomainDetails, includeGSuiteDetails, recordEvent, createUserAndSiteBeforeTransaction ]
+		[
+			includeDomainDetails,
+			includeGSuiteDetails,
+			recordEvent,
+			createUserAndSiteBeforeTransaction,
+			stripeConfiguration,
+		]
 	);
 	const dataForRedirectProcessor = useMemo(
 		() => ( {
 			...dataForProcessor,
 			getThankYouUrl,
 			siteSlug,
-			createUserAndSiteBeforeTransaction,
 		} ),
-		[ dataForProcessor, getThankYouUrl, siteSlug, createUserAndSiteBeforeTransaction ]
+		[ dataForProcessor, getThankYouUrl, siteSlug ]
 	);
 
 	const paymentProcessors = useMemo(

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -51,11 +51,11 @@ import {
 	freePurchaseProcessor,
 	multiPartnerCardProcessor,
 	fullCreditsProcessor,
-	existingCardProcessor,
 	payPalProcessor,
 	genericRedirectProcessor,
 	weChatProcessor,
 } from './payment-method-processors';
+import existingCardProcessor from './lib/existing-card-processor';
 import useGetThankYouUrl from './hooks/use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
 import { useProductVariants } from './hooks/product-variants';

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -489,13 +489,16 @@ export default function CompositeCheckout( {
 				fullCreditsProcessor( transactionData, dataForProcessor, transactionOptions ),
 			'existing-card': ( transactionData: unknown ) =>
 				existingCardProcessor(
-					mergeIfObjects( transactionData, {
-						country: countryCode,
-						postalCode,
-						subdivisionCode,
-						siteId: siteId ? String( siteId ) : undefined,
-						domainDetails,
-					} ),
+					mergeIfObjects( [
+						transactionData,
+						{
+							country: countryCode,
+							postalCode,
+							subdivisionCode,
+							siteId: siteId ? String( siteId ) : undefined,
+							domainDetails,
+						},
+					] ),
 					dataForProcessor
 				),
 			paypal: ( transactionData: unknown ) =>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -493,7 +493,7 @@ export default function CompositeCheckout( {
 						country: countryCode,
 						postalCode,
 						subdivisionCode,
-						siteId,
+						siteId: siteId ? String( siteId ) : '',
 						domainDetails,
 					} ),
 					dataForProcessor

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -489,16 +489,13 @@ export default function CompositeCheckout( {
 				fullCreditsProcessor( transactionData, dataForProcessor, transactionOptions ),
 			'existing-card': ( transactionData: unknown ) =>
 				existingCardProcessor(
-					mergeIfObjects( [
-						transactionData,
-						{
-							country: countryCode,
-							postalCode,
-							subdivisionCode,
-							siteId: siteId ? String( siteId ) : undefined,
-							domainDetails,
-						},
-					] ),
+					mergeIfObjects( transactionData, {
+						country: countryCode,
+						postalCode,
+						subdivisionCode,
+						siteId: siteId ? String( siteId ) : undefined,
+						domainDetails,
+					} ),
 					dataForProcessor
 				),
 			paypal: ( transactionData: unknown ) =>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -56,6 +56,7 @@ import {
 	weChatProcessor,
 } from './payment-method-processors';
 import existingCardProcessor from './lib/existing-card-processor';
+import type { ExistingCardProcessorData } from './lib/existing-card-processor';
 import useGetThankYouUrl from './hooks/use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
 import { useProductVariants } from './hooks/product-variants';
@@ -473,7 +474,7 @@ export default function CompositeCheckout( {
 				genericRedirectProcessor( 'brazil-tef', transactionData, dataForRedirectProcessor ),
 			'full-credits': ( transactionData: unknown ) =>
 				fullCreditsProcessor( transactionData, dataForProcessor, transactionOptions ),
-			'existing-card': ( transactionData: unknown ) =>
+			'existing-card': ( transactionData: ExistingCardProcessorData ) =>
 				existingCardProcessor( transactionData, dataForProcessor ),
 			paypal: ( transactionData: unknown ) =>
 				payPalProcessor(

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -139,7 +139,6 @@ export default function CompositeCheckout( {
 	const isPrivate = useSelector( ( state ) => siteId && isPrivateSite( state, siteId ) ) || false;
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const createUserAndSiteBeforeTransaction = Boolean( isLoggedOutCart || isNoSiteCart );
-	const transactionOptions = { createUserAndSiteBeforeTransaction };
 	const reduxDispatch = useDispatch();
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const recordEvent: ( action: ReactStandardAction ) => void = useCallback(
@@ -416,21 +415,24 @@ export default function CompositeCheckout( {
 	const contactDetailsType = getContactDetailsType( responseCart );
 	const includeDomainDetails = contactDetailsType === 'domain';
 	const includeGSuiteDetails = contactDetailsType === 'gsuite';
+	const transactionOptions = { createUserAndSiteBeforeTransaction };
 	const dataForProcessor = useMemo(
 		() => ( {
 			includeDomainDetails,
 			includeGSuiteDetails,
 			recordEvent,
+			createUserAndSiteBeforeTransaction,
 		} ),
-		[ includeDomainDetails, includeGSuiteDetails, recordEvent ]
+		[ includeDomainDetails, includeGSuiteDetails, recordEvent, createUserAndSiteBeforeTransaction ]
 	);
 	const dataForRedirectProcessor = useMemo(
 		() => ( {
 			...dataForProcessor,
 			getThankYouUrl,
 			siteSlug,
+			createUserAndSiteBeforeTransaction,
 		} ),
-		[ dataForProcessor, getThankYouUrl, siteSlug ]
+		[ dataForProcessor, getThankYouUrl, siteSlug, createUserAndSiteBeforeTransaction ]
 	);
 
 	const paymentProcessors = useMemo(
@@ -466,7 +468,7 @@ export default function CompositeCheckout( {
 			'full-credits': ( transactionData: unknown ) =>
 				fullCreditsProcessor( transactionData, dataForProcessor, transactionOptions ),
 			'existing-card': ( transactionData: unknown ) =>
-				existingCardProcessor( transactionData, dataForProcessor, transactionOptions ),
+				existingCardProcessor( transactionData, dataForProcessor ),
 			paypal: ( transactionData: unknown ) =>
 				payPalProcessor(
 					transactionData,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -493,7 +493,7 @@ export default function CompositeCheckout( {
 						country: countryCode,
 						postalCode,
 						subdivisionCode,
-						siteId: siteId ? String( siteId ) : '',
+						siteId: siteId ? String( siteId ) : undefined,
 						domainDetails,
 					} ),
 					dataForProcessor

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -11,7 +11,6 @@ import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
  */
 import { createTransactionEndpointRequestPayloadFromLineItems } from './translate-cart';
 import { wpcomTransaction } from '../payment-method-helpers';
-import saveTransactionResponseToWpcomStore from './save-transaction-response-to-wpcom-store';
 import type { CardProcessorOptions } from '../types/payment-processors';
 import type { TransactionRequestWithLineItems } from '../types/transaction-endpoint';
 
@@ -29,7 +28,6 @@ export default async function existingCardProcessor(
 		throw new Error( 'Stripe configuration is required' );
 	}
 	return submitExistingCardPayment( transactionData, dataForProcessor )
-		.then( saveTransactionResponseToWpcomStore )
 		.then( ( stripeResponse ) => {
 			if ( stripeResponse?.message?.payment_intent_client_secret ) {
 				// 3DS authentication required

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -11,14 +11,14 @@ import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
  */
 import { createTransactionEndpointRequestPayloadFromLineItems } from './translate-cart';
 import { wpcomTransaction } from '../payment-method-helpers';
-import type { CardProcessorOptions } from '../types/payment-processors';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { TransactionRequestWithLineItems } from '../types/transaction-endpoint';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
 
 export default async function existingCardProcessor(
 	transactionData: unknown,
-	dataForProcessor: CardProcessorOptions
+	dataForProcessor: PaymentProcessorOptions
 ): Promise< PaymentProcessorResponse > {
 	if ( ! isValidTransactionData( transactionData ) ) {
 		throw new Error( 'Required purchase data is missing' );
@@ -49,7 +49,7 @@ export default async function existingCardProcessor(
 
 async function submitExistingCardPayment(
 	transactionData: ExistingCardTransactionRequest,
-	transactionOptions: CardProcessorOptions
+	transactionOptions: PaymentProcessorOptions
 ) {
 	debug( 'formatting existing card transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -12,7 +12,7 @@ import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import { createTransactionEndpointRequestPayloadFromLineItems } from './translate-cart';
 import { wpcomTransaction } from '../payment-method-helpers';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
-import type { TransactionRequestWithLineItems } from '../types/transaction-endpoint';
+import type { ExistingCardTransactionRequestWithLineItems } from '../types/transaction-endpoint';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
 
@@ -61,7 +61,10 @@ async function submitExistingCardPayment(
 	return wpcomTransaction( formattedTransactionData, transactionOptions );
 }
 
-type ExistingCardTransactionRequest = Omit< TransactionRequestWithLineItems, 'paymentMethodType' >;
+type ExistingCardTransactionRequest = Omit<
+	ExistingCardTransactionRequestWithLineItems,
+	'paymentMethodType'
+>;
 
 function isValidTransactionData(
 	submitData: unknown

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -31,10 +31,18 @@ export default async function existingCardProcessor(
 	submitData: ExistingCardProcessorData,
 	dataForProcessor: CardProcessorOptions
 ): Promise< PaymentProcessorResponse > {
-	const { includeDomainDetails, includeGSuiteDetails, recordEvent } = dataForProcessor;
-	const country = select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value;
-	const subdivisionCode = select( 'wpcom' )?.getContactInfo?.()?.state?.value;
-	const siteId = select( 'wpcom' )?.getSiteId?.();
+	const {
+		includeDomainDetails,
+		includeGSuiteDetails,
+		stripeConfiguration,
+		recordEvent,
+	} = dataForProcessor;
+	const country: string | undefined = select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value;
+	const subdivisionCode: string | undefined = select( 'wpcom' )?.getContactInfo?.()?.state?.value;
+	const siteId: string | undefined = select( 'wpcom' )?.getSiteId?.();
+	if ( ! stripeConfiguration ) {
+		throw new Error( 'Stripe configuration is required' );
+	}
 	return submitExistingCardPayment(
 		{
 			...submitData,
@@ -52,7 +60,7 @@ export default async function existingCardProcessor(
 				// 3DS authentication required
 				recordEvent( { type: 'SHOW_MODAL_AUTHORIZATION' } );
 				return confirmStripePaymentIntent(
-					dataForProcessor.stripeConfiguration,
+					stripeConfiguration,
 					stripeResponse?.message?.payment_intent_client_secret
 				);
 			}

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -68,21 +68,31 @@ function isValidTransactionData(
 ): submitData is ExistingCardTransactionRequest {
 	const data = submitData as ExistingCardTransactionRequest;
 	if ( ! ( data?.items?.length > 0 ) ) {
-		return false;
+		throw new Error( 'Transaction requires items and none were provided' );
 	}
 	// Validate data required for this payment method type. Some other data may
 	// be required by the server but not required here since the server will give
 	// a better localized error message than we can provide.
-	if (
-		! data.siteId ||
-		! data.country ||
-		! data.postalCode ||
-		! data.storedDetailsId ||
-		! data.name ||
-		! data.paymentMethodToken ||
-		! data.paymentPartnerProcessorId
-	) {
-		return false;
+	if ( ! data.siteId ) {
+		throw new Error( 'Transaction requires siteId and none was provided' );
+	}
+	if ( ! data.country ) {
+		throw new Error( 'Transaction requires country code and none was provided' );
+	}
+	if ( ! data.postalCode ) {
+		throw new Error( 'Transaction requires postal code and none was provided' );
+	}
+	if ( ! data.storedDetailsId ) {
+		throw new Error( 'Transaction requires saved card information and none was provided' );
+	}
+	if ( ! data.name ) {
+		throw new Error( 'Transaction requires cardholder name and none was provided' );
+	}
+	if ( ! data.paymentMethodToken ) {
+		throw new Error( 'Transaction requires a Stripe token and none was provided' );
+	}
+	if ( ! data.paymentPartnerProcessorId ) {
+		throw new Error( 'Transaction requires a processor id and none was provided' );
 	}
 	return true;
 }

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -50,7 +50,7 @@ export default async function existingCardProcessor(
 }
 
 async function submitExistingCardPayment(
-	transactionData: TransactionRequestWithLineItems,
+	transactionData: ExistingCardTransactionRequest,
 	transactionOptions: CardProcessorOptions
 ) {
 	debug( 'formatting existing card transaction', transactionData );
@@ -63,10 +63,12 @@ async function submitExistingCardPayment(
 	return wpcomTransaction( formattedTransactionData, transactionOptions );
 }
 
+type ExistingCardTransactionRequest = Omit< TransactionRequestWithLineItems, 'paymentMethodType' >;
+
 function isValidTransactionData(
 	submitData: unknown
-): submitData is TransactionRequestWithLineItems {
-	const data = submitData as TransactionRequestWithLineItems;
+): submitData is ExistingCardTransactionRequest {
+	const data = submitData as ExistingCardTransactionRequest;
 	if ( ! ( data?.items?.length > 0 ) ) {
 		return false;
 	}
@@ -79,7 +81,6 @@ function isValidTransactionData(
 		! data.postalCode ||
 		! data.storedDetailsId ||
 		! data.name ||
-		! data.paymentMethodType ||
 		! data.paymentMethodToken ||
 		! data.paymentPartnerProcessorId
 	) {

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import {
+	defaultRegistry,
+	makeSuccessResponse,
+	makeRedirectResponse,
+} from '@automattic/composite-checkout';
+import { confirmStripePaymentIntent } from '@automattic/calypso-stripe';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+
+/**
+ * Internal dependencies
+ */
+import { createTransactionEndpointRequestPayloadFromLineItems } from '../types/transaction-endpoint';
+import { getPostalCode, getDomainDetails, wpcomTransaction } from '../payment-method-helpers';
+import saveTransactionResponseToWpcomStore from './save-transaction-response-to-wpcom-store';
+
+const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
+const { select } = defaultRegistry;
+
+export default async function existingCardProcessor(
+	submitData,
+	{ includeDomainDetails, includeGSuiteDetails, recordEvent },
+	transactionOptions
+): Promise< PaymentProcessorResponse > {
+	return submitExistingCardPayment(
+		{
+			...submitData,
+			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+			postalCode: getPostalCode(),
+			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		},
+		wpcomTransaction,
+		transactionOptions
+	)
+		.then( saveTransactionResponseToWpcomStore )
+		.then( ( stripeResponse ) => {
+			if ( stripeResponse?.message?.payment_intent_client_secret ) {
+				// 3DS authentication required
+				recordEvent( { type: 'SHOW_MODAL_AUTHORIZATION' } );
+				return confirmStripePaymentIntent(
+					submitData.stripeConfiguration,
+					stripeResponse?.message?.payment_intent_client_secret
+				);
+			}
+			return stripeResponse;
+		} )
+		.then( ( stripeResponse ) => {
+			if ( stripeResponse?.redirect_url ) {
+				return makeRedirectResponse( stripeResponse.redirect_url );
+			}
+			return makeSuccessResponse( stripeResponse );
+		} );
+}
+
+async function submitExistingCardPayment( transactionData, submit, transactionOptions ) {
+	debug( 'formatting existing card transaction', transactionData );
+	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
+		...transactionData,
+		paymentMethodType: 'WPCOM_Billing_MoneyPress_Stored',
+	} );
+	debug( 'submitting existing card transaction', formattedTransactionData );
+	return submit( formattedTransactionData, transactionOptions );
+}

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -22,7 +22,7 @@ export default async function existingCardProcessor(
 	dataForProcessor: CardProcessorOptions
 ): Promise< PaymentProcessorResponse > {
 	if ( ! isValidTransactionData( transactionData ) ) {
-		throw new Error( 'Missing data for processor' );
+		throw new Error( 'Required purchase data is missing' );
 	}
 	const { stripeConfiguration, recordEvent } = dataForProcessor;
 	if ( ! stripeConfiguration ) {
@@ -70,11 +70,16 @@ function isValidTransactionData(
 	if ( ! ( data?.items?.length > 0 ) ) {
 		return false;
 	}
-	// Data required for this payment method type
+	// Validate data required for this payment method type. Some other data may
+	// be required by the server but not required here since the server will give
+	// a better localized error message than we can provide.
 	if (
 		! data.siteId ||
+		! data.country ||
+		! data.postalCode ||
 		! data.storedDetailsId ||
 		! data.name ||
+		! data.paymentMethodType ||
 		! data.paymentMethodToken ||
 		! data.paymentPartnerProcessorId
 	) {

--- a/client/my-sites/checkout/composite-checkout/lib/get-domain-details.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-domain-details.ts
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { defaultRegistry } from '@automattic/composite-checkout';
+import type { DomainContactDetails } from '@automattic/shopping-cart';
+
+/**
+ * Internal dependencies
+ */
+import { prepareDomainContactDetailsForTransaction } from 'calypso/my-sites/checkout/composite-checkout/types/wpcom-store-state';
+import type { ManagedContactDetails } from '../types/wpcom-store-state';
+
+const { select } = defaultRegistry;
+
+export default function getDomainDetails( {
+	includeDomainDetails,
+	includeGSuiteDetails,
+}: {
+	includeDomainDetails: boolean;
+	includeGSuiteDetails: boolean;
+} ): DomainContactDetails | null {
+	const managedContactDetails: ManagedContactDetails | undefined = select(
+		'wpcom'
+	)?.getContactInfo();
+	if ( ! managedContactDetails ) {
+		return null;
+	}
+	const domainDetails = prepareDomainContactDetailsForTransaction( managedContactDetails );
+	return includeDomainDetails || includeGSuiteDetails ? domainDetails : null;
+}

--- a/client/my-sites/checkout/composite-checkout/lib/get-domain-details.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-domain-details.ts
@@ -18,13 +18,13 @@ export default function getDomainDetails( {
 }: {
 	includeDomainDetails: boolean;
 	includeGSuiteDetails: boolean;
-} ): DomainContactDetails | null {
+} ): DomainContactDetails | undefined {
 	const managedContactDetails: ManagedContactDetails | undefined = select(
 		'wpcom'
 	)?.getContactInfo();
 	if ( ! managedContactDetails ) {
-		return null;
+		return undefined;
 	}
 	const domainDetails = prepareDomainContactDetailsForTransaction( managedContactDetails );
-	return includeDomainDetails || includeGSuiteDetails ? domainDetails : null;
+	return includeDomainDetails || includeGSuiteDetails ? domainDetails : undefined;
 }

--- a/client/my-sites/checkout/composite-checkout/lib/get-postal-code.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-postal-code.ts
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { defaultRegistry } from '@automattic/composite-checkout';
+
+/**
+ * Internal dependencies
+ */
+import { tryToGuessPostalCodeFormat } from 'calypso/lib/postal-code';
+import type { ManagedContactDetails } from '../types/wpcom-store-state';
+
+const { select } = defaultRegistry;
+
+export default function getPostalCode(): string {
+	const managedContactDetails: ManagedContactDetails | undefined = select(
+		'wpcom'
+	)?.getContactInfo();
+	if ( ! managedContactDetails ) {
+		return '';
+	}
+	const countryCode = managedContactDetails.countryCode?.value ?? '';
+	const postalCode = managedContactDetails.postalCode?.value ?? '';
+	return tryToGuessPostalCodeFormat( postalCode.toUpperCase(), countryCode );
+}

--- a/client/my-sites/checkout/composite-checkout/lib/merge-if-objects.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/merge-if-objects.ts
@@ -1,8 +1,10 @@
-export default function mergeIfObjects( obj1: unknown, obj2: unknown ): MergedObject {
-	if ( typeof obj1 === 'object' && typeof obj2 === 'object' ) {
-		return { ...obj1, ...obj2 };
-	}
-	return {};
+export default function mergeIfObjects( objects: unknown[] ): MergedObject {
+	return objects.reduce( ( merged: MergedObject, obj: unknown ): MergedObject => {
+		if ( typeof obj !== 'object' ) {
+			return merged;
+		}
+		return { ...merged, ...obj };
+	}, {} );
 }
 
 type MergedObject = Record< string, unknown >;

--- a/client/my-sites/checkout/composite-checkout/lib/merge-if-objects.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/merge-if-objects.ts
@@ -1,0 +1,8 @@
+export default function mergeIfObjects( obj1: unknown, obj2: unknown ): MergedObject {
+	if ( typeof obj1 === 'object' && typeof obj2 === 'object' ) {
+		return { ...obj1, ...obj2 };
+	}
+	return {};
+}
+
+type MergedObject = Record< string, unknown >;

--- a/client/my-sites/checkout/composite-checkout/lib/merge-if-objects.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/merge-if-objects.ts
@@ -1,4 +1,4 @@
-export default function mergeIfObjects( objects: unknown[] ): MergedObject {
+export default function mergeIfObjects( ...objects: unknown[] ): MergedObject {
 	return objects.reduce( ( merged: MergedObject, obj: unknown ): MergedObject => {
 		if ( typeof obj !== 'object' ) {
 			return merged;

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -289,7 +289,7 @@ export function createTransactionEndpointCartFromLineItems( {
 	items,
 	contactDetails,
 }: {
-	siteId: string;
+	siteId: string | undefined;
 	couponId?: string;
 	country: string;
 	postalCode: string;

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -13,7 +13,6 @@ import wp from 'calypso/lib/wp';
 import { createTransactionEndpointRequestPayloadFromLineItems } from './types/transaction-endpoint';
 import { createPayPalExpressEndpointRequestPayloadFromLineItems } from './types/paypal-express';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from './lib/translate-payment-method-names';
-import { prepareDomainContactDetailsForTransaction } from 'calypso/my-sites/checkout/composite-checkout/types/wpcom-store-state';
 import { tryToGuessPostalCodeFormat } from 'calypso/lib/postal-code';
 import { getSavedVariations } from 'calypso/lib/abtest';
 import { stringifyBody } from 'calypso/state/login/utils';
@@ -39,12 +38,6 @@ export async function submitPayPalExpressRequest( transactionData, submit, trans
 	} );
 	debug( 'sending paypal transaction', formattedTransactionData );
 	return submit( formattedTransactionData, transactionOptions );
-}
-
-export function getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ) {
-	const managedContactDetails = select( 'wpcom' )?.getContactInfo?.() ?? {};
-	const domainDetails = prepareDomainContactDetailsForTransaction( managedContactDetails );
-	return includeDomainDetails || includeGSuiteDetails ? domainDetails : null;
 }
 
 export async function fetchStripeConfiguration( requestArgs, wpcom ) {

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -22,16 +22,6 @@ import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
 const { select } = defaultRegistry;
 
-export async function submitExistingCardPayment( transactionData, submit, transactionOptions ) {
-	debug( 'formatting existing card transaction', transactionData );
-	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
-		...transactionData,
-		paymentMethodType: 'WPCOM_Billing_MoneyPress_Stored',
-	} );
-	debug( 'submitting existing card transaction', formattedTransactionData );
-	return submit( formattedTransactionData, transactionOptions );
-}
-
 export async function submitApplePayPayment( transactionData, submit, transactionOptions ) {
 	debug( 'formatting apple-pay transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -13,7 +13,6 @@ import wp from 'calypso/lib/wp';
 import { createTransactionEndpointRequestPayloadFromLineItems } from './types/transaction-endpoint';
 import { createPayPalExpressEndpointRequestPayloadFromLineItems } from './types/paypal-express';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from './lib/translate-payment-method-names';
-import { tryToGuessPostalCodeFormat } from 'calypso/lib/postal-code';
 import { getSavedVariations } from 'calypso/lib/abtest';
 import { stringifyBody } from 'calypso/state/login/utils';
 import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
@@ -255,10 +254,4 @@ export function createStripePaymentMethodToken( { stripe, name, country, postalC
 			postal_code: postalCode,
 		},
 	} );
-}
-
-export function getPostalCode() {
-	const countryCode = select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value ?? '';
-	const postalCode = select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value ?? '';
-	return tryToGuessPostalCodeFormat( postalCode.toUpperCase(), countryCode );
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -14,7 +14,6 @@ import { confirmStripePaymentIntent } from '@automattic/calypso-stripe';
  * Internal dependencies
  */
 import {
-	getPostalCode,
 	createStripePaymentMethodToken,
 	wpcomTransaction,
 	wpcomPayPalExpress,
@@ -26,6 +25,7 @@ import {
 	submitCreditsTransaction,
 	submitPayPalExpressRequest,
 } from './payment-method-helpers';
+import getPostalCode from './lib/get-postal-code';
 import getDomainDetails from './lib/get-domain-details';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
 import userAgent from 'calypso/lib/user-agent';

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -15,7 +15,6 @@ import { confirmStripePaymentIntent } from '@automattic/calypso-stripe';
  */
 import {
 	getPostalCode,
-	getDomainDetails,
 	createStripePaymentMethodToken,
 	wpcomTransaction,
 	wpcomPayPalExpress,
@@ -27,6 +26,7 @@ import {
 	submitCreditsTransaction,
 	submitPayPalExpressRequest,
 } from './payment-method-helpers';
+import getDomainDetails from './lib/get-domain-details';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
 import userAgent from 'calypso/lib/user-agent';
 

--- a/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
+++ b/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
@@ -12,6 +12,6 @@ export interface CardProcessorOptions {
 	includeDomainDetails: boolean;
 	includeGSuiteDetails: boolean;
 	createUserAndSiteBeforeTransaction: boolean;
-	stripeConfiguration: StripeConfiguration;
+	stripeConfiguration: StripeConfiguration | null;
 	recordEvent: ( action: ReactStandardAction ) => void;
 }

--- a/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
+++ b/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
@@ -8,7 +8,7 @@ import type { StripeConfiguration } from '@automattic/calypso-stripe';
  */
 import type { ReactStandardAction } from '../types/analytics';
 
-export interface CardProcessorOptions {
+export interface PaymentProcessorOptions {
 	includeDomainDetails: boolean;
 	includeGSuiteDetails: boolean;
 	createUserAndSiteBeforeTransaction: boolean;

--- a/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
+++ b/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { StripeConfiguration } from '@automattic/calypso-stripe';
+
+/**
  * Internal dependencies
  */
 import type { ReactStandardAction } from '../types/analytics';
@@ -7,5 +12,6 @@ export interface CardProcessorOptions {
 	includeDomainDetails: boolean;
 	includeGSuiteDetails: boolean;
 	createUserAndSiteBeforeTransaction: boolean;
+	stripeConfiguration: StripeConfiguration;
 	recordEvent: ( action: ReactStandardAction ) => void;
 }

--- a/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
+++ b/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import type { ReactStandardAction } from '../types/analytics';
+
+export interface CardProcessorOptions {
+	includeDomainDetails: boolean;
+	includeGSuiteDetails: boolean;
+	createUserAndSiteBeforeTransaction: boolean;
+	recordEvent: ( action: ReactStandardAction ) => void;
+}

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -41,6 +41,21 @@ export interface TransactionRequestWithLineItems {
 	nik?: string | undefined;
 }
 
+export type ExistingCardTransactionRequestWithLineItems = Partial< TransactionRequestWithLineItems > &
+	Required<
+		Pick<
+			TransactionRequestWithLineItems,
+			| 'country'
+			| 'postalCode'
+			| 'items'
+			| 'name'
+			| 'storedDetailsId'
+			| 'siteId'
+			| 'paymentMethodToken'
+			| 'paymentPartnerProcessorId'
+		>
+	>;
+
 export type WPCOMTransactionEndpoint = (
 	_: WPCOMTransactionEndpointRequestPayload
 ) => Promise< WPCOMTransactionEndpointResponse >;

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -1,19 +1,44 @@
 /**
  * External dependencies
  */
-import debugFactory from 'debug';
-import { ResponseCartProductExtra } from '@automattic/shopping-cart';
+import type { ResponseCartProductExtra } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
-import { getNonProductWPCOMCartItemTypes } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-cart';
 import type { WPCOMCartItem } from './checkout-cart';
 import type { Purchase } from './wpcom-store-state';
 import type { DomainContactDetails } from './backend/domain-contact-details-components';
-import { isGSuiteProductSlug } from 'calypso/lib/gsuite';
 
-const debug = debugFactory( 'calypso:composite-checkout:transaction-endpoint' );
+export interface TransactionRequestWithLineItems {
+	siteId: string;
+	couponId?: string;
+	country: string;
+	state?: string;
+	postalCode: string;
+	subdivisionCode?: string;
+	city?: string;
+	address?: string;
+	streetNumber?: string;
+	phoneNumber?: string;
+	document?: string;
+	deviceId?: string;
+	domainDetails?: DomainContactDetails;
+	items: WPCOMCartItem[];
+	paymentMethodType: string;
+	paymentMethodToken?: string;
+	paymentPartnerProcessorId?: string;
+	storedDetailsId?: string;
+	name: string;
+	email?: string;
+	successUrl?: string;
+	cancelUrl?: string;
+	idealBank?: string;
+	tefBank?: string;
+	pan?: string;
+	gstin?: string;
+	nik?: string;
+}
 
 export type WPCOMTransactionEndpoint = (
 	_: WPCOMTransactionEndpointRequestPayload
@@ -72,192 +97,13 @@ export type WPCOMTransactionEndpointCart = {
 	};
 };
 
-type WPCOMTransactionEndpointCartItem = {
+export type WPCOMTransactionEndpointCartItem = {
 	product_id: number;
 	meta?: string;
 	currency: string;
 	volume: number;
 	extra?: ResponseCartProductExtra;
 };
-
-// Create cart object as required by the WPCOM transactions endpoint
-// '/me/transactions/': WPCOM_JSON_API_Transactions_Endpoint
-export function createTransactionEndpointCartFromLineItems( {
-	siteId,
-	couponId,
-	country,
-	postalCode,
-	subdivisionCode,
-	items,
-	contactDetails,
-}: {
-	siteId: string;
-	couponId?: string;
-	country: string;
-	postalCode: string;
-	subdivisionCode?: string;
-	items: WPCOMCartItem[];
-	contactDetails: DomainContactDetails | null;
-} ): WPCOMTransactionEndpointCart {
-	debug( 'creating cart from items', items );
-
-	const currency: string = items.reduce(
-		( firstValue: string, item ) => firstValue || item.amount.currency,
-		''
-	);
-
-	return {
-		blog_id: siteId || '0',
-		cart_key: siteId || 'no-site',
-		create_new_blog: siteId ? false : true,
-		coupon: couponId || '',
-		currency: currency || '',
-		temporary: false,
-		extra: [],
-		products: items
-			.filter( ( product ) => ! getNonProductWPCOMCartItemTypes().includes( product.type ) )
-			.map( ( item ) => addRegistrationDataToGSuiteItem( item, contactDetails ) )
-			.map( createTransactionEndpointCartItemFromLineItem ),
-		tax: {
-			location: {
-				country_code: country,
-				postal_code: postalCode,
-				subdivision_code: subdivisionCode,
-			},
-		},
-	};
-}
-
-function createTransactionEndpointCartItemFromLineItem(
-	item: WPCOMCartItem
-): WPCOMTransactionEndpointCartItem {
-	return {
-		product_id: item.wpcom_meta?.product_id,
-		meta: item.wpcom_meta?.meta,
-		currency: item.amount.currency,
-		volume: item.wpcom_meta?.volume ?? 1,
-		quantity: item.wpcom_meta?.quantity ?? null,
-		extra: item.wpcom_meta?.extra,
-	} as WPCOMTransactionEndpointCartItem;
-}
-
-function addRegistrationDataToGSuiteItem(
-	item: WPCOMCartItem,
-	contactDetails: DomainContactDetails | null
-): WPCOMCartItem {
-	if ( ! isGSuiteProductSlug( item.wpcom_meta?.product_slug ) ) {
-		return item;
-	}
-	return {
-		...item,
-		wpcom_meta: {
-			...item.wpcom_meta,
-			extra: { ...item.wpcom_meta.extra, google_apps_registration_data: contactDetails },
-		},
-	} as WPCOMCartItem;
-}
-
-export function createTransactionEndpointRequestPayloadFromLineItems( {
-	siteId,
-	couponId,
-	country,
-	state,
-	postalCode,
-	subdivisionCode,
-	city,
-	address,
-	streetNumber,
-	phoneNumber,
-	document,
-	deviceId,
-	domainDetails,
-	items,
-	paymentMethodType,
-	paymentMethodToken,
-	paymentPartnerProcessorId,
-	storedDetailsId,
-	name,
-	email,
-	cancelUrl,
-	successUrl,
-	idealBank,
-	tefBank,
-	pan,
-	gstin,
-	nik,
-}: {
-	siteId: string;
-	couponId?: string;
-	country: string;
-	state?: string;
-	postalCode: string;
-	subdivisionCode?: string;
-	city?: string;
-	address?: string;
-	streetNumber?: string;
-	phoneNumber?: string;
-	document?: string;
-	deviceId?: string;
-	domainDetails?: DomainContactDetails;
-	items: WPCOMCartItem[];
-	paymentMethodType: string;
-	paymentMethodToken?: string;
-	paymentPartnerProcessorId?: string;
-	storedDetailsId?: string;
-	name: string;
-	email?: string;
-	successUrl?: string;
-	cancelUrl?: string;
-	idealBank?: string;
-	tefBank?: string;
-	pan?: string;
-	gstin?: string;
-	nik?: string;
-} ): WPCOMTransactionEndpointRequestPayload {
-	return {
-		cart: createTransactionEndpointCartFromLineItems( {
-			siteId,
-			couponId: couponId || getCouponIdFromProducts( items ),
-			country,
-			postalCode,
-			subdivisionCode,
-			items: items.filter( ( item ) => item.type !== 'tax' ),
-			contactDetails: domainDetails || {},
-		} ),
-		domainDetails,
-		payment: {
-			paymentMethod: paymentMethodType,
-			paymentKey: paymentMethodToken,
-			paymentPartner: paymentPartnerProcessorId,
-			storedDetailsId,
-			name,
-			email,
-			country,
-			countryCode: country,
-			state,
-			postalCode,
-			zip: postalCode, // TODO: do we need this in addition to postalCode?
-			city,
-			address,
-			streetNumber,
-			phoneNumber,
-			document,
-			deviceId,
-			successUrl,
-			cancelUrl,
-			idealBank,
-			tefBank,
-			pan,
-			gstin,
-			nik,
-		},
-	};
-}
-
-function getCouponIdFromProducts( items: WPCOMCartItem[] ): string | undefined {
-	const couponItem = items.find( ( item ) => item.type === 'coupon' );
-	return couponItem?.wpcom_meta?.couponCode;
-}
 
 export type WPCOMTransactionEndpointResponse = {
 	success: boolean;

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -11,7 +11,7 @@ import type { Purchase } from './wpcom-store-state';
 import type { DomainContactDetails } from './backend/domain-contact-details-components';
 
 export interface TransactionRequestWithLineItems {
-	siteId: string | undefined;
+	siteId: string | number | undefined;
 	couponId?: string;
 	country: string | undefined;
 	state?: string;

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -10,34 +10,35 @@ import type { WPCOMCartItem } from './checkout-cart';
 import type { Purchase } from './wpcom-store-state';
 import type { DomainContactDetails } from './backend/domain-contact-details-components';
 
+// The data required by createTransactionEndpointRequestPayloadFromLineItems
 export interface TransactionRequestWithLineItems {
-	siteId: string | undefined;
-	couponId?: string;
 	country: string;
-	state?: string;
 	postalCode: string;
-	subdivisionCode?: string | undefined;
-	city?: string | undefined;
-	address?: string;
-	streetNumber?: string;
-	phoneNumber?: string;
-	document?: string;
-	deviceId?: string;
-	domainDetails?: DomainContactDetails | undefined;
 	items: WPCOMCartItem[];
 	paymentMethodType: string;
-	paymentMethodToken?: string;
-	paymentPartnerProcessorId?: string;
-	storedDetailsId?: string;
 	name: string;
-	email?: string;
-	successUrl?: string;
-	cancelUrl?: string;
-	idealBank?: string;
-	tefBank?: string;
-	pan?: string;
-	gstin?: string;
-	nik?: string;
+	siteId?: string | undefined;
+	couponId?: string | undefined;
+	state?: string | undefined;
+	subdivisionCode?: string | undefined;
+	city?: string | undefined;
+	address?: string | undefined;
+	streetNumber?: string | undefined;
+	phoneNumber?: string | undefined;
+	document?: string | undefined;
+	deviceId?: string | undefined;
+	domainDetails?: DomainContactDetails | undefined;
+	paymentMethodToken?: string | undefined;
+	paymentPartnerProcessorId?: string | undefined;
+	storedDetailsId?: string | undefined;
+	email?: string | undefined;
+	successUrl?: string | undefined;
+	cancelUrl?: string | undefined;
+	idealBank?: string | undefined;
+	tefBank?: string | undefined;
+	pan?: string | undefined;
+	gstin?: string | undefined;
+	nik?: string | undefined;
 }
 
 export type WPCOMTransactionEndpoint = (

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -11,19 +11,19 @@ import type { Purchase } from './wpcom-store-state';
 import type { DomainContactDetails } from './backend/domain-contact-details-components';
 
 export interface TransactionRequestWithLineItems {
-	siteId: string;
+	siteId: string | undefined;
 	couponId?: string;
-	country: string;
+	country: string | undefined;
 	state?: string;
 	postalCode: string;
-	subdivisionCode?: string;
-	city?: string;
+	subdivisionCode?: string | undefined;
+	city?: string | undefined;
 	address?: string;
 	streetNumber?: string;
 	phoneNumber?: string;
 	document?: string;
 	deviceId?: string;
-	domainDetails?: DomainContactDetails;
+	domainDetails?: DomainContactDetails | null;
 	items: WPCOMCartItem[];
 	paymentMethodType: string;
 	paymentMethodToken?: string;

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -11,7 +11,7 @@ import type { Purchase } from './wpcom-store-state';
 import type { DomainContactDetails } from './backend/domain-contact-details-components';
 
 export interface TransactionRequestWithLineItems {
-	siteId: string | number | undefined;
+	siteId: string | undefined;
 	couponId?: string;
 	country: string | undefined;
 	state?: string;

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -23,7 +23,7 @@ export interface TransactionRequestWithLineItems {
 	phoneNumber?: string;
 	document?: string;
 	deviceId?: string;
-	domainDetails?: DomainContactDetails | null;
+	domainDetails?: DomainContactDetails | undefined;
 	items: WPCOMCartItem[];
 	paymentMethodType: string;
 	paymentMethodToken?: string;

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -13,7 +13,7 @@ import type { DomainContactDetails } from './backend/domain-contact-details-comp
 export interface TransactionRequestWithLineItems {
 	siteId: string | undefined;
 	couponId?: string;
-	country: string | undefined;
+	country: string;
 	state?: string;
 	postalCode: string;
 	subdivisionCode?: string | undefined;

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -290,7 +290,6 @@ function useCreateApplePay( {
 
 export function useCreateExistingCards( {
 	storedCards,
-	stripeConfiguration,
 	activePayButtonText = undefined,
 } ) {
 	const existingCardMethods = useMemo( () => {
@@ -304,11 +303,10 @@ export function useCreateExistingCards( {
 				storedDetailsId: storedDetails.stored_details_id,
 				paymentMethodToken: storedDetails.mp_ref,
 				paymentPartnerProcessorId: storedDetails.payment_partner,
-				stripeConfiguration,
 				activePayButtonText,
 			} )
 		);
-	}, [ stripeConfiguration, storedCards, activePayButtonText ] );
+	}, [ storedCards, activePayButtonText ] );
 	return existingCardMethods;
 }
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -376,21 +376,6 @@ Creates a [Payment Method](#payment-methods) object. Requires passing an object 
 
 Creates a [data store](#data-stores) registry to be passed (optionally) to [CheckoutProvider](#checkoutprovider). See the `@wordpress/data` [docs for this function](https://developer.wordpress.org/block-editor/packages/packages-data/#createRegistry).
 
-### createExistingCardMethod
-
-Creates a [Payment Method](#payment-methods) object for an existing credit card. Requires passing an object with the following properties:
-
-- `registerStore: object => object`. The `registerStore` function from the return value of [createRegistry](#createRegistry).
-- `submitTransaction: async ?object => object`. An async function that sends the request to the endpoint process the payment.
-- `getCountry: () => string`. A function that returns the country to use for the transaction.
-- `getPostalCode: () => string`. A function that returns the postal code for the transaction.
-- `getSubdivisionCode: () => string`. A function that returns the subdivision code for the transaction.
-- `id: string`. A unique id for this payment method (since there are likely to be several existing cards).
-- `cardholderName: string`. The cardholder's name. Used for display only.
-- `cardExpiry: string`. The card's expiry date. Used for display only.
-- `brand: string`. The card's brand (eg: `visa`). Used for display only.
-- `last4: string`. The card's last four digits. Used for display only.
-
 ### createPayPalMethod
 
 Creates a [Payment Method](#payment-methods) object. Requires passing an object with the following properties:

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -122,7 +122,6 @@ function ExistingCardPayButton( {
 				onEvent( { type: 'EXISTING_CARD_TRANSACTION_BEGIN' } );
 				onClick( 'existing-card', {
 					items,
-					total,
 					name: cardholderName,
 					storedDetailsId,
 					paymentMethodToken,

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -27,7 +27,6 @@ export function createExistingCardMethod( {
 	storedDetailsId,
 	paymentMethodToken,
 	paymentPartnerProcessorId,
-	stripeConfiguration,
 	activePayButtonText = undefined,
 } ) {
 	debug( 'creating a new existing credit card payment method', {
@@ -50,7 +49,6 @@ export function createExistingCardMethod( {
 		),
 		submitButton: (
 			<ExistingCardPayButton
-				stripeConfiguration={ stripeConfiguration }
 				cardholderName={ cardholderName }
 				storedDetailsId={ storedDetailsId }
 				paymentMethodToken={ paymentMethodToken }
@@ -106,7 +104,6 @@ const CardHolderName = styled.span`
 function ExistingCardPayButton( {
 	disabled,
 	onClick,
-	stripeConfiguration,
 	cardholderName,
 	storedDetailsId,
 	paymentMethodToken,
@@ -130,7 +127,6 @@ function ExistingCardPayButton( {
 					storedDetailsId,
 					paymentMethodToken,
 					paymentPartnerProcessorId,
-					stripeConfiguration,
 				} );
 			} }
 			buttonType="primary"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This moves the composite checkout payment processor function `existingCardProcessor` to its own file and converts it to TypeScript. This is the first payment processor to be converted to TypeScript so it will set the stage for the rest to be converted as well by cleaning up the types and API. Notably it creates a `PaymentProcessorOptions` type which is the data passed into each processor.

This also refactors the processor a bit to decouple it from the 'wpcom' `@wordpress/data` Store so it can be used in other parts of calypso more easily. It does this mostly by fetching data it needs within the closure inside `CompositeCheckout`, making it possible for `existingCardProcessor` to rely only on its inputs.

The reason we are starting with this processor is that it can be used for "one-click checkout" (see #48132).

#### Testing instructions

- Make sure your browser devtools are recording network calls, and make sure that those calls are preserved after a redirect.
- Add a plan with a domain to your cart and visit checkout.
- Complete checkout using a saved credit card.
- Verify that the transaction completes as expected and that you are redirected as expected.
- Verify that the network request to the `/me/transactions` endpoint includes `domainDetails`.