### PR TITLE
Domain Management: Finish replacing CartData with ShoppingCartProvider

### DIFF
--- a/client/components/data/domain-management/README.md
+++ b/client/components/data/domain-management/README.md
@@ -32,7 +32,6 @@ export default MyComponent;
 
 Currently we have both Flux and Redux mixed. Props for loading data:
 
-- `needsCart` - Loads the `CartStore` (Flux)
 - `needsContactDetails` - Loads Contact Details for current user (Redux)
 - `needsDomains` - Loads domain for currently selected site (Redux)
 - `needsPlans` - Loads plans for given site (Redux)

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import CartStore from 'calypso/lib/cart/store';
 import { fetchUsers } from 'calypso/lib/users/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getPlansBySite } from 'calypso/state/sites/plans/selectors';
@@ -27,7 +26,6 @@ import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopp
 
 function getStateFromStores( props ) {
 	return {
-		cart: CartStore.get(),
 		context: props.context,
 		domains: props.selectedSite ? props.domains : null,
 		isRequestingSiteDomains: props.isRequestingSiteDomains,
@@ -47,7 +45,6 @@ class DomainManagementData extends React.Component {
 		context: PropTypes.object.isRequired,
 		domains: PropTypes.array,
 		isRequestingSiteDomains: PropTypes.bool,
-		needsCart: PropTypes.bool,
 		needsContactDetails: PropTypes.bool,
 		needsDns: PropTypes.bool,
 		needsDomains: PropTypes.bool,
@@ -81,7 +78,6 @@ class DomainManagementData extends React.Component {
 
 	render() {
 		const {
-			needsCart,
 			needsContactDetails,
 			needsDomains,
 			needsPlans,
@@ -91,9 +87,6 @@ class DomainManagementData extends React.Component {
 		} = this.props;
 
 		const stores = [];
-		if ( needsCart ) {
-			stores.push( CartStore );
-		}
 		if ( needsUsers ) {
 			stores.push( UsersStore );
 		}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -167,15 +167,8 @@ class DomainRegistrationSuggestion extends React.Component {
 			buttonContent = translate( 'Unavailable', {
 				context: 'Domain suggestion is not available for registration',
 			} );
-		} else if ( pendingCheckSuggestion ) {
-			if ( pendingCheckSuggestion.domain_name === suggestion.domain_name ) {
-				buttonStyles = { ...buttonStyles, busy: true };
-			} else {
-				buttonStyles = { ...buttonStyles, disabled: true };
-			}
-		}
-		if ( this.props.isCartPendingUpdate ) {
-			buttonStyles = { ...buttonStyles, busy: true };
+		} else if ( pendingCheckSuggestion || this.props.isCartPendingUpdate ) {
+			buttonStyles = { ...buttonStyles, busy: true, disabled: true };
 		}
 		return {
 			buttonContent,

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -39,6 +39,7 @@ const NOTICE_GREEN = '#4ab866';
 class DomainRegistrationSuggestion extends React.Component {
 	static propTypes = {
 		isDomainOnly: PropTypes.bool,
+		isCartPendingUpdate: PropTypes.bool,
 		isSignupStep: PropTypes.bool,
 		showStrikedOutPrice: PropTypes.bool,
 		isFeatured: PropTypes.bool,
@@ -172,6 +173,9 @@ class DomainRegistrationSuggestion extends React.Component {
 			} else {
 				buttonStyles = { ...buttonStyles, disabled: true };
 			}
+		}
+		if ( this.props.isCartPendingUpdate ) {
+			buttonStyles = { ...buttonStyles, busy: true };
 		}
 		return {
 			buttonContent,

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -38,6 +38,7 @@ class DomainSearchResults extends React.Component {
 		lastDomainStatus: PropTypes.string,
 		lastDomainSearched: PropTypes.string,
 		cart: PropTypes.object,
+		isCartPendingUpdate: PropTypes.bool,
 		premiumDomains: PropTypes.object,
 		products: PropTypes.object,
 		selectedSite: PropTypes.object,
@@ -263,6 +264,7 @@ class DomainSearchResults extends React.Component {
 			featuredSuggestionElement = (
 				<FeaturedDomainSuggestions
 					cart={ this.props.cart }
+					isCartPendingUpdate={ this.props.isCartPendingUpdate }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					isDomainOnly={ isDomainOnly }
 					fetchAlgo={ this.props.fetchAlgo }
@@ -288,6 +290,7 @@ class DomainSearchResults extends React.Component {
 
 				return (
 					<DomainRegistrationSuggestion
+						isCartPendingUpdate={ this.props.isCartPendingUpdate }
 						isDomainOnly={ isDomainOnly }
 						suggestion={ suggestion }
 						key={ suggestion.domain_name }

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -21,6 +21,7 @@ import './style.scss';
 export class FeaturedDomainSuggestions extends Component {
 	static propTypes = {
 		cart: PropTypes.object,
+		isCartPendingUpdate: PropTypes.bool,
 		fetchAlgo: PropTypes.string,
 		showStrikedOutPrice: PropTypes.bool,
 		primarySuggestion: PropTypes.object,
@@ -34,6 +35,7 @@ export class FeaturedDomainSuggestions extends Component {
 	getChildProps() {
 		const childKeys = [
 			'cart',
+			'isCartPendingUpdate',
 			'isDomainOnly',
 			'domainsWithPlansOnly',
 			'showStrikedOutPrice',

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -176,6 +176,7 @@ class MapDomainStep extends React.Component {
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					key={ suggestion.domain_name }
 					cart={ this.props.cart }
+					isCartPendingUpdate={ this.props.cart.hasPendingServerUpdates }
 					onButtonClick={ this.registerSuggestedDomain }
 				/>
 			</div>

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -131,6 +131,7 @@ function getQueryObject( props ) {
 class RegisterDomainStep extends React.Component {
 	static propTypes = {
 		cart: PropTypes.object,
+		isCartPendingUpdate: PropTypes.bool,
 		isDomainOnly: PropTypes.bool,
 		onDomainsAvailabilityChange: PropTypes.func,
 		products: PropTypes.object,
@@ -1191,6 +1192,7 @@ class RegisterDomainStep extends React.Component {
 						suggestion={ suggestion }
 						key={ suggestion.domain_name }
 						cart={ this.props.cart }
+						isCartPendingUpdate={ this.props.isCartPendingUpdate }
 						selectedSite={ this.props.selectedSite }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 						onButtonClick={ this.onAddDomain }
@@ -1372,6 +1374,7 @@ class RegisterDomainStep extends React.Component {
 				railcarId={ this.state.railcarId }
 				fetchAlgo={ this.getFetchAlgo() }
 				cart={ this.props.cart }
+				isCartPendingUpdate={ this.props.isCartPendingUpdate }
 				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 				unavailableDomains={ this.state.unavailableDomains }
 				onSkip={ this.props.onSkip }

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -452,6 +452,7 @@ class TransferDomainStep extends React.Component {
 			<div className={ 'transfer-domain-step__domain-availability' }>
 				<DomainRegistrationSuggestion
 					cart={ this.props.cart }
+					isCartPendingUpdate={ this.props.cart.hasPendingServerUpdates }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					key={ suggestion.domain_name }
 					onButtonClick={ this.registerSuggestedDomain }

--- a/client/components/upgrades/gsuite/README.md
+++ b/client/components/upgrades/gsuite/README.md
@@ -1,12 +1,12 @@
 # GSuiteUpgrade
 
-GSuiteUpgrade is a React component used to add G Suite email addresses to domains. It expects to be wrapped in a `CartData` Component.
+GSuiteUpgrade is a React component used to add G Suite email addresses to domains. It expects to be wrapped in a `ShoppingCartProvider` Component.
 
 ## Usage
 
 ```jsx
 import React from 'react';
-import CartData from 'calypso/components/data/cart';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import GSuiteUpgrade from 'calypso/components/upgrades/gsuite';
 import productsListFactory from 'calypso/lib/products-list';
 
@@ -15,9 +15,9 @@ const productsList = productsListFactory();
 class MyComponent extends React.Component {
 	render() {
 		return (
-			<CartData>
+			<CalypsoShoppingCartProvider>
 				<GSuiteUpgrade domain={ domain } />;
-			</CartData>
+			</CalypsoShoppingCartProvider>
 		);
 	}
 }

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -210,9 +210,9 @@ const googleAppsWithRegistration = ( context, next ) => {
 						args: { domain: context.params.registerDomain },
 					} ) }
 				/>
-				<CartData>
+				<CalypsoShoppingCartProvider>
 					<GSuiteUpgrade domain={ context.params.registerDomain } />
-				</CartData>
+				</CalypsoShoppingCartProvider>
 			</Main>
 		);
 	}

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -45,7 +45,6 @@ export default {
 				analyticsTitle="Domain Management"
 				component={ DomainManagement.List }
 				context={ pageContext }
-				needsCart
 				needsContactDetails
 				needsDomains
 				needsPlans
@@ -74,7 +73,6 @@ export default {
 				analyticsTitle="Domain Management > Edit"
 				component={ DomainManagement.Edit }
 				context={ pageContext }
-				needsCart
 				needsContactDetails
 				needsDomains
 				needsPlans
@@ -92,7 +90,6 @@ export default {
 				analyticsTitle="Domain Management > Edit"
 				component={ DomainManagement.SiteRedirect }
 				context={ pageContext }
-				needsCart
 				needsContactDetails
 				needsDomains
 				needsPlans
@@ -110,7 +107,6 @@ export default {
 				analyticsTitle="Domain Management > Edit"
 				component={ DomainManagement.TransferIn }
 				context={ pageContext }
-				needsCart
 				needsContactDetails
 				needsDomains
 				needsPlans
@@ -142,7 +138,6 @@ export default {
 				analyticsTitle="Domain Management > Contacts and Privacy > Manage Consent for Personal Data Use"
 				component={ DomainManagement.ManageConsent }
 				context={ pageContext }
-				needsCart
 				needsContactDetails
 				needsDomains
 				needsPlans

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -64,7 +64,6 @@ export class List extends React.Component {
 		selectedSite: PropTypes.object.isRequired,
 		domains: PropTypes.array.isRequired,
 		isRequestingDomains: PropTypes.bool,
-		cart: PropTypes.object,
 		context: PropTypes.object,
 		renderAllSites: PropTypes.bool,
 		hasSingleSite: PropTypes.bool,
@@ -154,7 +153,6 @@ export class List extends React.Component {
 					/>
 					<div className="domains__header-buttons">
 						<HeaderCart
-							cart={ this.props.cart }
 							selectedSite={ this.props.selectedSite }
 							currentRoute={ this.props.currentRoute }
 						/>

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -47,6 +47,7 @@ import EmailVerificationGate from 'calypso/components/email-verification/email-v
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
+import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 
 /**
  * Style dependencies
@@ -89,7 +90,9 @@ class DomainSearch extends Component {
 
 	handleAddMapping = ( domain ) => {
 		this.props.shoppingCartManager
-			.addProductsToCart( [ domainMapping( { domain } ) ] )
+			.addProductsToCart( [
+				fillInSingleCartItemAttributes( domainMapping( { domain } ), this.props.productsList ),
+			] )
 			.then( () => {
 				page( '/checkout/' + this.props.selectedSiteSlug );
 			} );
@@ -97,7 +100,9 @@ class DomainSearch extends Component {
 
 	handleAddTransfer = ( domain ) => {
 		this.props.shoppingCartManager
-			.addProductsToCart( [ domainTransfer( { domain } ) ] )
+			.addProductsToCart( [
+				fillInSingleCartItemAttributes( domainTransfer( { domain } ), this.props.productsList ),
+			] )
 			.then( () => {
 				page( '/checkout/' + this.props.selectedSiteSlug );
 			} );
@@ -139,13 +144,17 @@ class DomainSearch extends Component {
 			registration = updatePrivacyForDomain( registration, true );
 		}
 
-		this.props.shoppingCartManager.addProductsToCart( [ registration ] ).then( () => {
-			if ( canDomainAddGSuite( domain ) ) {
-				page( '/domains/add/' + domain + '/google-apps/' + this.props.selectedSiteSlug );
-			} else {
-				page( '/checkout/' + this.props.selectedSiteSlug );
-			}
-		} );
+		this.props.shoppingCartManager
+			.addProductsToCart( [
+				fillInSingleCartItemAttributes( registration, this.props.productsList ),
+			] )
+			.then( () => {
+				if ( canDomainAddGSuite( domain ) ) {
+					page( '/domains/add/' + domain + '/google-apps/' + this.props.selectedSiteSlug );
+				} else {
+					page( '/checkout/' + this.props.selectedSiteSlug );
+				}
+			} );
 	}
 
 	removeDomain( suggestion ) {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -68,6 +68,8 @@ class DomainSearch extends Component {
 		selectedSiteSlug: PropTypes.string,
 	};
 
+	isMounted = false;
+
 	state = {
 		domainRegistrationAvailable: true,
 		domainRegistrationMaintenanceEndTime: null,
@@ -94,7 +96,7 @@ class DomainSearch extends Component {
 				fillInSingleCartItemAttributes( domainMapping( { domain } ), this.props.productsList ),
 			] )
 			.then( () => {
-				page( '/checkout/' + this.props.selectedSiteSlug );
+				this.isMounted && page( '/checkout/' + this.props.selectedSiteSlug );
 			} );
 	};
 
@@ -104,7 +106,7 @@ class DomainSearch extends Component {
 				fillInSingleCartItemAttributes( domainTransfer( { domain } ), this.props.productsList ),
 			] )
 			.then( () => {
-				page( '/checkout/' + this.props.selectedSiteSlug );
+				this.isMounted && page( '/checkout/' + this.props.selectedSiteSlug );
 			} );
 	};
 
@@ -116,6 +118,14 @@ class DomainSearch extends Component {
 		if ( nextProps.selectedSiteId !== this.props.selectedSiteId ) {
 			this.checkSiteIsUpgradeable( nextProps );
 		}
+	}
+
+	componentWillUnmount() {
+		this.isMounted = false;
+	}
+
+	componentDidMount() {
+		this.isMounted = true;
 	}
 
 	checkSiteIsUpgradeable( props ) {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -211,7 +211,6 @@ class DomainSearch extends Component {
 							{ ! isManagingAllDomains /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ && (
 								<div className="domains__header-buttons">
 									<HeaderCart
-										cart={ this.props.cart }
 										selectedSite={ this.props.selectedSite }
 										currentRoute={ this.props.currentRoute }
 									/>

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -170,15 +170,10 @@ class DomainSearch extends Component {
 	removeDomain( suggestion ) {
 		this.props.recordRemoveDomainButtonClick( suggestion.domain_name );
 
-		const productToRemove = this.props.cart.products.find( ( product ) => {
-			if (
-				product.meta === suggestion.domain_name &&
-				product.product_slug === suggestion.product_slug
-			) {
-				return true;
-			}
-			return false;
-		} );
+		const productToRemove = this.props.cart.products.find(
+			( product ) =>
+				product.meta === suggestion.domain_name && product.product_slug === suggestion.product_slug
+		);
 		if ( productToRemove ) {
 			const uuidToRemove = productToRemove.uuid;
 			this.props.shoppingCartManager.removeProductFromCart( uuidToRemove );

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -257,6 +257,7 @@ class DomainSearch extends Component {
 								onAddDomain={ this.handleAddRemoveDomain }
 								onAddMapping={ this.handleAddMapping }
 								onAddTransfer={ this.handleAddTransfer }
+								isCartPendingUpdate={ this.props.shoppingCartManager.isPendingUpdate }
 								offerUnavailableOption
 								selectedSite={ selectedSite }
 								basePath={ this.props.basePath }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/47605 we updated PopoverCart to replace the `CartData` wrapper with the `ShoppingCartProvider` within the domains management components (this will help us eventually remove `CartData`; see #24019), but there were some things that were missed.

First, although `HeaderCart` (a parent of `PopoverCart`) was changed to use `withShoppingCart` to provide its `cart` prop, that prop was still being explicitly passed in by the parents of that component. This PR removes those props in case they might cause confusion or bugs.

Second, the `DomainSearch` component uses cart actions to add and remove products from the cart, but those actions still use `CartStore`. This PR converts that component to use the `ShoppingCartProvider` functions for manipulating the cart.

Third, the `DomainManagementData` wrapper has a `needsCart` property that fetches the cart from the `CartStore`. This PR removes that property. Many of the pages under the domain management section had that property enabled, but from what I can tell, almost none of them used it, so this does not add `withShoppingCart` to any of the children (but if any of them need the cart, that would be an easy solution).

<img width="1058" alt="Screen Shot 2020-12-11 at 9 33 37 PM" src="https://user-images.githubusercontent.com/2036909/101970487-bb958a80-3bf8-11eb-901f-f4f1787499e5.png">

This also updates `GSuiteUpgrade` to use `useShoppingCart` from `@automattic/shopping-cart` in place of `CartData`. This is similar to the upgrade to `GSuiteNudge` from https://github.com/Automattic/wp-calypso/pull/48438. We had to include this here because otherwise either the domain that was added by the domain search page will not have finished updating the cart by the time we hit the G Suite page, causing the G Suite submission to overwrite it (which will probably fail since it will be in a cart without a domain), or the G Suite page will redirect back to the domain search page because it can't see the domain in the cart.

#### Testing instructions

- Click through to the domains management page using the sidebar links "Manage" > "Domains".
- Add a domain to your cart and click through to checkout.
- Leave checkout without completing the purchase by clicking the "X" in the upper-left.
- Click through to the domains management page again using the sidebar links "Manage" > "Domains".
- Verify that the cart icon appears in the upper-right of the page after a moment and that it shows a "1" dot.
- Verify that clicking on the cart icon shows the domain you added.

We should also verify that the other domain management pages still work as expected since the cart data has been removed from them. I'm not 100% sure how to test each of these but it may be enough to look at each one and verify that they don't use the `cart` prop.

- `DomainManagement.Edit`
- `DomainManagement.SiteRedirect`
- `DomainManagement.TransferIn`
- `DomainManagement.ManageConsent`

#### Testing instructions for the G Suite nudge

- Add a domain to your cart.
- Verify that you see the G Suite upsell before you reach checkout.
- Add a G Suite product to your cart from the upsell.
- Verify that you arrive at checkout and that the cart contains both your domain and the G Suite product.