### PR TITLE
update stylelint config: css border-radius to allow multiple values

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,7 +3,7 @@
 	"rules": {
 		"scales/font-weight": [[ 400, 600, 700, "normal", "bold", "inherit" ]],
 		"scales/font-size": [[ 0.75, 0.875, 1, 1.25, 1.5, 2, 2.25, 3, 3.375 ], { unit: "rem" }],
-		"scales/radii": [[ 2 ], { unit: "px" }],
+		"scales/radii": [[ 2, 4, 8, 12], { unit: "px" }],
 
 		"color-hex-case": "lower",
 		"color-no-invalid-hex": true,


### PR DESCRIPTION

## Changes proposed in this Pull Request

Update stylelint config to allow border-radius to have values other than 2px.

Because this error doesn't seem logical:
<img width="679" alt="Screen Shot 2020-12-10 at 15 35 46" src="https://user-images.githubusercontent.com/5665959/101737734-6171c800-3b19-11eb-8f03-120ae2fdec74.png">



I don't have the background knowledge to know why this was previously set to `"scales/radii": [[ 2 ], { unit: "px" }]`.

Should additional values be included in addition to :
`"scales/radii": [[ 2, 4, 8, 12], { unit: "px" }],` 

## Testing instructions

* Pull down this branch
* Update any scss file with a valid border-radius (equal to one of the allowed values)
* Commit the change and ensure linter doesn't complain
* Then update with an invalid border-radius value
* Commit the change and ensure it DOES complain

(Note it is possible to run the linter via `npm run lint` but then the linting report includes issues in whole code base, of which there are a lot.)

