### PR TITLE
update: improve QueryUserSettings

### DIFF
--- a/client/components/data/query-user-settings/README.md
+++ b/client/components/data/query-user-settings/README.md
@@ -1,0 +1,27 @@
+# QueryUserSettings
+
+`<QueryUserSettings />` is a React component used in managing network requests for current user's settings.
+
+## Usage
+
+Render the component. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import { useSelector } from 'react-redux';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import { getUserSettings } from 'calypso/state/selectors/get-user-settings';
+
+export default function CurrentUser() {
+	const userSettings = useSelector( ( state ) => getUserSettings( state ) );
+	const loginName = userSettings?.login_name;
+
+	return (
+		<div>
+			<QueryUserSettings />
+
+			<p>Current user: { loginName }</p>
+		</div>
+	);
+}
+```

--- a/client/components/data/query-user-settings/index.jsx
+++ b/client/components/data/query-user-settings/index.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import { fetchUserSettings } from 'calypso/state/user-settings/actions';
 
 class QueryUserSettings extends Component {
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		this.props.fetchUserSettings();
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add README for `<QueryUserSettings />` component
* Replace `UNSAFE_componentWillMount` with `componentDidMount`

#### Testing instructions

* A quick smoke test for the following is probably sufficient
* Check the following usages of `<QueryUserSettings />` and make sure there's a request for `/settings` and the UI renders as expected:
  * `/me/security`
  * `/me/security/two-step`
  * `/read` (the app promo in the sidebar should show up for users who haven't used the desktop app yet)
  * `/following/manage`
  * `/read/feeds/:feedId`
  * `/me/concierge/:site`
* With a non-english user and activated community translator (do this in `/me/account`) make sure the Translator button appears on the bottom right above the InlineHelp button.

part of #24162 
