### PR TITLE
Analytics: add user_locale prop to some Tracks events

### DIFF
--- a/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
+++ b/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
@@ -3,6 +3,7 @@
  */
 import * as React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -21,13 +22,14 @@ export default function useTrackOnboardingStart() {
 	const { hasOnboardingStarted } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const { startOnboarding } = useDispatch( ONBOARD_STORE );
 	const flow = useOnboardingFlow();
+	const locale = useLocale();
 
 	React.useEffect( () => {
 		if ( ! hasOnboardingStarted && currentUser !== undefined ) {
 			const ref = new URLSearchParams( window.location.search ).get( 'ref' ) || '';
 			const siteCount = currentUser?.site_count ?? 0;
-			recordOnboardingStart( ref, siteCount, flow );
+			recordOnboardingStart( ref, siteCount, flow, locale );
 			startOnboarding();
 		}
-	}, [ currentUser, hasOnboardingStarted, startOnboarding ] );
+	}, [ currentUser, hasOnboardingStarted, startOnboarding, flow, locale ] );
 }

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -32,12 +32,18 @@ export function trackEventWithFlow( eventId: string, params = {}, flow = FLOW_ID
  * @param {string} ref  The value of a `ref` query parameter, usually set by marketing landing pages
  * @param {number} site_count The number of sites owned by the current user or 0 if there is no logged in user
  * @param {string} flow the current onboarding flow
+ * @param {string} locale the current user locale
  */
-export function recordOnboardingStart( ref = '', site_count: number, flow: string ): void {
+export function recordOnboardingStart(
+	ref = '',
+	site_count: number,
+	flow: string,
+	locale: string
+): void {
 	if ( ! ref ) {
 		ref = new URLSearchParams( window.location.search ).get( 'ref' ) || ref;
 	}
-	const eventProps = { ref, site_count };
+	const eventProps = { ref, site_count, user_locale: locale };
 	trackEventWithFlow( 'calypso_newsite_start', eventProps, flow );
 	// Also fire the signup start|complete events. See: pbmFJ6-95-p2
 	trackEventWithFlow( 'calypso_signup_start', eventProps, flow );

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -8,7 +8,10 @@ import config from '@automattic/calypso-config';
  */
 import { shouldReportOmitBlogId } from 'calypso/lib/analytics/utils';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import {
+	getCurrentUserSiteCount,
+	getCurrentUserLocale,
+} from 'calypso/state/current-user/selectors';
 
 const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 	const state = reduxStore.getState();
@@ -19,6 +22,7 @@ const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 		site_count: getCurrentUserSiteCount( state ) || 0,
 		site_id_label: 'wpcom',
 		client: config( 'client_slug' ),
+		user_lang: getCurrentUserLocale( state ),
 	};
 
 	const omitSelectedSite = shouldReportOmitBlogId( eventProperties.path );

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -22,7 +22,7 @@ const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 		site_count: getCurrentUserSiteCount( state ) || 0,
 		site_id_label: 'wpcom',
 		client: config( 'client_slug' ),
-		user_lang: getCurrentUserLocale( state ),
+		user_locale: getCurrentUserLocale( state ),
 	};
 
 	const omitSelectedSite = shouldReportOmitBlogId( eventProperties.path );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Start recording user locale to enable building tracks funnels and segmenting by locale when frontend events are used.

#### To Do
- [x] record correct value for `user_locale` prop in Gutenboarding for all users
- [x] record correct value for `user_locale` prop in Calypso for logged in users
- [ ] record correct value for `user_locale` prop in Calypso for non-logged in users (eg: `/start/domains` in incognito)
- [ ] add `user_locale` prop to other events in Gutenboarding
- [ ] add `user_locale` prop to other events outside Calypso (eg: Editing Toolkit)

#### Testing instructions
* Go to `/start/domains` and `/new` as logged-in user. 
  * `calypso_signup_start` event should be logged with prop `user_lang: {USER_LOCALE}` having the value of `USER_LOCALE` from user account settings. 
* Go to `/new/es` as logged-in user and as a new user (incognito)
  * `calypso_signup_start` event should be logged with prop `user_lang: 'es'`.

#### Context
p1607408253425500-slack-C0KDTA48Y
