### PR TITLE
Forbid package-relative imports in jest mocks

### DIFF
--- a/client/auth/test/login.jsx
+++ b/client/auth/test/login.jsx
@@ -23,7 +23,7 @@ jest.mock( '../login-request', () => ( {
 	errorTypes: {},
 } ) );
 
-jest.mock( 'lib/analytics/ga', () => ( {
+jest.mock( 'calypso/lib/analytics/ga', () => ( {
 	gaRecordEvent: () => {},
 } ) );
 

--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -18,13 +18,13 @@ import React from 'react';
 import { DailyPostButton } from '../index';
 import { sites, dailyPromptPost } from './fixtures';
 
-jest.mock( 'reader/stats', () => ( {
+jest.mock( 'calypso/reader/stats', () => ( {
 	pageViewForPost: () => {},
 	recordAction: () => {},
 	recordGaEvent: () => {},
 	recordTrackForPost: () => {},
 } ) );
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 jest.mock( 'page', () => require( 'sinon' ).spy() );
 const markPostSeen = jest.fn();
 

--- a/client/blocks/edit-gravatar/test/index.jsx
+++ b/client/blocks/edit-gravatar/test/index.jsx
@@ -23,10 +23,10 @@ import VerifyEmailDialog from 'calypso/components/email-verification/email-verif
 import DropZone from 'calypso/components/drop-zone';
 
 jest.mock( 'event', () => require( 'component-event' ), { virtual: true } );
-jest.mock( 'lib/oauth-token', () => ( {
+jest.mock( 'calypso/lib/oauth-token', () => ( {
 	getToken: () => 'bearerToken',
 } ) );
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'EditGravatar', () => {
 	let sandbox;

--- a/client/blocks/get-apps/test/apps-badge.js
+++ b/client/blocks/get-apps/test/apps-badge.js
@@ -14,7 +14,7 @@ import { identity } from 'lodash';
  */
 import { AppsBadge } from '../apps-badge';
 
-jest.mock( 'lib/i18n-utils', () => ( {
+jest.mock( 'calypso/lib/i18n-utils', () => ( {
 	getLocaleSlug: () => {
 		return 'en';
 	},

--- a/client/blocks/image-editor/test/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/test/image-editor-canvas.jsx
@@ -14,7 +14,7 @@ import React from 'react';
  */
 import { ImageEditorCanvas } from '../image-editor-canvas';
 
-jest.mock( 'blocks/image-editor/image-editor-crop', () => {
+jest.mock( 'calypso/blocks/image-editor/image-editor-crop', () => {
 	const { Component } = require( 'react' );
 
 	class ImageEditorCropMock extends Component {

--- a/client/blocks/image-selector/test/index.jsx
+++ b/client/blocks/image-selector/test/index.jsx
@@ -18,23 +18,23 @@ import sinon from 'sinon';
 import { ImageSelector } from '../';
 
 jest.mock( 'event', () => {}, { virtual: true } );
-jest.mock( 'state/ui/media-modal/selectors', () => ( {
+jest.mock( 'calypso/state/ui/media-modal/selectors', () => ( {
 	view: () => {},
 	getMediaModalView: () => {},
 } ) );
-jest.mock( 'state/selectors/get-sites-items', () => ( {
+jest.mock( 'calypso/state/selectors/get-sites-items', () => ( {
 	__esModule: true,
 	default: () => ( { 1: '' } ),
 } ) );
-jest.mock( 'state/editor/selectors', () => ( {
+jest.mock( 'calypso/state/editor/selectors', () => ( {
 	postId: '',
 	getEditorPostId: () => {},
 } ) );
-jest.mock( 'state/ui/selectors', () => ( {
+jest.mock( 'calypso/state/ui/selectors', () => ( {
 	getSelectedSiteId: jest.fn( () => require( './fixtures' ).DUMMY_SITE_ID ),
 	getSelectedSite: () => {},
 } ) );
-jest.mock( 'state/selectors/get-current-locale-slug', () => () => 'en' );
+jest.mock( 'calypso/state/selectors/get-current-locale-slug', () => () => 'en' );
 
 describe( 'ImageSelector', () => {
 	const testProps = {

--- a/client/blocks/nps-survey/test/index.jsx
+++ b/client/blocks/nps-survey/test/index.jsx
@@ -18,9 +18,9 @@ jest.mock( 'react-redux', () => ( {
 	connect: () => () => {},
 } ) );
 
-jest.mock( 'state/nps-survey/actions' );
-jest.mock( 'state/analytics/actions' );
-jest.mock( 'state/notices/actions' );
+jest.mock( 'calypso/state/nps-survey/actions' );
+jest.mock( 'calypso/state/analytics/actions' );
+jest.mock( 'calypso/state/notices/actions' );
 
 describe( 'NpsSurvey', () => {
 	const mockedProps = {

--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -1,4 +1,4 @@
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 

--- a/client/blocks/plan-storage/test/plan-storage.jsx
+++ b/client/blocks/plan-storage/test/plan-storage.jsx
@@ -1,4 +1,4 @@
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 

--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -1,11 +1,11 @@
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'blocks/upsell-nudge', () => 'UpsellNudge' );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'calypso/blocks/upsell-nudge', () => 'UpsellNudge' );
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: ( Comp ) => ( props ) => (

--- a/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
+++ b/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
@@ -29,8 +29,14 @@ import {
  */
 import { ProductPurchaseFeaturesList } from '../index';
 
-jest.mock( 'blocks/product-purchase-features-list/google-vouchers', () => 'GoogleVouchers' );
-jest.mock( 'blocks/product-purchase-features-list/video-audio-posts', () => 'VideoAudioPosts' );
+jest.mock(
+	'calypso/blocks/product-purchase-features-list/google-vouchers',
+	() => 'GoogleVouchers'
+);
+jest.mock(
+	'calypso/blocks/product-purchase-features-list/video-audio-posts',
+	() => 'VideoAudioPosts'
+);
 
 describe( 'ProductPurchaseFeaturesList basic tests', () => {
 	const props = {

--- a/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
@@ -1,4 +1,4 @@
-jest.mock( 'components/purchase-detail', () => 'PurchaseDetail' );
+jest.mock( 'calypso/components/purchase-detail', () => 'PurchaseDetail' );
 jest.mock( '../google-vouchers', () => 'GoogleVouchers' );
 
 /**

--- a/client/blocks/reader-author-link/test/index.js
+++ b/client/blocks/reader-author-link/test/index.js
@@ -9,7 +9,7 @@ import React from 'react';
  */
 import ReaderAuthorLink from '../index';
 
-jest.mock( 'reader/stats', () => ( {
+jest.mock( 'calypso/reader/stats', () => ( {
 	recordAction: () => {},
 	recordGaEvent: () => {},
 	recordTrackForPost: () => {},

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -1,13 +1,13 @@
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.mock( 'blocks/dismissible-card', () => {
+jest.mock( 'calypso/blocks/dismissible-card', () => {
 	const React = require( 'react' );
 	return class DismissibleCard extends React.Component {};
 } );
 
-jest.mock( 'lib/analytics/track-component-view', () => {
+jest.mock( 'calypso/lib/analytics/track-component-view', () => {
 	const React = require( 'react' );
 	return class TrackComponentView extends React.Component {};
 } );

--- a/client/components/community-translator/test/utils.js
+++ b/client/components/community-translator/test/utils.js
@@ -24,7 +24,7 @@ jest.mock( '@automattic/viewport', () => ( {
 	isMobile: jest.fn(),
 } ) );
 
-jest.mock( 'lib/user-settings', () => ( {
+jest.mock( 'calypso/lib/user-settings', () => ( {
 	getSetting: jest.fn(),
 	getOriginalSetting: jest.fn(),
 } ) );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
@@ -20,7 +20,7 @@ jest.mock( 'i18n-calypso', () => ( {
 } ) );
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'EU Address Fieldset', () => {
 	const defaultProps = {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
@@ -24,7 +24,7 @@ jest.mock( 'i18n-calypso', () => ( {
 } ) );
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'Region Address Fieldsets', () => {
 	const defaultProps = {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
@@ -20,7 +20,7 @@ jest.mock( 'i18n-calypso', () => ( {
 } ) );
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'UK Address Fieldset', () => {
 	const defaultProps = {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
@@ -20,7 +20,7 @@ jest.mock( 'i18n-calypso', () => ( {
 } ) );
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'US Address Fieldset', () => {
 	const defaultProps = {

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -22,7 +22,7 @@ jest.mock( 'i18n-calypso', () => ( {
 } ) );
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'ContactDetailsFormFields', () => {
 	const defaultProps = {

--- a/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
+++ b/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
@@ -15,7 +15,7 @@ import { difference, identity, set } from 'lodash';
  */
 import { ValidatedRegistrantExtraInfoUkForm, RegistrantExtraInfoUkForm } from '../uk-form';
 
-jest.mock( 'state/selectors/get-validation-schemas', () => () => ( {
+jest.mock( 'calypso/state/selectors/get-validation-schemas', () => () => ( {
 	uk: require( './uk-schema.json' ),
 } ) );
 

--- a/client/components/head/test/favicons.jsx
+++ b/client/components/head/test/favicons.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-jest.mock( 'lib/jetpack/is-jetpack-cloud' );
+jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud' );
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import Favicons from '../favicons';
 

--- a/client/components/jetpack/daily-backup-status/test/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/test/action-buttons.jsx
@@ -17,10 +17,10 @@ import ActionButtons from '../action-buttons';
 /**
  * Mocked dependencies
  */
-jest.mock( 'state/ui/selectors' );
+jest.mock( 'calypso/state/ui/selectors' );
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-jest.mock( 'state/selectors/get-does-rewind-need-credentials' );
+jest.mock( 'calypso/state/selectors/get-does-rewind-need-credentials' );
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 
 import * as record from 'calypso/state/analytics/actions/record';

--- a/client/components/jetpack/daily-backup-status/test/index.jsx
+++ b/client/components/jetpack/daily-backup-status/test/index.jsx
@@ -28,14 +28,14 @@ jest.mock( 'react-redux', () => ( {
 	useSelector: jest.fn().mockImplementation( ( selector ) => selector() ),
 } ) );
 
-jest.mock( 'state/ui/selectors/get-selected-site-id' );
-jest.mock( 'state/selectors/get-site-timezone-value' );
-jest.mock( 'state/selectors/get-site-gmt-offset' );
+jest.mock( 'calypso/state/ui/selectors/get-selected-site-id' );
+jest.mock( 'calypso/state/selectors/get-site-timezone-value' );
+jest.mock( 'calypso/state/selectors/get-site-gmt-offset' );
 
-jest.mock( 'state/selectors/get-rewind-capabilities' );
+jest.mock( 'calypso/state/selectors/get-rewind-capabilities' );
 import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
 
-jest.mock( 'lib/jetpack/backup-utils' );
+jest.mock( 'calypso/lib/jetpack/backup-utils' );
 import {
 	isSuccessfulDailyBackup,
 	isSuccessfulRealtimeBackup,

--- a/client/components/jetpack/has-vaultpress-switch/test/index.js
+++ b/client/components/jetpack/has-vaultpress-switch/test/index.js
@@ -11,9 +11,9 @@ jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
 	useSelector: jest.fn().mockImplementation( ( selector ) => selector() ),
 } ) );
-jest.mock( 'state/ui/selectors/get-selected-site-id' );
-jest.mock( 'state/selectors/get-rewind-state' );
-jest.mock( 'state/selectors/get-site-scan-state' );
+jest.mock( 'calypso/state/ui/selectors/get-selected-site-id' );
+jest.mock( 'calypso/state/selectors/get-rewind-state' );
+jest.mock( 'calypso/state/selectors/get-site-scan-state' );
 
 /**
  * Internal dependencies

--- a/client/components/jetpack/with-server-credentials-form/test/index.js
+++ b/client/components/jetpack/with-server-credentials-form/test/index.js
@@ -19,12 +19,12 @@ import withServerCredentialsForm from 'calypso/components/jetpack/with-server-cr
 /**
  * Mocks
  */
-jest.mock( 'components/data/query-site-credentials', () => {
+jest.mock( 'calypso/components/data/query-site-credentials', () => {
 	const QuerySiteCredentials = () => <div />;
 	return QuerySiteCredentials;
 } );
 
-jest.mock( 'state/selectors/get-jetpack-credentials', () => ( {
+jest.mock( 'calypso/state/selectors/get-jetpack-credentials', () => ( {
 	__esModule: true,
 	default: () => ( {
 		user: 'jetpackUser',
@@ -34,11 +34,13 @@ jest.mock( 'state/selectors/get-jetpack-credentials', () => ( {
 	} ),
 } ) );
 
-jest.mock( 'state/sites/selectors', () => ( {
+jest.mock( 'calypso/state/sites/selectors', () => ( {
 	getSiteSlug: () => 'site-slug',
 } ) );
 
-jest.mock( 'state/selectors/get-jetpack-credentials-update-status', () => () => 'unsubmitted' );
+jest.mock( 'calypso/state/selectors/get-jetpack-credentials-update-status', () => () =>
+	'unsubmitted'
+);
 
 /**
  * Helper functions

--- a/client/components/locale-suggestions/test/index.jsx
+++ b/client/components/locale-suggestions/test/index.jsx
@@ -14,10 +14,10 @@ import { getLocaleSlug } from 'i18n-calypso';
  */
 import { LocaleSuggestions } from '../';
 
-jest.mock( 'lib/i18n-utils', () => ( { addLocaleToPath: ( locale ) => locale } ) );
+jest.mock( 'calypso/lib/i18n-utils', () => ( { addLocaleToPath: ( locale ) => locale } ) );
 jest.mock( 'i18n-calypso', () => ( { getLocaleSlug: jest.fn( () => '' ) } ) );
 
-jest.mock( 'components/notice', () => ( props ) => [ ...props.children ] );
+jest.mock( 'calypso/components/notice', () => ( props ) => [ ...props.children ] );
 
 describe( 'LocaleSuggestions', () => {
 	const defaultProps = {

--- a/client/components/notes-formatted-block/test/blocks.js
+++ b/client/components/notes-formatted-block/test/blocks.js
@@ -7,7 +7,7 @@ import { shallow } from 'enzyme';
 /**
  * Mock dependencies
  */
-jest.mock( 'lib/jetpack/is-jetpack-cloud' );
+jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud' );
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 // NOTE: There's a repeating pattern in these tests that links to WordPress.com

--- a/client/components/payment-country-select/test/index.jsx
+++ b/client/components/payment-country-select/test/index.jsx
@@ -16,8 +16,8 @@ import CountrySelect from 'calypso/my-sites/domains/components/form/country-sele
 import { PaymentCountrySelect } from '../';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
-jest.mock( 'lib/cart/actions', () => ( {
+jest.mock( 'calypso/lib/user', () => () => {} );
+jest.mock( 'calypso/lib/cart/actions', () => ( {
 	setTaxCountryCode: () => {},
 } ) );
 

--- a/client/components/search/test/index.jsx
+++ b/client/components/search/test/index.jsx
@@ -15,7 +15,7 @@ import sinon from 'sinon';
  */
 import searchClass from '../';
 
-jest.mock( 'lib/analytics/ga', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/ga', () => ( {} ) );
 jest.mock( 'gridicons', () => require( 'calypso/components/empty-component' ) );
 
 describe( 'Search', () => {

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -18,7 +18,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import SectionNav from '../';
 
 jest.mock( 'gridicons', () => require( 'calypso/components/empty-component' ) );
-jest.mock( 'lib/analytics/ga', () => ( {
+jest.mock( 'calypso/lib/analytics/ga', () => ( {
 	recordEvent: () => {},
 } ) );
 

--- a/client/components/seo/preview-upgrade-nudge/test/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/test/index.jsx
@@ -1,12 +1,12 @@
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'lib/analytics/track-component-view', () => 'TrackComponentView' );
-jest.mock( 'blocks/upsell-nudge', () => 'UpsellNudge' );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'calypso/lib/analytics/track-component-view', () => 'TrackComponentView' );
+jest.mock( 'calypso/blocks/upsell-nudge', () => 'UpsellNudge' );
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: ( Comp ) => ( props ) => (

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -15,7 +15,7 @@ jest.mock( 'uuid', () => ( {
 	v4: () => 'fake-uuid',
 } ) );
 
-jest.mock( 'components/data/query-verticals', () => 'QueryVerticals' );
+jest.mock( 'calypso/components/data/query-verticals', () => 'QueryVerticals' );
 
 const defaultProps = {
 	onChange: jest.fn(),

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -16,7 +16,7 @@ import sinon from 'sinon';
  */
 import { SitesDropdown } from '..';
 
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'index', () => {
 	describe( 'component rendering', () => {

--- a/client/components/suggestion-search/test/index.js
+++ b/client/components/suggestion-search/test/index.js
@@ -10,7 +10,7 @@ import { shallow } from 'enzyme';
 import SuggestionSearch from '..';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-jest.mock( 'lib/analytics/tracks', () => ( {
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	recordTracksEvent: jest.fn(),
 } ) );
 

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -19,9 +19,9 @@ import { shallow } from 'enzyme';
  */
 import { Theme } from '../';
 
-jest.mock( 'components/popover/menu', () => 'components--popover--menu' );
-jest.mock( 'components/popover/menu-item', () => 'components--popover--menu-item' );
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/components/popover/menu', () => 'components--popover--menu' );
+jest.mock( 'calypso/components/popover/menu-item', () => 'components--popover--menu-item' );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'Theme', () => {
 	let props;

--- a/client/components/tinymce/plugins/embed/test/dialog.js
+++ b/client/components/tinymce/plugins/embed/test/dialog.js
@@ -18,7 +18,7 @@ const testSiteId = 5089392;
 describe( 'EmbedDialog', () => {
 	let EmbedDialog;
 	beforeAll( () => {
-		jest.mock( 'lib/wp', () => ( {
+		jest.mock( 'calypso/lib/wp', () => ( {
 			undocumented: () => ( {
 				site: () => ( {
 					embeds: () => {},

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -20,7 +20,7 @@ import TokenFieldWrapper from './lib/token-field-wrapper';
 /**
  * Module constants
  */
-jest.mock( 'components/tooltip', () => require( 'calypso/components/empty-component' ) );
+jest.mock( 'calypso/components/tooltip', () => require( 'calypso/components/empty-component' ) );
 
 /**
  * Module variables

--- a/client/components/translator-invite/test/utils.js
+++ b/client/components/translator-invite/test/utils.js
@@ -7,7 +7,7 @@
  */
 import { isDefaultLocale, getCurrentNonDefaultLocale } from '../utils';
 
-jest.mock( 'config', () => ( key ) => {
+jest.mock( 'calypso/config', () => ( key ) => {
 	if ( 'i18n_default_locale_slug' === key ) {
 		return 'it';
 	}

--- a/client/devdocs/design/test/component-playground.js
+++ b/client/devdocs/design/test/component-playground.js
@@ -14,7 +14,7 @@ import { LiveProvider } from 'react-live';
  */
 import ComponentPlayground from '../component-playground';
 
-jest.mock( 'devdocs/design/playground-scope', () => 'PlaygroundScope' );
+jest.mock( 'calypso/devdocs/design/playground-scope', () => 'PlaygroundScope' );
 
 describe( 'ComponentPlayground', () => {
 	test( 'LiveProvider should use the components scope by default', () => {

--- a/client/devdocs/test/doc.jsx
+++ b/client/devdocs/test/doc.jsx
@@ -13,7 +13,7 @@ import { shallow } from 'enzyme';
  */
 import SingleDocClass from '../doc';
 
-jest.mock( 'devdocs/service', () => ( {
+jest.mock( 'calypso/devdocs/service', () => ( {
 	fetch: () => {},
 } ) );
 

--- a/client/extensions/woocommerce/state/data-layer/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/test/index.js
@@ -4,7 +4,7 @@
 import { expect } from 'chai';
 import { spy, match } from 'sinon';
 
-jest.mock( 'lib/warn', () => () => {} );
+jest.mock( 'calypso/lib/warn', () => () => {} );
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/state/data-layer/ui/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/products/test/index.js
@@ -28,7 +28,7 @@ import {
 	editProductRemoveCategory,
 } from 'woocommerce/state/ui/products/actions';
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 
 describe( 'handlers', () => {
 	describe( '#actionAppendProductVariations', () => {

--- a/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
@@ -20,7 +20,7 @@ import { createProduct, productUpdated } from 'woocommerce/state/sites/products/
 
 const siteId = 123;
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 
 describe( 'edits-reducer', () => {
 	const newVariableProduct1 = {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -64,7 +64,7 @@ const DEFAULT_PROPS = deepFreeze( {
 	userAlreadyConnected: false,
 } );
 
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	const mock = () => 'development';
 	mock.isEnabled = jest.fn( () => true );
 	return mock;

--- a/client/jetpack-connect/test/main-wrapper.jsx
+++ b/client/jetpack-connect/test/main-wrapper.jsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-jest.mock( 'components/data/document-head', () => 'DocumentHead' );
+jest.mock( 'calypso/components/data/document-head', () => 'DocumentHead' );
 
 /**
  * External dependencies

--- a/client/jetpack-connect/test/utils.js
+++ b/client/jetpack-connect/test/utils.js
@@ -20,7 +20,7 @@ import {
 
 import { JPC_PATH_PLANS, JPC_PATH_REMOTE_INSTALL, REMOTE_PATH_AUTH } from '../constants';
 
-jest.mock( 'config', () => ( input ) => {
+jest.mock( 'calypso/config', () => ( input ) => {
 	const lookupTable = {
 		env_id: 'mocked-test-env-id',
 	};
@@ -141,7 +141,7 @@ describe( 'parseAuthorizationQuery', () => {
 	} );
 } );
 
-jest.mock( 'lib/route/path', () => ( {
+jest.mock( 'calypso/lib/route/path', () => ( {
 	externalRedirect: jest.fn(),
 } ) );
 

--- a/client/layout/test/index.js
+++ b/client/layout/test/index.js
@@ -10,11 +10,11 @@ import { renderToString } from 'react-dom/server';
  */
 import LayoutLoggedOut from '../logged-out';
 
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
-jest.mock( 'lib/signup/step-actions', () => ( {} ) );
-jest.mock( 'lib/user', () => () => {
+jest.mock( 'calypso/lib/signup/step-actions', () => ( {} ) );
+jest.mock( 'calypso/lib/user', () => () => {
 	return {
 		get() {
 			return {};

--- a/client/lib/abtest/test/index.js
+++ b/client/lib/abtest/test/index.js
@@ -22,7 +22,7 @@ afterAll( () => {
 	process.env.NODE_ENV = NODE_ENV;
 } );
 
-jest.mock( 'lib/abtest/active-tests', () => ( {
+jest.mock( 'calypso/lib/abtest/active-tests', () => ( {
 	mockedTest: {
 		datestamp: '20160627',
 		variations: {
@@ -78,7 +78,7 @@ jest.mock( 'lib/abtest/active-tests', () => ( {
 		allowExistingUsers: true,
 	},
 } ) );
-jest.mock( 'lib/user', () => {
+jest.mock( 'calypso/lib/user', () => {
 	const getStub = jest.fn();
 
 	const user = () => ( {

--- a/client/lib/analytics/test/cart.js
+++ b/client/lib/analytics/test/cart.js
@@ -6,15 +6,15 @@ import { recordAddToCart } from 'calypso/lib/analytics/record-add-to-cart';
 import { getAllCartItems } from 'calypso/lib/cart-values/cart-items';
 import { recordEvents } from 'calypso/lib/analytics/cart';
 
-jest.mock( 'lib/analytics/tracks', () => ( {
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	__esModule: true,
 	recordTracksEvent: jest.fn(),
 } ) );
-jest.mock( 'lib/analytics/record-add-to-cart', () => ( {
+jest.mock( 'calypso/lib/analytics/record-add-to-cart', () => ( {
 	__esModule: true,
 	recordAddToCart: jest.fn(),
 } ) );
-jest.mock( 'lib/cart-values/cart-items', () => ( { getAllCartItems: jest.fn() } ) );
+jest.mock( 'calypso/lib/cart-values/cart-items', () => ( { getAllCartItems: jest.fn() } ) );
 
 const previousCart = {};
 const nextCart = {};

--- a/client/lib/analytics/test/google-analytics.js
+++ b/client/lib/analytics/test/google-analytics.js
@@ -6,7 +6,7 @@
  */
 import { makeGoogleAnalyticsTrackingFunction } from '../ga';
 
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	const isEnabled = ( feature ) => {
 		const features = {
 			'ad-tracking': true,
@@ -26,7 +26,7 @@ jest.mock( 'config', () => {
 	return configApi;
 } );
 
-jest.mock( 'lib/analytics/utils', () => ( {
+jest.mock( 'calypso/lib/analytics/utils', () => ( {
 	isGoogleAnalyticsAllowed: () => true,
 	isPiiUrl: () => false,
 	mayWeTrackCurrentUserGdpr: () => true,

--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -17,8 +17,8 @@ import { initializeAnalytics } from 'calypso/lib/analytics/init';
 import { bumpStat, bumpStatWithPageView } from 'calypso/lib/analytics/mc';
 import { recordAliasInFloodlight } from 'calypso/lib/analytics/ad-tracking';
 
-jest.mock( 'config', () => require( './mocks/config' ) );
-jest.mock( 'lib/analytics/ad-tracking', () => ( {
+jest.mock( 'calypso/config', () => require( './mocks/config' ) );
+jest.mock( 'calypso/lib/analytics/ad-tracking', () => ( {
 	retarget: () => {},
 	recordAliasInFloodlight: jest.fn(),
 } ) );

--- a/client/lib/automated-transfer/test/index.js
+++ b/client/lib/automated-transfer/test/index.js
@@ -1,15 +1,15 @@
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	const defaultExport = jest.fn();
 	defaultExport.isEnabled = jest.fn();
 	defaultExport.default = jest.fn();
 	return defaultExport;
 } );
 
-jest.mock( 'lib/site/utils', () => ( {
+jest.mock( 'calypso/lib/site/utils', () => ( {
 	userCan: jest.fn(),
 } ) );
 

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -20,7 +20,7 @@ import { GSUITE_BASIC_SLUG } from 'calypso/lib/gsuite/constants';
 import { PRODUCT_JETPACK_BACKUP_DAILY } from 'calypso/lib/products-values/constants';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 const cartItems = require( '../cart-items' );
 const { getPlan } = require( 'calypso/lib/plans' );

--- a/client/lib/cart-values/test/index.js
+++ b/client/lib/cart-values/test/index.js
@@ -11,7 +11,7 @@ import * as cartValues from '../index';
 import * as cartItems from '../cart-items';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'index', () => {
 	const TEST_BLOG_ID = 1;

--- a/client/lib/cart/store/test/cart-synchronizer.js
+++ b/client/lib/cart/store/test/cart-synchronizer.js
@@ -10,7 +10,7 @@ import CartSynchronizer from '../cart-synchronizer';
 import FakeWPCOM from './fake-wpcom';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 const TEST_CART_KEY = 91234567890;
 

--- a/client/lib/cart/store/test/index.js
+++ b/client/lib/cart/store/test/index.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-jest.mock( 'lib/analytics/cart', () => ( {
+jest.mock( 'calypso/lib/analytics/cart', () => ( {
 	recordEvents: () => ( {} ),
 } ) );
 jest.mock( '../cart-synchronizer', () => () => {
@@ -16,18 +16,18 @@ jest.mock( '../cart-synchronizer', () => () => {
 		_poll: { bind: () => ( {} ) },
 	};
 } );
-jest.mock( 'lib/cart-values', () => {
+jest.mock( 'calypso/lib/cart-values', () => {
 	return {
 		fillInAllCartItemAttributes: jest.fn( () => ( {} ) ),
 		removeCoupon: jest.fn( () => ( i ) => i ),
 	};
 } );
-jest.mock( 'lib/data-poller', () => ( {
+jest.mock( 'calypso/lib/data-poller', () => ( {
 	add: () => ( {} ),
 	remove: () => ( {} ),
 } ) );
-jest.mock( 'lib/products-list', () => () => ( { get: () => [] } ) );
-jest.mock( 'lib/wp', () => ( {
+jest.mock( 'calypso/lib/products-list', () => () => ( { get: () => [] } ) );
+jest.mock( 'calypso/lib/wp', () => ( {
 	undocumented: () => ( {} ),
 	me: () => ( {
 		get: async () => ( {} ),
@@ -62,7 +62,7 @@ describe( 'Cart Store', () => {
 		let disableCart;
 		let removeCoupon;
 		jest.isolateModules( () => {
-			const cartActions = jest.requireActual( 'lib/cart/actions' );
+			const cartActions = jest.requireActual( 'calypso/lib/cart/actions' );
 			disableCart = cartActions.disableCart;
 			removeCoupon = cartActions.removeCoupon;
 		} );

--- a/client/lib/domains/email-forwarding/test/index.js
+++ b/client/lib/domains/email-forwarding/test/index.js
@@ -6,7 +6,7 @@ import {
 	getEmailForwardingSupportedDomains,
 } from 'calypso/lib/domains/email-forwarding';
 
-jest.mock( 'lib/user/', () => {
+jest.mock( 'calypso/lib/user/', () => {
 	return () => {
 		return {
 			get: () => {

--- a/client/lib/follow-list/test/index.js
+++ b/client/lib/follow-list/test/index.js
@@ -14,7 +14,7 @@ import sinon from 'sinon';
 import FollowList from 'calypso/lib/follow-list';
 import FollowListSite from 'calypso/lib/follow-list/site';
 
-jest.mock( 'lib/wp', () => require( './mocks/lib/wp' ) );
+jest.mock( 'calypso/lib/wp', () => require( './mocks/lib/wp' ) );
 
 describe( 'index', () => {
 	let followList;

--- a/client/lib/gsuite/test/index.js
+++ b/client/lib/gsuite/test/index.js
@@ -13,7 +13,7 @@ import {
 	hasPendingGSuiteUsers,
 } from 'calypso/lib/gsuite';
 
-jest.mock( 'lib/user/', () => {
+jest.mock( 'calypso/lib/user/', () => {
 	return () => {
 		return {
 			get: () => {

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -20,7 +20,7 @@ import {
 	isMagnificentLocale,
 } from 'calypso/lib/i18n-utils';
 
-jest.mock( 'config', () => ( key ) => {
+jest.mock( 'calypso/config', () => ( key ) => {
 	if ( 'i18n_default_locale_slug' === key ) {
 		return 'en';
 	}

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -14,7 +14,7 @@ import { map } from 'lodash';
 import * as MediaUtils from '../utils';
 import { ValidationErrors as MediaValidationErrors } from '../constants';
 
-jest.mock( 'lib/impure-lodash', () => ( {
+jest.mock( 'calypso/lib/impure-lodash', () => ( {
 	uniqueId: () => 'media-13',
 } ) );
 

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -3,7 +3,7 @@
  */
 import { login } from '../';
 
-jest.mock( 'config', () => ( {
+jest.mock( 'calypso/config', () => ( {
 	__esModule: true,
 	default: jest.fn( ( key ) => {
 		if ( 'login_url' === key ) {

--- a/client/lib/performance-tracking/test/use-performance-tracker-stop.js
+++ b/client/lib/performance-tracking/test/use-performance-tracker-stop.js
@@ -21,7 +21,7 @@ jest.mock( 'react-redux', () => ( {
 jest.mock( '../lib', () => ( {
 	stopPerformanceTracking: jest.fn(),
 } ) );
-jest.mock( 'state/ui/selectors', () => ( {
+jest.mock( 'calypso/state/ui/selectors', () => ( {
 	getSectionName: jest.fn(),
 } ) );
 

--- a/client/lib/plugins/test/store.js
+++ b/client/lib/plugins/test/store.js
@@ -19,7 +19,7 @@ import Dispatcher from 'calypso/dispatcher';
 import PluginsStore from 'calypso/lib/plugins/store';
 import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
 
-jest.mock( 'lib/redux-bridge', () => require( './mocks/redux-bridge' ) );
+jest.mock( 'calypso/lib/redux-bridge', () => require( './mocks/redux-bridge' ) );
 
 // Helper to retrieve a particular plugin from flux while we're migrating to Redux.
 const getSitePlugin = ( siteObject, pluginSlug ) =>

--- a/client/lib/plugins/wporg-data/test/actions.js
+++ b/client/lib/plugins/wporg-data/test/actions.js
@@ -9,8 +9,8 @@ import { spy } from 'sinon';
  */
 import WPorgActions from 'calypso/lib/plugins/wporg-data/actions';
 import * as mockedWporg from 'calypso/lib/wporg';
-jest.mock( 'lib/wporg', () => require( './mocks/wporg' ) );
-jest.mock( 'lib/impure-lodash', () => ( {
+jest.mock( 'calypso/lib/wporg', () => require( './mocks/wporg' ) );
+jest.mock( 'calypso/lib/impure-lodash', () => ( {
 	debounce: ( cb ) => cb,
 } ) );
 

--- a/client/lib/plugins/wporg-data/test/list-store.js
+++ b/client/lib/plugins/wporg-data/test/list-store.js
@@ -11,10 +11,10 @@ import actionsSpies from './mocks/actions';
 import Dispatcher from 'calypso/dispatcher';
 import PluginsListsStore from 'calypso/lib/plugins/wporg-data/list-store';
 
-jest.mock( 'config', () => ( {
+jest.mock( 'calypso/config', () => ( {
 	isEnabled: () => true,
 } ) );
-jest.mock( 'lib/plugins/wporg-data/actions', () => require( './mocks/actions' ) );
+jest.mock( 'calypso/lib/plugins/wporg-data/actions', () => require( './mocks/actions' ) );
 
 describe( 'WPORG Plugins Lists Store', () => {
 	let pluginsList;

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-jest.mock( 'lib/safe-image-url', () => require( './mocks/lib/safe-image-url' ) );
+jest.mock( 'calypso/lib/safe-image-url', () => require( './mocks/lib/safe-image-url' ) );
 
 /**
  * External dependencies

--- a/client/lib/purchases/test/assembler.js
+++ b/client/lib/purchases/test/assembler.js
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import { createPurchasesArray } from '../assembler';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'assembler', () => {
 	test( 'should be a function', () => {

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -35,8 +35,8 @@ const {
 } = data;
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
-jest.mock( 'lib/analytics/tracks', () => ( { recordTracksEvent: jest.fn() } ) );
+jest.mock( 'calypso/lib/user', () => () => {} );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( { recordTracksEvent: jest.fn() } ) );
 jest.mock( 'page', () => jest.fn() );
 
 describe( 'index', () => {

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -18,10 +18,12 @@ import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
 import SignupFlowController from '../flow-controller';
 
-jest.mock( 'signup/config/flows', () => require( './mocks/signup/config/flows' ) );
-jest.mock( 'signup/config/flows-pure', () => require( './mocks/signup/config/flows-pure' ) );
-jest.mock( 'signup/config/steps', () => require( './mocks/signup/config/steps' ) );
-jest.mock( 'signup/config/steps-pure', () => require( './mocks/signup/config/steps' ) );
+jest.mock( 'calypso/signup/config/flows', () => require( './mocks/signup/config/flows' ) );
+jest.mock( 'calypso/signup/config/flows-pure', () =>
+	require( './mocks/signup/config/flows-pure' )
+);
+jest.mock( 'calypso/signup/config/steps', () => require( './mocks/signup/config/steps' ) );
+jest.mock( 'calypso/signup/config/steps-pure', () => require( './mocks/signup/config/steps' ) );
 
 function createSignupStore( initialState ) {
 	return createStore(

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -16,9 +16,9 @@ import flows from 'calypso/signup/config/flows';
 import { isDomainStepSkippable } from 'calypso/signup/config/steps';
 import { getUserStub } from 'calypso/lib/user';
 
-jest.mock( 'lib/abtest', () => ( { abtest: () => '' } ) );
+jest.mock( 'calypso/lib/abtest', () => ( { abtest: () => '' } ) );
 
-jest.mock( 'lib/user', () => {
+jest.mock( 'calypso/lib/user', () => {
 	const getStub = jest.fn();
 
 	const user = () => ( {
@@ -29,9 +29,11 @@ jest.mock( 'lib/user', () => {
 	return user;
 } );
 
-jest.mock( 'signup/config/steps', () => require( './mocks/signup/config/steps' ) );
-jest.mock( 'signup/config/flows', () => require( './mocks/signup/config/flows' ) );
-jest.mock( 'signup/config/flows-pure', () => require( './mocks/signup/config/flows-pure' ) );
+jest.mock( 'calypso/signup/config/steps', () => require( './mocks/signup/config/steps' ) );
+jest.mock( 'calypso/signup/config/flows', () => require( './mocks/signup/config/flows' ) );
+jest.mock( 'calypso/signup/config/flows-pure', () =>
+	require( './mocks/signup/config/flows-pure' )
+);
 
 describe( 'createSiteWithCart()', () => {
 	// createSiteWithCart() function is not designed to be easy for test at the moment.

--- a/client/lib/user-settings/test/index.js
+++ b/client/lib/user-settings/test/index.js
@@ -7,8 +7,8 @@
  */
 import userSettings from '..';
 
-jest.mock( 'lib/wp', () => require( './mocks/wp' ) );
-jest.mock( 'lib/user/utils', () => require( './mocks/user-utils' ) );
+jest.mock( 'calypso/lib/wp', () => require( './mocks/wp' ) );
+jest.mock( 'calypso/lib/user/utils', () => require( './mocks/user-utils' ) );
 
 describe( 'User Settings', () => {
 	beforeEach( () => {

--- a/client/lib/user/test/utils.js
+++ b/client/lib/user/test/utils.js
@@ -7,7 +7,7 @@ import User from 'calypso/lib/user';
 
 const user = User();
 
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	const mock = jest.fn();
 	mock.isEnabled = jest.fn();
 

--- a/client/me/concierge/test/main.js
+++ b/client/me/concierge/test/main.js
@@ -1,4 +1,4 @@
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 

--- a/client/me/help/help-courses/test/index.jsx
+++ b/client/me/help/help-courses/test/index.jsx
@@ -29,23 +29,23 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from 'calypso/lib/plans/constants';
 
-jest.mock( 'lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'lib/user', () => () => {} );
-jest.mock( 'components/main', () => 'Main' );
-jest.mock( 'components/section-header', () => 'SectionHeader' );
-jest.mock( 'me/sidebar-navigation', () => 'MeSidebarNavigation' );
-jest.mock( 'state/current-user/selectors', () => ( {
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/lib/user', () => () => {} );
+jest.mock( 'calypso/components/main', () => 'Main' );
+jest.mock( 'calypso/components/section-header', () => 'SectionHeader' );
+jest.mock( 'calypso/me/sidebar-navigation', () => 'MeSidebarNavigation' );
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
 	getCurrentUserId: jest.fn( () => 12 ),
 	isCurrentUserEmailVerified: jest.fn( () => true ),
 } ) );
 
-jest.mock( 'state/purchases/selectors', () => ( {
+jest.mock( 'calypso/state/purchases/selectors', () => ( {
 	getUserPurchases: jest.fn(),
 	isFetchingUserPurchases: jest.fn( () => false ),
 	hasLoadedUserPurchasesFromServer: jest.fn( () => true ),
 } ) );
 
-jest.mock( 'state/help/courses/selectors', () => ( {
+jest.mock( 'calypso/state/help/courses/selectors', () => ( {
 	getHelpCourses: jest.fn( () => [] ),
 } ) );
 

--- a/client/me/help/test/main.jsx
+++ b/client/me/help/test/main.jsx
@@ -29,18 +29,18 @@ import {
 } from 'calypso/lib/plans/constants';
 import { mapStateToProps } from '../main';
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/user', () => jest.fn() );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/user', () => jest.fn() );
 jest.mock( '../help-unverified-warning', () => 'HelpUnverifiedWarning' );
-jest.mock( 'components/main', () => 'Main' );
-jest.mock( 'components/section-header', () => 'SectionHeader' );
-jest.mock( 'me/sidebar-navigation', () => 'MeSidebarNavigation' );
-jest.mock( 'state/current-user/selectors', () => ( {
+jest.mock( 'calypso/components/main', () => 'Main' );
+jest.mock( 'calypso/components/section-header', () => 'SectionHeader' );
+jest.mock( 'calypso/me/sidebar-navigation', () => 'MeSidebarNavigation' );
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
 	getCurrentUserId: jest.fn( () => 12 ),
 	isCurrentUserEmailVerified: jest.fn( () => true ),
 } ) );
 
-jest.mock( 'state/purchases/selectors', () => ( {
+jest.mock( 'calypso/state/purchases/selectors', () => ( {
 	getUserPurchases: jest.fn(),
 	isFetchingUserPurchases: jest.fn( () => false ),
 } ) );

--- a/client/me/pending-payments/test/index.js
+++ b/client/me/pending-payments/test/index.js
@@ -9,7 +9,7 @@ import { shallow } from 'enzyme';
  */
 import { PendingPayments, requestId } from '../index';
 
-jest.mock( 'state/data-layer/http-data', () => ( {
+jest.mock( 'calypso/state/data-layer/http-data', () => ( {
 	requestHttpData: ( x ) => x,
 } ) );
 

--- a/client/me/pending-payments/test/pending-list-item.js
+++ b/client/me/pending-payments/test/pending-list-item.js
@@ -12,7 +12,7 @@ import { PendingListItem } from '../pending-list-item';
 import { PLAN_BUSINESS } from 'calypso/lib/plans/constants';
 import * as localizedMoment from 'calypso/components/localized-moment';
 
-jest.mock( 'components/localized-moment' );
+jest.mock( 'calypso/components/localized-moment' );
 localizedMoment.useLocalizedMoment.mockReturnValue( moment );
 
 describe( 'PendingListItem', () => {

--- a/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
@@ -10,8 +10,8 @@ import { cancellationEffectDetail, cancellationEffectHeadline } from '../cancell
 import productsValues from 'calypso/lib/products-values';
 import purchases from 'calypso/lib/purchases';
 
-jest.mock( 'lib/products-values', () => ( {} ) );
-jest.mock( 'lib/purchases', () => ( {} ) );
+jest.mock( 'calypso/lib/products-values', () => ( {} ) );
+jest.mock( 'calypso/lib/purchases', () => ( {} ) );
 
 describe( 'cancellation-effect', () => {
 	const purchase = { domain: 'example.com' };

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -37,11 +37,11 @@ const props = {
 	moment,
 };
 
-jest.mock( 'lib/cart-values/cart-items', () => ( {
+jest.mock( 'calypso/lib/cart-values/cart-items', () => ( {
 	planItem: jest.fn(),
 } ) );
 
-jest.mock( 'lib/cart/actions', () => ( {
+jest.mock( 'calypso/lib/cart/actions', () => ( {
 	addItem: jest.fn(),
 } ) );
 

--- a/client/me/purchases/track-purchase-page-view/test/index.js
+++ b/client/me/purchases/track-purchase-page-view/test/index.js
@@ -11,7 +11,7 @@ import deepFreeze from 'deep-freeze';
 import { TrackPurchasePageView } from '..';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 const baseProps = deepFreeze( {
 	eventName: 'calypso_testtracking_purchase_view',

--- a/client/my-sites/checkout/cart/test/cart-item.js
+++ b/client/my-sites/checkout/cart/test/cart-item.js
@@ -41,7 +41,7 @@ const mockPlansModule = () => {
 };
 mockPlansModule();
 
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	const fn = () => {};
 	fn.isEnabled = jest.fn( () => null );
 	return fn;
@@ -49,7 +49,7 @@ jest.mock( 'config', () => {
 jest.mock( '@automattic/format-currency', () => ( {
 	getCurrencyObject: ( price ) => ( { integer: price } ),
 } ) );
-jest.mock( 'lib/products-values', () => ( {
+jest.mock( 'calypso/lib/products-values', () => ( {
 	isPlan: jest.fn( () => null ),
 	isTheme: jest.fn( () => null ),
 	isMonthly: jest.fn( () => null ),

--- a/client/my-sites/checkout/cart/test/cart-plan-discount-ad.js
+++ b/client/my-sites/checkout/cart/test/cart-plan-discount-ad.js
@@ -9,8 +9,8 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 jest.mock( 'page' );
-jest.mock( 'state/sites/plans/actions' );
-jest.mock( 'state/analytics/actions' );
+jest.mock( 'calypso/state/sites/plans/actions' );
+jest.mock( 'calypso/state/analytics/actions' );
 
 import { CartPlanDiscountAd } from '../cart-plan-discount-ad';
 import CartAd from '../cart-ad';

--- a/client/my-sites/checkout/checkout-thank-you/test/header.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/header.js
@@ -9,20 +9,20 @@ import React from 'react';
  */
 import { CheckoutThankYouHeader } from '../header';
 
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.unmock( 'lib/plans' );
+jest.unmock( 'calypso/lib/plans' );
 const plans = require( 'calypso/lib/plans' );
 plans.getFeatureByKey = () => null;
 plans.shouldFetchSitePlans = () => false;
 
-jest.unmock( 'lib/products-values' );
+jest.unmock( 'calypso/lib/products-values' );
 const isDotComPlan = require( 'calypso/lib/products-values/is-dot-com-plan' );
 isDotComPlan.isDotComPlan = jest.fn( () => false );
 
-jest.mock( 'lib/analytics/tracks', () => ( {
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	recordTracksEvent: () => null,
 } ) );
 jest.mock( '../domain-registration-details', () => 'component--domain-registration-details' );
@@ -30,14 +30,14 @@ jest.mock( '../google-apps-details', () => 'component--google-apps-details' );
 jest.mock( '../jetpack-plan-details', () => 'component--jetpack-plan-details' );
 jest.mock( '../rebrand-cities-thank-you', () => 'component--RebrandCitiesThankYou' );
 jest.mock( '../atomic-store-thank-you-card', () => 'component--AtomicStoreThankYouCard' );
-jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'components/happiness-support', () => 'HappinessSupport' );
-jest.mock( 'lib/rebrand-cities', () => ( {
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'calypso/components/happiness-support', () => 'HappinessSupport' );
+jest.mock( 'calypso/lib/rebrand-cities', () => ( {
 	isRebrandCitiesSiteUrl: jest.fn( () => false ),
 } ) );
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 const translate = ( x ) => x;
 

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -28,21 +28,21 @@ import {
  */
 import { CheckoutThankYou } from '../index';
 
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.unmock( 'lib/plans' );
+jest.unmock( 'calypso/lib/plans' );
 const plans = require( 'calypso/lib/plans' );
 plans.getFeatureByKey = () => null;
 plans.shouldFetchSitePlans = () => false;
 
-jest.unmock( 'lib/products-values' );
+jest.unmock( 'calypso/lib/products-values' );
 const productValues = require( 'calypso/lib/products-values' );
 const isDotComPlan = require( 'calypso/lib/products-values/is-dot-com-plan' );
 isDotComPlan.isDotComPlan = jest.fn( () => false );
 
-jest.mock( 'lib/analytics/tracks', () => ( {
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	recordTracksEvent: () => null,
 } ) );
 jest.mock( '../domain-registration-details', () => 'component--domain-registration-details' );
@@ -50,15 +50,15 @@ jest.mock( '../google-apps-details', () => 'component--google-apps-details' );
 jest.mock( '../jetpack-plan-details', () => 'component--jetpack-plan-details' );
 jest.mock( '../rebrand-cities-thank-you', () => 'component--RebrandCitiesThankYou' );
 jest.mock( '../atomic-store-thank-you-card', () => 'component--AtomicStoreThankYouCard' );
-jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 jest.mock( '../header', () => 'CheckoutThankYouHeader' );
-jest.mock( 'components/happiness-support', () => 'HappinessSupport' );
-jest.mock( 'lib/rebrand-cities', () => ( {
+jest.mock( 'calypso/components/happiness-support', () => 'HappinessSupport' );
+jest.mock( 'calypso/lib/rebrand-cities', () => ( {
 	isRebrandCitiesSiteUrl: jest.fn( () => false ),
 } ) );
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 import RebrandCities from 'calypso/lib/rebrand-cities';
 

--- a/client/my-sites/checkout/checkout/test/country-specific-payment-fields.js
+++ b/client/my-sites/checkout/checkout/test/country-specific-payment-fields.js
@@ -15,7 +15,7 @@ import { identity } from 'lodash';
 import { CountrySpecificPaymentFields } from '../country-specific-payment-fields';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 const defaultProps = {
 	countryCode: 'BR',

--- a/client/my-sites/checkout/composite-checkout/components/test/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/test/secondary-cart-promotions.tsx
@@ -22,7 +22,7 @@ import { responseCartWithRenewal, storeData } from './lib/fixtures';
 import SecondaryCartPromotions from '../secondary-cart-promotions';
 
 const mockConfig = ( config as unknown ) as { isEnabled: jest.Mock };
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	const mock = () => '';
 	mock.isEnabled = jest.fn();
 	return mock;

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -12,20 +12,20 @@ import { isEnabled } from 'calypso/config';
 import { PLAN_ECOMMERCE } from '../../../../lib/plans/constants';
 
 let mockGSuiteCountryIsValid = true;
-jest.mock( 'lib/user', () =>
+jest.mock( 'calypso/lib/user', () =>
 	jest.fn( () => ( {
 		get: () => ( { is_valid_google_apps_country: mockGSuiteCountryIsValid } ),
 	} ) )
 );
 
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	const mock = () => 'development';
 	mock.isEnabled = jest.fn();
 	return mock;
 } );
 
 // Temporary A/B test to dial down the concierge upsell, check pau2Xa-1bk-p2.
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: jest.fn( ( name ) => {
 		if ( 'conciergeUpsellDial' === name ) {
 			return 'offer';

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -22,16 +22,16 @@ import CompositeCheckout from '../composite-checkout';
 /**
  * Mocked dependencies
  */
-jest.mock( 'state/sites/selectors' );
+jest.mock( 'calypso/state/sites/selectors' );
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-jest.mock( 'state/selectors/is-site-automated-transfer' );
+jest.mock( 'calypso/state/selectors/is-site-automated-transfer' );
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 
 jest.mock( 'page', () => ( {
 	redirect: jest.fn(),
 } ) );
 
-jest.mock( 'components/data/query-experiments' );
+jest.mock( 'calypso/components/data/query-experiments' );
 
 const domainProduct = {
 	product_name: '.cash Domain',

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -18,7 +18,7 @@ import { DomainWarnings } from '../';
 import { type as domainTypes } from 'calypso/lib/domains/constants';
 import { MAP_EXISTING_DOMAIN_UPDATE_DNS, MAP_SUBDOMAIN } from 'calypso/lib/url/support';
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 
 describe( 'index', () => {
 	describe( 'rules', () => {

--- a/client/my-sites/domains/components/form/test/hidden-input.js
+++ b/client/my-sites/domains/components/form/test/hidden-input.js
@@ -12,7 +12,7 @@ import React from 'react';
 import { HiddenInput } from '../hidden-input';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'HiddenInput', () => {
 	const defaultProps = {

--- a/client/my-sites/domains/components/form/test/select.js
+++ b/client/my-sites/domains/components/form/test/select.js
@@ -14,7 +14,7 @@ import React from 'react';
 import Select from '../select';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( '<Select />', () => {
 	const defaultProps = {

--- a/client/my-sites/domains/domain-management/list/test/index.js
+++ b/client/my-sites/domains/domain-management/list/test/index.js
@@ -18,7 +18,7 @@ import { ShoppingCartProvider, getEmptyResponseCart } from '@automattic/shopping
 import { List as DomainList } from '..';
 import { createReduxStore } from 'calypso/state';
 
-jest.mock( 'lib/wp', () => ( {
+jest.mock( 'calypso/lib/wp', () => ( {
 	undocumented: () => ( {
 		getProducts: () => {},
 		getSitePlans: () => {},

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
@@ -1,10 +1,10 @@
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: ( Comp ) => ( props ) => (

--- a/client/my-sites/domains/map-domain/test/map-domain.js
+++ b/client/my-sites/domains/map-domain/test/map-domain.js
@@ -17,7 +17,7 @@ import MapDomainStep from 'calypso/components/domains/map-domain-step';
 import HeaderCake from 'calypso/components/header-cake';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 jest.mock( 'page', () => {
 	const { spy } = require( 'sinon' );
 	const pageSpy = spy();

--- a/client/my-sites/email/gsuite-purchase-cta/test/index.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/index.js
@@ -12,9 +12,15 @@ import renderer from 'react-test-renderer';
 import { GSuitePurchaseCta } from '../';
 
 // components to mock
-jest.mock( 'components/email-verification/email-verification-gate', () => 'EmailVerificationGate' );
-jest.mock( 'my-sites/email/gsuite-purchase-cta/sku-info', () => 'GSuitePurchaseCtaSkuInfo' );
-jest.mock( 'components/data/query-products-list', () => 'QueryProductsList' );
+jest.mock(
+	'calypso/components/email-verification/email-verification-gate',
+	() => 'EmailVerificationGate'
+);
+jest.mock(
+	'calypso/my-sites/email/gsuite-purchase-cta/sku-info',
+	() => 'GSuitePurchaseCtaSkuInfo'
+);
+jest.mock( 'calypso/components/data/query-products-list', () => 'QueryProductsList' );
 
 describe( 'GSuitePurchaseCta', () => {
 	test( 'renders correctly', () => {

--- a/client/my-sites/email/gsuite-purchase-cta/test/sku-info.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/sku-info.js
@@ -9,8 +9,8 @@ import renderer from 'react-test-renderer';
  */
 import GSuitePurchaseCtaSkuInfo from '../sku-info';
 
-jest.mock( 'components/forms/form-button', () => 'Button' );
-jest.mock( 'components/info-popover', () => 'InfoPopover' );
+jest.mock( 'calypso/components/forms/form-button', () => 'Button' );
+jest.mock( 'calypso/components/info-popover', () => 'InfoPopover' );
 
 describe( 'GSuitePurchaseCta', () => {
 	test( 'it renders GSuitePurchaseCtaSkuInfo with all props', () => {

--- a/client/my-sites/media-library/test/data-source.jsx
+++ b/client/my-sites/media-library/test/data-source.jsx
@@ -20,12 +20,12 @@ import { setStore } from 'calypso/state/redux-store';
 
 // we need to check the correct children are rendered, so this mocks the
 // PopoverMenu component with one that simply renders the children
-jest.mock( 'components/popover/menu', () => {
+jest.mock( 'calypso/components/popover/menu', () => {
 	return ( props ) => <div>{ props.children }</div>;
 } );
 // only enable the external-media options, enabling everything causes an
 // electron related build error
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	const config = () => 'development';
 	config.isEnabled = ( property ) => property.startsWith( 'external-media' );
 	return config;

--- a/client/my-sites/media-library/test/index.jsx
+++ b/client/my-sites/media-library/test/index.jsx
@@ -15,22 +15,22 @@ import React from 'react';
 import MediaLibrary from '..';
 import { requestKeyringConnections as requestStub } from 'calypso/state/sharing/keyring/actions';
 
-jest.mock( 'components/data/query-preferences', () =>
+jest.mock( 'calypso/components/data/query-preferences', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'my-sites/media-library/content', () =>
+jest.mock( 'calypso/my-sites/media-library/content', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'my-sites/media-library/drop-zone', () =>
+jest.mock( 'calypso/my-sites/media-library/drop-zone', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'my-sites/media-library/filter-bar', () =>
+jest.mock( 'calypso/my-sites/media-library/filter-bar', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'state/sharing/keyring/actions', () => ( {
+jest.mock( 'calypso/state/sharing/keyring/actions', () => ( {
 	requestKeyringConnections: require( 'sinon' ).stub(),
 } ) );
-jest.mock( 'state/sharing/keyring/selectors', () => ( {
+jest.mock( 'calypso/state/sharing/keyring/selectors', () => ( {
 	getKeyringConnections: () => null,
 	isKeyringConnectionsFetching: () => null,
 } ) );

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -25,12 +25,14 @@ import fixtures from './fixtures';
 const DUMMY_SITE_ID = 2916284;
 const mockSelectedItems = [];
 
-jest.mock( 'lib/user', () => () => {} );
-jest.mock( 'components/infinite-list', () => require( 'calypso/components/empty-component' ) );
-jest.mock( 'my-sites/media-library/list-item', () =>
+jest.mock( 'calypso/lib/user', () => () => {} );
+jest.mock( 'calypso/components/infinite-list', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'my-sites/media-library/list-plan-upgrade-nudge', () =>
+jest.mock( 'calypso/my-sites/media-library/list-item', () =>
+	require( 'calypso/components/empty-component' )
+);
+jest.mock( 'calypso/my-sites/media-library/list-plan-upgrade-nudge', () =>
 	require( 'calypso/components/empty-component' )
 );
 

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -2,13 +2,13 @@
  * @jest-environment jsdom
  */
 
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: ( Comp ) => ( props ) => (

--- a/client/my-sites/plan-features/test/index.jsx
+++ b/client/my-sites/plan-features/test/index.jsx
@@ -1,13 +1,13 @@
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'lib/analytics/ad-tracking', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/ad-tracking', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 
-jest.mock( 'state/sites/plans/selectors', () => ( {
+jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
 	getPlanDiscountedRawPrice: jest.fn(),
 	getSitePlanRawPrice: jest.fn(),
 } ) );

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -1,27 +1,27 @@
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
 jest.mock( 'react-redux', () => ( {
 	connect: () => ( component ) => component,
 } ) );
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'config', () => {
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'calypso/config', () => {
 	const fn = () => {
 		return [];
 	};
 	fn.isEnabled = jest.fn( () => true );
 	return fn;
 } );
-jest.mock( 'components/happychat/connection-connected', () => 'HappychatConnection' );
-jest.mock( 'components/data/query-plans', () => 'QueryPlans' );
-jest.mock( 'components/data/query-site-plans', () => 'QuerySitePlans' );
-jest.mock( 'components/data/cart', () => 'CartData' );
-jest.mock( 'my-sites/plan-features', () => 'PlanFeatures' );
-jest.mock( 'my-sites/plans-features-main/wpcom-faq', () => 'WpcomFAQ' );
-jest.mock( 'my-sites/plans-features-main/jetpack-faq', () => 'JetpackFAQ' );
+jest.mock( 'calypso/components/happychat/connection-connected', () => 'HappychatConnection' );
+jest.mock( 'calypso/components/data/query-plans', () => 'QueryPlans' );
+jest.mock( 'calypso/components/data/query-site-plans', () => 'QuerySitePlans' );
+jest.mock( 'calypso/components/data/cart', () => 'CartData' );
+jest.mock( 'calypso/my-sites/plan-features', () => 'PlanFeatures' );
+jest.mock( 'calypso/my-sites/plans-features-main/wpcom-faq', () => 'WpcomFAQ' );
+jest.mock( 'calypso/my-sites/plans-features-main/jetpack-faq', () => 'JetpackFAQ' );
 
 /**
  * External dependencies

--- a/client/my-sites/plans/test/index.js
+++ b/client/my-sites/plans/test/index.js
@@ -9,16 +9,16 @@ jest.mock( '../controller', () => ( {
 jest.mock( '../current-plan/controller', () => ( {
 	currentPlan: jest.fn(),
 } ) );
-jest.mock( 'controller', () => ( {
+jest.mock( 'calypso/controller', () => ( {
 	makeLayout: jest.fn(),
 	render: jest.fn(),
 } ) );
-jest.mock( 'my-sites/controller', () => ( {
+jest.mock( 'calypso/my-sites/controller', () => ( {
 	navigation: jest.fn(),
 	siteSelection: jest.fn(),
 	sites: jest.fn(),
 } ) );
-jest.mock( 'my-sites/plans/jetpack-plans', () => jest.fn() );
+jest.mock( 'calypso/my-sites/plans/jetpack-plans', () => jest.fn() );
 
 /**
  * External dependencies

--- a/client/my-sites/plugins/plugin-action/test/index.jsx
+++ b/client/my-sites/plugins/plugin-action/test/index.jsx
@@ -14,7 +14,9 @@ import React from 'react';
  */
 import PluginAction from '../plugin-action';
 
-jest.mock( 'components/info-popover', () => require( 'calypso/components/empty-component' ) );
+jest.mock( 'calypso/components/info-popover', () =>
+	require( 'calypso/components/empty-component' )
+);
 
 describe( 'PluginAction', () => {
 	describe( 'rendering with form toggle', () => {

--- a/client/my-sites/plugins/plugin-activate-toggle/test/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/index.jsx
@@ -16,7 +16,7 @@ import { spy } from 'sinon';
 import fixtures from './fixtures';
 import { PluginActivateToggle } from 'calypso/my-sites/plugins/plugin-activate-toggle';
 
-jest.mock( 'my-sites/plugins/plugin-action/plugin-action', () =>
+jest.mock( 'calypso/my-sites/plugins/plugin-action/plugin-action', () =>
 	require( './mocks/plugin-action' )
 );
 

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/test/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/test/index.jsx
@@ -16,7 +16,7 @@ import { spy } from 'sinon';
 import fixtures from './fixtures';
 import { PluginAutoUpdateToggle } from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 
-jest.mock( 'my-sites/plugins/plugin-action/plugin-action', () =>
+jest.mock( 'calypso/my-sites/plugins/plugin-action/plugin-action', () =>
 	require( './mocks/plugin-action' )
 );
 jest.mock( 'query', () => require( 'component-query' ), { virtual: true } );

--- a/client/my-sites/plugins/plugin-meta/test/index.js
+++ b/client/my-sites/plugins/plugin-meta/test/index.js
@@ -26,32 +26,32 @@ import {
 	PLAN_BLOGGER_2_YEARS,
 } from 'calypso/lib/plans/constants';
 
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'lib/translator-jumpstart', () => ( {} ) );
-jest.mock( 'lib/plugins/wporg-data/actions', () => ( {} ) );
-jest.mock( 'lib/plugins/wporg-data/list-store', () => ( {
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'calypso/lib/translator-jumpstart', () => ( {} ) );
+jest.mock( 'calypso/lib/plugins/wporg-data/actions', () => ( {} ) );
+jest.mock( 'calypso/lib/plugins/wporg-data/list-store', () => ( {
 	getShortList: () => {},
 	getFullList: () => {},
 	getSearchList: () => {},
 	on: () => {},
 } ) );
-jest.mock( 'state/guided-tours/selectors', () => ( {} ) );
-jest.mock( 'my-sites/plugins/utils', () => ( {
+jest.mock( 'calypso/state/guided-tours/selectors', () => ( {} ) );
+jest.mock( 'calypso/my-sites/plugins/utils', () => ( {
 	getExtensionSettingsPath: () => '',
 } ) );
-jest.mock( 'layout/guided-tours/positioning', () => 'Positioning' );
-jest.mock( 'layout/guided-tours/tours/main-tour', () => 'MainTour' );
-jest.mock( 'layout/masterbar/logged-in', () => 'LoggedIn' );
-jest.mock( 'layout/community-translator/launcher', () => 'Launcher' );
-jest.mock( 'blocks/upsell-nudge', () => 'UpsellNudge' );
-jest.mock( 'components/notice', () => 'Notice' );
-jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
+jest.mock( 'calypso/layout/guided-tours/positioning', () => 'Positioning' );
+jest.mock( 'calypso/layout/guided-tours/tours/main-tour', () => 'MainTour' );
+jest.mock( 'calypso/layout/masterbar/logged-in', () => 'LoggedIn' );
+jest.mock( 'calypso/layout/community-translator/launcher', () => 'Launcher' );
+jest.mock( 'calypso/blocks/upsell-nudge', () => 'UpsellNudge' );
+jest.mock( 'calypso/components/notice', () => 'Notice' );
+jest.mock( 'calypso/components/notice/notice-action', () => 'NoticeAction' );
 
 const selectedSite = {
 	plan: {

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -1,23 +1,23 @@
 /** @jest-environment jsdom */
 
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'lib/plugins/wporg-data/list-store', () => ( {
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'calypso/lib/plugins/wporg-data/list-store', () => ( {
 	getShortList: () => {},
 	getFullList: () => {},
 	getSearchList: () => {},
 	on: () => {},
 } ) );
-jest.mock( 'lib/plugins/wporg-data/actions', () => ( {} ) );
-jest.mock( 'components/main', () => 'MainComponent' );
-jest.mock( 'blocks/upsell-nudge', () => 'UpsellNudge' );
-jest.mock( 'components/notice', () => 'Notice' );
-jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
+jest.mock( 'calypso/lib/plugins/wporg-data/actions', () => ( {} ) );
+jest.mock( 'calypso/components/main', () => 'MainComponent' );
+jest.mock( 'calypso/blocks/upsell-nudge', () => 'UpsellNudge' );
+jest.mock( 'calypso/components/notice', () => 'Notice' );
+jest.mock( 'calypso/components/notice/notice-action', () => 'NoticeAction' );
 
 /**
  * External dependencies

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -15,22 +15,22 @@ import { MySitesSidebar } from '..';
 import config from 'calypso/config';
 import { abtest } from 'calypso/lib/abtest';
 
-jest.mock( 'lib/user', () => () => null );
-jest.mock( 'lib/user/index', () => () => {} );
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/user', () => () => null );
+jest.mock( 'calypso/lib/user/index', () => () => {} );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: jest.fn( () => {
 		return 'sidebarUpsells';
 	} ),
 } ) );
-jest.mock( 'lib/cart/store/index', () => null );
-jest.mock( 'lib/analytics/track-component-view', () => 'TrackComponentView' );
-jest.mock( 'my-sites/sidebar/utils', () => ( {
+jest.mock( 'calypso/lib/cart/store/index', () => null );
+jest.mock( 'calypso/lib/analytics/track-component-view', () => 'TrackComponentView' );
+jest.mock( 'calypso/my-sites/sidebar/utils', () => ( {
 	itemLinkMatches: jest.fn( () => true ),
 } ) );
 
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	const configMock = () => '';
 	configMock.isEnabled = jest.fn( () => true );
 	return configMock;

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
-jest.mock( 'blocks/upsell-nudge', () => 'UpsellNudge' );
-jest.mock( 'components/notice', () => 'Notice' );
-jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
+jest.mock( 'calypso/blocks/upsell-nudge', () => 'UpsellNudge' );
+jest.mock( 'calypso/components/notice', () => 'Notice' );
+jest.mock( 'calypso/components/notice/notice-action', () => 'NoticeAction' );
 
 /**
  * External dependencies

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -1,10 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'blocks/upsell-nudge', () => 'UpsellNudge' );
-jest.mock( 'components/notice', () => 'Notice' );
-jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'calypso/blocks/upsell-nudge', () => 'UpsellNudge' );
+jest.mock( 'calypso/components/notice', () => 'Notice' );
+jest.mock( 'calypso/components/notice/notice-action', () => 'NoticeAction' );
 
 /**
  * External dependencies

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
@@ -12,14 +12,14 @@ jest.mock( 'store', () => ( {
 } ) );
 
 jest.mock(
-	'blocks/upsell-nudge',
+	'calypso/blocks/upsell-nudge',
 	() =>
 		function UpsellNudge() {
 			return <div />;
 		}
 );
 
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	const mock = jest.fn();
 	mock.isEnabled = jest.fn();
 

--- a/client/my-sites/stats/test/index.js
+++ b/client/my-sites/stats/test/index.js
@@ -12,12 +12,12 @@ jest.mock( '../controller', () => ( {
 	redirectToDefaultSitePage: jest.fn(),
 	redirectToDefaultWordAdsPeriod: jest.fn(),
 } ) );
-jest.mock( 'my-sites/controller', () => ( {
+jest.mock( 'calypso/my-sites/controller', () => ( {
 	navigation: jest.fn(),
 	siteSelection: jest.fn(),
 	sites: jest.fn(),
 } ) );
-jest.mock( 'controller', () => ( {
+jest.mock( 'calypso/controller', () => ( {
 	makeLayout: jest.fn(),
 	render: jest.fn(),
 } ) );

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -13,14 +13,16 @@ import { createReduxStore } from 'calypso/state';
 import { setStore } from 'calypso/state/redux-store';
 import { receiveTheme, themeRequestFailure } from 'calypso/state/themes/actions';
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/wp', () => ( {
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/wp', () => ( {
 	undocumented: () => ( {
 		getProducts: () => {},
 	} ),
 } ) );
-jest.mock( 'my-sites/themes/theme-preview', () => require( 'calypso/components/empty-component' ) );
-jest.mock( 'my-sites/themes/themes-site-selector-modal', () =>
+jest.mock( 'calypso/my-sites/themes/theme-preview', () =>
+	require( 'calypso/components/empty-component' )
+);
+jest.mock( 'calypso/my-sites/themes/themes-site-selector-modal', () =>
 	require( 'calypso/components/empty-component' )
 );
 

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -15,12 +15,14 @@ import { THEMES_REQUEST_FAILURE } from 'calypso/state/themes/action-types';
 import { receiveThemes } from 'calypso/state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 
-jest.mock( 'lib/abtest', () => ( { abtest: () => {} } ) );
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view-tracker', () =>
+jest.mock( 'calypso/lib/abtest', () => ( { abtest: () => {} } ) );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'my-sites/themes/theme-preview', () => require( 'calypso/components/empty-component' ) );
+jest.mock( 'calypso/my-sites/themes/theme-preview', () =>
+	require( 'calypso/components/empty-component' )
+);
 
 describe( 'logged-out', () => {
 	describe( 'when calling renderToString()', () => {

--- a/client/post-editor/media-modal/detail/test/index.jsx
+++ b/client/post-editor/media-modal/detail/test/index.jsx
@@ -15,10 +15,10 @@ import React from 'react';
 import { EditorMediaModalDetailItem as DetailItem } from '../detail-item';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
-jest.mock( 'post-editor/media-modal/detail/detail-fields', () =>
+jest.mock( 'calypso/post-editor/media-modal/detail/detail-fields', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'post-editor/media-modal/detail/detail-file-info', () =>
+jest.mock( 'calypso/post-editor/media-modal/detail/detail-file-info', () =>
 	require( 'calypso/components/empty-component' )
 );
 

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -27,20 +27,22 @@ jest.mock(
 	} ),
 	{ virtual: true }
 );
-jest.mock( 'post-editor/media-modal/detail', () => ( {
+jest.mock( 'calypso/post-editor/media-modal/detail', () => ( {
 	default: require( 'calypso/components/empty-component' ),
 } ) );
-jest.mock( 'post-editor/media-modal/gallery', () =>
+jest.mock( 'calypso/post-editor/media-modal/gallery', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'post-editor/media-modal/markup', () => ( {
+jest.mock( 'calypso/post-editor/media-modal/markup', () => ( {
 	get: ( x ) => x,
 } ) );
-jest.mock( 'post-editor/media-modal/secondary-actions', () =>
+jest.mock( 'calypso/post-editor/media-modal/secondary-actions', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'lib/accept', () => require( 'sinon' ).stub().callsArgWithAsync( 1, true ) );
-jest.mock( 'my-sites/media-library', () => require( 'calypso/components/empty-component' ) );
+jest.mock( 'calypso/lib/accept', () => require( 'sinon' ).stub().callsArgWithAsync( 1, true ) );
+jest.mock( 'calypso/my-sites/media-library', () =>
+	require( 'calypso/components/empty-component' )
+);
 
 /**
  * Module variables

--- a/client/reader/discover/test/helper.js
+++ b/client/reader/discover/test/helper.js
@@ -13,10 +13,10 @@ import { get, omit } from 'lodash';
  */
 import * as helper from '../helper';
 import * as fixtures from './fixtures';
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	return () => require( './fixtures' ).discoverSiteId;
 } );
-jest.mock( 'lib/user/utils', () => ( { getLocaleSlug: () => 'en' } ) );
+jest.mock( 'calypso/lib/user/utils', () => ( { getLocaleSlug: () => 'en' } ) );
 
 describe( 'helper', () => {
 	const { discoverPost } = fixtures;

--- a/client/reader/stream/test/utils.js
+++ b/client/reader/stream/test/utils.js
@@ -9,7 +9,7 @@ import moment from 'moment';
  */
 import { sameDay, sameSite, combine, combineCards, injectRecommendations } from '../utils';
 
-jest.mock( 'lib/user/utils', () => ( {} ) );
+jest.mock( 'calypso/lib/user/utils', () => ( {} ) );
 
 describe( 'reader stream', () => {
 	const today = moment().toDate();

--- a/client/reader/test/utils.js
+++ b/client/reader/test/utils.js
@@ -13,11 +13,11 @@ import page from 'page';
  */
 import { showSelectedPost } from '../utils';
 
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 jest.mock( 'page', () => ( {
 	show: require( 'sinon' ).spy(),
 } ) );
-jest.mock( 'lib/redux-bridge', () => ( {
+jest.mock( 'calypso/lib/redux-bridge', () => ( {
 	reduxGetState: function () {
 		return { reader: { posts: { items: {} } } };
 	},

--- a/client/server/lib/analytics/test/index.js
+++ b/client/server/lib/analytics/test/index.js
@@ -11,8 +11,8 @@ import superagent from 'superagent';
 import { statsdTimingUrl, statsdCountingUrl } from 'calypso/lib/analytics/statsd-utils';
 import analytics from '../index';
 import config from 'calypso/config';
-jest.mock( 'config', () => require( 'sinon' ).stub() );
-jest.mock( 'lib/analytics/statsd-utils', () => ( {
+jest.mock( 'calypso/config', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/lib/analytics/statsd-utils', () => ( {
 	statsdTimingUrl: require( 'sinon' ).stub(),
 	statsdCountingUrl: require( 'sinon' ).stub(),
 } ) );

--- a/client/server/middleware/test/logger.js
+++ b/client/server/middleware/test/logger.js
@@ -15,10 +15,10 @@ const requestLogger = {
 const mockRootLogger = {
 	child: jest.fn( () => requestLogger ),
 };
-jest.mock( 'server/lib/logger', () => ( {
+jest.mock( 'calypso/server/lib/logger', () => ( {
 	getLogger: () => mockRootLogger,
 } ) );
-jest.mock( 'config', () => jest.fn() );
+jest.mock( 'calypso/config', () => jest.fn() );
 jest.mock( 'uuid', () => ( {
 	v4: jest.fn( () => '00000000-0000-0000-0000-000000000000' ),
 } ) );

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -8,21 +8,21 @@ jest.mock( 'child_process', () => ( {
 
 jest.mock( 'superagent', () => jest.fn() );
 
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	const impl = jest.fn();
 	impl.isEnabled = jest.fn();
 	return impl;
 } );
 
-jest.mock( 'server/sanitize', () => jest.fn() );
+jest.mock( 'calypso/server/sanitize', () => jest.fn() );
 
-jest.mock( 'server/bundler/utils', () => ( {
+jest.mock( 'calypso/server/bundler/utils', () => ( {
 	hashFile: jest.fn( () => 'hash' ),
-	getUrl: jest.fn( jest.requireActual( 'server/bundler/utils' ).getUrl ),
+	getUrl: jest.fn( jest.requireActual( 'calypso/server/bundler/utils' ).getUrl ),
 } ) );
 
-jest.mock( 'sections', () => {
-	const sections = jest.requireActual( 'sections' );
+jest.mock( 'calypso/sections', () => {
+	const sections = jest.requireActual( 'calypso/sections' );
 	sections
 		.filter( ( section ) => section.isomorphic )
 		.forEach( ( section ) => {
@@ -33,9 +33,9 @@ jest.mock( 'sections', () => {
 	return sections;
 } );
 
-jest.mock( 'sections-filter', () => jest.fn( () => true ) );
+jest.mock( 'calypso/sections-filter', () => jest.fn( () => true ) );
 
-jest.mock( 'login', () => {
+jest.mock( 'calypso/login', () => {
 	const impl = jest.fn();
 	impl.LOGIN_SECTION_DEFINITION = {
 		name: 'login',
@@ -47,12 +47,12 @@ jest.mock( 'login', () => {
 	return impl;
 } );
 
-jest.mock( 'server/isomorphic-routing', () => ( {
+jest.mock( 'calypso/server/isomorphic-routing', () => ( {
 	serverRouter: jest.fn(),
 	getNormalizedPath: jest.fn(),
 } ) );
 
-jest.mock( 'server/render', () => ( {
+jest.mock( 'calypso/server/render', () => ( {
 	serverRender: jest.fn(),
 	renderJsx: jest.fn(),
 	attachBuildTimestamp: jest.fn(),
@@ -60,30 +60,30 @@ jest.mock( 'server/render', () => ( {
 	attachI18n: jest.fn(),
 } ) );
 
-jest.mock( 'server/state-cache', () => jest.fn() );
+jest.mock( 'calypso/server/state-cache', () => jest.fn() );
 
-jest.mock( 'server/user-bootstrap', () => jest.fn() );
+jest.mock( 'calypso/server/user-bootstrap', () => jest.fn() );
 
-jest.mock( 'state', () => ( {
+jest.mock( 'calypso/state', () => ( {
 	createReduxStore: jest.fn(),
 } ) );
 
-jest.mock( 'state/redux-store', () => ( {
+jest.mock( 'calypso/state/redux-store', () => ( {
 	setStore: jest.fn(),
 } ) );
 
-jest.mock( 'state/reducer', () => jest.fn() );
+jest.mock( 'calypso/state/reducer', () => jest.fn() );
 
-jest.mock( 'state/action-types', () => ( {
+jest.mock( 'calypso/state/action-types', () => ( {
 	DESERIALIZE: 'DESERIALIZE',
 	LOCALE_SET: 'LOCALE_SET',
 } ) );
 
-jest.mock( 'state/current-user/actions', () => ( {
+jest.mock( 'calypso/state/current-user/actions', () => ( {
 	setCurrentUser: jest.fn(),
 } ) );
 
-jest.mock( 'lib/paths', () => ( {
+jest.mock( 'calypso/lib/paths', () => ( {
 	login: jest.fn(),
 } ) );
 
@@ -91,22 +91,22 @@ jest.mock( './analytics', () => ( {
 	logSectionResponse: jest.fn(),
 } ) );
 
-jest.mock( 'server/lib/analytics', () => ( {
+jest.mock( 'calypso/server/lib/analytics', () => ( {
 	tracks: {
 		recordEvent: jest.fn(),
 	},
 } ) );
 
-jest.mock( 'lib/i18n-utils', () => ( {
+jest.mock( 'calypso/lib/i18n-utils', () => ( {
 	getLanguage: jest.fn( ( lang ) => ( { langSlug: lang } ) ),
 	filterLanguageRevisions: jest.fn(),
 } ) );
 
-jest.mock( 'lib/oauth2-clients', () => ( {
+jest.mock( 'calypso/lib/oauth2-clients', () => ( {
 	isWooOAuth2Client: jest.fn(),
 } ) );
 
-jest.mock( 'landing/gutenboarding/section', () => ( {
+jest.mock( 'calypso/landing/gutenboarding/section', () => ( {
 	GUTENBOARDING_SECTION_DEFINITION: {
 		name: 'gutenboarding',
 		paths: [ '/new' ],

--- a/client/server/render/test/index.js
+++ b/client/server/render/test/index.js
@@ -32,13 +32,13 @@ function remock( newReturnValues ) {
 	);
 }
 
-jest.mock( 'lib/i18n-utils', () => {
+jest.mock( 'calypso/lib/i18n-utils', () => {
 	return {
 		isDefaultLocale: () => mockReturnValues.isDefaultLocale,
 	};
 } );
 
-jest.mock( 'config', () => {
+jest.mock( 'calypso/config', () => {
 	const fn = () => {};
 	fn.isEnabled = ( feature_key ) =>
 		feature_key === 'server-side-rendering' ? mockReturnValues.configServerSideRender : false;

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -9,11 +9,11 @@ import { intersection, isEmpty, keys } from 'lodash';
 import flows from '../flows';
 import steps from '../steps';
 
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
-jest.mock( 'lib/signup/step-actions', () => ( {} ) );
-jest.mock( 'lib/user', () => () => {
+jest.mock( 'calypso/lib/signup/step-actions', () => ( {} ) );
+jest.mock( 'calypso/lib/user', () => () => {
 	return {
 		get() {
 			return {};

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -11,7 +11,7 @@ import { noop } from 'lodash';
 import { NavigationLink } from '../';
 import Gridicon from 'calypso/components/gridicon';
 
-jest.mock( 'signup/utils', () => ( {
+jest.mock( 'calypso/signup/utils', () => ( {
 	getStepUrl: jest.fn(),
 	getFilteredSteps: jest.fn(),
 } ) );

--- a/client/signup/steps/plans-atomic-store/test/index.jsx
+++ b/client/signup/steps/plans-atomic-store/test/index.jsx
@@ -1,5 +1,5 @@
-jest.mock( 'signup/step-wrapper', () => 'step-wrapper' );
-jest.mock( 'my-sites/plan-features', () => 'plan-features' );
+jest.mock( 'calypso/signup/step-wrapper', () => 'step-wrapper' );
+jest.mock( 'calypso/my-sites/plan-features', () => 'plan-features' );
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: ( c ) => c,

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -1,5 +1,5 @@
-jest.mock( 'signup/step-wrapper', () => 'step-wrapper' );
-jest.mock( 'my-sites/plan-features', () => 'plan-features' );
+jest.mock( 'calypso/signup/step-wrapper', () => 'step-wrapper' );
+jest.mock( 'calypso/my-sites/plan-features', () => 'plan-features' );
 
 /**
  * External dependencies

--- a/client/signup/steps/site-picker/test/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/test/site-picker-submit.jsx
@@ -1,10 +1,10 @@
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.mock( 'lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 
 /**
  * External dependencies

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -17,13 +17,13 @@ import { noop } from 'lodash';
  */
 import { UserStep as User } from '../';
 
-jest.mock( 'blocks/signup-form', () => require( 'calypso/components/empty-component' ) );
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/blocks/signup-form', () => require( 'calypso/components/empty-component' ) );
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 	getABTestVariation: () => null,
 } ) );
-jest.mock( 'signup/step-wrapper', () => require( 'calypso/components/empty-component' ) );
-jest.mock( 'signup/utils', () => ( {
+jest.mock( 'calypso/signup/step-wrapper', () => require( 'calypso/components/empty-component' ) );
+jest.mock( 'calypso/signup/utils', () => ( {
 	getFlowSteps: ( flow ) => {
 		let flowSteps = null;
 

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -15,7 +15,7 @@ import mockedFlows from './fixtures/flows';
 import flows from 'calypso/signup/config/flows';
 import userFactory from 'calypso/lib/user';
 
-jest.mock( 'lib/user', () => require( './mocks/lib/user' ) );
+jest.mock( 'calypso/lib/user', () => require( './mocks/lib/user' ) );
 
 describe( 'Signup Flows Configuration', () => {
 	describe( 'getFlow', () => {

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -19,14 +19,14 @@ import {
 } from '../utils';
 import flows from 'calypso/signup/config/flows';
 
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
-jest.mock( 'lib/user', () => () => ( {
+jest.mock( 'calypso/lib/user', () => () => ( {
 	get: () => {},
 } ) );
 
-jest.mock( 'signup/config/flows-pure', () => ( {
+jest.mock( 'calypso/signup/config/flows-pure', () => ( {
 	generateFlows: () => require( './fixtures/flows' ).default,
 } ) );
 

--- a/client/signup/wpcom-login-form/test/index.jsx
+++ b/client/signup/wpcom-login-form/test/index.jsx
@@ -10,7 +10,7 @@ import React from 'react';
  */
 import WpcomLoginForm from '..';
 import config from 'calypso/config';
-jest.mock( 'config', () => jest.fn().mockReturnValueOnce( 'wordpress.com' ) );
+jest.mock( 'calypso/config', () => jest.fn().mockReturnValueOnce( 'wordpress.com' ) );
 
 describe( 'WpcomLoginForm', () => {
 	const props = {

--- a/client/state/account/test/actions.js
+++ b/client/state/account/test/actions.js
@@ -4,7 +4,7 @@
 import { ACCOUNT_CLOSE, ACCOUNT_CLOSE_SUCCESS } from 'calypso/state/action-types';
 import { closeAccount, closeAccountSuccess } from 'calypso/state/account/actions';
 
-jest.mock( 'lib/user', () => () => {
+jest.mock( 'calypso/lib/user', () => () => {
 	return { clear: jest.fn() };
 } );
 

--- a/client/state/active-promotions/test/selectors.js
+++ b/client/state/active-promotions/test/selectors.js
@@ -1,4 +1,4 @@
-jest.mock( 'lib/plans/constants', () => ( {
+jest.mock( 'calypso/lib/plans/constants', () => ( {
 	GROUP_WPCOM: 'GROUP_WPCOM',
 	GROUP_JETPACK: 'GROUP_JETPACK',
 

--- a/client/state/analytics/test/middleware.js
+++ b/client/state/analytics/test/middleware.js
@@ -27,7 +27,7 @@ import { spy as mockPageView } from 'calypso/lib/analytics/page-view';
 import { spy as mockTracks } from 'calypso/lib/analytics/tracks';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 
-jest.mock( 'lib/analytics/page-view', () => {
+jest.mock( 'calypso/lib/analytics/page-view', () => {
 	const pageViewSpy = require( 'sinon' ).spy();
 	const { pageViewMock } = require( './helpers/analytics-mock' );
 
@@ -37,7 +37,7 @@ jest.mock( 'lib/analytics/page-view', () => {
 	return mock;
 } );
 
-jest.mock( 'lib/analytics/tracks', () => {
+jest.mock( 'calypso/lib/analytics/tracks', () => {
 	const tracksSpy = require( 'sinon' ).spy();
 	const { tracksMock } = require( './helpers/analytics-mock' );
 
@@ -47,7 +47,7 @@ jest.mock( 'lib/analytics/tracks', () => {
 	return mock;
 } );
 
-jest.mock( 'lib/analytics/ad-tracking', () => {
+jest.mock( 'calypso/lib/analytics/ad-tracking', () => {
 	const adTrackingSpy = require( 'sinon' ).spy();
 	const { adTrackingMock } = require( './helpers/analytics-mock' );
 
@@ -57,7 +57,7 @@ jest.mock( 'lib/analytics/ad-tracking', () => {
 	return mock;
 } );
 
-jest.mock( 'lib/analytics/mc', () => {
+jest.mock( 'calypso/lib/analytics/mc', () => {
 	const mcSpy = require( 'sinon' ).spy();
 	const { mcMock } = require( './helpers/analytics-mock' );
 
@@ -67,7 +67,7 @@ jest.mock( 'lib/analytics/mc', () => {
 	return mock;
 } );
 
-jest.mock( 'lib/analytics/ga', () => {
+jest.mock( 'calypso/lib/analytics/ga', () => {
 	const gaSpy = require( 'sinon' ).spy();
 	const { gaMock } = require( './helpers/analytics-mock' );
 
@@ -77,7 +77,7 @@ jest.mock( 'lib/analytics/ga', () => {
 	return mock;
 } );
 
-jest.mock( 'lib/analytics/hotjar', () => ( {
+jest.mock( 'calypso/lib/analytics/hotjar', () => ( {
 	addHotJarScript: require( 'sinon' ).spy(),
 } ) );
 

--- a/client/state/data-layer/wpcom/concierge/initial/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/initial/test/index.js
@@ -12,7 +12,7 @@ import { updateConciergeInitial } from 'calypso/state/concierge/actions';
 import { CONCIERGE_INITIAL_REQUEST } from 'calypso/state/action-types';
 
 // we are mocking impure-lodash here, so that conciergeInitialFetchError() will contain the expected id in the tests
-jest.mock( 'lib/impure-lodash', () => ( {
+jest.mock( 'calypso/lib/impure-lodash', () => ( {
 	uniqueId: () => 'mock-unique-id',
 } ) );
 

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/book/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/book/test/index.js
@@ -15,7 +15,7 @@ import {
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 
 // we are mocking impure-lodash here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'lib/impure-lodash', () => ( {
+jest.mock( 'calypso/lib/impure-lodash', () => ( {
 	uniqueId: () => 'mock-unique-id',
 } ) );
 

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/test/index.js
@@ -8,7 +8,7 @@ import { CONCIERGE_APPOINTMENT_CANCEL } from 'calypso/state/action-types';
 import { CONCIERGE_STATUS_CANCELLING } from 'calypso/me/concierge/constants';
 
 // we are mocking impure-lodash here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'lib/impure-lodash', () => ( {
+jest.mock( 'calypso/lib/impure-lodash', () => ( {
 	uniqueId: () => 'mock-unique-id',
 } ) );
 

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/index.js
@@ -9,7 +9,7 @@ import { updateConciergeAppointmentDetails } from 'calypso/state/concierge/actio
 import { CONCIERGE_APPOINTMENT_DETAILS_REQUEST } from 'calypso/state/action-types';
 
 // we are mocking impure-lodash here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'lib/impure-lodash', () => ( {
+jest.mock( 'calypso/lib/impure-lodash', () => ( {
 	uniqueId: () => 'mock-unique-id',
 } ) );
 

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/test/index.js
@@ -9,7 +9,7 @@ import { CONCIERGE_STATUS_BOOKING } from 'calypso/me/concierge/constants';
 import toApi from '../to-api';
 
 // we are mocking impure-lodash here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'lib/impure-lodash', () => ( {
+jest.mock( 'calypso/lib/impure-lodash', () => ( {
 	uniqueId: () => 'mock-unique-id',
 } ) );
 

--- a/client/state/data-layer/wpcom/me/account/close/test/index.js
+++ b/client/state/data-layer/wpcom/me/account/close/test/index.js
@@ -11,7 +11,7 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { closeAccount } from 'calypso/state/account/actions';
 import { ACCOUNT_CLOSE_SUCCESS } from 'calypso/state/action-types';
 
-jest.mock( 'lib/user', () => () => {
+jest.mock( 'calypso/lib/user', () => () => {
 	return { clear: jest.fn() };
 } );
 

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -14,13 +14,13 @@ import {
 	receiveUpdates,
 } from 'calypso/state/reader/streams/actions';
 
-jest.mock( 'lib/analytics/tracks', () => ( {
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	recordTracksEvent: jest.fn(),
 } ) );
 
-jest.mock( 'lib/wp' );
-jest.mock( 'reader/stats', () => ( { recordTrack: () => {} } ) );
-jest.mock( 'lib/warn', () => () => {} );
+jest.mock( 'calypso/lib/wp' );
+jest.mock( 'calypso/reader/stats', () => ( { recordTrack: () => {} } ) );
+jest.mock( 'calypso/lib/warn', () => () => {} );
 
 describe( 'streams', () => {
 	const action = deepfreeze( requestPageAction( { streamKey: 'following', page: 2 } ) );

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -32,8 +32,8 @@ const ERROR_RESPONSE = {
 	message: 'folder_exists',
 };
 
-jest.mock( 'dispatcher' );
-jest.mock( 'state/sites/selectors' );
+jest.mock( 'calypso/dispatcher' );
+jest.mock( 'calypso/state/sites/selectors' );
 
 describe( 'uploadPlugin', () => {
 	test( 'should return an http request action', () => {

--- a/client/state/guided-tours/test/contexts.js
+++ b/client/state/guided-tours/test/contexts.js
@@ -23,10 +23,10 @@ import {
 } from 'calypso/components/tinymce/plugins/wpcom-track-paste/sources';
 import { EDITOR_PASTE_EVENT } from 'calypso/state/action-types';
 
-jest.mock( 'layout/guided-tours/config', () => {
+jest.mock( 'calypso/layout/guided-tours/config', () => {
 	return require( 'calypso/state/guided-tours/test/fixtures/config' );
 } );
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 

--- a/client/state/guided-tours/test/selectors.js
+++ b/client/state/guided-tours/test/selectors.js
@@ -13,10 +13,10 @@ import { constant, times } from 'lodash';
  */
 import { findEligibleTour, getGuidedTourState, hasTourJustBeenVisible } from '../selectors';
 
-jest.mock( 'layout/guided-tours/config', () => {
+jest.mock( 'calypso/layout/guided-tours/config', () => {
 	return require( 'calypso/state/guided-tours/test/fixtures/config' );
 } );
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'selectors', () => {
 	describe( '#hasTourJustBeenVisible', () => {

--- a/client/state/happychat/ui/test/index.js
+++ b/client/state/happychat/ui/test/index.js
@@ -15,7 +15,7 @@ import {
 	HAPPYCHAT_SET_CURRENT_MESSAGE,
 } from 'calypso/state/action-types';
 import { lostFocusAt, currentMessage } from '../reducer';
-jest.mock( 'lib/warn', () => () => {} );
+jest.mock( 'calypso/lib/warn', () => () => {} );
 
 // Simulate the time Feb 27, 2017 05:25 UTC
 const NOW = 1488173100125;

--- a/client/state/media/thunks/test/add-external-media.js
+++ b/client/state/media/thunks/test/add-external-media.js
@@ -4,7 +4,7 @@
 import { addExternalMedia as addExternalMediaThunk } from 'calypso/state/media/thunks/add-external-media';
 import { uploadMedia } from 'calypso/state/media/thunks/upload-media';
 
-jest.mock( 'state/media/thunks/upload-media', () => ( {
+jest.mock( 'calypso/state/media/thunks/upload-media', () => ( {
 	uploadMedia: jest.fn(),
 	uploadSingleMedia: jest.fn(),
 } ) );

--- a/client/state/media/thunks/test/add-media.js
+++ b/client/state/media/thunks/test/add-media.js
@@ -5,8 +5,8 @@ import { addMedia as addMediaThunk } from 'calypso/state/media/thunks/add-media'
 import { uploadMedia } from 'calypso/state/media/thunks/upload-media';
 import { getFileUploader } from 'calypso/lib/media/utils';
 
-jest.mock( 'lib/media/utils', () => ( { getFileUploader: jest.fn() } ) );
-jest.mock( 'state/media/thunks/upload-media', () => ( {
+jest.mock( 'calypso/lib/media/utils', () => ( { getFileUploader: jest.fn() } ) );
+jest.mock( 'calypso/state/media/thunks/upload-media', () => ( {
 	uploadMedia: jest.fn(),
 	uploadSingleMedia: jest.fn(),
 } ) );

--- a/client/state/media/thunks/test/create-transient-media-items.js
+++ b/client/state/media/thunks/test/create-transient-media-items.js
@@ -6,7 +6,7 @@ import { createTransientMedia, validateMediaItem } from 'calypso/lib/media/utils
 import * as dateUtils from 'calypso/state/media/utils/transient-date';
 import * as syncActions from 'calypso/state/media/actions';
 
-jest.mock( 'lib/media/utils', () => ( {
+jest.mock( 'calypso/lib/media/utils', () => ( {
 	createTransientMedia: jest.fn(),
 	validateMediaItem: jest.fn(),
 } ) );

--- a/client/state/media/thunks/test/upload-media.js
+++ b/client/state/media/thunks/test/upload-media.js
@@ -5,15 +5,15 @@ import { uploadMedia as uploadMediaThunk } from 'calypso/state/media/thunks/uplo
 import * as syncActions from 'calypso/state/media/actions';
 import { createTransientMediaItems } from 'calypso/state/media/thunks/create-transient-media-items';
 
-jest.mock( 'state/media/utils/is-file-list', () => ( {
+jest.mock( 'calypso/state/media/utils/is-file-list', () => ( {
 	isFileList: jest.fn(),
 } ) );
 
-jest.mock( 'state/media/thunks/create-transient-media-items', () => ( {
+jest.mock( 'calypso/state/media/thunks/create-transient-media-items', () => ( {
 	createTransientMediaItems: jest.fn(),
 } ) );
 
-jest.mock( 'state/sites/media-storage/actions', () => ( {
+jest.mock( 'calypso/state/sites/media-storage/actions', () => ( {
 	requestMediaStorage: jest.fn(),
 } ) );
 

--- a/client/state/nps-survey/test/actions.js
+++ b/client/state/nps-survey/test/actions.js
@@ -18,7 +18,7 @@ import {
 } from 'calypso/state/action-types';
 
 // mock modules
-jest.mock( 'lib/wp', () => ( {
+jest.mock( 'calypso/lib/wp', () => ( {
 	undocumented: () => ( {
 		// TODO: use mockResolvedValue instead when we update jest to 22.2 or later
 		submitNPSSurvey: jest.fn().mockReturnValue( Promise.resolve() ),
@@ -26,10 +26,10 @@ jest.mock( 'lib/wp', () => ( {
 		sendNPSSurveyFeedback: jest.fn().mockReturnValue( Promise.resolve() ),
 	} ),
 } ) );
-jest.mock( 'lib/analytics/tracks', () => ( {
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	recordTracksEvent: jest.fn(),
 } ) );
-jest.mock( 'lib/analytics/mc', () => ( {
+jest.mock( 'calypso/lib/analytics/mc', () => ( {
 	bumpStat: jest.fn(),
 } ) );
 

--- a/client/state/plans/test/selectors.js
+++ b/client/state/plans/test/selectors.js
@@ -1,4 +1,4 @@
-jest.mock( 'lib/plans/constants', () => ( {
+jest.mock( 'calypso/lib/plans/constants', () => ( {
 	GROUP_WPCOM: 'GROUP_WPCOM',
 	GROUP_JETPACK: 'GROUP_JETPACK',
 
@@ -13,7 +13,7 @@ jest.mock( 'lib/plans/constants', () => ( {
 	TYPE_ECOMMERCE: 'TYPE_ECOMMERCE',
 } ) );
 
-jest.mock( 'lib/plans/plans-list', () => ( {
+jest.mock( 'calypso/lib/plans/plans-list', () => ( {
 	PLANS_LIST: {
 		jetpack_premium_monthly: {
 			term: 'TERM_MONTHLY',

--- a/client/state/plugins/wporg/test/actions.js
+++ b/client/state/plugins/wporg/test/actions.js
@@ -12,7 +12,7 @@ import wporgReducer from '../reducer';
 import { combineReducers } from 'calypso/state/utils';
 import * as wporg from 'calypso/lib/wporg';
 
-jest.mock( 'lib/wporg', () => ( {
+jest.mock( 'calypso/lib/wporg', () => ( {
 	fetchPluginInformation: jest.fn( ( slug ) => Promise.resolve( { slug } ) ),
 } ) );
 

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -20,11 +20,11 @@ import { getPlanRawPrice } from 'calypso/state/plans/selectors';
 import { TERM_MONTHLY, TERM_ANNUALLY } from 'calypso/lib/plans/constants';
 const plans = require( 'calypso/lib/plans' );
 
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.mock( 'state/sites/plans/selectors', () => ( {
+jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
 	getPlanDiscountedRawPrice: jest.fn(),
 } ) );
 
@@ -33,7 +33,7 @@ plans.getPlan = jest.fn();
 
 const { getPlan } = plans;
 
-jest.mock( 'state/plans/selectors', () => ( {
+jest.mock( 'calypso/state/plans/selectors', () => ( {
 	getPlanRawPrice: jest.fn(),
 } ) );
 

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -14,7 +14,7 @@ import {
 } from '../selectors';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'selectors', () => {
 	describe( 'getPurchases', () => {

--- a/client/state/reader/follows/test/actions.js
+++ b/client/state/reader/follows/test/actions.js
@@ -16,7 +16,7 @@ import {
 	READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS,
 } from 'calypso/state/reader/action-types';
 
-jest.mock( 'state/reader/posts/actions', () => ( {
+jest.mock( 'calypso/state/reader/posts/actions', () => ( {
 	receivePosts: ( posts ) => Promise.resolve( posts ),
 } ) );
 

--- a/client/state/reader/posts/test/actions.js
+++ b/client/state/reader/posts/test/actions.js
@@ -8,17 +8,17 @@ import { bumpStat } from 'calypso/lib/analytics/mc';
 import { READER_POSTS_RECEIVE, READER_POST_SEEN } from 'calypso/state/reader/action-types';
 import wp from 'calypso/lib/wp';
 
-jest.mock( 'reader/stats', () => ( { pageViewForPost: jest.fn() } ) );
+jest.mock( 'calypso/reader/stats', () => ( { pageViewForPost: jest.fn() } ) );
 
-jest.mock( 'lib/analytics/tracks', () => ( {
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	recordTracksEvent: jest.fn(),
 } ) );
 
-jest.mock( 'lib/analytics/mc', () => ( {
+jest.mock( 'calypso/lib/analytics/mc', () => ( {
 	bumpStat: jest.fn(),
 } ) );
 
-jest.mock( 'lib/wp', () => {
+jest.mock( 'calypso/lib/wp', () => {
 	const readFeedPost = jest.fn();
 	const readSitePost = jest.fn();
 

--- a/client/state/reader/related-posts/test/actions.js
+++ b/client/state/reader/related-posts/test/actions.js
@@ -15,7 +15,7 @@ import {
 	READER_RELATED_POSTS_RECEIVE,
 } from 'calypso/state/reader/action-types';
 import useNock from 'calypso/test-helpers/use-nock';
-jest.mock( 'state/reader/posts/actions', () => ( {
+jest.mock( 'calypso/state/reader/posts/actions', () => ( {
 	receivePosts( posts ) {
 		return Promise.resolve( posts );
 	},

--- a/client/state/reader/streams/test/reducer.js
+++ b/client/state/reader/streams/test/reducer.js
@@ -26,8 +26,8 @@ import {
 	PENDING_ITEMS_DEFAULT,
 } from '../reducer';
 
-jest.mock( 'lib/warn', () => () => {} );
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/warn', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 const TIME1 = '2018-01-01T00:00:00.000Z';
 const TIME2 = '2018-01-02T00:00:00.000Z';

--- a/client/state/reader/watermarks/test/reducer.js
+++ b/client/state/reader/watermarks/test/reducer.js
@@ -5,7 +5,7 @@ import { viewStream } from '../actions';
 import { watermarks } from '../reducer';
 import { DESERIALIZE, SERIALIZE } from 'calypso/state/action-types';
 
-jest.mock( 'lib/warn', () => () => {} );
+jest.mock( 'calypso/lib/warn', () => () => {} );
 
 const streamKey = 'special-chicken-stream';
 const mark = Date.now();

--- a/client/state/selectors/test/get-active-discount.js
+++ b/client/state/selectors/test/get-active-discount.js
@@ -14,23 +14,23 @@ import {
 	TERM_BIENNIALLY,
 } from 'calypso/lib/plans/constants';
 
-jest.mock( 'state/active-promotions/selectors', () => ( {
+jest.mock( 'calypso/state/active-promotions/selectors', () => ( {
 	hasActivePromotion: jest.fn( () => null ),
 } ) );
 
-jest.mock( 'lib/abtest', () => ( {
+jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: jest.fn( () => null ),
 } ) );
 
-jest.mock( 'lib/discounts', () => ( {
+jest.mock( 'calypso/lib/discounts', () => ( {
 	activeDiscounts: [],
 } ) );
 
-jest.mock( 'state/sites/selectors', () => ( {
+jest.mock( 'calypso/state/sites/selectors', () => ( {
 	getSitePlanSlug: jest.fn( () => null ),
 } ) );
 
-jest.mock( 'state/ui/selectors', () => ( {
+jest.mock( 'calypso/state/ui/selectors', () => ( {
 	getSelectedSiteId: jest.fn( () => 1 ),
 } ) );
 

--- a/client/state/selectors/test/get-current-plan-term.js
+++ b/client/state/selectors/test/get-current-plan-term.js
@@ -7,11 +7,11 @@ import { getSitePlan } from 'calypso/state/sites/selectors';
 import getCurrentPlanTerm from '../get-current-plan-term';
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'calypso/lib/plans/constants';
 
-jest.mock( 'state/sites/selectors', () => ( {
+jest.mock( 'calypso/state/sites/selectors', () => ( {
 	getSitePlan: jest.fn( () => ( {} ) ),
 } ) );
 
-jest.mock( 'lib/plans', () => ( {
+jest.mock( 'calypso/lib/plans', () => ( {
 	getPlan: jest.fn( () => ( {} ) ),
 } ) );
 

--- a/client/state/selectors/test/get-reader-stream-offset-item.js
+++ b/client/state/selectors/test/get-reader-stream-offset-item.js
@@ -8,9 +8,9 @@ import deepFreeze from 'deep-freeze';
  */
 import { getOffsetItem } from 'calypso/state/reader/streams/selectors';
 
-jest.mock( 'lib/user/utils', () => ( { getLocaleSlug: () => 'en' } ) );
-jest.mock( 'reader/stream/utils' );
-jest.mock( 'state/reader/follows/selectors/get-reader-follows' );
+jest.mock( 'calypso/lib/user/utils', () => ( { getLocaleSlug: () => 'en' } ) );
+jest.mock( 'calypso/reader/stream/utils' );
+jest.mock( 'calypso/state/reader/follows/selectors/get-reader-follows' );
 
 const postKey1 = { postId: 1, feedId: 1 };
 const postKey2 = { postId: 1, blogId: 1 };

--- a/client/state/selectors/test/get-reader-stream-should-request-recommendations.js
+++ b/client/state/selectors/test/get-reader-stream-should-request-recommendations.js
@@ -10,9 +10,9 @@ import { getDistanceBetweenRecs } from 'calypso/reader/stream/utils';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import { shouldRequestRecs } from 'calypso/state/reader/streams/selectors';
 
-jest.mock( 'lib/user/utils', () => ( { getLocaleSlug: () => 'en' } ) );
-jest.mock( 'reader/stream/utils' );
-jest.mock( 'state/reader/follows/selectors/get-reader-follows' );
+jest.mock( 'calypso/lib/user/utils', () => ( { getLocaleSlug: () => 'en' } ) );
+jest.mock( 'calypso/reader/stream/utils' );
+jest.mock( 'calypso/state/reader/follows/selectors/get-reader-follows' );
 
 describe( 'shouldRequestRecs', () => {
 	const generateState = ( { following, recs } ) => ( {

--- a/client/state/selectors/test/is-business-plan-user.js
+++ b/client/state/selectors/test/is-business-plan-user.js
@@ -10,7 +10,7 @@ import isBusinessPlanUser from 'calypso/state/selectors/is-business-plan-user';
 import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from 'calypso/lib/plans/constants';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'isBusinessPlanUser()', () => {
 	test( 'should return true if any purchase is a business plan.', () => {

--- a/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -12,10 +12,10 @@ import isMappedDomainSite from 'calypso/state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 
-jest.mock( 'state/selectors/can-current-user', () => require( 'sinon' ).stub() );
-jest.mock( 'state/selectors/is-mapped-domain-site', () => require( 'sinon' ).stub() );
-jest.mock( 'state/selectors/is-site-on-free-plan', () => require( 'sinon' ).stub() );
-jest.mock( 'state/selectors/is-vip-site', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/state/selectors/can-current-user', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/state/selectors/is-mapped-domain-site', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/state/selectors/is-site-on-free-plan', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/state/selectors/is-vip-site', () => require( 'sinon' ).stub() );
 
 describe( 'isEligibleForDomainToPaidPlanUpsell', () => {
 	const state = 'state';

--- a/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
@@ -13,11 +13,13 @@ import isMappedDomainSite from 'calypso/state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 
-jest.mock( 'state/selectors/can-current-user', () => require( 'sinon' ).stub() );
-jest.mock( 'state/sites/selectors', () => ( { isJetpackSite: require( 'sinon' ).stub() } ) );
-jest.mock( 'state/selectors/is-mapped-domain-site', () => require( 'sinon' ).stub() );
-jest.mock( 'state/selectors/is-site-on-free-plan', () => require( 'sinon' ).stub() );
-jest.mock( 'state/selectors/is-vip-site', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/state/selectors/can-current-user', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	isJetpackSite: require( 'sinon' ).stub(),
+} ) );
+jest.mock( 'calypso/state/selectors/is-mapped-domain-site', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/state/selectors/is-site-on-free-plan', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/state/selectors/is-vip-site', () => require( 'sinon' ).stub() );
 
 describe( 'isEligibleForFreeToPaidUpsell', () => {
 	const state = 'state';

--- a/client/state/selectors/test/is-site-google-my-business-eligible.js
+++ b/client/state/selectors/test/is-site-google-my-business-eligible.js
@@ -18,7 +18,7 @@ import {
 } from 'calypso/lib/plans/constants';
 import selectors from 'calypso/state/sites/selectors';
 
-jest.mock( 'state/sites/selectors', () => ( {
+jest.mock( 'calypso/state/sites/selectors', () => ( {
 	getSitePlanSlug: jest.fn(),
 } ) );
 

--- a/client/state/selectors/test/is-site-on-free-plan.js
+++ b/client/state/selectors/test/is-site-on-free-plan.js
@@ -10,7 +10,9 @@ import deepFreeze from 'deep-freeze';
 import isSiteOnFreePlan from '../is-site-on-free-plan';
 import { PLAN_BUSINESS, PLAN_FREE, PLAN_JETPACK_FREE } from 'calypso/lib/plans/constants';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-jest.mock( 'state/sites/plans/selectors', () => ( { getCurrentPlan: require( 'sinon' ).stub() } ) );
+jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
+	getCurrentPlan: require( 'sinon' ).stub(),
+} ) );
 
 describe( 'isSiteOnFreePlan', () => {
 	const state = deepFreeze( {} );

--- a/client/state/selectors/test/is-site-on-paid-plan.js
+++ b/client/state/selectors/test/is-site-on-paid-plan.js
@@ -16,7 +16,9 @@ import {
 	PLAN_JETPACK_FREE,
 } from 'calypso/lib/plans/constants';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-jest.mock( 'state/sites/plans/selectors', () => ( { getCurrentPlan: require( 'sinon' ).stub() } ) );
+jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
+	getCurrentPlan: require( 'sinon' ).stub(),
+} ) );
 
 describe( 'isSiteOnPaidPlan', () => {
 	const state = deepFreeze( {} );

--- a/client/state/selectors/test/is-user-registration-days-within-range.js
+++ b/client/state/selectors/test/is-user-registration-days-within-range.js
@@ -3,7 +3,7 @@
  */
 import isUserRegistrationDaysWithinRange from '../is-user-registration-days-within-range';
 import { getCurrentUserDate } from 'calypso/state/current-user/selectors';
-jest.mock( 'state/current-user/selectors', () => ( {
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
 	getCurrentUserDate: require( 'sinon' ).stub(),
 } ) );
 

--- a/client/state/signup/progress/test/reducer.js
+++ b/client/state/signup/progress/test/reducer.js
@@ -12,14 +12,14 @@ import {
 } from 'calypso/state/action-types';
 
 // Mock necessary for testing certain utils
-jest.mock( 'signup/config/flows-pure', () => ( {
+jest.mock( 'calypso/signup/config/flows-pure', () => ( {
 	'new-flow': {
 		steps: [ 'something', 'everything' ],
 	},
 } ) );
 
 // Mock necessary for testing step submission behavior
-jest.mock( 'signup/config/steps-pure', () => ( {
+jest.mock( 'calypso/signup/config/steps-pure', () => ( {
 	stepWithAPI: { apiRequestFunction: () => {} },
 	stepWithoutAPI: {},
 } ) );

--- a/client/state/sites/domains/test/actions.js
+++ b/client/state/sites/domains/test/actions.js
@@ -27,7 +27,7 @@ import useNock from 'calypso/test-helpers/use-nock';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'actions', () => {
 	let sandbox;

--- a/client/state/sites/domains/test/reducer.js
+++ b/client/state/sites/domains/test/reducer.js
@@ -38,7 +38,7 @@ import {
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'reducer', () => {
 	let sandbox;

--- a/client/state/sites/domains/test/selectors.js
+++ b/client/state/sites/domains/test/selectors.js
@@ -16,7 +16,7 @@ import {
 } from './fixture';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'selectors', () => {
 	describe( '#getDomainsBySite()', () => {

--- a/client/state/support-articles-alternates/test/actions.js
+++ b/client/state/support-articles-alternates/test/actions.js
@@ -17,7 +17,7 @@ import {
 
 const mockSupportAlternates = jest.fn( () => Promise.resolve() );
 
-jest.mock( 'lib/wp', () => ( {
+jest.mock( 'calypso/lib/wp', () => ( {
 	undocumented: () => ( {
 		supportAlternates: mockSupportAlternates,
 	} ),

--- a/client/state/test/index.js
+++ b/client/state/test/index.js
@@ -10,7 +10,7 @@ import { createReduxStore } from '../';
 import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/selectors';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'index', () => {
 	describe( 'createReduxStore', () => {

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -38,12 +38,12 @@ const initialReducer = combineReducers( {
 	postTypes,
 } );
 
-jest.mock( 'lib/user', () => () => ( {
+jest.mock( 'calypso/lib/user', () => () => ( {
 	get: () => ( {
 		ID: 123456789,
 	} ),
 } ) );
-jest.mock( 'lib/user/support-user-interop', () => ( {
+jest.mock( 'calypso/lib/user/support-user-interop', () => ( {
 	isSupportSession: jest.fn().mockReturnValue( false ),
 } ) );
 

--- a/client/state/test/persistence.js
+++ b/client/state/test/persistence.js
@@ -11,7 +11,7 @@ import { createReduxStore } from 'calypso/state';
 import reducer from 'calypso/state/reducer';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'persistence', () => {
 	test( 'initial state should serialize and deserialize without errors or warnings', () => {

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -19,7 +19,7 @@ import {
 } from 'calypso/state/utils';
 import warn from 'calypso/lib/warn';
 
-jest.mock( 'lib/warn', () => jest.fn() );
+jest.mock( 'calypso/lib/warn', () => jest.fn() );
 
 describe( 'utils', () => {
 	beforeEach( () => warn.mockReset() );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -63,7 +63,7 @@ import {
 import useNock from 'calypso/test-helpers/use-nock';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'actions', () => {
 	const spy = sinon.spy();

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -49,7 +49,7 @@ import {
 import ThemeQueryManager from 'calypso/lib/query-manager/theme';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'calypso/lib/user', () => () => {} );
 
 const twentyfifteen = {
 	id: 'twentyfifteen',

--- a/packages/eslint-plugin-wpcalypso/lib/rules/no-package-relative-imports.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/no-package-relative-imports.js
@@ -181,6 +181,26 @@ module.exports = {
 				) {
 					return reportImport( node, node.arguments[ 0 ] );
 				}
+
+				if (
+					node.callee &&
+					node.callee.type === 'MemberExpression' &&
+					node.callee.object.type === 'Identifier' &&
+					node.callee.object.name === 'jest' &&
+					node.callee.property.type === 'Identifier' &&
+					[
+						'createMockFromModule',
+						'mock',
+						'unmock',
+						'doMock',
+						'dontMock',
+						'setMock',
+						'requireActual',
+						'requireMock',
+					].includes( node.callee.property.name )
+				) {
+					return reportImport( node, node.arguments[ 0 ] );
+				}
 			},
 			JSXElement: ( node ) => {
 				if ( node.openingElement.name.name === 'AsyncLoad' ) {


### PR DESCRIPTION
See #44602

#### Changes proposed in this Pull Request

* Change eslint rule `wpcalypso/no-package-relative-imports` to detect `jest.mock(<string>)` and other mocking related functions.
* Fix newly discovered eslint errors

Note that all changed files are tests, as expected. If anything is wrong it should show up in unit tests.