### PR TITLE
Importers: improve and enhance API interaction unit tests

### DIFF
--- a/client/lib/importer/common.js
+++ b/client/lib/importer/common.js
@@ -80,7 +80,7 @@ export function fromApi( state ) {
 		importerState: apiToAppState( importStatus ),
 		type: `importer-type-${ type }`,
 		progress,
-		customData: generateSourceAuthorIds( customData ),
+		...( customData && { customData: generateSourceAuthorIds( customData ) } ),
 		site: { ID: siteId },
 		errorData,
 	};

--- a/client/lib/importer/test/api-interaction.js
+++ b/client/lib/importer/test/api-interaction.js
@@ -20,7 +20,9 @@ const resetStore = () => Dispatcher.handleViewAction( { type: IMPORTS_STORE_RESE
 const queuePayload = ( payload ) =>
 	nock( 'https://public-api.wordpress.com:443' )
 		.get( `/rest/v1.1/sites/${ testSiteId }/imports/` )
-		.replyWithFile( 200, `${ __dirname }/api-payloads/${ payload }.json` );
+		.replyWithFile( 200, `${ __dirname }/api-payloads/${ payload }.json`, {
+			'Content-Type': 'application/json',
+		} );
 
 describe( 'Importer store', () => {
 	beforeEach( resetStore );

--- a/client/lib/importer/test/api-interaction.js
+++ b/client/lib/importer/test/api-interaction.js
@@ -10,6 +10,7 @@ import { fetchState } from '../actions';
 import store from '../store';
 import Dispatcher from 'calypso/dispatcher';
 import { IMPORTS_STORE_RESET } from 'calypso/state/action-types';
+import { appStates } from 'calypso/state/imports/constants';
 
 const testSiteId = 'en.blog.wordpress.com';
 const hydratedState = () => store.get().api.isHydrated;
@@ -39,6 +40,15 @@ describe( 'Importer store', () => {
 			await fetchState( testSiteId );
 			expect( hydratedState() ).toBe( true );
 			expect( importersState() ).toEqual( {} );
+		} );
+
+		test( 'should hydrate if the API returns a running importer', async () => {
+			const testImporterId = 'runningImporter';
+			expect( hydratedState() ).toBe( false );
+			queuePayload( 'running-importer' );
+			await fetchState( testSiteId );
+			expect( hydratedState() ).toBe( true );
+			expect( importersState()[ testImporterId ]?.importerState ).toBe( appStates.IMPORTING );
 		} );
 	} );
 } );

--- a/client/lib/importer/test/api-interaction.js
+++ b/client/lib/importer/test/api-interaction.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-import { get, partial } from 'lodash';
+import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -11,11 +10,9 @@ import { fetchState } from '../actions';
 import store from '../store';
 import Dispatcher from 'calypso/dispatcher';
 import { IMPORTS_STORE_RESET } from 'calypso/state/action-types';
-import { nock, useNock } from 'calypso/test-helpers/use-nock';
 
 const testSiteId = 'en.blog.wordpress.com';
-const fetchTestState = partial( fetchState, testSiteId );
-const hydratedState = () => get( store.get(), [ 'api', 'isHydrated' ] );
+const hydratedState = () => store.get().api.isHydrated;
 const resetStore = () => Dispatcher.handleViewAction( { type: IMPORTS_STORE_RESET } );
 
 const queuePayload = ( payload ) =>
@@ -24,37 +21,21 @@ const queuePayload = ( payload ) =>
 		.replyWithFile( 200, `${ __dirname }/api-payloads/${ payload }.json` );
 
 describe( 'Importer store', () => {
-	useNock();
-
 	beforeEach( resetStore );
 
 	describe( 'API integration', () => {
-		test( 'should hydrate if the API returns a blank body', () => {
-			return new Promise( ( done ) => {
-				expect( hydratedState(), 'before fetch' ).to.be.false;
-
-				queuePayload( 'no-imports' );
-				fetchTestState()
-					.then( () => {
-						expect( hydratedState(), 'after fetch' ).to.be.true;
-					} )
-					.then( done )
-					.catch( done );
-			} );
+		test( 'should hydrate if the API returns a blank body', async () => {
+			expect( hydratedState() ).toBe( false );
+			queuePayload( 'no-imports' );
+			await fetchState( testSiteId );
+			expect( hydratedState() ).toBe( true );
 		} );
 
-		test( 'should hydrate if the API returns a defunct importer', () => {
-			return new Promise( ( done ) => {
-				expect( hydratedState(), 'before fetch' ).to.be.false;
-
-				queuePayload( 'defunct-importer' );
-				fetchTestState()
-					.then( () => {
-						expect( hydratedState(), 'after fetch' ).to.be.true;
-					} )
-					.then( done )
-					.catch( done );
-			} );
+		test( 'should hydrate if the API returns a defunct importer', async () => {
+			expect( hydratedState() ).toBe( false );
+			queuePayload( 'defunct-importer' );
+			await fetchState( testSiteId );
+			expect( hydratedState() ).toBe( true );
 		} );
 	} );
 } );

--- a/client/lib/importer/test/api-interaction.js
+++ b/client/lib/importer/test/api-interaction.js
@@ -13,6 +13,7 @@ import { IMPORTS_STORE_RESET } from 'calypso/state/action-types';
 
 const testSiteId = 'en.blog.wordpress.com';
 const hydratedState = () => store.get().api.isHydrated;
+const importersState = () => store.get().importers;
 const resetStore = () => Dispatcher.handleViewAction( { type: IMPORTS_STORE_RESET } );
 
 const queuePayload = ( payload ) =>
@@ -29,6 +30,7 @@ describe( 'Importer store', () => {
 			queuePayload( 'no-imports' );
 			await fetchState( testSiteId );
 			expect( hydratedState() ).toBe( true );
+			expect( importersState() ).toEqual( {} );
 		} );
 
 		test( 'should hydrate if the API returns a defunct importer', async () => {
@@ -36,6 +38,7 @@ describe( 'Importer store', () => {
 			queuePayload( 'defunct-importer' );
 			await fetchState( testSiteId );
 			expect( hydratedState() ).toBe( true );
+			expect( importersState() ).toEqual( {} );
 		} );
 	} );
 } );

--- a/client/lib/importer/test/api-payloads/running-importer.json
+++ b/client/lib/importer/test/api-payloads/running-importer.json
@@ -1,0 +1,6 @@
+{
+	"importId": "runningImporter",
+	"type": "wordpress",
+	"importStatus": "importing",
+	"siteId": 0
+}


### PR DESCRIPTION
A spinoff from #48213 that improves API interaction unit tests and fixes some bugs that the test uncovers.

The first commit refactors the `api-interaction` unit test without changing any behavior. Import and use `nock` directly rather than using the legacy `useNock` wrapper. Use Jest asserts instead of Chai. Use async function instead of manually creating and resolving a promise. Remove usage of Lodash `partial` and `get`.

The second commit adds a new check: after receiving empty state or state with ignored imports (defunct/stopped), check that the importers state is indeed an empty object.

The third commit adds a new test: receive a status of active importer (import running) and verify that it's received into state. This new test fails because the existing app and test code is buggy, in a way not detected by previous tests.

The fourth commit fixes the bugs that stop the new test from succeeding:
- add a `Content-Type: application/json` header to the `nock` response. Without it, the response JSON was never parsed and the response was always `{}`. Tests that test empty responses don't mind, but test for an active importer does.
- stop the `fromApi` function from crashing when `customData` field is missing from the response. The `TypeError` would be caught and ignored by the `apiFailure` handler and the response would never be received into state.
