### PR TITLE
Checkout: extract calling payment processor and handling response to useProcessPayment hook

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -91,6 +91,7 @@ export default function useCreatePaymentCompleteCallback( {
 		( { paymentMethodId, transactionLastResponse }: PaymentCompleteCallbackArguments ): void => {
 			debug( 'payment completed successfully' );
 			const transactionResult = normalizeTransactionResponse( transactionLastResponse );
+			const hideNudge = shouldHideUpsellNudges( { isComingFromUpsell, transactionLastResponse } );
 			const getThankYouPageUrlArguments = {
 				siteSlug: siteSlug || undefined,
 				adminUrl,
@@ -105,6 +106,7 @@ export default function useCreatePaymentCompleteCallback( {
 				isEligibleForSignupDestinationResult,
 				shouldShowOneClickTreatment,
 				hideNudge: !! isComingFromUpsell,
+				hideNudge,
 				isInEditor,
 				previousRoute,
 			};
@@ -338,4 +340,23 @@ function recordPaymentCompleteAnalytics( {
 				) || '',
 		} )
 	);
+}
+
+function shouldHideUpsellNudges( {
+	isComingFromUpsell,
+	transactionLastResponse,
+}: {
+	isComingFromUpsell?: boolean;
+	transactionLastResponse: unknown;
+} ): boolean {
+	if ( isComingFromUpsell ) {
+		return true;
+	}
+	if (
+		transactionLastResponse &&
+		( transactionLastResponse as { isComingFromUpsell: boolean } ).isComingFromUpsell
+	) {
+		return true;
+	}
+	return false;
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -91,7 +91,6 @@ export default function useCreatePaymentCompleteCallback( {
 		( { paymentMethodId, transactionLastResponse }: PaymentCompleteCallbackArguments ): void => {
 			debug( 'payment completed successfully' );
 			const transactionResult = normalizeTransactionResponse( transactionLastResponse );
-			const hideNudge = shouldHideUpsellNudges( { isComingFromUpsell, transactionLastResponse } );
 			const getThankYouPageUrlArguments = {
 				siteSlug: siteSlug || undefined,
 				adminUrl,
@@ -105,8 +104,7 @@ export default function useCreatePaymentCompleteCallback( {
 				productAliasFromUrl,
 				isEligibleForSignupDestinationResult,
 				shouldShowOneClickTreatment,
-				hideNudge: !! isComingFromUpsell,
-				hideNudge,
+				hideNudge: isComingFromUpsell,
 				isInEditor,
 				previousRoute,
 			};
@@ -233,13 +231,6 @@ export default function useCreatePaymentCompleteCallback( {
 	);
 }
 
-export function withPaymentCompleteCallback< P >( Component: React.ComponentType< P > ) {
-	return function PaymentCompleteWrapper( props: P ): JSX.Element {
-		const paymentCompleteCallback = useCreatePaymentCompleteCallback( {} );
-		return <Component { ...props } paymentCompleteCallback={ paymentCompleteCallback } />;
-	};
-}
-
 function displayRenewalSuccessNotice(
 	responseCart: ResponseCart,
 	purchases: Record< number, Purchase >,
@@ -347,23 +338,4 @@ function recordPaymentCompleteAnalytics( {
 				) || '',
 		} )
 	);
-}
-
-function shouldHideUpsellNudges( {
-	isComingFromUpsell,
-	transactionLastResponse,
-}: {
-	isComingFromUpsell?: boolean;
-	transactionLastResponse: unknown;
-} ): boolean {
-	if ( isComingFromUpsell ) {
-		return true;
-	}
-	if (
-		transactionLastResponse &&
-		( transactionLastResponse as { isComingFromUpsell: boolean } ).isComingFromUpsell
-	) {
-		return true;
-	}
-	return false;
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -233,6 +233,13 @@ export default function useCreatePaymentCompleteCallback( {
 	);
 }
 
+export function withPaymentCompleteCallback< P >( Component: React.ComponentType< P > ) {
+	return function PaymentCompleteWrapper( props: P ): JSX.Element {
+		const paymentCompleteCallback = useCreatePaymentCompleteCallback( {} );
+		return <Component { ...props } paymentCompleteCallback={ paymentCompleteCallback } />;
+	};
+}
+
 function displayRenewalSuccessNotice(
 	responseCart: ResponseCart,
 	purchases: Record< number, Purchase >,

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -538,20 +538,10 @@ export function StripeHookProvider( {
  */
 export function useStripe(): StripeData {
 	const stripeData = useContext( StripeContext );
-	return (
-		stripeData || {
-			stripe: null,
-			stripeConfiguration: null,
-			isStripeLoading: false,
-			stripeLoadingError: null,
-			reloadStripeConfiguration: () => {
-				// eslint-disable-next-line no-console
-				console.error(
-					`You cannot use reloadStripeConfiguration until stripe has been initialized.`
-				);
-			},
-		}
-	);
+	if ( ! stripeData ) {
+		throw new Error( 'useStripe can only be used inside a StripeHookProvider' );
+	}
+	return stripeData;
 }
 
 /**

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -449,6 +449,10 @@ The `registerStore` function on the [#defaultRegistry](default registry). Don't 
 
 A React Hook that will return an array of all payment method objects. See `usePaymentMethod()`, which returns the active object only. Only works within [CheckoutProvider](#CheckoutProvider).
 
+### useCreatePaymentProcessorOnClick
+
+A React Hook that will return the function passed to each [payment method's submitButton component](#payment-methods). Call it with a payment method ID and data for the payment processor and it will handle the transaction.
+
 ### useDispatch
 
 A React Hook that will return all the bound action creators for a [Data store](#data-stores). Only works within [CheckoutProvider](#CheckoutProvider).

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -449,10 +449,6 @@ The `registerStore` function on the [#defaultRegistry](default registry). Don't 
 
 A React Hook that will return an array of all payment method objects. See `usePaymentMethod()`, which returns the active object only. Only works within [CheckoutProvider](#CheckoutProvider).
 
-### useCreatePaymentProcessorOnClick
-
-A React Hook that will return the function passed to each [payment method's submitButton component](#payment-methods). Call it with a payment method ID and data for the payment processor and it will handle the transaction.
-
 ### useDispatch
 
 A React Hook that will return all the bound action creators for a [Data store](#data-stores). Only works within [CheckoutProvider](#CheckoutProvider).
@@ -509,6 +505,10 @@ A React Hook that returns a payment processor function as passed to the `payment
 ### usePaymentProcessors
 
 A React Hook that returns all the payment processor functions in a Record.
+
+### useProcessPayment
+
+A React Hook that will return the function passed to each [payment method's submitButton component](#payment-methods). Call it with a payment method ID and data for the payment processor and it will handle the transaction.
 
 ### useRegisterStore
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -107,7 +107,7 @@ If not using the `onClick` function, when the `submitButton` component has been 
 
 1. Call `setTransactionPending()` from [useTransactionStatus](#useTransactionStatus). This will change the [form status](#useFormStatus) to [`.SUBMITTING`](#FormStatus) and disable the form.
 2. Call the payment processor function returned from [usePaymentProcessor](#usePaymentProcessor]), passing whatever data that function requires. Each payment processor will be different, so you'll need to know the API of that function explicitly.
-3. Payment processor functions return a `Promise`. When the `Promise` resolves, call `setTransactionComplete()` from [useTransactionStatus](#useTransactionStatus) if the transaction was a success. Depending on the payment processor, some transactions might require additional actions before they are complete. If the transaction requires a redirect, call `setTransactionRedirecting(url: string)` instead.
+3. Payment processor functions return a `Promise`. When the `Promise` resolves, check its value (it will be one of [makeManualResponse](#makeManualResponse), [makeRedirectResponse](#makeRedirectResponse), or [makeSuccessResponse](#makeSuccessResponse)). Then call `setTransactionComplete(responseData: unknown)` from [useTransactionStatus](#useTransactionStatus) if the transaction was a success. If the transaction requires a redirect, call `setTransactionRedirecting(url: string)` instead.
 4. If the `Promise` rejects, call `setTransactionError(message: string)`.
 5. At this point the [CheckoutProvider](#CheckoutProvider) will automatically take action if the transaction status is [`.COMPLETE`](#TransactionStatus) (call [onPaymentComplete](#CheckoutProvider)), [`.ERROR`](#TransactionStatus) (display the error and re-enable the form), or [`.REDIRECTING`](#TransactionStatus) (redirect to the url). If for some reason the transaction should be cancelled, call `resetTransaction()`.
 
@@ -534,9 +534,9 @@ A React Hook that returns an object with the following properties to be used by 
 - `previousTransactionStatus: `[`TransactionStatus.`](#TransactionStatus). The last status of the transaction.
 - `transactionError: string | null`. The most recent error message encountered by the transaction if its status is [`.ERROR`](#TransactionStatus).
 - `transactionRedirectUrl: string | null`. The redirect url to use if the transaction status is [`.REDIRECTING`](#TransactionStatus).
-- `transactionLastResponse: object | null`. The most recent full response object as returned by the transaction's endpoint and passed to `setTransactionComplete`.
+- `transactionLastResponse: unknown | null`. The most recent full response object as returned by the transaction's endpoint and passed to `setTransactionComplete`.
 - `resetTransaction: () => void`. Function to change the transaction status to [`.NOT_STARTED`](#TransactionStatus).
-- `setTransactionComplete: ( object ) => void`. Function to change the transaction status to [`.COMPLETE`](#TransactionStatus) and save the response object in `transactionLastResponse`.
+- `setTransactionComplete: ( transactionResponse: unknown ) => void`. Function to change the transaction status to [`.COMPLETE`](#TransactionStatus) and save the response object in `transactionLastResponse`.
 - `setTransactionError: ( string ) => void`. Function to change the transaction status to [`.ERROR`](#TransactionStatus) and save the error in `transactionError`.
 - `setTransactionPending: () => void`. Function to change the transaction status to [`.PENDING`](#TransactionStatus).
 - `setTransactionRedirecting: ( string ) => void`. Function to change the transaction status to [`.REDIRECTING`](#TransactionStatus) and save the redirect URL in `transactionRedirectUrl`.

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useCallback, useMemo } from 'react';
-import debugFactory from 'debug';
+import React from 'react';
 import { useI18n } from '@automattic/react-i18n';
 
 /**
@@ -11,15 +10,7 @@ import { useI18n } from '@automattic/react-i18n';
 import joinClasses from '../lib/join-classes';
 import { useFormStatus, FormStatus } from '../public-api';
 import CheckoutErrorBoundary from './checkout-error-boundary';
-import { usePaymentMethod, usePaymentProcessors, useTransactionStatus } from '../public-api';
-import {
-	PaymentProcessorResponse,
-	PaymentProcessorResponseType,
-	SetTransactionComplete,
-	SetTransactionRedirecting,
-} from '../types';
-
-const debug = debugFactory( 'composite-checkout:checkout-submit-button' );
+import { usePaymentMethod, useCreatePaymentProcessorOnClick } from '../public-api';
 
 export default function CheckoutSubmitButton( {
 	className,
@@ -56,91 +47,4 @@ export default function CheckoutSubmitButton( {
 			</div>
 		</CheckoutErrorBoundary>
 	);
-}
-
-function useCreatePaymentProcessorOnClick() {
-	const paymentProcessors = usePaymentProcessors();
-	const { setTransactionPending } = useTransactionStatus();
-	const handlePaymentProcessorPromise = useHandlePaymentProcessorResponse();
-
-	return useCallback(
-		async ( paymentProcessorId: string, submitData: unknown ) => {
-			debug( 'beginning payment processor onClick handler' );
-			if ( ! paymentProcessors[ paymentProcessorId ] ) {
-				throw new Error( `No payment processor found with key: ${ paymentProcessorId }` );
-			}
-			setTransactionPending();
-			debug( 'calling payment processor function', paymentProcessorId );
-			return handlePaymentProcessorPromise(
-				paymentProcessorId,
-				paymentProcessors[ paymentProcessorId ]( submitData )
-			);
-		},
-		[ handlePaymentProcessorPromise, paymentProcessors, setTransactionPending ]
-	);
-}
-
-function useHandlePaymentProcessorResponse() {
-	const { __ } = useI18n();
-	const redirectErrorMessage = useMemo(
-		() =>
-			__(
-				'An error occurred while redirecting to the payment partner. Please try again or contact support.'
-			),
-		[ __ ]
-	);
-	const {
-		setTransactionComplete,
-		setTransactionRedirecting,
-		setTransactionError,
-	} = useTransactionStatus();
-
-	return useCallback(
-		async (
-			paymentProcessorId: string,
-			processorPromise: Promise< PaymentProcessorResponse >
-		): Promise< PaymentProcessorResponse | void > => {
-			return processorPromise
-				.then( ( response ) =>
-					handlePaymentProcessorResponse( response, paymentProcessorId, redirectErrorMessage, {
-						setTransactionRedirecting,
-						setTransactionComplete,
-					} )
-				)
-				.catch( ( error: Error ) => {
-					setTransactionError( error.message );
-				} );
-		},
-		[ redirectErrorMessage, setTransactionError, setTransactionComplete, setTransactionRedirecting ]
-	);
-}
-
-async function handlePaymentProcessorResponse(
-	processorResponse: PaymentProcessorResponse,
-	paymentProcessorId: string,
-	redirectErrorMessage: string,
-	{
-		setTransactionRedirecting,
-		setTransactionComplete,
-	}: {
-		setTransactionRedirecting: SetTransactionRedirecting;
-		setTransactionComplete: SetTransactionComplete;
-	}
-): Promise< PaymentProcessorResponse > {
-	debug( 'payment processor function response', processorResponse );
-	if ( processorResponse.type === PaymentProcessorResponseType.REDIRECT ) {
-		if ( ! processorResponse.payload ) {
-			throw new Error( redirectErrorMessage );
-		}
-		setTransactionRedirecting( processorResponse.payload );
-		return processorResponse;
-	}
-	if ( processorResponse.type === PaymentProcessorResponseType.SUCCESS ) {
-		setTransactionComplete( processorResponse.payload );
-		return processorResponse;
-	}
-	if ( processorResponse.type === PaymentProcessorResponseType.MANUAL ) {
-		return processorResponse;
-	}
-	throw new Error( `Unknown payment processor response for processor "${ paymentProcessorId }"` );
 }

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -10,7 +10,7 @@ import { useI18n } from '@automattic/react-i18n';
 import joinClasses from '../lib/join-classes';
 import { useFormStatus, FormStatus } from '../public-api';
 import CheckoutErrorBoundary from './checkout-error-boundary';
-import { usePaymentMethod, useCreatePaymentProcessorOnClick } from '../public-api';
+import { usePaymentMethod, useProcessPayment } from '../public-api';
 
 export default function CheckoutSubmitButton( {
 	className,
@@ -24,7 +24,7 @@ export default function CheckoutSubmitButton( {
 	const { formStatus } = useFormStatus();
 	const { __ } = useI18n();
 	const isDisabled = disabled || formStatus !== FormStatus.READY;
-	const onClick = useCreatePaymentProcessorOnClick();
+	const onClick = useProcessPayment();
 
 	const paymentMethod = usePaymentMethod();
 	if ( ! paymentMethod ) {

--- a/packages/composite-checkout/src/components/use-create-payment-processor-on-click.ts
+++ b/packages/composite-checkout/src/components/use-create-payment-processor-on-click.ts
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo } from 'react';
+import debugFactory from 'debug';
+import { useI18n } from '@automattic/react-i18n';
+
+/**
+ * Internal dependencies
+ */
+import { usePaymentProcessors, useTransactionStatus } from '../public-api';
+import {
+	PaymentProcessorResponse,
+	PaymentProcessorResponseType,
+	SetTransactionComplete,
+	SetTransactionRedirecting,
+	PaymentProcessorOnClick,
+} from '../types';
+
+const debug = debugFactory( 'composite-checkout:use-create-payment-processor-on-click' );
+
+export default function useCreatePaymentProcessorOnClick(): PaymentProcessorOnClick {
+	const paymentProcessors = usePaymentProcessors();
+	const { setTransactionPending } = useTransactionStatus();
+	const handlePaymentProcessorPromise = useHandlePaymentProcessorResponse();
+
+	return useCallback(
+		async ( paymentProcessorId, submitData ) => {
+			debug( 'beginning payment processor onClick handler' );
+			if ( ! paymentProcessors[ paymentProcessorId ] ) {
+				throw new Error( `No payment processor found with key: ${ paymentProcessorId }` );
+			}
+			setTransactionPending();
+			debug( 'calling payment processor function', paymentProcessorId );
+			return handlePaymentProcessorPromise(
+				paymentProcessorId,
+				paymentProcessors[ paymentProcessorId ]( submitData )
+			);
+		},
+		[ handlePaymentProcessorPromise, paymentProcessors, setTransactionPending ]
+	);
+}
+
+function useHandlePaymentProcessorResponse() {
+	const { __ } = useI18n();
+	const redirectErrorMessage = useMemo(
+		() =>
+			__(
+				'An error occurred while redirecting to the payment partner. Please try again or contact support.'
+			),
+		[ __ ]
+	);
+	const {
+		setTransactionComplete,
+		setTransactionRedirecting,
+		setTransactionError,
+	} = useTransactionStatus();
+
+	return useCallback(
+		async (
+			paymentProcessorId: string,
+			processorPromise: Promise< PaymentProcessorResponse >
+		): Promise< PaymentProcessorResponse | void > => {
+			return processorPromise
+				.then( ( response ) =>
+					handlePaymentProcessorResponse( response, paymentProcessorId, redirectErrorMessage, {
+						setTransactionRedirecting,
+						setTransactionComplete,
+					} )
+				)
+				.catch( ( error: Error ) => {
+					setTransactionError( error.message );
+				} );
+		},
+		[ redirectErrorMessage, setTransactionError, setTransactionComplete, setTransactionRedirecting ]
+	);
+}
+
+async function handlePaymentProcessorResponse(
+	processorResponse: PaymentProcessorResponse,
+	paymentProcessorId: string,
+	redirectErrorMessage: string,
+	{
+		setTransactionRedirecting,
+		setTransactionComplete,
+	}: {
+		setTransactionRedirecting: SetTransactionRedirecting;
+		setTransactionComplete: SetTransactionComplete;
+	}
+): Promise< PaymentProcessorResponse > {
+	debug( 'payment processor function response', processorResponse );
+	if ( processorResponse.type === PaymentProcessorResponseType.REDIRECT ) {
+		if ( ! processorResponse.payload ) {
+			throw new Error( redirectErrorMessage );
+		}
+		setTransactionRedirecting( processorResponse.payload );
+		return processorResponse;
+	}
+	if ( processorResponse.type === PaymentProcessorResponseType.SUCCESS ) {
+		setTransactionComplete( processorResponse.payload );
+		return processorResponse;
+	}
+	if ( processorResponse.type === PaymentProcessorResponseType.MANUAL ) {
+		return processorResponse;
+	}
+	throw new Error( `Unknown payment processor response for processor "${ paymentProcessorId }"` );
+}

--- a/packages/composite-checkout/src/components/use-create-payment-processor-on-click.ts
+++ b/packages/composite-checkout/src/components/use-create-payment-processor-on-click.ts
@@ -60,7 +60,7 @@ function useHandlePaymentProcessorResponse() {
 		async (
 			paymentProcessorId: string,
 			processorPromise: Promise< PaymentProcessorResponse >
-		): Promise< PaymentProcessorResponse | void > => {
+		): Promise< PaymentProcessorResponse > => {
 			return processorPromise
 				.then( ( response ) =>
 					handlePaymentProcessorResponse( response, paymentProcessorId, redirectErrorMessage, {
@@ -70,6 +70,7 @@ function useHandlePaymentProcessorResponse() {
 				)
 				.catch( ( error: Error ) => {
 					setTransactionError( error.message );
+					throw error;
 				} );
 		},
 		[ redirectErrorMessage, setTransactionError, setTransactionComplete, setTransactionRedirecting ]

--- a/packages/composite-checkout/src/components/use-process-payment.ts
+++ b/packages/composite-checkout/src/components/use-process-payment.ts
@@ -14,12 +14,12 @@ import {
 	PaymentProcessorResponseType,
 	SetTransactionComplete,
 	SetTransactionRedirecting,
-	PaymentProcessorOnClick,
+	ProcessPayment,
 } from '../types';
 
 const debug = debugFactory( 'composite-checkout:use-create-payment-processor-on-click' );
 
-export default function useCreatePaymentProcessorOnClick(): PaymentProcessorOnClick {
+export default function useProcessPayment(): ProcessPayment {
 	const paymentProcessors = usePaymentProcessors();
 	const { setTransactionPending } = useTransactionStatus();
 	const handlePaymentProcessorPromise = useHandlePaymentProcessorResponse();

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -81,7 +81,7 @@ import {
 	makeSuccessResponse,
 	makeRedirectResponse,
 } from './lib/payment-processors';
-import useCreatePaymentProcessorOnClick from './components/use-create-payment-processor-on-click';
+import useProcessPayment from './components/use-process-payment';
 import RadioButton from './components/radio-button';
 import checkoutTheme from './lib/theme';
 export * from './types';
@@ -144,7 +144,6 @@ export {
 	makeSuccessResponse,
 	registerStore,
 	useAllPaymentMethods,
-	useCreatePaymentProcessorOnClick,
 	useDispatch,
 	useEvents,
 	useFormStatus,
@@ -157,6 +156,7 @@ export {
 	usePaymentMethodId,
 	usePaymentProcessor,
 	usePaymentProcessors,
+	useProcessPayment,
 	useRegisterStore,
 	useRegistry,
 	useSelect,

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -81,6 +81,7 @@ import {
 	makeSuccessResponse,
 	makeRedirectResponse,
 } from './lib/payment-processors';
+import useCreatePaymentProcessorOnClick from './components/use-payment-processor-on-click';
 import RadioButton from './components/radio-button';
 import checkoutTheme from './lib/theme';
 export * from './types';
@@ -143,6 +144,7 @@ export {
 	makeSuccessResponse,
 	registerStore,
 	useAllPaymentMethods,
+	useCreatePaymentProcessorOnClick,
 	useDispatch,
 	useEvents,
 	useFormStatus,

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -81,7 +81,7 @@ import {
 	makeSuccessResponse,
 	makeRedirectResponse,
 } from './lib/payment-processors';
-import useCreatePaymentProcessorOnClick from './components/use-payment-processor-on-click';
+import useCreatePaymentProcessorOnClick from './components/use-create-payment-processor-on-click';
 import RadioButton from './components/radio-button';
 import checkoutTheme from './lib/theme';
 export * from './types';

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -131,8 +131,10 @@ export type PaymentProcessorResponse =
 	| PaymentProcessorRedirect
 	| PaymentProcessorManual;
 
+export type PaymentProcessorSubmitData = unknown;
+
 export type PaymentProcessorFunction = (
-	submitData: unknown
+	submitData: PaymentProcessorSubmitData
 ) => Promise< PaymentProcessorResponse >;
 
 export enum PaymentProcessorResponseType {
@@ -205,6 +207,11 @@ export interface TransactionStatusManager extends TransactionStatusState {
 	setTransactionPending: SetTransactionPending;
 	setTransactionRedirecting: SetTransactionRedirecting;
 }
+
+export type PaymentProcessorOnClick = (
+	paymentProcessorId: string,
+	processorData: PaymentProcessorSubmitData
+) => Promise< PaymentProcessorResponse | void >;
 
 export type SetTransactionRedirecting = ( url: string ) => void;
 

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -205,7 +205,7 @@ export interface TransactionStatusManager extends TransactionStatusState {
 	setTransactionRedirecting: SetTransactionRedirecting;
 }
 
-export type PaymentProcessorOnClick = (
+export type ProcessPayment = (
 	paymentProcessorId: string,
 	processorData: PaymentProcessorSubmitData
 ) => Promise< PaymentProcessorResponse >;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -211,7 +211,7 @@ export interface TransactionStatusManager extends TransactionStatusState {
 export type PaymentProcessorOnClick = (
 	paymentProcessorId: string,
 	processorData: PaymentProcessorSubmitData
-) => Promise< PaymentProcessorResponse | void >;
+) => Promise< PaymentProcessorResponse >;
 
 export type SetTransactionRedirecting = ( url: string ) => void;
 

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -101,10 +101,7 @@ export interface PaymentProcessorProp {
 	[ key: string ]: PaymentProcessorFunction;
 }
 
-export type PaymentCompleteCallback = ( {
-	paymentMethodId,
-	transactionLastResponse,
-}: PaymentCompleteCallbackArguments ) => void;
+export type PaymentCompleteCallback = ( args: PaymentCompleteCallbackArguments ) => void;
 
 export type PaymentCompleteCallbackArguments = {
 	paymentMethodId: string | null;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -199,12 +199,22 @@ export type TransactionStatusPayload =
 export type TransactionStatusAction = ReactStandardAction< 'STATUS_SET', TransactionStatusPayload >;
 
 export interface TransactionStatusManager extends TransactionStatusState {
-	resetTransaction: () => void;
-	setTransactionError: ( message: string ) => void;
-	setTransactionComplete: ( response: PaymentProcessorResponseData ) => void;
-	setTransactionPending: () => void;
-	setTransactionRedirecting: ( url: string ) => void;
+	resetTransaction: ResetTransaction;
+	setTransactionError: SetTransactionError;
+	setTransactionComplete: SetTransactionComplete;
+	setTransactionPending: SetTransactionPending;
+	setTransactionRedirecting: SetTransactionRedirecting;
 }
+
+export type SetTransactionRedirecting = ( url: string ) => void;
+
+export type SetTransactionPending = () => void;
+
+export type SetTransactionComplete = ( response: PaymentProcessorResponseData ) => void;
+
+export type SetTransactionError = ( message: string ) => void;
+
+export type ResetTransaction = () => void;
 
 export interface LineItemsState {
 	items: LineItem[];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a payment method's `submitButton` prop is rendered by `@automattic/composite-checkout`, it is provided with an `onClick` prop that can be used to call a payment processor function and handle the response. As consumers of the package (like the one-click upsell; see https://github.com/Automattic/wp-calypso/pull/48152) might want to implement their own submit button, we should expose that automated process in its own hook.

This PR creates a hook called `useProcessPayment` that does just that and adds it to the `@automattic/composite-checkout` package.

This PR shouldn't have any user-facing effect on checkout.

#### Testing instructions

1. Add a product to your cart and visit checkout.
1. Complete checkout with any payment method.
1. Verify that the transaction completes successfully and that you are redirected to a thank-you page as expected.