### PR TITLE
Invites: restore bindActionCreators call

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -55,7 +55,6 @@ export function generateInviteLinks( siteId ) {
 	debug( 'generateInviteLinks', siteId );
 
 	return ( dispatch ) => {
-		debug( 'generateInviteLinks API request', siteId );
 		wpcom
 			.undocumented()
 			.site( siteId )

--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -55,6 +55,7 @@ export function generateInviteLinks( siteId ) {
 	debug( 'generateInviteLinks', siteId );
 
 	return ( dispatch ) => {
+		debug( 'generateInviteLinks API request', siteId );
 		wpcom
 			.undocumented()
 			.site( siteId )

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -7,6 +7,7 @@ import page from 'page';
 import { filter, flowRight, get, groupBy, includes, pickBy, some } from 'lodash';
 import debugModule from 'debug';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -764,9 +765,14 @@ const mapStateToProps = ( state ) => {
 };
 
 const mapDispatchToProps = ( dispatch ) => ( {
-	activateModule,
-	generateInviteLinks: ( siteId ) => dispatch( generateInviteLinks( siteId ) ),
-	disableInviteLinks: ( siteId ) => dispatch( disableInviteLinks( siteId ) ),
+	...bindActionCreators(
+		{
+			activateModule,
+			generateInviteLinks,
+			disableInviteLinks,
+		},
+		dispatch
+	),
 	errorNotice,
 	successNotice,
 	recordTracksEventAction,

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -765,8 +765,8 @@ const mapStateToProps = ( state ) => {
 
 const mapDispatchToProps = ( dispatch ) => ( {
 	activateModule,
-	generateInviteLinks,
-	disableInviteLinks,
+	generateInviteLinks: ( siteId ) => dispatch( generateInviteLinks( siteId ) ),
+	disableInviteLinks: ( siteId ) => dispatch( disableInviteLinks( siteId ) ),
 	errorNotice,
 	successNotice,
 	recordTracksEventAction,

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -770,11 +770,11 @@ const mapDispatchToProps = ( dispatch ) => ( {
 			activateModule,
 			generateInviteLinks,
 			disableInviteLinks,
+			errorNotice,
+			successNotice,
 		},
 		dispatch
 	),
-	errorNotice,
-	successNotice,
 	recordTracksEventAction,
 
 	onFocusTokenField: () =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* [Brings back ](https://github.com/Automattic/wp-calypso/pull/48089)`bindActionCreators(...)` inside `mapDispatchToProps`, required for triggering some actions.
* Fixes unresponsive P2 Invite Link section buttons/links, and missing regular invite success/error notices.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Manage > People > Invite and invite a new user/email address to your test site.
2. You should see a success/error notice depending on the outcome. (You should see a notice, regardless.)

P2 sites only
1. Go to Manage > People > Invite and at the bottom of the page, you should see the Invite Link section.
2. Click the **Generate link** button and you should get your set of invite links. Perform Step 3 first if you don't see the button.
3. Click **Disable invite link** (beside the Expiry date text) and you should get the **Generate link** button back.
