### PR TITLE
Calypso editor: set Calypsoify for sites running Jetpack 9.2.1+

### DIFF
--- a/client/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe.js
+++ b/client/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe.js
@@ -12,14 +12,15 @@ import { getSiteOption } from 'calypso/state/sites/selectors';
 import versionCompare from 'calypso/lib/version-compare';
 
 export const isEligibleForGutenframe = ( state, siteId ) => {
-	// On some Jetpack sites (9.2+, not Atomic),
-	// Calypsoify is currently broken.
+	// On some Jetpack sites (9.2, not Atomic),
+	// Calypsoify is broken.
 	// Let's not enable it for them.
-	// Reference: https://github.com/Automattic/jetpack/pull/17939
+	// This problem was then fixed in Jetpack 9.2.1.
 	const jetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
 	const isBrokenJetpack =
 		jetpackVersion &&
 		versionCompare( jetpackVersion, '9.2-alpha', '>=' ) &&
+		versionCompare( jetpackVersion, '9.2.1', '<=' ) &&
 		! isAtomicSite( state, siteId );
 
 	return ! isBrokenJetpack && get( state, [ 'gutenbergIframeEligible', siteId ], true );

--- a/client/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe.js
+++ b/client/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe.js
@@ -20,7 +20,7 @@ export const isEligibleForGutenframe = ( state, siteId ) => {
 	const isBrokenJetpack =
 		jetpackVersion &&
 		versionCompare( jetpackVersion, '9.2-alpha', '>=' ) &&
-		versionCompare( jetpackVersion, '9.2.1', '<=' ) &&
+		versionCompare( jetpackVersion, '9.2.1', '<' ) &&
 		! isAtomicSite( state, siteId );
 
 	return ! isBrokenJetpack && get( state, [ 'gutenbergIframeEligible', siteId ], true );


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Follow-up from #47925

Jetpack's Calypsoify broke in version 9.2, and was then fixed in 9.2.1. We consequently only need to exclude sites that run 9.2 (alpha, betas, and stable).

**Note**: I considered simplifying things by only checking if the version was `9.2`; I am not sure if checking for alphas and betas is worth it.

#### Testing instructions

Get yourself 3 sites, all connected to WordPress.com, and all with the SSO feature enabled.
- One must be running Jetpack 9.1
- The other 9.2
- The last one 9.2.1

(You can use [the WP Rollback plugin](https://wordpress.org/plugins/wp-rollback/) to quickly switch to a previous version of the Jetpack plugin on 2 of the sites)

For each site:

* Go to `http://calypso.localhost:3000/posts/mysite.com`
* Click to start a new post
    * 9.1 and 9.2.1 should redirect you to the iFramed post editor with Calypsoify
    * 9.2 should not.

