### PR TITLE
Respect redirect_after_auth if Jetpack Boost has triggered the flow.

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -153,6 +153,7 @@ export class JetpackAuthorize extends Component {
 			this.isSso( nextProps ) ||
 			this.isWooRedirect( nextProps ) ||
 			this.isFromJpo( nextProps ) ||
+			this.isFromJetpackBoost( nextProps ) ||
 			this.shouldRedirectJetpackStart( nextProps ) ||
 			this.props.isVip
 		) {
@@ -222,6 +223,7 @@ export class JetpackAuthorize extends Component {
 			this.isSso() ||
 			this.isWooRedirect() ||
 			this.isFromJpo() ||
+			this.isFromJetpackBoost() ||
 			this.isFromBlockEditor() ||
 			this.shouldRedirectJetpackStart() ||
 			getRoleFromScope( scope ) === 'subscriber' ||
@@ -264,6 +266,11 @@ export class JetpackAuthorize extends Component {
 	isFromJpo( props = this.props ) {
 		const { from } = props.authQuery;
 		return startsWith( from, 'jpo' );
+	}
+
+	isFromJetpackBoost( props = this.props ) {
+		const { from } = props.authQuery;
+		return startsWith( from, 'jetpack-boost' );
 	}
 
 	isFromBlockEditor( props = this.props ) {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -203,7 +203,7 @@ describe( 'JetpackAuthorize', () => {
 		} );
 	} );
 
-	describe( 'shouldSeePlans', () => {
+	describe( 'isJetpackUpgradeFlow', () => {
 		const isJetpackUpgradeFlow = new JetpackAuthorize().isJetpackUpgradeFlow;
 
 		test( 'should see plans', () => {
@@ -224,6 +224,30 @@ describe( 'JetpackAuthorize', () => {
 			};
 
 			expect( isJetpackUpgradeFlow( props ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isFromJetpackBoost', () => {
+		const isFromJetpackBoost = new JetpackAuthorize().isFromJetpackBoost;
+
+		test( 'is from jetpack boost', () => {
+			const props = {
+				authQuery: {
+					from: 'jetpack-boost-something',
+				},
+			};
+
+			expect( isFromJetpackBoost( props ) ).toBe( true );
+		} );
+
+		test( 'is not from jetpack boost', () => {
+			const props = {
+				authQuery: {
+					from: 'not-jetpack-boost-something',
+				},
+			};
+
+			expect( isFromJetpackBoost( props ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
Jetpack Boost needs to redirect new users back to wp-admin after connection. In part this is to match user expectations, but also because Calypso is kinda broken if you only have Boost installed and not Jetpack.

#### Changes proposed in this Pull Request

* Honor redirects for Jetpack Boost connection flow

#### Testing instructions

* Use Calypso in development mode, and hack Boost to pass the calypso_env=development flag as part of the authorize URL
* Go through a Jetpack Boost connection flow
* You should be redirected back to the Boost page in wp-admin after authorizing.

Fixes 144-gh-Automattic/jetpack-boost
