### PR TITLE
Account for undefined downgradeable plans when spreading into downgrade array

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -326,8 +326,9 @@ class CancelPurchaseForm extends React.Component {
 		const { productSlug: productBeingRemoved } = this.props.purchase;
 
 		// get all downgradable plans and products for downgrade question dropdown
+		const downgradablePlans = DOWNGRADEABLE_PLANS_FROM_PLAN[ productBeingRemoved ];
 		const downgradableJetpackPlansAndProducts = [
-			...DOWNGRADEABLE_PLANS_FROM_PLAN[ productBeingRemoved ],
+			...( downgradablePlans ? downgradablePlans : [] ),
 			...JETPACK_PRODUCTS_LIST,
 		];
 		const selectBoxItems = downgradableJetpackPlansAndProducts


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Checks that the downgradable plans array is defined and if not spreads empty array instead of failing with non-iterable error

#### Testing instructions

* Check out patch locally and go to plan management page for a number of differently configured page and make sure the plan details page displays without errors

Fixes: #48332
