### PR TITLE
Importers: uploadExportFile response already contains siteId, no need to add it

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -241,11 +241,7 @@ export const startUpload = ( importerStatus, file ) => {
 			onabort: () => cancelImport( siteId, importerId ),
 		} )
 		.then( ( data ) => {
-			const finishUploadAction = createFinishUploadAction(
-				importerId,
-				fromApi( { ...data, siteId } )
-			);
-
+			const finishUploadAction = createFinishUploadAction( importerId, fromApi( data ) );
 			Dispatcher.handleViewAction( finishUploadAction );
 			reduxDispatch( finishUploadAction );
 		} )


### PR DESCRIPTION
Little update of the `.then` handler when `uploadExportFile` successfully uploads an export file. The response always contains the `siteId` attribute:

<img width="497" alt="Screenshot 2020-12-16 at 15 46 56" src="https://user-images.githubusercontent.com/664258/102364584-e8f68580-3fb6-11eb-893d-788689f748db.png">

You can also verify that the server-side PHP implementation of `/imports/new` in v1.1 returns the current state of the importer (result of `Import_v1_1_Helpers::get_import_status`) just like the `/imports` endpoint does. With the old v1.0 it might have been different, but we use only the v1.1 endpoints these days.

A simple spinoff from #48213.