### PR TITLE
Checkout: Cache and hard-code countryCode in CreditCardFields

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
 import { useTheme } from 'emotion-theming';
 import { useI18n } from '@automattic/react-i18n';
@@ -46,6 +46,16 @@ export default function CreditCardFields( { shouldUseEbanx } ) {
 	const { setFieldValue, changeBrand, setCardDataError, setCardDataComplete } = useDispatch(
 		'credit-card'
 	);
+
+	// We need the countryCode for the country specific payment fields which have
+	// no country selector but require country data during validation and submit
+	// as well as the code that decides which fields to display. Since Ebanx is
+	// only available in BR, we will hard-code it here, but if we ever expand
+	// Ebanx to other countries, this will need to be changed.
+	const contactCountryCode = shouldUseEbanx ? 'BR' : '';
+	useEffect( () => {
+		setFieldValue( 'countryCode', contactCountryCode );
+	}, [ contactCountryCode, setFieldValue ] );
 
 	const cardholderName = getField( 'cardholderName' );
 	const cardholderNameErrorMessages = getErrorMessagesForField( 'cardholderName' ) || [];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a regression added in https://github.com/Automattic/wp-calypso/pull/48187 which broke new credit card processing in Brazil.

The reason was that when you load checkout with a BR country code and a BRL currency, we use Ebanx card fields and processing instead of Stripe; the Ebanx processor (and, critically, the client-side validator) also requires additional contact fields which we display inside the credit card form. Strangely, those fields require a countryCode, but do not include a country selector. To handle this situation in the past, we cached a copy of the countryCode from the contact form and used that. In the above PR, however, we wanted to use the credit card payment method outside of checkout, meaning that the contact form countryCode was not available, and not fully understanding the caching, we removed it, replacing it with a boolean flag, `shouldUseEbanx`.

In this PR, we restore the caching. Rather than having a dependency on the contact form, however, we assume that if the `shouldUseEbanx` flag is true, then the countryCode is `BR`, since that's the only country where Ebanx is currently used.

Fixes https://github.com/Automattic/wp-calypso/issues/48265

#### Testing instructions

- Complete a payment using a credit card processed through Ebanx.
  - Set your currency to `BRL`.
  - In the contact information step, choose "Brazil" for the country.
  - In the final step, choose "Credit or debit card".
  - Verify that the form asks for all the Ebanx fields in addition to the credit card fields (Taxpayer Identification Number, Phone, etc.)
  - Use an [ebanx test card](https://developer.ebanx.com/docs/resources/testCreditCards/) and [test customer info](https://developer.ebanx.com/docs/resources/testCustomerData/).
  - Verify that the payment succeeds and that you are redirected to the thank-you page.