### PR TITLE
Purchase Cancellation Survey: CSS tweak select box label

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -6,9 +6,8 @@
 .dialog__content .cancel-purchase-form__reason-select {
 	margin: 6px 0 0 24px;
 	&.form-label {
-		color: var( --studio-gray-50 );
 		font-weight: 600;
-		font-size: 1rem;
+		font-size: 0.75rem;
 	}
 
 	.select-dropdown {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Per https://github.com/Automattic/wp-calypso/pull/48280#issuecomment-745437642 this PR makes a small CSS change to the select box label in the Purchase Cancellation Form (For the cancellation reason: "I'd like to downgrade to another plan.")

#### Testing instructions

* Checkout and run this PR or open the Calypso Live Link
* Select a site with any paid Jetpack plan (not Jetpack Free)
* Go to the Plans --> Billing section located at `/purchases/subscriptions/:site`
* Select the site's plan.
* Click on the `[Remove :planName]` button at the bottom of the section. (This will open the Purchase Cancellation Survey dialog)
* Select the radio option labeled as `I'd like to downgrade to another plan`.
* Verify the "Mind telling us which one?" label looks like the "**After**" screenshot below.

**Before:**

![Markup 2020-12-16 at 10 07 53](https://user-images.githubusercontent.com/11078128/102390154-e41add00-3f88-11eb-8475-75f737ae1e1b.png)

**After:**

![Markup 2020-12-16 at 10 09 32](https://user-images.githubusercontent.com/11078128/102390160-e7ae6400-3f88-11eb-8ea3-8769f0603f7d.png)
 

