### PR TITLE
Jetpack Backup: keep local time when applying offset to date

### DIFF
--- a/client/components/jetpack/backup-delta/style.scss
+++ b/client/components/jetpack/backup-delta/style.scss
@@ -30,7 +30,7 @@
 }
 
 .backup-delta__realtime .pagination {
-	margin: 20px 0;
+	margin: 30px 0 20px;
 }
 
 /* WordPress.com-only styles */

--- a/client/lib/site/timezone.js
+++ b/client/lib/site/timezone.js
@@ -20,12 +20,12 @@ import moment, { MomentInput, Moment } from 'moment-timezone';
  *                        Moment with gmtOffset applied if no timezone is provided.
  *                        If neither is provided, the original moment is returned.
  */
-export function applySiteOffset( input, { timezone, gmtOffset } ) {
+export function applySiteOffset( input, { timezone, gmtOffset, keepLocalTime = false } ) {
 	if ( timezone ) {
 		return moment.tz( input, timezone );
 	}
 	if ( gmtOffset || gmtOffset === 0 ) {
-		return moment( input ).utcOffset( gmtOffset );
+		return moment( input ).utcOffset( gmtOffset, keepLocalTime );
 	}
 	return moment( input );
 }

--- a/client/lib/site/timezone.js
+++ b/client/lib/site/timezone.js
@@ -22,7 +22,7 @@ import moment, { MomentInput, Moment } from 'moment-timezone';
  */
 export function applySiteOffset( input, { timezone, gmtOffset, keepLocalTime = false } ) {
 	if ( timezone ) {
-		return moment.tz( input, timezone );
+		return moment( input ).tz( timezone, keepLocalTime );
 	}
 	if ( gmtOffset || gmtOffset === 0 ) {
 		return moment( input ).utcOffset( gmtOffset, keepLocalTime );

--- a/client/my-sites/backup/date-picker.jsx
+++ b/client/my-sites/backup/date-picker.jsx
@@ -31,7 +31,7 @@ const DatePicker = ( { onSelectDate, selectedDate } ) => {
 	const firstKnownBackupAttempt = useFirstKnownBackupAttempt( siteId );
 	const oldestDateAvailable = useDateWithOffset(
 		firstKnownBackupAttempt.backupAttempt?.activityTs,
-		!! firstKnownBackupAttempt.backupAttempt
+		{ shouldExecute: !! firstKnownBackupAttempt.backupAttempt }
 	);
 
 	return (

--- a/client/my-sites/backup/hooks.js
+++ b/client/my-sites/backup/hooks.js
@@ -154,15 +154,15 @@ export const useFirstMatchingBackupAttempt = (
 // Tolerates null settings values, unlike the implementation in `calypso/components/site-offset`;
 // I don't want to disturb existing behavior, but we may want to come back later
 // and DRY up this bit of code.
-export const useDateWithOffset = ( date, shouldExecute = true ) => {
+export const useDateWithOffset = ( date, { shouldExecute = true, keepLocalTime = false } = {} ) => {
 	const siteId = useSelector( getSelectedSiteId );
 
 	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
 	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
 
 	const dateWithOffset = useMemo(
-		() => applySiteOffset( date, { timezone, gmtOffset, keepLocalTime: true } ),
-		[ date, timezone, gmtOffset ]
+		() => applySiteOffset( date, { timezone, gmtOffset, keepLocalTime } ),
+		[ date, timezone, gmtOffset, keepLocalTime ]
 	);
 
 	return shouldExecute ? dateWithOffset : undefined;

--- a/client/my-sites/backup/hooks.js
+++ b/client/my-sites/backup/hooks.js
@@ -160,11 +160,10 @@ export const useDateWithOffset = ( date, shouldExecute = true ) => {
 	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
 	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
 
-	const dateWithOffset = useMemo( () => applySiteOffset( date, { timezone, gmtOffset } ), [
-		date,
-		timezone,
-		gmtOffset,
-	] );
+	const dateWithOffset = useMemo(
+		() => applySiteOffset( date, { timezone, gmtOffset, keepLocalTime: true } ),
+		[ date, timezone, gmtOffset ]
+	);
 
 	return shouldExecute ? dateWithOffset : undefined;
 };

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -51,7 +51,9 @@ const BackupPage = ( { queryDate } ) => {
 
 	const moment = useLocalizedMoment();
 	const parsedQueryDate = queryDate ? moment( queryDate, INDEX_FORMAT ) : moment();
-	const selectedDate = useDateWithOffset( parsedQueryDate );
+	const selectedDate = useDateWithOffset( parsedQueryDate, {
+		keepLocalTime: true,
+	} );
 
 	return (
 		<div

--- a/client/my-sites/backup/status/index.jsx
+++ b/client/my-sites/backup/status/index.jsx
@@ -34,10 +34,9 @@ export const DailyStatus = ( { selectedDate } ) => {
 	useDailyBackupStatus( siteId, moment( selectedDate ).subtract( 1, 'day' ) );
 	useDailyBackupStatus( siteId, moment( selectedDate ).add( 1, 'day' ) );
 
-	const lastBackupDate = useDateWithOffset(
-		lastBackupBeforeDate?.activityTs,
-		!! lastBackupBeforeDate
-	);
+	const lastBackupDate = useDateWithOffset( lastBackupBeforeDate?.activityTs, {
+		shouldExecute: !! lastBackupBeforeDate,
+	} );
 
 	if ( isLoading ) {
 		return <BackupPlaceholder showDatePicker={ false } />;
@@ -72,10 +71,9 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 	useRealtimeBackupStatus( siteId, moment( selectedDate ).subtract( 1, 'day' ) );
 	useRealtimeBackupStatus( siteId, moment( selectedDate ).add( 1, 'day' ) );
 
-	const lastBackupDate = useDateWithOffset(
-		lastBackupBeforeDate?.activityTs,
-		!! lastBackupBeforeDate
-	);
+	const lastBackupDate = useDateWithOffset( lastBackupBeforeDate?.activityTs, {
+		shouldExecute: !! lastBackupBeforeDate,
+	} );
 
 	if ( isLoading ) {
 		return <BackupPlaceholder showDatePicker={ false } />;

--- a/client/my-sites/backup/status/simplified-i4.jsx
+++ b/client/my-sites/backup/status/simplified-i4.jsx
@@ -39,10 +39,9 @@ export const DailyStatus = ( { selectedDate } ) => {
 	useDailyBackupStatus( siteId, moment( dateWithOffset ).subtract( 1, 'day' ) );
 	useDailyBackupStatus( siteId, moment( dateWithOffset ).add( 1, 'day' ) );
 
-	const lastBackupDate = useDateWithOffset(
-		lastBackupBeforeDate?.activityTs,
-		!! lastBackupBeforeDate
-	);
+	const lastBackupDate = useDateWithOffset( lastBackupBeforeDate?.activityTs, {
+		shouldExecute: !! lastBackupBeforeDate,
+	} );
 
 	if ( isLoading ) {
 		return <BackupPlaceholder showDatePicker={ false } />;
@@ -89,10 +88,9 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 	useRealtimeBackupStatus( siteId, moment( selectedDate ).subtract( 1, 'day' ) );
 	useRealtimeBackupStatus( siteId, moment( selectedDate ).add( 1, 'day' ) );
 
-	const lastBackupDate = useDateWithOffset(
-		lastBackupBeforeDate?.activityTs,
-		!! lastBackupBeforeDate
-	);
+	const lastBackupDate = useDateWithOffset( lastBackupBeforeDate?.activityTs, {
+		shouldExecute: !! lastBackupBeforeDate,
+	} );
 
 	if ( isLoading ) {
 		return <BackupPlaceholder showDatePicker={ false } />;


### PR DESCRIPTION
#### Motivation

Fixes 1164141197617539-as-1199565147906101

To navigate between dates, we use a query parameter to pass the selected as a string using the following format: `YYYYMMDD`. The app then parses this date and uses it to fetch data about backups and to populate set the new dates on the navigation component. This works fine in most cases, but if the user timezone is further than the site timezone, things will break down. In a case like that, the app will parse the date that came in the URL and will change the date to the previous day. If that happens, the forward navigation button won't work, which is exactly what is described in the linked ticket above.

#### Changes proposed in this Pull Request

* Keep the same local time when applying an offset to a date. This will probably change the Universal Time but will keep the user on the same date. We are only applying this change at the moment the date that comes from the URL is parsed. Everywhere else the behavior stays the same.

#### Testing instructions

Prerequisite: a Jetpack site with Jetpack Backup enabled and a couple of days of backups.

First, let's replicate the issue to understand what's going on currently.
* Visit WordPress.com.
* Select a Jetpack site.
* Visit `wordpress.com/settings/general/:site`.
* Change the site's timezone to any timezone before the one you configured on your computer. For instance, if your computer is configured with UTC-3, configure your site with UTC-4/5/6.
* Visit `wordpress.com/backup/:site`.
* Click on the navigation button to go back one day.
* Verify that the `date` query parameter showcases a different date than the one you can see in the main card at the center. As an example, see how in the capture below, the `date` query parameter is `20201210` but the date on the card is Dec 9, not 10.

![image](https://user-images.githubusercontent.com/3418513/101923064-b2cb9700-3bad-11eb-8f22-d8e43edf0f4a.png)

* Click on the navigation button to go forward one day.
* Verify that the button doesn't work.

Now, let's test the solution.
* Use the horizon URL or download the PR and run it locally (Calypso Blue is enough).
* Select the same Jetpack site and make sure the timezone is the same you configured above.
* Visit `/backup/:site`.
* Click on the navigation button to go back one day.
* Verify that the `date` query parameter showcases the same date you can see in the main card at the center.
* Click on the navigation button to go forward one day.
* Verify that the button works as expected.

#### Demo – The issue
![Kapture 2020-12-11 at 12 40 10](https://user-images.githubusercontent.com/3418513/101923382-13f36a80-3bae-11eb-808c-a8cb65f85bfa.gif)

#### Demo – The solution
![Kapture 2020-12-11 at 12 59 17](https://user-images.githubusercontent.com/3418513/101925668-e1973c80-3bb0-11eb-9c6a-ef9f82c1c335.gif)
