### PR TITLE
Updates copy for launch flow domain upsell

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -66,7 +66,7 @@ export default {
 		allowExistingUsers: false,
 	},
 	freePlansDomainUpsell: {
-		datestamp: '20201209',
+		datestamp: '20201210',
 		variations: {
 			test: 50,
 			control: 50,

--- a/client/signup/steps/domain-upsell/index.jsx
+++ b/client/signup/steps/domain-upsell/index.jsx
@@ -34,12 +34,15 @@ export default function DomainUpsellStep( props ) {
 		signupDependencies: { siteSlug },
 	} = props;
 
-	const subHeaderText = translate(
-		'You can select an easier-to-remember name below at a one-time discounted price:'
-	);
 	const headerText = translate( 'Congrats, %s is almost ready!', {
 		args: [ siteSlug ],
 	} );
+	const subHeaderText = translate(
+		'You can buy a custom domain to make your site address easier to share and remember. When a visitor uses your custom domain they will be re-directed to %s',
+		{
+			args: [ siteSlug ],
+		}
+	);
 
 	return (
 		<div className="domain-upsell__step-secton-wrapper">
@@ -181,7 +184,7 @@ function RecommendedDomains( props ) {
 			</Card>
 			<div className="domain-upsell__continue-link">
 				<Button compact borderless plain onClick={ handleSkipButtonClick }>
-					{ translate( 'No thanks, continue to %s', {
+					{ translate( `No thanks, I'll stick with %s`, {
 						args: [ siteSlug ],
 					} ) }
 				</Button>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the copy for the domain upsell step used in the launch flow. The relevant experiment is `freePlansDomainUpsell`.
* Updates the datestamp of the AB test.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Please follow the testing instructions in https://github.com/Automattic/wp-calypso/pull/47963
The final step of the launch flow should look like this:
![image](https://user-images.githubusercontent.com/5436027/101745158-222f8100-3af1-11eb-855e-c55e90a5f1d3.png)

