### PR TITLE
Modularise jitm state

### DIFF
--- a/client/state/jitm/actions.js
+++ b/client/state/jitm/actions.js
@@ -7,7 +7,9 @@ import { get } from 'lodash';
  * Internal Dependencies
  */
 import { JITM_DISMISS, JITM_FETCH, JITM_SET } from 'calypso/state/action-types';
+
 import 'calypso/state/data-layer/wpcom/sites/jitm';
+import 'calypso/state/jitm/init';
 
 /**
  * Dismisses a jitm

--- a/client/state/jitm/init.js
+++ b/client/state/jitm/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'jitm' ], reducer );

--- a/client/state/jitm/package.json
+++ b/client/state/jitm/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/jitm/reducer.js
+++ b/client/state/jitm/reducer.js
@@ -2,12 +2,14 @@
  * Internal dependencies
  */
 import { JITM_SET } from 'calypso/state/action-types';
-import { combineReducers, keyedReducer } from 'calypso/state/utils';
+import { combineReducers, keyedReducer, withStorageKey } from 'calypso/state/utils';
 
 export const storeJITM = ( state = {}, { type, jitms } ) => ( type === JITM_SET ? jitms : state );
 
 const sitePathJITM = keyedReducer( 'keyedPath', storeJITM );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	sitePathJITM,
 } );
+
+export default withStorageKey( 'jitm', combinedReducer );

--- a/client/state/jitm/selectors.js
+++ b/client/state/jitm/selectors.js
@@ -3,8 +3,12 @@
  */
 import { get } from 'lodash';
 
-/** Internal dependencies */
+/**
+ * Internal dependencies
+ */
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+import 'calypso/state/jitm/init';
 
 /**
  * Get the list of available jitms for the current site/section

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -20,7 +20,6 @@ import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import documentHead from './document-head/reducer';
 import i18n from './i18n/reducer';
 import importerNux from './importer-nux/reducer';
-import jitm from './jitm/reducer';
 import mySites from './my-sites/reducer';
 import sites from './sites/reducer';
 import support from './support/reducer';
@@ -38,7 +37,6 @@ const reducers = {
 	httpData,
 	i18n,
 	importerNux,
-	jitm,
 	mySites,
 	sites,
 	support,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles jitm state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42454.

#### Changes proposed in this Pull Request

* Modularise jitm state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `jitm` key, even if you expand the list of keys. This indicates that the jitm state hasn't been loaded yet.
* Click `My Sites` on the top bar.
* Verify that an `jitm` key is added with the jitm state. This indicates that the jitm state has now been loaded.
* If you can, please ensure that jitm still works correctly.