### PR TITLE
Patterns: Swap can_register_pattern logic from using a tag, to using pattern_meta instead

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -186,23 +186,27 @@ class Block_Patterns_From_API {
 	/**
 	 * Check that the pattern is allowed to be registered.
 	 *
-	 * Checks for tags with a prefix of `requires-` in the slug, and then attempts to match
-	 * the remainder of the slug to a theme feature.
+	 * Checks for pattern_meta tags with a prefix of `requires-` in the name, and then attempts to match
+	 * the remainder of the name to a theme feature.
 	 *
 	 * For example, to prevent patterns that depend on wide or full-width block alignment support
 	 * from being registered in sites where the active theme does not have `align-wide` support,
-	 * we can add the `requires-align-wide` tag to the pattern. This function will then match
-	 * against that tag slug, and then return `false`.
+	 * we can add the `requires-align-wide` pattern_meta tag to the pattern. This function will
+	 * then match against that pattern_meta tag, and then return `false`.
 	 *
-	 * @param array $pattern    A pattern with a 'tags' array where the key is the tag slug in English.
+	 * @param array $pattern    A pattern with a 'pattern_meta' array where the key is the tag slug in English.
 	 *
 	 * @return bool
 	 */
 	private function can_register_pattern( $pattern ) {
+		if ( empty( $pattern['pattern_meta'] ) ) {
+			// Default to allowing patterns without metadata to be registered.
+			return true;
+		}
 
-		foreach ( $pattern['tags'] as $tag_slug => $value ) {
+		foreach ( $pattern['pattern_meta'] as $pattern_meta => $value ) {
 			// Match against tags with a non-translated slug beginning with `requires-`.
-			$split_slug = preg_split( '/^requires-/', $tag_slug );
+			$split_slug = preg_split( '/^requires-/', $pattern_meta );
 
 			// If the theme does not support the matched feature, then skip registering the pattern.
 			if ( isset( $split_slug[1] ) && false === get_theme_support( $split_slug[1] ) ) {


### PR DESCRIPTION
This is a follow-up to #47571 which added in support to skip registering patterns if they contain a tag with the prefix `requires-` that matches a theme feature via `get_theme_support`.

This change swaps out the use of a tag on the pattern, with a `pattern_meta` tag instead.

#### Changes proposed in this Pull Request

* Swap out usage of checking for a `requires-` feature from a tag on the pattern, to checking for the existence of a `pattern_meta` tag instead.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Note: these testing instructions are practically the same as the ones for https://github.com/Automattic/wp-calypso/pull/47571 — see that PR for screenshots.

1. Sandbox the diff associated with this PR or run `yarn run dev --sync`
2. In your sandbox's `0-sandbox.ph` file add the following to ensure you're using fresh results from the patterns API that include the appropriate tags:

```
define( 'WP_DISABLE_PATTERN_CACHE', true );
```

3. With your test site sandboxed, and using a theme with align-wide support (e.g. any of the suggested themes / Varia child themes such as Maywood), go to edit a post or page, click the inserter and in the Patterns tab, under the Gallery category you should see the pattern with the title "Images" and the text within the pattern will include "5am, the beach"

4. Switch your theme to one that does not support `align-wide` (e.g. Hemingway Rewritten) and open up a post. In the inserter, under the Gallery category, you should not be able to see the pattern in question ("Images")

Fixes #
