### PR TITLE
Domains: Update RegisterDomainStep to use withShoppingCart and remove CartData

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -26,6 +26,7 @@ import { v4 as uuid } from 'uuid';
 import { stringify } from 'qs';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -1538,4 +1539,4 @@ export default connect(
 		hideSitePreview,
 		showSitePreview,
 	}
-)( localize( RegisterDomainStep ) );
+)( withShoppingCart( localize( RegisterDomainStep ) ) );

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -231,7 +231,6 @@ class DomainSearch extends Component {
 								onAddDomain={ this.handleAddRemoveDomain }
 								onAddMapping={ this.handleAddMapping }
 								onAddTransfer={ this.handleAddTransfer }
-								cart={ this.props.cart }
 								offerUnavailableOption
 								selectedSite={ selectedSite }
 								basePath={ this.props.basePath }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -14,7 +14,6 @@ import MapDomainStep from 'calypso/components/domains/map-domain-step';
 import TransferDomainStep from 'calypso/components/domains/transfer-domain-step';
 import UseYourDomainStep from 'calypso/components/domains/use-your-domain-step';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
-import CartData from 'calypso/components/data/cart';
 import { getStepUrl } from 'calypso/signup/utils';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import {
@@ -485,7 +484,7 @@ class DomainsStep extends React.Component {
 			? TRUENAME_TLDS
 			: null;
 
-		const registerDomainStep = (
+		return (
 			<RegisterDomainStep
 				key="domainForm"
 				path={ this.props.path }
@@ -523,12 +522,6 @@ class DomainsStep extends React.Component {
 				isReskinned={ this.props.isReskinned }
 			/>
 		);
-
-		if ( 'launch-site' === this.props.flowName ) {
-			return <CartData>{ registerDomainStep }</CartData>;
-		}
-
-		return registerDomainStep;
 	};
 
 	mappingForm = () => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -58,6 +58,8 @@ import { getStepModuleName } from 'calypso/signup/config/step-components';
 import { tracksAnonymousUserId } from 'calypso/lib/analytics/ad-tracking';
 import QueryExperiments from 'calypso/components/data/query-experiments';
 import { getExternalBackUrl } from './utils';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+
 /**
  * Style dependencies
  */
@@ -485,42 +487,49 @@ class DomainsStep extends React.Component {
 			: null;
 
 		return (
-			<RegisterDomainStep
-				key="domainForm"
-				path={ this.props.path }
-				initialState={ initialState }
-				onAddDomain={ this.handleAddDomain }
-				products={ this.props.productsList }
-				basePath={ this.props.path }
-				promoTlds={ trueNamePromoTlds }
-				mapDomainUrl={ this.getMapDomainUrl() }
-				transferDomainUrl={ this.getTransferDomainUrl() }
-				useYourDomainUrl={ this.getUseYourDomainUrl() }
-				onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
-				onSave={ this.handleSave.bind( this, 'domainForm' ) }
-				offerUnavailableOption={ ! this.props.isDomainOnly }
-				isDomainOnly={ this.props.isDomainOnly }
-				analyticsSection={ this.getAnalyticsSection() }
-				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-				includeWordPressDotCom={ trueNamePromoTlds ? false : includeWordPressDotCom }
-				includeDotBlogSubdomain={ trueNamePromoTlds ? false : this.shouldIncludeDotBlogSubdomain() }
-				isSignupStep
-				isPlanSelectionAvailableInFlow={ isPlanSelectionAvailableInFlow }
-				showExampleSuggestions={ showExampleSuggestions }
-				suggestion={ initialQuery }
-				designType={ this.getDesignType() }
-				vendor={ getSuggestionsVendor( { isSignup: true, isDomainOnly: this.props.isDomainOnly } ) }
-				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
-				selectedSite={ this.props.selectedSite }
-				showSkipButton={ this.props.showSkipButton }
-				vertical={ this.props.vertical }
-				onSkip={ this.handleSkip }
-				hideFreePlan={ this.handleSkip }
-				forceHideFreeDomainExplainerAndStrikeoutUi={
-					this.props.forceHideFreeDomainExplainerAndStrikeoutUi
-				}
-				isReskinned={ this.props.isReskinned }
-			/>
+			<CalypsoShoppingCartProvider>
+				<RegisterDomainStep
+					key="domainForm"
+					path={ this.props.path }
+					initialState={ initialState }
+					onAddDomain={ this.handleAddDomain }
+					products={ this.props.productsList }
+					basePath={ this.props.path }
+					promoTlds={ trueNamePromoTlds }
+					mapDomainUrl={ this.getMapDomainUrl() }
+					transferDomainUrl={ this.getTransferDomainUrl() }
+					useYourDomainUrl={ this.getUseYourDomainUrl() }
+					onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
+					onSave={ this.handleSave.bind( this, 'domainForm' ) }
+					offerUnavailableOption={ ! this.props.isDomainOnly }
+					isDomainOnly={ this.props.isDomainOnly }
+					analyticsSection={ this.getAnalyticsSection() }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					includeWordPressDotCom={ trueNamePromoTlds ? false : includeWordPressDotCom }
+					includeDotBlogSubdomain={
+						trueNamePromoTlds ? false : this.shouldIncludeDotBlogSubdomain()
+					}
+					isSignupStep
+					isPlanSelectionAvailableInFlow={ isPlanSelectionAvailableInFlow }
+					showExampleSuggestions={ showExampleSuggestions }
+					suggestion={ initialQuery }
+					designType={ this.getDesignType() }
+					vendor={ getSuggestionsVendor( {
+						isSignup: true,
+						isDomainOnly: this.props.isDomainOnly,
+					} ) }
+					deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
+					selectedSite={ this.props.selectedSite }
+					showSkipButton={ this.props.showSkipButton }
+					vertical={ this.props.vertical }
+					onSkip={ this.handleSkip }
+					hideFreePlan={ this.handleSkip }
+					forceHideFreeDomainExplainerAndStrikeoutUi={
+						this.props.forceHideFreeDomainExplainerAndStrikeoutUi
+					}
+					isReskinned={ this.props.isReskinned }
+				/>
+			</CalypsoShoppingCartProvider>
 		);
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This replaces the `CartData` wrapper around `RegisterDomainStep` with `withShoppingCart`. This will help us eventually remove `CartData` (see https://github.com/Automattic/wp-calypso/issues/24019).

The only thing I wasn't able to determine is if there was a reason why `CartData` was [only being used in signup](https://github.com/Automattic/wp-calypso/blob/369e0272cb8fa7de2014c8fb98cffab2051ee72c/client/signup/steps/domains/index.jsx#L526-L528) if `'launch-site' === this.props.flowName`. If the cart should be ignored otherwise, we may need to add some additional logic inside `RegisterDomainStep` to ignore `cart` in that case. That code originated in https://github.com/Automattic/wp-calypso/pull/42162 so I'm pinging @eltongo for advice!

#### Testing instructions

Unknown. Help me Obi Wan Cobalt! You're my only hope! 