### PR TITLE
Purchases: enable stored credit cards

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -82,7 +82,7 @@
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"press-this": false,
-		"purchases/new-payment-methods": false,
+		"purchases/new-payment-methods": true,
 		"reader": true,
 		"reader/full-errors": false,
 		"republicize": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -102,7 +102,7 @@
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"publicize-preview": true,
-		"purchases/new-payment-methods": false,
+		"purchases/new-payment-methods": true,
 		"press-this": true,
 		"privacy-policy": true,
 		"reader": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -47,7 +47,7 @@
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
 		"oauth": false,
-		"purchases/new-payment-methods": false,
+		"purchases/new-payment-methods": true,
 		"site-indicator": false,
 		"support-user": true,
 		"upgrades/redirect-payments": true

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -45,7 +45,7 @@
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
 		"oauth": true,
-		"purchases/new-payment-methods": false,
+		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
 		"support-user": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -48,7 +48,7 @@
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
 		"oauth": true,
-		"purchases/new-payment-methods": false,
+		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
 		"support-user": true,

--- a/config/production.json
+++ b/config/production.json
@@ -111,7 +111,7 @@
 		"press-this": true,
 		"privacy-policy": true,
 		"publicize-preview": true,
-		"purchases/new-payment-methods": false,
+		"purchases/new-payment-methods": true,
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -117,7 +117,7 @@
 		"press-this": true,
 		"privacy-policy": true,
 		"publicize-preview": true,
-		"purchases/new-payment-methods": false,
+		"purchases/new-payment-methods": true,
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,

--- a/config/test.json
+++ b/config/test.json
@@ -88,7 +88,7 @@
 		"post-editor/image-editor": true,
 		"press-this": true,
 		"publicize-preview": true,
-		"purchases/new-payment-methods": false,
+		"purchases/new-payment-methods": true,
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enables the stored credit cards payment method so people can update their payment methods easier.

#### Testing instructions

* Visit a purchase made with a credit card and click on change payment method. Confirm that you see your existing credit cards and that you can either save with one of those or add a new one. 
* Delete all your payment methods, then go to a purchase and click on "Change Payment Method" you should see the Credit card form on its own. 
* Click on the "Add Payment Method" button on the payment method screens. You should only see a credit card form there.