### PR TITLE
New Onboarding: update existing users non-EN experiment slug

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -186,7 +186,7 @@ class Layout extends Component {
 		return (
 			<div className={ sectionClass }>
 				<QueryExperiments />
-				<Experiment name="new_onboarding_existing_users_non_en_v4" />
+				<Experiment name="new_onboarding_existing_users_non_en_v5" />
 				<BodySectionCssClass
 					group={ this.props.sectionGroup }
 					section={ this.props.sectionName }

--- a/client/state/selectors/get-onboarding-url.js
+++ b/client/state/selectors/get-onboarding-url.js
@@ -28,7 +28,7 @@ export default function getOnboardingUrl( state ) {
 
 	const existingUsersOnboardingVariant = getVariationForUser(
 		state,
-		'new_onboarding_existing_users_non_en_v4'
+		'new_onboarding_existing_users_non_en_v5'
 	);
 	if ( existingUsersOnboardingVariant === 'treatment' ) {
 		return config( 'gutenboarding_url' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bump experiment slug to `new_onboarding_existing_users_non_en_v5` which is adding an exposure event to improve metrics accuracy.

#### Testing instructions

The functionality should be unchanged from #48350 
* As a user with a non-EN language set in the account, when creating a site from Calypso:
**A**. 'control' variation =>  `/start`
**B**. 'treatment' variation =>  `/new`
