### PR TITLE
Comment: Do not render user input content as HTML

### DIFF
--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -56,6 +56,7 @@ export class CommentContent extends Component {
 			commentId,
 			commentStatus,
 			isBulkMode,
+			isCommentSaved,
 			isParentCommentLoaded,
 			isPostView,
 			parentCommentContent,
@@ -101,10 +102,25 @@ export class CommentContent extends Component {
 
 						<AutoDirection>
 							<Emojify>
-								<div
-									className="comment__content-body"
-									dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
-								/>
+								{ /* Don't trust comment content unless it was provided by the API */ }
+								{ isCommentSaved ? (
+									<div
+										className="comment__content-body"
+										dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
+									/>
+								) : (
+									<div className="comment__content-body">
+										{ commentContent &&
+											commentContent.split( '\n' ).map( ( item, key ) => {
+												return (
+													<span key={ key }>
+														{ item }
+														<br />
+													</span>
+												);
+											} ) }
+									</div>
+								) }
 							</Emojify>
 						</AutoDirection>
 					</div>
@@ -133,6 +149,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 	return {
 		commentContent: get( comment, 'content' ),
 		commentStatus: get( comment, 'status' ),
+		isCommentSaved: get( comment, 'isSaved' ),
 		isJetpack,
 		isParentCommentLoaded: ! parentCommentId || !! parentCommentContent,
 		parentCommentContent,

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -86,6 +86,8 @@ export const receiveCommentsError = ( { siteId, commentId } ) => ( {
  * @param {number} options.siteId site identifier
  * @param {number} options.postId post identifier
  * @param {string} options.status status filter. Defaults to approved posts
+ * @param {string} options.direction Determines how the returned comments are sorted. Defaults to before (descending order).
+ * @param {boolean} options.isPoll Whether to include poll comments. Defaults to false.
  * @returns {Function} action that requests comments for a given post
  */
 export function requestPostComments( {
@@ -326,14 +328,18 @@ export const changeCommentStatus = (
  * @param {number} postId Post identifier
  * @param {number} commentId Comment identifier
  * @param {Comment} comment New comment data
+ * @param {boolean} isSaved Whether the comment has been already saved in the server
  * @returns {object} Action that edits a comment
  */
-export const editComment = ( siteId, postId, commentId, comment ) => ( {
+export const editComment = ( siteId, postId, commentId, comment, isSaved = false ) => ( {
 	type: COMMENTS_EDIT,
 	siteId,
 	postId,
 	commentId,
-	comment,
+	comment: {
+		...comment,
+		isSaved,
+	},
 } );
 
 /**

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -79,6 +79,7 @@ const updateComment = ( commentId, newProperties ) => ( comment ) => {
 					url: newProperties.authorUrl,
 				},
 				content: newProperties.commentContent,
+				isSaved: newProperties.isSaved,
 		  }
 		: { ...comment, ...newProperties };
 
@@ -128,6 +129,7 @@ export function items( state = {}, action ) {
 				..._comment,
 				contiguous: ! action.commentById,
 				has_link: commentHasLink( _comment.content, _comment.has_link ),
+				isSaved: true,
 			} ) );
 			const allComments = unionBy( state[ stateKey ], comments, 'ID' );
 			return {

--- a/client/state/comments/test/actions.js
+++ b/client/state/comments/test/actions.js
@@ -10,6 +10,7 @@ import {
 	COMMENTS_REPLY_WRITE,
 	COMMENTS_SET_ACTIVE_REPLY,
 	COMMENTS_CHANGE_STATUS,
+	COMMENTS_EDIT,
 } from '../../action-types';
 import {
 	requestPostComments,
@@ -20,6 +21,7 @@ import {
 	unlikeComment,
 	setActiveReply,
 	changeCommentStatus,
+	editComment,
 } from '../actions';
 import { NUMBER_OF_COMMENTS_PER_FETCH } from '../constants';
 import { setFeatureFlag } from 'calypso/test-helpers/config';
@@ -220,6 +222,20 @@ describe( 'actions', () => {
 					postId: POST_ID,
 					commentId: 1,
 				},
+			} );
+		} );
+	} );
+
+	describe( '#editComment()', () => {
+		test( 'should return an action to edit a comment', () => {
+			const action = editComment( SITE_ID, POST_ID, 1, { ID: 1 } );
+
+			expect( action ).toMatchObject( {
+				type: COMMENTS_EDIT,
+				siteId: SITE_ID,
+				postId: POST_ID,
+				commentId: 1,
+				comment: { ID: 1, isSaved: false },
 			} );
 		} );
 	} );

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -200,6 +200,19 @@ describe( 'reducer', () => {
 			} );
 			expect( result[ '1-1' ] ).toHaveLength( 1 );
 		} );
+
+		test( 'should set all comments as saved', () => {
+			const response = items( undefined, {
+				type: COMMENTS_RECEIVE,
+				siteId: 1,
+				postId: 1,
+				comments: [ ...commentsNestedTree ].sort( () => ( ( Math.random() * 2 ) % 2 ? -1 : 1 ) ),
+			} );
+			const areSaved = map( response[ '1-1' ], 'isSaved' );
+
+			expect( response[ '1-1' ] ).toHaveLength( 6 );
+			expect( areSaved ).toEqual( [ true, true, true, true, true, true ] );
+		} );
 	} );
 
 	describe( '#pendingItems', () => {

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -217,7 +217,7 @@ export const editComment = ( action ) => ( dispatch, getState ) => {
 					content: comment.commentContent,
 					date: comment.commentDate,
 			  }
-			: comment;
+			: omit( comment, 'isSaved' );
 
 	dispatch(
 		http(
@@ -234,7 +234,9 @@ export const editComment = ( action ) => ( dispatch, getState ) => {
 
 export const updateComment = ( action, data ) => [
 	removeNotice( `comment-notice-error-${ action.commentId }` ),
-	bypassDataLayer( editCommentAction( action.siteId, action.postId, action.commentId, data ) ),
+	bypassDataLayer(
+		editCommentAction( action.siteId, action.postId, action.commentId, data, true )
+	),
 ];
 
 export const announceEditFailure = ( action ) => [

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -14,6 +14,7 @@ import {
 	requestComment,
 	receiveCommentError,
 	receiveCommentSuccess,
+	updateComment,
 } from '../';
 import { COMMENTS_EDIT, NOTICE_REMOVE, COMMENTS_RECEIVE } from 'calypso/state/action-types';
 import {
@@ -248,7 +249,10 @@ describe( '#announceEditFailure', () => {
 				siteId: 1,
 				postId: 1,
 				commentId: 123,
-				comment: originalComment,
+				comment: {
+					...originalComment,
+					isSaved: false,
+				},
 			} )
 		);
 	} );
@@ -308,5 +312,29 @@ describe( '#handleChangeCommentStatusSuccess', () => {
 				},
 			},
 		] );
+	} );
+} );
+
+describe( '#updateComment', () => {
+	const comment = { ID: 123, text: 'lorem ipsum' };
+	const action = {
+		siteId: 1,
+		postId: 1,
+		commentId: 123,
+	};
+
+	test( 'should set the comment as saved', () => {
+		expect( updateComment( action, comment ) ).toContainEqual(
+			bypassDataLayer( {
+				type: COMMENTS_EDIT,
+				siteId: 1,
+				postId: 1,
+				commentId: 123,
+				comment: {
+					...comment,
+					isSaved: true,
+				},
+			} )
+		);
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR ensures the content of the comments Comment Management section of Calypso (Site > Comments) is rendered as HTML only when it is safe: saved in the server and provided by the API (which removes any unsafe markup from the content).

#### Testing instructions

- Navigate to Site > Comments (`/comments/all/:site`).
- Edit an existing comment and replace it with `"><img src=x onerror="alert(0);">`.
- Save the comment. 
- Make sure the JS alert is not displayed.

Fixes 368-gh-Automattic/dotcom-manage