### PR TITLE
Checkout: hide free domain credit if it's already used

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -13,7 +13,6 @@ import {
 	useFormStatus,
 	useLineItemsOfType,
 	useTotal,
-	useSelect,
 } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -53,6 +52,7 @@ import getPlanFeatures from '../lib/get-plan-features';
 import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 
 export default function WPCheckoutOrderSummary( {
+	siteId,
 	onChangePlanLength,
 	nextDomainIsFree = false,
 } = {} ) {
@@ -84,6 +84,7 @@ export default function WPCheckoutOrderSummary( {
 					<LoadingCheckoutSummaryFeaturesList />
 				) : (
 					<CheckoutSummaryFeaturesList
+						siteId={ siteId }
 						isMonthlyPricingTest={ isMonthlyPricingTest }
 						hasMonthlyPlan={ hasMonthlyPlan }
 						nextDomainIsFree={ nextDomainIsFree }
@@ -154,7 +155,7 @@ function CheckoutSummaryFeaturesList( props ) {
 	const domains = useDomainsInCart();
 	const hasPlanInCart = useHasPlanInCart();
 	const translate = useTranslate();
-	const siteId = useSelect( ( select ) => select( 'wpcom' )?.getSiteId?.() );
+	const siteId = props.siteId;
 	const isJetpackNotAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId )
 	);
@@ -267,12 +268,11 @@ function CheckoutSummaryFeaturesListDomainItem( {
 	);
 }
 
-function CheckoutSummaryPlanFeatures( { isMonthlyPricingTest } ) {
+function CheckoutSummaryPlanFeatures( { isMonthlyPricingTest, siteId } ) {
 	const translate = useTranslate();
 	const hasDomainsInCart = useHasDomainsInCart();
 	const planInCart = usePlanInCart();
 	const hasRenewalInCart = useHasRenewalInCart();
-	const siteId = useSelect( ( select ) => select( 'wpcom' )?.getSiteId?.() );
 	const planHasDomainCredit = useSelector( ( state ) => hasDomainCredit( state, siteId ) );
 	const planFeatures = getPlanFeatures(
 		planInCart,

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -50,6 +50,7 @@ import Gridicon from 'calypso/components/gridicon';
 import { useIsLoading } from 'calypso/state/experiments/hooks';
 import { isTreatmentInMonthlyPricingTest } from 'calypso/state/marketing/selectors';
 import getPlanFeatures from '../lib/get-plan-features';
+import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 
 export default function WPCheckoutOrderSummary( {
 	onChangePlanLength,
@@ -271,12 +272,15 @@ function CheckoutSummaryPlanFeatures( { isMonthlyPricingTest } ) {
 	const hasDomainsInCart = useHasDomainsInCart();
 	const planInCart = usePlanInCart();
 	const hasRenewalInCart = useHasRenewalInCart();
+	const siteId = useSelect( ( select ) => select( 'wpcom' )?.getSiteId?.() );
+	const planHasDomainCredit = useSelector( ( state ) => hasDomainCredit( state, siteId ) );
 	const planFeatures = getPlanFeatures(
 		planInCart,
 		translate,
 		hasDomainsInCart,
 		hasRenewalInCart,
-		isMonthlyPricingTest
+		isMonthlyPricingTest,
+		planHasDomainCredit
 	);
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -307,6 +307,7 @@ export default function WPCheckout( {
 					</CheckoutSummaryTitleLink>
 					<CheckoutSummaryBody>
 						<WPCheckoutOrderSummary
+							siteId={ siteId }
 							onChangePlanLength={ changePlanLength }
 							nextDomainIsFree={ responseCart?.next_domain_is_free }
 						/>

--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -22,9 +22,10 @@ export default function getPlanFeatures(
 	translate: ReturnType< typeof useTranslate >,
 	hasDomainsInCart: boolean,
 	hasRenewalInCart: boolean,
-	isMonthlyPricingTest: boolean
+	isMonthlyPricingTest: boolean,
+	planHasDomainCredit: boolean
 ): string[] {
-	const showFreeDomainFeature = ! hasDomainsInCart && ! hasRenewalInCart;
+	const showFreeDomainFeature = ! hasDomainsInCart && ! hasRenewalInCart && planHasDomainCredit;
 	const productSlug = plan?.wpcom_meta?.product_slug;
 
 	if ( ! productSlug ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR hides the free domain credit benefit from the checkout feature list item if the domain credit has already been used.

Before:
![image](https://user-images.githubusercontent.com/6981253/102400849-75517a00-3fb0-11eb-964e-02bb8404e162.png)


After:
![image](https://user-images.githubusercontent.com/6981253/102400812-6c60a880-3fb0-11eb-95a7-993ba53e8064.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Find a site that has a plan and that you've used your domain credit.
* Upgrade the site to another plan and confirm you don't see the free domain messaging.
* Find a site that has a plan but you haven't used your domain credit.
* Upgrade the site to another plan and confirm you see the free domain messaging.

Fixes https://github.com/Automattic/wp-calypso/issues/48336

cc @jordesign 