### PR TITLE
Add debug items to View menu

### DIFF
--- a/client/desktop/lib/menu/debug-menu.js
+++ b/client/desktop/lib/menu/debug-menu.js
@@ -1,29 +1,11 @@
-/**
- * External Dependencies
- */
-const { BrowserWindow } = require( 'electron' );
-
 module.exports = [
 	{
-		label: 'Reload',
-		accelerator: 'CmdOrCtrl+R',
-		click: function () {
-			const focusedWindow = BrowserWindow.getFocusedWindow();
-
-			if ( focusedWindow ) {
-				focusedWindow.reload();
-			}
-		},
+		role: 'reload',
 	},
 	{
-		label: 'Developer Tools',
-		accelerator: 'Alt+CmdOrCtrl+I',
-		click: function () {
-			const focusedWindow = BrowserWindow.getFocusedWindow();
-
-			if ( focusedWindow ) {
-				focusedWindow.toggleDevTools();
-			}
-		},
+		role: 'forceReload',
+	},
+	{
+		role: 'toggleDevTools',
 	},
 ];

--- a/client/desktop/lib/menu/view-menu.js
+++ b/client/desktop/lib/menu/view-menu.js
@@ -3,18 +3,13 @@ const { BrowserWindow } = require( 'electron' );
 /**
  * Internal dependencies
  */
-const Config = require( 'calypso/desktop/lib/config' );
 const debugMenu = require( './debug-menu' );
 const platform = require( 'calypso/desktop/lib/platform' );
 
 /**
  * Module variables
  */
-let menuItems = [];
-
-if ( Config.debug ) {
-	menuItems = debugMenu;
-}
+const menuItems = [];
 
 menuItems.push(
 	{
@@ -72,5 +67,14 @@ menuItems.push(
 		accelerator: 'CommandOrControl+num0',
 	}
 );
+
+if ( process.env.WP_DESKTOP_DEBUG ) {
+	menuItems.push(
+		{
+			type: 'separator',
+		},
+		...debugMenu
+	);
+}
 
 module.exports = menuItems;


### PR DESCRIPTION
### Description

This PR adds the following debug/developer items to the View menu:

- Reload
- Force Reload (ignore cache)
- Toggle Developer Tools

Enabling these items is triggered by the setting the environment variable `WP_DESKTOP_DEBUG`.

<p align="center">
<img width="272" alt="mac-debug-menu" src="https://user-images.githubusercontent.com/8979548/101832714-1d6ccc00-3af5-11eb-9a59-64f2bee4602f.png">
</p>

### To Test/Use

Start the application in the terminal using the command `WP_DESKTOP_DEBUG=1 open path/to/WordPress.com.app` and verify the debug menu items appear in the View menu.