### PR TITLE
Pricing page: use deprecated A/B test instead of ExPlat experiment

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -74,4 +74,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
+	jetpackPricingReversePlans: {
+		datestamp: '20201208',
+		variations: {
+			priceAsc: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/plans/jetpack-plans/experiments.ts
+++ b/client/my-sites/plans/jetpack-plans/experiments.ts
@@ -1,5 +1,12 @@
 /**
- * Experiment: jetpack_pricing_switch_plan_sides
+ * Tracks A/B test: jetpackPricingReversePlans
+ */
+export const REVERSE_PLANS_AB_TEST = 'jetpackPricingReversePlans';
+export const REVERSE_PLANS_CONTROL = 'control';
+export const REVERSE_PLANS_VARIANT = 'priceAsc';
+
+/**
+ * ExPlat experiment: jetpack_pricing_switch_plan_sides
  */
 export const SWITCH_PLAN_SIDES_EXPERIMENT = 'jetpack_pricing_switch_plan_sides2';
 export const SWITCH_PLAN_SIDES_CONTROL = 'control';

--- a/client/my-sites/plans/jetpack-plans/plans-filter-bar-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-filter-bar-i5/index.tsx
@@ -35,17 +35,19 @@ interface FilterBarProps {
 	duration?: Duration;
 	onDurationChange?: DurationChangeCallback;
 	onProductTypeChange?: ( arg0: ProductType ) => void;
+	withTreatmentVariant: boolean;
 }
 
 type DiscountMessageProps = {
 	primary?: boolean;
+	withTreatmentVariant: boolean;
 };
 
 const CLOUD_MASTERBAR_STICKY = false;
 const CALYPSO_MASTERBAR_HEIGHT = 47;
 const CLOUD_MASTERBAR_HEIGHT = CLOUD_MASTERBAR_STICKY ? 94 : 0;
 
-const DiscountMessage: React.FC< DiscountMessageProps > = ( { primary } ) => {
+const DiscountMessage: React.FC< DiscountMessageProps > = ( { primary, withTreatmentVariant } ) => {
 	const translate = useTranslate();
 	const isMobile: boolean = useMobileBreakpoint();
 
@@ -63,7 +65,12 @@ const DiscountMessage: React.FC< DiscountMessageProps > = ( { primary } ) => {
 	}
 
 	return (
-		<div className={ classNames( 'plans-filter-bar-i5__discount-message', { primary: primary } ) }>
+		<div
+			className={ classNames( 'plans-filter-bar-i5__discount-message', {
+				primary,
+				treatment: withTreatmentVariant,
+			} ) }
+		>
 			<div>
 				<span className="plans-filter-bar-i5__discount-message-text">
 					{ isMobile
@@ -86,6 +93,7 @@ const PlansFilterBarI5: React.FC< FilterBarProps > = ( {
 	showDiscountMessage,
 	duration,
 	onDurationChange,
+	withTreatmentVariant,
 } ) => {
 	const translate = useTranslate();
 	const isInConnectStore = useMemo( isConnectStore, [] );
@@ -120,7 +128,12 @@ const PlansFilterBarI5: React.FC< FilterBarProps > = ( {
 				/>
 				<span className="plans-filter-bar-i5__toggle-on-label">{ translate( 'Bill yearly' ) }</span>
 			</div>
-			{ showDiscountMessage && <DiscountMessage primary={ durationChecked } /> }
+			{ showDiscountMessage && (
+				<DiscountMessage
+					primary={ durationChecked }
+					withTreatmentVariant={ withTreatmentVariant }
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/plans-filter-bar-i5/style.scss
+++ b/client/my-sites/plans/jetpack-plans/plans-filter-bar-i5/style.scss
@@ -93,6 +93,10 @@
 	}
 }
 
+.plans-filter-bar-i5__discount-message.treatment .plans-filter-bar-i5__discount-message-text {
+	text-decoration: underline;
+}
+
 .plans-filter-bar-i5.sticky {
 	position: fixed;
 	width: 100%;

--- a/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { SWITCH_PLAN_SIDES_TREATMENT } from '../experiments';
+import { REVERSE_PLANS_VARIANT } from '../experiments';
 import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 import {
 	PLAN_JETPACK_SECURITY_DAILY,
@@ -100,7 +100,7 @@ export function getProductPosition(
 		case 'v2':
 			return PRODUCT_POSITION_IN_GRID_V2[ slug ];
 		case 'i5':
-			return SWITCH_PLAN_SIDES_TREATMENT === variation
+			return REVERSE_PLANS_VARIANT === variation
 				? PRODUCT_POSITION_IN_GRID_I5_TREATMENT[ slug ]
 				: PRODUCT_POSITION_IN_GRID_I5_CONTROL[ slug ];
 		default:

--- a/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
@@ -134,6 +134,7 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 						showDiscountMessage
 						onDurationChange={ onDurationChange }
 						duration={ duration }
+						withTreatmentVariant={ exPlatVariation === SWITCH_PLAN_SIDES_TREATMENT }
 					/>
 				</div>
 				<ul
@@ -151,14 +152,10 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 								currencyCode={ currencyCode }
 								selectedTerm={ duration }
 								isAligned={ ! isPlanRowWrapping }
-								featuredPlans={
-									// Whether a featured plan is set or not will
-									// allow us to test the experiment in staging
-									// more easily
-									exPlatVariation === SWITCH_PLAN_SIDES_TREATMENT
-										? []
-										: [ PLAN_JETPACK_SECURITY_REALTIME, PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ]
-								}
+								featuredPlans={ [
+									PLAN_JETPACK_SECURITY_REALTIME,
+									PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+								] }
 							/>
 						</li>
 					) ) }

--- a/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
@@ -10,7 +10,11 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { SWITCH_PLAN_SIDES_EXPERIMENT } from '../experiments';
+import {
+	REVERSE_PLANS_AB_TEST,
+	SWITCH_PLAN_SIDES_EXPERIMENT,
+	SWITCH_PLAN_SIDES_TREATMENT,
+} from '../experiments';
 import PlansFilterBarI5 from '../plans-filter-bar-i5';
 import ProductCardI5 from '../product-card-i5';
 import { getProductPosition } from '../product-grid/products-order';
@@ -18,13 +22,14 @@ import { getPlansToDisplay, getProductsToDisplay, isConnectionFlow } from '../pr
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
 import Experiment from 'calypso/components/experiment';
 import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card-i5';
+import { abtest } from 'calypso/lib/abtest';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	PLAN_JETPACK_SECURITY_REALTIME,
 	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
 } from 'calypso/lib/plans/constants';
 import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
-import { getVariationForUser, isLoading } from 'calypso/state/experiments/selectors';
+import { getVariationForUser } from 'calypso/state/experiments/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import MoreInfoBox from '../more-info-box';
@@ -58,9 +63,9 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const currentPlanSlug =
 		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
-	const variation =
+	const tracksVariation = abtest( REVERSE_PLANS_AB_TEST );
+	const exPlatVariation =
 		useSelector( ( state ) => getVariationForUser( state, SWITCH_PLAN_SIDES_EXPERIMENT ) ) || '';
-	const isVariationLoading = useSelector( isLoading );
 
 	const { availableProducts, purchasedProducts, includedInPlanProducts } = useGetPlansGridProducts(
 		siteId
@@ -71,9 +76,9 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 	const sortedPlans = useMemo(
 		() =>
 			sortBy( getPlansToDisplay( { duration, currentPlanSlug } ), ( item ) =>
-				getProductPosition( item.productSlug as JetpackPlanSlugs, variation )
+				getProductPosition( item.productSlug as JetpackPlanSlugs, tracksVariation )
 			),
-		[ duration, currentPlanSlug, variation ]
+		[ duration, currentPlanSlug, tracksVariation ]
 	);
 	const sortedProducts = useMemo(
 		() =>
@@ -84,9 +89,9 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 					purchasedProducts,
 					includedInPlanProducts,
 				} ),
-				( item ) => getProductPosition( item.productSlug as JetpackProductSlug, variation )
+				( item ) => getProductPosition( item.productSlug as JetpackProductSlug, tracksVariation )
 			),
-		[ duration, availableProducts, includedInPlanProducts, purchasedProducts, variation ]
+		[ duration, availableProducts, includedInPlanProducts, purchasedProducts, tracksVariation ]
 	);
 
 	const scrollToComparison = () => {
@@ -131,62 +136,60 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 						duration={ duration }
 					/>
 				</div>
-				{ ! isVariationLoading && (
-					<>
-						<ul
-							className={ classNames( 'products-grid-i5__plan-grid', {
-								'is-wrapping': isPlanRowWrapping,
-							} ) }
-							ref={ planGridRef }
-						>
-							{ sortedPlans.map( ( product ) => (
-								<li key={ product.iconSlug }>
-									<ProductCardI5
-										item={ product }
-										onClick={ onSelectProduct }
-										siteId={ siteId }
-										currencyCode={ currencyCode }
-										selectedTerm={ duration }
-										isAligned={ ! isPlanRowWrapping }
-										featuredPlans={ [
-											PLAN_JETPACK_SECURITY_REALTIME,
-											PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
-										] }
-									/>
-								</li>
-							) ) }
-						</ul>
-						<div
-							className={ classNames( 'products-grid-i5__more', {
-								'is-detached': isPlanRowWrapping,
-							} ) }
-						>
-							<MoreInfoBox
-								headline={ translate( 'Need more info?' ) }
-								buttonLabel={ translate( 'Compare all product bundles' ) }
-								onButtonClick={ scrollToComparison }
+				<ul
+					className={ classNames( 'products-grid-i5__plan-grid', {
+						'is-wrapping': isPlanRowWrapping,
+					} ) }
+					ref={ planGridRef }
+				>
+					{ sortedPlans.map( ( product ) => (
+						<li key={ product.iconSlug }>
+							<ProductCardI5
+								item={ product }
+								onClick={ onSelectProduct }
+								siteId={ siteId }
+								currencyCode={ currencyCode }
+								selectedTerm={ duration }
+								isAligned={ ! isPlanRowWrapping }
+								featuredPlans={
+									// Whether a featured plan is set or not will
+									// allow us to test the experiment in staging
+									// more easily
+									exPlatVariation === SWITCH_PLAN_SIDES_TREATMENT
+										? []
+										: [ PLAN_JETPACK_SECURITY_REALTIME, PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ]
+								}
 							/>
-						</div>
-					</>
-				) }
+						</li>
+					) ) }
+				</ul>
+				<div
+					className={ classNames( 'products-grid-i5__more', {
+						'is-detached': isPlanRowWrapping,
+					} ) }
+				>
+					<MoreInfoBox
+						headline={ translate( 'Need more info?' ) }
+						buttonLabel={ translate( 'Compare all product bundles' ) }
+						onButtonClick={ scrollToComparison }
+					/>
+				</div>
 			</section>
 			<section className="products-grid-i5__section">
 				<h2 className="products-grid-i5__section-title">{ translate( 'Individual Products' ) }</h2>
-				{ ! isVariationLoading && (
-					<ul className="products-grid-i5__product-grid">
-						{ sortedProducts.map( ( product ) => (
-							<li key={ product.iconSlug }>
-								<ProductCardI5
-									item={ product }
-									onClick={ onSelectProduct }
-									siteId={ siteId }
-									currencyCode={ currencyCode }
-									selectedTerm={ duration }
-								/>
-							</li>
-						) ) }
-					</ul>
-				) }
+				<ul className="products-grid-i5__product-grid">
+					{ sortedProducts.map( ( product ) => (
+						<li key={ product.iconSlug }>
+							<ProductCardI5
+								item={ product }
+								onClick={ onSelectProduct }
+								siteId={ siteId }
+								currencyCode={ currencyCode }
+								selectedTerm={ duration }
+							/>
+						</li>
+					) ) }
+				</ul>
 				<div className="products-grid-i5__free">
 					{ ( isInConnectFlow || isInJetpackCloud ) && (
 						<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />


### PR DESCRIPTION
### Changes proposed in this Pull Request

We ran into some issues trying to make the `jetpack_pricing_switch_plan_sides` experiment work in Jetpack cloud, with the new ExPlat framework (#47971). This PR switches to the Tracks (deprecated) implementation.

In order to still be able to debug the ExPlat implementation, we've kept it but updated the target of the experiment: the discount message. See details in the instructions below.

### Implementation notes

I voluntarily tried to keep the nomenclature usually associated to Tracks (based on existing code), to have a better distinction between the 2 implementation in the codebase.

### Testing instructions

#### Tracks

_Prerequisites: notice the experiment in the `ABTESTS` menu_
<img width="618" alt="Screen Shot 2020-12-08 at 2 05 40 PM" src="https://user-images.githubusercontent.com/1620183/101531003-a7cff700-3960-11eb-8eeb-7a679fb30e60.png">

- Download the PR
- Run Calypso (`yarn start`) and Jetpack cloud concurrently (`yarn start-jetpack-cloud-p`, once Calypso is running)
- Select a self-hosted Jetpack site in Calypso
- Visit the pricing page in both platforms: `http://calypso.localhost:3000/plans/:site` and `http://jetpack.cloud.localhost:3001/pricing`
- If the selected variation in the `ABTESTS` menu is `control`, check that you see _Complete_ first (see capture)
- If the variation is `priceAsc`, check that you see _Complete_ last (see capture)

#### ExPlat

_Prerequisites: visit the experiment page (search `jetpack_pricing_switch_plan_sides2` in Abacus) and add the bookmarks that allow you to switch between the control and treatment variations_
<img width="625" alt="Screen Shot 2020-12-02 at 2 12 15 PM" src="https://user-images.githubusercontent.com/1620183/100919904-6941c480-34a8-11eb-9da0-756165fb9e8d.png">

In Calypso only for now:
- Verify that you see the `control` variation of the pricing page (i.e. discount message **not** underlined)
- Then switch to the `treatment` variation by clicking on the bookmark, and check that the discount message is underlined (see capture)

_The result of the endpoint is cached for about 60 seconds, so make sure that the call to `/experiments/0.1.0/assignments/calypso` is made in the Network panel as you test._

### Screenshots

#### Tracks

_control_
<img width="1075" alt="Screen Shot 2020-12-08 at 2 06 35 PM" src="https://user-images.githubusercontent.com/1620183/101530776-5aec2080-3960-11eb-8d38-714adb33d2ba.png">



_priceAsc_
<img width="1106" alt="Screen Shot 2020-12-08 at 2 06 16 PM" src="https://user-images.githubusercontent.com/1620183/101530787-5e7fa780-3960-11eb-8d02-ead74e255372.png">


#### ExPlat

_treatment_
<img width="448" alt="Screen Shot 2020-12-08 at 2 37 07 PM" src="https://user-images.githubusercontent.com/1620183/101532651-d949c200-3962-11eb-98df-a77a01c60e82.png">


