### PR TITLE
Purchases: update payment method notices

### DIFF
--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -195,10 +195,8 @@ class PurchaseNotice extends Component {
 		}
 
 		if (
-			( ! hasPaymentMethod( purchase ) &&
-				( ! canExplicitRenew( purchase ) ||
-					shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) ) ) ||
-			isPaidWithCredits( purchase )
+			! hasPaymentMethod( purchase ) &&
+			( ! canExplicitRenew( purchase ) || shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) )
 		) {
 			return (
 				<NoticeAction href={ changePaymentMethodPath }>

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -135,13 +135,13 @@ class PurchaseNotice extends Component {
 		if ( isPaidWithCredits( purchase ) ) {
 			if ( autoRenewingUpgradesLink ) {
 				return translate(
-					"You purchased %(purchaseName)s with credits – please add a credit card before your plan expires %(expiry)s so that you don't lose out on your paid features! You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.",
+					"You purchased %(purchaseName)s with credits – please add a payment method before your plan expires %(expiry)s so that you don't lose out on your paid features! You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.",
 					translateOptions
 				);
 			}
 
 			return translate(
-				"You purchased %(purchaseName)s with credits. Please add a credit card before your plan expires %(expiry)s so that you don't lose out on your paid features!",
+				"You purchased %(purchaseName)s with credits. Please add a payment method before your plan expires %(expiry)s so that you don't lose out on your paid features!",
 				translateOptions
 			);
 		}
@@ -176,7 +176,7 @@ class PurchaseNotice extends Component {
 
 		if ( autoRenewingUpgradesLink ) {
 			return translate(
-				"%(purchaseName)s will expire and be removed from your site %(expiry)s – add a credit card so you don't lose out on your paid features! You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.",
+				"%(purchaseName)s will expire and be removed from your site %(expiry)s – add a payment method so you don't lose out on your paid features! You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.",
 				translateOptions
 			);
 		}
@@ -195,8 +195,10 @@ class PurchaseNotice extends Component {
 		}
 
 		if (
-			! hasPaymentMethod( purchase ) &&
-			( ! canExplicitRenew( purchase ) || shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) )
+			( ! hasPaymentMethod( purchase ) &&
+				( ! canExplicitRenew( purchase ) ||
+					shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) ) ) ||
+			isPaidWithCredits( purchase )
 		) {
 			return (
 				<NoticeAction href={ changePaymentMethodPath }>

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -135,13 +135,13 @@ class PurchaseNotice extends Component {
 		if ( isPaidWithCredits( purchase ) ) {
 			if ( autoRenewingUpgradesLink ) {
 				return translate(
-					"You purchased %(purchaseName)s with credits – please add a payment method before your plan expires %(expiry)s so that you don't lose out on your paid features! You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.",
+					"You purchased %(purchaseName)s with credits – please update your payment information before your plan expires %(expiry)s so that you don't lose out on your paid features! You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.",
 					translateOptions
 				);
 			}
 
 			return translate(
-				"You purchased %(purchaseName)s with credits. Please add a payment method before your plan expires %(expiry)s so that you don't lose out on your paid features!",
+				"You purchased %(purchaseName)s with credits. Please update your payment information before your plan expires %(expiry)s so that you don't lose out on your paid features!",
 				translateOptions
 			);
 		}
@@ -176,7 +176,7 @@ class PurchaseNotice extends Component {
 
 		if ( autoRenewingUpgradesLink ) {
 			return translate(
-				"%(purchaseName)s will expire and be removed from your site %(expiry)s – add a payment method so you don't lose out on your paid features! You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.",
+				"%(purchaseName)s will expire and be removed from your site %(expiry)s – update your payment information so you don't lose out on your paid features! You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.",
 				translateOptions
 			);
 		}

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -182,7 +182,7 @@ class PurchaseNotice extends Component {
 		}
 
 		return translate(
-			"%(purchaseName)s will expire and be removed from your site %(expiry)s. Add a credit card so you don't lose out on your paid features!",
+			"%(purchaseName)s will expire and be removed from your site %(expiry)s. Update your payment information so you don't lose out on your paid features!",
 			translateOptions
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates some notices for the manage purchase screen when you have no payment methods on your account or if you make a purchase with credits. 

**Before**
<img width="1497" alt="Screen Shot 2020-12-17 at 6 44 41 PM" src="https://user-images.githubusercontent.com/6981253/102557155-8b3a6a00-4098-11eb-95df-5e9eecdaa774.png">

![image](https://user-images.githubusercontent.com/6981253/102557964-6515c980-409a-11eb-91c3-97459cf66b84.png)


**After**
<img width="1498" alt="Screen Shot 2020-12-17 at 6 44 31 PM" src="https://user-images.githubusercontent.com/6981253/102557166-92617800-4098-11eb-816d-2ceed0f2c9b1.png">

![image](https://user-images.githubusercontent.com/6981253/102557951-5af3cb00-409a-11eb-8621-2d3996d8ac9f.png)

(Note that the "Add Payment Method" vs. "Renew Now" links in the screenshots aren't actually changing in the before/after as a result of this pull request.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**No payment methods**
* Remove all your payment methods
* Visit a purchase screen at the site or account level and confirm the messaging isn't credit card specific.

**Credits**
* Make a purchase with credits
* Visit the manage purchase screen for that purchase and confirm that it asks you to add a payment method.
