### PR TITLE
AnchorFM: Augment Signup Events with Podcasting Site Information

### DIFF
--- a/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
+++ b/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
@@ -10,6 +10,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { recordOnboardingStart } from '../lib/analytics';
 import { USER_STORE } from '../stores/user';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
+import { useIsAnchorFm } from '../path';
 
 /**
  * Records an event in tracks on starting the onboarding flow, after trying to get the current user
@@ -19,12 +20,13 @@ export default function useTrackOnboardingStart() {
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const { hasOnboardingStarted } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const { startOnboarding } = useDispatch( ONBOARD_STORE );
+	const isAnchorFmSignup = useIsAnchorFm();
 
 	React.useEffect( () => {
 		if ( ! hasOnboardingStarted && currentUser !== undefined ) {
 			const ref = new URLSearchParams( window.location.search ).get( 'ref' ) || '';
 			const siteCount = currentUser?.site_count ?? 0;
-			recordOnboardingStart( ref, siteCount );
+			recordOnboardingStart( ref, siteCount, isAnchorFmSignup );
 			startOnboarding();
 		}
 	}, [ currentUser, hasOnboardingStarted, startOnboarding ] );

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -41,10 +41,12 @@ export function recordOnboardingStart(
 	if ( ! ref ) {
 		ref = new URLSearchParams( window.location.search ).get( 'ref' ) || ref;
 	}
-
-	trackEventWithFlow( 'calypso_newsite_start', { ref, site_count, is_podcasting_site } );
+	const eventProps = is_podcasting_site
+		? { ref, site_count, flow: 'anchor-fm' }
+		: { ref, site_count };
+	trackEventWithFlow( 'calypso_newsite_start', eventProps );
 	// Also fire the signup start|complete events. See: pbmFJ6-95-p2
-	trackEventWithFlow( 'calypso_signup_start', { ref, site_count, is_podcasting_site } );
+	trackEventWithFlow( 'calypso_signup_start', eventProps );
 }
 
 /**

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -31,15 +31,20 @@ export function trackEventWithFlow( eventId: string, params = {}, flow = FLOW_ID
  *
  * @param {string} ref  The value of a `ref` query parameter, usually set by marketing landing pages
  * @param {number} site_count The number of sites owned by the current user or 0 if there is no logged in user
+ * @param {boolean} is_podcasting_site If the current onboarding flow is a Podcast-flavored onboarding flow
  */
-export function recordOnboardingStart( ref = '', site_count: number ): void {
+export function recordOnboardingStart(
+	ref = '',
+	site_count: number,
+	is_podcasting_site: boolean
+): void {
 	if ( ! ref ) {
 		ref = new URLSearchParams( window.location.search ).get( 'ref' ) || ref;
 	}
 
-	trackEventWithFlow( 'calypso_newsite_start', { ref, site_count } );
+	trackEventWithFlow( 'calypso_newsite_start', { ref, site_count, is_podcasting_site } );
 	// Also fire the signup start|complete events. See: pbmFJ6-95-p2
-	trackEventWithFlow( 'calypso_signup_start', { ref, site_count } );
+	trackEventWithFlow( 'calypso_signup_start', { ref, site_count, is_podcasting_site } );
 }
 
 /**

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -41,12 +41,11 @@ export function recordOnboardingStart(
 	if ( ! ref ) {
 		ref = new URLSearchParams( window.location.search ).get( 'ref' ) || ref;
 	}
-	const eventProps = is_podcasting_site
-		? { ref, site_count, flow: 'anchor-fm' }
-		: { ref, site_count };
-	trackEventWithFlow( 'calypso_newsite_start', eventProps );
+	const flow = is_podcasting_site ? 'anchor-fm' : '';
+	const eventProps = { ref, site_count };
+	trackEventWithFlow( 'calypso_newsite_start', eventProps, flow );
 	// Also fire the signup start|complete events. See: pbmFJ6-95-p2
-	trackEventWithFlow( 'calypso_signup_start', eventProps );
+	trackEventWithFlow( 'calypso_signup_start', eventProps, flow );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a `is_podcasting_site` event prop to the `calypso_newsite_start` and `calypso_signup_start` event to answer the question "How many podcast sites were launched?". Context for this approach to support funneling: p1608037471216200-slack-C0Q664T29

Screenshots
Calypso Signup Start
<img width="846" alt="Screen Shot 2020-12-15 at 9 20 48 PM" src="https://user-images.githubusercontent.com/66652282/102296933-615c3880-3f1c-11eb-8fbf-04ea55963e6e.png">
Calypso Newsite Start
<img width="808" alt="Screen Shot 2020-12-15 at 9 20 02 PM" src="https://user-images.githubusercontent.com/66652282/102296935-61f4cf00-3f1c-11eb-81b4-481ea553b201.png">

#### Testing instructions

1. Go to http://calypso.localhost:3000/new?anchor_podcast={podcast_id}
2. After 5 minutes go to MC -- `/tracks/live/?eventname=calypso_signup_start` and ` `/tracks/live/?eventname=calypso_signup_start` look for your specific signup (the username isn't captured so it could be difficult to find) and ensure there is a the `is_podcasting_site` prop

Fixes 374-gh-Automattic/dotcom-manage