### PR TITLE
Plugins: Decouple plugins from sites in PluginSiteUpdateIndicator

### DIFF
--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -12,9 +12,12 @@ import React from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import Gridicon from 'calypso/components/gridicon';
-import { getPluginStatusesByType } from 'calypso/state/plugins/installed/selectors';
-import { UPDATE_PLUGIN } from 'calypso/lib/plugins/constants';
+import {
+	getPluginOnSite,
+	getPluginStatusesByType,
+} from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
+import { UPDATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { updatePlugin } from 'calypso/state/plugins/installed/actions';
 
 /**
@@ -71,11 +74,11 @@ class PluginSiteUpdateIndicator extends React.Component {
 
 		if ( isUpdating ) {
 			message = this.props.translate( 'Updating to version %(version)s', {
-				args: { version: this.props.site.plugin.update.new_version },
+				args: { version: this.props.pluginOnSite.update.new_version },
 			} );
 		} else {
 			message = this.props.translate( 'Update to %(version)s', {
-				args: { version: this.props.site.plugin.update.new_version },
+				args: { version: this.props.pluginOnSite.update.new_version },
 			} );
 		}
 		return (
@@ -98,7 +101,7 @@ class PluginSiteUpdateIndicator extends React.Component {
 		}
 		if (
 			this.props.site.canUpdateFiles &&
-			( ( this.props.site.plugin.update && ! this.props.site.plugin.update.recentlyUpdated ) ||
+			( ( this.props.pluginOnSite.update && ! this.props.pluginOnSite.update.recentlyUpdated ) ||
 				this.isUpdating() )
 		) {
 			if ( ! this.props.expanded ) {
@@ -118,8 +121,9 @@ class PluginSiteUpdateIndicator extends React.Component {
 }
 
 export default connect(
-	( state ) => ( {
+	( state, { plugin, site } ) => ( {
 		inProgressStatuses: getPluginStatusesByType( state, 'inProgress' ),
+		pluginOnSite: getPluginOnSite( state, site.ID, plugin.slug ),
 	} ),
 	{ removePluginStatuses, updatePlugin }
 )( localize( PluginSiteUpdateIndicator ) );


### PR DESCRIPTION
We're deeply into reduxifying plugins now, and we're right now reduxifying the plugin sites. However, in the flux implementation, we have a `plugin.sites[ siteId ].plugin.site` relationship that goes in circles from plugin to site to plugin to site, and requires all that information to be in the store. However, we're not duplicating all that information in the Redux implementation, so we need to break out of that circle. To do that, we're altering the way we're retrieving the plugin for a site or a set of sites - it will no longer expect a plugin's site to contain info about the installed plugin; rather, we'll retrieve that information from Redux. This PR addresses that for `PluginSiteUpdateIndicator`.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Decouple plugins from sites in PluginSiteUpdateIndicator

#### Testing instructions

* Get several Jetpack sites with some plugins for testing. Ideally, you should also have a multisite network with 1 or more subsites connected.
* `PluginSiteUpdateIndicator` is used in site plugin items when there is an update for a plugin on that site.
* Thoroughly test lists of sites in `/plugins/:plugin`; compare against production and verify that they still work the same way when a plugin has an update, while it is being updated, and after that.
* Verify all tests pass.

#### Note

Lint errors are expected and aren't coming from this PR.