### PR TITLE
New Onboarding: Social Signup Experiment

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -31,7 +31,8 @@ import {
 } from '../../lib/analytics';
 import { localizeUrl } from '../../../../lib/i18n-utils';
 import { useTrackModal } from '../../hooks/use-track-modal';
-import config from '../../../../config';
+import config, { isEnabled } from '../../../../config';
+import LoginStep from '../../onboarding-block/login';
 
 interface Props {
 	onRequestClose: () => void;
@@ -257,6 +258,10 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 						</div>
 					</fieldset>
 				</form>
+				{
+					/* Temporary spot for social login button */
+					isEnabled( 'gutenboarding/social-login' ) && <LoginStep />
+				}
 			</div>
 
 			<div id="g-recaptcha"></div>

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -44,6 +44,11 @@
 		padding: 44px 20px 0;
 		text-align: center;
 
+		// Accomodate social login temporarily
+		form {
+			margin-bottom: 20px;
+		}
+
 		@include break-mobile {
 			padding: 0 20px 20px;
 			position: absolute;

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -22,6 +22,8 @@ import Features from './features';
 import Plans from './plans';
 import Domains from './domains';
 import Language from './language';
+import Login from './login';
+import { isEnabled } from 'calypso/config';
 
 import './colors.scss';
 import './style.scss';
@@ -123,6 +125,12 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 				</Route>
 
 				<Route path={ makePath( Step.CreateSite ) }>{ createSiteOrError() }</Route>
+
+				{ isEnabled( 'gutenboarding/social-login' ) && (
+					<Route path={ makePath( Step.Login ) }>
+						<Login />
+					</Route>
+				) }
 			</Switch>
 		</div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/login/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/login/index.tsx
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { Provider } from 'react-redux';
+import * as React from 'react';
+import { useI18n } from '@automattic/react-i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import config from 'calypso/config';
+import { createReduxStore } from 'calypso/state';
+import { setStore } from 'calypso/state/redux-store';
+import GoogleLoginButton from 'calypso/components/social-buttons/google';
+import AppleLoginButton from 'calypso/components/social-buttons/apple';
+import { USER_STORE } from '../../stores/user';
+
+const store = createReduxStore();
+setStore( store );
+
+interface Props {
+	test?: boolean;
+}
+
+const LoginStep: React.FunctionComponent< Props > = () => {
+	const { __ } = useI18n();
+
+	const { createSocialAccount } = useDispatch( USER_STORE );
+
+	const handleGoogleResponse = async ( response ) => {
+		if ( ! response.getAuthResponse ) {
+			return;
+		}
+
+		console.log( 'googleAuthResponse', response );
+
+		const tokens = response.getAuthResponse();
+
+		if ( ! tokens || ! tokens.access_token || ! tokens.id_token ) {
+			return;
+		}
+
+		const result = await createSocialAccount( {
+			service: 'google',
+			id_token: tokens.id_token,
+			access_token: tokens.access_token,
+		} );
+
+		if ( result.ok ) {
+			// Nothing to do here because receiveNewUser() action
+			// will cause a domino effect elsewhere where site will
+			// be creted and later redirected to cart or block editor.
+		}
+	};
+
+	const handleAppleResponse = async ( response ) => {
+		if ( ! response.id_token ) {
+			return;
+		}
+
+		const extraUserData = response.user && {
+			user_name: response.user.name,
+			user_email: response.user.email,
+		};
+
+		console.log( 'appleAuthResponse', response );
+
+		const result = await createSocialAccount( {
+			service: 'apple',
+			id_token: tokens.id_token,
+			access_token: tokens.access_token,
+			...extraUserData,
+		} );
+
+		if ( result.ok ) {
+			// Nothing to do here because receiveNewUser() action
+			// will cause a domino effect elsewhere where site will
+			// be creted and later redirected to cart or block editor.
+		}
+	};
+
+	return (
+		<div className="gutenboarding-page login">
+			<Provider store={ store }>
+				<GoogleLoginButton
+					clientId={ config( 'google_oauth_client_id' ) }
+					responseHandler={ handleGoogleResponse }
+					// onClick={ // TODO: Tracking? See trackSocialLogin(). }
+				/>
+				<AppleLoginButton
+					// FIX: TS issue - not sure why clientId is an invalid prop.
+					clientId={ config( 'apple_oauth_client_id' ) }
+					responseHandler={ handleAppleResponse }
+					// onClick={ // TODO: Tracking? See trackSocialLogin(). }
+				/>
+			</Provider>
+		</div>
+	);
+};
+
+export default LoginStep;

--- a/config/development.json
+++ b/config/development.json
@@ -73,6 +73,7 @@
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/show-vertical-input": false,
+		"gutenboarding/social-login": false,
 		"help": true,
 		"help/courses": true,
 		"home/layout-dev": true,

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -9,11 +9,21 @@ import { stringify } from 'qs';
 import type {
 	CurrentUser,
 	CreateAccountParams,
+	CreateSocialAccountParams,
 	NewUserErrorResponse,
 	NewUserSuccessResponse,
 } from './types';
 import { wpcomRequest, requestAllBlogsAccess, reloadProxy } from '../wpcom-request-controls';
 import type { WpcomClientCredentials } from '../shared-types';
+
+// Temporarily put it here
+function stringifyBody( bodyObj ) {
+	// Clone bodyObj, replacing null or undefined values with empty strings.
+	const body = Object.fromEntries(
+		Object.entries( bodyObj ?? {} ).map( ( [ key, val ] ) => [ key, val ?? '' ] )
+	);
+	return new globalThis.URLSearchParams( body ).toString();
+}
 
 export function createActions( clientCreds: WpcomClientCredentials ) {
 	const receiveCurrentUser = ( currentUser: CurrentUser ) => ( {
@@ -80,6 +90,76 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		}
 	}
 
+	function* createSocialAccount( params: CreateSocialAccountParams ) {
+		yield fetchNewUser();
+		try {
+			// This endpoint will create user if it doesn't exist
+			// wpcom-json-endpoints/class.wpcom-json-api-users-social-endpoint.php
+			// You can identify if this is a newly created user by checking the
+			// `created: true` property in the response.
+			const newUser = yield wpcomRequest( {
+				body: {
+					signup_flow_name: 'gutenboarding',
+					locale: 'en',
+					...clientCreds,
+					...params,
+				},
+				path: '/users/social/new',
+				apiVersion: '1.1',
+				method: 'post',
+				query: stringify( {
+					http_envelope: 1,
+					locale: params.locale,
+				} ),
+			} );
+
+			console.log( 'newUser', newUser );
+
+			// Even though the newUser object is received from the above API,
+			// it doesn't log the user in (missing wp_set_auth_cookie()
+			// in the previous request), so we need to do another request
+			// to log user in.
+			const loginResponse = yield window
+				.fetch(
+					`https://wordpress.com/wp-login.php?action=social-login-endpoint&locale=${
+						params.locale || 'en'
+					}`,
+					{
+						method: 'POST',
+						credentials: 'include',
+						headers: {
+							Accept: 'application/json',
+							'Content-Type': 'application/x-www-form-urlencoded',
+						},
+						body: stringifyBody( {
+							...params,
+							...clientCreds,
+						} ),
+					}
+				)
+				.then( ( response ) => {
+					// TODO: Error handling
+					return { body: response.json() };
+				} );
+
+			console.log( 'loginResponse', loginResponse );
+
+			// Not sure if these are needed but just call them anyway
+			yield reloadProxy();
+
+			// Not sure if these are needed but just call them anyway
+			// Need to rerequest access after the proxy is reloaded
+			yield requestAllBlogsAccess();
+
+			yield receiveNewUser( newUser );
+
+			return { ok: true } as const;
+		} catch ( newUserError ) {
+			yield receiveNewUserFailed( newUserError );
+			return { ok: false, newUserError } as const;
+		}
+	}
+
 	return {
 		receiveCurrentUser,
 		receiveCurrentUserFailed,
@@ -88,7 +168,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveNewUserFailed,
 		clearErrors,
 		createAccount,
-	};
+		createSocialAccount,
+	} as const;
 }
 
 type ActionCreators = ReturnType< typeof createActions >;
@@ -101,6 +182,8 @@ export type Action =
 			| ActionCreators[ 'receiveNewUser' ]
 			| ActionCreators[ 'receiveNewUserFailed' ]
 			| ActionCreators[ 'clearErrors' ]
+			| ActionCreators[ 'createAccount' ]
+			| ActionCreators[ 'createSocialAccount' ]
 	  >
 	// Type added so we can dispatch actions in tests, but has no runtime cost
 	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/user/types.ts
+++ b/packages/data-stores/src/user/types.ts
@@ -76,6 +76,16 @@ export interface CreateAccountParams {
 	};
 }
 
+export interface CreateSocialAccountParams {
+	service: 'google' | 'apple';
+	id_token: string;
+	access_token?: string; // google specific
+	user_name?: string; // apple specific
+	user_email?: string; // apple specific
+	signup_flow_name?: string;
+	locale?: string;
+}
+
 export interface CreateAccountAction extends Action {
 	params?: CreateAccountParams;
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

DO NOT MERGE this PR.
This is an spike PR to see how social login can be implemented.
It is rough and ignores all code cleanliness & TS issues.

Video: https://drive.google.com/file/d/1HYUdrQg_9sU2feeIOh2nY0B6BPkeycwe/view
(just ignore places where I'm going through the `debugger;` breakpoints).

## Testing instructions

**Getting to the signup page**

1. Open up an incognito window.
2. Go to `/new?flags=gutenboarding/social-login` and follow through all steps until you reach the signup page.
   * Or go directly to `/new/login?flags=gutenboarding/social-login` to test faster (but this will only show the social buttons and nothing else).

**Testing a new Google account not linked with WP**
1. Create a new Google account.
2. Connect using your new Google account using the social login button.
3. It will:
    * Create a new WP account in the background
    * Login with your new WP account in the background
    * Continue with the usual creation site and then redirection to block editor or cart depending on the plan chosen.
4. Go to `/me`, you should see your newly created user.
   
**Testing with an existing Google account that is already linked to WP**

Repeat the steps above. You can reuse the same Google account.

After completing the above steps and going back to `/me`, you should still see the same user, not a new user.

Note: Closing & reopening incognito window will remember your previously logged-in user. So you might want to logout in your incognito window before testing again.

**Known Issues**
1. New social sign-in that matches an existing the email of an WP account will fail, as WP's behaviour is to ask user to login using username and password instead, and there is no UI fallback implemented for this at the moment.
2. Existing social sign-in to an existing WP account that as 2FA enabled will fail, as there is no UI fallback implemented for this at the moment.

**Screenshot**
![image](https://user-images.githubusercontent.com/1287077/102475332-66c39b00-4062-11eb-91c7-7afee4ef96f0.png)
