### PR TITLE
Jetpack Backup: add pagination to real-time backups

### DIFF
--- a/client/components/jetpack/backup-delta/index.jsx
+++ b/client/components/jetpack/backup-delta/index.jsx
@@ -1,28 +1,37 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { useMemo, useState } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import ActivityCard from 'calypso/components/activity-card';
+import Pagination from 'calypso/components/pagination';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-class BackupDelta extends Component {
-	renderRealtime() {
-		const { realtimeBackups, translate, isToday } = this.props;
+const BACKUPS_PER_PAGE = 10;
 
-		const cards = realtimeBackups.map( ( activity ) => (
-			<ActivityCard activity={ activity } key={ activity.activityId } />
-		) );
+const BackupDelta = ( { realtimeBackups, translate, isToday } ) => {
+	const [ currentPage, setCurrentPage ] = useState( 1 );
 
-		return (
+	const onPageChange = ( pageNumber ) => setCurrentPage( pageNumber );
+
+	const cards = useMemo(
+		() =>
+			realtimeBackups
+				.slice( ( currentPage - 1 ) * BACKUPS_PER_PAGE, currentPage * BACKUPS_PER_PAGE )
+				.map( ( activity ) => <ActivityCard activity={ activity } key={ activity.activityId } /> ),
+		[ currentPage, realtimeBackups ]
+	);
+
+	return (
+		<div className="backup-delta">
 			<div className="backup-delta__realtime">
 				<div className="backup-delta__realtime-header">
 					{ isToday
@@ -34,6 +43,12 @@ class BackupDelta extends Component {
 						'Your site is backed up in real time (as you make changes) as well as in one daily backup.'
 					) }
 				</div>
+				<Pagination
+					page={ currentPage }
+					perPage={ BACKUPS_PER_PAGE }
+					total={ realtimeBackups.length }
+					pageClick={ onPageChange }
+				/>
 				{ cards.length ? (
 					cards
 				) : (
@@ -42,12 +57,9 @@ class BackupDelta extends Component {
 					</div>
 				) }
 			</div>
-		);
-	}
-
-	render() {
-		return <div className="backup-delta">{ this.renderRealtime() }</div>;
-	}
-}
+			);
+		</div>
+	);
+};
 
 export default localize( BackupDelta );

--- a/client/components/jetpack/backup-delta/index.jsx
+++ b/client/components/jetpack/backup-delta/index.jsx
@@ -57,7 +57,6 @@ const BackupDelta = ( { realtimeBackups, translate, isToday } ) => {
 					</div>
 				) }
 			</div>
-			);
 		</div>
 	);
 };

--- a/client/components/jetpack/backup-delta/style.scss
+++ b/client/components/jetpack/backup-delta/style.scss
@@ -29,6 +29,10 @@
 	margin-top: 1rem;
 }
 
+.backup-delta__realtime .pagination {
+	margin: 20px 0;
+}
+
 /* WordPress.com-only styles */
 .wordpressdotcom .backup-delta {
 	margin: initial;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 1164141197617539-as-1199565147906101

Sites with real-time backups can have an unlimited number of backups on a given day and our UI always shows all of them. Thus, owners of sites with a lot of activities will experience a poorer UX than the rest of the users because of this. In `6204-gh-Automattic/jpop-issues` we have a report coming from a user that couldn't use the date pagination controller because of the number of backups some dates have.

* Add a pagination controller to the backups of the day section. This pagination only appears when the site has more than 10 backups on a given date.

#### Notes

* This should bring a noticeable performance improvement to sites with hundreds of backups per day. To verify this, you will need access to a Jetpack site with these characteristics.
* If you see a `);` in the captures below, it was a mistake that has been fixed.

#### Testing instructions

Prerequisite: a Jetpack site with more than 10 backups on a given date.

* Run this PR (both Calypsos).
* Visit `/backup/:site`.
* Move around dates and select one that has more than 10 backups.
* Verify that you see the pagination controller on the backups section.

#### Demo – Calypso Blue
![Kapture 2020-12-10 at 11 41 38](https://user-images.githubusercontent.com/3418513/101790464-3b303600-3ae1-11eb-8807-5a26bf82a859.gif)

#### Demo – Calypso Green
![Kapture 2020-12-10 at 12 02 11](https://user-images.githubusercontent.com/3418513/101790452-379caf00-3ae1-11eb-9d17-c48f83d5fffe.gif)
