### PR TITLE
Ensure the `wp-gutenberg-experimental-features-spec` runs on CI

### DIFF
--- a/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/wp-gutenberg-experimental-features-spec.js
@@ -50,7 +50,7 @@ before( async function () {
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] Experimental features we depend on are available (${ screenSize })`, function () {
+describe( `[${ host }] Experimental features we depend on are available (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	step( 'Can log in', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the @parallel tag the outer describe in  so it's picked up by Magellan on CI

#### Testing instructions

* In the "Checks" section in this PR, find the `ci/wp-e2e-tests-full-desktop` and `ci/wp-e2e-tests-full-mobile` jobs, ALT-click "Details" on each of them;
* In their tabs, find the "Run Tests" accordion, click it to expand the log;
* Search for `Experimental features we depend on are available`, it should appear in the list of tests there;
* All tests should pass

Fixes #47839
