### PR TITLE
New onboarding: user who picked “free” from plans grid A/B test non-EN|ES

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -9,15 +9,6 @@
 /* See /client/components/experiment/readme.md for more info!
 /**************************************************************************************************/
 
-/**
- * Internal dependencies
- */
-import { getLanguageSlugs } from '../../lib/i18n-utils/utils';
-
-const nonENLanguageSlugs = getLanguageSlugs().filter(
-	( slug ) => ! [ 'en', 'en-gb' ].includes( slug )
-);
-
 export default {
 	cartNudgeUpdateToPremium: {
 		datestamp: '20180917',
@@ -89,7 +80,7 @@ export default {
 			newOnboarding: 50,
 			control: 50,
 		},
-		localeTargets: nonENLanguageSlugs,
+		localeExceptions: [ 'en', 'es' ],
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -75,7 +75,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	newUsersWithFreePlan: {
-		datestamp: '20210104',
+		datestamp: '20210107',
 		variations: {
 			newOnboarding: 50,
 			control: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -9,6 +9,15 @@
 /* See /client/components/experiment/readme.md for more info!
 /**************************************************************************************************/
 
+/**
+ * Internal dependencies
+ */
+import { getLanguageSlugs } from '../../lib/i18n-utils/utils';
+
+const nonENLanguageSlugs = getLanguageSlugs().filter(
+	( slug ) => ! [ 'en', 'en-gb' ].includes( slug )
+);
+
 export default {
 	cartNudgeUpdateToPremium: {
 		datestamp: '20180917',
@@ -73,5 +82,15 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
+	},
+	newUsersWithFreePlan: {
+		datestamp: '20201218',
+		variations: {
+			newOnboarding: 50,
+			control: 50,
+		},
+		localeTargets: nonENLanguageSlugs,
+		defaultVariation: 'control',
+		allowExistingUsers: false,
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -80,6 +80,7 @@ export default {
 			newOnboarding: 50,
 			control: 50,
 		},
+		localeTargets: 'any',
 		localeExceptions: [ 'en', 'es' ],
 		defaultVariation: 'control',
 		allowExistingUsers: false,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -75,7 +75,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	newUsersWithFreePlan: {
-		datestamp: '20201218',
+		datestamp: '20210104',
 		variations: {
 			newOnboarding: 50,
 			control: 50,

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -62,6 +62,20 @@ const removeWhiteBackground = function () {
 	document.body.classList.remove( 'is-white-signup' );
 };
 
+const gutenbergRedirect = function ( flowName, locale ) {
+	const url = new URL( window.location );
+	let path = '/new';
+	if ( [ 'free', 'personal', 'premium', 'business', 'ecommerce' ].includes( flowName ) ) {
+		path += `/${ flowName }`;
+	}
+	if ( locale ) {
+		path += `/${ locale }`;
+	}
+
+	url.pathname = path;
+	window.location.replace( url.toString() );
+};
+
 export const addP2SignupClassName = () => {
 	if ( ! document ) {
 		return;
@@ -113,6 +127,14 @@ export default {
 			waitForHttpData( () => ( { geo: requestGeoLocation() } ) )
 				.then( ( { geo } ) => {
 					const countryCode = geo.data;
+					const localeFromParams = context.params.lang;
+					const flowName = getFlowName( context.params );
+
+					if ( flowName === 'free' && 'newOnboarding' === abtest( 'newUsersWithFreePlan' ) ) {
+						gutenbergRedirect( flowName, localeFromParams );
+						return;
+					}
+
 					if (
 						( ! user() || ! user().get() ) &&
 						-1 === context.pathname.indexOf( 'free' ) &&
@@ -126,7 +148,6 @@ export default {
 						removeWhiteBackground();
 						const stepName = getStepName( context.params );
 						const stepSectionName = getStepSectionName( context.params );
-						const localeFromParams = context.params.lang;
 						const urlWithLocale = getStepUrl(
 							'onboarding-registrationless',
 							stepName,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Add code for `newUsersWithFreePlan` experiment as described in pbxNRc-xd-p2.

#### Testing Tips

1. If you are using incognito window, enable third-party cookies (from the eye icon in the address bar).
2. You can monitor and remove the `ABTests` value via **Dev Console > Application > Local Storage > calypso.localhost:3000 > ABTests**.

#### Testing instructions

As **logged-out user without variation**:
- Going to `/start/free` should redirect to `/start/free/user`.
- Going to `/start/free/[en|es]` should redirect to `/start/free/user/[en|es]`.
- Going to `/start/free/[any-locale-except-en-es]`:
  - 50% should redirect to `/new/free/[any-locale-except-en-es]`
  - 50% should redirect to `/start/free/[any-locale-except-en-es]`

As **logged-out user with `control` variation** by executing `localStorage.setItem( 'ABTests', '{"newUsersWithFreePlan_20210104":"control"}' );`:
- Going to `/start/free` should redirect to `/start/free/user`.
- Going to `/start/free/[any-locale]` should redirect to `/start/free/user/[any-locale]`.

As **logged-out user with `newOnboarding` variation** by executing `localStorage.setItem( 'ABTests', '{"newUsersWithFreePlan_20210104":"newOnboarding"}' );`:
- Going to `/start/free` should redirect to `/new/free`.
- Going to `/start/free/[any-locale]` should redirect to `/new/free/[any-locale]`.

As **newly created logged-in user with EN/ES locale**:
- Set your browser language to EN/ES at `chrome://settings/languages`.
- Create a new user.
- Going to `/start/free` should redirect to `/start/free/domains`.

As **newly created logged-in user with non-EN/ES locale**:
- Set your browser language to anything other than EN/ES at `chrome://settings/languages`.
- Create a new user.
- Going to `/start/free`:
  - 50% should redirect to `/new/free`
  - 50% should redirect to `/start/free/domains`
