### PR TITLE
Plugins: Reduxify single plugin retrieval

### DIFF
--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -48,12 +48,6 @@ The Data is stored in a private variable but can be accessed though the stores p
 
 ### Public Methods
 
-#### PluginsStore.getPlugin( sites, pluginSlug );
-
-Returns a plugin object that has a sites attribute which stores an array of sites objects that have that particular plugin.
-
----
-
 #### PluginsStore.getPlugins( sites, pluginFilter );
 
 Returns an array of plugin object that has a sites attribute which stores an array of sites objects that have that particular plugin.

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -110,35 +110,6 @@ function updatePlugins( site, plugins ) {
 }
 
 const PluginsStore = {
-	getPlugin: function ( sites, pluginSlug ) {
-		let pluginData = {};
-		let fetched = false;
-		pluginData.sites = [];
-
-		sites = ! isArray( sites ) ? [ sites ] : sites;
-
-		sites.forEach( function ( site ) {
-			const sitePlugins = PluginsStore.getSitePlugins( site );
-			if ( typeof sitePlugins !== 'undefined' ) {
-				fetched = true;
-			}
-			if ( ! sitePlugins ) {
-				return;
-			}
-			sitePlugins.forEach( function ( plugin ) {
-				if ( plugin.slug === pluginSlug ) {
-					pluginData = assign( pluginData, plugin );
-					pluginData.sites.push( assign( {}, site, { plugin: plugin } ) );
-				}
-			}, this );
-		} );
-
-		if ( ! fetched ) {
-			return;
-		}
-		return pluginData;
-	},
-
 	getPlugins: function ( sites, pluginFilter ) {
 		let fetched = false;
 		let plugins = {};

--- a/client/lib/plugins/test/store.js
+++ b/client/lib/plugins/test/store.js
@@ -39,28 +39,6 @@ describe( 'Plugins Store', () => {
 			assert.isNotNull( PluginsStore.getSitePlugins( site ) );
 		} );
 
-		describe( 'getPlugin method', () => {
-			test( 'Store should have method getPlugin', () => {
-				assert.isFunction( PluginsStore.getPlugin );
-			} );
-
-			test( 'should return an object', () => {
-				assert.isObject( PluginsStore.getPlugin( site, 'akismet' ) );
-			} );
-
-			test( 'should accept sites as an array of objects or object', () => {
-				assert.deepEqual(
-					PluginsStore.getPlugin( site, 'akismet' ),
-					PluginsStore.getPlugin( [ site ], 'akismet' )
-				);
-			} );
-
-			test( 'should return an object with attribute sites array', () => {
-				const Plugin = PluginsStore.getPlugin( site, 'akismet' );
-				assert.isArray( Plugin.sites );
-			} );
-		} );
-
 		describe( 'getPlugins method', () => {
 			test( 'Store should have method getPlugins', () => {
 				assert.isFunction( PluginsStore.getPlugins );
@@ -78,30 +56,18 @@ describe( 'Plugins Store', () => {
 				assert.isObject( Plugins[ 0 ].sites[ 0 ] );
 			} );
 
-			test( 'should return the same object as getPlugin', () => {
-				const Plugins = PluginsStore.getPlugins( site );
-				const Plugin = PluginsStore.getPlugin( site, Plugins[ 0 ].slug );
-				assert.deepEqual( Plugins[ 0 ], Plugin );
-			} );
-
 			test( 'should return active Plugins', () => {
 				const Plugins = PluginsStore.getPlugins( site, 'active' );
-				const Plugin = PluginsStore.getPlugin( site, Plugins[ 0 ].slug );
-				assert.deepEqual( Plugins[ 0 ], Plugin );
 				assert.isTrue( Plugins[ 0 ].active );
 			} );
 
 			test( 'should return inactive Plugins', () => {
 				const Plugins = PluginsStore.getPlugins( site, 'inactive' );
-				const Plugin = PluginsStore.getPlugin( site, Plugins[ 0 ].slug );
-				assert.deepEqual( Plugins[ 0 ], Plugin );
 				assert.isFalse( Plugins[ 0 ].active );
 			} );
 
 			test( 'should return needs update Plugins', () => {
 				const Plugins = PluginsStore.getPlugins( site, 'updates' );
-				const Plugin = PluginsStore.getPlugin( site, Plugins[ 0 ].slug );
-				assert.deepEqual( Plugins[ 0 ], Plugin );
 				assert.isObject( Plugins[ 0 ].update );
 			} );
 

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -41,7 +41,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import NoPermissionsError from './no-permissions-error';
 import getToursHistory from 'calypso/state/guided-tours/selectors/get-tours-history';
 import hasNavigated from 'calypso/state/selectors/has-navigated';
-import { getSitesWithoutPlugin } from 'calypso/state/plugins/installed/selectors';
+import { getPluginOnSites, getSitesWithoutPlugin } from 'calypso/state/plugins/installed/selectors';
 
 /* eslint-disable react/prefer-es6-class */
 
@@ -87,14 +87,13 @@ const SinglePlugin = createReactClass( {
 		const props = nextProps || this.props;
 
 		const sites = uniq( props.sites );
-		const sitePlugin = PluginsStore.getPlugin( sites, props.pluginSlug );
 		const plugin = Object.assign(
 			{
 				name: props.pluginSlug,
 				id: props.pluginSlug,
 				slug: props.pluginSlug,
 			},
-			sitePlugin
+			props.plugin
 		);
 
 		const notInstalledSites = props.sitesWithoutPlugin.map( ( siteId ) =>
@@ -178,7 +177,8 @@ const SinglePlugin = createReactClass( {
 		const sites = this.props.sites;
 
 		// If the plugin has at least one site then we know it exists
-		if ( plugin.sites && plugin.sites[ 0 ] ) {
+		const pluginSites = Object.values( plugin.sites );
+		if ( pluginSites && pluginSites[ 0 ] ) {
 			return true;
 		}
 
@@ -360,6 +360,7 @@ export default connect(
 		const siteIds = uniq( sites.map( ( site ) => site.ID ) );
 
 		return {
+			plugin: getPluginOnSites( state, siteIds, props.pluginSlug ),
 			wporgPlugin: getWporgPlugin( state, props.pluginSlug ),
 			wporgFetching: isWporgPluginFetching( state, props.pluginSlug ),
 			wporgFetched: isWporgPluginFetched( state, props.pluginSlug ),

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -94,6 +94,10 @@ export function getPluginsWithUpdates( state, siteIds ) {
 	} ) );
 }
 
+export function getPluginOnSites( state, siteIds, pluginSlug ) {
+	return getPlugins( state, siteIds ).find( ( plugin ) => plugin.slug === pluginSlug );
+}
+
 export function getPluginOnSite( state, siteId, pluginSlug ) {
 	const pluginList = getPlugins( state, [ siteId ] );
 	return find( pluginList, { slug: pluginSlug } );

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -66,14 +66,15 @@ export function getPlugins( state, siteIds, pluginFilter ) {
 			const list = state.plugins.installed.plugins[ siteId ] || [];
 			list.forEach( ( item ) => {
 				const sitePluginInfo = pick( item, [ 'active', 'autoupdate', 'update' ] );
-				if ( memo[ item.slug ] ) {
-					memo[ item.slug ].sites = {
-						...memo[ item.slug ].sites,
+
+				memo[ item.slug ] = {
+					...memo[ item.slug ],
+					...item,
+					sites: {
+						...memo[ item.slug ]?.sites,
 						[ siteId ]: sitePluginInfo,
-					};
-				} else {
-					memo[ item.slug ] = { ...item, sites: { [ siteId ]: sitePluginInfo } };
-				}
+					},
+				};
 			} );
 			return memo;
 		},
@@ -83,6 +84,7 @@ export function getPlugins( state, siteIds, pluginFilter ) {
 	if ( pluginFilter && _filters[ pluginFilter ] ) {
 		pluginList = filter( pluginList, _filters[ pluginFilter ] );
 	}
+
 	return values( sortBy( pluginList, ( item ) => item.slug.toLowerCase() ) );
 }
 

--- a/client/state/plugins/installed/test/selectors.js
+++ b/client/state/plugins/installed/test/selectors.js
@@ -223,6 +223,27 @@ describe( 'Installed plugin selectors', () => {
 		} );
 	} );
 
+	describe( 'getPluginOnSites', () => {
+		test( 'Should get an undefined value if the requested sites are not in the current state', () => {
+			const siteIds = [ 'no.site', 'some.site' ];
+			expect( selectors.getPluginOnSites( state, siteIds, 'akismet' ) ).to.be.undefined;
+		} );
+
+		test( 'Should get an undefined value if the requested plugin on these sites is not in the current state', () => {
+			expect( selectors.getPluginOnSites( state, [ 'site.one' ], 'jetpack' ) ).to.be.undefined;
+		} );
+
+		test( 'Should get the plugin if the it exists on one or more of the requested sites', () => {
+			const siteIds = [ 'site.one', 'site.two' ];
+			const plugin = selectors.getPluginOnSites( state, siteIds, 'hello-dolly' );
+			const sitesWithPlugins = {
+				[ 'site.one' ]: pick( helloDolly, [ 'active', 'autoupdate', 'update' ] ),
+				[ 'site.two' ]: pick( helloDolly, [ 'active', 'autoupdate', 'update' ] ),
+			};
+			expect( plugin ).to.eql( { ...helloDolly, sites: sitesWithPlugins } );
+		} );
+	} );
+
 	describe( 'getSitesWithPlugin', () => {
 		test( 'Should get an empty array if the requested site is not in the current state', () => {
 			expect( selectors.getSitesWithPlugin( state, [ 'no.site' ], 'akismet' ) ).to.have.lengthOf(


### PR DESCRIPTION
We're currently using flux for retrieving the plugin information (including the sites that a plugin is installed on). This PR introduces a new selector for that, updates the code to use this new selector, and removes the old flux method.

This PR is part of #24180.

#### Changes proposed in this Pull Request

* State: Introduce a simple `getPluginOnSites` selector with tests.
* Plugins: Use Redux `getPluginOnSites` instead of flux's `getPlugin()` method.
* Plugins: Remove unused `PluginStore.getPlugin()` method and related tests and docs

#### Testing instructions

Keeping an eye on the console for errors, verify there are no functional or behavioral changes in the following:

* Go to `/plugins/:plugin` where `:plugin` is one of the plugins you have installed on one or more sites. Make sure you have at least one site with an old version of it.
* For several sites, try installing, removing, updating, toggling autoupdates, activating, deactivating and make sure everything works like it did before.
* Go to `/plugins/:plugin/:site` where `:site` is one of your sites, and try the same as above within the selected site. 
