### PR TITLE
Pricing page: add loading state (for when page is fetching experiment variation)

### DIFF
--- a/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { sortBy } from 'lodash';
+import { range, sortBy } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
 import React, { useMemo, useRef, useState, useEffect, useCallback, RefObject } from 'react';
 import { useSelector } from 'react-redux';
@@ -131,15 +131,17 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 						duration={ duration }
 					/>
 				</div>
-				{ ! isVariationLoading && (
-					<>
-						<ul
-							className={ classNames( 'products-grid-i5__plan-grid', {
-								'is-wrapping': isPlanRowWrapping,
-							} ) }
-							ref={ planGridRef }
-						>
-							{ sortedPlans.map( ( product ) => (
+				<ul
+					className={ classNames( 'products-grid-i5__plan-grid', {
+						'is-wrapping': isPlanRowWrapping,
+					} ) }
+					ref={ planGridRef }
+				>
+					{ isVariationLoading
+						? range( 3 ).map( ( n, index ) => (
+								<li className="products-grid-i5__placeholder" key={ index }></li>
+						  ) )
+						: sortedPlans.map( ( product ) => (
 								<li key={ product.iconSlug }>
 									<ProductCardI5
 										item={ product }
@@ -154,39 +156,39 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 										] }
 									/>
 								</li>
-							) ) }
-						</ul>
-						<div
-							className={ classNames( 'products-grid-i5__more', {
-								'is-detached': isPlanRowWrapping,
-							} ) }
-						>
-							<MoreInfoBox
-								headline={ translate( 'Need more info?' ) }
-								buttonLabel={ translate( 'Compare all product bundles' ) }
-								onButtonClick={ scrollToComparison }
-							/>
-						</div>
-					</>
-				) }
+						  ) ) }
+				</ul>
+				<div
+					className={ classNames( 'products-grid-i5__more', {
+						'is-detached': isPlanRowWrapping,
+					} ) }
+				>
+					<MoreInfoBox
+						headline={ translate( 'Need more info?' ) }
+						buttonLabel={ translate( 'Compare all product bundles' ) }
+						onButtonClick={ scrollToComparison }
+					/>
+				</div>
 			</section>
 			<section className="products-grid-i5__section">
 				<h2 className="products-grid-i5__section-title">{ translate( 'Individual Products' ) }</h2>
-				{ ! isVariationLoading && (
-					<ul className="products-grid-i5__product-grid">
-						{ sortedProducts.map( ( product ) => (
-							<li key={ product.iconSlug }>
-								<ProductCardI5
-									item={ product }
-									onClick={ onSelectProduct }
-									siteId={ siteId }
-									currencyCode={ currencyCode }
-									selectedTerm={ duration }
-								/>
-							</li>
-						) ) }
-					</ul>
-				) }
+				<ul className="products-grid-i5__product-grid">
+					{ isVariationLoading
+						? range( 3 ).map( ( n, index ) => (
+								<li className="products-grid-i5__placeholder" key={ index }></li>
+						  ) )
+						: sortedProducts.map( ( product ) => (
+								<li key={ product.iconSlug }>
+									<ProductCardI5
+										item={ product }
+										onClick={ onSelectProduct }
+										siteId={ siteId }
+										currencyCode={ currencyCode }
+										selectedTerm={ duration }
+									/>
+								</li>
+						  ) ) }
+				</ul>
 				<div className="products-grid-i5__free">
 					{ ( isInConnectFlow || isInJetpackCloud ) && (
 						<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />

--- a/client/my-sites/plans/jetpack-plans/products-grid-i5/style.scss
+++ b/client/my-sites/plans/jetpack-plans/products-grid-i5/style.scss
@@ -58,12 +58,24 @@
 			position: relative;
 			left: -8px;
 		}
+
+		&.products-grid-i5__placeholder {
+			position: static;
+
+			width: 96%;
+		}
 	}
 }
 
 .products-grid-i5__product-grid {
 	> li {
 		height: 100%;
+
+		&.products-grid-i5__placeholder {
+			position: static;
+
+			width: 100%;
+		}
 	}
 }
 
@@ -82,4 +94,12 @@
 
 .products-grid-i5__more.is-detached {
 	margin-top: 48px;
+}
+
+.products-grid-i5__placeholder {
+	@include placeholder();
+
+	min-height: 550px;
+
+	border-radius: 8px;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a loading state to the pricing page, so that there's no glitch in the interface when the product cards are rendered.

### Testing instructions

- Download the PR
- Run Calypso or cloud
- Visit the pricing page and notice the loading state (see capture below) while the call to fetch the experiment variation is made

_Note: the result of the call is cached for about 60 seconds. You'll need to wait this amount of time for the call to be made again if you refresh the pag._

### Screenshots

_Loading state for the plans row_
<img width="1063" alt="Screen Shot 2020-12-08 at 10 50 33 AM" src="https://user-images.githubusercontent.com/1620183/101508809-1ce20300-3946-11eb-90d7-887da1acd286.png">
