### PR TITLE
Editing Toolkit: Update to 2.8.15

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.14
+ * Version: 2.8.15
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.14' );
+define( 'PLUGIN_VERSION', '2.8.15' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.14
+Stable tag: 2.8.15
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,12 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.15 =
+* Page layout selector: Use description of the templates as label for screen readers. (https://github.com/Automattic/wp-calypso/pull/48128)
+* Remove usages of lodash trimEnd(). (https://github.com/Automattic/wp-calypso/pull/48255)
+* NUX: New Welcome Tour Component. (https://github.com/Automattic/wp-calypso/pull/47779)
+* NUX: Custom Welcome Guide for Anchor users. (https://github.com/Automattic/wp-calypso/pull/48357)
 
 = 2.8.14 =
 * Premium Patterns: add pink dot to indicate a premium pattern in the inserter. (https://github.com/Automattic/wp-calypso/pull/47896)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -46,6 +46,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Patterns: Swap `can_register_pattern` logic from using a tag, to using `pattern_meta` instead (https://github.com/Automattic/wp-calypso/pull/48330)
 * NUX: New Welcome Tour Component (https://github.com/Automattic/wp-calypso/pull/47779)
 * NUX: Custom Welcome Guide for Anchor users (https://github.com/Automattic/wp-calypso/pull/48357)
+* Newspack Blocks: Update to 1.17.0 (https://github.com/Automattic/wp-calypso/pull/48450)
 
 = 2.8.14 =
 * Premium Patterns: add pink dot to indicate a premium pattern in the inserter. (https://github.com/Automattic/wp-calypso/pull/47896)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -46,7 +46,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Patterns: Swap `can_register_pattern` logic from using a tag, to using `pattern_meta` instead (https://github.com/Automattic/wp-calypso/pull/48330)
 * NUX: New Welcome Tour Component (https://github.com/Automattic/wp-calypso/pull/47779)
 * NUX: Custom Welcome Guide for Anchor users (https://github.com/Automattic/wp-calypso/pull/48357)
-* Newspack Blocks: Update to 1.17.0 (https://github.com/Automattic/wp-calypso/pull/48450)
+* Newspack Blocks: Update to 1.17.1 (https://github.com/Automattic/wp-calypso/pull/48456)
 
 = 2.8.14 =
 * Premium Patterns: add pink dot to indicate a premium pattern in the inserter. (https://github.com/Automattic/wp-calypso/pull/47896)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -41,10 +41,11 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 2.8.15 =
-* Page layout selector: Use description of the templates as label for screen readers. (https://github.com/Automattic/wp-calypso/pull/48128)
-* Remove usages of lodash trimEnd(). (https://github.com/Automattic/wp-calypso/pull/48255)
-* NUX: New Welcome Tour Component. (https://github.com/Automattic/wp-calypso/pull/47779)
-* NUX: Custom Welcome Guide for Anchor users. (https://github.com/Automattic/wp-calypso/pull/48357)
+* Page layout selector: Use description of the templates as label for screen readers (https://github.com/Automattic/wp-calypso/pull/48128)
+* Remove usages of lodash trimEnd() (https://github.com/Automattic/wp-calypso/pull/48255)
+* Patterns: Swap `can_register_pattern` logic from using a tag, to using `pattern_meta` instead (https://github.com/Automattic/wp-calypso/pull/48330)
+* NUX: New Welcome Tour Component (https://github.com/Automattic/wp-calypso/pull/47779)
+* NUX: Custom Welcome Guide for Anchor users (https://github.com/Automattic/wp-calypso/pull/48357)
 
 = 2.8.14 =
 * Premium Patterns: add pink dot to indicate a premium pattern in the inserter. (https://github.com/Automattic/wp-calypso/pull/47896)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.14",
+	"version": "2.8.15",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bumps version of Editing Toolkit to 2.8.15

#### [Changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)

* Page layout selector: Use description of the templates as label for screen readers (https://github.com/Automattic/wp-calypso/pull/48128)
* Remove usages of lodash trimEnd() (https://github.com/Automattic/wp-calypso/pull/48255)
* Patterns: Swap can_register_pattern logic from using a tag, to using pattern_meta instead (https://github.com/Automattic/wp-calypso/pull/48330)
* NUX: New Welcome Tour Component (https://github.com/Automattic/wp-calypso/pull/47779)
* NUX: Custom Welcome Guide for Anchor users (https://github.com/Automattic/wp-calypso/pull/48357)
* Newspack Blocks: Update to 1.17.1 (https://github.com/Automattic/wp-calypso/pull/48456).

#### Testing instructions

* Apply D54434-code to your sandbox and confirm that the above changes work correctly.
  * https://github.com/Automattic/wp-calypso/pull/48128:
    * Enable voiceover (on Mac: Command + F5)
    * Go to Pages > Add New Page in Calypso
    * Tab through the list of templates
    * Make sure the description of the templates is announced by VoiceOver (not all templates have a description)
    * ![](https://user-images.githubusercontent.com/2256104/101770334-9c0f3c80-3ae8-11eb-8ccd-16eb807d1d5f.gif)
  * https://github.com/Automattic/wp-calypso/pull/48255:
    * Go to Posts > Add New Post in Calypso
    * Insert a Premium Content block (requires a Premium plan)
    * Check the block settings in the sidebar and make sure all the currencies are displayed without a dot at the end
    * <img width="120" alt="Screen Shot 2020-12-18 at 12 39 18" src="https://user-images.githubusercontent.com/1233880/102610787-1154c000-412e-11eb-82e9-79555b3347c5.png">
  * https://github.com/Automattic/wp-calypso/pull/48330:
    * In your sandbox's `0-sandbox.ph` file add the following to ensure you're using fresh results from the patterns API that include the appropriate tags: `define( 'WP_DISABLE_PATTERN_CACHE', true );`
    * Switch to a theme with align-wide support (e.g. any of the suggested themes / Varia child themes such as Maywood).
    * Go to edit a post or page, click the inserter and in the Patterns tab, under the Gallery category you should see the pattern with the title "Images" and the text within the pattern will include "5am, the beach"
    * <img width="200" alt="Screen Shot 2020-12-18 at 12 46 07" src="https://user-images.githubusercontent.com/1233880/102611357-08b0b980-412f-11eb-8565-585b72ec784a.png">
    * Switch your theme to one that does not support align-wide (e.g. Hemingway Rewritten) and open up a post.
    * In the inserter, under the Gallery category, you should not be able to see the pattern in question ("Images" with the "5am, the beach" text).
  * https://github.com/Automattic/wp-calypso/pull/48357:
    * Mark your site as a podcasting site:
      * Open a WP shell in your WP.com sandbox: `wp shell --user=<YOUR_WPCOM_USERNAME> --url=<YOUR_SITE_ADDRESS>.`
      * Require the Anchor lib: `require_once( WP_CONTENT_DIR . '/lib/anchor.php' );`
      * Update the site : `\A8C\Anchor\mark_site_as_podcasting_site( <SITE_ID>, 'test_podcast_id' );`.
    * Go to Posts > Add New Post in Calypso and add these params to the editor URL: `?anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d834c0d8222138&spotify_show_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q` 
    * Open the "Options" menu (aka 3 dots) and click on "Welcome guide".
    * Make sure the custom Welcome guide for Anchor is displayed (first step: "Create your first episode")
    * <img width="400" alt="Screen Shot 2020-12-18 at 12 56 33" src="https://user-images.githubusercontent.com/1233880/102612206-9d67e700-4130-11eb-8a68-f0d9d2c12d0e.png">
  * https://github.com/Automattic/wp-calypso/pull/47779:
    * In your sandbox's `0-sandbox.ph` file add the following to enable the new welcome tour: `define( 'SHOW_WELCOME_TOUR', true );`
    * Go to Posts > Add New Post in Calypso
    * Open the "Options" menu (aka 3 dots) and click on "Welcome guide".
    * You should see the new welcome guide in the bottom left corner
    * <img width="200" alt="Screen Shot 2020-12-18 at 12 52 05" src="https://user-images.githubusercontent.com/1233880/102611744-d9e71300-412f-11eb-818c-46648714dd4d.png">
  * https://github.com/Automattic/wp-calypso/pull/48456
    * Go to Posts > Add New Post in Calypso
    * Insert some Newspack blocks (Blog Posts, Post Carousel) and smoke test them.
    * Make sure they work as expected.
  

* Test that the new version of the plugin doesn't break Atomic sites as outlined in PCYsg-ly5-p2#atomic-testing.