### PR TITLE
Include `home` to the eligible JITM messaging paths.

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -182,7 +182,6 @@ class Layout extends Component {
 		}
 
 		const { shouldShowAppBanner } = this.props;
-
 		return (
 			<div className={ sectionClass }>
 				<QueryExperiments />

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -182,6 +182,7 @@ class Layout extends Component {
 		}
 
 		const { shouldShowAppBanner } = this.props;
+
 		return (
 			<div className={ sectionClass }>
 				<QueryExperiments />
@@ -291,9 +292,14 @@ export default compose(
 			wooDnaConfig( currentQuery ).isWooDnaFlow();
 		const oauth2Client = getCurrentOAuth2Client( state );
 		const wccomFrom = currentQuery?.[ 'wccom-from' ];
-		const isEligibleForJITM = [ 'stats', 'plans', 'themes', 'plugins', 'comments' ].includes(
-			sectionName
-		);
+		const isEligibleForJITM = [
+			'home',
+			'stats',
+			'plans',
+			'themes',
+			'plugins',
+			'comments',
+		].includes( sectionName );
 		const isNewLaunchFlow = startsWith( currentRoute, '/start/new-launch' );
 
 		return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds `/home` path to the eligible JITM messaging path.

#### Testing instructions

The only application for this JITM path for now is code-D54419. Please follow the test instruction there.
