### PR TITLE
Silence un-useful warning for selectors that need to have unused params

### DIFF
--- a/packages/data-stores/src/plans/reducer.ts
+++ b/packages/data-stores/src/plans/reducer.ts
@@ -18,7 +18,7 @@ import {
 import type { PlanAction } from './actions';
 import type { Plan, PlanFeature, PlanFeatureType, PlanSlug } from './types';
 
-type PricesMap = {
+export type PricesMap = {
 	[ slug in PlanSlug ]: string;
 };
 

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -6,11 +6,13 @@ import { select } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import type { State } from './reducer';
-import { DEFAULT_PAID_PLAN, PLAN_ECOMMERCE, PLAN_FREE, STORE_KEY } from './constants';
-
-import type { PlanPath } from './constants';
+import type { State, PricesMap } from './reducer';
+import { DEFAULT_PAID_PLAN, PLAN_ECOMMERCE, PLAN_FREE, STORE_KEY, PlanPath } from './constants';
 import type { Plan, PlanFeature, PlanFeatureType, PlanSlug } from './types';
+
+// Some of these selectors require unused parameters because those
+// params are used by the associated resolver.
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 export const getFeatures = ( state: State ): Record< string, PlanFeature > => state.features;
 
@@ -44,18 +46,18 @@ export const getPlanByPath = ( state: State, path?: PlanPath ): Plan | undefined
 	return path ? getSupportedPlans( state ).find( ( plan ) => plan?.pathSlug === path ) : undefined;
 };
 
-export const getPlansDetails = ( state: State, _: string ): State => state; // eslint-disable-line @typescript-eslint/no-unused-vars
+export const getPlansDetails = ( state: State, _: string ): State => state;
 
 export const getPlansPaths = ( state: State ): string[] => {
 	return getSupportedPlans( state ).map( ( plan ) => plan?.pathSlug );
 };
 
-export const getPrices = ( state: State, _: string ) => state.prices; // eslint-disable-line @typescript-eslint/no-unused-vars
+export const getPrices = ( state: State, _: string ): PricesMap => state.prices;
 
-export const isPlanEcommerce = ( _: State, planSlug?: PlanSlug ) => {
+export const isPlanEcommerce = ( _: State, planSlug?: PlanSlug ): boolean => {
 	return planSlug === PLAN_ECOMMERCE;
 };
 
-export const isPlanFree = ( _: State, planSlug?: PlanSlug ) => {
+export const isPlanFree = ( _: State, planSlug?: PlanSlug ): boolean => {
 	return planSlug === PLAN_FREE;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Silence `no-unused-vars` warning for the whole selector file, instead of having to silence each individual selector.
* Added return types for all selectors

As I mentioned in the comment that disables the warning, it's normal for a selector to have unused params if those params are used by the associated resolver.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build shouldn't fail (I thought TS would also have had a build error about unused variables, but that doesn't seem to be happening).
* Double check plans are appearing at `/new/plans`

