### PR TITLE
ci: fix Circle regex filter for Desktop jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1105,8 +1105,8 @@ workflows:
             branches:
               only:
                 - trunk
-                - release/*
-                - desktop/*
+                - /release\/.*/
+                - /desktop\/.*/
       - wp-desktop-mac:
           requires:
             - wp-desktop-source


### PR DESCRIPTION
### Description

This PR fixes the regex filter for the wp-desktop `source` jobs to ensure that in addition to `trunk`, a full build is triggered only for branches prefixed with `release/` and `desktop`.

### To Test

Verify that the full suite of desktop CI has been ran for this PR, whose branch is prefix with `desktop/`.