### PR TITLE
Checkout: Update G Suite nudge to replace CartData with withShoppingCart

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -34,7 +34,7 @@ import UpsellNudge, {
 	CONCIERGE_SUPPORT_SESSION,
 	CONCIERGE_QUICKSTART_SESSION,
 } from './upsell-nudge';
-import CalypsoShoppingCartProvider from 'client/my-sites/checkout/calypso-shopping-cart-provider';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 export function checkout( context, next ) {
 	const { feature, plan, domainOrProduct, purchaseId } = context.params;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -34,6 +34,7 @@ import UpsellNudge, {
 	CONCIERGE_SUPPORT_SESSION,
 	CONCIERGE_QUICKSTART_SESSION,
 } from './upsell-nudge';
+import CalypsoShoppingCartProvider from 'client/my-sites/checkout/calypso-shopping-cart-provider';
 
 export function checkout( context, next ) {
 	const { feature, plan, domainOrProduct, purchaseId } = context.params;
@@ -175,13 +176,13 @@ export function gsuiteNudge( context, next ) {
 	}
 
 	context.primary = (
-		<CheckoutContainer purchaseId={ Number( receiptId ) }>
+		<CalypsoShoppingCartProvider>
 			<GSuiteNudge
 				domain={ domain }
 				receiptId={ Number( receiptId ) }
 				selectedSiteId={ selectedSite.ID }
 			/>
-		</CheckoutContainer>
+		</CalypsoShoppingCartProvider>
 	);
 
 	next();

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -20,7 +20,6 @@ import QuerySites from 'calypso/components/data/query-sites';
 import { getSiteSlug, getSiteTitle } from 'calypso/state/sites/selectors';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
 import isEligibleForDotcomChecklist from 'calypso/state/selectors/is-eligible-for-dotcom-checklist';
-import { getAllCartItems } from 'calypso/lib/cart-values/cart-items';
 import { isDotComPlan } from 'calypso/lib/products-values';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
@@ -61,7 +60,6 @@ export class GSuiteNudge extends React.Component {
 
 	handleAddEmailClick = ( cartItems ) => {
 		const { siteSlug, receiptId, productsList } = this.props;
-		this.removePlanFromCart();
 
 		this.props.shoppingCartManager
 			.addProductsToCart(
@@ -76,12 +74,6 @@ export class GSuiteNudge extends React.Component {
 			.then( () => {
 				this.isMounted && page( `/checkout/${ siteSlug }` );
 			} );
-	};
-
-	removePlanFromCart = () => {
-		const items = getAllCartItems( this.props.cart );
-		const filteredProducts = items.filter( isDotComPlan );
-		this.props.shoppingCartManager.replaceProductsInCart( filteredProducts );
 	};
 
 	render() {

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -25,6 +25,7 @@ import { isDotComPlan } from 'calypso/lib/products-values';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductsList } from 'calypso/state/products-list/selectors/get-products-list';
+import getThankYouPageUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url';
 
 /**
  * Style dependencies
@@ -39,7 +40,13 @@ export class GSuiteNudge extends React.Component {
 	};
 
 	handleSkipClick = () => {
-		this.props.handleCheckoutCompleteRedirect();
+		const getThankYouPageUrlArguments = {
+			siteSlug: this.props.siteSlug,
+			receiptId: this.props.receiptId,
+			cart: this.props.cart,
+		};
+		const url = getThankYouPageUrl( getThankYouPageUrlArguments );
+		page.redirect( url );
 	};
 
 	handleAddEmailClick = ( cartItems ) => {

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -74,7 +74,7 @@ export class GSuiteNudge extends React.Component {
 					.map( ( item ) => fillInSingleCartItemAttributes( item, productsList ) )
 			)
 			.then( () => {
-				this.props.isMounted && page( `/checkout/${ siteSlug }` );
+				this.isMounted && page( `/checkout/${ siteSlug }` );
 			} );
 	};
 

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -39,6 +39,16 @@ export class GSuiteNudge extends React.Component {
 		selectedSiteId: PropTypes.number.isRequired,
 	};
 
+	isMounted = false;
+
+	componentDidMount() {
+		this.isMounted = true;
+	}
+
+	componentWillUnmount() {
+		this.isMounted = false;
+	}
+
 	handleSkipClick = () => {
 		const getThankYouPageUrlArguments = {
 			siteSlug: this.props.siteSlug,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the `GSuiteNudge` component to replace `CartData` with `useShoppingCart`. This should help us eventually remove `CartData` (see https://github.com/Automattic/wp-calypso/issues/24019).

#### Testing instructions

~I'm not sure how to trigger this upsell naturally. Pinging @stephanethomas for assistance please!~ Turns out this is disabled.

You can force it though by visiting `/checkout/:site/with-gsuite/:domain/:receiptId?` (eg: http://calypso.localhost:3000/checkout/example.com/with-gsuite/example.com)

- Visit the G Suite upsell page (see above).
- Click "Skip for now" and verify that you are redirected to a thank-you page.
- Fill out the form and click "Purchase G Suite" and verify that you are redirected to checkout with the G Suite product in the cart. 
