### PR TITLE
Plugins: Decouple plugins from sites in PluginsList

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -30,7 +30,10 @@ import {
 	removePlugin,
 	updatePlugin,
 } from 'calypso/state/plugins/installed/actions';
-import { getPluginStatusesByType } from 'calypso/state/plugins/installed/selectors';
+import {
+	getPluginOnSites,
+	getPluginStatusesByType,
+} from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 
 /**
@@ -157,25 +160,28 @@ export class PluginsList extends React.Component {
 	filterSelection = {
 		active( plugin ) {
 			if ( this.isSelected( plugin ) && plugin.slug !== 'jetpack' ) {
-				return plugin.sites.some( ( site ) => site.plugin && site.plugin.active );
+				return plugin.sites.some( ( site ) => {
+					const sitePlugin = this.props.pluginsOnSites[ plugin.slug ]?.sites[ site.ID ];
+					return sitePlugin?.active;
+				} );
 			}
 			return false;
 		},
 		inactive( plugin ) {
 			if ( this.isSelected( plugin ) && plugin.slug !== 'jetpack' ) {
-				return plugin.sites.some( ( site ) => site.plugin && ! site.plugin.active );
+				return plugin.sites.some( ( site ) => {
+					const sitePlugin = this.props.pluginsOnSites[ plugin.slug ]?.sites[ site.ID ];
+					return ! sitePlugin?.active;
+				} );
 			}
 			return false;
 		},
 		updates( plugin ) {
 			if ( this.isSelected( plugin ) ) {
-				return plugin.sites.some(
-					( site ) =>
-						site.plugin &&
-						site.plugin.update &&
-						site.plugin.update.new_version &&
-						site.canUpdateFiles
-				);
+				return plugin.sites.some( ( site ) => {
+					const sitePlugin = this.props.pluginsOnSites[ plugin.slug ]?.sites[ site.ID ];
+					return sitePlugin?.update?.new_version && site.canUpdateFiles;
+				} );
 			}
 			return false;
 		},
@@ -230,7 +236,12 @@ export class PluginsList extends React.Component {
 		this.props.plugins
 			.filter( this.isSelected ) // only use selected sites
 			.filter( negate( isDeactivatingAndJetpackSelected ) ) // ignore sites that are deactiving or activating jetpack
-			.map( ( p ) => p.sites ) // list of plugins -> list of list of sites
+			.map( ( p ) => {
+				return p.sites.map( ( site ) => {
+					site.plugin = p;
+					return site;
+				} );
+			} ) // list of plugins -> list of list of sites
 			.reduce( flattenArrays, [] ) // flatten the list into one big list of sites
 			.forEach( ( site ) => {
 				// Our Redux actions only need a site ID instead of an entire site object
@@ -239,16 +250,20 @@ export class PluginsList extends React.Component {
 			} );
 	}
 
-	pluginHasUpdate( plugin ) {
-		return plugin.sites.some(
-			( site ) => site.plugin && site.plugin.update && site.canUpdateFiles
-		);
-	}
+	pluginHasUpdate = ( plugin ) => {
+		return plugin.sites.some( ( site ) => {
+			const sitePlugin = this.props.pluginsOnSites[ plugin.slug ]?.sites[ site.ID ];
+			return sitePlugin?.update && site.canUpdateFiles;
+		} );
+	};
 
 	updateAllPlugins = () => {
 		this.removePluginStatuses();
 		this.props.plugins.forEach( ( plugin ) => {
-			plugin.sites.forEach( ( site ) => this.props.updatePlugin( site.ID, site.plugin ) );
+			plugin.sites.forEach( ( site ) => {
+				const sitePlugin = this.props.pluginsOnSites[ plugin.slug ]?.sites[ site.ID ];
+				return this.props.updatePlugin( site.ID, sitePlugin );
+			} );
 		} );
 		this.recordEvent( 'Clicked Update all Plugins', true );
 	};
@@ -558,10 +573,19 @@ export class PluginsList extends React.Component {
 }
 
 export default connect(
-	( state ) => {
+	( state, { plugins } ) => {
 		const selectedSite = getSelectedSite( state );
 
+		/* eslint-disable wpcalypso/redux-no-bound-selectors */
+		const pluginsOnSites = Object.values( plugins ).reduce( ( acc, plugin ) => {
+			const siteIds = plugin.sites.map( ( site ) => site.ID );
+			acc[ plugin.slug ] = getPluginOnSites( state, siteIds, plugin.slug );
+			return acc;
+		}, {} );
+		/* eslint-enable wpcalypso/redux-no-bound-selectors */
+
 		return {
+			pluginsOnSites,
 			selectedSite,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 			inProgressStatuses: getPluginStatusesByType( state, 'inProgress' ),

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -161,7 +161,7 @@ export class PluginsList extends React.Component {
 		active( plugin ) {
 			if ( this.isSelected( plugin ) && plugin.slug !== 'jetpack' ) {
 				return plugin.sites.some( ( site ) => {
-					const sitePlugin = this.props.pluginsOnSites[ plugin.slug ]?.sites[ site.ID ];
+					const sitePlugin = this.getSitePlugin( plugin, site );
 					return sitePlugin?.active;
 				} );
 			}
@@ -170,7 +170,7 @@ export class PluginsList extends React.Component {
 		inactive( plugin ) {
 			if ( this.isSelected( plugin ) && plugin.slug !== 'jetpack' ) {
 				return plugin.sites.some( ( site ) => {
-					const sitePlugin = this.props.pluginsOnSites[ plugin.slug ]?.sites[ site.ID ];
+					const sitePlugin = this.getSitePlugin( plugin, site );
 					return ! sitePlugin?.active;
 				} );
 			}
@@ -179,7 +179,7 @@ export class PluginsList extends React.Component {
 		updates( plugin ) {
 			if ( this.isSelected( plugin ) ) {
 				return plugin.sites.some( ( site ) => {
-					const sitePlugin = this.props.pluginsOnSites[ plugin.slug ]?.sites[ site.ID ];
+					const sitePlugin = this.getSitePlugin( plugin, site );
 					return sitePlugin?.update?.new_version && site.canUpdateFiles;
 				} );
 			}
@@ -250,9 +250,16 @@ export class PluginsList extends React.Component {
 			} );
 	}
 
+	getSitePlugin = ( plugin, site ) => {
+		return {
+			...plugin,
+			...this.props.pluginsOnSites[ plugin.slug ]?.sites[ site.ID ],
+		};
+	};
+
 	pluginHasUpdate = ( plugin ) => {
 		return plugin.sites.some( ( site ) => {
-			const sitePlugin = this.props.pluginsOnSites[ plugin.slug ]?.sites[ site.ID ];
+			const sitePlugin = this.getSitePlugin( plugin, site );
 			return sitePlugin?.update && site.canUpdateFiles;
 		} );
 	};
@@ -261,7 +268,7 @@ export class PluginsList extends React.Component {
 		this.removePluginStatuses();
 		this.props.plugins.forEach( ( plugin ) => {
 			plugin.sites.forEach( ( site ) => {
-				const sitePlugin = this.props.pluginsOnSites[ plugin.slug ]?.sites[ site.ID ];
+				const sitePlugin = this.getSitePlugin( plugin, site );
 				return this.props.updatePlugin( site.ID, sitePlugin );
 			} );
 		} );

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -34,6 +34,10 @@ describe( 'PluginsList', () => {
 				isPlaceholder: false,
 				pluginUpdateCount: plugins.length,
 				inProgressStatuses: [],
+				pluginsOnSites: {
+					hello: plugins[ 0 ],
+					jetpack: plugins[ 1 ],
+				},
 			};
 		} );
 


### PR DESCRIPTION
We're deeply into reduxifying plugins now, and we're right now reduxifying the plugin sites. However, in the flux implementation, we have a `plugin.sites[ siteId ].plugin.site` relationship that goes in circles from plugin to site to plugin to site, and requires all that information to be in the store. However, we're not duplicating all that information in the Redux implementation, so we need to break out of that circle. To do that, we're altering the way we're retrieving the plugin for a site or a set of sites - it will no longer expect a plugin's site to contain info about the installed plugin; rather, we'll retrieve that information from Redux. This PR addresses that for `PluginsList`.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Decouple plugins from sites in PluginsList

#### Testing instructions

* Get several Jetpack sites with some plugins for testing. 
* `PluginsList` is used to create plugin lists, and we have plugin lists on all non-single-plugin pages.
* Thoroughly test lists of plugins in all plugin scenarios; compare against production and verify that they still work the same way when updating, installing, or removing plugins, as well as toggling auto-updates and activating/deactivating plugins:
  * `/plugins`
  * `/plugins/manage`
  * `/plugins/manage` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
  * `/plugins/manage/:site` - for a single plugin
  * `/plugins/manage/:site` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
* Make sure to specifically test updating an old plugin and verify everything behaves the same way before, during, and after the update.
* Make sure to test filtering of plugins specifically.
* Verify all tests pass.
