### PR TITLE
Docs: Add yarn command to steps listed 

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If you’d like to contribute code, first, you will need to run Calypso locally.
 1. Make sure you have `git`, `node`, and `npm` installed.
 2. Clone this repository locally.
 3. Add `127.0.0.1 calypso.localhost` to your local hosts file.
-4. Execute `yarn start` from the root directory of the repository.
+4. Execute `yarn` and then `yarn start` from the root directory of the repository.
 5. Open `http://calypso.localhost:3000` in your browser.
 
 For more detailed instructions, see [Installing Calypso](../docs/install.md).

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ You can install Calypso directly on your machine by following the next steps, or
 1. Check that you have all prerequisites (Git, Node, NPM). See [below](install.md#prerequisites) for more details. Pay close attention to software versions.
 2. Clone this repository locally.
 3. Add `127.0.0.1 calypso.localhost` to your local `hosts` file.
-4. Execute `yarn start` from the root directory of the repository.
+4. Execute `yarn` and then `yarn start` from the root directory of the repository.
 5. Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
 
 ## Prerequisites
@@ -25,6 +25,7 @@ Clone this git repository to your machine via the terminal using the `git clone`
 ```bash
 $ git clone https://github.com/Automattic/wp-calypso.git
 $ cd wp-calypso
+$ yarn
 $ yarn start
 ```
 


### PR DESCRIPTION
This PR adds the `yarn` command to the steps listed to get started, as is already shown in the main `README.md` file. Without this `yarn` command, anybody following the steps will encounter an error about missing modules when running `yarn start`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify the changed doc files are formatted correctly.
