### PR TITLE
Pricing page: make alternative SelectorPage default

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1195,7 +1195,7 @@ body.is-section-jetpack-connect .layout {
 }
 
 // The new Plans grid uses as primary color a darker version Jetpack's green.
-.is-section-jetpack-connect .selector-alt__main {
+.is-section-jetpack-connect .selector__main {
 	--color-accent: var( --studio-jetpack-green-40 );
 	--color-primary: var( --studio-jetpack-green-40 );
 

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { getSelectorComponent } from './iterations';
+import SelectorPage from './selector';
 import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { TERM_ANNUALLY } from 'calypso/lib/plans/constants';
@@ -24,20 +24,17 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 		( siteId && ( getCurrentPlanTerm( state, siteId ) as Duration ) ) ||
 		( TERM_ANNUALLY as Duration );
 	const urlQueryArgs: QueryArgs = context.query;
-	const SelectorComponent = getSelectorComponent();
 
-	if ( SelectorComponent ) {
-		context.primary = (
-			<SelectorComponent
-				defaultDuration={ duration }
-				rootUrl={ rootUrl }
-				siteSlug={ context.params.site || context.query.site }
-				urlQueryArgs={ urlQueryArgs }
-				header={ context.header }
-				footer={ context.footer }
-			/>
-		);
-	}
+	context.primary = (
+		<SelectorPage
+			defaultDuration={ duration }
+			rootUrl={ rootUrl }
+			siteSlug={ context.params.site || context.query.site }
+			urlQueryArgs={ urlQueryArgs }
+			header={ context.header }
+			footer={ context.footer }
+		/>
+	);
 
 	next();
 };

--- a/client/my-sites/plans/jetpack-plans/iterations.ts
+++ b/client/my-sites/plans/jetpack-plans/iterations.ts
@@ -6,14 +6,12 @@ import ProductsGridAlt2 from './products-grid-alt-2';
 import ProductsGridI5 from './products-grid-i5';
 import JetpackFAQ from 'calypso/my-sites/plans-features-main/jetpack-faq';
 import JetpackFAQi5 from 'calypso/my-sites/plans-features-main/jetpack-faq-i5';
-
-import SelectorPageAlt from './selector-alt';
 import { getJetpackCROActiveVersion as getIteration } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 
 /**
  * Type dependencies
  */
-import type { SelectorPageProps, ProductsGridProps } from './types';
+import type { ProductsGridProps } from './types';
 
 /**
  * Iterations
@@ -28,14 +26,6 @@ export enum Iterations {
 /**
  * Getters
  */
-
-export function getSelectorComponent(): React.FC< SelectorPageProps > | undefined {
-	return {
-		[ Iterations.V1 ]: SelectorPageAlt,
-		[ Iterations.V2 ]: SelectorPageAlt,
-		[ Iterations.I5 ]: SelectorPageAlt,
-	}[ getIteration() as Iterations ];
-}
 
 export function getGridComponent(): React.FC< ProductsGridProps > | undefined {
 	return {

--- a/client/my-sites/plans/jetpack-plans/records-details-alt/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/records-details-alt/index.tsx
@@ -15,6 +15,11 @@ import { getAvailableProductsBySiteId } from 'calypso/state/sites/products/selec
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**
+ * Style dependencies
+ */
+import '../records-details/styles.scss';
+
+/**
  * Type dependencies
  */
 import type { ProductTranslations } from 'calypso/lib/products-values/types';

--- a/client/my-sites/plans/jetpack-plans/records-details/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/records-details/index.tsx
@@ -21,6 +21,11 @@ import { getAvailableProductsBySiteId } from 'calypso/state/sites/products/selec
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**
+ * Style dependencies
+ */
+import './styles.scss';
+
+/**
  * Type dependencies
  */
 import type { ProductTranslations } from 'calypso/lib/products-values/types';

--- a/client/my-sites/plans/jetpack-plans/records-details/styles.scss
+++ b/client/my-sites/plans/jetpack-plans/records-details/styles.scss
@@ -1,0 +1,64 @@
+.records-details {
+	background-color: var( --studio-gray-0 );
+	border: solid 1px var( --studio-wordpress-blue-30 );
+	color: var( --color-text-subtle );
+}
+
+.records-details__records {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	padding: 14px;
+
+	border-bottom: solid 1px var( --studio-gray-5 );
+
+	.info-popover {
+		margin-top: 3px;
+		margin-left: 6px;
+
+		fill: var( --studio-gray-20 );
+	}
+}
+
+.records-details__details {
+	padding: 16px;
+
+	text-align: center;
+}
+
+.records-details__tier {
+	margin-bottom: 8px;
+
+	color: var( --color-text );
+	font-weight: 600;
+}
+
+.records-details-alt {
+	text-align: center;
+
+	color: var( --color-text );
+}
+
+.records-details-alt__records {
+	font-size: $font-body;
+	font-weight: 600;
+}
+
+.records-details-alt__tier {
+	margin: 8px 0 0;
+
+	font-size: $font-body-small;
+
+	color: var( --color-text-subtle );
+}
+
+.records-details__price {
+	display: flex;
+	justify-content: center;
+}
+
+.records-details__timeframe {
+	margin-top: -4px;
+	font-size: 0.75rem;
+}

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -9,10 +9,10 @@ import { useDispatch, useSelector } from 'react-redux';
  * Internal dependencies
  */
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import PlansFilterBar from './plans-filter-bar';
-import { EXTERNAL_PRODUCTS_LIST } from './constants';
-import { checkout } from './utils';
-import QueryProducts from './query-products';
+import PlansFilterBar from 'calypso/my-sites/plans/jetpack-plans/plans-filter-bar';
+import { EXTERNAL_PRODUCTS_LIST } from 'calypso/my-sites/plans/jetpack-plans/constants';
+import { checkout } from 'calypso/my-sites/plans/jetpack-plans/utils';
+import QueryProducts from 'calypso/my-sites/plans/jetpack-plans/query-products';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getYearlyPlanByMonthly } from 'calypso/lib/plans';
 import { getProductYearlyVariant, isJetpackPlan } from 'calypso/lib/products-values';
@@ -23,17 +23,25 @@ import Main from 'calypso/components/main';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QuerySites from 'calypso/components/data/query-sites';
 import QueryProductsList from 'calypso/components/data/query-products-list';
-import { getGridComponent, showFilterBarInSelector } from './iterations';
+import {
+	getGridComponent,
+	showFilterBarInSelector,
+} from 'calypso/my-sites/plans/jetpack-plans/iterations';
 
 /**
  * Type dependencies
  */
-import type { Duration, SelectorPageProps, SelectorProduct, PurchaseCallback } from './types';
+import type {
+	Duration,
+	SelectorPageProps,
+	SelectorProduct,
+	PurchaseCallback,
+} from 'calypso/my-sites/plans/jetpack-plans/types';
 import type { ProductSlug } from 'calypso/lib/products-values/types';
 
 import './style.scss';
 
-const SelectorPageAlt: React.FC< SelectorPageProps > = ( {
+const SelectorPage: React.FC< SelectorPageProps > = ( {
 	defaultDuration = TERM_ANNUALLY,
 	siteSlug: siteSlugProp,
 	rootUrl,
@@ -132,7 +140,7 @@ const SelectorPageAlt: React.FC< SelectorPageProps > = ( {
 	const viewTrackerProps = siteId ? { site: siteSlug } : {};
 
 	return (
-		<Main className="selector-alt__main" wideLayout>
+		<Main className="selector__main" wideLayout>
 			<PageViewTracker path={ viewTrackerPath } properties={ viewTrackerProps } title="Plans" />
 
 			{ header }
@@ -160,4 +168,4 @@ const SelectorPageAlt: React.FC< SelectorPageProps > = ( {
 	);
 };
 
-export default SelectorPageAlt;
+export default SelectorPage;

--- a/client/my-sites/plans/jetpack-plans/style.scss
+++ b/client/my-sites/plans/jetpack-plans/style.scss
@@ -1,13 +1,10 @@
-@import '~@wordpress/base-styles/breakpoints';
-@import '~@wordpress/base-styles/mixins';
-
-.selector-alt__main {
+.selector__main {
 	position: relative;
 }
 
 // Override WordPress.com primary colors with Jetpack Cloud primary colors.
 // This only affects the Plans grid and the Filter bar.
-.selector-alt__main {
+.selector__main {
 	.plans-filter-bar,
 	.plans-filter-bar-i5,
 	.products-grid-alt,
@@ -21,86 +18,6 @@
 	}
 }
 
-.selector-alt__divider {
-	margin: 40px 0;
-
-	border-bottom: solid 1px var( --color-border-subtle );
-	visibility: hidden;
-
-	@include break-large {
-		visibility: visible;
-	}
-}
-
 .jetpack-plans__heading {
 	padding: 1rem 0;
-}
-
-/**
- * Record slider
- */
-
-.records-details {
-	background-color: var( --studio-gray-0 );
-	border: solid 1px var( --studio-wordpress-blue-30 );
-	color: var( --color-text-subtle );
-}
-
-.records-details__records {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-
-	padding: 14px;
-
-	border-bottom: solid 1px var( --studio-gray-5 );
-
-	.info-popover {
-		margin-top: 3px;
-		margin-left: 6px;
-
-		fill: var( --studio-gray-20 );
-	}
-}
-
-.records-details__details {
-	padding: 16px;
-
-	text-align: center;
-}
-
-.records-details__tier {
-	margin-bottom: 8px;
-
-	color: var( --color-text );
-	font-weight: 600;
-}
-
-.records-details-alt {
-	text-align: center;
-
-	color: var( --color-text );
-}
-
-.records-details-alt__records {
-	font-size: $font-body;
-	font-weight: 600;
-}
-
-.records-details-alt__tier {
-	margin: 8px 0 0;
-
-	font-size: $font-body-small;
-
-	color: var( --color-text-subtle );
-}
-
-.records-details__price {
-	display: flex;
-	justify-content: center;
-}
-
-.records-details__timeframe {
-	margin-top: -4px;
-	font-size: 0.75rem;
 }

--- a/test/e2e/lib/pages/external/jetpackcom-pricing-page.js
+++ b/test/e2e/lib/pages/external/jetpackcom-pricing-page.js
@@ -14,7 +14,7 @@ export default class JetpackComPricingPage extends AsyncBaseContainer {
 		if ( ! url ) {
 			url = 'https://cloud.jetpack.com/pricing/';
 		}
-		super( driver, By.css( '.is-section-jetpack-cloud-pricing .selector-alt__main' ), url );
+		super( driver, By.css( '.is-section-jetpack-cloud-pricing .selector__main' ), url );
 	}
 
 	async buyJetpackPlan( planSlug ) {

--- a/test/e2e/lib/pages/plans-page.js
+++ b/test/e2e/lib/pages/plans-page.js
@@ -36,7 +36,7 @@ export default class PlansPage extends AsyncBaseContainer {
 
 	async waitForComparison() {
 		const plansPageMainCssClass =
-			host === 'WPCOM' ? '.plans-features-main__group' : '.selector-alt__main';
+			host === 'WPCOM' ? '.plans-features-main__group' : '.selector__main';
 		return await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
 			by.css( plansPageMainCssClass )
@@ -67,7 +67,7 @@ export default class PlansPage extends AsyncBaseContainer {
 
 	async planTypesShown( planType ) {
 		const plansCssHandle =
-			planType === 'jetpack' ? '.selector-alt__main' : `[data-e2e-plans="${ planType }"]`;
+			planType === 'jetpack' ? '.selector__main' : `[data-e2e-plans="${ planType }"]`;
 		return await driverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
 			by.css( plansCssHandle )

--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -16,7 +16,7 @@ import { getJetpackHost } from '../../data-helper.js';
 export default class PickAPlanPage extends AsyncBaseContainer {
 	constructor( driver ) {
 		const host = getJetpackHost();
-		const plansCssHandle = host !== 'WPCOM' ? '.selector-alt__main' : '.plans-features-main__group';
+		const plansCssHandle = host !== 'WPCOM' ? '.selector__main' : '.plans-features-main__group';
 		super( driver, By.css( plansCssHandle ), null, config.get( 'explicitWaitMS' ) * 2 );
 		this.host = host;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

Since several iterations of the pricing page have been removed completely, the alternative component `SelectorPageAlt` is now the only page selector. This PR renames the component and reorganizes a bit of code (see next section).

### Implementation notes

- Renamed `SelectorPageAlt` to `SelectorPage`
- Removed condition to get primary component in `controller.tsx`
- Deleted unused styles in `styles.scss`
- Moved `record-details` rules to the corresponding component folder

### Testing instructions

- Download the PR
- Run Calypso or cloud
- Check that the pricing page looks like production
- Prepend the URL with `?cloud-pricing-page=v2`, and check that the information tooltip in the _Search_ card still looks okay
- Repeat with `?cloud-pricing-page=v1`
