### PR TITLE
New Onboarding launch: pre-select subdomain

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -28,6 +28,7 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 	const { setDomain, unsetDomain, unsetPlan, confirmDomainSelection } = useDispatch( LAUNCH_STORE );
 
 	const handleNext = () => {
+		confirmDomainSelection();
 		onNextStep?.();
 	};
 
@@ -44,7 +45,6 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 	};
 
 	const handleExistingSubdomainSelect = () => {
-		confirmDomainSelection();
 		unsetDomain();
 	};
 
@@ -75,7 +75,7 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 					initialDomainSearch={ domainSearch }
 					onSetDomainSearch={ setDomainSearch }
 					onDomainSearchBlur={ trackDomainSearchInteraction }
-					currentDomain={ currentDomain }
+					currentDomain={ currentDomain || mockDomainSuggestion( siteSubdomain?.domain ) }
 					existingSubdomain={ mockDomainSuggestion( siteSubdomain?.domain ) }
 					onDomainSelect={ handleDomainSelect }
 					onExistingSubdomainSelect={ handleExistingSubdomainSelect }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* pre-select subdomain in Step by step launch flow

#### Testing instructions
* Create a free site starting from `/new`
* Sync ET plugin and sandbox the site.
* Open Launch flow in the editor. 
* Advance to second step and sub-domain should be pre-selected.

Fixes https://github.com/Automattic/wp-calypso/issues/48246
