### PR TITLE
Forbid package-relative imports in asyncRequire calls

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -222,7 +222,7 @@ const configureReduxStore = ( currentUser, reduxStore ) => {
 	}
 
 	if ( config.isEnabled( 'network-connection' ) ) {
-		asyncRequire( 'lib/network-connection', ( networkConnection ) =>
+		asyncRequire( 'calypso/lib/network-connection', ( networkConnection ) =>
 			networkConnection.init( reduxStore )
 		);
 	}
@@ -389,7 +389,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 		config.isEnabled( 'dev/test-helper' ) &&
 		document.querySelector( '.environment.is-tests' )
 	) {
-		asyncRequire( 'lib/abtest/test-helper', ( testHelper ) => {
+		asyncRequire( 'calypso/lib/abtest/test-helper', ( testHelper ) => {
 			testHelper( document.querySelector( '.environment.is-tests' ) );
 		} );
 	}
@@ -397,7 +397,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 		config.isEnabled( 'dev/preferences-helper' ) &&
 		document.querySelector( '.environment.is-prefs' )
 	) {
-		asyncRequire( 'lib/preferences-helper', ( prefHelper ) => {
+		asyncRequire( 'calypso/lib/preferences-helper', ( prefHelper ) => {
 			prefHelper( document.querySelector( '.environment.is-prefs' ), reduxStore );
 		} );
 	}
@@ -405,7 +405,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 		config.isEnabled( 'dev/features-helper' ) &&
 		document.querySelector( '.environment.is-features' )
 	) {
-		asyncRequire( 'lib/features-helper', ( featureHelper ) => {
+		asyncRequire( 'calypso/lib/features-helper', ( featureHelper ) => {
 			featureHelper( document.querySelector( '.environment.is-features' ) );
 		} );
 	}

--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -62,7 +62,7 @@ function renderDevHelpers( reduxStore ) {
 	if ( config.isEnabled( 'dev/test-helper' ) ) {
 		const testHelperEl = document.querySelector( '.environment.is-tests' );
 		if ( testHelperEl ) {
-			asyncRequire( 'lib/abtest/test-helper', ( testHelper ) => {
+			asyncRequire( 'calypso/lib/abtest/test-helper', ( testHelper ) => {
 				testHelper( testHelperEl );
 			} );
 		}
@@ -71,7 +71,7 @@ function renderDevHelpers( reduxStore ) {
 	if ( config.isEnabled( 'dev/preferences-helper' ) ) {
 		const prefHelperEl = document.querySelector( '.environment.is-prefs' );
 		if ( prefHelperEl ) {
-			asyncRequire( 'lib/preferences-helper', ( prefHelper ) => {
+			asyncRequire( 'calypso/lib/preferences-helper', ( prefHelper ) => {
 				prefHelper( prefHelperEl, reduxStore );
 			} );
 		}
@@ -80,7 +80,7 @@ function renderDevHelpers( reduxStore ) {
 	if ( config.isEnabled( 'features-helper' ) ) {
 		const featureHelperEl = document.querySelector( '.environment.is-features' );
 		if ( featureHelperEl ) {
-			asyncRequire( 'lib/features-helper', ( featureHelper ) => {
+			asyncRequire( 'calypso/lib/features-helper', ( featureHelper ) => {
 				featureHelper( featureHelperEl );
 			} );
 		}
@@ -99,7 +99,7 @@ export const configureReduxStore = ( currentUser, reduxStore ) => {
 	}
 
 	if ( config.isEnabled( 'network-connection' ) ) {
-		asyncRequire( 'lib/network-connection', ( networkConnection ) =>
+		asyncRequire( 'calypso/lib/network-connection', ( networkConnection ) =>
 			networkConnection.init( reduxStore )
 		);
 	}

--- a/client/lib/happychat/connection-async.js
+++ b/client/lib/happychat/connection-async.js
@@ -9,7 +9,9 @@ export default function buildConnection() {
 	// Async load the connection library and return a promise with its default export.
 	// That's a factory function that creates and returns the `Connection` class instance.
 	function importConnectionLib() {
-		return new Promise( ( resolve ) => asyncRequire( 'lib/happychat/connection', resolve ) );
+		return new Promise( ( resolve ) =>
+			asyncRequire( 'calypso/lib/happychat/connection', resolve )
+		);
 	}
 
 	function getConnection() {

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -6,7 +6,7 @@ import { uniqWith, isEqual, isArray } from 'lodash';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import config from 'calypso/config';
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import {
 	DOCUMENT_HEAD_LINK_SET,

--- a/packages/eslint-plugin-wpcalypso/lib/rules/no-package-relative-imports.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/no-package-relative-imports.js
@@ -176,10 +176,10 @@ module.exports = {
 				if (
 					node.callee &&
 					node.callee.type === 'Identifier' &&
-					( node.callee.name === 'require' || node.callee.name === 'asyncRequire' ) &&
-					node.arguments.length === 1
+					( ( node.callee.name === 'require' && node.arguments.length === 1 ) ||
+						node.callee.name === 'asyncRequire' )
 				) {
-					reportImport( node, node.arguments[ 0 ] );
+					return reportImport( node, node.arguments[ 0 ] );
 				}
 			},
 			JSXElement: ( node ) => {


### PR DESCRIPTION
See #44602

#### Changes proposed in this Pull Request

* Change eslint rule `wpcalypso/no-package-relative-imports` to detect `asyncRequire(<string>,<callback>)`
* Fix newly discovered eslint errors 

Before this change, the rule was only detecting (and auto-fixing) the pattern `asyncRequire(<string>)`