### PR TITLE
Anchor Gutenboarding: Remember spotify_show_url parameter

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -18,7 +18,7 @@ import {
 	usePath,
 	Step,
 	useCurrentStep,
-	useAnchorFmPodcastId,
+	useAnchorFmParams,
 	useIsAnchorFm,
 } from '../../path';
 import ModalSubmitButton from '../modal-submit-button';
@@ -50,7 +50,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	const makePath = usePath();
 	const currentStep = useCurrentStep();
 	const isMobile = useViewportMatch( 'small', '<' );
-	const anchorFmPodcastId = useAnchorFmPodcastId();
+	const { anchorFmPodcastId } = useAnchorFmParams();
 	const isAnchorFmSignup = useIsAnchorFm();
 
 	const closeModal = () => {
@@ -171,7 +171,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 		isAnchorFmSignup
 			? `${ window.location.origin }/new${ makePath(
 					Step.IntentGathering
-			  ) }?new&anchor_podcast=${ anchorFmPodcastId }`
+			  ) }?new&anchor_podcast=${ anchorFmPodcastId }` // Fix in #48389
 			: `${ window.location.origin }/new${ makePath( Step.CreateSite ) }?new`
 	);
 	const signupUrl = encodeURIComponent( `/new${ makePath( Step[ currentStep ] ) }?signup` );

--- a/client/landing/gutenboarding/hooks/use-on-login.ts
+++ b/client/landing/gutenboarding/hooks/use-on-login.ts
@@ -44,6 +44,7 @@ export default function useOnLogin(): void {
 				visibility,
 				anchorFmPodcastId: null,
 				anchorFmEpisodeId: null,
+				anchorFmSpotifyShowUrl: null,
 			} );
 		}
 	}, [

--- a/client/landing/gutenboarding/hooks/use-on-signup.ts
+++ b/client/landing/gutenboarding/hooks/use-on-signup.ts
@@ -12,7 +12,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
 import { useNewSiteVisibility } from './use-selected-plan';
-import { useIsAnchorFm, useAnchorFmPodcastId, useAnchorFmEpisodeId } from '../path';
+import { useIsAnchorFm, useAnchorFmParams } from '../path';
 
 /**
  * After signup a site is automatically created using the username and bearerToken
@@ -26,8 +26,7 @@ export default function useOnSignup() {
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
 	const visibility = useNewSiteVisibility();
 	const isAnchorFmSignup = useIsAnchorFm();
-	const anchorFmPodcastId = useAnchorFmPodcastId();
-	const anchorFmEpisodeId = useAnchorFmEpisodeId();
+	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyShowUrl } = useAnchorFmParams();
 
 	const handleCreateSite = React.useCallback(
 		( username: string, isPublicSite: number, bearerToken?: string ) => {
@@ -38,9 +37,10 @@ export default function useOnSignup() {
 				visibility: isPublicSite,
 				anchorFmPodcastId,
 				anchorFmEpisodeId,
+				anchorFmSpotifyShowUrl,
 			} );
 		},
-		[ createSite, locale ]
+		[ createSite, locale, anchorFmPodcastId, anchorFmEpisodeId ]
 	);
 
 	React.useEffect( () => {

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -8,14 +8,7 @@ import { useLocale } from '@automattic/i18n-utils';
 /**
  * Internal dependencies
  */
-import {
-	GutenLocationStateType,
-	Step,
-	usePath,
-	useCurrentStep,
-	useAnchorFmPodcastId,
-	useAnchorFmEpisodeId,
-} from '../path';
+import { GutenLocationStateType, Step, usePath, useCurrentStep, useAnchorFmParams } from '../path';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
 import { useNewSiteVisibility } from './use-selected-plan';
@@ -42,8 +35,7 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	// @TODO: move site creation to a separate hook or an action on the ONBOARD store
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
-	const anchorFmPodcastId = useAnchorFmPodcastId();
-	const anchorFmEpisodeId = useAnchorFmEpisodeId();
+	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyShowUrl } = useAnchorFmParams();
 
 	const { createSite } = useDispatch( ONBOARD_STORE );
 	const newSiteVisibility = useNewSiteVisibility();
@@ -57,6 +49,7 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 				visibility: newSiteVisibility,
 				anchorFmPodcastId,
 				anchorFmEpisodeId,
+				anchorFmSpotifyShowUrl,
 			} );
 		}
 		// Adding a newUser check works for Anchor.fm flow.  Without it, we ask for login twice.
@@ -68,6 +61,7 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 				visibility: newSiteVisibility,
 				anchorFmPodcastId,
 				anchorFmEpisodeId,
+				anchorFmSpotifyShowUrl,
 			} );
 		}
 		return onSignupDialogOpen();

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -86,6 +86,9 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	if ( anchorFmEpisodeId ) {
 		locationState.anchorFmEpisodeId = anchorFmEpisodeId;
 	}
+	if ( anchorFmSpotifyShowUrl ) {
+		locationState.anchorFmSpotifyShowUrl = anchorFmSpotifyShowUrl;
+	}
 
 	const handleBack = () => history.push( previousStepPath, locationState );
 	const handleNext = () =>

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -158,18 +158,6 @@ export function useAnchorFmParams(): AnchorFmParams {
 }
 
 /*
-// Returns the anchor podcast id. First looks in "location state",
-// provided by react-router-dom, if not available there, checks the query string.
-export function useAnchorFmPodcastId(): string | null {
-	return;
-}
-
-// Returns the anchor episode id. First looks in "location state",
-// provided by react-router-dom, if not available there, checks the query string.
-export function useAnchorFmEpisodeId(): string | null {}
-*/
-
-/*
  useAnchorParameter is an internal helper for finding a value that comes from either a query string, or location state.
  Outside callers shouldn't use it, so it's not exported.
 

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -53,6 +53,7 @@ export type StepNameType = keyof typeof Step;
 export interface GutenLocationStateType {
 	anchorFmPodcastId?: string;
 	anchorFmEpisodeId?: string;
+	anchorFmSpotifyShowUrl?: string;
 }
 export type GutenLocationStateKeyType = keyof GutenLocationStateType;
 
@@ -111,34 +112,57 @@ export function useNewQueryParam() {
 }
 
 export function useIsAnchorFm(): boolean {
-	const podcastId = useAnchorFmPodcastId();
-	return Boolean( podcastId && podcastId.match( /^[0-9a-f]{7,8}$/i ) );
+	const { anchorFmPodcastId } = useAnchorFmParams();
+	return Boolean( anchorFmPodcastId && anchorFmPodcastId.match( /^[0-9a-f]{7,8}$/i ) );
 }
 
+export interface AnchorFmParams {
+	anchorFmPodcastId: string | null;
+	anchorFmEpisodeId: string | null;
+	anchorFmSpotifyShowUrl: string | null;
+}
+export function useAnchorFmParams(): AnchorFmParams {
+	const sanitizePodcast = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
+	const anchorFmPodcastId = useAnchorParameter( {
+		queryParamName: 'anchor_podcast',
+		locationStateParamName: 'anchorFmPodcastId',
+		sanitize: sanitizePodcast,
+	} );
+
+	// Allow all characters allowed in urls
+	// Reserved characters: !*'();:@&=+$,/?#[]
+	// Unreserved: A-Za-z0-9_.~-    (possibly % as a part of percent-encoding)
+	const sanitizeEpisode = ( id: string ) => id.replace( /[^A-Za-z0-9_.\-~%]/g, '' );
+	const anchorFmEpisodeId = useAnchorParameter( {
+		queryParamName: 'anchor_episode',
+		locationStateParamName: 'anchorFmEpisodeId',
+		sanitize: sanitizeEpisode,
+	} );
+
+	const anchorFmSpotifyShowUrl = useAnchorParameter( {
+		queryParamName: 'spotify_show_url',
+		locationStateParamName: 'anchorFmSpotifyShowUrl',
+		sanitize: sanitizeEpisode,
+	} );
+
+	return {
+		anchorFmPodcastId,
+		anchorFmEpisodeId,
+		anchorFmSpotifyShowUrl,
+	};
+}
+
+/*
 // Returns the anchor podcast id. First looks in "location state",
 // provided by react-router-dom, if not available there, checks the query string.
 export function useAnchorFmPodcastId(): string | null {
-	const sanitize = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
-	return useAnchorParameter( {
-		queryParamName: 'anchor_podcast',
-		locationStateParamName: 'anchorFmPodcastId',
-		sanitize,
-	} );
+	return;
 }
 
 // Returns the anchor episode id. First looks in "location state",
 // provided by react-router-dom, if not available there, checks the query string.
-export function useAnchorFmEpisodeId(): string | null {
-	// Allow all characters allowed in urls
-	// Reserved characters: !*'();:@&=+$,/?#[]
-	// Unreserved: A-Za-z0-9_.~-    (possibly % as a part of percent-encoding)
-	const sanitize = ( id: string ) => id.replace( /[^A-Za-z0-9_.\-~%]/g, '' );
-	return useAnchorParameter( {
-		queryParamName: 'anchor_episode',
-		locationStateParamName: 'anchorFmEpisodeId',
-		sanitize,
-	} );
-}
+export function useAnchorFmEpisodeId(): string | null {}
+*/
 
 /*
  useAnchorParameter is an internal helper for finding a value that comes from either a query string, or location state.

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -139,10 +139,15 @@ export function useAnchorFmParams(): AnchorFmParams {
 		sanitize: sanitizeEpisode,
 	} );
 
+	// Allow all characters allowed in urls
+	// Reserved characters: !*'();:@&=+$,/?#[]
+	// Unreserved: A-Za-z0-9_.~-    (possibly % as a part of percent-encoding)
+	const sanitizeShowUrl = ( id: string ) =>
+		id.replace( /[^A-Za-z0-9_.\-~%!*'();:@&=+$,/?#[\]]/g, '' );
 	const anchorFmSpotifyShowUrl = useAnchorParameter( {
 		queryParamName: 'spotify_show_url',
 		locationStateParamName: 'anchorFmSpotifyShowUrl',
-		sanitize: sanitizeEpisode,
+		sanitize: sanitizeShowUrl,
 	} );
 
 	return {

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -43,6 +43,7 @@ export interface CreateSiteActionParameters {
 	visibility: number;
 	anchorFmPodcastId: string | null;
 	anchorFmEpisodeId: string | null;
+	anchorFmSpotifyShowUrl: string | null;
 }
 
 export function* createSite( {
@@ -52,6 +53,7 @@ export function* createSite( {
 	visibility = Site.Visibility.PublicNotIndexed,
 	anchorFmPodcastId = null,
 	anchorFmEpisodeId = null,
+	anchorFmSpotifyShowUrl = null,
 }: CreateSiteActionParameters ) {
 	const {
 		domain,
@@ -101,6 +103,9 @@ export function* createSite( {
 			} ),
 			...( anchorFmEpisodeId && {
 				anchor_fm_episode_id: anchorFmEpisodeId,
+			} ),
+			...( anchorFmSpotifyShowUrl && {
+				anchor_fm_spotify_show_url: anchorFmSpotifyShowUrl,
 			} ),
 		},
 		...( bearerToken && { authToken: bearerToken } ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Anchor.FM Gutenboarding passes along spotify_show_url as well

#### Testing instructions

* Visit  http://calypso.localhost:3000/new?&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q in an incognito window
* Go through the gutenboarding process, creating a site and account
* Check the network tab when you finish, the spotify_show_url from the initial url will be passed to the wpcom site creation

After this is merged, #48389 will be updated to pass this to the editor.