### PR TITLE
Fix: Restore 'Enable SSO and Continue' Feature

### DIFF
--- a/desktop/e2e/appStart.js
+++ b/desktop/e2e/appStart.js
@@ -21,7 +21,7 @@ describe( 'check app loads', function () {
 					mainWindow.webContents.send( 'is-calypso' );
 				} );
 
-				ipcMain.on( 'is-calypso-response', function ( ev, value ) {
+				ipcMain.on( 'is-calypso-response', function ( _, value ) {
 					expect( value ).to.be.true;
 					done();
 				} );

--- a/desktop/public_desktop/desktop-app.js
+++ b/desktop/public_desktop/desktop-app.js
@@ -95,9 +95,10 @@ function startDesktopApp() {
 	}
 
 	// This is called by Calypso
+	// eslint-disable-next-line no-unused-vars
 	startApp = function () {
 		document.addEventListener( 'dragover', ( ev ) => {
-			if ( [ ...event.dataTransfer.types ].includes( 'text/uri-list' ) ) {
+			if ( [ ...ev.dataTransfer.types ].includes( 'text/uri-list' ) ) {
 				ev.preventDefault();
 			}
 		} );
@@ -117,7 +118,7 @@ function startDesktopApp() {
 		const build = window.electron.config.build;
 		document.documentElement.classList.add( 'build-' + build );
 
-		if ( navigator.onLine ) {
+		if ( typeof window.navigator !== 'undefined' && window.navigator.onLine ) {
 			startCalypso();
 
 			if ( calysoHasLoaded() ) {
@@ -138,7 +139,7 @@ try {
 		window.electron.receive( 'is-calypso-response', document.getElementById( 'wpcom' ) !== null );
 	} );
 
-	window.electron.receive( 'app-config', function ( _, details ) {
+	window.electron.receive( 'app-config', function ( details ) {
 		// if this is the first run, and on the login page, show Windows and Mac users a pin app reminder
 		if ( details.firstRun && document.querySelectorAll( '.logged-out-auth' ).length > 0 ) {
 			if ( details.platform === 'windows' || details.platform === 'darwin' ) {

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -21,9 +21,12 @@ const sendChannels = [
 // Incoming IPC message channels from Main process to Renderer.
 // Maintain this list in alphabetical order.
 const receiveChannels = [
+	'app-config',
 	'cookie-auth-complete',
 	'enable-notification-badge',
 	'enable-site-option',
+	'is-calypso',
+	'is-calypso-response',
 	'navigate',
 	'new-post',
 	'notification-clicked',

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -4,6 +4,7 @@ const { ipcRenderer, contextBridge } = require( 'electron' );
 // Maintain this list in alphabetical order.
 const sendChannels = [
 	'cannot-use-editor',
+	'enable-site-option-response',
 	'get-config',
 	'get-settings',
 	'log',
@@ -11,6 +12,10 @@ const sendChannels = [
 	'unread-notices-count',
 	'user-auth',
 	'user-login-status',
+	'view-post-clicked',
+	'print',
+	'secrets',
+	'toggle-dev-tools',
 ];
 
 // Incoming IPC message channels from Main process to Renderer.


### PR DESCRIPTION
### Description

Turns out a recent security patch which deprecated the Electron remote module (see #47513) silently broke the "Enable SSO" feature for Atomic sites (and apparently a couple of other features!). Reason: all sending and receiving IPC channels are now explicitly specified in the Desktop app's preload script ([link](https://github.com/Automattic/wp-calypso/blob/0eb078457ddf4fc756ccc008718f1168fcd1b501/desktop/public_desktop/preload.js#L5-L13)), and a few were erroneously omitted. 

The resulting bug was caught when smoking-testing the "Enable SSO" feature triggered by attempting to use Gutenberg in an Atomic site (note: the bug is present in the latest v6.6.0-beta1 and in Calypso `trunk`, but not the latest stable release v6.5.0) (see #47344). 

This PR restores the missing channels, thereby restoring this and other silently broken features (per the IPC channels missing from the preload file).

Thanks to @pablinos and @creativecoder for diligently testing the Desktop app and catching this - much appreciated!

### To Test

1. Build and run the desktop app in this branch using `yarn run build-desktop`
2. Select an Atomic site for which SSO is disabled, and attempt to create a new post
3. Select `Enable SSO and Continue` when prompted
4. After a delay (the delay may be noticeably lengthy), the Desktop app should navigate to the Gutenberg editor

Fixes #48096 
