### PR TITLE
Share the same __i18n_text_domain__ mock for all package tests

### DIFF
--- a/packages/domain-picker/jest.config.js
+++ b/packages/domain-picker/jest.config.js
@@ -1,7 +1,4 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
-	globals: {
-		__i18n_text_domain__: 'default',
-	},
 };

--- a/packages/launch/jest.config.js
+++ b/packages/launch/jest.config.js
@@ -1,7 +1,4 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
-	globals: {
-		__i18n_text_domain__: 'default',
-	},
 };

--- a/packages/onboarding/jest.config.js
+++ b/packages/onboarding/jest.config.js
@@ -1,7 +1,4 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
-	globals: {
-		__i18n_text_domain__: 'default',
-	},
 };

--- a/test/packages/jest-preset.js
+++ b/test/packages/jest-preset.js
@@ -5,4 +5,7 @@ module.exports = {
 	...base,
 	cacheDirectory: path.join( __dirname, '../../.cache/jest' ),
 	resolver: path.join( __dirname, '../../test/module-resolver.js' ),
+	globals: {
+		__i18n_text_domain__: 'default',
+	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Mock the `__i18n_text_domain__` in the jest config shared by all packages

Since we don't know what text domain to use when translating text in JS packages, the `__i18n_text_domain__` constant can be used instead e.g. `__( 'Hello, world!', __i18n_text_domain__ )`

The runtime value of the constsant is defined in `client/webpack.config.js` and `apps/editing-toolkit/webpack.config.js`, but it also needs to be defined in unit tests.

This PR simply shares the definition for all package tests rather than having to configure it anew each time we add tests to a new package

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check CI passes
* `yarn test-packages`

