### PR TITLE
Revert "Editor Deprecation: Consolidate the editor URL selectors"

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -28,7 +28,7 @@ import { clearLastNonEditorRoute, setRoute } from 'calypso/state/route/actions';
 import { updateSiteFrontPage } from 'calypso/state/sites/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPostTypeTrashUrl from 'calypso/state/selectors/get-post-type-trash-url';
-import getEditorUrl from 'calypso/state/selectors/get-editor-url';
+import getGutenbergEditorUrl from 'calypso/state/selectors/get-gutenberg-editor-url';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import getEditorCloseConfig from 'calypso/state/selectors/get-editor-close-config';
 import wpcom from 'calypso/lib/wp';
@@ -850,7 +850,7 @@ const mapStateToProps = (
 		customizerUrl: getCustomizerUrl( state, siteId ),
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 		getTemplateEditorUrl: partial(
-			getEditorUrl,
+			getGutenbergEditorUrl,
 			state,
 			siteId,
 			partial.placeholder,

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -11,7 +11,7 @@ import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible
 import { EDITOR_START, POST_EDIT } from 'calypso/state/action-types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoifyIframe from './calypsoify-iframe';
-import getEditorUrl from 'calypso/state/selectors/get-editor-url';
+import getGutenbergEditorUrl from 'calypso/state/selectors/get-gutenberg-editor-url';
 import { addQueryArgs } from 'calypso/lib/route';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import { requestSelectedEditor } from 'calypso/state/selected-editor/actions';
@@ -184,7 +184,7 @@ export const redirect = async ( context, next ) => {
 
 		const url =
 			postType || ! isSiteUsingCoreSiteEditor( state, siteId )
-				? getEditorUrl( state, siteId, postId, postType )
+				? getGutenbergEditorUrl( state, siteId, postId, postType )
 				: getSiteEditorUrl( state, siteId );
 		// pass along parameters, for example press-this
 		return window.location.replace( addQueryArgs( context.query, url ) );

--- a/client/state/selectors/get-editor-close-config.js
+++ b/client/state/selectors/get-editor-close-config.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  */
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import getPostTypeAllPostsUrl from 'calypso/state/selectors/get-post-type-all-posts-url';
-import getEditorUrl from 'calypso/state/selectors/get-editor-url';
+import getGutenbergEditorUrl from 'calypso/state/selectors/get-gutenberg-editor-url';
 import getLastNonEditorRoute from 'calypso/state/selectors/get-last-non-editor-route';
 
 /**
@@ -28,7 +28,7 @@ export default function getEditorCloseConfig( state, siteId, postType, fseParent
 	if ( 'wp_template_part' === postType && fseParentPageId ) {
 		// Note: the label is handled correctly by the FSE plugin in this case.
 		return {
-			url: getEditorUrl( state, siteId, fseParentPageId, 'page' ),
+			url: getGutenbergEditorUrl( state, siteId, fseParentPageId, 'page' ),
 		};
 	}
 

--- a/client/state/selectors/get-editor-url.js
+++ b/client/state/selectors/get-editor-url.js
@@ -1,14 +1,15 @@
 /**
  * Internal dependencies
  */
-import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
-import { getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
-import { getEditorPath } from 'calypso/state/editor/selectors';
-import { addQueryArgs } from 'calypso/lib/route';
-import isVipSite from 'calypso/state/selectors/is-vip-site';
+import getGutenbergEditorUrl from 'calypso/state/selectors/get-gutenberg-editor-url';
+import isClassicEditorForced from 'calypso/state/selectors/is-classic-editor-forced';
+import isEligibleForGutenframe from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 
 export const getEditorUrl = ( state, siteId, postId = null, postType = 'post' ) => {
-	if ( ! isEligibleForGutenframe( state, siteId ) ) {
+	// isEligibleForGutenframe deals with the server side checks for classic editor plugin etc.
+	// isClassicEditerForced has the client side checks. We should combine these!
+	if ( ! isEligibleForGutenframe( state, siteId ) || isClassicEditorForced( state, siteId ) ) {
 		const siteAdminUrl = getSiteAdminUrl( state, siteId );
 		let url = `${ siteAdminUrl }post-new.php?post_type=${ postType }`;
 
@@ -16,23 +17,10 @@ export const getEditorUrl = ( state, siteId, postId = null, postType = 'post' ) 
 			url = `${ siteAdminUrl }post.php?post=${ postId }&action=edit`;
 		}
 
-		if ( ! isVipSite( state, siteId ) ) {
-			url = addQueryArgs( { calypsoify: '1' }, url );
-		}
-
 		return url;
 	}
 
-	if ( postId ) {
-		return getEditorPath( state, siteId, postId, postType );
-	}
-
-	const siteSlug = getSiteSlug( state, siteId );
-
-	if ( 'post' === postType || 'page' === postType ) {
-		return `/${ postType }/${ siteSlug }`;
-	}
-	return `/edit/${ postType }/${ siteSlug }`;
+	return getGutenbergEditorUrl( state, siteId, postId, postType );
 };
 
 export default getEditorUrl;

--- a/client/state/selectors/get-gutenberg-editor-url.js
+++ b/client/state/selectors/get-gutenberg-editor-url.js
@@ -1,0 +1,38 @@
+/**
+ * Internal dependencies
+ */
+import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
+import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
+import { getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getEditorPath } from 'calypso/state/editor/selectors';
+import { addQueryArgs } from 'calypso/lib/route';
+
+export const getGutenbergEditorUrl = ( state, siteId, postId = null, postType = 'post' ) => {
+	if ( ! isEligibleForGutenframe( state, siteId ) ) {
+		const siteAdminUrl = getSiteAdminUrl( state, siteId );
+		let url = `${ siteAdminUrl }post-new.php?post_type=${ postType }`;
+
+		if ( postId ) {
+			url = `${ siteAdminUrl }post.php?post=${ postId }&action=edit`;
+		}
+
+		if ( 'gutenberg-redirect-and-style' === getSelectedEditor( state, siteId ) ) {
+			url = addQueryArgs( { calypsoify: '1' }, url );
+		}
+
+		return url;
+	}
+
+	if ( postId ) {
+		return getEditorPath( state, siteId, postId, postType );
+	}
+
+	const siteSlug = getSiteSlug( state, siteId );
+
+	if ( 'post' === postType || 'page' === postType ) {
+		return `/${ postType }/${ siteSlug }`;
+	}
+	return `/edit/${ postType }/${ siteSlug }`;
+};
+
+export default getGutenbergEditorUrl;

--- a/client/state/selectors/test/get-editor-close-config.js
+++ b/client/state/selectors/test/get-editor-close-config.js
@@ -3,7 +3,7 @@
  */
 import getEditorCloseConfig from 'calypso/state/selectors/get-editor-close-config';
 import getPostTypeAllPostsUrl from 'calypso/state/selectors/get-post-type-all-posts-url';
-import getEditorUrl from 'calypso/state/selectors/get-editor-url';
+import getGutenbergEditorUrl from 'calypso/state/selectors/get-gutenberg-editor-url';
 import PostQueryManager from 'calypso/lib/query-manager/post';
 
 const postType = 'post';
@@ -78,7 +78,7 @@ describe( 'getEditorCloseConfig()', () => {
 			ui: { selectedSiteId: siteId },
 		};
 
-		const parentPostEditorUrl = getEditorUrl( state, siteId, parentPostId, pagePostType );
+		const parentPostEditorUrl = getGutenbergEditorUrl( state, siteId, parentPostId, pagePostType );
 
 		expect( getEditorCloseConfig( state, siteId, templatePostType, parentPostId ).url ).toEqual(
 			parentPostEditorUrl


### PR DESCRIPTION
Reverts Automattic/wp-calypso#47344

After merging, I discovered this effectively reverses the fix in #47925 for disabling Calypsoify on Jetpack sites >=9.2-alpha