### PR TITLE
Checkout: Remove onEvent from composite-checkout package

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -13,7 +13,6 @@ import {
 	CheckoutSummaryArea as CheckoutSummaryAreaUnstyled,
 	getDefaultPaymentMethodStep,
 	useDispatch,
-	useEvents,
 	useFormStatus,
 	useIsStepActive,
 	useIsStepComplete,
@@ -113,18 +112,18 @@ export default function WPCheckout( {
 	isLoggedOutCart,
 	infoMessage,
 	createUserAndSiteBeforeTransaction,
+	recordEvent,
 } ) {
 	const translate = useTranslate();
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const total = useTotal();
 	const activePaymentMethod = usePaymentMethod();
-	const onEvent = useEvents();
 	const { transactionError } = useTransactionStatus();
 	const [ paymentMethodId ] = usePaymentMethodId();
 
 	useActOnceOnStrings( [ transactionError ].filter( doesValueExist ), ( messages ) => {
 		messages.forEach( ( message ) =>
-			onEvent( {
+			recordEvent( {
 				type: 'TRANSACTION_ERROR',
 				payload: { message, paymentMethodId },
 			} )
@@ -173,7 +172,7 @@ export default function WPCheckout( {
 				emailTakenLoginRedirectMessage
 			);
 			handleContactValidationResult( {
-				recordEvent: onEvent,
+				recordEvent,
 				showErrorMessage: showErrorMessageBriefly,
 				paymentMethodId: activePaymentMethod.id,
 				validationResult,
@@ -193,7 +192,7 @@ export default function WPCheckout( {
 			const validationResult = await getDomainValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
 			handleContactValidationResult( {
-				recordEvent: onEvent,
+				recordEvent,
 				showErrorMessage: showErrorMessageBriefly,
 				paymentMethodId: activePaymentMethod.id,
 				validationResult,
@@ -204,7 +203,7 @@ export default function WPCheckout( {
 			const validationResult = await getGSuiteValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
 			handleContactValidationResult( {
-				recordEvent: onEvent,
+				recordEvent,
 				showErrorMessage: showErrorMessageBriefly,
 				paymentMethodId: activePaymentMethod.id,
 				validationResult,
@@ -280,26 +279,26 @@ export default function WPCheckout( {
 
 	const onReviewError = useCallback(
 		( error ) =>
-			onEvent( {
+			recordEvent( {
 				type: 'STEP_LOAD_ERROR',
 				payload: {
 					message: error,
 					stepId: 'review',
 				},
 			} ),
-		[ onEvent ]
+		[ recordEvent ]
 	);
 
 	const onSummaryError = useCallback(
 		( error ) =>
-			onEvent( {
+			recordEvent( {
 				type: 'STEP_LOAD_ERROR',
 				payload: {
 					message: error,
 					stepId: 'summary',
 				},
 			} ),
-		[ onEvent ]
+		[ recordEvent ]
 	);
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -57,8 +57,8 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import QueryExperiments from 'calypso/components/data/query-experiments';
 import PaymentMethodStep from './payment-method-step';
-import useActOnceOnStrings from './hooks/use-act-once-on-strings';
-import doesValueExist from './lib/does-value-exist';
+import useActOnceOnStrings from '../hooks/use-act-once-on-strings';
+import doesValueExist from '../lib/does-value-exist';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -301,6 +301,20 @@ export default function WPCheckout( {
 		[ recordEvent ]
 	);
 
+	const onStepNumberChange = useCallback(
+		( { stepNumber, previousStepNumber } ) => {
+			recordEvent( {
+				type: 'STEP_NUMBER_CHANGED',
+				payload: {
+					stepNumber,
+					previousStepNumber,
+					paymentMethodId,
+				},
+			} );
+		},
+		[ paymentMethodId, recordEvent ]
+	);
+
 	return (
 		<Checkout>
 			<QueryExperiments />
@@ -379,7 +393,10 @@ export default function WPCheckout( {
 					}
 					formStatus={ formStatus }
 				/>
-				<CheckoutSteps areStepsActive={ ! isOrderReviewActive }>
+				<CheckoutSteps
+					areStepsActive={ ! isOrderReviewActive }
+					onStepNumberChange={ onStepNumberChange }
+				>
 					{ shouldShowContactStep && (
 						<CheckoutStep
 							stepId={ 'contact-form' }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -315,6 +315,22 @@ export default function WPCheckout( {
 		[ paymentMethodId, recordEvent ]
 	);
 
+	const onLoadError = useCallback(
+		( type, error ) => {
+			const typeForAnalytics = type.replace( /\s.*/, '' );
+			const stepIdMatches = type.match( /FOR STEP (\d+)/ );
+			const stepId = stepIdMatches?.length > 1 ? stepIdMatches[ 1 ] : undefined;
+			recordEvent( {
+				type: typeForAnalytics,
+				payload: {
+					message: error,
+					stepId,
+				},
+			} );
+		},
+		[ recordEvent ]
+	);
+
 	return (
 		<Checkout>
 			<QueryExperiments />
@@ -348,6 +364,7 @@ export default function WPCheckout( {
 			<CheckoutStepArea
 				submitButtonHeader={ <SubmitButtonHeader /> }
 				disableSubmitButton={ isOrderReviewActive }
+				onLoadError={ onLoadError }
 			>
 				{ infoMessage }
 				<CheckoutStepBody
@@ -399,6 +416,7 @@ export default function WPCheckout( {
 				>
 					{ shouldShowContactStep && (
 						<CheckoutStep
+							onLoadError={ onLoadError }
 							stepId={ 'contact-form' }
 							isCompleteCallback={ () => {
 								setShouldShowContactDetailsValidationErrors( true );
@@ -441,6 +459,7 @@ export default function WPCheckout( {
 						/>
 					) }
 					<CheckoutStep
+						onLoadError={ onLoadError }
 						stepId="payment-method-step"
 						activeStepContent={
 							<PaymentMethodStep

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -427,6 +427,7 @@ export default function CompositeCheckout( {
 			recordEvent,
 			createUserAndSiteBeforeTransaction,
 			stripeConfiguration,
+			reduxDispatch,
 		} ),
 		[
 			includeDomainDetails,
@@ -434,6 +435,7 @@ export default function CompositeCheckout( {
 			recordEvent,
 			createUserAndSiteBeforeTransaction,
 			stripeConfiguration,
+			reduxDispatch,
 		]
 	);
 	const dataForRedirectProcessor = useMemo(
@@ -441,9 +443,8 @@ export default function CompositeCheckout( {
 			...dataForProcessor,
 			getThankYouUrl,
 			siteSlug,
-			reduxDispatch,
 		} ),
-		[ dataForProcessor, getThankYouUrl, siteSlug, reduxDispatch ]
+		[ dataForProcessor, getThankYouUrl, siteSlug ]
 	);
 
 	const domainDetails = getDomainDetails( {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -89,6 +89,7 @@ import getPostalCode from './lib/get-postal-code';
 import mergeIfObjects from './lib/merge-if-objects';
 import type { ReactStandardAction } from './types/analytics';
 import useCreatePaymentCompleteCallback from './hooks/use-create-payment-complete-callback';
+import type { PaymentProcessorOptions } from './types/payment-processors';
 
 const { colors } = colorStudio;
 const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
@@ -420,7 +421,7 @@ export default function CompositeCheckout( {
 	const includeDomainDetails = contactDetailsType === 'domain';
 	const includeGSuiteDetails = contactDetailsType === 'gsuite';
 	const transactionOptions = { createUserAndSiteBeforeTransaction };
-	const dataForProcessor = useMemo(
+	const dataForProcessor: PaymentProcessorOptions = useMemo(
 		() => ( {
 			includeDomainDetails,
 			includeGSuiteDetails,
@@ -460,7 +461,7 @@ export default function CompositeCheckout( {
 			'free-purchase': ( transactionData: unknown ) =>
 				freePurchaseProcessor( transactionData, dataForProcessor ),
 			card: ( transactionData: unknown ) =>
-				multiPartnerCardProcessor( transactionData, dataForProcessor, transactionOptions ),
+				multiPartnerCardProcessor( transactionData, dataForProcessor ),
 			alipay: ( transactionData: unknown ) =>
 				genericRedirectProcessor( 'alipay', transactionData, dataForRedirectProcessor ),
 			p24: ( transactionData: unknown ) =>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -634,6 +634,7 @@ export default function CompositeCheckout( {
 				initiallySelectedPaymentMethodId={ paymentMethods?.length ? paymentMethods[ 0 ].id : null }
 			>
 				<WPCheckout
+					recordEvent={ recordEvent }
 					removeProductFromCart={ removeProductFromCart }
 					updateLocation={ updateLocation }
 					applyCoupon={ applyCoupon }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -455,7 +455,7 @@ export default function CompositeCheckout( {
 	const paymentProcessors = useMemo(
 		() => ( {
 			'apple-pay': ( transactionData: unknown ) =>
-				applePayProcessor( transactionData, dataForProcessor, transactionOptions ),
+				applePayProcessor( transactionData, dataForRedirectProcessor ),
 			'free-purchase': ( transactionData: unknown ) =>
 				freePurchaseProcessor( transactionData, dataForProcessor ),
 			card: ( transactionData: unknown ) =>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -496,18 +496,13 @@ export default function CompositeCheckout( {
 					dataForProcessor
 				),
 			paypal: ( transactionData: unknown ) =>
-				payPalProcessor(
-					transactionData,
-					{ ...dataForProcessor, getThankYouUrl, couponItem },
-					transactionOptions
-				),
+				payPalProcessor( transactionData, { ...dataForRedirectProcessor, couponItem } ),
 		} ),
 		[
 			siteId,
 			couponItem,
 			dataForProcessor,
 			dataForRedirectProcessor,
-			getThankYouUrl,
 			transactionOptions,
 			countryCode,
 			subdivisionCode,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -441,8 +441,9 @@ export default function CompositeCheckout( {
 			...dataForProcessor,
 			getThankYouUrl,
 			siteSlug,
+			reduxDispatch,
 		} ),
-		[ dataForProcessor, getThankYouUrl, siteSlug ]
+		[ dataForProcessor, getThankYouUrl, siteSlug, reduxDispatch ]
 	);
 
 	const domainDetails = getDomainDetails( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -45,9 +45,9 @@ import {
 import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-for-signup-destination';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { logStashLoadErrorEventAction } from '../lib/analytics';
 import { isTreatmentOneClickTest } from 'calypso/state/marketing/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import { recordCompositeCheckoutErrorDuringAnalytics } from '../lib/analytics';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-on-payment-complete' );
 
@@ -121,24 +121,11 @@ export default function useCreatePaymentCompleteCallback( {
 					reduxDispatch,
 				} );
 			} catch ( err ) {
-				// This is a fallback to catch any errors caused by the analytics code
-				// Anything in this block should remain very simple and extremely
-				// tolerant of any kind of data. It should make no assumptions about
-				// the data it uses.  There's no fallback for the fallback!
-				debug( 'checkout event error', err.message );
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_error', {
-						error_message: err.message,
-						action_type: 'useCreatePaymentCompleteCallback',
-						action_payload: '',
-					} )
-				);
-				reduxDispatch(
-					logStashLoadErrorEventAction( 'calypso_checkout_composite_error', err.message, {
-						action_type: 'useCreatePaymentCompleteCallback',
-						action_payload: '',
-					} )
-				);
+				recordCompositeCheckoutErrorDuringAnalytics( {
+					reduxDispatch,
+					errorObject: err,
+					failureDescription: 'useCreatePaymentCompleteCallback',
+				} );
 			}
 
 			const receiptId = transactionResult?.receipt_id;

--- a/client/my-sites/checkout/composite-checkout/lib/analytics.js
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.js
@@ -4,6 +4,7 @@
 import { logToLogstash } from 'calypso/state/logstash/actions';
 import config from 'calypso/config';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from '../lib/translate-payment-method-names';
 
 export function logStashLoadErrorEventAction( errorType, errorMessage, additionalData = {} ) {
 	return logStashEventAction( 'composite checkout load error', {
@@ -45,4 +46,35 @@ export function recordCompositeCheckoutErrorDuringAnalytics( {
 			action_type: failureDescription,
 		} )
 	);
+}
+
+export function recordTransactionBeginAnalytics( { reduxDispatch, paymentMethodId } ) {
+	try {
+		reduxDispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_form_submit', {
+				credits: null,
+				payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ) || '',
+			} )
+		);
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_composite_form_submit', {
+				credits: null,
+				payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ) || '',
+			} )
+		);
+		const paymentMethodIdForTracks = paymentMethodId.replace( /-/, '_' ).toLowerCase();
+		reduxDispatch(
+			recordTracksEvent(
+				`calypso_checkout_composite_${ paymentMethodIdForTracks }_submit_clicked`,
+				{}
+			)
+		);
+	} catch ( errorObject ) {
+		recordCompositeCheckoutErrorDuringAnalytics( {
+			reduxDispatch,
+			errorObject,
+			failureDescription: `transaction-begin: ${ paymentMethodId }`,
+		} );
+	}
 }

--- a/client/my-sites/checkout/composite-checkout/lib/analytics.js
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.js
@@ -3,6 +3,7 @@
  */
 import { logToLogstash } from 'calypso/state/logstash/actions';
 import config from 'calypso/config';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export function logStashLoadErrorEventAction( errorType, errorMessage, additionalData = {} ) {
 	return logStashEventAction( 'composite checkout load error', {
@@ -22,4 +23,26 @@ export function logStashEventAction( message, dataForLog = {} ) {
 			...dataForLog,
 		},
 	} );
+}
+
+export function recordCompositeCheckoutErrorDuringAnalytics( {
+	errorObject,
+	failureDescription,
+	reduxDispatch,
+} ) {
+	// This is a fallback to catch any errors caused by the analytics code
+	// Anything in this block should remain very simple and extremely
+	// tolerant of any kind of data. It should make no assumptions about
+	// the data it uses. There's no fallback for the fallback!
+	reduxDispatch(
+		recordTracksEvent( 'calypso_checkout_composite_error', {
+			error_message: errorObject.message,
+			action_type: failureDescription,
+		} )
+	);
+	reduxDispatch(
+		logStashLoadErrorEventAction( 'calypso_checkout_composite_error', errorObject.message, {
+			action_type: failureDescription,
+		} )
+	);
 }

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -13,6 +13,7 @@ import { createTransactionEndpointRequestPayloadFromLineItems } from './translat
 import { wpcomTransaction } from '../payment-method-helpers';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { ExistingCardTransactionRequestWithLineItems } from '../types/transaction-endpoint';
+import { recordTransactionBeginAnalytics } from './analytics';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
 
@@ -20,6 +21,10 @@ export default async function existingCardProcessor(
 	transactionData: unknown,
 	dataForProcessor: PaymentProcessorOptions
 ): Promise< PaymentProcessorResponse > {
+	recordTransactionBeginAnalytics( {
+		reduxDispatch: dataForProcessor.reduxDispatch,
+		paymentMethodId: 'card',
+	} );
 	if ( ! isValidTransactionData( transactionData ) ) {
 		throw new Error( 'Required purchase data is missing' );
 	}

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -21,10 +21,6 @@ export default async function existingCardProcessor(
 	transactionData: unknown,
 	dataForProcessor: PaymentProcessorOptions
 ): Promise< PaymentProcessorResponse > {
-	recordTransactionBeginAnalytics( {
-		reduxDispatch: dataForProcessor.reduxDispatch,
-		paymentMethodId: 'card',
-	} );
 	if ( ! isValidTransactionData( transactionData ) ) {
 		throw new Error( 'Required purchase data is missing' );
 	}
@@ -32,6 +28,10 @@ export default async function existingCardProcessor(
 	if ( ! stripeConfiguration ) {
 		throw new Error( 'Stripe configuration is required' );
 	}
+	recordTransactionBeginAnalytics( {
+		reduxDispatch: dataForProcessor.reduxDispatch,
+		paymentMethodId: 'card',
+	} );
 	return submitExistingCardPayment( transactionData, dataForProcessor )
 		.then( ( stripeResponse ) => {
 			if ( stripeResponse?.message?.payment_intent_client_secret ) {

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -146,11 +146,9 @@ export async function weChatProcessor(
 	} );
 }
 
-export async function applePayProcessor(
-	submitData,
-	{ includeDomainDetails, includeGSuiteDetails },
-	transactionOptions
-) {
+export async function applePayProcessor( submitData, transactionOptions ) {
+	const { includeDomainDetails, includeGSuiteDetails, reduxDispatch } = transactionOptions;
+	recordApplePayTransactionBeginAnalytics( { reduxDispatch } );
 	return submitApplePayPayment(
 		{
 			...submitData,
@@ -353,11 +351,37 @@ function recordRedirectTransactionBeginAnalytics( { reduxDispatch, paymentMethod
 				{}
 			)
 		);
-	} catch ( err ) {
+	} catch ( errorObject ) {
 		recordCompositeCheckoutErrorDuringAnalytics( {
 			reduxDispatch,
-			errorObject: err,
-			failureDescription: 'useCreatePaymentCompleteCallback',
+			errorObject,
+			failureDescription: 'redirect',
+		} );
+	}
+}
+
+function recordApplePayTransactionBeginAnalytics( { reduxDispatch } ) {
+	try {
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_form_submit', {
+				credits: null,
+				payment_method: 'WPCOM_Billing_Web_Payment',
+			} )
+		);
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_composite_form_submit', {
+				credits: null,
+				payment_method: 'WPCOM_Billing_Web_Payment',
+			} )
+		);
+		return reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
+		);
+	} catch ( errorObject ) {
+		recordCompositeCheckoutErrorDuringAnalytics( {
+			reduxDispatch,
+			errorObject,
+			failureDescription: 'apple-pay',
 		} );
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -66,18 +66,10 @@ export async function genericRedirectProcessor(
 		query: cancelUrlQuery,
 	} );
 
-	try {
-		recordRedirectTransactionBeginAnalytics( {
-			paymentMethodId,
-			reduxDispatch,
-		} );
-	} catch ( err ) {
-		recordCompositeCheckoutErrorDuringAnalytics( {
-			reduxDispatch,
-			errorObject: err,
-			failureDescription: 'useCreatePaymentCompleteCallback',
-		} );
-	}
+	recordRedirectTransactionBeginAnalytics( {
+		paymentMethodId,
+		reduxDispatch,
+	} );
 
 	return submitRedirectTransaction(
 		paymentMethodId,
@@ -328,24 +320,32 @@ export async function payPalProcessor(
 }
 
 function recordRedirectTransactionBeginAnalytics( { reduxDispatch, paymentMethodId } ) {
-	reduxDispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
-	reduxDispatch(
-		recordTracksEvent( 'calypso_checkout_form_submit', {
-			credits: null,
-			payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ) || '',
-		} )
-	);
-	reduxDispatch(
-		recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-			credits: null,
-			payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ) || '',
-		} )
-	);
-	const paymentMethodIdForTracks = paymentMethodId.replace( /-/, '_' ).toLowerCase();
-	return reduxDispatch(
-		recordTracksEvent(
-			`calypso_checkout_composite_${ paymentMethodIdForTracks }_submit_clicked`,
-			{}
-		)
-	);
+	try {
+		reduxDispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_form_submit', {
+				credits: null,
+				payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ) || '',
+			} )
+		);
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_composite_form_submit', {
+				credits: null,
+				payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ) || '',
+			} )
+		);
+		const paymentMethodIdForTracks = paymentMethodId.replace( /-/, '_' ).toLowerCase();
+		return reduxDispatch(
+			recordTracksEvent(
+				`calypso_checkout_composite_${ paymentMethodIdForTracks }_submit_clicked`,
+				{}
+			)
+		);
+	} catch ( err ) {
+		recordCompositeCheckoutErrorDuringAnalytics( {
+			reduxDispatch,
+			errorObject: err,
+			failureDescription: 'useCreatePaymentCompleteCallback',
+		} );
+	}
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -91,9 +91,13 @@ export async function genericRedirectProcessor(
 
 export async function weChatProcessor(
 	submitData,
-	{ getThankYouUrl, siteSlug, includeDomainDetails, includeGSuiteDetails }
+	{ getThankYouUrl, siteSlug, includeDomainDetails, includeGSuiteDetails, reduxDispatch }
 ) {
 	const paymentMethodId = 'wechat';
+	recordRedirectTransactionBeginAnalytics( {
+		reduxDispatch,
+		paymentMethodId,
+	} );
 	const { protocol, hostname, port, pathname } = parseUrl(
 		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com',
 		true
@@ -284,12 +288,20 @@ export async function fullCreditsProcessor(
 	).then( makeSuccessResponse );
 }
 
-export async function payPalProcessor(
-	submitData,
-	{ getThankYouUrl, couponItem, includeDomainDetails, includeGSuiteDetails },
-	transactionOptions
-) {
-	const { createUserAndSiteBeforeTransaction } = transactionOptions;
+export async function payPalProcessor( submitData, transactionOptions ) {
+	const {
+		getThankYouUrl,
+		couponItem,
+		includeDomainDetails,
+		includeGSuiteDetails,
+		createUserAndSiteBeforeTransaction,
+		reduxDispatch,
+	} = transactionOptions;
+	recordRedirectTransactionBeginAnalytics( {
+		reduxDispatch,
+		paymentMethodId: 'paypal',
+	} );
+
 	const { protocol, hostname, port, pathname } = parseUrl( window.location.href, true );
 
 	const successUrl = resolveUrl( window.location.href, getThankYouUrl() );

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -29,7 +29,7 @@ import getPostalCode from './lib/get-postal-code';
 import getDomainDetails from './lib/get-domain-details';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
 import userAgent from 'calypso/lib/user-agent';
-import { recordTransactionBeginAnalytics } from '../lib/analytics';
+import { recordTransactionBeginAnalytics } from './lib/analytics';
 
 const { select } = defaultRegistry;
 

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -9,7 +9,6 @@ import {
 	Button,
 	FormStatus,
 	useLineItems,
-	useEvents,
 	useFormStatus,
 	useSelect,
 } from '@automattic/composite-checkout';
@@ -35,7 +34,6 @@ export default function CreditCardPayButton( {
 	const fields = useSelect( ( select ) => select( 'credit-card' ).getFields() );
 	const cardholderName = fields.cardholderName;
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const paymentPartner = shouldUseEbanx ? 'ebanx' : 'stripe';
 
 	return (
@@ -45,7 +43,6 @@ export default function CreditCardPayButton( {
 				if ( isCreditCardFormValid( store, paymentPartner, __ ) ) {
 					if ( paymentPartner === 'stripe' ) {
 						debug( 'submitting stripe payment' );
-						onEvent( { type: 'STRIPE_TRANSACTION_BEGIN' } );
 						onClick( 'card', {
 							stripe,
 							name: cardholderName?.value,
@@ -60,7 +57,6 @@ export default function CreditCardPayButton( {
 					}
 					if ( paymentPartner === 'ebanx' ) {
 						debug( 'submitting ebanx payment' );
-						onEvent( { type: 'EBANX_TRANSACTION_BEGIN' } );
 						onClick( 'card', {
 							name: cardholderName?.value || '',
 							countryCode: fields?.countryCode?.value || '',

--- a/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
@@ -10,7 +10,6 @@ import {
 	Button,
 	FormStatus,
 	useLineItems,
-	useEvents,
 	useFormStatus,
 	registerStore,
 	useSelect,
@@ -286,7 +285,6 @@ function EbanxTefPayButton( { disabled, onClick, store } ) {
 	const { __ } = useI18n();
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'ebanx-tef' ).getCustomerName() );
 	const customerBank = useSelect( ( select ) => select( 'ebanx-tef' ).getCustomerBank() );
 	const fields = useSelect( ( select ) => select( 'ebanx-tef' ).getFields() );
@@ -304,10 +302,6 @@ function EbanxTefPayButton( { disabled, onClick, store } ) {
 			onClick={ () => {
 				if ( isFormValid( store, contactCountryCode, __ ) ) {
 					debug( 'submitting ebanx-tef payment' );
-					onEvent( {
-						type: 'REDIRECT_TRANSACTION_BEGIN',
-						payload: { paymentMethodId: 'ebanx-tef' },
-					} );
 					onClick( 'ebanx-tef', {
 						...massagedFields,
 						name: customerName?.value, // this needs to come after massagedFields to prevent it from being overridden

--- a/client/my-sites/checkout/composite-checkout/payment-methods/id-wallet.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/id-wallet.js
@@ -9,7 +9,6 @@ import { useI18n } from '@automattic/react-i18n';
 import {
 	Button,
 	useLineItems,
-	useEvents,
 	useFormStatus,
 	registerStore,
 	useSelect,
@@ -214,7 +213,6 @@ function IdWalletPayButton( { disabled, onClick, store } ) {
 	const { __ } = useI18n();
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'id_wallet' ).getCustomerName() );
 	const fields = useSelect( ( select ) => select( 'id_wallet' ).getFields() );
 	const massagedFields = Object.entries( fields ).reduce(
@@ -231,10 +229,6 @@ function IdWalletPayButton( { disabled, onClick, store } ) {
 			onClick={ () => {
 				if ( isFormValid( store, contactCountryCode, __ ) ) {
 					debug( 'submitting id wallet payment' );
-					onEvent( {
-						type: 'REDIRECT_TRANSACTION_BEGIN',
-						payload: { paymentMethodId: 'id_wallet' },
-					} );
 					onClick( 'id_wallet', {
 						...massagedFields,
 						name: customerName?.value,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -10,7 +10,6 @@ import {
 	Button,
 	FormStatus,
 	useLineItems,
-	useEvents,
 	useFormStatus,
 	registerStore,
 	useSelect,
@@ -215,7 +214,6 @@ function NetBankingPayButton( { disabled, onClick, store } ) {
 	const { __ } = useI18n();
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'netbanking' ).getCustomerName() );
 	const fields = useSelect( ( select ) => select( 'netbanking' ).getFields() );
 	const massagedFields = Object.entries( fields ).reduce(
@@ -232,10 +230,6 @@ function NetBankingPayButton( { disabled, onClick, store } ) {
 			onClick={ () => {
 				if ( isFormValid( store, contactCountryCode, __ ) ) {
 					debug( 'submitting netbanking payment' );
-					onEvent( {
-						type: 'REDIRECT_TRANSACTION_BEGIN',
-						payload: { paymentMethodId: 'netbanking' },
-					} );
 					onClick( 'netbanking', {
 						...massagedFields,
 						name: customerName?.value,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/wechat/index.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/wechat/index.js
@@ -10,7 +10,6 @@ import {
 	Button,
 	FormStatus,
 	useLineItems,
-	useEvents,
 	useFormStatus,
 	useTransactionStatus,
 	registerStore,
@@ -143,7 +142,6 @@ function WeChatPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
 	const { resetTransaction } = useTransactionStatus();
-	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'wechat' ).getCustomerName() );
 	const { responseCart: cart } = useShoppingCart();
 	const [ stripeResponseWithCode, setStripeResponseWithCode ] = useState( null );
@@ -171,7 +169,6 @@ function WeChatPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting wechat payment' );
-					onEvent( { type: 'REDIRECT_TRANSACTION_BEGIN', payload: { paymentMethodId: 'wechat' } } );
 					onClick( 'wechat', {
 						stripe,
 						name: customerName?.value,

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -274,23 +274,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_full_credits_submit_clicked', {} )
 					);
 				}
-				case 'EXISTING_CARD_TRANSACTION_BEGIN': {
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_MoneyPress_Stored',
-						} )
-					);
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_MoneyPress_Stored',
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_existing_card_submit_clicked', {} )
-					);
-				}
 				case 'VALIDATE_DOMAIN_CONTACT_INFO': {
 					// TODO: Decide what to do here
 					return;

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -257,36 +257,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_free_purchase_submit_clicked', {} )
 					);
 				}
-				case 'REDIRECT_TRANSACTION_BEGIN': {
-					reduxDispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_form_submit', {
-							credits: null,
-							payment_method:
-								translateCheckoutPaymentMethodToWpcomPaymentMethod(
-									action.payload.paymentMethodId
-								) || '',
-						} )
-					);
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-							credits: null,
-							payment_method:
-								translateCheckoutPaymentMethodToWpcomPaymentMethod(
-									action.payload.paymentMethodId
-								) || '',
-						} )
-					);
-					const paymentMethodIdForTracks = action.payload.paymentMethodId
-						.replace( /-/, '_' )
-						.toLowerCase();
-					return reduxDispatch(
-						recordTracksEvent(
-							`calypso_checkout_composite_${ paymentMethodIdForTracks }_submit_clicked`,
-							{}
-						)
-					);
-				}
 				case 'FULL_CREDITS_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -12,7 +12,11 @@ import {
  * Internal dependencies
  */
 import { recordAddEvent } from 'calypso/lib/analytics/cart';
-import { logStashLoadErrorEventAction, logStashEventAction } from './lib/analytics';
+import {
+	logStashLoadErrorEventAction,
+	logStashEventAction,
+	recordCompositeCheckoutErrorDuringAnalytics,
+} from './lib/analytics';
 
 const debug = debugFactory( 'calypso:composite-checkout:record-analytics' );
 
@@ -382,25 +386,11 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					);
 			}
 		} catch ( err ) {
-			// This is a fallback to catch any errors caused by the analytics code
-			// (particularly for the error reporting analytics code). Anything in
-			// this block should remain very simple and extremely tolerant of any
-			// kind of data. It should make no assumptions about the data it uses.
-			// There's no fallback for the fallback!
-			debug( 'checkout event error', err.message );
-			reduxDispatch(
-				recordTracksEvent( 'calypso_checkout_composite_error', {
-					error_message: err.message,
-					action_type: String( action?.type ),
-					action_payload: String( action?.payload ),
-				} )
-			);
-			return reduxDispatch(
-				logStashLoadErrorEventAction( 'calypso_checkout_composite_error', err.message, {
-					action_type: String( action?.type ),
-					action_payload: String( action?.payload ),
-				} )
-			);
+			recordCompositeCheckoutErrorDuringAnalytics( {
+				reduxDispatch,
+				errorObject: err,
+				failureDescription: String( action?.type ) + ':' + String( action?.payload ),
+			} );
 		}
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -291,30 +291,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_existing_card_submit_clicked', {} )
 					);
 				}
-				case 'APPLE_PAY_TRANSACTION_BEGIN': {
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_Web_Payment',
-						} )
-					);
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_Web_Payment',
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
-					);
-				}
-				case 'APPLE_PAY_LOADING_ERROR':
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_apple_pay_error', {
-							error_message: String( action.payload ),
-							is_loading_error: true,
-						} )
-					);
 				case 'VALIDATE_DOMAIN_CONTACT_INFO': {
 					// TODO: Decide what to do here
 					return;

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -183,40 +183,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							step: action.payload.stepNumber,
 						} )
 					);
-				case 'STRIPE_TRANSACTION_BEGIN': {
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
-						} )
-					);
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
-					);
-				}
-				case 'EBANX_TRANSACTION_BEGIN': {
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_Ebanx',
-						} )
-					);
-					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-							credits: null,
-							payment_method: 'WPCOM_Billing_Ebanx',
-						} )
-					);
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
-					);
-				}
 				case 'TRANSACTION_ERROR': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_payment_error', {

--- a/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
+++ b/client/my-sites/checkout/composite-checkout/types/payment-processors.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useDispatch } from 'react-redux';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
 
 /**
@@ -14,4 +15,5 @@ export interface PaymentProcessorOptions {
 	createUserAndSiteBeforeTransaction: boolean;
 	stripeConfiguration: StripeConfiguration | null;
 	recordEvent: ( action: ReactStandardAction ) => void;
+	reduxDispatch: ReturnType< typeof useDispatch >;
 }

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -261,6 +261,7 @@ This component's props are:
 A wrapper for [CheckoutStep](#CheckoutStep) objects that will connect the steps and provide a way to switch between them. Should be a direct child of [Checkout](#Checkout). It has the following props.
 
 - `areStepsActive?: boolean`. Whether or not the set of steps is active and able to be edited. Defaults to `true`.
+- `onStepNumberChange?: ( { stepNumber, previousStepNumber }: { stepNumber: number | null; previousStepNumber: number | null; } ) => void`. Optional callback for when the step number changes.
 
 ### CheckoutSubmitButton
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -207,6 +207,7 @@ This component's props are:
 - `titleContent: React.ReactNode`. Displays as the title of the step.
 - `activeStepContent?: React.ReactNode`. Displays as the content of the step when it is active. It is also displayed when the step is inactive but is hidden by CSS.
 - `completeStepContent?: React.ReactNode`. Displays as the content of the step when it is inactive and complete as defined by the `isCompleteCallback`.
+- `onLoadError?: ( type: string, error: Error ) => void`. A function that will be called if the error boundary is triggered.
 - `isCompleteCallback: () => boolean | Promise<boolean>`. Used to determine if a step is complete for purposes of validation. Note that this is not called for the last step!
 - `editButtonAriaLabel?: string`. Used to fill in the `aria-label` attribute for the "Edit" button if one exists.
 - `nextStepButtonAriaLabel?: string`. Used to fill in the `aria-label` attribute for the "Continue" button if one exists.
@@ -217,12 +218,13 @@ This component's props are:
 
 ## CheckoutStepArea
 
-Creates the Checkout form and provides a wrapper for [CheckoutStep](#CheckoutStep) and [CheckoutStepBody](#CheckoutStepBody) objects. Should be a direct child of [Checkout](#Checkout).
+Creates the Checkout form and provides a wrapper for [CheckoutStep](#CheckoutStep) and [CheckoutStepBody](#CheckoutStepBody) objects. Should be a direct child of [Checkout](#Checkout). Also renders the CheckoutSubmitButton.
 
 This component's props are:
 
 - `submitButtonHeader: React.ReactNode`. Displays with the Checkout submit button.
 - `disableSubmitButton: boolean`. If true, the submit button will always be disabled. If false (the default), the submit button will be enabled only on the last step and only if the [formStatus](#useFormStatus) is [`.READY`](#FormStatus).
+- `onLoadError?: ( type: string, error: Error ) => void`. A function that will be called if the error boundary is triggered on the submit button.
 
 ## CheckoutStepAreaWrapper
 

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -24,14 +24,21 @@ import {
 	validateTotal,
 } from '../lib/validation';
 import TransactionStatusHandler from './transaction-status-handler';
-import { CheckoutProviderProps, FormStatus, PaymentMethod } from '../types';
+import { LineItem, CheckoutProviderProps, FormStatus, PaymentMethod } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout-provider' );
 
+const emptyTotal: LineItem = {
+	id: 'total',
+	type: 'total',
+	amount: { value: 0, displayValue: '0', currency: 'USD' },
+	label: 'Total',
+};
+
 export function CheckoutProvider( props: CheckoutProviderProps ): JSX.Element {
 	const {
-		total,
-		items,
+		total = emptyTotal,
+		items = [],
 		onPaymentComplete,
 		showErrorMessage,
 		showInfoMessage,

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -35,10 +35,27 @@ const emptyTotal: LineItem = {
 	label: 'Total',
 };
 
-export function CheckoutProvider( props: CheckoutProviderProps ): JSX.Element {
-	const {
-		total = emptyTotal,
-		items = [],
+export function CheckoutProvider( {
+	total = emptyTotal,
+	items = [],
+	onPaymentComplete,
+	showErrorMessage,
+	showInfoMessage,
+	showSuccessMessage,
+	redirectToUrl,
+	theme,
+	paymentMethods,
+	paymentProcessors,
+	registry,
+	onEvent,
+	isLoading,
+	isValidating,
+	initiallySelectedPaymentMethodId = null,
+	children,
+}: CheckoutProviderProps ): JSX.Element {
+	const propsToValidate = {
+		total,
+		items,
 		onPaymentComplete,
 		showErrorMessage,
 		showInfoMessage,
@@ -51,9 +68,9 @@ export function CheckoutProvider( props: CheckoutProviderProps ): JSX.Element {
 		onEvent,
 		isLoading,
 		isValidating,
+		initiallySelectedPaymentMethodId,
 		children,
-		initiallySelectedPaymentMethodId = null,
-	} = props;
+	};
 	const [ paymentMethodId, setPaymentMethodId ] = useState< string | null >(
 		initiallySelectedPaymentMethodId
 	);
@@ -131,7 +148,7 @@ export function CheckoutProvider( props: CheckoutProviderProps ): JSX.Element {
 	);
 	return (
 		<CheckoutErrorBoundary errorMessage={ errorMessage } onError={ onError }>
-			<CheckoutProviderPropValidator propsToValidate={ props } />
+			<CheckoutProviderPropValidator propsToValidate={ propsToValidate } />
 			<ThemeProvider theme={ theme || defaultTheme }>
 				<RegistryProvider value={ registryRef.current }>
 					<LineItemsProvider items={ items } total={ total }>

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ThemeProvider } from 'emotion-theming';
 import debugFactory from 'debug';
 import { useI18n } from '@automattic/react-i18n';
@@ -28,7 +28,7 @@ import { CheckoutProviderProps, FormStatus, PaymentMethod } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout-provider' );
 
-export const CheckoutProvider: FunctionComponent< CheckoutProviderProps > = ( props ) => {
+export function CheckoutProvider( props: CheckoutProviderProps ): JSX.Element {
 	const {
 		total,
 		items,
@@ -137,7 +137,7 @@ export const CheckoutProvider: FunctionComponent< CheckoutProviderProps > = ( pr
 			</ThemeProvider>
 		</CheckoutErrorBoundary>
 	);
-};
+}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noop(): void {}

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -30,11 +30,10 @@ import {
 	getDefaultOrderSummary,
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,
-	useEvents,
 } from '../public-api';
 import styled from '../lib/styled';
 import { Theme } from '../lib/theme';
-import { FormStatus, CheckoutStepsProps, IsCompleteCallback } from '../types';
+import { OnLoadError, FormStatus, CheckoutStepsProps, IsCompleteCallback } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout' );
 
@@ -283,6 +282,7 @@ export const CheckoutStep = ( {
 	nextStepButtonAriaLabel,
 	validatingButtonText,
 	validatingButtonAriaLabel,
+	onLoadError,
 }: {
 	stepId: string;
 	titleContent: React.ReactNode;
@@ -296,9 +296,9 @@ export const CheckoutStep = ( {
 	nextStepButtonAriaLabel?: string;
 	validatingButtonText?: string;
 	validatingButtonAriaLabel?: string;
+	onLoadError?: OnLoadError;
 } ): JSX.Element => {
 	const { __ } = useI18n();
-	const onEvent = useEvents();
 	const { setActiveStepNumber, setStepCompleteStatus, stepCompleteStatus } = useContext(
 		CheckoutStepDataContext
 	);
@@ -335,15 +335,8 @@ export const CheckoutStep = ( {
 	];
 
 	const onError = useCallback(
-		( error ) =>
-			onEvent( {
-				type: 'STEP_LOAD_ERROR',
-				payload: {
-					message: error,
-					stepId,
-				},
-			} ),
-		[ onEvent, stepId ]
+		( error ) => onLoadError?.( 'STEP_LOAD_ERROR FOR STEP ' + stepId, error ),
+		[ onLoadError, stepId ]
 	);
 
 	return (
@@ -482,21 +475,21 @@ export function CheckoutStepArea( {
 	className,
 	submitButtonHeader,
 	disableSubmitButton,
+	onLoadError,
 }: {
 	children: React.ReactNode;
 	className?: string;
 	submitButtonHeader?: React.ReactNode;
 	disableSubmitButton?: boolean;
+	onLoadError?: OnLoadError;
 } ): JSX.Element {
-	const onEvent = useEvents();
-
 	const { activeStepNumber, totalSteps } = useContext( CheckoutStepDataContext );
 	const actualActiveStepNumber =
 		activeStepNumber > totalSteps && totalSteps > 0 ? totalSteps : activeStepNumber;
 	const isThereAnotherNumberedStep = actualActiveStepNumber < totalSteps;
 	const onSubmitButtonLoadError = useCallback(
-		( error ) => onEvent( { type: 'SUBMIT_BUTTON_LOAD_ERROR', payload: error } ),
-		[ onEvent ]
+		( error ) => onLoadError?.( 'SUBMIT_BUTTON_LOAD_ERROR', error ),
+		[ onLoadError ]
 	);
 
 	const classNames = joinClasses( [

--- a/packages/composite-checkout/src/components/transaction-status-handler.ts
+++ b/packages/composite-checkout/src/components/transaction-status-handler.ts
@@ -8,9 +8,7 @@ import { useI18n } from '@automattic/react-i18n';
 /**
  * Internal dependencies
  */
-import { usePaymentMethodId } from '../lib/payment-methods';
 import useMessages from './use-messages';
-import useEvents from './use-events';
 import { useFormStatus } from '../lib/form-status';
 import { useTransactionStatus } from '../lib/transaction-status';
 import { TransactionStatus } from '../types';
@@ -39,8 +37,6 @@ export function useTransactionStatusHandler( redirectToUrl: ( url: string ) => v
 		resetTransaction,
 		setTransactionError,
 	} = useTransactionStatus();
-	const onEvent = useEvents();
-	const [ paymentMethodId ] = usePaymentMethodId();
 
 	const genericErrorMessage = __( 'An error occurred during the transaction' );
 	const redirectErrormessage = __(
@@ -59,10 +55,6 @@ export function useTransactionStatusHandler( redirectToUrl: ( url: string ) => v
 		if ( transactionStatus === TransactionStatus.ERROR ) {
 			debug( 'showing error', transactionError );
 			showErrorMessage( transactionError || genericErrorMessage );
-			onEvent( {
-				type: 'TRANSACTION_ERROR',
-				payload: { message: transactionError || '', paymentMethodId },
-			} );
 			resetTransaction();
 		}
 		if ( transactionStatus === TransactionStatus.COMPLETE ) {

--- a/packages/composite-checkout/src/lib/payment-methods/alipay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/alipay.js
@@ -12,7 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Field from '../../components/field';
 import Button from '../../components/button';
-import { FormStatus, useLineItems, useEvents } from '../../public-api';
+import { FormStatus, useLineItems } from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
@@ -128,7 +128,6 @@ const AlipayField = styled( Field )`
 function AlipayPayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'alipay' ).getCustomerName() );
 
 	return (
@@ -137,7 +136,6 @@ function AlipayPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting alipay payment' );
-					onEvent( { type: 'REDIRECT_TRANSACTION_BEGIN', payload: { paymentMethodId: 'alipay' } } );
 					onClick( 'alipay', {
 						stripe,
 						name: customerName?.value,

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -8,7 +8,7 @@ import { useI18n } from '@automattic/react-i18n';
 /**
  * Internal dependencies
  */
-import { useLineItems, useEvents } from '../../public-api';
+import { useLineItems } from '../../public-api';
 import PaymentRequestButton from '../../components/payment-request-button';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
@@ -40,14 +40,11 @@ export function ApplePayLabel() {
 }
 
 export function ApplePaySubmitButton( { disabled, onClick, stripe, stripeConfiguration } ) {
-	const { __ } = useI18n();
 	const paymentRequestOptions = usePaymentRequestOptions( stripeConfiguration );
 	const [ items, total ] = useLineItems();
-	const onEvent = useEvents();
 	const onSubmit = useCallback(
 		( { name, paymentMethodToken } ) => {
 			debug( 'submitting stripe payment with key', paymentMethodToken );
-			onEvent( { type: 'APPLE_PAY_TRANSACTION_BEGIN' } );
 			onClick( 'apple-pay', {
 				stripe,
 				paymentMethodToken,
@@ -57,7 +54,7 @@ export function ApplePaySubmitButton( { disabled, onClick, stripe, stripeConfigu
 				stripeConfiguration,
 			} );
 		},
-		[ onClick, onEvent, items, total, stripe, stripeConfiguration ]
+		[ onClick, items, total, stripe, stripeConfiguration ]
 	);
 	const { paymentRequest, canMakePayment, isLoading } = useStripePaymentRequest( {
 		paymentRequestOptions,
@@ -67,15 +64,7 @@ export function ApplePaySubmitButton( { disabled, onClick, stripe, stripeConfigu
 	debug( 'apple-pay button isLoading', isLoading );
 
 	if ( ! isLoading && ! canMakePayment ) {
-		onEvent( { type: 'APPLE_PAY_LOADING_ERROR', payload: 'This payment type is not supported' } );
-		return (
-			<PaymentRequestButton
-				paymentRequest={ paymentRequest }
-				paymentType="apple-pay"
-				disabled
-				disabledReason={ __( 'This payment type is not supported' ) }
-			/>
-		);
+		throw new Error( 'This payment type is not supported' );
 	}
 
 	return (

--- a/packages/composite-checkout/src/lib/payment-methods/bancontact.js
+++ b/packages/composite-checkout/src/lib/payment-methods/bancontact.js
@@ -12,7 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Field from '../../components/field';
 import Button from '../../components/button';
-import { FormStatus, useLineItems, useEvents } from '../../public-api';
+import { FormStatus, useLineItems } from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
@@ -130,7 +130,6 @@ const BancontactField = styled( Field )`
 function BancontactPayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'bancontact' ).getCustomerName() );
 
 	return (
@@ -139,10 +138,6 @@ function BancontactPayButton( { disabled, onClick, store, stripe, stripeConfigur
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting bancontact payment' );
-					onEvent( {
-						type: 'REDIRECT_TRANSACTION_BEGIN',
-						payload: { paymentMethodId: 'bancontact' },
-					} );
 					onClick( 'bancontact', {
 						stripe,
 						name: customerName?.value,

--- a/packages/composite-checkout/src/lib/payment-methods/eps.js
+++ b/packages/composite-checkout/src/lib/payment-methods/eps.js
@@ -12,7 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Field from '../../components/field';
 import Button from '../../components/button';
-import { FormStatus, useLineItems, useEvents } from '../../public-api';
+import { FormStatus, useLineItems } from '../../public-api';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { useFormStatus } from '../form-status';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
@@ -124,7 +124,6 @@ const EpsField = styled( Field )`
 function EpsPayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'eps' ).getCustomerName() );
 
 	return (
@@ -133,7 +132,6 @@ function EpsPayButton( { disabled, onClick, store, stripe, stripeConfiguration }
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting eps payment' );
-					onEvent( { type: 'REDIRECT_TRANSACTION_BEGIN', payload: { paymentMethodId: 'eps' } } );
 					onClick( 'eps', {
 						stripe,
 						name: customerName?.value,

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -11,7 +11,7 @@ import { useI18n } from '@automattic/react-i18n';
  * Internal dependencies
  */
 import Button from '../../components/button';
-import { FormStatus, useLineItems, useEvents } from '../../public-api';
+import { FormStatus, useLineItems } from '../../public-api';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { useFormStatus } from '../form-status';
 import PaymentLogo from './payment-logo.js';
@@ -112,14 +112,12 @@ function ExistingCardPayButton( {
 } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 
 	return (
 		<Button
 			disabled={ disabled }
 			onClick={ () => {
 				debug( 'submitting existing card payment' );
-				onEvent( { type: 'EXISTING_CARD_TRANSACTION_BEGIN' } );
 				onClick( 'existing-card', {
 					items,
 					name: cardholderName,

--- a/packages/composite-checkout/src/lib/payment-methods/giropay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/giropay.js
@@ -12,7 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Field from '../../components/field';
 import Button from '../../components/button';
-import { FormStatus, useLineItems, useEvents } from '../../public-api';
+import { FormStatus, useLineItems } from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
@@ -128,7 +128,6 @@ const GiropayField = styled( Field )`
 function GiropayPayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'giropay' ).getCustomerName() );
 
 	return (
@@ -137,10 +136,6 @@ function GiropayPayButton( { disabled, onClick, store, stripe, stripeConfigurati
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting giropay payment' );
-					onEvent( {
-						type: 'REDIRECT_TRANSACTION_BEGIN',
-						payload: { paymentMethodId: 'giropay' },
-					} );
 					onClick( 'giropay', {
 						stripe,
 						name: customerName?.value,

--- a/packages/composite-checkout/src/lib/payment-methods/ideal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/ideal.js
@@ -12,7 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Field from '../../components/field';
 import Button from '../../components/button';
-import { FormStatus, useLineItems, useEvents } from '../../public-api';
+import { FormStatus, useLineItems } from '../../public-api';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { useFormStatus } from '../form-status';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
@@ -199,7 +199,6 @@ const SelectWrapper = styled.div`
 function IdealPayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'ideal' ).getCustomerName() );
 	const customerBank = useSelect( ( select ) => select( 'ideal' ).getCustomerBank() );
 
@@ -209,7 +208,6 @@ function IdealPayButton( { disabled, onClick, store, stripe, stripeConfiguration
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting ideal payment' );
-					onEvent( { type: 'REDIRECT_TRANSACTION_BEGIN', payload: { paymentMethodId: 'ideal' } } );
 					onClick( 'ideal', {
 						stripe,
 						name: customerName?.value,

--- a/packages/composite-checkout/src/lib/payment-methods/p24.js
+++ b/packages/composite-checkout/src/lib/payment-methods/p24.js
@@ -12,7 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Field from '../../components/field';
 import Button from '../../components/button';
-import { FormStatus, useLineItems, useEvents } from '../../public-api';
+import { FormStatus, useLineItems } from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
@@ -145,7 +145,6 @@ const P24Field = styled( Field )`
 function P24PayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'p24' ).getCustomerName() );
 	const customerEmail = useSelect( ( select ) => select( 'p24' ).getCustomerEmail() );
 
@@ -155,10 +154,6 @@ function P24PayButton( { disabled, onClick, store, stripe, stripeConfiguration }
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting p24 payment' );
-					onEvent( {
-						type: 'REDIRECT_TRANSACTION_BEGIN',
-						payload: { paymentMethodId: 'p24' },
-					} );
 					onClick( 'p24', {
 						stripe,
 						name: customerName?.value,

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -13,7 +13,6 @@ import Button from '../../components/button';
 import {
 	FormStatus,
 	TransactionStatus,
-	useEvents,
 	useTransactionStatus,
 	useLineItems,
 } from '../../public-api';
@@ -48,12 +47,10 @@ export function PaypalLabel() {
 
 export function PaypalSubmitButton( { disabled, onClick } ) {
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const { transactionStatus } = useTransactionStatus();
 	const [ items ] = useLineItems();
 
 	const handleButtonPress = () => {
-		onEvent( { type: 'REDIRECT_TRANSACTION_BEGIN', payload: { paymentMethodId: 'paypal' } } );
 		onClick( 'paypal', {
 			items,
 		} );

--- a/packages/composite-checkout/src/lib/payment-methods/sofort.js
+++ b/packages/composite-checkout/src/lib/payment-methods/sofort.js
@@ -12,7 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Field from '../../components/field';
 import Button from '../../components/button';
-import { FormStatus, useLineItems, useEvents } from '../../public-api';
+import { FormStatus, useLineItems } from '../../public-api';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { useFormStatus } from '../form-status';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
@@ -128,7 +128,6 @@ const SofortField = styled( Field )`
 function SofortPayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const onEvent = useEvents();
 	const customerName = useSelect( ( select ) => select( 'sofort' ).getCustomerName() );
 
 	return (
@@ -137,7 +136,6 @@ function SofortPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting sofort payment' );
-					onEvent( { type: 'REDIRECT_TRANSACTION_BEGIN', payload: { paymentMethodId: 'sofort' } } );
 					onClick( 'sofort', {
 						stripe,
 						name: customerName?.value,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -19,7 +19,7 @@ import Field from '../../components/field';
 import GridRow from '../../components/grid-row';
 import Button from '../../components/button';
 import PaymentLogo from './payment-logo';
-import { FormStatus, useLineItems, useEvents } from '../../public-api';
+import { FormStatus, useLineItems } from '../../public-api';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import Spinner from '../../components/spinner';
 import { useFormStatus } from '../form-status';
@@ -142,7 +142,6 @@ export function createStripeMethod( { store, stripe, stripeConfiguration } ) {
 function StripeCreditCardFields() {
 	const { __ } = useI18n();
 	const theme = useTheme();
-	const onEvent = useEvents();
 	const [ isStripeFullyLoaded, setIsStripeFullyLoaded ] = useState( false );
 	const cardholderName = useSelect( ( select ) => select( 'stripe' ).getCardholderName() );
 	const brand = useSelect( ( select ) => select( 'stripe' ).getBrand() );
@@ -162,14 +161,6 @@ function StripeCreditCardFields() {
 		}
 
 		if ( input.error && input.error.message ) {
-			onEvent( {
-				type: 'a8c_checkout_stripe_field_invalid_error',
-				payload: {
-					type: 'Stripe field error',
-					field: input.elementType,
-					message: input.error.message,
-				},
-			} );
 			setCardDataError( input.elementType, input.error.message );
 			return;
 		}

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -251,3 +251,19 @@ export interface StripePaymentRequestHandlerEvent {
 	};
 	complete: () => void;
 }
+
+export interface CheckoutStepsProps {
+	children?: React.ReactNode;
+	areStepsActive?: boolean;
+	onStepNumberChange?: OnStepNumberChange;
+}
+
+export type OnStepNumberChange = ( {
+	stepNumber,
+	previousStepNumber,
+}: {
+	stepNumber: number | null;
+	previousStepNumber: number | null;
+} ) => void;
+
+export type IsCompleteCallback = () => boolean | Promise< boolean >;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -267,3 +267,5 @@ export type OnStepNumberChange = ( {
 } ) => void;
 
 export type IsCompleteCallback = () => boolean | Promise< boolean >;
+
+export type OnLoadError = ( type: string, error: Error ) => void;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -82,13 +82,13 @@ export type ReactStandardAction< T = string, P = unknown > = P extends void
 export interface CheckoutProviderProps {
 	theme?: Theme;
 	registry?: DataRegistry;
-	total: LineItem;
-	items: LineItem[];
+	total?: LineItem;
+	items?: LineItem[];
 	paymentMethods: PaymentMethod[];
 	onPaymentComplete: PaymentCompleteCallback;
-	showErrorMessage: ( message: string ) => void;
-	showInfoMessage: ( message: string ) => void;
-	showSuccessMessage: ( message: string ) => void;
+	showErrorMessage: ShowNoticeFunction;
+	showInfoMessage: ShowNoticeFunction;
+	showSuccessMessage: ShowNoticeFunction;
 	onEvent?: ( event: ReactStandardAction ) => void;
 	isLoading?: boolean;
 	redirectToUrl?: ( url: string ) => void;
@@ -97,6 +97,8 @@ export interface CheckoutProviderProps {
 	initiallySelectedPaymentMethodId?: string | null;
 	children: React.ReactNode;
 }
+
+export type ShowNoticeFunction = ( message: string ) => void;
 
 export interface PaymentProcessorProp {
 	[ key: string ]: PaymentProcessorFunction;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -95,6 +95,7 @@ export interface CheckoutProviderProps {
 	paymentProcessors: PaymentProcessorProp;
 	isValidating?: boolean;
 	initiallySelectedPaymentMethodId?: string | null;
+	children: React.ReactNode;
 }
 
 export interface PaymentProcessorProp {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `onEvent`/`useEvents` mechanism of `CheckoutProvider` is meant to allow recording analytics for things happening in the package, but it's a leaky abstraction and there are better ways to do things. This PR removes the prop and hook.

Depends on https://github.com/Automattic/wp-calypso/pull/48069

#### Testing instructions

TBD