### PR TITLE
i18n-utils: Fully handle invalid URLs in localizeUrl

### DIFF
--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -92,7 +92,12 @@ const urlLocalizationMapping: UrlLocalizationMapping = {
 };
 
 export function localizeUrl( fullUrl: string, locale: Locale ): string {
-	const url = new URL( String( fullUrl ), INVALID_URL );
+	let url;
+	try {
+		url = new URL( String( fullUrl ), INVALID_URL );
+	} catch ( e ) {
+		return fullUrl;
+	}
 
 	// Ignore and passthrough /relative/urls that have no host specified
 	if ( url.origin === INVALID_URL ) {

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -61,7 +61,7 @@ describe( '#localizeUrl', () => {
 	} );
 
 	test( 'handles invalid URLs', () => {
-		[ undefined, null, [], {}, { href: 'https://test' }, 'not-a-url', () => {} ].forEach(
+		[ undefined, null, [], {}, { href: 'https://test' }, 'not-a-url', () => {}, 'http://' ].forEach(
 			( fullUrl ) => {
 				expect( localizeUrl( fullUrl, 'en' ) ).toEqual( fullUrl );
 				expect( localizeUrl( fullUrl, 'fr' ) ).toEqual( fullUrl );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update tests to cause `new URL` to throw an error
* Return `fullUrl` when handling the error like we do for other non-critical URL errors below.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Leave a comment on a test blog and manually update the author URL to be `http://` verify that this breaks production comments page at `/comments/all/:site`. Then try the same comments page on Calypso.live for this branch and verify that it works now.

Fixes https://github.com/Automattic/wp-calypso/issues/47355