### PR TITLE
New Onboarding: Fix language path related issues

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -14,7 +14,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import DomainPickerButton from '../domain-picker-button';
 import PlansButton from '../plans-button';
-import { useCurrentStep, useIsAnchorFm, Step } from '../../path';
+import { useCurrentStep, useIsAnchorFm, usePath, Step } from '../../path';
 import { isEnabled } from '../../../../config';
 import Link from '../link';
 
@@ -28,6 +28,7 @@ const Header: React.FunctionComponent = () => {
 	const locale = useLocale();
 	const currentStep = useCurrentStep();
 	const isAnchorFmSignup = useIsAnchorFm();
+	const makePath = usePath();
 
 	const { siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 
@@ -51,7 +52,7 @@ const Header: React.FunctionComponent = () => {
 		if ( isEnabled( 'gutenboarding/language-picker' ) ) {
 			return (
 				<div className="gutenboarding__header-section-item gutenboarding__header-language-section">
-					<Link to={ Step.LanguageModal }>
+					<Link to={ makePath( Step.LanguageModal ) }>
 						<span>{ __( 'Site Language' ) } </span>
 						<span className="gutenboarding__header-site-language-badge">{ locale }</span>
 					</Link>

--- a/client/landing/gutenboarding/hooks/use-previous.ts
+++ b/client/landing/gutenboarding/hooks/use-previous.ts
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Custom hook to provide the previous value of state or props in a functional component
+ *
+ * see https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+ *
+ * @param  {any}  value state or prop value for which previous value is required
+ * @returns {any}  previous value of requested state or prop value
+ */
+export function usePrevious< T >( value: T ): T {
+	const ref = useRef< T >();
+
+	useEffect( () => {
+		ref.current = value;
+	}, [ value ] );
+
+	return ref.current as T;
+}

--- a/client/landing/gutenboarding/hooks/use-previous.ts
+++ b/client/landing/gutenboarding/hooks/use-previous.ts
@@ -8,15 +8,15 @@ import { useEffect, useRef } from '@wordpress/element';
  *
  * see https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
  *
- * @param  {any}  value state or prop value for which previous value is required
- * @returns {any}  previous value of requested state or prop value
+ * @param value state or prop value for which previous value is required
+ * @returns previous value of requested state or prop value
  */
-export function usePrevious< T >( value: T ): T {
+export function usePrevious< T >( value: T ): T | undefined {
 	const ref = useRef< T >();
 
 	useEffect( () => {
 		ref.current = value;
 	}, [ value ] );
 
-	return ref.current as T;
+	return ref.current;
 }

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -2,9 +2,10 @@
  * External dependencies
  */
 import * as React from 'react';
-import { Redirect, Switch, Route, useLocation } from 'react-router-dom';
+import { Redirect, Switch, Route, useHistory, useLocation } from 'react-router-dom';
 import type { BlockEditProps } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
+import { useLocale } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
@@ -15,7 +16,14 @@ import DesignSelector from './design-selector';
 import CreateSite from './create-site';
 import CreateSiteError from './create-site-error';
 import type { Attributes } from './types';
-import { Step, usePath, useNewQueryParam, useIsAnchorFm } from '../path';
+import {
+	Step,
+	useIsAnchorFm,
+	usePath,
+	useNewQueryParam,
+	useCurrentStep,
+	useLangRouteParam,
+} from '../path';
 import AcquireIntent from './acquire-intent';
 import StylePreview from './style-preview';
 import Features from './features';
@@ -35,12 +43,22 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 	const isAnchorFmSignup = useIsAnchorFm();
 
 	const makePath = usePath();
+	const locale = useLocale();
+	const history = useHistory();
+	const currentStep = useCurrentStep();
+	const langRouteParam = useLangRouteParam();
 
 	const { pathname } = useLocation();
 
 	React.useEffect( () => {
 		setTimeout( () => window.scrollTo( 0, 0 ), 0 );
 	}, [ pathname ] );
+
+	React.useEffect( () => {
+		if ( langRouteParam && langRouteParam !== locale ) {
+			history.replace( makePath( Step[ currentStep ], locale ) );
+		}
+	}, [ langRouteParam, locale, pathname, history, currentStep, makePath ] );
 
 	const canUseDesignStep = React.useCallback( (): boolean => {
 		return !! siteTitle;

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -2,34 +2,28 @@
  * External dependencies
  */
 import * as React from 'react';
-import { Redirect, Switch, Route, useHistory, useLocation } from 'react-router-dom';
-import type { BlockEditProps } from '@wordpress/blocks';
+import { Redirect, Switch, Route, useLocation } from 'react-router-dom';
 import { useSelect } from '@wordpress/data';
-import { useLocale } from '@automattic/i18n-utils';
+import type { BlockEditProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '../stores/onboard';
 import { SITE_STORE } from '../stores/site';
+import { Step, useIsAnchorFm, useCurrentStep, usePath, useNewQueryParam } from '../path';
+import { usePrevious } from '../hooks/use-previous';
 import DesignSelector from './design-selector';
 import CreateSite from './create-site';
 import CreateSiteError from './create-site-error';
-import type { Attributes } from './types';
-import {
-	Step,
-	useIsAnchorFm,
-	usePath,
-	useNewQueryParam,
-	useCurrentStep,
-	useLangRouteParam,
-} from '../path';
 import AcquireIntent from './acquire-intent';
 import StylePreview from './style-preview';
 import Features from './features';
 import Plans from './plans';
 import Domains from './domains';
 import Language from './language';
+
+import type { Attributes } from './types';
 
 import './colors.scss';
 import './style.scss';
@@ -43,22 +37,14 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 	const isAnchorFmSignup = useIsAnchorFm();
 
 	const makePath = usePath();
-	const locale = useLocale();
-	const history = useHistory();
 	const currentStep = useCurrentStep();
-	const langRouteParam = useLangRouteParam();
+	const previousStep = usePrevious( currentStep );
 
 	const { pathname } = useLocation();
 
 	React.useEffect( () => {
 		setTimeout( () => window.scrollTo( 0, 0 ), 0 );
 	}, [ pathname ] );
-
-	React.useEffect( () => {
-		if ( langRouteParam && langRouteParam !== locale ) {
-			history.replace( makePath( Step[ currentStep ], locale ) );
-		}
-	}, [ langRouteParam, locale, pathname, history, currentStep, makePath ] );
 
 	const canUseDesignStep = React.useCallback( (): boolean => {
 		return !! siteTitle;
@@ -138,7 +124,7 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 				</Route>
 
 				<Route path={ makePath( Step.LanguageModal ) }>
-					<Language />
+					<Language previousStep={ previousStep } />
 				</Route>
 
 				<Route path={ makePath( Step.CreateSite ) }>{ createSiteOrError() }</Route>

--- a/client/landing/gutenboarding/onboarding-block/language/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/language/index.tsx
@@ -20,6 +20,8 @@ import { ChangeLocaleContextConsumer } from '../../components/locale-context';
 import { I18N_STORE } from '../../stores/i18n';
 import { PLANS_STORE } from '../../stores/plans';
 import { USER_STORE } from '../../stores/user';
+import { Step, usePath } from '../../path';
+import type { StepNameType } from '../../path';
 
 /**
  * Style dependencies
@@ -28,7 +30,11 @@ import './style.scss';
 
 const LOCALIZED_LANGUAGE_NAMES_FALLBACK_LOCALE = 'en';
 
-const LanguageStep: React.FunctionComponent = () => {
+interface Props {
+	previousStep?: StepNameType;
+}
+
+const LanguageStep: React.FunctionComponent< Props > = ( { previousStep } ) => {
 	const { __ } = useI18n();
 
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
@@ -39,12 +45,18 @@ const LanguageStep: React.FunctionComponent = () => {
 		)
 	);
 
+	// keep a static reference to the previous step
+	const staticPreviousStep = React.useRef( previousStep );
+
 	const history = useHistory();
+	const makePath = usePath();
 
 	const { invalidateResolution } = useDispatch( 'core/data' );
 
-	const goBack = () => {
-		history.goBack();
+	const goBack = ( lang = '' ) => {
+		staticPreviousStep.current
+			? history.replace( makePath( Step[ staticPreviousStep.current ], lang ) )
+			: history.goBack();
 	};
 
 	return (
@@ -55,7 +67,7 @@ const LanguageStep: React.FunctionComponent = () => {
 						headingTitle={ __( 'Select your site language' ) }
 						headingButtons={
 							<ActionButtons>
-								<BackButton onClick={ goBack } />
+								<BackButton onClick={ () => goBack() } />
 							</ActionButtons>
 						}
 						languageGroups={ createLanguageGroups( __ ) }
@@ -68,7 +80,7 @@ const LanguageStep: React.FunctionComponent = () => {
 							invalidateResolution( PLANS_STORE, 'getPrices', [ language.langSlug ] );
 
 							changeLocale( language.langSlug );
-							goBack();
+							goBack( language.langSlug );
 						} }
 						localizedLanguageNames={ localizedLanguageNames }
 					/>

--- a/client/landing/gutenboarding/onboarding-block/language/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/language/index.tsx
@@ -55,7 +55,7 @@ const LanguageStep: React.FunctionComponent< Props > = ( { previousStep } ) => {
 
 	const goBack = ( lang = '' ) => {
 		staticPreviousStep.current
-			? history.replace( makePath( Step[ staticPreviousStep.current ], lang ) )
+			? history.push( makePath( Step[ staticPreviousStep.current ], lang ) )
 			: history.goBack();
 	};
 

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -4,13 +4,14 @@
 import { findKey } from 'lodash';
 import { generatePath, useLocation, useRouteMatch } from 'react-router-dom';
 import { Plans } from '@automattic/data-stores';
+import languages from '@automattic/languages';
+
 import type { ValuesType } from 'utility-types';
 
 /**
  * Internal dependencies
  */
 import config from 'calypso/config';
-import { getLanguageRouteParam } from '../../lib/i18n-utils';
 
 type PlanPath = Plans.PlanPath;
 
@@ -41,7 +42,7 @@ const routeFragments = {
 	// We add the possibility of an empty step fragment through the `?` question mark at the end of that fragment.
 	step: `:step(${ steps.join( '|' ) })?`,
 	plan: `:plan(${ plansPaths.join( '|' ) })?`,
-	lang: getLanguageRouteParam(),
+	lang: `:lang(${ languages.map( ( lang ) => lang.langSlug ).join( '|' ) })?`,
 };
 
 export const path = [ '', ...Object.values( routeFragments ) ].join( '/' );

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -98,7 +98,7 @@ export function usePlanRouteParam() {
 	return match?.params.plan;
 }
 
-export function useCurrentStep() {
+export function useCurrentStep(): StepNameType {
 	const stepRouteParam = useStepRouteParam();
 	return findKey( Step, ( step ) => step === stepRouteParam ) as StepNameType;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -69,6 +69,7 @@
 		"google-my-business": true,
 		"google-drive": true,
 		"gutenboarding/alpha-templates": true,
+		"gutenboarding/language-picker": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/show-vertical-input": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,6 +42,7 @@
 		"gdpr-banner": true,
 		"google-my-business": false,
 		"gutenboarding/alpha-templates": true,
+		"gutenboarding/language-picker": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
 		"happychat": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Fix Language picker redirecting to the Gutenboarding base path.
* Fix language param not being updated in path after making a selection in Language modal.
* Import `languages` from `@automattic/languages` remove Calypso `/lib` dependency.
* Enable `gutenboarding/language-picker` feature flag in development and horizon for testing.

#### Testing instructions
1. Starting at URL: [/new/es?flags=gutenboarding/language-picker](https://hash-60980ae88e9789254b6bde72a4d182e431ac497c.calypso.live/new/es?flags=gutenboarding/language-picker)
2. Skip setting a site title
3. Open the language picker => URL pathname should become `/new/language-modal/es`
4. Choose another language => when the language modal closes, pathname should be `new/{PREVIOUS_STEP}/{NEW_LOCALE}`

*Note that full translation of the page doesn't happen instantly, except when loading EN.

Fixes #48197
Fixes #48198
