### PR TITLE
Jetpack credentials form: update copy on save button

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
@@ -244,7 +244,7 @@ const AdvancedCredentials: FunctionComponent< Props > = ( { action, host, role }
 				onClick={ handleUpdateCredentials }
 				disabled={ ! isEmpty( formErrors ) || disableForm }
 			>
-				{ translate( 'Save credentials' ) }
+				{ translate( 'Test and save credentials' ) }
 			</Button>
 		</>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the "save credentials" button to "test and save credentials" based on some feedback we got during a user test.

![Screenshot 2020-12-15 at 11 39 19](https://user-images.githubusercontent.com/411945/102204873-b1aaaa80-3eca-11eb-96e9-282478d0a229.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `npm run start-jetpack-cloud`
* Test the settings section
* Check the button has been updated
