### PR TITLE
Reader Related Posts: remove lodash from reducer, refactor query component to hooks

### DIFF
--- a/client/components/data/query-reader-related-posts/index.jsx
+++ b/client/components/data/query-reader-related-posts/index.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -14,65 +12,24 @@ import { shouldFetchRelated } from 'calypso/state/reader/related-posts/selectors
 import { requestRelatedPosts } from 'calypso/state/reader/related-posts/actions';
 import { SCOPE_ALL, SCOPE_SAME, SCOPE_OTHER } from 'calypso/state/reader/related-posts/utils';
 
-class QueryReaderRelatedPosts extends Component {
-	UNSAFE_componentWillMount() {
-		if ( this.props.shouldFetch ) {
-			this.props.requestRelatedPosts( this.props.siteId, this.props.postId, this.props.scope );
-		}
+const request = ( siteId, postId, scope ) => ( dispatch, getState ) => {
+	if ( shouldFetchRelated( getState(), siteId, postId, scope ) ) {
+		dispatch( requestRelatedPosts( siteId, postId, scope ) );
 	}
+};
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if (
-			! nextProps.shouldFetch ||
-			( this.props.siteId === nextProps.siteId &&
-				this.props.postId === nextProps.postId &&
-				this.props.scope === nextProps.scope )
-		) {
-			return;
-		}
+export default function QueryReaderRelatedPosts( { siteId, postId, scope = SCOPE_ALL } ) {
+	const dispatch = useDispatch();
 
-		nextProps.requestRelatedPosts( nextProps.siteId, nextProps.postId, nextProps.scope );
-	}
+	useEffect( () => {
+		dispatch( request( siteId, postId, scope ) );
+	}, [ dispatch, siteId, postId, scope ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
 
 QueryReaderRelatedPosts.propTypes = {
 	siteId: PropTypes.number,
 	postId: PropTypes.number,
 	scope: PropTypes.oneOf( [ SCOPE_ALL, SCOPE_SAME, SCOPE_OTHER ] ),
-	shouldFetch: PropTypes.bool,
-	requestRelatedPosts: PropTypes.func,
 };
-
-QueryReaderRelatedPosts.defaultProps = {
-	scope: SCOPE_ALL,
-	requestRelatedPosts: () => {},
-};
-
-export default connect(
-	( state, ownProps ) => {
-		const { siteId, postId, scope } = ownProps;
-		return {
-			shouldFetch: shouldFetchRelated( state, siteId, postId, scope ),
-		};
-	},
-	( dispatch ) => {
-		return bindActionCreators(
-			{
-				requestRelatedPosts,
-			},
-			dispatch
-		);
-	}
-)( QueryReaderRelatedPosts );
-
-export function QueryReaderRelatedPostsSameSite( props ) {
-	return <QueryReaderRelatedPosts scope={ SCOPE_SAME } { ...props } />;
-}
-
-export function QueryReaderRelatedPostsOtherSites( props ) {
-	return <QueryReaderRelatedPosts scope={ SCOPE_OTHER } { ...props } />;
-}

--- a/client/state/reader/related-posts/reducer.js
+++ b/client/state/reader/related-posts/reducer.js
@@ -1,12 +1,7 @@
 /**
- * External Dependencies
- */
-import { assign, map, partial } from 'lodash';
-
-/**
  * Internal Dependencies
  */
-import { combineReducers, withoutPersistence } from 'calypso/state/utils';
+import { combineReducers } from 'calypso/state/utils';
 import {
 	READER_RELATED_POSTS_RECEIVE,
 	READER_RELATED_POSTS_REQUEST,
@@ -15,41 +10,39 @@ import {
 } from 'calypso/state/reader/action-types';
 import { key } from './utils';
 
-export const items = withoutPersistence( ( state = {}, action ) => {
-	switch ( action.type ) {
-		case READER_RELATED_POSTS_RECEIVE: {
-			state = assign( {}, state, {
-				[ key( action.payload.siteId, action.payload.postId, action.payload.scope ) ]: map(
-					action.payload.posts,
-					'global_ID'
-				),
-			} );
-			return state;
-		}
-	}
-
-	return state;
-} );
-
-function setRequestFlag( val, state, action ) {
+function setStateForKey( state, action, val ) {
 	const { siteId, postId, scope } = action.payload;
-	return assign( {}, state, {
+	return {
+		...state,
 		[ key( siteId, postId, scope ) ]: val,
-	} );
+	};
 }
 
-export const queuedRequests = withoutPersistence( ( state = {}, action ) => {
+export const items = ( state = {}, action ) => {
 	switch ( action.type ) {
-		case READER_RELATED_POSTS_REQUEST:
-			return partial( setRequestFlag, true )( state, action );
-		case READER_RELATED_POSTS_REQUEST_SUCCESS:
-			return partial( setRequestFlag, false )( state, action );
-		case READER_RELATED_POSTS_REQUEST_FAILURE:
-			return partial( setRequestFlag, false )( state, action );
+		case READER_RELATED_POSTS_RECEIVE:
+			return setStateForKey(
+				state,
+				action,
+				action.payload.posts.map( ( p ) => p.global_ID )
+			);
 	}
 
 	return state;
-} );
+};
+
+export const queuedRequests = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case READER_RELATED_POSTS_REQUEST:
+			return setStateForKey( state, action, true );
+		case READER_RELATED_POSTS_REQUEST_SUCCESS:
+			return setStateForKey( state, action, false );
+		case READER_RELATED_POSTS_REQUEST_FAILURE:
+			return setStateForKey( state, action, false );
+	}
+
+	return state;
+};
 
 export default combineReducers( {
 	items,

--- a/client/state/reader/related-posts/utils.js
+++ b/client/state/reader/related-posts/utils.js
@@ -1,11 +1,3 @@
-/**
- * External Dependencies
- */
-
-/**
- * Internal Dependencies
- */
-
 export const SCOPE_ALL = 'all';
 export const SCOPE_SAME = 'same';
 export const SCOPE_OTHER = 'other';


### PR DESCRIPTION
Two rather independent refactors in Reader Related Posts that can be, however, conveniently tested together.

First, remove Lodash from the `related-posts` reducer. Also extracts a `keyedReducer`-like logic to the `setStateForKey` function and removes the redundant `withoutPersistence` wrapper. The risky part is changing `map( action.payload.posts )` to `action.payload.posts.map()`. While reviewing, make sure that `posts` is always an array. I verified that the action creator is always called with an array, defaulted when needed, and also that the `/related` REST endpoint always returns an array, too.

Second, refactor `QueryReaderRelatedPosts` to a much smaller component with hooks. I extracted a `request` thunk that checks the `shouldFetch` condition (true if the data are not already in Redux and when request is not in progress) and issues the request atomically, in one event loop tick. The previous code would execute them both at different times (render vs effect), creating opportunity for race conditions.

Third, a very simple removal of "external/internal dependencies" docblocks from a module that does no imports.