### PR TITLE
Checkout: Make sure we do not call translate payment method function in analytics with null

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -121,6 +121,7 @@ export default function useCreatePaymentCompleteCallback( {
 					reduxDispatch,
 				} );
 			} catch ( err ) {
+				console.error( err ); // eslint-disable-line no-console
 				// This is a fallback to catch any errors caused by the analytics code
 				// Anything in this block should remain very simple and extremely
 				// tolerant of any kind of data. It should make no assumptions about

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -34,7 +34,6 @@ import type { TransactionResponse, Purchase } from '../types/wpcom-store-state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { recordPurchase } from 'calypso/lib/analytics/record-purchase';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from '../lib/translate-payment-method-names';
-import type { CheckoutPaymentMethodSlug } from '../types/checkout-payment-method-slug';
 import normalizeTransactionResponse from '../lib/normalize-transaction-response';
 import getThankYouPageUrl from './use-get-thank-you-url/get-thank-you-page-url';
 import {
@@ -210,6 +209,8 @@ export default function useCreatePaymentCompleteCallback( {
 			page.redirect( url );
 		},
 		[
+			previousRoute,
+			shouldShowOneClickTreatment,
 			siteSlug,
 			adminUrl,
 			redirectTo,
@@ -305,14 +306,14 @@ function recordPaymentCompleteAnalytics( {
 	responseCart: ResponseCart;
 	reduxDispatch: ReturnType< typeof useDispatch >;
 } ) {
+	const wpcomPaymentMethod = paymentMethodId
+		? translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId )
+		: null;
 	reduxDispatch(
 		recordTracksEvent( 'calypso_checkout_payment_success', {
 			coupon_code: responseCart.coupon,
 			currency: responseCart.currency,
-			payment_method:
-				translateCheckoutPaymentMethodToWpcomPaymentMethod(
-					paymentMethodId as CheckoutPaymentMethodSlug
-				) || '',
+			payment_method: wpcomPaymentMethod || '',
 			total_cost: responseCart.total_cost,
 		} )
 	);
@@ -333,10 +334,7 @@ function recordPaymentCompleteAnalytics( {
 			coupon_code: responseCart.coupon,
 			total: responseCart.total_cost_integer,
 			currency: responseCart.currency,
-			payment_method:
-				translateCheckoutPaymentMethodToWpcomPaymentMethod(
-					paymentMethodId as CheckoutPaymentMethodSlug
-				) || '',
+			payment_method: wpcomPaymentMethod || '',
 		} )
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
@@ -59,7 +59,7 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 }
 
 export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
-	paymentMethod: CheckoutPaymentMethodSlug
+	paymentMethod: CheckoutPaymentMethodSlug | string
 ): WPCOMPaymentMethod | null {
 	// existing cards have unique paymentMethodIds
 	if ( paymentMethod.startsWith( 'existingCard' ) ) {
@@ -105,6 +105,7 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 		case 'free-purchase':
 			return 'WPCOM_Billing_WPCOM';
 	}
+	return null;
 }
 
 export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod | null {

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
@@ -87,7 +87,7 @@ export default function PurchaseModalWrapper( props ) {
 					existingCardProcessor( transactionData, dataForProcessor ),
 			} }
 		>
-			<PurchaseModal { ...props } />;
+			<PurchaseModal { ...props } />
 		</CheckoutProvider>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a small regression from https://github.com/Automattic/wp-calypso/pull/48152. A fatal error occurs when completing the upsell modal purchase, but the error is hidden because there is a fallback if `recordPaymentCompleteAnalytics` fails, which is great because it means the fallback is working and users should not have seen any issues. Unfortunately, since it was hidden we didn't know about it until it got to production.

The issue was that we were forcing a type on a value to please TypeScript, but that's always a bad idea and in this case it was hiding a null value that was expected to be a string.

#### Testing instructions

- Purchase a personal plan through checkout.
- Verify that you see an upsell.
- Click through and purchase the upsell using the modal.
- Verify that there are no errors in the console.
