### PR TITLE
New onboarding launch: Fix selecting subdomain and update menu

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/index.tsx
@@ -24,7 +24,7 @@ const LaunchMenu: React.FunctionComponent< Props > = ( { onMenuItemClick } ) => 
 	const LaunchStep = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchStep() );
 	const LaunchSequence = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchSequence() );
 	const isStepCompleted = useSelect( ( select ) => select( LAUNCH_STORE ).isStepCompleted );
-	const isFlowStarted = useSelect( ( select ) => select( LAUNCH_STORE ).isFlowStarted() );
+	const isFlowCompleted = useSelect( ( select ) => select( LAUNCH_STORE ).isFlowCompleted() );
 
 	const LaunchStepMenuItemTitles = {
 		[ LaunchStep.Name ]: __( 'Name your site', 'full-site-editing' ),
@@ -51,7 +51,7 @@ const LaunchMenu: React.FunctionComponent< Props > = ( { onMenuItemClick } ) => 
 						isCompleted={ isStepCompleted( step ) }
 						isCurrent={ step === currentStep }
 						onClick={ () => handleClick( step ) }
-						isDisabled={ step === LaunchStep.Final && ! isFlowStarted }
+						isDisabled={ step === LaunchStep.Final && ! isFlowCompleted }
 					/>
 				) ) }
 			</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -44,6 +44,7 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 	};
 
 	const handleExistingSubdomainSelect = () => {
+		confirmDomainSelection();
 		unsetDomain();
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Allow subdomain selection
* Disable final step unless all items in the flow are completed

#### Testing instructions
* Run `yarn start` and `cd apps/editing-toolkit && yarn dev --sync`
* Go to /new and create a free site. Sandbox the site.
* Click Launch button in editor to open launch flow
* Selecting a subdomain before selecting a domain should work
* Only when all the steps are completed (title, domain, plan), last menu item should be enabled.

Fixes #48098, #48118, p1607374070199700-slack-CRNF6A9DX
Fixes https://github.com/Automattic/wp-calypso/issues/48086