### PR TITLE
Jetpack Cloud: Subtle placeholders on forms

### DIFF
--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -13,6 +13,10 @@
 		padding-right: 16px;
 	}
 
+	input::placeholder {
+		color: var( --color-neutral-10 ) !important;
+	}
+
 	.current-section {
 		margin: 0 -16px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The placeholders were a little strong and made the credentials form look pre-filled. This PR softens them:

**Before:**

![Screenshot 2020-12-15 at 11 50 54](https://user-images.githubusercontent.com/411945/102211050-4c0eec00-3ed3-11eb-84ef-a3fd719329ff.png)

**After**

![Screenshot 2020-12-15 at 11 59 02](https://user-images.githubusercontent.com/411945/102211059-5204cd00-3ed3-11eb-91f9-5a1cc87fad3b.png)

