### PR TITLE
Framework: Remove lodash's initial()

### DIFF
--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -36,7 +36,6 @@ import {
 	camelCase,
 	flowRight as compose,
 	get,
-	initial,
 	last,
 	map,
 	mapKeys,
@@ -88,7 +87,7 @@ export const nativeToRaw = unary(
 				const lastPiece = last( format );
 
 				if ( lastPiece && 'string' === lastPiece.type && 'string' === piece.type ) {
-					return [ ...initial( format ), mergeStringPieces( lastPiece, piece ) ];
+					return [ ...format.slice( 0, -1 ), mergeStringPieces( lastPiece, piece ) ];
 				}
 
 				return [ ...format, piece ];

--- a/client/lib/notifications/note-block-parser.js
+++ b/client/lib/notifications/note-block-parser.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { compact, find, initial } from 'lodash';
+import { compact, find } from 'lodash';
 
 /**
  * Comparator function for sorting formatted ranges
@@ -11,10 +11,14 @@ import { compact, find, initial } from 'lodash';
  *   - it starts before the other
  *   - it has the same start but ends before the other
  *
- * @param {number} aStart start index of first range
- * @param {number} aEnd end index of first range
- * @param {number} bStart start index of second range
- * @param {number} bEnd end index of second range
+ * @param {object} rangeA                  First range
+ * @param {Array}  rangeA.indices          Start and end of the first range
+ * @param {number} rangeA.indices.0 aStart Start index of first range
+ * @param {number} rangeA.indices.1 aEnd   End index of first range
+ * @param {object} rangeB                  Second range
+ * @param {Array}  rangeB.indices          Start and end of the second range
+ * @param {number} rangeB.indices.0 aStart Start index of second range
+ * @param {number} rangeB.indices.1 aEnd   End index of second range
  * @returns {number} -1/0/1 indicating sort order
  */
 const rangeSort = ( { indices: [ aStart, aEnd ] }, { indices: [ bStart, bEnd ] } ) => {
@@ -48,8 +52,10 @@ const rangeSort = ( { indices: [ aStart, aEnd ] }, { indices: [ bStart, bEnd ] }
  *
  * The initial "invisible token" ranges are not enclosed
  *
- * @param {number} innerStart start of possibly-inner range
- * @param {number} innerEnd end of possibly-inner range
+ * @param {object} range                      Range
+ * @param {Array}  range.indices              Start and end of the range
+ * @param {number} range.indices.0 innerStart Start index of the range
+ * @param {number} range.indices.1 innerEnd   End index of the range
  * @returns {Function({indices: Number[]}): boolean} performs the check
  */
 const encloses = ( { indices: [ innerStart, innerEnd ] } ) =>
@@ -86,7 +92,7 @@ const addRange = ( ranges, range ) => {
 	const parent = find( ranges, encloses( range ) );
 
 	return parent
-		? [ ...initial( ranges ), { ...parent, children: addRange( parent.children, range ) } ]
+		? [ ...ranges.slice( 0, -1 ), { ...parent, children: addRange( parent.children, range ) } ]
 		: [ ...ranges, range ];
 };
 
@@ -207,8 +213,9 @@ const newNode = ( text, range = {} ) => ( {
 /**
  * Reducer to combine ongoing results with new results
  *
- * @param {?Array} reduced existing results
- * @param {?Array} remainder new results
+ * @param {Array}  results   All results
+ * @param {?Array} results.0 Existing results
+ * @param {?Array} results.1 New results
  * @returns {Array} combined results
  */
 const joinResults = ( [ reduced, remainder ] ) =>
@@ -230,10 +237,11 @@ const joinResults = ( [ reduced, remainder ] ) =>
  * to implement some kind of stack safety here such
  * as the use of a "trampoline".
  *
- * @param {Array} accum.0 previously parsed results
- * @param {string} accum.1 remaining text to parse
- * @param {number} accum.2 current index into text string
- * @param {object} nextRange next range from formatted block
+ * @param {Array}  reducer   Reducer arguments
+ * @param {Array}  reducer.0 Previously parsed results
+ * @param {string} reducer.1 Remaining text to parse
+ * @param {number} reducer.2 Current index into text string
+ * @param {object} nextRange Next range from formatted block
  * @returns {Array} parsed results: text and nodes
  */
 const parse = ( [ prev, text, offset ], nextRange ) => {

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import { initial, flatMap, trim } from 'lodash';
+import { flatMap, trim } from 'lodash';
 import { connect, useDispatch } from 'react-redux';
 import config from 'calypso/config';
 
@@ -45,12 +45,10 @@ function handleSearch( query ) {
 const FollowingStream = ( props ) => {
 	const suggestionList =
 		props.suggestions &&
-		initial(
-			flatMap( props.suggestions, ( query ) => [
-				<Suggestion suggestion={ query.text } source="following" railcar={ query.railcar } />,
-				', ',
-			] )
-		);
+		flatMap( props.suggestions, ( query ) => [
+			<Suggestion suggestion={ query.text } source="following" railcar={ query.railcar } />,
+			', ',
+		] ).slice( 0, -1 );
 	const placeholderText = getSearchPlaceholderText();
 	const { translate } = props;
 	const dispatch = useDispatch();

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { trim, initial, flatMap } from 'lodash';
+import { trim, flatMap } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import classnames from 'classnames';
@@ -140,17 +140,15 @@ class SearchStream extends React.Component {
 		const singleColumnResultsClasses = classnames( 'search-stream__single-column-results', {
 			'is-post-results': searchType === SEARCH_TYPES.POSTS && query,
 		} );
-		const suggestionList = initial(
-			flatMap( suggestions, ( suggestion ) => [
-				<Suggestion
-					suggestion={ suggestion.text }
-					source="search"
-					sort={ sortOrder === 'date' ? sortOrder : undefined }
-					railcar={ suggestion.railcar }
-				/>,
-				', ',
-			] )
-		);
+		const suggestionList = flatMap( suggestions, ( suggestion ) => [
+			<Suggestion
+				suggestion={ suggestion.text }
+				source="search"
+				sort={ sortOrder === 'date' ? sortOrder : undefined }
+				railcar={ suggestion.railcar }
+			/>,
+			', ',
+		] ).slice( 0, -1 );
 
 		/* eslint-disable jsx-a11y/no-autofocus */
 		return (

--- a/client/state/posts/utils/append-to-post-edits-log.js
+++ b/client/state/posts/utils/append-to-post-edits-log.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { initial, isEmpty, isString, last } from 'lodash';
+import { isEmpty, isString, last } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,7 +29,7 @@ export function appendToPostEditsLog( postEditsLog, newPostEdits ) {
 		return [ ...postEditsLog, newPostEdits ];
 	}
 
-	const newEditsLog = initial( postEditsLog );
+	const newEditsLog = postEditsLog.slice( 0, -1 );
 	newEditsLog.push( mergePostEdits( lastEdits, newPostEdits ) );
 	return newEditsLog;
 }


### PR DESCRIPTION
We have only a couple usages of lodash's `initial()` method. They can be refactored to use native methods. This PR removes them, in order to make us a bit less dependent on lodash.

This PR should not offer any visual or functional changes.

#### Changes proposed in this Pull Request

* Framework: Remove usages of lodash `initial()` in favor of a simple `Array.slice` usage.
* Fix some inline docs in the way

#### Testing instructions

* Changes are pretty straightforward - just verify they make sense.
* If you really want to test an instance of that,  go to `/read/search` and verify that there isn't a comma after the last suggested keyword below the search form. Note that there is still a dot there instead 😉 