### PR TITLE
Enable View Menu on All Platforms

### DIFF
--- a/client/desktop/lib/menu/main-menu.js
+++ b/client/desktop/lib/menu/main-menu.js
@@ -19,6 +19,10 @@ module.exports = function ( app, mainWindow ) {
 			submenu: editMenu,
 		},
 		{
+			label: 'View',
+			submenu: viewMenu,
+		},
+		{
 			label: 'Window',
 			role: 'window',
 			submenu: windowMenu( mainWindow ),
@@ -29,14 +33,6 @@ module.exports = function ( app, mainWindow ) {
 			submenu: helpMenu( mainWindow ),
 		},
 	];
-
-	if ( platform.isOSX() ) {
-		// OS X needs a view menu for 'enter full screen' - insert just after the edit menu
-		menu.splice( 2, 0, {
-			label: 'View',
-			submenu: viewMenu,
-		} );
-	}
 
 	return menu;
 };

--- a/client/desktop/lib/menu/view-menu.js
+++ b/client/desktop/lib/menu/view-menu.js
@@ -14,7 +14,7 @@ const menuItems = [];
 menuItems.push(
 	{
 		label: 'Toggle Full Screen',
-		accelerator: platform.isOSX() ? 'Command+Ctrl+F' : undefined,
+		accelerator: platform.isOSX() ? 'Command+Ctrl+F' : 'Ctrl+Alt+F',
 		fullscreen: true,
 		click: function () {
 			const focusedWindow = BrowserWindow.getFocusedWindow();


### PR DESCRIPTION
### Description

TIL that for some strange reason, the View menu was enabled only on Mac. We have some nice goodies in there now (such as zoom and debugging controls), so we should make this menu available on all platforms.

<h4>Linux</h4>
<img src="https://user-images.githubusercontent.com/8979548/102281072-7d93b180-3eeb-11eb-84e3-6cbbd8c17ad7.png" width=250>

<h4>Windows</h4>
<img src="https://user-images.githubusercontent.com/8979548/102281080-81bfcf00-3eeb-11eb-8599-581149f9d561.png" width=250>

<h4>Mac</h4>
<img src="https://user-images.githubusercontent.com/8979548/102281141-9f8d3400-3eeb-11eb-8007-fefbf57f6776.png" width=250>

### To Test

Build the app locally (or download the built artifacts from this branch) and verify that the View submenu is present and works as intended.