### PR TITLE
Deduplicate postcss

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22995,25 +22995,7 @@ postcss@^6.0.14:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.23, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.5, postcss@^7.0.6, postcss@^7.0.7:
-  version "7.0.27"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.27.tgz#cc67cdc6b0daa375105b7c424a85567345fc54d9"
-  integrity sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
-
-postcss@^7.0.18:
-  version "7.0.29"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.29.tgz#d3a903872bd52280b83bce38cdc83ce55c06129e"
-  integrity sha512-ba0ApvR3LxGvRMMiUa9n0WR4HjzcYm7tS+ht4/2Nd0NLtHpPIH77fuB9Xh1/yJVz9O/E/95Y/dn8ygWsyffXtw==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
-
-postcss@^7.0.21, postcss@^7.0.32:
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.17, postcss@^7.0.18, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.23, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6, postcss@^7.0.7:
   version "7.0.32"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
   integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `postcss` (done automatically with `npx yarn-deduplicate --packages postcss`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@6.4.0 -> ... -> postcss@7.0.27
< wp-calypso@0.17.0 -> @signal-noise/stylelint-scales@1.5.0 -> ... -> postcss@7.0.27
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> postcss@7.0.27
< wp-calypso@0.17.0 -> autoprefixer@9.7.3 -> ... -> postcss@7.0.27
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> postcss@7.0.27
< wp-calypso@0.17.0 -> node-sass-package-importer@5.3.2 -> ... -> postcss@7.0.27
< wp-calypso@0.17.0 -> postcss-cli@6.1.3 -> ... -> postcss@7.0.27
< wp-calypso@0.17.0 -> postcss-custom-properties@9.1.1 -> ... -> postcss@7.0.27
< wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> postcss@7.0.27
> wp-calypso@0.17.0 -> @automattic/calypso-build@6.4.0 -> ... -> postcss@7.0.32
> wp-calypso@0.17.0 -> @signal-noise/stylelint-scales@1.5.0 -> ... -> postcss@7.0.32
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> postcss@7.0.32
> wp-calypso@0.17.0 -> autoprefixer@9.7.3 -> ... -> postcss@7.0.32
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> postcss@7.0.32
> wp-calypso@0.17.0 -> node-sass-package-importer@5.3.2 -> ... -> postcss@7.0.32
> wp-calypso@0.17.0 -> postcss-cli@6.1.3 -> ... -> postcss@7.0.32
> wp-calypso@0.17.0 -> postcss-custom-properties@9.1.1 -> ... -> postcss@7.0.32
> wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> postcss@7.0.32
```

CHANGELOG: https://github.com/postcss/postcss/blob/main/CHANGELOG.md#7032