### PR TITLE
Prevent `bumpStat` from triggering exception in node

### DIFF
--- a/client/lib/analytics/mc.js
+++ b/client/lib/analytics/mc.js
@@ -45,7 +45,7 @@ export function bumpStat( group, name ) {
 		mcDebug( 'Bumping stat %s:%s', group, name );
 	}
 
-	if ( config( 'mc_analytics_enabled' ) ) {
+	if ( 'undefined' !== typeof window && config( 'mc_analytics_enabled' ) ) {
 		const uriComponent = buildQuerystring( group, name );
 		new window.Image().src =
 			document.location.protocol +
@@ -64,7 +64,7 @@ export function bumpStatWithPageView( group, name ) {
 		mcDebug( 'Bumping page view %s:%s', group, name );
 	}
 
-	if ( config( 'mc_analytics_enabled' ) ) {
+	if ( 'undefined' !== typeof window && config( 'mc_analytics_enabled' ) ) {
 		const uriComponent = buildQuerystringNoPrefix( group, name );
 		new window.Image().src =
 			document.location.protocol +


### PR DESCRIPTION
### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/48360, the `abtest` function was introduced in code that's run server-side. This raised the follow exception:
```
/calypso/build/webpack:/client/lib/analytics/mc.js:50
        new window.Image().src =
  ^
ReferenceError: window is not defined
    at bumpStat (/calypso/build/webpack:/client/lib/analytics/mc.js:50:3)
```

This PR prevents the app from crashing by checking the window object.

### Testing instructions

- Review code
- I'm not sure how to reproduce the error server side. However, you can test that it still works on the frontend by visiting `/plans/:site` in Calypso with a self-hosted Jetpack site, update the `jetpackPricingReversePlans` experiment variation (see capture), and check that there's no error in the console.

### Captures

<img width="648" alt="Screen Shot 2020-12-17 at 2 08 07 PM" src="https://user-images.githubusercontent.com/1620183/102532001-4949fd80-4071-11eb-9d85-5f219ae3507e.png">

