### PR TITLE
Purchases: Fix site icon for memberships

### DIFF
--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -107,11 +107,11 @@ const Icon = ( { subscription }: { subscription: MembershipSubscription } ) => {
 		fetchData();
 	}, [ siteId ] );
 
-	if ( site && ! hasError ) {
+	if ( site && ! hasError && site.icon ) {
 		return <img src={ site.icon.ico } width="36" height="36" alt="" />;
 	}
 
-	return <SiteIcon size={ 24 } />;
+	return <SiteIcon size={ 36 } />;
 };
 
 export default function MembershipItem( {

--- a/client/me/purchases/style.scss
+++ b/client/me/purchases/style.scss
@@ -96,7 +96,8 @@
 	@include placeholder();
 }
 
-.purchase-item__site {
+.purchase-item__site,
+.membership-item {
 	.site-icon {
 		border-radius: 2px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While sandboxed, I noticed an error on the purchase listing screen. I found out that the screen wouldn't load for purchases made to third party sites that had no site icon. This PR fixes that so the list renders correctly.

**Before**
[White screen]

**After**
![image](https://user-images.githubusercontent.com/6981253/102369986-8f786180-3f8a-11eb-97a3-baa19703c942.png)


#### Testing instructions
* If you can make a purchase from a site without a site icon that would be great, otherwise a purchase from any third party site would work.
* Visit your account-level purchase screen
* Make sure everything looks good
