### PR TITLE
Purchases: change site name to site address

### DIFF
--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -40,8 +40,7 @@ const MembershipTerms = ( { subscription }: { subscription: MembershipSubscripti
 
 const SiteLink = ( { subscription }: { subscription: MembershipSubscription } ) => {
 	const translate = useTranslate();
-	const lastSlashInUrl = subscription.site_url.lastIndexOf( '/' );
-	const siteUrl = subscription.site_url.substring( lastSlashInUrl + 1 );
+	const siteUrl = subscription.site_url.replace( /^(https?:|)\/\//, '' );
 
 	return (
 		<button

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -40,6 +40,8 @@ const MembershipTerms = ( { subscription }: { subscription: MembershipSubscripti
 
 const SiteLink = ( { subscription }: { subscription: MembershipSubscription } ) => {
 	const translate = useTranslate();
+	const lastSlashInUrl = subscription.site_url.lastIndexOf( '/' );
+	const siteUrl = subscription.site_url.substring( lastSlashInUrl + 1 );
 
 	return (
 		<button
@@ -49,13 +51,13 @@ const SiteLink = ( { subscription }: { subscription: MembershipSubscription } ) 
 				event.preventDefault();
 				window.location = subscription.site_url;
 			} }
-			title={ translate( 'Visit %(siteName)s', {
+			title={ translate( 'Visit %(siteUrl)s', {
 				args: {
-					siteName: subscription.site_title,
+					siteUrl: subscription.site_url,
 				},
 			} ) }
 		>
-			{ subscription.site_title }
+			{ siteUrl }
 		</button>
 	);
 };

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -40,7 +40,7 @@ const MembershipTerms = ( { subscription }: { subscription: MembershipSubscripti
 
 const SiteLink = ( { subscription }: { subscription: MembershipSubscription } ) => {
 	const translate = useTranslate();
-	const siteUrl = subscription.site_url.replace( /^(https?:|)\/\//, '' );
+	const siteUrl = subscription.site_url.replace( /^https?:\/\//, '' );
 
 	return (
 		<button

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -209,7 +209,7 @@ class PurchaseItem extends Component {
 	}
 
 	getPurchaseType() {
-		const { purchase, site, translate, slug, showSite, isDisconnectedSite, name } = this.props;
+		const { purchase, site, translate, slug, showSite, isDisconnectedSite } = this.props;
 		const productType = purchaseType( purchase );
 
 		if ( showSite && site ) {
@@ -217,7 +217,7 @@ class PurchaseItem extends Component {
 				return translate( '%(purchaseType)s for {{button}}%(site)s{{/button}}', {
 					args: {
 						purchaseType: productType,
-						site: site.name,
+						site: site.domain,
 					},
 					components: {
 						button: (
@@ -241,7 +241,7 @@ class PurchaseItem extends Component {
 
 			return translate( 'for {{button}}%(site)s{{/button}}', {
 				args: {
-					site: site.name,
+					site: site.domain,
 				},
 				components: {
 					button: (
@@ -267,7 +267,7 @@ class PurchaseItem extends Component {
 			return translate( '%(purchaseType)s for %(site)s', {
 				args: {
 					purchaseType: productType,
-					site: name,
+					site: purchase.domain,
 				},
 			} );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the site name to the site address so it's clearer to people which site the purchase is referencing as customers tend to use the same name for multiple sites.

**Before**
![image](https://user-images.githubusercontent.com/6981253/101945707-7d7a7580-3bbc-11eb-87f8-d548da9194d4.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/101945592-705d8680-3bbc-11eb-968f-33faf1bf0a69.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the account level screen for purchases, confirm that you see the site address instead of the name and that clicking on it takes you to the site-level purchases screen.
- Confirm everything looks good on the site-level screen. 

