### PR TITLE
Plugins: Untangle PluginsLog from PluginsList and rely on redux instead

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -18,7 +18,6 @@ import acceptDialog from 'calypso/lib/accept';
 import { warningNotice } from 'calypso/state/notices/actions';
 import PluginItem from 'calypso/my-sites/plugins/plugin-item/plugin-item';
 import PluginsListHeader from 'calypso/my-sites/plugins/plugin-list-header';
-import PluginsLog from 'calypso/lib/plugins/log-store';
 import PluginNotices from 'calypso/lib/plugins/notices';
 import { Card } from '@automattic/components';
 import SectionHeader from 'calypso/components/section-header';
@@ -95,7 +94,7 @@ export const PluginsList = createReactClass( {
 			return true;
 		}
 
-		if ( this.state.disconnectJetpackDialog !== nextState.disconnectJetpackDialog ) {
+		if ( this.state.disconnectJetpackNotice !== nextState.disconnectJetpackNotice ) {
 			return true;
 		}
 
@@ -110,20 +109,16 @@ export const PluginsList = createReactClass( {
 		return false;
 	},
 
+	componentDidUpdate() {
+		this.maybeShowDisconnectNotice();
+	},
+
 	getInitialState() {
 		return {
-			disconnectJetpackDialog: false,
+			disconnectJetpackNotice: false,
 			bulkManagementActive: false,
 			selectedPlugins: {},
 		};
-	},
-
-	componentDidMount() {
-		PluginsLog.on( 'change', this.showDisconnectDialog );
-	},
-
-	componentWillUnmount() {
-		PluginsLog.removeListener( 'change', this.showDisconnectDialog );
 	},
 
 	isSelected( { slug } ) {
@@ -296,7 +291,7 @@ export const PluginsList = createReactClass( {
 		);
 
 		if ( waitForDeactivate && this.props.selectedSite ) {
-			this.setState( { disconnectJetpackDialog: true } );
+			this.setState( { disconnectJetpackNotice: true } );
 		}
 
 		this.recordEvent( 'Clicked Deactivate Plugin(s) and Disconnect Jetpack', true );
@@ -429,12 +424,12 @@ export const PluginsList = createReactClass( {
 		}
 	},
 
-	showDisconnectDialog() {
+	maybeShowDisconnectNotice() {
 		const { translate } = this.props;
 
-		if ( this.state.disconnectJetpackDialog && ! this.props.inProgressStatuses.length ) {
+		if ( this.state.disconnectJetpackNotice && ! this.props.inProgressStatuses.length ) {
 			this.setState( {
-				disconnectJetpackDialog: false,
+				disconnectJetpackNotice: false,
 			} );
 
 			this.props.warningNotice(

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import page from 'page';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -443,15 +442,6 @@ export const PluginsList = createReactClass( {
 				)
 			);
 		}
-	},
-
-	closeDialog( action ) {
-		if ( 'continue' === action ) {
-			page.redirect( '/settings/general/' + this.props.selectedSiteSlug );
-			return;
-		}
-		this.setState( { showJetpackDisconnectDialog: false } );
-		this.forceUpdate();
 	},
 
 	// Renders


### PR DESCRIPTION
In the process of reduxifying plugins, we're removing the `PluginsLog` in favor of its redux counterpart. This PR removes it from `PluginsList` and does a couple of minor improvements to the related code.

This PR is part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Rely on redux instead of `PluginsLog` for showing disconnection notice
* Rename a couple of vars and methods to reflect their true purpose:
  * `showDisconnectDialog()` -> `maybeShowDisconnectNotice()`
  * `disconnectJetpackDialog` -> `disconnectJetpackNotice`
* Remove unused `closeDialog` method.

#### Testing instructions

* Go to `/plugins/manage/:site` where `:site` is a Jetpack site.
* Click the "Edit All" button in the plugin list header.
* Select one active plugin (for example "Hello Dolly") and Jetpack.
* Click the "Deactivate" button in the plugin list header.
* Verify the first plugin deactivates, and you get a notice that Jetpack couldn't be deactivated, with no errors in the console.

