### PR TITLE
i18n: Make domain types text translatable

### DIFF
--- a/client/lib/domains/get-domain-type-text.js
+++ b/client/lib/domains/get-domain-type-text.js
@@ -3,26 +3,43 @@
  */
 import { type as domainTypes } from './constants';
 
-export function getDomainTypeText( domain = {} ) {
+/**
+ * Translate function placeholder.
+ *
+ * @param   {string} string Input string
+ * @returns {string}        Returns the input string
+ */
+function translatePlaceholder( string ) {
+	return string;
+}
+
+/**
+ * Get domain type text.
+ *
+ * @param   {Object}   domain Domain object
+ * @param   {Function} __     Translate function
+ * @returns {string}          Domain type text
+ */
+export function getDomainTypeText( domain = {}, __ = translatePlaceholder ) {
 	switch ( domain.type ) {
 		case domainTypes.MAPPED:
-			return 'Mapped Domain';
+			return __( 'Mapped Domain' );
 
 		case domainTypes.REGISTERED:
 			if ( domain?.isPremium ) {
-				return 'Premium Domain';
+				return __( 'Premium Domain' );
 			}
 
-			return 'Registered Domain';
+			return __( 'Registered Domain' );
 
 		case domainTypes.SITE_REDIRECT:
-			return 'Site Redirect';
+			return __( 'Site Redirect' );
 
 		case domainTypes.WPCOM:
-			return 'Default Site Domain';
+			return __( 'Default Site Domain' );
 
 		case domainTypes.TRANSFER:
-			return 'Domain Transfer';
+			return __( 'Domain Transfer' );
 
 		default:
 			return '';

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -59,9 +59,9 @@ class Edit extends React.Component {
 
 	getDomainTypeText( domain ) {
 		if ( this.props.hasDomainOnlySite ) {
-			return 'Parked Domain';
+			return this.props.translate( 'Parked Domain' );
 		}
-		return getDomainTypeText( domain );
+		return getDomainTypeText( domain, this.props.translate );
 	}
 
 	getDetailsForType = ( type ) => {

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -389,7 +389,7 @@ class DomainItem extends PureComponent {
 			);
 		}
 
-		return <React.Fragment>{ getDomainTypeText( domainDetails ) }</React.Fragment>;
+		return <React.Fragment>{ getDomainTypeText( domainDetails, translate ) }</React.Fragment>;
 	}
 
 	busyMessage() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Extend `getDomainTypeText` to accept translate function as parameter and call it with the domain type string to get it translated.
* Pass down the translate function to `getDomainTypeText` in components that should render the translated domain type text.

**Before:**
![image](https://user-images.githubusercontent.com/2722412/102356737-450cda00-3fb6-11eb-8392-310485010506.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/102356512-f7906d00-3fb5-11eb-841e-63fdebe77765.png)

#### Testing instructions

1. Change your UI to a non-English language, preferably Bulgarian, as it already has translations for all domain types.
2. Go to calypso.live (or run locally) and navigate to `/domains/manage/{SITE}`, where `{SITE}` is a site with associated additional domain(s), other than the free domain.
3. Confirm domain type in the domain lists renders translated
4. Select a domain from the list to navigate to it's edit screen, i.e. `/domains/manage/{SITE}/edit/{DOMAIN}`
5. Confirm domain type in the screen header bar renders translated.

Fixes 187-gh-Automattic-i18n-issues
