### PR TITLE
Lint all files in the main code-style build

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -651,14 +651,8 @@ object CheckCodeStyle : BuildType({
 
 				export NODE_ENV="test"
 
-				FILES_TO_LINT=${'$'}(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -E '(\.[jt]sx?|\.md)${'$'}' || exit 0)
-
-				echo "Files to lint:"
-				echo ${'$'}FILES_TO_LINT
-				echo ""
-
 				# Lint files
-				yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/results.xml" ${'$'}FILES_TO_LINT
+				yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/results.xml" .
 			""".trimIndent()
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 			dockerPull = true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Changes `Check code style` build to lint all files. This build only runs for `trunk` and it is used to track how "linted" our repo is over time. It doesn't make sense to have any kind of "find modified files" logic.
