### PR TITLE
Importer: remove Lodash memoize and flow

### DIFF
--- a/client/my-sites/importer/importer-action-buttons/close-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/close-button.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import { flow } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -63,4 +62,4 @@ export class ImporterCloseButton extends React.PureComponent {
 	}
 }
 
-export default flow( connect( null, { recordTracksEvent } ), localize )( ImporterCloseButton );
+export default connect( null, { recordTracksEvent } )( localize( ImporterCloseButton ) );

--- a/client/my-sites/importer/importer-action-buttons/done-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/done-button.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import { flow } from 'lodash';
 import { connect } from 'react-redux';
 import page from 'page';
 
@@ -80,13 +79,10 @@ export class DoneButton extends React.PureComponent {
 	}
 }
 
-export default flow(
-	connect(
-		( state ) => ( {
-			isSignup: isImportingFromSignupFlow( state ),
-			siteSlug: getSelectedSiteSlug( state ),
-		} ),
-		{ clearImportingFromSignupFlow, setImportOriginSiteDetails, recordTracksEvent }
-	),
-	localize
-)( DoneButton );
+export default connect(
+	( state ) => ( {
+		isSignup: isImportingFromSignupFlow( state ),
+		siteSlug: getSelectedSiteSlug( state ),
+	} ),
+	{ clearImportingFromSignupFlow, setImportOriginSiteDetails, recordTracksEvent }
+)( localize( DoneButton ) );

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { filter, flow, get, isEmpty, memoize, once } from 'lodash';
+import { filter, get, isEmpty, once } from 'lodash';
 
 /**
  * Internal dependencies
@@ -70,7 +70,7 @@ const filterImportsForSite = ( siteID, imports ) => {
 	return filter( imports, ( importItem ) => importItem.site.ID === siteID );
 };
 
-const getImporterTypeForEngine = memoize( ( engine ) => `importer-type-${ engine }` );
+const getImporterTypeForEngine = ( engine ) => `importer-type-${ engine }`;
 
 class SectionImport extends Component {
 	static propTypes = {
@@ -368,20 +368,17 @@ class SectionImport extends Component {
 	}
 }
 
-export default flow(
-	connect(
-		( state ) => {
-			const siteID = getSelectedSiteId( state );
-			return {
-				engine: getSelectedImportEngine( state ),
-				fromSite: getImporterSiteUrl( state ),
-				site: getSelectedSite( state ),
-				siteSlug: getSelectedSiteSlug( state ),
-				siteTitle: getSiteTitle( state, siteID ),
-				canImport: canCurrentUser( state, siteID, 'manage_options' ),
-			};
-		},
-		{ recordTracksEvent }
-	),
-	localize
-)( SectionImport );
+export default connect(
+	( state ) => {
+		const siteID = getSelectedSiteId( state );
+		return {
+			engine: getSelectedImportEngine( state ),
+			fromSite: getImporterSiteUrl( state ),
+			site: getSelectedSite( state ),
+			siteSlug: getSelectedSiteSlug( state ),
+			siteTitle: getSiteTitle( state, siteID ),
+			canImport: canCurrentUser( state, siteID, 'manage_options' ),
+		};
+	},
+	{ recordTracksEvent }
+)( localize( SectionImport ) );

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -6,7 +6,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { defer, flow, includes, noop, truncate } from 'lodash';
+import { defer, includes, noop, truncate } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -176,10 +176,7 @@ class UploadingPane extends React.PureComponent {
 	}
 }
 
-export default flow(
-	connect( ( state ) => ( {
-		filename: getUploadFilename( state ),
-		percentComplete: getUploadPercentComplete( state ),
-	} ) ),
-	localize
-)( UploadingPane );
+export default connect( ( state ) => ( {
+	filename: getUploadFilename( state ),
+	percentComplete: getUploadPercentComplete( state ),
+} ) )( localize( UploadingPane ) );


### PR DESCRIPTION
A simple spinoff from #48213. Removes usage of `flow` (when composing two HOCs) and `memoize` (function that does only string concat doesn't need to be memoized. The overhead from maintaining a map is not worth it)

