### PR TITLE
Purchases: Update payment method loader

### DIFF
--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -1,3 +1,7 @@
+.credit-card-form-fields__loading-placeholder {
+	margin-bottom: 16px;
+}
+
 .credit-card-form-fields__extras {
 	display: flex;
 	flex-wrap: wrap;

--- a/client/me/purchases/components/payment-method-loader/index.jsx
+++ b/client/me/purchases/components/payment-method-loader/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Card, CompactCard } from '@automattic/components';
+import { Card } from '@automattic/components';
 import CreditCardFormFieldsLoadingPlaceholder from 'calypso/components/credit-card-form-fields/loading-placeholder';
 import FormButton from 'calypso/components/forms/form-button';
 import LoadingPlaceholder from 'calypso/me/purchases/components/loading-placeholder';
@@ -26,11 +26,9 @@ export default function PaymentMethodLoader( { title } ) {
 				<Column type="main">
 					<Card className="payment-method-loader__credit-card-content credit-card-form__content">
 						<CreditCardFormFieldsLoadingPlaceholder />
-					</Card>
 
-					<CompactCard className="payment-method-loader__credit-card-footer credit-card-form__footer">
 						<FormButton isPrimary={ false } />
-					</CompactCard>
+					</Card>
 				</Column>
 				<Column type="sidebar">
 					<Card className="payment-method-loader__top-card">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes a minor tweak to the payment method loader to better match the new UI.

**Before**
![image](https://user-images.githubusercontent.com/6981253/102381053-bf2d6680-3f96-11eb-8553-63688a989361.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/102380697-3b737a00-3f96-11eb-8968-9fe17b015a1d.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Reviewing the screenshots is probably fine or you can load up the change/add payment method screens to review.
