### PR TITLE
Plugins: Update manage connection route

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -442,7 +442,7 @@ export const PluginsList = createReactClass( {
 					'Jetpack cannot be deactivated from WordPress.com. {{link}}Manage connection{{/link}}',
 					{
 						components: {
-							link: <a href={ '/settings/general/' + this.props.selectedSiteSlug } />,
+							link: <a href={ '/settings/manage-connection/' + this.props.selectedSiteSlug } />,
 						},
 					}
 				)


### PR DESCRIPTION
Since #15716 we have a dedicated settings page to manage the Jetpack connection. However, in the plugins notice when attempting to deactivate Jetpack, we still render a link to the general settings. This PR changes the link to lead to the manage connection settings page instead.

This PR is part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Update disconnection notice link to lead to manage connection page

#### Testing instructions

* Go to `/plugins/manage/:site` where `:site` is a Jetpack site.
* Click the "Edit All" button in the plugin list header.
* Select one active plugin (for example "Hello Dolly") and Jetpack.
* Click the "Deactivate" button in the plugin list header.
* You'll get a notice that Jetpack couldn't be deactivated.
* In the notice, click the link and verify it gets you to the "Manage Connection" settings page.
