### PR TITLE
Gutenboarding Anchor: Remove Domains and Plans buttons from header

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -14,7 +14,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import DomainPickerButton from '../domain-picker-button';
 import PlansButton from '../plans-button';
-import { useCurrentStep, Step } from '../../path';
+import { useCurrentStep, useIsAnchorFm, Step } from '../../path';
 import { isEnabled } from '../../../../config';
 import Link from '../link';
 
@@ -27,20 +27,18 @@ const Header: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const locale = useLocale();
 	const currentStep = useCurrentStep();
+	const isAnchorFmSignup = useIsAnchorFm();
 
 	const { siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 
 	// steps (including modals) where we show Domains button
-	const showDomainsButton = [
-		'DesignSelection',
-		'Style',
-		'Features',
-		'Plans',
-		'PlansModal',
-	].includes( currentStep );
+	const showDomainsButton =
+		[ 'DesignSelection', 'Style', 'Features', 'Plans', 'PlansModal' ].includes( currentStep ) &&
+		! isAnchorFmSignup;
 
 	// steps (including modals) where we show Plans button
-	const showPlansButton = [ 'DesignSelection', 'Style', 'Features' ].includes( currentStep );
+	const showPlansButton =
+		[ 'DesignSelection', 'Style', 'Features' ].includes( currentStep ) && ! isAnchorFmSignup;
 
 	// CreateSite step clears state before redirecting, don't show the default text in this case
 	const siteTitleDefault = 'CreateSite' === currentStep ? '' : __( 'Start your website' );

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -15,7 +15,7 @@ import DesignSelector from './design-selector';
 import CreateSite from './create-site';
 import CreateSiteError from './create-site-error';
 import type { Attributes } from './types';
-import { Step, usePath, useNewQueryParam } from '../path';
+import { Step, usePath, useNewQueryParam, useIsAnchorFm } from '../path';
 import AcquireIntent from './acquire-intent';
 import StylePreview from './style-preview';
 import Features from './features';
@@ -32,6 +32,7 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 	const isCreatingSite = useSelect( ( select ) => select( SITE_STORE ).isFetchingSite() );
 	const newSiteError = useSelect( ( select ) => select( SITE_STORE ).getNewSiteError() );
 	const shouldTriggerCreate = useNewQueryParam();
+	const isAnchorFmSignup = useIsAnchorFm();
 
 	const makePath = usePath();
 
@@ -54,7 +55,7 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 	}, [ isCreatingSite, isRedirecting ] );
 
 	const getLatestStepPath = (): string => {
-		if ( canUseStyleStep() ) {
+		if ( canUseStyleStep() && ! isAnchorFmSignup ) {
 			return makePath( Step.Plans );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When in the Anchor-specific gutenboarding flow, remove Domains and Plans buttons from header
  * The non-anchor gutenboarding flow is not affected
  * These two buttons refer to steps that were removed in the anchor flow

![2020-12-15_13-16](https://user-images.githubusercontent.com/937354/102262216-60091c80-3ed8-11eb-8d38-dd6bcea4659e.png)

#### Testing instructions

* (Anchor Flow) In dev, visit http://calypso.localhost:3000/new?anchor_podcast=cafef00d in a new incognito window and proceed through the anchor flow.
  * Note the buttons in the screenshot above are removed.
* (Non-Anchor Flow) In dev, visit http://calypso.localhost:3000/new in a new incognito window and proceed through the non-anchor flow.
  * Note the buttons in the screenshot above remain.
