### PR TITLE
Pricing page: align featured card header with other cards

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-i5/style.scss
@@ -11,7 +11,6 @@
 
 	&.is-featured.is-aligned {
 		position: relative;
-		top: 8px;
 		z-index: 1;
 
 		margin-left: -8px;
@@ -35,7 +34,7 @@
 
 	.is-aligned & {
 		position: absolute;
-		top: -16px;
+		bottom: 100%;
 		left: 0;
 	}
 }
@@ -52,6 +51,13 @@
 		border-top: none;
 		border-bottom-left-radius: inherit;
 		border-bottom-right-radius: inherit;
+	}
+
+	.is-featured.is-aligned & {
+		box-sizing: border-box;
+		height: calc( 100% + 8px );
+
+		background-color: inherit;
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR tweaks the style of the featured card in the pricing page.

Fixes 1196341175636977-as-1199508074334639/f

### Testing instructions

- Visit the live link or download the PR and run Calypso or cloud
- Visit the plans/pricing page
- Check that the header of the featured card is aligned with the top of the other cards in the row (see capture)

### Screenshots

_Before_
![current](https://user-images.githubusercontent.com/1620183/101377003-4edc6200-387f-11eb-8610-7f0f1eb4d5e7.jpg)



_After_
<img width="1049" alt="Screen Shot 2020-12-07 at 11 23 03 AM" src="https://user-images.githubusercontent.com/1620183/101377016-526fe900-387f-11eb-9147-0305c86fa59d.png">