### PR TITLE
Focused-Launch: Add error handling for LaunchSite

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -105,15 +105,26 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		siteId,
 	} );
 
+	const launchSiteError = ( siteId: number, error: string ) => ( {
+		type: 'LAUNCH_SITE_ERROR' as const,
+		siteId,
+		error,
+	} );
+
 	function* launchSite( siteId: number ) {
 		yield launchSiteStart( siteId );
-		yield wpcomRequest( {
-			path: `/sites/${ siteId }/launch`,
-			apiVersion: '1.1',
-			method: 'post',
-		} );
-		yield launchSiteComplete( siteId );
-		return true;
+		try {
+			yield wpcomRequest( {
+				path: `/sites/${ siteId }/launch`,
+				apiVersion: '1.1',
+				method: 'post',
+			} );
+			yield launchSiteComplete( siteId );
+			return true;
+		} catch ( error ) {
+			yield launchSiteError( siteId, error );
+			return false;
+		}
 	}
 
 	// TODO: move getCart and setCart to a 'cart' data-store
@@ -171,6 +182,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		launchSite,
 		launchSiteStart,
 		launchSiteComplete,
+		launchSiteError,
 		getCart,
 		setCart,
 	};
@@ -192,6 +204,7 @@ export type Action =
 			| ActionCreators[ 'resetNewSiteFailed' ]
 			| ActionCreators[ 'launchSiteStart' ]
 			| ActionCreators[ 'launchSiteComplete' ]
+			| ActionCreators[ 'launchSiteError' ]
 	  >
 	// Type added so we can dispatch actions in tests, but has no runtime cost
 	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -9,9 +9,11 @@ import type {
 	SiteError,
 	Cart,
 	Domain,
+	SiteLaunchError as SiteLaunchErrorType,
 } from './types';
 import type { WpcomClientCredentials } from '../shared-types';
 import { wpcomRequest } from '../wpcom-request-controls';
+import { SiteLaunchError } from './types';
 
 export function createActions( clientCreds: WpcomClientCredentials ) {
 	const fetchSite = () => ( {
@@ -95,8 +97,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		type: 'RESET_RECEIVE_NEW_SITE_FAILED' as const,
 	} );
 
-	const launchSiteIdle = ( siteId: number ) => ( {
-		type: 'LAUNCH_SITE_IDLE' as const,
+	const launchSiteStart = ( siteId: number ) => ( {
+		type: 'LAUNCH_SITE_START' as const,
 		siteId,
 	} );
 
@@ -105,14 +107,14 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		siteId,
 	} );
 
-	const launchSiteFailure = ( siteId: number, error: string ) => ( {
+	const launchSiteFailure = ( siteId: number, error: SiteLaunchErrorType ) => ( {
 		type: 'LAUNCH_SITE_FAILURE' as const,
 		siteId,
 		error,
 	} );
 
 	function* launchSite( siteId: number ) {
-		yield launchSiteIdle( siteId );
+		yield launchSiteStart( siteId );
 		try {
 			yield wpcomRequest( {
 				path: `/sites/${ siteId }/launch`,
@@ -120,10 +122,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 				method: 'post',
 			} );
 			yield launchSiteSuccess( siteId );
-			return true;
-		} catch ( error ) {
-			yield launchSiteFailure( siteId, error );
-			return false;
+		} catch ( _ ) {
+			yield launchSiteFailure( siteId, SiteLaunchError.INTERNAL );
 		}
 	}
 
@@ -180,7 +180,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveSiteFailed,
 		reset,
 		launchSite,
-		launchSiteIdle,
+		launchSiteStart,
 		launchSiteSuccess,
 		launchSiteFailure,
 		getCart,
@@ -202,7 +202,7 @@ export type Action =
 			| ActionCreators[ 'receiveSiteFailed' ]
 			| ActionCreators[ 'reset' ]
 			| ActionCreators[ 'resetNewSiteFailed' ]
-			| ActionCreators[ 'launchSiteIdle' ]
+			| ActionCreators[ 'launchSiteStart' ]
 			| ActionCreators[ 'launchSiteSuccess' ]
 			| ActionCreators[ 'launchSiteFailure' ]
 	  >

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -95,34 +95,34 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		type: 'RESET_RECEIVE_NEW_SITE_FAILED' as const,
 	} );
 
-	const launchSiteStart = ( siteId: number ) => ( {
-		type: 'LAUNCH_SITE_START' as const,
+	const launchSiteIdle = ( siteId: number ) => ( {
+		type: 'LAUNCH_SITE_IDLE' as const,
 		siteId,
 	} );
 
-	const launchSiteComplete = ( siteId: number ) => ( {
-		type: 'LAUNCH_SITE_COMPLETE' as const,
+	const launchSiteSuccess = ( siteId: number ) => ( {
+		type: 'LAUNCH_SITE_SUCCESS' as const,
 		siteId,
 	} );
 
-	const launchSiteError = ( siteId: number, error: string ) => ( {
-		type: 'LAUNCH_SITE_ERROR' as const,
+	const launchSiteFailure = ( siteId: number, error: string ) => ( {
+		type: 'LAUNCH_SITE_FAILURE' as const,
 		siteId,
 		error,
 	} );
 
 	function* launchSite( siteId: number ) {
-		yield launchSiteStart( siteId );
+		yield launchSiteIdle( siteId );
 		try {
 			yield wpcomRequest( {
 				path: `/sites/${ siteId }/launch`,
 				apiVersion: '1.1',
 				method: 'post',
 			} );
-			yield launchSiteComplete( siteId );
+			yield launchSiteSuccess( siteId );
 			return true;
 		} catch ( error ) {
-			yield launchSiteError( siteId, error );
+			yield launchSiteFailure( siteId, error );
 			return false;
 		}
 	}
@@ -180,9 +180,9 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveSiteFailed,
 		reset,
 		launchSite,
-		launchSiteStart,
-		launchSiteComplete,
-		launchSiteError,
+		launchSiteIdle,
+		launchSiteSuccess,
+		launchSiteFailure,
 		getCart,
 		setCart,
 	};
@@ -202,9 +202,9 @@ export type Action =
 			| ActionCreators[ 'receiveSiteFailed' ]
 			| ActionCreators[ 'reset' ]
 			| ActionCreators[ 'resetNewSiteFailed' ]
-			| ActionCreators[ 'launchSiteStart' ]
-			| ActionCreators[ 'launchSiteComplete' ]
-			| ActionCreators[ 'launchSiteError' ]
+			| ActionCreators[ 'launchSiteIdle' ]
+			| ActionCreators[ 'launchSiteSuccess' ]
+			| ActionCreators[ 'launchSiteFailure' ]
 	  >
 	// Type added so we can dispatch actions in tests, but has no runtime cost
 	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -113,19 +113,19 @@ export const launchStatus: Reducer< { [ key: number ]: SiteLaunchState }, Action
 	state = {},
 	action
 ) => {
-	if ( action.type === 'LAUNCH_SITE_START' ) {
+	if ( action.type === 'LAUNCH_SITE_IDLE' ) {
 		return {
 			...state,
 			[ action.siteId ]: { status: SiteLaunchStatus.IDLE, errorCode: undefined },
 		};
 	}
-	if ( action.type === 'LAUNCH_SITE_COMPLETE' ) {
+	if ( action.type === 'LAUNCH_SITE_SUCCESS' ) {
 		return {
 			...state,
 			[ action.siteId ]: { status: SiteLaunchStatus.SUCCESS, errorCode: undefined },
 		};
 	}
-	if ( action.type === 'LAUNCH_SITE_ERROR' ) {
+	if ( action.type === 'LAUNCH_SITE_FAILURE' ) {
 		return {
 			...state,
 			[ action.siteId ]: {

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -111,6 +111,9 @@ export const launchStatus: Reducer<
 	if ( action.type === 'LAUNCH_SITE_COMPLETE' ) {
 		return { ...state, [ action.siteId ]: { isSiteLaunched: true, isSiteLaunching: false } };
 	}
+	if ( action.type === 'LAUNCH_SITE_ERROR' ) {
+		return { ...state, [ action.siteId ]: { isSiteLaunched: false, isSiteLaunching: false } };
+	}
 	return state;
 };
 

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -14,7 +14,6 @@ import {
 	Domain,
 	SiteLaunchState,
 	SiteLaunchStatus,
-	SiteLaunchError,
 } from './types';
 import type { Action } from './actions';
 
@@ -113,10 +112,10 @@ export const launchStatus: Reducer< { [ key: number ]: SiteLaunchState }, Action
 	state = {},
 	action
 ) => {
-	if ( action.type === 'LAUNCH_SITE_IDLE' ) {
+	if ( action.type === 'LAUNCH_SITE_START' ) {
 		return {
 			...state,
-			[ action.siteId ]: { status: SiteLaunchStatus.IDLE, errorCode: undefined },
+			[ action.siteId ]: { status: SiteLaunchStatus.IN_PROGRESS, errorCode: undefined },
 		};
 	}
 	if ( action.type === 'LAUNCH_SITE_SUCCESS' ) {
@@ -130,7 +129,7 @@ export const launchStatus: Reducer< { [ key: number ]: SiteLaunchState }, Action
 			...state,
 			[ action.siteId ]: {
 				status: SiteLaunchStatus.FAILURE,
-				errorCode: SiteLaunchError.INTERNAL,
+				errorCode: action.error,
 			},
 		};
 	}

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -7,7 +7,15 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import type { NewSiteBlogDetails, NewSiteErrorResponse, SiteDetails, Domain } from './types';
+import {
+	NewSiteBlogDetails,
+	NewSiteErrorResponse,
+	SiteDetails,
+	Domain,
+	SiteLaunchState,
+	SiteLaunchStatus,
+	SiteLaunchError,
+} from './types';
 import type { Action } from './actions';
 
 export const newSiteData: Reducer< NewSiteBlogDetails | undefined, Action > = ( state, action ) => {
@@ -101,18 +109,30 @@ export const sitesDomains: Reducer< { [ key: number ]: Domain[] }, Action > = (
 	return state;
 };
 
-export const launchStatus: Reducer<
-	{ [ key: number ]: { isSiteLaunched: boolean; isSiteLaunching: boolean } },
-	Action
-> = ( state = {}, action ) => {
+export const launchStatus: Reducer< { [ key: number ]: SiteLaunchState }, Action > = (
+	state = {},
+	action
+) => {
 	if ( action.type === 'LAUNCH_SITE_START' ) {
-		return { ...state, [ action.siteId ]: { isSiteLaunched: false, isSiteLaunching: true } };
+		return {
+			...state,
+			[ action.siteId ]: { status: SiteLaunchStatus.IDLE, errorCode: undefined },
+		};
 	}
 	if ( action.type === 'LAUNCH_SITE_COMPLETE' ) {
-		return { ...state, [ action.siteId ]: { isSiteLaunched: true, isSiteLaunching: false } };
+		return {
+			...state,
+			[ action.siteId ]: { status: SiteLaunchStatus.SUCCESS, errorCode: undefined },
+		};
 	}
 	if ( action.type === 'LAUNCH_SITE_ERROR' ) {
-		return { ...state, [ action.siteId ]: { isSiteLaunched: false, isSiteLaunching: false } };
+		return {
+			...state,
+			[ action.siteId ]: {
+				status: SiteLaunchStatus.FAILURE,
+				errorCode: SiteLaunchError.INTERNAL,
+			},
+		};
 	}
 	return state;
 };

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -8,6 +8,7 @@ import { select } from '@wordpress/data';
  */
 import type { State } from './reducer';
 import { STORE_KEY } from './constants';
+import { SiteLaunchStatus } from './types';
 
 export const getState = ( state: State ) => state;
 
@@ -32,12 +33,19 @@ export const getSite = ( state: State, siteId: number ) => {
 export const getSiteTitle = ( _: State, siteId: number ) =>
 	select( STORE_KEY ).getSite( siteId )?.name;
 
+// @TODO: Return LaunchStatus instead of a boolean
 export const isSiteLaunched = ( state: State, siteId: number ) => {
-	return state.launchStatus[ siteId ]?.isSiteLaunched;
+	return state.launchStatus[ siteId ]?.status === SiteLaunchStatus.SUCCESS;
 };
 
+// @TODO: Return LaunchStatus instead of a boolean
 export const isSiteLaunching = ( state: State, siteId: number ) => {
-	return state.launchStatus[ siteId ]?.isSiteLaunching;
+	return state.launchStatus[ siteId ]?.status === SiteLaunchStatus.IDLE;
+};
+
+export const getSiteLaunchStatus = ( state: State, siteId: number ) => {
+	console.log( state, siteId );
+	return state.launchStatus[ siteId ]?.status;
 };
 
 export const getSiteDomains = ( state: State, siteId: number ) => {

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -43,10 +43,6 @@ export const isSiteLaunching = ( state: State, siteId: number ) => {
 	return state.launchStatus[ siteId ]?.status === SiteLaunchStatus.IDLE;
 };
 
-export const getSiteLaunchStatus = ( state: State, siteId: number ) => {
-	return state.launchStatus[ siteId ]?.status;
-};
-
 export const getSiteDomains = ( state: State, siteId: number ) => {
 	return state.sitesDomains[ siteId ];
 };

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -40,7 +40,7 @@ export const isSiteLaunched = ( state: State, siteId: number ) => {
 
 // @TODO: Return LaunchStatus instead of a boolean
 export const isSiteLaunching = ( state: State, siteId: number ) => {
-	return state.launchStatus[ siteId ]?.status === SiteLaunchStatus.IDLE;
+	return state.launchStatus[ siteId ]?.status === SiteLaunchStatus.IN_PROGRESS;
 };
 
 export const getSiteDomains = ( state: State, siteId: number ) => {

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -44,7 +44,6 @@ export const isSiteLaunching = ( state: State, siteId: number ) => {
 };
 
 export const getSiteLaunchStatus = ( state: State, siteId: number ) => {
-	console.log( state, siteId );
 	return state.launchStatus[ siteId ]?.status;
 };
 

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -5,24 +5,25 @@
  * Internal dependencies
  */
 import { createActions } from '../actions';
+import { SiteLaunchError } from '../types';
 
 const client_id = 'magic_client_id';
 const client_secret = 'magic_client_secret';
 const mockedClientCredentials = { client_id, client_secret };
 const siteId = 12345;
-const error = 'Something went wrong terribly';
+const error = SiteLaunchError.INTERNAL;
 
 describe( 'Site Actions', () => {
 	describe( 'LAUNCH_SITE Actions', () => {
-		it( 'should return a LAUNCH_SITE_IDLE Action', () => {
-			const { launchSiteIdle } = createActions( mockedClientCredentials );
+		it( 'should return a LAUNCH_SITE_START Action', () => {
+			const { launchSiteStart } = createActions( mockedClientCredentials );
 
 			const expected = {
-				type: 'LAUNCH_SITE_IDLE',
+				type: 'LAUNCH_SITE_START',
 				siteId,
 			};
 
-			expect( launchSiteIdle( siteId ) ).toEqual( expected );
+			expect( launchSiteStart( siteId ) ).toEqual( expected );
 		} );
 
 		it( 'should return a LAUNCH_SITE_SUCCESS Action', () => {
@@ -63,7 +64,7 @@ describe( 'Site Actions', () => {
 
 			// First iteration: LAUNCH_SITE_IDLE is fired
 			expect( generator.next().value ).toEqual( {
-				type: 'LAUNCH_SITE_IDLE',
+				type: 'LAUNCH_SITE_START',
 				siteId,
 			} );
 
@@ -92,7 +93,7 @@ describe( 'Site Actions', () => {
 
 			// First iteration: LAUNCH_SITE_IDLE is fired
 			expect( generator.next().value ).toEqual( {
-				type: 'LAUNCH_SITE_IDLE',
+				type: 'LAUNCH_SITE_START',
 				siteId,
 			} );
 

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -9,7 +9,8 @@ import { createActions } from '../actions';
 const client_id = 'magic_client_id';
 const client_secret = 'magic_client_secret';
 const mockedClientCredentials = { client_id, client_secret };
-const siteId = 11;
+const siteId = 12345;
+const error = 'Something went wrong terribly';
 
 describe( 'Site Actions', () => {
 	describe( 'LAUNCH_SITE Actions', () => {
@@ -37,7 +38,6 @@ describe( 'Site Actions', () => {
 
 		it( 'should return a LAUNCH_SITE_ERROR Action', () => {
 			const { launchSiteError } = createActions( mockedClientCredentials );
-			const error = 'Something went wrong';
 
 			const expected = {
 				type: 'LAUNCH_SITE_ERROR',
@@ -80,7 +80,6 @@ describe( 'Site Actions', () => {
 		it( 'should fail to launch a site', () => {
 			const { launchSite } = createActions( mockedClientCredentials );
 			const generator = launchSite( siteId );
-			const error = 'something went wrong';
 
 			const mockedApiResponse = {
 				request: {

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Internal dependencies
+ */
+import { createActions } from '../actions';
+
+const client_id = 'magic_client_id';
+const client_secret = 'magic_client_secret';
+const mockedClientCredentials = { client_id, client_secret };
+const siteId = 11;
+
+describe( 'Site Actions', () => {
+	describe( 'LAUNCH_SITE Actions', () => {
+		it( 'should return a LAUNCH_SITE_START Action', () => {
+			const { launchSiteStart } = createActions( mockedClientCredentials );
+
+			const expected = {
+				type: 'LAUNCH_SITE_START',
+				siteId,
+			};
+
+			expect( launchSiteStart( siteId ) ).toEqual( expected );
+		} );
+
+		it( 'should return a LAUNCH_SITE_COMPLETE Action', () => {
+			const { launchSiteComplete } = createActions( mockedClientCredentials );
+
+			const expected = {
+				type: 'LAUNCH_SITE_COMPLETE',
+				siteId,
+			};
+
+			expect( launchSiteComplete( siteId ) ).toEqual( expected );
+		} );
+
+		it( 'should return a LAUNCH_SITE_ERROR Action', () => {
+			const { launchSiteError } = createActions( mockedClientCredentials );
+			const error = 'Something went wrong';
+
+			const expected = {
+				type: 'LAUNCH_SITE_ERROR',
+				siteId,
+				error,
+			};
+
+			expect( launchSiteError( siteId, error ) ).toEqual( expected );
+		} );
+
+		it( 'should launch a site successfully', () => {
+			const { launchSite } = createActions( mockedClientCredentials );
+			const generator = launchSite( siteId );
+
+			const mockedApiResponse = {
+				request: {
+					apiVersion: '1.1',
+					method: 'post',
+					path: `/sites/${ siteId }/launch`,
+				},
+				type: 'WPCOM_REQUEST',
+			};
+
+			// First iteration: LAUNCH_SITE_START is fired
+			expect( generator.next().value ).toEqual( {
+				type: 'LAUNCH_SITE_START',
+				siteId,
+			} );
+
+			// Second iteration: WP_COM_REQUEST is fired
+			expect( generator.next().value ).toEqual( mockedApiResponse );
+
+			// Third iteration: LAUNCH_SITE_COMPLETE is fired
+			expect( generator.next().value ).toEqual( {
+				type: 'LAUNCH_SITE_COMPLETE',
+				siteId,
+			} );
+		} );
+
+		it( 'should fail to launch a site', () => {
+			const { launchSite } = createActions( mockedClientCredentials );
+			const generator = launchSite( siteId );
+			const error = 'something went wrong';
+
+			const mockedApiResponse = {
+				request: {
+					apiVersion: '1.1',
+					method: 'post',
+					path: `/sites/${ siteId }/launch`,
+				},
+				type: 'WPCOM_REQUEST',
+			};
+
+			// First iteration: LAUNCH_SITE_START is fired
+			expect( generator.next().value ).toEqual( {
+				type: 'LAUNCH_SITE_START',
+				siteId,
+			} );
+
+			// Second iteration: WP_COM_REQUEST is fired
+			expect( generator.next().value ).toEqual( mockedApiResponse );
+
+			// Third iteration: Throw an error
+			expect( generator.throw( error ).value ).toEqual( {
+				type: 'LAUNCH_SITE_ERROR',
+				siteId,
+				error,
+			} );
+
+			// Fourth iteration: Complete the cycle
+			const finalResult = generator.next();
+
+			expect( finalResult.value ).toBeFalsy();
+			expect( finalResult.done ).toBe( true );
+		} );
+	} );
+} );

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -14,38 +14,38 @@ const error = 'Something went wrong terribly';
 
 describe( 'Site Actions', () => {
 	describe( 'LAUNCH_SITE Actions', () => {
-		it( 'should return a LAUNCH_SITE_START Action', () => {
-			const { launchSiteStart } = createActions( mockedClientCredentials );
+		it( 'should return a LAUNCH_SITE_IDLE Action', () => {
+			const { launchSiteIdle } = createActions( mockedClientCredentials );
 
 			const expected = {
-				type: 'LAUNCH_SITE_START',
+				type: 'LAUNCH_SITE_IDLE',
 				siteId,
 			};
 
-			expect( launchSiteStart( siteId ) ).toEqual( expected );
+			expect( launchSiteIdle( siteId ) ).toEqual( expected );
 		} );
 
-		it( 'should return a LAUNCH_SITE_COMPLETE Action', () => {
-			const { launchSiteComplete } = createActions( mockedClientCredentials );
+		it( 'should return a LAUNCH_SITE_SUCCESS Action', () => {
+			const { launchSiteSuccess } = createActions( mockedClientCredentials );
 
 			const expected = {
-				type: 'LAUNCH_SITE_COMPLETE',
+				type: 'LAUNCH_SITE_SUCCESS',
 				siteId,
 			};
 
-			expect( launchSiteComplete( siteId ) ).toEqual( expected );
+			expect( launchSiteSuccess( siteId ) ).toEqual( expected );
 		} );
 
-		it( 'should return a LAUNCH_SITE_ERROR Action', () => {
-			const { launchSiteError } = createActions( mockedClientCredentials );
+		it( 'should return a LAUNCH_SITE_FAILURE Action', () => {
+			const { launchSiteFailure } = createActions( mockedClientCredentials );
 
 			const expected = {
-				type: 'LAUNCH_SITE_ERROR',
+				type: 'LAUNCH_SITE_FAILURE',
 				siteId,
 				error,
 			};
 
-			expect( launchSiteError( siteId, error ) ).toEqual( expected );
+			expect( launchSiteFailure( siteId, error ) ).toEqual( expected );
 		} );
 
 		it( 'should launch a site successfully', () => {
@@ -61,18 +61,18 @@ describe( 'Site Actions', () => {
 				type: 'WPCOM_REQUEST',
 			};
 
-			// First iteration: LAUNCH_SITE_START is fired
+			// First iteration: LAUNCH_SITE_IDLE is fired
 			expect( generator.next().value ).toEqual( {
-				type: 'LAUNCH_SITE_START',
+				type: 'LAUNCH_SITE_IDLE',
 				siteId,
 			} );
 
 			// Second iteration: WP_COM_REQUEST is fired
 			expect( generator.next().value ).toEqual( mockedApiResponse );
 
-			// Third iteration: LAUNCH_SITE_COMPLETE is fired
+			// Third iteration: LAUNCH_SITE_SUCCESS is fired
 			expect( generator.next().value ).toEqual( {
-				type: 'LAUNCH_SITE_COMPLETE',
+				type: 'LAUNCH_SITE_SUCCESS',
 				siteId,
 			} );
 		} );
@@ -90,9 +90,9 @@ describe( 'Site Actions', () => {
 				type: 'WPCOM_REQUEST',
 			};
 
-			// First iteration: LAUNCH_SITE_START is fired
+			// First iteration: LAUNCH_SITE_IDLE is fired
 			expect( generator.next().value ).toEqual( {
-				type: 'LAUNCH_SITE_START',
+				type: 'LAUNCH_SITE_IDLE',
 				siteId,
 			} );
 
@@ -101,7 +101,7 @@ describe( 'Site Actions', () => {
 
 			// Third iteration: Throw an error
 			expect( generator.throw( error ).value ).toEqual( {
-				type: 'LAUNCH_SITE_ERROR',
+				type: 'LAUNCH_SITE_FAILURE',
 				siteId,
 				error,
 			} );

--- a/packages/data-stores/src/site/test/reducer.ts
+++ b/packages/data-stores/src/site/test/reducer.ts
@@ -10,7 +10,13 @@
  * Internal dependencies
  */
 import { sites, launchStatus } from '../reducer';
-import { SiteDetails, SiteError } from '../types';
+import {
+	SiteLaunchError,
+	SiteLaunchState,
+	SiteLaunchStatus,
+	SiteDetails,
+	SiteError,
+} from '../types';
 import { createActions } from '../actions';
 
 describe( 'Site', () => {
@@ -60,15 +66,12 @@ describe( 'Site', () => {
 
 	describe( 'Launch Status', () => {
 		type ClientCredentials = { client_id: string; client_secret: string };
-		type LaunchStatusState = {
-			[ key: number ]: { isSiteLaunched: boolean; isSiteLaunching: boolean };
-		};
 
 		let siteId: number;
 		let client_id: string;
 		let client_secret: string;
 		let mockedClientCredentials: ClientCredentials;
-		let originalState: LaunchStatusState;
+		let originalState: { [ key: number ]: SiteLaunchState };
 
 		beforeEach( () => {
 			siteId = 12345;
@@ -76,7 +79,7 @@ describe( 'Site', () => {
 			client_secret = 'magic_client_secret';
 			mockedClientCredentials = { client_id, client_secret };
 			originalState = {
-				[ siteId ]: { isSiteLaunched: false, isSiteLaunching: false },
+				[ siteId ]: { status: SiteLaunchStatus.UNINITIALIZED, errorCode: undefined },
 			};
 		} );
 
@@ -91,7 +94,7 @@ describe( 'Site', () => {
 			const action = launchSiteStart( siteId );
 			const expected = {
 				...originalState,
-				[ siteId ]: { ...originalState[ siteId ], isSiteLaunching: true },
+				[ siteId ]: { ...originalState[ siteId ], status: SiteLaunchStatus.IDLE },
 			};
 
 			expect( launchStatus( originalState, action ) ).toEqual( expected );
@@ -103,7 +106,7 @@ describe( 'Site', () => {
 			const action = launchSiteComplete( siteId );
 			const expected = {
 				...originalState,
-				[ siteId ]: { ...originalState[ siteId ], isSiteLaunched: true },
+				[ siteId ]: { ...originalState[ siteId ], status: SiteLaunchStatus.SUCCESS },
 			};
 
 			expect( launchStatus( originalState, action ) ).toEqual( expected );
@@ -115,6 +118,11 @@ describe( 'Site', () => {
 			const action = launchSiteError( siteId, error );
 			const expected = {
 				...originalState,
+				[ siteId ]: {
+					...originalState[ siteId ],
+					status: SiteLaunchStatus.FAILURE,
+					errorCode: SiteLaunchError.INTERNAL,
+				},
 			};
 
 			expect( launchStatus( originalState, action ) ).toEqual( expected );

--- a/packages/data-stores/src/site/test/reducer.ts
+++ b/packages/data-stores/src/site/test/reducer.ts
@@ -9,8 +9,9 @@
 /**
  * Internal dependencies
  */
-import { sites } from '../reducer';
+import { sites, launchStatus } from '../reducer';
 import { SiteDetails, SiteError } from '../types';
+import { createActions } from '../actions';
 
 describe( 'Site', () => {
 	const siteDetailsResponse: SiteDetails = {
@@ -54,6 +55,69 @@ describe( 'Site', () => {
 
 		expect( updatedState ).toEqual( {
 			12345: siteDetailsResponse,
+		} );
+	} );
+
+	describe( 'Launch Status', () => {
+		type ClientCredentials = { client_id: string; client_secret: string };
+		type LaunchStatusState = {
+			[ key: number ]: { isSiteLaunched: boolean; isSiteLaunching: boolean };
+		};
+
+		let siteId: number;
+		let client_id: string;
+		let client_secret: string;
+		let mockedClientCredentials: ClientCredentials;
+		let originalState: LaunchStatusState;
+
+		beforeEach( () => {
+			siteId = 12345;
+			client_id = 'magic_client_id';
+			client_secret = 'magic_client_secret';
+			mockedClientCredentials = { client_id, client_secret };
+			originalState = {
+				[ siteId ]: { isSiteLaunched: false, isSiteLaunching: false },
+			};
+		} );
+
+		it( 'should default to the initial state when an unknown action is dispatched', () => {
+			const state = launchStatus( undefined, { type: 'TEST_ACTION' } );
+			expect( state ).toStrictEqual( {} );
+		} );
+
+		it( 'should set isSiteLaunching to true when a LAUNCH_SITE_START action is dispatched', () => {
+			const { launchSiteStart } = createActions( mockedClientCredentials );
+
+			const action = launchSiteStart( siteId );
+			const expected = {
+				...originalState,
+				[ siteId ]: { ...originalState[ siteId ], isSiteLaunching: true },
+			};
+
+			expect( launchStatus( originalState, action ) ).toEqual( expected );
+		} );
+
+		it( 'should set isSiteLaunched to true when a LAUNCH_SITE_COMPLETE action is dispatched', () => {
+			const { launchSiteComplete } = createActions( mockedClientCredentials );
+
+			const action = launchSiteComplete( siteId );
+			const expected = {
+				...originalState,
+				[ siteId ]: { ...originalState[ siteId ], isSiteLaunched: true },
+			};
+
+			expect( launchStatus( originalState, action ) ).toEqual( expected );
+		} );
+
+		it( 'should set both isSiteLaunching & isSiteLaunched to false when a LAUNCH_SITE_ERROR action is dispatched', () => {
+			const { launchSiteError } = createActions( mockedClientCredentials );
+			const error = 'Error Message';
+			const action = launchSiteError( siteId, error );
+			const expected = {
+				...originalState,
+			};
+
+			expect( launchStatus( originalState, action ) ).toEqual( expected );
 		} );
 	} );
 } );

--- a/packages/data-stores/src/site/test/reducer.ts
+++ b/packages/data-stores/src/site/test/reducer.ts
@@ -88,10 +88,10 @@ describe( 'Site', () => {
 			expect( state ).toStrictEqual( {} );
 		} );
 
-		it( 'should set isSiteLaunching to true when a LAUNCH_SITE_START action is dispatched', () => {
-			const { launchSiteStart } = createActions( mockedClientCredentials );
+		it( 'should set the status to SiteLaunchStatus.IDLE when a LAUNCH_SITE_IDLE action is dispatched', () => {
+			const { launchSiteIdle } = createActions( mockedClientCredentials );
 
-			const action = launchSiteStart( siteId );
+			const action = launchSiteIdle( siteId );
 			const expected = {
 				...originalState,
 				[ siteId ]: { ...originalState[ siteId ], status: SiteLaunchStatus.IDLE },
@@ -100,10 +100,10 @@ describe( 'Site', () => {
 			expect( launchStatus( originalState, action ) ).toEqual( expected );
 		} );
 
-		it( 'should set isSiteLaunched to true when a LAUNCH_SITE_COMPLETE action is dispatched', () => {
-			const { launchSiteComplete } = createActions( mockedClientCredentials );
+		it( 'should set the status to SiteLaunchStatus.SUCCESS when a LAUNCH_SITE_SUCCESS action is dispatched', () => {
+			const { launchSiteSuccess } = createActions( mockedClientCredentials );
 
-			const action = launchSiteComplete( siteId );
+			const action = launchSiteSuccess( siteId );
 			const expected = {
 				...originalState,
 				[ siteId ]: { ...originalState[ siteId ], status: SiteLaunchStatus.SUCCESS },
@@ -112,10 +112,10 @@ describe( 'Site', () => {
 			expect( launchStatus( originalState, action ) ).toEqual( expected );
 		} );
 
-		it( 'should set both isSiteLaunching & isSiteLaunched to false when a LAUNCH_SITE_ERROR action is dispatched', () => {
-			const { launchSiteError } = createActions( mockedClientCredentials );
+		it( 'should set the status to SiteLaunchStatus.FAILURE and set an errorCode when a LAUNCH_SITE_FAILURE action is dispatched', () => {
+			const { launchSiteFailure } = createActions( mockedClientCredentials );
 			const error = 'Error Message';
-			const action = launchSiteError( siteId, error );
+			const action = launchSiteFailure( siteId, error );
 			const expected = {
 				...originalState,
 				[ siteId ]: {

--- a/packages/data-stores/src/site/test/reducer.ts
+++ b/packages/data-stores/src/site/test/reducer.ts
@@ -88,13 +88,13 @@ describe( 'Site', () => {
 			expect( state ).toStrictEqual( {} );
 		} );
 
-		it( 'should set the status to SiteLaunchStatus.IDLE when a LAUNCH_SITE_IDLE action is dispatched', () => {
-			const { launchSiteIdle } = createActions( mockedClientCredentials );
+		it( 'should set the status to SiteLaunchStatus.IN_PROGRESS when a LAUNCH_SITE_START action is dispatched', () => {
+			const { launchSiteStart } = createActions( mockedClientCredentials );
 
-			const action = launchSiteIdle( siteId );
+			const action = launchSiteStart( siteId );
 			const expected = {
 				...originalState,
-				[ siteId ]: { ...originalState[ siteId ], status: SiteLaunchStatus.IDLE },
+				[ siteId ]: { ...originalState[ siteId ], status: SiteLaunchStatus.IN_PROGRESS },
 			};
 
 			expect( launchStatus( originalState, action ) ).toEqual( expected );
@@ -114,7 +114,7 @@ describe( 'Site', () => {
 
 		it( 'should set the status to SiteLaunchStatus.FAILURE and set an errorCode when a LAUNCH_SITE_FAILURE action is dispatched', () => {
 			const { launchSiteFailure } = createActions( mockedClientCredentials );
-			const error = 'Error Message';
+			const error = SiteLaunchError.INTERNAL;
 			const action = launchSiteFailure( siteId, error );
 			const expected = {
 				...originalState,

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -186,7 +186,7 @@ export enum SiteLaunchError {
 
 export enum SiteLaunchStatus {
 	UNINITIALIZED = 'unintialized',
-	IDLE = 'idle',
+	IN_PROGRESS = 'in_progress',
 	SUCCESS = 'success',
 	FAILURE = 'failure',
 }

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -174,3 +174,19 @@ export interface Domain {
 	product_slug?: any;
 	owner: string;
 }
+
+export interface SiteLaunchState {
+	status: SiteLaunchStatus;
+	errorCode: SiteLaunchError | undefined;
+}
+
+export enum SiteLaunchError {
+	INTERNAL = 'internal',
+}
+
+export enum SiteLaunchStatus {
+	UNINITIALIZED = 'unintialized',
+	IDLE = 'idle',
+	SUCCESS = 'success',
+	FAILURE = 'failure',
+}

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -21,8 +21,7 @@ import { useDomainSuggestionFromCart, usePlanFromCart } from '../hooks';
 import './style.scss';
 
 const FocusedLaunch: React.FunctionComponent = () => {
-	const { isSiteLaunched, isSiteLaunching, siteLaunchStatus } = useSite();
-	console.log( typeof siteLaunchStatus );
+	const { isSiteLaunched, isSiteLaunching } = useSite();
 	const { enablePersistentSuccessView } = useDispatch( LAUNCH_STORE );
 
 	const [ hasSelectedDomain, selectedPlan, shouldDisplaySuccessView ] = useSelect( ( select ) => {

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -21,8 +21,8 @@ import { useDomainSuggestionFromCart, usePlanFromCart } from '../hooks';
 import './style.scss';
 
 const FocusedLaunch: React.FunctionComponent = () => {
-	const { isSiteLaunched, isSiteLaunching } = useSite();
-
+	const { isSiteLaunched, isSiteLaunching, siteLaunchStatus } = useSite();
+	console.log( typeof siteLaunchStatus );
 	const { enablePersistentSuccessView } = useDispatch( LAUNCH_STORE );
 
 	const [ hasSelectedDomain, selectedPlan, shouldDisplaySuccessView ] = useSelect( ( select ) => {

--- a/packages/launch/src/hooks/use-site.ts
+++ b/packages/launch/src/hooks/use-site.ts
@@ -9,6 +9,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { SITE_STORE } from '../stores';
 import LaunchContext from '../context';
+import type { SiteLaunchStatus } from '@automattic/data-stores/src/site/types';
 
 export function useSite() {
 	const { siteId } = React.useContext( LaunchContext );
@@ -16,12 +17,16 @@ export function useSite() {
 	const isSiteLaunched = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunched( siteId ) );
 	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
 	const isLoading = useSelect( ( select ) => select( SITE_STORE ).isFetchingSiteDetails() );
+	const siteLaunchStatus = useSelect( ( select ) =>
+		select( SITE_STORE ).getSiteLaunchStatus( siteId )
+	) as SiteLaunchStatus;
 
 	return {
 		sitePlan: site?.plan,
 		isPaidPlan: site && ! site.plan?.is_free, // sometimes plan will not be available: https://github.com/Automattic/wp-calypso/pull/44895
 		isSiteLaunched,
 		isSiteLaunching,
+		siteLaunchStatus,
 		selectedFeatures: site?.options?.selected_features,
 		isLoadingSite: !! isLoading,
 	};

--- a/packages/launch/src/hooks/use-site.ts
+++ b/packages/launch/src/hooks/use-site.ts
@@ -9,7 +9,6 @@ import { useSelect } from '@wordpress/data';
  */
 import { SITE_STORE } from '../stores';
 import LaunchContext from '../context';
-import type { SiteLaunchStatus } from '@automattic/data-stores/src/site/types';
 
 export function useSite() {
 	const { siteId } = React.useContext( LaunchContext );
@@ -17,16 +16,12 @@ export function useSite() {
 	const isSiteLaunched = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunched( siteId ) );
 	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
 	const isLoading = useSelect( ( select ) => select( SITE_STORE ).isFetchingSiteDetails() );
-	const siteLaunchStatus = useSelect( ( select ) =>
-		select( SITE_STORE ).getSiteLaunchStatus( siteId )
-	) as SiteLaunchStatus;
 
 	return {
 		sitePlan: site?.plan,
 		isPaidPlan: site && ! site.plan?.is_free, // sometimes plan will not be available: https://github.com/Automattic/wp-calypso/pull/44895
 		isSiteLaunched,
 		isSiteLaunching,
-		siteLaunchStatus,
 		selectedFeatures: site?.options?.selected_features,
 		isLoadingSite: !! isLoading,
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The user can get stuck in non-responsive screens when something went wrong w/ API-calls. This PR contains updates to the `automattic/site` store that paves the road for us to provide the user with proper "error state views". 

#### Technical changes
* Add a `LAUNCH_SITE_FAILURE` action type;
* Add `SiteLaunchState` interface;
* Add `SiteLaunchError` & `SiteLaunchStatus` enum;
* Add unit tests for actions, reducers & selectors;
* Renamed `LAUNCH_SITE_COMPLETE` to `LAUNCH_SITE_SUCCESS`;
* Update `launchSite()` action generator in a try-catch to enable error handling;
* Update `launchStatus` reducer;
* Update `isSiteLaunched` & `isSiteLaunching` logic;

#### Testing instructions
**Automated Tests**
1. Checkout this branch (`gh pr checkout 48348` w/ [GH CLI](https://github.com/cli/cli))
2. Run `yarn && yarn test-packages packages/data-stores/src/site/test`.
    * [ ] All unit tests pass

**Focused Launch**
1. Go to `/page/UNLAUNCHED_SITE_ID_CREATED_WITH_START.wordpress.com/home?flags=create/focused-launch-flow-calypso`.
2. Complete the `name your site`, `confirm your domain` & `confirm your plan` steps **but don't click the "Launch your site" button yet!**
3. Open DevTools, switch to the network tab, and go **offline**.
4. Switch to the [Redux DevTools](https://github.com/reduxjs/redux-devtools) tab and select the `automattic/site` instance.
5. Click the "Launch your site" button.
6. Check that:
    * [ ] a `LAUNCH_SITE_START` action is dispatched;
    * [ ] a `LAUNCH_SITE_FAILURE` action is dispatched;

**Editing Toolkit Step-by-Step Launch - Regression testing**
1. Checkout this branch and run `yarn dev --sync` from `/apps/editing-toolkit` ensuring you're also logged into your sandbox environment.
2. Go to [/new](https://hash-6eba9d3719a13801c0367c6e3d0f6092fe7b7b4b.calypso.live/new) and go through the process to create a new site, you will land in the editing experience.
3. Sandbox your newly created site in your host file.
4. Flush your cache & DNS and then refresh your site made in step 1 and ensure that you're using the `dev` version of the Editing Toolkit.
5. Click "Launch". This should open the launch modal. Follow the steps but **don't click the Launch Button yet**!
6. Open DevTools, switch to the network tab, and go **offline**.
7. Switch to the [Redux DevTools](https://github.com/reduxjs/redux-devtools) tab and select the `automattic/site` instance.
8. Click the "Launch your site" button.
9. Check that:
    * [ ] a `LAUNCH_SITE_START` action is dispatched;
    * [ ] a `LAUNCH_SITE_FAILURE` action is dispatched;

Fixes #48166
