### PR TITLE
Domains: Wrap DomainSearch in withShoppingCart

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
+import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -273,4 +274,4 @@ export default connect(
 		recordAddDomainButtonClick,
 		recordRemoveDomainButtonClick,
 	}
-)( localize( DomainSearch ) );
+)( withShoppingCart( localize( DomainSearch ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/47605 we updated PopoverCart to replace the deprecated `CartData` wrapper with `ShoppingCartProvider` within the domains management components, but there was a regression on `DomainSearch`.

The `DomainSearch` component, which uses the `cart` prop, was not wrapped in `withShoppingCart`, meaning that its `cart` prop was effectively removed by the changes in https://github.com/Automattic/wp-calypso/pull/47605. This PR adds that wrapper, restoring the prop.

The missing prop in `DomainSearch` (and specifically `RegisterDomainStep`) appears to have had only a subtle effect on the page. It's hard to tell what might not be working, but there are a few obvious things. Notably, there is various logic meant to cause different behavior for when the cart already contains a domain.

As an example, after adding a domain suggestion to your cart, without the `cart` prop the button will still allow adding that domain again (although the shopping cart endpoint will not allow duplicate products so you'll still end up with only one).

Before:

<img width="499" alt="Screen Shot 2020-12-11 at 10 02 03 PM" src="https://user-images.githubusercontent.com/2036909/101971077-8ab75480-3bfc-11eb-9437-6a666cea435b.png">

After:

<img width="499" alt="Screen Shot 2020-12-11 at 10 00 30 PM" src="https://user-images.githubusercontent.com/2036909/101971080-8ee37200-3bfc-11eb-8859-91be85ca6e62.png">

(This is extracted from https://github.com/Automattic/wp-calypso/pull/48202 which completes converting the domain management pages.)

#### Testing instructions

- Visit the domain search page and add a domain to your cart from the list.
- With the domain still in your cart, return to the domain search page and try to add the same domain to your cart.
- Verify that the button reads "In cart" and that it is disabled.
