### PR TITLE
Purchases: fix another alignment issue

### DIFF
--- a/client/me/purchases/style.scss
+++ b/client/me/purchases/style.scss
@@ -60,6 +60,7 @@
 
 		@include breakpoint-deprecated( '>960px' ) {
 			display: block;
+			margin-top: 0;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes another alignment issue on the site-level purchases screen.

**Before**
![image](https://user-images.githubusercontent.com/6981253/101543207-ef12b380-3971-11eb-9b45-c678413cbcbe.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/101535501-bcaf8900-3966-11eb-8936-ad6a9705a0ae.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the site-level purchases screen and make sure there isn't awkward spacing in the header. 
* Check it on mobile and the account-level view to confirm there aren't any other side effects.
