### PR TITLE
Add missing 'jetpack_connect_url' prop to _shared config file

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -25,6 +25,7 @@
 	"lasagna_url": "wss://rt-api.wordpress.com/socket",
 	"login_url": false,
 	"logout_url": false,
+	"jetpack_connect_url": false,
 	"mc_analytics_enabled": false,
 	"oauth_client_id": false,
 	"olark_chat_identity": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #48460, I forgot to add this prop to the shared file and I only added it to Jetpack cloud's config files.

* Add the `jetpack_connect_url` prop to the shared config file.

#### Testing instructions

* Code review.
