### PR TITLE
Starter page templates - fix wrong close button issue.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -15,7 +15,7 @@ class SidebarModalOpener extends Component {
 	};
 
 	toggleTemplateModal = () => {
-		this.setState( { isOpenFromSidebar: ! this.state.isOpenFromSidebar } );
+		this.setState( state => ( { isOpenFromSidebar: ! state.isOpenFromSidebar } ) );
 	};
 
 	toggleWarningModal = () => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -2,9 +2,7 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
-import { withSelect, withDispatch } from '@wordpress/data';
 import { Button, Modal } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -13,10 +11,11 @@ import { PageTemplatesPlugin } from '../index';
 class SidebarModalOpener extends Component {
 	state = {
 		isWarningOpen: false,
+		isOpenFromSidebar: false,
 	};
 
 	toggleTemplateModal = () => {
-		this.props.setIsOpen( ! this.props.isOpen );
+		this.setState( { isOpenFromSidebar: ! this.state.isOpenFromSidebar } );
 	};
 
 	toggleWarningModal = () => {
@@ -24,7 +23,8 @@ class SidebarModalOpener extends Component {
 	};
 
 	render() {
-		const { templates, theme, vertical, segment, hidePageTitle, isFrontPage, isOpen } = this.props;
+		const { templates, theme, vertical, segment, hidePageTitle, isFrontPage } = this.props;
+		const { isOpenFromSidebar } = this.state;
 
 		return (
 			<div className="sidebar-modal-opener">
@@ -32,7 +32,7 @@ class SidebarModalOpener extends Component {
 					{ __( 'Change Layout', 'full-site-editing' ) }
 				</Button>
 
-				{ isOpen && (
+				{ isOpenFromSidebar && (
 					<PageTemplatesPlugin
 						shouldPrefetchAssets={ false }
 						templates={ templates }
@@ -43,6 +43,7 @@ class SidebarModalOpener extends Component {
 						hidePageTitle={ hidePageTitle }
 						isFrontPage={ isFrontPage }
 						isPromptedFromSidebar
+						isOpen={ true }
 					/>
 				) }
 
@@ -74,13 +75,4 @@ class SidebarModalOpener extends Component {
 	}
 }
 
-const SidebarTemplatesPlugin = compose(
-	withSelect( ( select ) => ( {
-		isOpen: select( 'automattic/starter-page-layouts' ).isOpen(),
-	} ) ),
-	withDispatch( ( dispatch ) => ( {
-		setIsOpen: dispatch( 'automattic/starter-page-layouts' ).setIsOpen,
-	} ) )
-)( SidebarModalOpener );
-
-export default SidebarTemplatesPlugin;
+export default SidebarModalOpener;

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -15,7 +15,7 @@ class SidebarModalOpener extends Component {
 	};
 
 	toggleTemplateModal = () => {
-		this.setState( state => ( { isOpenFromSidebar: ! state.isOpenFromSidebar } ) );
+		this.setState( ( state ) => ( { isOpenFromSidebar: ! state.isOpenFromSidebar } ) );
 	};
 
 	toggleWarningModal = () => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -528,10 +528,10 @@ class PageTemplateModal extends Component {
 }
 
 export const PageTemplatesPlugin = compose(
-	withSelect( ( select ) => {
+	withSelect( ( select, ownProps ) => {
 		const getMeta = () => select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 		const { _starter_page_template } = getMeta();
-		const isOpen = select( 'automattic/starter-page-layouts' ).isOpen();
+		const isOpen = ownProps.isOpen || select( 'automattic/starter-page-layouts' ).isOpen();
 		const currentBlocks = select( 'core/editor' ).getBlocks();
 		return {
 			isOpen,

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -531,7 +531,7 @@ export const PageTemplatesPlugin = compose(
 	withSelect( ( select, ownProps ) => {
 		const getMeta = () => select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 		const { _starter_page_template } = getMeta();
-		const isOpen = ownProps.isOpen || select( 'automattic/starter-page-layouts' ).isOpen();
+		const isOpen = ownProps.isPromptedFromSidebar ? ownProps.isOpen : select( 'automattic/starter-page-layouts' ).isOpen();
 		const currentBlocks = select( 'core/editor' ).getBlocks();
 		return {
 			isOpen,

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -531,7 +531,9 @@ export const PageTemplatesPlugin = compose(
 	withSelect( ( select, ownProps ) => {
 		const getMeta = () => select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 		const { _starter_page_template } = getMeta();
-		const isOpen = ownProps.isPromptedFromSidebar ? ownProps.isOpen : select( 'automattic/starter-page-layouts' ).isOpen();
+		const isOpen = ownProps.isPromptedFromSidebar
+			? ownProps.isOpen
+			: select( 'automattic/starter-page-layouts' ).isOpen();
 		const currentBlocks = select( 'core/editor' ).getBlocks();
 		return {
 			isOpen,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes the page template modal displaying the wrong button as outlined in #48370.

Some history:

There are 2 versions of the SPT modal.  1 - triggers when we create a new page.  2 - triggers when we click the 'change layout' button in the sidebar.

At one point the NUX was interfering with version 1.  This prompted us to add the open state to the store so we could hide the NUX until the SPT modal was closed (#40347).  Unfortunately, it seems we added version 2 to this store state as well causing it to open at the same time as version 1.  So when creating a new page 2 versions of the modal are rendered which could result in the wrong version being visible:

![Screen Shot 2020-12-15 at 2 39 12 PM](https://user-images.githubusercontent.com/28742426/102267994-ad8d8580-3ee8-11eb-9ad9-70571358cd28.png)

Similarly, after closing the modal (by selecting a layout) and opening the sidebar version, both versions would open again since they both were subject to the same `isOpen` condition.

Here, we have removed the store state from version 2 and made it rely on local component state.  This seems reasonable since there was no reason to add this version to the store anyways.  The NUX could only conflict with version 1, as version 2 can not be opened without dismissing the NUX anyways.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync these editing toolkit changes to your sandbox.
* Sandbox your site and the public api.
* Create a new page.
* Verify the correct SPT modal is present, it should have the "<" button leading back to calypso.  
![Screen Shot 2020-12-15 at 2 39 52 PM](https://user-images.githubusercontent.com/28742426/102268428-520fc780-3ee9-11eb-9176-1de8dd204e94.png)
* With this modal open, use `document.querySelectorAll( '.page-template-modal' );` in the console to verify only 1 modal is present.
* Select a layout (or blank layout) to dismiss this modal and land in the editor.  Select "change layout" from the right sidebar.  Verify this is the correct version with the "X" that dismisses the modal and leaves you in the editor.  
![Screen Shot 2020-12-15 at 2 40 23 PM](https://user-images.githubusercontent.com/28742426/102268581-82effc80-3ee9-11eb-9fd4-7389df975812.png)
* With this modal open, use `document.querySelectorAll( '.page-template-modal' );` in the console to verify only 1 modal is present.

* Test this through different flows of new and current pages.  
* Verify that for new pages the modal has the "<" button that leads back to calypso.  
* Verify that opening the modal through the sidebar has the "X" button that dismissed the modal and leaves you in the editor.

Fixes #48370
