### PR TITLE
Checkout: Stop memoizing domainDetails for existingCardProcessor

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -445,14 +445,10 @@ export default function CompositeCheckout( {
 		[ dataForProcessor, getThankYouUrl, siteSlug ]
 	);
 
-	const domainDetails = useMemo(
-		() =>
-			getDomainDetails( {
-				includeDomainDetails,
-				includeGSuiteDetails,
-			} ),
-		[ includeGSuiteDetails, includeDomainDetails ]
-	);
+	const domainDetails = getDomainDetails( {
+		includeDomainDetails,
+		includeGSuiteDetails,
+	} );
 	const postalCode = getPostalCode();
 
 	const paymentProcessors = useMemo(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Make sure domain details for existing card purchases is always up-to-date. Otherwise if the contact details are modified and the cart doesn't change, the domain details submitted to the transactions endpoint will be out-of-date, resulting in weird errors about missing data when there's clearly no data missing.

The underlying issue is that `getDomainDetails` is not a pure function. It fetches data from a `@wordpress/data` store and so it has a hidden dependency that isn't in the dependencies for `useMemo`.

This was a regression added by https://github.com/Automattic/wp-calypso/pull/48069

#### Testing instructions

- Purchase a .ca TLD using an existing card.
- Make sure that the purchase completes with no errors.