### PR TITLE
Fix import autostart by deferring action dispatch

### DIFF
--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { filter, get, isEmpty, once } from 'lodash';
+import { defer, filter, get, isEmpty, once } from 'lodash';
 
 /**
  * Internal dependencies
@@ -96,7 +96,7 @@ class SectionImport extends Component {
 			return;
 		}
 
-		startImport( site.ID, getImporterTypeForEngine( engine ) );
+		defer( () => startImport( site.ID, getImporterTypeForEngine( engine ) ) );
 	} );
 
 	handleStateChanges = () => {


### PR DESCRIPTION
Going to `https://wordpress.com/import/:site?engine=wordpress`, i.e., instructing the importer to autostart a WordPress import, ends with a crash after #48295.

The error is that `apiSuccess` Flux dispatch triggers a React rerender, and `componentDidUpdate` is sychronously called and calls `onceAutoStartImport`, which dispatches another Flux action, `startImport`, while the previous dispatch is still running. Flux doesn't like that.

Apparently, before #48295, `apiSuccess` was not called in favor of `apiFailure`, and the fix in `customData` changed that.