### PR TITLE
Reader: fix Following intro banner

### DIFF
--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -18,7 +17,7 @@ import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tour
 import cssSafeUrl from 'calypso/lib/css-safe-url';
 
 /**
- * Image dependencies
+ * Asset dependencies
  */
 import readerImage from 'calypso/assets/images/reader/reader-intro-character.svg';
 import readerBackground from 'calypso/assets/images/reader/reader-intro-background.svg';
@@ -101,18 +100,14 @@ export default connect(
 			isNewUser: isUserNewerThan( WEEK_IN_MILLISECONDS * 2 )( state ),
 		};
 	},
-	( dispatch ) =>
-		bindActionCreators(
-			{
-				dismiss: () => {
-					recordTrack( 'calypso_reader_following_intro_dismiss' );
-					return savePreference( 'is_new_reader', false );
-				},
-				handleManageLinkClick: () => {
-					recordTrack( 'calypso_reader_following_intro_link_clicked' );
-					return savePreference( 'is_new_reader', false );
-				},
-			},
-			dispatch
-		)
+	{
+		dismiss: () => {
+			recordTrack( 'calypso_reader_following_intro_dismiss' );
+			return savePreference( 'is_new_reader', false );
+		},
+		handleManageLinkClick: () => {
+			recordTrack( 'calypso_reader_following_intro_link_clicked' );
+			return savePreference( 'is_new_reader', false );
+		},
+	}
 )( localize( FollowingIntro ) );

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -25,7 +25,6 @@ import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
 import { SECTION_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
 import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizations/selectors';
 import { NO_ORG_ID } from 'calypso/state/reader/organizations/constants';
-import FollowingVoteBanner from './vote-banner';
 
 /**
  * Style dependencies
@@ -54,16 +53,14 @@ const FollowingStream = ( props ) => {
 	const placeholderText = getSearchPlaceholderText();
 	const { translate } = props;
 	const dispatch = useDispatch();
-	const voteBanner = <FollowingVoteBanner />;
 	const markAllAsSeen = ( feedsInfo ) => {
 		const { feedIds, feedUrls } = feedsInfo;
 		dispatch( requestMarkAllAsSeen( { identifier: SECTION_FOLLOWING, feedIds, feedUrls } ) );
 	};
-
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<Stream { ...props }>
-			{ voteBanner ? voteBanner : <FollowingIntro /> }
+			<FollowingIntro />
 			<CompactCard className="following__search">
 				<SearchInput
 					onSearch={ handleSearch }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In p5PDj3-4WY-p2 we noticed that the Reader following intro banner was not being displayed for new users. This PR restores it.

Fixes #47984.

<img width="924" alt="Screen Shot 2020-12-07 at 15 40 18" src="https://user-images.githubusercontent.com/17325/101303406-d25b7a80-38a2-11eb-880e-d45fafc52bfb.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Sign up as a brand new user (http://calypso.localhost:3000/start/reader is nice and quick). 
2. Ensure that you're shown the Reader intro banner pictured above at http://calypso.localhost:3000/read.
3. Ensure that you can dismiss the intro banner using the 'x' icon.
