### PR TITLE
    Add wpcom_block_picker_tab_panel_selected tracks event

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -8,6 +8,7 @@ import debugFactory from 'debug';
  */
 import wpcomBlockEditorCloseClick from './wpcom-block-editor-close-click';
 import wpcomInserterInlineSearchTerm from './wpcom-inserter-inline-search-term';
+import wpcomInserterTabPanelSelected from './wpcom-inserter-tab-panel-selected';
 import wpcomBlockDonationsPlanUpgrade from './wpcom-block-donations-plan-upgrade';
 import wpcomBlockDonationsStripeConnect from './wpcom-block-donations-stripe-connect';
 import wpcomBlockPremiumContentPlanUpgrade from './wpcom-block-premium-content-plan-upgrade';
@@ -25,6 +26,7 @@ const debug = debugFactory( 'wpcom-block-editor:tracking' );
 const EVENTS_MAPPING = [
 	wpcomBlockEditorCloseClick(),
 	wpcomInserterInlineSearchTerm(),
+	wpcomInserterTabPanelSelected(),
 	wpcomBlockDonationsPlanUpgrade(),
 	wpcomBlockDonationsStripeConnect(),
 	wpcomBlockPremiumContentPlanUpgrade(),
@@ -36,9 +38,9 @@ const EVENTS_MAPPING = [
  * the desired target element. Accounts for event
  * bubbling.
  *
- * @param  {DOMEvent} event          the DOM event
+ * @param  {object} event          the DOM Event
  * @param  {string|Function} targetSelector the CSS selector for the target element
- * @returns {Node}                the target element if found
+ * @returns {object}                the target Element if found
  */
 const getMatchingEventTarget = ( event, targetSelector ) => {
 	if ( typeof targetSelector === 'function' ) {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-tab-panel-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-tab-panel-selected.js
@@ -3,6 +3,9 @@
  */
 import tracksRecordEvent from './track-record-event';
 
+// Curiously, the numeric ids of the tabs increment every time you close and
+// reopen the inserter, so we use this regex to ignore that and grab the tab
+// slug
 const tabPanelRegex = /tab-panel-\d*-(\w*)/;
 const gutenbergTabPanelName = ( tabPanel ) =>
 	( tabPanel.id.match( tabPanelRegex ) || [ null, null ] )[ 1 ];

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-tab-panel-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-tab-panel-selected.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import tracksRecordEvent from './track-record-event';
+
+const tabPanelRegex = /tab-panel-\d*-(\w*)/;
+const gutenbergTabPanelName = ( tabPanel ) =>
+	( tabPanel.id.match( tabPanelRegex ) || [ null, null ] )[ 1 ];
+
+/**
+ * Return the event definition object to track `wpcom_block_picker_tab_panel_selected`.
+ *
+ * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ */
+export default () => ( {
+	// It would be nice to filter out events where the tab `is-active` before
+	// the click, but we can't do that because the update has already happened
+	selector: ( e ) => gutenbergTabPanelName( e.target ),
+	type: 'click',
+	handler: ( _event, tabName ) =>
+		tracksRecordEvent( 'wpcom_block_picker_tab_panel_selected', {
+			tab: tabName,
+		} ),
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new tracks event `wpcom_block_picker_tab_panel_selected` to the gutenberg editor when the panels in the inserter are clicked, with a `tab` property containing the name of the tab clicked:

![Edit_Page_‹_Julesaus_Test_Headstart_KO_—_WordPress](https://user-images.githubusercontent.com/5952255/102610523-11c67880-4179-11eb-9baa-ab853817322c.jpg)

I checked for a redux action first, but there were no useful events, only a `SET_IS_INSERTER_OPENED` event that has only a boolean payload is triggered by both the side-bar and the quick-inserter.

Curiously, when you open and close the inserter, the tab panels numeric ids are incremented

#### Testing instructions

You'll need a sandbox with a `wpcom-sandbox` alias set up as described in the wpcom-block-editor README, then:
`cd apps/wpcom-block-editor; yarn install; yarn dev --sync`

Then sandbox `widgets.wp.com` and load up a simple or atomic site.

The easiest way to check it is to `localStorage.setItem( 'debug' )` in your console, open up the inserter (the "+" in the top left, not the "quick inserter" plus symbols that appear in the document) and click on the "block" and "patterns" tabs a few times and check the output.

It's also nice to confirm that the events are triggered when you select the panel using the keyboard.

A more comprehensive test is to check that they appear in tracks:
![Tracks_Live_View_-_Metrimattic](https://user-images.githubusercontent.com/5952255/102611575-e2b10680-417a-11eb-9ee7-d6db6d59034c.jpg)

and that the events include the `tab` event property:
![Tracks_Live_View_-_Metrimattic](https://user-images.githubusercontent.com/5952255/102611631-02482f00-417b-11eb-8579-b9c968993fc2.jpg)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
