### PR TITLE
Reader: stop sending subscription_count = 0 with Tracks events

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -110,14 +110,9 @@ function getLocation( path ) {
  */
 export function recordTrack( eventName, eventProperties, { pathnameOverride } = {} ) {
 	debug( 'reader track', ...arguments );
-	const subCount = 0; // todo: fix subCount by moving to redux middleware for recordTrack
 
 	const location = getLocation( pathnameOverride || window.location.pathname );
 	eventProperties = Object.assign( { ui_algo: location }, eventProperties );
-
-	if ( subCount != null ) {
-		eventProperties = Object.assign( { subscription_count: subCount }, eventProperties );
-	}
 
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're in the process of migrating away from `recordTrack()` to a new action `recordReaderTracksEvent()` - see 
https://github.com/Automattic/wp-calypso/pull/47983 for example.

There are some events that we may not be able to migrate easily, because they’re not fired inside a React component.

I checked with @martinremy and we decided that, in those cases where we can't obtain the subs count, we should omit the property from the event (p5PDj3-4WA-p2). This PR stops sending `subscription_count: 0` with each event from recordTrack().

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Turn on Analytics logging in your console with:

localStorage.setItem('debug', 'calypso:analytics*');

Look for an event that is triggered by the old recordTrack() - a good example is `calypso_reader_following_loaded` on the Followed Sites stream. Make sure that the event does not contain a `subscription_count` event prop.
