### PR TITLE
Plugins: Decouple plugins from sites in PluginItem

### DIFF
--- a/client/my-sites/plugins/plugin-item/README.md
+++ b/client/my-sites/plugins/plugin-item/README.md
@@ -33,4 +33,3 @@ function render() {
 - `allowedActions`: an object of allowed plugin actions: `activation`, `autoupdate`. Used to display/hide plugin actions.
 - `isAutoManaged`: a boolean if the plugin is auto managed. If true it will dispaly an auto managed message. Defaults to false.
 - `progress`: an array of progress steps.
-- `hasUpdate`: a function to determine if a plugin has an update available. Defaults to a function returning false.

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -152,10 +152,7 @@ class PluginItem extends Component {
 		const updated_versions = this.props.plugin.sites
 			.map( ( site ) => {
 				const sitePlugin = pluginsOnSites?.sites[ site.ID ];
-				if ( sitePlugin?.update?.new_version ) {
-					return sitePlugin.update.new_version;
-				}
-				return false;
+				return sitePlugin.update.new_version;
 			} )
 			.filter( ( version ) => version );
 

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -543,7 +543,6 @@ export class PluginsList extends React.Component {
 				isSelected={ this.isSelected( plugin ) }
 				isSelectable={ isSelectable }
 				onClick={ selectThisPlugin }
-				hasUpdate={ this.pluginHasUpdate }
 				selectedSite={ this.props.selectedSite }
 				pluginLink={ '/plugins/' + encodeURIComponent( plugin.slug ) + this.siteSuffix() }
 				allowedActions={ allowedPluginActions }


### PR DESCRIPTION
We're deeply into reduxifying plugins now, and we're right now reduxifying the plugin sites. However, in the flux implementation, we have a `plugin.sites[ siteId ].plugin.site` relationship that goes in circles from plugin to site to plugin to site, and requires all that information to be in the store. However, we're not duplicating all that information in the Redux implementation, so we need to break out of that circle. To do that, we're altering the way we're retrieving the plugin for a site or a set of sites - it will no longer expect a plugin's site to contain info about the installed plugin; rather, we'll retrieve that information from Redux. This PR addresses that for `PluginItem`.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Decouple plugins from sites in PluginItem

#### Testing instructions

* Get several Jetpack sites with some plugins for testing. 
* `PluginItem` is used in the plugin lists, and we have plugin lists on all non-single-plugin pages.
* Thoroughly test lists of plugins in all plugin the following scenarios; compare against production and verify that they still work the same way when updating, installing, or removing plugins, as well as toggling auto-updates and activating/deactivating plugins:
  * `/plugins`
  * `/plugins/manage`
  * `/plugins/manage` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
  * `/plugins/manage/:site` - for a single plugin
  * `/plugins/manage/:site` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
* Make sure to specifically test updating an old plugin and verify everything behaves the same way, including the fact that when a plugin in a plugins list gets updated, it moves to the bottom and has a label "Updated".
* Verify all tests pass.
