### PR TITLE
Strip leading and trailing whitespace from domain contact fields on blur

### DIFF
--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -151,7 +151,7 @@ export class ManagedContactDetailsFormFields extends Component {
 			isError: !! form[ camelName ]?.errors?.length,
 			errorMessage: customErrorMessage || getFirstError( form[ camelName ] ),
 			onChange: this.handleFieldChangeEvent,
-			onBlur: this.handleBlur,
+			onBlur: this.handleBlur( name ),
 			value: form[ camelName ]?.value ?? '',
 			name,
 			eventFormName,
@@ -165,7 +165,7 @@ export class ManagedContactDetailsFormFields extends Component {
 		} );
 	};
 
-	handleBlur = () => {
+	handleBlur = ( name ) => () => {
 		const form = getFormFromContactDetails(
 			this.props.contactDetails,
 			this.props.contactDetailsErrors
@@ -181,6 +181,10 @@ export class ManagedContactDetailsFormFields extends Component {
 				this.handleFieldChange( 'postal-code', formattedPostalCode );
 			}
 		} );
+
+		// Strip leading and trailing whitespace
+		const sanitizedValue = form[ camelCase( name ) ]?.value.trim();
+		this.handleFieldChange( name, sanitizedValue );
 	};
 
 	renderContactDetailsEmailPhone() {

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, createElement } from 'react';
 import { connect } from 'react-redux';
-import { camelCase } from 'lodash';
+import { camelCase, deburr } from 'lodash';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
 
@@ -183,7 +183,7 @@ export class ManagedContactDetailsFormFields extends Component {
 		} );
 
 		// Strip leading and trailing whitespace
-		const sanitizedValue = form[ camelCase( name ) ]?.value.trim();
+		const sanitizedValue = deburr( form[ camelCase( name ) ]?.value.trim() );
 		this.handleFieldChange( name, sanitizedValue );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Trim whitespace in `ManagedContactDomainFormFields` on blur.

#### Testing instructions

* Enter checkout with a domain in your cart.
* At the contact details step, first enter a complete and valid set of details if it is not auto-filled (this is to avoid triggering one of the other validation rules, so we can see this behavior in isolation.)
* Select a field and enter one or more trailing or leading space characters. (Note that the phone number field already doesn't allow these.)
* Try to submit your contact details by clicking "Continue". Provided there are no other errors this should succeed.
* Inspect the body of the network call to `domain-contact-information/validate`. There should be no leading or trailing whitespace in the field you altered two steps ago.
* Repeat, this time submitting only space characters for an optional field such as `address-2`.

Fixes #48305
