### PR TITLE
Add Dialog to Classic Editor Redirect Flow

### DIFF
--- a/client/desktop/window-handlers/external-links/editor/index.js
+++ b/client/desktop/window-handlers/external-links/editor/index.js
@@ -61,7 +61,7 @@ function selectedEnableSSOandContinue( mainWindow, info ) {
 
 function selectedProceedInBrowser( mainWindow, { origin, wpAdminLoginUrl } ) {
 	log.info( "User selected 'Proceed in Browser'..." );
-	openInBrowser( null, wpAdminLoginUrl );
+	openInBrowser( wpAdminLoginUrl );
 	navigateToShowMySites( mainWindow, origin );
 }
 
@@ -175,10 +175,10 @@ function handleUndefined( mainWindow, info ) {
 		log.info(
 			`Falling back to opening editor in browser with admin login URL: '${ wpAdminLoginUrl }'`
 		);
-		openInBrowser( null, wpAdminLoginUrl );
+		openInBrowser( wpAdminLoginUrl );
 	} else if ( editorUrl ) {
 		log.info( `Falling back to opening editor in browser with editor URL: '${ editorUrl }'` );
-		openInBrowser( null, editorUrl );
+		openInBrowser( editorUrl );
 	} else {
 		log.error( 'Failed to open editor in browser as fallback: invalid admin and editor urls' );
 	}

--- a/client/desktop/window-handlers/external-links/index.js
+++ b/client/desktop/window-handlers/external-links/index.js
@@ -11,6 +11,7 @@ const Config = require( 'calypso/desktop/lib/config' );
 const { handleJetpackEnableSSO, handleUndefined } = require( './editor' );
 const openInBrowser = require( './open-in-browser' );
 const log = require( 'calypso/desktop/lib/logger' )( 'desktop:external-links' );
+const platform = require( 'calypso/desktop/lib/platform' );
 
 /**
  * Module variables
@@ -71,7 +72,7 @@ module.exports = function ( mainWindow ) {
 
 			const redirectDialogOptions = {
 				buttons: [ 'Confirm', 'Cancel' ],
-				title: 'Proceed in External Browser?',
+				title: platform.isWindows() ? 'WordPress.com' : 'Proceed in External Browser?',
 				message: 'Proceed in External Browser?',
 				detail:
 					`Please note: WordPress Desktop does not support the Classic Editor plugin.` +

--- a/client/desktop/window-handlers/external-links/index.js
+++ b/client/desktop/window-handlers/external-links/index.js
@@ -71,10 +71,12 @@ module.exports = function ( mainWindow ) {
 
 			const redirectDialogOptions = {
 				buttons: [ 'Confirm', 'Cancel' ],
-				title: 'Proceed In External Browser?', // Note: title is specific to Windows + Linux
-				message: 'Proceed In External Browser?',
-				detail: `Please note: WordPress Desktop does not support the Classic Editor plugin.\n
-				In addition, Single Sign On is required to use this feature if on a Business Plan.`,
+				title: 'Proceed in External Browser?',
+				message: 'Proceed in External Browser?',
+				detail:
+					`Please note: WordPress Desktop does not support the Classic Editor plugin.` +
+					`\n\n` +
+					`In addition, Single Sign On is required to use this feature if on a Business Plan.`,
 			};
 
 			const selected = await dialog.showMessageBox( mainWindow, redirectDialogOptions );

--- a/client/desktop/window-handlers/external-links/index.js
+++ b/client/desktop/window-handlers/external-links/index.js
@@ -64,9 +64,10 @@ module.exports = function ( mainWindow ) {
 			}
 		}
 
+		event.preventDefault();
+
 		if ( isWpAdminPostUrl( url ) ) {
-			event.preventDefault();
-			log.info( `Prompting user to navigate to WP-Admin editor URL: '${ url }'` );
+			log.info( `Prompting to navigate to WP-Admin URL: '${ url }'` );
 
 			const redirectDialogOptions = {
 				buttons: [ 'Confirm', 'Cancel' ],
@@ -80,16 +81,16 @@ module.exports = function ( mainWindow ) {
 			const button = selected.response;
 
 			if ( button === 0 ) {
-				log.info( `WP-Admin redirect: user selected 'Confirm'` );
+				log.info( `WP-Admin redirect prompt: selected 'Confirm'` );
 				// no-op -- proceed to open in browser
-				openInBrowser( null, url );
+				openInBrowser( url );
 			} else {
-				log.info( `WP-Admin redirect: user selected 'Cancel'` );
+				log.info( `WP-Admin redirect prompt: selected 'Cancel'` );
 			}
 			return;
 		}
 
-		openInBrowser( event, url );
+		openInBrowser( url );
 	} );
 
 	webContents.on( 'new-window', function ( event, url, frameName, disposition, options ) {
@@ -111,10 +112,11 @@ module.exports = function ( mainWindow ) {
 			}
 		}
 
-		parsedUrl = replaceInternalCalypsoUrl( parsedUrl );
+		event.preventDefault();
 
+		parsedUrl = replaceInternalCalypsoUrl( parsedUrl );
 		const openUrl = format( parsedUrl );
-		openInBrowser( event, openUrl );
+		openInBrowser( openUrl );
 	} );
 
 	ipc.on( 'cannot-use-editor', ( _, info ) => {
@@ -131,6 +133,6 @@ module.exports = function ( mainWindow ) {
 
 	ipc.on( 'view-post-clicked', ( _, url ) => {
 		log.info( `View Post handler for URL: ${ url }` );
-		openInBrowser( null, url );
+		openInBrowser( url );
 	} );
 };

--- a/client/desktop/window-handlers/external-links/index.js
+++ b/client/desktop/window-handlers/external-links/index.js
@@ -71,10 +71,10 @@ module.exports = function ( mainWindow ) {
 
 			const redirectDialogOptions = {
 				buttons: [ 'Confirm', 'Cancel' ],
-				title: 'Proceed In External Browser?',
-				message: `Unable to use this feature.\n
-					Please see https://www.google.com for more information.`,
-				detail: `Proceed in an external browser?`,
+				title: 'Proceed In External Browser?', // Note: title is specific to Windows + Linux
+				message: 'Proceed In External Browser?',
+				detail: `Please note: WordPress Desktop does not support the Classic Editor plugin.\n
+				In addition, Single Sign On is required to use this feature if on a Business Plan.`,
 			};
 
 			const selected = await dialog.showMessageBox( mainWindow, redirectDialogOptions );

--- a/client/desktop/window-handlers/external-links/index.js
+++ b/client/desktop/window-handlers/external-links/index.js
@@ -75,9 +75,11 @@ module.exports = function ( mainWindow ) {
 				title: platform.isWindows() ? 'WordPress.com' : 'Proceed in External Browser?',
 				message: 'Proceed in External Browser?',
 				detail:
-					`Please note: WordPress Desktop does not support the Classic Editor plugin.` +
+					// eslint-disable-next-line prettier/prettier
+					`You have one or more plugins that prevent editing content` +
+					` within WordPress Desktop.` +
 					`\n\n` +
-					`In addition, Single Sign On is required to use this feature if on a Business Plan.`,
+					`Continue in an external browser?`,
 			};
 
 			const selected = await dialog.showMessageBox( mainWindow, redirectDialogOptions );

--- a/client/desktop/window-handlers/external-links/open-in-browser/index.js
+++ b/client/desktop/window-handlers/external-links/open-in-browser/index.js
@@ -19,13 +19,9 @@ function isValidBrowserUrl( url ) {
 	return false;
 }
 
-module.exports = function ( event, url ) {
+module.exports = function ( url ) {
 	if ( isValidBrowserUrl( url ) ) {
 		log.info( `Using system default handler for URL: ${ url }` );
 		shell.openExternal( url );
-	}
-
-	if ( event ) {
-		event.preventDefault();
 	}
 };


### PR DESCRIPTION
### Description

This PR adds a dialog to the flow in which the user is transported away from the application to WP Admin due to either having the Classic Editor plugin enabled or not having SSO enabled (for self-hosted sites).

### To Test

1. Feel free to give the app for a spin by either building from this branch or downloading a pre-built artifact from this PR.
2. Attempt to create a new post - or edit an existing one - from a site for which the Classic Editor plugin is installed and activated.

<h4>Windows</h4>
<img src="https://user-images.githubusercontent.com/8979548/102282024-34dcf800-3eed-11eb-9e32-8f551321cbd0.png" width=400>

<h4>Linux</h4>
<img src="https://user-images.githubusercontent.com/8979548/102282044-3c9c9c80-3eed-11eb-980b-89b0728e37a0.png" width=400>

<h4>Mac</h4>
<img src="https://user-images.githubusercontent.com/8979548/102282040-3c040600-3eed-11eb-9d59-0c7c0d7a9ad9.png" width=300>

Fixes #47924