### PR TITLE
Page layout selector: Use description of the templates as label for screen readers

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -19,6 +19,7 @@ import replacePlaceholders from '../utils/replace-placeholders';
 
 export const TemplateSelectorControl = ( {
 	label,
+	legendLabel,
 	className,
 	help,
 	instanceId,
@@ -49,6 +50,7 @@ export const TemplateSelectorControl = ( {
 			<ul
 				className="template-selector-control__options"
 				data-testid="template-selector-control-options"
+				aria-label={ legendLabel }
 			>
 				{ map( templates, ( { slug, title, preview, previewAlt } ) => (
 					<li key={ `${ id }-${ slug }` } className="template-selector-control__template">

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -52,12 +52,13 @@ export const TemplateSelectorControl = ( {
 				data-testid="template-selector-control-options"
 				aria-label={ legendLabel }
 			>
-				{ map( templates, ( { slug, title, preview, previewAlt } ) => (
+				{ map( templates, ( { slug, title, description, preview, previewAlt } ) => (
 					<li key={ `${ id }-${ slug }` } className="template-selector-control__template">
 						<TemplateSelectorItem
 							id={ id }
 							value={ slug }
-							label={ replacePlaceholders( title, siteInformation ) }
+							title={ replacePlaceholders( title, siteInformation ) }
+							description={ description }
 							help={ help }
 							onSelect={ onTemplateSelect }
 							staticPreviewImg={ preview }

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -14,7 +14,8 @@ const TemplateSelectorItem = ( props ) => {
 		id,
 		value,
 		onSelect,
-		label,
+		title,
+		description,
 		useDynamicPreview = false,
 		staticPreviewImg,
 		staticPreviewImgAlt = '',
@@ -22,7 +23,7 @@ const TemplateSelectorItem = ( props ) => {
 		isSelected,
 	} = props;
 
-	if ( isNil( id ) || isNil( label ) || isNil( value ) ) {
+	if ( isNil( id ) || isNil( title ) || isNil( value ) ) {
 		return null;
 	}
 
@@ -41,9 +42,7 @@ const TemplateSelectorItem = ( props ) => {
 		/>
 	);
 
-	const labelId = `label-${ id }-${ value }`;
-
-	const handleLabelClick = () => {
+	const handleClick = () => {
 		onSelect( value );
 	};
 
@@ -54,8 +53,8 @@ const TemplateSelectorItem = ( props ) => {
 				'is-selected': isSelected,
 			} ) }
 			value={ value }
-			onClick={ handleLabelClick }
-			aria-labelledby={ `${ id } ${ labelId }` }
+			onClick={ handleClick }
+			aria-label={ description }
 		>
 			<span className="template-selector-item__preview-wrap">{ innerPreview }</span>
 		</button>

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/test/__snapshots__/template-selector-control.test.js.snap
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/test/__snapshots__/template-selector-control.test.js.snap
@@ -22,7 +22,6 @@ exports[`TemplateSelectorControl Basic rendering renders with required props 1`]
           class="template-selector-control__template"
         >
           <button
-            aria-labelledby="template-selector-control-17 label-template-selector-control-17-blank"
             class="template-selector-item__label"
             type="button"
             value="blank"
@@ -41,7 +40,6 @@ exports[`TemplateSelectorControl Basic rendering renders with required props 1`]
           class="template-selector-control__template"
         >
           <button
-            aria-labelledby="template-selector-control-17 label-template-selector-control-17-template-1"
             class="template-selector-item__label"
             type="button"
             value="template-1"
@@ -61,7 +59,6 @@ exports[`TemplateSelectorControl Basic rendering renders with required props 1`]
           class="template-selector-control__template"
         >
           <button
-            aria-labelledby="template-selector-control-17 label-template-selector-control-17-template-2"
             class="template-selector-item__label"
             type="button"
             value="template-2"
@@ -81,7 +78,6 @@ exports[`TemplateSelectorControl Basic rendering renders with required props 1`]
           class="template-selector-control__template"
         >
           <button
-            aria-labelledby="template-selector-control-17 label-template-selector-control-17-template-3"
             class="template-selector-item__label"
             type="button"
             value="template-3"

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -352,6 +352,7 @@ class PageTemplateModal extends Component {
 				<legend className="page-template-modal__form-title">{ legendLabel }</legend>
 				<TemplateSelectorControl
 					label={ __( 'Layout', 'full-site-editing' ) }
+					legendLabel={ legendLabel }
 					templates={ filteredTemplatesList }
 					blocksByTemplates={ blocksByTemplateSlug }
 					onTemplateSelect={ this.previewTemplate }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a label to the list and each item. The description of the templates is used as a label for the templates.

Also adds a label to the different categories.

#### Testing instructions

* Enable voiceover (on Mac: Command + F5)
* Go to Pages > Add New Page in Calypso
* Tab through the list of templates

**NOTE:** Some of the templates don't have a description which results in just a `button` as a voiceover.

| before | after |
| - | - |
| ![](https://user-images.githubusercontent.com/2256104/101770515-d7aa0680-3ae8-11eb-9972-550b72e0fb61.gif) | ![](https://user-images.githubusercontent.com/2256104/101770334-9c0f3c80-3ae8-11eb-8ccd-16eb807d1d5f.gif) |


Fixes #41468
