### PR TITLE
Calypso-stripe: Rename setStripeError to reloadStripeConfiguration

### DIFF
--- a/client/me/purchases/components/payment-method-form/index.jsx
+++ b/client/me/purchases/components/payment-method-form/index.jsx
@@ -62,7 +62,7 @@ export function PaymentMethodForm( {
 	const {
 		stripe,
 		stripeConfiguration,
-		setStripeError,
+		reloadStripeConfiguration,
 		isStripeLoading,
 		stripeLoadingError,
 	} = useStripe();
@@ -140,7 +140,7 @@ export function PaymentMethodForm( {
 		} catch ( error ) {
 			debug( 'Error while submitting', error );
 			setFormSubmitting( false );
-			error && setStripeError && setStripeError( error );
+			error && reloadStripeConfiguration && reloadStripeConfiguration();
 			error && displayError( { translate, error } );
 		}
 	};

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -35,9 +35,17 @@ export default ( router ) => {
 				makeLayout,
 				clientRender
 			);
-		} else {
-			router( paths.addCreditCard, sidebar, controller.addCreditCard, makeLayout, clientRender );
 		}
+
+		router(
+			paths.addCreditCard,
+			sidebar,
+			config.isEnabled( 'purchases/new-payment-methods' )
+				? controller.addNewPaymentMethod
+				: controller.addCreditCard,
+			makeLayout,
+			clientRender
+		);
 
 		// redirect legacy urls
 		router( '/payment-methods/add-credit-card', () => {

--- a/packages/calypso-stripe/README.md
+++ b/packages/calypso-stripe/README.md
@@ -1,3 +1,28 @@
 # Calypso Stripe
 
-This is a library of components and functions for using Stripe in Calypso.
+This is a library of components and functions for using Stripe for credit card processing in Calypso.
+
+This uses [Stripe elements](https://stripe.com/payments/elements), but with [an older version of the npm package](https://github.com/stripe/react-stripe-elements). We plan to migrate to [the newer version](https://github.com/stripe/react-stripe-js) eventually.
+
+## StripeHookProvider
+
+You'll need to wrap this context provider around any component that wishes to use `useStripe` or `withStripeProps`. It accepts the following props:
+
+- `children: JSX.Element`
+- `fetchStripeConfiguration: GetStripeConfiguration` A function to fetch the stripe configuration from the WP.com HTTP API.
+- `configurationArgs?: undefined | null | GetStripeConfigurationArgs` Options to pass to the fetchStripeConfiguration function, specifically `country` and/or `needs_intent`, the latter of which can be used to request a payment intent for adding a new card without a purchase.
+- `locale?: undefined | string` An optional locale string used to localize error messages for the Stripe elements fields.
+
+## useStripe
+
+A React hook that allows access to Stripe.js. This returns an object with the following properties:
+
+- `stripe: null | Stripe` The instance of the stripe library.
+- `stripeConfiguration: null | StripeConfiguration` The object containing the data returned by the wpcom stripe configuration endpoint. May include a payment intent.
+- `isStripeLoading: boolean` A boolean that is true if stripe is currently being loaded.
+- `stripeLoadingError: undefined | null | Error` An optional object that will be set if there is an error loading stripe.
+- `reloadStripeConfiguration: ReloadStripeConfiguration` A function that can be called with a value to force the stripe configuration to reload.
+
+## withStripeProps
+
+A higher-order-component function for use when using `useStripe` is not possible. Provides the same data as returned by `useStripe` as props to a component.

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -101,8 +101,8 @@ export interface UseStripeJs {
 	stripeLoadingError: null | undefined | string;
 }
 
-type GetStripeConfigurationArgs = { country?: string; needs_intent?: boolean };
-type GetStripeConfiguration = (
+export type GetStripeConfigurationArgs = { country?: string; needs_intent?: boolean };
+export type GetStripeConfiguration = (
 	requestArgs: GetStripeConfigurationArgs
 ) => Promise< StripeConfiguration >;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `setStripeError` function is a mechanism to force the stripe configuration to be reloaded by setting a unique string and then watching that string for changes. However, this is not semantic and can give the impression that the string _does_ something. This renames it to `reloadStripeConfiguration` which is much more clear and doesn't require a string to operate.

This also adds a proper README to the `calypso-stripe` package.

#### Testing instructions

- Sandbox the store so you can use [Stripe test cards](https://stripe.com/docs/testing#cards).
- Visit `/me/purchases/add-credit-card`.
- Submit the form to add a new credit card using a card that will fail, such as `4000000000000002`.
- Verify that you see an error.
- Without reloading the page, change the card number to a working card, such as `4242424242424242` and submit the add credit card form again.
- Verify that the card is added (payment intents can only be used once so this proves that the intent was recreated).