### PR TITLE
Add store deprecated notice when woocommerce/store-deprecated flag is set to true

### DIFF
--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -15,6 +15,7 @@ import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'calypso/components/main';
 import OrdersList from './orders-list';
+import StoreDeprecatedNotice from '../../components/store-deprecated-notice';
 
 function Orders( { className, params, site, translate } ) {
 	let addButton = null;
@@ -32,6 +33,7 @@ function Orders( { className, params, site, translate } ) {
 			<ActionHeader breadcrumbs={ <span>{ translate( 'Orders' ) }</span> }>
 				{ addButton }
 			</ActionHeader>
+			{ config.isEnabled( 'woocommerce/store-deprecated' ) && <StoreDeprecatedNotice /> }
 			<OrdersList currentStatus={ params && params.filter } />
 		</Main>
 	);

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { trim } from 'lodash';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies
@@ -30,6 +31,7 @@ import ProductsList from './products-list';
 import ProductsListSearchResults from './products-list-search-results';
 import SectionNav from 'calypso/components/section-nav';
 import Search from 'calypso/components/search';
+import StoreDeprecatedNotice from '../../components/store-deprecated-notice';
 
 class Products extends Component {
 	static propTypes = {
@@ -126,6 +128,7 @@ class Products extends Component {
 						{ translate( 'Add a product' ) }
 					</Button>
 				</ActionHeader>
+				{ config.isEnabled( 'woocommerce/store-deprecated' ) && <StoreDeprecatedNotice /> }
 				{ this.renderSectionNav() }
 				{ productsDisplay }
 			</Main>

--- a/client/extensions/woocommerce/app/promotions/index.js
+++ b/client/extensions/woocommerce/app/promotions/index.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies
@@ -24,6 +25,7 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'calypso/components/main';
 import PromotionsList from './promotions-list';
 import SearchCard from 'calypso/components/search-card';
+import StoreDeprecatedNotice from '../../components/store-deprecated-notice';
 
 class Promotions extends Component {
 	static propTypes = {
@@ -109,6 +111,7 @@ class Promotions extends Component {
 						{ translate( 'Add promotion' ) }
 					</Button>
 				</ActionHeader>
+				{ config.isEnabled( 'woocommerce/store-deprecated' ) && <StoreDeprecatedNotice /> }
 				{ content }
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/reviews/index.js
+++ b/client/extensions/woocommerce/app/reviews/index.js
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies
@@ -14,6 +15,7 @@ import PropTypes from 'prop-types';
 import ActionHeader from 'woocommerce/components/action-header';
 import Main from 'calypso/components/main';
 import ReviewsList from './reviews-list';
+import StoreDeprecatedNotice from '../../components/store-deprecated-notice';
 
 class Reviews extends Component {
 	static propTypes = {
@@ -31,6 +33,7 @@ class Reviews extends Component {
 		return (
 			<Main className={ classes } wideLayout>
 				<ActionHeader breadcrumbs={ <span>{ translate( 'Reviews' ) }</span> } />
+				{ config.isEnabled( 'woocommerce/store-deprecated' ) && <StoreDeprecatedNotice /> }
 				<ReviewsList
 					productId={ params && params.product_id && Number( params.product_id ) }
 					currentStatus={ params && params.filter }

--- a/client/extensions/woocommerce/app/settings/navigation.js
+++ b/client/extensions/woocommerce/app/settings/navigation.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
+import config from 'calypso/config';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ import { getLink } from 'woocommerce/lib/nav-utils';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import SectionNav from 'calypso/components/section-nav';
+import StoreDeprecatedNotice from '../../components/store-deprecated-notice';
 
 export const SettingsNavigation = ( { site, activeSection, translate } ) => {
 	const items = [
@@ -42,18 +44,21 @@ export const SettingsNavigation = ( { site, activeSection, translate } ) => {
 
 	const section = find( items, { id: activeSection } );
 	return (
-		<SectionNav selectedText={ section && section.title }>
-			<NavTabs>
-				{ items.map( ( { id, path, title } ) => {
-					const link = getLink( path, site );
-					return (
-						<NavItem selected={ activeSection === id } key={ id } path={ link }>
-							{ title }
-						</NavItem>
-					);
-				} ) }
-			</NavTabs>
-		</SectionNav>
+		<div>
+			{ config.isEnabled( 'woocommerce/store-deprecated' ) && <StoreDeprecatedNotice /> }
+			<SectionNav selectedText={ section && section.title }>
+				<NavTabs>
+					{ items.map( ( { id, path, title } ) => {
+						const link = getLink( path, site );
+						return (
+							<NavItem selected={ activeSection === id } key={ id } path={ link }>
+								{ title }
+							</NavItem>
+						);
+					} ) }
+				</NavTabs>
+			</SectionNav>
+		</div>
 	);
 };
 

--- a/client/extensions/woocommerce/components/store-deprecated-notice/index.js
+++ b/client/extensions/woocommerce/components/store-deprecated-notice/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+
+import { translate } from 'i18n-calypso';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import './style.scss';
+
+class StoreDeprecatedNotice extends Component {
+	render() {
+		return (
+			<div className="store-deprecated-notice">
+				<Notice
+					status="is-success"
+					icon="notice"
+					text={ translate( 'Store is moving to WooCommerce' ) }
+					showDismiss={ false }
+				>
+					<NoticeAction href="https://wordpress.com/support/store/">
+						{ translate( 'More' ) }
+					</NoticeAction>
+				</Notice>
+			</div>
+		);
+	}
+}
+
+export default StoreDeprecatedNotice;

--- a/client/extensions/woocommerce/components/store-deprecated-notice/style.scss
+++ b/client/extensions/woocommerce/components/store-deprecated-notice/style.scss
@@ -1,0 +1,8 @@
+.store-deprecated-notice {
+    .notice__icon-wrapper {
+        background: #d3af3f !important;
+        .notice__icon-wrapper-drop {
+            background: #9a752e !important;
+        }
+    }
+}

--- a/client/extensions/woocommerce/components/store-deprecated-notice/style.scss
+++ b/client/extensions/woocommerce/components/store-deprecated-notice/style.scss
@@ -1,8 +1,6 @@
-.store-deprecated-notice {
-    .notice__icon-wrapper {
-        background: #d3af3f !important;
-        .notice__icon-wrapper-drop {
-            background: #9a752e !important;
-        }
+.layout__content .notice.is-success .notice__icon-wrapper {
+    background: #d3af3f;
+    .notice__icon-wrapper-drop {
+        background: #9a752e;
     }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes #48393 
* Added `StoreDeprecatedNotice` component for reusuability 
* Orders, Products, Promotions, Reviews, and Settings pages display `StoreDeprecatedNotice` when `woocommerce/store-deprecated` flag is set to true

#### Testing instructions

1. Start Calypso locally
2. Navigate to http://calypso.localhost:3000/ 
3. Click "Switch Site" from the sidebar and choose your eCommerce site.
4. Replace "home" to "store" and append `?flags=woocommerce/store-deprecated` from your browser's URL and hit enter.
5. Click each sidebar link and confirm that they have `StoreDeprecatedNotice` component displayed (refer to the screenshot below)

**URL replacement example:**

http://calypso.localhost:3000/home/calypsotest363078866.wpcomstaging.com

**to**

http://calypso.localhost:3000/store/calypsotest363078866.wpcomstaging.com?flags=woocommerce/store-deprecated

#### Screenshots

![Screen Shot 2020-12-16 at 4 29 33 PM](https://user-images.githubusercontent.com/4723145/102422564-ee0a0380-3fbb-11eb-9b76-13d6f022c631.jpg)
