### PR TITLE
remove `userSettings` prop from route components where its unnecessary

### DIFF
--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -39,7 +39,6 @@ export function apps( context, next ) {
 	context.store.dispatch( setTitle( i18n.translate( 'Get Apps', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( AppsComponent, {
-		userSettings: userSettings,
 		path: context.path,
 	} );
 	next();

--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -19,7 +19,6 @@ export function notifications( context, next ) {
 	context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( NotificationsComponent, {
-		userSettings: userSettings,
 		path: context.path,
 	} );
 	next();

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -35,7 +35,6 @@ class SecurityCheckupComponent extends React.Component {
 	static propTypes = {
 		path: PropTypes.string,
 		translate: PropTypes.func.isRequired,
-		userSettings: PropTypes.object,
 	};
 
 	render() {

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -47,7 +47,6 @@ export function twoStep( context, next ) {
 
 export function connectedApplications( context, next ) {
 	context.primary = React.createElement( ConnectedAppsComponent, {
-		userSettings: userSettings,
 		path: context.path,
 	} );
 	next();

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -84,7 +84,6 @@ export function socialLogin( context, next ) {
 		path: context.path,
 		socialService,
 		socialServiceResponse,
-		userSettings,
 	} );
 	next();
 }

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -63,7 +63,6 @@ export function accountRecovery( context, next ) {
 
 export function securityCheckup( context, next ) {
 	context.primary = React.createElement( SecurityCheckupComponent, {
-		userSettings: userSettings,
 		path: context.path,
 	} );
 	next();

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -54,7 +54,6 @@ export function connectedApplications( context, next ) {
 
 export function accountRecovery( context, next ) {
 	context.primary = React.createElement( AccountRecoveryComponent, {
-		userSettings: userSettings,
 		path: context.path,
 	} );
 	next();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As we're going forward removing `lib/user-settings` this PR attempts to remove the `userSettings` prop from route components which don't make any use of it. Therefore it's 

#### Testing instructions

* Test the following routes and make sure they load fine without any errors and the UI renders as expected:
  * `/me/notifications`
  * `/me/security`
  * `/me/security/connected-applications`
  * `/me/security/account-recovery`
  * `/me/security/social-login`
  * `/me/get-apps`
* You may also look at the mentioned components' code and make sure `userSettings` isn't used there

part of #24162 
