### PR TITLE
Checkout: Fix domain add race condition

### DIFF
--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -20,6 +20,7 @@ const wpcomGetCart = ( cartKey: string ) => wpcom.getCart( cartKey );
 const wpcomSetCart = ( cartKey: string, cartData: RequestCart ) =>
 	wpcom.setCart( cartKey, cartData );
 
+// A convenience wrapper around ShoppingCartProvider to set the necessary props for calypso
 export default function CalypsoShoppingCartProvider( {
 	children,
 	cartKey,
@@ -31,9 +32,12 @@ export default function CalypsoShoppingCartProvider( {
 } ): JSX.Element {
 	const selectedSite = useSelector( getSelectedSite );
 
+	// If cartKey is null, we pass that to ShoppingCartProvider because it is
+	// probably intentional to delay loading. If cartKey is undefined, we try to
+	// get our own.
 	return (
 		<ShoppingCartProvider
-			cartKey={ cartKey || getCartKey( { selectedSite } ) }
+			cartKey={ cartKey === undefined ? getCartKey( { selectedSite } ) : cartKey }
 			getCart={ getCart || wpcomGetCart }
 			setCart={ wpcomSetCart }
 		>

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -80,16 +80,22 @@ export default function CheckoutSystemDecider( {
 		[ reduxDispatch ]
 	);
 
+	// We have to monitor the old cart manager in case it's waiting on a
+	// requested change. To prevent race conditions, we will return undefined in
+	// that case, which will cause the ShoppingCartProvider to enter a loading
+	// state. We have to use null because CalypsoShoppingCartProvider assumes
+	// undefined means to try for its own cartKey.
 	const waitForOtherCartUpdates =
 		otherCart?.hasPendingServerUpdates || ! otherCart?.hasLoadedFromServer;
 	const cartKey = useMemo(
 		() =>
-			getCartKey( {
-				selectedSite,
-				isLoggedOutCart,
-				isNoSiteCart,
-				waitForOtherCartUpdates,
-			} ),
+			waitForOtherCartUpdates
+				? null
+				: getCartKey( {
+						selectedSite,
+						isLoggedOutCart,
+						isNoSiteCart,
+				  } ),
 		[ waitForOtherCartUpdates, selectedSite, isLoggedOutCart, isNoSiteCart ]
 	);
 	debug( 'cartKey is', cartKey );

--- a/client/my-sites/checkout/get-cart-key.ts
+++ b/client/my-sites/checkout/get-cart-key.ts
@@ -7,21 +7,11 @@ export default function getCartKey( {
 	selectedSite,
 	isLoggedOutCart,
 	isNoSiteCart,
-	waitForOtherCartUpdates,
 }: {
 	selectedSite: SiteData | undefined | null;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
-	waitForOtherCartUpdates?: boolean;
 } ): string | number | undefined {
-	// We have to monitor the old cart manager in case it's waiting on a
-	// requested change. To prevent race conditions, we will return undefined in
-	// that case, which will cause the ShoppingCartProvider to enter a loading
-	// state.
-	if ( waitForOtherCartUpdates ) {
-		return undefined;
-	}
-
 	if ( ! selectedSite?.slug && ( isLoggedOutCart || isNoSiteCart ) ) {
 		return 'no-user';
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a regression added in https://github.com/Automattic/wp-calypso/pull/47605 which broke the code that guards against race conditions between the deprecated `CartStore` and the new `ShoppingCartProvider`/`useShoppingCart`. This could be seen by adding a domain to the shopping cart (which uses `CartStore`) and then very quickly navigating to checkout (skipping the G Suite step).

In #47605 we added a convenience component called `CalypsoShoppingCartProvider` which can be used instead of `ShoppingCartProvider` and already has the required props for calypso. If needed, those props can be overridden by setting them on `CalypsoShoppingCartProvider`. However, the race condition guard operated by causing the `cartKey` prop to be  set to `undefined` and `CalypsoShoppingCartProvider` interpreted that to mean that its default `cartKey` was not being overridden and bypassing the guard.

In this PR we make two changes: first we guard against the race condition by setting the `cartKey` to `null` instead of `undefined`, then we make `CalypsoShoppingCartProvider` allow using `null` to override the `cartKey`.

#### Testing instructions

- Apply the following patch to quickly get from domain search to checkout:

```diff
diff --git a/client/my-sites/domains/domain-search/index.jsx b/client/my-sites/domains/domain-search/index.jsx
index 93ccb88fa1..1282de707b 100644
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -135,11 +135,7 @@ class DomainSearch extends Component {
 
 		addItem( registration );
 
-		if ( canDomainAddGSuite( domain ) ) {
-			page( '/domains/add/' + domain + '/google-apps/' + this.props.selectedSiteSlug );
-		} else {
-			page( '/checkout/' + this.props.selectedSiteSlug );
-		}
+		page( '/checkout/' + this.props.selectedSiteSlug );
 	}
 
 	removeDomain( suggestion ) {
```

- Next, visit the Domains page and click to add a domain to your cart. Pick a domain name which will redirect you to checkout.
- Verify that checkout loads with the product in the cart.
- You may need to try this several times to prove the race condition cannot occur.