### PR TITLE
Jetpack Cloud: hide Jetpack Free card when site is connected

### DIFF
--- a/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
@@ -35,6 +35,8 @@ import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import MoreInfoBox from '../more-info-box';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
 
+import getSiteId from 'calypso/state/selectors/get-site-id';
+
 /**
  * Type dependencies
  */
@@ -60,6 +62,11 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 	const [ isPlanRowWrapping, setPlanRowWrapping ] = useState( false );
 
 	const siteId = useSelector( getSelectedSiteId );
+
+	// If a site is passed by URL and the site is found in the app's state, we will assume the site
+	// is connected, and thus, we don't need to show the Jetpack Free card.
+	const isUrlSiteConnected = useSelector( ( state ) => getSiteId( state, urlQueryArgs?.site ) );
+
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const currentPlanSlug =
 		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
@@ -188,7 +195,7 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 					) ) }
 				</ul>
 				<div className="products-grid-i5__free">
-					{ ( isInConnectFlow || isInJetpackCloud ) && (
+					{ ( isInConnectFlow || ( isInJetpackCloud && ! isUrlSiteConnected ) ) && (
 						<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
 					) }
 				</div>

--- a/client/state/selectors/get-site-id.js
+++ b/client/state/selectors/get-site-id.js
@@ -17,7 +17,7 @@ import { getSite } from 'calypso/state/sites/selectors';
  *
  * @param  {object}  state       Global state tree
  * @param  {number|string|null}  siteIdOrSlug Site ID
- * @returns {?object}             Site object
+ * @returns {?number}             Site object
  */
 export default function getSiteId( state, siteIdOrSlug ) {
 	if ( ! siteIdOrSlug ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 1164141197617539-as-1199609940112363

On Jetpack cloud, the Jetpack Free card sends users to the Jetpack Connect flow. This is confusing to users that came from wp-admin because, by definition, their site was already connected when they clicked the button that brought them to the cloud. Additionally, their site was already on Jetpack Free or on another paid plan, which is another reason to not show the card.

* On Jetpack cloud, hide the Jetpack Free card when the site passed by URL is connected (found in the app's state).
 
#### Testing instructions

Prerequisite: a Jetpack site.

* Run this PR and build both Calypsos with `yarn start` and `yarn start-jetpack-cloud-p` to run them in parallel.

**Calypso Green**
* Visit `http://jetpack.cloud.localhost:3001/pricing`.
* Click the Jetpack Free card.
* Verify that you are redirected to the Jetpack Connect flow.
* Visit `http://jetpack.cloud.localhost:3001/pricing?site=:site&source=jetpack-plans` (replace `:site` with your Jetpack site URL).
* Verify that there is no Jetpack Free card (if you do this in an incognito window, you should still see the card).

**Calypso Blue (here the behavior of the app shouldn't have changed)**
* Visit `http://calypso.localhost:3000/plans/:site` (replace `:site` with your Jetpack site URL).
* Verify that there is no Jetpack Free card.
* Visit `http://calypso.localhost:3000/plans/smoggy-pintail.jurassic.ninja?site=:site&source=jetpack-connect-plans` (replace `:site` with your Jetpack site URL).
* Click the Jetpack Free card.
* Verify that you are redirected to your site's wp-admin dashboard.
