### PR TITLE
[Webpack 5]: Use default export for JSON modules

### DIFF
--- a/client/blocks/login/two-factor-authentication/push-notification-illustration.jsx
+++ b/client/blocks/login/two-factor-authentication/push-notification-illustration.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { colors as PALETTE } from '@automattic/color-studio';
+import colorStudio from '@automattic/color-studio';
 
 /**
  * Style dependencies
@@ -12,6 +12,7 @@ import './push-notification-illustration.scss';
 /**
  * Module constants
  */
+const PALETTE = colorStudio.colors;
 const COLOR_BLUE_10 = PALETTE[ 'WordPress Blue 10' ];
 const COLOR_BLUE_20 = PALETTE[ 'WordPress Blue 20' ];
 const COLOR_BLUE_40 = PALETTE[ 'WordPress Blue 40' ];

--- a/client/components/jetpack-logo/index.jsx
+++ b/client/components/jetpack-logo/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { colors as PALETTE } from '@automattic/color-studio';
+import colorStudio from '@automattic/color-studio';
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 /**
  * Module constants
  */
+const PALETTE = colorStudio.colors;
 const COLOR_JETPACK = PALETTE[ 'Jetpack Green' ];
 const COLOR_WHITE = PALETTE[ 'White' ]; // eslint-disable-line dot-notation
 

--- a/client/components/jetpack-plus-wpcom-logo/index.jsx
+++ b/client/components/jetpack-plus-wpcom-logo/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { colors as PALETTE } from '@automattic/color-studio';
+import colorStudio from '@automattic/color-studio';
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 /**
  * Module constants
  */
+const PALETTE = colorStudio.colors;
 const COLOR_JETPACK = PALETTE[ 'Jetpack Green 40' ];
 const COLOR_WORDPRESS = PALETTE[ 'WordPress Blue 40' ];
 const COLOR_WHITE = PALETTE[ 'White' ]; // eslint-disable-line dot-notation

--- a/client/extensions/woocommerce/woocommerce-services/lib/pdf-label-utils/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/pdf-label-utils/index.js
@@ -61,5 +61,5 @@ export const getPrintURL = ( paperSize, labels ) => {
 };
 
 export const getPreviewURL = ( paperSize, labels ) => {
-	return _getPDFURL( paperSize, labels, api.url.labelTestPrint() );
+	return _getPDFURL( paperSize, labels, api.url.labelsTestPrint() );
 };

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -17,7 +17,7 @@ import {
 } from '@automattic/composite-checkout';
 import { ThemeProvider } from 'emotion-theming';
 import { useShoppingCart, ResponseCart } from '@automattic/shopping-cart';
-import { colors } from '@automattic/color-studio';
+import colorStudio from '@automattic/color-studio';
 import { useStripe } from '@automattic/calypso-stripe';
 
 /**
@@ -86,6 +86,7 @@ import getContactDetailsType from './lib/get-contact-details-type';
 import type { ReactStandardAction } from './types/analytics';
 import useCreatePaymentCompleteCallback from './hooks/use-create-payment-complete-callback';
 
+const { colors } = colorStudio;
 const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
 
 const { select, registerStore } = defaultRegistry;

--- a/client/server/api/index.js
+++ b/client/server/api/index.js
@@ -6,10 +6,12 @@ import express from 'express';
 /**
  * Internal dependencies
  */
-import { version } from '../../package.json';
+import pkgJson from '../../package.json';
 import config from 'calypso/config';
 import oauth from './oauth';
 import signInWithApple from './sign-in-with-apple';
+
+const { version } = pkgJson;
 
 export default function api() {
 	const app = express();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the default export for JSON modules. Current syntax breaks webpack 5 (https://webpack.js.org/blog/2020-10-10-webpack-5-release/#json-modules).
* Fix typo in imported function

#### Testing instructions

I was able to get screenshots of the components to verify the colors:

![PushNotificationIlustration](https://user-images.githubusercontent.com/975703/101503064-00f45680-3972-11eb-8d07-f7a929334378.png)
![JetpackPlusWpcomLogo](https://user-images.githubusercontent.com/975703/101503115-0ea9dc00-3972-11eb-98a4-9f554dbd526b.png)
![JetpakLogo](https://user-images.githubusercontent.com/975703/101503118-0f427280-3972-11eb-992e-9d2889c7adc8.png)

