### PR TITLE
i18n: Propagate locale in login flow redirects

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -94,7 +94,9 @@ class Login extends Component {
 	componentDidMount() {
 		if ( ! this.props.twoFactorEnabled && this.props.twoFactorAuthType ) {
 			// Disallow access to the 2FA pages unless the user has 2FA enabled
-			page( login( { isNative: true, isJetpack: this.props.isJetpack } ) );
+			page(
+				login( { isNative: true, isJetpack: this.props.isJetpack, locale: this.props.locale } )
+			);
 		}
 
 		window.scrollTo( 0, 0 );
@@ -152,6 +154,7 @@ class Login extends Component {
 					isGutenboarding: this.props.isGutenboarding,
 					// If no notification is sent, the user is using the authenticator for 2FA by default
 					twoFactorAuthType: authType,
+					locale: this.props.locale,
 				} )
 			);
 		}
@@ -165,6 +168,7 @@ class Login extends Component {
 				login( {
 					isNative: true,
 					socialConnect: true,
+					locale: this.props.locale,
 				} )
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pass the locale prop to the `login` path helper in login block to preserve the locale in the redirected URL.

#### Testing instructions

* Checkout the branch locally or open calypso.live build URL in a non-logged tab
* Navigate to `/log-in/fr` and log in to an account with enabled 2FA.
* Confirm that after submitting the password, all translations for the specific language are displayed properly and the redirected URL still has the locale parameter, i.e. `/log-in/{auth_type}/{locale}`
* Open a new non-logged tab and go straight to `/log-in/push/fr`. Confirm you get redirected to the initial login screen and the locale param is preserved in the URL, i.e. `/log-in/fr`
* Additionally, repeat the same steps for `/log-in/new/fr`

Fixes ##23126
