### PR TITLE
Plugins: Reduxify, cleanup and modernize notices

### DIFF
--- a/client/lib/plugins/test/utils.js
+++ b/client/lib/plugins/test/utils.js
@@ -162,21 +162,20 @@ describe( 'Plugins Utils', () => {
 				{
 					status: 'status',
 					action: 'action',
-					site: { ID: '123' },
-					plugin: { slug: 'jetpack' },
+					siteId: 123,
+					pluginId: 'jetpack',
 				},
 				{
 					status: 'status',
 					action: 'action',
-					site: { ID: '321' },
-					plugin: {},
+					siteId: 321,
 				},
 			];
 		} );
 
 		test( 'should return a list of notices that match the site', () => {
-			logs[ 0 ].plugin = {};
-			const log = PluginUtils.filterNotices( logs, { ID: '123' }, null );
+			logs[ 0 ].pluginId = undefined;
+			const log = PluginUtils.filterNotices( logs, 123, null );
 			assert.deepEqual( log, [ logs[ 0 ] ] );
 		} );
 
@@ -186,7 +185,7 @@ describe( 'Plugins Utils', () => {
 		} );
 
 		test( 'should return a list of notices that match the site and plugin', () => {
-			const log = PluginUtils.filterNotices( logs, { ID: '123' }, 'jetpack' );
+			const log = PluginUtils.filterNotices( logs, 123, 'jetpack' );
 			assert.deepEqual( log, [ logs[ 0 ] ] );
 		} );
 	} );

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -25,7 +25,26 @@ function isSameSiteNotice( siteId, log ) {
  * @returns {boolean} True if notice matches criteria
  */
 function isSamePluginNotice( pluginId, log ) {
-	return pluginId && log.pluginId && log.pluginId === pluginId;
+	if ( ! pluginId || ! log.pluginId ) {
+		return false;
+	}
+
+	return isSamePluginIdSlug( log.pluginId, pluginId );
+}
+
+/**
+ * @param  {string} idOrSlug First plugin ID or slug for comparison
+ * @param  {string} slugOrId Second plugin ID or slug for comparison
+ * @returns {boolean} True if the plugin ID and slug match
+ */
+export function isSamePluginIdSlug( idOrSlug, slugOrId ) {
+	return (
+		idOrSlug === slugOrId ||
+		idOrSlug.startsWith( slugOrId + '/' ) ||
+		idOrSlug.endsWith( '/' + slugOrId ) ||
+		slugOrId.startsWith( idOrSlug + '/' ) ||
+		slugOrId.endsWith( '/' + idOrSlug )
+	);
 }
 
 /**

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -11,40 +11,40 @@ import { decodeEntities, parseHtml } from 'calypso/lib/formatting';
 import { sanitizeSectionContent } from './sanitize-section-content';
 
 /**
- * @param  {object} site       Site Object
+ * @param  {number} siteId     Site Object
  * @param  {object} log        Notice log Object
  * @returns {boolean} True if notice matches criteria
  */
-function isSameSiteNotice( site, log ) {
-	return site && log.site && log.site.ID === site.ID;
+function isSameSiteNotice( siteId, log ) {
+	return siteId && log.siteId && parseInt( log.siteId ) === siteId;
 }
 
 /**
- * @param  {string} pluginSlug Plugin Slug
- * @param  {object} log        Notice log Object
+ * @param  {string} pluginId Plugin ID
+ * @param  {object} log      Notice log Object
  * @returns {boolean} True if notice matches criteria
  */
-function isSamePluginNotice( pluginSlug, log ) {
-	return pluginSlug && log.plugin && log.plugin.slug === pluginSlug;
+function isSamePluginNotice( pluginId, log ) {
+	return pluginId && log.pluginId && log.pluginId === pluginId;
 }
 
 /**
  * Filter function that return notices that fit a certain criteria.
  *
- * @param  {object} site       Site Object
- * @param  {string} pluginSlug Plugin Slug
- * @param  {object} log        Notice log Object
+ * @param  {number} siteId   Site Object
+ * @param  {string} pluginId Plugin Id
+ * @param  {object} log      Notice log Object
  * @returns {boolean} True if notice matches criteria
  */
-function filterNoticesBy( site, pluginSlug, log ) {
-	if ( ! site && ! pluginSlug ) {
+function filterNoticesBy( siteId, pluginId, log ) {
+	if ( ! siteId && ! pluginId ) {
 		return true;
 	}
-	if ( isSameSiteNotice( site, log ) && isSamePluginNotice( pluginSlug, log ) ) {
+	if ( isSameSiteNotice( siteId, log ) && isSamePluginNotice( pluginId, log ) ) {
 		return true;
-	} else if ( ! pluginSlug && isSameSiteNotice( site, log ) ) {
+	} else if ( ! pluginId && isSameSiteNotice( siteId, log ) ) {
 		return true;
-	} else if ( ! site && isSamePluginNotice( pluginSlug, log ) ) {
+	} else if ( ! siteId && isSamePluginNotice( pluginId, log ) ) {
 		return true;
 	}
 	return false;
@@ -213,12 +213,12 @@ export function normalizePluginsList( pluginsList ) {
 /**
  * Return logs that match a certain critia.
  *
- * @param  {Array} logs        List of all notices
- * @param  {object} site       Site Object
- * @param  {string} pluginSlug Plugin Slug
+ * @param  {Array} logs      List of all notices
+ * @param  {number} siteId   Site Object
+ * @param  {string} pluginId Plugin ID
  *
  * @returns {Array} Array of filtered logs that match the criteria
  */
-export function filterNotices( logs, site, pluginSlug ) {
-	return filter( logs, filterNoticesBy.bind( this, site, pluginSlug ) );
+export function filterNotices( logs, siteId, pluginId ) {
+	return filter( logs, filterNoticesBy.bind( this, siteId, pluginId ) );
 }

--- a/client/my-sites/plugins/notices.jsx
+++ b/client/my-sites/plugins/notices.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { uniqBy } from 'lodash';
-import i18n from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * WordPress dependencies
@@ -130,30 +130,26 @@ class PluginNotices extends React.Component {
 	};
 
 	successMessage = ( action, combination, translateArg ) => {
+		const { translate } = this.props;
+
 		switch ( action ) {
 			case 'INSTALL_PLUGIN':
 				if ( translateArg.isMultiSite ) {
 					switch ( combination ) {
 						case '1 site 1 plugin':
-							return i18n.translate( 'Successfully installed %(plugin)s on %(site)s.', {
+							return translate( 'Successfully installed %(plugin)s on %(site)s.', {
 								args: translateArg,
 							} );
 						case '1 site n plugins':
-							return i18n.translate(
-								'Successfully installed %(numberOfPlugins)d plugins on %(site)s.',
-								{
-									args: translateArg,
-								}
-							);
+							return translate( 'Successfully installed %(numberOfPlugins)d plugins on %(site)s.', {
+								args: translateArg,
+							} );
 						case 'n sites 1 plugin':
-							return i18n.translate(
-								'Successfully installed %(plugin)s on %(numberOfSites)d sites.',
-								{
-									args: translateArg,
-								}
-							);
+							return translate( 'Successfully installed %(plugin)s on %(numberOfSites)d sites.', {
+								args: translateArg,
+							} );
 						case 'n sites n plugins':
-							return i18n.translate(
+							return translate(
 								'Successfully installed %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 								{
 									args: translateArg,
@@ -163,25 +159,25 @@ class PluginNotices extends React.Component {
 				}
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Successfully installed and activated %(plugin)s on %(site)s.', {
+						return translate( 'Successfully installed and activated %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully installed and activated %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'Successfully installed and activated %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully installed and activated %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -193,22 +189,19 @@ class PluginNotices extends React.Component {
 			case 'REMOVE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Successfully removed %(plugin)s on %(site)s.', {
+						return translate( 'Successfully removed %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
-							'Successfully removed %(numberOfPlugins)d plugins on %(site)s.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully removed %(numberOfPlugins)d plugins on %(site)s.', {
+							args: translateArg,
+						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Successfully removed %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Successfully removed %(plugin)s on %(numberOfSites)d sites.', {
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully removed %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -219,22 +212,19 @@ class PluginNotices extends React.Component {
 			case 'UPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Successfully updated %(plugin)s on %(site)s.', {
+						return translate( 'Successfully updated %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
-							'Successfully updated %(numberOfPlugins)d plugins on %(site)s.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully updated %(numberOfPlugins)d plugins on %(site)s.', {
+							args: translateArg,
+						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Successfully updated %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Successfully updated %(plugin)s on %(numberOfSites)d sites.', {
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully updated %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -245,25 +235,19 @@ class PluginNotices extends React.Component {
 			case 'ACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Successfully activated %(plugin)s on %(site)s.', {
+						return translate( 'Successfully activated %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
-							'Successfully activated %(numberOfPlugins)d plugins on %(site)s.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully activated %(numberOfPlugins)d plugins on %(site)s.', {
+							args: translateArg,
+						} );
 					case 'n sites 1 plugin':
-						return i18n.translate(
-							'Successfully activated %(plugin)s on %(numberOfSites)d sites.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully activated %(plugin)s on %(numberOfSites)d sites.', {
+							args: translateArg,
+						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully activated %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -274,25 +258,19 @@ class PluginNotices extends React.Component {
 			case 'DEACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Successfully deactivated %(plugin)s on %(site)s.', {
+						return translate( 'Successfully deactivated %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
-							'Successfully deactivated %(numberOfPlugins)d plugins on %(site)s.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully deactivated %(numberOfPlugins)d plugins on %(site)s.', {
+							args: translateArg,
+						} );
 					case 'n sites 1 plugin':
-						return i18n.translate(
-							'Successfully deactivated %(plugin)s on %(numberOfSites)d sites.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully deactivated %(plugin)s on %(numberOfSites)d sites.', {
+							args: translateArg,
+						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully deactivated %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -303,25 +281,25 @@ class PluginNotices extends React.Component {
 			case 'ENABLE_AUTOUPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Successfully enabled autoupdates for %(plugin)s on %(site)s.', {
+						return translate( 'Successfully enabled autoupdates for %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully enabled autoupdates for %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'Successfully enabled autoupdates for %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully enabled autoupdates for %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -332,28 +310,25 @@ class PluginNotices extends React.Component {
 			case 'DISABLE_AUTOUPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate(
-							'Successfully disabled autoupdates for %(plugin)s on %(site)s.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully disabled autoupdates for %(plugin)s on %(site)s.', {
+							args: translateArg,
+						} );
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully disabled autoupdates for %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'Successfully disabled autoupdates for %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully disabled autoupdates for %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -362,33 +337,35 @@ class PluginNotices extends React.Component {
 				}
 				break;
 			case 'PLUGIN_UPLOAD':
-				return i18n.translate( "You've successfully installed the %(plugin)s plugin.", {
+				return translate( "You've successfully installed the %(plugin)s plugin.", {
 					args: translateArg,
 				} );
 		}
 	};
 
 	inProgressMessage = ( action, combination, translateArg ) => {
+		const { translate } = this.props;
+
 		switch ( action ) {
 			case 'INSTALL_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Installing %(plugin)s on %(site)s.', {
+						return translate( 'Installing %(plugin)s on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate( 'Installing %(numberOfPlugins)d plugins on %(site)s.', {
+						return translate( 'Installing %(numberOfPlugins)d plugins on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Installing %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Installing %(plugin)s on %(numberOfSites)d sites.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Installing %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								context: 'In progress message',
@@ -400,70 +377,64 @@ class PluginNotices extends React.Component {
 			case 'REMOVE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Removing %(plugin)s on %(site)s.', { args: translateArg } );
+						return translate( 'Removing %(plugin)s on %(site)s.', { args: translateArg } );
 					case '1 site n plugins':
-						return i18n.translate( 'Removing %(numberOfPlugins)d plugins on %(site)s.', {
+						return translate( 'Removing %(numberOfPlugins)d plugins on %(site)s.', {
 							args: translateArg,
 						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Removing %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Removing %(plugin)s on %(numberOfSites)d sites.', {
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
-							'Removing %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Removing %(numberOfPlugins)d plugins on %(numberOfSites)d sites.', {
+							args: translateArg,
+						} );
 				}
 				break;
 			case 'UPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Updating %(plugin)s on %(site)s.', {
+						return translate( 'Updating %(plugin)s on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate( 'Updating %(numberOfPlugins)d plugins on %(site)s.', {
+						return translate( 'Updating %(numberOfPlugins)d plugins on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Updating %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Updating %(plugin)s on %(numberOfSites)d sites.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
-							'Updating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
-							{
-								context: 'In progress message',
-								args: translateArg,
-							}
-						);
+						return translate( 'Updating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.', {
+							context: 'In progress message',
+							args: translateArg,
+						} );
 				}
 				break;
 			case 'ACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Activating %(plugin)s on %(site)s.', {
+						return translate( 'Activating %(plugin)s on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate( 'Activating %(numberOfPlugins)d plugins on %(site)s.', {
+						return translate( 'Activating %(numberOfPlugins)d plugins on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Activating %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Activating %(plugin)s on %(numberOfSites)d sites.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Activating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								context: 'In progress message',
@@ -475,22 +446,22 @@ class PluginNotices extends React.Component {
 			case 'DEACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Deactivating %(plugin)s on %(site)s', {
+						return translate( 'Deactivating %(plugin)s on %(site)s', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate( 'Deactivating %(numberOfPlugins)d plugins on %(site)s.', {
+						return translate( 'Deactivating %(numberOfPlugins)d plugins on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Deactivating %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Deactivating %(plugin)s on %(numberOfSites)d sites.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Deactivating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								context: 'In progress message',
@@ -502,28 +473,22 @@ class PluginNotices extends React.Component {
 			case 'ENABLE_AUTOUPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Enabling autoupdates for %(plugin)s on %(site)s.', {
+						return translate( 'Enabling autoupdates for %(plugin)s on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
-							'Enabling autoupdates for %(numberOfPlugins)d plugins on %(site)s.',
-							{
-								context: 'In progress message',
-								args: translateArg,
-							}
-						);
+						return translate( 'Enabling autoupdates for %(numberOfPlugins)d plugins on %(site)s.', {
+							context: 'In progress message',
+							args: translateArg,
+						} );
 					case 'n sites 1 plugin':
-						return i18n.translate(
-							'Enabling autoupdates for %(plugin)s on %(numberOfSites)d sites.',
-							{
-								context: 'In progress message',
-								args: translateArg,
-							}
-						);
+						return translate( 'Enabling autoupdates for %(plugin)s on %(numberOfSites)d sites.', {
+							context: 'In progress message',
+							args: translateArg,
+						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Enabling autoupdates for %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								context: 'In progress message',
@@ -535,12 +500,12 @@ class PluginNotices extends React.Component {
 			case 'DISABLE_AUTOUPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Disabling autoupdates for %(plugin)s on %(site)s.', {
+						return translate( 'Disabling autoupdates for %(plugin)s on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'Disabling autoupdates for %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								context: 'In progress message',
@@ -548,15 +513,12 @@ class PluginNotices extends React.Component {
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
-							'Disabling autoupdates for %(plugin)s on %(numberOfSites)d sites.',
-							{
-								context: 'In progress message',
-								args: translateArg,
-							}
-						);
+						return translate( 'Disabling autoupdates for %(plugin)s on %(numberOfSites)d sites.', {
+							context: 'In progress message',
+							args: translateArg,
+						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Disabling autoupdates for %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								context: 'In progress message',
@@ -579,6 +541,8 @@ class PluginNotices extends React.Component {
 	};
 
 	errorMessage = ( action, combination, translateArg, sampleLog ) => {
+		const { translate } = this.props;
+
 		if ( combination === '1 site 1 plugin' ) {
 			return this.singleErrorMessage( action, translateArg, sampleLog );
 		}
@@ -586,21 +550,21 @@ class PluginNotices extends React.Component {
 			case 'INSTALL_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors installing %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'There were errors installing %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors installing %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -611,21 +575,18 @@ class PluginNotices extends React.Component {
 			case 'REMOVE_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors removing %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
-							'There were errors removing %(plugin)s on %(numberOfSites)d sites.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'There were errors removing %(plugin)s on %(numberOfSites)d sites.', {
+							args: translateArg,
+						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors removing %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -636,21 +597,18 @@ class PluginNotices extends React.Component {
 			case 'UPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors updating %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
-							'There were errors updating %(plugin)s on %(numberOfSites)d sites.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'There were errors updating %(plugin)s on %(numberOfSites)d sites.', {
+							args: translateArg,
+						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors updating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -661,21 +619,21 @@ class PluginNotices extends React.Component {
 			case 'ACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors activating %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'There were errors activating %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors activating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -686,21 +644,21 @@ class PluginNotices extends React.Component {
 			case 'DEACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors deactivating %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'There were errors deactivating %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors deactivating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -711,21 +669,21 @@ class PluginNotices extends React.Component {
 			case 'ENABLE_AUTOUPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors enabling autoupdates %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'There were errors enabling autoupdates %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors enabling autoupdates %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -736,21 +694,21 @@ class PluginNotices extends React.Component {
 			case 'DISABLE_AUTOUPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors disabling autoupdates %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'There were errors disabling autoupdates %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors disabling autoupdates %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -759,7 +717,7 @@ class PluginNotices extends React.Component {
 				}
 				break;
 			case 'RECEIVE_PLUGINS':
-				return i18n.translate(
+				return translate(
 					'Error fetching plugins on %(numberOfSites)d site.',
 					'Error fetching plugins on %(numberOfSites)d sites.',
 					{
@@ -771,70 +729,72 @@ class PluginNotices extends React.Component {
 	};
 
 	additionalExplanation = ( error_code ) => {
+		const { translate } = this.props;
+
 		switch ( error_code ) {
 			case 'no_package':
-				return i18n.translate( "Plugin doesn't exist in the plugin repo." );
+				return translate( "Plugin doesn't exist in the plugin repo." );
 
 			case 'resource_not_found':
-				return i18n.translate( 'The site could not be reached.' );
+				return translate( 'The site could not be reached.' );
 
 			case 'download_failed':
-				return i18n.translate( 'Download failed.' );
+				return translate( 'Download failed.' );
 
 			case 'plugin_already_installed':
-				return i18n.translate( 'Plugin is already installed.' );
+				return translate( 'Plugin is already installed.' );
 
 			case 'incompatible_archive':
-				return i18n.translate( 'Incompatible Archive. The package could not be installed.' );
+				return translate( 'Incompatible Archive. The package could not be installed.' );
 
 			case 'empty_archive_pclzip':
-				return i18n.translate( 'Empty archive.' );
+				return translate( 'Empty archive.' );
 
 			case 'disk_full_unzip_file':
-				return i18n.translate( 'Could not copy files. You may have run out of disk space.' );
+				return translate( 'Could not copy files. You may have run out of disk space.' );
 
 			case 'mkdir_failed_ziparchive':
 			case 'mkdir_failed_pclzip':
-				return i18n.translate( 'Could not create directory.' );
+				return translate( 'Could not create directory.' );
 
 			case 'copy_failed_pclzip':
-				return i18n.translate( 'Could not copy file.' );
+				return translate( 'Could not copy file.' );
 
 			case 'md5_mismatch':
-				return i18n.translate( "The checksum of the files don't match." );
+				return translate( "The checksum of the files don't match." );
 
 			case 'bad_request':
-				return i18n.translate( 'Invalid Data provided.' );
+				return translate( 'Invalid Data provided.' );
 
 			case 'fs_unavailable':
-				return i18n.translate( 'Could not access filesystem.' );
+				return translate( 'Could not access filesystem.' );
 
 			case 'fs_error':
-				return i18n.translate( 'Filesystem error.' );
+				return translate( 'Filesystem error.' );
 
 			case 'fs_no_root_dir':
-				return i18n.translate( 'Unable to locate WordPress Root directory.' );
+				return translate( 'Unable to locate WordPress Root directory.' );
 
 			case 'fs_no_content_dir':
-				return i18n.translate( 'Unable to locate WordPress Content directory (wp-content).' );
+				return translate( 'Unable to locate WordPress Content directory (wp-content).' );
 
 			case 'fs_no_plugins_dir':
-				return i18n.translate( 'Unable to locate WordPress Plugin directory.' );
+				return translate( 'Unable to locate WordPress Plugin directory.' );
 
 			case 'fs_no_folder':
-				return i18n.translate( 'Unable to locate needed folder.' );
+				return translate( 'Unable to locate needed folder.' );
 
 			case 'no_files':
-				return i18n.translate( 'The package contains no files.' );
+				return translate( 'The package contains no files.' );
 
 			case 'folder_exists':
-				return i18n.translate( 'Destination folder already exists.' );
+				return translate( 'Destination folder already exists.' );
 
 			case 'mkdir_failed':
-				return i18n.translate( 'Could not create directory.' );
+				return translate( 'Could not create directory.' );
 
 			case 'files_not_writable':
-				return i18n.translate(
+				return translate(
 					'The update cannot be installed because we will be unable to copy some files. This is usually due to inconsistent file permissions.'
 				);
 		}
@@ -843,12 +803,14 @@ class PluginNotices extends React.Component {
 	};
 
 	singleErrorMessage = ( action, translateArg, sampleLog ) => {
+		const { translate } = this.props;
 		const additionalExplanation = this.additionalExplanation( sampleLog.error.error );
+
 		switch ( action ) {
 			case 'INSTALL_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
+						return translate(
 							'Error installing %(plugin)s on %(site)s, remote management is off.',
 							{
 								args: translateArg,
@@ -858,14 +820,14 @@ class PluginNotices extends React.Component {
 					default:
 						if ( additionalExplanation ) {
 							translateArg.additionalExplanation = additionalExplanation;
-							return i18n.translate(
+							return translate(
 								'Error installing %(plugin)s on %(site)s. %(additionalExplanation)s',
 								{
 									args: translateArg,
 								}
 							);
 						}
-						return i18n.translate( 'An error occurred while installing %(plugin)s on %(site)s.', {
+						return translate( 'An error occurred while installing %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 				}
@@ -873,14 +835,11 @@ class PluginNotices extends React.Component {
 			case 'REMOVE_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
-							'Error removing %(plugin)s on %(site)s, remote management is off.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Error removing %(plugin)s on %(site)s, remote management is off.', {
+							args: translateArg,
+						} );
 					default:
-						return i18n.translate( 'An error occurred while removing %(plugin)s on %(site)s.', {
+						return translate( 'An error occurred while removing %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 				}
@@ -888,23 +847,20 @@ class PluginNotices extends React.Component {
 			case 'UPDATE_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
-							'Error updating %(plugin)s on %(site)s, remote management is off.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Error updating %(plugin)s on %(site)s, remote management is off.', {
+							args: translateArg,
+						} );
 					default:
 						if ( additionalExplanation ) {
 							translateArg.additionalExplanation = additionalExplanation;
-							return i18n.translate(
+							return translate(
 								'Error updating %(plugin)s on %(site)s. %(additionalExplanation)s',
 								{
 									args: translateArg,
 								}
 							);
 						}
-						return i18n.translate( 'An error occurred while updating %(plugin)s on %(site)s.', {
+						return translate( 'An error occurred while updating %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 				}
@@ -912,14 +868,14 @@ class PluginNotices extends React.Component {
 			case 'ACTIVATE_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
+						return translate(
 							'Error activating %(plugin)s on %(site)s, remote management is off.',
 							{
 								args: translateArg,
 							}
 						);
 					default:
-						return i18n.translate( 'An error occurred while activating %(plugin)s on %(site)s.', {
+						return translate( 'An error occurred while activating %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 				}
@@ -927,14 +883,14 @@ class PluginNotices extends React.Component {
 			case 'DEACTIVATE_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
+						return translate(
 							'Error deactivating %(plugin)s on %(site)s, remote management is off.',
 							{
 								args: translateArg,
 							}
 						);
 					default:
-						return i18n.translate( 'An error occurred while deactivating %(plugin)s on %(site)s.', {
+						return translate( 'An error occurred while deactivating %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 				}
@@ -942,14 +898,14 @@ class PluginNotices extends React.Component {
 			case 'ENABLE_AUTOUPDATE_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
+						return translate(
 							'Error enabling autoupdates for %(plugin)s on %(site)s, remote management is off.',
 							{
 								args: translateArg,
 							}
 						);
 					default:
-						return i18n.translate(
+						return translate(
 							'An error occurred while enabling autoupdates for %(plugin)s on %(site)s.',
 							{
 								args: translateArg,
@@ -960,14 +916,14 @@ class PluginNotices extends React.Component {
 			case 'DISABLE_AUTOUPDATE_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
+						return translate(
 							'Error disabling autoupdates for %(plugin)s on %(site)s, remote management is off.',
 							{
 								args: translateArg,
 							}
 						);
 					default:
-						return i18n.translate(
+						return translate(
 							'An error occurred while disabling autoupdates for %(plugin)s on %(site)s.',
 							{
 								args: translateArg,
@@ -976,7 +932,7 @@ class PluginNotices extends React.Component {
 				}
 
 			case 'RECEIVE_PLUGINS':
-				return i18n.translate( 'Error fetching plugins on %(site)s.', {
+				return translate( 'Error fetching plugins on %(site)s.', {
 					args: translateArg,
 				} );
 		}
@@ -1001,4 +957,4 @@ export default connect(
 		successNotice,
 		warningNotice,
 	}
-)( PluginNotices );
+)( localize( PluginNotices ) );

--- a/client/my-sites/plugins/notices.jsx
+++ b/client/my-sites/plugins/notices.jsx
@@ -20,7 +20,7 @@ import {
 	successNotice,
 	warningNotice,
 } from 'calypso/state/notices/actions';
-import { filterNotices } from 'calypso/lib/plugins/utils';
+import { filterNotices, isSamePluginIdSlug } from 'calypso/lib/plugins/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import { getPluginStatusesByType } from 'calypso/state/plugins/installed/selectors';
@@ -54,7 +54,10 @@ class PluginNotices extends React.Component {
 	};
 
 	getPluginById( pluginId ) {
-		return this.props.plugins.find( ( plugin ) => plugin.id === pluginId );
+		return this.props.plugins.find(
+			( plugin ) =>
+				isSamePluginIdSlug( plugin.id, pluginId ) || isSamePluginIdSlug( plugin.slug, pluginId )
+		);
 	}
 
 	getCombination( translateArg ) {

--- a/client/my-sites/plugins/notices.jsx
+++ b/client/my-sites/plugins/notices.jsx
@@ -17,7 +17,6 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import notices from 'calypso/notices';
 import { filterNotices } from 'calypso/lib/plugins/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import { getPluginStatusesByType } from 'calypso/state/plugins/installed/selectors';
 
@@ -93,17 +92,17 @@ class PluginNotices extends React.Component {
 
 		if ( currentNotices.completed.length > 0 && currentNotices.errors.length > 0 ) {
 			notices.warning( this.erroredAndCompletedMessage( currentNotices ), {
-				onRemoveCallback: () => reduxDispatch( removePluginStatuses( 'completed', 'error' ) ),
+				onRemoveCallback: () => this.props.removePluginStatuses( 'completed', 'error' ),
 			} );
 		} else if ( currentNotices.errors.length > 0 ) {
 			notices.error( this.getMessage( currentNotices.errors, this.errorMessage, 'error' ), {
-				onRemoveCallback: () => reduxDispatch( removePluginStatuses( 'error' ) ),
+				onRemoveCallback: () => this.props.removePluginStatuses( 'error' ),
 			} );
 		} else if ( currentNotices.completed.length > 0 ) {
 			notices.success(
 				this.getMessage( currentNotices.completed, this.successMessage, 'completed' ),
 				{
-					onRemoveCallback: () => reduxDispatch( removePluginStatuses( 'completed' ) ),
+					onRemoveCallback: () => this.props.removePluginStatuses( 'completed' ),
 					showDismiss: true,
 				}
 			);
@@ -975,9 +974,14 @@ class PluginNotices extends React.Component {
 	}
 }
 
-export default connect( ( state ) => ( {
-	completedNotices: getPluginStatusesByType( state, 'completed' ),
-	errorNotices: getPluginStatusesByType( state, 'error' ),
-	inProgressNotices: getPluginStatusesByType( state, 'inProgress' ),
-	siteId: getSelectedSiteId( state ),
-} ) )( PluginNotices );
+export default connect(
+	( state ) => ( {
+		completedNotices: getPluginStatusesByType( state, 'completed' ),
+		errorNotices: getPluginStatusesByType( state, 'error' ),
+		inProgressNotices: getPluginStatusesByType( state, 'inProgress' ),
+		siteId: getSelectedSiteId( state ),
+	} ),
+	{
+		removePluginStatuses,
+	}
+)( PluginNotices );

--- a/client/my-sites/plugins/notices.jsx
+++ b/client/my-sites/plugins/notices.jsx
@@ -14,7 +14,12 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 /**
  * Internal dependencies
  */
-import notices from 'calypso/notices';
+import {
+	errorNotice,
+	infoNotice,
+	successNotice,
+	warningNotice,
+} from 'calypso/state/notices/actions';
 import { filterNotices } from 'calypso/lib/plugins/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
@@ -84,26 +89,34 @@ class PluginNotices extends React.Component {
 		const currentNotices = this.getCurrentNotices();
 
 		if ( currentNotices.inProgress.length > 0 ) {
-			notices.info(
-				this.getMessage( currentNotices.inProgress, this.inProgressMessage, 'inProgress' )
+			this.props.infoNotice(
+				this.getMessage( currentNotices.inProgress, this.inProgressMessage, 'inProgress' ),
+				{
+					id: 'plugin-notice',
+				}
 			);
 			return;
 		}
 
 		if ( currentNotices.completed.length > 0 && currentNotices.errors.length > 0 ) {
-			notices.warning( this.erroredAndCompletedMessage( currentNotices ), {
-				onRemoveCallback: () => this.props.removePluginStatuses( 'completed', 'error' ),
+			this.props.warningNotice( this.erroredAndCompletedMessage( currentNotices ), {
+				onDismissClick: () => this.props.removePluginStatuses( 'completed', 'error' ),
+				id: 'plugin-notice',
 			} );
 		} else if ( currentNotices.errors.length > 0 ) {
-			notices.error( this.getMessage( currentNotices.errors, this.errorMessage, 'error' ), {
-				onRemoveCallback: () => this.props.removePluginStatuses( 'error' ),
-			} );
+			this.props.errorNotice(
+				this.getMessage( currentNotices.errors, this.errorMessage, 'error' ),
+				{
+					onDismissClick: () => this.props.removePluginStatuses( 'error' ),
+					id: 'plugin-notice',
+				}
+			);
 		} else if ( currentNotices.completed.length > 0 ) {
-			notices.success(
+			this.props.successNotice(
 				this.getMessage( currentNotices.completed, this.successMessage, 'completed' ),
 				{
-					onRemoveCallback: () => this.props.removePluginStatuses( 'completed' ),
-					showDismiss: true,
+					onDismissClick: () => this.props.removePluginStatuses( 'completed' ),
+					id: 'plugin-notice',
 				}
 			);
 		}
@@ -982,6 +995,10 @@ export default connect(
 		siteId: getSelectedSiteId( state ),
 	} ),
 	{
+		errorNotice,
+		infoNotice,
 		removePluginStatuses,
+		successNotice,
+		warningNotice,
 	}
 )( PluginNotices );

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -288,7 +288,7 @@ class SinglePlugin extends React.Component {
 	}
 
 	render() {
-		const { pluginSlug, selectedSite } = this.props;
+		const { selectedSite } = this.props;
 		if ( ! this.props.isRequestingSites && ! this.props.userCanManagePlugins ) {
 			return <NoPermissionsError title={ this.getPageTitle() } />;
 		}
@@ -314,7 +314,7 @@ class SinglePlugin extends React.Component {
 				<DocumentHead title={ this.getPageTitle() } />
 				<PageViewTracker path={ analyticsPath } title="Plugins > Plugin Details" />
 				<SidebarNavigation />
-				<PluginNotices pluginSlug={ pluginSlug } />
+				<PluginNotices pluginId={ plugin.id } sites={ this.props.sites } plugins={ [ plugin ] } />
 
 				<div className="plugin__page">
 					{ this.displayHeader( calypsoify ) }

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -435,6 +435,19 @@ export class PluginsList extends React.Component {
 		}
 	}
 
+	getPluginsSites() {
+		const { plugins } = this.props;
+		return plugins.reduce( ( sites, plugin ) => {
+			plugin.sites.map( ( pluginSite ) => {
+				if ( ! sites.find( ( site ) => site.ID === pluginSite.ID ) ) {
+					sites.push( pluginSite );
+				}
+			} );
+
+			return sites;
+		}, [] );
+	},
+
 	// Renders
 	render() {
 		const itemListClasses = classNames( 'plugins-list__elements', {
@@ -462,7 +475,7 @@ export class PluginsList extends React.Component {
 
 		return (
 			<div className="plugins-list">
-				<PluginNotices />
+				<PluginNotices sites={ this.getPluginsSites() } plugins={ this.props.plugins } />
 				<PluginsListHeader
 					label={ this.props.header }
 					isBulkManagementActive={ this.state.bulkManagementActive }

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -446,7 +446,7 @@ export class PluginsList extends React.Component {
 
 			return sites;
 		}, [] );
-	},
+	}
 
 	// Renders
 	render() {


### PR DESCRIPTION
This PR reduxifies, cleans up and modernizes the `PluginNotices` component. It grew rather a bit larger than I was hoping, but it's really a huge step for it and changes it to a state where we can just leave it be. 

It may make a lot of sense to review different commits separately, as changes make more sense that way. I'll also do a self-review in hope that it'll make the PR easier to review.

This PR is part of #24180.

#### Changes proposed in this Pull Request

* Update plugin `filter*` utility methods (and their tests) to work with site IDs and plugin IDs.
* Update `PluginNotices` to use Redux for retrieving and managing notices. This requires a lot of changes because of the different ways we're now storing those in Redux (for example, site IDs and not site objects; plugin IDs and not plugin objects).
* Update `SinglePlugin` to pass plugins and sites to `PluginNotices`
* Update `PluginsList` to pass plugins and sites to `PluginNotices`
* Dispatch Redux actions directly instead of using the redux bridge
* Use Redux for notices instead of the notices library.
* Use `localize()` instead of raw `i18n.translate` to subscribe to eventual locale changes

#### Testing instructions

* Get several Jetpack sites with some plugins for testing. Ideally, you would also have a connected multisite with 1-2 subsites that are also connected too. 
* Thoroughly test notices in all plugin scenarios; compare against production and verify that global and inline notices in plugin items still work the same way when updating, installing, or removing plugins, as well as toggling auto-updates and activating/deactivating plugins:
  * `/plugins/:plugin/:site`
  * `/plugins/:plugin`
  * `/plugins`
  * `/plugins/manage`
  * `/plugins/manage` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
  * `/plugins/manage/:site` - for a single plugin
  * `/plugins/manage/:site` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
* Verify all tests pass.

