### PR TITLE
Pause the Launch-Site Domain Upsell Experiment

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -66,7 +66,7 @@ export default {
 		allowExistingUsers: false,
 	},
 	freePlansDomainUpsell: {
-		datestamp: '20201209',
+		datestamp: '20301209',
 		variations: {
 			test: 50,
 			control: 50,


### PR DESCRIPTION
A concern has been raised that the copy is not appropriate for our non-primary domain policy and some users may be misled that their site will work on that address and in reality, it will only work as a redirect

#### Changes proposed in this Pull Request

Pause the experiment while we resolve the issue

#### Testing instructions

1. Create a new site with an 'en' locale
2. Launch it. Make sure it's fine

