### PR TITLE
G Suite: Add support for purchasing Google Workspace accounts

### DIFF
--- a/client/components/gsuite/gsuite-features/index.jsx
+++ b/client/components/gsuite/gsuite-features/index.jsx
@@ -8,7 +8,11 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from 'calypso/lib/gsuite/constants';
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GSUITE_BASIC_SLUG,
+	GSUITE_BUSINESS_SLUG,
+} from 'calypso/lib/gsuite/constants';
 import GSuiteSingleFeature from './single-feature';
 
 /**
@@ -22,7 +26,9 @@ const GSuiteFeatures = ( { compact, domainName, productSlug, type } ) => {
 	const getStorageText = () => {
 		if ( compact ) {
 			return undefined;
-		} else if ( GSUITE_BASIC_SLUG === productSlug ) {
+		} else if (
+			[ GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY, GSUITE_BASIC_SLUG ].includes( productSlug )
+		) {
 			return translate( 'Get 30GB of storage for all your files synced across devices.' );
 		} else if ( GSUITE_BUSINESS_SLUG === productSlug ) {
 			return translate( 'Get unlimited storage for all your files synced across devices.' );
@@ -34,7 +40,9 @@ const GSuiteFeatures = ( { compact, domainName, productSlug, type } ) => {
 	const getStorageTitle = () => {
 		if ( ! compact ) {
 			return translate( 'Keep all your files secure' );
-		} else if ( GSUITE_BASIC_SLUG === productSlug ) {
+		} else if (
+			[ GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY, GSUITE_BASIC_SLUG ].includes( productSlug )
+		) {
 			return translate( '30GB of cloud storage' );
 		} else if ( GSUITE_BUSINESS_SLUG === productSlug ) {
 			return translate( 'Unlimited cloud storage (or 1TB per user if fewer than 5 users)' );

--- a/client/components/upgrades/gsuite/index.jsx
+++ b/client/components/upgrades/gsuite/index.jsx
@@ -10,8 +10,12 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { addItems } from 'calypso/lib/cart/actions';
+import config from 'calypso/config';
 import { hasDomainInCart } from 'calypso/lib/cart-values/cart-items';
-import { GSUITE_BASIC_SLUG } from 'calypso/lib/gsuite/constants';
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GSUITE_BASIC_SLUG,
+} from 'calypso/lib/gsuite/constants';
 import GSuiteUpsellCard from './gsuite-upsell-card';
 import HeaderCake from 'calypso/components/header-cake';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -40,6 +44,10 @@ const GSuiteUpgrade = ( { cart, domain, selectedSiteSlug } ) => {
 
 	const translate = useTranslate();
 
+	const productSlug = config.isEnabled( 'google-workspace-migration' )
+		? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+		: GSUITE_BASIC_SLUG;
+
 	return (
 		<div>
 			<HeaderCake onClick={ handleGoBack }>
@@ -48,7 +56,7 @@ const GSuiteUpgrade = ( { cart, domain, selectedSiteSlug } ) => {
 
 			<GSuiteUpsellCard
 				domain={ domain }
-				productSlug={ GSUITE_BASIC_SLUG }
+				productSlug={ productSlug }
 				onSkipClick={ handleSkipClick }
 				onAddEmailClick={ handleAddEmailClick }
 			/>

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -23,7 +23,12 @@ import emailValidator from 'email-validator';
 /**
  * Internal dependencies
  */
-import { GSUITE_BASIC_SLUG, GSUITE_EXTRA_LICENSE_SLUG } from 'calypso/lib/gsuite/constants';
+import config from 'calypso/config';
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GSUITE_BASIC_SLUG,
+	GSUITE_EXTRA_LICENSE_SLUG,
+} from 'calypso/lib/gsuite/constants';
 import {
 	formatProduct,
 	getDomain,
@@ -741,7 +746,12 @@ export function getGoogleApps( cart ) {
 }
 
 export function googleApps( properties ) {
-	const productSlug = properties.product_slug || GSUITE_BASIC_SLUG;
+	const productSlug =
+		properties.product_slug ||
+		( config.isEnabled( 'google-workspace-migration' )
+			? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+			: GSUITE_BASIC_SLUG );
+
 	const item = domainItem( productSlug, properties.meta ? properties.meta : properties.domain );
 
 	return assign( item, { extra: { google_apps_users: properties.users } } );

--- a/client/lib/gsuite/constants.js
+++ b/client/lib/gsuite/constants.js
@@ -3,13 +3,14 @@
  */
 import PropTypes from 'prop-types';
 
+export const GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY =
+	'wp_google_workspace_business_starter_yearly';
 export const GSUITE_BASIC_SLUG = 'gapps';
 export const GSUITE_BUSINESS_SLUG = 'gapps_unlimited';
 export const GSUITE_EXTRA_LICENSE_SLUG = 'gapps_extra_license';
 
 export const GSUITE_SLUG_PROP_TYPES = PropTypes.oneOf( [
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 	GSUITE_BASIC_SLUG,
 	GSUITE_BUSINESS_SLUG,
 ] );
-
-export const GSUITE_LINK_PREFIX = 'https://mail.google.com/a/';

--- a/client/lib/gsuite/gsuite-product-slug.js
+++ b/client/lib/gsuite/gsuite-product-slug.js
@@ -2,10 +2,21 @@
  * Internal dependencies
  */
 import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 	GSUITE_BASIC_SLUG,
 	GSUITE_BUSINESS_SLUG,
 	GSUITE_EXTRA_LICENSE_SLUG,
 } from 'calypso/lib/gsuite/constants';
+
+/**
+ * Determines whether the specified product slug is for Google Workspace Business Starter.
+ *
+ * @param {string} productSlug - slug of the product
+ * @returns {boolean} true if the slug refers to Google Workspace Business Starter, false otherwise
+ */
+export function isGoogleWorkspaceProductSlug( productSlug ) {
+	return productSlug === GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY;
+}
 
 /**
  * Determines whether the specified product slug is for G Suite Basic or Business.
@@ -35,4 +46,14 @@ export function isGSuiteExtraLicenseProductSlug( productSlug ) {
  */
 export function isGSuiteOrExtraLicenseProductSlug( productSlug ) {
 	return isGSuiteProductSlug( productSlug ) || isGSuiteExtraLicenseProductSlug( productSlug );
+}
+
+/**
+ * Determines whether the specified product slug refers to either G Suite or Google Workspace.
+ *
+ * @param {string} productSlug - slug of the product
+ * @returns {boolean} true if the slug refers to G Suite or Google Workspace, false otherwise
+ */
+export function isGSuiteOrGoogleWorkspaceProductSlug( productSlug ) {
+	return isGSuiteProductSlug( productSlug ) || isGoogleWorkspaceProductSlug( productSlug );
 }

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -6,8 +6,10 @@ export { getGSuiteMailboxCount } from './get-gsuite-mailbox-count';
 export { getLoginUrlWithTOSRedirect } from './get-login-url-with-tos-redirect';
 export { getMonthlyPrice } from './get-monthly-price';
 export {
+	isGoogleWorkspaceProductSlug,
 	isGSuiteExtraLicenseProductSlug,
 	isGSuiteOrExtraLicenseProductSlug,
+	isGSuiteOrGoogleWorkspaceProductSlug,
 	isGSuiteProductSlug,
 } from './gsuite-product-slug';
 export { getGSuiteSupportedDomains, hasGSuiteSupportedDomain } from './gsuite-supported-domain';

--- a/client/lib/products-values/is-google-apps.js
+++ b/client/lib/products-values/is-google-apps.js
@@ -1,7 +1,10 @@
 /**
  * Internal dependencies
  */
-import { isGSuiteOrExtraLicenseProductSlug } from 'calypso/lib/gsuite';
+import {
+	isGoogleWorkspaceProductSlug,
+	isGSuiteOrExtraLicenseProductSlug,
+} from 'calypso/lib/gsuite';
 import { assertValidProduct } from 'calypso/lib/products-values/utils/assert-valid-product';
 import { formatProduct } from 'calypso/lib/products-values/format-product';
 
@@ -9,5 +12,8 @@ export function isGoogleApps( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return isGSuiteOrExtraLicenseProductSlug( product.product_slug );
+	return (
+		isGSuiteOrExtraLicenseProductSlug( product.product_slug ) ||
+		isGoogleWorkspaceProductSlug( product.product_slug )
+	);
 }

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -26,8 +26,12 @@ import {
 	isBundled,
 	isDomainProduct,
 } from 'calypso/lib/products-values';
-import { isGSuiteProductSlug } from 'calypso/lib/gsuite';
-import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from 'calypso/lib/gsuite/constants';
+import { isGSuiteOrGoogleWorkspaceProductSlug } from 'calypso/lib/gsuite';
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GSUITE_BASIC_SLUG,
+	GSUITE_BUSINESS_SLUG,
+} from 'calypso/lib/gsuite/constants';
 import { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } from 'calypso/lib/plans';
 
 export class CartItem extends React.Component {
@@ -63,7 +67,7 @@ export class CartItem extends React.Component {
 			return <span className="cart__free-text">{ translate( 'Free' ) }</span>;
 		}
 
-		if ( isGSuiteProductSlug( cartItem.product_slug ) ) {
+		if ( isGSuiteOrGoogleWorkspaceProductSlug( cartItem.product_slug ) ) {
 			const {
 				cost_before_coupon: costPerProductBeforeCoupon,
 				is_sale_coupon_applied: isSaleCouponApplied,
@@ -306,6 +310,7 @@ export class CartItem extends React.Component {
 			return cartItem.product_name;
 		} else if ( cartItem.volume === 1 ) {
 			switch ( cartItem.product_slug ) {
+				case GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY:
 				case GSUITE_BASIC_SLUG:
 				case GSUITE_BUSINESS_SLUG:
 					return translate( '%(productName)s (1 User)', {
@@ -319,6 +324,7 @@ export class CartItem extends React.Component {
 			}
 		} else {
 			switch ( cartItem.product_slug ) {
+				case GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY:
 				case GSUITE_BASIC_SLUG:
 				case GSUITE_BUSINESS_SLUG:
 					return translate(

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -21,7 +21,10 @@ import {
 	isPlan,
 	isSiteRedirect,
 } from 'calypso/lib/products-values';
-import { isGSuiteExtraLicenseProductSlug, isGSuiteProductSlug } from 'calypso/lib/gsuite';
+import {
+	isGSuiteExtraLicenseProductSlug,
+	isGSuiteOrGoogleWorkspaceProductSlug,
+} from 'calypso/lib/gsuite';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { localize } from 'i18n-calypso';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -180,7 +183,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			);
 		}
 
-		if ( isGSuiteProductSlug( primaryPurchase.productSlug ) ) {
+		if ( isGSuiteOrGoogleWorkspaceProductSlug( primaryPurchase.productSlug ) ) {
 			return preventWidows(
 				translate(
 					'Your domain {{strong}}%(domainName)s{{/strong}} will be using G Suite very soon.',

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -20,7 +20,11 @@ import { useSelector } from 'react-redux';
 import joinClasses from './join-classes';
 import { useHasDomainsInCart } from '../hooks/has-domains';
 import { ItemVariationPicker } from './item-variation-picker';
-import { isGSuiteProductSlug, isGSuiteOrExtraLicenseProductSlug } from 'calypso/lib/gsuite';
+import {
+	isGoogleWorkspaceProductSlug,
+	isGSuiteOrExtraLicenseProductSlug,
+	isGSuiteOrGoogleWorkspaceProductSlug,
+} from 'calypso/lib/gsuite';
 import { planMatches, isWpComPlan } from 'calypso/lib/plans';
 import {
 	isMonthly as isMonthlyPlan,
@@ -73,9 +77,11 @@ function WPLineItem( {
 	const isRenewal = item.wpcom_meta?.extra?.purchaseId;
 	// Show the variation picker when this is not a renewal
 	const shouldShowVariantSelector = getItemVariants && item.wpcom_meta && ! isRenewal;
-	const isGSuite = isGSuiteOrExtraLicenseProductSlug( item.wpcom_meta?.product_slug );
 
 	const productSlug = item.wpcom_meta?.product_slug;
+
+	const isGSuite =
+		isGSuiteOrExtraLicenseProductSlug( productSlug ) || isGoogleWorkspaceProductSlug( productSlug );
 
 	// Unless a user in the monthly pricing test, reset the related monthly plan costs
 	if ( ! isMonthlyPricingTest && item.wpcom_meta ) {
@@ -503,7 +509,10 @@ function LineItemSublabelAndPrice( { item, isMonthlyPricingTest = false } ) {
 	const translate = useTranslate();
 	const isDomainRegistration = item.wpcom_meta?.is_domain_registration;
 	const isDomainMap = item.type === 'domain_map';
-	const isGSuite = isGSuiteOrExtraLicenseProductSlug( item.wpcom_meta?.product_slug );
+	const productSlug = item.wpcom_meta?.product_slug;
+
+	const isGSuite =
+		isGSuiteOrExtraLicenseProductSlug( productSlug ) || isGoogleWorkspaceProductSlug( productSlug );
 
 	if ( item.type === 'plan' && item.wpcom_meta?.months_per_bill_period > 1 ) {
 		if ( isMonthlyPricingTest ) {
@@ -597,7 +606,9 @@ function DomainDiscountCallout( { item } ) {
 
 function GSuiteDiscountCallout( { item } ) {
 	const translate = useTranslate();
-	const isGSuite = isGSuiteProductSlug( item.wpcom_meta?.product_slug );
+
+	const isGSuite = isGSuiteOrGoogleWorkspaceProductSlug( item.wpcom_meta?.product_slug );
+
 	if (
 		isGSuite &&
 		item.amount.value < item.wpcom_meta?.item_original_subtotal_integer &&

--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { isLineItemADomain } from 'calypso/my-sites/checkout/composite-checkout/hooks/has-domains';
-import { isGSuiteProductSlug } from 'calypso/lib/gsuite';
+import { isGSuiteOrGoogleWorkspaceProductSlug } from 'calypso/lib/gsuite';
 import {
 	prepareDomainContactValidationRequest,
 	prepareGSuiteContactValidationRequest,
@@ -123,7 +123,7 @@ export async function getSignupEmailValidationResult( email, emailTakenLoginRedi
 
 export async function getGSuiteValidationResult( items, contactInfo ) {
 	const domainNames = items
-		.filter( ( item ) => isGSuiteProductSlug( item.wpcom_meta?.product_slug ) )
+		.filter( ( item ) => isGSuiteOrGoogleWorkspaceProductSlug( item.wpcom_meta?.product_slug ) )
 		.map( ( item ) => item.wpcom_meta?.meta ?? '' );
 	const formattedContactDetails = prepareContactDetailsForValidation( 'gsuite', contactInfo );
 	return wpcomValidateGSuiteContactInformation( formattedContactDetails, domainNames );

--- a/client/my-sites/checkout/composite-checkout/lib/get-contact-details-type.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-contact-details-type.ts
@@ -12,14 +12,14 @@ import {
 	hasTransferProduct,
 	hasOnlyRenewalItems,
 } from 'calypso/lib/cart-values/cart-items';
-import { isGSuiteProductSlug } from 'calypso/lib/gsuite';
+import { isGSuiteOrGoogleWorkspaceProductSlug } from 'calypso/lib/gsuite';
 import doesPurchaseHaveFullCredits from './does-purchase-have-full-credits';
 
 export default function getContactDetailsType( responseCart: ResponseCart ): ContactDetailsType {
 	const hasDomainProduct =
 		hasDomainRegistration( responseCart ) || hasTransferProduct( responseCart );
 	const hasNewGSuite = responseCart.products.some(
-		( product ) => isGSuiteProductSlug( product.product_slug ) // Do not show the G Suite form for extra licenses
+		( product ) => isGSuiteOrGoogleWorkspaceProductSlug( product.product_slug ) // Do not show the G Suite form for extra licenses
 	);
 	const isOnlyRenewals = hasOnlyRenewalItems( responseCart );
 	const isPurchaseFree = responseCart.total_cost_integer === 0;

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -30,7 +30,7 @@ import type {
 	WPCOMTransactionEndpointRequestPayload,
 	TransactionRequestWithLineItems,
 } from '../types/transaction-endpoint';
-import { isGSuiteProductSlug } from 'calypso/lib/gsuite';
+import { isGSuiteOrGoogleWorkspaceProductSlug } from 'calypso/lib/gsuite';
 
 const debug = debugFactory( 'calypso:composite-checkout:translate-cart' );
 
@@ -343,7 +343,7 @@ function addRegistrationDataToGSuiteItem(
 	item: WPCOMCartItem,
 	contactDetails: DomainContactDetails | null
 ): WPCOMCartItem {
-	if ( ! isGSuiteProductSlug( item.wpcom_meta?.product_slug ) ) {
+	if ( ! isGSuiteOrGoogleWorkspaceProductSlug( item.wpcom_meta?.product_slug ) ) {
 		return item;
 	}
 	return {

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -11,8 +11,12 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import config from 'calypso/config';
 import DocumentHead from 'calypso/components/data/document-head';
-import { GSUITE_BASIC_SLUG } from 'calypso/lib/gsuite/constants';
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GSUITE_BASIC_SLUG,
+} from 'calypso/lib/gsuite/constants';
 import GSuiteUpsellCard from 'calypso/components/upgrades/gsuite/gsuite-upsell-card';
 import Main from 'calypso/components/main';
 import QuerySites from 'calypso/components/data/query-sites';
@@ -63,6 +67,10 @@ export class GSuiteNudge extends React.Component {
 	render() {
 		const { domain, receiptId, selectedSiteId, siteSlug, siteTitle, translate } = this.props;
 
+		const productSlug = config.isEnabled( 'google-workspace-migration' )
+			? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+			: GSUITE_BASIC_SLUG;
+
 		return (
 			<Main className="gsuite-nudge">
 				<PageViewTracker
@@ -82,7 +90,7 @@ export class GSuiteNudge extends React.Component {
 				<QuerySites siteId={ selectedSiteId } />
 				<GSuiteUpsellCard
 					domain={ this.props.domain }
-					productSlug={ GSUITE_BASIC_SLUG }
+					productSlug={ productSlug }
 					onSkipClick={ this.handleSkipClick }
 					onAddEmailClick={ this.handleAddEmailClick }
 				/>

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -19,7 +19,10 @@ import {
 	getCurrentUserLocale,
 } from 'calypso/state/current-user/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
-import { GSUITE_BASIC_SLUG } from 'calypso/lib/gsuite/constants';
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GSUITE_BASIC_SLUG,
+} from 'calypso/lib/gsuite/constants';
 import { getAnnualPrice } from 'calypso/lib/gsuite';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -61,8 +64,14 @@ class EmailProvidersComparison extends React.Component {
 
 	goToAddGSuite = () => {
 		const { domain, currentRoute, selectedSiteSlug } = this.props;
+
 		recordTracksEvent( 'calypso_email_providers_add_click', { provider: 'gsuite' } );
-		page( emailManagementNewGSuiteAccount( selectedSiteSlug, domain.name, 'basic', currentRoute ) );
+
+		const planType = config.isEnabled( 'google-workspace-migration' ) ? 'starter' : 'basic';
+
+		page(
+			emailManagementNewGSuiteAccount( selectedSiteSlug, domain.name, planType, currentRoute )
+		);
 	};
 
 	onAddTitanClick = () => {
@@ -251,10 +260,14 @@ class EmailProvidersComparison extends React.Component {
 
 export default connect(
 	( state ) => {
+		const productSlug = config.isEnabled( 'google-workspace-migration' )
+			? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+			: GSUITE_BASIC_SLUG;
+
 		return {
 			currencyCode: getCurrentUserCurrencyCode( state ),
 			currentUserLocale: getCurrentUserLocale( state ),
-			gSuiteProduct: getProductBySlug( state, GSUITE_BASIC_SLUG ),
+			gSuiteProduct: getProductBySlug( state, productSlug ),
 			currentRoute: getCurrentRoute( state ),
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 		};

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -31,7 +31,10 @@ import {
 	validateAgainstExistingUsers,
 } from 'calypso/lib/gsuite/new-users';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from 'calypso/lib/gsuite/constants';
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GSUITE_BASIC_SLUG,
+} from 'calypso/lib/gsuite/constants';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
@@ -80,7 +83,7 @@ class GSuiteAddUsers extends React.Component {
 			addItems(
 				getItemsForCart(
 					domains,
-					'business' === planType ? GSUITE_BUSINESS_SLUG : GSUITE_BASIC_SLUG,
+					'basic' === planType ? GSUITE_BASIC_SLUG : GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 					users
 				)
 			);
@@ -265,7 +268,7 @@ GSuiteAddUsers.propTypes = {
 	domains: PropTypes.array.isRequired,
 	gsuiteUsers: PropTypes.array,
 	isRequestingDomains: PropTypes.bool.isRequired,
-	planType: PropTypes.oneOf( [ 'basic', 'business' ] ),
+	planType: PropTypes.oneOf( [ 'basic', 'starter' ] ),
 	selectedDomainName: PropTypes.string.isRequired,
 	selectedSite: PropTypes.shape( {
 		slug: PropTypes.string.isRequired,

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -17,7 +17,10 @@ import EmailVerificationGate from 'calypso/components/email-verification/email-v
 import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { GSUITE_BASIC_SLUG } from 'calypso/lib/gsuite/constants';
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GSUITE_BASIC_SLUG,
+} from 'calypso/lib/gsuite/constants';
 import GSuiteFeatures from 'calypso/components/gsuite/gsuite-features';
 import GSuiteLearnMore from 'calypso/components/gsuite/gsuite-learn-more';
 import GSuitePrice from 'calypso/components/gsuite/gsuite-price';
@@ -44,7 +47,9 @@ export const GSuitePurchaseCta = ( {
 		} );
 	}, [ domainName ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
-	const goToAddGSuiteUsers = ( planType ) => {
+	const goToAddGSuiteUsers = () => {
+		const planType = config.isEnabled( 'google-workspace-migration' ) ? 'starter' : 'basic';
+
 		recordEvent( 'calypso_email_gsuite_purchase_cta_get_gsuite_click', {
 			domain_name: domainName,
 			plan_type: planType,
@@ -97,9 +102,7 @@ export const GSuitePurchaseCta = ( {
 						{ upgradeAvailable && (
 							<Button
 								className="gsuite-purchase-cta__get-gsuite-button"
-								onClick={ () => {
-									goToAddGSuiteUsers( 'basic' );
-								} }
+								onClick={ goToAddGSuiteUsers }
 								primary
 							>
 								{ translate( 'Add G Suite' ) }
@@ -114,7 +117,7 @@ export const GSuitePurchaseCta = ( {
 			</CompactCard>
 
 			<CompactCard className="gsuite-purchase-cta__info">
-				<GSuiteFeatures domainName={ domainName } productSlug={ GSUITE_BASIC_SLUG } />
+				<GSuiteFeatures domainName={ domainName } productSlug={ product.product_slug } />
 
 				<GSuiteLearnMore onLearnMoreClick={ handleLearnMoreClick } />
 			</CompactCard>
@@ -131,11 +134,17 @@ GSuitePurchaseCta.propTypes = {
 };
 
 export default connect(
-	( state ) => ( {
-		currentRoute: getCurrentRoute( state ),
-		currencyCode: getCurrentUserCurrencyCode( state ),
-		product: getProductBySlug( state, GSUITE_BASIC_SLUG ),
-		selectedSiteSlug: getSelectedSiteSlug( state ),
-	} ),
+	( state ) => {
+		const productSlug = config.isEnabled( 'google-workspace-migration' )
+			? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+			: GSUITE_BASIC_SLUG;
+
+		return {
+			currentRoute: getCurrentRoute( state ),
+			currencyCode: getCurrentUserCurrencyCode( state ),
+			product: getProductBySlug( state, productSlug ),
+			selectedSiteSlug: getSelectedSiteSlug( state ),
+		};
+	},
 	{ recordTracksEvent }
 )( GSuitePurchaseCta );

--- a/config/development.json
+++ b/config/development.json
@@ -68,6 +68,7 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"google-drive": true,
+		"google-workspace-migration": false,
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,


### PR DESCRIPTION
This pull request, together with D52862-code, make the changes required to be able to purchase Google Workspace Business Starter instead of G Suite. They are hidden behind a new `google-workspace-migration` feature flag.

#### Testing instructions

See D52862-code for instructions.