### PR TITLE
Plugins: Fix Jetpack in bulk deactivation mode

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -286,10 +286,14 @@ export const PluginsList = createReactClass( {
 	deactiveAndDisconnectSelected() {
 		let waitForDeactivate = false;
 
-		this.doActionOverSelected( 'deactivating', ( site, plugin ) => {
-			waitForDeactivate = true;
-			this.props.deactivatePlugin( site, plugin, true );
-		} );
+		this.doActionOverSelected(
+			'deactivating',
+			( site, plugin ) => {
+				waitForDeactivate = true;
+				this.props.deactivatePlugin( site, plugin, true );
+			},
+			true
+		);
 
 		if ( waitForDeactivate && this.props.selectedSite ) {
 			this.setState( { disconnectJetpackDialog: true } );


### PR DESCRIPTION
This PR fixes the deactivation of Jetpack in bulk editing mode, which was broken since https://github.com/Automattic/wp-calypso/pull/47711 landed.

This PR is part of the plugins reduxification effort in #24180.

#### Changes proposed in this Pull Request

* Plugins: Fix Jetpack in bulk deactivation mode

#### Testing instructions

* Go to `/plugins/manage/:site` where `:site` is a Jetpack site.
* Click the "Edit All" button in the plugin list header.
* Select one active plugin (for example "Hello Dolly") and Jetpack.
* Click the "Deactivate" button in the plugin list header.
* Verify the first plugin deactivates, and you get a notice that Jetpack couldn't be deactivated, with no errors in the console.
