### PR TITLE
me/profile: create and use `withFormBase` hoc

### DIFF
--- a/client/me/form-base/with-form-base.jsx
+++ b/client/me/form-base/with-form-base.jsx
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'calypso:me:form-base' );
+
+/**
+ * Internal dependencies
+ */
+import notices from 'calypso/notices';
+import user from 'calypso/lib/user';
+
+const withFormBase = ( WrappedComponent ) => {
+	return class extends React.Component {
+		static displayName = `withFormBase(${ WrappedComponent.displayName || WrappedComponent.name })`;
+
+		state = {
+			redirect: false,
+			submittingForm: false,
+			changingUsername: false,
+			usernameAction: 'new',
+			showNotice: false,
+		};
+
+		componentDidMount() {
+			this.props.userSettings.getSettings();
+		}
+
+		componentWillUnmount() {
+			// Silently clean up unsavedSettings before unmounting
+			this.props.userSettings.unsavedSettings = {};
+		}
+
+		UNSAFE_componentWillReceiveProps( nextProp ) {
+			if ( nextProp.showNoticeInitially ) {
+				this.setState( { showNotice: nextProp.showNoticeInitially } );
+			}
+		}
+
+		UNSAFE_componentWillUpdate() {
+			this.showNotice();
+		}
+
+		getDisabledState = () => {
+			return this.state.submittingForm;
+		};
+
+		showNotice() {
+			if ( this.props.userSettings.initialized && this.state.showNotice ) {
+				notices.clearNotices( 'notices' );
+				notices.success( this.props.translate( 'Settings saved successfully!' ) );
+				this.state.showNotice = false;
+			}
+		}
+
+		getSetting = ( settingName ) => {
+			return this.props.userSettings.getSetting( settingName ) || '';
+		};
+
+		toggleSetting = ( event ) => {
+			const { name } = event.currentTarget;
+			this.props.userSettings.updateSetting( name, ! this.getSetting( name ) );
+		};
+
+		updateSetting = ( event ) => {
+			const { name, value } = event.currentTarget;
+			this.props.userSettings.updateSetting( name, value );
+		};
+
+		submitForm = ( event ) => {
+			event.preventDefault();
+			debug( 'Submitting form' );
+
+			this.setState( { submittingForm: true } );
+			this.props.userSettings.saveSettings(
+				function ( error, response ) {
+					if ( error ) {
+						debug( 'Error saving settings: ' + JSON.stringify( error ) );
+
+						// handle error case here
+						if ( error.message ) {
+							notices.error( error.message );
+						} else {
+							notices.error( this.props.translate( 'There was a problem saving your changes.' ) );
+						}
+						this.setState( { submittingForm: false } );
+					} else {
+						this.props.markSaved && this.props.markSaved();
+
+						if ( this.state && this.state.redirect ) {
+							user()
+								.clear()
+								.then( () => {
+									// Sometimes changes in settings require a url refresh to update the UI.
+									// For example when the user changes the language.
+									window.location = this.state.redirect + '?updated=success';
+								} );
+							return;
+						}
+						// if we set submittingForm too soon the UI updates before the response is handled
+						this.setState( { showNotice: true, submittingForm: false } );
+						this.showNotice();
+						debug( 'Settings saved successfully ' + JSON.stringify( response ) );
+					}
+				}.bind( this )
+			);
+		};
+
+		getFormBaseProps = () => ( {
+			getDisabledState: this.getDisabledState,
+			getSetting: this.getSetting,
+			toggleSetting: this.toggleSetting,
+			updateSetting: this.updateSetting,
+			submitForm: this.submitForm,
+			formState: this.state,
+		} );
+
+		render() {
+			return <WrappedComponent { ...this.props } { ...this.getFormBaseProps() } />;
+		}
+	};
+};
+
+export default withFormBase;

--- a/client/me/form-base/with-form-base.jsx
+++ b/client/me/form-base/with-form-base.jsx
@@ -31,12 +31,6 @@ const withFormBase = ( WrappedComponent ) => {
 			userSettings.unsavedSettings = {};
 		}
 
-		UNSAFE_componentWillReceiveProps( nextProp ) {
-			if ( nextProp.showNoticeInitially ) {
-				this.setState( { showNotice: nextProp.showNoticeInitially } );
-			}
-		}
-
 		componentDidUpdate() {
 			this.showNotice();
 		}

--- a/client/me/form-base/with-form-base.jsx
+++ b/client/me/form-base/with-form-base.jsx
@@ -2,10 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
-
-const debug = debugFactory( 'calypso:me:form-base' );
 
 /**
  * Internal dependencies
@@ -71,14 +68,11 @@ const withFormBase = ( WrappedComponent ) => {
 
 		submitForm = ( event ) => {
 			event.preventDefault();
-			debug( 'Submitting form' );
 
 			this.setState( { submittingForm: true } );
 			this.props.userSettings.saveSettings(
-				function ( error, response ) {
+				function ( error ) {
 					if ( error ) {
-						debug( 'Error saving settings: ' + JSON.stringify( error ) );
-
 						// handle error case here
 						if ( error.message ) {
 							notices.error( error.message );
@@ -102,7 +96,6 @@ const withFormBase = ( WrappedComponent ) => {
 						// if we set submittingForm too soon the UI updates before the response is handled
 						this.setState( { showNotice: true, submittingForm: false } );
 						this.showNotice();
-						debug( 'Settings saved successfully ' + JSON.stringify( response ) );
 					}
 				}.bind( this )
 			);

--- a/client/me/form-base/with-form-base.jsx
+++ b/client/me/form-base/with-form-base.jsx
@@ -19,7 +19,6 @@ const withFormBase = ( WrappedComponent ) => {
 		state = {
 			redirect: false,
 			submittingForm: false,
-			changingUsername: false,
 			usernameAction: 'new',
 			showNotice: false,
 		};

--- a/client/me/form-base/with-form-base.jsx
+++ b/client/me/form-base/with-form-base.jsx
@@ -17,7 +17,6 @@ const withFormBase = ( WrappedComponent ) => {
 		state = {
 			redirect: false,
 			submittingForm: false,
-			usernameAction: 'new',
 			showNotice: false,
 		};
 

--- a/client/me/form-base/with-form-base.jsx
+++ b/client/me/form-base/with-form-base.jsx
@@ -3,13 +3,14 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import notices from 'calypso/notices';
 import user from 'calypso/lib/user';
 import userSettings from 'calypso/lib/user-settings';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 const withFormBase = ( WrappedComponent ) => {
 	class EnhancedComponent extends React.Component {
@@ -36,7 +37,7 @@ const withFormBase = ( WrappedComponent ) => {
 			}
 		}
 
-		UNSAFE_componentWillUpdate() {
+		componentDidUpdate() {
 			this.showNotice();
 		}
 
@@ -46,8 +47,9 @@ const withFormBase = ( WrappedComponent ) => {
 
 		showNotice() {
 			if ( userSettings.initialized && this.state.showNotice ) {
-				notices.clearNotices( 'notices' );
-				notices.success( this.props.translate( 'Settings saved successfully!' ) );
+				this.props.successNotice( this.props.translate( 'Settings saved successfully!' ), {
+					id: 'form-base',
+				} );
 				this.state.showNotice = false;
 			}
 		}
@@ -75,9 +77,12 @@ const withFormBase = ( WrappedComponent ) => {
 					if ( error ) {
 						// handle error case here
 						if ( error.message ) {
-							notices.error( error.message );
+							this.props.errorNotice( error.message, { id: 'form-base' } );
 						} else {
-							notices.error( this.props.translate( 'There was a problem saving your changes.' ) );
+							this.props.errorNotice(
+								this.props.translate( 'There was a problem saving your changes.' ),
+								{ id: 'form-base' }
+							);
 						}
 						this.setState( { submittingForm: false } );
 					} else {
@@ -115,7 +120,7 @@ const withFormBase = ( WrappedComponent ) => {
 		}
 	}
 
-	return localize( EnhancedComponent );
+	return connect( null, { errorNotice, successNotice } )( localize( EnhancedComponent ) );
 };
 
 export default withFormBase;

--- a/client/me/form-base/with-form-base.jsx
+++ b/client/me/form-base/with-form-base.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import notices from 'calypso/notices';
 import user from 'calypso/lib/user';
+import userSettings from 'calypso/lib/user-settings';
 
 const withFormBase = ( WrappedComponent ) => {
 	class EnhancedComponent extends React.Component {
@@ -21,12 +22,12 @@ const withFormBase = ( WrappedComponent ) => {
 		};
 
 		componentDidMount() {
-			this.props.userSettings.getSettings();
+			userSettings.getSettings();
 		}
 
 		componentWillUnmount() {
 			// Silently clean up unsavedSettings before unmounting
-			this.props.userSettings.unsavedSettings = {};
+			userSettings.unsavedSettings = {};
 		}
 
 		UNSAFE_componentWillReceiveProps( nextProp ) {
@@ -44,7 +45,7 @@ const withFormBase = ( WrappedComponent ) => {
 		};
 
 		showNotice() {
-			if ( this.props.userSettings.initialized && this.state.showNotice ) {
+			if ( userSettings.initialized && this.state.showNotice ) {
 				notices.clearNotices( 'notices' );
 				notices.success( this.props.translate( 'Settings saved successfully!' ) );
 				this.state.showNotice = false;
@@ -52,24 +53,24 @@ const withFormBase = ( WrappedComponent ) => {
 		}
 
 		getSetting = ( settingName ) => {
-			return this.props.userSettings.getSetting( settingName ) || '';
+			return userSettings.getSetting( settingName ) || '';
 		};
 
 		toggleSetting = ( event ) => {
 			const { name } = event.currentTarget;
-			this.props.userSettings.updateSetting( name, ! this.getSetting( name ) );
+			userSettings.updateSetting( name, ! this.getSetting( name ) );
 		};
 
 		updateSetting = ( event ) => {
 			const { name, value } = event.currentTarget;
-			this.props.userSettings.updateSetting( name, value );
+			userSettings.updateSetting( name, value );
 		};
 
 		submitForm = ( event ) => {
 			event.preventDefault();
 
 			this.setState( { submittingForm: true } );
-			this.props.userSettings.saveSettings(
+			userSettings.saveSettings(
 				function ( error ) {
 					if ( error ) {
 						// handle error case here

--- a/client/me/form-base/with-form-base.jsx
+++ b/client/me/form-base/with-form-base.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
 
 const debug = debugFactory( 'calypso:me:form-base' );
 
@@ -13,7 +14,7 @@ import notices from 'calypso/notices';
 import user from 'calypso/lib/user';
 
 const withFormBase = ( WrappedComponent ) => {
-	return class extends React.Component {
+	class EnhancedComponent extends React.Component {
 		static displayName = `withFormBase(${ WrappedComponent.displayName || WrappedComponent.name })`;
 
 		state = {
@@ -119,7 +120,9 @@ const withFormBase = ( WrappedComponent ) => {
 		render() {
 			return <WrappedComponent { ...this.props } { ...this.getFormBaseProps() } />;
 		}
-	};
+	}
+
+	return localize( EnhancedComponent );
 };
 
 export default withFormBase;

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import { Card } from '@automattic/components';
 import EditGravatar from 'calypso/blocks/edit-gravatar';
-import formBase from 'calypso/me/form-base';
+import withFormBase from 'calypso/me/form-base/with-form-base';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -43,7 +43,7 @@ const debug = debugFactory( 'calypso:me:profile' );
 const Profile = createReactClass( {
 	displayName: 'Profile',
 
-	mixins: [ formBase, observe( 'userSettings' ) ],
+	mixins: [ observe( 'userSettings' ) ],
 
 	componentDidMount() {
 		debug( this.displayName + ' component is mounted.' );
@@ -107,28 +107,28 @@ const Profile = createReactClass( {
 
 					<EditGravatar />
 
-					<form onSubmit={ this.submitForm } onChange={ this.props.markChanged }>
+					<form onSubmit={ this.props.submitForm } onChange={ this.props.markChanged }>
 						<FormFieldset>
 							<FormLabel htmlFor="first_name">{ this.props.translate( 'First name' ) }</FormLabel>
 							<FormTextInput
-								disabled={ this.getDisabledState() }
+								disabled={ this.props.getDisabledState() }
 								id="first_name"
 								name="first_name"
-								onChange={ this.updateSetting }
+								onChange={ this.props.updateSetting }
 								onFocus={ this.getFocusHandler( 'First Name Field' ) }
-								value={ this.getSetting( 'first_name' ) }
+								value={ this.props.getSetting( 'first_name' ) }
 							/>
 						</FormFieldset>
 
 						<FormFieldset>
 							<FormLabel htmlFor="last_name">{ this.props.translate( 'Last name' ) }</FormLabel>
 							<FormTextInput
-								disabled={ this.getDisabledState() }
+								disabled={ this.props.getDisabledState() }
 								id="last_name"
 								name="last_name"
-								onChange={ this.updateSetting }
+								onChange={ this.props.updateSetting }
 								onFocus={ this.getFocusHandler( 'Last Name Field' ) }
-								value={ this.getSetting( 'last_name' ) }
+								value={ this.props.getSetting( 'last_name' ) }
 							/>
 						</FormFieldset>
 
@@ -137,35 +137,35 @@ const Profile = createReactClass( {
 								{ this.props.translate( 'Public display name' ) }
 							</FormLabel>
 							<FormTextInput
-								disabled={ this.getDisabledState() }
+								disabled={ this.props.getDisabledState() }
 								id="display_name"
 								name="display_name"
-								onChange={ this.updateSetting }
+								onChange={ this.props.updateSetting }
 								onFocus={ this.getFocusHandler( 'Display Name Field' ) }
-								value={ this.getSetting( 'display_name' ) }
+								value={ this.props.getSetting( 'display_name' ) }
 							/>
 						</FormFieldset>
 
 						<FormFieldset>
 							<FormLabel htmlFor="description">{ this.props.translate( 'About me' ) }</FormLabel>
 							<FormTextarea
-								disabled={ this.getDisabledState() }
+								disabled={ this.props.getDisabledState() }
 								id="description"
 								name="description"
-								onChange={ this.updateSetting }
+								onChange={ this.props.updateSetting }
 								onFocus={ this.getFocusHandler( 'About Me Field' ) }
-								value={ this.getSetting( 'description' ) }
+								value={ this.props.getSetting( 'description' ) }
 							/>
 						</FormFieldset>
 
 						<p className="profile__submit-button-wrapper">
 							<FormButton
 								disabled={
-									! this.props.userSettings.hasUnsavedSettings() || this.getDisabledState()
+									! this.props.userSettings.hasUnsavedSettings() || this.props.getDisabledState()
 								}
 								onClick={ this.getClickHandler( 'Save Profile Details Button' ) }
 							>
-								{ this.state.submittingForm
+								{ this.props.formState.submittingForm
 									? this.props.translate( 'Saving…' )
 									: this.props.translate( 'Save profile details' ) }
 							</FormButton>
@@ -181,4 +181,4 @@ const Profile = createReactClass( {
 
 const connectComponent = connect( null, { recordGoogleEvent } );
 
-export default flowRight( connectComponent, protectForm, localize )( Profile );
+export default flowRight( connectComponent, protectForm, localize, withFormBase )( Profile );


### PR DESCRIPTION
This PR is part of the efforts to remove the [`lib/user-settings`](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/user-settings/index.js) flux store and actions and replace it with the corresponding redux state and actions. The redux side of things is (mostly) already in place, but to fully use it we have to take a few other steps first.

For `me/profile` and other account related sections the [`formBase`](https://github.com/Automattic/wp-calypso/blob/trunk/client/me/form-base/index.js) mixin is tightly coupled with `lib/user-settings`. In order to use redux we have to migrate the `formBase` mixin to use the redux actions. However, that'd mean a quite huge and hard-to-test PR because it would affect all components which use the `formBase` mixin. Therefore, and because mixins are considered bad practice in React land anyway [for a number of reasons](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html), I created a `withFormBase` higher order component which I will switch over to using redux in a subsequent PR. Then step by step we will move the remaining components over to use the hoc as well.

#### Changes proposed in this Pull Request

* Create a `withFormBase` higher order component which provides the same functionality as the existing `formBase` mixin
* Migrate `me/profile` to use the newly created `withFormBase` hoc

#### Testing instructions

* Go to `/me`
* Make sure the profile form behaves exactly the same as on prod, e.g.
  * Enable the _Save profile details_ if you change your profile settings
  * Input fields are disabled while submitting a request
  * Show a success and/or error notice after saving your details
  * Reset unsaved settings when leaving the page (switch back and check whether the settings got reset)

part of #24162 
