### PR TITLE
Adds route & sales page for Ultimate Traffic Guide

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -58,6 +58,7 @@ import {
 	isUnlimitedThemes,
 	isVideoPress,
 	isConciergeSession,
+	isTrafficGuide,
 	isMonthly,
 } from 'calypso/lib/products-values';
 import sortProducts from 'calypso/lib/products-values/sort';
@@ -549,6 +550,16 @@ export function hasOnlyRenewalItems( cart ) {
  */
 export function hasConciergeSession( cart ) {
 	return some( getAllCartItems( cart ), isConciergeSession );
+}
+
+/**
+ * Determines whether there is a traffic guide item in the specified shopping cart.
+ *
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {boolean} true if there is a traffic guide item, false otherwise
+ */
+export function hasTrafficGuide( cart ) {
+	return some( getAllCartItems( cart ), isTrafficGuide );
 }
 
 /**

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -122,3 +122,5 @@ export const JETPACK_PRODUCT_PRICE_MATRIX = {
 		ratio: 12,
 	},
 };
+
+export const WPCOM_TRAFFIC_GUIDE = 'traffic-guide';

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -71,3 +71,4 @@ export { isUnlimitedThemes } from './is-unlimited-themes';
 export { isVideoPress } from './is-video-press';
 export { isVipPlan } from './is-vip-plan';
 export { isYearly } from './is-yearly';
+export { isTrafficGuide } from './is-traffic-guide';

--- a/client/lib/products-values/is-traffic-guide.js
+++ b/client/lib/products-values/is-traffic-guide.js
@@ -3,10 +3,11 @@
  */
 import { assertValidProduct } from 'calypso/lib/products-values/utils/assert-valid-product';
 import { formatProduct } from 'calypso/lib/products-values/format-product';
+import { WPCOM_TRAFFIC_GUIDE } from 'calypso/lib/products-values/constants';
 
 export function isTrafficGuide( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return 'traffic-guide' === product.product_slug;
+	return WPCOM_TRAFFIC_GUIDE === product.product_slug;
 }

--- a/client/lib/products-values/is-traffic-guide.js
+++ b/client/lib/products-values/is-traffic-guide.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { assertValidProduct } from 'calypso/lib/products-values/utils/assert-valid-product';
+import { formatProduct } from 'calypso/lib/products-values/format-product';
+
+export function isTrafficGuide( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return 'traffic-guide' === product.product_slug;
+}

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -38,6 +38,7 @@ import Gridicon from 'calypso/components/gridicon';
 import getCheckoutUpgradeIntent from '../../../state/selectors/get-checkout-upgrade-intent';
 import { Button } from '@automattic/components';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { downloadTrafficGuide } from 'calypso/my-sites/marketing/ultimate-traffic-guide';
 
 export class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
@@ -344,10 +345,10 @@ export class CheckoutThankYouHeader extends PureComponent {
 		window.location.href = '/me/concierge/' + selectedSite.slug + '/book';
 	};
 
-	downloadTrafficGuide = ( event ) => {
+	downloadTrafficGuideHandler = ( event ) => {
 		event.preventDefault();
 
-		//TODO redirect to download page
+		downloadTrafficGuide();
 	};
 
 	startTransfer = ( event ) => {
@@ -508,7 +509,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 		} else if ( this.isSingleDomainPurchase() ) {
 			clickHandler = this.visitDomain;
 		} else if ( isTrafficGuidePurchase ) {
-			clickHandler = this.downloadTrafficGuide;
+			clickHandler = this.downloadTrafficGuideHandler;
 		}
 
 		return (

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -133,10 +133,10 @@ export class CheckoutThankYouHeader extends PureComponent {
 				return translate(
 					// eslint-disable-next-line inclusive-language/use-inclusive-words
 					'{{p}}Congratulations for taking this important step towards mastering the art of online marketing!' +
-						'To download your copy of The Ultimate Traffic Guide, simply click the button below and confirm the download prompt.{{/p}}' +
+						' To download your copy of The Ultimate Traffic Guide, simply click the button below and confirm the download prompt.{{/p}}' +
 						'{{p}}The Ultimate Traffic Guide is a goldmine of traffic tips and how-tos that reveals the exact “Breakthrough Traffic” process we’ve developed over the past decade.{{/p}}' +
 						'{{p}}We’ve done all the hard work for you.' +
-						'We’ve sifted through an ocean of marketing articles, tested the ideas to see if they actually work, and then distilled the very best ideas into this printable guide.{{/p}}',
+						' We’ve sifted through an ocean of marketing articles, tested the ideas to see if they actually work, and then distilled the very best ideas into this printable guide.{{/p}}',
 					{
 						components: {
 							p: <p />,

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -129,6 +129,22 @@ export class CheckoutThankYouHeader extends PureComponent {
 				);
 			}
 
+			if ( 'traffic-guide' === displayMode ) {
+				return translate(
+					// eslint-disable-next-line inclusive-language/use-inclusive-words
+					'{{p}}Congratulations for taking this important step towards mastering the art of online marketing!' +
+						'To download your copy of The Ultimate Traffic Guide, simply click the button below and confirm the download prompt.{{/p}}' +
+						'{{p}}The Ultimate Traffic Guide is a goldmine of traffic tips and how-tos that reveals the exact “Breakthrough Traffic” process we’ve developed over the past decade.{{/p}}' +
+						'{{p}}We’ve done all the hard work for you.' +
+						'We’ve sifted through an ocean of marketing articles, tested the ideas to see if they actually work, and then distilled the very best ideas into this printable guide.{{/p}}',
+					{
+						components: {
+							p: <p />,
+						},
+					}
+				);
+			}
+
 			return translate( 'You will receive an email confirmation shortly.' );
 		}
 
@@ -328,6 +344,12 @@ export class CheckoutThankYouHeader extends PureComponent {
 		window.location.href = '/me/concierge/' + selectedSite.slug + '/book';
 	};
 
+	downloadTrafficGuide = ( event ) => {
+		event.preventDefault();
+
+		//TODO redirect to download page
+	};
+
 	startTransfer = ( event ) => {
 		event.preventDefault();
 
@@ -378,6 +400,10 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		if ( 'concierge' === displayMode ) {
 			return translate( 'Schedule my session' );
+		}
+
+		if ( 'traffic-guide' === displayMode ) {
+			return translate( 'Click here to download your copy now.' );
 		}
 
 		if ( ! selectedSite.slug && hasFailedPurchases ) {
@@ -441,6 +467,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 		} = this.props;
 		const headerButtonClassName = 'button is-primary';
 		const isConciergePurchase = 'concierge' === displayMode;
+		const isTrafficGuidePurchase = 'traffic-guide' === displayMode;
 		const isSearch = purchases?.length > 0 && purchases[ 0 ].productType === 'search';
 
 		if ( isSearch ) {
@@ -455,6 +482,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		if (
 			! isConciergePurchase &&
+			! isTrafficGuidePurchase &&
 			( hasFailedPurchases ||
 				! primaryPurchase ||
 				! selectedSite ||
@@ -475,10 +503,12 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		let clickHandler = this.visitSite;
 
-		if ( 'concierge' === displayMode ) {
+		if ( isConciergePurchase ) {
 			clickHandler = this.visitScheduler;
 		} else if ( this.isSingleDomainPurchase() ) {
 			clickHandler = this.visitDomain;
+		} else if ( isTrafficGuidePurchase ) {
+			clickHandler = this.downloadTrafficGuide;
 		}
 
 		return (

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -26,7 +26,6 @@ import {
 	hasPremiumPlan,
 	hasEcommercePlan,
 	hasPlan,
-	hasTrafficGuide,
 } from 'calypso/lib/cart-values/cart-items';
 import {
 	isJetpackProductSlug,
@@ -366,10 +365,6 @@ export class Checkout extends React.Component {
 		// when purchasing a concierge session.
 		if ( hasConciergeSession( cart ) ) {
 			displayModeParam = { d: 'concierge' };
-		}
-
-		if ( hasTrafficGuide( cart ) ) {
-			displayModeParam = { d: 'traffic-guide' };
 		}
 
 		if ( this.props.isEligibleForSignupDestination ) {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -26,6 +26,7 @@ import {
 	hasPremiumPlan,
 	hasEcommercePlan,
 	hasPlan,
+	hasTrafficGuide,
 } from 'calypso/lib/cart-values/cart-items';
 import {
 	isJetpackProductSlug,
@@ -365,6 +366,10 @@ export class Checkout extends React.Component {
 		// when purchasing a concierge session.
 		if ( hasConciergeSession( cart ) ) {
 			displayModeParam = { d: 'concierge' };
+		}
+
+		if ( hasTrafficGuide( cart ) ) {
+			displayModeParam = { d: 'traffic-guide' };
 		}
 
 		if ( this.props.isEligibleForSignupDestination ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -24,6 +24,7 @@ import {
 	hasBusinessPlan,
 	hasEcommercePlan,
 	hasMonthlyCartItem,
+	hasTrafficGuide,
 } from 'calypso/lib/cart-values/cart-items';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
@@ -378,6 +379,9 @@ function getQuickstartUrl( {
 function getDisplayModeParamFromCart( cart: ResponseCart | undefined ): Record< string, string > {
 	if ( cart && hasConciergeSession( cart ) ) {
 		return { d: 'concierge' };
+	}
+	if ( cart && hasTrafficGuide( cart ) ) {
+		return { d: 'traffic-guide' };
 	}
 	return {};
 }

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -741,4 +741,21 @@ describe( 'getThankYouPageUrl', () => {
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
+
+	it( 'redirects to thank you page (with traffic guide display mode) if traffic guide is in cart', () => {
+		const cart = {
+			products: [
+				{
+					product_slug: 'traffic-guide',
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+			receiptId: '1234abcd',
+		} );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd?d=traffic-guide' );
+	} );
 } );

--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -15,6 +15,7 @@ import Sharing from './main';
 import SharingButtons from './buttons/buttons';
 import SharingConnections from './connections/connections';
 import Traffic from './traffic/';
+import UltimateTrafficGuide from './ultimate-traffic-guide';
 import { requestSite } from 'calypso/state/sites/actions';
 import {
 	getSiteSlug,
@@ -141,6 +142,12 @@ export const sharingButtons = ( context, next ) => {
 
 export const traffic = ( context, next ) => {
 	context.contentComponent = createElement( Traffic );
+
+	next();
+};
+
+export const ultimateTrafficGuide = ( context, next ) => {
+	context.contentComponent = createElement( UltimateTrafficGuide );
 
 	next();
 };

--- a/client/my-sites/marketing/index.js
+++ b/client/my-sites/marketing/index.js
@@ -18,6 +18,7 @@ import {
 	redirectSharingButtons,
 	sharingButtons,
 	traffic,
+	ultimateTrafficGuide,
 } from './controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 
@@ -28,6 +29,7 @@ export default function () {
 		'/marketing/sharing-buttons',
 		'/marketing/tools',
 		'/marketing/traffic',
+		'/marketing/ultimate-traffic-guide',
 		'/sharing',
 		'/sharing/buttons',
 		'/marketing/business-tools',
@@ -89,6 +91,17 @@ export default function () {
 		siteSelection,
 		navigation,
 		marketingBusinessTools,
+		layout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/marketing/ultimate-traffic-guide/:domain',
+		siteSelection,
+		sites,
+		navigation,
+		ultimateTrafficGuide,
 		layout,
 		makeLayout,
 		clientRender

--- a/client/my-sites/marketing/paths.ts
+++ b/client/my-sites/marketing/paths.ts
@@ -13,3 +13,7 @@ export const marketingBusinessTools = ( siteSlug?: string | null ): string => {
 export const marketingSharingButtons = ( siteSlug?: string | null ): string => {
 	return `/marketing/sharing-buttons/${ siteSlug || '' }`;
 };
+
+export const marketingUltimateTrafficGuide = ( siteSlug?: string | null ): string => {
+	return `/marketing/ultimate-traffic-guide/${ siteSlug || '' }`;
+};

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import page from 'page';
 import React, { Fragment, FunctionComponent } from 'react';
 import { useTranslate, getLocaleSlug } from 'i18n-calypso';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies
@@ -96,6 +97,8 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 
 		page( marketingUltimateTrafficGuide( selectedSiteSlug ) );
 	};
+
+	const isEnglish = config( 'english_locales' ).includes( getLocaleSlug() );
 
 	return (
 		<Fragment>
@@ -223,15 +226,18 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 					</Button>
 				</MarketingToolsFeature>
 
-				<MarketingToolsFeature
-					title={ translate( 'Introducing the WordPress.com Ultimate Traffic Guide' ) }
-					description={ translate( 'Discover today’s most important traffic secrets' ) }
-					imagePath="/calypso/images/marketing/upwork-logo.png"
-				>
-					<Button onClick={ handleUltimateTrafficGuideClick }>
-						{ translate( 'Download now' ) }
-					</Button>
-				</MarketingToolsFeature>
+				{ isEnglish && (
+					<MarketingToolsFeature
+						title={ translate( 'Introducing the WordPress.com Ultimate Traffic Guide' ) }
+						description={ translate( 'Discover today’s most important traffic secrets' ) }
+						imagePath="/calypso/images/marketing/upwork-logo.png"
+						// TODO: Fix image
+					>
+						<Button onClick={ handleUltimateTrafficGuideClick }>
+							{ translate( 'Download now' ) }
+						</Button>
+					</MarketingToolsFeature>
+				) }
 			</div>
 		</Fragment>
 	);

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -13,7 +13,11 @@ import { Button } from '@automattic/components';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import MarketingToolsFeature from './feature';
 import MarketingToolsHeader from './header';
-import { marketingConnections, marketingBusinessTools } from 'calypso/my-sites/marketing/paths';
+import {
+	marketingConnections,
+	marketingBusinessTools,
+	marketingUltimateTrafficGuide,
+} from 'calypso/my-sites/marketing/paths';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 
@@ -85,6 +89,12 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 		recordTracksEvent( 'calypso_marketing_tools_start_sharing_button_click' );
 
 		page( marketingConnections( selectedSiteSlug ) );
+	};
+
+	const handleUltimateTrafficGuideClick = () => {
+		recordTracksEvent( 'calypso_marketing_tools_ultimate_traffic_guide_button_click' );
+
+		page( marketingUltimateTrafficGuide( selectedSiteSlug ) );
 	};
 
 	return (
@@ -210,6 +220,16 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 						target="_blank"
 					>
 						{ translate( 'Start creating content' ) }
+					</Button>
+				</MarketingToolsFeature>
+
+				<MarketingToolsFeature
+					title={ translate( 'Introducing the WordPress.com Ultimate Traffic Guide' ) }
+					description={ translate( 'Discover today’s most important traffic secrets' ) }
+					imagePath="/calypso/images/marketing/upwork-logo.png"
+				>
+					<Button onClick={ handleUltimateTrafficGuideClick }>
+						{ translate( 'Download now' ) }
 					</Button>
 				</MarketingToolsFeature>
 			</div>

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -32,6 +32,7 @@ import canvaLogo from 'calypso/assets/images/illustrations/canva-logo.svg';
 import sendinblueLogo from 'calypso/assets/images/illustrations/sendinblue-logo.svg';
 import simpletextLogo from 'calypso/assets/images/illustrations/simpletext-logo.png';
 import verblioLogo from 'calypso/assets/images/illustrations/verblio-logo.png';
+import rocket from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 
 /**
  * Types
@@ -229,9 +230,11 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 				{ isEnglish && (
 					<MarketingToolsFeature
 						title={ translate( 'Introducing the WordPress.com Ultimate Traffic Guide' ) }
-						description={ translate( 'Discover today’s most important traffic secrets' ) }
-						imagePath="/calypso/images/marketing/upwork-logo.png"
-						// TODO: Fix image
+						description={ translate(
+							"Our brand new Ultimate Traffic Guide reveals more than a dozen of today's most effective traffic techniques. " +
+								'The guide is appropriate for beginner to intermediate users.'
+						) }
+						imagePath={ rocket }
 					>
 						<Button onClick={ handleUltimateTrafficGuideClick }>
 							{ translate( 'Download now' ) }

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import page from 'page';
 import React, { Fragment, FunctionComponent } from 'react';
 import { useTranslate, getLocaleSlug } from 'i18n-calypso';
@@ -12,6 +12,9 @@ import config from 'calypso/config';
  */
 import { Button } from '@automattic/components';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { hasTrafficGuidePurchase } from 'calypso/my-sites/marketing/ultimate-traffic-guide';
 import MarketingToolsFeature from './feature';
 import MarketingToolsHeader from './header';
 import {
@@ -21,6 +24,7 @@ import {
 } from 'calypso/my-sites/marketing/paths';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 
 /**
  * Images
@@ -44,16 +48,15 @@ import * as T from 'calypso/types';
  */
 import './style.scss';
 
-interface Props {
-	recordTracksEvent: typeof recordTracksEventAction;
-	selectedSiteSlug: T.SiteSlug | null;
-}
-
-export const MarketingTools: FunctionComponent< Props > = ( {
-	recordTracksEvent,
-	selectedSiteSlug,
-} ) => {
+export const MarketingTools: FunctionComponent = () => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const recordTracksEvent = ( event: string ) => dispatch( recordTracksEventAction( event ) );
+	const userId = useSelector( ( state ) => getCurrentUserId( state ) ) || 0;
+	const selectedSiteSlug: T.SiteSlug | null = useSelector( ( state ) =>
+		getSelectedSiteSlug( state )
+	);
+	const purchases = useSelector( ( state ) => getUserPurchases( state, userId ) );
 
 	const handleBusinessToolsClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_business_tools_button_click' );
@@ -103,6 +106,7 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 
 	return (
 		<Fragment>
+			{ ! purchases && <QueryUserPurchases userId={ userId } /> }
 			<PageViewTracker path="/marketing/tools/:site" title="Marketing > Tools" />
 
 			<MarketingToolsHeader handleButtonClick={ handleBusinessToolsClick } />
@@ -237,7 +241,9 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 						imagePath={ rocket }
 					>
 						<Button onClick={ handleUltimateTrafficGuideClick }>
-							{ translate( 'Download now' ) }
+							{ hasTrafficGuidePurchase( purchases )
+								? translate( 'Download now' )
+								: translate( 'Learn more' ) }
 						</Button>
 					</MarketingToolsFeature>
 				) }
@@ -246,11 +252,4 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 	);
 };
 
-export default connect(
-	( state ) => ( {
-		selectedSiteSlug: getSelectedSiteSlug( state ),
-	} ),
-	{
-		recordTracksEvent: recordTracksEventAction,
-	}
-)( MarketingTools );
+export default MarketingTools;

--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -32,7 +32,12 @@ import {
  */
 import './style.scss';
 
-const WPCOM_TRAFFIC_GUIDE = 'traffic-guide';
+export const WPCOM_TRAFFIC_GUIDE = 'traffic-guide';
+
+export const hasTrafficGuidePurchase = ( purchases ) =>
+	!! (
+		purchases && purchases.find( ( purchase ) => WPCOM_TRAFFIC_GUIDE === purchase.productSlug )
+	);
 
 export const downloadTrafficGuide = () => {
 	window.location.href = 'https://public-api.wordpress.com/wpcom/v2/traffic-guide-download';
@@ -43,13 +48,7 @@ export default function UltimateTrafficGuide() {
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const isLoading = useSelector( ( state ) => isFetchingUserPurchases( state ) );
 	const purchases = useSelector( ( state ) => getUserPurchases( state, userId ) );
-	let hasPurchase = false;
-	if (
-		purchases &&
-		purchases.find( ( purchase ) => WPCOM_TRAFFIC_GUIDE === purchase.productSlug )
-	) {
-		hasPurchase = true;
-	}
+	const hasPurchase = hasTrafficGuidePurchase( purchases );
 
 	const renderContent = () => {
 		return (
@@ -257,11 +256,6 @@ const SalesPage = ( { translate } ) => {
 };
 
 const DownloadPage = ( { translate } ) => {
-	const handleDownloadPageButtonClick = () => {
-		//download
-		downloadTrafficGuide();
-	};
-
 	return (
 		<>
 			<p>
@@ -286,7 +280,7 @@ const DownloadPage = ( { translate } ) => {
 				) }
 			</p>
 			<p>
-				<Button onClick={ handleDownloadPageButtonClick } primary>
+				<Button onClick={ () => downloadTrafficGuide() } primary>
 					{ translate( 'Click here to download your copy now.' ) }
 				</Button>
 			</p>

--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -25,6 +25,8 @@ import Experiment, {
 	LoadingVariations,
 	Variation,
 } from 'calypso/components/experiment';
+import { isTrafficGuide } from 'calypso/lib/products-values';
+import { WPCOM_TRAFFIC_GUIDE } from 'calypso/lib/products-values/constants';
 
 /**
  * Style dependencies
@@ -34,9 +36,7 @@ import './style.scss';
 export const WPCOM_TRAFFIC_GUIDE = 'traffic-guide';
 
 export const hasTrafficGuidePurchase = ( purchases ) =>
-	!! (
-		purchases && purchases.find( ( purchase ) => WPCOM_TRAFFIC_GUIDE === purchase.productSlug )
-	);
+	!! ( purchases && purchases.find( ( purchase ) => isTrafficGuide( purchase ) ) );
 
 export const downloadTrafficGuide = () => {
 	window.location.href = 'https://public-api.wordpress.com/wpcom/v2/traffic-guide-download';

--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
@@ -15,11 +15,17 @@ import {
 	isProductsListFetching,
 } from 'calypso/state/products-list/selectors';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { isFetchingUserPurchases, getUserPurchases } from 'calypso/state/purchases/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import {
+	DefaultVariation,
+	Experiment,
+	LoadingVariations,
+	Variation,
+} from 'calypso/components/experiment';
 
 /**
  * Style dependencies
@@ -28,44 +34,54 @@ import './style.scss';
 
 const WPCOM_TRAFFIC_GUIDE = 'traffic-guide';
 
+export const downloadTrafficGuide = () => {
+	window.location.href = 'https://public-api.wordpress.com/wpcom/v2/traffic-guide-download';
+};
+
 export default function UltimateTrafficGuide() {
 	const translate = useTranslate();
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const isLoading = useSelector( ( state ) => isFetchingUserPurchases( state ) );
 	const purchases = useSelector( ( state ) => getUserPurchases( state, userId ) );
-	const [ hasPurchase, setHasPurchase ] = useState( false );
-	useEffect( () => {
-		if (
-			purchases &&
-			purchases.find( ( purchase ) => WPCOM_TRAFFIC_GUIDE === purchase.productSlug )
-		) {
-			setHasPurchase( true );
-		}
-	}, [ purchases, setHasPurchase ] );
-
-	const renderPlaceholders = () =>
-		[ ...Array( 5 ) ].map( ( e, i ) => <Placeholder key={ `${ i }` } /> );
+	let hasPurchase = false;
+	if (
+		purchases &&
+		purchases.find( ( purchase ) => WPCOM_TRAFFIC_GUIDE === purchase.productSlug )
+	) {
+		hasPurchase = true;
+	}
 
 	const renderContent = () => {
-		return hasPurchase ? (
-			<DownloadPage translate={ translate } />
-		) : (
-			<SalesPage translate={ translate } />
+		return (
+			<>
+				<PageViewTracker
+					path={ '/marketing/ultimate-traffic-guide' }
+					title={ 'Ultimate Traffic Guide' }
+					properties={ { has_purchase: hasPurchase } }
+				/>
+				{ hasPurchase ? (
+					<DownloadPage translate={ translate } />
+				) : (
+					<SalesPage translate={ translate } />
+				) }
+			</>
 		);
 	};
 
 	return (
 		<CompactCard className="ultimate-traffic-guide">
 			{ ! purchases && <QueryUserPurchases userId={ userId } /> }
-			{ ! purchases ? renderPlaceholders() : renderContent() }
+			{ isLoading || ! purchases ? <Placeholder num={ 5 } /> : renderContent() }
 		</CompactCard>
 	);
 }
 
-const Placeholder = () => (
-	<div className="ultimate-traffic-guide__placeholder">
-		<div className="ultimate-traffic-guide__placeholder-animation"></div>
-	</div>
-);
+const Placeholder = ( { num = 1 } ) =>
+	[ ...Array( num ) ].map( ( e, i ) => (
+		<div key={ `${ i }` } className="ultimate-traffic-guide__placeholder">
+			<div className="ultimate-traffic-guide__placeholder-animation"></div>
+		</div>
+	) );
 
 const SalesPage = ( { translate } ) => {
 	const cost = useSelector( ( state ) => getProductDisplayCost( state, WPCOM_TRAFFIC_GUIDE ) );
@@ -157,79 +173,80 @@ const SalesPage = ( { translate } ) => {
 		</>
 	);
 
-	// const treatmentVariation = () => (
-	// 	<>
-	// 		<h1 className="ultimate-traffic-guide__header">
-	// 			{ translate(
-	// 				'Discover the most important traffic secrets used by our most successful customers'
-	// 			) }
-	// 		</h1>
-	// 		<h2 className="ultimate-traffic-guide__sub-header">
-	// 			{ translate( 'Claim your copy of the Ultimate Traffic Guide today' ) }
-	// 		</h2>
-	// 		<p>
-	// 			{ translate(
-	// 				'Do you want more traffic to your website?' +
-	// 					' Of course you do, who builds a website and doesn’t want traffic?' +
-	// 					' You’ve time building your website and you’ve just realized that “if you build it, they will come” does not always apply.'
-	// 			) }
-	// 		</p>
-	// 		<p>
-	// 			{ translate(
-	// 				'Our marketing team developed The Ultimate Traffic Guide to help WordPress.com users learn some of the same tactics and strategies our most successful customers use to build their audiences. ' +
-	// 					'This easy-to-follow and beginner-friendly guide reveals today’s best strategies and tactics for attracting more visitors.'
-	// 			) }
-	// 		</p>
-	// 		<p>
-	// 			{ translate( 'Here are just some of the topics we cover in The Ultimate Traffic Guide:' ) }
-	// 		</p>
-	// 		<ul>
-	// 			<li>
-	// 				{ translate(
-	// 					'{{b}}Use Your Traffic to Build Even More Traffic{{/b}} The Ultimate Traffic Guide covers how to use your own site stats to further increase your traffic, keep visitors on your site longer, and convert traffic into qualified leads.',
-	// 					{
-	// 						components: { b: <b /> },
-	// 					}
-	// 				) }
-	// 			</li>
-	// 			<li>
-	// 				{ translate(
-	// 					'{{b}}Leverage Social Media to Expand Your Reach{{/b}} Know where your ideal audience spends time and learn how to leverage those social channels to increase traffic.',
-	// 					{
-	// 						components: { b: <b /> },
-	// 					}
-	// 				) }
-	// 			</li>
-	// 			<li>
-	// 				{ translate(
-	// 					'{{b}}Keeping the Engagement Going{{/b}} we’ll share how to choose the right newsletter service, write compelling content, build your list, and monitor key performance indicators to manage the critical ongoing relationship with your site visitors.',
-	// 					{
-	// 						components: { b: <b /> },
-	// 					}
-	// 				) }
-	// 			</li>
-	// 		</ul>
-	// 		<p>
-	// 			{ translate(
-	// 				'You’re going to want to print out all 96 pages of the Ultimate Traffic Guide and keep it by your desk, because you’re going to consult this guide often.'
-	// 			) }
-	// 		</p>
-	// 		<p>
-	// 			{ translate(
-	// 				'TODO: Similar resources are valued up to $100, but this amazing resource is available to our users at $X. But for a limited time we’re offering the Ultimate Traffic Guide to you for just $4.95.'
-	// 			) }
-	// 		</p>
-	// 	</>
-	// );
+	const treatmentVariation = () => (
+		<>
+			<h1 className="ultimate-traffic-guide__header">
+				{ translate(
+					'Discover the most important traffic secrets used by our most successful customers'
+				) }
+			</h1>
+			<h2 className="ultimate-traffic-guide__sub-header">
+				{ translate( 'Claim your copy of the Ultimate Traffic Guide today' ) }
+			</h2>
+			<p>
+				{ translate(
+					'Do you want more traffic to your website?' +
+						' Of course you do, who builds a website and doesn’t want traffic?' +
+						' You’ve time building your website and you’ve just realized that “if you build it, they will come” does not always apply.'
+				) }
+			</p>
+			<p>
+				{ translate(
+					'Our marketing team developed The Ultimate Traffic Guide to help WordPress.com users learn some of the same tactics and strategies our most successful customers use to build their audiences. ' +
+						'This easy-to-follow and beginner-friendly guide reveals today’s best strategies and tactics for attracting more visitors.'
+				) }
+			</p>
+			<p>
+				{ translate( 'Here are just some of the topics we cover in The Ultimate Traffic Guide:' ) }
+			</p>
+			<ul>
+				<li>
+					{ translate(
+						'{{b}}Use Your Traffic to Build Even More Traffic{{/b}} The Ultimate Traffic Guide covers how to use your own site stats to further increase your traffic, keep visitors on your site longer, and convert traffic into qualified leads.',
+						{
+							components: { b: <b /> },
+						}
+					) }
+				</li>
+				<li>
+					{ translate(
+						'{{b}}Leverage Social Media to Expand Your Reach{{/b}} Know where your ideal audience spends time and learn how to leverage those social channels to increase traffic.',
+						{
+							components: { b: <b /> },
+						}
+					) }
+				</li>
+				<li>
+					{ translate(
+						'{{b}}Keeping the Engagement Going{{/b}} we’ll share how to choose the right newsletter service, write compelling content, build your list, and monitor key performance indicators to manage the critical ongoing relationship with your site visitors.',
+						{
+							components: { b: <b /> },
+						}
+					) }
+				</li>
+			</ul>
+			<p>
+				{ translate(
+					'You’re going to want to print out all 96 pages of the Ultimate Traffic Guide and keep it by your desk, because you’re going to consult this guide often.'
+				) }
+			</p>
+			<p>
+				{ translate(
+					'Similar resources are valued up to $100, but this amazing resource is available to our users at $17.'
+				) }
+			</p>
+		</>
+	);
 
 	return (
 		<>
-			<PageViewTracker
-				path={ '/marketing/ultimate-traffic-guide' }
-				title={ 'Ultimate Traffic Guide' }
-			/>
-			{ defaultVariation() }
-			{ /* { treatmentVariation() } */ }
+			<Experiment name="traffic_guide_copy_test">
+				<DefaultVariation>{ defaultVariation() }</DefaultVariation>
+				<Variation name="treatment">{ treatmentVariation() }</Variation>
+				<LoadingVariations>
+					<Placeholder num={ 5 } />
+				</LoadingVariations>
+			</Experiment>
 			<p>
 				<Button href={ `/checkout/${ siteSlug }/${ WPCOM_TRAFFIC_GUIDE }` } primary>
 					{ translate( 'Click here to buy the guide now!' ) }
@@ -242,6 +259,7 @@ const SalesPage = ( { translate } ) => {
 const DownloadPage = ( { translate } ) => {
 	const handleDownloadPageButtonClick = () => {
 		//download
+		downloadTrafficGuide();
 	};
 
 	return (

--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -1,0 +1,192 @@
+/**
+ * External dependencies
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Button, CompactCard } from '@automattic/components';
+import {
+	getProductDisplayCost,
+	isProductsListFetching,
+} from 'calypso/state/products-list/selectors';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const WPCOM_TRAFFIC_GUIDE = 'traffic-guide';
+
+const Placeholder = () => (
+	<div className="ultimate-traffic-guide__placeholder">
+		<div className="ultimate-traffic-guide__placeholder-animation"></div>
+	</div>
+);
+
+const SalesPage = ( { translate } ) => {
+	const cost = useSelector( ( state ) => getProductDisplayCost( state, WPCOM_TRAFFIC_GUIDE ) );
+	const isLoading = useSelector( ( state ) => isProductsListFetching( state ) );
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+
+	return (
+		<>
+			<h1>{ translate( 'Introducing the WordPress.com Ultimate Traffic Guide' ) }</h1>
+			<h2>{ translate( 'Discover today’s most important traffic secrets' ) }</h2>
+			<p>
+				{ translate(
+					'We developed this 96 page guide to teach you every modern website traffic trick you need to know in 2020 and beyond.'
+				) }
+			</p>
+			<p>
+				{ translate(
+					'Here are just a few of the topics we cover in {{i}}The Ultimate Traffic Guide:{{/i}}',
+					{
+						components: {
+							i: <i />,
+						},
+					}
+				) }
+			</p>
+			<p>
+				<strong>{ translate( 'The complete SEO checklist for your website (page 53)' ) }</strong>
+				<br></br>
+				{ translate(
+					'Following this simple 7-step checklist will help you get your site featured at the top of search engine results for your most important keywords (and help you avoid the most common pitfalls that you absolutely must avoid if you want to rank well).'
+				) }
+			</p>
+			<p>
+				<strong>
+					{ translate(
+						'Why email is STILL a must-have marketing channel (hint: it’s simple, free, and effective) (page 88)'
+					) }
+				</strong>
+				<br></br>
+				{ translate(
+					'This guide will teach you everything you need to know: from which email marketing tools you should use, to how to collect email addresses and write great subject lines, and more.'
+				) }
+			</p>
+			<p>
+				<strong>
+					{ translate( 'Harness the power of social media to expand your reach (page 65)' ) }
+				</strong>
+				<br></br>
+				{ translate(
+					'Discover the best ways to leverage social media channels like FaceBook, Twitter, and LinkedIn to connect with your audience and turn them into raving fans.'
+				) }
+			</p>
+			<p>
+				<strong>
+					{ translate(
+						'How to build a simple “traffic magnet” to instantly attract the right audience (page 7)'
+					) }
+				</strong>
+				<br></br>
+				{ translate(
+					'It’s so effective you don’t even have to come close to a “perfect” site before you launch… even the ugliest site can drive an endless stream of business if you get this right!'
+				) }
+			</p>
+			<p>
+				{ translate(
+					'If you’ve spent any time looking for marketing help, you know that marketing guides like this often cost $100 or more. But you won’t have to pay anywhere near that amount.'
+				) }
+			</p>
+
+			{ isLoading ? (
+				<Placeholder />
+			) : (
+				<p>
+					<strong>
+						{ translate(
+							'In fact, if you act today you’ll pay just %(cost)s for The Ultimate Traffic Guide.',
+							{
+								args: { cost },
+							}
+						) }
+					</strong>
+				</p>
+			) }
+
+			<p>
+				<Button href={ `/checkout/${ siteSlug }/${ WPCOM_TRAFFIC_GUIDE }` } primary>
+					{ translate( 'Click here to buy the guide now!' ) }
+				</Button>
+			</p>
+		</>
+	);
+};
+
+const DownloadPage = ( { translate } ) => {
+	const handleDownloadPageButtonClick = () => {
+		//download
+	};
+
+	return (
+		<>
+			<p>
+				{ translate(
+					// eslint-disable-next-line inclusive-language/use-inclusive-words
+					'Congratulations for taking this important step towards mastering the art of online marketing! To download your copy of The Ultimate Traffic Guide, simply click the button below and confirm the download prompt.'
+				) }
+			</p>
+			<p>
+				{ translate(
+					'The Ultimate Traffic GuideThis is a goldmine of traffic tips and how-tos that reveals the exact “Breakthrough Traffic” process we’ve developed over the past decade.'
+				) }
+			</p>
+			<p>
+				{ translate(
+					'We’ve done all the hard work for you. We’ve sifted through an ocean of marketing articles, tested the ideas to see if they actually work, and then distilled the very best ideas into this printable guide.'
+				) }
+			</p>
+			<p>
+				<Button onClick={ handleDownloadPageButtonClick } primary>
+					{ translate( 'Click here to download your copy now.' ) }
+				</Button>
+			</p>
+		</>
+	);
+};
+
+export default function UltimateTrafficGuide() {
+	const translate = useTranslate();
+	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const purchases = useSelector( ( state ) => getUserPurchases( state, userId ) );
+	const [ hasPurchase, setHasPurchase ] = useState( false );
+	useEffect( () => {
+		if (
+			purchases &&
+			purchases.find( ( purchase ) => WPCOM_TRAFFIC_GUIDE === purchase.productSlug )
+		) {
+			setHasPurchase( true );
+		}
+	}, [ purchases, setHasPurchase ] );
+
+	const renderPlaceholders = () =>
+		[ ...Array( 5 ) ].map( ( e, i ) => <Placeholder key={ `${ i }` } /> );
+
+	const renderContent = () => {
+		return hasPurchase ? (
+			<DownloadPage translate={ translate } />
+		) : (
+			<SalesPage translate={ translate } />
+		);
+	};
+
+	return (
+		<CompactCard className="ultimate-traffic-guide">
+			{ ! purchases && <QueryUserPurchases userId={ userId } /> }
+			{ ! purchases ? renderPlaceholders() : renderContent() }
+		</CompactCard>
+	);
+}

--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -20,9 +20,8 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import {
+import Experiment, {
 	DefaultVariation,
-	Experiment,
 	LoadingVariations,
 	Variation,
 } from 'calypso/components/experiment';

--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -41,8 +41,12 @@ const SalesPage = ( { translate } ) => {
 
 	return (
 		<>
-			<h1>{ translate( 'Introducing the WordPress.com Ultimate Traffic Guide' ) }</h1>
-			<h2>{ translate( 'Discover today’s most important traffic secrets' ) }</h2>
+			<h1 className="ultimate-traffic-guide__header">
+				{ translate( 'Introducing the WordPress.com Ultimate Traffic Guide' ) }
+			</h1>
+			<h2 className="ultimate-traffic-guide__sub-header">
+				{ translate( 'Discover today’s most important traffic secrets' ) }
+			</h2>
 			<p>
 				{ translate(
 					'We developed this 96 page guide to teach you every modern website traffic trick you need to know in 2020 and beyond.'

--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -12,7 +12,6 @@ import { Button, CompactCard } from '@automattic/components';
  * Internal dependencies
  */
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { getProductCost, isProductsListFetching } from 'calypso/state/products-list/selectors';
 import { isFetchingUserPurchases, getUserPurchases } from 'calypso/state/purchases/selectors';
 import { getCurrentUserCurrencyCode, getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -84,7 +83,6 @@ const SalesPage = ( { translate } ) => {
 	const isLoading = useSelector( ( state ) => isProductsListFetching( state ) );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
-	const moment = useLocalizedMoment();
 
 	/**
 	 * The reference cost is calculated to the nearest 100
@@ -114,7 +112,7 @@ const SalesPage = ( { translate } ) => {
 				{ translate(
 					'We developed this 96 page guide to teach you every modern website traffic trick you need to know in %(currentYear)s and beyond.',
 					{
-						args: { currentYear: moment().format( 'YYYY' ) },
+						args: { currentYear: new Date().getFullYear() },
 					}
 				) }
 			</p>

--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -15,6 +15,7 @@ import {
 	isProductsListFetching,
 } from 'calypso/state/products-list/selectors';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { isFetchingUserPurchases, getUserPurchases } from 'calypso/state/purchases/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -86,6 +87,7 @@ const SalesPage = ( { translate } ) => {
 	const isLoading = useSelector( ( state ) => isProductsListFetching( state ) );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+	const moment = useLocalizedMoment();
 
 	const defaultVariation = () => (
 		<>
@@ -97,7 +99,10 @@ const SalesPage = ( { translate } ) => {
 			</h2>
 			<p>
 				{ translate(
-					'We developed this 96 page guide to teach you every modern website traffic trick you need to know in 2020 and beyond.'
+					'We developed this 96 page guide to teach you every modern website traffic trick you need to know in %(currentYear)s and beyond.',
+					{
+						args: { currentYear: moment().format( 'YYYY' ) },
+					}
 				) }
 			</p>
 			<p>

--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -19,6 +19,7 @@ import { getUserPurchases } from 'calypso/state/purchases/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 /**
  * Style dependencies
@@ -26,6 +27,39 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 const WPCOM_TRAFFIC_GUIDE = 'traffic-guide';
+
+export default function UltimateTrafficGuide() {
+	const translate = useTranslate();
+	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const purchases = useSelector( ( state ) => getUserPurchases( state, userId ) );
+	const [ hasPurchase, setHasPurchase ] = useState( false );
+	useEffect( () => {
+		if (
+			purchases &&
+			purchases.find( ( purchase ) => WPCOM_TRAFFIC_GUIDE === purchase.productSlug )
+		) {
+			setHasPurchase( true );
+		}
+	}, [ purchases, setHasPurchase ] );
+
+	const renderPlaceholders = () =>
+		[ ...Array( 5 ) ].map( ( e, i ) => <Placeholder key={ `${ i }` } /> );
+
+	const renderContent = () => {
+		return hasPurchase ? (
+			<DownloadPage translate={ translate } />
+		) : (
+			<SalesPage translate={ translate } />
+		);
+	};
+
+	return (
+		<CompactCard className="ultimate-traffic-guide">
+			{ ! purchases && <QueryUserPurchases userId={ userId } /> }
+			{ ! purchases ? renderPlaceholders() : renderContent() }
+		</CompactCard>
+	);
+}
 
 const Placeholder = () => (
 	<div className="ultimate-traffic-guide__placeholder">
@@ -39,7 +73,7 @@ const SalesPage = ( { translate } ) => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
-	return (
+	const defaultVariation = () => (
 		<>
 			<h1 className="ultimate-traffic-guide__header">
 				{ translate( 'Introducing the WordPress.com Ultimate Traffic Guide' ) }
@@ -120,7 +154,82 @@ const SalesPage = ( { translate } ) => {
 					</strong>
 				</p>
 			) }
+		</>
+	);
 
+	// const treatmentVariation = () => (
+	// 	<>
+	// 		<h1 className="ultimate-traffic-guide__header">
+	// 			{ translate(
+	// 				'Discover the most important traffic secrets used by our most successful customers'
+	// 			) }
+	// 		</h1>
+	// 		<h2 className="ultimate-traffic-guide__sub-header">
+	// 			{ translate( 'Claim your copy of the Ultimate Traffic Guide today' ) }
+	// 		</h2>
+	// 		<p>
+	// 			{ translate(
+	// 				'Do you want more traffic to your website?' +
+	// 					' Of course you do, who builds a website and doesn’t want traffic?' +
+	// 					' You’ve time building your website and you’ve just realized that “if you build it, they will come” does not always apply.'
+	// 			) }
+	// 		</p>
+	// 		<p>
+	// 			{ translate(
+	// 				'Our marketing team developed The Ultimate Traffic Guide to help WordPress.com users learn some of the same tactics and strategies our most successful customers use to build their audiences. ' +
+	// 					'This easy-to-follow and beginner-friendly guide reveals today’s best strategies and tactics for attracting more visitors.'
+	// 			) }
+	// 		</p>
+	// 		<p>
+	// 			{ translate( 'Here are just some of the topics we cover in The Ultimate Traffic Guide:' ) }
+	// 		</p>
+	// 		<ul>
+	// 			<li>
+	// 				{ translate(
+	// 					'{{b}}Use Your Traffic to Build Even More Traffic{{/b}} The Ultimate Traffic Guide covers how to use your own site stats to further increase your traffic, keep visitors on your site longer, and convert traffic into qualified leads.',
+	// 					{
+	// 						components: { b: <b /> },
+	// 					}
+	// 				) }
+	// 			</li>
+	// 			<li>
+	// 				{ translate(
+	// 					'{{b}}Leverage Social Media to Expand Your Reach{{/b}} Know where your ideal audience spends time and learn how to leverage those social channels to increase traffic.',
+	// 					{
+	// 						components: { b: <b /> },
+	// 					}
+	// 				) }
+	// 			</li>
+	// 			<li>
+	// 				{ translate(
+	// 					'{{b}}Keeping the Engagement Going{{/b}} we’ll share how to choose the right newsletter service, write compelling content, build your list, and monitor key performance indicators to manage the critical ongoing relationship with your site visitors.',
+	// 					{
+	// 						components: { b: <b /> },
+	// 					}
+	// 				) }
+	// 			</li>
+	// 		</ul>
+	// 		<p>
+	// 			{ translate(
+	// 				'You’re going to want to print out all 96 pages of the Ultimate Traffic Guide and keep it by your desk, because you’re going to consult this guide often.'
+	// 			) }
+	// 		</p>
+	// 		<p>
+	// 			{ translate(
+	// 				'TODO: Similar resources are valued up to $100, but this amazing resource is available to our users at $X. But for a limited time we’re offering the Ultimate Traffic Guide to you for just $4.95.'
+	// 			) }
+	// 		</p>
+	// 	</>
+	// );
+
+	return (
+		<>
+			<PageViewTracker
+				path={ '/marketing/ultimate-traffic-guide' }
+				title={ 'Ultimate Traffic Guide' }
+			/>
+			{ defaultVariation() }
+			{ /* { treatmentVariation() } */ }
 			<p>
 				<Button href={ `/checkout/${ siteSlug }/${ WPCOM_TRAFFIC_GUIDE }` } primary>
 					{ translate( 'Click here to buy the guide now!' ) }
@@ -145,7 +254,12 @@ const DownloadPage = ( { translate } ) => {
 			</p>
 			<p>
 				{ translate(
-					'The Ultimate Traffic GuideThis is a goldmine of traffic tips and how-tos that reveals the exact “Breakthrough Traffic” process we’ve developed over the past decade.'
+					'{{i}}The Ultimate Traffic Guide{{/i}} is a goldmine of traffic tips and how-tos that reveals the exact “Breakthrough Traffic” process we’ve developed over the past decade.',
+					{
+						components: {
+							i: <i />,
+						},
+					}
 				) }
 			</p>
 			<p>
@@ -161,36 +275,3 @@ const DownloadPage = ( { translate } ) => {
 		</>
 	);
 };
-
-export default function UltimateTrafficGuide() {
-	const translate = useTranslate();
-	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
-	const purchases = useSelector( ( state ) => getUserPurchases( state, userId ) );
-	const [ hasPurchase, setHasPurchase ] = useState( false );
-	useEffect( () => {
-		if (
-			purchases &&
-			purchases.find( ( purchase ) => WPCOM_TRAFFIC_GUIDE === purchase.productSlug )
-		) {
-			setHasPurchase( true );
-		}
-	}, [ purchases, setHasPurchase ] );
-
-	const renderPlaceholders = () =>
-		[ ...Array( 5 ) ].map( ( e, i ) => <Placeholder key={ `${ i }` } /> );
-
-	const renderContent = () => {
-		return hasPurchase ? (
-			<DownloadPage translate={ translate } />
-		) : (
-			<SalesPage translate={ translate } />
-		);
-	};
-
-	return (
-		<CompactCard className="ultimate-traffic-guide">
-			{ ! purchases && <QueryUserPurchases userId={ userId } /> }
-			{ ! purchases ? renderPlaceholders() : renderContent() }
-		</CompactCard>
-	);
-}

--- a/client/my-sites/marketing/ultimate-traffic-guide/style.scss
+++ b/client/my-sites/marketing/ultimate-traffic-guide/style.scss
@@ -1,0 +1,19 @@
+.ultimate-traffic-guide {
+	h1 {
+		font-size: $font-title-large;
+	}
+
+	h2 {
+		font-size: $font-title-medium;
+		margin-bottom: 1em;
+	}
+	.ultimate-traffic-guide__placeholder {
+		margin-bottom: 1.5em;
+		.ultimate-traffic-guide__placeholder-animation {
+			animation: pulse-light 1.6s ease-in-out infinite;
+			background-color: var( --color-neutral-10 );
+			color: transparent;
+			min-height: $font-title-small;
+		}
+	}
+}

--- a/client/my-sites/marketing/ultimate-traffic-guide/style.scss
+++ b/client/my-sites/marketing/ultimate-traffic-guide/style.scss
@@ -7,13 +7,38 @@
 		font-size: $font-title-medium;
 		margin-bottom: 1em;
 	}
-	.ultimate-traffic-guide__placeholder {
+	&__placeholder {
 		margin-bottom: 1.5em;
-		.ultimate-traffic-guide__placeholder-animation {
+		&__placeholder-animation {
 			animation: pulse-light 1.6s ease-in-out infinite;
 			background-color: var( --color-neutral-10 );
 			color: transparent;
 			min-height: $font-title-small;
+		}
+	}
+
+	&__header {
+		font-size: $font-title-medium;
+		text-align: center;
+		font-weight: 600;
+		line-height: 1.4;
+		margin-top: 0.5em;
+		margin-bottom: 1.4em;
+
+		@include breakpoint-deprecated( '<660px' ) {
+			font-size: $font-title-small;
+		}
+	}
+
+	&__sub-header {
+		font-size: $font-title-small;
+		font-weight: 600;
+		line-height: 1.4;
+		margin-top: 0.5em;
+		margin-bottom: 1.4em;
+
+		@include breakpoint-deprecated( '<660px' ) {
+			font-size: $font-title-small;
 		}
 	}
 }

--- a/client/my-sites/marketing/ultimate-traffic-guide/style.scss
+++ b/client/my-sites/marketing/ultimate-traffic-guide/style.scss
@@ -9,7 +9,7 @@
 	}
 	&__placeholder {
 		margin-bottom: 1.5em;
-		&__placeholder-animation {
+		&-animation {
 			animation: pulse-light 1.6s ease-in-out infinite;
 			background-color: var( --color-neutral-10 );
 			color: transparent;

--- a/client/state/purchases/selectors/get-user-purchases.js
+++ b/client/state/purchases/selectors/get-user-purchases.js
@@ -10,7 +10,7 @@ import 'calypso/state/purchases/init';
  *
  * @param   {object} state       global state
  * @param   {number} userId      the user id
- * @returns {object} the matching purchases if there are some
+ * @returns {Array.<object>} the matching purchases if there are some
  */
 export const getUserPurchases = ( state, userId ) =>
 	state.purchases.hasLoadedUserPurchasesFromServer &&


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Adds a new card to the Marketing Tools tab
* Clicking on the CTA in the card should navigate to the sales page for the Ultimate Traffic Guide

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Marketing tools card
* Go to My Site -> Tools -> Marketing
* Confirm that the card is visible only if the locale is English.
![image](https://user-images.githubusercontent.com/5436027/102484305-0fd2bb80-408c-11eb-9d20-217d044dbde0.png)
* If the user has purchased the traffic guide, the CTA should be "Download now". If not, it should be "Learn more".

### Sales page
* Click on the CTA on the Marketing tools card.
* Ensure that the sales page renders correctly and the copy is correct.
![screenshot](https://d.pr/i/jOxhOq+) **Image Link:** https://d.pr/i/jOxhOq
* Switch to `treatment` for the `traffic_guide_copy_test` experiment. The alternate copy should be shown. ~(**This is currently broken**)~ (works now)

### Checkout
* Clicking on the CTA should lead to the checkout page with the product added in cart
![screenshot](https://d.pr/i/S5o3ta+) **Image Link:** https://d.pr/i/S5o3ta
* Once the purchase is complete, it should show a thank you page with a link to download
![screenshot](https://d.pr/i/Ognmt4+) **Image Link:** https://d.pr/i/Ognmt4
* Clicking on the download CTA should download the file.

### Download Page
* Accessing the Traffic Guide page through the card should now show a Download page instead of the Sales page
![screenshot](https://d.pr/i/0ZR8sv+) **Image Link:** https://d.pr/i/0ZR8sv
* Clicking on the download CTA should download the file.

* The purchase is per-user, so this behaviour should remain consistent irrespective of the site chosen.