### PR TITLE
State: Modularize mySites

### DIFF
--- a/client/state/my-sites/init.js
+++ b/client/state/my-sites/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'mySites' ], reducer );

--- a/client/state/my-sites/reducer.js
+++ b/client/state/my-sites/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
+import { combineReducers, withSchemaValidation, withStorageKey } from 'calypso/state/utils';
 import sidebar from './sidebar/reducer';
 
 const schema = {
@@ -15,6 +15,9 @@ const schema = {
 	additionalProperties: false,
 };
 
-export default combineReducers( {
-	sidebarSections: withSchemaValidation( schema, sidebar ),
-} );
+export default withStorageKey(
+	'mySites',
+	combineReducers( {
+		sidebarSections: withSchemaValidation( schema, sidebar ),
+	} )
+);

--- a/client/state/my-sites/sidebar/actions.js
+++ b/client/state/my-sites/sidebar/actions.js
@@ -1,13 +1,14 @@
 /**
  * Internal dependencies
  */
-
 import {
 	MY_SITES_SIDEBAR_SECTION_TOGGLE,
 	MY_SITES_SIDEBAR_SECTION_EXPAND,
 	MY_SITES_SIDEBAR_SECTION_COLLAPSE,
 	MY_SITES_SIDEBAR_SECTIONS_COLLAPSE_ALL,
 } from 'calypso/state/action-types';
+
+import 'calypso/state/my-sites/init';
 
 const createSidebarAction = ( type ) => ( sidebarSection ) => ( {
 	type,

--- a/client/state/my-sites/sidebar/selectors.js
+++ b/client/state/my-sites/sidebar/selectors.js
@@ -1,2 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/my-sites/init';
+
 export const isSidebarSectionOpen = ( state, section ) =>
 	state.mySites.sidebarSections[ section ]?.isOpen;

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -19,7 +19,6 @@ import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import documentHead from './document-head/reducer';
 import i18n from './i18n/reducer';
 import importerNux from './importer-nux/reducer';
-import mySites from './my-sites/reducer';
 import sites from './sites/reducer';
 import support from './support/reducer';
 import userSettings from './user-settings/reducer';
@@ -35,7 +34,6 @@ const reducers = {
 	httpData,
 	i18n,
 	importerNux,
-	mySites,
 	sites,
 	support,
 	userSettings,


### PR DESCRIPTION
This PR is one of many working on the modularizing state in Calypso. This one handles the `mySites` state tree.

For more details on state modularization, see the [modularized state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42459.

#### Changes proposed in this Pull Request

* State: Modularize `mySites`

#### Testing instructions

* Go to `/read?debug`
* Type `state.mySites` in the console and verify it returns `undefined`.
* Click on "My Sites".
* Type `state.mySites` in the console and verify it returns an object with `sidebarSections` in it.
* Smoke test expanding and collapsing sections in the sidebar and verify everything works the same way, with no errors in the console.

#### Note

Linting errors are expected - they're coming from the non-modularized reducer, and will disappear once we modularize all of it.