### PR TITLE
Link sidebar links in Store to WooCommerce pages

### DIFF
--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -201,15 +201,23 @@ class StoreSidebar extends Component {
 	};
 
 	settings = () => {
-		const { site, siteSuffix, translate } = this.props;
-		const link = '/store/settings' + siteSuffix;
+		const { site, siteSuffix, translate, isStoreRemoved } = this.props;
 		const childLinks = [
 			'/store/settings/payments',
 			'/store/settings/shipping',
 			'/store/settings/taxes',
 			'/store/settings/email',
 		];
-		const selected = this.isItemLinkSelected( [ link, ...childLinks ] );
+		let link;
+		let selected;
+		if ( isStoreRemoved ) {
+			link = site.URL + '/wp-admin/admin.php?page=wc-settings';
+			selected = false;
+		} else {
+			link = '/store/settings' + siteSuffix;
+			selected = this.isItemLinkSelected( [ link, ...childLinks ] );
+		}
+
 		const classes = classNames( {
 			settings: true,
 			'is-placeholder': ! site,

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -167,10 +167,18 @@ class StoreSidebar extends Component {
 	};
 
 	orders = () => {
-		const { totalNewOrders, site, siteSuffix, translate } = this.props;
-		const link = '/store/orders' + siteSuffix;
-		const childLinks = [ '/store/order', '/store/orders' ];
-		const selected = this.isItemLinkSelected( childLinks );
+		const { totalNewOrders, site, siteSuffix, translate, isStoreRemoved } = this.props;
+		let link;
+		let selected;
+
+		if ( isStoreRemoved ) {
+			link = site.URL + '/wp-admin/edit.php?post_type=shop_order';
+			selected = false;
+		} else {
+			link = '/store/orders' + siteSuffix;
+			selected = this.isItemLinkSelected( [ '/store/order', '/store/orders' ] );
+		}
+
 		const classes = classNames( {
 			orders: true,
 			'is-placeholder': ! site,

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -136,9 +136,18 @@ class StoreSidebar extends Component {
 	};
 
 	reviews = () => {
-		const { site, siteSuffix, translate, totalPendingReviews } = this.props;
-		const link = '/store/reviews' + siteSuffix;
-		const selected = this.isItemLinkSelected( [ '/store/reviews' ] );
+		const { site, siteSuffix, translate, totalPendingReviews, isStoreRemoved } = this.props;
+		let link;
+		let selected;
+
+		if ( isStoreRemoved ) {
+			link = site.URL + '/wp-admin/edit-comments.php';
+			selected = false;
+		} else {
+			link = '/store/reviews' + siteSuffix;
+			selected = this.isItemLinkSelected( [ '/store/reviews' ] );
+		}
+
 		const classes = classNames( {
 			reviews: true,
 			'is-placeholder': ! site,

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -107,11 +107,11 @@ class StoreSidebar extends Component {
 	};
 
 	products = () => {
-		const { site, siteSuffix, translate, isPostSunset } = this.props;
+		const { site, siteSuffix, translate, isStoreRemoved } = this.props;
 		let link;
 		let selected;
 
-		if ( isPostSunset ) {
+		if ( isStoreRemoved ) {
 			link = site.URL + '/wp-admin/edit.php?post_type=product';
 			selected = false;
 		} else {
@@ -286,7 +286,7 @@ function mapStateToProps( state ) {
 	const storeLocation = getStoreLocation( state, siteId );
 	const pluginsLoaded = arePluginsLoaded( state, siteId );
 	const allRequiredPluginsActive = areAllRequiredPluginsActive( state, siteId );
-	const isPostSunset = config.isEnabled( 'woocommerce/store-post-sunset' );
+	const isStoreRemoved = config.isEnabled( 'woocommerce/store-removed' );
 
 	return {
 		allRequiredPluginsActive,
@@ -301,7 +301,7 @@ function mapStateToProps( state ) {
 		siteId,
 		siteSuffix: site ? '/' + site.slug : '',
 		storeLocation,
-		isPostSunset,
+		isStoreRemoved,
 	};
 }
 

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -107,13 +107,11 @@ class StoreSidebar extends Component {
 	};
 
 	products = () => {
-		const { site, siteSuffix, translate } = this.props;
-		const link = '/store/products' + siteSuffix;
-		const selected = this.isItemLinkSelected( [ link, '/store/products/categories' + siteSuffix ] );
+		const { site, translate } = this.props;
+		const link = site.URL + '/wp-admin/edit.php?post_type=product';
 		const classes = classNames( {
 			products: true,
 			'is-placeholder': ! site,
-			selected,
 		} );
 
 		return (

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -190,9 +190,18 @@ class StoreSidebar extends Component {
 			return null;
 		}
 
-		const { site, siteSuffix, translate } = this.props;
-		const link = '/store/promotions' + siteSuffix;
-		const selected = this.isItemLinkSelected( [ link ] );
+		const { site, siteSuffix, translate, isStoreRemoved } = this.props;
+		let link;
+		let selected;
+
+		if ( isStoreRemoved ) {
+			link = site.URL + '/wp-admin/edit.php?post_type=shop_coupon';
+			selected = false;
+		} else {
+			link = '/store/promotions' + siteSuffix;
+			selected = this.isItemLinkSelected( [ link ] );
+		}
+
 		const classes = classNames( {
 			promotions: true,
 			'is-placeholder': ! site,

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -107,11 +107,22 @@ class StoreSidebar extends Component {
 	};
 
 	products = () => {
-		const { site, translate } = this.props;
-		const link = site.URL + '/wp-admin/edit.php?post_type=product';
+		const { site, siteSuffix, translate, isPostSunset } = this.props;
+		let link;
+		let selected;
+
+		if ( isPostSunset ) {
+			link = site.URL + '/wp-admin/edit.php?post_type=product';
+			selected = false;
+		} else {
+			link = '/store/products' + siteSuffix;
+			selected = this.isItemLinkSelected( [ link, '/store/products/categories' + siteSuffix ] );
+		}
+
 		const classes = classNames( {
 			products: true,
 			'is-placeholder': ! site,
+			selected,
 		} );
 
 		return (
@@ -275,6 +286,7 @@ function mapStateToProps( state ) {
 	const storeLocation = getStoreLocation( state, siteId );
 	const pluginsLoaded = arePluginsLoaded( state, siteId );
 	const allRequiredPluginsActive = areAllRequiredPluginsActive( state, siteId );
+	const isPostSunset = config.isEnabled( 'woocommerce/store-post-sunset' );
 
 	return {
 		allRequiredPluginsActive,
@@ -289,6 +301,7 @@ function mapStateToProps( state ) {
 		siteId,
 		siteSuffix: site ? '/' + site.slug : '',
 		storeLocation,
+		isPostSunset,
 	};
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -213,8 +213,8 @@
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
 		"woocommerce/store-on-non-atomic-sites": true,
-		"woocommerce/store-pre-sunset": false,
-		"woocommerce/store-post-sunset": true,
+		"woocommerce/store-deprecated": false,
+		"woocommerce/store-removed": false,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -213,6 +213,8 @@
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
 		"woocommerce/store-on-non-atomic-sites": true,
+		"woocommerce/store-pre-sunset": true,
+		"woocommerce/store-post-sunset": true,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -213,7 +213,7 @@
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
 		"woocommerce/store-on-non-atomic-sites": true,
-		"woocommerce/store-pre-sunset": true,
+		"woocommerce/store-pre-sunset": false,
 		"woocommerce/store-post-sunset": true,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/production.json
+++ b/config/production.json
@@ -167,8 +167,8 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
-		"woocommerce/store-pre-sunset": false,
-		"woocommerce/store-post-sunset": false,
+		"woocommerce/store-deprecated": false,
+		"woocommerce/store-removed": false,
 		"wpcom-user-bootstrap": true
 	},
 	"rtl": false,

--- a/config/production.json
+++ b/config/production.json
@@ -167,6 +167,8 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
+		"woocommerce/store-pre-sunset": false,
+		"woocommerce/store-post-sunset": false,
 		"wpcom-user-bootstrap": true
 	},
 	"rtl": false,


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR updates links in the sidebar to WooCommerce Admin

* Fixes #48156 for products 
* Fixes #48160 for settings
* Fixes #48159 for reviews
* Fixes #48158 for promotions
* Fixes #48157 for orders


## Testing instructions

**Testing sidebar links**

1. Start Calypso locally
2. Navigate to http://calypso.localhost:3000/ 
3. Click "Switch Site" from the sidebar and choose your eCommerce site.
4. Replace "home" to "store" and append `?flags=woocommerce/store-removed` from your browser's URL and hit enter.
5. Once you are on your store page, make sure that the sidebar links have an external link icon (screenshot below)
6. Click each sidebar link and confirm that they open the corresponding WC Admin page.

**URL replacement example:**

http://calypso.localhost:3000/home/calypsotest363078866.wpcomstaging.com

**to**

http://calypso.localhost:3000/store/calypsotest363078866.wpcomstaging.com?flags=store-removed

## Screenshots

![Screen Shot 2020-12-14 at 3 08 56 PM](https://user-images.githubusercontent.com/4723145/102146776-72268480-3e1e-11eb-889a-dea2f286776f.jpg)
