### PR TITLE
Removes reference to WP.com from Cloud backup

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/no-backups-yet.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/no-backups-yet.jsx
@@ -45,13 +45,10 @@ const NoBackupsYet = () => {
 			<div className="status-card__label">
 				{ isJetpackCloud()
 					? translate(
-							'Your first backup will appear here {{strong}}within 24 hours{{/strong}} and you will receive a {{wpcomLink/}} notification once the backup has been completed.',
+							'Your first backup will appear here {{strong}}within 24 hours{{/strong}} and you will receive an email once the backup has been completed.',
 							{
 								components: {
 									strong: <strong />,
-									wpcomLink: (
-										<ExternalLink href="https://wordpress.com">WordPress.com</ExternalLink>
-									),
 								},
 							}
 					  )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes text on Jetpack.com to not reference WP.com for the first backup.

#### Screenshot
<img width="742" alt="Screen Shot 2020-12-07 at 2 59 04 PM" src="https://user-images.githubusercontent.com/1760168/101399215-295e5100-389d-11eb-92d6-35cd10ffdbf6.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Connect a new site to Jetpack and purchase Backup.
2. Go to Cloud and verify text matches screenshot above.
3. Go to Calypso Blue and verify text matches production.

Fixes 1164141197617539-as-1199529817304509