### PR TITLE
WPCom Block Editor: produce correct artifacts

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -482,7 +482,7 @@ object RunAllUnitTests : BuildType({
 				(cd apps/o2-blocks/ && yarn build --output-path="../../artifacts/o2-blocks")
 
 				# Build wpcom-block-editor
-				(cd apps/wpcom-block-editor/ && yarn build --output-path="../../artifacts/wpcom-block-editor")
+				(cd apps/wpcom-block-editor/ &&  NODE_ENV=development yarn build --output-path="../../artifacts/wpcom-block-editor")
 
 				# Build notifications
 				(cd apps/notifications/ && yarn build --output-path="../../artifacts/notifications")


### PR DESCRIPTION
The TeamCity artifact generation sets ENV to production, which does not produce unminified files.

This should generate the correct artifacts for deploying.

#### Testing instructions

See if the TeamCity task generates unminified assets.