### PR TITLE
Anchor: Include info about Anchor flavoring when submitting Gutenboarding signup.

### DIFF
--- a/client/config/index.js
+++ b/client/config/index.js
@@ -68,7 +68,6 @@ if (
 		applyFlags( match[ 1 ], 'URL' );
 	}
 }
-
 const configApi = createConfig( configData );
 
 export default configApi;

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -103,7 +103,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 			password: passwordVal,
 			signup_flow_name: 'gutenboarding',
 			locale: langParam,
-			extra: { username_hint },
+			extra: { username_hint, is_anchor_fm_signup: isAnchorFmSignup },
 			is_passwordless: false,
 		} );
 

--- a/packages/data-stores/src/user/types.ts
+++ b/packages/data-stores/src/user/types.ts
@@ -73,6 +73,7 @@ export interface CreateAccountParams {
 		first_name?: string;
 		last_name?: string;
 		username_hint: string | null | undefined;
+		is_anchor_fm_signup?: boolean | undefined;
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds logic to include info about whether a Gutenboarding signup was from an anchor referral when the request is made to the signup API endpoint.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check this branch out to your local Calypso environment and follow testing instructions in D54542-code .

Fixes 376-gh-Automattic/dotcom-manage