### PR TITLE
Focused Launch: Only launch site if checkout is complete

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -21,17 +21,11 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 	render: function LaunchSidebar() {
 		const currentSiteId = window._currentSiteId;
 
-		const [ isFocusedLaunchOpen, shouldDisplaySuccessView, isSiteLaunched ] = useSelect(
-			( select ) => {
-				const { isFocusedLaunchOpen, shouldDisplaySuccessView } = select( LAUNCH_STORE ).getState();
+		const [ isFocusedLaunchOpen, isSiteLaunched ] = useSelect( ( select ) => {
+			const { isFocusedLaunchOpen } = select( LAUNCH_STORE ).getState();
 
-				return [
-					isFocusedLaunchOpen,
-					shouldDisplaySuccessView,
-					select( SITE_STORE ).isSiteLaunched( currentSiteId ),
-				];
-			}
-		);
+			return [ isFocusedLaunchOpen, select( SITE_STORE ).isSiteLaunched( currentSiteId ) ];
+		} );
 
 		// Add a class to hide the Launch button from editor bar when site is launched
 		React.useEffect( () => {
@@ -40,7 +34,7 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 			}
 		}, [ isSiteLaunched ] );
 
-		return isFocusedLaunchOpen || shouldDisplaySuccessView ? (
+		return isFocusedLaunchOpen ? (
 			<FocusedLaunchModal
 				locale={ window.wpcomEditorSiteLaunch?.locale }
 				openCheckout={ openCheckout }

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -9,6 +9,7 @@ import FocusedLaunchModal from '@automattic/launch';
 /**
  * Internal dependencies
  */
+import { inIframe } from '../../block-inserter-modifications/contextual-tips/utils';
 import { LAUNCH_STORE, SITE_STORE } from './stores';
 import { openCheckout, redirectToWpcomPath, getCurrentLaunchFlowUrl } from './utils';
 
@@ -46,6 +47,7 @@ registerPlugin( 'a8c-editor-editor-focused-launch', {
 				redirectTo={ redirectToWpcomPath }
 				siteId={ currentSiteId }
 				getCurrentLaunchFlowUrl={ getCurrentLaunchFlowUrl }
+				isInIframe={ inIframe() }
 			/>
 		) : null;
 	},

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/constants.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/constants.ts
@@ -2,6 +2,7 @@ export const FLOW_ID = 'gutenboarding';
 export const GUTENBOARDING_LAUNCH_FLOW = 'gutenboarding-launch';
 export const FOCUSED_LAUNCH_FLOW = 'focused-launch';
 export const SITE_LAUNCH_FLOW = 'launch-site';
+export const IMMEDIATE_LAUNCH_QUERY_ARG = 'should_launch';
 declare global {
 	interface Window {
 		wpcomEditorSiteLaunch?: {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
@@ -3,7 +3,7 @@
  */
 import { doAction, hasAction } from '@wordpress/hooks';
 import { addQueryArgs } from '@wordpress/url';
-import { FOCUSED_LAUNCH_FLOW } from './constants';
+import { FOCUSED_LAUNCH_FLOW, IMMEDIATE_LAUNCH_QUERY_ARG } from './constants';
 
 interface CalypsoifyWindow extends Window {
 	currentSiteId?: number;
@@ -50,7 +50,7 @@ export const openCheckout = (
 			checkoutOnSuccessCallback: onSuccessCallback,
 			isFocusedLaunch: true,
 			redirectTo: addQueryArgs( urlWithoutArgs, {
-				should_launch: true,
+				[ IMMEDIATE_LAUNCH_QUERY_ARG ]: true,
 			} ),
 		} );
 		return;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
@@ -34,13 +34,19 @@ export const getCurrentLaunchFlowUrl = (): string | undefined => {
 	}
 };
 
-export const openCheckout = ( siteSlug: string, isEcommerce = false ): void => {
+export const openCheckout = (
+	siteSlug: string = window?.currentSiteId?.toString() || '',
+	isEcommerce = false,
+	onSuccessCallback?: () => void
+): void => {
 	const HOOK_OPEN_CHECKOUT_MODAL = 'a8c.wpcom-block-editor.openCheckoutModal';
 	const isFocusedLaunchFlow = window?.wpcomEditorSiteLaunch?.launchFlow === FOCUSED_LAUNCH_FLOW;
 
 	// only in focused launch, open checkout modal assuming the cart is already updated
 	if ( hasAction( HOOK_OPEN_CHECKOUT_MODAL ) && isFocusedLaunchFlow ) {
-		doAction( HOOK_OPEN_CHECKOUT_MODAL );
+		doAction( HOOK_OPEN_CHECKOUT_MODAL, {
+			checkoutOnSuccessCallback: onSuccessCallback,
+		} );
 		return;
 	}
 

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -966,12 +966,12 @@ function handleCheckoutModalOpened( calypsoPort, data ) {
 
 	// Remove checkoutOnSuccessCallback from data to prevent
 	// the `data` object could not be cloned in postMessage()
-	const { checkoutOnSuccessCallback, ...cartData } = data;
+	const { checkoutOnSuccessCallback, ...checkoutModalOptions } = data;
 
 	calypsoPort.postMessage(
 		{
 			action: 'openCheckoutModal',
-			payload: cartData,
+			payload: checkoutModalOptions,
 		},
 		[ port2 ]
 	);

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -4,10 +4,10 @@
 import React, { useMemo, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { Icon, wordpress } from '@wordpress/icons';
-import type { RequestCart } from '@automattic/shopping-cart';
 import { Modal } from '@wordpress/components';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { useTranslate } from 'i18n-calypso';
+import type { RequestCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -27,6 +27,12 @@ import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopp
  */
 import './style.scss';
 
+export interface CheckoutModalOptions {
+	cartData?: RequestCart;
+	redirectTo?: string;
+	isFocusedLaunch?: boolean;
+}
+
 const wpcom = wp.undocumented();
 
 function fetchStripeConfigurationWpcom( args: Record< string, unknown > ) {
@@ -44,7 +50,15 @@ function removeHashFromUrl(): void {
 }
 
 const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
-	const { site, isOpen, onClose, cartData, checkoutOnSuccessCallback } = props;
+	const {
+		site,
+		isOpen,
+		onClose,
+		cartData,
+		redirectTo,
+		isFocusedLaunch,
+		checkoutOnSuccessCallback,
+	} = props;
 
 	const translate = useTranslate();
 
@@ -93,8 +107,9 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 					locale={ props.locale }
 				>
 					<CompositeCheckout
+						redirectTo={ redirectTo } // custom thank-you URL for payments that are processed after a redirect (eg: Paypal)
 						isInEditor
-						isFocusedLaunch={ ! cartData?.products } // we currently know we're not passing cartData from Focused Launch
+						isFocusedLaunch={ isFocusedLaunch }
 						siteId={ site?.ID }
 						siteSlug={ site?.slug }
 						productAliasFromUrl={ commaSeparatedProductSlugs }
@@ -106,14 +121,14 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 	) : null;
 };
 
-type Props = {
+interface Props extends CheckoutModalOptions {
 	site: SiteData | null;
-	cartData?: RequestCart;
 	onClose: () => void;
 	isOpen: boolean;
 	locale: string | undefined;
 	checkoutOnSuccessCallback?: () => void;
-};
+	isFocusedLaunch?: boolean;
+}
 
 EditorCheckoutModal.defaultProps = {
 	site: null,

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -57,7 +57,7 @@ import { REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE } from 'calypso/state/de
 import { setMediaLibrarySelectedItems } from 'calypso/state/media/actions';
 import { fetchMediaItem, getMediaItem } from 'calypso/state/media/thunks';
 import Iframe from './iframe';
-import type { RequestCart } from '@automattic/shopping-cart';
+import type { CheckoutModalOptions } from 'calypso/blocks/editor-checkout-modal';
 
 /**
  * Types
@@ -100,7 +100,7 @@ interface State {
 	multiple?: any;
 	postUrl?: T.URL;
 	previewUrl: T.URL;
-	cartData?: RequestCart;
+	checkoutModalOptions?: CheckoutModalOptions;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -144,7 +144,7 @@ class CalypsoifyIframe extends Component<
 		isPreviewVisible: false,
 		previewUrl: 'about:blank',
 		currentIFrameUrl: '',
-		cartData: undefined,
+		checkoutModalOptions: undefined,
 	};
 
 	iframeRef: React.RefObject< HTMLIFrameElement > = React.createRef();
@@ -297,7 +297,7 @@ class CalypsoifyIframe extends Component<
 			this.checkoutPort = ports[ 0 ];
 			this.setState( {
 				isCheckoutModalVisible: true,
-				cartData: payload,
+				checkoutModalOptions: payload,
 			} );
 		}
 
@@ -726,7 +726,7 @@ class CalypsoifyIframe extends Component<
 			postUrl,
 			editedPost,
 			currentIFrameUrl,
-			cartData,
+			checkoutModalOptions,
 		} = this.state;
 
 		const isUsingClassicBlock = !! classicBlockEditorId;
@@ -773,9 +773,11 @@ class CalypsoifyIframe extends Component<
 						checkoutOnSuccessCallback={ this.handleCheckoutSuccess }
 						require="calypso/blocks/editor-checkout-modal"
 						onClose={ this.closeCheckoutModal }
-						cartData={ cartData }
 						placeholder={ null }
 						isOpen={ isCheckoutModalVisible }
+						cartData={ checkoutModalOptions?.cartData }
+						redirectTo={ checkoutModalOptions?.redirectTo }
+						isFocusedLaunch={ checkoutModalOptions?.isFocusedLaunch }
 					/>
 				) }
 				<AsyncLoad

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -24,6 +24,7 @@ import type {
 } from '@automattic/shopping-cart';
 import colorStudio from '@automattic/color-studio';
 import { useStripe } from '@automattic/calypso-stripe';
+import type { PaymentCompleteCallbackArguments } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -139,6 +140,8 @@ export default function CompositeCheckout( {
 	isNoSiteCart,
 	infoMessage,
 	isInEditor,
+	onAfterPaymentComplete,
+	isFocusedLaunch,
 }: {
 	siteSlug: string | undefined;
 	siteId: number | undefined;
@@ -155,6 +158,8 @@ export default function CompositeCheckout( {
 	isNoSiteCart?: boolean;
 	isInEditor?: boolean;
 	infoMessage?: JSX.Element;
+	onAfterPaymentComplete?: () => void;
+	isFocusedLaunch?: boolean;
 } ): JSX.Element {
 	const translate = useTranslate();
 	const isJetpackNotAtomic =
@@ -600,6 +605,7 @@ export default function CompositeCheckout( {
 		feature,
 		isInEditor,
 		isComingFromUpsell,
+		isFocusedLaunch,
 	} );
 
 	if (
@@ -640,6 +646,11 @@ export default function CompositeCheckout( {
 		);
 	}
 
+	const handlePaymentComplete = ( args: PaymentCompleteCallbackArguments ) => {
+		onPaymentComplete?.( args );
+		onAfterPaymentComplete?.();
+	};
+
 	return (
 		<React.Fragment>
 			<QuerySitePlans siteId={ siteId } />
@@ -652,7 +663,7 @@ export default function CompositeCheckout( {
 			<CheckoutProvider
 				items={ itemsForCheckout }
 				total={ total }
-				onPaymentComplete={ onPaymentComplete }
+				onPaymentComplete={ handlePaymentComplete }
 				showErrorMessage={ showErrorMessage }
 				showInfoMessage={ showInfoMessage }
 				showSuccessMessage={ showSuccessMessage }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -608,6 +608,14 @@ export default function CompositeCheckout( {
 		isFocusedLaunch,
 	} );
 
+	const handlePaymentComplete = useCallback(
+		( args: PaymentCompleteCallbackArguments ) => {
+			onPaymentComplete?.( args );
+			onAfterPaymentComplete?.();
+		},
+		[ onPaymentComplete, onAfterPaymentComplete ]
+	);
+
 	if (
 		shouldShowEmptyCartPage( {
 			responseCart,
@@ -645,11 +653,6 @@ export default function CompositeCheckout( {
 			</React.Fragment>
 		);
 	}
-
-	const handlePaymentComplete = ( args: PaymentCompleteCallbackArguments ) => {
-		onPaymentComplete?.( args );
-		onAfterPaymentComplete?.();
-	};
 
 	return (
 		<React.Fragment>

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -244,6 +244,7 @@ export default function useCreatePaymentCompleteCallback( {
 			translate,
 			responseCart,
 			createUserAndSiteBeforeTransaction,
+			isFocusedLaunch,
 		]
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -18,7 +18,12 @@ import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
  * Internal dependencies
  */
 import { infoNotice, successNotice } from 'calypso/state/notices/actions';
-import { hasRenewalItem, getRenewalItems, hasPlan } from 'calypso/lib/cart-values/cart-items';
+import {
+	hasRenewalItem,
+	getRenewalItems,
+	hasPlan,
+	hasEcommercePlan,
+} from 'calypso/lib/cart-values/cart-items';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import { fetchReceiptCompleted } from 'calypso/state/receipts/actions';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -62,6 +67,7 @@ export default function useCreatePaymentCompleteCallback( {
 	feature,
 	isInEditor,
 	isComingFromUpsell,
+	isFocusedLaunch,
 }: {
 	createUserAndSiteBeforeTransaction?: boolean;
 	productAliasFromUrl?: string | undefined;
@@ -70,6 +76,7 @@ export default function useCreatePaymentCompleteCallback( {
 	feature?: string | undefined;
 	isInEditor?: boolean;
 	isComingFromUpsell?: boolean;
+	isFocusedLaunch?: boolean;
 } ): PaymentCompleteCallback {
 	const { responseCart } = useShoppingCart();
 	const reduxDispatch = useDispatch();
@@ -191,6 +198,9 @@ export default function useCreatePaymentCompleteCallback( {
 				}
 			}
 
+			if ( isInEditor && isFocusedLaunch && ! hasEcommercePlan( responseCart ) ) {
+				return;
+			}
 			debug( 'just redirecting to', url );
 
 			if ( createUserAndSiteBeforeTransaction ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -198,9 +198,12 @@ export default function useCreatePaymentCompleteCallback( {
 				}
 			}
 
+			// Focused Launch is showing a success dialog directly in editor instead of a thank you page.
+			// See https://github.com/Automattic/wp-calypso/pull/47808#issuecomment-755196691
 			if ( isInEditor && isFocusedLaunch && ! hasEcommercePlan( responseCart ) ) {
 				return;
 			}
+
 			debug( 'just redirecting to', url );
 
 			if ( createUserAndSiteBeforeTransaction ) {

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -124,16 +124,6 @@ export const hideModalTitle = () =>
 		type: 'HIDE_MODAL_TITLE',
 	} as const );
 
-export const enablePersistentSuccessView = () =>
-	( {
-		type: 'ENABLE_SUCCESS_VIEW',
-	} as const );
-
-export const disablePersistentSuccessView = () =>
-	( {
-		type: 'DISABLE_SUCCESS_VIEW',
-	} as const );
-
 export type LaunchAction = ReturnType<
 	| typeof setSiteTitle
 	| typeof unsetDomain
@@ -156,6 +146,4 @@ export type LaunchAction = ReturnType<
 	| typeof unsetModalDismissible
 	| typeof showModalTitle
 	| typeof hideModalTitle
-	| typeof enablePersistentSuccessView
-	| typeof disablePersistentSuccessView
 >;

--- a/packages/data-stores/src/launch/index.ts
+++ b/packages/data-stores/src/launch/index.ts
@@ -38,7 +38,6 @@ export function register(): typeof STORE_KEY {
 				'isExperimental',
 				'isAnchorFm',
 				'isSiteTitleStepVisible',
-				'shouldDisplaySuccessView',
 			],
 		} );
 	}

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -149,19 +149,6 @@ const isModalTitleVisible: Reducer< boolean, LaunchAction > = ( state = true, ac
 	return state;
 };
 
-// Check if launch Success view should be displayed (user didn't dismissed the Success View modal)
-const shouldDisplaySuccessView: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
-	if ( action.type === 'ENABLE_SUCCESS_VIEW' ) {
-		return true;
-	}
-
-	if ( action.type === 'DISABLE_SUCCESS_VIEW' ) {
-		return false;
-	}
-
-	return state;
-};
-
 const reducer = combineReducers( {
 	step,
 	siteTitle,
@@ -177,7 +164,6 @@ const reducer = combineReducers( {
 	isSiteTitleStepVisible,
 	isModalDismissible,
 	isModalTitleVisible,
-	shouldDisplaySuccessView,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -38,7 +38,7 @@ export const getPaidPlanProductId = ( state: State ): number | undefined => {
 	const productId = state.planProductId;
 	const isFree = select( PLANS_STORE ).isPlanProductFree( productId );
 
-	return productId && ! isFree ? state.planProductId : undefined;
+	return productId && ! isFree ? productId : undefined;
 };
 
 // Check if a domain has been explicitly selected (including free subdomain)

--- a/packages/launch/src/context.ts
+++ b/packages/launch/src/context.ts
@@ -7,7 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
 interface LaunchContext {
 	siteId: number;
 	redirectTo: ( url: string ) => void;
-	openCheckout: ( siteSlug: string, isEcommerce?: boolean ) => void;
+	openCheckout: ( siteSlug: string, isEcommerce?: boolean, onSuccessCallback?: () => void ) => void;
 	getCurrentLaunchFlowUrl: () => string | undefined;
 	flow: string;
 }

--- a/packages/launch/src/context.ts
+++ b/packages/launch/src/context.ts
@@ -7,9 +7,14 @@ import { addQueryArgs } from '@wordpress/url';
 interface LaunchContext {
 	siteId: number;
 	redirectTo: ( url: string ) => void;
-	openCheckout: ( siteSlug: string, isEcommerce?: boolean, onSuccessCallback?: () => void ) => void;
+	openCheckout: (
+		siteSlug?: string,
+		isEcommerce?: boolean,
+		onSuccessCallback?: () => void
+	) => void;
 	getCurrentLaunchFlowUrl: () => string | undefined;
 	flow: string;
+	isInIframe: boolean;
 }
 
 const defaultRedirectTo = ( url: string ) => {
@@ -39,6 +44,7 @@ const LaunchContext = React.createContext< LaunchContext >( {
 		);
 	},
 	flow: 'launch',
+	isInIframe: false,
 } );
 
 export default LaunchContext;

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -21,7 +21,7 @@ import { useDomainSuggestionFromCart, usePlanProductIdFromCart } from '../hooks'
 import './style.scss';
 
 const FocusedLaunch: React.FunctionComponent = () => {
-	const { isSiteLaunched, isSiteLaunching } = useSite();
+	const { hasPaidPlan, isSiteLaunched, isSiteLaunching } = useSite();
 
 	const [ hasSelectedDomain, selectedPlanProductId ] = useSelect( ( select ) => {
 		const { planProductId } = select( LAUNCH_STORE ).getState();
@@ -41,16 +41,24 @@ const FocusedLaunch: React.FunctionComponent = () => {
 	}, [ hasSelectedDomain, domainSuggestionFromCart, setDomain ] );
 
 	// @TODO: extract to some hook for reusability (Eg: use-products-from-cart)
-	// If there is no selected plan, but there is a plan in cart,
+	// If there is no selected plan and the site has no paid plan, but there is a plan in cart,
 	// set the plan from cart as the selected plan.
 	const planProductIdFromCart = usePlanProductIdFromCart();
 	const { setPlanProductId } = useDispatch( LAUNCH_STORE );
 
 	React.useEffect( () => {
-		if ( ! selectedPlanProductId && planProductIdFromCart ) {
+		if ( ! selectedPlanProductId && planProductIdFromCart && ! hasPaidPlan ) {
 			setPlanProductId( planProductIdFromCart );
 		}
-	}, [ selectedPlanProductId, planProductIdFromCart, setPlanProductId ] );
+	}, [ selectedPlanProductId, planProductIdFromCart, setPlanProductId, hasPaidPlan ] );
+
+	// If there is a purchased plan, remove any selected plan from Launch store
+	const { unsetPlanProductId } = useDispatch( LAUNCH_STORE );
+	React.useEffect( () => {
+		if ( hasPaidPlan ) {
+			unsetPlanProductId();
+		}
+	}, [ hasPaidPlan, unsetPlanProductId ] );
 
 	return (
 		<Router>

--- a/packages/launch/src/focused-launch/index.tsx
+++ b/packages/launch/src/focused-launch/index.tsx
@@ -22,28 +22,12 @@ import './style.scss';
 
 const FocusedLaunch: React.FunctionComponent = () => {
 	const { isSiteLaunched, isSiteLaunching } = useSite();
-	const { enablePersistentSuccessView } = useDispatch( LAUNCH_STORE );
 
-	const [ hasSelectedDomain, selectedPlanProductId, shouldDisplaySuccessView ] = useSelect(
-		( select ) => {
-			const { planProductId, shouldDisplaySuccessView } = select( LAUNCH_STORE ).getState();
+	const [ hasSelectedDomain, selectedPlanProductId ] = useSelect( ( select ) => {
+		const { planProductId } = select( LAUNCH_STORE ).getState();
 
-			return [
-				select( LAUNCH_STORE ).hasSelectedDomain(),
-				planProductId,
-				shouldDisplaySuccessView,
-			];
-		}
-	);
-
-	// Force Success view to be the default view when opening Focused Launch modal.
-	// This is used in case the user opens the Focused Launch modal after launching
-	// the site (e.g. when redirected back after the checkout screen)
-	React.useEffect( () => {
-		if ( isSiteLaunched ) {
-			enablePersistentSuccessView();
-		}
-	}, [ isSiteLaunched, enablePersistentSuccessView ] );
+		return [ select( LAUNCH_STORE ).hasSelectedDomain(), planProductId ];
+	} );
 
 	// @TODO: extract to some hook for reusability (Eg: use-products-from-cart)
 	// If there is no selected domain, but there is a domain in cart,
@@ -69,10 +53,7 @@ const FocusedLaunch: React.FunctionComponent = () => {
 	}, [ selectedPlanProductId, planProductIdFromCart, setPlanProductId ] );
 
 	return (
-		<Router
-			initialEntries={ [ FocusedLaunchRoute.Summary, FocusedLaunchRoute.Success ] }
-			initialIndex={ shouldDisplaySuccessView ? 1 : 0 }
-		>
+		<Router>
 			<ScrollToTop selector=".components-modal__content" />
 			{ ( isSiteLaunched || isSiteLaunching ) && <Redirect to={ FocusedLaunchRoute.Success } /> }
 			<Switch>

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -16,7 +16,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useSiteDomains } from '../../hooks';
 import Confetti from './confetti';
 import LaunchContext from '../../context';
-import { LAUNCH_STORE, PLANS_STORE, SITE_STORE } from '../../stores';
+import { LAUNCH_STORE, SITE_STORE } from '../../stores';
 
 import './style.scss';
 
@@ -27,13 +27,9 @@ const Success: React.FunctionComponent = () => {
 
 	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
 
-	const selectedPlanProductId = useSelect(
-		( select ) => select( LAUNCH_STORE ).getSelectedPlanProductId(),
+	const isSelectedPlanPaid = useSelect(
+		( select ) => !! select( LAUNCH_STORE ).getPaidPlanProductId(),
 		[]
-	);
-	const isSelectedPlanFree = useSelect(
-		( select ) => select( PLANS_STORE ).isPlanProductFree( selectedPlanProductId ),
-		[ selectedPlanProductId ]
 	);
 
 	const { unsetModalDismissible, hideModalTitle, closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
@@ -55,14 +51,14 @@ const Success: React.FunctionComponent = () => {
 	}, [ unsetModalDismissible, hideModalTitle ] );
 
 	const continueEditing = () => {
-		if ( isSelectedPlanFree ) {
-			// If the site was launched without purchasing a paid plan, don't reload the page
-			closeFocusedLaunch();
-		} else {
+		if ( isSelectedPlanPaid ) {
 			// After a plan was purchased, we need to reload the page for plans data to be picked up by Jetpack Premium blocks
 			// @TODO: see if there is a way to prevent reloading
 			const pathName = new URL( getCurrentLaunchFlowUrl() || '' )?.pathname;
 			redirectTo( pathName || `/page/${ siteSubdomain?.domain }/home` );
+		} else {
+			// If the site was launched without purchasing a paid plan, don't reload the page
+			closeFocusedLaunch();
 		}
 	};
 

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -36,12 +36,7 @@ const Success: React.FunctionComponent = () => {
 		[ selectedPlanProductId ]
 	);
 
-	const {
-		unsetModalDismissible,
-		hideModalTitle,
-		closeFocusedLaunch,
-		disablePersistentSuccessView,
-	} = useDispatch( LAUNCH_STORE );
+	const { unsetModalDismissible, hideModalTitle, closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
 
 	const { siteSubdomain, sitePrimaryDomain } = useSiteDomains();
 
@@ -62,7 +57,6 @@ const Success: React.FunctionComponent = () => {
 	const continueEditing = () => {
 		if ( isSelectedPlanFree ) {
 			// If the site was launched without purchasing a paid plan, don't reload the page
-			disablePersistentSuccessView();
 			closeFocusedLaunch();
 		} else {
 			// After a plan was purchased, we need to reload the page for plans data to be picked up by Jetpack Premium blocks
@@ -73,7 +67,6 @@ const Success: React.FunctionComponent = () => {
 	};
 
 	const redirectToHome = () => {
-		disablePersistentSuccessView();
 		redirectTo( `/home/${ siteSubdomain?.domain }` );
 	};
 

--- a/packages/launch/src/focused-launch/success/index.tsx
+++ b/packages/launch/src/focused-launch/success/index.tsx
@@ -16,16 +16,25 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useSiteDomains } from '../../hooks';
 import Confetti from './confetti';
 import LaunchContext from '../../context';
-import { LAUNCH_STORE, SITE_STORE } from '../../stores';
+import { LAUNCH_STORE, PLANS_STORE, SITE_STORE } from '../../stores';
 
 import './style.scss';
 
 // Success is shown when the site is launched but also while the site is still launching.
 // This view is technically going to be the selected view in the modal even while the user goes through the checkout flow (which is rendered on top of this view).
 const Success: React.FunctionComponent = () => {
-	const { redirectTo, siteId } = React.useContext( LaunchContext );
+	const { redirectTo, siteId, getCurrentLaunchFlowUrl } = React.useContext( LaunchContext );
 
 	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
+
+	const selectedPlanProductId = useSelect(
+		( select ) => select( LAUNCH_STORE ).getSelectedPlanProductId(),
+		[]
+	);
+	const isSelectedPlanFree = useSelect(
+		( select ) => select( PLANS_STORE ).isPlanProductFree( selectedPlanProductId ),
+		[ selectedPlanProductId ]
+	);
 
 	const {
 		unsetModalDismissible,
@@ -51,8 +60,16 @@ const Success: React.FunctionComponent = () => {
 	}, [ unsetModalDismissible, hideModalTitle ] );
 
 	const continueEditing = () => {
-		disablePersistentSuccessView();
-		closeFocusedLaunch();
+		if ( isSelectedPlanFree ) {
+			// If the site was launched without purchasing a paid plan, don't reload the page
+			disablePersistentSuccessView();
+			closeFocusedLaunch();
+		} else {
+			// After a plan was purchased, we need to reload the page for plans data to be picked up by Jetpack Premium blocks
+			// @TODO: see if there is a way to prevent reloading
+			const pathName = new URL( getCurrentLaunchFlowUrl() || '' )?.pathname;
+			redirectTo( pathName || `/page/${ siteSubdomain?.domain }/home` );
+		}
 	};
 
 	const redirectToHome = () => {

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -567,8 +567,9 @@ const Summary: React.FunctionComponent = () => {
 	}, [ title, showSiteTitleStep, isSiteTitleStepVisible ] );
 
 	const handleLaunch = () => {
-		launchSite( siteId );
-		if ( selectedDomain || ! isSelectedPlanFree ) {
+		if ( ! selectedDomain && isSelectedPlanFree ) {
+			launchSite( siteId );
+		} else {
 			goToCheckout();
 		}
 	};

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -527,11 +527,11 @@ const Summary: React.FunctionComponent = () => {
 		const { isSiteTitleStepVisible, domain, planProductId } = launchStore.getState();
 
 		return [ launchStore.hasSelectedDomain(), isSiteTitleStepVisible, domain, planProductId ];
-	} );
+	}, [] );
 
-	const isSelectedPlanFree = useSelect(
-		( select ) => select( PLANS_STORE ).isPlanProductFree( selectedPlanProductId ),
-		[ selectedPlanProductId ]
+	const isSelectedPlanPaid = useSelect(
+		( select ) => !! select( LAUNCH_STORE ).getPaidPlanProductId(),
+		[]
 	);
 
 	const { launchSite } = useDispatch( SITE_STORE );
@@ -541,11 +541,12 @@ const Summary: React.FunctionComponent = () => {
 		showModalTitle,
 		showSiteTitleStep,
 	} = useDispatch( LAUNCH_STORE );
+
 	const { title, updateTitle } = useTitle();
 	const { siteSubdomain, hasPaidDomain } = useSiteDomains();
 	const { onDomainSelect, onExistingSubdomainSelect, currentDomain } = useDomainSelection();
 	const { domainSearch, isLoading } = useDomainSearch();
-	const { isPaidPlan: hasPaidPlan } = useSite();
+	const { hasPaidPlan } = useSite();
 
 	const locale = useLocale();
 	const localizeUrl = useLocalizeUrl();
@@ -576,7 +577,7 @@ const Summary: React.FunctionComponent = () => {
 	const handleLaunch = () => {
 		// Launch the site directly if Free plan and subdomain are selected.
 		// Otherwise, show checkout as the next step.
-		if ( ! selectedDomain && isSelectedPlanFree ) {
+		if ( ! selectedDomain && ! isSelectedPlanPaid ) {
 			launchSite( siteId );
 		} else {
 			goToCheckoutAndLaunch();

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -545,7 +545,7 @@ const Summary: React.FunctionComponent = () => {
 
 	const { siteId } = React.useContext( LaunchContext );
 
-	const { goToCheckout } = useCart();
+	const { goToCheckoutAndLaunch } = useCart();
 
 	const locale = useLocale();
 	const localizeUrl = useLocalizeUrl();
@@ -567,10 +567,12 @@ const Summary: React.FunctionComponent = () => {
 	}, [ title, showSiteTitleStep, isSiteTitleStepVisible ] );
 
 	const handleLaunch = () => {
+		// Launch the site directly if Free plan and subdomain are selected.
+		// Otherwise, show checkout as the next step.
 		if ( ! selectedDomain && isSelectedPlanFree ) {
 			launchSite( siteId );
 		} else {
-			goToCheckout();
+			goToCheckoutAndLaunch();
 		}
 	};
 

--- a/packages/launch/src/focused-launch/summary/style.scss
+++ b/packages/launch/src/focused-launch/summary/style.scss
@@ -201,6 +201,22 @@ $commentary-column-gap-wide: 100px;
 
 	.focused-launch-summary__launch-button {
 		flex-grow: 1;
+		background-color: $onboarding-accent-blue;
+
+		&:disabled,
+		&:hover:not( :disabled ),
+		&:active:not( :disabled ),
+		&:focus:not( :disabled ) {
+			background: $onboarding-accent-blue;
+		}
+
+		&:focus:not( :disabled ) {
+			box-shadow: inset 0 0 0 1px #fff, 0 0 0 var( --wp-admin-border-width-focus ) $onboarding-accent-blue;
+		}
+
+		&--is-loading {
+			@include onboarding-loading( $onboarding-accent-blue );
+		}
 	}
 
 	@include break-small {

--- a/packages/launch/src/hooks/use-cart.ts
+++ b/packages/launch/src/hooks/use-cart.ts
@@ -33,7 +33,9 @@ export function useCart(): { goToCheckout: () => Promise< void > } {
 
 	const { siteSubdomain } = useSiteDomains();
 
-	const { getCart, setCart } = useDispatch( SITE_STORE );
+	const { getCart, setCart, launchSite } = useDispatch( SITE_STORE );
+
+	const onSuccess = () => launchSite( siteId );
 
 	const goToCheckout = async () => {
 		// setting the cart with Launch products can be extracted
@@ -48,7 +50,7 @@ export function useCart(): { goToCheckout: () => Promise< void > } {
 		} );
 
 		// open checkout modal or redirect to /checkout only after the cart is updated
-		openCheckout( siteSubdomain?.domain || siteId.toString(), isEcommercePlan );
+		openCheckout( siteSubdomain?.domain || siteId.toString(), isEcommercePlan, onSuccess );
 	};
 
 	return {

--- a/packages/launch/src/hooks/use-cart.ts
+++ b/packages/launch/src/hooks/use-cart.ts
@@ -13,22 +13,29 @@ import LaunchContext from '../context';
 import { getDomainProduct, getPlanProductForFlow } from '../utils';
 import { useSiteDomains } from '../hooks';
 
-export function useCart(): { goToCheckout: () => Promise< void > } {
-	const { siteId, flow, openCheckout } = React.useContext( LaunchContext );
+export function useCart(): {
+	goToCheckout: () => Promise< void >; // used in gutenboarding-launch
+	goToCheckoutAndLaunch: () => Promise< void >; // used in focused-launch integrated with Editor Checkout modal
+	isCartUpdating: boolean;
+} {
+	const { siteId, flow, openCheckout, isInIframe } = React.useContext( LaunchContext );
+
 	const locale = useLocale();
 
-	const { planProductId, domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+	const [ planProductId, domain ] = useSelect( ( select ) => [
+		select( LAUNCH_STORE ).getSelectedPlanProductId(),
+		select( LAUNCH_STORE ).getSelectedDomain(),
+	] );
 
-	const planProduct = useSelect( ( select ) =>
-		select( PLANS_STORE ).getPlanProductById( planProductId as number )
-	);
-
-	const plan = useSelect( ( select ) =>
-		select( PLANS_STORE ).getPlanByProductId( planProductId, locale )
-	);
-
-	const isEcommercePlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).isPlanEcommerce( plan?.periodAgnosticSlug )
+	const { planProduct, isEcommercePlan } = useSelect(
+		( select ) => {
+			const plan = select( PLANS_STORE ).getPlanByProductId( planProductId, locale );
+			return {
+				planProduct: select( PLANS_STORE ).getPlanProductById( planProductId as number ),
+				isEcommercePlan: select( PLANS_STORE ).isPlanEcommerce( plan?.periodAgnosticSlug ),
+			};
+		},
+		[ planProductId, locale ]
 	);
 
 	const { siteSubdomain } = useSiteDomains();
@@ -37,23 +44,44 @@ export function useCart(): { goToCheckout: () => Promise< void > } {
 
 	const onSuccess = () => launchSite( siteId );
 
-	const goToCheckout = async () => {
-		// setting the cart with Launch products can be extracted
-		// to an action creator on the Launch data-store
+	const [ isCartUpdating, setIsCartUpdating ] = React.useState( false );
+
+	const addProductsToCart = async () => {
+		if ( isCartUpdating ) {
+			return;
+		}
+
+		setIsCartUpdating( true );
+
+		// @TODO: setting the cart with Launch products can be extracted to an action creator on the Launch store
 		const domainProductForFlow = domain && getDomainProduct( domain, flow );
 		const planProductForFlow = planProduct && getPlanProductForFlow( planProduct, flow );
-
 		const cart = await getCart( siteId );
 		await setCart( siteId, {
 			...cart,
+			// replace any existing products from cart
 			products: [ planProductForFlow, domainProductForFlow ],
 		} );
 
-		// open checkout modal or redirect to /checkout only after the cart is updated
-		openCheckout( siteSubdomain?.domain || siteId.toString(), isEcommercePlan, onSuccess );
+		setIsCartUpdating( false );
+	};
+
+	const goToCheckout = async () => {
+		await addProductsToCart();
+		openCheckout( siteSubdomain?.domain, isEcommercePlan, onSuccess );
+	};
+
+	const goToCheckoutAndLaunch = async () => {
+		if ( ! isInIframe ) {
+			// if Focused Launch is loaded outside Calypso iframe (in wp-admin), we launch the site and then redirect to /checkout
+			await launchSite( siteId );
+		}
+		goToCheckout();
 	};
 
 	return {
 		goToCheckout,
+		goToCheckoutAndLaunch,
+		isCartUpdating,
 	};
 }

--- a/packages/launch/src/hooks/use-cart.ts
+++ b/packages/launch/src/hooks/use-cart.ts
@@ -13,11 +13,13 @@ import LaunchContext from '../context';
 import { getDomainProduct, getPlanProductForFlow } from '../utils';
 import { useSiteDomains } from '../hooks';
 
-export function useCart(): {
+type LaunchCart = {
 	goToCheckout: () => Promise< void >; // used in gutenboarding-launch
 	goToCheckoutAndLaunch: () => Promise< void >; // used in focused-launch integrated with Editor Checkout modal
 	isCartUpdating: boolean;
-} {
+};
+
+export function useCart(): LaunchCart {
 	const { siteId, flow, openCheckout, isInIframe } = React.useContext( LaunchContext );
 
 	const locale = useLocale();
@@ -29,10 +31,11 @@ export function useCart(): {
 
 	const { planProduct, isEcommercePlan } = useSelect(
 		( select ) => {
-			const plan = select( PLANS_STORE ).getPlanByProductId( planProductId, locale );
+			const plansStore = select( PLANS_STORE );
+			const plan = plansStore.getPlanByProductId( planProductId, locale );
 			return {
-				planProduct: select( PLANS_STORE ).getPlanProductById( planProductId as number ),
-				isEcommercePlan: select( PLANS_STORE ).isPlanEcommerce( plan?.periodAgnosticSlug ),
+				planProduct: plansStore.getPlanProductById( planProductId as number ),
+				isEcommercePlan: plansStore.isPlanEcommerce( plan?.periodAgnosticSlug ),
 			};
 		},
 		[ planProductId, locale ]

--- a/packages/launch/src/hooks/use-cart.ts
+++ b/packages/launch/src/hooks/use-cart.ts
@@ -75,8 +75,10 @@ export function useCart(): LaunchCart {
 	};
 
 	const goToCheckoutAndLaunch = async () => {
-		if ( ! isInIframe ) {
-			// if Focused Launch is loaded outside Calypso iframe (in wp-admin), we launch the site and then redirect to /checkout
+		if ( ! isInIframe || isEcommercePlan ) {
+			// We launch the site first and then open Checkout in these cases:
+			// - Focused Launch is loaded outside Calypso iframe (in wp-admin)
+			// - eCommerce plan is selected so Checkout will handle thank-you redirect after purchase
 			await launchSite( siteId );
 		}
 		goToCheckout();

--- a/packages/launch/src/hooks/use-plans.tsx
+++ b/packages/launch/src/hooks/use-plans.tsx
@@ -21,15 +21,10 @@ export function usePlans(): {
 } {
 	const locale = useLocale();
 
-	const defaultPaidPlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).getDefaultPaidPlan( locale )
-	);
-
-	const defaultFreePlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).getDefaultFreePlan( locale )
-	);
-
-	return { defaultPaidPlan, defaultFreePlan };
+	return useSelect( ( select ) => ( {
+		defaultPaidPlan: select( PLANS_STORE ).getDefaultPaidPlan( locale ),
+		defaultFreePlan: select( PLANS_STORE ).getDefaultFreePlan( locale ),
+	} ) );
 }
 
 export function usePlanProductFromCart(): PlanProductForFlow | undefined {

--- a/packages/launch/src/hooks/use-site.ts
+++ b/packages/launch/src/hooks/use-site.ts
@@ -12,14 +12,24 @@ import LaunchContext from '../context';
 
 export function useSite() {
 	const { siteId } = React.useContext( LaunchContext );
-	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
-	const isSiteLaunched = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunched( siteId ) );
-	const isSiteLaunching = useSelect( ( select ) => select( SITE_STORE ).isSiteLaunching( siteId ) );
-	const isLoading = useSelect( ( select ) => select( SITE_STORE ).isFetchingSiteDetails() );
+
+	const [ site, isSiteLaunched, isSiteLaunching, isLoading ] = useSelect(
+		( select ) => {
+			const siteStore = select( SITE_STORE );
+
+			return [
+				siteStore.getSite( siteId ),
+				siteStore.isSiteLaunched( siteId ),
+				siteStore.isSiteLaunching( siteId ),
+				siteStore.isFetchingSiteDetails(),
+			];
+		},
+		[ siteId ]
+	);
 
 	return {
 		sitePlan: site?.plan,
-		isPaidPlan: site && ! site.plan?.is_free, // sometimes plan will not be available: https://github.com/Automattic/wp-calypso/pull/44895
+		hasPaidPlan: site && ! site.plan?.is_free, // sometimes plan will not be available: https://github.com/Automattic/wp-calypso/pull/44895
 		isSiteLaunched,
 		isSiteLaunching,
 		selectedFeatures: site?.options?.selected_features,

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -21,9 +21,10 @@ import './styles.scss';
 interface Props {
 	locale?: string;
 	siteId: number;
-	openCheckout: ( siteSlug: string, isEcommerce?: boolean ) => void;
+	openCheckout: ( siteSlug?: string, isEcommerce?: boolean ) => void;
 	redirectTo: ( path: string ) => void;
 	getCurrentLaunchFlowUrl: () => string | undefined;
+	isInIframe: boolean;
 }
 
 const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
@@ -32,6 +33,7 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
 	openCheckout,
 	redirectTo,
 	getCurrentLaunchFlowUrl,
+	isInIframe,
 } ) => {
 	const {
 		isModalDismissible,
@@ -40,7 +42,6 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
 	} = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 
 	const { closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
-
 	return (
 		<LocaleProvider localeSlug={ locale }>
 			<Modal
@@ -67,6 +68,7 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
 							openCheckout,
 							flow: FOCUSED_LAUNCH_FLOW_ID,
 							getCurrentLaunchFlowUrl,
+							isInIframe,
 						} }
 					>
 						<FocusedLaunch />

--- a/packages/launch/src/launch/index.tsx
+++ b/packages/launch/src/launch/index.tsx
@@ -35,22 +35,18 @@ const FocusedLaunchModal: React.FunctionComponent< Props > = ( {
 	getCurrentLaunchFlowUrl,
 	isInIframe,
 } ) => {
-	const {
-		isModalDismissible,
-		isModalTitleVisible,
-		shouldDisplaySuccessView,
-	} = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+	const { isModalDismissible, isModalTitleVisible } = useSelect( ( select ) =>
+		select( LAUNCH_STORE ).getState()
+	);
 
 	const { closeFocusedLaunch } = useDispatch( LAUNCH_STORE );
+
 	return (
 		<LocaleProvider localeSlug={ locale }>
 			<Modal
 				open={ true }
 				className={ classNames( 'launch__focused-modal', {
 					'launch__focused-modal--hide-title': ! isModalTitleVisible,
-				} ) }
-				overlayClassName={ classNames( 'launch__focused-modal-overlay', {
-					'launch__focused-modal-overlay--delay-animation-in': shouldDisplaySuccessView,
 				} ) }
 				bodyOpenClassName="has-focused-launch-modal"
 				onRequestClose={ closeFocusedLaunch }

--- a/packages/launch/src/launch/styles.scss
+++ b/packages/launch/src/launch/styles.scss
@@ -15,6 +15,18 @@ body.has-focused-launch-modal {
 	overflow: hidden;
 }
 
+.launch__focused-modal-overlay {
+	&.launch__focused-modal-overlay--delay-animation-in {
+		animation-delay: 1s;
+		// "fill-mode: both" keeps the modal invisible until the animation starts
+		animation-fill-mode: both;
+
+		.launch__focused-modal {
+			animation-delay: inherit;
+		}
+	}
+}
+
 .launch__focused-modal {
 	&.components-modal__frame {
 		transform: none;

--- a/packages/launch/src/launch/styles.scss
+++ b/packages/launch/src/launch/styles.scss
@@ -15,18 +15,6 @@ body.has-focused-launch-modal {
 	overflow: hidden;
 }
 
-.launch__focused-modal-overlay {
-	&.launch__focused-modal-overlay--delay-animation-in {
-		animation-delay: 1s;
-		// "fill-mode: both" keeps the modal invisible until the animation starts
-		animation-fill-mode: both;
-
-		.launch__focused-modal {
-			animation-delay: inherit;
-		}
-	}
-}
-
 .launch__focused-modal {
 	&.components-modal__frame {
 		transform: none;

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -9,22 +9,19 @@
 
 @mixin onboarding-heading-text {
 	@include onboarding-font-recoleta;
-	/* stylelint-disable-line */
-	font-size: 42px;
+	font-size: 42px; /* stylelint-disable-line */
 	line-height: 57px;
 }
 
 @mixin onboarding-heading-text-tablet {
 	@include onboarding-font-recoleta;
-	/* stylelint-disable-line */
-	font-size: 36px;
+	font-size: 36px; /* stylelint-disable-line */
 	line-height: 40px;
 }
 
 @mixin onboarding-heading-text-mobile {
 	@include onboarding-font-recoleta;
-	/* stylelint-disable-line */
-	font-size: 32px;
+	font-size: 32px; /* stylelint-disable-line */
 	line-height: 40px;
 }
 
@@ -42,8 +39,7 @@
 }
 
 @mixin onboarding-large-text {
-	/* stylelint-disable-line */
-	font-size: 16px;
+	font-size: 16px; /* stylelint-disable-line */
 	line-height: 24px;
 }
 
@@ -205,13 +201,17 @@
 // onaboarding-placeholder() mixin is a copy of 'client/assets/stylesheets/shared/mixins/placeholder'
 
 @mixin onboarding-placeholder( $color-property: $gray-100 ) {
-	animation: onboarding-loading-pulse 1.6s ease-in-out infinite;
-	background: $color-property;
+	@include onboarding-loading( $color-property );
 	color: transparent;
 
 	&::after {
 		content: '\00a0';
 	}
+}
+
+@mixin onboarding-loading( $color-property: $gray-100 ) {
+	animation: onboarding-loading-pulse 1.6s ease-in-out infinite;
+	background: $color-property;
 }
 
 // a pulsing animation for placeholders


### PR DESCRIPTION
Demo for the full paid flow: https://cloudup.com/cZCigAVkgu0

**WBE diff [WIP]** <s>to be approved and merged before merging this PR:</s> D56875-code
[Note] WBE diff also contains several [undeployed changes](https://github.com/Automattic/wp-calypso/commits/trunk/apps/wpcom-block-editor)

### Changes proposed in this Pull Request

- [x] If Launch flow is in Calypso (iframed editor), don't launch the site if there are selected paid items and just open checkout modal
- [x] Show a loading state while the products are added to cart. Disable and animate the Launch button and make the modal non-dismissible. Demo: https://cloudup.com/cxGliq5vaWL (quickly approved by @ollierozdarz on Slack)
- [x] Don't redirect to a thank-you upsell page when checkout is completed using Editor Checkout Modal 
- [x] After purchasing paid items and checkout modal is closed, continue with launching inside the editor and show success dialog with options to Continue editing and go to Home.
- [x] Update editor status to reflect the newly purchased plan (corresponding premium blocks should be available without refresh). Currently, this is done by refreshing the editor when clicking _Continue Editing_
- [x] Clean-up `shouldDisplaySuccessView` and `enablePersistentSuccessView`
- [x] Fix plan showing up in cart without being displayed as selected during flow in all cases reported in #49958

#### [Update] New changes proposed in the context of https://github.com/Automattic/wp-calypso/pull/48452#discussion_r575347459
- [x] After the payment processing is redirecting the user away to complete the purchase (eg: Paypal), they are being redirected back to the editor where their site is launched automatically.
- [x] As an exception to the rule above, if the eCommerce plan is selected, [the site will be launched before the Checkout step](https://github.com/Automattic/wp-calypso/pull/48452/commits/d53f569309407420723beb562ebb498ea59b2b25) and [after completing purchase the user will be redirected](https://github.com/Automattic/wp-calypso/pull/48452#discussion_r573730375) to the default `/checkout/thank-you` page to begin the atomic transfer.

**Follow up ideas:**
- [x] #50185 Find a way to use the newly purchased plan to enable Jetpack Premium blocks without reloading editor.
- [ ] Check if having a purchased domain and a domain from cart or previously selected domain in Focused Launch is causing bugs similar to #49958

### Testing instructions

**Setup:**
1. Checkout this branch or go to https://calypso.live/?branch=update/focused-launch/launch-after-checkout
2. Run `yarn start` in Claypso
2. Run `yarn dev --sync` in `apps/editing-toolkit`
3. Run `yarn dev --sync` in `apps/wpcom-block-editor` after you make sure `wpcom-sandbox` is aliased (28543-pb) 
4. Sandbox an unlaunched site created via `/start` to test changes and via `/new` for regression testing

**Focused launch**

* **Specific examples of test cases**: p1613379716423600/1613375164.421500-slack-C0KDTA48Y

1. Check Focused Launch (free and paid) in Calypso (inside iframe)
  * Go to `/page/{UNLAUNCHED_SITE_ID_CREATED_WITH_START}.wordpress.com/home`
  * Free flow should be unchanged and paid flow should match the changes described above

2. Check Focused Launch (free and paid) in wp-admin (no iframe)
  * Go to `/page/{UNLAUNCHED_SITE_ID_CREATED_WITH_START}.wordpress.com/wp-admin/post-new.php`
  * Both flows should be unchanged. For paid flow, you'll get redirected to `/checkout` after the site is launched
  
**Gutenboarding launch (regression testing)**
1. Check Gutenboarding launch (free and paid) in Calypso 
  * Go to `/page/{UNLAUNCHED_SITE_ID_CREATED_WITH_GUTENBOARDING}.wordpress.com/home`

2. Check Gutenboarding launch (free and paid) in wp-admin 
  * Go to `{UNLAUNCHED_SITE_ID_CREATED_WITH_GUTENBOARDING}.wordpress.com/wp-admin/post-new.php`

Fixes #48081
Fixes #47798
Fixes #49958