### PR TITLE
Plugins: Decouple plugins from sites in PluginSite components

### DIFF
--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -17,7 +17,10 @@ import PluginInstallButton from 'calypso/my-sites/plugins/plugin-install-button'
 import PluginRemoveButton from 'calypso/my-sites/plugins/plugin-remove-button';
 import Site from 'calypso/blocks/site';
 import { Button } from '@automattic/components';
-import { isPluginActionInProgress } from 'calypso/state/plugins/installed/selectors';
+import {
+	getPluginOnSite,
+	isPluginActionInProgress,
+} from 'calypso/state/plugins/installed/selectors';
 
 /**
  * Style dependencies
@@ -76,7 +79,7 @@ class PluginSiteJetpack extends React.Component {
 
 		const showAutoManagedMessage = this.props.isAutoManaged;
 
-		const settingsLink = this.props?.site?.plugin?.action_links?.Settings ?? null;
+		const settingsLink = this.props?.pluginOnSite?.action_links?.Settings ?? null;
 
 		return (
 			<FoldableCard
@@ -101,17 +104,17 @@ class PluginSiteJetpack extends React.Component {
 			>
 				<div>
 					{ canToggleActivation && (
-						<PluginActivateToggle site={ this.props.site } plugin={ this.props.site.plugin } />
+						<PluginActivateToggle site={ this.props.site } plugin={ this.props.pluginOnSite } />
 					) }
 					{ canToggleAutoupdate && (
 						<PluginAutoupdateToggle
 							site={ this.props.site }
-							plugin={ this.props.site.plugin }
+							plugin={ this.props.pluginOnSite }
 							wporg={ true }
 						/>
 					) }
 					{ canToggleRemove && (
-						<PluginRemoveButton plugin={ this.props.site.plugin } site={ this.props.site } />
+						<PluginRemoveButton plugin={ this.props.pluginOnSite } site={ this.props.site } />
 					) }
 					{ settingsLink && (
 						<Button compact href={ settingsLink }>
@@ -133,7 +136,7 @@ class PluginSiteJetpack extends React.Component {
 			return null;
 		}
 
-		if ( ! this.props.site.plugin ) {
+		if ( ! this.props.pluginOnSite ) {
 			return this.renderInstallPlugin();
 		}
 
@@ -142,5 +145,6 @@ class PluginSiteJetpack extends React.Component {
 }
 
 export default connect( ( state, { site, plugin } ) => ( {
+	pluginOnSite: getPluginOnSite( state, site.ID, plugin.slug ),
 	installInProgress: isPluginActionInProgress( state, site.ID, plugin.id, 'INSTALL_PLUGIN' ),
 } ) )( localize( PluginSiteJetpack ) );

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -15,6 +15,7 @@ import isConnectedSecondaryNetworkSite from 'calypso/state/selectors/is-connecte
 import PluginSite from 'calypso/my-sites/plugins/plugin-site/plugin-site';
 import PluginsStore from 'calypso/lib/plugins/store';
 import SectionHeader from 'calypso/components/section-header';
+import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 
 /**
  * Style dependencies
@@ -30,7 +31,8 @@ export class PluginSiteList extends Component {
 	};
 
 	getSecondaryPluginSites( site, secondarySites ) {
-		const secondaryPluginSites = site.plugin
+		const sitePlugin = this.props.pluginsOnSites?.sites[ site.ID ];
+		const secondaryPluginSites = sitePlugin
 			? PluginsStore.getSites( secondarySites, this.props.plugin.slug )
 			: secondarySites;
 		return compact( secondaryPluginSites );
@@ -74,6 +76,12 @@ function getSitesWithSecondarySites( state, sites ) {
 		} ) );
 }
 
-export default connect( ( state, props ) => ( {
-	sitesWithSecondarySites: getSitesWithSecondarySites( state, props.sites ),
-} ) )( PluginSiteList );
+export default connect( ( state, { plugin, sites } ) => {
+	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+	const siteIds = sites.map( ( site ) => site.ID );
+
+	return {
+		sitesWithSecondarySites: getSitesWithSecondarySites( state, sites ),
+		pluginsOnSites: getPluginOnSites( state, siteIds, plugin.slug ),
+	};
+} )( PluginSiteList );

--- a/client/my-sites/plugins/plugin-site-network/index.jsx
+++ b/client/my-sites/plugins/plugin-site-network/index.jsx
@@ -137,7 +137,10 @@ class PluginSiteNetwork extends React.Component {
 	};
 
 	renderSecondarySiteActions = ( site ) => {
-		const sitePlugin = this.props.pluginsOnSecondarySites?.sites[ site.ID ];
+		const sitePlugin = {
+			...this.props.plugin,
+			...this.props.pluginsOnSecondarySites?.sites[ site.ID ],
+		};
 
 		return (
 			<div className="plugin-site-network__secondary-site-actions">

--- a/client/my-sites/plugins/plugin-site-network/index.jsx
+++ b/client/my-sites/plugins/plugin-site-network/index.jsx
@@ -18,7 +18,11 @@ import PluginUpdateIndicator from 'calypso/my-sites/plugins/plugin-site-update-i
 import PluginInstallButton from 'calypso/my-sites/plugins/plugin-install-button';
 import PluginRemoveButton from 'calypso/my-sites/plugins/plugin-remove-button';
 import Site from 'calypso/blocks/site';
-import { isPluginActionInProgress } from 'calypso/state/plugins/installed/selectors';
+import {
+	getPluginOnSite,
+	getPluginOnSites,
+	isPluginActionInProgress,
+} from 'calypso/state/plugins/installed/selectors';
 
 /**
  * Style dependencies
@@ -78,10 +82,10 @@ class PluginSiteNetwork extends React.Component {
 			<div className="plugin-site-network__actions">
 				<PluginAutoupdateToggle
 					site={ this.props.site }
-					plugin={ this.props.site.plugin }
+					plugin={ this.props.pluginOnSite }
 					wporg={ true }
 				/>
-				<PluginRemoveButton plugin={ this.props.site.plugin } site={ this.props.site } />
+				<PluginRemoveButton plugin={ this.props.pluginOnSite } site={ this.props.site } />
 			</div>
 		);
 	};
@@ -133,9 +137,11 @@ class PluginSiteNetwork extends React.Component {
 	};
 
 	renderSecondarySiteActions = ( site ) => {
+		const sitePlugin = this.props.pluginsOnSecondarySites?.sites[ site.ID ];
+
 		return (
 			<div className="plugin-site-network__secondary-site-actions">
-				<PluginActivateToggle site={ site } plugin={ site.plugin } />
+				<PluginActivateToggle site={ site } plugin={ sitePlugin } />
 			</div>
 		);
 	};
@@ -145,7 +151,7 @@ class PluginSiteNetwork extends React.Component {
 			return null;
 		}
 
-		if ( ! this.props.site.plugin ) {
+		if ( ! this.props.pluginOnSite ) {
 			return this.renderInstallPlugin();
 		}
 
@@ -153,6 +159,13 @@ class PluginSiteNetwork extends React.Component {
 	}
 }
 
-export default connect( ( state, { site, plugin } ) => ( {
-	installInProgress: isPluginActionInProgress( state, site.ID, plugin.id, 'INSTALL_PLUGIN' ),
-} ) )( localize( PluginSiteNetwork ) );
+export default connect( ( state, { plugin, secondarySites, site } ) => {
+	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+	const secondarySiteIds = secondarySites.map( ( secSite ) => secSite.ID );
+
+	return {
+		pluginOnSite: getPluginOnSite( state, site.ID, plugin.slug ),
+		pluginsOnSecondarySites: getPluginOnSites( state, secondarySiteIds, plugin.slug ),
+		installInProgress: isPluginActionInProgress( state, site.ID, plugin.id, 'INSTALL_PLUGIN' ),
+	};
+} )( localize( PluginSiteNetwork ) );


### PR DESCRIPTION
We're deeply into reduxifying plugins now, and we're right now reduxifying the plugin sites. However, in the flux implementation, we have a `plugin.sites[ siteId ].plugin.site` relationship that goes in circles from plugin to site to plugin to site, and requires all that information to be in the store. However, we're not duplicating all that information in the Redux implementation, so we need to break out of that circle. To do that, we're altering the way we're retrieving the plugin for a site or a set of sites - it will no longer expect a plugin's site to contain info about the installed plugin; rather, we'll retrieve that information from Redux. This PR addresses that for `PluginSite` components.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Decouple plugins from sites in PluginSite components

#### Testing instructions

* Get several Jetpack sites with some plugins for testing. Ideally, you should also have a multisite network with 1 or more subsites connected.
* `PluginSite` components are used in the single plugin view, when all sites are selected.
* Thoroughly test lists of sites in `/plugins/:plugin`; compare against production and verify that they still work the same way when updating, installing, or removing plugins.
* Verify all tests pass.