### PR TITLE
Purchases, add event to track payment method change

### DIFF
--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -277,6 +277,7 @@ function ChangePaymentMethodList( {
 }
 
 function onChangeComplete( { successCallback, translate, showSuccessMessage } ) {
+	recordTracksEvent( 'calypso_purchases_save_new_payment_method' );
 	showSuccessMessage( translate( 'Your payment method has been set.' ) );
 	successCallback();
 }

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -4,7 +4,7 @@
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Fragment, useMemo, useCallback } from 'react';
-import { connect, useSelector } from 'react-redux';
+import { connect, useSelector, useDispatch } from 'react-redux';
 import { createStripeSetupIntent, StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import {
 	CheckoutProvider,
@@ -213,6 +213,7 @@ function ChangePaymentMethodList( {
 	apiParams,
 } ) {
 	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
 	const { isStripeLoading, stripe, stripeConfiguration } = useStripe();
 	const paymentMethods = useAssignablePaymentMethods();
 
@@ -239,7 +240,7 @@ function ChangePaymentMethodList( {
 				label: 'fake thing',
 			} }
 			onPaymentComplete={ () =>
-				onChangeComplete( { successCallback, translate, showSuccessMessage } )
+				onChangeComplete( { successCallback, translate, showSuccessMessage, reduxDispatch } )
 			}
 			showErrorMessage={ showErrorMessage }
 			showInfoMessage={ showInfoMessage }
@@ -276,8 +277,8 @@ function ChangePaymentMethodList( {
 	);
 }
 
-function onChangeComplete( { successCallback, translate, showSuccessMessage } ) {
-	recordTracksEvent( 'calypso_purchases_save_new_payment_method' );
+function onChangeComplete( { successCallback, translate, showSuccessMessage, reduxDispatch } ) {
+	reduxDispatch( recordTracksEvent( 'calypso_purchases_save_new_payment_method' ) );
 	showSuccessMessage( translate( 'Your payment method has been set.' ) );
 	successCallback();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds an event for when stored payment methods are saved. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a purchase and change the payment method.
* Make sure the `calypso_purchases_save_new_payment_method` event fires.
