### PR TITLE
Update the test data to use subdir instead of subdomain for 11 locales

### DIFF
--- a/test/e2e/localization-data.json
+++ b/test/e2e/localization-data.json
@@ -21,7 +21,7 @@
 		"currency_symbol": "€",
 		"nux_landing_page_string": "Schritt",
 		"wpcom_landing_page_string": "Anmelden",
-		"wpcom_base_url": "de.wordpress.com",
+		"wpcom_base_url": "wordpress.com/de",
 
 		"google_searches": [
 			{
@@ -61,7 +61,7 @@
 		"currency_symbol": "€",
 		"nux_landing_page_string": "Paso",
 		"wpcom_landing_page_string": "Acceder",
-		"wpcom_base_url": "es.wordpress.com",
+		"wpcom_base_url": "wordpress.com/es",
 
 		"google_searches": [
 			{
@@ -78,7 +78,7 @@
 		"currency_symbol": "€",
 		"nux_landing_page_string": "Étape",
 		"wpcom_landing_page_string": "Se Connecter",
-		"wpcom_base_url": "fr.wordpress.com",
+		"wpcom_base_url": "wordpress.com/fr",
 
 		"google_searches": [
 			{
@@ -112,7 +112,7 @@
 		"currency_symbol": "$",
 		"nux_landing_page_string": "Langkah",
 		"wpcom_landing_page_string": "Log Masuk",
-		"wpcom_base_url": "id.wordpress.com",
+		"wpcom_base_url": "wordpress.com/id",
 
 		"google_searches": [
 			{
@@ -129,7 +129,7 @@
 		"currency_symbol": "€",
 		"nux_landing_page_string": "Passaggio",
 		"wpcom_landing_page_string": "Accedi",
-		"wpcom_base_url": "it.wordpress.com",
+		"wpcom_base_url": "wordpress.com/it",
 
 		"google_searches": [
 			{
@@ -146,7 +146,7 @@
 		"currency_symbol": "¥",
 		"nux_landing_page_string": "ステップ",
 		"wpcom_landing_page_string": "ログイン",
-		"wpcom_base_url": "ja.wordpress.com",
+		"wpcom_base_url": "wordpress.com/ja",
 
 		"google_searches": [
 			{
@@ -180,7 +180,7 @@
 		"currency_symbol": "€",
 		"nux_landing_page_string": "Stap",
 		"wpcom_landing_page_string": "Inloggen",
-		"wpcom_base_url": "nl.wordpress.com",
+		"wpcom_base_url": "wordpress.com/nl",
 
 		"google_searches": [
 			{
@@ -214,7 +214,7 @@
 		"currency_symbol": "$",
 		"nux_landing_page_string": "Шаг",
 		"wpcom_landing_page_string": "Войти",
-		"wpcom_base_url": "ru.wordpress.com",
+		"wpcom_base_url": "wordpress.com/ru",
 
 		"google_searches": [
 			{
@@ -248,7 +248,7 @@
 		"currency_symbol": "$",
 		"nux_landing_page_string": "başlayalım",
 		"wpcom_landing_page_string": "Giriş",
-		"wpcom_base_url": "tr.wordpress.com",
+		"wpcom_base_url": "wordpress.com/tr",
 
 		"google_searches": [
 			{
@@ -265,7 +265,7 @@
 		"currency_symbol": "$",
 		"nux_landing_page_string": "步",
 		"wpcom_landing_page_string": "登录",
-		"wpcom_base_url": "zh-cn.wordpress.com",
+		"wpcom_base_url": "wordpress.com/zh-cn",
 
 		"google_searches": [
 			{
@@ -282,7 +282,7 @@
 		"currency_symbol": "$",
 		"nux_landing_page_string": "步",
 		"wpcom_landing_page_string": "登入",
-		"wpcom_base_url": "zh-tw.wordpress.com",
+		"wpcom_base_url": "wordpress.com/zh-tw",
 
 		"google_searches": [
 			{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With the introduction of subdirs for locales instead of subdomains and fully enabling additional eleven locales, the e2e tests should be updated to use wordpress.com/[locale] instead of [locale].wordpress.com .

#### Testing instructions

1. Follow the steps at https://github.com/Automattic/wp-calypso/blob/master/test/e2e/README.md and https://github.com/Automattic/wp-calypso/blob/master/test/e2e/docs/running-tests.md#getting-started to prepare for running e2e tests locally
2. Within local Calypso instance `cd test/e2e` and run `./run.sh -I`
3. Confirm that all `logged-out-redirect-i18n-spec.js e2e test (should redirect to the correct url for wordpress.com ([locale]))` have passed successfully
