### PR TITLE
E2E: Fix failing signup test stuck on upsell page

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -288,6 +288,7 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 		return (
 			<footer className="business-plan-upgrade-upsell__footer">
 				<Button
+					data-e2e-button="decline"
 					className="business-plan-upgrade-upsell__decline-offer-button"
 					onClick={ handleClickDecline }
 				>

--- a/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
@@ -257,6 +257,7 @@ export class ConciergeQuickstartSession extends PureComponent {
 				{ isLoggedIn && (
 					<>
 						<Button
+							data-e2e-button="decline"
 							className="concierge-quickstart-session__decline-offer-button"
 							onClick={ handleClickDecline }
 						>

--- a/client/my-sites/checkout/upsell-nudge/concierge-support-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-support-session/index.jsx
@@ -205,6 +205,7 @@ export class ConciergeSupportSession extends PureComponent {
 		return (
 			<footer className="concierge-support-session__footer">
 				<Button
+					data-e2e-button="decline"
 					className="concierge-support-session__decline-offer-button"
 					onClick={ handleClickDecline }
 				>

--- a/client/my-sites/checkout/upsell-nudge/premium-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/premium-plan-upgrade-upsell/index.jsx
@@ -230,6 +230,7 @@ export class PremiumPlanUpgradeUpsell extends PureComponent {
 		return (
 			<footer className="premium-plan-upgrade-upsell__footer">
 				<Button
+					data-e2e-button="decline"
 					className="premium-plan-upgrade-upsell__decline-offer-button"
 					onClick={ handleClickDecline }
 				>

--- a/test/e2e/lib/pages/signup/upsell-page.js
+++ b/test/e2e/lib/pages/signup/upsell-page.js
@@ -11,14 +11,19 @@ import AsyncBaseContainer from '../../async-base-container';
 
 export default class UpsellPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.concierge-quickstart-session, .plan-upgrade-upsell' ) );
+		super(
+			driver,
+			By.css(
+				'.concierge-quickstart-session, .premium-plan-upgrade-upsell, .business-plan-upgrade-upsell'
+			)
+		);
 	}
 
 	async declineOffer() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css(
-				'.concierge-quickstart-session__decline-offer-button, .plan-upgrade-upsell__decline-offer-button'
+				'.concierge-quickstart-session__decline-offer-button, .business-plan-upgrade-upsell__decline-offer-button, .premium-plan-upgrade-upsell__decline-offer-button'
 			)
 		);
 	}

--- a/test/e2e/lib/pages/signup/upsell-page.js
+++ b/test/e2e/lib/pages/signup/upsell-page.js
@@ -22,9 +22,7 @@ export default class UpsellPage extends AsyncBaseContainer {
 	async declineOffer() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css(
-				'.concierge-quickstart-session__decline-offer-button, .business-plan-upgrade-upsell__decline-offer-button, .premium-plan-upgrade-upsell__decline-offer-button'
-			)
+			By.css( 'button[data-e2e-button="decline"]' )
 		);
 	}
 }


### PR DESCRIPTION
**Context**: class names on the upsell page were changed in #47948 from `.plan-upgrade-upsell*` to `.{PLAN_NAME}-plan-upgrade-upsell*` and this was breaking the e2e signup tests that got to that page.

#### Changes proposed in this Pull Request

* Update page selectors used in UpsellPage
* Add `data-e2e-button="decline"` attr to Decline buttons on upsell pages and use it in e2e test.

#### Testing instructions

* `wp-signup-spec` should pass

Fixes p1608109879204000-slack-C1A1EKDGQ