### PR TITLE
Gutenboarding plans/details: Force resolution cache invalidation

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/language/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/language/index.tsx
@@ -5,20 +5,21 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useI18n } from '@automattic/react-i18n';
 import { ActionButtons, BackButton } from '@automattic/onboarding';
+import languages from '@automattic/languages';
 import LanguagePicker, { createLanguageGroups } from '@automattic/language-picker';
-import { I18N_STORE } from '../../stores/i18n';
-import { USER_STORE } from '../../stores/user';
 
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { ChangeLocaleContextConsumer } from '../../components/locale-context';
-import languages from '@automattic/languages';
+import { I18N_STORE } from '../../stores/i18n';
+import { PLANS_STORE } from '../../stores/plans';
+import { USER_STORE } from '../../stores/user';
 
 /**
  * Style dependencies
@@ -40,6 +41,8 @@ const LanguageStep: React.FunctionComponent = () => {
 
 	const history = useHistory();
 
+	const { invalidateResolution } = useDispatch( 'core/data' );
+
 	const goBack = () => {
 		history.goBack();
 	};
@@ -58,6 +61,12 @@ const LanguageStep: React.FunctionComponent = () => {
 						languageGroups={ createLanguageGroups( __ ) }
 						languages={ languages }
 						onSelectLanguage={ ( language ) => {
+							// Invalidate the resolution cache for getPrices and getPlansDetails
+							// when the locale changes, to force the data for the plans grid
+							// to be fetched again, fresh from the plans/details and plans endpoints.
+							invalidateResolution( PLANS_STORE, 'getPlansDetails', [ language.langSlug ] );
+							invalidateResolution( PLANS_STORE, 'getPrices', [ language.langSlug ] );
+
 							changeLocale( language.langSlug );
 							goBack();
 						} }


### PR DESCRIPTION
This is a fix for the issue flagged in #48232 where the plans grid text was not updating when switching locale.

The assumption is that the resolver has been caching plans details information that isn't getting refreshed when the locale is changed via the language picker. The solution here is to invalidate the resolver cache for the target locale for the plans details and plans pricing information, so that the browser fetches fresh data for this when switching locales.

#### Changes proposed in this Pull Request

* When the locale changes via the language picker, invalidate the resolution cache for `getPlansDetails` and `getPrices` so that that data is fetched freshly again.

#### Screenshot

![plans-details-language-picker-small](https://user-images.githubusercontent.com/14988353/102308158-2a3c6480-3fba-11eb-99c9-ced9e007ab33.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the PR and go to `/new?flags=gutenboarding/language-picker`
* At the Plans step or using the modal, switch locales and ensure that the plans details text (eventually) is in the correct language
* Open up the Network inspector and look for requests to the `plans/details` endpoint. Make sure that the endpoint isn't being called too frequently, ideally we should see one request to plans/details and one request for pricing information, per locale.

Part of fixing #48196
