### PR TITLE
New onboarding: Skip mandatory Plans step on /new/free flow

### DIFF
--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -9,10 +9,12 @@ import { useLocale } from '@automattic/i18n-utils';
  * Internal dependencies
  */
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
-import { PLANS_STORE, Plan } from '../stores/plans';
+import { PLANS_STORE } from '../stores/plans';
 import { WPCOM_FEATURES_STORE } from '../stores/wpcom-features';
 import { usePlanRouteParam } from '../path';
 import { isEnabled } from 'calypso/config';
+
+import type { Plan } from '../stores/plans';
 
 /**
  * A React hook that returns the WordPress.com plan from path.

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -17,21 +17,21 @@ import { isEnabled } from 'calypso/config';
 /**
  * A React hook that returns the WordPress.com plan from path.
  *
- * Exception: Free plan is not returned while a paid domain is selected
+ * Exception: Free plan is not returned while features are selected
  *
  * @returns { Plan } An object describing a WordPress.com plan
  */
 export function usePlanFromPath(): Plan | undefined {
 	const planPath = usePlanRouteParam();
 
-	const [ isPlanFree, planFromPath, hasPaidDomain ] = useSelect( ( select ) => [
+	const [ isPlanFree, planFromPath, selectedFeatures ] = useSelect( ( select ) => [
 		select( PLANS_STORE ).isPlanFree,
 		select( PLANS_STORE ).getPlanByPath( planPath ),
-		select( ONBOARD_STORE ).hasPaidDomain(),
+		select( ONBOARD_STORE ).getSelectedFeatures(),
 	] );
 
-	// don't return Free plan if paid domain is currently selected
-	if ( isPlanFree( planFromPath?.storeSlug ) && hasPaidDomain ) {
+	// don't return Free plan if any feature is currently selected
+	if ( isPlanFree( planFromPath?.storeSlug ) && selectedFeatures.length ) {
 		return;
 	}
 

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -70,9 +70,13 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	};
 
 	const currentStepIndex = steps.findIndex( ( step ) => step === Step[ currentStep ] );
+
 	const previousStepPath = currentStepIndex > 0 ? makePath( steps[ currentStepIndex - 1 ] ) : '';
 	const nextStepPath =
-		currentStepIndex < steps.length - 1 ? makePath( steps[ currentStepIndex + 1 ] ) : '';
+		currentStepIndex !== -1 && // check first if current step still exists
+		currentStepIndex < steps.length - 1
+			? makePath( steps[ currentStepIndex + 1 ] )
+			: '';
 
 	const isLastStep = currentStepIndex === steps.length - 1;
 

--- a/client/landing/gutenboarding/hooks/use-steps.ts
+++ b/client/landing/gutenboarding/hooks/use-steps.ts
@@ -53,8 +53,8 @@ export default function useSteps(): Array< StepType > {
 	}
 
 	// Don't show the mandatory Plans steps:
-	// - if the user landed from a marketing page after selecting a plan (in this case, hide also the Features step)
-	// - if a plan has been selected using the PlansModal but only if there is no Features step
+	// - if the user landed from a marketing page after selecting a plan
+	// - if a plan has been explicitly selected using the PlansModal
 	if ( ( hasPlanFromPath || plan ) && ! hasUsedPlansStep ) {
 		steps = steps.filter( ( step ) => step !== Step.Plans );
 	}

--- a/client/landing/gutenboarding/hooks/use-steps.ts
+++ b/client/landing/gutenboarding/hooks/use-steps.ts
@@ -41,6 +41,7 @@ export default function useSteps(): Array< StepType > {
 	}
 
 	// Logic necessary to skip Domains or Plans steps
+	// General rule: if a step has been used already, don't remove it.
 	const { domain, hasUsedDomainsStep, hasUsedPlansStep } = useSelect( ( select ) =>
 		select( ONBOARD_STORE ).getState()
 	);
@@ -51,16 +52,11 @@ export default function useSteps(): Array< StepType > {
 		steps = steps.filter( ( step ) => step !== Step.Domains );
 	}
 
-	// Don't show the mandatory Plans step:
+	// Don't show the mandatory Plans steps:
 	// - if the user landed from a marketing page after selecting a plan (in this case, hide also the Features step)
-	// - if this is an Anchor.fm signup
 	// - if a plan has been selected using the PlansModal but only if there is no Features step
-	if (
-		hasPlanFromPath ||
-		isAnchorFmSignup ||
-		( ! steps.includes( Step.Features ) && plan && ! hasUsedPlansStep )
-	) {
-		steps = steps.filter( ( step ) => step !== Step.Plans && step !== Step.Features );
+	if ( ( hasPlanFromPath || plan ) && ! hasUsedPlansStep ) {
+		steps = steps.filter( ( step ) => step !== Step.Plans );
 	}
 
 	return steps;

--- a/client/landing/gutenboarding/hooks/use-steps.ts
+++ b/client/landing/gutenboarding/hooks/use-steps.ts
@@ -8,7 +8,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { Step, StepType, useIsAnchorFm } from '../path';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
-import { useHasPaidPlanFromPath } from './use-selected-plan';
+import { usePlanFromPath } from './use-selected-plan';
 
 export default function useSteps(): Array< StepType > {
 	const { hasSiteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ) );
@@ -45,18 +45,18 @@ export default function useSteps(): Array< StepType > {
 		select( ONBOARD_STORE ).getState()
 	);
 	const plan = useSelect( ( select ) => select( ONBOARD_STORE ).getPlan() );
-	const hasPaidPlanFromPath = useHasPaidPlanFromPath();
+	const hasPlanFromPath = !! usePlanFromPath();
 
 	if ( domain && ! hasUsedDomainsStep ) {
 		steps = steps.filter( ( step ) => step !== Step.Domains );
 	}
 
 	// Don't show the mandatory Plans step:
-	// - if the user landed from a marketing page after selecting a paid plan (in this case, hide also the Features step)
+	// - if the user landed from a marketing page after selecting a plan (in this case, hide also the Features step)
 	// - if this is an Anchor.fm signup
 	// - if a plan has been selected using the PlansModal but only if there is no Features step
 	if (
-		hasPaidPlanFromPath ||
+		hasPlanFromPath ||
 		isAnchorFmSignup ||
 		( ! steps.includes( Step.Features ) && plan && ! hasUsedPlansStep )
 	) {

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -12,6 +12,8 @@ import type { ValuesType } from 'utility-types';
 import config from 'calypso/config';
 import { getLanguageRouteParam } from '../../lib/i18n-utils';
 
+type PlanPath = Plans.PlanPath;
+
 const plansPaths = Plans.plansPaths;
 
 // The first step (IntentGathering), which is found at the root route (/), is set as
@@ -89,7 +91,7 @@ export function useStepRouteParam() {
 }
 
 export function usePlanRouteParam() {
-	const match = useRouteMatch< { plan?: string } >( path );
+	const match = useRouteMatch< { plan?: PlanPath } >( path );
 	return match?.params.plan;
 }
 

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -166,6 +166,10 @@ const selectedFeatures: Reducer< FeatureId[], OnboardAction > = (
 		return [ ...state, 'domain' ];
 	}
 
+	if ( action.type === 'SET_DOMAIN' && action.domain?.is_free ) {
+		return state.filter( ( id ) => id !== 'domain' );
+	}
+
 	if ( action.type === 'REMOVE_FEATURE' ) {
 		return state.filter( ( id ) => id !== action.featureId );
 	}

--- a/client/landing/gutenboarding/stores/plans/index.ts
+++ b/client/landing/gutenboarding/stores/plans/index.ts
@@ -4,3 +4,4 @@
 import { Plans } from '@automattic/data-stores';
 
 export const PLANS_STORE = Plans.register();
+export type Plan = Plans.Plan;

--- a/packages/data-stores/src/plans/constants.ts
+++ b/packages/data-stores/src/plans/constants.ts
@@ -19,7 +19,7 @@ interface Currency {
 
 export const plansOrder = [ PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE ];
 
-export const plansPaths = [ 'beginner', 'personal', 'premium', 'business', 'ecommerce' ];
+export const plansPaths = [ 'free', 'personal', 'premium', 'business', 'ecommerce' ];
 
 export const plansProductSlugs = [
 	PLAN_FREE,

--- a/packages/data-stores/src/plans/constants.ts
+++ b/packages/data-stores/src/plans/constants.ts
@@ -19,7 +19,9 @@ interface Currency {
 
 export const plansOrder = [ PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE ];
 
-export const plansPaths = [ 'free', 'personal', 'premium', 'business', 'ecommerce' ];
+export type PlanPath = 'free' | 'personal' | 'premium' | 'business' | 'ecommerce';
+
+export const plansPaths: PlanPath[] = [ 'free', 'personal', 'premium', 'business', 'ecommerce' ];
 
 export const plansProductSlugs = [
 	PLAN_FREE,

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -7,7 +7,7 @@ import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from './constants';
+import { STORE_KEY, PlanPath } from './constants';
 import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
@@ -16,6 +16,7 @@ import { controls } from '../wpcom-request-controls';
 
 export type { State };
 export type { Plan, PlanSlug } from './types';
+export type { PlanPath };
 
 // plansPaths is used to construct the route that accepts plan slugs like (/beginner, /business, etc..)
 export {

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -7,7 +7,7 @@ import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 /**
  * Internal dependencies
  */
-import { STORE_KEY, PlanPath } from './constants';
+import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
@@ -16,7 +16,7 @@ import { controls } from '../wpcom-request-controls';
 
 export type { State };
 export type { Plan, PlanSlug } from './types';
-export type { PlanPath };
+export type { PlanPath } from './constants';
 
 // plansPaths is used to construct the route that accepts plan slugs like (/beginner, /business, etc..)
 export {

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -7,7 +7,7 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import type { State } from './reducer';
-import { DEFAULT_PAID_PLAN, PLAN_ECOMMERCE, PLAN_FREE, STORE_KEY } from './constants';
+import { DEFAULT_PAID_PLAN, PLAN_ECOMMERCE, PLAN_FREE, STORE_KEY, PlanPath } from './constants';
 import type { Plan, PlanFeature, PlanFeatureType, PlanSlug } from './types';
 
 export const getFeatures = ( state: State ): Record< string, PlanFeature > => state.features;
@@ -38,13 +38,13 @@ export const getSupportedPlans = ( state: State ): Plan[] => {
 	return supportedPlans;
 };
 
-export const getPlanByPath = ( state: State, path?: string ): Plan | undefined => {
+export const getPlanByPath = ( state: State, path?: PlanPath ): Plan | undefined => {
 	return path ? getSupportedPlans( state ).find( ( plan ) => plan?.pathSlug === path ) : undefined;
 };
 
 export const getPlansDetails = ( state: State, _: string ): State => state; // eslint-disable-line @typescript-eslint/no-unused-vars
 
-export const getPlansPaths = ( state: State ) => {
+export const getPlansPaths = ( state: State ): string[] => {
 	return getSupportedPlans( state ).map( ( plan ) => plan?.pathSlug );
 };
 

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -7,7 +7,9 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import type { State } from './reducer';
-import { DEFAULT_PAID_PLAN, PLAN_ECOMMERCE, PLAN_FREE, STORE_KEY, PlanPath } from './constants';
+import { DEFAULT_PAID_PLAN, PLAN_ECOMMERCE, PLAN_FREE, STORE_KEY } from './constants';
+
+import type { PlanPath } from './constants';
 import type { Plan, PlanFeature, PlanFeatureType, PlanSlug } from './types';
 
 export const getFeatures = ( state: State ): Record< string, PlanFeature > => state.features;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Replace 'beginner' with 'free' as Free plan path slug
* Update condition to remove Features an Plans steps also for Free plan if the following conditions are met:
  * The user hasn't selected a paid domain.
  * The user hasn't seen yet Plans step.

#### Testing instructions

- Go to `/new/free?fresh` and try these scenarios:
1. Complete the flow by skipping domain selection (or by selecting the free subdomain) and feature selection => Site should be created (Plans step shouldn't be displayed).
2. Select a paid domain or a feature and advance to Plans step. The corresponding plan should have a "recommended" badge. Then go back and select free domain / deselect all features. When advancing again, Plans step should be still there with Premium plan having the "Popular" badge.
3. Repeat 2nd scenario but advance only to the Features step. You'll see the recommended plan in the top-right corner. Then pick a free domain & deselect all features and you should see the Free plan there. Press _Skip for now_ on Features step to create the site (Plans step shouldn't be displayed).

- Regular flow should stay unchanged (Plans step is mandatory unless the users selects a plan using Plans Modal).

#### Context
pbxNRc-xd-p2