### PR TITLE
Price anchor A/B test: Show plans in descending order of price

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -552,6 +552,8 @@ export function createAccount(
 
 		const marketing_price_group = response?.marketing_price_group ?? '';
 
+		const plans_reorder_abtest_variation = response?.plans_reorder_abtest_variation ?? '';
+
 		// Fire after a new user registers.
 		recordRegistration( {
 			userData: registrationUserData,
@@ -559,7 +561,10 @@ export function createAccount(
 			type: signupType,
 		} );
 
-		const providedDependencies = assign( { username, marketing_price_group }, bearerToken );
+		const providedDependencies = assign(
+			{ username, marketing_price_group, plans_reorder_abtest_variation },
+			bearerToken
+		);
 
 		if ( signupType === SIGNUP_TYPE_DEFAULT && oauth2Signup ) {
 			assign( providedDependencies, {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -221,6 +221,7 @@ export class PlansFeaturesMain extends Component {
 			hidePersonalPlan,
 			hidePremiumPlan,
 			sitePlanSlug,
+			showTreatmentPlansReorderTest,
 		} = this.props;
 
 		const currentPlan = getPlan( selectedPlan );
@@ -287,6 +288,10 @@ export class PlansFeaturesMain extends Component {
 
 		if ( ! isEnabled( 'plans/personal-plan' ) && ! displayJetpackPlans ) {
 			plans.splice( plans.indexOf( plans.filter( ( p ) => p === PLAN_PERSONAL )[ 0 ] ), 1 );
+		}
+
+		if ( showTreatmentPlansReorderTest ) {
+			return plans.reverse();
 		}
 
 		return plans;

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -109,6 +109,7 @@ class Plans extends React.Component {
 			customerType,
 			isWPForTeamsSite,
 			hasWpcomMonthlyPlan,
+			showTreatmentPlansReorderTest,
 		} = this.props;
 
 		if ( ! selectedSite || this.isInvalidPlanInterval() ) {
@@ -157,7 +158,7 @@ class Plans extends React.Component {
 										discountEndDate={ this.props.discountEndDate }
 										site={ selectedSite }
 										plansWithScroll={ false }
-										isTreatmentPlansReorderTest={ isTreatmentPlansReorderTest }
+										showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
 									/>
 								) }
 								<PerformanceTrackerStop />
@@ -191,6 +192,6 @@ export default connect( ( state ) => {
 		isWPForTeamsSite: isSiteWPForTeams( state, selectedSiteId ),
 		hasWpcomMonthlyPlan:
 			isWpComPlan( currentPlan?.productSlug ) && isMonthly( currentPlan?.productSlug ),
-		isTreatmentPlansReorderTest: isTreatmentPlansReorderTest( state ),
+		showTreatmentPlansReorderTest: isTreatmentPlansReorderTest( state ),
 	};
 } )( localize( withTrackingTool( 'HotJar' )( Plans ) ) );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -35,6 +35,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getPlan, isWpComPlan } from 'calypso/lib/plans';
 import getIntervalTypeForTerm from 'calypso/lib/plans/get-interval-type-for-term';
 import { isMonthly } from 'calypso/lib/plans/constants';
+import { isTreatmentPlansReorderTest } from 'calypso/state/marketing/selectors';
 
 class Plans extends React.Component {
 	static propTypes = {
@@ -156,6 +157,7 @@ class Plans extends React.Component {
 										discountEndDate={ this.props.discountEndDate }
 										site={ selectedSite }
 										plansWithScroll={ false }
+										isTreatmentPlansReorderTest={ isTreatmentPlansReorderTest }
 									/>
 								) }
 								<PerformanceTrackerStop />
@@ -189,5 +191,6 @@ export default connect( ( state ) => {
 		isWPForTeamsSite: isSiteWPForTeams( state, selectedSiteId ),
 		hasWpcomMonthlyPlan:
 			isWpComPlan( currentPlan?.productSlug ) && isMonthly( currentPlan?.productSlug ),
+		isTreatmentPlansReorderTest: isTreatmentPlansReorderTest( state ),
 	};
 } )( localize( withTrackingTool( 'HotJar' )( Plans ) ) );

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -155,7 +155,13 @@ export function generateSteps( {
 			stepName: 'user',
 			apiRequestFunction: createAccount,
 			providesToken: true,
-			providesDependencies: [ 'bearer_token', 'username', 'marketing_price_group' ],
+			providesDependencies: [
+				'bearer_token',
+				'username',
+				'marketing_price_group',
+				'plans_reorder_abtest_variation',
+			],
+			optionalDependencies: [ 'plans_reorder_abtest_variation' ],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 			},
@@ -171,12 +177,14 @@ export function generateSteps( {
 				'bearer_token',
 				'username',
 				'marketing_price_group',
+				'plans_reorder_abtest_variation',
 				'allowUnauthenticated',
 			],
 			optionalDependencies: [
 				'bearer_token',
 				'username',
 				'marketing_price_group',
+				'plans_reorder_abtest_variation',
 				'allowUnauthenticated',
 			],
 			props: {
@@ -386,7 +394,9 @@ export function generateSteps( {
 				'oauth2_client_id',
 				'oauth2_redirect',
 				'marketing_price_group',
+				'plans_reorder_abtest_variation',
 			],
+			optionalDependencies: [ 'plans_reorder_abtest_variation' ],
 		},
 
 		'oauth2-name': {
@@ -399,7 +409,9 @@ export function generateSteps( {
 				'oauth2_client_id',
 				'oauth2_redirect',
 				'marketing_price_group',
+				'plans_reorder_abtest_variation',
 			],
+			optionalDependencies: [ 'plans_reorder_abtest_variation' ],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 				oauth2Signup: true,

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -30,7 +30,10 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
 import { getUrlParts } from 'calypso/lib/url/url-parts';
 import QueryExperiments from 'calypso/components/data/query-experiments';
-import { isTreatmentInMonthlyPricingTest } from 'calypso/state/marketing/selectors';
+import {
+	isTreatmentInMonthlyPricingTest,
+	isTreatmentPlansReorderTest,
+} from 'calypso/state/marketing/selectors';
 
 /**
  * Style dependencies
@@ -143,6 +146,7 @@ export class PlansStep extends Component {
 			planTypes,
 			flowName,
 			isMonthlyPricingTest,
+			showTreatmentPlansReorderTest,
 		} = this.props;
 
 		return (
@@ -167,6 +171,7 @@ export class PlansStep extends Component {
 					flowName={ flowName }
 					customHeader={ this.getGutenboardingHeader() }
 					isMonthlyPricingTest={ isMonthlyPricingTest }
+					showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
 				/>
 			</div>
 		);
@@ -250,6 +255,7 @@ PlansStep.propTypes = {
 	planTypes: PropTypes.array,
 	flowName: PropTypes.string,
 	isMonthlyPricingTest: PropTypes.bool,
+	isTreatmentPlansReorderTest: PropTypes.bool,
 };
 
 /**
@@ -282,6 +288,7 @@ export default connect(
 		siteType: getSiteType( state ),
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 		isMonthlyPricingTest: isTreatmentInMonthlyPricingTest( state ),
+		showTreatmentPlansReorderTest: isTreatmentPlansReorderTest( state ),
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep }
 )( localize( PlansStep ) );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -275,7 +275,10 @@ export const isDotBlogDomainRegistration = ( domainItem ) => {
 };
 
 export default connect(
-	( state, { path, signupDependencies: { siteSlug, domainItem } } ) => ( {
+	(
+		state,
+		{ path, signupDependencies: { siteSlug, domainItem, plans_reorder_abtest_variation } }
+	) => ( {
 		// Blogger plan is only available if user chose either a free domain or a .blog domain registration
 		disableBloggerPlanWithNonBlogDomain:
 			domainItem && ! isSubdomain( domainItem.meta ) && ! isDotBlogDomainRegistration( domainItem ),
@@ -288,7 +291,8 @@ export default connect(
 		siteType: getSiteType( state ),
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 		isMonthlyPricingTest: isTreatmentInMonthlyPricingTest( state ),
-		showTreatmentPlansReorderTest: isTreatmentPlansReorderTest( state ),
+		showTreatmentPlansReorderTest:
+			'treatment' === plans_reorder_abtest_variation || isTreatmentPlansReorderTest( state ),
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep }
 )( localize( PlansStep ) );

--- a/client/state/marketing/selectors.ts
+++ b/client/state/marketing/selectors.ts
@@ -8,6 +8,7 @@ import cookie from 'cookie';
  */
 import type { AppState } from 'calypso/types';
 import { getVariationForUser } from 'calypso/state/experiments/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 export function isTreatmentInMonthlyPricingTest( state: AppState ): boolean {
 	const countryCode =
@@ -22,4 +23,8 @@ export function isTreatmentInMonthlyPricingTest( state: AppState ): boolean {
 
 export function isTreatmentOneClickTest( state: AppState ): boolean {
 	return 'treatment' === getVariationForUser( state, 'one_click_premium_plan_upgrade_v3' );
+}
+
+export function isTreatmentPlansReorderTest( state: AppState ): boolean {
+	return 'treatment' === getCurrentUser( state )?.meta.plans_reorder_abtest_variation;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As part of the price anchor A/B test (described in pbxNRc-Bs-p2, we will show the plans listed in descending order of the price of the plan. So, eCommerce first, followed by Business etc.

* Users enter the A/B test via logged out pages (deployed in D54165-code and D54169-code). We will then check their variation to decide whether to show the plans in descending order of price.
* For eligible users, we will display plans in descending order in signup flow plans step, Calypso's /plans page, and launch flow plans step.

<img width="1665" alt="Screenshot 2020-12-16 at 7 17 40 PM" src="https://user-images.githubusercontent.com/1269602/102358482-8d87c000-3fd5-11eb-9ab1-223f79b049a0.png">

<img width="1675" alt="Screenshot 2020-12-16 at 7 18 09 PM" src="https://user-images.githubusercontent.com/1269602/102358494-94163780-3fd5-11eb-9774-90a037180b46.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D54287-code and follow the testing instructions there.
