### PR TITLE
Billing: Allow adding new cards from rebuilt update payment method screen

### DIFF
--- a/client/me/purchases/components/payment-method-form/helpers.js
+++ b/client/me/purchases/components/payment-method-form/helpers.js
@@ -56,7 +56,7 @@ export async function saveOrUpdateCreditCard( {
 	} );
 }
 
-async function getTokenForSavingCard( {
+export async function getTokenForSavingCard( {
 	formFieldValues,
 	createCardToken,
 	parseTokenFromResponse,
@@ -82,7 +82,7 @@ async function saveCreditCard( { token, translate, saveStoredCard, stripeConfigu
 	} );
 }
 
-async function updateCreditCard( {
+export async function updateCreditCard( {
 	formFieldValues,
 	apiParams,
 	purchase,

--- a/client/me/purchases/components/payment-method-form/style.scss
+++ b/client/me/purchases/components/payment-method-form/style.scss
@@ -47,6 +47,15 @@
 
 /* Override checkout styles */
 .change-payment-method__content {
+	.credit-card-fields-inner-wrapper {
+		max-width: 525px;
+	}
+
+	.contact-fields {
+		margin-top: 16px;
+		padding-bottom: 8px;
+	}
+
 	.checkout__step-wrapper.checkout__step-wrapper--last-step {
 		margin-bottom: 0;
 		border: 0;
@@ -54,9 +63,11 @@
 		max-width: none;
 	}
 
-	.checkout-steps__submit-button-wrapper {
+	.checkout__step-wrapper--last-step .checkout-steps__submit-button-wrapper {
 		background: transparent;
 		padding: 0;
+		position: relative;
+		border: 0;
 	}
 
 	.checkout-submit-button .checkout-button {

--- a/client/me/purchases/components/payment-method-form/style.scss
+++ b/client/me/purchases/components/payment-method-form/style.scss
@@ -2,7 +2,8 @@
 	margin-bottom: 0;
 }
 
-.payment-method-form__terms {
+.payment-method-form__terms,
+.change-payment-method__terms {
 	color: var( --color-text-subtle );
 	margin: 5px 0 0;
 	padding: 0;
@@ -42,4 +43,23 @@
 .payment-method-form__heading {
 	font-size: $font-title-small;
 	padding: 0 0 16px;
+}
+
+/* Override checkout styles */
+.change-payment-method__content {
+	.checkout__step-wrapper.checkout__step-wrapper--last-step {
+		margin-bottom: 0;
+		border: 0;
+		width: 100%;
+		max-width: none;
+	}
+
+	.checkout-steps__submit-button-wrapper {
+		background: transparent;
+		padding: 0;
+	}
+
+	.checkout-submit-button .checkout-button {
+		width: auto;
+	}
 }

--- a/client/me/purchases/components/payment-method-form/style.scss
+++ b/client/me/purchases/components/payment-method-form/style.scss
@@ -72,5 +72,9 @@
 
 	.checkout-submit-button .checkout-button {
 		width: auto;
+
+		&:focus {
+			outline: var( --color-primary-light ) solid 2px;
+		}
 	}
 }

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -335,6 +335,7 @@ const mapStateToProps = ( state, { cardId, purchaseId } ) => ( {
 } );
 
 function useAssignablePaymentMethods() {
+	const translate = useTranslate();
 	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
 
 	const paypalMethod = useCreatePayPal();
@@ -346,6 +347,7 @@ function useAssignablePaymentMethods() {
 		stripe,
 		shouldUseEbanx: false,
 		shouldShowTaxFields: true,
+		activePayButtonText: translate( 'Save card' ),
 	} );
 
 	// getStoredCards always returns a new array, but we need a memoized version
@@ -355,6 +357,7 @@ function useAssignablePaymentMethods() {
 	const existingCardMethods = useCreateExistingCards( {
 		storedCards,
 		stripeConfiguration,
+		activePayButtonText: translate( 'Use this card' ),
 	} );
 
 	const paymentMethods = useMemo(

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -61,6 +61,7 @@ import {
 	updateCreditCard,
 	getInitializedFields,
 } from 'calypso/me/purchases/components/payment-method-form/helpers';
+import 'calypso/me/purchases/components/payment-method-form/style.scss';
 
 function ChangePaymentMethod( props ) {
 	const { isStripeLoading } = useStripe();

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -9,7 +9,7 @@ import { createStripeSetupIntent, StripeHookProvider, useStripe } from '@automat
 import {
 	CheckoutProvider,
 	CheckoutPaymentMethods,
-	CheckoutStepArea,
+	CheckoutSubmitButton,
 	makeSuccessResponse,
 } from '@automattic/composite-checkout';
 import { Card } from '@automattic/components';
@@ -226,15 +226,15 @@ function ChangePaymentMethodList( {
 			<Card className="change-payment-method__content">
 				<QueryPaymentCountries />
 
-				<CheckoutStepArea>
-					<CheckoutPaymentMethods className="change-payment-method__list" isComplete={ false } />
-					<div className="change-payment-method__terms">
-						<Gridicon icon="info-outline" size={ 18 } />
-						<p>
-							<TosText translate={ translate } />
-						</p>
-					</div>
-				</CheckoutStepArea>
+				<CheckoutPaymentMethods className="change-payment-method__list" isComplete={ false } />
+				<div className="change-payment-method__terms">
+					<Gridicon icon="info-outline" size={ 18 } />
+					<p>
+						<TosText translate={ translate } />
+					</p>
+				</div>
+
+				<CheckoutSubmitButton />
 			</Card>
 		</CheckoutProvider>
 	);

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -50,7 +50,6 @@ import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-
 import { isEnabled } from 'calypso/config';
 import { concatTitle } from 'calypso/lib/react-helpers';
 import {
-	useCreatePayPal,
 	useCreateCreditCard,
 	useCreateExistingCards,
 } from 'calypso/my-sites/checkout/composite-checkout/use-create-payment-methods';
@@ -338,8 +337,6 @@ function useAssignablePaymentMethods() {
 	const translate = useTranslate();
 	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
 
-	const paypalMethod = useCreatePayPal();
-
 	const stripeMethod = useCreateCreditCard( {
 		isStripeLoading,
 		stripeLoadingError,
@@ -361,8 +358,8 @@ function useAssignablePaymentMethods() {
 	} );
 
 	const paymentMethods = useMemo(
-		() => [ ...existingCardMethods, stripeMethod, paypalMethod ].filter( Boolean ),
-		[ paypalMethod, stripeMethod, existingCardMethods ]
+		() => [ ...existingCardMethods, stripeMethod ].filter( Boolean ),
+		[ stripeMethod, existingCardMethods ]
 	);
 
 	return paymentMethods;

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
@@ -2,27 +2,30 @@
  * External dependencies
  */
 import React from 'react';
-import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { FormStatus, useFormStatus, useSelect } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
  */
 import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
 import CountrySpecificPaymentFields from '../../components/country-specific-payment-fields';
+import TaxFields from 'calypso/my-sites/checkout/composite-checkout/components/tax-fields';
 
 export default function ContactFields( {
 	getFieldValue,
 	setFieldValue,
 	getErrorMessagesForField,
 	shouldUseEbanx,
+	shouldShowTaxFields,
 } ) {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 	const countriesList = useCountryList( [] );
+	const fields = useSelect( ( select ) => select( 'credit-card' ).getFields() );
 
 	return (
 		<div className="contact-fields">
-			{ shouldUseEbanx && (
+			{ shouldUseEbanx && ! shouldShowTaxFields && (
 				<CountrySpecificPaymentFields
 					countryCode={ getFieldValue( 'countryCode' ) }
 					countriesList={ countriesList }
@@ -30,6 +33,16 @@ export default function ContactFields( {
 					getFieldValue={ getFieldValue }
 					handleFieldChange={ setFieldValue }
 					disableFields={ isDisabled }
+				/>
+			) }
+			{ shouldShowTaxFields && ! shouldUseEbanx && (
+				<TaxFields
+					section="update-to-new-card"
+					taxInfo={ fields }
+					countriesList={ countriesList }
+					isDisabled={ isDisabled }
+					updateCountryCode={ ( value ) => setFieldValue( 'countryCode', value ) }
+					updatePostalCode={ ( value ) => setFieldValue( 'postalCode', value ) }
 				/>
 			) }
 		</div>

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -111,64 +111,66 @@ export default function CreditCardFields( { shouldUseEbanx, shouldShowTaxFields 
 			{ ! isLoaded && <LoadingFields /> }
 
 			<CreditCardFieldsWrapper isLoaded={ isLoaded }>
-				<CreditCardField
-					id="cardholder-name"
-					type="Text"
-					autoComplete="cc-name"
-					label={ __( 'Cardholder name' ) }
-					description={ __( "Enter your name as it's written on the card" ) }
-					value={ cardholderName?.value ?? '' }
-					onChange={ ( value ) => setFieldValue( 'cardholderName', value ) }
-					isError={ !! cardholderNameErrorMessage }
-					errorMessage={ cardholderNameErrorMessage }
-					disabled={ isDisabled }
-				/>
-
-				<FieldRow>
-					<CreditCardNumberField
-						setIsStripeFullyLoaded={ setIsStripeFullyLoaded }
-						handleStripeFieldChange={ handleStripeFieldChange }
-						stripeElementStyle={ stripeElementStyle }
-						shouldUseEbanx={ shouldUseEbanx }
-						getErrorMessagesForField={ getErrorMessagesForField }
-						setFieldValue={ setFieldValue }
-						getFieldValue={ getFieldValue }
+				<div className="credit-card-fields-inner-wrapper">
+					<CreditCardField
+						id="cardholder-name"
+						type="Text"
+						autoComplete="cc-name"
+						label={ __( 'Cardholder name' ) }
+						description={ __( "Enter your name as it's written on the card" ) }
+						value={ cardholderName?.value ?? '' }
+						onChange={ ( value ) => setFieldValue( 'cardholderName', value ) }
+						isError={ !! cardholderNameErrorMessage }
+						errorMessage={ cardholderNameErrorMessage }
+						disabled={ isDisabled }
 					/>
 
-					<FieldRow gap="4%" columnWidths="48% 48%">
-						<LeftColumn>
-							<CreditCardExpiryField
-								handleStripeFieldChange={ handleStripeFieldChange }
-								stripeElementStyle={ stripeElementStyle }
-								shouldUseEbanx={ shouldUseEbanx }
-								getErrorMessagesForField={ getErrorMessagesForField }
-								setFieldValue={ setFieldValue }
-								getFieldValue={ getFieldValue }
-							/>
-						</LeftColumn>
-						<RightColumn>
-							<CreditCardCvvField
-								handleStripeFieldChange={ handleStripeFieldChange }
-								stripeElementStyle={ stripeElementStyle }
-								shouldUseEbanx={ shouldUseEbanx }
-								getErrorMessagesForField={ getErrorMessagesForField }
-								setFieldValue={ setFieldValue }
-								getFieldValue={ getFieldValue }
-							/>
-						</RightColumn>
+					<FieldRow>
+						<CreditCardNumberField
+							setIsStripeFullyLoaded={ setIsStripeFullyLoaded }
+							handleStripeFieldChange={ handleStripeFieldChange }
+							stripeElementStyle={ stripeElementStyle }
+							shouldUseEbanx={ shouldUseEbanx }
+							getErrorMessagesForField={ getErrorMessagesForField }
+							setFieldValue={ setFieldValue }
+							getFieldValue={ getFieldValue }
+						/>
+
+						<FieldRow gap="4%" columnWidths="48% 48%">
+							<LeftColumn>
+								<CreditCardExpiryField
+									handleStripeFieldChange={ handleStripeFieldChange }
+									stripeElementStyle={ stripeElementStyle }
+									shouldUseEbanx={ shouldUseEbanx }
+									getErrorMessagesForField={ getErrorMessagesForField }
+									setFieldValue={ setFieldValue }
+									getFieldValue={ getFieldValue }
+								/>
+							</LeftColumn>
+							<RightColumn>
+								<CreditCardCvvField
+									handleStripeFieldChange={ handleStripeFieldChange }
+									stripeElementStyle={ stripeElementStyle }
+									shouldUseEbanx={ shouldUseEbanx }
+									getErrorMessagesForField={ getErrorMessagesForField }
+									setFieldValue={ setFieldValue }
+									getFieldValue={ getFieldValue }
+								/>
+							</RightColumn>
+						</FieldRow>
 					</FieldRow>
-				</FieldRow>
 
-				{ shouldShowContactFields && (
-					<ContactFields
-						getField={ getField }
-						getFieldValue={ getFieldValue }
-						setFieldValue={ setFieldValue }
-						getErrorMessagesForField={ getErrorMessagesForField }
-						shouldUseEbanx={ shouldUseEbanx }
-						shouldShowTaxFields={ shouldShowTaxFields }
-					/>
-				) }
+					{ shouldShowContactFields && (
+						<ContactFields
+							getField={ getField }
+							getFieldValue={ getFieldValue }
+							setFieldValue={ setFieldValue }
+							getErrorMessagesForField={ getErrorMessagesForField }
+							shouldUseEbanx={ shouldUseEbanx }
+							shouldShowTaxFields={ shouldShowTaxFields }
+						/>
+					) }
+				</div>
 			</CreditCardFieldsWrapper>
 		</StripeFields>
 	);

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -28,7 +28,7 @@ import CreditCardCvvField from './credit-card-cvv-field';
 import { FieldRow, CreditCardFieldsWrapper, CreditCardField } from './form-layout-components';
 import CreditCardLoading from './credit-card-loading';
 
-export default function CreditCardFields( { shouldUseEbanx } ) {
+export default function CreditCardFields( { shouldUseEbanx, shouldShowTaxFields } ) {
 	const { __ } = useI18n();
 	const theme = useTheme();
 	const onEvent = useEvents();
@@ -84,7 +84,7 @@ export default function CreditCardFields( { shouldUseEbanx } ) {
 		setCardDataError( input.elementType, null );
 	};
 
-	const shouldShowContactFields = shouldUseEbanx;
+	const shouldShowContactFields = shouldUseEbanx || shouldShowTaxFields;
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 
@@ -166,6 +166,7 @@ export default function CreditCardFields( { shouldUseEbanx } ) {
 						setFieldValue={ setFieldValue }
 						getErrorMessagesForField={ getErrorMessagesForField }
 						shouldUseEbanx={ shouldUseEbanx }
+						shouldShowTaxFields={ shouldShowTaxFields }
 					/>
 				) }
 			</CreditCardFieldsWrapper>

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -28,6 +28,7 @@ export default function CreditCardPayButton( {
 	stripe,
 	stripeConfiguration,
 	shouldUseEbanx,
+	activeButtonText = undefined,
 } ) {
 	const { __ } = useI18n();
 	const [ items, total ] = useLineItems();
@@ -88,18 +89,22 @@ export default function CreditCardPayButton( {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } total={ total } />
+			<ButtonContents
+				formStatus={ formStatus }
+				total={ total }
+				activeButtonText={ activeButtonText }
+			/>
 		</Button>
 	);
 }
 
-function ButtonContents( { formStatus, total } ) {
+function ButtonContents( { formStatus, total, activeButtonText = undefined } ) {
 	const { __ } = useI18n();
 	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
-		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
+		return activeButtonText || sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );
 }

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/index.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/index.js
@@ -164,7 +164,13 @@ export function createCreditCardPaymentMethodStore() {
 	return { ...store, actions, selectors };
 }
 
-export function createCreditCardMethod( { store, stripe, stripeConfiguration, shouldUseEbanx } ) {
+export function createCreditCardMethod( {
+	store,
+	stripe,
+	stripeConfiguration,
+	shouldUseEbanx,
+	shouldShowTaxFields,
+} ) {
 	return {
 		id: 'card',
 		label: <CreditCardLabel />,
@@ -173,6 +179,7 @@ export function createCreditCardMethod( { store, stripe, stripeConfiguration, sh
 				stripe={ stripe }
 				stripeConfiguration={ stripeConfiguration }
 				shouldUseEbanx={ shouldUseEbanx }
+				shouldShowTaxFields={ shouldShowTaxFields }
 			/>
 		),
 		submitButton: (

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/index.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/index.js
@@ -187,6 +187,7 @@ export function createCreditCardMethod( {
 				store={ store }
 				stripe={ stripe }
 				stripeConfiguration={ stripeConfiguration }
+				shouldUseEbanx={ shouldUseEbanx }
 			/>
 		),
 		inactiveContent: <CreditCardSummary />,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/index.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/index.js
@@ -169,7 +169,8 @@ export function createCreditCardMethod( {
 	stripe,
 	stripeConfiguration,
 	shouldUseEbanx,
-	shouldShowTaxFields,
+	shouldShowTaxFields = false,
+	activePayButtonText = undefined,
 } ) {
 	return {
 		id: 'card',
@@ -188,6 +189,7 @@ export function createCreditCardMethod( {
 				stripe={ stripe }
 				stripeConfiguration={ stripeConfiguration }
 				shouldUseEbanx={ shouldUseEbanx }
+				activeButtonText={ activePayButtonText }
 			/>
 		),
 		inactiveContent: <CreditCardSummary />,

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -58,6 +58,7 @@ export function useCreateCreditCard( {
 	stripeConfiguration,
 	stripe,
 	shouldUseEbanx,
+	shouldShowTaxFields = false,
 } ) {
 	const shouldLoadStripeMethod = ! isStripeLoading && ! stripeLoadingError;
 	const stripePaymentMethodStore = useMemo( () => createCreditCardPaymentMethodStore(), [] );
@@ -69,6 +70,7 @@ export function useCreateCreditCard( {
 						stripe,
 						stripeConfiguration,
 						shouldUseEbanx,
+						shouldShowTaxFields,
 				  } )
 				: null,
 		[
@@ -77,6 +79,7 @@ export function useCreateCreditCard( {
 			stripe,
 			stripeConfiguration,
 			shouldUseEbanx,
+			shouldShowTaxFields,
 		]
 	);
 	return stripeMethod;

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -59,6 +59,7 @@ export function useCreateCreditCard( {
 	stripe,
 	shouldUseEbanx,
 	shouldShowTaxFields = false,
+	activePayButtonText = undefined,
 } ) {
 	const shouldLoadStripeMethod = ! isStripeLoading && ! stripeLoadingError;
 	const stripePaymentMethodStore = useMemo( () => createCreditCardPaymentMethodStore(), [] );
@@ -71,6 +72,7 @@ export function useCreateCreditCard( {
 						stripeConfiguration,
 						shouldUseEbanx,
 						shouldShowTaxFields,
+						activePayButtonText,
 				  } )
 				: null,
 		[
@@ -80,6 +82,7 @@ export function useCreateCreditCard( {
 			stripeConfiguration,
 			shouldUseEbanx,
 			shouldShowTaxFields,
+			activePayButtonText,
 		]
 	);
 	return stripeMethod;
@@ -285,7 +288,11 @@ function useCreateApplePay( {
 	return applePayMethod;
 }
 
-export function useCreateExistingCards( { storedCards, stripeConfiguration } ) {
+export function useCreateExistingCards( {
+	storedCards,
+	stripeConfiguration,
+	activePayButtonText = undefined,
+} ) {
 	const existingCardMethods = useMemo( () => {
 		return storedCards.map( ( storedDetails ) =>
 			createExistingCardMethod( {
@@ -298,9 +305,10 @@ export function useCreateExistingCards( { storedCards, stripeConfiguration } ) {
 				paymentMethodToken: storedDetails.mp_ref,
 				paymentPartnerProcessorId: storedDetails.payment_partner,
 				stripeConfiguration,
+				activePayButtonText,
 			} )
 		);
-	}, [ stripeConfiguration, storedCards ] );
+	}, [ stripeConfiguration, storedCards, activePayButtonText ] );
 	return existingCardMethods;
 }
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -262,6 +262,16 @@ A wrapper for [CheckoutStep](#CheckoutStep) objects that will connect the steps 
 
 - `areStepsActive?: boolean`. Whether or not the set of steps is active and able to be edited. Defaults to `true`.
 
+### CheckoutSubmitButton
+
+The submit button for the form. This actually renders the submit button for the currently active payment method, but it provides the `onClick` handler to attach it to the payment processor function, a `disabled` prop when the form should be disabled, and a React Error boundary. Normally this is already rendered by [CheckoutStepArea](#CheckoutStepArea), but if you want to use it directly, you can.
+
+The props you can provide to this component are as follows.
+
+- `className?: string`. An optional className.
+- `disabled?: boolean`. The button will automatically be disabled if the [form status](#useFormStatus) is not `ready`, but you can disable it for other cases as well.
+- `onLoadError?: ( error: string ) => void`. A callback that will be called if the error boundary is triggered.
+
 ### CheckoutSummaryArea
 
 Renders its `children` prop and acts as a wrapper to flow outside of the [`CheckoutSteps`](#CheckoutSteps) wrapper (floated on desktop, collapsed on mobile). It has the following props.

--- a/packages/composite-checkout/src/components/checkout-error-boundary.tsx
+++ b/packages/composite-checkout/src/components/checkout-error-boundary.tsx
@@ -11,6 +11,11 @@ import styled from '../lib/styled';
 
 const debug = debugFactory( 'composite-checkout:checkout-error-boundary' );
 
+const ErrorContainer = styled.div`
+	margin: 2em;
+	text-align: center;
+`;
+
 export default class CheckoutErrorBoundary extends React.Component< CheckoutErrorBoundaryProps > {
 	constructor( props: CheckoutErrorBoundaryProps ) {
 		super( props );
@@ -40,14 +45,9 @@ export default class CheckoutErrorBoundary extends React.Component< CheckoutErro
 
 interface CheckoutErrorBoundaryProps {
 	errorMessage: React.ReactNode;
-	onError?: ( message: string ) => void;
+	onError?: ( message: string ) => void | undefined;
 }
 
 function ErrorFallback( { errorMessage }: { errorMessage: React.ReactNode } ) {
 	return <ErrorContainer>{ errorMessage }</ErrorContainer>;
 }
-
-const ErrorContainer = styled.div`
-	margin: 2em;
-	text-align: center;
-`;

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -490,7 +490,6 @@ export function CheckoutStepArea( {
 	disableSubmitButton?: boolean;
 } ): JSX.Element {
 	const onEvent = useEvents();
-	const { formStatus } = useFormStatus();
 
 	const { activeStepNumber, totalSteps } = useContext( CheckoutStepDataContext );
 	const actualActiveStepNumber =
@@ -514,9 +513,7 @@ export function CheckoutStepArea( {
 			<SubmitButtonWrapper className="checkout-steps__submit-button-wrapper">
 				{ submitButtonHeader ? submitButtonHeader : null }
 				<CheckoutSubmitButton
-					disabled={
-						isThereAnotherNumberedStep || formStatus !== FormStatus.READY || disableSubmitButton
-					}
+					disabled={ isThereAnotherNumberedStep || disableSubmitButton }
 					onLoadError={ onSubmitButtonLoadError }
 				/>
 			</SubmitButtonWrapper>

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -489,7 +489,6 @@ export function CheckoutStepArea( {
 	submitButtonHeader?: React.ReactNode;
 	disableSubmitButton?: boolean;
 } ): JSX.Element {
-	const { __ } = useI18n();
 	const onEvent = useEvents();
 	const { formStatus } = useFormStatus();
 
@@ -514,16 +513,12 @@ export function CheckoutStepArea( {
 
 			<SubmitButtonWrapper className="checkout-steps__submit-button-wrapper">
 				{ submitButtonHeader ? submitButtonHeader : null }
-				<CheckoutErrorBoundary
-					errorMessage={ __( 'There was a problem with the submit button.' ) }
-					onError={ onSubmitButtonLoadError }
-				>
-					<CheckoutSubmitButton
-						disabled={
-							isThereAnotherNumberedStep || formStatus !== FormStatus.READY || disableSubmitButton
-						}
-					/>
-				</CheckoutErrorBoundary>
+				<CheckoutSubmitButton
+					disabled={
+						isThereAnotherNumberedStep || formStatus !== FormStatus.READY || disableSubmitButton
+					}
+					onLoadError={ onSubmitButtonLoadError }
+				/>
 			</SubmitButtonWrapper>
 		</CheckoutStepAreaWrapper>
 	);

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -512,7 +512,7 @@ export function CheckoutStepArea( {
 		<CheckoutStepAreaWrapper className={ classNames }>
 			{ children }
 
-			<SubmitButtonWrapper>
+			<SubmitButtonWrapper className="checkout-steps__submit-button-wrapper">
 				{ submitButtonHeader ? submitButtonHeader : null }
 				<CheckoutErrorBoundary
 					errorMessage={ __( 'There was a problem with the submit button.' ) }

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -9,7 +9,13 @@ import { useI18n } from '@automattic/react-i18n';
  * Internal dependencies
  */
 import joinClasses from '../lib/join-classes';
-import { usePaymentMethod, usePaymentProcessors, useTransactionStatus } from '../public-api';
+import {
+	usePaymentMethod,
+	usePaymentProcessors,
+	useTransactionStatus,
+	useFormStatus,
+	FormStatus,
+} from '../public-api';
 import { PaymentProcessorResponse, PaymentProcessorResponseType } from '../types';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 
@@ -31,10 +37,12 @@ export default function CheckoutSubmitButton( {
 		setTransactionPending,
 	} = useTransactionStatus();
 	const paymentProcessors = usePaymentProcessors();
+	const { formStatus } = useFormStatus();
 	const { __ } = useI18n();
 	const redirectErrorMessage = __(
 		'An error occurred while redirecting to the payment partner. Please try again or contact support.'
 	);
+	const isDisabled = disabled || formStatus !== FormStatus.READY;
 
 	const onClick = useCallback(
 		async ( paymentProcessorId: string, submitData: unknown ) => {
@@ -90,7 +98,7 @@ export default function CheckoutSubmitButton( {
 	}
 
 	// We clone the element to add props
-	const clonedSubmitButton = React.cloneElement( submitButton, { disabled, onClick } );
+	const clonedSubmitButton = React.cloneElement( submitButton, { disabled: isDisabled, onClick } );
 	return (
 		<CheckoutErrorBoundary
 			errorMessage={ __( 'There was a problem with the submit button.' ) }

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -11,15 +11,18 @@ import { useI18n } from '@automattic/react-i18n';
 import joinClasses from '../lib/join-classes';
 import { usePaymentMethod, usePaymentProcessors, useTransactionStatus } from '../public-api';
 import { PaymentProcessorResponse, PaymentProcessorResponseType } from '../types';
+import CheckoutErrorBoundary from './checkout-error-boundary';
 
 const debug = debugFactory( 'composite-checkout:checkout-submit-button' );
 
 export default function CheckoutSubmitButton( {
 	className,
 	disabled,
+	onLoadError,
 }: {
 	className?: string;
 	disabled?: boolean;
+	onLoadError?: ( error: string ) => void;
 } ): JSX.Element | null {
 	const {
 		setTransactionComplete,
@@ -89,8 +92,13 @@ export default function CheckoutSubmitButton( {
 	// We clone the element to add props
 	const clonedSubmitButton = React.cloneElement( submitButton, { disabled, onClick } );
 	return (
-		<div className={ joinClasses( [ className, 'checkout-submit-button' ] ) }>
-			{ clonedSubmitButton }
-		</div>
+		<CheckoutErrorBoundary
+			errorMessage={ __( 'There was a problem with the submit button.' ) }
+			onError={ onLoadError }
+		>
+			<div className={ joinClasses( [ className, 'checkout-submit-button' ] ) }>
+				{ clonedSubmitButton }
+			</div>
+		</CheckoutErrorBoundary>
 	);
 }

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -28,6 +28,7 @@ export function createExistingCardMethod( {
 	paymentMethodToken,
 	paymentPartnerProcessorId,
 	stripeConfiguration,
+	activePayButtonText = undefined,
 } ) {
 	debug( 'creating a new existing credit card payment method', {
 		id,
@@ -54,6 +55,7 @@ export function createExistingCardMethod( {
 				storedDetailsId={ storedDetailsId }
 				paymentMethodToken={ paymentMethodToken }
 				paymentPartnerProcessorId={ paymentPartnerProcessorId }
+				activeButtonText={ activePayButtonText }
 			/>
 		),
 		inactiveContent: (
@@ -109,6 +111,7 @@ function ExistingCardPayButton( {
 	storedDetailsId,
 	paymentMethodToken,
 	paymentPartnerProcessorId,
+	activeButtonText = undefined,
 } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
@@ -134,18 +137,22 @@ function ExistingCardPayButton( {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } total={ total } />
+			<ButtonContents
+				formStatus={ formStatus }
+				total={ total }
+				activeButtonText={ activeButtonText }
+			/>
 		</Button>
 	);
 }
 
-function ButtonContents( { formStatus, total } ) {
+function ButtonContents( { formStatus, total, activeButtonText = undefined } ) {
 	const { __ } = useI18n();
 	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
 	if ( formStatus === FormStatus.READY ) {
-		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
+		return activeButtonText || sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );
 }

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -7,6 +7,7 @@ import PaymentLogo from './lib/payment-methods/payment-logo';
 import { CheckoutProvider } from './components/checkout-provider';
 import useMessages from './components/use-messages';
 import useEvents from './components/use-events';
+import CheckoutSubmitButton from './components/checkout-submit-button';
 import {
 	Checkout,
 	CheckoutStep,
@@ -101,6 +102,7 @@ export {
 	CheckoutStepAreaWrapper,
 	CheckoutStepBody,
 	CheckoutSteps,
+	CheckoutSubmitButton,
 	CheckoutSummaryArea,
 	CheckoutSummaryCard,
 	MainContentWrapper,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In #48187, we added some UI elements to a new version of the Update Payment Method screen aimed at allowing users to change the payment method on a subscription to PayPal or a stored card, in addition to a new card; however that PR did not include any of the functionality. This companion PR adds in that functionality for new cards.

#### Testing instructions

* On a site with at least one existing purchase, navigate to the billing management page at `Plans > Billing` and select an upgrade to manage.
* Click through to the "Change Payment Method" screen.
* Verify that the currently assigned stored card is preselected.
* Select the "Credit or debit card" option and complete the form with valid (test) card details. Click "Save card".
* Check that you are redirected to the billing page and see a calypso success notification, and that the billing page reflects your newly assigned payment method.
* Navigate back to the "Update Payment Method" screen and verify that your newly added card (1) appears in the list and (2) is preselected.
* Repeat with some special case cards: one requiring 3DS authentication (success and failure) and one returning an error code from the payment gateway. In case of error, verify that the screen becomes interactable again.

This also touches checkout components, so we should check for regressions there. It should be enough to make sure you can complete a purchase.
