### PR TITLE
New onboarding launch: use site slug instead of siteId when redirecting

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
@@ -24,7 +24,7 @@ export const redirectToWpcomPath = ( url: string ) => {
 	redirectParentWindow( `${ origin }${ path }` );
 };
 
-export const openCheckout = ( siteId = window?.currentSiteId, isEcommerce = false ) => {
+export const openCheckout = ( siteSlug: string, isEcommerce = false ): void => {
 	const HOOK_OPEN_CHECKOUT_MODAL = 'a8c.wpcom-block-editor.openCheckoutModal';
 	const isFocusedLaunchFlow = window?.calypsoifyGutenberg?.isFocusedLaunchFlow;
 
@@ -35,9 +35,9 @@ export const openCheckout = ( siteId = window?.currentSiteId, isEcommerce = fals
 	}
 
 	// fallback: redirect to /checkout page
-	const checkoutUrl = addQueryArgs( `/checkout/${ siteId }`, {
+	const checkoutUrl = addQueryArgs( `/checkout/${ siteSlug }`, {
 		// Redirect to My Home after checkout only if the selected plan is not eCommerce
-		...( ! isEcommerce && { redirect_to: `/home/${ siteId }` } ),
+		...( ! isEcommerce && { redirect_to: `/home/${ siteSlug }` } ),
 	} );
 	redirectToWpcomPath( checkoutUrl );
 };

--- a/packages/launch/src/context.ts
+++ b/packages/launch/src/context.ts
@@ -7,7 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
 interface LaunchContext {
 	siteId: number;
 	redirectTo: ( url: string ) => void;
-	openCheckout: ( siteId: number, isEcommerce?: boolean ) => void;
+	openCheckout: ( siteSlug: string, isEcommerce?: boolean ) => void;
 	flow: string;
 }
 
@@ -19,12 +19,12 @@ const defaultRedirectTo = ( url: string ) => {
 const LaunchContext = React.createContext< LaunchContext >( {
 	siteId: 0,
 	redirectTo: defaultRedirectTo,
-	openCheckout: ( siteId, isEcommerce ) => {
+	openCheckout: ( siteSlug, isEcommerce ) => {
 		defaultRedirectTo(
-			addQueryArgs( `/checkout/${ siteId }`, {
+			addQueryArgs( `/checkout/${ siteSlug }`, {
 				preLaunch: 1,
 				// Redirect to My Home after checkout only if the selected plan is not eCommerce
-				...( ! isEcommerce && { redirect_to: `/home/${ siteId }` } ),
+				...( ! isEcommerce && { redirect_to: `/home/${ siteSlug }` } ),
 			} )
 		);
 	},

--- a/packages/launch/src/hooks/use-cart.ts
+++ b/packages/launch/src/hooks/use-cart.ts
@@ -10,6 +10,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
 import LaunchContext from '../context';
 import { getPlanProduct, getDomainProduct } from '../utils';
+import { useSiteDomains } from '../hooks';
 
 export function useCart(): { goToCheckout: () => Promise< void > } {
 	const { siteId, flow, openCheckout } = React.useContext( LaunchContext );
@@ -18,6 +19,7 @@ export function useCart(): { goToCheckout: () => Promise< void > } {
 	const isEcommercePlan = useSelect( ( select ) =>
 		select( PLANS_STORE ).isPlanEcommerce( plan?.storeSlug )
 	);
+	const { siteSubdomain } = useSiteDomains();
 
 	const { getCart, setCart } = useDispatch( SITE_STORE );
 
@@ -34,7 +36,7 @@ export function useCart(): { goToCheckout: () => Promise< void > } {
 		} );
 
 		// open checkout modal or redirect to /checkout only after the cart is updated
-		openCheckout( siteId, isEcommercePlan );
+		openCheckout( siteSubdomain?.domain || siteId.toString(), isEcommercePlan );
 	};
 
 	return {

--- a/packages/launch/src/hooks/use-on-launch.ts
+++ b/packages/launch/src/hooks/use-on-launch.ts
@@ -9,7 +9,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { LAUNCH_STORE } from '../stores';
 import LaunchContext from '../context';
-import { useCart } from '../hooks';
+import { useCart, useSiteDomains } from '../hooks';
 import { useSite } from './';
 
 // Hook used exclusively in Step-by-step launch flow until it will be using Editor Checkout Modal
@@ -19,6 +19,7 @@ export const useOnLaunch = () => {
 	const { plan } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 
 	const { isSiteLaunched } = useSite();
+	const { siteSubdomain } = useSiteDomains();
 	const { goToCheckout } = useCart();
 
 	React.useEffect( () => {
@@ -29,7 +30,7 @@ export const useOnLaunch = () => {
 				return;
 			}
 			// if free plan is selected, redirect to My Home
-			redirectTo( `/home/${ siteId }` );
+			redirectTo( `/home/${ siteSubdomain?.domain || siteId }` );
 		}
 	}, [ isSiteLaunched ] ); // eslint-disable-line react-hooks/exhaustive-deps
 };

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -21,7 +21,7 @@ import './styles.scss';
 interface Props {
 	locale?: string;
 	siteId: number;
-	openCheckout: ( siteId: number, isEcommerce?: boolean ) => void;
+	openCheckout: ( siteSlug: string, isEcommerce?: boolean ) => void;
 	redirectTo: ( path: string ) => void;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use site slug instead of `siteId` when redirecting to `/checkout`.
* Use site slug when redirecting to home after launching the site.

#### Testing instructions

* Create a site starting from `/new`
* Sync ET plugin and sandbox the site
* Start Launch from the editor and complete the flow by choosing paid plan => redirect to `/checkout/{SITE_SLUG}` with no errors when loading cart (see #47150).
* Repeat previous steps but choose a Free plan instead => redirect to `/home/{SITE_SLUG}`

Fixes #48091
Fixes #47150
