### PR TITLE
Deduplicate resolve

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -25705,14 +25705,7 @@ resolve@1.1.7, resolve@~1.1.0:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.18.1:
+resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130"
   integrity sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `resolve` (done automatically with `npx yarn-deduplicate --packages resolve`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@6.4.0 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> @automattic/wp-babel-makepot@1.0.2 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> @babel/core@7.12.3 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> @storybook/addon-actions@6.1.10 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> @wordpress/components@10.0.5 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.2.0 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> babel-eslint@10.1.0 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> concurrently@5.1.0 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> eslint-plugin-import@2.22.1 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> node-sass-package-importer@5.3.2 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> node-sass@4.13.0 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> npm-run-all@4.1.5 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> resolve@1.17.0
< wp-calypso@0.17.0 -> whybundled@1.4.2 -> ... -> resolve@1.17.0
> wp-calypso@0.17.0 -> @automattic/calypso-build@6.4.0 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> @automattic/wp-babel-makepot@1.0.2 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> @babel/core@7.12.3 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> @storybook/addon-actions@6.1.10 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> @wordpress/components@10.0.5 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.2.0 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> babel-eslint@10.1.0 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> concurrently@5.1.0 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> eslint-plugin-import@2.22.1 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> lerna@3.20.2 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> node-sass-package-importer@5.3.2 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> node-sass@4.13.0 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> npm-run-all@4.1.5 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> resolve@1.18.1
> wp-calypso@0.17.0 -> whybundled@1.4.2 -> ... -> resolve@1.18.1
```