### PR TITLE
[Webpack 5]: Use webpack resolution algorithm to resolve aliases

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -226,6 +226,7 @@
 		"autoprefixer": "^9.7.3",
 		"component-event": "^0.1.4",
 		"component-query": "^0.0.3",
+		"pkg-dir": "^5.0.0",
 		"postcss-custom-properties": "^9.1.1"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13252,7 +13252,7 @@ find-up@4.1.0, find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-find-up@5.0.0:
+find-up@5.0.0, find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
@@ -21426,6 +21426,13 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-dir@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
+  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
+  dependencies:
+    find-up "^5.0.0"
 
 pkg-up@3.1.0, pkg-up@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
The original code uses `require.resolve` to resolve an alias. This uses node's resolution algorithm, which finds the package, reads `package.json` and returns the file listed in `main`, which is usually a CJS module.

This PR changes it to use webpack's resolution algorithm. The main difference is that it uses the file indicated in `module`, which is a ESM module. This should result in a slightly smaller bundle and slightly faster compilation.

The previous behaviour breaks the transition to Webpack 5.

#### Testing instructions

* Smoke test the live branch.
