### PR TITLE
Checkout: Disable concierge nudges for e2e tests

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -68,6 +68,7 @@ import {
 import { isExternal, addQueryArgs } from 'calypso/lib/url';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { abtest } from 'calypso/lib/abtest';
+import { isE2ETest } from 'calypso/lib/e2e';
 
 /**
  * Style dependencies
@@ -204,7 +205,7 @@ export class Checkout extends React.Component {
 
 	maybeRedirectToConciergeNudge( pendingOrReceiptId, stepResult, shouldHideUpsellNudges ) {
 		// Using hideNudge prop will disable any redirect to Nudge
-		if ( this.props.hideNudge || shouldHideUpsellNudges ) {
+		if ( this.props.hideNudge || shouldHideUpsellNudges || isE2ETest() ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR disables the concierge nudges in e2e tests. I've noticed that these nudges consistently break our e2e tests, so I'm suggesting we disable them for e2e tests only.

#### Changes proposed in this Pull Request

* Checkout: Disable concierge nudges for e2e tests

#### Testing instructions

* Verify all tests pass. Including e2e ones 😉 
