### PR TITLE
Onboarding: Fix plan picker comparison table width on large displays

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
@@ -10,10 +10,5 @@
 	.plans-grid__details-container {
 		position: relative;
 		@include onboarding-block-edge2edge-container;
-		@include break-huge {
-			width: 100%;
-			margin-left: 0;
-			margin-right: 0;
-		}
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
@@ -10,5 +10,10 @@
 	.plans-grid__details-container {
 		position: relative;
 		@include onboarding-block-edge2edge-container;
+		@include break-huge {
+			width: 100%;
+			margin-left: 0;
+			margin-right: 0;
+		}
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/styles.scss
@@ -1,4 +1,5 @@
 @import '~@automattic/onboarding/styles/mixins';
+@import '~@automattic/plans-grid/src/variables';
 
 .nux-launch-modal.step-plan {
 	// Remove extraneous whitespace after plans details.
@@ -10,5 +11,10 @@
 	.plans-grid__details-container {
 		position: relative;
 		@include onboarding-block-edge2edge-container;
+
+		@media ( min-width: $plans-grid-max-page-width ) {
+			margin-left: 0;
+			margin-right: 0;
+		}
 	}
 }

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -152,29 +152,12 @@
 		margin-left: #{$onboarding-block-margin-medium * -1};
 		margin-right: #{$onboarding-block-margin-medium * -1};
 	}
-
-	@include break-huge {
-		margin-left: 0;
-		margin-right: 0;
-	}
 }
 
 @mixin onboarding-block-edge2edge-container {
 	@include onboarding-block-edge2edge;
 
-	width: calc( 100% + #{$onboarding-block-margin-mobile * 2} );
-
-	@include break-small {
-		width: calc( 100% + #{$onboarding-block-margin-small * 2} );
-	}
-
-	@include break-medium {
-		width: calc( 100% + #{$onboarding-block-margin-medium * 2} );
-	}
-
-	@include break-huge {
-		width: 100%;
-	}
+	width: auto;
 }
 
 @mixin onboarding-block-edge2edge-content {

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -152,6 +152,11 @@
 		margin-left: #{$onboarding-block-margin-medium * -1};
 		margin-right: #{$onboarding-block-margin-medium * -1};
 	}
+
+	@include break-huge {
+		margin-left: 0;
+		margin-right: 0;
+	}
 }
 
 @mixin onboarding-block-edge2edge-container {
@@ -165,6 +170,10 @@
 
 	@include break-medium {
 		width: calc( 100% + #{$onboarding-block-margin-medium * 2} );
+	}
+
+	@include break-huge {
+		width: 100%;
 	}
 }
 

--- a/packages/plans-grid/src/plans-details/style.scss
+++ b/packages/plans-grid/src/plans-details/style.scss
@@ -2,6 +2,7 @@
 @import '~@wordpress/base-styles/mixins';
 @import '~@automattic/onboarding/styles/mixins';
 @import '~@automattic/typography/styles/variables';
+@import '../variables';
 
 // Used to "counter" the negative margin set on the container, while allowing the
 // table to scroll horizontally in case it doesn't fit in the viewport.
@@ -17,6 +18,11 @@
 	@include break-medium {
 		padding-left: $onboarding-block-margin-medium;
 		padding-right: $onboarding-block-margin-medium;
+	}
+
+	@media ( min-width: $plans-grid-max-page-width ) {
+		padding-left: 0;
+		padding-right: 0;
 	}
 }
 

--- a/packages/plans-grid/src/plans-details/style.scss
+++ b/packages/plans-grid/src/plans-details/style.scss
@@ -3,11 +3,30 @@
 @import '~@automattic/onboarding/styles/mixins';
 @import '~@automattic/typography/styles/variables';
 
+// Used to "counter" the negative margin set on the container, while allowing the
+// table to scroll horizontally in case it doesn't fit in the viewport.
+@mixin plans-grid-edge2edge-padding {
+	padding-left: $onboarding-block-margin-mobile;
+	padding-right: $onboarding-block-margin-mobile;
+
+	@include break-small {
+		padding-left: $onboarding-block-margin-small;
+		padding-right: $onboarding-block-margin-small;
+	}
+
+	@include break-medium {
+		padding-left: $onboarding-block-margin-medium;
+		padding-right: $onboarding-block-margin-medium;
+	}
+}
+
 .plans-grid__details-heading {
 	margin-bottom: 20px;
 }
 
 .plans-details__table {
+	@include plans-grid-edge2edge-padding;
+
 	width: 100%;
 	border-spacing: 0;
 
@@ -32,20 +51,6 @@
 	// TODO: Deal with a11y later.
 	.hidden {
 		display: none;
-	}
-
-	padding-right: $onboarding-block-margin-mobile;
-
-	@include break-small {
-		padding-right: $onboarding-block-margin-small;
-	}
-
-	@include break-medium {
-		padding-right: $onboarding-block-margin-medium;
-	}
-
-	@include break-huge {
-		padding-right: 0;
 	}
 }
 

--- a/packages/plans-grid/src/plans-details/style.scss
+++ b/packages/plans-grid/src/plans-details/style.scss
@@ -33,6 +33,20 @@
 	.hidden {
 		display: none;
 	}
+
+	padding-right: $onboarding-block-margin-mobile;
+
+	@include break-small {
+		padding-right: $onboarding-block-margin-small;
+	}
+
+	@include break-medium {
+		padding-right: $onboarding-block-margin-medium;
+	}
+
+	@include break-huge {
+		padding-right: 0;
+	}
 }
 
 .plans-details__header-row {

--- a/packages/plans-grid/src/plans-grid/style.scss
+++ b/packages/plans-grid/src/plans-grid/style.scss
@@ -4,21 +4,6 @@
 @import '~@automattic/onboarding/styles/mixins';
 @import '../variables.scss';
 
-@mixin plans-grid-edge2edge-padding {
-	padding-left: $onboarding-block-margin-mobile;
-	padding-right: $onboarding-block-margin-mobile;
-
-	@include break-small {
-		padding-left: $onboarding-block-margin-small;
-		padding-right: $onboarding-block-margin-small;
-	}
-
-	@include break-medium {
-		padding-left: $onboarding-block-margin-medium;
-		padding-right: $onboarding-block-margin-medium;
-	}
-}
-
 .plans-grid {
 	// Space to accomadate sticky footer
 	margin-bottom: 85px; // @TODO: replace with a variable
@@ -45,8 +30,6 @@
 		width: 100%;
 		position: absolute;
 		left: 0;
-
-		@include plans-grid-edge2edge-padding;
 	}
 	// this is needed on mobiles to uncover the CTA button
 	// without it, it's covered by the sticky bottom bar

--- a/packages/plans-grid/src/plans-grid/style.scss
+++ b/packages/plans-grid/src/plans-grid/style.scss
@@ -25,7 +25,8 @@
 }
 
 .plans-grid__details-container {
-	@media ( max-width: $plans-grid-max-page-width ) {
+	// -1px is becuase this is a `max-width` media query, instead of the usual `min-width`
+	@media ( max-width: $plans-grid-max-page-width - 1px ) {
 		overflow-x: auto;
 		width: 100%;
 		position: absolute;

--- a/packages/plans-grid/src/variables.scss
+++ b/packages/plans-grid/src/variables.scss
@@ -23,4 +23,5 @@ $plans-details-min-width-desktop-medium: #{to-number( $plans-table-total-content
 	$onboarding-block-margin-medium * 2};
 $plans-details-min-width-mobile: 700px;
 
-$plans-grid-max-page-width: 1440px;
+// $break-wide defined in @wordpress/base-styles/_breakpoints.scss
+$plans-grid-max-page-width: $break-huge;


### PR DESCRIPTION
## Changes proposed in this Pull Request

- Fix comparison table being wider than the container on large desktop screens
- Add padding at the end of the comparison table so that, when scrolling horizontally on narrow screens, it would line up with the rest of the page's content

## Testing instructions

### Prepare for testing

* Check out the branch on your machine and run in two parallel terminal windows:
  - `yarn && yarn start`
  - `cd apps/editing-toolkit && yarn dev --sync`
* Add an _unlaunched_ site created with `/new` to your sandbox (for convenience, `SITE_ID.wordpress.com`)
* Visit the block editor (e.g. `/page/SITE_ID.wordpress.com/home`)
* Click on "Launch" button — Step by Step Launch modal should appear
* Navigate to the Plans step

### Testing checklist

Please carry out the tests **across different browsers** (at least Chrome / Firefox / Safari)

- [x] Check that the left side of the Plan comparison table is always aligned with its container
- [x] Check that, when the viewport is wide enough, the right border of the Plan comparison table is aligned with its container
  - [x] Check that, when the viewport is not wide enough, the table overflows its container to the right (and the section can be scrolled horizontally), while maintaining the right padding


Additionally, **test for potential regressions in other flows** importing `@automattic/onboarding` and `@automattic/plans-grid`:

- [x] New Onboarding
- [x] Focused Launch

| before | after |
| - | - |
| ![image](https://user-images.githubusercontent.com/2256104/101488954-8c64ec00-3960-11eb-839f-99febc91e76e.png) | ![image](https://user-images.githubusercontent.com/2256104/101488736-4871e700-3960-11eb-969e-feec3f980f22.png) |


Fixes #47883 
