### PR TITLE
Update Site Editor 'back to dashboard' button in calypso

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -608,7 +608,7 @@ function handleCloseInLegacyEditors( handleClose ) {
 	const navSidebarCloseSelector = '.wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button';
 	const selector = `.edit-post-header .edit-post-fullscreen-mode-close:not(${ wpcomCloseSelector }):not(${ navSidebarCloseSelector })`;
 
-	const siteEditorSelector = '.edit-site-header .edit-site-fullscreen-mode-close';
+	const siteEditorSelector = '.edit-site-navigation-panel__back-to-dashboard';
 
 	$( '#editor' ).on( 'click', `${ legacySelector }, ${ selector }`, handleClose );
 	$( '#edit-site-editor' ).on( 'click', `${ siteEditorSelector }`, handleClose );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Makes the navigation panel's "Back to dashboard" button work from the wpcom block editor / calypso iframe.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* sync the changes from apps/wpcom-block-editor/ to you sandbox using `yarn dev --sync`
* sandbox widgets.wp.com
* load the site editor from calypso and verify the back to dashboard button in the nav panel takes you back to calypso as expected.

Fixes #46822
