### PR TITLE
Modularise atomic transfer state

### DIFF
--- a/client/state/atomic-transfer/actions.js
+++ b/client/state/atomic-transfer/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import {
 	ATOMIC_TRANSFER_REQUEST,
 	ATOMIC_TRANSFER_REQUEST_FAILURE,
@@ -10,6 +9,7 @@ import {
 } from 'calypso/state/action-types';
 
 import 'calypso/state/data-layer/wpcom/sites/transfers/latest';
+import 'calypso/state/atomic-transfer/init';
 
 /**
  * Query the atomic transfer for a given site.

--- a/client/state/atomic-transfer/init.js
+++ b/client/state/atomic-transfer/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'atomicTransfer' ], reducer );

--- a/client/state/atomic-transfer/package.json
+++ b/client/state/atomic-transfer/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/atomic-transfer/reducer.js
+++ b/client/state/atomic-transfer/reducer.js
@@ -4,8 +4,9 @@
 import {
 	combineReducers,
 	keyedReducer,
-	withSchemaValidation,
 	withoutPersistence,
+	withSchemaValidation,
+	withStorageKey,
 } from 'calypso/state/utils';
 import { atomicTransfer as schema } from './schema';
 import {
@@ -45,4 +46,4 @@ export const atomicTransferReducers = combineReducers( {
 } );
 
 //export default atomicTransferReducers;
-export default keyedReducer( 'siteId', atomicTransferReducers );
+export default withStorageKey( 'atomicTransfer', keyedReducer( 'siteId', atomicTransferReducers ) );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -14,7 +14,6 @@ import { reducer as httpData } from 'calypso/state/data-layer/http-data';
 /**
  * Reducers
  */
-import atomicTransfer from './atomic-transfer/reducer';
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import documentHead from './document-head/reducer';
@@ -31,7 +30,6 @@ import users from './users/reducer';
 // The reducers in this list are not modularized, and are always loaded on boot.
 // Please do not add to this list. See #39261 and p4TIVU-9lM-p2 for more details.
 const reducers = {
-	atomicTransfer,
 	currentUser,
 	dataRequests,
 	documentHead,

--- a/client/state/selectors/get-atomic-transfer.js
+++ b/client/state/selectors/get-atomic-transfer.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/atomic-transfer/init';
+
 export default ( state, siteId ) => {
 	return get( state, [ 'atomicTransfer', siteId, 'atomicTransfer' ], {} );
 };

--- a/client/state/selectors/is-fetching-atomic-transfer.js
+++ b/client/state/selectors/is-fetching-atomic-transfer.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/atomic-transfer/init';
 
 /**
  * Returns whether we are already fetching the Atomic transfer for given siteId.


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles atomic transfer state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42424.

#### Changes proposed in this Pull Request

* Modularise atomic transfer state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/home` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `atomicTransfer` key, even if you expand the list of keys. This indicates that the atomic transfer state hasn't been loaded yet.
* Place something in your cart and go to checkout.
* Verify that an `atomicTransfer` key is added with the atomic transfer empty state. This indicates that the atomic transfer state has now been loaded.
* If you can, please ensure that atomic transfer still work correctly.