### PR TITLE
Reader: update client/reader components to use new recordReaderTracksEvent action - part two

### DIFF
--- a/client/reader/following-manage/empty.jsx
+++ b/client/reader/following-manage/empty.jsx
@@ -3,22 +3,26 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class FollowingManageEmptyContent extends React.Component {
 	componentDidMount() {
-		recordTrack( 'calypso_reader_empty_manage_following_loaded' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_empty_manage_following_loaded' );
 	}
 
 	recordAction = () => {
 		recordAction( 'clicked_discover_on_empty_manage_following' );
 		recordGaEvent( 'Clicked Discover on EmptyContent in Manage Following' );
-		recordTrack( 'calypso_reader_discover_on_empty_manage_following_clicked' );
+		this.props.recordReaderTracksEvent(
+			'calypso_reader_discover_on_empty_manage_following_clicked'
+		);
 	};
 
 	render() {
@@ -47,4 +51,6 @@ class FollowingManageEmptyContent extends React.Component {
 	}
 }
 
-export default localize( FollowingManageEmptyContent );
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( localize( FollowingManageEmptyContent ) );

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -12,9 +12,9 @@ import { connect } from 'react-redux';
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import { recordTrack } from 'calypso/reader/stats';
 import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
 import cssSafeUrl from 'calypso/lib/css-safe-url';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Asset dependencies
@@ -33,20 +33,30 @@ class FollowingIntro extends React.Component {
 		}
 	}
 
+	dismiss = () => {
+		this.props.recordReaderTracksEvent( 'calypso_reader_following_intro_dismiss' );
+		return this.props.savePreference( 'is_new_reader', false );
+	};
+
+	handleManageLinkClick = () => {
+		this.props.recordReaderTracksEvent( 'calypso_reader_following_intro_link_clicked' );
+		return this.props.savePreference( 'is_new_reader', false );
+	};
+
 	recordRenderTrack = ( props = this.props ) => {
 		if ( props.isNewReader === true ) {
-			recordTrack( 'calypso_reader_following_intro_render' );
+			this.props.recordReaderTracksEvent( 'calypso_reader_following_intro_render' );
 		}
 	};
 
 	render() {
-		const { isNewReader, translate, dismiss, isNewUser } = this.props;
+		const { isNewReader, isNewUser, translate } = this.props;
 
 		if ( ! isNewReader || ! isNewUser ) {
 			return null;
 		}
 
-		const linkElement = <a onClick={ this.props.handleManageLinkClick } href="/following/manage" />;
+		const linkElement = <a onClick={ this.handleManageLinkClick } href="/following/manage" />;
 
 		return (
 			<header
@@ -72,11 +82,12 @@ class FollowingIntro extends React.Component {
 							) }
 						</span>
 					</div>
+
 					<img className="following__intro-character" src={ readerImage } alt="" />
 
 					<button
 						className="following__intro-close"
-						onClick={ dismiss }
+						onClick={ this.dismiss }
 						title={ translate( 'Close' ) }
 						aria-label={ translate( 'Close' ) }
 					>
@@ -101,13 +112,7 @@ export default connect(
 		};
 	},
 	{
-		dismiss: () => {
-			recordTrack( 'calypso_reader_following_intro_dismiss' );
-			return savePreference( 'is_new_reader', false );
-		},
-		handleManageLinkClick: () => {
-			recordTrack( 'calypso_reader_following_intro_link_clicked' );
-			return savePreference( 'is_new_reader', false );
-		},
+		recordReaderTracksEvent,
+		savePreference,
 	}
 )( localize( FollowingIntro ) );

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -3,14 +3,15 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
-import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class TagEmptyContent extends React.Component {
 	shouldComponentUpdate() {
@@ -20,13 +21,7 @@ class TagEmptyContent extends React.Component {
 	recordAction = () => {
 		recordAction( 'clicked_following_on_empty_likes' );
 		recordGaEvent( 'Clicked Following on Empty Like Stream' );
-		recordTrack( 'calypso_reader_following_on_empty_like_stream_clicked' );
-	};
-
-	recordSecondaryAction = () => {
-		recordAction( 'clicked_discover_on_empty_likes' );
-		recordGaEvent( 'Clicked Discover on Empty Like Stream' );
-		recordTrack( 'calypso_reader_discover_on_empty_like_stream_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_following_on_empty_like_stream_clicked' );
 	};
 
 	render() {
@@ -40,22 +35,12 @@ class TagEmptyContent extends React.Component {
 				{ this.props.translate( 'Back to Following' ) }
 			</a>
 		);
-		const secondaryAction = isDiscoverEnabled() ? (
-			<a
-				className="empty-content__action button"
-				onClick={ this.recordSecondaryAction }
-				href="/discover"
-			>
-				{ this.props.translate( 'Explore' ) }
-			</a>
-		) : null;
 
 		return (
 			<EmptyContent
 				title={ this.props.translate( 'No likes yet' ) }
 				line={ this.props.translate( 'Posts that you like will appear here.' ) }
 				action={ action }
-				secondaryAction={ secondaryAction }
 				illustration={ '/calypso/images/illustrations/illustration-empty-results.svg' }
 				illustrationWidth={ 400 }
 			/>
@@ -64,4 +49,6 @@ class TagEmptyContent extends React.Component {
 	}
 }
 
-export default withPerformanceTrackerStop( localize( TagEmptyContent ) );
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( withPerformanceTrackerStop( localize( TagEmptyContent ) ) );

--- a/client/reader/list-gap/index.jsx
+++ b/client/reader/list-gap/index.jsx
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -8,10 +8,11 @@ import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { fillGap } from 'calypso/state/reader/streams/actions';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Style dependencies
@@ -32,7 +33,7 @@ class Gap extends React.Component {
 		this.props.fillGap( { streamKey, gap } );
 		recordAction( 'fill_gap' );
 		recordGaEvent( 'Clicked Fill Gap' );
-		recordTrack( 'calypso_reader_filled_gap', { stream: streamKey } );
+		this.props.recordReaderTracksEvent( 'calypso_reader_filled_gap', { stream: streamKey } );
 
 		this.setState( { isFilling: true } );
 	};
@@ -61,4 +62,4 @@ class Gap extends React.Component {
 	}
 }
 
-export default localize( connect( null, { fillGap } )( Gap ) );
+export default localize( connect( null, { fillGap, recordReaderTracksEvent } )( Gap ) );

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -3,13 +3,14 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
-import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class ListEmptyContent extends React.Component {
 	shouldComponentUpdate() {
@@ -19,13 +20,7 @@ class ListEmptyContent extends React.Component {
 	recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
-		recordTrack( 'calypso_reader_following_on_empty_list_stream_clicked' );
-	};
-
-	recordSecondaryAction = () => {
-		recordAction( 'clicked_discover_on_empty' );
-		recordGaEvent( 'Clicked Discover on EmptyContent' );
-		recordTrack( 'calypso_reader_discover_on_empty_list_stream_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_following_on_empty_list_stream_clicked' );
 	};
 
 	render() {
@@ -39,22 +34,12 @@ class ListEmptyContent extends React.Component {
 				{ this.props.translate( 'Back to Following' ) }
 			</a>
 		);
-		const secondaryAction = isDiscoverEnabled() ? (
-			<a
-				className="empty-content__action button"
-				onClick={ this.recordSecondaryAction }
-				href="/discover"
-			>
-				{ this.props.translate( 'Explore' ) }
-			</a>
-		) : null;
 
 		return (
 			<EmptyContent
 				title={ this.props.translate( 'No recent posts' ) }
 				line={ this.props.translate( 'The sites in this list have not posted anything recently.' ) }
 				action={ action }
-				secondaryAction={ secondaryAction }
 				illustration={ '/calypso/images/illustrations/illustration-empty-results.svg' }
 				illustrationWidth={ 400 }
 			/>
@@ -63,4 +48,6 @@ class ListEmptyContent extends React.Component {
 	}
 }
 
-export default localize( ListEmptyContent );
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( localize( ListEmptyContent ) );

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -21,7 +21,8 @@ import {
 	isMissingByOwnerAndSlug,
 } from 'calypso/state/reader/lists/selectors';
 import QueryReaderList from 'calypso/components/data/query-reader-list';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Style dependencies
@@ -33,6 +34,7 @@ class ListStream extends React.Component {
 		super( props );
 		this.title = props.translate( 'Loading list' );
 	}
+
 	toggleFollowing = ( isFollowRequested ) => {
 		const list = this.props.list;
 
@@ -47,7 +49,7 @@ class ListStream extends React.Component {
 			isFollowRequested ? 'Clicked Follow List' : 'Clicked Unfollow List',
 			list.owner + ':' + list.slug
 		);
-		recordTrack(
+		this.props.recordReaderTracksEvent(
 			isFollowRequested
 				? 'calypso_reader_reader_list_followed'
 				: 'calypso_reader_reader_list_unfollowed',
@@ -129,5 +131,5 @@ export default connect(
 			isMissing: isMissingByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
 		};
 	},
-	{ followList, unfollowList }
+	{ followList, recordReaderTracksEvent, unfollowList }
 )( localize( ListStream ) );

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -4,14 +4,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'calypso/components/empty-content';
-import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
 import QueryReaderList from 'calypso/components/data/query-reader-list';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class ListMissing extends React.Component {
 	static propTypes = {
@@ -22,13 +23,7 @@ class ListMissing extends React.Component {
 	recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
-		recordTrack( 'calypso_reader_following_on_missing_list_clicked' );
-	};
-
-	recordSecondaryAction = () => {
-		recordAction( 'clicked_discover_on_empty' );
-		recordGaEvent( 'Clicked Discover on EmptyContent' );
-		recordTrack( 'calypso_reader_discover_on_missing_list_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_following_on_missing_list_clicked' );
 	};
 
 	render() {
@@ -42,15 +37,6 @@ class ListMissing extends React.Component {
 				{ this.props.translate( 'Back to Followed Sites' ) }
 			</a>
 		);
-		const secondaryAction = isDiscoverEnabled() ? (
-			<a
-				className="empty-content__action button"
-				onClick={ this.recordSecondaryAction }
-				href="/discover"
-			>
-				{ this.props.translate( 'Explore' ) }
-			</a>
-		) : null;
 
 		return (
 			<div>
@@ -59,7 +45,6 @@ class ListMissing extends React.Component {
 					title={ this.props.translate( 'List not found' ) }
 					line={ this.props.translate( "Sorry, we couldn't find that list." ) }
 					action={ action }
-					secondaryAction={ secondaryAction }
 					illustration={ '/calypso/images/illustrations/illustration-empty-results.svg' }
 					illustrationWidth={ 500 }
 				/>
@@ -69,4 +54,6 @@ class ListMissing extends React.Component {
 	}
 }
 
-export default localize( ListMissing );
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( localize( ListMissing ) );

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -4,14 +4,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
-import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class SearchEmptyContent extends React.Component {
 	static propTypes = {
@@ -25,13 +26,7 @@ class SearchEmptyContent extends React.Component {
 	recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
-		recordTrack( 'calypso_reader_following_on_empty_search_stream_clicked' );
-	};
-
-	recordSecondaryAction = () => {
-		recordAction( 'clicked_discover_on_empty' );
-		recordGaEvent( 'Clicked Discover on EmptyContent' );
-		recordTrack( 'calypso_reader_discover_on_empty_search_stream_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_following_on_empty_search_stream_clicked' );
 	};
 
 	render() {
@@ -46,16 +41,6 @@ class SearchEmptyContent extends React.Component {
 			</a>
 		);
 
-		const secondaryAction = isDiscoverEnabled() ? (
-			<a
-				className="empty-content__action button"
-				onClick={ this.recordSecondaryAction }
-				href="/discover"
-			>
-				{ this.props.translate( 'Explore' ) }
-			</a>
-		) : null;
-
 		const message = this.props.translate( 'No posts found for {{query /}} for your language.', {
 			components: {
 				query: <em>{ this.props.query }</em>,
@@ -67,7 +52,6 @@ class SearchEmptyContent extends React.Component {
 				title={ this.props.translate( 'No results' ) }
 				line={ message }
 				action={ action }
-				secondaryAction={ secondaryAction }
 				illustration={ '/calypso/images/illustrations/illustration-empty-results.svg' }
 				illustrationWidth={ 400 }
 			/>
@@ -76,4 +60,6 @@ class SearchEmptyContent extends React.Component {
 	}
 }
 
-export default withPerformanceTrackerStop( localize( SearchEmptyContent ) );
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( withPerformanceTrackerStop( localize( SearchEmptyContent ) ) );

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -10,14 +10,14 @@ import page from 'page';
 import classnames from 'classnames';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import BlankSuggestions from 'calypso/reader/components/reader-blank-suggestions';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { CompactCard } from '@automattic/components';
 import DocumentHead from 'calypso/components/data/document-head';
 import SearchInput from 'calypso/components/search';
-import { recordAction, recordTrack } from 'calypso/reader/stats';
+import { recordAction } from 'calypso/reader/stats';
 import SiteResults from './site-results';
 import PostResults from './post-results';
 import ReaderMain from 'calypso/reader/components/reader-main';
@@ -35,6 +35,7 @@ import { SEARCH_RESULTS_URL_INPUT } from 'calypso/reader/follow-sources';
 import FollowButton from 'calypso/reader/follow-button';
 import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
 import { getSearchPlaceholderText } from 'calypso/reader/search/utils';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Style dependencies
@@ -87,7 +88,7 @@ class SearchStream extends React.Component {
 	useRelevanceSort = () => {
 		const sort = 'relevance';
 		recordAction( 'search_page_clicked_relevance_sort' );
-		recordTrack( 'calypso_reader_clicked_search_sort', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_clicked_search_sort', {
 			query: this.props.query,
 			sort,
 		} );
@@ -97,7 +98,7 @@ class SearchStream extends React.Component {
 	useDateSort = () => {
 		const sort = 'date';
 		recordAction( 'search_page_clicked_date_sort' );
-		recordTrack( 'calypso_reader_clicked_search_sort', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_clicked_search_sort', {
 			query: this.props.query,
 			sort,
 		} );
@@ -260,7 +261,14 @@ const wrapWithMain = ( Component ) => ( props ) => (
 );
 /* eslint-enable */
 
-export default connect( ( state, ownProps ) => ( {
-	readerAliasedFollowFeedUrl:
-		ownProps.query && getReaderAliasedFollowFeedUrl( state, ownProps.query ),
-} ) )( localize( SuggestionProvider( wrapWithMain( withDimensions( SearchStream ) ) ) ) );
+export default connect(
+	( state, ownProps ) => (
+		{
+			readerAliasedFollowFeedUrl:
+				ownProps.query && getReaderAliasedFollowFeedUrl( state, ownProps.query ),
+		},
+		{
+			recordReaderTracksEvent,
+		}
+	)
+)( localize( SuggestionProvider( wrapWithMain( withDimensions( SearchStream ) ) ) ) );

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -262,13 +262,11 @@ const wrapWithMain = ( Component ) => ( props ) => (
 /* eslint-enable */
 
 export default connect(
-	( state, ownProps ) => (
-		{
-			readerAliasedFollowFeedUrl:
-				ownProps.query && getReaderAliasedFollowFeedUrl( state, ownProps.query ),
-		},
-		{
-			recordReaderTracksEvent,
-		}
-	)
+	( state, ownProps ) => ( {
+		readerAliasedFollowFeedUrl:
+			ownProps.query && getReaderAliasedFollowFeedUrl( state, ownProps.query ),
+	} ),
+	{
+		recordReaderTracksEvent,
+	}
 )( localize( SuggestionProvider( wrapWithMain( withDimensions( SearchStream ) ) ) ) );

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -1,15 +1,17 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
+import { connect } from 'react-redux';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import { recordTrack, recordTracksRailcarInteract } from 'calypso/reader/stats';
+import { recordTracksRailcarInteract } from 'calypso/reader/stats';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 export class Suggestion extends Component {
 	static propTypes = {
@@ -26,7 +28,10 @@ export class Suggestion extends Component {
 
 	handleSuggestionClick = () => {
 		const { suggestion, source, railcar } = this.props;
-		recordTrack( 'calypso_reader_search_suggestion_click', { suggestion, source } );
+		this.props.recordReaderTracksEvent( 'calypso_reader_search_suggestion_click', {
+			suggestion,
+			source,
+		} );
 		recordTracksRailcarInteract( 'search_suggestion_click', railcar );
 	};
 
@@ -48,4 +53,6 @@ export class Suggestion extends Component {
 	}
 }
 
-export default Suggestion;
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( Suggestion );

--- a/client/reader/sidebar/reader-sidebar-lists/list-item-create-link.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item-create-link.jsx
@@ -1,49 +1,47 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import React, { Component } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Gridicon from 'calypso/components/gridicon';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import ReaderSidebarHelper from '../helper';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
-export class ReaderSidebarListsListItemCreateLink extends Component {
-	handleListSidebarClick = () => {
+const ReaderSidebarListsListItemCreateLink = ( props ) => {
+	const dispatch = useDispatch();
+
+	const handleListSidebarClick = () => {
 		recordAction( 'clicked_reader_sidebar_list_item_create_link' );
 		recordGaEvent( 'Clicked Reader Sidebar List Item Create Link' );
-		recordTrack( 'calypso_reader_sidebar_list_item_create_link_clicked' );
+		dispatch( recordReaderTracksEvent( 'calypso_reader_sidebar_list_item_create_link_clicked' ) );
 	};
 
-	render() {
-		const relativePath = '/read/list/new';
-		const classes = classNames( 'sidebar__menu-item--create-reader-list-link', {
-			selected: ReaderSidebarHelper.pathStartsWithOneOf( [ relativePath ], this.props.path ),
-		} );
+	const relativePath = '/read/list/new';
+	const classes = classNames( 'sidebar__menu-item--create-reader-list-link', {
+		selected: ReaderSidebarHelper.pathStartsWithOneOf( [ relativePath ], props.path ),
+	} );
 
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		return (
-			<li className={ classes }>
-				<a
-					className="sidebar__menu-link"
-					href="/read/list/new"
-					onClick={ this.handleListSidebarClick }
-				>
-					<div className="sidebar__menu-item-title">
-						<Gridicon icon="add-outline" />{ ' ' }
-						<span className="sidebar__menu-item-title-text">
-							{ this.props.translate( 'Create new list' ) }
-						</span>
-					</div>
-				</a>
-			</li>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
-	}
-}
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<li className={ classes }>
+			<a className="sidebar__menu-link" href="/read/list/new" onClick={ handleListSidebarClick }>
+				<div className="sidebar__menu-item-title">
+					<Gridicon icon="add-outline" />{ ' ' }
+					<span className="sidebar__menu-item-title-text">
+						{ props.translate( 'Create new list' ) }
+					</span>
+				</div>
+			</a>
+		</li>
+	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+};
 
 export default localize( ReaderSidebarListsListItemCreateLink );

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -3,16 +3,17 @@
  */
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { last } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import ReaderSidebarHelper from '../helper';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 export class ReaderSidebarListsListItem extends Component {
 	static propTypes = {
@@ -36,7 +37,7 @@ export class ReaderSidebarListsListItem extends Component {
 	handleListSidebarClick = () => {
 		recordAction( 'clicked_reader_sidebar_list_item' );
 		recordGaEvent( 'Clicked Reader Sidebar List Item' );
-		recordTrack( 'calypso_reader_sidebar_list_item_clicked', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_list_item_clicked', {
 			list: decodeURIComponent( this.props.list.slug ),
 		} );
 	};
@@ -51,7 +52,9 @@ export class ReaderSidebarListsListItem extends Component {
 			listRelativeUrl + '/delete',
 		];
 
-		const lastPathSegment = last( this.props.path.split( '/' ) );
+		const pathSegments = this.props.path?.split( '/' );
+		const lastPathSegment =
+			Array.isArray( pathSegments ) && pathSegments[ pathSegments.length - 1 ];
 		const isCurrentList =
 			lastPathSegment &&
 			// Prevents partial slug matches (e.g. bluefuton/test and bluefuton/test2)
@@ -87,4 +90,6 @@ export class ReaderSidebarListsListItem extends Component {
 	}
 }
 
-export default localize( ReaderSidebarListsListItem );
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( localize( ReaderSidebarListsListItem ) );

--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -3,14 +3,16 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import ReaderSidebarHelper from '../helper';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import Count from 'calypso/components/count';
 import Favicon from 'calypso/reader/components/favicon';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Styles
@@ -26,7 +28,7 @@ export class ReaderSidebarOrganizationsListItem extends Component {
 	handleSidebarClick = () => {
 		recordAction( 'clicked_reader_sidebar_organization_item' );
 		recordGaEvent( 'Clicked Reader Sidebar Organization Item' );
-		recordTrack( 'calypso_reader_sidebar_organization_item_clicked', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_organization_item_clicked', {
 			blog: decodeURIComponent( this.props.site ),
 		} );
 	};
@@ -58,4 +60,6 @@ export class ReaderSidebarOrganizationsListItem extends Component {
 	}
 }
 
-export default ReaderSidebarOrganizationsListItem;
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( ReaderSidebarOrganizationsListItem );

--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -10,12 +10,12 @@ import React, { Component } from 'react';
 import ReaderSidebarHelper from '../helper';
 import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
 import Count from 'calypso/components/count';
+import Favicon from 'calypso/reader/components/favicon';
 
 /**
  * Styles
  */
 import '../style.scss';
-import Favicon from 'calypso/reader/components/favicon';
 
 export class ReaderSidebarOrganizationsListItem extends Component {
 	static propTypes = {

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -14,9 +14,10 @@ import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import ReaderSidebarTagsList from './list';
 import QueryReaderFollowedTags from 'calypso/components/data/query-reader-followed-tags';
 import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { requestFollowTag } from 'calypso/state/reader/tags/items/actions';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 export class ReaderSidebarTags extends Component {
 	static propTypes = {
@@ -45,7 +46,7 @@ export class ReaderSidebarTags extends Component {
 		this.props.followTag( decodeURIComponent( tag ) );
 		recordAction( 'followed_topic' );
 		recordGaEvent( 'Clicked Follow Topic', tag );
-		recordTrack( 'calypso_reader_reader_tag_followed', { tag } );
+		this.props.recordReaderTracksEvent( 'calypso_reader_reader_tag_followed', { tag } );
 		this.props.onFollowTag( tag );
 
 		// reset the FormTextInputWithAction field to empty by rerendering it with a new `key`
@@ -83,5 +84,6 @@ export default connect(
 	} ),
 	{
 		followTag: requestFollowTag,
+		recordReaderTracksEvent,
 	}
 )( localize( ReaderSidebarTags ) );

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -6,12 +6,19 @@ import { identity } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
-import '../style.scss';
+import { connect } from 'react-redux';
+
 /**
  * Internal dependencies
  */
 import ReaderSidebarHelper from '../helper';
-import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+
+/**
+ * Style dependencies
+ */
+import '../style.scss';
 
 export class ReaderSidebarTagsListItem extends Component {
 	static propTypes = {
@@ -36,7 +43,7 @@ export class ReaderSidebarTagsListItem extends Component {
 	handleTagSidebarClick = () => {
 		recordAction( 'clicked_reader_sidebar_tag_item' );
 		recordGaEvent( 'Clicked Reader Sidebar Tag Item' );
-		recordTrack( 'calypso_reader_sidebar_tag_item_clicked', {
+		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_tag_item_clicked', {
 			tag: decodeURIComponent( this.props.tag.slug ),
 		} );
 	};
@@ -71,4 +78,6 @@ export class ReaderSidebarTagsListItem extends Component {
 	}
 }
 
-export default localize( ReaderSidebarTagsListItem );
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( localize( ReaderSidebarTagsListItem ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request  

Following up on #47818, which added a new Redux thunk for recording Tracks events in Reader, replacing the old recordTrack() function.

This is part of an effort to remedy #14470. We want to send a subscription count with each event and that's currently broken.

This PR switches over Reader components to use the new `recordReaderTracksEvent` action. This adds the subscription count to every event.

### Testing instructions

Turn on Analytics logging in your console with:

`localStorage.setItem('debug', 'calypso:analytics*');`

Using the Reader, verify that you can fire the following Tracks events, and that they all include subscription_count:

- [x] calypso_reader_empty_manage_following_loaded
- [x] calypso_reader_discover_on_empty_manage_following_clicked
- [x] calypso_reader_following_manage_search_performed
- [x] calypso_reader_following_manage_search_closed
- [x] calypso_reader_following_manage_search_more_click
- [x] calypso_reader_following_manage_follow_by_url_render
- [x] calypso_reader_following_intro_render
- [x] calypso_reader_following_intro_dismiss
- [x] calypso_reader_following_intro_link_clicked
- [x] calypso_reader_following_on_empty_like_stream_clicked
- [ ] calypso_reader_filled_gap
- [x] calypso_reader_following_on_empty_list_stream_clicked
- [x] calypso_reader_reader_list_followed
- [x] calypso_reader_reader_list_unfollowed
- [ ] calypso_reader_following_on_missing_list_clicked
- [x] calypso_reader_following_on_empty_search_stream_clicked
- [x] calypso_reader_clicked_search_sort
- [x] calypso_reader_search_suggestion_click
- [x] calypso_reader_sidebar_list_item_create_link_clicked
- [x] calypso_reader_sidebar_list_item_clicked
- [x] calypso_reader_sidebar_organization_item_clicked
- [x] calypso_reader_reader_tag_followed
- [x] calypso_reader_sidebar_tag_item_clicked

See #14470.