### PR TITLE
Prepare @automattic/webpack-rtl-plugin to release 3.0.0

### DIFF
--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -35,7 +35,7 @@
 	],
 	"dependencies": {
 		"@automattic/mini-css-extract-plugin-with-rtl": "^0.8.0",
-		"@automattic/webpack-rtl-plugin": "^2.0.0",
+		"@automattic/webpack-rtl-plugin": "^3.0.0",
 		"@babel/cli": "^7.12.1",
 		"@babel/compat-data": "^7.12.5",
 		"@babel/core": "^7.12.3",

--- a/packages/webpack-rtl-plugin/CHANGELOG.md
+++ b/packages/webpack-rtl-plugin/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## 3.0.0 - 2020-12-11
+
+Initial publication after the fork.

--- a/packages/webpack-rtl-plugin/package.json
+++ b/packages/webpack-rtl-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/webpack-rtl-plugin",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"description": "Webpack plugin to produce a rtl css bundle.",
 	"main": "src/index.js",
 	"author": "Automattic Inc.",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a CHANGELOG to `@automattic/webpack-rtl-plugin`
* Prepare for doing an initial release after the fork.

#### Notes

I bumped it from `2.0.0` to `3.0.0` because apparently 2.0.0 was already released:

```
npm ERR! code E400
npm ERR! 400 Bad Request - PUT https://registry.npmjs.org/@automattic%2fwebpack-rtl-plugin - Cannot publish over previously published version "2.0.0".
```
(maybe from https://github.com/Automattic/webpack-rtl-plugin ? )