### PR TITLE
[@automattic/webpack-inline-constant-exports-plugin] - Add files declaration to package.json

### DIFF
--- a/packages/webpack-inline-constant-exports-plugin/CHANGELOG.md
+++ b/packages/webpack-inline-constant-exports-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 1.0.0 - 2020-12-09
+## 1.0.0 - 2020-12-11
 
 ### Added
 

--- a/packages/webpack-inline-constant-exports-plugin/package.json
+++ b/packages/webpack-inline-constant-exports-plugin/package.json
@@ -26,5 +26,8 @@
 	"devDependencies": {
 		"rimraf": "^3.0.0",
 		"webpack": "^5.7.0"
-	}
+	},
+	"files": [
+		"index.js"
+	]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `files` declaration to avoid publishing tests.
* Update the release date of `1.0.0`

After this change, this is the content of the published package:

```
$ npm pack

npm notice
npm notice 📦  @automattic/webpack-inline-constant-exports-plugin@1.0.0
npm notice === Tarball Contents ===
npm notice 9.3kB index.js
npm notice 816B  package.json
npm notice 473B  CHANGELOG.md
npm notice 1.7kB README.md
npm notice === Tarball Details ===
npm notice name:          @automattic/webpack-inline-constant-exports-plugin
npm notice version:       1.0.0
npm notice filename:      automattic-webpack-inline-constant-exports-plugin-1.0.0.tgz
npm notice package size:  4.3 kB
npm notice unpacked size: 12.3 kB
npm notice shasum:        d5f36fb0de0f750f58f5978c2b0760b3aa4e85c1
npm notice integrity:     sha512-Umn6epEC/6rnf[...]VikYVdcqc90Mw==
npm notice total files:   4
npm notice
```
