### PR TITLE
Manage Purchases: Fix PurchasesSiteHeader displaying wrong site name

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -583,7 +583,6 @@ class ManagePurchase extends Component {
 
 		const {
 			purchase,
-			siteId,
 			translate,
 			isProductOwner,
 			getManagePurchaseUrlFor,
@@ -601,6 +600,7 @@ class ManagePurchase extends Component {
 		} );
 		const siteName = purchase.siteName;
 		const siteDomain = purchase.domain;
+		const siteId = purchase.siteId;
 
 		return (
 			<Fragment>


### PR DESCRIPTION
### Changes proposed in this Pull Request

#### Here's a screen capture of the issue:

![chrome-capture (17)](https://user-images.githubusercontent.com/11078128/102253011-aac86b80-3ebb-11eb-90c8-e5d4b7000040.gif)

### Testing instructions

To reproduce the issue:

1. In the Calypso sidebar, select "Switch Site" --> and select any one of your sites.
2. Next, select Plans --> Billing --> "View all purchases"  (Make these selections in the UI, don't go there directly by manually changing your url to `/me/purchases`).
3. Now select any site **that is Not** the site you selected in step 1.
4. Notice that the Site Header is not displaying the site you selected in step 3, but rather is displaying the site you originally selected in step 1.

To test that this PR fixes the issue:

1. checkout and run this PR
2. complete steps 1 thru 3 above in the "To reproduce the issue:" section.
3. Verify that the PurchasesSiteHeader is now displaying the correct site name that is associated with the purchase you selected.

