### PR TITLE
fix(followers): make sure to call correct api endpoint

### DIFF
--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -76,7 +76,7 @@ class Followers extends Component {
 						'People',
 						'Clicked Remove Button In Remove ' + listType + ' Confirmation'
 					);
-					this.props.requestRemoveFollower( this.props.site.ID, follower );
+					this.props.requestRemoveFollower( this.props.site.ID, follower, this.props.type );
 				} else {
 					gaRecordEvent(
 						'People',

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -34,6 +34,7 @@ const FollowersList = ( { site, search, type = 'wpcom' } ) => {
 				query={ query }
 				site={ site }
 				currentPage={ currentPage }
+				type={ type }
 				incrementPage={ () => setCurrentPage( currentPage + 1 ) }
 			/>
 		</>

--- a/client/state/data-layer/wpcom/followers/index.js
+++ b/client/state/data-layer/wpcom/followers/index.js
@@ -33,13 +33,15 @@ const receiveFollowers = ( { query }, data ) => [ requestFollowersSuccess( query
 const requestFollowersError = ( { query }, error ) => [ requestFollowersFailure( query, error ) ];
 
 const removeFollower = ( action ) => {
-	const { siteId, follower } = action;
+	const { siteId, follower, followerType } = action;
+
+	const followersEndpoint = followerType === 'email' ? 'email-followers' : 'followers';
 
 	return [
 		http(
 			{
 				method: 'POST',
-				path: `/sites/${ siteId }/followers/${ follower.ID }/delete`,
+				path: `/sites/${ siteId }/${ followersEndpoint }/${ follower.ID }/delete`,
 				apiVersion: '1.1',
 			},
 			action

--- a/client/state/followers/actions.js
+++ b/client/state/followers/actions.js
@@ -58,11 +58,13 @@ export const requestFollowersFailure = ( query, error ) => ( {
  *
  * @param {number} siteId Site identifier
  * @param {object} follower Object containing follower data
+ * @param {string} followerType Either `email` or `wpcom` (default)
  */
-export const requestRemoveFollower = ( siteId, follower ) => ( {
+export const requestRemoveFollower = ( siteId, follower, followerType ) => ( {
 	type: FOLLOWER_REMOVE_REQUEST,
 	siteId,
 	follower,
+	followerType,
 } );
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make sure to call correct API endpoint depending on follower type

#### Testing instructions

* Open [calypso.live](https://calypso.live/?branch=fix/email-followers-api-call) and go to `/people/followers/:site`
* Attempt to remove a follower as well as email an email follower
* Make sure both work correctly and changes are persistent after reload

Fixes #48045
