### PR TITLE
Update `@automattic/webpack-inline-constant-exports-plugin` to support Webpack 5

### DIFF
--- a/packages/webpack-inline-constant-exports-plugin/CHANGELOG.md
+++ b/packages/webpack-inline-constant-exports-plugin/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## 1.0.0 - 2020-12-09
+
+### Added
+
+- Updated peerDependency `webpack` to ^5.7.0
+
+### Breaking
+
+- Drop support for Webpack 4, this plugin works with Webpack 5 only.
+
+## 0.0.1 - 2019-06-03
+
+- Initial release

--- a/packages/webpack-inline-constant-exports-plugin/CHANGELOG.md
+++ b/packages/webpack-inline-constant-exports-plugin/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
-- Drop support for Webpack 4, this plugin works with Webpack 5 only.
+- Drop support for webpack 4, this plugin works with webpack 5 only.
 
 ## 0.0.1 - 2019-06-03
 

--- a/packages/webpack-inline-constant-exports-plugin/index.js
+++ b/packages/webpack-inline-constant-exports-plugin/index.js
@@ -152,7 +152,7 @@ class InlineConstantExportsPlugin {
 							 *
 							 * ---
 							 *
-							 * Webpack 5 keep tracks of re-exported dependencies:
+							 * webpack 5 keep tracks of re-exported dependencies:
 							 *   //const.js
 							 *   export const FOO=1;
 							 *

--- a/packages/webpack-inline-constant-exports-plugin/index.js
+++ b/packages/webpack-inline-constant-exports-plugin/index.js
@@ -9,9 +9,9 @@ function addConstantExport( module, name, value ) {
 	module.constantExports[ name ] = value;
 }
 
-function removeDependency( module, dep ) {
+function removeDependency( moduleGraph, module, dep ) {
 	module.removeDependency( dep );
-	dep.module.reasons = dep.module.reasons.filter( ( r ) => r.dependency !== dep );
+	moduleGraph.removeConnection( dep );
 }
 
 class InlineConstantExportsPlugin {
@@ -113,8 +113,9 @@ class InlineConstantExportsPlugin {
 						const usesConstantDependencies = new Map(); // Module -> Boolean
 						const importSpecifierDependencies = []; // [ ImportSpecifierDependency ]
 
-						for ( const dep of module.dependencies ) {
-							if ( ! this.isConstantsModule( dep.module ) ) {
+						for ( const dep of module.dependencies.values() ) {
+							const dependencyModule = compilation.moduleGraph.getModule( dep );
+							if ( ! this.isConstantsModule( dependencyModule ) ) {
 								continue;
 							}
 
@@ -125,11 +126,11 @@ class InlineConstantExportsPlugin {
 							 *
 							 * We track these dependencies per-module because if all the imported bindings
 							 * turn out to be constants and we inline them, we'll remove the import completely.
-							 * That means that we treat constant modules as side-effect fee, i.e., we can safely
+							 * That means that we treat constant modules as side-effect free, i.e., we can safely
 							 * remove the import.
 							 */
 							if ( dep instanceof HarmonyImportSideEffectDependency ) {
-								importSideEffectDependencies.set( dep.module, dep );
+								importSideEffectDependencies.set( dependencyModule, dep );
 							}
 
 							/*
@@ -148,9 +149,29 @@ class InlineConstantExportsPlugin {
 							 *
 							 * When inlining a constant, we remove the ImportSpecifierDependency and replace it
 							 * with a ConstDependency that inserts the inlined code verbatim.
+							 *
+							 * ---
+							 *
+							 * Webpack 5 keep tracks of re-exported dependencies:
+							 *   //const.js
+							 *   export const FOO=1;
+							 *
+							 *   //api.js
+							 *   export * as api from 'const';
+							 *
+							 *   //index.js
+							 *   import { api } from 'api';
+							 *   console.log( api.FOO );
+							 *
+							 * But this plugin does not support them. If a dependency has multiple IDs it means it is a
+							 * re-exported dep (eg: `api.FOO`), so we skip it.
 							 */
-							if ( dep instanceof HarmonyImportSpecifierDependency ) {
-								if ( dep.module.constantExports && dep.id in dep.module.constantExports ) {
+							if ( dep instanceof HarmonyImportSpecifierDependency && dep.ids.length === 1 ) {
+								const depId = dep.ids[ 0 ];
+								if (
+									dependencyModule.constantExports &&
+									depId in dependencyModule.constantExports
+								) {
 									// Mark the dependency for removal: we'll remove it after we're finished
 									// traversing the dependency graph.
 									importSpecifierDependencies.push( dep );
@@ -163,10 +184,10 @@ class InlineConstantExportsPlugin {
 									 * Then we need to expand the shorthand into `{ BLOGGER: __inline_value__ }`
 									 */
 									if ( dep.shorthand ) {
-										inlinedCode = `${ dep.name }: ${ dep.module.constantExports[ dep.id ] }`;
+										inlinedCode = `${ dep.name }: ${ dependencyModule.constantExports[ depId ] }`;
 									} else {
 										/* Every other usage is just inlined as is */
-										inlinedCode = dep.module.constantExports[ dep.id ];
+										inlinedCode = dependencyModule.constantExports[ depId ];
 									}
 									const inlineDep = new ConstDependency( '/* inline */ ' + inlinedCode, dep.range );
 									inlineDep.loc = dep.loc;
@@ -175,11 +196,11 @@ class InlineConstantExportsPlugin {
 									/* Remember the fact that we inlined some constant. We remove import statements
 									 * only for modules where we inlined at least something. The other modules we
 									 * leave as they are. */
-									usesConstantDependencies.set( dep.module, true );
+									usesConstantDependencies.set( dependencyModule, true );
 								} else {
 									/* This dependency was not a constant and cannot be inlined. Remember this fact
 									 * so that we don't remove the import statement for this module. */
-									usesNonConstantDependencies.set( dep.module, true );
+									usesNonConstantDependencies.set( dependencyModule, true );
 								}
 							}
 						}
@@ -190,13 +211,13 @@ class InlineConstantExportsPlugin {
 								usesConstantDependencies.get( depModule ) &&
 								! usesNonConstantDependencies.get( depModule )
 							) {
-								removeDependency( module, depImport );
+								removeDependency( compilation.moduleGraph, module, depImport );
 							}
 						}
 
 						/* Remove the ImportSpecifierDependencies that were replaced with ConstDependencies */
 						for ( const dep of importSpecifierDependencies ) {
-							removeDependency( module, dep );
+							removeDependency( compilation.moduleGraph, module, dep );
 						}
 					}
 				} );

--- a/packages/webpack-inline-constant-exports-plugin/package.json
+++ b/packages/webpack-inline-constant-exports-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/webpack-inline-constant-exports-plugin",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"author": "Automattic Inc.",
 	"description": "Webpack plugin to inline constant exports from modules",
 	"license": "GPL-2.0-or-later",
@@ -21,9 +21,10 @@
 	},
 	"scripts": {},
 	"peerDependencies": {
-		"webpack": "^4.44.2"
+		"webpack": "^5.7.0"
 	},
 	"devDependencies": {
-		"rimraf": "^3.0.0"
+		"rimraf": "^3.0.0",
+		"webpack": "^5.7.0"
 	}
 }

--- a/packages/webpack-inline-constant-exports-plugin/package.json
+++ b/packages/webpack-inline-constant-exports-plugin/package.json
@@ -5,7 +5,7 @@
 	"description": "Webpack plugin to inline constant exports from modules",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
-		"Webpack"
+		"webpack"
 	],
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/webpack-inline-constant-exports-plugin",
 	"publishConfig": {

--- a/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
@@ -1,16 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`webpack-inline-constant-exports-plugin should produce expected output: Output bundle should match snapshot 1`] = `
-"(window[\\"webpackJsonp\\"] = window[\\"webpackJsonp\\"] || []).push([[\\"main\\"],{
+"(window[\\"webpackChunk\\"] = window[\\"webpackChunk\\"] || []).push([[\\"main\\"],{
 
 /***/ \\"./index.js\\":
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
+/***/ (function() {
 
 \\"use strict\\";
-// ESM COMPAT FLAG
-__webpack_require__.r(__webpack_exports__);
 
-// CONCATENATED MODULE: ./plans.js
+;// CONCATENATED MODULE: ./plans.js
 /*
  * Export two plan constants and a a constant array of all plans. The array should not be inlined
  * and the module should stay in the dependency graph.
@@ -19,17 +17,25 @@ const BLOGGER = 'BLOGGER_PLAN';
 const PREMIUM = 'PREMIUM_PLAN';
 /* harmony default export */ var plans = ([ BLOGGER, PREMIUM ]);
 
-// CONCATENATED MODULE: ./paths.js
+;// CONCATENATED MODULE: ./paths.js
 /*
  * The export is eligible for inlining, but the module is not specified in the plugin config.
  * Therefore no inlining should happen.
  */
 const HOME_PATH = '/';
 
-// CONCATENATED MODULE: ./index.js
+;// CONCATENATED MODULE: ./constants2.js
+/*
+ * The export is eligible for inlining, but the module is not used directly but re-exported from \`./export.js\`.
+ * Re-exporting is not supported, therefore no inlining should happen.
+ */
+const FOO = 'bar';
+
+;// CONCATENATED MODULE: ./index.js
 /**
  * Internal dependencies
  */
+
 
 
 
@@ -40,9 +46,11 @@ console.log( /* inline */ 'PLANS_REQUEST', /* inline */ 'PLANS_RECEIVE' );
 console.log( /* inline */ 'BLOGGER_PLAN', /* inline */ 'PREMIUM_PLAN', plans );
 console.log( /* inline */ 42, /* inline */ 3.14159, /* inline */ true, /* inline */ false, /* inline */ null );
 console.log( HOME_PATH );
+console.log( FOO );
 
 
 /***/ })
 
-},[[\\"./index.js\\",\\"runtime~main\\"]]]);"
+},
+0,[[\\"./index.js\\",\\"runtime~main\\"]]]);"
 `;

--- a/packages/webpack-inline-constant-exports-plugin/test/fixtures/basic/constants2.js
+++ b/packages/webpack-inline-constant-exports-plugin/test/fixtures/basic/constants2.js
@@ -1,0 +1,5 @@
+/*
+ * The export is eligible for inlining, but the module is not used directly but re-exported from `./export.js`.
+ * Re-exporting is not supported, therefore no inlining should happen.
+ */
+export const FOO = 'bar';

--- a/packages/webpack-inline-constant-exports-plugin/test/fixtures/basic/export.js
+++ b/packages/webpack-inline-constant-exports-plugin/test/fixtures/basic/export.js
@@ -1,0 +1,4 @@
+/**
+ * Re-export constants is not supported, this file should not get inlined.
+ */
+export { FOO } from './constants2.js';

--- a/packages/webpack-inline-constant-exports-plugin/test/fixtures/basic/index.js
+++ b/packages/webpack-inline-constant-exports-plugin/test/fixtures/basic/index.js
@@ -5,9 +5,11 @@ import { PLANS_REQUEST, PLANS_RECEIVE } from './actions';
 import ALL_PLANS, { BLOGGER, PREMIUM } from './plans';
 import THE_ANSWER, { PI, YES, NO, NULL } from './constants';
 import { HOME_PATH } from './paths';
+import { FOO } from './export';
 
 /* eslint-disable no-console */
 console.log( PLANS_REQUEST, PLANS_RECEIVE );
 console.log( BLOGGER, PREMIUM, ALL_PLANS );
 console.log( THE_ANSWER, PI, YES, NO, NULL );
 console.log( HOME_PATH );
+console.log( FOO );

--- a/packages/webpack-inline-constant-exports-plugin/test/index.js
+++ b/packages/webpack-inline-constant-exports-plugin/test/index.js
@@ -35,12 +35,15 @@ describe( 'webpack-inline-constant-exports-plugin', () => {
 				},
 				output: {
 					path: outputDirectory,
+					globalObject: 'window',
 				},
 				plugins: [
 					new InlineConstantExportsPlugin( [
 						/\/actions\.js$/,
 						/\/plans\.js$/,
 						/\/constants\.js$/,
+						/\/constants2\.js$/,
+						/\/export\.js$/,
 					] ),
 				],
 			};

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,11 @@
     loose-envify "^1.4.0"
     react-lifecycles-compat "^3.0.4"
 
+"@automattic/webpack-inline-constant-exports-plugin@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@automattic/webpack-inline-constant-exports-plugin/-/webpack-inline-constant-exports-plugin-0.0.1.tgz#a6e3625ed5e2d3c5ef26ee1da9914fcdeda1e470"
+  integrity sha512-GblKlip1VR5Hj0pg6FtKRgEzOyY1hj6DgwsSB9cSvLikyEWBbxH8o1AGGVWYtQcZEqmoxnw4Lq6NeswuxA4N7w==
+
 "@babel/cli@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.12.1.tgz#e08a0b1cb6fcd4b9eb6a606ba5602c5c0fe24a0c"
@@ -3800,6 +3805,27 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
+"@types/eslint-scope@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"
+  integrity sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==
+  dependencies:
+    "@types/eslint" "*"
+    "@types/estree" "*"
+
+"@types/eslint@*":
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.6.tgz#5e9aff555a975596c03a98b59ecd103decc70c3c"
+  integrity sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
+"@types/estree@*", "@types/estree@^0.0.45":
+  version "0.0.45"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
+  integrity sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==
+
 "@types/fast-json-stable-stringify@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#40363bb847cb86b2c2e1599f1398d11e8329c921"
@@ -3900,7 +3926,7 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.14.tgz#37daaf78069e7948520474c87b80092ea912520a"
   integrity sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==
 
-"@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
+"@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
@@ -6335,6 +6361,11 @@ acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.0.4.tgz#7a3ae4191466a6984eee0fe3407a4f3aa9db8354"
+  integrity sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==
 
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
@@ -11698,6 +11729,14 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+enhanced-resolve@^5.3.1:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.4.0.tgz#a8bcf23b00affac9455cf71efd80844f4054f4dc"
+  integrity sha512-ZmqfWURB2lConOBM1JdCVfPyMRv5RdKWktLXO6123p97ovVm2CLBgw9t5MBj3jJWA6eHyOeIws9iJQoGFR4euQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.0.0"
+
 enquirer@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -12583,6 +12622,11 @@ events@^3.0.0, events@^3.1.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
   integrity sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==
 
+events@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
+  integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
+
 eventsource@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.0.7.tgz#8fbc72c93fcd34088090bc0a4e64f4b5cee6d8d0"
@@ -13252,7 +13296,7 @@ find-up@4.1.0, find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-find-up@5.0.0:
+find-up@5.0.0, find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
@@ -13994,6 +14038,11 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
+glob-to-regexp@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@7.1.6, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1, glob@~7.1.2:
   version "7.1.6"
@@ -17315,7 +17364,7 @@ jest-worker@^26.1.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest-worker@^26.2.1:
+jest-worker@^26.2.1, jest-worker@^26.6.1:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
   integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
@@ -18062,6 +18111,11 @@ loader-runner@^2.3.1, loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
+
+loader-runner@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.1.0.tgz#f70bc0c29edbabdf2043e7ee73ccc3fe1c96b42d"
+  integrity sha512-oR4lB4WvwFoC70ocraKhn5nkKSs23t57h9udUgw8o0iH8hMXeEoRuUgfcvgUwAJ1ZpRqBvcou4N2SMvM1DwMrA==
 
 loader-utils@1.2.3:
   version "1.2.3"
@@ -19689,6 +19743,11 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
+
+neo-async@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   version "2.1.0"
@@ -21426,6 +21485,13 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-dir@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
+  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
+  dependencies:
+    find-up "^5.0.0"
 
 pkg-up@3.1.0, pkg-up@^3.1.0:
   version "3.1.0"
@@ -26052,7 +26118,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.16, source-map-support@^0.5.19, source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.16, source-map-support@^0.5.19, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -26087,7 +26153,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3:
+source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -27069,6 +27135,11 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tapable@^2.0.0, tapable@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
+  integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
+
 tar-fs@^1.16.3:
   version "1.16.3"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.3.tgz#966a628841da2c4010406a82167cbd5e0c72d509"
@@ -27273,6 +27344,18 @@ terser-webpack-plugin@^4.2.2:
     terser "^5.3.2"
     webpack-sources "^1.4.3"
 
+terser-webpack-plugin@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz#ec60542db2421f45735c719d2e17dabfbb2e3e42"
+  integrity sha512-zFdGk8Lh9ZJGPxxPE6jwysOlATWB8GMW8HcfGULWA/nPal+3VdATflQvSBSLQJRCmYZnfFJl6vkRTiwJGNgPiQ==
+  dependencies:
+    jest-worker "^26.6.1"
+    p-limit "^3.0.2"
+    schema-utils "^3.0.0"
+    serialize-javascript "^5.0.1"
+    source-map "^0.6.1"
+    terser "^5.3.8"
+
 terser@^4.1.2, terser@^4.6.3, terser@^4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
@@ -27299,6 +27382,15 @@ terser@^5.3.2:
     commander "^2.20.0"
     source-map "~0.6.1"
     source-map-support "~0.5.12"
+
+terser@^5.3.8:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.5.1.tgz#540caa25139d6f496fdea056e414284886fb2289"
+  integrity sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
 
 test-exclude@^5.2.3:
   version "5.2.3"
@@ -28976,6 +29068,14 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
 
+watchpack@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.1.0.tgz#e63194736bf3aa22026f7b191cd57907b0f9f696"
+  integrity sha512-UjgD1mqjkG99+3lgG36at4wPnUXNvis2v1utwTgQ43C22c4LD71LsYMExdWXh4HZ+RmW+B0t1Vrg2GpXAkTOQw==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
@@ -29176,6 +29276,14 @@ webpack-sources@^2.0.1:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
 
+webpack-sources@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
+  integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
+
 webpack-virtual-modules@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.2.2.tgz#20863dc3cb6bb2104729fff951fbe14b18bd0299"
@@ -29211,6 +29319,36 @@ webpack@^4.42.0, webpack@^4.44.2, webpack@^4.8.3:
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
+
+webpack@^5.7.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.10.0.tgz#6f77c31522a2c525152d9c344f9765d168b3df08"
+  integrity sha512-P0bHAXmIz0zsNcHNLqFmLY1ZtrT+jtBr7FqpuDtA2o7GiHC+zBsfhgK7SmJ1HG7BAEb3G9JoMdSVi7mEDvG3Zg==
+  dependencies:
+    "@types/eslint-scope" "^3.7.0"
+    "@types/estree" "^0.0.45"
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-module-context" "1.9.0"
+    "@webassemblyjs/wasm-edit" "1.9.0"
+    "@webassemblyjs/wasm-parser" "1.9.0"
+    acorn "^8.0.4"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.3.1"
+    eslint-scope "^5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.4"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.1.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    pkg-dir "^5.0.0"
+    schema-utils "^3.0.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.0.3"
+    watchpack "^2.0.0"
+    webpack-sources "^2.1.1"
 
 websocket-driver@0.6.5:
   version "0.6.5"


### PR DESCRIPTION
Extracted from #47733.

This PR updates the plugin `@automattic/webpack-inline-constant-exports-plugin` to support Webpack 5. Once merge, it will be published as `@automattic/webpack-inline-constant-exports-plugin@1.0.0`.

Note: Calypso still uses `@automattic/webpack-inline-constant-exports-plugin@0.0.1`. So when doing `yarn install`, we'll have a plugin in `node_modules/@automattic/webpack-inline-constant-exports-plugin` (downloaded from the NPM registry) which **is not the same version** than the plugin in `packages/webpack-inline-constant-exports-plugin`

Once we are done with the Webpack 5 migration, Calypso will depend on `1.0.0` and we won't need to download it from the NPM registry.

Update: these changes seems to work in #47733, but of course we haven't tested it in prod yet. So before the final Calypso migration we may need to tweak this plugin. If so, depending on the size of the tweak, we can do it together with the final migration or release 1.0.1 in a separate PR.

#### Changes proposed in this Pull Request

* Adapt `@automattic/webpack-inline-constant-exports-plugin` to support Webpack 5 and drop support for Webpack 4.
* Prepare to release it as 1.0.0

#### Testing instructions

* Check unit tests pass.
