### PR TITLE
Earn: Update color variable for icons

### DIFF
--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -20,9 +20,9 @@
 }
 
 .earn .promo-section__promos .gridicon {
-    fill: var( --studio-blue-10 );
-    position: relative;
-    top: -8px;
+	fill: var( --color-primary-10 );
+	position: relative;
+	top: -8px;
 }
 
 @include break-wide {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust the color variable for icons on the Earn page to use the primary color rather than a hard-coded blue, so they better match with custom color schemes.

**Before**

<img width="1533" alt="Screen Shot 2020-12-18 at 3 55 29 PM" src="https://user-images.githubusercontent.com/2124984/102660784-a44f2380-4149-11eb-96bf-e9b993ee3cd6.png">

**After**

<img width="1523" alt="Screen Shot 2020-12-18 at 3 56 30 PM" src="https://user-images.githubusercontent.com/2124984/102660778-a0bb9c80-4149-11eb-86dc-9b3ee70302f1.png">


Fixes #48508

#### Testing instructions

* Switch to this PR and navigate to `/earn`
* Look at the icons on each card, and change color schemes a few times. The colors should change with the color scheme's primary color.
