### PR TITLE
Editing Toolkit - Update to v2.8.13

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.12
+ * Version: 2.8.13
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.12' );
+define( 'PLUGIN_VERSION', '2.8.13' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.12
+Stable tag: 2.8.13
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.13 =
+* Removes unnecessary site editor implemtation from the plugin.
 
 = 2.8.12 =
 * New onboarding Launch: Fix subdomain selection and update menu (https://github.com/Automattic/wp-calypso/pull/47913)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -42,7 +42,6 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 = 2.8.13 =
 * Removes unnecessary site editor implemtation from the plugin. (https://github.com/Automattic/wp-calypso/pull/47301)
-* Updates newspack blocks to v1.17.0. (https://github.com/Automattic/wp-calypso/pull/48179)
 
 = 2.8.12 =
 * New onboarding Launch: Fix subdomain selection and update menu (https://github.com/Automattic/wp-calypso/pull/47913)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -41,8 +41,8 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 2.8.13 =
-* Removes unnecessary site editor implemtation from the plugin.
-* Updates newspack blocks to v1.17.0.
+* Removes unnecessary site editor implemtation from the plugin. (https://github.com/Automattic/wp-calypso/pull/47301)
+* Updates newspack blocks to v1.17.0. (https://github.com/Automattic/wp-calypso/pull/48179)
 
 = 2.8.12 =
 * New onboarding Launch: Fix subdomain selection and update menu (https://github.com/Automattic/wp-calypso/pull/47913)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -41,7 +41,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 2.8.13 =
-* Removes unnecessary site editor implemtation from the plugin. (https://github.com/Automattic/wp-calypso/pull/47301)
+* Removes unnecessary site editor implementation from the plugin. (https://github.com/Automattic/wp-calypso/pull/47301)
 
 = 2.8.12 =
 * New onboarding Launch: Fix subdomain selection and update menu (https://github.com/Automattic/wp-calypso/pull/47913)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -42,6 +42,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 = 2.8.13 =
 * Removes unnecessary site editor implemtation from the plugin.
+* Updates newspack blocks to v1.17.0.
 
 = 2.8.12 =
 * New onboarding Launch: Fix subdomain selection and update menu (https://github.com/Automattic/wp-calypso/pull/47913)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.12",
+	"version": "2.8.13",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bump Editing Toolkit version to 2.8.13

### Changes Included:

* Remove site editor integration from toolkit (#47301)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the diff on your sandbox and confirm that the above changes work correctly.
* Test that the new version of the plugin doesn't break Atomic sites as outlined in PCYsg-ly5-p2.

