### PR TITLE
Add support for new Stripe Australia and Stripe Canada accounts to our Apple Pay implementation

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
@@ -83,7 +83,7 @@ export default function useIsApplePayAvailable(
 		}
 
 		// Ask Stripe if apple pay can be used. This is async.
-		let countryCode: string = 'US';
+		let countryCode = 'US';
 
 		if ( stripeConfiguration ) {
 			switch ( stripeConfiguration.processor_id ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-is-apple-pay-available.ts
@@ -83,8 +83,24 @@ export default function useIsApplePayAvailable(
 		}
 
 		// Ask Stripe if apple pay can be used. This is async.
-		const countryCode =
-			stripeConfiguration && stripeConfiguration.processor_id === 'stripe_ie' ? 'IE' : 'US';
+		let countryCode: string = 'US';
+
+		if ( stripeConfiguration ) {
+			switch ( stripeConfiguration.processor_id ) {
+				case 'stripe_ie':
+					countryCode = 'IE';
+					break;
+				case 'stripe_au':
+					countryCode = 'AU';
+					break;
+				case 'stripe_ca':
+					countryCode = 'CA';
+					break;
+				default:
+					break;
+			}
+		}
+
 		const currency = items.reduce(
 			( firstCurrency, item ) => firstCurrency || item.amount.currency,
 			null

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -213,5 +213,22 @@ function completePaymentMethodTransaction( { onSubmit, complete, paymentMethod, 
 }
 
 function getProcessorCountryFromStripeConfiguration( stripeConfiguration ) {
-	return stripeConfiguration && stripeConfiguration.processor_id === 'stripe_ie' ? 'IE' : 'US';
+	let countryCode = 'US';
+
+	if ( stripeConfiguration ) {
+		switch ( stripeConfiguration.processor_id ) {
+			case 'stripe_ie':
+				countryCode = 'IE';
+				break;
+			case 'stripe_au':
+				countryCode = 'AU';
+				break;
+			case 'stripe_ca':
+				countryCode = 'CA';
+				break;
+			default:
+				break;
+		}
+	}
+	return countryCode;
 }


### PR DESCRIPTION
We're setting up new Stripe accounts for our Australian and Canadian customers. This PR adds support for these accounts to our Apple Pay implementation.

#### Changes proposed in this Pull Request

* This PR implements a switch case block responsible for designating the country code for a given Stripe processor.

#### Testing instructions

* @sirbrillig helped with testing this :). Testing Apple Pay is really complicated, so don't bother :)