### PR TITLE
Protect against null/undefined domain name in `getFixedDomainSearch()`

### DIFF
--- a/client/lib/domains/get-fixed-domain-search.js
+++ b/client/lib/domains/get-fixed-domain-search.js
@@ -1,5 +1,6 @@
 export function getFixedDomainSearch( domainName ) {
-	return domainName
+	const domain = domainName ?? '';
+	return domain
 		.trim()
 		.toLowerCase()
 		.replace( /^(https?:\/\/)?(www[0-9]?\.)?/, '' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a defensive check for a `null`/`undefined` value in `getFixedDomainSearch()` 

#### Testing instructions

* Navigate to `/domains/start`
* Empty the search box
* Click on the "Filters" button to the right of the domain search box
* Check "Show exact matches only"
* Click on "Apply"
* Verify that the screen remains visible and you can still search for a domain

Feel free to repeat the instructions, provided the search box remains empty.

Fixes #48224
