### PR TITLE
Focused Launch: Render free sub-domain last

### DIFF
--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -50,6 +50,7 @@ export const ItemGroupLabel: FunctionComponent = function ItemGroupLabel( { chil
 	return <p className="domain-picker__suggestion-group-label">{ children }</p>;
 };
 
+// For free sub-domains we mock the DomainSuggestion object and set the price as an empty string ''
 function domainIsFree( suggestion: DomainSuggestion ): boolean {
 	return ! suggestion.cost || suggestion.cost === '';
 }

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -50,11 +50,6 @@ export const ItemGroupLabel: FunctionComponent = function ItemGroupLabel( { chil
 	return <p className="domain-picker__suggestion-group-label">{ children }</p>;
 };
 
-// For free sub-domains we mock the DomainSuggestion object and set the price as an empty string ''
-function domainIsFree( suggestion: DomainSuggestion ): boolean {
-	return ! suggestion.cost || suggestion.cost === '';
-}
-
 export interface Props {
 	header?: React.ReactElement;
 
@@ -306,7 +301,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					<div className="domain-picker__suggestion-sections">
 						{ groupOrder.map( ( group: DomainGroups ) => {
 							const groupedSuggestions = domainSuggestionsWithSubdomain?.filter( ( suggestion ) =>
-								group === 'free' ? domainIsFree( suggestion ) : ! domainIsFree( suggestion )
+								group === 'free' ? suggestion?.is_free : ! suggestion?.is_free
 							);
 
 							if ( group === 'free' ) {

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -105,7 +105,7 @@ export interface Props {
 	locale?: string;
 
 	/** Whether we show the free .wordpress.com sub-domain first or last */
-	positionExistingSubDomainLast?: boolean;
+	positionExistingSubdomainLast?: boolean;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {
@@ -128,7 +128,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	itemType = ITEM_TYPE_RADIO,
 	locale,
 	areDependenciesLoading = false,
-	positionExistingSubDomainLast = false,
+	positionExistingSubdomainLast = false,
 } ) => {
 	const label = __( 'Search for a domain', __i18n_text_domain__ );
 
@@ -292,34 +292,36 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					) }
 					<div className="domain-picker__suggestion-sections">
 						<>
-							{ segregateFreeAndPaid && (
+							{ ! positionExistingSubdomainLast && segregateFreeAndPaid && (
 								<ItemGroupLabel>{ __( 'Keep sub-domain', __i18n_text_domain__ ) }</ItemGroupLabel>
 							) }
-							<ItemGrouper groupItems={ segregateFreeAndPaid }>
-								{ existingSubdomain?.domain_name && (
-									<SuggestionItem
-										key={ existingSubdomain?.domain_name }
-										domain={ existingSubdomain?.domain_name }
-										cost="Free"
-										isFree
-										isExistingSubdomain
-										railcarId={ baseRailcarId ? `${ baseRailcarId }${ 0 }` : undefined }
-										onRender={ () =>
-											handleItemRender(
-												existingSubdomain?.domain_name,
-												`${ baseRailcarId }${ 0 }`,
-												0,
-												false
-											)
-										}
-										selected={ currentDomain?.domain_name === existingSubdomain?.domain_name }
-										onSelect={ () => {
-											onExistingSubdomainSelect?.( existingSubdomain?.domain_name );
-										} }
-										type={ itemType }
-									/>
-								) }
-							</ItemGrouper>
+							{ ! positionExistingSubdomainLast && (
+								<ItemGrouper groupItems={ segregateFreeAndPaid }>
+									{ existingSubdomain?.domain_name && (
+										<SuggestionItem
+											key={ existingSubdomain?.domain_name }
+											domain={ existingSubdomain?.domain_name }
+											cost="Free"
+											isFree
+											isExistingSubdomain
+											railcarId={ baseRailcarId ? `${ baseRailcarId }${ 0 }` : undefined }
+											onRender={ () =>
+												handleItemRender(
+													existingSubdomain?.domain_name,
+													`${ baseRailcarId }${ 0 }`,
+													0,
+													false
+												)
+											}
+											selected={ currentDomain?.domain_name === existingSubdomain?.domain_name }
+											onSelect={ () => {
+												onExistingSubdomainSelect?.( existingSubdomain?.domain_name );
+											} }
+											type={ itemType }
+										/>
+									) }
+								</ItemGrouper>
+							) }
 							{ segregateFreeAndPaid && (
 								<ItemGroupLabel>
 									{ __( 'Professional domains', __i18n_text_domain__ ) }
@@ -370,6 +372,36 @@ const DomainPicker: FunctionComponent< Props > = ( {
 										<SuggestionItemPlaceholder type={ itemType } key={ i } />
 									) ) }
 							</ItemGrouper>
+							{ positionExistingSubdomainLast && segregateFreeAndPaid && (
+								<ItemGroupLabel>{ __( 'Keep sub-domain', __i18n_text_domain__ ) }</ItemGroupLabel>
+							) }
+							{ positionExistingSubdomainLast && (
+								<ItemGrouper groupItems={ segregateFreeAndPaid }>
+									{ existingSubdomain?.domain_name && (
+										<SuggestionItem
+											key={ existingSubdomain?.domain_name }
+											domain={ existingSubdomain?.domain_name }
+											cost="Free"
+											isFree
+											isExistingSubdomain
+											railcarId={ baseRailcarId ? `${ baseRailcarId }${ 0 }` : undefined }
+											onRender={ () =>
+												handleItemRender(
+													existingSubdomain?.domain_name,
+													`${ baseRailcarId }${ 0 }`,
+													0,
+													false
+												)
+											}
+											selected={ currentDomain?.domain_name === existingSubdomain?.domain_name }
+											onSelect={ () => {
+												onExistingSubdomainSelect?.( existingSubdomain?.domain_name );
+											} }
+											type={ itemType }
+										/>
+									) }
+								</ItemGrouper>
+							) }
 						</>
 
 						{ ! isExpanded &&

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -243,9 +243,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	const showDomainSuggestionsResults = ! showErrorMessage && ! isDomainSearchEmpty;
 	const showDomainSuggestionsEmpty = ! showErrorMessage && isDomainSearchEmpty;
 
-	// If we know the existing domain while the suggestions are loading, we need one less placeholder although the persistent domain is in addition to the quantity.
-	const neededPlaceholdersCount =
-		( persistentSelectedDomain ? quantity + 1 : quantity ) - ( existingSubdomain ? 1 : 0 );
+	const neededPlaceholdersCount = domainSuggestionsWithSubdomain
+		? domainSuggestionsWithSubdomain?.length
+		: quantity + ( persistentSelectedDomain ? 1 : 0 );
 
 	// We are specifcying the order of domains by sub-domains and professional domains.
 	const groupOrder: DomainGroups[] = [ 'sub-domain', 'professional' ];
@@ -300,6 +300,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					) }
 					<div className="domain-picker__suggestion-sections">
 						{ groupOrder.map( ( group: DomainGroups ) => {
+							// There will only one domain max in the sub-domain group so we alter the placeholder renders to reflect this below.
 							const groupedSuggestions = domainSuggestionsWithSubdomain?.filter( ( suggestion ) =>
 								group === 'sub-domain'
 									? suggestion?.domain_name === existingSubdomain?.domain_name
@@ -320,29 +321,32 @@ const DomainPicker: FunctionComponent< Props > = ( {
 											</ItemGroupLabel>
 										) }
 										<ItemGrouper groupItems={ segregateFreeAndPaid }>
-											{ groupedSuggestions?.map( ( suggestion ) => (
-												<SuggestionItem
-													key={ suggestion?.domain_name }
-													domain={ suggestion?.domain_name }
-													cost="Free"
-													isFree
-													isExistingSubdomain
-													railcarId={ baseRailcarId ? `${ baseRailcarId }${ 0 }` : undefined }
-													onRender={ () =>
-														handleItemRender(
-															suggestion?.domain_name,
-															`${ baseRailcarId }${ 0 }`,
-															0,
-															false
-														)
-													}
-													selected={ currentDomain?.domain_name === suggestion?.domain_name }
-													onSelect={ () => {
-														onExistingSubdomainSelect?.( suggestion?.domain_name );
-													} }
-													type={ itemType }
-												/>
-											) ) }
+											{ ( ! areDependenciesLoading &&
+												groupedSuggestions?.map( ( suggestion ) => {
+													return (
+														<SuggestionItem
+															key={ suggestion?.domain_name }
+															domain={ suggestion?.domain_name }
+															cost="Free"
+															isFree
+															isExistingSubdomain
+															railcarId={ baseRailcarId ? `${ baseRailcarId }${ 0 }` : undefined }
+															onRender={ () =>
+																handleItemRender(
+																	suggestion?.domain_name,
+																	`${ baseRailcarId }${ 0 }`,
+																	0,
+																	false
+																)
+															}
+															selected={ currentDomain?.domain_name === suggestion?.domain_name }
+															onSelect={ () => {
+																onExistingSubdomainSelect?.( suggestion?.domain_name );
+															} }
+															type={ itemType }
+														/>
+													);
+												} ) ) || <SuggestionItemPlaceholder type={ itemType } /> }
 										</ItemGrouper>
 									</Fragment>
 								);
@@ -396,7 +400,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 													/>
 												);
 											} ) ) ||
-											times( neededPlaceholdersCount, ( i ) => (
+											times( neededPlaceholdersCount - 1, ( i ) => (
 												<SuggestionItemPlaceholder type={ itemType } key={ i } />
 											) ) }
 									</ItemGrouper>

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -103,6 +103,9 @@ export interface Props {
 	itemType?: SUGGESTION_ITEM_TYPE;
 
 	locale?: string;
+
+	/** Whether we show the free .wordpress.com sub-domain first or last */
+	positionExistingSubDomainLast?: boolean;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {
@@ -125,6 +128,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	itemType = ITEM_TYPE_RADIO,
 	locale,
 	areDependenciesLoading = false,
+	positionExistingSubDomainLast = false,
 } ) => {
 	const label = __( 'Search for a domain', __i18n_text_domain__ );
 

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -45,6 +45,10 @@ export const ItemGrouper: FunctionComponent< {
 	return <>{ children }</>;
 };
 
+export const ItemGroupLabel: FunctionComponent = function ItemGroupLabel( { children } ) {
+	return <p className="domain-picker__suggestion-group-label">{ children }</p>;
+};
+
 export interface Props {
 	header?: React.ReactElement;
 
@@ -285,9 +289,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					<div className="domain-picker__suggestion-sections">
 						<>
 							{ segregateFreeAndPaid && (
-								<p className="domain-picker__suggestion-group-label">
-									{ __( 'Keep sub-domain', __i18n_text_domain__ ) }
-								</p>
+								<ItemGroupLabel>{ __( 'Keep sub-domain', __i18n_text_domain__ ) }</ItemGroupLabel>
 							) }
 							<ItemGrouper groupItems={ segregateFreeAndPaid }>
 								{ existingSubdomain?.domain_name && (
@@ -315,9 +317,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 								) }
 							</ItemGrouper>
 							{ segregateFreeAndPaid && (
-								<p className="domain-picker__suggestion-group-label">
+								<ItemGroupLabel>
 									{ __( 'Professional domains', __i18n_text_domain__ ) }
-								</p>
+								</ItemGroupLabel>
 							) }
 							<ItemGrouper groupItems={ segregateFreeAndPaid }>
 								{ ( ! areDependenciesLoading &&

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -230,9 +230,13 @@ const DomainPicker: FunctionComponent< Props > = ( {
 
 	let placeholdersCount = quantity;
 	// If persistentSelectedDomain exists, a placeholder will be appended to the list when doing next search
-	if ( persistentSelectedDomain ) placeholdersCount += 1;
+	if ( persistentSelectedDomain ) {
+		placeholdersCount += 1;
+	}
 	// If existingSubdomain is defined, it will be rendered separately with its own placeholder
-	if ( existingSubdomain ) placeholdersCount -= 1;
+	if ( existingSubdomain ) {
+		placeholdersCount -= 1;
+	}
 
 	// We are specifcying the order of domains by sub-domains and professional domains.
 	const groupOrder: DomainGroup[] = [ 'professional' ];

--- a/packages/domain-picker/src/hooks/index.ts
+++ b/packages/domain-picker/src/hooks/index.ts
@@ -1,0 +1,3 @@
+export * from './use-domain-availabilities';
+export * from './use-domain-suggestions';
+export * from './use-persistent-selected-domain';

--- a/packages/domain-picker/src/hooks/use-persistent-selected-domain.ts
+++ b/packages/domain-picker/src/hooks/use-persistent-selected-domain.ts
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import type { DomainSuggestions } from '@automattic/data-stores';
+
+type DomainSuggestion = DomainSuggestions.DomainSuggestion;
+
+export function usePersistentSelectedDomain(
+	domainSuggestions?: DomainSuggestion[],
+	existingSubdomain?: DomainSuggestion,
+	currentDomain?: DomainSuggestion
+): DomainSuggestion | undefined {
+	// Keep the users selected domain in local state so we can always show it to the user.
+	const [ persistentSelectedDomain, setPersistentSelectedDomain ] = React.useState<
+		DomainSuggestion | undefined
+	>();
+
+	// Make a complete list of suggestions with the subdomain
+	const domainSuggestionsWithSubdomain =
+		existingSubdomain && Array.isArray( domainSuggestions )
+			? [ existingSubdomain, ...domainSuggestions ]
+			: domainSuggestions;
+
+	React.useEffect( () => {
+		const currentDomainIsInSuggestions = domainSuggestionsWithSubdomain?.some(
+			( suggestion ) => suggestion.domain_name === currentDomain?.domain_name
+		);
+
+		if ( domainSuggestionsWithSubdomain?.length && ! currentDomainIsInSuggestions ) {
+			setPersistentSelectedDomain( currentDomain );
+		}
+	}, [ currentDomain, domainSuggestionsWithSubdomain ] );
+
+	const persistentSelectedDomainIsInSuggestions = domainSuggestionsWithSubdomain?.some(
+		( suggestion ) => suggestion?.domain_name === persistentSelectedDomain?.domain_name
+	);
+
+	if ( persistentSelectedDomainIsInSuggestions ) {
+		return;
+	}
+
+	return persistentSelectedDomain;
+}

--- a/packages/domain-picker/src/utils.ts
+++ b/packages/domain-picker/src/utils.ts
@@ -16,5 +16,6 @@ export function mockDomainSuggestion(
 		cost: '',
 		product_id: 0,
 		product_slug: '',
+		is_free: true,
 	};
 }

--- a/packages/domain-picker/src/utils.ts
+++ b/packages/domain-picker/src/utils.ts
@@ -16,6 +16,5 @@ export function mockDomainSuggestion(
 		cost: '',
 		product_id: 0,
 		product_slug: '',
-		is_free: true,
 	};
 }

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -211,7 +211,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							quantityExpanded={ 3 }
 							itemType="individual-item"
 							locale={ locale }
-							orderFreeDomainsLast={ true }
+							orderSubDomainsLast={ true }
 						/>
 						<Link to={ Route.DomainDetails } className="focused-launch-summary__details-link">
 							{ __( 'View all domains', __i18n_text_domain__ ) }

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -211,7 +211,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							quantityExpanded={ 3 }
 							itemType="individual-item"
 							locale={ locale }
-							positionExistingSubdomainLast={ true }
+							orderFreeDomainsLast={ true }
 						/>
 						<Link to={ Route.DomainDetails } className="focused-launch-summary__details-link">
 							{ __( 'View all domains', __i18n_text_domain__ ) }

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -211,6 +211,7 @@ const DomainStep: React.FunctionComponent< DomainStepProps > = ( {
 							quantityExpanded={ 3 }
 							itemType="individual-item"
 							locale={ locale }
+							positionExistingSubdomainLast={ true }
 						/>
 						<Link to={ Route.DomainDetails } className="focused-launch-summary__details-link">
 							{ __( 'View all domains', __i18n_text_domain__ ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When using the `<DomainPicker />` component in the Summary view of the Focused Launch modal we need to have the option of rendering the free wordpress.com sub domain last in the list of suggestions.

#### Testing instructions

Please read the acceptance criteria(s) associated with https://github.com/Automattic/wp-calypso/issues/47748 to ensure they are satisfied by this PR

Also some refactoring to the persistent domain logic has been done as part of this PR. For testing instructions on this please refer to https://github.com/Automattic/wp-calypso/pull/47633

**Focused launch**

1. Go to `/page/SITE_ID_CREATED_WITH_START.wordpress.com/home?flags=create/focused-launch-flow-calypso`
2. Check that the free .wordpress.com sub domain is last in the list of suggestions.
3. Click "View all domains" and check that the free .wordpress.com sub domain remains first in the list of suggestions.
4. Select a premium domain, and go back to the Summary view to check that the free .wordpress.com sub domain is still last in the list of suggestions.

**Gutenboarding - Regression testing**

1. Go to `/new`.
2. Enter a site name. Go to next step which should be the domain step.
3. Your free .wordpress.com sub domain should be first in the list of domains suggestions as seen in the below screenshot

<img width="1487" alt="Screenshot 2020-12-07 at 15 13 51" src="https://user-images.githubusercontent.com/8639742/101368258-d6859900-389e-11eb-8510-712faa7ae88e.png">

**Editing Toolkit Step-by-Step Launch - Regression testing**

1. Checkout this branch and run `npm run dev --sync` from `wp-calypso/apps/editing-toolkit` ensuring you're also logged into your sandbox environment.
2. Go to `/new` and go through the process to create a new site, you will land in the editing experience.
3. Sandbox your newly created site in your host file
4. Flush your cache & DNS and then refresh your site made in step 1 and ensure that you're using the `dev` version of the Editing Toolkit
5. Click "Launch". This should open the launch modal. Proceed to the step "Select a domain" and your free .wordpress.com sub domain should be separated by a heading and first in the list as viewed in the below screenshot

<img width="1381" alt="Screenshot 2020-12-07 at 15 11 54" src="https://user-images.githubusercontent.com/8639742/101368092-a6d69100-389e-11eb-8b31-ca669199113b.png">

Fixes https://github.com/Automattic/wp-calypso/issues/47748