### PR TITLE
Billing: add stored card functionality to new Update Payment Method screen

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -918,6 +918,25 @@ Undocumented.prototype.getPaymentMethods = function ( query, fn ) {
 };
 
 /**
+ * Assign a stored payment method to a subscription.
+ *
+ * @param {string} subscriptionId The subscription ID (a.k.a. purchase ID) to be assigned
+ * @param {string} stored_details_id The payment method ID to assign
+ * @param {Function} [fn] The callback function
+ */
+Undocumented.prototype.assignPaymentMethod = function ( subscriptionId, stored_details_id, fn ) {
+	debug( '/upgrades/assign-payment-method query', { subscriptionId, stored_details_id } );
+	return this.wpcom.req.post(
+		{
+			path: '/upgrades/' + subscriptionId + '/assign-payment-method',
+			body: { stored_details_id },
+			apiVersion: '1',
+		},
+		fn
+	);
+};
+
+/**
  * Return a list of third-party services that WordPress.com can integrate with for a specific site
  *
  * @param {number|string} siteId The site ID or domain

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -176,15 +176,10 @@ function ChangePaymentMethodList( { currentPaymentMethod, purchase, successCallb
 
 	const disabled = isStripeLoading || formSubmitting || stripeLoadingError || ! paymentMethods;
 
-	const showErrorMessage = useCallback(
-		( error ) => {
-			const message = error && error.toString ? error.toString() : error;
-			notices.error(
-				message || translate( 'An error occurred while reassigning your payment method.' )
-			);
-		},
-		[ translate ]
-	);
+	const showErrorMessage = useCallback( ( error ) => {
+		const message = error?.toString ? error.toString() : error;
+		notices.error( message );
+	}, [] );
 
 	const showInfoMessage = useCallback( ( message ) => {
 		notices.info( message );

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -172,7 +172,7 @@ function ChangePaymentMethodList( { currentPaymentMethod, purchase, successCallb
 	const [ formSubmitting, setFormSubmitting ] = useState( false );
 	const translate = useTranslate();
 	const { isStripeLoading, stripeLoadingError } = useStripe();
-	const [ paymentMethods ] = useAssignablePaymentMethods();
+	const paymentMethods = useAssignablePaymentMethods();
 
 	const disabled = isStripeLoading || formSubmitting || stripeLoadingError || ! paymentMethods;
 
@@ -358,11 +358,11 @@ function useAssignablePaymentMethods() {
 	} );
 
 	const paymentMethods = useMemo(
-		() => [ paypalMethod, stripeMethod, ...existingCardMethods ].filter( Boolean ),
+		() => [ ...existingCardMethods, stripeMethod, paypalMethod ].filter( Boolean ),
 		[ paypalMethod, stripeMethod, existingCardMethods ]
 	);
 
-	return [ paymentMethods ];
+	return paymentMethods;
 }
 
 function ChangePaymentMethodWrapper( props ) {

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -124,7 +124,6 @@ function ChangePaymentMethod( props ) {
 						<ChangePaymentMethodList
 							currentPaymentMethod={ props.card }
 							purchase={ props.purchase }
-							isDataLoading={ isDataLoading }
 							successCallback={ successCallback }
 						/>
 					) : (
@@ -167,12 +166,7 @@ const wpcom = wp.undocumented();
 const wpcomAssignPaymentMethod = ( subscriptionId, stored_details_id, fn ) =>
 	wpcom.assignPaymentMethod( subscriptionId, stored_details_id, fn );
 
-function ChangePaymentMethodList( {
-	currentPaymentMethod,
-	purchase,
-	isDataLoading,
-	successCallback,
-} ) {
+function ChangePaymentMethodList( { currentPaymentMethod, purchase, successCallback } ) {
 	const currentlyAssignedPaymentMethodId = 'existingCard-' + currentPaymentMethod.stored_details_id; // TODO: make this work for paypal.
 
 	const [ formSubmitting, setFormSubmitting ] = useState( false );
@@ -215,7 +209,7 @@ function ChangePaymentMethodList( {
 			showSuccessMessage={ showSuccessMessage }
 			paymentMethods={ paymentMethods }
 			paymentProcessors={ {} }
-			isLoading={ isDataLoading || isStripeLoading }
+			isLoading={ isStripeLoading }
 			initiallySelectedPaymentMethodId={ currentlyAssignedPaymentMethodId }
 		>
 			<Card className="change-payment-method__content">

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -255,6 +255,8 @@ function SaveButton( {
 
 	const isSubmitting = disabled || formSubmitting;
 
+	const isStoredCard = /^existingCard-/.test( selectedPaymentMethodId );
+
 	const onClick = () => {
 		setFormSubmitting( true );
 		wpcomAssignPaymentMethod( purchase.id, selectedPaymentMethodId.replace( /^existingCard-/, '' ) )
@@ -269,18 +271,33 @@ function SaveButton( {
 			} );
 	};
 
+	let buttonText = null;
+	if ( isStoredCard ) {
+		buttonText = formSubmitting
+			? translate( 'Saving card…', {
+					context: 'Button label',
+					comment: 'Credit card',
+			  } )
+			: translate( 'Use this card', {
+					context: 'Button label',
+					comment: 'Credit card',
+			  } );
+	} else {
+		buttonText = formSubmitting
+			? translate( 'Saving card…', {
+					context: 'Button label',
+					comment: 'Credit card',
+			  } )
+			: translate( 'Save card', {
+					context: 'Button label',
+					comment: 'Credit card',
+			  } );
+	}
+
 	return (
 		// TODO: change button text based on payment method
 		<Button disabled={ isSubmitting } busy={ isSubmitting } onClick={ onClick } primary>
-			{ formSubmitting
-				? translate( 'Saving card…', {
-						context: 'Button label',
-						comment: 'Credit card',
-				  } )
-				: translate( 'Save card', {
-						context: 'Button label',
-						comment: 'Credit card',
-				  } ) }
+			{ buttonText }
 		</Button>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In #48187, we added some UI elements to a new version of the Update Payment Method screen aimed at allowing users to change the payment method on a subscription to PayPal or a stored card, in addition to a new card; however that PR did not include any of the functionality.

This companion PR adds in that functionality for stored cards.

Fixes #48013
Depends on #48328

To do:
- [x] preselect the current stored card
- [x] show calypso notifications when the reassignment request completes (success or failure)
- [x] redirect to billing page after successful submission

#### Testing instructions

* First check that your account has at least two different stored cards, preferably with different last 4s. If you need to add a second one you'll have to use the `?flags=-purchases/new-payment-methods` to turn off this update as the new screen does not handle new cards yet. :)
* On a site with at least one existing purchase with an assigned payment method, navigate to the billing management page at `Plans > Billing` and select an upgrade to manage.
* If the current payment method is a stored card, note the last 4 (or the payment method ID).
* Click through to the "Change Payment Method" screen.
* Verify that the currently assigned stored card is preselected.
* Select a different stored card (paypal and new cards are not currently implemented) and click "Use this card"
* Check that you are redirected to the billing page and see a calypso success notification, and that the billing page reflects your newly assigned payment method.
