### PR TITLE
Help: Update "More resources" section

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -13,7 +13,6 @@ import { some } from 'lodash';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { Button, CompactCard, Card } from '@automattic/components';
 import Gridicon from 'calypso/components/gridicon';
-import HappinessEngineers from 'calypso/me/help/help-happiness-engineers';
 import HelpResult from './help-results/item';
 import HelpSearch from './help-search';
 import HelpTeaserButton from './help-teaser-button';
@@ -328,7 +327,6 @@ class Help extends React.PureComponent {
 				{ this.getHelpfulArticles() }
 				{ this.getSupportLinks() }
 				{ this.getContactUs() }
-				<HappinessEngineers />
 				<QueryConciergeInitial />
 				<QueryUserPurchases userId={ userId } />
 			</Main>

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -206,8 +206,6 @@ class Help extends React.PureComponent {
 	};
 
 	getCoursesTeaser = () => {
-		const { translate } = this.props;
-
 		if ( ! this.props.showCoursesTeaser ) {
 			return null;
 		}

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -15,7 +15,6 @@ import { Button, CompactCard, Card } from '@automattic/components';
 import Gridicon from 'calypso/components/gridicon';
 import HelpResult from './help-results/item';
 import HelpSearch from './help-search';
-import HelpTeaserButton from './help-teaser-button';
 import HelpUnverifiedWarning from './help-unverified-warning';
 import Main from 'calypso/components/main';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
@@ -127,23 +126,7 @@ class Help extends React.PureComponent {
 			<>
 				<h2 className="help__section-title">{ this.props.translate( 'More Resources' ) }</h2>
 				<div className="help__support-links">
-					<CompactCard
-						className="help__support-link"
-						href={ localizeUrl( 'https://wordpress.com/support/' ) }
-						target="__blank"
-					>
-						<Gridicon icon="book" size={ 36 } />
-						<div className="help__support-link-section">
-							<h2 className="help__support-link-title">
-								{ this.props.translate( 'All articles' ) }
-							</h2>
-							<p className="help__support-link-content">
-								{ this.props.translate(
-									'Looking to learn more about a feature? Our docs have all the details.'
-								) }
-							</p>
-						</div>
-					</CompactCard>
+					{ this.getCoursesTeaser() }
 					<CompactCard
 						className="help__support-link"
 						href={ localizeUrl( 'https://wordpress.com/support/video-tutorials/' ) }
@@ -230,15 +213,20 @@ class Help extends React.PureComponent {
 		}
 
 		return (
-			<HelpTeaserButton
+			<CompactCard
+				className="help__support-link"
+				href={ localizeUrl( 'https://wordpress.com/webinars' ) }
 				onClick={ this.trackCoursesButtonClick }
-				href="https://wordpress.com/webinars"
-				target="_blank"
-				title={ translate( 'Courses' ) }
-				description={ translate(
-					'Learn how to make the most of your site with these courses and webinars'
-				) }
-			/>
+				target="__blank"
+			>
+				<Gridicon icon="chat" size={ 36 } />
+				<div className="help__support-link-section">
+					<h2 className="help__support-link-title">{ this.props.translate( 'Webinars' ) }</h2>
+					<p className="help__support-link-content">
+						{ this.props.translate( 'Make the most of your site with courses and webinars.' ) }
+					</p>
+				</div>
+			</CompactCard>
 		);
 	};
 
@@ -322,7 +310,6 @@ class Help extends React.PureComponent {
 				<MeSidebarNavigation />
 				<HelpSearch />
 				{ ! isEmailVerified && <HelpUnverifiedWarning /> }
-				{ this.getCoursesTeaser() }
 				{ this.supportSessionCard() }
 				{ this.getHelpfulArticles() }
 				{ this.getSupportLinks() }

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -121,89 +121,83 @@ class Help extends React.PureComponent {
 		);
 	};
 
-	getSupportLinks = () => {
-		return (
-			<>
-				<h2 className="help__section-title">{ this.props.translate( 'More Resources' ) }</h2>
-				<div className="help__support-links">
-					{ this.getCoursesTeaser() }
-					<CompactCard
-						className="help__support-link"
-						href={ localizeUrl( 'https://wordpress.com/support/video-tutorials/' ) }
-						target="__blank"
-					>
-						<Gridicon icon="video" size={ 36 } />
-						<div className="help__support-link-section">
-							<h2 className="help__support-link-title">
-								{ this.props.translate( 'Video tutorials' ) }
-							</h2>
-							<p className="help__support-link-content">
-								{ this.props.translate(
-									'These short videos will demonstrate some of our most popular features.'
-								) }
-							</p>
-						</div>
-					</CompactCard>
-					<CompactCard
-						className="help__support-link"
-						href="https://dailypost.wordpress.com/blogging-university/"
-						target="__blank"
-					>
-						<Gridicon icon="mail" size={ 36 } />
-						<div className="help__support-link-section">
-							<h2 className="help__support-link-title">
-								{ this.props.translate( 'Email courses' ) }
-							</h2>
-							<p className="help__support-link-content">
-								{ this.props.translate(
-									'Pick from our ever-growing list of free email courses to improve your knowledge.'
-								) }
-							</p>
-						</div>
-					</CompactCard>
-					<CompactCard
-						className="help__support-link"
-						href="https://learn.wordpress.com"
-						target="__blank"
-					>
-						<Gridicon icon="list-ordered" size={ 36 } />
-						<div className="help__support-link-section">
-							<h2 className="help__support-link-title">{ this.props.translate( 'Guides' ) }</h2>
-							<p className="help__support-link-content">
-								{ this.props.translate(
-									'A step-by-step guide to getting familiar with the platform.'
-								) }
-							</p>
-						</div>
-					</CompactCard>
-				</div>
-			</>
-		);
-	};
-
-	getContactUs = () => {
-		return (
-			<>
-				<h2 className="help__section-title">{ this.props.translate( 'Contact Us' ) }</h2>
-				<CompactCard className="help__contact-us-card" href="/help/contact/">
-					<Gridicon icon="help" size={ 36 } />
-					<div className="help__contact-us-section">
-						<h3 className="help__contact-us-title">
-							{ this.props.translate( 'Contact support' ) }
-						</h3>
-						<p className="help__contact-us-content">
+	getSupportLinks = () => (
+		<>
+			<h2 className="help__section-title">{ this.props.translate( 'More Resources' ) }</h2>
+			<div className="help__support-links">
+				{ this.getCoursesTeaser() }
+				<CompactCard
+					className="help__support-link"
+					href={ localizeUrl( 'https://wordpress.com/support/video-tutorials/' ) }
+					target="__blank"
+				>
+					<Gridicon icon="video" size={ 36 } />
+					<div className="help__support-link-section">
+						<h2 className="help__support-link-title">
+							{ this.props.translate( 'Video tutorials' ) }
+						</h2>
+						<p className="help__support-link-content">
 							{ this.props.translate(
-								"Can't find the answer? Drop us a line and we'll lend a hand."
+								'These short videos will demonstrate some of our most popular features.'
 							) }
 						</p>
 					</div>
-					<Button className="help__contact-us-button">
-						{ this.props.translate( 'Contact support' ) }
-					</Button>
 				</CompactCard>
-			</>
-		);
-	};
+				<CompactCard
+					className="help__support-link"
+					href="https://dailypost.wordpress.com/blogging-university/"
+					target="__blank"
+				>
+					<Gridicon icon="mail" size={ 36 } />
+					<div className="help__support-link-section">
+						<h2 className="help__support-link-title">
+							{ this.props.translate( 'Email courses' ) }
+						</h2>
+						<p className="help__support-link-content">
+							{ this.props.translate(
+								'Pick from our ever-growing list of free email courses to improve your knowledge.'
+							) }
+						</p>
+					</div>
+				</CompactCard>
+				<CompactCard
+					className="help__support-link"
+					href="https://learn.wordpress.com"
+					target="__blank"
+				>
+					<Gridicon icon="list-ordered" size={ 36 } />
+					<div className="help__support-link-section">
+						<h2 className="help__support-link-title">{ this.props.translate( 'Guides' ) }</h2>
+						<p className="help__support-link-content">
+							{ this.props.translate(
+								'A step-by-step guide to getting familiar with the platform.'
+							) }
+						</p>
+					</div>
+				</CompactCard>
+			</div>
+		</>
+	);
+
+	getContactUs = () => (
+		<>
+			<h2 className="help__section-title">{ this.props.translate( 'Contact Us' ) }</h2>
+			<CompactCard className="help__contact-us-card" href="/help/contact/">
+				<Gridicon icon="help" size={ 36 } />
+				<div className="help__contact-us-section">
+					<h3 className="help__contact-us-title">{ this.props.translate( 'Contact support' ) }</h3>
+					<p className="help__contact-us-content">
+						{ this.props.translate(
+							"Can't find the answer? Drop us a line and we'll lend a hand."
+						) }
+					</p>
+				</div>
+				<Button className="help__contact-us-button">
+					{ this.props.translate( 'Contact support' ) }
+				</Button>
+			</CompactCard>
+		</>
+	);
 
 	getCoursesTeaser = () => {
 		if ( ! this.props.showCoursesTeaser ) {
@@ -283,17 +277,15 @@ class Help extends React.PureComponent {
 		} );
 	};
 
-	getPlaceholders = () => {
-		return (
-			<Main className="help" wideLayout>
-				<MeSidebarNavigation />
-				<div className="help-search is-placeholder" />
-				<div className="help__help-teaser-button is-placeholder" />
-				<div className="help-results is-placeholder" />
-				<div className="help__support-links is-placeholder" />
-			</Main>
-		);
-	};
+	getPlaceholders = () => (
+		<Main className="help" wideLayout>
+			<MeSidebarNavigation />
+			<div className="help-search is-placeholder" />
+			<div className="help__help-teaser-button is-placeholder" />
+			<div className="help-results is-placeholder" />
+			<div className="help__support-links is-placeholder" />
+		</Main>
+	);
 
 	render() {
 		const { isEmailVerified, userId, isLoading } = this.props;

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -12,6 +12,7 @@ import { some } from 'lodash';
  */
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { Button, CompactCard, Card } from '@automattic/components';
+import Gridicon from 'calypso/components/gridicon';
 import HappinessEngineers from 'calypso/me/help/help-happiness-engineers';
 import HelpResult from './help-results/item';
 import HelpSearch from './help-search';
@@ -124,88 +125,101 @@ class Help extends React.PureComponent {
 
 	getSupportLinks = () => {
 		return (
-			<div className="help__support-links">
-				<CompactCard
-					className="help__support-link"
-					href={ localizeUrl( 'https://wordpress.com/support/' ) }
-					target="__blank"
-				>
-					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">
-							{ this.props.translate( 'All support articles' ) }
-						</h2>
-						<p className="help__support-link-content">
-							{ this.props.translate(
-								'Looking to learn more about a feature? Our docs have all the details.'
-							) }
-						</p>
-					</div>
-				</CompactCard>
-				<CompactCard
-					className="help__support-link"
-					href={ localizeUrl( 'https://wordpress.com/support/video-tutorials/' ) }
-					target="__blank"
-				>
-					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">
-							{ this.props.translate( 'Quick help video tutorials' ) }
-						</h2>
-						<p className="help__support-link-content">
-							{ this.props.translate(
-								'These short videos will demonstrate some of our most popular features.'
-							) }
-						</p>
-					</div>
-				</CompactCard>
-				<CompactCard
-					className="help__support-link"
-					href="https://dailypost.wordpress.com/blogging-university/"
-					target="__blank"
-				>
-					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">
-							{ this.props.translate( 'Self-guided email courses for site owners and bloggers' ) }
-						</h2>
-						<p className="help__support-link-content">
-							{ this.props.translate(
-								'Pick from our ever-growing list of free email courses to improve your knowledge.'
-							) }
-						</p>
-					</div>
-				</CompactCard>
-				<CompactCard
-					className="help__support-link"
-					href="https://learn.wordpress.com"
-					target="__blank"
-				>
-					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">
-							{ this.props.translate( 'Self-guided online tutorial' ) }
-						</h2>
-						<p className="help__support-link-content">
-							{ this.props.translate(
-								'A step-by-step guide to getting familiar with the platform.'
-							) }
-						</p>
-					</div>
-				</CompactCard>
-				<CompactCard
-					className="help__support-link help__support-link-contact"
-					href="/help/contact/"
-				>
-					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">{ this.props.translate( 'Get in touch' ) }</h2>
-						<p className="help__support-link-content">
+			<>
+				<h2 className="help__section-title">{ this.props.translate( 'More Resources' ) }</h2>
+				<div className="help__support-links">
+					<CompactCard
+						className="help__support-link"
+						href={ localizeUrl( 'https://wordpress.com/support/' ) }
+						target="__blank"
+					>
+						<Gridicon icon="book" size={ 36 } />
+						<div className="help__support-link-section">
+							<h2 className="help__support-link-title">
+								{ this.props.translate( 'All articles' ) }
+							</h2>
+							<p className="help__support-link-content">
+								{ this.props.translate(
+									'Looking to learn more about a feature? Our docs have all the details.'
+								) }
+							</p>
+						</div>
+					</CompactCard>
+					<CompactCard
+						className="help__support-link"
+						href={ localizeUrl( 'https://wordpress.com/support/video-tutorials/' ) }
+						target="__blank"
+					>
+						<Gridicon icon="video" size={ 36 } />
+						<div className="help__support-link-section">
+							<h2 className="help__support-link-title">
+								{ this.props.translate( 'Video tutorials' ) }
+							</h2>
+							<p className="help__support-link-content">
+								{ this.props.translate(
+									'These short videos will demonstrate some of our most popular features.'
+								) }
+							</p>
+						</div>
+					</CompactCard>
+					<CompactCard
+						className="help__support-link"
+						href="https://dailypost.wordpress.com/blogging-university/"
+						target="__blank"
+					>
+						<Gridicon icon="mail" size={ 36 } />
+						<div className="help__support-link-section">
+							<h2 className="help__support-link-title">
+								{ this.props.translate( 'Email courses' ) }
+							</h2>
+							<p className="help__support-link-content">
+								{ this.props.translate(
+									'Pick from our ever-growing list of free email courses to improve your knowledge.'
+								) }
+							</p>
+						</div>
+					</CompactCard>
+					<CompactCard
+						className="help__support-link"
+						href="https://learn.wordpress.com"
+						target="__blank"
+					>
+						<Gridicon icon="list-ordered" size={ 36 } />
+						<div className="help__support-link-section">
+							<h2 className="help__support-link-title">{ this.props.translate( 'Guides' ) }</h2>
+							<p className="help__support-link-content">
+								{ this.props.translate(
+									'A step-by-step guide to getting familiar with the platform.'
+								) }
+							</p>
+						</div>
+					</CompactCard>
+				</div>
+			</>
+		);
+	};
+
+	getContactUs = () => {
+		return (
+			<>
+				<h2 className="help__section-title">{ this.props.translate( 'Contact Us' ) }</h2>
+				<CompactCard className="help__contact-us-card" href="/help/contact/">
+					<Gridicon icon="help" size={ 36 } />
+					<div className="help__contact-us-section">
+						<h3 className="help__contact-us-title">
+							{ this.props.translate( 'Contact support' ) }
+						</h3>
+						<p className="help__contact-us-content">
 							{ this.props.translate(
 								"Can't find the answer? Drop us a line and we'll lend a hand."
 							) }
 						</p>
 					</div>
-					<Button className="help__support-link-button" primary>
-						{ this.props.translate( 'Contact Us' ) }
+					<Button className="help__contact-us-button">
+						{ this.props.translate( 'Contact support' ) }
 					</Button>
 				</CompactCard>
-			</div>
+			</>
 		);
 	};
 
@@ -313,6 +327,7 @@ class Help extends React.PureComponent {
 				{ this.supportSessionCard() }
 				{ this.getHelpfulArticles() }
 				{ this.getSupportLinks() }
+				{ this.getContactUs() }
 				<HappinessEngineers />
 				<QueryConciergeInitial />
 				<QueryUserPurchases userId={ userId } />

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -315,15 +315,15 @@ function planHasOnboarding( { productSlug } ) {
 	return planHasFeature( productSlug, FEATURE_BUSINESS_ONBOARDING );
 }
 
-export const mapStateToProps = ( state, ownProps ) => {
+export const mapStateToProps = ( state ) => {
 	const isEmailVerified = isCurrentUserEmailVerified( state );
 	const userId = getCurrentUserId( state );
 	const purchases = getUserPurchases( state, userId );
 	const isLoading = isFetchingUserPurchases( state );
 	const isBusinessPlanUser = some( purchases, planHasOnboarding );
-	const showCoursesTeaser = ownProps.isCoursesEnabled && isBusinessPlanUser;
 	const hasAppointment = getConciergeNextAppointment( state );
 	const scheduleId = getConciergeScheduleId( state );
+	const showCoursesTeaser = isBusinessPlanUser;
 
 	return {
 		userId,

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -23,7 +23,11 @@
 
 .help__section-title {
 	font-size: $font-title-small;
-	margin: 32px 0 16px;
+	margin: 32px 16px 16px;
+
+	@include break-small {
+		margin: 32px 0 16px;
+	}
 }
 
 .help__support-link .gridicons-external {
@@ -43,11 +47,10 @@
 }
 
 .help__support-links {
-	@include break-large {
+	@include break-xlarge {
 		display: grid;
-		grid-template-columns: 1fr 1fr 1fr 1fr;
+		grid-template-columns: repeat( 4, 1fr );
 		gap: 24px;
-		justify-items: start;
 		align-items: end;
 	}
 }
@@ -64,8 +67,12 @@
 	margin-right: 16px;
 	position: relative;
 	left: -2px;
+	width: 24px;
+	height: 24px;
 
-	@include break-large {
+	@include break-xlarge {
+		width: 36px;
+		height: 36px;
 		margin-right: 0;
 		margin-bottom: 24px;
 	}
@@ -74,6 +81,7 @@
 .help__support-link-section {
 	margin: auto;
 	margin-bottom: 0;
+	width: 100%;
 }
 
 .help__support-links.is-placeholder {

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -58,6 +58,10 @@
 .help__support-link.card.is-card-link {
 	height: 100%;
 	padding: 16px;
+
+	@include break-xlarge {
+		padding: 16px 24px;
+	}
 }
 
 .help__support-link .gridicon {

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -4,7 +4,7 @@
 .help .upwork-banner {
 	margin: 10px 10px 20px;
 
-	@include break-small {
+	@include break-medium {
 		margin: 0 0 24px;
 	}
 }
@@ -12,52 +12,68 @@
 .help__support-link {
 	display: flex;
 
+	@include break-large {
+		flex-direction: column;
+	}
+
 	&:hover {
 		background-color: var( --color-primary-0 );
-
-		.help__support-link-title {
-			color: var( --color-primary-dark );
-		}
 	}
 }
 
-.help__support-link .help__support-link-section {
-	padding-right: 32px;
+.help__section-title {
+	font-size: $font-title-small;
+	margin: 32px 0 16px;
 }
 
-.help__support-link-contact.is-card-link {
-	padding-right: 24px;
-}
-
-.help__support-link-contact .help__support-link-section {
-	flex-grow: 1;
-}
-
-.help__support-link-contact .gridicon {
+.help__support-link .gridicons-external {
 	display: none;
 }
 
-.help__support-link-button {
-	flex: 0 0 auto;
-	align-self: center;
-}
-
-.help__support-link.is-compact.is-card-link {
-	padding-right: 16px;
-}
-
 .help__support-link-title {
+	color: var( --color-neutral-70 );
 	font-size: $font-body;
-	color: var( --color-primary );
-	@include break-small {
-		font-size: $font-title-small;
-	}
+	font-weight: 600;
 }
 
 .help__support-link-content {
 	margin-bottom: 0;
 	font-size: $font-body-small;
-	color: var( --color-neutral-70 );
+	color: var( --color-neutral-60 );
+}
+
+.help__support-links {
+	@include break-large {
+		display: grid;
+		grid-template-columns: 1fr 1fr 1fr 1fr;
+		gap: 24px;
+		justify-items: start;
+		align-items: end;
+	}
+}
+
+.help__support-link.card.is-card-link {
+	height: 100%;
+	padding: 16px;
+}
+
+.help__support-link .gridicon {
+	fill: var( --color-primary-20 );
+	flex-shrink: 0;
+	margin-top: 0;
+	margin-right: 16px;
+	position: relative;
+	left: -2px;
+
+	@include break-large {
+		margin-right: 0;
+		margin-bottom: 24px;
+	}
+}
+
+.help__support-link-section {
+	margin: auto;
+	margin-bottom: 0;
 }
 
 .help__support-links.is-placeholder {
@@ -148,4 +164,42 @@
 	.help__support-session-action {
 		margin-right: 16px;
 	}
+}
+
+.help__contact-us-card.card.is-card-link {
+	padding: 16px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.help__contact-us-card .gridicons-chevron-right {
+	display: none;
+}
+
+.help__contact-us-card .gridicon {
+	flex-shrink: 0;
+	margin-right: 16px;
+	position: relative;
+	left: -2px;
+}
+
+.help__contact-us-section {
+	margin-right: 24px;
+}
+
+.help__contact-us-title {
+	color: var( --color-neutral-70 );
+	font-weight: 600;
+}
+
+.help__contact-us-content {
+	color: var( --color-neutral-60 );
+	margin: 0;
+}
+
+.help__contact-us-button {
+	margin: auto;
+	margin-right: 0;
+	white-space: nowrap;
 }

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -179,6 +179,11 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	margin-bottom: 48px;
+
+	&:hover .gridicon {
+		fill: var( --color-primary );
+	}
 }
 
 .help__contact-us-card .gridicons-chevron-right {
@@ -189,7 +194,7 @@
 	flex-shrink: 0;
 	margin-right: 16px;
 	position: relative;
-	left: -2px;
+	left: -4px;
 }
 
 .help__contact-us-section {

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -51,7 +51,6 @@
 		display: grid;
 		grid-template-columns: repeat( 4, 1fr );
 		gap: 24px;
-		align-items: end;
 	}
 }
 
@@ -83,8 +82,6 @@
 }
 
 .help__support-link-section {
-	margin: auto;
-	margin-bottom: 0;
 	width: 100%;
 }
 

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -12,7 +12,7 @@
 .help__support-link {
 	display: flex;
 
-	@include break-large {
+	@include break-xlarge {
 		flex-direction: column;
 	}
 
@@ -25,7 +25,7 @@
 	font-size: $font-title-small;
 	margin: 32px 16px 16px;
 
-	@include break-small {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 32px 0 16px;
 	}
 }
@@ -66,7 +66,7 @@
 	margin-top: 0;
 	margin-right: 16px;
 	position: relative;
-	left: -2px;
+	left: -3px;
 	width: 24px;
 	height: 24px;
 

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -47,9 +47,11 @@
 }
 
 .help__support-links {
+	margin-bottom: 24px;
+
 	@include break-xlarge {
 		display: grid;
-		grid-template-columns: repeat( 4, 1fr );
+		grid-template-columns: repeat( auto-fit, minmax( 200px, 1fr ) );
 		gap: 24px;
 	}
 }
@@ -178,12 +180,16 @@
 .help__contact-us-card.card.is-card-link {
 	padding: 16px;
 	display: flex;
+	align-items: flex-start;
 	justify-content: space-between;
-	align-items: center;
 	margin-bottom: 48px;
 
 	&:hover .gridicon {
 		fill: var( --color-primary );
+	}
+
+	@include break-xlarge {
+		align-items: center;
 	}
 }
 
@@ -196,6 +202,13 @@
 	margin-right: 16px;
 	position: relative;
 	left: -4px;
+	width: 24px;
+	height: 24px;
+
+	@include break-xlarge {
+		width: 36px;
+		height: 36px;
+	}
 }
 
 .help__contact-us-section {
@@ -214,6 +227,12 @@
 
 .help__contact-us-button {
 	margin: auto;
+	margin-top: 0;
 	margin-right: 0;
 	white-space: nowrap;
+	overflow: visible;
+
+	@include break-xlarge {
+		margin-top: auto;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show "More Resources" in blocks rather than horizontal cards to add visual hierarchy to the support page.
* Move the contact item to its own block.
* Move the Courses/Webinars item under More Resources
* Remove the "All articles" item since it's duplicative of search results.
* Remove the HE Gravatars.

**Before**

<img width="770" alt="Screen Shot 2020-12-10 at 11 12 18 AM" src="https://user-images.githubusercontent.com/2124984/101798038-a6293f00-3ad8-11eb-91a9-167c2f08e892.png">

**After**

<img width="1143" alt="Screen Shot 2020-12-11 at 11 23 32 AM" src="https://user-images.githubusercontent.com/2124984/101928245-56637a00-3ba3-11eb-94af-7115783f5602.png">

#### Testing instructions

* Switch to this PR and navigate to `/help`
* Scroll down and you'll see the "More resources" section has a new visual presentation; the courses card at the top has moved into the More resources section, 
* Cards should rearrange to a horizontal card format on mobile and small screen views

Part of #40870 
