### PR TITLE
Plugins: Use Redux for sites in PluginsBrowserListElement

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -11,12 +11,12 @@ import { flowRight as compose, includes } from 'lodash';
  * Internal dependencies
  */
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
-import PluginsStore from 'calypso/lib/plugins/store';
 import { Button } from '@automattic/components';
 import Rating from 'calypso/components/rating';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
 
 /**
  * Style dependencies
@@ -42,13 +42,6 @@ class PluginsBrowserListElement extends Component {
 		return url;
 	}
 
-	getSites() {
-		if ( this.props.site && this.props.currentSites ) {
-			return PluginsStore.getSites( this.props.currentSites, this.props.plugin.slug );
-		}
-		return [];
-	}
-
 	trackPluginLinkClick = () => {
 		recordTracksEvent( 'calypso_plugin_browser_item_click', {
 			site: this.props.site,
@@ -70,8 +63,8 @@ class PluginsBrowserListElement extends Component {
 	}
 
 	renderInstalledIn() {
-		const sites = this.getSites();
-		if ( ( sites && sites.length > 0 ) || this.isWpcomPreinstalled() ) {
+		const { sitesWithPlugin } = this.props;
+		if ( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) || this.isWpcomPreinstalled() ) {
 			return (
 				<div className="plugins-browser-item__installed">
 					<Gridicon icon="checkmark" size={ 18 } />
@@ -142,11 +135,22 @@ class PluginsBrowserListElement extends Component {
 }
 
 export default compose(
-	connect( ( state ) => {
+	connect( ( state, { currentSites, plugin, site } ) => {
 		const selectedSiteId = getSelectedSiteId( state );
+
+		const sitesWithPlugin =
+			site && currentSites
+				? getSitesWithPlugin(
+						state,
+						// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+						currentSites.map( ( currentSite ) => currentSite.ID ),
+						plugin.slug
+				  )
+				: [];
 
 		return {
 			isJetpackSite: isJetpackSite( state, selectedSiteId ),
+			sitesWithPlugin,
 		};
 	} ),
 	localize


### PR DESCRIPTION
This PR reduxifies `PluginsBrowserListElement` and suggests that we now use Redux for retrieving the sites with a particular plugin, instead of the flux store.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Use Redux for sites in `PluginsBrowserListElement`

#### Testing instructions

* Verify the plugin browser items are still working well on:
  * `/plugins`
  * `/plugins/manage` - the "More Plugins" sections at the bottom
  * `/plugins/:site` - keep an eye on the "Installed" label that should appear when the plugin is installed on that site.
  * `/plugins/manage/:site` - keep an eye on the "Installed" label that should appear when the plugin is installed on that site.
* Verify all tests still pass.