### PR TITLE
Plugins: Decouple plugins from sites in PluginMeta

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -413,13 +413,11 @@ export class PluginMeta extends Component {
 				}
 
 				const sitePlugin = pluginsOnSites?.sites[ site.ID ];
-				if ( sitePlugin?.update ) {
-					if ( 'error' !== sitePlugin.update?.new_version ) {
-						return {
-							title: site.title,
-							newVersion: sitePlugin.update.new_version,
-						};
-					}
+				if ( 'error' !== sitePlugin?.update?.new_version ) {
+					return {
+						title: site.title,
+						newVersion: sitePlugin.update.new_version,
+					};
 				}
 			} )
 			.filter( ( newVersions ) => newVersions );

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -45,6 +45,7 @@ import { isAutomatedTransferActive } from 'calypso/state/automated-transfer/sele
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import { isATEnabled } from 'calypso/lib/automated-transfer';
+import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import { updatePlugin } from 'calypso/state/plugins/installed/actions';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 
@@ -404,16 +405,19 @@ export class PluginMeta extends Component {
 	}
 
 	getAvailableNewVersions() {
+		const { pluginsOnSites } = this.props;
 		return this.props.sites
 			.map( ( site ) => {
 				if ( ! site.canUpdateFiles ) {
 					return null;
 				}
-				if ( site.plugin && site.plugin.update ) {
-					if ( 'error' !== site.plugin.update && site.plugin.update.new_version ) {
+
+				const sitePlugin = pluginsOnSites?.sites[ site.ID ];
+				if ( sitePlugin?.update ) {
+					if ( 'error' !== sitePlugin.update?.new_version ) {
 						return {
 							title: site.title,
-							newVersion: site.plugin.update.new_version,
+							newVersion: sitePlugin.update.new_version,
 						};
 					}
 				}
@@ -577,9 +581,11 @@ export class PluginMeta extends Component {
 	}
 }
 
-const mapStateToProps = ( state ) => {
+const mapStateToProps = ( state, { plugin, sites } ) => {
 	const siteId = getSelectedSiteId( state );
 	const selectedSite = getSelectedSite( state );
+	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+	const siteIds = sites.map( ( site ) => site.ID );
 
 	return {
 		atEnabled: isATEnabled( selectedSite ),
@@ -587,6 +593,7 @@ const mapStateToProps = ( state ) => {
 		automatedTransferSite: isSiteAutomatedTransfer( state, siteId ),
 		isVipSite: isVipSite( state, siteId ),
 		slug: getSiteSlug( state, siteId ),
+		pluginsOnSites: getPluginOnSites( state, siteIds, plugin.slug ),
 	};
 };
 


### PR DESCRIPTION
We're deeply into reduxifying plugins now, and we're right now reduxifying the plugin sites. However, in the flux implementation, we have a `plugin.sites[ siteId ].plugin.site` relationship that goes in circles from plugin to site to plugin to site, and requires all that information to be in the store. However, we're not duplicating all that information in the Redux implementation, so we need to break out of that circle. To do that, we're altering the way we're retrieving the plugin for a site or a set of sites - it will no longer expect a plugin's site to contain info about the installed plugin; rather, we'll retrieve that information from Redux. This PR addresses that for `PluginMeta`.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Decouple plugins from sites in PluginMeta

#### Testing instructions

* Get several Jetpack sites with some plugins for testing. 
* `PluginMeta` is used in the single-plugin pages.
* Thoroughly test single plugin pages in the following scenarios; compare against production and verify that they still work the same way when updating, installing, or removing plugins, as well as toggling auto-updates and activating/deactivating plugins:
  * `/plugins/:plugin/:site`
  * `/plugins/:plugin`
* Make sure in both instances to specifically test updating an old plugin and verify everything behaves the same way before, during, and after the update.
* Verify all tests pass.
