### PR TITLE
Importers: fix cancelling an autostarted import

### DIFF
--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -1,38 +1,23 @@
 /**
  * External dependencies
  */
-import page from 'page';
 import React from 'react';
-import { get, isEmpty, omit, pick } from 'lodash';
+import page from 'page';
 
 /**
  * Internal Dependencies
  */
 import SectionImport from 'calypso/my-sites/importer/section-import';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
-import { addQueryArgs } from 'calypso/lib/route';
 
 export function importSite( context, next ) {
-	const { query } = context;
-	const argsToExtract = [ 'engine', 'signup', 'from-site' ];
+	const engine = context.query?.engine;
+	const fromSite = decodeURIComponentIfValid( context.query?.[ 'from-site' ] );
 
-	// Pull supported query arguments into state (& out of the address bar)
-	const extractedArgs = pick( query, argsToExtract );
+	const afterStartImport = () => page.replace( context.pathname );
 
-	if ( ! isEmpty( extractedArgs ) ) {
-		const destination = addQueryArgs( omit( query, argsToExtract ), context.pathname );
-
-		page.replace( destination, {
-			engine: query.engine,
-			isFromSignup: query.signup,
-			siteUrl: query[ 'from-site' ],
-		} );
-		return;
-	}
-
-	const engine = get( context, 'state.engine' );
-	const fromSite = decodeURIComponentIfValid( get( context, 'state.siteUrl' ) );
-
-	context.primary = <SectionImport engine={ engine } fromSite={ fromSite } />;
+	context.primary = (
+		<SectionImport engine={ engine } fromSite={ fromSite } afterStartImport={ afterStartImport } />
+	);
 	next();
 }

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -92,12 +92,12 @@ class SectionImport extends Component {
 				// After import was started, redirect back to the route without `engine` query arg.
 				// That removes the `engine` prop from this component and doesn't spoil future
 				// rendering when the import is, e.g., cancelled.
-				afterStartImport?.( true );
+				afterStartImport?.();
 			} );
 		} else {
 			// We decided to not start the import despite being requested by the `engine` query arg.
 			// Redirect back to route without the request.
-			afterStartImport?.( false );
+			afterStartImport?.();
 		}
 	} );
 

--- a/client/state/importer-nux/reducer.js
+++ b/client/state/importer-nux/reducer.js
@@ -4,13 +4,8 @@
 import { combineReducers } from 'calypso/state/utils';
 import {
 	IMPORTER_NUX_SITE_DETAILS_SET,
-	IMPORTS_IMPORT_CANCEL,
 	IMPORTER_NUX_URL_INPUT_SET,
 } from 'calypso/state/action-types';
-
-import { registerActionForward } from 'calypso/lib/redux-bridge';
-
-registerActionForward( IMPORTS_IMPORT_CANCEL );
 
 export const urlInputValue = ( state = '', action ) => {
 	switch ( action.type ) {
@@ -18,8 +13,6 @@ export const urlInputValue = ( state = '', action ) => {
 			const { value = '' } = action;
 			return value;
 		}
-		case 'FLUX_IMPORTS_IMPORT_CANCEL':
-			return '';
 	}
 
 	return state;
@@ -38,8 +31,6 @@ export const siteDetails = ( state = null, action ) => {
 				importerTypes,
 			};
 		}
-		case 'FLUX_IMPORTS_IMPORT_CANCEL':
-			return null;
 	}
 
 	return state;


### PR DESCRIPTION
Fixes a regression introduced by #48413:
- start an import with `/import/example.blog?engine=wix`
- cancel that import with the "Cancel" button
- after cancelling, the Import page shows an empty list of available importers
- the expected behavior is a list of 6 available importers displayed

The list is empty because the `engine=wix` param is still in the router history state, and present as a `<SectionImport engine="wix" />` prop, so the component waits for the import to be autostarted and shows an empty list.

Before #48413, the `engine` prop was not passed directly by the route handler, but was selected from the `importers-nux` Redux state, which was reset on the `IMPORTS_IMPORT_CANCEL` action dispatch.

This PR reworks the autostart logic:
- remove `IMPORTS_IMPORT_CANCEL` from the `importers-nux` reducer because the action is no longer used: the reducer is used only in Signup, never in Imports.
- remove the code from the route handler that moves the query args to router state. Leave the query args there, and redirect to a route without them after the requested import was successfully started (or when the code decides it's not going to start it)
