### PR TITLE
Always send plan data in English

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -190,12 +190,12 @@ class HelpContact extends React.Component {
 
 	submitKayakoTicket = ( contactForm ) => {
 		const { subject, message, howCanWeHelp, howYouFeel, site } = contactForm;
-		const { currentUserLocale, supportVariation, translate } = this.props;
+		const { currentUserLocale, supportVariation } = this.props;
 		let plan = 'N/A';
 		if ( site ) {
 			plan = `${ site.plan.product_name_short } (${ getPlanTermLabel(
 				site.plan.product_slug,
-				translate
+				( val ) => val // Passing an identity function instead of `translate` to always return the English string
 			) })`;
 		}
 		const ticketMeta = [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When submitting a ticket, this change replaces `translate` with an identity function so that it will always return the English string.
* For additional context, please see pcbrnV-wF-p2#comment-1659

I am open to suggestions if there are better ways to do this!

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Login as a user with a valid plan.
* Change the interface language to any language except English. This can be done by navigating to `/me/account` and changing the language from there.
* Create a ticket by clicking on the "?" icon in the bottom right and select "Contact Us".
* Inspect the network response for the request sent to create the ticket.
* The plan name and term should be present in the message body and should be in English.