### PR TITLE
Checkout: Fix import of createTransactionEndpointRequestPayloadFromLineItems

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -10,12 +10,12 @@ import { createStripePaymentMethod } from '@automattic/calypso-stripe';
  * Internal dependencies
  */
 import wp from 'calypso/lib/wp';
-import { createTransactionEndpointRequestPayloadFromLineItems } from './types/transaction-endpoint';
 import { createPayPalExpressEndpointRequestPayloadFromLineItems } from './types/paypal-express';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from './lib/translate-payment-method-names';
 import { getSavedVariations } from 'calypso/lib/abtest';
 import { stringifyBody } from 'calypso/state/login/utils';
 import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
+import { createTransactionEndpointRequestPayloadFromLineItems } from './lib/translate-cart';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
 const { select } = defaultRegistry;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a regression added by https://github.com/Automattic/wp-calypso/pull/48069  where we moved `createTransactionEndpointRequestPayloadFromLineItems` but failed to update all the imports.

#### Testing instructions

- Complete checkout with a new card. Verify there are no fatals.