### PR TITLE
Editing Toolkit: Update to 2.8.14

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.13
+ * Version: 2.8.14
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.13' );
+define( 'PLUGIN_VERSION', '2.8.14' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.13
+Stable tag: 2.8.14
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.14 =
+* Premium Patterns: add pink dot to indicate a premium pattern in the inserter. (https://github.com/Automattic/wp-calypso/pull/47896)
+* Coming Soon: add coming soon wpcom localized url filter. (https://github.com/Automattic/wp-calypso/pull/48076)
 
 = 2.8.13 =
 * Removes unnecessary site editor implementation from the plugin. (https://github.com/Automattic/wp-calypso/pull/47301)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.13",
+	"version": "2.8.14",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
Bump Editing Toolkit plugin to version 2.8.14

#### Changes proposed in this Pull Request

**Includes the following PRs:**

* Premium Patterns: add pink dot to indicate a premium pattern in the inserter. (https://github.com/Automattic/wp-calypso/pull/47896) (note: this feature will be deployed in the "off" state, so for this release we only need to test that the patterns inserter still works as normal)
* Coming Soon: add coming soon wpcom localized url filter. (https://github.com/Automattic/wp-calypso/pull/48076)

#### Other [changes](https://github.com/Automattic/wp-calypso/commits/trunk/packages) included from the [imported @automattic packages](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/tsconfig.json#L37-L46) and their imports:

* Focused-Launch: Refactor Plan Summary Items rendering (#48042)
* Focused-Launch: Fix scroll to top when transitioning between routes (#48114)
* Focused Launch: Render free sub-domain last (#48083)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the diff on your sandbox and confirm that the above changes work correctly.
* Test that the new version of the plugin doesn't break Atomic sites as outlined in PCYsg-ly5-p2.
