### PR TITLE
Plugins: Refactor from createReactClass to React.Component

### DIFF
--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -5,8 +5,6 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 
-import createReactClass from 'create-react-class';
-
 /**
  * Internal dependencies
  */
@@ -19,27 +17,25 @@ import { gaRecordEvent } from 'calypso/lib/analytics/ga';
  */
 import './style.scss';
 
-const PluginRatings = createReactClass( {
-	displayName: 'PluginRatings',
+const ratingTiers = [ 5, 4, 3, 2, 1 ];
 
-	propTypes: {
+class PluginRatings extends React.Component {
+	static propTypes = {
 		rating: PropTypes.number,
 		ratings: PropTypes.oneOfType( [ PropTypes.object, PropTypes.array ] ),
 		downloaded: PropTypes.number,
 		slug: PropTypes.string,
 		numRatings: PropTypes.number,
-	},
+	};
 
-	ratingTiers: [ 5, 4, 3, 2, 1 ],
-
-	getDefaultProps() {
-		return { barWidth: 88 };
-	},
+	static defaultProps = {
+		barWidth: 88,
+	};
 
 	buildReviewUrl( ratingTier ) {
 		const { slug } = this.props;
 		return `https://wordpress.org/support/plugin/${ slug }/reviews/?filter=${ ratingTier }`;
-	},
+	}
 
 	renderPlaceholder() {
 		return (
@@ -51,7 +47,7 @@ const PluginRatings = createReactClass( {
 				<div className="plugin-ratings__rating-text">{ this.props.translate( 'Based on' ) }</div>
 			</div>
 		);
-	},
+	}
 
 	renderRatingTier( ratingTier ) {
 		const { ratings, slug, numRatings } = this.props;
@@ -86,7 +82,7 @@ const PluginRatings = createReactClass( {
 				</span>
 			</a>
 		);
-	},
+	}
 
 	renderDownloaded() {
 		let downloaded = this.props.downloaded;
@@ -105,7 +101,7 @@ const PluginRatings = createReactClass( {
 				} ) }
 			</div>
 		);
-	},
+	}
 
 	render() {
 		const { placeholder, ratings, rating, numRatings } = this.props;
@@ -118,7 +114,7 @@ const PluginRatings = createReactClass( {
 			return null;
 		}
 
-		const tierViews = this.ratingTiers.map( ( tierLevel ) => this.renderRatingTier( tierLevel ) );
+		const tierViews = ratingTiers.map( ( tierLevel ) => this.renderRatingTier( tierLevel ) );
 		return (
 			<div className="plugin-ratings">
 				<div className="plugin-ratings__rating-stars">
@@ -138,7 +134,7 @@ const PluginRatings = createReactClass( {
 				{ this.renderDownloaded() }
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default localize( PluginRatings );

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -114,7 +114,7 @@ class PluginRatings extends React.Component {
 			return null;
 		}
 
-		const tierViews = ratingTiers.map( ( tierLevel ) => this.renderRatingTier( tierLevel ) );
+		const tierViews = ratingTiers.map( this.renderRatingTier );
 		return (
 			<div className="plugin-ratings">
 				<div className="plugin-ratings__rating-stars">

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -49,7 +49,7 @@ class PluginRatings extends React.Component {
 		);
 	}
 
-	renderRatingTier( ratingTier ) {
+	renderRatingTier = ( ratingTier ) => {
 		const { ratings, slug, numRatings } = this.props;
 		const numberOfRatings = ratings && ratings[ ratingTier ] ? ratings[ ratingTier ] : 0;
 		const onClickPluginRatingsLink = () => {
@@ -82,7 +82,7 @@ class PluginRatings extends React.Component {
 				</span>
 			</a>
 		);
-	}
+	};
 
 	renderDownloaded() {
 		let downloaded = this.props.downloaded;

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { includes, uniq } from 'lodash';
@@ -51,26 +50,24 @@ function goBack() {
 	window.history.back();
 }
 
-/* eslint-disable react/prefer-es6-class */
-const SinglePlugin = createReactClass( {
-	displayName: 'SinglePlugin',
-	_DEFAULT_PLUGINS_BASE_PATH: 'http://wordpress.org/plugins/',
+class SinglePlugin extends React.Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = this.getSitesPlugin();
+	}
 
 	UNSAFE_componentWillMount() {
 		if ( ! this.isFetched() ) {
 			this.props.wporgFetchPluginData( this.props.pluginSlug );
 		}
-	},
+	}
 
 	componentDidMount() {
 		PluginsStore.on( 'change', this.refreshSitesAndPlugins );
 		PluginsLog.on( 'change', this.refreshSitesAndPlugins );
 		this.hasAlreadyShownTheTour = false;
-	},
-
-	getInitialState() {
-		return this.getSitesPlugin();
-	},
+	}
 
 	componentWillUnmount() {
 		PluginsStore.removeListener( 'change', this.refreshSitesAndPlugins );
@@ -79,13 +76,13 @@ const SinglePlugin = createReactClass( {
 		if ( this.pluginRefreshTimeout ) {
 			clearTimeout( this.pluginRefreshTimeout );
 		}
-	},
+	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		this.refreshSitesAndPlugins( nextProps );
-	},
+	}
 
-	getSitesPlugin( nextProps ) {
+	getSitesPlugin = ( nextProps ) => {
 		const props = nextProps || this.props;
 
 		const sites = uniq( props.sites );
@@ -107,11 +104,11 @@ const SinglePlugin = createReactClass( {
 			notInstalledSites,
 			plugin,
 		};
-	},
+	};
 
-	refreshSitesAndPlugins( nextProps ) {
+	refreshSitesAndPlugins = ( nextProps ) => {
 		this.setState( this.getSitesPlugin( nextProps ) );
-	},
+	};
 
 	getPageTitle() {
 		const plugin = this.getPlugin();
@@ -120,11 +117,11 @@ const SinglePlugin = createReactClass( {
 			textOnly: true,
 			context: 'Page title: Plugin detail',
 		} );
-	},
+	}
 
 	recordEvent( eventAction ) {
 		this.props.recordGoogleEvent( 'Plugins', eventAction, 'Plugin Name', this.props.pluginSlug );
-	},
+	}
 
 	getPreviousListUrl() {
 		const splitPluginUrl = this.props.prevPath.split( '/' + this.props.pluginSlug + '/' );
@@ -140,7 +137,7 @@ const SinglePlugin = createReactClass( {
 			( this.props.siteUrl || '' ) +
 			( this.props.prevQuerystring ? '?' + this.props.prevQuerystring : '' )
 		);
-	},
+	}
 
 	backHref( shouldUseHistoryBack ) {
 		const { prevPath, siteUrl } = this.props;
@@ -148,7 +145,7 @@ const SinglePlugin = createReactClass( {
 			return this.getPreviousListUrl();
 		}
 		return ! shouldUseHistoryBack ? '/plugins/manage/' + ( siteUrl || '' ) : null;
-	},
+	}
 
 	displayHeader( calypsoify ) {
 		if ( ! this.props.selectedSite || calypsoify ) {
@@ -166,7 +163,7 @@ const SinglePlugin = createReactClass( {
 				onClick={ shouldUseHistoryBack ? goBack : undefined }
 			/>
 		);
-	},
+	}
 
 	pluginExists( plugin ) {
 		if ( this.isFetching() ) {
@@ -187,20 +184,20 @@ const SinglePlugin = createReactClass( {
 		}
 
 		return false;
-	},
+	}
 
 	isFetching() {
 		return this.props.wporgFetching;
-	},
+	}
 
 	isFetched() {
 		return this.props.wporgFetched;
-	},
+	}
 
 	getPlugin() {
 		// assign it .org details
 		return { ...this.state.plugin, ...this.props.wporgPlugin };
-	},
+	}
 
 	getPluginDoesNotExistView( selectedSite ) {
 		const { translate } = this.props;
@@ -218,7 +215,7 @@ const SinglePlugin = createReactClass( {
 				/>
 			</MainComponent>
 		);
-	},
+	}
 
 	getAllowedPluginActions( plugin ) {
 		const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
@@ -230,7 +227,7 @@ const SinglePlugin = createReactClass( {
 			activation: ! hiddenForAutomatedTransfer,
 			remove: ! hiddenForAutomatedTransfer,
 		};
-	},
+	}
 
 	isPluginInstalledOnsite() {
 		if ( this.props.requestingPluginsForSites ) {
@@ -238,7 +235,7 @@ const SinglePlugin = createReactClass( {
 		}
 
 		return !! PluginsStore.getSitePlugin( this.props.selectedSite, this.state.plugin.slug );
-	},
+	}
 
 	renderSitesList( plugin ) {
 		if ( this.props.siteUrl || this.isFetching() ) {
@@ -269,7 +266,7 @@ const SinglePlugin = createReactClass( {
 				) }
 			</div>
 		);
-	},
+	}
 
 	renderPluginPlaceholder() {
 		const { selectedSite } = this.props;
@@ -290,7 +287,7 @@ const SinglePlugin = createReactClass( {
 				</div>
 			</MainComponent>
 		);
-	},
+	}
 
 	render() {
 		const { pluginSlug, selectedSite } = this.props;
@@ -346,8 +343,8 @@ const SinglePlugin = createReactClass( {
 				</div>
 			</MainComponent>
 		);
-	},
-} );
+	}
+}
 
 export default connect(
 	( state, props ) => {

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -119,9 +119,9 @@ class SinglePlugin extends React.Component {
 		} );
 	}
 
-	recordEvent( eventAction ) {
+	recordEvent = ( eventAction ) => {
 		this.props.recordGoogleEvent( 'Plugins', eventAction, 'Plugin Name', this.props.pluginSlug );
-	}
+	};
 
 	getPreviousListUrl() {
 		const splitPluginUrl = this.props.prevPath.split( '/' + this.props.pluginSlug + '/' );
@@ -139,13 +139,13 @@ class SinglePlugin extends React.Component {
 		);
 	}
 
-	backHref( shouldUseHistoryBack ) {
+	backHref = ( shouldUseHistoryBack ) => {
 		const { prevPath, siteUrl } = this.props;
 		if ( prevPath ) {
 			return this.getPreviousListUrl();
 		}
 		return ! shouldUseHistoryBack ? '/plugins/manage/' + ( siteUrl || '' ) : null;
-	}
+	};
 
 	displayHeader( calypsoify ) {
 		if ( ! this.props.selectedSite || calypsoify ) {

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -111,9 +111,9 @@ export class PluginsList extends React.Component {
 		selectedPlugins: {},
 	};
 
-	isSelected( { slug } ) {
+	isSelected = ( { slug } ) => {
 		return !! this.state.selectedPlugins[ slug ];
-	}
+	};
 
 	togglePlugin = ( plugin ) => {
 		const { slug } = plugin;
@@ -134,7 +134,7 @@ export class PluginsList extends React.Component {
 		return canAutoupdate || canActivate;
 	}
 
-	setBulkSelectionState( plugins, selectionState ) {
+	setBulkSelectionState = ( plugins, selectionState ) => {
 		const slugsToBeUpdated = reduce(
 			plugins,
 			( slugs, plugin ) => {
@@ -147,7 +147,7 @@ export class PluginsList extends React.Component {
 		this.setState( {
 			selectedPlugins: Object.assign( {}, this.state.selectedPlugins, slugsToBeUpdated ),
 		} );
-	}
+	};
 
 	getPluginBySlug( slug ) {
 		const { plugins } = this.props;
@@ -203,7 +203,7 @@ export class PluginsList extends React.Component {
 	}
 
 	// Actions
-	toggleBulkManagement() {
+	toggleBulkManagement = () => {
 		const activateBulkManagement = ! this.state.bulkManagementActive;
 
 		if ( activateBulkManagement ) {
@@ -215,7 +215,7 @@ export class PluginsList extends React.Component {
 			this.removePluginStatuses();
 			this.recordEvent( 'Clicked Manage Done' );
 		}
-	}
+	};
 
 	removePluginStatuses() {
 		this.props.removePluginStatuses( 'completed', 'error' );
@@ -245,30 +245,30 @@ export class PluginsList extends React.Component {
 		);
 	}
 
-	updateAllPlugins() {
+	updateAllPlugins = () => {
 		this.removePluginStatuses();
 		this.props.plugins.forEach( ( plugin ) => {
 			plugin.sites.forEach( ( site ) => this.props.updatePlugin( site.ID, site.plugin ) );
 		} );
 		this.recordEvent( 'Clicked Update all Plugins', true );
-	}
+	};
 
-	updateSelected() {
+	updateSelected = () => {
 		this.doActionOverSelected( 'updating', this.props.updatePlugin, true );
 		this.recordEvent( 'Clicked Update Plugin(s)', true );
-	}
+	};
 
-	activateSelected() {
+	activateSelected = () => {
 		this.doActionOverSelected( 'activating', this.props.activatePlugin, true );
 		this.recordEvent( 'Clicked Activate Plugin(s)', true );
-	}
+	};
 
-	deactivateSelected() {
+	deactivateSelected = () => {
 		this.doActionOverSelected( 'deactivating', this.props.deactivatePlugin, true );
 		this.recordEvent( 'Clicked Deactivate Plugin(s)', true );
-	}
+	};
 
-	deactiveAndDisconnectSelected() {
+	deactiveAndDisconnectSelected = () => {
 		let waitForDeactivate = false;
 
 		this.doActionOverSelected(
@@ -285,17 +285,17 @@ export class PluginsList extends React.Component {
 		}
 
 		this.recordEvent( 'Clicked Deactivate Plugin(s) and Disconnect Jetpack', true );
-	}
+	};
 
-	setAutoupdateSelected() {
+	setAutoupdateSelected = () => {
 		this.doActionOverSelected( 'enablingAutoupdates', this.props.enableAutoupdatePlugin, true );
 		this.recordEvent( 'Clicked Enable Autoupdate Plugin(s)', true );
-	}
+	};
 
-	unsetAutoupdateSelected() {
+	unsetAutoupdateSelected = () => {
 		this.doActionOverSelected( 'disablingAutoupdates', this.props.disableAutoupdatePlugin, true );
 		this.recordEvent( 'Clicked Disable Autoupdate Plugin(s)', true );
-	}
+	};
 
 	getConfirmationText() {
 		const pluginsList = {};
@@ -390,7 +390,7 @@ export class PluginsList extends React.Component {
 		}
 	}
 
-	removePluginDialog() {
+	removePluginDialog = () => {
 		const { translate } = this.props;
 
 		const message = (
@@ -405,14 +405,14 @@ export class PluginsList extends React.Component {
 			this.removeSelected,
 			translate( 'Remove', { context: 'Verb. Presented to user as a label for a button.' } )
 		);
-	}
+	};
 
-	removeSelected( accepted ) {
+	removeSelected = ( accepted ) => {
 		if ( accepted ) {
 			this.doActionOverSelected( 'removing', this.props.removePlugin, true );
 			this.recordEvent( 'Clicked Remove Plugin(s)', true );
 		}
-	}
+	};
 
 	maybeShowDisconnectNotice() {
 		const { translate } = this.props;

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -53,11 +52,8 @@ function checkPropsChange( nextProps, propArr ) {
 	return false;
 }
 
-// eslint-disable-next-line react/prefer-es6-class
-export const PluginsList = createReactClass( {
-	displayName: 'PluginsList',
-
-	propTypes: {
+export class PluginsList extends React.Component {
+	static propTypes = {
 		plugins: PropTypes.arrayOf(
 			PropTypes.shape( {
 				sites: PropTypes.array,
@@ -70,13 +66,11 @@ export const PluginsList = createReactClass( {
 		selectedSiteSlug: PropTypes.string,
 		pluginUpdateCount: PropTypes.number,
 		isPlaceholder: PropTypes.bool.isRequired,
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			recordGoogleEvent: () => {},
-		};
-	},
+	static defaultProps = {
+		recordGoogleEvent: () => {},
+	};
 
 	shouldComponentUpdate( nextProps, nextState ) {
 		const propsToCheck = [ 'plugins', 'sites', 'selectedSite', 'pluginUpdateCount' ];
@@ -105,25 +99,23 @@ export const PluginsList = createReactClass( {
 		}
 
 		return false;
-	},
+	}
 
 	componentDidUpdate() {
 		this.maybeShowDisconnectNotice();
-	},
+	}
 
-	getInitialState() {
-		return {
-			disconnectJetpackNotice: false,
-			bulkManagementActive: false,
-			selectedPlugins: {},
-		};
-	},
+	state = {
+		disconnectJetpackNotice: false,
+		bulkManagementActive: false,
+		selectedPlugins: {},
+	};
 
 	isSelected( { slug } ) {
 		return !! this.state.selectedPlugins[ slug ];
-	},
+	}
 
-	togglePlugin( plugin ) {
+	togglePlugin = ( plugin ) => {
 		const { slug } = plugin;
 		const { selectedPlugins } = this.state;
 		const oldValue = selectedPlugins[ slug ];
@@ -133,14 +125,14 @@ export const PluginsList = createReactClass( {
 			selectedPlugins: Object.assign( {}, selectedPlugins, { [ slug ]: ! oldValue } ),
 		} );
 		this.props.recordGoogleEvent( 'Plugins', eventAction, 'Plugin Name', slug );
-	},
+	};
 
 	canBulkSelect( plugin ) {
 		const { autoupdate: canAutoupdate, activation: canActivate } = this.getAllowedPluginActions(
 			plugin
 		);
 		return canAutoupdate || canActivate;
-	},
+	}
 
 	setBulkSelectionState( plugins, selectionState ) {
 		const slugsToBeUpdated = reduce(
@@ -155,14 +147,14 @@ export const PluginsList = createReactClass( {
 		this.setState( {
 			selectedPlugins: Object.assign( {}, this.state.selectedPlugins, slugsToBeUpdated ),
 		} );
-	},
+	}
 
 	getPluginBySlug( slug ) {
 		const { plugins } = this.props;
 		return find( plugins, ( plugin ) => plugin.slug === slug );
-	},
+	}
 
-	filterSelection: {
+	filterSelection = {
 		active( plugin ) {
 			if ( this.isSelected( plugin ) && plugin.slug !== 'jetpack' ) {
 				return plugin.sites.some( ( site ) => site.plugin && site.plugin.active );
@@ -190,15 +182,15 @@ export const PluginsList = createReactClass( {
 		selected( plugin ) {
 			return this.isSelected( plugin );
 		},
-	},
+	};
 
 	getSelected() {
 		return this.props.plugins.filter( this.filterSelection.selected.bind( this ) );
-	},
+	}
 
 	siteSuffix() {
 		return this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '';
-	},
+	}
 
 	recordEvent( eventAction, includeSelectedPlugins ) {
 		eventAction += this.props.selectedSite ? '' : ' on Multisite';
@@ -208,7 +200,7 @@ export const PluginsList = createReactClass( {
 		} else {
 			this.props.recordGoogleEvent( 'Plugins', eventAction );
 		}
-	},
+	}
 
 	// Actions
 	toggleBulkManagement() {
@@ -223,11 +215,11 @@ export const PluginsList = createReactClass( {
 			this.removePluginStatuses();
 			this.recordEvent( 'Clicked Manage Done' );
 		}
-	},
+	}
 
 	removePluginStatuses() {
 		this.props.removePluginStatuses( 'completed', 'error' );
-	},
+	}
 
 	doActionOverSelected( actionName, action, siteIdOnly = false ) {
 		const isDeactivatingAndJetpackSelected = ( { slug } ) =>
@@ -245,13 +237,13 @@ export const PluginsList = createReactClass( {
 				const siteArg = siteIdOnly ? site.ID : site;
 				return action( siteArg, site.plugin );
 			} );
-	},
+	}
 
 	pluginHasUpdate( plugin ) {
 		return plugin.sites.some(
 			( site ) => site.plugin && site.plugin.update && site.canUpdateFiles
 		);
-	},
+	}
 
 	updateAllPlugins() {
 		this.removePluginStatuses();
@@ -259,22 +251,22 @@ export const PluginsList = createReactClass( {
 			plugin.sites.forEach( ( site ) => this.props.updatePlugin( site.ID, site.plugin ) );
 		} );
 		this.recordEvent( 'Clicked Update all Plugins', true );
-	},
+	}
 
 	updateSelected() {
 		this.doActionOverSelected( 'updating', this.props.updatePlugin, true );
 		this.recordEvent( 'Clicked Update Plugin(s)', true );
-	},
+	}
 
 	activateSelected() {
 		this.doActionOverSelected( 'activating', this.props.activatePlugin, true );
 		this.recordEvent( 'Clicked Activate Plugin(s)', true );
-	},
+	}
 
 	deactivateSelected() {
 		this.doActionOverSelected( 'deactivating', this.props.deactivatePlugin, true );
 		this.recordEvent( 'Clicked Deactivate Plugin(s)', true );
-	},
+	}
 
 	deactiveAndDisconnectSelected() {
 		let waitForDeactivate = false;
@@ -293,17 +285,17 @@ export const PluginsList = createReactClass( {
 		}
 
 		this.recordEvent( 'Clicked Deactivate Plugin(s) and Disconnect Jetpack', true );
-	},
+	}
 
 	setAutoupdateSelected() {
 		this.doActionOverSelected( 'enablingAutoupdates', this.props.enableAutoupdatePlugin, true );
 		this.recordEvent( 'Clicked Enable Autoupdate Plugin(s)', true );
-	},
+	}
 
 	unsetAutoupdateSelected() {
 		this.doActionOverSelected( 'disablingAutoupdates', this.props.disableAutoupdatePlugin, true );
 		this.recordEvent( 'Clicked Disable Autoupdate Plugin(s)', true );
-	},
+	}
 
 	getConfirmationText() {
 		const pluginsList = {};
@@ -396,7 +388,7 @@ export const PluginsList = createReactClass( {
 					}
 				);
 		}
-	},
+	}
 
 	removePluginDialog() {
 		const { translate } = this.props;
@@ -413,14 +405,14 @@ export const PluginsList = createReactClass( {
 			this.removeSelected,
 			translate( 'Remove', { context: 'Verb. Presented to user as a label for a button.' } )
 		);
-	},
+	}
 
 	removeSelected( accepted ) {
 		if ( accepted ) {
 			this.doActionOverSelected( 'removing', this.props.removePlugin, true );
 			this.recordEvent( 'Clicked Remove Plugin(s)', true );
 		}
-	},
+	}
 
 	maybeShowDisconnectNotice() {
 		const { translate } = this.props;
@@ -441,7 +433,7 @@ export const PluginsList = createReactClass( {
 				)
 			);
 		}
-	},
+	}
 
 	// Renders
 	render() {
@@ -501,7 +493,7 @@ export const PluginsList = createReactClass( {
 				</Card>
 			</div>
 		);
-	},
+	}
 
 	getAllowedPluginActions( plugin ) {
 		const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
@@ -512,16 +504,16 @@ export const PluginsList = createReactClass( {
 			autoupdate: ! hiddenForAutomatedTransfer,
 			activation: ! hiddenForAutomatedTransfer,
 		};
-	},
+	}
 
 	orderPluginsByUpdates( plugins ) {
 		return sortBy( plugins, ( plugin ) => {
 			// Bring the plugins requiring updates to the front of the array
 			return this.pluginHasUpdate( plugin ) ? 0 : 1;
 		} );
-	},
+	}
 
-	renderPlugin( plugin ) {
+	renderPlugin = ( plugin ) => {
 		const selectThisPlugin = this.togglePlugin.bind( this, plugin );
 		const allowedPluginActions = this.getAllowedPluginActions( plugin );
 		const isSelectable =
@@ -545,13 +537,13 @@ export const PluginsList = createReactClass( {
 				isAutoManaged={ ! allowedPluginActions.autoupdate }
 			/>
 		);
-	},
+	};
 
 	renderPlaceholders() {
 		const placeholderCount = 18;
 		return range( placeholderCount ).map( ( i ) => <PluginItem key={ 'placeholder-' + i } /> );
-	},
-} );
+	}
+}
 
 export default connect(
 	( state ) => {


### PR DESCRIPTION
This PR removes any usage of `createReactClass` in plugins. `createReactClass` being deprecated isn't the only reason; using React components contributes to making iterations and further reduxification and cleanups much easier.

Part of #24180.

#### Changes proposed in this Pull Request

Refactor from using `createReactClass` to using `React.Component`:

* `SinglePlugin`
* `PluginsList`
* `PluginRatings`

This PR should introduce no functional or behavioral changes.

#### Testing instructions

* Get a Jetpack site with some plugins for testing.
* Keep an eye at the console for errors - there should be none of them.
* Compare against production and verify that everything the same way when updating, installing, or removing plugins, as well as toggling auto-updates and activating/deactivating plugins:
  * `/plugins/:plugin/:site` also keep an eye on the plugin rating.
  * `/plugins/:plugin` - also keep an eye on the plugin rating.
  * `/plugins`
  * `/plugins/manage`
  * `/plugins/manage/:site` - for a single plugin
  * `/plugins/manage/:site` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
* Verify all tests still pass.