### PR TITLE
Payment Methods: check if currentPaymentMethod is defined

### DIFF
--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -180,7 +180,7 @@ function ChangePaymentMethodList( {
 	siteSlug,
 	apiParams,
 } ) {
-	const currentlyAssignedPaymentMethodId = 'existingCard-' + currentPaymentMethod.stored_details_id; // TODO: make this work for paypal.
+	const currentlyAssignedPaymentMethodId = 'existingCard-' + currentPaymentMethod?.stored_details_id; // TODO: make this work for paypal.
 
 	const translate = useTranslate();
 	const { isStripeLoading, stripe, stripeConfiguration } = useStripe();

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -180,7 +180,8 @@ function ChangePaymentMethodList( {
 	siteSlug,
 	apiParams,
 } ) {
-	const currentlyAssignedPaymentMethodId = 'existingCard-' + currentPaymentMethod?.stored_details_id; // TODO: make this work for paypal.
+	const currentlyAssignedPaymentMethodId =
+		'existingCard-' + currentPaymentMethod?.stored_details_id; // TODO: make this work for paypal.
 
 	const translate = useTranslate();
 	const { isStripeLoading, stripe, stripeConfiguration } = useStripe();


### PR DESCRIPTION
When a card is expired, `currentPaymentMethod` might be undefined, triggering an error.