### PR TITLE
Billing: Fix - Purchase plan details stuck in loading state 2

### DIFF
--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -19,9 +19,9 @@ import PlanBillingPeriod from './billing-period';
 import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
 import {
 	getByPurchaseId,
+	hasLoadedSitePurchasesFromServer,
 	hasLoadedUserPurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
-import { isDataLoading } from 'calypso/me/purchases/utils';
 import { getName, isExpired, isPartnerPurchase } from 'calypso/lib/purchases';
 import { isJetpackPlan, isFreeJetpackPlan } from 'calypso/lib/products-values';
 import { getPluginsForSite } from 'calypso/state/plugins/premium/selectors';
@@ -40,7 +40,7 @@ export class PurchasePlanDetails extends Component {
 		// Connected props
 		purchase: PropTypes.object,
 		hasLoadedSites: PropTypes.bool,
-		hasLoadedUserPurchasesFromServer: PropTypes.bool,
+		hasLoadedPurchasesFromServer: PropTypes.bool,
 		pluginList: PropTypes.arrayOf(
 			PropTypes.shape( {
 				slug: PropTypes.string.isRequired,
@@ -80,7 +80,7 @@ export class PurchasePlanDetails extends Component {
 			return null;
 		}
 
-		if ( isDataLoading( this.props ) || this.props.isPlaceholder ) {
+		if ( ! this.props.hasLoadedPurchasesFromServer || this.props.isPlaceholder ) {
 			return this.renderPlaceholder();
 		}
 
@@ -123,14 +123,15 @@ export class PurchasePlanDetails extends Component {
 	}
 }
 
-// hasLoadedSites & hasLoadedUserPurchasesFromServer are used in isDataLoading
 export default connect( ( state, props ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
 	const siteId = purchase ? purchase.siteId : null;
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
 		site: purchase ? getSite( state, purchase.siteId ) : null,
-		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+		hasLoadedPurchasesFromServer: siteId
+			? hasLoadedSitePurchasesFromServer( state )
+			: hasLoadedUserPurchasesFromServer( state ),
 		purchase,
 		pluginList: getPluginsForSite( state, siteId ),
 		siteId,

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -72,6 +72,10 @@ export class PurchasePlanDetails extends Component {
 		}
 	}
 
+	isDataLoading( props ) {
+		return ! props.hasLoadedSites || ! props.hasLoadedPurchasesFromServer;
+	}
+
 	render() {
 		const { pluginList, purchase, site, siteId, translate, isProductOwner } = this.props;
 
@@ -80,7 +84,7 @@ export class PurchasePlanDetails extends Component {
 			return null;
 		}
 
-		if ( ! this.props.hasLoadedPurchasesFromServer || this.props.isPlaceholder ) {
+		if ( this.isDataLoading( this.props ) || this.props.isPlaceholder ) {
 			return this.renderPlaceholder();
 		}
 

--- a/client/me/purchases/manage-purchase/plan-details/test/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/index.jsx
@@ -23,7 +23,7 @@ const props = {
 		expiryStatus: 'active',
 	},
 	hasLoadedSites: true,
-	hasLoadedUserPurchasesFromServer: true,
+	hasLoadedPurchasesFromServer: true,
 	pluginList: [
 		{
 			slug: 'vaultpress',


### PR DESCRIPTION
This PR is a second attempt at https://github.com/Automattic/wp-calypso/pull/47982 which had to be reverted (https://github.com/Automattic/wp-calypso/pull/48022) because it was breaking domain cancellations.

### Changes proposed in this Pull Request

This PR fixes the Plan Details being stuck in a loading state. (see screenshot):

![Markup 2020-12-08 at 11 08 21](https://user-images.githubusercontent.com/11078128/101529701-c5439780-3945-11eb-911b-f591704352a6.png)

### Testing instructions

**To view the issue:**
1. Go to wordpress.com staging, (logged in)
2. Select any site with a purchased plan (not a Jetpack Free site)
3. Go to Plans --> Billing --> click/select the Plan (to open the plan details/settings)
4. You should see the plan purchase details area is stuck in a never ending loading state (See screenshot above)

**To test the issue is fixed:**
1. Checkout and run this PR or open the live link.
2. Select any site with a purchased plan (not a Jetpack Free site)
3. Go to Plans --> Billing --> click/select the Plan (to open the plan details/settings)
4. Verify that the PurchasePlanDetails component (billing expiration info) is showing and that it is no longer stuck in a loading state. (see screenshot)

![Markup 2020-12-08 at 11 50 48](https://user-images.githubusercontent.com/11078128/101534331-d42d4880-394b-11eb-8a22-3df3dbcbff0e.png)


**Also, check that domains removal is working.**
5. Next, select a wp.com site, go to Manage --> Domains, and buy a domain.
6. Go to Plans --> Billing --> click/select the domain
7. Make sure the "Remove {your domain name}" button is present and working.

![Markup 2020-12-08 at 11 51 42](https://user-images.githubusercontent.com/11078128/101534354-db545680-394b-11eb-9d21-a6db977f8571.png)


Fixes 1164141197617539-as-1199504839490770
