### PR TITLE
Shopping Cart: Throw Error when adding invalid products

### DIFF
--- a/packages/shopping-cart/src/create-request-cart-product.ts
+++ b/packages/shopping-cart/src/create-request-cart-product.ts
@@ -1,14 +1,13 @@
 /**
  * Internal dependencies
  */
-import type { RequestCartProduct } from './shopping-cart-endpoint';
+import type { RequestCartProduct, MinimalRequestCartProduct } from './shopping-cart-endpoint';
 
 export default function createRequestCartProduct(
-	properties: Partial< RequestCartProduct > &
-		Pick< RequestCartProduct, 'product_slug' | 'product_id' >
+	properties: MinimalRequestCartProduct
 ): RequestCartProduct {
 	if ( ! properties.product_slug || ! properties.product_id ) {
-		throw new Error( 'Both product_slug and product_id are required for createRequestCartProduct' );
+		throw new Error( 'Both product_slug and product_id are required for request cart products' );
 	}
 	return {
 		meta: '',
@@ -17,4 +16,10 @@ export default function createRequestCartProduct(
 		extra: {},
 		...properties,
 	};
+}
+
+export function createRequestCartProducts(
+	products: MinimalRequestCartProduct[]
+): RequestCartProduct[] {
+	return products.map( createRequestCartProduct );
 }

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -51,6 +51,12 @@ export interface RequestCartProduct {
 }
 
 /**
+ * Product data that a client might use to request adding a product
+ */
+export type MinimalRequestCartProduct = Partial< RequestCartProduct > &
+	Pick< RequestCartProduct, 'product_slug' | 'product_id' >;
+
+/**
  * Response schema for the shopping cart endpoint
  */
 export interface ResponseCart< P = ResponseCartProduct > {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -7,6 +7,7 @@ import type {
 	RequestCart,
 	RequestCartProduct,
 	CartLocation,
+	MinimalRequestCartProduct,
 } from './shopping-cart-endpoint';
 
 export * from './shopping-cart-endpoint';
@@ -41,9 +42,9 @@ export type ReplaceProductInCart = (
 
 export type ReloadCartFromServer = () => Promise< void >;
 
-export type ReplaceProductsInCart = ( products: RequestCartProduct[] ) => Promise< void >;
+export type ReplaceProductsInCart = ( products: MinimalRequestCartProduct[] ) => Promise< void >;
 
-export type AddProductsToCart = ( products: RequestCartProduct[] ) => Promise< void >;
+export type AddProductsToCart = ( products: MinimalRequestCartProduct[] ) => Promise< void >;
 
 export type RemoveCouponFromCart = () => Promise< void >;
 

--- a/packages/shopping-cart/src/use-cart-update-and-revalidate.ts
+++ b/packages/shopping-cart/src/use-cart-update-and-revalidate.ts
@@ -28,6 +28,12 @@ export default function useCartUpdateAndRevalidate(
 	hookDispatch: ( arg0: ShoppingCartAction ) => void
 ): void {
 	const pendingResponseCart = useRef< TempResponseCart >( responseCart );
+	const isMounted = useRef< boolean >( true );
+	useEffect( () => {
+		return () => {
+			isMounted.current = false;
+		};
+	}, [] );
 
 	useEffect( () => {
 		if ( cacheStatus !== 'invalid' ) {
@@ -52,18 +58,20 @@ export default function useCartUpdateAndRevalidate(
 					debug( 'ignoring updated cart because there is a newer request pending' );
 					return;
 				}
-				hookDispatch( {
-					type: 'RECEIVE_UPDATED_RESPONSE_CART',
-					updatedResponseCart: convertRawResponseCartToResponseCart( response ),
-				} );
+				isMounted.current &&
+					hookDispatch( {
+						type: 'RECEIVE_UPDATED_RESPONSE_CART',
+						updatedResponseCart: convertRawResponseCartToResponseCart( response ),
+					} );
 			} )
 			.catch( ( error ) => {
 				debug( 'error while setting cart', error );
-				hookDispatch( {
-					type: 'RAISE_ERROR',
-					error: 'SET_SERVER_CART_ERROR',
-					message: error.message,
-				} );
+				isMounted.current &&
+					hookDispatch( {
+						type: 'RAISE_ERROR',
+						error: 'SET_SERVER_CART_ERROR',
+						message: error.message,
+					} );
 			} );
-	}, [ setServerCart, cacheStatus, responseCart, hookDispatch ] );
+	}, [ isMounted, setServerCart, cacheStatus, responseCart, hookDispatch ] );
 }

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -55,6 +55,13 @@ export default function useShoppingCartManager( {
 	const cacheStatus: CacheStatus = hookState.cacheStatus;
 	const loadingError: string | undefined = hookState.loadingError;
 	const loadingErrorType: ShoppingCartError | undefined = hookState.loadingErrorType;
+	const isMounted = useRef< boolean >( true );
+
+	useEffect( () => {
+		return () => {
+			isMounted.current = false;
+		};
+	}, [] );
 
 	useEffect( () => {
 		if ( ! cartKey ) {
@@ -64,7 +71,7 @@ export default function useShoppingCartManager( {
 			debug(
 				`cart key "${ cartKey }" has changed from "${ previousCartKey.current }"; re-initializing cart`
 			);
-			hookDispatch( { type: 'CART_RELOAD' } );
+			isMounted.current && hookDispatch( { type: 'CART_RELOAD' } );
 		}
 		previousCartKey.current = cartKey;
 	}, [ cartKey, hookDispatch ] );
@@ -77,11 +84,11 @@ export default function useShoppingCartManager( {
 	const dispatchAndWaitForValid = useCallback(
 		( action ) => {
 			return new Promise< void >( ( resolve ) => {
-				hookDispatch( action );
+				isMounted.current && hookDispatch( action );
 				cartValidCallbacks.current.push( resolve );
 			} );
 		},
-		[ hookDispatch ]
+		[ hookDispatch, isMounted ]
 	);
 
 	const addProductsToCart: AddProductsToCart = useCallback(

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -30,6 +30,7 @@ import { convertTempResponseCartToResponseCart } from './cart-functions';
 import useShoppingCartReducer from './use-shopping-cart-reducer';
 import useInitializeCartFromServer from './use-initialize-cart-from-server';
 import useCartUpdateAndRevalidate from './use-cart-update-and-revalidate';
+import { createRequestCartProducts } from './create-request-cart-product';
 
 const debug = debugFactory( 'shopping-cart:use-shopping-cart-manager' );
 
@@ -84,12 +85,20 @@ export default function useShoppingCartManager( {
 	);
 
 	const addProductsToCart: AddProductsToCart = useCallback(
-		( products ) => dispatchAndWaitForValid( { type: 'CART_PRODUCTS_ADD', products } ),
+		( products ) =>
+			dispatchAndWaitForValid( {
+				type: 'CART_PRODUCTS_ADD',
+				products: createRequestCartProducts( products ),
+			} ),
 		[ dispatchAndWaitForValid ]
 	);
 
 	const replaceProductsInCart: ReplaceProductsInCart = useCallback(
-		( products ) => dispatchAndWaitForValid( { type: 'CART_PRODUCTS_REPLACE_ALL', products } ),
+		( products ) =>
+			dispatchAndWaitForValid( {
+				type: 'CART_PRODUCTS_REPLACE_ALL',
+				products: createRequestCartProducts( products ),
+			} ),
 		[ dispatchAndWaitForValid ]
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies the shopping cart manager functions `addProductsToCart` and `replaceProductsInCart` so that they do a minimal validation on each product; specifically they make sure each product is an object with at least a `product_id` and `product_slug` property. If that validation fails, the function will throw an Error.

The old shopping cart functions, like `addItems`, automatically fetch the `product_id` if it's missing, and the product creation functions, like `domainItem`, do not provide a `product_id`. We cannot easily perform the same operation since the product list is stored in calypso's Redux store and the shopping cart manager is in its own package, relying instead on the consumer to find the `product_id` themselves.

For example, adding a product with the old cart store system looks like this:

```js
addItem( domainItem( 'domain_reg', 'example.com' ) )
```

Adding a product with the new system looks like this:

```js
addProductsToCart( [ fillInSingleCartItemAttributes( domainItem( 'domain_reg', 'example.com' ), productList ) ] )
```

The reason for this PR is to help prevent developers from missing this important point when using the above functions.

As an added bonus, this PR adds an `isMounted` check to async shopping cart actions to remove the warnings that occur if the page has changed while a request is in-flight.

#### Testing instructions

There are automated tests covering the behavior, but you can test checkout to be sure that adding a product still works safely.

- Add a plan to your cart and visit checkout.
- Verify that the plan is in your cart and there are no errors.