### PR TITLE
Anchor Gutenboarding sends the user to new post, not edit homepage

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -14,7 +14,7 @@ import { SITE_STORE } from '../stores/site';
 import { recordOnboardingComplete } from '../lib/analytics';
 import { useSelectedPlan, useShouldRedirectToEditorAfterCheckout } from './use-selected-plan';
 import { clearLastNonEditorRoute } from '../lib/clear-last-non-editor-route';
-import { useIsAnchorFm } from '../path';
+import { useIsAnchorFm, useAnchorFmPodcastId, useAnchorFmEpisodeId } from '../path';
 
 const wpcom = wp.undocumented();
 
@@ -64,7 +64,10 @@ export default function useOnSiteCreation(): void {
 	const selectedPlan = useSelectedPlan();
 	const shouldRedirectToEditorAfterCheckout = useShouldRedirectToEditorAfterCheckout();
 	const design = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+
 	const isAnchorFmSignup = useIsAnchorFm();
+	const anchorFmPodcastId = useAnchorFmPodcastId();
+	const anchorFmEpisodeId = useAnchorFmEpisodeId();
 
 	const { resetOnboardStore, setIsRedirecting, setSelectedSite } = useDispatch( ONBOARD_STORE );
 	const flowCompleteTrackingParams = {
@@ -132,7 +135,13 @@ export default function useOnSiteCreation(): void {
 			if ( design?.is_fse ) {
 				destination = `/site-editor/${ newSite.site_slug }/`;
 			} else if ( isAnchorFmSignup ) {
-				destination = `/post/${ newSite.site_slug }`;
+				// Working URL for creating a new post w/ anchor in wp-admin:
+				// http://localhost:8888/wp-admin/post-new.php?action=edit&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q
+				// In Jetpack, anchor-fm.php looks for these
+				// However, we're on calypso.. that means we might need to make sure another step passes along the info correctly
+				// what does /post/{site} do in calypso?
+				// can we make query strings get passed from the parent to iframe?
+				destination = `/post/${ newSite.site_slug }?anchor_podcast=${ anchorFmPodcastId }&anchor_episode=${ anchorFmEpisodeId }`;
 			} else {
 				destination = `/page/${ newSite.site_slug }/home`;
 			}

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -141,7 +141,17 @@ export default function useOnSiteCreation(): void {
 				// However, we're on calypso.. that means we might need to make sure another step passes along the info correctly
 				// what does /post/{site} do in calypso?
 				// can we make query strings get passed from the parent to iframe?
-				destination = `/post/${ newSite.site_slug }?anchor_podcast=${ anchorFmPodcastId }&anchor_episode=${ anchorFmEpisodeId }`;
+				const params = {
+					anchor_podcast: anchorFmPodcastId,
+					anchor_episode: anchorFmEpisodeId,
+					spotify_show_url:
+						'https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q', // WIP TODO - Where is this coming from?
+				};
+				const queryString = Object.keys( params )
+					.filter( ( key ) => params[ key as keyof typeof params ] != null )
+					.map( ( key ) => key + '=' + params[ key as keyof typeof params ] )
+					.join( '&' );
+				destination = `/post/${ newSite.site_slug }?${ queryString }`;
 			} else {
 				destination = `/page/${ newSite.site_slug }/home`;
 			}

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -14,7 +14,7 @@ import { SITE_STORE } from '../stores/site';
 import { recordOnboardingComplete } from '../lib/analytics';
 import { useSelectedPlan, useShouldRedirectToEditorAfterCheckout } from './use-selected-plan';
 import { clearLastNonEditorRoute } from '../lib/clear-last-non-editor-route';
-import { useIsAnchorFm, useAnchorFmPodcastId, useAnchorFmEpisodeId } from '../path';
+import { useIsAnchorFm, useAnchorFmParams } from '../path';
 
 const wpcom = wp.undocumented();
 
@@ -66,8 +66,7 @@ export default function useOnSiteCreation(): void {
 	const design = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 
 	const isAnchorFmSignup = useIsAnchorFm();
-	const anchorFmPodcastId = useAnchorFmPodcastId();
-	const anchorFmEpisodeId = useAnchorFmEpisodeId();
+	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyShowUrl } = useAnchorFmParams();
 
 	const { resetOnboardStore, setIsRedirecting, setSelectedSite } = useDispatch( ONBOARD_STORE );
 	const flowCompleteTrackingParams = {
@@ -135,17 +134,10 @@ export default function useOnSiteCreation(): void {
 			if ( design?.is_fse ) {
 				destination = `/site-editor/${ newSite.site_slug }/`;
 			} else if ( isAnchorFmSignup ) {
-				// Working URL for creating a new post w/ anchor in wp-admin:
-				// http://localhost:8888/wp-admin/post-new.php?action=edit&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q
-				// In Jetpack, anchor-fm.php looks for these
-				// However, we're on calypso.. that means we might need to make sure another step passes along the info correctly
-				// what does /post/{site} do in calypso?
-				// can we make query strings get passed from the parent to iframe?
 				const params = {
 					anchor_podcast: anchorFmPodcastId,
 					anchor_episode: anchorFmEpisodeId,
-					spotify_show_url:
-						'https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q', // WIP TODO - Where is this coming from?
+					spotify_show_url: anchorFmSpotifyShowUrl,
 				};
 				const queryString = Object.keys( params )
 					.filter( ( key ) => params[ key as keyof typeof params ] != null )
@@ -170,5 +162,8 @@ export default function useOnSiteCreation(): void {
 		shouldRedirectToEditorAfterCheckout,
 		design,
 		isAnchorFmSignup,
+		anchorFmPodcastId,
+		anchorFmEpisodeId,
+		anchorFmSpotifyShowUrl,
 	] );
 }

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -56,7 +56,7 @@ interface Cart {
  * 3. The user is still seeing 'Free Plan' label on PlansButton => redirect to editor
  **/
 
-export default function useOnSiteCreation() {
+export default function useOnSiteCreation(): void {
 	const { domain } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const isRedirecting = useSelect( ( select ) => select( ONBOARD_STORE ).getIsRedirecting() );
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
@@ -132,30 +132,10 @@ export default function useOnSiteCreation() {
 			if ( design?.is_fse ) {
 				destination = `/site-editor/${ newSite.site_slug }/`;
 			} else if ( isAnchorFmSignup ) {
-				/*
-				* Currently, this never triggers. (isAnchorFmSignup is always false, even
-				when on an anchor flow.)
-
-				I believe we get here from onboarding-block/edit.tsx redirecting in this
-				bit of code:
-					return (
-						<div className="onboarding-block">
-							{ isCreatingSite && (
-								<Redirect
-									push={ shouldTriggerCreate ? undefined : true }
-									to={ makePath( Step.CreateSite ) }
-								/>
-							) }
-
-				This ends up calling usePath from path.ts, which isn't aware of anchor
-				location state and needs to pass it on.
-				* 
-				*/
 				destination = `/post/${ newSite.site_slug }`;
 			} else {
 				destination = `/page/${ newSite.site_slug }/home`;
 			}
-			//console.log( { isAnchorFmSignup, destination } );
 			window.location.href = destination;
 		}
 	}, [

--- a/client/landing/gutenboarding/onboarding-block/create-site-error/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site-error/index.tsx
@@ -6,6 +6,7 @@ import { ExternalLink } from '@wordpress/components';
 import React, { FunctionComponent, useEffect } from 'react';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
+import type { LocationDescriptor } from 'history';
 
 /**
  * Internal dependencies
@@ -21,7 +22,7 @@ import { Title, SubTitle } from '@automattic/onboarding';
 import './style.scss';
 
 interface Props {
-	linkTo: string;
+	linkTo: string | LocationDescriptor;
 }
 
 const CreateSiteError: FunctionComponent< Props > = ( { linkTo } ) => {

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -11,7 +11,15 @@ import type { BlockEditProps } from '@wordpress/blocks';
  */
 import { STORE_KEY } from '../stores/onboard';
 import { SITE_STORE } from '../stores/site';
-import { GutenLocationStateType, Step, StepType, useIsAnchorFm, useCurrentStep, usePath, useNewQueryParam } from '../path';
+import {
+	GutenLocationStateType,
+	Step,
+	StepType,
+	useIsAnchorFm,
+	useCurrentStep,
+	usePath,
+	useNewQueryParam,
+} from '../path';
 import { usePrevious } from '../hooks/use-previous';
 import DesignSelector from './design-selector';
 import CreateSite from './create-site';

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -56,7 +56,7 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 				state: locationState,
 			};
 		},
-		[ locationState ]
+		[ makePath, locationState ]
 	);
 
 	const canUseDesignStep = React.useCallback( (): boolean => {

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -46,10 +46,10 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 		setTimeout( () => window.scrollTo( 0, 0 ), 0 );
 	}, [ pathname ] );
 
-	// makePathState( path: StepType ) - A wrapper around makePath() that preserves location state.
+	// makePathWithState( path: StepType ) - A wrapper around makePath() that preserves location state.
 	// This uses makePath() to generate a string path, then transforms that
 	// string path into an object that also contains the location state.
-	const makePathState = React.useCallback(
+	const makePathWithState = React.useCallback(
 		( path: StepType ) => {
 			return {
 				pathname: makePath( path ),
@@ -73,14 +73,14 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 
 	const getLatestStepPath = () => {
 		if ( canUseStyleStep() && ! isAnchorFmSignup ) {
-			return makePathState( Step.Plans );
+			return makePathWithState( Step.Plans );
 		}
 
 		if ( canUseDesignStep() ) {
-			return makePathState( Step.DesignSelection );
+			return makePathWithState( Step.DesignSelection );
 		}
 
-		return makePathState( Step.IntentGathering );
+		return makePathWithState( Step.IntentGathering );
 	};
 
 	const redirectToLatestStep = <Redirect to={ getLatestStepPath() } />;
@@ -100,7 +100,7 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 			{ isCreatingSite && (
 				<Redirect
 					push={ shouldTriggerCreate ? undefined : true }
-					to={ makePathState( Step.CreateSite ) }
+					to={ makePathWithState( Step.CreateSite ) }
 				/>
 			) }
 			<Switch>

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -11,7 +11,7 @@ import type { BlockEditProps } from '@wordpress/blocks';
  */
 import { STORE_KEY } from '../stores/onboard';
 import { SITE_STORE } from '../stores/site';
-import { Step, useIsAnchorFm, useCurrentStep, usePath, useNewQueryParam } from '../path';
+import { GutenLocationStateType, Step, StepType, useIsAnchorFm, useCurrentStep, usePath, useNewQueryParam } from '../path';
 import { usePrevious } from '../hooks/use-previous';
 import DesignSelector from './design-selector';
 import CreateSite from './create-site';
@@ -40,11 +40,24 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 	const currentStep = useCurrentStep();
 	const previousStep = usePrevious( currentStep );
 
-	const { pathname } = useLocation();
+	const { pathname, state: locationState = {} } = useLocation< GutenLocationStateType >();
 
 	React.useEffect( () => {
 		setTimeout( () => window.scrollTo( 0, 0 ), 0 );
 	}, [ pathname ] );
+
+	// makePathState( path: StepType ) - A wrapper around makePath() that preserves location state.
+	// This uses makePath() to generate a string path, then transforms that
+	// string path into an object that also contains the location state.
+	const makePathState = React.useCallback(
+		( path: StepType ) => {
+			return {
+				pathname: makePath( path ),
+				state: locationState,
+			};
+		},
+		[ locationState ]
+	);
 
 	const canUseDesignStep = React.useCallback( (): boolean => {
 		return !! siteTitle;
@@ -58,16 +71,16 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 		return isCreatingSite || isRedirecting;
 	}, [ isCreatingSite, isRedirecting ] );
 
-	const getLatestStepPath = (): string => {
+	const getLatestStepPath = () => {
 		if ( canUseStyleStep() && ! isAnchorFmSignup ) {
-			return makePath( Step.Plans );
+			return makePathState( Step.Plans );
 		}
 
 		if ( canUseDesignStep() ) {
-			return makePath( Step.DesignSelection );
+			return makePathState( Step.DesignSelection );
 		}
 
-		return makePath( Step.IntentGathering );
+		return makePathState( Step.IntentGathering );
 	};
 
 	const redirectToLatestStep = <Redirect to={ getLatestStepPath() } />;
@@ -87,7 +100,7 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 			{ isCreatingSite && (
 				<Redirect
 					push={ shouldTriggerCreate ? undefined : true }
-					to={ makePath( Step.CreateSite ) }
+					to={ makePathState( Step.CreateSite ) }
 				/>
 			) }
 			<Switch>

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -61,7 +61,7 @@ export function usePath() {
 	const langParam = useLangRouteParam();
 	const planParam = usePlanRouteParam();
 
-	return ( step?: StepType, lang?: string, plan?: string ) => {
+	return ( step?: StepType, lang?: string, plan?: string ): string => {
 		// When lang is null, remove lang.
 		// When lang is empty or undefined, get lang from route param.
 		lang = lang === null ? '' : lang || langParam;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Anchor Gutenboarding sends the user to new post, not edit homepage
* Still missing: How do we get the spotify_show_url?
  * It looks like gutenboarding will need to look for this in the query string and pass it along.

#### Testing instructions

* Visit http://calypso.localhost:3000/new?&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q
* Go through Gutenboarding process
* Finish and land in the editor
  *  The editor should bring you to a new post, not the homepage
  *  The title of the episode should be inserted at the top of the post
  * The listen to spotify button should be present
  
![2020-12-16_14-56](https://user-images.githubusercontent.com/937354/102405502-dd9f5c00-3fae-11eb-9d78-84ecf458f279.png)
