### PR TITLE
Billing: add payment method selector to update payment method screen

### DIFF
--- a/client/lib/checkout/processor-specific.js
+++ b/client/lib/checkout/processor-specific.js
@@ -3,7 +3,7 @@
  *
  */
 import i18n from 'i18n-calypso';
-import { isUndefined, isEmpty, pick } from 'lodash';
+import { isUndefined, pick } from 'lodash';
 import { CPF, CNPJ } from 'cpf_cnpj';
 
 /**
@@ -31,20 +31,6 @@ export function isEbanxCreditCardProcessingEnabledForCountry( countryCode = '', 
 			'ebanx',
 			cart.allowed_payment_methods?.map( translateWpcomPaymentMethodToCheckoutPaymentMethod )
 		)
-	);
-}
-
-/**
- * Returns whether
- *
- * @param {string} countryCode - a two-letter country code, e.g., 'DE', 'BR'
- * @param {import('@automattic/shopping-cart').ResponseCart} [cart] - The shopping cart
- * @returns {boolean} Whether the country requires additional fields
- */
-export function shouldRenderAdditionalCountryFields( countryCode = '', cart = null ) {
-	return (
-		isEbanxCreditCardProcessingEnabledForCountry( countryCode, cart ) &&
-		! isEmpty( PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ countryCode ].fields )
 	);
 }
 

--- a/client/lib/checkout/test/ebanx.js
+++ b/client/lib/checkout/test/ebanx.js
@@ -13,7 +13,6 @@ import {
 	isEbanxCreditCardProcessingEnabledForCountry,
 	isValidCPF,
 	isValidCNPJ,
-	shouldRenderAdditionalCountryFields,
 } from '../processor-specific';
 
 describe( 'Ebanx payment processing methods', () => {
@@ -47,16 +46,6 @@ describe( 'Ebanx payment processing methods', () => {
 		test( 'should return false for invalid CPF', () => {
 			expect( isValidCNPJ( '94065313000170' ) ).toEqual( false );
 			expect( isValidCNPJ( '94.065.313/0001-70' ) ).toEqual( false );
-		} );
-	} );
-
-	describe( 'shouldRenderAdditionalCountryFields', () => {
-		test( 'should return false for non-ebanx country', () => {
-			expect( shouldRenderAdditionalCountryFields( 'AU', cart ) ).toEqual( false );
-		} );
-		test( 'should return true for ebanx country that requires additional fields', () => {
-			expect( shouldRenderAdditionalCountryFields( 'BR', cart ) ).toEqual( true );
-			expect( shouldRenderAdditionalCountryFields( 'MX', cart ) ).toEqual( true );
 		} );
 	} );
 } );

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -204,11 +204,7 @@ function ChangePaymentMethodList() {
 			<Card className="change-payment-method__content">
 				<QueryPaymentCountries />
 
-				<CheckoutPaymentMethods
-					summary={ false }
-					isComplete={ false }
-					className={ 'change-payment-method__list' }
-				/>
+				<CheckoutPaymentMethods className="change-payment-method__list" />
 				<div className="change-payment-method__terms">
 					<Gridicon icon="info-outline" size={ 18 } />
 					<p>

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -3,18 +3,27 @@
  */
 import page from 'page';
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { connect } from 'react-redux';
-import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
+import {
+	CheckoutProvider,
+	CheckoutPaymentMethods,
+	usePaymentMethodId,
+} from '@automattic/composite-checkout';
+import { Card, Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
+import wp from 'calypso/lib/wp';
 import PaymentMethodForm from 'calypso/me/purchases/components/payment-method-form';
 import HeaderCake from 'calypso/components/header-cake';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryStoredCards from 'calypso/components/data/query-stored-cards';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import QueryPaymentCountries from 'calypso/components/data/query-countries/payments';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import { clearPurchases } from 'calypso/state/purchases/actions';
@@ -37,6 +46,15 @@ import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method
 import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
 import { isEnabled } from 'calypso/config';
 import { concatTitle } from 'calypso/lib/react-helpers';
+import useStoredCards from 'calypso/my-sites/checkout/composite-checkout/hooks/use-stored-cards';
+import {
+	useCreatePayPal,
+	useCreateCreditCard,
+	useCreateExistingCards,
+} from 'calypso/my-sites/checkout/composite-checkout/use-create-payment-methods';
+import Gridicon from 'calypso/components/gridicon';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'calypso/lib/url/support';
 
 function ChangePaymentMethod( props ) {
 	const isDataLoading = ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;
@@ -99,14 +117,18 @@ function ChangePaymentMethod( props ) {
 						configurationArgs={ { needs_intent: true } }
 						fetchStripeConfiguration={ getStripeConfiguration }
 					>
-						<PaymentMethodForm
-							apiParams={ { purchaseId: props.purchase.id } }
-							initialValues={ props.card }
-							purchase={ props.purchase }
-							recordFormSubmitEvent={ recordFormSubmitEvent }
-							siteSlug={ props.siteSlug }
-							successCallback={ successCallback }
-						/>
+						{ isEnabled( 'purchases/new-payment-methods' ) ? (
+							<ChangePaymentMethodList />
+						) : (
+							<PaymentMethodForm
+								apiParams={ { purchaseId: props.purchase.id } }
+								initialValues={ props.card }
+								purchase={ props.purchase }
+								recordFormSubmitEvent={ recordFormSubmitEvent }
+								siteSlug={ props.siteSlug }
+								successCallback={ successCallback }
+							/>
+						) }
 					</StripeHookProvider>
 				</Column>
 				<Column type="sidebar">
@@ -133,6 +155,131 @@ ChangePaymentMethod.propTypes = {
 	getManagePurchaseUrlFor: PropTypes.func.isRequired,
 	isFullWidth: PropTypes.bool.isRequired,
 };
+
+const wpcom = wp.undocumented();
+const wpcomGetStoredCards = () => wpcom.getStoredCards();
+
+function ChangePaymentMethodList() {
+	const [ formSubmitting ] = useState( false );
+	const translate = useTranslate();
+
+	const { storedCards } = useStoredCards( wpcomGetStoredCards, false );
+	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
+
+	const paypalMethod = useCreatePayPal();
+
+	const stripeMethod = useCreateCreditCard( {
+		isStripeLoading,
+		stripeLoadingError,
+		stripeConfiguration,
+		stripe,
+		shouldUseEbanx: false,
+	} );
+
+	const existingCardMethods = useCreateExistingCards( {
+		storedCards,
+		stripeConfiguration,
+	} );
+
+	const paymentMethods = [ paypalMethod, stripeMethod, ...existingCardMethods ].filter( Boolean );
+	const disabled = isStripeLoading || stripeLoadingError;
+
+	return (
+		<CheckoutProvider
+			items={ [] }
+			total={ {
+				amount: { value: 0, currency: 'USD', displayValue: '$0' },
+				id: 'xyzzy',
+				type: 'FAAAKE',
+				label: 'fake thing',
+			} }
+			onPaymentComplete={ () => {} }
+			showErrorMessage={ () => {} }
+			showInfoMessage={ () => {} }
+			showSuccessMessage={ () => {} }
+			paymentMethods={ paymentMethods }
+			paymentProcessors={ {} }
+			isLoading={ false }
+		>
+			<Card className="change-payment-method__content">
+				<QueryPaymentCountries />
+
+				<CheckoutPaymentMethods
+					summary={ false }
+					isComplete={ false }
+					className={ 'change-payment-method__list' }
+				/>
+				<div className="change-payment-method__terms">
+					<Gridicon icon="info-outline" size={ 18 } />
+					<p>
+						<TosText translate={ translate } />
+					</p>
+				</div>
+
+				<SaveButton
+					translate={ translate }
+					disabled={ disabled }
+					formSubmitting={ formSubmitting }
+				/>
+			</Card>
+		</CheckoutProvider>
+	);
+}
+
+function SaveButton( { translate, disabled, formSubmitting } ) {
+	const [ paymentMethodId ] = usePaymentMethodId();
+
+	// TODO: make sure the button busy state works correctly
+	const isSubmitting = disabled || formSubmitting;
+
+	const onClick = () => {
+		// TODO: do the actual submission here
+		window.alert( 'YOU CLICKED SUBMIT ' + paymentMethodId );
+	};
+
+	return (
+		// TODO: change button text based on payment method
+		<Button disabled={ isSubmitting } busy={ isSubmitting } onClick={ onClick } primary>
+			{ formSubmitting
+				? translate( 'Saving card…', {
+						context: 'Button label',
+						comment: 'Credit card',
+				  } )
+				: translate( 'Save card', {
+						context: 'Button label',
+						comment: 'Credit card',
+				  } ) }
+		</Button>
+	);
+}
+
+function TosText( { translate } ) {
+	// TODO: Make sure we use the correct ToS text for paypal
+	return translate(
+		'By saving a credit card, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and if ' +
+			'you use it to pay for a subscription or plan, you authorize your credit card to be charged ' +
+			'on a recurring basis until you cancel, which you can do at any time. ' +
+			'You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} ' +
+			'and {{managePurchasesSupportPage}}how to cancel{{/managePurchasesSupportPage}}.',
+		{
+			components: {
+				tosLink: (
+					<a
+						href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+				autoRenewalSupportPage: (
+					<a href={ AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
+				),
+				managePurchasesSupportPage: (
+					<a href={ MANAGE_PURCHASES } target="_blank" rel="noopener noreferrer" />
+				),
+			},
+		}
+	);
+}
 
 const mapStateToProps = ( state, { cardId, purchaseId } ) => ( {
 	card: getStoredCardById( state, cardId ),

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -44,7 +44,7 @@ import useIsApplePayAvailable from './hooks/use-is-apple-pay-available';
 import filterAppropriatePaymentMethods from './lib/filter-appropriate-payment-methods';
 import useStoredCards from './hooks/use-stored-cards';
 import usePrepareProductsForCart from './hooks/use-prepare-products-for-cart';
-import useCreatePaymentMethodsForCheckout from './use-create-payment-methods';
+import useCreatePaymentMethods from './use-create-payment-methods';
 import {
 	applePayProcessor,
 	freePurchaseProcessor,
@@ -330,7 +330,7 @@ export default function CompositeCheckout( {
 		isLoading: isApplePayLoading,
 	} = useIsApplePayAvailable( stripe, stripeConfiguration, !! stripeLoadingError, items );
 
-	const paymentMethodObjects = useCreatePaymentMethodsForCheckout( {
+	const paymentMethodObjects = useCreatePaymentMethods( {
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -44,7 +44,7 @@ import useIsApplePayAvailable from './hooks/use-is-apple-pay-available';
 import filterAppropriatePaymentMethods from './lib/filter-appropriate-payment-methods';
 import useStoredCards from './hooks/use-stored-cards';
 import usePrepareProductsForCart from './hooks/use-prepare-products-for-cart';
-import useCreatePaymentMethods from './use-create-payment-methods';
+import useCreatePaymentMethodsForCheckout from './use-create-payment-methods';
 import {
 	applePayProcessor,
 	freePurchaseProcessor,
@@ -330,7 +330,7 @@ export default function CompositeCheckout( {
 		isLoading: isApplePayLoading,
 	} = useIsApplePayAvailable( stripe, stripeConfiguration, !! stripeLoadingError, items );
 
-	const paymentMethodObjects = useCreatePaymentMethods( {
+	const paymentMethodObjects = useCreatePaymentMethodsForCheckout( {
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
@@ -3,28 +3,26 @@
  */
 import React from 'react';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
-import { useShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
 import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
-import { shouldRenderAdditionalCountryFields } from 'calypso/lib/checkout/processor-specific';
 import CountrySpecificPaymentFields from '../../components/country-specific-payment-fields';
 
 export default function ContactFields( {
 	getFieldValue,
 	setFieldValue,
 	getErrorMessagesForField,
+	shouldUseEbanx,
 } ) {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 	const countriesList = useCountryList( [] );
-	const { responseCart } = useShoppingCart();
 
 	return (
 		<div className="contact-fields">
-			{ shouldRenderAdditionalCountryFields( getFieldValue( 'countryCode' ), responseCart ) && (
+			{ shouldUseEbanx && (
 				<CountrySpecificPaymentFields
 					countryCode={ getFieldValue( 'countryCode' ) }
 					countriesList={ countriesList }

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-cvv-field.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-cvv-field.js
@@ -5,12 +5,10 @@ import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { CardCvcElement } from 'react-stripe-elements';
 import { FormStatus, useFormStatus, useSelect } from '@automattic/composite-checkout';
-import { useShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
-import { shouldRenderAdditionalCountryFields } from 'calypso/lib/checkout/processor-specific';
 import {
 	LeftColumn,
 	RightColumn,
@@ -28,7 +26,7 @@ import CVVImage from './cvv-image';
 export default function CreditCardCvvField( {
 	handleStripeFieldChange,
 	stripeElementStyle,
-	countryCode,
+	shouldUseEbanx,
 	getErrorMessagesForField,
 	setFieldValue,
 	getFieldValue,
@@ -41,9 +39,8 @@ export default function CreditCardCvvField( {
 	);
 	const errorMessages = getErrorMessagesForField( 'cvv' );
 	const errorMessage = errorMessages?.length > 0 ? errorMessages[ 0 ] : null;
-	const { responseCart } = useShoppingCart();
 
-	if ( countryCode && shouldRenderAdditionalCountryFields( countryCode, responseCart ) ) {
+	if ( shouldUseEbanx ) {
 		return (
 			<Input
 				inputMode="numeric"

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-expiry-field.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-expiry-field.js
@@ -5,19 +5,17 @@ import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { CardExpiryElement } from 'react-stripe-elements';
 import { FormStatus, useFormStatus, useSelect } from '@automattic/composite-checkout';
-import { useShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
-import { shouldRenderAdditionalCountryFields } from 'calypso/lib/checkout/processor-specific';
 import { Label, LabelText, StripeFieldWrapper, StripeErrorMessage } from './form-layout-components';
 import { Input } from 'calypso/my-sites/domains/components/form';
 
 export default function CreditCardExpiryField( {
 	handleStripeFieldChange,
 	stripeElementStyle,
-	countryCode,
+	shouldUseEbanx,
 	getErrorMessagesForField,
 	setFieldValue,
 	getFieldValue,
@@ -30,9 +28,8 @@ export default function CreditCardExpiryField( {
 	);
 	const errorMessages = getErrorMessagesForField( 'expiration-date' );
 	const errorMessage = errorMessages?.length > 0 ? errorMessages[ 0 ] : null;
-	const { responseCart } = useShoppingCart();
 
-	if ( countryCode && shouldRenderAdditionalCountryFields( countryCode, responseCart ) ) {
+	if ( shouldUseEbanx ) {
 		return (
 			<Input
 				inputMode="numeric"

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import { useTheme } from 'emotion-theming';
 import { useI18n } from '@automattic/react-i18n';
@@ -12,7 +12,6 @@ import {
 	useDispatch,
 	useFormStatus,
 } from '@automattic/composite-checkout';
-import { useShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -28,7 +27,6 @@ import CreditCardExpiryField from './credit-card-expiry-field';
 import CreditCardCvvField from './credit-card-cvv-field';
 import { FieldRow, CreditCardFieldsWrapper, CreditCardField } from './form-layout-components';
 import CreditCardLoading from './credit-card-loading';
-import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from '../../lib/translate-payment-method-names';
 
 export default function CreditCardFields( { shouldUseEbanx } ) {
 	const { __ } = useI18n();
@@ -48,7 +46,6 @@ export default function CreditCardFields( { shouldUseEbanx } ) {
 	const { setFieldValue, changeBrand, setCardDataError, setCardDataComplete } = useDispatch(
 		'credit-card'
 	);
-	const { responseCart: cart } = useShoppingCart();
 
 	const cardholderName = getField( 'cardholderName' );
 	const cardholderNameErrorMessages = getErrorMessagesForField( 'cardholderName' ) || [];
@@ -77,23 +74,9 @@ export default function CreditCardFields( { shouldUseEbanx } ) {
 		setCardDataError( input.elementType, null );
 	};
 
-	const contactCountryCode = useSelect(
-		( select ) => select( 'wpcom' )?.getContactInfo().countryCode?.value
-	);
-	const shouldShowContactFields =
-		contactCountryCode === 'BR' &&
-		Boolean(
-			cart?.allowed_payment_methods?.includes(
-				translateCheckoutPaymentMethodToWpcomPaymentMethod( 'ebanx' )
-			)
-		);
+	const shouldShowContactFields = shouldUseEbanx;
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
-
-	// Cache the country code in our store for use by the processor function
-	useEffect( () => {
-		setFieldValue( 'countryCode', contactCountryCode );
-	}, [ contactCountryCode, setFieldValue ] );
 
 	const stripeElementStyle = {
 		base: {

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -30,7 +30,7 @@ import { FieldRow, CreditCardFieldsWrapper, CreditCardField } from './form-layou
 import CreditCardLoading from './credit-card-loading';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from '../../lib/translate-payment-method-names';
 
-export default function CreditCardFields() {
+export default function CreditCardFields( { shouldUseEbanx } ) {
 	const { __ } = useI18n();
 	const theme = useTheme();
 	const onEvent = useEvents();

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -136,7 +136,7 @@ export default function CreditCardFields( { shouldUseEbanx } ) {
 						setIsStripeFullyLoaded={ setIsStripeFullyLoaded }
 						handleStripeFieldChange={ handleStripeFieldChange }
 						stripeElementStyle={ stripeElementStyle }
-						countryCode={ getFieldValue( 'countryCode' ) }
+						shouldUseEbanx={ shouldUseEbanx }
 						getErrorMessagesForField={ getErrorMessagesForField }
 						setFieldValue={ setFieldValue }
 						getFieldValue={ getFieldValue }
@@ -147,7 +147,7 @@ export default function CreditCardFields( { shouldUseEbanx } ) {
 							<CreditCardExpiryField
 								handleStripeFieldChange={ handleStripeFieldChange }
 								stripeElementStyle={ stripeElementStyle }
-								countryCode={ getFieldValue( 'countryCode' ) }
+								shouldUseEbanx={ shouldUseEbanx }
 								getErrorMessagesForField={ getErrorMessagesForField }
 								setFieldValue={ setFieldValue }
 								getFieldValue={ getFieldValue }
@@ -157,7 +157,7 @@ export default function CreditCardFields( { shouldUseEbanx } ) {
 							<CreditCardCvvField
 								handleStripeFieldChange={ handleStripeFieldChange }
 								stripeElementStyle={ stripeElementStyle }
-								countryCode={ getFieldValue( 'countryCode' ) }
+								shouldUseEbanx={ shouldUseEbanx }
 								getErrorMessagesForField={ getErrorMessagesForField }
 								setFieldValue={ setFieldValue }
 								getFieldValue={ getFieldValue }
@@ -172,6 +172,7 @@ export default function CreditCardFields( { shouldUseEbanx } ) {
 						getFieldValue={ getFieldValue }
 						setFieldValue={ setFieldValue }
 						getErrorMessagesForField={ getErrorMessagesForField }
+						shouldUseEbanx={ shouldUseEbanx }
 					/>
 				) }
 			</CreditCardFieldsWrapper>

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-number-field.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-number-field.js
@@ -5,12 +5,10 @@ import React from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import { CardNumberElement } from 'react-stripe-elements';
 import { FormStatus, useFormStatus, useSelect, PaymentLogo } from '@automattic/composite-checkout';
-import { useShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
-import { shouldRenderAdditionalCountryFields } from 'calypso/lib/checkout/processor-specific';
 import CreditCardNumberInput from 'calypso/components/upgrades/credit-card-number-input';
 import { Label, LabelText, StripeFieldWrapper, StripeErrorMessage } from './form-layout-components';
 
@@ -18,7 +16,7 @@ export default function CreditCardNumberField( {
 	setIsStripeFullyLoaded,
 	handleStripeFieldChange,
 	stripeElementStyle,
-	countryCode,
+	shouldUseEbanx = false,
 	getErrorMessagesForField,
 	setFieldValue,
 	getFieldValue,
@@ -32,9 +30,8 @@ export default function CreditCardNumberField( {
 	);
 	const errorMessages = getErrorMessagesForField( 'number' );
 	const errorMessage = errorMessages?.length > 0 ? errorMessages[ 0 ] : null;
-	const { responseCart } = useShoppingCart();
 
-	if ( countryCode && shouldRenderAdditionalCountryFields( countryCode, responseCart ) ) {
+	if ( shouldUseEbanx ) {
 		return (
 			<CreditCardNumberInput
 				isError={ !! errorMessage }

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/index.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/index.js
@@ -164,12 +164,16 @@ export function createCreditCardPaymentMethodStore() {
 	return { ...store, actions, selectors };
 }
 
-export function createCreditCardMethod( { store, stripe, stripeConfiguration } ) {
+export function createCreditCardMethod( { store, stripe, stripeConfiguration, shouldUseEbanx } ) {
 	return {
 		id: 'card',
 		label: <CreditCardLabel />,
 		activeContent: (
-			<CreditCardFields stripe={ stripe } stripeConfiguration={ stripeConfiguration } />
+			<CreditCardFields
+				stripe={ stripe }
+				stripeConfiguration={ stripeConfiguration }
+				shouldUseEbanx={ shouldUseEbanx }
+			/>
 		),
 		submitButton: (
 			<CreditCardPayButton

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -20,8 +20,8 @@ import {
 	createEpsPaymentMethodStore,
 	createApplePayMethod,
 	createExistingCardMethod,
-	useShoppingCart,
 } from '@automattic/composite-checkout';
+import { useShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -301,7 +301,7 @@ function useCreateExistingCards( { storedCards, stripeConfiguration } ) {
 	return existingCardMethods;
 }
 
-export default function useCreatePaymentMethods( {
+export default function useCreatePaymentMethodsForCheckout( {
 	isStripeLoading,
 	stripeLoadingError,
 	stripeConfiguration,

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -301,7 +301,7 @@ export function useCreateExistingCards( { storedCards, stripeConfiguration } ) {
 	return existingCardMethods;
 }
 
-export default function useCreatePaymentMethodsForCheckout( {
+export default function useCreatePaymentMethods( {
 	isStripeLoading,
 	stripeLoadingError,
 	stripeConfiguration,

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -47,12 +47,12 @@ import { createFullCreditsMethod } from './payment-methods/full-credits';
 import { createFreePaymentMethod } from './payment-methods/free-purchase';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 
-function useCreatePayPal() {
+export function useCreatePayPal() {
 	const paypalMethod = useMemo( createPayPalMethod, [] );
 	return paypalMethod;
 }
 
-function useCreateCreditCard( {
+export function useCreateCreditCard( {
 	isStripeLoading,
 	stripeLoadingError,
 	stripeConfiguration,
@@ -282,7 +282,7 @@ function useCreateApplePay( {
 	return applePayMethod;
 }
 
-function useCreateExistingCards( { storedCards, stripeConfiguration } ) {
+export function useCreateExistingCards( { storedCards, stripeConfiguration } ) {
 	const existingCardMethods = useMemo( () => {
 		return storedCards.map( ( storedDetails ) =>
 			createExistingCardMethod( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We currently only allow customers to change the payment method on an existing subscription to a new credit card from the update payment method screen at `/purchases/subscriptions/:siteurl/:receiptId/payment-method/change/:paymentMethodId`. In this PR we add a radio button component that allows the user to choose a PayPal account or a stored card as well. This PR **does not** actually do the switching, it just adds the UI components.

These changes are behind the `purchases/new-payment-methods` feature flag, so they should not appear for anyone in production.

We're reusing the payment method list components from checkout, and doing so required refactoring them a little. The testing instructions should cover these changes too.

Part of #47516

#### Testing instructions

1. Check that our changes to the checkout payment methods do not break checkout.
    - Make a test purchase using a new stripe card. (Set your country code outside of Brazil at the contact details step.) Check that the purchase completes.
    - Make a test purchase using a new ebanx card. (Set your country code to Brazil at the contact details step.) Check that the purchase completes.
2. Check that the update payment method functionality is unchanged.
    - Use the `?flags=-purchases/new-payment-methods` query parameter to turn off the UI updates in your dev environment if needed.
    - On a site with an existing plan, navigate to the site level billing page via `Plan > Billing` and select a subscription.
    - Click "Change Payment Method" to load the change payment method screen.
    - Check that only the credit card form is shown and that it works as expected.

