### PR TITLE
Plugins: Reduxify plugin "is fetching" states

### DIFF
--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
@@ -10,6 +10,7 @@ import Gridicon from 'calypso/components/gridicon';
 import meta from './meta';
 import PluginsStore from 'calypso/lib/plugins/store';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { isRequesting } from 'calypso/state/plugins/installed/selectors';
 import {
 	ButtonRow,
 	Continue,
@@ -36,8 +37,8 @@ export const JetpackPluginUpdatesTour = makeTour(
 		{ ...meta }
 		when={ ( state ) => {
 			const site = getSelectedSite( state );
-			const res =
-				! PluginsStore.isFetchingSite( site ) && !! PluginsStore.getSitePlugin( site, 'jetpack' );
+			const isRequestingPlugins = isRequesting( state, site.ID );
+			const res = ! isRequestingPlugins && !! PluginsStore.getSitePlugin( site, 'jetpack' );
 			return res;
 		} }
 	>

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -200,10 +200,6 @@ const PluginsStore = {
 		} );
 	},
 
-	isFetchingSite: function ( site ) {
-		return _fetching[ site.ID ];
-	},
-
 	emitChange: function () {
 		this.emit( 'change' );
 	},

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -51,6 +51,7 @@ import {
 	isRequesting,
 	hasRequested,
 } from 'calypso/state/plugins/premium/selectors';
+import { isRequesting as isRequestingInstalledPlugins } from 'calypso/state/plugins/installed/selectors';
 // Store for existing plugins
 import PluginsStore from 'calypso/lib/plugins/store';
 
@@ -165,7 +166,7 @@ class PlansSetup extends React.Component {
 
 		const getPluginFromStore = function () {
 			const sitePlugin = PluginsStore.getSitePlugin( site, plugin.slug );
-			if ( ! sitePlugin && PluginsStore.isFetchingSite( site ) ) {
+			if ( ! sitePlugin && this.props.requestingInstalledPlugins ) {
 				// if the Plugins are still being fetched, we wait. We are not using flux
 				// store events because it would be more messy to handle the one-time-only
 				// callback with bound parameters than to do it this way.
@@ -245,8 +246,7 @@ class PlansSetup extends React.Component {
 	};
 
 	renderPlugins = ( hidden = false ) => {
-		const site = this.props.selectedSite;
-		if ( this.props.isRequesting || PluginsStore.isFetchingSite( site ) ) {
+		if ( this.props.isRequesting || this.props.requestingInstalledPlugins ) {
 			return this.renderPluginsPlaceholders();
 		}
 
@@ -529,7 +529,7 @@ class PlansSetup extends React.Component {
 			site &&
 			! this.props.isRequestingSites &&
 			! this.props.isRequesting &&
-			! PluginsStore.isFetchingSite( site ) &&
+			! this.props.requestingInstalledPlugins &&
 			! this.props.plugins.length
 		) {
 			return this.renderNoJetpackPlan();
@@ -563,6 +563,7 @@ export default connect(
 		return {
 			wporgPlugins: getAllWporgPlugins( state ),
 			isRequesting: isRequesting( state, siteId ),
+			requestingInstalledPlugins: isRequestingInstalledPlugins( state, siteId ),
 			hasRequested: hasRequested( state, siteId ),
 			isInstalling: isInstalling( state, siteId, forSpecificPlugin ),
 			isFinished: isFinished( state, siteId, forSpecificPlugin ),

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -42,6 +42,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import { isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
 import { Button } from '@automattic/components';
 import { isEnabled } from 'calypso/config';
 
@@ -166,7 +167,7 @@ export class PluginsMain extends Component {
 	}
 
 	isFetchingPlugins() {
-		return this.props.sites.some( PluginsStore.isFetchingSite );
+		return this.props.requestingPluginsForSites;
 	}
 
 	getSelectedText() {
@@ -484,9 +485,11 @@ export default flow(
 	localize,
 	urlSearch,
 	connect(
-		( state ) => {
+		( state, { sites } ) => {
 			const selectedSite = getSelectedSite( state );
 			const selectedSiteId = getSelectedSiteId( state );
+			/* eslint-disable wpcalypso/redux-no-bound-selectors */
+			const siteIds = sites?.map( ( site ) => site.ID ) ?? [];
 
 			return {
 				hasJetpackSites: hasJetpackSites( state ),
@@ -504,6 +507,7 @@ export default flow(
 				/* eslint-enable wpcalypso/redux-no-bound-selectors */
 				wporgPlugins: getAllWporgPlugins( state ),
 				isRequestingSites: isRequestingSites( state ),
+				requestingPluginsForSites: isRequestingForSites( state, siteIds ),
 				userCanManagePlugins: selectedSiteId
 					? canCurrentUser( state, selectedSiteId, 'manage_options' )
 					: canCurrentUserManagePlugins( state ),

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -41,14 +41,17 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import NoPermissionsError from './no-permissions-error';
 import getToursHistory from 'calypso/state/guided-tours/selectors/get-tours-history';
 import hasNavigated from 'calypso/state/selectors/has-navigated';
-import { getPluginOnSites, getSitesWithoutPlugin } from 'calypso/state/plugins/installed/selectors';
-
-/* eslint-disable react/prefer-es6-class */
+import {
+	getPluginOnSites,
+	getSitesWithoutPlugin,
+	isRequestingForSites,
+} from 'calypso/state/plugins/installed/selectors';
 
 function goBack() {
 	window.history.back();
 }
 
+/* eslint-disable react/prefer-es6-class */
 const SinglePlugin = createReactClass( {
 	displayName: 'SinglePlugin',
 	_DEFAULT_PLUGINS_BASE_PATH: 'http://wordpress.org/plugins/',
@@ -174,15 +177,13 @@ const SinglePlugin = createReactClass( {
 			return true;
 		}
 
-		const sites = this.props.sites;
-
 		// If the plugin has at least one site then we know it exists
 		const pluginSites = Object.values( plugin.sites );
 		if ( pluginSites && pluginSites[ 0 ] ) {
 			return true;
 		}
 
-		if ( sites.some( PluginsStore.isFetchingSite ) ) {
+		if ( this.props.requestingPluginsForSites ) {
 			return 'unknown';
 		}
 
@@ -195,10 +196,6 @@ const SinglePlugin = createReactClass( {
 
 	isFetched() {
 		return this.props.wporgFetched;
-	},
-
-	isFetchingSites() {
-		return this.props.sites.every( PluginsStore.isFetchingSite );
 	},
 
 	getPlugin() {
@@ -237,7 +234,7 @@ const SinglePlugin = createReactClass( {
 	},
 
 	isPluginInstalledOnsite() {
-		if ( this.isFetchingSites() ) {
+		if ( this.props.requestingPluginsForSites ) {
 			return null;
 		}
 
@@ -369,6 +366,7 @@ export default connect(
 			isAtomicSite: isSiteAutomatedTransfer( state, selectedSiteId ),
 			isJetpackSite: selectedSiteId && isJetpackSite( state, selectedSiteId ),
 			isRequestingSites: isRequestingSites( state ),
+			requestingPluginsForSites: isRequestingForSites( state, siteIds ),
 			userCanManagePlugins: selectedSiteId
 				? canCurrentUser( state, selectedSiteId, 'manage_options' )
 				: canCurrentUserManagePlugins( state ),


### PR DESCRIPTION
We're currently using flux for retrieving whether the plugin data for one or more sites is being fetched. 

This PR updates the code to use Redux for that and removes the old flux method.

This PR is part of #24180.

#### Changes proposed in this Pull Request

* Guided Tours: Reduxify plugin fetching state in `JetpackPluginUpdatesTour`
* Plugins: Reduxify plugin fetching state in `PlansSetup`
* Plugins: Reduxify plugin fetching state in `PluginsMain`
* Plugins: Reduxify plugin fetching state in `SinglePlugin`
* Plugins: Remove unused `isFetchingSite` flux method

#### Testing instructions

Before each of these steps, make sure to **clear your Redux store**.

Keeping an eye on the console for errors, verify there are no functional or behavioral changes in the following:

* Go to `/plugins/manage/:site?tour=jetpackPluginUpdates` where `:site` is one of your Jetpack sites. Verify the guided tour runs correctly after plugin data is loaded (first step of the tour is a popover appearing next to the Jetpack autoupdates toggle).
* Go to `/plugins/setup/:site` for a new Jetpack site with a paid plan, and verify plugin installation commences after plugin data has been loaded.
* Go to `/plugins/setup/:site` again, verify it still works well with no errors.
* Go to `/plugins/manage` and verify placeholders are shown while loading, and then everything loads correctly.
* Go to `/plugins/:plugin` and verify placeholders are shown while loading, and then everything loads correctly.
* Go to `/plugins/:plugin/:site` and verify placeholders are shown while loading, and then everything loads correctly.

#### Notes

We are intentionally leaving the `_fetching` flags in the rest of the store because those are still necessary as stopgaps for some existing flux methods that are still in use.