### PR TITLE
Jetpack Cloud: Update Dreamhost FTP docs link

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
@@ -317,7 +317,7 @@ export const topHosts: Host[] = [
 		name: 'Dreamhost',
 		supportLink: 'https://www.dreamhost.com/support/',
 		credentialLinks: {
-			ftp: 'https://help.dreamhost.com/hc/en-us/sections/203242517-Connecting-To-Your-Server',
+			ftp: 'https://help.dreamhost.com/hc/en-us/articles/115000675027-FTP-overview-and-credentials',
 			sftp: 'https://help.dreamhost.com/hc/en-us/articles/216385837-Enabling-Shell-access',
 		},
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update dreamhost support link for FTP documentation

Requested here: pc062P-c0-p2#comment-674

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `npm run jetpack-cloud-start`
* Visit settings and enter the credentials flow
* Check link for FTP when using Dreamhost