### PR TITLE
Composite checkout: set initial payment method selection with props

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -593,6 +593,7 @@ export default function CompositeCheckout( {
 				isLoading={ isLoading }
 				isValidating={ isCartPendingUpdate }
 				theme={ theme }
+				initiallySelectedPaymentMethodId={ paymentMethods?.length ? paymentMethods[ 0 ].id : null }
 			>
 				<WPCheckout
 					removeProductFromCart={ removeProductFromCart }

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -180,6 +180,7 @@ It has the following props.
 - `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder and the form status will be set to [`.LOADING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
 - `isValidating?: boolean`. If set and true, the form status will be set to [`.VALIDATING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
 - `redirectToUrl?: (url: string) => void`. Will be used by [useTransactionStatus](#useTransactionStatus) if it needs to redirect. If not set, it will change `window.location.href`.
+- `initiallySelectedPaymentMethodId?: string | null`. If set, is used to preselect a payment method when the `paymentMethods` array changes. Default is `null`, which yields no initial selection. To change the selection in code, see the [`usePaymentMethodId`](#usePaymentMethodId) hook.
 
 The line items are for display purposes only. They should also include subtotals, discounts, and taxes. No math will be performed on the line items. Instead, the amount to be charged will be specified by the required prop `total`, which is another line item.
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -365,6 +365,8 @@ function MyCheckout() {
 	);
 	paypalMethod.submitTransaction = makePayPalExpressRequest;
 
+	const paymentMethods = [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean );
+
 	return (
 		<CheckoutProvider
 			items={ items }
@@ -376,8 +378,9 @@ function MyCheckout() {
 			showSuccessMessage={ showSuccessMessage }
 			registry={ defaultRegistry }
 			isLoading={ isLoading }
-			paymentMethods={ [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean ) }
+			paymentMethods={ paymentMethods }
 			paymentProcessors={ { 'apple-pay': applePayProcessor, card: stripeCardProcessor } }
+			initiallySelectedPaymentMethodId={ paymentMethods[ 0 ]?.id }
 		>
 			<MyCheckoutBody />
 		</CheckoutProvider>

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -52,10 +52,15 @@ export const CheckoutProvider: FunctionComponent< CheckoutProviderProps > = ( pr
 	);
 	const [ prevPaymentMethods, setPrevPaymentMethods ] = useState< PaymentMethod[] >( [] );
 	useEffect( () => {
-		if ( paymentMethods.length !== prevPaymentMethods.length ) {
-			debug( 'paymentMethods changed; setting payment method to first of', paymentMethods );
-			setPaymentMethodId( initiallySelectedPaymentMethodId );
+		if ( paymentMethods !== prevPaymentMethods ) {
+			debug(
+				'paymentMethods changed; setting payment method to initial selection ',
+				initiallySelectedPaymentMethodId,
+				'from',
+				paymentMethods
+			);
 			setPrevPaymentMethods( paymentMethods );
+			setPaymentMethodId( initiallySelectedPaymentMethodId );
 		}
 	}, [ paymentMethods, prevPaymentMethods, initiallySelectedPaymentMethodId ] );
 

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -45,18 +45,19 @@ export const CheckoutProvider: FunctionComponent< CheckoutProviderProps > = ( pr
 		isLoading,
 		isValidating,
 		children,
+		initiallySelectedPaymentMethodId = null,
 	} = props;
 	const [ paymentMethodId, setPaymentMethodId ] = useState< string | null >(
-		paymentMethods?.length ? paymentMethods[ 0 ].id : null
+		initiallySelectedPaymentMethodId
 	);
 	const [ prevPaymentMethods, setPrevPaymentMethods ] = useState< PaymentMethod[] >( [] );
 	useEffect( () => {
 		if ( paymentMethods.length !== prevPaymentMethods.length ) {
 			debug( 'paymentMethods changed; setting payment method to first of', paymentMethods );
-			setPaymentMethodId( paymentMethods?.length ? paymentMethods[ 0 ].id : null );
+			setPaymentMethodId( initiallySelectedPaymentMethodId );
 			setPrevPaymentMethods( paymentMethods );
 		}
-	}, [ paymentMethods, prevPaymentMethods ] );
+	}, [ paymentMethods, prevPaymentMethods, initiallySelectedPaymentMethodId ] );
 
 	const [ formStatus, setFormStatus ] = useFormStatusManager(
 		Boolean( isLoading ),

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -52,7 +52,12 @@ export const CheckoutProvider: FunctionComponent< CheckoutProviderProps > = ( pr
 	);
 	const [ prevPaymentMethods, setPrevPaymentMethods ] = useState< PaymentMethod[] >( [] );
 	useEffect( () => {
-		if ( paymentMethods !== prevPaymentMethods ) {
+		const paymentMethodIds = paymentMethods.map( ( x ) => x?.id );
+		const prevPaymentMethodIds = prevPaymentMethods.map( ( x ) => x?.id );
+		const paymentMethodsChanged =
+			paymentMethodIds.some( ( x ) => ! prevPaymentMethodIds.includes( x ) ) ||
+			prevPaymentMethodIds.some( ( x ) => ! paymentMethodIds.includes( x ) );
+		if ( paymentMethodsChanged ) {
 			debug(
 				'paymentMethods changed; setting payment method to initial selection ',
 				initiallySelectedPaymentMethodId,

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -94,6 +94,7 @@ export interface CheckoutProviderProps {
 	redirectToUrl?: ( url: string ) => void;
 	paymentProcessors: PaymentProcessorProp;
 	isValidating?: boolean;
+	initiallySelectedPaymentMethodId?: string | null;
 }
 
 export interface PaymentProcessorProp {

--- a/packages/composite-checkout/test/checkout-provider.js
+++ b/packages/composite-checkout/test/checkout-provider.js
@@ -130,7 +130,7 @@ describe( 'CheckoutProvider', () => {
 					showSuccessMessage={ noop }
 					paymentMethods={ [ mockMethod ] }
 					paymentProcessors={ {} }
-					initiallySelectedPaymentMethod={ mockMethod.id }
+					initiallySelectedPaymentMethodId={ mockMethod.id }
 				>
 					<CustomFormWithFormStatus />
 				</CheckoutProvider>
@@ -206,7 +206,7 @@ describe( 'CheckoutProvider', () => {
 					showSuccessMessage={ noop }
 					paymentMethods={ [ mockMethod ] }
 					paymentProcessors={ {} }
-					initiallySelectedPaymentMethod={ mockMethod.id }
+					initiallySelectedPaymentMethodId={ mockMethod.id }
 				>
 					<CustomFormWithTransactionStatus />
 				</CheckoutProvider>

--- a/packages/composite-checkout/test/checkout-provider.js
+++ b/packages/composite-checkout/test/checkout-provider.js
@@ -130,6 +130,7 @@ describe( 'CheckoutProvider', () => {
 					showSuccessMessage={ noop }
 					paymentMethods={ [ mockMethod ] }
 					paymentProcessors={ {} }
+					initiallySelectedPaymentMethod={ mockMethod.id }
 				>
 					<CustomFormWithFormStatus />
 				</CheckoutProvider>
@@ -205,6 +206,7 @@ describe( 'CheckoutProvider', () => {
 					showSuccessMessage={ noop }
 					paymentMethods={ [ mockMethod ] }
 					paymentProcessors={ {} }
+					initiallySelectedPaymentMethod={ mockMethod.id }
 				>
 					<CustomFormWithTransactionStatus />
 				</CheckoutProvider>

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -53,6 +53,7 @@ describe( 'Checkout', () => {
 						showSuccessMessage={ noop }
 						paymentMethods={ [ mockMethod ] }
 						paymentProcessors={ getMockPaymentProcessors() }
+						initiallySelectedPaymentMethod={ mockMethod.id }
 					>
 						<Checkout />
 					</CheckoutProvider>
@@ -119,6 +120,7 @@ describe( 'Checkout', () => {
 						paymentMethods={ [ mockMethod ] }
 						paymentProcessors={ getMockPaymentProcessors() }
 						registry={ registry }
+						initiallySelectedPaymentMethod={ mockMethod.id }
 					>
 						<Checkout />
 					</CheckoutProvider>
@@ -183,6 +185,7 @@ describe( 'Checkout', () => {
 						showSuccessMessage={ noop }
 						paymentMethods={ [ mockMethod ] }
 						paymentProcessors={ getMockPaymentProcessors() }
+						initiallySelectedPaymentMethod={ mockMethod.id }
 					>
 						<Checkout />
 					</CheckoutProvider>
@@ -227,6 +230,7 @@ describe( 'Checkout', () => {
 						showSuccessMessage={ noop }
 						paymentMethods={ [ mockMethod ] }
 						paymentProcessors={ getMockPaymentProcessors() }
+						initiallySelectedPaymentMethod={ mockMethod.id }
 					>
 						<Checkout />
 					</CheckoutProvider>
@@ -273,6 +277,7 @@ describe( 'Checkout', () => {
 							showSuccessMessage={ noop }
 							paymentMethods={ [ mockMethod ] }
 							paymentProcessors={ getMockPaymentProcessors() }
+							initiallySelectedPaymentMethod={ mockMethod.id }
 						>
 							<Checkout>
 								{ createStepsFromStepObjects( props.steps || steps, paymentData ) }

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -53,7 +53,7 @@ describe( 'Checkout', () => {
 						showSuccessMessage={ noop }
 						paymentMethods={ [ mockMethod ] }
 						paymentProcessors={ getMockPaymentProcessors() }
-						initiallySelectedPaymentMethod={ mockMethod.id }
+						initiallySelectedPaymentMethodId={ mockMethod.id }
 					>
 						<Checkout />
 					</CheckoutProvider>
@@ -120,7 +120,7 @@ describe( 'Checkout', () => {
 						paymentMethods={ [ mockMethod ] }
 						paymentProcessors={ getMockPaymentProcessors() }
 						registry={ registry }
-						initiallySelectedPaymentMethod={ mockMethod.id }
+						initiallySelectedPaymentMethodId={ mockMethod.id }
 					>
 						<Checkout />
 					</CheckoutProvider>
@@ -185,7 +185,7 @@ describe( 'Checkout', () => {
 						showSuccessMessage={ noop }
 						paymentMethods={ [ mockMethod ] }
 						paymentProcessors={ getMockPaymentProcessors() }
-						initiallySelectedPaymentMethod={ mockMethod.id }
+						initiallySelectedPaymentMethodId={ mockMethod.id }
 					>
 						<Checkout />
 					</CheckoutProvider>
@@ -230,7 +230,7 @@ describe( 'Checkout', () => {
 						showSuccessMessage={ noop }
 						paymentMethods={ [ mockMethod ] }
 						paymentProcessors={ getMockPaymentProcessors() }
-						initiallySelectedPaymentMethod={ mockMethod.id }
+						initiallySelectedPaymentMethodId={ mockMethod.id }
 					>
 						<Checkout />
 					</CheckoutProvider>
@@ -277,7 +277,7 @@ describe( 'Checkout', () => {
 							showSuccessMessage={ noop }
 							paymentMethods={ [ mockMethod ] }
 							paymentProcessors={ getMockPaymentProcessors() }
-							initiallySelectedPaymentMethod={ mockMethod.id }
+							initiallySelectedPaymentMethodId={ mockMethod.id }
 						>
 							<Checkout>
 								{ createStepsFromStepObjects( props.steps || steps, paymentData ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the payment method list component, we use a `useEffect` to make an initial selection, which by default is currently just the first item in the list. In this PR we move the "payment method ID to select initially" to a prop and pass it from composite checkout, anticipating the use of this component in other contexts where we wish to preselect a different method.

#### Testing instructions

This PR changes the way the initial payment method selection is made, but it should not change _which_ method is selected in checkout. To test it we need to get into a situation where the payment methods array changes while checkout is loaded.

- Enter checkout with some combination of products that allows us to change the payment method array on the fly. Some examples include:
    - A plan upgrade and (not bundled!) domain, plus enough wpcom credits to cover the plan but not the domain. You can reach this state on a site with e.g. a personal plan and a domain by adding a new domain and a plan upgrade to the cart.
    - A plan with enough credits to cover the one year term, but not two years.
    - A product with a coupon, plus enough credits to cover the discounted price but not the full price.
- Once in checkout, verify that the payment method list works as expected. The first payment method should be preselected, and choosing a different method should work as expected.
- Change your cart in a way that changes the available payment methods (e.g. remove the domain product, change the term length, remove the coupon).
- Verify that the payment method list still works as expected.
- Verify that you can complete a purchase and that the correct payment method appears on the receipt.
