### PR TITLE
Update Create Site URL inside Calypso for existing users

### DIFF
--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -3,12 +3,12 @@
  */
 import { intersection, words, memoize } from 'lodash';
 import { translate } from 'i18n-calypso';
-import { getCustomizerUrl } from 'calypso/state/sites/selectors';
 
 /**
  * Internal Dependencies
  */
-import config from 'calypso/config';
+import { getCustomizerUrl } from 'calypso/state/sites/selectors';
+import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { SUPPORT_TYPE_ADMIN_SECTION } from './constants';
 
@@ -368,7 +368,7 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 	},
 	{
 		title: translate( 'Create a new site' ),
-		link: `${ config( 'signup_url' ) }?ref=calypso-selector`,
+		link: `${ getOnboardingUrl( state ) }?ref=calypso-inline-help`,
 		synonyms: [ 'site' ],
 		icon: 'cog',
 	},

--- a/client/components/empty-content/no-sites-message/index.jsx
+++ b/client/components/empty-content/no-sites-message/index.jsx
@@ -3,21 +3,23 @@
  */
 
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import config from 'calypso/config';
 import EmptyContent from 'calypso/components/empty-content';
+import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 
 const NoSitesMessage = ( { translate } ) => {
+	const onboardingUrl = useSelector( ( state ) => getOnboardingUrl( state ) );
 	return (
 		<EmptyContent
 			title={ translate( "You don't have any WordPress sites yet." ) }
 			line={ translate( 'Would you like to start one?' ) }
 			action={ translate( 'Create Site' ) }
-			actionURL={ config( 'signup_url' ) + '?ref=calypso-nosites' }
+			actionURL={ onboardingUrl + '?ref=calypso-nosites' }
 			illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }
 		/>
 	);

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -4,14 +4,14 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
+import { Button } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
-import config from 'calypso/config';
-import { Button } from '@automattic/components';
+import Gridicon from 'calypso/components/gridicon';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 
 class SiteSelectorAddSite extends Component {
 	recordAddNewSite = () => {
@@ -19,12 +19,12 @@ class SiteSelectorAddSite extends Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { onboardingUrl, translate } = this.props;
 		return (
 			<span className="site-selector__add-new-site">
 				<Button
 					borderless
-					href={ `${ config( 'signup_url' ) }?ref=calypso-selector` }
+					href={ `${ onboardingUrl }?ref=calypso-selector` }
 					onClick={ this.recordAddNewSite }
 				>
 					<Gridicon icon="add-outline" /> { translate( 'Add new site' ) }
@@ -34,4 +34,9 @@ class SiteSelectorAddSite extends Component {
 	}
 }
 
-export default connect( null, { recordTracksEvent } )( localize( SiteSelectorAddSite ) );
+export default connect(
+	( state ) => ( {
+		onboardingUrl: getOnboardingUrl( state ),
+	} ),
+	{ recordTracksEvent }
+)( localize( SiteSelectorAddSite ) );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -44,6 +44,7 @@ import LayoutLoader from './loader';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { withCurrentRoute } from 'calypso/components/route';
 import QueryExperiments from 'calypso/components/data/query-experiments';
+import Experiment from 'calypso/components/experiment';
 import { getVariationForUser } from 'calypso/state/experiments/selectors';
 
 /**
@@ -185,6 +186,7 @@ class Layout extends Component {
 		return (
 			<div className={ sectionClass }>
 				<QueryExperiments />
+				<Experiment name="new_onboarding_existing_users_non_en_v4" />
 				<BodySectionCssClass
 					group={ this.props.sectionGroup }
 					section={ this.props.sectionName }

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -10,7 +10,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'calypso/config';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dialog, Button } from '@automattic/components';
 import Gridicon from 'calypso/components/gridicon';
@@ -19,6 +18,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { closeAccount } from 'calypso/state/account/actions';
+import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 
 /**
  * Style dependencies
@@ -71,14 +71,14 @@ class AccountCloseConfirmDialog extends React.Component {
 	};
 
 	render() {
-		const { isVisible, currentUsername, translate } = this.props;
+		const { currentUsername, isVisible, onboardingUrl, translate } = this.props;
 		const isDeleteButtonDisabled = currentUsername && this.state.inputValue !== currentUsername;
 
 		const alternativeOptions = [
 			{
 				englishText: 'Start a new site',
 				text: translate( 'Start a new site' ),
-				href: config( 'signup_url' ),
+				href: onboardingUrl + '?ref=me-account-close',
 				supportLink:
 					'https://wordpress.com/support/create-a-blog/#adding-a-new-site-or-blog-to-an-existing-account',
 				supportPostId: 3991,
@@ -218,6 +218,7 @@ export default connect(
 
 		return {
 			currentUsername: user && user.username,
+			onboardingUrl: getOnboardingUrl( state ),
 		};
 	},
 	{

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -46,6 +46,7 @@ import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getLanguage, isLocaleVariant, canBeTranslated } from 'calypso/lib/i18n-utils';
 import isRequestingMissingSites from 'calypso/state/selectors/is-requesting-missing-sites';
+import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { canDisplayCommunityTranslator } from 'calypso/components/community-translator/utils';
 import { ENABLE_TRANSLATOR_KEY } from 'calypso/lib/i18n-utils/constants';
@@ -572,12 +573,12 @@ const Account = createReactClass( {
 	},
 
 	renderPrimarySite() {
-		const { requestingMissingSites, translate, visibleSiteCount } = this.props;
+		const { onboardingUrl, requestingMissingSites, translate, visibleSiteCount } = this.props;
 
 		if ( ! visibleSiteCount ) {
 			return (
 				<Button
-					href={ config( 'signup_url' ) }
+					href={ onboardingUrl + '?ref=me-account-settings' }
 					onClick={ this.getClickHandler( 'Primary Site Add New WordPress Button' ) }
 				>
 					{ translate( 'Add New Site' ) }
@@ -933,6 +934,7 @@ export default compose(
 			currentUserDisplayName: getCurrentUserDisplayName( state ),
 			currentUserName: getCurrentUserName( state ),
 			visibleSiteCount: getCurrentUserVisibleSiteCount( state ),
+			onboardingUrl: getOnboardingUrl( state ),
 		} ),
 		{ bumpStat, errorNotice, recordGoogleEvent, recordTracksEvent, successNotice }
 	),

--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 import { find, noop } from 'lodash';
 
 /**
@@ -12,11 +11,10 @@ import { find, noop } from 'lodash';
  */
 import getSites from 'calypso/state/selectors/get-sites';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
-import EmptyContentComponent from 'calypso/components/empty-content';
+import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import Blog from './blog';
 import InfiniteList from 'calypso/components/infinite-list';
 import Placeholder from './placeholder';
-import config from 'calypso/config';
 
 /**
  * Style dependencies
@@ -39,22 +37,14 @@ class BlogsSettings extends Component {
 	};
 
 	render() {
-		const { sites, requestingSites, translate } = this.props;
+		const { sites, requestingSites } = this.props;
 
 		if ( ! sites || ! this.props.settings ) {
 			return <Placeholder />;
 		}
 
 		if ( sites.length === 0 && ! requestingSites ) {
-			return (
-				<EmptyContentComponent
-					title={ translate( "You don't have any WordPress sites yet." ) }
-					line={ translate( 'Would you like to start one?' ) }
-					action={ translate( 'Create Site' ) }
-					actionURL={ config( 'signup_url' ) + '?ref=calypso-nosites' }
-					illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }
-				/>
-			);
+			return <NoSitesMessage />;
 		}
 
 		const renderBlog = ( site, index, disableToggle = false ) => {
@@ -100,4 +90,4 @@ const mapStateToProps = ( state ) => ( {
 	requestingSites: isRequestingSites( state ),
 } );
 
-export default connect( mapStateToProps )( localize( BlogsSettings ) );
+export default connect( mapStateToProps )( BlogsSettings );

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -10,13 +10,13 @@ import { find, map, pickBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import config from 'calypso/config';
 import FormButton from 'calypso/components/forms/form-button';
 import ProfileLinksAddWordPressSite from './site';
 import { addUserProfileLinks } from 'calypso/state/profile-links/actions';
 import getPublicSites from 'calypso/state/selectors/get-public-sites';
 import getSites from 'calypso/state/selectors/get-sites';
 import isSiteInProfileLinks from 'calypso/state/selectors/is-site-in-profile-links';
+import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 /**
@@ -106,7 +106,7 @@ class ProfileLinksAddWordPress extends Component {
 
 	onCreateSite = ( event ) => {
 		event.preventDefault();
-		window.open( config( 'signup_url' ) + '?ref=me-profile-links' );
+		window.open( this.props.onboardingUrl + '?ref=me-profile-links' );
 		this.props.onCancel();
 	};
 
@@ -171,6 +171,7 @@ class ProfileLinksAddWordPress extends Component {
 						{
 							components: {
 								jetpackLink: (
+									/* eslint-disable-next-line jsx-a11y/anchor-is-valid */
 									<a
 										href="#"
 										className="profile-links-add-wordpress__jetpack-link"
@@ -218,6 +219,7 @@ export default connect(
 			publicSites,
 			publicSitesNotInProfileLinks,
 			sites: getSites( state ),
+			onboardingUrl: getOnboardingUrl( state ),
 		};
 	},
 	{

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -110,9 +110,7 @@ class ProfileLinksAddWordPress extends Component {
 		this.props.onCancel();
 	};
 
-	onJetpackMe = ( event ) => {
-		event.preventDefault();
-		window.open( 'http://jetpack.me/' );
+	onJetpackMe = () => {
 		this.props.onCancel();
 	};
 
@@ -171,9 +169,10 @@ class ProfileLinksAddWordPress extends Component {
 						{
 							components: {
 								jetpackLink: (
-									/* eslint-disable-next-line jsx-a11y/anchor-is-valid */
 									<a
-										href="#"
+										href="http://jetpack.me"
+										target="_blank"
+										rel="noreferrer"
 										className="profile-links-add-wordpress__jetpack-link"
 										onClick={ this.handleJetpackLinkClick }
 									/>

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -170,7 +170,7 @@ class ProfileLinksAddWordPress extends Component {
 							components: {
 								jetpackLink: (
 									<a
-										href="http://jetpack.me"
+										href="https://jetpack.me"
 										target="_blank"
 										rel="noreferrer"
 										className="profile-links-add-wordpress__jetpack-link"

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -36,6 +36,7 @@ import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import {
 	domainManagementContactsPrivacy,
 	domainManagementDns,
@@ -112,7 +113,6 @@ function renderNoVisibleSites( context ) {
 	const { getState } = getStore( context );
 	const currentUser = getCurrentUser( getState() );
 	const hiddenSites = currentUser && currentUser.site_count - currentUser.visible_site_count;
-	const signup_url = config( 'signup_url' );
 
 	setSectionMiddleware( { group: 'sites' } )( context );
 
@@ -137,7 +137,7 @@ function renderNoVisibleSites( context ) {
 		action: i18n.translate( 'Change Visibility' ),
 		actionURL: '//dashboard.wordpress.com/wp-admin/index.php?page=my-blogs',
 		secondaryAction: i18n.translate( 'Create New Site' ),
-		secondaryActionURL: `${ signup_url }?ref=calypso-nosites`,
+		secondaryActionURL: `${ getOnboardingUrl() }?ref=calypso-nosites`,
 	} );
 
 	makeLayout( context, noop );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -111,9 +111,10 @@ function renderEmptySites( context ) {
 
 function renderNoVisibleSites( context ) {
 	const { getState } = getStore( context );
-	const currentUser = getCurrentUser( getState() );
+	const state = getState();
+	const currentUser = getCurrentUser( state );
 	const hiddenSites = currentUser && currentUser.site_count - currentUser.visible_site_count;
-	const onboardingUrl = getOnboardingUrl( getState() );
+	const onboardingUrl = getOnboardingUrl( state );
 
 	setSectionMiddleware( { group: 'sites' } )( context );
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -113,6 +113,7 @@ function renderNoVisibleSites( context ) {
 	const { getState } = getStore( context );
 	const currentUser = getCurrentUser( getState() );
 	const hiddenSites = currentUser && currentUser.site_count - currentUser.visible_site_count;
+	const onboardingUrl = getOnboardingUrl( getState() );
 
 	setSectionMiddleware( { group: 'sites' } )( context );
 
@@ -137,7 +138,7 @@ function renderNoVisibleSites( context ) {
 		action: i18n.translate( 'Change Visibility' ),
 		actionURL: '//dashboard.wordpress.com/wp-admin/index.php?page=my-blogs',
 		secondaryAction: i18n.translate( 'Create New Site' ),
-		secondaryActionURL: `${ getOnboardingUrl() }?ref=calypso-nosites`,
+		secondaryActionURL: `${ onboardingUrl }?ref=calypso-nosites`,
 	} );
 
 	makeLayout( context, noop );

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -12,7 +12,7 @@ import { ProgressBar } from '@automattic/components';
 /**
  * Internal dependencies
  */
-import config, { isEnabled } from 'calypso/config';
+import { isEnabled } from 'calypso/config';
 import CurrentSite from 'calypso/my-sites/current-site';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import ExternalLink from 'calypso/components/external-link';
@@ -81,6 +81,7 @@ import {
 import canSiteViewAtomicHosting from 'calypso/state/selectors/can-site-view-atomic-hosting';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import { isUnderDomainManagementAll } from 'calypso/my-sites/domains/paths';
 import { isUnderEmailManagementAll } from 'calypso/my-sites/email/paths';
 import JetpackSidebarMenuItems from 'calypso/components/jetpack/sidebar/menu-items/calypso';
@@ -919,7 +920,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarItem
 				label={ this.props.translate( 'Add new site' ) }
-				link={ `${ config( 'signup_url' ) }?ref=calypso-selector` }
+				link={ `${ this.props.onboardingUrl }?ref=calypso-sidebar` }
 				onNavigate={ this.trackAddNewSiteClick }
 				icon="add-outline"
 			/>
@@ -1130,6 +1131,7 @@ function mapStateToProps( state ) {
 		isAllSitesView: isAllDomainsView || getSelectedSiteId( state ) === null,
 		isWpMobile: isWpMobileApp(), // This doesn't rely on state, but we inject it here for future testability
 		sitePlanSlug: getSitePlanSlug( state, siteId ),
+		onboardingUrl: getOnboardingUrl( state ),
 	};
 }
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -27,7 +27,7 @@ import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import store from 'store';
 import { setCurrentFlowName } from 'calypso/state/signup/flow/actions';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
 import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
 import {
@@ -43,7 +43,6 @@ import { requestGeoLocation } from 'calypso/state/data-getters';
 import { getDotBlogVerticalId } from './config/dotblog-verticals';
 import { abtest } from 'calypso/lib/abtest';
 import user from 'calypso/lib/user';
-import { getVariationForUser } from 'calypso/state/experiments/selectors';
 
 /**
  * Constants
@@ -61,16 +60,6 @@ const removeWhiteBackground = function () {
 	}
 
 	document.body.classList.remove( 'is-white-signup' );
-};
-
-const gutenbergRedirect = function ( flowName ) {
-	const url = new URL( window.location );
-	if ( [ 'beginner', 'personal', 'premium', 'business', 'ecommerce' ].includes( flowName ) ) {
-		url.pathname = `/new/${ flowName }`;
-	} else {
-		url.pathname = '/new';
-	}
-	window.location.replace( url.toString() );
 };
 
 export const addP2SignupClassName = () => {
@@ -121,27 +110,6 @@ export default {
 
 			next();
 		} else {
-			const state = context.store.getState();
-			const locale = getCurrentUserLocale( state );
-			const flowName = getFlowName( context.params );
-			const userLoggedIn = isUserLoggedIn( state );
-
-			if ( userLoggedIn && flowName === 'onboarding' ) {
-				// Assign to the experiment only logged-in users creating a site using 'onboarding' flow.
-				const existingUsersOnboardingVariant = getVariationForUser(
-					state,
-					'new_onboarding_existing_users_non_en_v2'
-				);
-
-				if (
-					existingUsersOnboardingVariant === 'treatment' ||
-					[ 'en', 'en-gb' ].includes( locale )
-				) {
-					gutenbergRedirect( context.params.flowName );
-					return;
-				}
-			}
-
 			waitForHttpData( () => ( { geo: requestGeoLocation() } ) )
 				.then( ( { geo } ) => {
 					const countryCode = geo.data;

--- a/client/state/selectors/get-onboarding-url.js
+++ b/client/state/selectors/get-onboarding-url.js
@@ -13,9 +13,11 @@ import config from 'calypso/config';
  * @returns {string}  URL of the onboarding flow for existing users.
  */
 
+const GUTENBOARDING_LOCALES = [ 'en', 'en-gb' ];
+
 export default function getOnboardingUrl( state ) {
 	const userLocale = getCurrentUserLocale( state );
-	if ( [ 'en', 'en-gb' ].includes( userLocale ) ) {
+	if ( GUTENBOARDING_LOCALES.includes( userLocale ) ) {
 		return config( 'new_onboarding_url' );
 	}
 

--- a/client/state/selectors/get-onboarding-url.js
+++ b/client/state/selectors/get-onboarding-url.js
@@ -18,7 +18,7 @@ const GUTENBOARDING_LOCALES = [ 'en', 'en-gb' ];
 export default function getOnboardingUrl( state ) {
 	const userLocale = getCurrentUserLocale( state );
 	if ( GUTENBOARDING_LOCALES.includes( userLocale ) ) {
-		return config( 'new_onboarding_url' );
+		return config( 'gutenboarding_url' );
 	}
 
 	const existingUsersOnboardingVariant = getVariationForUser(
@@ -26,7 +26,7 @@ export default function getOnboardingUrl( state ) {
 		'new_onboarding_existing_users_non_en_v4'
 	);
 	if ( existingUsersOnboardingVariant === 'treatment' ) {
-		return config( 'new_onboarding_url' );
+		return config( 'gutenboarding_url' );
 	}
 
 	return config( 'signup_url' );

--- a/client/state/selectors/get-onboarding-url.js
+++ b/client/state/selectors/get-onboarding-url.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { getVariationForUser } from 'calypso/state/experiments/selectors';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import config from 'calypso/config';
+
+/**
+ * Returns the onboarding URL.
+ *
+ *
+ * @param {object}  state Global state tree
+ * @returns {string}  URL of the onboarding flow for existing users.
+ */
+
+export default function getOnboardingUrl( state ) {
+	const userLocale = getCurrentUserLocale( state );
+	if ( [ 'en', 'en-gb' ].includes( userLocale ) ) {
+		return config( 'new_onboarding_url' );
+	}
+
+	const existingUsersOnboardingVariant = getVariationForUser(
+		state,
+		'new_onboarding_existing_users_non_en_v4'
+	);
+	if ( existingUsersOnboardingVariant === 'treatment' ) {
+		return config( 'new_onboarding_url' );
+	}
+
+	return config( 'signup_url' );
+}

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -122,7 +122,7 @@
 	"rtl": false,
 	"siftscience_key": false,
 	"signup_url": false,
-	"new_onboarding_url": false,
+	"gutenboarding_url": false,
 	"signup/social-management": false,
 	"twemoji_cdn_url": "https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/",
 	"woocommerce_blog_id": 113771570,

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -122,6 +122,7 @@
 	"rtl": false,
 	"siftscience_key": false,
 	"signup_url": false,
+	"new_onboarding_url": false,
 	"signup/social-management": false,
 	"twemoji_cdn_url": "https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/",
 	"woocommerce_blog_id": 113771570,

--- a/config/development.json
+++ b/config/development.json
@@ -20,6 +20,7 @@
 	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
+	"new_onboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/development.json
+++ b/config/development.json
@@ -20,7 +20,7 @@
 	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
-	"new_onboarding_url": "/new",
+	"gutenboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -7,6 +7,7 @@
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
 	"signup_url": "/start",
+	"new_onboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -7,7 +7,7 @@
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
 	"signup_url": "/start",
-	"new_onboarding_url": "/new",
+	"gutenboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/production.json
+++ b/config/production.json
@@ -6,7 +6,7 @@
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",
 	"signup_url": "/start",
-	"new_onboarding_url": "/new",
+	"gutenboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/production.json
+++ b/config/production.json
@@ -6,6 +6,7 @@
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",
 	"signup_url": "/start",
+	"new_onboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/stage.json
+++ b/config/stage.json
@@ -8,6 +8,7 @@
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
 	"signup_url": "/start",
+	"new_onboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/stage.json
+++ b/config/stage.json
@@ -8,7 +8,7 @@
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
 	"signup_url": "/start",
-	"new_onboarding_url": "/new",
+	"gutenboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/test.json
+++ b/config/test.json
@@ -18,6 +18,7 @@
 	"google_recaptcha_site_key": "",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
+	"new_onboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/test.json
+++ b/config/test.json
@@ -18,7 +18,7 @@
 	"google_recaptcha_site_key": "",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
-	"new_onboarding_url": "/new",
+	"gutenboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -9,7 +9,7 @@
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
 	"signup_url": "/start",
-	"new_onboarding_url": "/new",
+	"gutenboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -9,6 +9,7 @@
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
 	"signup_url": "/start",
+	"new_onboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",


### PR DESCRIPTION
This is a follow up of #46484 to improve UX by skipping a redirect. Current solution has been first mentioned in pbxNRc-qE-p2#comment-1048

This PR is a dependency for the existing users non-EN experiment (pbxNRc-vn-p2) in context of a current exPlat limitation to fetch experiments outside a React application (tracked in 536-gh-Automattic/experimentation-platform).

#### Changes proposed in this Pull Request

* Update URL for all the "Create Site" buttons displayed in Calypso for logged in users.
* Cleanup redirect logic from `/start` to `/new` in signup controller to prevent any unwanted redirect.

#### Other changes
* Add `new_onboarding_url` property to config files.
* Re-use `<NoSitesMessage />` component in `<BlogsSettings />`.
* Add `ref=calypso-inline-help` when creating a site from `InlineHelp` block.
* Add `ref=me-account-settings` query when creating a site from Account Settings page.
* Add `ref=me-account-close` query when creating a site from `AccountCloseConfirmDialog`.
* Add `ref=calypso-sidebar` query when creating a site from `MySitesSidebar`.

#### Testing instructions
* As an existing user with EN language set in your account and without any site, check if correct link to create a site (`/new?ref={REF_SLUG}` is available for "Create Site" buttons on:
  * `/stats/day`
  * `/me` and go to "Profile Links" section  https://cloudup.com/cKwt6mSB7HY
  * `/me` and click on the bottom-right question mark icon to open Inline Help and search for "Create" 
  * `/me/account` and look for the button below "Primary Site" label
  * `/me/notifications`
  * `/me/account/close` and look for the "Start a new site" buttonhttps://cloudup.com/cobxG1YYddv

* Once you create your first site, go to My Home (`/home/{SITE_SLUG}`) and look for "Add New Site" button in the left sidebar.
* Once you create your second site, go to My Home (`/home/{SITE_SLUG}`), click on "Switch Site" button at the top of left sidebar and look for "Add New Site" button below the site entries.
* As an existing user with non-EN language set in your account, if you repeat all the above, you should get redirected to `/start?ref={REF_SLUG}` except if you are assigned to `treatment` variation of `new_onboarding_existing_users_non_en_v4` exPlat test (introduced in #48063 and described in pbxNRc-vn-p2)