### PR TITLE
Checkout: Fix import of createTransactionEndpointCartFromLineItems for PayPal

### DIFF
--- a/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
+++ b/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
@@ -1,15 +1,13 @@
 /**
- * External dependencies
- */
-import { getNonProductWPCOMCartItemTypes } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-cart';
-import type { WPCOMCartItem } from 'calypso/my-sites/checkout/composite-checkout/types/checkout-cart';
-import type { DomainContactDetails } from 'calypso/my-sites/checkout/composite-checkout/types/backend/domain-contact-details-components';
-
-/**
  * Internal dependencies
  */
+import {
+	getNonProductWPCOMCartItemTypes,
+	createTransactionEndpointCartFromLineItems,
+} from 'calypso/my-sites/checkout/composite-checkout/lib/translate-cart';
+import type { WPCOMCartItem } from 'calypso/my-sites/checkout/composite-checkout/types/checkout-cart';
+import type { DomainContactDetails } from 'calypso/my-sites/checkout/composite-checkout/types/backend/domain-contact-details-components';
 import { WPCOMTransactionEndpointCart } from './transaction-endpoint';
-import { createTransactionEndpointCartFromLineItems } from '../lib/translate-cart';
 
 export type PayPalExpressEndpoint = (
 	_: PayPalExpressEndpointRequestPayload

--- a/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
+++ b/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
@@ -8,10 +8,8 @@ import type { DomainContactDetails } from 'calypso/my-sites/checkout/composite-c
 /**
  * Internal dependencies
  */
-import {
-	WPCOMTransactionEndpointCart,
-	createTransactionEndpointCartFromLineItems,
-} from './transaction-endpoint';
+import { WPCOMTransactionEndpointCart } from './transaction-endpoint';
+import { createTransactionEndpointCartFromLineItems } from '../lib/translate-cart';
 
 export type PayPalExpressEndpoint = (
 	_: PayPalExpressEndpointRequestPayload
@@ -65,4 +63,4 @@ export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 	};
 }
 
-export type PayPalExpressEndpointResponse = {};
+export type PayPalExpressEndpointResponse = unknown;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a regression added by https://github.com/Automattic/wp-calypso/pull/48069  where we moved `createTransactionEndpointCartFromLineItems ` but failed to update all the imports.

Same as https://github.com/Automattic/wp-calypso/pull/48427 but for PayPal

#### Testing instructions

- Test a paypal purchase and be sure you're redirected to PayPal and there's no errors. No need to actually complete the purchase. If the redirect works, it should work.