### PR TITLE
Add "WooCommerce" menu item for Business customers with WooCommerce plugin activated

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -29,7 +29,7 @@ import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QueryScanState from 'calypso/components/data/query-jetpack-scan';
 import ToolsMenu from './tools-menu';
-import { isEcommerce } from 'calypso/lib/products-values';
+import { isBusiness, isEcommerce } from 'calypso/lib/products-values';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import isJetpackSectionEnabledForSite from 'calypso/state/selectors/is-jetpack-section-enabled-for-site';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -698,18 +698,16 @@ export class MySitesSidebar extends Component {
 	woocommerce() {
 		const { site, siteSuffix, canUserUseStore } = this.props;
 
-		const calypsoStoreDeprecatedOrRemoved =
+		const isCalypsoStoreDeprecatedOrRemoved =
 			isEnabled( 'woocommerce/store-deprecated' ) || isEnabled( 'woocommerce/store-removed' );
 
 		if (
-			! calypsoStoreDeprecatedOrRemoved ||
 			! isEnabled( 'woocommerce/extension-dashboard' ) ||
-			! site
+			! isCalypsoStoreDeprecatedOrRemoved ||
+			! site ||
+			! isBusiness( site.plan ) ||
+			! canUserUseStore
 		) {
-			return null;
-		}
-
-		if ( ! canUserUseStore ) {
 			return null;
 		}
 

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -719,7 +719,6 @@ export class MySitesSidebar extends Component {
 				link={ storeLink }
 				onNavigate={ this.trackWooCommerceClick }
 				materialIcon="shopping_cart"
-				forceInternalLink
 			/>
 		);
 	}

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -696,7 +696,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	woocommerce() {
-		const { site, siteSuffix, canUserUseStore } = this.props;
+		const { site, canUserUseStore } = this.props;
 
 		const isCalypsoStoreDeprecatedOrRemoved =
 			isEnabled( 'woocommerce/store-deprecated' ) || isEnabled( 'woocommerce/store-removed' );
@@ -711,10 +711,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		let storeLink = '/store' + siteSuffix;
-		if ( isEcommerce( site.plan ) ) {
-			storeLink = site.options.admin_url + 'admin.php?page=wc-admin&calypsoify=1';
-		}
+		const storeLink = site.options.admin_url + 'admin.php?page=wc-admin';
 
 		return (
 			<SidebarItem

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -689,6 +689,46 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
+	trackWooCommerceClick = () => {
+		this.trackMenuItemClick( 'woocommerce' );
+		this.props.recordTracksEvent( 'calypso_woocommerce_store_woo_core_item_click' );
+		this.onNavigate();
+	};
+
+	woocommerce() {
+		const { site, siteSuffix, canUserUseStore } = this.props;
+
+		const calypsoStoreDeprecatedOrRemoved =
+			isEnabled( 'woocommerce/store-deprecated' ) || isEnabled( 'woocommerce/store-removed' );
+
+		if (
+			! calypsoStoreDeprecatedOrRemoved ||
+			! isEnabled( 'woocommerce/extension-dashboard' ) ||
+			! site
+		) {
+			return null;
+		}
+
+		if ( ! canUserUseStore ) {
+			return null;
+		}
+
+		let storeLink = '/store' + siteSuffix;
+		if ( isEcommerce( site.plan ) ) {
+			storeLink = site.options.admin_url + 'admin.php?page=wc-admin&calypsoify=1';
+		}
+
+		return (
+			<SidebarItem
+				label="WooCommerce"
+				link={ storeLink }
+				onNavigate={ this.trackWooCommerceClick }
+				materialIcon="shopping_cart"
+				forceInternalLink
+			/>
+		);
+	}
+
 	trackMenuItemClick = ( menuItemName ) => {
 		this.props.recordTracksEvent(
 			'calypso_mysites_sidebar_' + menuItemName.replace( /-/g, '_' ) + '_clicked'
@@ -941,6 +981,7 @@ export class MySitesSidebar extends Component {
 					{ this.stats() }
 					{ this.planMenu() }
 					{ this.store() }
+					{ this.woocommerce() }
 				</SidebarMenu>
 
 				{ this.props.siteId && <QuerySiteChecklist siteId={ this.props.siteId } /> }

--- a/config/development.json
+++ b/config/development.json
@@ -212,6 +212,8 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/onboarding-oauth": true,
+		"woocommerce/store-deprecated": false,
+		"woocommerce/store-removed": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	}


### PR DESCRIPTION
_This PR is part of the [Sunset Store on the Business Plan epic](https://github.com/woocommerce/woocommerce-admin/issues/5816), which will replace the existing limited Calypso-based Store experience with the full WooCommerce experience._

#### Changes proposed in this Pull Request

<img width="1077" alt="Screen Shot 2020-12-13 at 09 16 29" src="https://user-images.githubusercontent.com/2098816/102014682-365bc400-3d25-11eb-9c41-2883f96a96f3.png">

* Adds a "WooCommerce" menu item to the Calypso sidebar
* Clicking on this menu item brings the user to the full WooCommerce Core experience in wp-admin (without Calypsoify-ing the UI)
* This "WooCommerce" menu item should appear only for sites with a Business plan that have the WooCommerce plugin installed.
* It is behind the feature flags `woocommerce/store-deprecated` and `woocommerce/store-removed` -- if either of those flags are enabled, the feature is eligible to be shown (if the criteria above is met). If the feature flags are not enabled, the menu item will never be shown (so, no change to the existing experience).
* Any changes to the existing "Store" menu item in the sidebar as part of the larger epic will be handled in separate issues/PRs.

#### Testing instructions

##### Verify that with the feature flags disabled, the experience is not modified

* Run branch with the feature flags disabled (the default)
* Verify that the existing experience is not modified at all

##### Verify that with the feature flag enabled, the experience is modified

* Run branch with the `woocommerce/store-deprecated` enabled

```
ENABLE_FEATURES=woocommerce/store-deprecated yarn start
```

or, by appending the following to your URL: 

```
/?flags=woocommerce/store-deprecated
```

* Verify that the "WooCommerce" menu item does not appear for a site with the Personal plan
* Verify that the "WooCommerce" menu item does not appear for a site with the eCommerce plan

* Verify that the "WooCommerce" menu item does not appear for a site with the Business plan without the WooCommerce plugin installed and activated

* Verify that the "WooCommerce" menu item appears for a site with the Business plan with the WooCommerce plugin activated

##### Verify that clicking the menu item works properly 

You can see Tracks events in the browser developer console by enabling debugging:
```
localStorage.setItem( 'debug', 'calypso:analytics*' )
```

* Verify that clicking on the "WooCommerce" menu item triggers the logging of the `calypso_woocommerce_store_woo_core_item_click` Tracks event
* Verify that clicking on the "WooCommerce" menu item goes to the full WooCommerce Core experience in wp-admin, without Calypsoify (`/wp-admin/admin.php?page=wc-admin`)

Fixes #48027
