### PR TITLE
Billing: Remove unused code not behind new payment methods flag

### DIFF
--- a/client/me/purchases/add-new-payment-method/index.jsx
+++ b/client/me/purchases/add-new-payment-method/index.jsx
@@ -24,16 +24,13 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
-import { isEnabled } from '@automattic/calypso-config';
 import PaymentMethodSelector from 'calypso/me/purchases/manage-purchase/payment-method-selector';
 import { useCreateCreditCard } from 'calypso/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods';
 import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
 
 function AddNewPaymentMethod() {
 	const goToPaymentMethods = () => page( paymentMethods );
-	const addPaymentMethodTitle = isEnabled( 'purchases/new-payment-methods' )
-		? titles.addPaymentMethod
-		: titles.addCreditCard;
+	const addPaymentMethodTitle = titles.addPaymentMethod;
 
 	const translate = useTranslate();
 	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
@@ -61,11 +58,7 @@ function AddNewPaymentMethod() {
 	return (
 		<Main className="add-new-payment-method is-wide-layout">
 			<PageViewTracker
-				path={
-					isEnabled( 'purchases/new-payment-methods' )
-						? '/me/purchases/add-payment-method'
-						: '/me/purchases/add-credit-card'
-				}
+				path="/me/purchases/add-payment-method"
 				title={ concatTitle( titles.activeUpgrades, addPaymentMethodTitle ) }
 			/>
 			<DocumentHead title={ concatTitle( titles.activeUpgrades, addPaymentMethodTitle ) } />

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -102,35 +102,6 @@ export function confirmCancelDomain( context, next ) {
 	next();
 }
 
-export function editCardDetails( context, next ) {
-	const state = context.store.getState();
-
-	if ( userHasNoSites( state ) ) {
-		return noSites( context, '/me/purchases/:site/:purchaseId/payment/edit/:cardId' );
-	}
-
-	const EditCardDetailsWrapper = localize( () => {
-		return (
-			<PurchasesWrapper title={ titles.editCardDetails }>
-				<Main className="purchases__change is-wide-layout">
-					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-					<ChangePaymentMethod
-						cardId={ context.params.cardId }
-						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-						siteSlug={ context.params.site }
-						getManagePurchaseUrlFor={ managePurchaseUrl }
-						purchaseListUrl={ purchasesRoot }
-						isFullWidth={ true }
-					/>
-				</Main>
-			</PurchasesWrapper>
-		);
-	} );
-
-	context.primary = <EditCardDetailsWrapper />;
-	next();
-}
-
 export function list( context, next ) {
 	const ListWrapper = localize( () => {
 		return (

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -155,4 +155,12 @@ export default ( router ) => {
 	router( '/me/billing/:receiptId', ( { params: { receiptId } } ) =>
 		page.redirect( paths.billingHistoryReceipt( receiptId ) )
 	);
+	router( paths.addCardDetails( ':site', ':purchaseId' ), ( { params: { site, purchaseId } } ) =>
+		page.redirect( paths.addPaymentMethod( site, purchaseId ) )
+	);
+	router(
+		paths.editCardDetails( ':site', ':purchaseId', ':cardId' ),
+		( { params: { site, purchaseId, cardId } } ) =>
+			page.redirect( paths.changePaymentMethod( site, purchaseId, cardId ) )
+	);
 };

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -27,31 +27,25 @@ export default ( router ) => {
 			clientRender
 		);
 
-		if ( config.isEnabled( 'purchases/new-payment-methods' ) ) {
-			router(
-				paths.addNewPaymentMethod,
-				sidebar,
-				controller.addNewPaymentMethod,
-				makeLayout,
-				clientRender
-			);
-		}
+		router(
+			paths.addNewPaymentMethod,
+			sidebar,
+			controller.addNewPaymentMethod,
+			makeLayout,
+			clientRender
+		);
 
 		router(
 			paths.addCreditCard,
 			sidebar,
-			config.isEnabled( 'purchases/new-payment-methods' )
-				? controller.addNewPaymentMethod
-				: controller.addCreditCard,
+			controller.addNewPaymentMethod,
 			makeLayout,
 			clientRender
 		);
 
 		// redirect legacy urls
 		router( '/payment-methods/add-credit-card', () => {
-			config.isEnabled( 'purchases/new-payment-methods' )
-				? page.redirect( paths.addCreditCard )
-				: page.redirect( paths.addNewPaymentMethod );
+			page.redirect( paths.addCreditCard );
 		} );
 	}
 

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -35,7 +35,6 @@ import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
 import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
-import { isEnabled } from '@automattic/calypso-config';
 import { concatTitle } from 'calypso/lib/react-helpers';
 import PaymentMethodSelector from '../payment-method-selector';
 import getPaymentMethodIdFromPayment from '../payment-method-selector/get-payment-method-id-from-payment';
@@ -84,11 +83,7 @@ function ChangePaymentMethod( props ) {
 				purchaseId={ props.purchaseId }
 			/>
 			<PageViewTracker
-				path={
-					isEnabled( 'purchases/new-payment-methods' )
-						? '/me/purchases/:site/:purchaseId/payment-method/change/:cardId'
-						: '/me/purchases/:site/:purchaseId/payment/change/:cardId'
-				}
+				path="/me/purchases/:site/:purchaseId/payment-method/change/:cardId"
 				title={ concatTitle( titles.activeUpgrades, changePaymentMethodTitle ) }
 			/>
 
@@ -133,13 +128,10 @@ ChangePaymentMethod.propTypes = {
 };
 
 function getChangePaymentMethodTitleCopy( currentPaymentMethodId ) {
-	if ( isEnabled( 'purchases/new-payment-methods' ) ) {
-		if ( [ 'credits', 'none' ].includes( currentPaymentMethodId ) ) {
-			return titles.addPaymentMethod;
-		}
-		return titles.changePaymentMethod;
+	if ( [ 'credits', 'none' ].includes( currentPaymentMethodId ) ) {
+		return titles.addPaymentMethod;
 	}
-	return titles.editCardDetails;
+	return titles.changePaymentMethod;
 }
 
 const mapStateToProps = ( state, { cardId, purchaseId } ) => ( {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -827,9 +827,7 @@ function addPaymentMethodLinkText( { purchase, translate } ) {
 	if ( hasPaymentMethod( purchase ) && ! isPaidWithCredits( purchase ) ) {
 		linkText = translate( 'Change Payment Method' );
 	} else {
-		linkText = config.isEnabled( 'purchases/new-payment-methods' )
-			? translate( 'Add Payment Method' )
-			: translate( 'Add Credit Card' );
+		linkText = translate( 'Add Payment Method' );
 	}
 	return linkText;
 }

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -200,9 +200,7 @@ class PurchaseNotice extends Component {
 		) {
 			return (
 				<NoticeAction href={ changePaymentMethodPath }>
-					{ config.isEnabled( 'purchases/new-payment-methods' )
-						? translate( 'Add Payment Method' )
-						: translate( 'Add Credit Card' ) }
+					{ translate( 'Add Payment Method' ) }
 				</NoticeAction>
 			);
 		}

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -46,6 +46,7 @@ export function confirmCancelDomain( siteName, purchaseId ) {
 	return managePurchase( siteName, purchaseId ) + '/confirm-cancel-domain';
 }
 
+// legacy path
 export function addCardDetails( siteName, purchaseId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {
@@ -55,6 +56,7 @@ export function addCardDetails( siteName, purchaseId ) {
 	return managePurchase( siteName, purchaseId ) + '/payment/add';
 }
 
+// legacy path
 export function editCardDetails( siteName, purchaseId, cardId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if (

--- a/client/me/purchases/payment-methods/payment-method-list.jsx
+++ b/client/me/purchases/payment-methods/payment-method-list.jsx
@@ -68,9 +68,7 @@ class PaymentMethodList extends Component {
 
 		return (
 			<Button primary compact onClick={ this.goToAddPaymentMethod }>
-				{ config.isEnabled( 'purchases/new-payment-methods' )
-					? this.props.translate( 'Add payment method' )
-					: this.props.translate( 'Add credit card' ) }
+				{ this.props.translate( 'Add payment method' ) }
 			</Button>
 		);
 	}

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -9,7 +9,6 @@ const titles = {
 	addPaymentMethod: i18n.translate( 'Add Payment Method' ),
 	cancelPurchase: i18n.translate( 'Cancel Purchase' ),
 	confirmCancelDomain: i18n.translate( 'Cancel Domain' ),
-	editCardDetails: i18n.translate( 'Change Credit Card' ),
 	changePaymentMethod: i18n.translate( 'Change Payment Method' ),
 	addCardDetails: i18n.translate( 'Add Credit Card' ),
 	managePurchase: i18n.translate( 'Purchase Settings' ),
@@ -35,9 +34,6 @@ Object.defineProperties( titles, {
 	},
 	confirmCancelDomain: {
 		get: () => i18n.translate( 'Cancel Domain' ),
-	},
-	editCardDetails: {
-		get: () => i18n.translate( 'Change Credit Card' ),
 	},
 	changePaymentMethod: {
 		get: () => i18n.translate( 'Change Payment Method' ),

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -1,14 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	addCardDetails,
-	editCardDetails,
-	addCreditCard,
-	addPaymentMethod,
-	changePaymentMethod,
-	addNewPaymentMethod,
-} from './paths';
+import { addPaymentMethod, changePaymentMethod, addNewPaymentMethod } from './paths';
 import {
 	isExpired,
 	isIncludedWithPlan,
@@ -16,7 +9,6 @@ import {
 	isPaidWithCreditCard,
 } from 'calypso/lib/purchases';
 import { isDomainTransfer } from 'calypso/lib/products-values';
-import { isEnabled } from '@automattic/calypso-config';
 
 function isDataLoading( props ) {
 	return ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;
@@ -37,22 +29,14 @@ function getChangePaymentMethodPath( siteSlug, purchase ) {
 			payment: { creditCard },
 		} = purchase;
 
-		if ( isEnabled( 'purchases/new-payment-methods' ) ) {
-			return changePaymentMethod( siteSlug, purchase.id, creditCard.id );
-		}
-
-		return editCardDetails( siteSlug, purchase.id, creditCard.id );
+		return changePaymentMethod( siteSlug, purchase.id, creditCard.id );
 	}
 
-	if ( isEnabled( 'purchases/new-payment-methods' ) ) {
-		return addPaymentMethod( siteSlug, purchase.id );
-	}
-
-	return addCardDetails( siteSlug, purchase.id );
+	return addPaymentMethod( siteSlug, purchase.id );
 }
 
 function getAddNewPaymentMethodPath() {
-	return isEnabled( 'purchases/new-payment-methods' ) ? addNewPaymentMethod : addCreditCard;
+	return addNewPaymentMethod;
 }
 
 export {

--- a/client/my-sites/domains/domain-management/edit/card/notices/expiring-credit-card.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/notices/expiring-credit-card.jsx
@@ -11,7 +11,6 @@ import { Button } from '@automattic/components';
 import { shouldRenderExpiringCreditCard, creditCardHasAlreadyExpired } from 'calypso/lib/purchases';
 import { getChangePaymentMethodPath } from 'calypso/me/purchases/utils';
 import { type as domainTypes } from 'calypso/lib/domains/constants';
-import { isEnabled } from '@automattic/calypso-config';
 
 function ExpiringCreditCard( props ) {
 	const { selectedSite, purchase, domain } = props;
@@ -79,9 +78,7 @@ function ExpiringCreditCard( props ) {
 		<div>
 			<p>{ messageText }</p>
 			<Button primary={ true } href={ changePaymentMethodPath }>
-				{ isEnabled( 'purchases/new-payment-methods' )
-					? translate( 'Add a new payment method' )
-					: translate( 'Add a new credit card' ) }
+				{ translate( 'Add a new payment method' ) }
 			</Button>
 		</div>
 	);

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -20,7 +20,6 @@ import {
 	paymentMethods,
 	addPaymentMethod,
 } from './controller';
-import { isEnabled } from '@automattic/calypso-config';
 
 export default ( router ) => {
 	page( '/purchases', siteSelection, navigation, sites, makeLayout, clientRender );
@@ -72,61 +71,32 @@ export default ( router ) => {
 		clientRender
 	);
 
-	if ( isEnabled( 'purchases/new-payment-methods' ) ) {
-		page(
-			'/purchases/subscriptions/:site/:purchaseId/payment-method/add',
-			siteSelection,
-			navigation,
-			purchaseChangePaymentMethod,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/purchases/subscriptions/:site/:purchaseId/payment-method/add',
+		siteSelection,
+		navigation,
+		purchaseChangePaymentMethod,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/purchases/subscriptions/:site/:purchaseId/payment-method/change/:cardId',
-			siteSelection,
-			navigation,
-			purchaseChangePaymentMethod,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/purchases/subscriptions/:site/:purchaseId/payment-method/change/:cardId',
+		siteSelection,
+		navigation,
+		purchaseChangePaymentMethod,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/purchases/add-payment-method/:site',
-			siteSelection,
-			navigation,
-			addPaymentMethod,
-			makeLayout,
-			clientRender
-		);
-	} else {
-		page(
-			'/purchases/subscriptions/:site/:purchaseId/payment/add',
-			siteSelection,
-			navigation,
-			purchaseChangePaymentMethod,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			'/purchases/subscriptions/:site/:purchaseId/payment/edit/:cardId',
-			siteSelection,
-			navigation,
-			purchaseChangePaymentMethod,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			'/purchases/add-credit-card/:site',
-			siteSelection,
-			navigation,
-			addPaymentMethod,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		'/purchases/add-payment-method/:site',
+		siteSelection,
+		navigation,
+		addPaymentMethod,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/purchases/billing-history/:site',
@@ -172,21 +142,27 @@ export default ( router ) => {
 	router(
 		'/purchases/:siteName/:purchaseId/payment/add',
 		( { params: { siteName, purchaseId } } ) =>
-			isEnabled( 'purchases/new-payment-methods' )
-				? page.redirect(
-						`/purchases/subscriptions/${ siteName }/${ purchaseId }/payment-method/add`
-				  )
-				: page.redirect( `/purchases/subscriptions/${ siteName }/${ purchaseId }/payment/add` )
+			page.redirect( `/purchases/subscriptions/${ siteName }/${ purchaseId }/payment-method/add` )
 	);
 	router(
 		'/purchases/:siteName/:purchaseId/payment/edit/:cardId',
 		( { params: { siteName, purchaseId, cardId } } ) =>
-			isEnabled( 'purchases/new-payment-methods' )
-				? page.redirect(
-						`/purchases/subscriptions/${ siteName }/${ purchaseId }/payment-method/change/${ cardId }`
-				  )
-				: page.redirect(
-						`/purchases/subscriptions/${ siteName }/${ purchaseId }/payment/edit/${ cardId }`
-				  )
+			page.redirect(
+				`/purchases/subscriptions/${ siteName }/${ purchaseId }/payment-method/change/${ cardId }`
+			)
+	);
+	router(
+		'/purchases/subscriptions/:site/:purchaseId/payment/add',
+		( { params: { site, purchaseId } } ) =>
+			`/purchases/subscriptions/${ site }/${ purchaseId }/payment-method/add`
+	);
+	router(
+		'/purchases/subscriptions/:site/:purchaseId/payment/edit/:cardId',
+		( { params: { site, purchaseId, cardId } } ) =>
+			`/purchases/subscriptions/${ site }/${ purchaseId }/payment-method/change/${ cardId }`
+	);
+	router(
+		'/purchases/add-credit-card/:site',
+		( { params: { site } } ) => `/purchases/add-payment-method/${ site }`
 	);
 };

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -182,7 +182,7 @@ export function PurchaseChangePaymentMethod( {
 
 	return (
 		<Main className="purchases is-wide-layout">
-			<DocumentHead title={ titles.editCardDetails } />
+			<DocumentHead title={ titles.changePaymentMethod } />
 			<FormattedHeader
 				brandFont
 				className="purchases__page-heading"

--- a/client/my-sites/purchases/paths.ts
+++ b/client/my-sites/purchases/paths.ts
@@ -1,53 +1,45 @@
-/**
- * Internal Dependencies
- */
-import { isEnabled } from '@automattic/calypso-config';
-
 export const getManagePurchaseUrlFor = (
 	targetSiteSlug: string,
 	targetPurchaseId: string | number
-) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }`;
+): string => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }`;
 
 export const getConfirmCancelDomainUrlFor = (
 	targetSiteSlug: string,
 	targetPurchaseId: string | number
-) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/confirm-cancel-domain`;
+): string =>
+	`/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/confirm-cancel-domain`;
 
 export const getCancelPurchaseUrlFor = (
 	targetSiteSlug: string,
 	targetPurchaseId: string | number
-) => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/cancel`;
+): string => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/cancel`;
 
-export const getPurchaseListUrlFor = ( targetSiteSlug: string ) =>
+export const getPurchaseListUrlFor = ( targetSiteSlug: string ): string =>
 	`/purchases/subscriptions/${ targetSiteSlug }`;
 
 export const getAddPaymentMethodUrlFor = (
 	targetSiteSlug: string,
 	targetPurchaseId: string | number
-) =>
-	isEnabled( 'purchases/new-payment-methods' )
-		? `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/payment-method/add`
-		: `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/payment/add`;
+): string =>
+	`/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/payment-method/add`;
 
-export const getAddNewPaymentMethodUrlFor = ( targetSiteSlug: string ) =>
-	isEnabled( 'purchases/new-payment-methods' )
-		? `/purchases/add-payment-method/${ targetSiteSlug }`
-		: `/purchases/add-credit-card/${ targetSiteSlug }`;
+export const getAddNewPaymentMethodUrlFor = ( targetSiteSlug: string ): string =>
+	`/purchases/add-payment-method/${ targetSiteSlug }`;
 
-export const getPaymentMethodsUrlFor = ( targetSiteSlug: string ) =>
+export const getPaymentMethodsUrlFor = ( targetSiteSlug: string ): string =>
 	`/purchases/payment-methods/${ targetSiteSlug }`;
 
 export const getChangePaymentMethodUrlFor = (
 	targetSiteSlug: string,
 	targetPurchaseId: string | number,
 	targetCardId: string | number
-) =>
-	isEnabled( 'purchases/new-payment-methods' )
-		? `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/payment-method/change/${ targetCardId }`
-		: `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/payment/edit/${ targetCardId }`;
+): string =>
+	`/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/payment-method/change/${ targetCardId }`;
 
-export const getReceiptUrlFor = ( targetSiteSlug: string, targetReceiptId: string | number ) =>
-	`/purchases/billing-history/${ targetSiteSlug }/${ targetReceiptId }`;
+export const getReceiptUrlFor = (
+	targetSiteSlug: string,
+	targetReceiptId: string | number
+): string => `/purchases/billing-history/${ targetSiteSlug }/${ targetReceiptId }`;
 
-export const getBillingHistoryUrlFor = ( targetSiteSlug: string ) =>
+export const getBillingHistoryUrlFor = ( targetSiteSlug: string ): string =>
 	`/purchases/billing-history/${ targetSiteSlug }`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Once we're confident we won't need to turn off the `purchases/new-payment-methods` flag, we can clean up this code that's only active when the flag is not set.

#### Testing instructions

This PR should only be removing code that is inactive due to the `purchases/new-payment-methods` flag being permanently set in all deployment environments.

We should also make sure the old urls redirect correctly.

- `/me/purchases/:site/:purchaseId/payment/add` to `/me/purchases/:site/:purchaseId/payment-method/add`
- `/me/purchases/add-credit-card` to `/me/purchases/add-payment-method`
- `/me/purchases/:site/:purchaseId/payment/change/:cardId` to `/me/purchases/:site/:purchaseId/payment-method/change/:cardId`

Legacy URLs (not sure if these are used anywhere; it might be worth figuring that out so these can be removed):

- `/purchases/:siteName/:purchaseId/payment/add` to `/purchases/subscriptions/:siteName/:purchaseId/payment-method/add`
- `/purchases/:siteName/:purchaseId/payment/edit/:cardId` to `/purchases/subscriptions/:siteName/:purchaseId/payment-method/change/:cardId`
- `/purchases/subscriptions/:site/:purchaseId/payment/add` to `/purchases/subscriptions/:site/:purchaseId/payment-method/add`
- `/purchases/subscriptions/:site/:purchaseId/payment/edit/:cardId` to `/purchases/subscriptions/:site/:purchaseId/payment-method/change/:cardId`
- `/purchases/add-credit-card/:site` to `/purchases/add-payment-method/:site`