### PR TITLE
P2+: enable in production

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -319,7 +319,6 @@ export const FEATURE_P2_UNLIMITED_POSTS_PAGES = 'p2-unlimited-posts-pages';
 export const FEATURE_P2_SIMPLE_SEARCH = 'p2-simple-search';
 export const FEATURE_P2_CUSTOMIZATION_OPTIONS = 'p2-customization-options';
 export const FEATURE_P2_13GB_STORAGE = 'p2-13gb-storage';
-export const FEATURE_P2_UNLIMITED_FREE_VIEWERS = 'p2-unlimited-free-viewers';
 export const FEATURE_P2_ADVANCED_SEARCH = 'p2-advanced-search';
 export const FEATURE_P2_VIDEO_SHARING = 'p2-video-sharing';
 export const FEATURE_P2_MORE_FILE_TYPES = 'p2-more-file-types';

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1604,13 +1604,6 @@ export const FEATURES_LIST = {
 		getDescription: () => i18n.translate( 'Upload more files to your P2.' ),
 	},
 
-	[ constants.FEATURE_P2_UNLIMITED_FREE_VIEWERS ]: {
-		getSlug: () => constants.FEATURE_P2_UNLIMITED_FREE_VIEWERS,
-		getTitle: () => i18n.translate( 'Unlimited free viewers' ),
-		getDescription: () =>
-			i18n.translate( 'Viewers can read and comment posts, but can’t publish new ones.' ),
-	},
-
 	[ constants.FEATURE_P2_ADVANCED_SEARCH ]: {
 		getSlug: () => constants.FEATURE_P2_ADVANCED_SEARCH,
 		getTitle: () => i18n.translate( 'Advanced search' ),

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1637,7 +1637,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_P2_PRIORITY_CHAT_EMAIL_SUPPORT ]: {
 		getSlug: () => constants.FEATURE_P2_PRIORITY_CHAT_EMAIL_SUPPORT,
-		getTitle: () => i18n.translate( 'Priority chat and email support' ),
+		getTitle: () => i18n.translate( 'Priority customer support' ),
 		getDescription: () =>
 			i18n.translate(
 				'Live chat is available 24 hours a day from Monday through Friday. You can also email us any day of the week for personalized support.'

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -1535,7 +1535,6 @@ export const PLANS_LIST = {
 		getPlanCompareFeatures: () => [
 			// pay attention to ordering, shared features should align on /plan page
 			constants.FEATURE_P2_13GB_STORAGE,
-			constants.FEATURE_P2_UNLIMITED_FREE_VIEWERS,
 			constants.FEATURE_P2_ADVANCED_SEARCH,
 			constants.FEATURE_P2_VIDEO_SHARING,
 			constants.FEATURE_P2_MORE_FILE_TYPES,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -77,6 +77,7 @@
 		"me/notifications": true,
 		"nav-unification": false,
 		"oauth": true,
+		"p2/p2-plus": true,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -98,6 +98,7 @@
 		"me/notifications": true,
 		"nav-unification": false,
 		"network-connection": true,
+		"p2/p2-plus": true,
 		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -103,6 +103,7 @@
 		"nav-unification": false,
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,
+		"p2/p2-plus": true,
 		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -116,6 +116,7 @@
 		"network-connection": true,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
+		"p2/p2-plus": true,
 		"perfmon": true,
 		"plans/personal-plan": true,
 		"post-editor/checkout-overlay": true,


### PR DESCRIPTION
In this PR, we enable the P2+ paid plan in production!

## Testing

Code review. You can also test the P2+ itself by creating a new P2 site from https://wordpress.com/p2/ and buying P2+.