### PR TITLE
Jetpack Cloud: make the "Add New Site" button redirect users to the JC flow

### DIFF
--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -10,12 +10,16 @@ import { Button } from '@automattic/components';
  * Internal dependencies
  */
 import Gridicon from 'calypso/components/gridicon';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 
 class SiteSelectorAddSite extends Component {
 	recordAddNewSite = () => {
-		this.props.recordTracksEvent( 'calypso_add_new_wordpress_click' );
+		const event = isJetpackCloud()
+			? 'calypso_add_new_jetpack_click'
+			: 'calypso_add_new_wordpress_click';
+		this.props.recordTracksEvent( event );
 	};
 
 	render() {

--- a/client/state/selectors/get-onboarding-url.js
+++ b/client/state/selectors/get-onboarding-url.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getVariationForUser } from 'calypso/state/experiments/selectors';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import config from 'calypso/config';
@@ -16,6 +17,10 @@ import config from 'calypso/config';
 const GUTENBOARDING_LOCALES = [ 'en', 'en-gb' ];
 
 export default function getOnboardingUrl( state ) {
+	if ( isJetpackCloud() ) {
+		return config( 'jetpack_connect_url' );
+	}
+
 	const userLocale = getCurrentUserLocale( state );
 	if ( GUTENBOARDING_LOCALES.includes( userLocale ) ) {
 		return config( 'gutenboarding_url' );

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -10,6 +10,7 @@
 	"rtl": false,
 	"login_url": "/connect",
 	"logout_url": "https://jetpack.com",
+	"jetpack_connect_url": "https://wordpress.com/jetpack/connect",
 	"site_name": "Jetpack: WordPress Security, Backups, Speed, & Growth",
 	"meta": [
 		{

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -8,6 +8,7 @@
 	"rtl": false,
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"jetpack_connect_url": "https://wordpress.com/jetpack/connect",
 	"site_name": "Jetpack.com",
 	"meta": [
 		{

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -8,6 +8,7 @@
 	"rtl": false,
 	"login_url": "/connect",
 	"logout_url": "https://jetpack.com",
+	"jetpack_connect_url": "https://wordpress.com/jetpack/connect",
 	"site_name": "Jetpack.com",
 	"meta": [
 		{

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -8,6 +8,7 @@
 	"rtl": false,
 	"login_url": "/connect",
 	"logout_url": "https://jetpack.com",
+	"jetpack_connect_url": "https://wordpress.com/jetpack/connect",
 	"site_name": "Jetpack.com",
 	"meta": [
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 1164141197617539-as-1199631470030086

Currently, the `Add New Site` button, located inside the `SiteSelector`, sends users to a non-existent path, breaking the UX.

* On Jetpack cloud, make the `Add New Site` send users to the Jetpack Connect flow located at `wordpress.com/jetpack/connect`.

#### Testing instructions

Prerequisite: a user account with at least one Jetpack site.

* Download this PR and run it locally building both Calypsos (`yarn start` and `yarn start-jetpack-cloud-p`).

**Jetpack cloud**
* Visit `http://jetpack.cloud.localhost:3001`.
* Click on the `Switch Site` sidebar menu option.
* Click on the `Add new site` button located at the bottom of the component.
* Verify that you are redirected to `https://wordpress.com/jetpack/connect?ref=calypso-selector`.

**WordPress.com**
* Visit `http://calypso.localhost:3000`.
* Click on the `Switch Site` sidebar menu option.
* Click on the `Add new site` button located at the bottom of the component.
* Verify that you are redirected to `http://calypso.localhost:3000/new?ref=calypso-selector` if your locale is English or to `http://calypso.localhost:3000/start?ref=calypso-selector` if your locale is other than English.

#### Demo

#### Jetpack cloud – Before
![Kapture 2020-12-17 at 14 06 13](https://user-images.githubusercontent.com/3418513/102519377-29b2d500-4071-11eb-8abd-fe906f3d91e2.gif)

#### Jetpack cloud – After
![Kapture 2020-12-17 at 14 06 52](https://user-images.githubusercontent.com/3418513/102519371-27e91180-4071-11eb-8cdf-bd57ce1fdf51.gif)
