### PR TITLE
Plugins: Reduxify site plugin flux method

### DIFF
--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
@@ -8,9 +8,8 @@ import React, { Fragment } from 'react';
  */
 import Gridicon from 'calypso/components/gridicon';
 import meta from './meta';
-import PluginsStore from 'calypso/lib/plugins/store';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { isRequesting } from 'calypso/state/plugins/installed/selectors';
+import { getPluginOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
 import {
 	ButtonRow,
 	Continue,
@@ -38,7 +37,8 @@ export const JetpackPluginUpdatesTour = makeTour(
 		when={ ( state ) => {
 			const site = getSelectedSite( state );
 			const isRequestingPlugins = isRequesting( state, site.ID );
-			const res = ! isRequestingPlugins && !! PluginsStore.getSitePlugin( site, 'jetpack' );
+			const sitePlugin = getPluginOnSite( state, site.ID, 'jetpack' );
+			const res = ! isRequestingPlugins && !! sitePlugin;
 			return res;
 		} }
 	>

--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -62,12 +62,6 @@ Returns an array of plugin objects for a particular site.
 
 ---
 
-#### PluginsStore.getSitePlugin( site, pluginSlug );
-
-Returns a plugin objects for a particular site.
-
----
-
 #### PluginsStore.getSites( sites, pluginSlug );
 
 Returns an array of sites that have a particular plugin.

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -165,15 +165,6 @@ const PluginsStore = {
 		return values( _pluginsBySite[ site.ID ] );
 	},
 
-	getSitePlugin: function ( site, pluginSlug ) {
-		const plugins = this.getSitePlugins( site );
-		if ( ! plugins ) {
-			return plugins;
-		}
-
-		return find( plugins, _filters.isEqual.bind( this, pluginSlug ) );
-	},
-
 	// Array of sites with a particular plugin.
 	getSites: function ( sites, pluginSlug ) {
 		const plugins = this.getPlugins( sites );

--- a/client/lib/plugins/test/store.js
+++ b/client/lib/plugins/test/store.js
@@ -21,6 +21,10 @@ import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
 
 jest.mock( 'lib/redux-bridge', () => require( './mocks/redux-bridge' ) );
 
+// Helper to retrieve a particular plugin from flux while we're migrating to Redux.
+const getSitePlugin = ( siteObject, pluginSlug ) =>
+	PluginsStore.getSitePlugins( siteObject ).find( ( plugin ) => plugin.slug === pluginSlug );
+
 describe( 'Plugins Store', () => {
 	test( 'Store should be an object', () => {
 		assert.isObject( PluginsStore );
@@ -79,21 +83,6 @@ describe( 'Plugins Store', () => {
 			test( 'should return none Plugin', () => {
 				const Plugins = PluginsStore.getPlugins( site, 'none' );
 				assert.equal( Plugins.length, 0 );
-			} );
-		} );
-
-		describe( 'getSitePlugin method', () => {
-			test( 'Store should have method getSitePlugin', () => {
-				assert.isFunction( PluginsStore.getSitePlugin );
-			} );
-
-			test( 'Should have return a plugin object for a site', () => {
-				const Aksimet = PluginsStore.getSitePlugin( site, 'akismet' );
-				assert.isObject( Aksimet );
-			} );
-
-			test( "Should have return undefined for a site if the plugin doesn't exist", () => {
-				assert.isUndefined( PluginsStore.getSitePlugin( site, 'non-plugin-slug' ) );
 			} );
 		} );
 
@@ -215,7 +204,7 @@ describe( 'Plugins Store', () => {
 		describe( 'Updating Plugin', () => {
 			beforeEach( () => {
 				Dispatcher.handleViewAction( actions.updatePlugin );
-				HelloDolly = PluginsStore.getSitePlugin( site, 'hello-dolly' );
+				HelloDolly = getSitePlugin( site, 'hello-dolly' );
 			} );
 
 			test( "doesn't remove update when lauched", () => {
@@ -229,7 +218,7 @@ describe( 'Plugins Store', () => {
 
 			beforeEach( () => {
 				Dispatcher.handleViewAction( actions.updatedPlugin );
-				HelloDolly = PluginsStore.getSitePlugin( site, 'hello-dolly' );
+				HelloDolly = getSitePlugin( site, 'hello-dolly' );
 			} );
 
 			test( 'should set lastUpdated', () => {
@@ -248,7 +237,7 @@ describe( 'Plugins Store', () => {
 		describe( 'Remove Plugin Update Info', () => {
 			beforeEach( () => {
 				Dispatcher.handleViewAction( actions.clearPluginUpdate );
-				HelloDolly = PluginsStore.getSitePlugin( site, 'hello-dolly' );
+				HelloDolly = getSitePlugin( site, 'hello-dolly' );
 			} );
 
 			test( 'should remove lastUpdated', () => {
@@ -259,7 +248,7 @@ describe( 'Plugins Store', () => {
 		describe( 'Failed Plugin Update', () => {
 			beforeEach( () => {
 				Dispatcher.handleViewAction( actions.updatedPluginError );
-				HelloDolly = PluginsStore.getSitePlugin( site, 'hello-dolly' );
+				HelloDolly = getSitePlugin( site, 'hello-dolly' );
 			} );
 
 			test( 'should set update to an object', () => {
@@ -272,35 +261,35 @@ describe( 'Plugins Store', () => {
 		describe( 'Activaiting Plugin', () => {
 			test( 'Should set active = true if plugin is being activated', () => {
 				Dispatcher.handleViewAction( actions.activatePlugin );
-				assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				assert.isTrue( getSitePlugin( site, 'developer' ).active );
 			} );
 		} );
 
 		describe( 'Succesfully Activated Plugin', () => {
 			test( 'Should set active = true', () => {
 				Dispatcher.handleViewAction( actions.activatedPlugin );
-				assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				assert.isTrue( getSitePlugin( site, 'developer' ).active );
 			} );
 		} );
 
 		describe( 'Error while Activating Plugin', () => {
 			test( 'Should set active = false', () => {
 				Dispatcher.handleServerAction( actions.activatedPluginError );
-				assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				assert.isFalse( getSitePlugin( site, 'developer' ).active );
 			} );
 		} );
 
 		describe( 'Error while Activating Plugin with activation_error', () => {
 			test( 'Should set active = true if plugin is being activated with error plugin already active', () => {
 				Dispatcher.handleServerAction( actions.activatedPluginErrorAlreadyActive );
-				assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				assert.isTrue( getSitePlugin( site, 'developer' ).active );
 			} );
 		} );
 
 		describe( 'Error while Activating Broken Plugin', () => {
 			test( 'Should set active = false', () => {
 				Dispatcher.handleServerAction( actions.activatedBrokenPluginError );
-				assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				assert.isFalse( getSitePlugin( site, 'developer' ).active );
 			} );
 		} );
 	} );
@@ -309,28 +298,28 @@ describe( 'Plugins Store', () => {
 		describe( 'Deactivating Plugin', () => {
 			test( 'Should set active = false if plugin is being activated', () => {
 				Dispatcher.handleViewAction( actions.deactivatePlugin );
-				assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				assert.isFalse( getSitePlugin( site, 'developer' ).active );
 			} );
 		} );
 
 		describe( 'Succesfully Deactivated Plugin', () => {
 			test( 'Should set active = false', () => {
 				Dispatcher.handleViewAction( actions.deactivatedPlugin );
-				assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				assert.isFalse( getSitePlugin( site, 'developer' ).active );
 			} );
 		} );
 
 		describe( 'Error while Deactivating Plugin', () => {
 			test( 'Should set active = true', () => {
 				Dispatcher.handleServerAction( actions.deactivatedPluginError );
-				assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				assert.isTrue( getSitePlugin( site, 'developer' ).active );
 			} );
 		} );
 
 		describe( 'Error while Deactivating Plugin with deactivation_error', () => {
 			test( 'Should set active = false if plugin is being deactivated with error plugin already deactived', () => {
 				Dispatcher.handleServerAction( actions.deactivatedPluginErrorAlreadyNotActive );
-				assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				assert.isFalse( getSitePlugin( site, 'developer' ).active );
 			} );
 		} );
 	} );
@@ -338,34 +327,34 @@ describe( 'Plugins Store', () => {
 	describe( 'Enable AutoUpdates for Plugin', () => {
 		test( 'Should set autoupdate = true if autoupdates are being enabled', () => {
 			Dispatcher.handleViewAction( actions.enableAutoupdatePlugin );
-			assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate );
+			assert.isTrue( getSitePlugin( site, 'developer' ).autoupdate );
 		} );
 
 		test( 'Should set autoupdate = true after autoupdates enabling was successfully', () => {
 			Dispatcher.handleServerAction( actions.enabledAutoupdatePlugin );
-			assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate );
+			assert.isTrue( getSitePlugin( site, 'developer' ).autoupdate );
 		} );
 
 		test( 'Should set autoupdate = false after autoupdates enabling errored ', () => {
 			Dispatcher.handleServerAction( actions.enabledAutoupdatePluginError );
-			assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate );
+			assert.isFalse( getSitePlugin( site, 'developer' ).autoupdate );
 		} );
 	} );
 
 	describe( 'Disable AutoUpdated for Plugins', () => {
 		test( 'Should set autoupdate = false if autoupdates are being disabled', () => {
 			Dispatcher.handleViewAction( actions.disableAutoupdatePlugin );
-			assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate, false );
+			assert.isFalse( getSitePlugin( site, 'developer' ).autoupdate, false );
 		} );
 
 		test( 'Should set autoupdate = false after autoupdates disabling was successfully', () => {
 			Dispatcher.handleServerAction( actions.disabledAutoupdatePlugin );
-			assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate, false );
+			assert.isFalse( getSitePlugin( site, 'developer' ).autoupdate, false );
 		} );
 
 		test( 'Should set autoupdate = true after autoupdates disabling errored ', () => {
 			Dispatcher.handleServerAction( actions.disabledAutoupdatePluginError );
-			assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate, true );
+			assert.isTrue( getSitePlugin( site, 'developer' ).autoupdate, true );
 		} );
 	} );
 } );

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -155,7 +155,7 @@ class PlansSetup extends React.Component {
 	};
 
 	startNextPlugin = () => {
-		const { nextPlugin, sitePlugin } = this.props;
+		const { nextPlugin, requestingInstalledPlugins, sitePlugin } = this.props;
 
 		// We're already installing.
 		if ( this.props.isInstalling ) {
@@ -169,7 +169,7 @@ class PlansSetup extends React.Component {
 		let plugin = { ...nextPlugin, ...this.props.wporgPlugins?.[ nextPlugin.slug ] };
 
 		const getPluginFromStore = function () {
-			if ( ! sitePlugin && this.props.requestingInstalledPlugins ) {
+			if ( ! sitePlugin && requestingInstalledPlugins ) {
 				// if the Plugins are still being fetched, we wait. We are not using flux
 				// store events because it would be more messy to handle the one-time-only
 				// callback with bound parameters than to do it this way.

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -15,6 +15,7 @@ import { CompactCard } from '@automattic/components';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import Spinner from 'calypso/components/spinner';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryPluginKeys from 'calypso/components/data/query-plugin-keys';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
@@ -51,9 +52,10 @@ import {
 	isRequesting,
 	hasRequested,
 } from 'calypso/state/plugins/premium/selectors';
-import { isRequesting as isRequestingInstalledPlugins } from 'calypso/state/plugins/installed/selectors';
-// Store for existing plugins
-import PluginsStore from 'calypso/lib/plugins/store';
+import {
+	getPluginOnSite,
+	isRequesting as isRequestingInstalledPlugins,
+} from 'calypso/state/plugins/installed/selectors';
 
 const helpLinks = {
 	vaultpress: JETPACK_SERVICE_VAULTPRESS,
@@ -137,7 +139,7 @@ class PlansSetup extends React.Component {
 			! this.props.isInstalling &&
 			this.props.nextPlugin
 		) {
-			this.startNextPlugin( this.props.nextPlugin );
+			this.startNextPlugin();
 		}
 	}
 
@@ -152,7 +154,9 @@ class PlansSetup extends React.Component {
 		return beforeUnloadText;
 	};
 
-	startNextPlugin = ( plugin ) => {
+	startNextPlugin = () => {
+		const { nextPlugin, sitePlugin } = this.props;
+
 		// We're already installing.
 		if ( this.props.isInstalling ) {
 			return;
@@ -162,10 +166,9 @@ class PlansSetup extends React.Component {
 		const site = this.props.selectedSite;
 
 		// Merge wporg info into the plugin object
-		plugin = { ...plugin, ...this.props.wporgPlugins?.[ plugin.slug ] };
+		let plugin = { ...nextPlugin, ...this.props.wporgPlugins?.[ nextPlugin.slug ] };
 
 		const getPluginFromStore = function () {
-			const sitePlugin = PluginsStore.getSitePlugin( site, plugin.slug );
 			if ( ! sitePlugin && this.props.requestingInstalledPlugins ) {
 				// if the Plugins are still being fetched, we wait. We are not using flux
 				// store events because it would be more messy to handle the one-time-only
@@ -510,7 +513,7 @@ class PlansSetup extends React.Component {
 	};
 
 	render() {
-		const { sitesInitialized, translate } = this.props;
+		const { siteId, sitesInitialized, translate } = this.props;
 		const site = this.props.selectedSite;
 
 		if ( ! site && ( this.props.isRequestingSites || ! sitesInitialized ) ) {
@@ -539,6 +542,7 @@ class PlansSetup extends React.Component {
 			<div className="jetpack-plugins-setup">
 				<PageViewTracker path="/plugins/setup/:site" title="Jetpack Plugins Setup" />
 				<QueryPluginKeys siteId={ site.ID } />
+				{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 				<h1 className="jetpack-plugins-setup__header">
 					{ translate( 'Setting up your %(plan)s Plan', {
 						args: { plan: site.plan.product_name_short },
@@ -561,6 +565,7 @@ export default connect(
 		const forSpecificPlugin = ownProps.forSpecificPlugin || false;
 
 		return {
+			sitePlugin: forSpecificPlugin && getPluginOnSite( state, siteId, forSpecificPlugin ),
 			wporgPlugins: getAllWporgPlugins( state ),
 			isRequesting: isRequesting( state, siteId ),
 			requestingInstalledPlugins: isRequestingInstalledPlugins( state, siteId ),

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -40,6 +40,7 @@ import NoPermissionsError from './no-permissions-error';
 import getToursHistory from 'calypso/state/guided-tours/selectors/get-tours-history';
 import hasNavigated from 'calypso/state/selectors/has-navigated';
 import {
+	getPluginOnSite,
 	getPluginOnSites,
 	getSitesWithoutPlugin,
 	isPluginActionInProgress,
@@ -232,7 +233,7 @@ class SinglePlugin extends React.Component {
 			return null;
 		}
 
-		return !! PluginsStore.getSitePlugin( this.props.selectedSite, this.state.plugin.slug );
+		return !! this.props.sitePlugin;
 	}
 
 	renderSitesList( plugin ) {
@@ -350,6 +351,7 @@ export default connect(
 
 		return {
 			plugin: getPluginOnSites( state, siteIds, props.pluginSlug ),
+			sitePlugin: selectedSiteId && getPluginOnSite( state, selectedSiteId, props.pluginSlug ),
 			wporgPlugin: getWporgPlugin( state, props.pluginSlug ),
 			wporgFetching: isWporgPluginFetching( state, props.pluginSlug ),
 			wporgFetched: isWporgPluginFetched( state, props.pluginSlug ),

--- a/client/state/plugins/premium/README.md
+++ b/client/state/plugins/premium/README.md
@@ -18,13 +18,21 @@ fetchInstallInstructions( 106093271 );
 
 ### `installPlugin( plugin: object, siteId: object )`
 
-Start the install process for a plugin. Plugin object should be pulled from the [PluginsStore](https://github.com/Automattic/wp-calypso/tree/HEAD/client/lib/plugins).
+Start the install process for a plugin.
 
 ```js
+import { useDispatch, useSelector } from 'react-redux';
+import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import { installPlugin } from 'calypso/state/plugins/premium/actions';
 
-const plugin = PluginsStore.getSitePlugin( site, 'vaultpress' );
-installPlugin( plugin, site );
+const MyComponent = ( { site } ) => {
+	// Retrieve the plugin installed on the site via Redux
+	const plugin = useSelector( ( state ) => getPluginOnSite( state, site, 'vaultpress' ) );
+
+	// Install the plugin
+	const dispatch = useDispatch();
+	dispatch( installPlugin( plugin, site ) );
+};
 ```
 
 ## Reducer


### PR DESCRIPTION
We've been working on reduxifying the plugins flux stores. As we've reached the point where all the data is now in Redux, we're migrating and removing flux methods that are equal to redux's selectors. This PR handles `PluginsStore.getSitePlugin()` that is responsible for retrieving the installed plugin for a site. 

In this PR we're updating the 3 instances where this method was used to now use the Redux selector `getPluginOnSite`. Where needed, we're adding the `QueryJetpackPlugins` query component to make sure plugin data is loaded adequately.

We're also removing the unused `getSitePlugin` method, and updating docs and tests to reflect that.

This PR is part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Reduxify site plugin flux method

#### Testing instructions

* Install [React Developer Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi) if you don't have it yet.
* Clean up your Redux store.
* Go to `/plugins/setup/:site?only=akismet` where `:site` is a Jetpack site with Akismet installed.
* Inspecting the Components tree in your Chrome dev tools, verify that `PlanSetup` component has a valid state for the Akismet plugin, reflecting accurately whether the plugin is active or not. 
* Verify no errors are thrown in the console.
* Go to `/plugins/manage/:site?tour=jetpackPluginUpdates` and verify the tour still appears on the Jetpack plugin as it did before. Make sure to try that with a clean Redux store, too.
* On the following pages, where `:site` is a Jetpack site and `:plugin` is one of your plugins, make sure to verify with clean Redux store that loading a plugin still works the same way and no errors are thrown in the console:
  * `/plugins/:plugin/:site`
  * `/plugins/:plugin`
* Verify all tests pass.
