### PR TITLE
Importer Flux Store: remove unused bits of state

### DIFF
--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -9,8 +9,6 @@ import { get, includes, map, omit, omitBy } from 'lodash';
 import {
 	IMPORTS_AUTHORS_SET_MAPPING,
 	IMPORTS_AUTHORS_START_MAPPING,
-	IMPORTS_FETCH,
-	IMPORTS_FETCH_FAILED,
 	IMPORTS_FETCH_COMPLETED,
 	IMPORTS_IMPORT_CANCEL,
 	IMPORTS_IMPORT_LOCK,
@@ -36,13 +34,10 @@ import 'calypso/state/imports/init';
  * Module variables
  */
 const initialState = Object.freeze( {
-	count: 0,
 	importers: {},
 	importerLocks: {},
 	api: {
 		isHydrated: false,
-		isFetching: false,
-		retryCount: 0,
 	},
 } );
 
@@ -57,33 +52,12 @@ const ImporterStore = createReducerStore( function ( state, payload ) {
 			// unit-testing the store
 			return initialState;
 
-		case IMPORTS_FETCH:
-			return {
-				...state,
-				api: {
-					...state.api,
-					isFetching: true,
-				},
-			};
-
-		case IMPORTS_FETCH_FAILED:
-			return {
-				...state,
-				api: {
-					...state.api,
-					isFetching: false,
-					retryCount: get( state, 'api.retryCount', 0 ) + 1,
-				},
-			};
-
 		case IMPORTS_FETCH_COMPLETED:
 			return {
 				...state,
 				api: {
 					...state.api,
-					isFetching: false,
 					isHydrated: true,
-					retryCount: 0,
 				},
 			};
 
@@ -208,7 +182,6 @@ const ImporterStore = createReducerStore( function ( state, payload ) {
 		case IMPORTS_IMPORT_START:
 			return {
 				...state,
-				count: get( state, 'count', 0 ) + 1,
 				importers: {
 					...state.importers,
 					[ action.importerId ]: {


### PR DESCRIPTION
Removes unused state from the `ImporterStore`. Only `api.isHydrated`, `importers` and `importerLocks` keys are used.

Another small spinoff from #48213.

**How to test:**
Verify that the `SectionImport` component, when using the `ImporterStore` state (synced to local `this.state` on `change` events), uses only `api.isHydrated` and `importers`. The `importerLocks` are used when dispatching the `IMPORTS_IMPORT_RECEIVE` action, where it prevents receiving a server update into a locked importer.