### PR TITLE
Modularise document head state

### DIFF
--- a/client/landing/login/store.js
+++ b/client/landing/login/store.js
@@ -14,14 +14,12 @@ import {
 	enhancer as httpDataEnhancer,
 } from 'calypso/state/data-layer/http-data';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
-import documentHead from 'calypso/state/document-head/reducer';
 import i18n from 'calypso/state/i18n/reducer';
 import currentUser from 'calypso/state/current-user/reducer';
 
 // Legacy reducers
 // The reducers in this list are not modularized, and are always loaded on boot.
 const rootReducer = combineReducers( {
-	documentHead,
 	httpData,
 	i18n,
 	currentUser,

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -70,6 +70,7 @@ jest.mock( 'calypso/state', () => ( {
 
 jest.mock( 'calypso/state/redux-store', () => ( {
 	setStore: jest.fn(),
+	registerReducer: jest.fn(),
 } ) );
 
 jest.mock( 'calypso/state/reducer', () => jest.fn() );

--- a/client/state/document-head/actions.js
+++ b/client/state/document-head/actions.js
@@ -1,13 +1,14 @@
 /**
  * Internal dependencies
  */
-
 import {
 	DOCUMENT_HEAD_LINK_SET,
 	DOCUMENT_HEAD_META_SET,
 	DOCUMENT_HEAD_TITLE_SET,
 	DOCUMENT_HEAD_UNREAD_COUNT_SET,
 } from 'calypso/state/action-types';
+
+import 'calypso/state/document-head/init';
 
 /**
  * Returns an action object used in signalling that the document head title

--- a/client/state/document-head/init.js
+++ b/client/state/document-head/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'documentHead' ], reducer );

--- a/client/state/document-head/package.json
+++ b/client/state/document-head/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
+import config from '@automattic/calypso-config';
 import { uniqWith, isEqual } from 'lodash';
+import { withStorageKey } from '@automattic/state-utils';
 
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
-import { combineReducers, withSchemaValidation, withStorageKey } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import {
 	DOCUMENT_HEAD_LINK_SET,
 	DOCUMENT_HEAD_META_SET,

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -7,7 +7,7 @@ import { uniqWith, isEqual } from 'lodash';
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
-import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation, withStorageKey } from 'calypso/state/utils';
 import {
 	DOCUMENT_HEAD_LINK_SET,
 	DOCUMENT_HEAD_META_SET,
@@ -69,9 +69,11 @@ export const link = withSchemaValidation( linkSchema, ( state = [], action ) => 
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	link,
 	meta,
 	title,
 	unreadCount,
 } );
+
+export default withStorageKey( 'documentHead', combinedReducer );

--- a/client/state/document-head/selectors/get-document-head-formatted-title.js
+++ b/client/state/document-head/selectors/get-document-head-formatted-title.js
@@ -17,6 +17,7 @@ import { getDocumentHeadCappedUnreadCount } from 'calypso/state/document-head/se
 /**
  * Internal dependencies
  */
+import 'calypso/state/document-head/init';
 import 'calypso/state/ui/init';
 
 /**

--- a/client/state/document-head/selectors/get-document-head-link.js
+++ b/client/state/document-head/selectors/get-document-head-link.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/document-head/init';
+
+/**
  * Returns an array of document link objects as set by the DocumentHead
  * component or setDocumentHeadLink action.
  *

--- a/client/state/document-head/selectors/get-document-head-meta.js
+++ b/client/state/document-head/selectors/get-document-head-meta.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/document-head/init';
+
+/**
  * Returns an array of document meta objects as set by the DocumentHead
  * component or setDocumentHeadMeta action.
  *

--- a/client/state/document-head/selectors/get-document-head-title.js
+++ b/client/state/document-head/selectors/get-document-head-title.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/document-head/init';
+
+/**
  * Returns the document title as set by the DocumentHead component or setTitle
  * action.
  *

--- a/client/state/document-head/selectors/get-document-head-unread-count.js
+++ b/client/state/document-head/selectors/get-document-head-unread-count.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/document-head/init';
+
+/**
  * Returns a count reflecting unread items.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -17,7 +17,6 @@ import { reducer as httpData } from 'calypso/state/data-layer/http-data';
 import currencyCode from './currency-code/reducer';
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
-import documentHead from './document-head/reducer';
 import i18n from './i18n/reducer';
 import importerNux from './importer-nux/reducer';
 import sites from './sites/reducer';
@@ -30,7 +29,6 @@ const reducers = {
 	currencyCode,
 	currentUser,
 	dataRequests,
-	documentHead,
 	httpData,
 	i18n,
 	importerNux,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles document head state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42431.

#### Changes proposed in this Pull Request

* Modularise document head state

#### Testing instructions

Unfortunately, `documentHead` state gets loaded pretty early on in the boot process, through `Layout`. As such, it's not easy to test the automated loading process, but it should be enough to smoke-test functionality in order to ensure that it continues to work correctly, e.g. by ensuring that page titles (in the browser tab) are still updated correctly.