### PR TITLE
Terser ignores translation functions when mangling identifiers

### DIFF
--- a/apps/editing-toolkit/README.md
+++ b/apps/editing-toolkit/README.md
@@ -160,3 +160,5 @@ The tests make use of the 3rd party [React Testing Library](https://testing-libr
 When writing tests try to approach them **from the perspective of how a user would interact with your component**. Approaching tests in this fashion provides greater confidence that tests will capture true component behaviors and avoids the need for costly refactoring should the component's implementation need to change.
 
 For more on this approach please see the [excellent introduction in the React Testing Library docs](https://testing-library.com/docs/react-testing-library/intro).
+
+trigger plugin build

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -103,7 +103,7 @@ function getWebpackConfig(
 				terserOptions: {
 					ecma: 5,
 					safari10: true,
-					mangle: true,
+					mangle: { reserved: [ '__', '_n', '_nx', '_x' ] },
 				},
 			} ),
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The standard translation functions (e.g. `__`) aren't minified during a release build
* A readme change to trigger an ETK build in CI. Will remove before merging.

Only impacts webpack builds that are using the base webpack config from `calypso-build`, which currently includes:
- Editing Toolkit
- Notifications
- wpcom-block-editor

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #47884
