### PR TITLE
Starter page templates - fix double modal / wrong button appearing - alt approach

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.js
@@ -44,25 +44,21 @@ if ( screenAction === 'add' ) {
 	dispatch( 'automattic/starter-page-layouts' ).setOpenState( 'OPEN_FROM_ADD_PAGE' );
 }
 
-// Register plugin unconditionally so it may be opened through the sidebar.
-registerPlugin( 'page-templates', {
-	render: () => (
-		<PageTemplatesPlugin { ...templatesPluginSharedProps } shouldPrefetchAssets={ false } />
-	),
-} );
-
 // Always register ability to open from document sidebar.
-registerPlugin( 'page-templates-sidebar', {
+registerPlugin( 'page-templates', {
 	render: () => {
 		return (
-			<PluginDocumentSettingPanel
-				name="Template Modal Opener"
-				title={ __( 'Page Layout', 'full-site-editing' ) }
-				className="page-template-modal__sidebar" // eslint-disable-line wpcalypso/jsx-classname-namespace
-				icon="none"
-			>
-				<SidebarTemplatesPlugin />
-			</PluginDocumentSettingPanel>
+			<>
+				<PageTemplatesPlugin { ...templatesPluginSharedProps } shouldPrefetchAssets={ false } />
+				<PluginDocumentSettingPanel
+					name="Template Modal Opener"
+					title={ __( 'Page Layout', 'full-site-editing' ) }
+					className="page-template-modal__sidebar" // eslint-disable-line wpcalypso/jsx-classname-namespace
+					icon="none"
+				>
+					<SidebarTemplatesPlugin />
+				</PluginDocumentSettingPanel>
+			</>
 		);
 	},
 } );
@@ -70,13 +66,9 @@ registerPlugin( 'page-templates-sidebar', {
 // Make sidebar plugin open by default.
 const unsubscribe = subscribe( () => {
 	if (
-		! select( 'core/edit-post' ).isEditorPanelOpened(
-			'page-templates-sidebar/Template Modal Opener'
-		)
+		! select( 'core/edit-post' ).isEditorPanelOpened( 'page-templates/Template Modal Opener' )
 	) {
-		dispatch( 'core/edit-post' ).toggleEditorPanelOpened(
-			'page-templates-sidebar/Template Modal Opener'
-		);
+		dispatch( 'core/edit-post' ).toggleEditorPanelOpened( 'page-templates/Template Modal Opener' );
 	}
 	unsubscribe();
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.js
@@ -43,6 +43,8 @@ const templatesPluginSharedProps = {
 if ( screenAction === 'add' ) {
 	dispatch( 'automattic/starter-page-layouts' ).setOpenState( 'OPEN_FROM_ADD_PAGE' );
 }
+
+// Register plugin unconditionally so it may be opened through the sidebar.
 registerPlugin( 'page-templates', {
 	render: () => (
 		<PageTemplatesPlugin { ...templatesPluginSharedProps } shouldPrefetchAssets={ false } />

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.js
@@ -41,13 +41,13 @@ const templatesPluginSharedProps = {
 
 // Open plugin only if we are creating new page.
 if ( screenAction === 'add' ) {
-	dispatch( 'automattic/starter-page-layouts' ).setIsOpen( true );
-	registerPlugin( 'page-templates', {
-		render: () => (
-			<PageTemplatesPlugin { ...templatesPluginSharedProps } shouldPrefetchAssets={ false } />
-		),
-	} );
+	dispatch( 'automattic/starter-page-layouts' ).setOpenState( 'OPEN_FROM_ADD_PAGE' );
 }
+registerPlugin( 'page-templates', {
+	render: () => (
+		<PageTemplatesPlugin { ...templatesPluginSharedProps } shouldPrefetchAssets={ false } />
+	),
+} );
 
 // Always register ability to open from document sidebar.
 registerPlugin( 'page-templates-sidebar', {
@@ -59,7 +59,7 @@ registerPlugin( 'page-templates-sidebar', {
 				className="page-template-modal__sidebar" // eslint-disable-line wpcalypso/jsx-classname-namespace
 				icon="none"
 			>
-				<SidebarTemplatesPlugin { ...templatesPluginSharedProps } />
+				<SidebarTemplatesPlugin />
 			</PluginDocumentSettingPanel>
 		);
 	},

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.js
@@ -53,7 +53,7 @@ registerPlugin( 'page-templates', {
 				<PluginDocumentSettingPanel
 					name="Template Modal Opener"
 					title={ __( 'Page Layout', 'full-site-editing' ) }
-					className="page-template-modal__sidebar" // eslint-disable-line wpcalypso/jsx-classname-namespace
+					className="page-template-modal__sidebar"
 					icon="none"
 				>
 					<SidebarTemplatesPlugin />

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -2,49 +2,32 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withDispatch } from '@wordpress/data';
 import { Button, Modal } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-/**
- * Internal dependencies
- */
-import { PageTemplatesPlugin } from '../index';
+
 class SidebarModalOpener extends Component {
 	state = {
 		isWarningOpen: false,
 	};
 
-	toggleTemplateModal = () => {
-		this.props.setIsOpen( ! this.props.isOpen );
+	openTemplateModal = () => {
+		this.props.setIsOpen( true, true );
 	};
 
 	toggleWarningModal = () => {
-		this.setState( { isWarningOpen: ! this.state.isWarningOpen } );
+		this.setState( ( state ) => ( {
+			isWarningOpen: ! state.isWarningOpen,
+		} ) );
 	};
 
 	render() {
-		const { templates, theme, vertical, segment, hidePageTitle, isFrontPage, isOpen } = this.props;
-
 		return (
 			<div className="sidebar-modal-opener">
 				<Button isSecondary onClick={ this.toggleWarningModal }>
 					{ __( 'Change Layout', 'full-site-editing' ) }
 				</Button>
-
-				{ isOpen && (
-					<PageTemplatesPlugin
-						shouldPrefetchAssets={ false }
-						templates={ templates }
-						theme={ theme }
-						vertical={ vertical }
-						segment={ segment }
-						toggleTemplateModal={ this.toggleTemplateModal }
-						hidePageTitle={ hidePageTitle }
-						isFrontPage={ isFrontPage }
-						isPromptedFromSidebar
-					/>
-				) }
 
 				{ this.state.isWarningOpen && (
 					<Modal
@@ -63,7 +46,7 @@ class SidebarModalOpener extends Component {
 							<Button isDefault onClick={ this.toggleWarningModal }>
 								{ __( 'Cancel', 'full-site-editing' ) }
 							</Button>
-							<Button isPrimary onClick={ this.toggleTemplateModal }>
+							<Button isPrimary onClick={ this.openTemplateModal }>
 								{ __( 'Change Layout', 'full-site-editing' ) }
 							</Button>
 						</div>
@@ -75,9 +58,6 @@ class SidebarModalOpener extends Component {
 }
 
 const SidebarTemplatesPlugin = compose(
-	withSelect( ( select ) => ( {
-		isOpen: select( 'automattic/starter-page-layouts' ).isOpen(),
-	} ) ),
 	withDispatch( ( dispatch ) => ( {
 		setIsOpen: dispatch( 'automattic/starter-page-layouts' ).setIsOpen,
 	} ) )

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -13,7 +13,7 @@ class SidebarModalOpener extends Component {
 	};
 
 	openTemplateModal = () => {
-		this.props.setIsOpen( true, true );
+		this.props.setOpenState( 'OPEN_FROM_SIDEBAR' );
 	};
 
 	toggleWarningModal = () => {
@@ -59,7 +59,7 @@ class SidebarModalOpener extends Component {
 
 const SidebarTemplatesPlugin = compose(
 	withDispatch( ( dispatch ) => ( {
-		setIsOpen: dispatch( 'automattic/starter-page-layouts' ).setIsOpen,
+		setOpenState: dispatch( 'automattic/starter-page-layouts' ).setOpenState,
 	} ) )
 )( SidebarModalOpener );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -182,7 +182,7 @@ class PageTemplateModal extends Component {
 
 		// Skip setting template if user selects current layout
 		if ( 'current' === slug ) {
-			this.props.setIsOpen( false );
+			this.props.setOpenState( false );
 			return;
 		}
 
@@ -190,7 +190,7 @@ class PageTemplateModal extends Component {
 		// and reset the template if so.
 		if ( 'blank' === slug ) {
 			this.props.insertTemplate( '', [] );
-			this.props.setIsOpen( false );
+			this.props.setOpenState( false );
 			return;
 		}
 
@@ -205,7 +205,7 @@ class PageTemplateModal extends Component {
 		// Skip inserting if this is not a blank template
 		// and there's nothing to insert.
 		if ( ! blocks || ! blocks.length ) {
-			this.props.setIsOpen( false );
+			this.props.setOpenState( false );
 			return;
 		}
 
@@ -226,7 +226,7 @@ class PageTemplateModal extends Component {
 				}
 
 				this.props.insertTemplate( title, blocksWithAssets );
-				this.props.setIsOpen( false );
+				this.props.setOpenState( false );
 			} )
 			.catch( ( error ) => {
 				this.setState( {
@@ -361,7 +361,13 @@ class PageTemplateModal extends Component {
 
 	render() {
 		const { previewedTemplate, isLoading } = this.state;
-		const { isPromptedFromSidebar, hidePageTitle, isOpen, currentBlocks, setIsOpen } = this.props;
+		const {
+			isPromptedFromSidebar,
+			hidePageTitle,
+			isOpen,
+			currentBlocks,
+			setOpenState,
+		} = this.props;
 
 		if ( ! isOpen ) {
 			return null;
@@ -409,7 +415,7 @@ class PageTemplateModal extends Component {
 				{ isPromptedFromSidebar ? (
 					<IconButton
 						className="page-template-modal__close-button components-icon-button"
-						onClick={ () => setIsOpen( false ) }
+						onClick={ () => setOpenState( false ) }
 						icon="no-alt"
 						label={ __( 'Close Layout Selector', 'full-site-editing' ) }
 					/>
@@ -542,9 +548,9 @@ export const PageTemplatesPlugin = compose(
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const editorDispatcher = dispatch( 'core/editor' );
-		const { setIsOpen } = dispatch( 'automattic/starter-page-layouts' );
+		const { setOpenState } = dispatch( 'automattic/starter-page-layouts' );
 		return {
-			setIsOpen,
+			setOpenState,
 			saveTemplateChoice: ( slug ) => {
 				// Save selected template slug in meta.
 				const currentMeta = ownProps.getMeta();

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -246,11 +246,6 @@ class PageTemplateModal extends Component {
 		}
 
 		this.setTemplate( slug );
-
-		// Turn off sidebar's instance of modal
-		if ( this.props.isPromptedFromSidebar ) {
-			this.props.toggleTemplateModal();
-		}
 	};
 
 	previewTemplate = ( slug ) => {
@@ -366,7 +361,7 @@ class PageTemplateModal extends Component {
 
 	render() {
 		const { previewedTemplate, isLoading } = this.state;
-		const { isPromptedFromSidebar, hidePageTitle, isOpen, currentBlocks } = this.props;
+		const { isPromptedFromSidebar, hidePageTitle, isOpen, currentBlocks, setIsOpen } = this.props;
 
 		if ( ! isOpen ) {
 			return null;
@@ -414,7 +409,7 @@ class PageTemplateModal extends Component {
 				{ isPromptedFromSidebar ? (
 					<IconButton
 						className="page-template-modal__close-button components-icon-button"
-						onClick={ this.props.toggleTemplateModal }
+						onClick={ () => setIsOpen( false ) }
 						icon="no-alt"
 						label={ __( 'Close Layout Selector', 'full-site-editing' ) }
 					/>
@@ -531,10 +526,11 @@ export const PageTemplatesPlugin = compose(
 	withSelect( ( select ) => {
 		const getMeta = () => select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 		const { _starter_page_template } = getMeta();
-		const isOpen = select( 'automattic/starter-page-layouts' ).isOpen();
+		const { isOpen, isPromptedFromSidebar } = select( 'automattic/starter-page-layouts' );
 		const currentBlocks = select( 'core/editor' ).getBlocks();
 		return {
-			isOpen,
+			isOpen: isOpen(),
+			isPromptedFromSidebar: isPromptedFromSidebar(),
 			getMeta,
 			_starter_page_template,
 			currentBlocks,

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/store.js
@@ -9,13 +9,11 @@ const reducer = ( state = { isOpen: false, isPromptedFromSidebar: false }, { typ
 		: state;
 
 const actions = {
-	setIsOpen: ( isOpen, isPromptedFromSidebar ) => {
-		return {
-			type: 'SET_IS_OPEN',
-			isOpen,
-			isPromptedFromSidebar: !! isPromptedFromSidebar,
-		};
-	},
+	setIsOpen: ( isOpen, isPromptedFromSidebar ) => ( {
+		type: 'SET_IS_OPEN',
+		isOpen,
+		isPromptedFromSidebar: !! isPromptedFromSidebar,
+	} ),
 };
 
 const selectors = {

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/store.js
@@ -3,22 +3,19 @@
  */
 import { registerStore } from '@wordpress/data';
 
-const reducer = ( state = { isOpen: false, isPromptedFromSidebar: false }, { type, ...action } ) =>
-	'SET_IS_OPEN' === type
-		? { ...state, isOpen: action.isOpen, isPromptedFromSidebar: action.isPromptedFromSidebar }
-		: state;
+const reducer = ( state = 'CLOSED', { type, ...action } ) =>
+	'SET_IS_OPEN' === type ? action.openState : state;
 
 const actions = {
-	setIsOpen: ( isOpen, isPromptedFromSidebar ) => ( {
+	setOpenState: ( openState ) => ( {
 		type: 'SET_IS_OPEN',
-		isOpen,
-		isPromptedFromSidebar: !! isPromptedFromSidebar,
+		openState: openState || 'CLOSED',
 	} ),
 };
 
 const selectors = {
-	isOpen: ( state ) => state.isOpen,
-	isPromptedFromSidebar: ( state ) => state.isPromptedFromSidebar,
+	isOpen: ( state ) => 'CLOSED' !== state,
+	isPromptedFromSidebar: ( state ) => 'OPEN_FROM_SIDEBAR' === state,
 };
 
 registerStore( 'automattic/starter-page-layouts', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/store.js
@@ -3,18 +3,24 @@
  */
 import { registerStore } from '@wordpress/data';
 
-const reducer = ( state = { isOpen: false }, { type, ...action } ) =>
-	'SET_IS_OPEN' === type ? { ...state, isOpen: action.isOpen } : state;
+const reducer = ( state = { isOpen: false, isPromptedFromSidebar: false }, { type, ...action } ) =>
+	'SET_IS_OPEN' === type
+		? { ...state, isOpen: action.isOpen, isPromptedFromSidebar: action.isPromptedFromSidebar }
+		: state;
 
 const actions = {
-	setIsOpen: ( isOpen ) => ( {
-		type: 'SET_IS_OPEN',
-		isOpen,
-	} ),
+	setIsOpen: ( isOpen, isPromptedFromSidebar ) => {
+		return {
+			type: 'SET_IS_OPEN',
+			isOpen,
+			isPromptedFromSidebar: !! isPromptedFromSidebar,
+		};
+	},
 };
 
 const selectors = {
 	isOpen: ( state ) => state.isOpen,
+	isPromptedFromSidebar: ( state ) => state.isPromptedFromSidebar,
 };
 
 registerStore( 'automattic/starter-page-layouts', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Alternative approach to #48377 to solve #48370.

Behavior, description, and testing instructions should be the same as #48377.  Here we remove the separate instance of the modal and instead trigger the original one with an extra store state value to determine its context.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #48370
