### PR TITLE
Jetpack Cloud credentials: Set sensible port number when changing SFTP/FTP

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
@@ -58,7 +58,11 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 	const handleFormChange: FormEventHandler< HTMLInputElement > = ( { currentTarget } ) => {
 		switch ( currentTarget.name ) {
 			case 'protocol':
-				onFormStateChange( { ...formState, protocol: currentTarget.value as 'ftp' | 'ssh' } );
+				onFormStateChange( {
+					...formState,
+					protocol: currentTarget.value as 'ftp' | 'ssh',
+					port: currentTarget.value === 'ftp' ? 21 : 22,
+				} );
 				onModeChange( FormMode.Password );
 				break;
 			case 'host':

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
@@ -61,7 +61,17 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 				onFormStateChange( {
 					...formState,
 					protocol: currentTarget.value as 'ftp' | 'ssh',
-					port: currentTarget.value === 'ftp' ? 21 : 22,
+					port: ( () => {
+						let port = parseInt( formState.port );
+
+						if ( formState.port === 22 && currentTarget.value === 'ftp' ) {
+							port = 21;
+						} else if ( formState.port === 21 && currentTarget.value === 'ssh' ) {
+							port = 22;
+						}
+
+						return port;
+					} )(),
 				} );
 				onModeChange( FormMode.Password );
 				break;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When changing between SFTP/FTP, we should suggest a sensible port number:

![Kapture 2020-12-15 at 16 58 06](https://user-images.githubusercontent.com/411945/102240138-d2d5c000-3ef7-11eb-9451-8bacac164b0c.gif)

I am wondering if we should also check for anything in the box that is outside of 21/22 and only update it if it matches one of those?

#### Testing instructions

* `npm run jetpack-cloud-start`
* Visit settings and enter the credentials flow
* Check the port is updated when switching protocol

