### PR TITLE
P2 Invites: ensure 'links' from response is an array

### DIFF
--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -108,7 +108,7 @@ export const links = withSchemaValidation( inviteLinksSchema, ( state = {}, acti
 		case INVITES_REQUEST_SUCCESS: {
 			let inviteLinks = {};
 			const currentDate = moment();
-			action.links.forEach( ( link ) => {
+			Object.values( action.links ).forEach( ( link ) => {
 				// Do not process expired links
 				if ( link.expiry && currentDate.isAfter( link.expiry * 1000 ) ) {
 					return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Handle "not an array" error that happens when `links` from the API response is not zero-indexed.

#### Testing instructions

You will need a P2 with an admin user.
1. Visit Manage > People > Invite of any P2 site.
2. At the bottom of the page, you should see the Invite Links section.
3. Click `Generate new link` if the button is available. If not, you should see your set of invite links, one for each role.
4. Click `Disable invite link`. You should get the `Generate` button back.
5. Visit this same section for a P2 that has some expired links, e.g. private lighthouse P2
6. You should see a set of invite links, or be able to generate new ones.
