### PR TITLE
Framework: Remove usages of lodash trimEnd()

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { getCurrencyDefaults } from '@automattic/format-currency';
-import { trimEnd } from 'lodash';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
 
@@ -199,7 +198,7 @@ export const SUPPORTED_CURRENCIES = {
  */
 export const CURRENCY_OPTIONS = Object.keys( SUPPORTED_CURRENCIES ).map( ( value ) => {
 	const { symbol } = getCurrencyDefaults( value );
-	const label = symbol === value ? value : `${ value } ${ trimEnd( symbol, '.' ) }`;
+	const label = symbol === value ? value : `${ value } ${ symbol.replace( /\.+$/, '' ) }`;
 	return { value, label };
 } );
 

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -7,7 +7,6 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
-import { trim, trimEnd } from 'lodash';
 
 /**
  * Internal dependencies
@@ -98,7 +97,7 @@ class SiteRedirect extends React.Component {
 					page(
 						domainManagementRedirectSettings(
 							this.props.selectedSite.slug,
-							trim( trimEnd( this.state.redirectUrl, '/' ) ),
+							this.state.redirectUrl.replace( /\/+$/, '' ).trim(),
 							this.props.currentRoute
 						)
 					);

--- a/client/my-sites/site-settings/protect.jsx
+++ b/client/my-sites/site-settings/protect.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { includes, some, trim, trimEnd } from 'lodash';
+import { includes, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,7 +42,7 @@ class Protect extends Component {
 
 	handleAddToAllowedList = () => {
 		const { setFieldValue } = this.props;
-		let allowedIps = trimEnd( this.getProtectAllowedIps() );
+		let allowedIps = this.getProtectAllowedIps().trimEnd();
 
 		if ( allowedIps.length ) {
 			allowedIps += '\n';
@@ -79,7 +79,7 @@ class Protect extends Component {
 					return false;
 				}
 
-				const range = entry.split( '-' ).map( trim );
+				const range = entry.split( '-' ).map( ( ip ) => ip.trim() );
 				return includes( range, ipAddress );
 			} )
 		);


### PR DESCRIPTION
We have only a couple usages of lodash's `trimEnd()` method. They can be refactored to use native methods. This PR removes them, in order to make us a bit less dependent on lodash.

This PR should not offer any visual or functional changes.

#### Changes proposed in this Pull Request

* Framework: Remove usages of lodash `trimEnd()` and some `trim()` usages alongside that.

#### Testing instructions

* Go to `/domains/manage/:domain/redirect-settings/:site` where `:domain` and `:site` correspond to a WP.com site that has a site redirect enabled.
* Change the redirect to something else.
* Verify after the successful save, the domain part of the URL gets replaced with the new site redirect domain value.
* Go to `/settings/security/:site` where `:site` is a Jetpack site with a paid plan.
* Open the `Prevent brute force login attacks` card.
* Verify that if the IP address is in the allowed list, the button to add it there is disabled; and if it's not there, the button is enabled. 
* Verify that the button works as expected and appends the current IP to the list.
* ETK: Verify changes make sense (replacement is pretty straightforward).