### PR TITLE
Add zoom in/out/reset to WP Desktop View menu

### DIFF
--- a/client/desktop/lib/menu/view-menu.js
+++ b/client/desktop/lib/menu/view-menu.js
@@ -16,19 +16,33 @@ if ( Config.debug ) {
 	menuItems = debugMenu;
 }
 
-menuItems.push( {
-	label: 'Toggle Full Screen',
-	accelerator: platform.isOSX() ? 'Command+Ctrl+F' : undefined,
-	fullscreen: true,
-	click: function () {
-		const focusedWindow = BrowserWindow.getFocusedWindow();
+menuItems.push(
+	{
+		label: 'Toggle Full Screen',
+		accelerator: platform.isOSX() ? 'Command+Ctrl+F' : undefined,
+		fullscreen: true,
+		click: function () {
+			const focusedWindow = BrowserWindow.getFocusedWindow();
 
-		if ( focusedWindow ) {
-			const toggle = ! focusedWindow.isFullScreen();
+			if ( focusedWindow ) {
+				const toggle = ! focusedWindow.isFullScreen();
 
-			focusedWindow.setFullScreen( toggle );
-		}
+				focusedWindow.setFullScreen( toggle );
+			}
+		},
 	},
-} );
+	{
+		type: 'separator',
+	},
+	{
+		role: 'zoomIn',
+	},
+	{
+		role: 'zoomOut',
+	},
+	{
+		role: 'resetZoom',
+	}
+);
 
 module.exports = menuItems;

--- a/client/desktop/lib/menu/view-menu.js
+++ b/client/desktop/lib/menu/view-menu.js
@@ -47,6 +47,26 @@ menuItems.push(
 	},
 	{
 		role: 'resetZoom',
+	},
+	// backup shortcuts for numeric keypad,
+	// see https://github.com/electron/electron/issues/5256#issuecomment-692068367
+	{
+		role: 'zoomIn',
+		visible: false,
+		acceleratorWorksWhenHidden: true,
+		accelerator: 'CommandOrControl+numadd',
+	},
+	{
+		role: 'zoomOut',
+		visible: false,
+		acceleratorWorksWhenHidden: true,
+		accelerator: 'CommandOrControl+numsub',
+	},
+	{
+		role: 'resetZoom',
+		visible: false,
+		acceleratorWorksWhenHidden: true,
+		accelerator: 'CommandOrControl+num0',
 	}
 );
 

--- a/client/desktop/lib/menu/view-menu.js
+++ b/client/desktop/lib/menu/view-menu.js
@@ -35,7 +35,12 @@ menuItems.push(
 		type: 'separator',
 	},
 	{
+		// enable ZoomIn shortcut to work both with and without Shift
+		// the default accelerator added by Electron is CommandOrControl+Shift+=
 		role: 'zoomIn',
+		visible: false,
+		acceleratorWorksWhenHidden: true,
+		accelerator: 'CommandOrControl+=',
 	},
 	{
 		role: 'zoomOut',

--- a/client/desktop/lib/menu/view-menu.js
+++ b/client/desktop/lib/menu/view-menu.js
@@ -38,7 +38,7 @@ menuItems.push(
 		// enable ZoomIn shortcut to work both with and without Shift
 		// the default accelerator added by Electron is CommandOrControl+Shift+=
 		role: 'zoomIn',
-		visible: false,
+		visible: true,
 		acceleratorWorksWhenHidden: true,
 		accelerator: 'CommandOrControl+=',
 	},

--- a/client/desktop/lib/menu/view-menu.js
+++ b/client/desktop/lib/menu/view-menu.js
@@ -35,10 +35,13 @@ menuItems.push(
 		type: 'separator',
 	},
 	{
+		role: 'zoomIn',
+	},
+	{
 		// enable ZoomIn shortcut to work both with and without Shift
 		// the default accelerator added by Electron is CommandOrControl+Shift+=
 		role: 'zoomIn',
-		visible: true,
+		visible: false,
 		acceleratorWorksWhenHidden: true,
 		accelerator: 'CommandOrControl+=',
 	},


### PR DESCRIPTION
### Description

This PR adds zoom in/out/reset items to the Desktop's `View` menu. These actions are triggered by:

- `CMD +` (zoom in)
- `CMD -` (zoom out)
- `CMD 0` (reset zoom). 

For Windows and Linux, use `CTRL` instead of `CMD`.

_Extended Mac "Zoom In" Shortcut_

This change also ensures that on Mac, the "zoom in" keyboard shortcut can be triggered with _and_ without the `Shift` key (to explicitly select the `+` symbol), which is consistent with a number of other native applications.

<p align="center">
<img width="226" alt="zoom-menu-mac" src="https://user-images.githubusercontent.com/8979548/101687799-3f4c4d00-3a28-11eb-98cb-cba997cfce9a.png">
</p>

_Numeric Keypad Support_

Turns out the default keyboard shortcuts provided by Electron are specific to the main keyboard only. This change integrates hidden accelerators that also support selecting `+`, `-` and `0` on a numeric keypad. In other words, the shortcut will work when the user presses `CMD` and selects the `+` key either on the main keyboard or a numeric keypad.

### To Test

Build the app locally ([instructions](https://github.com/Automattic/wp-calypso/blob/trunk/desktop/README.md)). Run the app and inspect the `View` menu and corresponding shortcuts.