### PR TITLE
E2E: fix site creation tests for existing users

### DIFF
--- a/packages/plans-grid/src/plans-accordion-item/index.tsx
+++ b/packages/plans-grid/src/plans-accordion-item/index.tsx
@@ -122,6 +122,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 					</div>
 					<div className="plans-accordion-item__actions" hidden={ ! isOpen }>
 						<NextButton
+							data-e2e-button={ isFree ? 'freePlan' : 'paidPlan' }
 							onClick={ () => {
 								onSelect( slug );
 							} }

--- a/test/e2e/lib/flows/gutenboarding-flow.js
+++ b/test/e2e/lib/flows/gutenboarding-flow.js
@@ -1,0 +1,45 @@
+/**
+ * Internal dependencies
+ */
+import AcquireIntentPage from '../pages/gutenboarding/acquire-intent-page.js';
+import DesignSelectorPage from '../pages/gutenboarding/design-selector-page.js';
+import StylePreviewPage from '../pages/gutenboarding/style-preview-page.js';
+import PlansPage from '../pages/gutenboarding/plans-page.js';
+import DomainsPage from '../pages/gutenboarding/domains-page.js';
+import FeaturesPage from '../pages/gutenboarding/features-page.js';
+import GutenbergEditorComponent from '../gutenberg/gutenberg-editor-component';
+
+export default class CreateSiteFlow {
+	constructor( driver ) {
+		this.driver = driver;
+	}
+
+	async createFreeSite( name ) {
+		const acquireIntentPage = await AcquireIntentPage.Expect( this.driver );
+		if ( name ) {
+			await acquireIntentPage.enterSiteTitle( name );
+			await acquireIntentPage.goToNextStep();
+		} else {
+			await acquireIntentPage.skipStep();
+		}
+
+		const designSelectorPage = await DesignSelectorPage.Expect( this.driver );
+		await designSelectorPage.selectFreeDesign();
+
+		const stylePreviewPage = await StylePreviewPage.Expect( this.driver );
+		await stylePreviewPage.continue();
+
+		const domainsPage = await DomainsPage.Expect( this.driver );
+		await domainsPage.skipStep();
+
+		const featureswPage = await FeaturesPage.Expect( this.driver );
+		await featureswPage.skipStep();
+
+		const plansPage = await PlansPage.Expect( this.driver );
+		await plansPage.expandAllPlans();
+		await plansPage.selectFreePlan();
+
+		const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+		await gEditorComponent.initEditor();
+	}
+}

--- a/test/e2e/lib/pages/gutenboarding/plans-page.js
+++ b/test/e2e/lib/pages/gutenboarding/plans-page.js
@@ -27,7 +27,7 @@ export default class PlansPage extends AsyncBaseContainer {
 
 	async selectFreePlan() {
 		const freePlanSelector = By.css( 'button[data-e2e-button="freePlan"]' );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, freePlanSelector, 5000 );
+		await driverHelper.scrollIntoView( this.driver, freePlanSelector );
 		return await driverHelper.clickWhenClickable( this.driver, freePlanSelector );
 	}
 }

--- a/test/e2e/lib/pages/gutenboarding/plans-page.js
+++ b/test/e2e/lib/pages/gutenboarding/plans-page.js
@@ -20,4 +20,14 @@ export default class PlansPage extends AsyncBaseContainer {
 			By.css( '.plan-item__select-button.is-selected' )
 		);
 	}
+	async expandAllPlans() {
+		const toggleAllPlansSelector = By.css( 'button.plans-accordion__toggle-all-button' );
+		return await driverHelper.clickWhenClickable( this.driver, toggleAllPlansSelector );
+	}
+
+	async selectFreePlan() {
+		const freePlanSelector = By.css( 'button[data-e2e-button="freePlan"]' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, freePlanSelector, 5000 );
+		return await driverHelper.clickWhenClickable( this.driver, freePlanSelector );
+	}
 }

--- a/test/e2e/lib/pages/signup/start-page.js
+++ b/test/e2e/lib/pages/signup/start-page.js
@@ -25,7 +25,7 @@ export default class StartPage extends AsyncBaseContainer {
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.step-wrapper' ) );
 	}
 
-	static getStartURL( { culture = 'en', flow = '', query = '' } = {} ) {
+	static getStartURL( { culture = 'en', flow = 'domains', query = '' } = {} ) {
 		let route = 'start';
 		const queryStrings = [];
 		queryStrings.push( 'ref=e2e' );

--- a/test/e2e/specs/wp-launch-spec.js
+++ b/test/e2e/specs/wp-launch-spec.js
@@ -42,7 +42,7 @@ before( async function () {
 	driver = await driverManager.startBrowser();
 } );
 
-describe.skip( `[${ host }] Launch (${ screenSize }) @parallel`, function () {
+describe( `[${ host }] Launch (${ screenSize }) @signup @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	describe( 'Launch a free site', function () {

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -50,6 +50,7 @@ import DeletePlanFlow from '../lib/flows/delete-plan-flow';
 import SignUpStep from '../lib/flows/sign-up-step';
 import LaunchSiteFlow from '../lib/flows/launch-site-flow.js';
 import ActivateAccountFlow from '../lib/flows/activate-account-flow';
+import GutenboardingFlow from '../lib/flows/gutenboarding-flow';
 
 import * as sharedSteps from '../lib/shared-steps/wp-signup-spec';
 import MyHomePage from '../lib/pages/my-home-page';
@@ -1228,10 +1229,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 	} );
 
-	describe.skip( 'Sign up for an account only (no site) then add a site @signup', function () {
+	describe( 'Sign up for an account only (no site) then add a site as an existing user @signup', function () {
 		const userName = dataHelper.getNewBlogName();
 		const blogName = dataHelper.getNewBlogName();
-		// const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 
 		before( async function () {
 			await driverManager.ensureNotLoggedIn( driver );
@@ -1276,38 +1276,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			}
 		);
 
-		step(
-			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
-			async function () {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
-				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
-				// See https://github.com/Automattic/wp-calypso/pull/38641/
-				// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
-				// 	expectedBlogAddresses,
-				// 	blogName
-				// );
-				// const actualAddress = await findADomainComponent.freeBlogAddress();
-				// assert(
-				// 	expectedBlogAddresses.indexOf( actualAddress ) > -1,
-				// 	`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
-				//);
-				return await findADomainComponent.selectFreeAddress();
-			}
-		);
-
-		step( 'Can see the plans page and pick the free plan', async function () {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
-			return await pickAPlanPage.selectFreePlan();
+		step( 'We are creating the site using the New Onboarding (Gutenboarding)', async function () {
+			return await new GutenboardingFlow( driver ).createFreeSite();
 		} );
-
-		step(
-			'Can then see the sign up processing page which will finish automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-			}
-		);
-
-		sharedSteps.canSeeTheOnboardingChecklist();
 
 		after( 'Can delete our newly created account', async function () {
 			return await new DeleteAccountFlow( driver ).deleteAccount( userName );


### PR DESCRIPTION
Enable the e2e tests in `wp-signup-spec` and `wp-launch-spec` disabled in #48085.

#### Changes proposed in this Pull Request

* Use `/start/domains` (first step of the flow) instead of `/start` for creating new sites so we prevent redirect to `/new` after #48052.
* Non-logged in users will be redirected to `/start/user` as before.
* Add `GutenboardingFlow` to handle site creation for existing users.
* Add `@signup` tag to `wp-launch-spec`.