### PR TITLE
Onboarding: Onboarding related packages use react-i18n to translate copy

### DIFF
--- a/packages/domain-picker/src/domain-categories/index.tsx
+++ b/packages/domain-picker/src/domain-categories/index.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { Button } from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import classNames from 'classnames';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
@@ -25,6 +25,7 @@ export interface Props {
 }
 
 const DomainPickerCategories: React.FunctionComponent< Props > = ( { onSelect, selected } ) => {
+	const { __ } = useI18n();
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const handleSelect = ( slug?: string ) => {

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -8,7 +8,7 @@ import { Button, TextControl, Notice } from '@wordpress/components';
 import { Icon, search } from '@wordpress/icons';
 import { getNewRailcarId, recordTrainTracksRender } from '@automattic/calypso-analytics';
 import { DataStatus } from '@automattic/data-stores/src/domain-suggestions/constants';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
 /**
@@ -134,6 +134,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	areDependenciesLoading = false,
 	orderSubDomainsLast = false,
 } ) => {
+	const { __ } = useI18n();
 	const label = __( 'Search for a domain', __i18n_text_domain__ );
 
 	const [ isExpanded, setIsExpanded ] = useState( false );

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { FunctionComponent, useEffect, useState } from 'react';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -59,6 +59,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	selected,
 	type = ITEM_TYPE_RADIO,
 } ) => {
+	const { __ } = useI18n();
 	const localizeUrl = useLocalizeUrl();
 
 	const isMobile = useViewportMatch( 'small', '<' );

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -46,7 +46,6 @@
 		"history": "^5.0.0"
 	},
 	"peerDependencies": {
-		"@wordpress/i18n": "^3.14.0",
 		"react": "^16.8"
 	},
 	"private": true

--- a/packages/onboarding/src/action-buttons/index.tsx
+++ b/packages/onboarding/src/action-buttons/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Style dependencies
@@ -40,6 +40,8 @@ export const BackButton: React.FunctionComponent< Button.ButtonProps > = ( {
 	children,
 	...buttonProps
 } ) => {
+	const { __ } = useI18n();
+
 	return (
 		<Button
 			className={ classnames( 'action_buttons__button action-buttons__back', className ) }
@@ -58,6 +60,8 @@ export const NextButton: React.FunctionComponent< Button.ButtonProps > = ( {
 	children,
 	...buttonProps
 } ) => {
+	const { __ } = useI18n();
+
 	return (
 		<Button
 			className={ classnames( 'action_buttons__button action-buttons__next', className ) }
@@ -76,6 +80,8 @@ export const SkipButton: React.FunctionComponent< Button.ButtonProps > = ( {
 	children,
 	...buttonProps
 } ) => {
+	const { __ } = useI18n();
+
 	return (
 		<Button
 			className={ classnames( 'action_buttons__button action-buttons__skip', className ) }

--- a/packages/plans-grid/src/plans-accordion-item/index.tsx
+++ b/packages/plans-grid/src/plans-accordion-item/index.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 import { NextButton } from '@automattic/onboarding';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
@@ -59,6 +59,8 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 	onToggle,
 	disabledLabel,
 } ) => {
+	const { __ } = useI18n();
+
 	// show a nbps in price while loading to prevent a janky UI
 	const nbsp = '\u00A0\u00A0';
 

--- a/packages/plans-grid/src/plans-accordion/index.tsx
+++ b/packages/plans-grid/src/plans-accordion/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useState } from 'react';
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 import type { DomainSuggestions, Plans, WPCOMFeatures } from '@automattic/data-stores';
 import { Button, SVG, Path } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
@@ -47,6 +47,8 @@ const PlansTable: React.FunctionComponent< Props > = ( {
 	disabledPlans,
 	locale,
 } ) => {
+	const { __ } = useI18n();
+
 	const supportedPlans = useSelect( ( select ) => select( PLANS_STORE ).getSupportedPlans() );
 	const prices = useSelect( ( select ) => select( PLANS_STORE ).getPrices( locale ) );
 

--- a/packages/plans-grid/src/plans-details/index.tsx
+++ b/packages/plans-grid/src/plans-details/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 import { useSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
@@ -25,6 +25,8 @@ type Props = {
 };
 
 const PlansDetails: React.FunctionComponent< Props > = ( { onSelect, locale } ) => {
+	const { __ } = useI18n();
+
 	const { features, featuresByType, plans } = useSelect( ( select ) =>
 		select( PLANS_STORE ).getPlansDetails( locale )
 	);

--- a/packages/plans-grid/src/plans-feature-list/index.tsx
+++ b/packages/plans-grid/src/plans-feature-list/index.tsx
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 import { createInterpolateElement } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { Icon, check, close } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
 /**
@@ -111,6 +111,8 @@ const PlansFeatureList: React.FunctionComponent< Props > = ( {
 	disabledLabel,
 	multiColumn = false,
 } ) => {
+	const { __ } = useI18n();
+
 	const domainMessage = domainMessageStateMachine( isFree, domain, __ );
 
 	return (

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 import type { Plans, DomainSuggestions, WPCOMFeatures } from '@automattic/data-stores';
 import { Title } from '@automattic/onboarding';
 import debugFactory from 'debug';
@@ -56,6 +56,8 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 	popularBadgeVariation = 'ON_TOP',
 	customTagLines,
 } ) => {
+	const { __ } = useI18n();
+
 	isAccordion && debug( 'PlansGrid accordion version is active' );
 
 	return (

--- a/packages/plans-grid/src/plans-table/plan-item.tsx
+++ b/packages/plans-grid/src/plans-table/plan-item.tsx
@@ -5,7 +5,8 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { __, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 import type { DomainSuggestions } from '@automattic/data-stores';
 import type { CTAVariation, PopularBadgeVariation } from './types';
 
@@ -74,6 +75,8 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 	CTAVariation = 'NORMAL',
 	popularBadgeVariation = 'ON_TOP',
 } ) => {
+	const { __ } = useI18n();
+
 	const [ isOpenInternalState, setIsOpenInternalState ] = React.useState( false );
 
 	const isDesktop = useViewportMatch( 'mobile', '>=' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Copy in the new onboarding flow wasn't updating when switching languages. This happened because we switched onboarding over to use `@wordpress/i18n` as a temporary work around while `react-i18n` wasn't working in ETK. Now that `react-i18n` works in ETK we can use it everywhere, meaning components will re-render when the language is switched.

* Onboarding related packages switched to use `@automattic/react-i18n` instead of `@wordpress/i18n`

There's also an issue with the plan grid text that I was going to fix as part of this PR. But I think that one is going to need a bit of a refactor of the `plans` data store, so will do that in another PR.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/new?flags=gutenboarding/language-picker`
* Switch language on each step of onbaoarding and confirm that all the copy updates
* There's an issu on the plans step where the copy in the table doesn't update (see above) however the copy surrounding the table should update
* `cd apps/editing-toolkit && yarn dev --sync` and check that all the steps in the launch flow are still translated

Fixes #48196 
