### PR TITLE
Removing the coming-soon-v2 flag

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -22,7 +22,6 @@
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,
-		"coming-soon-v2": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -18,7 +18,6 @@
 		"async-payments": false,
 		"blogger-plan": false,
 		"catch-js-errors": false,
-		"coming-soon-v2": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,

--- a/config/development.json
+++ b/config/development.json
@@ -34,7 +34,6 @@
 		"automated-transfer": true,
 		"blogger-plan": true,
 		"calypsoify/plugins": true,
-		"coming-soon-v2": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,7 +21,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"coming-soon-v2": true,
 		"composite-checkout-testing": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,

--- a/config/production.json
+++ b/config/production.json
@@ -21,7 +21,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"coming-soon-v2": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -22,7 +22,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"coming-soon-v2": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -31,7 +31,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
-		"coming-soon-v2": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,7 +24,6 @@
 		"comments/management/threaded-view": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"coming-soon-v2": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request

We're no longer using the `coming-soon-v2` flag. This PR removes references from the config files.

Required dependencies:
- [x] https://github.com/Automattic/wp-calypso/pull/47852

### Testing instructions

Create a new site

Check that the site is in coming soon mode

![image](https://user-images.githubusercontent.com/6458278/102192709-3c14fd80-3f0f-11eb-979e-373a2b11fac7.png)

Toggle between public and private and coming soon

![image](https://user-images.githubusercontent.com/6458278/102192043-569aa700-3f0e-11eb-94af-1ee96ea10764.png)

Things should work as they do on production
