### PR TITLE
Coming Soon: remove update_option_blog_public hook

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -73,7 +73,8 @@ function add_public_coming_soon_to_settings_endpoint_get( $options ) {
 add_filter( 'site_settings_endpoint_get', __NAMESPACE__ . '\add_public_coming_soon_to_settings_endpoint_get' );
 
 /**
- * This filter makes sure it's possible to change `wpcom_public_coming_soon` option via public-api.wordpress.com.
+ * This filter makes sure it's possible to change `wpcom_public_coming_soon` option via public-api.wordpress.com settings endpoint.
+ * The settings endpoint updates the option.
  *
  * @param object $input Filtered POST input.
  * @param object $unfiltered_input Raw and unfiltered POST input.
@@ -87,23 +88,6 @@ function add_public_coming_soon_to_settings_endpoint_post( $input, $unfiltered_i
 	return $input;
 }
 add_filter( 'rest_api_update_site_settings', __NAMESPACE__ . '\add_public_coming_soon_to_settings_endpoint_post', 10, 2 );
-
-/**
- * Launch the site when the privacy mode changes from public-not-indexed
- * This can happen due to clicking the launch button from the banner
- * Or due to manually updating the setting in wp-admin or calypso settings page.
- *
- * @param string $old_value the old value of blog_public.
- * @param string $value     the new value of blog_public.
- */
-function disable_coming_soon_on_privacy_change( $old_value, $value ) {
-	if ( 0 !== (int) $old_value || 0 === (int) $value ) {
-		// Do nothing if not moving from public-not-indexed.
-		return;
-	}
-	update_option( 'wpcom_public_coming_soon', 0 );
-}
-add_action( 'update_option_blog_public', __NAMESPACE__ . '\disable_coming_soon_on_privacy_change', 10, 2 );
 
 // phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed
 /**


### PR DESCRIPTION
## Changes proposed in this Pull Request

Because both the site settings AND launch endpoints perform an option update anyway, we don't need to listen out for privacy changes to set the coming soon option on WPCOM.

In fact, because we're doing that in production, we're updating the `wpcom_public_coming_soon` option in response to a change in `blog_public` **before** the settings endpoint gets a chance to. The settings endpoint therefore rightly considers the options as unchanged when it tries to update, and doesn't include it in the updated response.

The frontend, not knowing that the coming soon setting has been updated, doesn't know to show or hide the Coming Soon site banner.

![Dec-09-2020 11-31-13](https://user-images.githubusercontent.com/6458278/101560118-a82ac980-3a16-11eb-913d-05485090e560.gif)

### Alternatives

There are no consequences to removing the `update_option_blog_public` hook in the ETK, because, as stated, the WPCOM endpoints set the value of `wpcom_public_coming_soon` anyway. 

In the future we could use more explicit filters to set Coming Soon rather than add side effects based on assumptions that public indexable and private `!==` Coming Soon mode.

For example:
1. We could set `wpcom_public_coming_soon` to `0` using the `update_option_launch-status` hook when `$old_value === 'unlaunched' && $value === 'launched'`
2. We could update the value ourselves by hooking into `site_settings_endpoint_update_wpcom_public_coming_soon` ([reference](https://developer.jetpack.com/hooks/site_settings_endpoint_update_key/)). The means the settings endpoint will always return `wpcom_public_coming-soon` as updated however.

## Testing instructions

This should only affect the settings page on WordPress.com.

### Simple sites

1. Run `yarn dev --sync` in `apps/editing-toolkit` 
2. Create new site 
3. The site should be in Coming Soon mode
4. Launch the site
5. The site should be public
6. Go to settings `/settings/general/{your_site}`
7. Toggle between Coming Soon and Public
8. The Site badge should update in a timely fashion


### Check that Atomic site settings updates are unaffected

1. Create a new ecommerce site via /start/domains (it'll be in Coming Soon mode)
2. The site should be in Coming Soon mode
3. Launch the site
4. The site should be public
5. Go to settings `/settings/general/{your_site}`
6. Toggle between Coming Soon and Public
7. The Site badge should update in a timely fashion