### PR TITLE
Mailing Lists: Add description for the WordPress.com 'Promotion' cate…

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -112,6 +112,8 @@ class MainComponent extends React.Component {
 			return this.props.translate( 'Digests' );
 		} else if ( 'news' === category ) {
 			return this.props.translate( 'Newsletter' );
+		} else if ( 'promotion' === category ) {
+			return this.props.translate( 'Promotions' );
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Jetpack Suggestions' );
 		} else if ( 'jetpack_research' === category ) {
@@ -143,6 +145,10 @@ class MainComponent extends React.Component {
 			);
 		} else if ( 'news' === category ) {
 			return this.props.translate( 'WordPress.com news, announcements, and product spotlights.' );
+		} else if ( 'promotion' === category ) {
+			return this.props.translate(
+				'Sales and promotions for WordPress.com products and services.'
+			);
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Tips for getting the most out of Jetpack.' );
 		} else if ( 'jetpack_research' === category ) {
@@ -150,7 +156,7 @@ class MainComponent extends React.Component {
 				'Opportunities to participate in Jetpack research and surveys.'
 			);
 		} else if ( 'jetpack_promotion' === category ) {
-			return this.props.translate( 'Promotions and deals on upgrades.' );
+			return this.props.translate( 'Sales and promotions for Jetpack products and services.' );
 		} else if ( 'jetpack_news' === category ) {
 			return this.props.translate( 'Jetpack news, announcements, and product spotlights.' );
 		}

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -114,7 +114,9 @@ class WPCOMNotifications extends React.Component {
 					name={ options.promotion }
 					isEnabled={ get( settings, options.promotion ) }
 					title={ translate( 'Promotions' ) }
-					description={ translate( 'Promotions and deals on upgrades.' ) }
+					description={ translate(
+						'Sales and promotions for WordPress.com products and services.'
+					) }
 				/>
 
 				<EmailCategory
@@ -160,7 +162,7 @@ class WPCOMNotifications extends React.Component {
 							name={ options.jetpack_promotion }
 							isEnabled={ get( settings, options.jetpack_promotion ) }
 							title={ translate( 'Promotions' ) }
-							description={ translate( 'Promotions and deals on upgrades.' ) }
+							description={ translate( 'Sales and promotions for Jetpack products and services.' ) }
 						/>
 
 						<EmailCategory


### PR DESCRIPTION
This change adds a formal description to the 'promotion' mailing list category for WordPress.com. It also updates the description for the Jetpack-specific promotion category so that the two share a similar description.

#### Changes proposed in this Pull Request

* Add a formal title to the "promotion" category; this essentially allows the "P" to be properly capitalized.
* Add a formal description to the "promotion" category.
* Update the description of the "jetpack_promotion" category so that it mirrors the new value assigned to the "promotion" (WordPress.com) category.


#### Testing instructions

1) Visit the unsubscribe URLs provided below.
2) Confirm that the unsubscribe (and resubscribe) action works, as expected.
3) Confirm that the title and description of each message type is correctly updated, according to the code.

http://calypso.localhost:3000/mailing-lists/unsubscribe?category=promotion&email=codefourcomics%40gmail.com&hmac=625efe95d31cc740b44272d3d605d567
http://calypso.localhost:3000/mailing-lists/unsubscribe?category=jetpack_promotion&email=codefourcomics%40gmail.com&hmac=2601310d75f189c6f7d981b0c8a199cf

Here is what you should see:

![Screen Shot 2020-12-08 at 3 30 28 PM](https://user-images.githubusercontent.com/625866/101537974-66444980-396a-11eb-8a6c-8f8a37870c05.png)

![Screen Shot 2020-12-08 at 3 31 21 PM](https://user-images.githubusercontent.com/625866/101538006-73f9cf00-396a-11eb-9ea2-cdd3d015fbae.png)
