### PR TITLE
Checkout: Convert PurchaseModal to use composite checkout alone

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -14,6 +14,7 @@ import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import GSuiteNudge from './gsuite-nudge';
 import CheckoutContainer from './checkout/checkout-container';
+import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutSystemDecider from './checkout-system-decider';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
@@ -219,14 +220,14 @@ export function upsellNudge( context, next ) {
 	setSectionMiddleware( { name: upsellType } )( context );
 
 	context.primary = (
-		<CheckoutContainer purchaseId={ Number( receiptId ) }>
+		<CalypsoShoppingCartProvider>
 			<UpsellNudge
 				siteSlugParam={ site }
 				receiptId={ Number( receiptId ) }
 				upsellType={ upsellType }
 				upgradeItem={ upgradeItem }
 			/>
-		</CheckoutContainer>
+		</CalypsoShoppingCartProvider>
 	);
 
 	next();

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import page from 'page';
 import { pick } from 'lodash';
 import { withShoppingCart, createRequestCartProduct } from '@automattic/shopping-cart';
+import { StripeHookProvider } from '@automattic/calypso-stripe';
 
 /**
  * Internal dependencies
@@ -47,6 +48,7 @@ import { getPlanByPathSlug } from 'calypso/lib/plans';
 import { isFetchingStoredCards, getStoredCards } from 'calypso/state/stored-cards/selectors';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url';
 import { extractStoredCardMetaValue } from './purchase-modal/util';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 
 /**
  * Style dependencies
@@ -298,14 +300,16 @@ export class UpsellNudge extends React.Component {
 		const isCartUpdating = this.props.shoppingCartManager.isPendingUpdate;
 
 		return (
-			<PurchaseModal
-				cart={ this.props.cart }
-				cards={ this.props.cards }
-				onClose={ () => this.setState( { showPurchaseModal: false } ) }
-				siteId={ this.props.selectedSiteId }
-				siteSlug={ this.props.siteSlug }
-				isCartUpdating={ isCartUpdating }
-			/>
+			<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration }>
+				<PurchaseModal
+					cart={ this.props.cart }
+					cards={ this.props.cards }
+					onClose={ () => this.setState( { showPurchaseModal: false } ) }
+					siteId={ this.props.selectedSiteId }
+					siteSlug={ this.props.siteSlug }
+					isCartUpdating={ isCartUpdating }
+				/>
+			</StripeHookProvider>
 		);
 	};
 

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import page from 'page';
 import { omit } from 'lodash';
+import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -362,4 +363,4 @@ export default connect(
 	{
 		trackUpsellButtonClick,
 	}
-)( localize( UpsellNudge ) );
+)( withShoppingCart( localize( UpsellNudge ) ) );

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -238,6 +238,7 @@ export class UpsellNudge extends React.Component {
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
 		const getThankYouPageUrlArguments = {
 			siteSlug: this.props.siteSlug,
+			receiptId: this.props.receiptId,
 			cart: this.props.cart,
 			hideNudge: shouldHideUpsellNudges,
 		};

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -44,7 +44,7 @@ import Gridicon from 'calypso/components/gridicon';
 import { isMonthly } from 'calypso/lib/plans/constants';
 import { getPlanByPathSlug } from 'calypso/lib/plans';
 import { isFetchingStoredCards, getStoredCards } from 'calypso/state/stored-cards/selectors';
-import { withPaymentCompleteCallback } from 'calypso/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback';
+import getThankYouPageUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url';
 
 /**
  * Style dependencies
@@ -231,10 +231,13 @@ export class UpsellNudge extends React.Component {
 		const { trackUpsellButtonClick, upsellType } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
-		this.props.paymentCompleteCallback( {
-			paymentMethodId: null,
-			transactionLastResponse: { isComingFromUpsell: shouldHideUpsellNudges },
-		} );
+		const getThankYouPageUrlArguments = {
+			siteSlug: this.props.siteSlug,
+			cart: this.props.cart,
+			hideNudge: shouldHideUpsellNudges,
+		};
+		const url = getThankYouPageUrl( getThankYouPageUrlArguments );
+		page.redirect( url );
 	};
 
 	handleClickAccept = ( buttonAction ) => {
@@ -361,4 +364,4 @@ export default connect(
 	{
 		trackUpsellButtonClick,
 	}
-)( withShoppingCart( withPaymentCompleteCallback( localize( UpsellNudge ) ) ) );
+)( withShoppingCart( localize( UpsellNudge ) ) );

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -46,6 +46,7 @@ import { isMonthly } from 'calypso/lib/plans/constants';
 import { getPlanByPathSlug } from 'calypso/lib/plans';
 import { isFetchingStoredCards, getStoredCards } from 'calypso/state/stored-cards/selectors';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url';
+import { extractStoredCardMetaValue } from './purchase-modal/util';
 
 /**
  * Style dependencies
@@ -252,6 +253,14 @@ export class UpsellNudge extends React.Component {
 		if ( this.isEligibleForOneClickUpsell( buttonAction ) ) {
 			this.setState( {
 				showPurchaseModal: true,
+			} );
+			const storedCard = this.props.cards[ 0 ];
+			const countryCode = extractStoredCardMetaValue( storedCard, 'country_code' );
+			const postalCode = extractStoredCardMetaValue( storedCard, 'card_zip' );
+			this.props.shoppingCartManager.updateLocation( {
+				countryCode,
+				postalCode,
+				subdivisionCode: null,
 			} );
 			this.props.shoppingCartManager.replaceProductsInCart( [ this.props.product ] );
 			return;

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -293,6 +293,7 @@ export class UpsellNudge extends React.Component {
 				cart={ this.props.cart }
 				cards={ this.props.cards }
 				onClose={ () => this.setState( { showPurchaseModal: false } ) }
+				siteId={ this.props.selectedSiteId }
 				siteSlug={ this.props.siteSlug }
 				isCartUpdating={ isCartUpdating }
 			/>

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -44,6 +44,7 @@ import Gridicon from 'calypso/components/gridicon';
 import { isMonthly } from 'calypso/lib/plans/constants';
 import { getPlanByPathSlug } from 'calypso/lib/plans';
 import { isFetchingStoredCards, getStoredCards } from 'calypso/state/stored-cards/selectors';
+import { withPaymentCompleteCallback } from 'calypso/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback';
 
 /**
  * Style dependencies
@@ -230,7 +231,10 @@ export class UpsellNudge extends React.Component {
 		const { trackUpsellButtonClick, upsellType } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
-		handleCheckoutCompleteRedirect( shouldHideUpsellNudges );
+		this.props.paymentCompleteCallback( {
+			paymentMethodId: null,
+			transactionLastResponse: { isComingFromUpsell: shouldHideUpsellNudges },
+		} );
 	};
 
 	handleClickAccept = ( buttonAction ) => {
@@ -357,4 +361,4 @@ export default connect(
 	{
 		trackUpsellButtonClick,
 	}
-)( withShoppingCart( localize( UpsellNudge ) ) );
+)( withShoppingCart( withPaymentCompleteCallback( localize( UpsellNudge ) ) ) );

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -84,7 +84,6 @@ export class UpsellNudge extends React.Component {
 		cards: PropTypes.arrayOf( PropTypes.object ),
 		cart: PropTypes.object,
 		isFetchingStoredCards: PropTypes.bool,
-		handleCheckoutCompleteRedirect: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -228,7 +227,7 @@ export class UpsellNudge extends React.Component {
 	}
 
 	handleClickDecline = ( shouldHideUpsellNudges = true ) => {
-		const { trackUpsellButtonClick, upsellType, handleCheckoutCompleteRedirect } = this.props;
+		const { trackUpsellButtonClick, upsellType } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
 		handleCheckoutCompleteRedirect( shouldHideUpsellNudges );
@@ -274,10 +273,6 @@ export class UpsellNudge extends React.Component {
 		return true;
 	};
 
-	handleOneClickUpsellComplete = () => {
-		this.props.handleCheckoutCompleteRedirect( true );
-	};
-
 	renderPurchaseModal = () => {
 		const isCartUpdating = this.props.shoppingCartManager.isPendingUpdate;
 
@@ -285,7 +280,6 @@ export class UpsellNudge extends React.Component {
 			<PurchaseModal
 				cart={ this.props.cart }
 				cards={ this.props.cards }
-				onComplete={ this.handleOneClickUpsellComplete }
 				onClose={ () => this.setState( { showPurchaseModal: false } ) }
 				siteSlug={ this.props.siteSlug }
 				isCartUpdating={ isCartUpdating }

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -60,6 +60,29 @@ export const BUSINESS_PLAN_UPGRADE_UPSELL = 'business-plan-upgrade-upsell';
 export class UpsellNudge extends React.Component {
 	static propTypes = {
 		receiptId: PropTypes.number,
+		upsellType: PropTypes.string,
+		upgradeItem: PropTypes.string,
+		siteSlugParam: PropTypes.string,
+
+		// Below are provided by HOCs
+		currencyCode: PropTypes.string,
+		isLoading: PropTypes.bool,
+		hasProductsList: PropTypes.bool,
+		hasSitePlans: PropTypes.bool,
+		product: PropTypes.object,
+		productCost: PropTypes.number,
+		productDisplayCost: PropTypes.string,
+		planRawPrice: PropTypes.string,
+		planDiscountedRawPrice: PropTypes.string,
+		isLoggedIn: PropTypes.bool,
+		siteSlug: PropTypes.string,
+		selectedSiteId: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
+		hasSevenDayRefundPeriod: PropTypes.bool,
+		trackUpsellButtonClick: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+		cards: PropTypes.arrayOf( PropTypes.object ),
+		cart: PropTypes.object,
+		isFetchingStoredCards: PropTypes.bool,
 		handleCheckoutCompleteRedirect: PropTypes.func.isRequired,
 	};
 

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -13,6 +13,7 @@ import { withShoppingCart, createRequestCartProduct } from '@automattic/shopping
  */
 import Main from 'calypso/components/main';
 import QuerySites from 'calypso/components/data/query-sites';
+import QueryStoredCards from 'calypso/components/data/query-stored-cards';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import { CompactCard } from '@automattic/components';
@@ -97,6 +98,7 @@ export class UpsellNudge extends React.Component {
 		return (
 			<Main className={ upsellType }>
 				<QuerySites siteId={ selectedSiteId } />
+				<QueryStoredCards />
 				{ ! hasProductsList && <QueryProductsList /> }
 				{ ! hasSitePlans && <QuerySitePlans siteId={ selectedSiteId } /> }
 				{ isLoading ? this.renderPlaceholders() : this.renderContent() }

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -44,6 +44,7 @@ import { replaceCartWithItems } from 'calypso/lib/cart/actions';
 import Gridicon from 'calypso/components/gridicon';
 import { isMonthly } from 'calypso/lib/plans/constants';
 import { getPlanByPathSlug } from 'calypso/lib/plans';
+import { isFetchingStoredCards, getStoredCards } from 'calypso/state/stored-cards/selectors';
 
 /**
  * Style dependencies
@@ -338,13 +339,16 @@ export default connect(
 		const annualPrice = getSitePlanRawPrice( state, selectedSiteId, planSlug, {
 			isMonthly: false,
 		} );
+		const isFetchingCards = isFetchingStoredCards( state );
 
 		const productSlug = resolveProductSlug( upsellType, upgradeItem );
 
 		return {
+			isFetchingStoredCards: isFetchingCards,
+			cards: getStoredCards( state ),
 			currencyCode: getCurrentUserCurrencyCode( state ),
 			isLoading:
-				props.isFetchingStoredCards ||
+				isFetchingCards ||
 				isProductsListFetching( state ) ||
 				isRequestingSitePlans( state, selectedSiteId ),
 			hasProductsList: Object.keys( productsList ).length > 0,

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -299,12 +299,17 @@ export class UpsellNudge extends React.Component {
 	renderPurchaseModal = () => {
 		const isCartUpdating = this.props.shoppingCartManager.isPendingUpdate;
 
+		const onCloseModal = () => {
+			this.props.shoppingCartManager.replaceProductsInCart( [] );
+			this.setState( { showPurchaseModal: false } );
+		};
+
 		return (
 			<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration }>
 				<PurchaseModal
 					cart={ this.props.cart }
 					cards={ this.props.cards }
-					onClose={ () => this.setState( { showPurchaseModal: false } ) }
+					onClose={ onCloseModal }
 					siteId={ this.props.selectedSiteId }
 					siteSlug={ this.props.siteSlug }
 					isCartUpdating={ isCartUpdating }

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -40,7 +40,7 @@ import { ConciergeSupportSession } from './concierge-support-session';
 import { BusinessPlanUpgradeUpsell } from './business-plan-upgrade-upsell';
 import { PremiumPlanUpgradeUpsell } from './premium-plan-upgrade-upsell';
 import getUpgradePlanSlugFromPath from 'calypso/state/selectors/get-upgrade-plan-slug-from-path';
-import { PurchaseModal } from './purchase-modal';
+import PurchaseModal from './purchase-modal';
 import Gridicon from 'calypso/components/gridicon';
 import { isMonthly } from 'calypso/lib/plans/constants';
 import { getPlanByPathSlug } from 'calypso/lib/plans';

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -263,8 +263,11 @@ export class UpsellNudge extends React.Component {
 	};
 
 	isEligibleForOneClickUpsell = ( buttonAction ) => {
-		const { cards, siteSlug, upsellType } = this.props;
+		const { product, cards, siteSlug, upsellType } = this.props;
 		const supportedUpsellTypes = [ 'concierge-quickstart-session', 'premium-plan-upgrade-upsell' ];
+		if ( ! product ) {
+			return false;
+		}
 
 		if ( 'accept' !== buttonAction || ! supportedUpsellTypes.includes( upsellType ) ) {
 			return false;
@@ -337,8 +340,15 @@ export default connect(
 			isMonthly: false,
 		} );
 		const isFetchingCards = isFetchingStoredCards( state );
-
 		const productSlug = resolveProductSlug( upsellType, upgradeItem );
+		const productProperties = pick( getProductBySlug( state, productSlug ), [
+			'product_slug',
+			'product_id',
+		] );
+		const product =
+			productProperties.product_slug && productProperties.product_id
+				? createRequestCartProduct( productProperties )
+				: null;
 
 		return {
 			isFetchingStoredCards: isFetchingCards,
@@ -350,9 +360,7 @@ export default connect(
 				isRequestingSitePlans( state, selectedSiteId ),
 			hasProductsList: Object.keys( productsList ).length > 0,
 			hasSitePlans: sitePlans && sitePlans.length > 0,
-			product: createRequestCartProduct(
-				pick( getProductBySlug( state, productSlug ), [ 'product_slug', 'product_id' ] )
-			),
+			product,
 			productCost: getProductCost( state, productSlug ),
 			productDisplayCost: getProductDisplayCost( state, productSlug ),
 			planRawPrice: annualPrice,

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
@@ -33,9 +33,6 @@ export function PurchaseModal( { cart, cards, isCartUpdating, onClose, siteSlug 
 		onClose,
 		successMessage: translate( 'Your purchase has been completed!' ),
 	} );
-	const onComplete = useCreatePaymentCompleteCallback( {
-		isComingFromUpsell: true,
-	} );
 	const contentProps = {
 		cards,
 		cart,
@@ -46,19 +43,26 @@ export function PurchaseModal( { cart, cards, isCartUpdating, onClose, siteSlug 
 	};
 
 	return (
+		<Dialog isVisible={ true } baseClassName="purchase-modal dialog" onClose={ onClose }>
+			{ isCartUpdating ? <Placeholder /> : <Content { ...contentProps } /> }
+		</Dialog>
+	);
+}
+
+export default function PurchaseModalWrapper( props ) {
+	const onComplete = useCreatePaymentCompleteCallback( {
+		isComingFromUpsell: true,
+	} );
+	return (
 		<CheckoutProvider
-			paymentMethods={ {
-				'existing-card': existingCardProcessor,
-			} }
+			paymentMethods={ [] }
 			onPaymentComplete={ onComplete }
 			showErrorMessage={ noop }
 			showInfoMessage={ noop }
 			showSuccessMessage={ noop }
-			paymentProcessors={ noop }
+			paymentProcessors={ { 'existing-card': existingCardProcessor } }
 		>
-			<Dialog isVisible={ true } baseClassName="purchase-modal dialog" onClose={ onClose }>
-				{ isCartUpdating ? <Placeholder /> : <Content { ...contentProps } /> }
-			</Dialog>
+			<PurchaseModal { ...props } />;
 		</CheckoutProvider>
 	);
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
@@ -1,10 +1,12 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
 import { Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { CheckoutProvider } from '@automattic/composite-checkout';
+import { useStripe } from '@automattic/calypso-stripe';
 
 /**
  * Internal dependencies
@@ -15,6 +17,7 @@ import Content from './content';
 import Placeholder from './placeholder';
 import useCreatePaymentCompleteCallback from 'calypso/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback';
 import existingCardProcessor from 'calypso/my-sites/checkout/composite-checkout/lib/existing-card-processor';
+import getContactDetailsType from 'calypso/my-sites/checkout/composite-checkout/lib/get-contact-details-type';
 
 /**
  * Style dependencies
@@ -23,11 +26,12 @@ import './style.scss';
 
 const noop = () => null;
 
-export function PurchaseModal( { cart, cards, isCartUpdating, onClose, siteSlug } ) {
+export function PurchaseModal( { cart, cards, isCartUpdating, onClose, siteSlug, siteId } ) {
 	const translate = useTranslate();
 	const [ step, setStep ] = useState( BEFORE_SUBMIT );
 	const submitTransaction = useSubmitTransaction( {
 		cart,
+		siteId,
 		setStep,
 		storedCard: cards?.[ 0 ],
 		onClose,
@@ -53,6 +57,24 @@ export default function PurchaseModalWrapper( props ) {
 	const onComplete = useCreatePaymentCompleteCallback( {
 		isComingFromUpsell: true,
 	} );
+	const { stripeConfiguration } = useStripe();
+	const reduxDispatch = useDispatch();
+
+	const contactDetailsType = getContactDetailsType( props.cart );
+	const includeDomainDetails = contactDetailsType === 'domain';
+	const includeGSuiteDetails = contactDetailsType === 'gsuite';
+	const dataForProcessor = useMemo(
+		() => ( {
+			includeDomainDetails,
+			includeGSuiteDetails,
+			recordEvent: noop,
+			stripeConfiguration,
+			createUserAndSiteBeforeTransaction: false,
+			reduxDispatch,
+		} ),
+		[ includeDomainDetails, includeGSuiteDetails, stripeConfiguration, reduxDispatch ]
+	);
+
 	return (
 		<CheckoutProvider
 			paymentMethods={ [] }
@@ -60,7 +82,10 @@ export default function PurchaseModalWrapper( props ) {
 			showErrorMessage={ noop }
 			showInfoMessage={ noop }
 			showSuccessMessage={ noop }
-			paymentProcessors={ { 'existing-card': existingCardProcessor } }
+			paymentProcessors={ {
+				'existing-card': ( transactionData ) =>
+					existingCardProcessor( transactionData, dataForProcessor ),
+			} }
 		>
 			<PurchaseModal { ...props } />;
 		</CheckoutProvider>

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
@@ -29,6 +29,7 @@ export function useSubmitTransaction( {
 		const wpcomCart = translateResponseCartToWPCOMCart( cart );
 		const countryCode = extractStoredCardMetaValue( storedCard, 'country_code' );
 		const postalCode = extractStoredCardMetaValue( storedCard, 'card_zip' );
+		setStep( 'processing' );
 		callPaymentProcessor( 'existing-card', {
 			items: wpcomCart.items,
 			name: storedCard.name,
@@ -40,7 +41,6 @@ export function useSubmitTransaction( {
 			siteId: siteId ? String( siteId ) : undefined,
 		} )
 			.then( () => {
-				setStep( name );
 				notices.success( successMessage, {
 					persistent: true,
 				} );

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
@@ -2,43 +2,14 @@
  * External dependencies
  */
 import { useCallback } from 'react';
-import { find, pick } from 'lodash';
+import { useProcessPayment } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
  */
-import { RECEIVED_WPCOM_RESPONSE } from 'calypso/lib/store-transactions/step-types';
-import { preprocessCartForServer } from 'calypso/lib/cart-values';
-import { submit } from 'calypso/lib/store-transactions';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import notices from 'calypso/notices';
-
-function extractStoredCardMetaValue( card, key ) {
-	return find( card.meta, [ 'meta_key', key ] )?.meta_value;
-}
-
-function generateTransactionData( cart, storedCard ) {
-	const countryCode = extractStoredCardMetaValue( storedCard, 'country_code' );
-	const postalCode = extractStoredCardMetaValue( storedCard, 'card_zip' );
-
-	return {
-		cart: {
-			...pick( cart, [ 'blog_id', 'cart_key' ] ),
-			...preprocessCartForServer( cart ),
-			create_new_blog: false,
-		},
-		domainDetails: null,
-		payment: {
-			paymentMethod: 'WPCOM_Billing_MoneyPress_Stored',
-			storedCard,
-			name: storedCard.name,
-			country: countryCode,
-			country_code: countryCode,
-			postal_code: postalCode,
-			zip: postalCode,
-		},
-	};
-}
+import { translateResponseCartToWPCOMCart } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-cart';
 
 export function useSubmitTransaction( {
 	cart,
@@ -48,30 +19,34 @@ export function useSubmitTransaction( {
 	onComplete,
 	successMessage,
 } ) {
+	const callPaymentProcessor = useProcessPayment();
+
 	return useCallback( () => {
-		const transactionData = generateTransactionData( cart, storedCard );
-		submit( transactionData, ( { name, data, error } ) => {
-			if ( error ) {
+		const wpcomCart = translateResponseCartToWPCOMCart( cart );
+		callPaymentProcessor( 'existing-card', {
+			items: wpcomCart.items,
+			name: storedCard.name,
+			storedDetailsId: storedCard.stored_details_id,
+			paymentMethodToken: storedCard.mp_ref,
+			paymentPartnerProcessorId: storedCard.payment_partner,
+		} )
+			.then( () => {
+				setStep( name );
+				notices.success( successMessage, {
+					persistent: true,
+				} );
+				recordTracksEvent( 'calypso_oneclick_upsell_payment_success', {} );
+				onComplete?.();
+			} )
+			.catch( ( error ) => {
 				recordTracksEvent( 'calypso_oneclick_upsell_payment_error', {
 					error_code: error.code || error.error,
 					reason: error.message,
 				} );
 				notices.error( error.message );
 				onClose();
-				return;
-			}
-
-			setStep( name );
-
-			if ( RECEIVED_WPCOM_RESPONSE === name && data && ! error ) {
-				notices.success( successMessage, {
-					persistent: true,
-				} );
-				recordTracksEvent( 'calypso_oneclick_upsell_payment_success', {} );
-				onComplete?.();
-			}
-		} );
-	}, [ cart, storedCard, setStep, onClose, onComplete, successMessage ] );
+			} );
+	}, [ callPaymentProcessor, cart, storedCard, setStep, onClose, onComplete, successMessage ] );
 }
 
 export function formatDate( cardExpiry ) {

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
@@ -11,14 +11,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import notices from 'calypso/notices';
 import { translateResponseCartToWPCOMCart } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-cart';
 
-export function useSubmitTransaction( {
-	cart,
-	storedCard,
-	setStep,
-	onClose,
-	onComplete,
-	successMessage,
-} ) {
+export function useSubmitTransaction( { cart, storedCard, setStep, onClose, successMessage } ) {
 	const callPaymentProcessor = useProcessPayment();
 
 	return useCallback( () => {
@@ -36,7 +29,6 @@ export function useSubmitTransaction( {
 					persistent: true,
 				} );
 				recordTracksEvent( 'calypso_oneclick_upsell_payment_success', {} );
-				onComplete?.();
 			} )
 			.catch( ( error ) => {
 				recordTracksEvent( 'calypso_oneclick_upsell_payment_error', {
@@ -46,7 +38,7 @@ export function useSubmitTransaction( {
 				notices.error( error.message );
 				onClose();
 			} );
-	}, [ callPaymentProcessor, cart, storedCard, setStep, onClose, onComplete, successMessage ] );
+	}, [ callPaymentProcessor, cart, storedCard, setStep, onClose, successMessage ] );
 }
 
 export function formatDate( cardExpiry ) {

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
@@ -11,7 +11,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import notices from 'calypso/notices';
 import { translateResponseCartToWPCOMCart } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-cart';
 
-function extractStoredCardMetaValue( card, key ) {
+export function extractStoredCardMetaValue( card, key ) {
 	return card.meta?.find( ( meta ) => meta.meta_key === key )?.meta_value;
 }
 

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -24,12 +24,36 @@ import {
 	validateTotal,
 } from '../lib/validation';
 import TransactionStatusHandler from './transaction-status-handler';
-import { CheckoutProviderProps, FormStatus, PaymentMethod } from '../types';
+import { LineItem, CheckoutProviderProps, FormStatus, PaymentMethod } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout-provider' );
 
-export function CheckoutProvider( props: CheckoutProviderProps ): JSX.Element {
-	const {
+const emptyTotal: LineItem = {
+	id: 'total',
+	type: 'total',
+	amount: { value: 0, displayValue: '0', currency: 'USD' },
+	label: 'Total',
+};
+
+export function CheckoutProvider( {
+	total = emptyTotal,
+	items = [],
+	onPaymentComplete,
+	showErrorMessage,
+	showInfoMessage,
+	showSuccessMessage,
+	redirectToUrl,
+	theme,
+	paymentMethods,
+	paymentProcessors,
+	registry,
+	onEvent,
+	isLoading,
+	isValidating,
+	initiallySelectedPaymentMethodId = null,
+	children,
+}: CheckoutProviderProps ): JSX.Element {
+	const propsToValidate = {
 		total,
 		items,
 		onPaymentComplete,
@@ -45,8 +69,8 @@ export function CheckoutProvider( props: CheckoutProviderProps ): JSX.Element {
 		isLoading,
 		isValidating,
 		children,
-		initiallySelectedPaymentMethodId = null,
-	} = props;
+		initiallySelectedPaymentMethodId,
+	};
 	const [ paymentMethodId, setPaymentMethodId ] = useState< string | null >(
 		initiallySelectedPaymentMethodId
 	);
@@ -124,7 +148,7 @@ export function CheckoutProvider( props: CheckoutProviderProps ): JSX.Element {
 	);
 	return (
 		<CheckoutErrorBoundary errorMessage={ errorMessage } onError={ onError }>
-			<CheckoutProviderPropValidator propsToValidate={ props } />
+			<CheckoutProviderPropValidator propsToValidate={ propsToValidate } />
 			<ThemeProvider theme={ theme || defaultTheme }>
 				<RegistryProvider value={ registryRef.current }>
 					<LineItemsProvider items={ items } total={ total }>

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ThemeProvider } from 'emotion-theming';
 import debugFactory from 'debug';
 import { useI18n } from '@automattic/react-i18n';
@@ -28,7 +28,7 @@ import { CheckoutProviderProps, FormStatus, PaymentMethod } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout-provider' );
 
-export const CheckoutProvider: FunctionComponent< CheckoutProviderProps > = ( props ) => {
+export function CheckoutProvider( props: CheckoutProviderProps ): JSX.Element {
 	const {
 		total,
 		items,
@@ -137,7 +137,7 @@ export const CheckoutProvider: FunctionComponent< CheckoutProviderProps > = ( pr
 			</ThemeProvider>
 		</CheckoutErrorBoundary>
 	);
-};
+}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noop(): void {}

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -82,13 +82,13 @@ export type ReactStandardAction< T = string, P = unknown > = P extends void
 export interface CheckoutProviderProps {
 	theme?: Theme;
 	registry?: DataRegistry;
-	total: LineItem;
-	items: LineItem[];
+	total?: LineItem;
+	items?: LineItem[];
 	paymentMethods: PaymentMethod[];
 	onPaymentComplete: PaymentCompleteCallback;
-	showErrorMessage: ( message: string ) => void;
-	showInfoMessage: ( message: string ) => void;
-	showSuccessMessage: ( message: string ) => void;
+	showErrorMessage: ShowNoticeFunction;
+	showInfoMessage: ShowNoticeFunction;
+	showSuccessMessage: ShowNoticeFunction;
 	onEvent?: ( event: ReactStandardAction ) => void;
 	isLoading?: boolean;
 	redirectToUrl?: ( url: string ) => void;
@@ -97,6 +97,8 @@ export interface CheckoutProviderProps {
 	initiallySelectedPaymentMethodId?: string | null;
 	children: React.ReactNode;
 }
+
+export type ShowNoticeFunction = ( message: string ) => void;
 
 export interface PaymentProcessorProp {
 	[ key: string ]: PaymentProcessorFunction;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -95,6 +95,7 @@ export interface CheckoutProviderProps {
 	paymentProcessors: PaymentProcessorProp;
 	isValidating?: boolean;
 	initiallySelectedPaymentMethodId?: string | null;
+	children: React.ReactNode;
 }
 
 export interface PaymentProcessorProp {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is the same changes as proposed in #48152 but without the dependencies merged in. That is, **this branch won't work** until https://github.com/Automattic/wp-calypso/pull/48283 and https://github.com/Automattic/wp-calypso/pull/48069 are merged. If you want to try them all together, check out #48152.  After they are merged, one or the other of these PRs should be closed and the other rebased. This is just here to make it easier to review the code while those PRs are pending.

#### Testing instructions

None. This won't work.