### PR TITLE
Purchases: cleanup UseEffect to prevent running on multiple renders

### DIFF
--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -89,27 +89,23 @@ const MembershipType = ( { subscription }: { subscription: MembershipSubscriptio
 const Icon = ( { subscription }: { subscription: MembershipSubscription } ) => {
 	const [ hasError, setErrors ] = useState( false );
 	const [ site, setSite ] = useState( null );
-	const [ loadData, setLoadData ] = useState( true );
-
-	async function fetchData() {
-		const data = await fetch(
-			'https://public-api.wordpress.com/rest/v1.1/sites/' + subscription.site_id
-		);
-
-		data
-			.json()
-			.then( ( data ) => {
-				setSite( data );
-				setLoadData( false );
-			} )
-			.catch( ( err ) => setErrors( err ) );
-	}
 
 	useEffect( () => {
-		if ( loadData ) {
-			fetchData();
+		async function fetchData() {
+			const data = await fetch(
+				'https://public-api.wordpress.com/rest/v1.1/sites/' + subscription.site_id
+			);
+
+			data
+				.json()
+				.then( ( data ) => {
+					setSite( data );
+				} )
+				.catch( ( err ) => setErrors( err ) );
 		}
-	} );
+
+		fetchData();
+	}, [] );
 
 	if ( site && ! hasError ) {
 		return <img src={ site.icon.ico } width="36" height="36" alt="" />;

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -89,12 +89,11 @@ const MembershipType = ( { subscription }: { subscription: MembershipSubscriptio
 const Icon = ( { subscription }: { subscription: MembershipSubscription } ) => {
 	const [ hasError, setErrors ] = useState( false );
 	const [ site, setSite ] = useState( null );
+	const siteId = subscription.site_id;
 
 	useEffect( () => {
 		async function fetchData() {
-			const data = await fetch(
-				'https://public-api.wordpress.com/rest/v1.1/sites/' + subscription.site_id
-			);
+			const data = await fetch( 'https://public-api.wordpress.com/rest/v1.1/sites/' + siteId );
 
 			data
 				.json()
@@ -105,7 +104,7 @@ const Icon = ( { subscription }: { subscription: MembershipSubscription } ) => {
 		}
 
 		fetchData();
-	}, [] );
+	}, [ siteId ] );
 
 	if ( site && ! hasError ) {
 		return <img src={ site.icon.ico } width="36" height="36" alt="" />;

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -142,7 +142,7 @@ class PurchasesList extends Component {
 		) {
 			if ( ! sites.length ) {
 				return (
-					<Main>
+					<Main className="purchases-list is-wide-layout">
 						<PageViewTracker path="/me/purchases" title="Purchases > No Sites" />
 						<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 						<PurchasesNavigation section="purchases" />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR cleans up a UseEffect method being used to get a memberships site logo. The way it was previously written had it running a method to fetch data on every render. The fix only calls it once on load. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the account level purchases screen for an account that has purchases made on third party sites like https://burlingtonbuddhist.org.
* Visit the account level purchases screen for an account that has no purchases from third party sites. 
* Confirm that everything loads in accordingly. 