### PR TITLE
Importers: remove confusing workarounds when rendering active importers 

### DIFF
--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -58,7 +58,6 @@ class FileImporter extends React.PureComponent {
 				description: PropTypes.string.isRequired,
 			} ),
 			importerState: PropTypes.string.isRequired,
-			siteTitle: PropTypes.string.isRequired,
 			statusMessage: PropTypes.string,
 			type: PropTypes.string.isRequired,
 		} ),

--- a/client/my-sites/importer/importer-blogger.jsx
+++ b/client/my-sites/importer/importer-blogger.jsx
@@ -19,13 +19,13 @@ class ImporterBlogger extends React.PureComponent {
 		site: PropTypes.shape( {
 			title: PropTypes.string.isRequired,
 		} ).isRequired,
+		siteTitle: PropTypes.string.isRequired,
 		importerStatus: PropTypes.shape( {
 			importerState: PropTypes.string.isRequired,
 			errorData: PropTypes.shape( {
 				type: PropTypes.string.isRequired,
 				description: PropTypes.string.isRequired,
 			} ),
-			siteTitle: PropTypes.string.isRequired,
 			statusMessage: PropTypes.string,
 		} ),
 	};

--- a/client/my-sites/importer/importer-godaddy-gocentral.jsx
+++ b/client/my-sites/importer/importer-godaddy-gocentral.jsx
@@ -16,13 +16,13 @@ class ImporterGoDaddyGoCentral extends React.PureComponent {
 	static displayName = 'ImporterGoDaddyGoCentral';
 
 	static propTypes = {
+		siteTitle: PropTypes.string.isRequired,
 		importerStatus: PropTypes.shape( {
 			importerState: PropTypes.string.isRequired,
 			errorData: PropTypes.shape( {
 				type: PropTypes.string.isRequired,
 				description: PropTypes.string.isRequired,
 			} ),
-			siteTitle: PropTypes.string.isRequired,
 			statusMessage: PropTypes.string,
 		} ),
 		fromSite: PropTypes.string,

--- a/client/my-sites/importer/importer-squarespace.jsx
+++ b/client/my-sites/importer/importer-squarespace.jsx
@@ -19,13 +19,13 @@ class ImporterSquarespace extends React.PureComponent {
 		site: PropTypes.shape( {
 			title: PropTypes.string.isRequired,
 		} ).isRequired,
+		siteTitle: PropTypes.string.isRequired,
 		importerStatus: PropTypes.shape( {
 			importerState: PropTypes.string.isRequired,
 			errorData: PropTypes.shape( {
 				type: PropTypes.string.isRequired,
 				description: PropTypes.string.isRequired,
 			} ),
-			siteTitle: PropTypes.string.isRequired,
 			statusMessage: PropTypes.string,
 		} ),
 	};

--- a/client/my-sites/importer/importer-wix.jsx
+++ b/client/my-sites/importer/importer-wix.jsx
@@ -16,13 +16,13 @@ class ImporterWix extends React.PureComponent {
 	static displayName = 'ImporterWix';
 
 	static propTypes = {
+		siteTitle: PropTypes.string.isRequired,
 		importerStatus: PropTypes.shape( {
 			importerState: PropTypes.string.isRequired,
 			errorData: PropTypes.shape( {
 				type: PropTypes.string.isRequired,
 				description: PropTypes.string.isRequired,
 			} ),
-			siteTitle: PropTypes.string.isRequired,
 			statusMessage: PropTypes.string,
 		} ),
 		fromSite: PropTypes.string,

--- a/client/my-sites/importer/importer-wordpress.jsx
+++ b/client/my-sites/importer/importer-wordpress.jsx
@@ -16,13 +16,13 @@ class ImporterWordPress extends React.PureComponent {
 	static displayName = 'ImporterWordPress';
 
 	static propTypes = {
+		siteTitle: PropTypes.string.isRequired,
 		importerStatus: PropTypes.shape( {
 			importerState: PropTypes.string.isRequired,
 			errorData: PropTypes.shape( {
 				type: PropTypes.string.isRequired,
 				description: PropTypes.string.isRequired,
 			} ),
-			siteTitle: PropTypes.string.isRequired,
 			statusMessage: PropTypes.string,
 		} ),
 	};

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -101,13 +101,11 @@ class ImportingPane extends React.PureComponent {
 			} ),
 			importerState: PropTypes.string.isRequired,
 			percentComplete: PropTypes.number,
-			site: PropTypes.shape( {
-				slug: PropTypes.string.isRequired,
-			} ),
 			statusMessage: PropTypes.string,
 		} ),
 		site: PropTypes.shape( {
 			ID: PropTypes.number.isRequired,
+			name: PropTypes.string.isRequired,
 			single_user_site: PropTypes.bool.isRequired,
 		} ).isRequired,
 		sourceType: PropTypes.string.isRequired,

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -182,7 +182,6 @@ class SectionImport extends Component {
 					siteTitle={ siteTitle }
 					importerStatus={ {
 						importerState: state,
-						siteTitle,
 						type: getImporterTypeForEngine( engine ),
 					} }
 				/>
@@ -216,7 +215,9 @@ class SectionImport extends Component {
 	 * @returns {Array} Importer react elements for the active import jobs
 	 */
 	renderActiveImporters( importsForSite ) {
-		return importsForSite.map( ( importItem, idx ) => {
+		const { fromSite, site, siteTitle } = this.props;
+
+		return importsForSite.map( ( importItem ) => {
 			const importer = getImporterByKey( importItem.type );
 			if ( ! importer ) {
 				return;
@@ -224,43 +225,14 @@ class SectionImport extends Component {
 
 			const ImporterComponent = importerComponents[ importer.engine ];
 
-			/**
-			 * Ugly hack™
-			 *
-			 * Sometimes due to the convoluted voodoo sorcery that is the Import Red(fl)ux store
-			 * the `site` object that gets passed in `importItem` contains only `{ ID: <site_id> }`.
-			 *
-			 * This makes the components down the chain fail as they expect to have the full `site` object
-			 * with all it's properties.
-			 *
-			 * That usually happens when you land on an import directly, such as when coming from a
-			 * `/?engine=wordpress` URL. In those cases a slew of artifacts occur - the upload reports issues,
-			 * the author mapping screen doesn't show any authors to choose from, etc.
-			 *
-			 * This hack makes sure to overwrite the the `site` object if it's the same as the current site.
-			 * Ideally this should always be the case, but if there's an instance where the current site is different
-			 * than what's stored in the import data, let it fail as it does now.
-			 */
-			const importItemId = get( importItem, 'site.ID', null );
-			const currentSiteId = get( this.props, 'site.ID', null );
-
-			if ( importItemId && importItemId === currentSiteId ) {
-				importItem.site = this.props.site;
-			}
-
-			const siteTitle = importItem.siteTitle || this.props.siteTitle;
-
 			return (
 				ImporterComponent && (
 					<ImporterComponent
-						key={ importItem.type + idx }
-						site={ importItem.site }
-						fromSite={ this.props.fromSite }
+						key={ importItem.importerId }
+						site={ site }
+						fromSite={ fromSite }
 						siteTitle={ siteTitle }
-						importerStatus={ {
-							...importItem,
-							siteTitle: siteTitle,
-						} }
+						importerStatus={ importItem }
 					/>
 				)
 			);
@@ -275,21 +247,22 @@ class SectionImport extends Component {
 	renderImporters() {
 		const {
 			api: { isHydrated },
-			importers: imports,
+			importers,
 		} = this.state;
 		const { engine, site, siteTitle } = this.props;
 
+		const importsForSite = filterImportsForSite( site.ID, importers );
+
+		// If starting a new import was requested by the `engine` query param, never show the list
+		// of available "idle" importers. Always render the list of active importers, even if it's
+		// initially empty. A new import will be started very soon by `onceAutoStartImport`.
 		if ( engine && importerComponents[ engine ] ) {
-			return this.renderActiveImporters( filterImportsForSite( site.ID, imports ) );
+			return this.renderActiveImporters( importsForSite );
 		}
 
 		if ( ! isHydrated ) {
 			return this.renderIdleImporters( site, siteTitle, appStates.DISABLED );
 		}
-
-		const importsForSite = filterImportsForSite( site.ID, imports )
-			// Add in the 'site' and 'siteTitle' properties to the import objects.
-			.map( ( item ) => Object.assign( {}, item, { site, siteTitle } ) );
 
 		if ( 0 === importsForSite.length ) {
 			return this.renderIdleImporters( site, siteTitle, appStates.INACTIVE );

--- a/client/my-sites/importer/site-importer/index.jsx
+++ b/client/my-sites/importer/site-importer/index.jsx
@@ -58,7 +58,6 @@ class SiteImporter extends React.PureComponent {
 			} ),
 			filename: PropTypes.string,
 			importerState: PropTypes.string.isRequired,
-			siteTitle: PropTypes.string.isRequired,
 			percentComplete: PropTypes.number,
 			statusMessage: PropTypes.string,
 			type: PropTypes.string.isRequired,


### PR DESCRIPTION
This PR kind of reverts a workaround introduced by @bisko in #39590, and fixes the original issue with what I believe is a much better and simpler fix 🙂 

The original issue was that when rendering the active importer, especially one started with a direct request in query params (`/import/example.blog?engine=wordpress`), the `ImporterComponent` sometimes "mysteriously" doesn't have valid `site` and `siteTitle` props.

The `importerStatus` prop object that is passed to `ImporterComponent` comes from the REST API, and is a [return value of the `fromApi` function](https://github.com/Automattic/wp-calypso/blob/679159c90eb4323cdba1611eb2de78e570531bf4/client/lib/importer/common.js#L85). It never has a `siteTitle` field, and the `site` field is mere `{ ID }`. So, if you want a full `site` and `siteTitle` props, they need to come from somewhere else.

If you look at the code that calls `this.renderActiveImporters()`, you'll see that it's called twice. The first call happens in the case where the importer is directly requested with `engine` query param, the second happens otherwise.

And you'll see that for the second call, the importer list is preprocessed with an additional `.map` call that adds the `site` and `siteTitle` fields, with their full values:
```
.map( ( item ) => Object.assign( {}, item, { site, siteTitle } ) )
```
The first call doesn't get this preprocessing though. That's why rendering a directly requested importer fails.

The `ImporterComponent` was then rendered with `site` and `siteTitle` props that were coming from this `importItem` object:
```js
<ImporterComponent
  importerStatus={ importItem }
  site={ importItem.site }
  siteTitle={ importItem.siteTitle }
/>
```
My patch removes that `site`- and `siteTitle`-adding preprocessing completely and gets these props from Redux:
```js
<ImporterComponent
  importerStatus={ importItem }
  site={ this.props.site }
  siteTitle={ this.props.siteTitle }
/>
```

It's important to know that the `ImporterComponent` components never use the `importerStatus.site` and `importerStatus.siteTitle` fields. They use only the `site` and `siteTitle` props, and once these have correct values, we are OK.

I reviewed the prop usage in all the components (importers for various services, `FileImporter`, `SiteImporter`) and verified that adding fields to `importerStatus` is indeed not necessary. While doing that review, I fixed several proptypes definitions, committed here as standalone commits.