### PR TITLE
New Onboarding: update design selector item border

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -112,7 +112,7 @@
 		width: 100%;
 		height: 0;
 		padding-top: 360px / 480px * 200%;
-		border: 2px solid var( --studio-gray-5 );
+		border: 1px solid var( --studio-gray-5 );
 		position: relative;
 		overflow: hidden;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use 1px border for design items as specified in Figma. 

#### Testing instructions

* Go to https://hash-3bc40f50a81fcb451df8a80097d2296fa2ea3c7a.calypso.live/new/design and check the change.

