### PR TITLE
Fix CheckoutContainer/ShoppingCartProvider imports

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -13,7 +13,6 @@ import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/ac
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import GSuiteNudge from './gsuite-nudge';
-import CheckoutContainer from './checkout/checkout-container';
 import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutSystemDecider from './checkout-system-decider';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
@@ -35,7 +34,6 @@ import UpsellNudge, {
 	CONCIERGE_SUPPORT_SESSION,
 	CONCIERGE_QUICKSTART_SESSION,
 } from './upsell-nudge';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 export function checkout( context, next ) {
 	const { feature, plan, domainOrProduct, purchaseId } = context.params;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a regression added by https://github.com/Automattic/wp-calypso/pull/48438 where an import was duplicated because https://github.com/Automattic/wp-calypso/pull/48152 also imported the same component. The branch passed but once it was merged it caused a conflict.

#### Testing instructions

Verify calypso builds