### PR TITLE
Sidebar: Redesign upsell nudge

### DIFF
--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -1,11 +1,10 @@
 .upsell-nudge.banner.card.is-compact {
 	background-color: var( --color-neutral-80 );
-	border-left-color: var( --color-accent );
 	box-shadow: none;
-	border-left-width: 4px;
+	border: 0;
+	border-radius: 2px;
 	color: var( --color-text-inverted );
-	margin-top: -1px;
-	margin-bottom: -1px;
+	margin: -4px 8px 8px;
 
 	a,
 	button {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -258,3 +258,7 @@
 .sidebar__footer {
 	margin-top: 16px;
 }
+
+.sidebar__menu-wrapper {
+	border-top: 1px solid var( --color-sidebar-border );
+}

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -105,3 +105,18 @@
 		white-space: normal;
 	}
 }
+
+//Certain color schemes use the same color for the notice
+//as the menu highlight background. Give these a bottom margin.
+.is-modern,
+.is-ocean,
+.is-sunrise,
+.is-sakura,
+.is-midnight,
+.is-coffee,
+.is-blue,
+.is-ectoplasm {
+	.current-site__notices {
+		margin-bottom: 2px;
+	}
+}

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -92,17 +92,22 @@
 
 .sidebar .notice.is-compact {
 	display: flex;
-	margin: 4px;
+	margin: -4px 8px 8px;
+	border-radius: 2px;
 
 	.notice__text {
-		width: 100%;
 		display: inline;
 		line-height: 1.3;
+		word-break: break-all;
 	}
 
 	.notice__action {
 		margin-left: auto;
 		white-space: normal;
+	}
+
+	& + .upsell-nudge.banner.card.is-compact {
+		margin-top: 8px;
 	}
 }
 

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -95,10 +95,14 @@
 	margin: -4px 8px 8px;
 	border-radius: 2px;
 
+	.notice__content {
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
 	.notice__text {
 		display: inline;
 		line-height: 1.3;
-		word-break: break-all;
 	}
 
 	.notice__action {

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -106,17 +106,7 @@
 	}
 }
 
-//Certain color schemes use the same color for the notice
-//as the menu highlight background. Give these a bottom margin.
-.is-modern,
-.is-ocean,
-.is-sunrise,
-.is-sakura,
-.is-midnight,
-.is-coffee,
-.is-blue,
-.is-ectoplasm {
-	.current-site__notices {
-		margin-bottom: 2px;
-	}
+.sidebar .current-site .site,
+.sidebar .current-site .all-sites {
+	border-bottom: 0;
 }

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -287,10 +287,7 @@ $font-size: rem( 14px );
 		color: #000;
 		padding: 7px 12px 7px 4px;
 		line-height: 26px;
-	}
-
-	.upsell-nudge.banner.card.is-compact .banner__content {
-		padding-left: 3px;
+		margin-top: 8px;
 	}
 
 	.upsell-nudge.banner.card.is-compact .banner__info .banner__title {
@@ -298,6 +295,7 @@ $font-size: rem( 14px );
 	}
 
 	.upsell-nudge.banner.card.is-compact .banner__action {
+		top: 0;
 		margin-left: 0;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Some color schemes use the same background and border color for the upsell nudge and the current highlighted menu item, making the two run together.
* This PR moves the upsell nudge into the site card area, adds a small margin around it and rounds the corners. Also removes the left colored border.

**Before**

<img width="330" alt="Screen Shot 2020-12-15 at 3 32 35 PM" src="https://user-images.githubusercontent.com/2124984/102270830-77520500-3eec-11eb-859e-d3e8b227a890.png">

**After**

<img width="290" alt="Screen Shot 2021-01-05 at 9 35 40 AM" src="https://user-images.githubusercontent.com/2124984/103662243-b4cf0e80-4f3d-11eb-9000-5d55c83b3c80.png"> <img width="292" alt="Screen Shot 2021-01-05 at 9 35 51 AM" src="https://user-images.githubusercontent.com/2124984/103662246-b567a500-4f3d-11eb-843c-47a0193ffa41.png"> <img width="294" alt="Screen Shot 2021-01-05 at 9 36 07 AM" src="https://user-images.githubusercontent.com/2124984/103662247-b567a500-4f3d-11eb-845c-61703849eaed.png"> <img width="291" alt="Screen Shot 2021-01-05 at 9 36 22 AM" src="https://user-images.githubusercontent.com/2124984/103662249-b567a500-4f3d-11eb-9d64-5722b69af72b.png">


#### Testing instructions

* Switch to this PR
* Switch color schemes in `/me/account` on a site that has a notice in the sidebar (Claim your free domain, for example)
* Go to My Home
* Check out the upsell nudge(s) and the new design.
* Switch to other color schemes to check the visuals.

Fixes #48367
