### PR TITLE
E2E: add coverage to signup and site creation to New onboarding

### DIFF
--- a/test/e2e/lib/flows/delete-account-flow.js
+++ b/test/e2e/lib/flows/delete-account-flow.js
@@ -18,7 +18,12 @@ export default class DeleteAccountFlow {
 			await accountSettingsPage.chooseCloseYourAccount();
 			const closeAccountPage = await CloseAccountPage.Expect( this.driver );
 			await closeAccountPage.chooseCloseAccount();
+
+			if ( ! name ) {
+				name = await closeAccountPage.getAccountName();
+			}
 			await closeAccountPage.enterAccountNameAndClose( name );
+
 			await closeAccountPage.ConfirmAccountHasBeenClosed();
 			return await LoggedOutMasterbarComponent.Expect( this.driver );
 		} )().catch( ( err ) => {

--- a/test/e2e/lib/pages/account/close-account-page.js
+++ b/test/e2e/lib/pages/account/close-account-page.js
@@ -55,6 +55,12 @@ export default class CloseAccountPage extends AsyncBaseContainer {
 		);
 	}
 
+	async getAccountName() {
+		return await this.driver
+			.findElement( by.css( '.account-close__confirm-dialog-target-username' ) )
+			.getText();
+	}
+
 	async ConfirmAccountHasBeenClosed() {
 		await driverHelper.verifyTextPresent(
 			this.driver,

--- a/test/e2e/lib/pages/gutenboarding/signup-page.js
+++ b/test/e2e/lib/pages/gutenboarding/signup-page.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverHelper from '../../driver-helper.js';
+import AsyncBaseContainer from '../../async-base-container';
+
+export default class SignupPage extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.signup-form' ) );
+	}
+
+	async enterEmail( email ) {
+		const emailInputSelector = By.css( 'input[type="email"]' );
+		return await driverHelper.setWhenSettable( this.driver, emailInputSelector, email );
+	}
+
+	async enterPassword( password ) {
+		const passwordInputSelector = By.css( 'input[type="password"]' );
+		return await driverHelper.setWhenSettable( this.driver, passwordInputSelector, password );
+	}
+
+	async createAccount() {
+		const createAccountButtonSelector = By.css( 'button[type="submit"]' );
+		return await driverHelper.clickWhenClickable( this.driver, createAccountButtonSelector );
+	}
+}


### PR DESCRIPTION
**Note:** This PR is a follow up of https://github.com/Automattic/wp-calypso/pull/48090

#### Changes proposed in this Pull Request
* Cover the entire New onboarding flow for new users in `wp-gutenboarding-spec`.
  * Add `signup-page` to `pages/gutenboarding`.
  * Add `@signup` tag.
* Update `DeleteAccountFlow` to handle the case where account name is not already known.
#### Testing instructions
* `wp-gutenboarding-spec` should pass

Fixes part of #41082
