### PR TITLE
Plugins: Port plugin recently updated flag to Redux

### DIFF
--- a/client/state/plugins/installed/reducer.js
+++ b/client/state/plugins/installed/reducer.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { omit, findIndex } from 'lodash';
+import { findIndex } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -116,7 +116,7 @@ function plugin( state, action ) {
 			if ( state.id !== action.data.id ) {
 				return state;
 			}
-			return Object.assign( {}, omit( state, 'update' ), action.data );
+			return Object.assign( {}, state, { update: { recentlyUpdated: true } }, action.data );
 		default:
 			return state;
 	}

--- a/client/state/plugins/installed/test/reducer.js
+++ b/client/state/plugins/installed/test/reducer.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -95,7 +94,7 @@ describe( 'reducer:', () => {
 
 		test( 'should show an updated plugin as up-to-date', () => {
 			const originalState = deepFreeze( { 'one.site': [ jetpack ] } );
-			const updatedPlugin = omit( jetpack, 'update' );
+			const updatedPlugin = { ...jetpack, update: { recentlyUpdated: true } };
 			const state = plugins( originalState, {
 				type: PLUGIN_UPDATE_REQUEST_SUCCESS,
 				siteId: 'one.site',


### PR DESCRIPTION
When we created the Redux version of the plugins store, we didn't port the [`recentlyUpdated` flag](https://github.com/Automattic/wp-calypso/blob/update/plugins-reducer-recently-updated/client/lib/plugins/store.js#L234). This PR takes care of that.

We need this in order to fill feature gaps in the Redux implementation and reduxify the plugin sites properly.

This flag isn't yet consumed by any Redux consumers, so the only way to test this is through unit testing.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Port plugin recently updated flag to Redux

#### Testing instructions

* Verify tests pass.
