### PR TITLE
Framework: Get rid of lodash's isNull

### DIFF
--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
-import { isNull, noop, omitBy } from 'lodash';
+import { noop, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ function CommentButton( props ) {
 				onClick,
 				target: 'a' === tagName ? target : null,
 			},
-			isNull
+			( prop ) => prop === null
 		),
 		<Gridicon icon="comment" size={ props.size } className="comment-button__icon" />,
 		<span className="comment-button__label">

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
-import { omitBy, isNull } from 'lodash';
+import { omitBy } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -122,7 +122,7 @@ class LikeButton extends PureComponent {
 					onMouseEnter,
 					onMouseLeave,
 				},
-				isNull
+				( prop ) => prop === null
 			),
 			<LikeIcons size={ this.props.iconSize } />,
 			labelElement

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -588,7 +588,7 @@ export class DateRange extends Component {
 	/**
 	 * Renders the Popover component
 	 *
-	 * @returns {JSX.Element} the Popover component
+	 * @returns {React.Element} the Popover component
 	 */
 	renderPopover() {
 		const headerProps = {
@@ -627,7 +627,7 @@ export class DateRange extends Component {
 	/**
 	 * Renders the DatePicker component
 	 *
-	 * @returns {JSX.Element} the DatePicker component
+	 * @returns {React.Element} the DatePicker component
 	 */
 	renderDatePicker() {
 		const fromDate = this.momentDateToJsDate( this.state.startDate );
@@ -679,7 +679,7 @@ export class DateRange extends Component {
 	/**
 	 * Renders the component
 	 *
-	 * @returns {JSX.Element} the DateRange component
+	 * @returns {React.Element} the DateRange component
 	 */
 	render() {
 		const rootClassNames = classNames( {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { noop, isNil, isNull, has } from 'lodash';
+import { noop, isNil, has } from 'lodash';
 import { DateUtils } from 'react-day-picker';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -230,9 +230,8 @@ export class DateRange extends Component {
 		// Either `startDate` or `endDate`
 		const stateKey = `${ startOrEnd.toLowerCase() }Date`;
 
-		const isSameDate = ! isNull( this.state[ stateKey ] )
-			? this.state[ stateKey ].isSame( date, 'day' )
-			: false;
+		const isSameDate =
+			this.state[ stateKey ] !== null ? this.state[ stateKey ].isSame( date, 'day' ) : false;
 
 		if ( isSameDate ) {
 			return;
@@ -279,8 +278,8 @@ export class DateRange extends Component {
 	 * Converts moment dates to a DateRange
 	 * as required by Day Picker DateUtils
 	 *
-	 * @param  {MomentJSDate} startDate the start date for the range
-	 * @param  {MomentJSDate} endDate   the end date for the range
+	 * @param  {Date} startDate the start date for the range
+	 * @param  {Date} endDate   the end date for the range
 	 * @returns {object}           the date range object
 	 */
 	toDateRange( startDate, endDate ) {
@@ -298,7 +297,7 @@ export class DateRange extends Component {
 	 *
 	 * Dates are only persisted via the commitDates method.
 	 *
-	 * @param  {MomentJSDate} date the newly selected date object
+	 * @param  {Date} date the newly selected date object
 	 */
 	onSelectDate = ( date ) => {
 		if ( ! this.isValidDate( date ) ) {
@@ -318,12 +317,12 @@ export class DateRange extends Component {
 		this.setState(
 			( previousState ) => {
 				// Update to date or `null` which means "not date"
-				const newStartDate = isNull( newRange.from )
-					? NO_DATE_SELECTED_VALUE
-					: this.nativeDateToMoment( newRange.from );
-				const newEndDate = isNull( newRange.to )
-					? NO_DATE_SELECTED_VALUE
-					: this.nativeDateToMoment( newRange.to );
+				const newStartDate =
+					newRange.from === null
+						? NO_DATE_SELECTED_VALUE
+						: this.nativeDateToMoment( newRange.from );
+				const newEndDate =
+					newRange.to === null ? NO_DATE_SELECTED_VALUE : this.nativeDateToMoment( newRange.to );
 
 				// Update start/end state values
 				let newState = {
@@ -445,7 +444,7 @@ export class DateRange extends Component {
 	/**
 	 * Converts a moment date to a native JS Date object
 	 *
-	 * @param  {MomentJSDate} momentDate a momentjs date object to convert
+	 * @param  {Date} momentDate a momentjs date object to convert
 	 * @returns {Date}            the converted JS Date object
 	 */
 	momentDateToJsDate( momentDate ) {
@@ -456,7 +455,7 @@ export class DateRange extends Component {
 	 * Converts a native JS Date object to a MomentJS Date object
 	 *
 	 * @param  {Date} nativeDate date to be converted
-	 * @returns {MomentJSDate}            the converted Date
+	 * @returns {Date}            the converted Date
 	 */
 	nativeDateToMoment( nativeDate ) {
 		return this.props.moment( nativeDate );
@@ -466,7 +465,7 @@ export class DateRange extends Component {
 	 * Formats a given date to the appropriate format for the
 	 * current locale
 	 *
-	 * @param  {Date|MomentJSDate} date the date to be converted
+	 * @param  {Date} date the date to be converted
 	 * @returns {string}      the date as a formatted locale string
 	 */
 	formatDateToLocale( date ) {
@@ -486,10 +485,11 @@ export class DateRange extends Component {
 	 * Enforces that given date is within the bounds of the
 	 * range specified
 	 *
-	 * @param  {Moment} date             momentJS instance
-	 * @param  {Moment|Date} options.dateFrom the start of the date range
-	 * @param  {Moment|Date} options.dateTo   the end of the date range
-	 * @returns {Moment}                  the date clamped to be within the range
+	 * @param  {Date}  date             momentJS instance
+	 * @param  {Array} options          date range
+	 * @param  {Date}  options.dateFrom the start of the date range
+	 * @param  {Date}  options.dateTo   the end of the date range
+	 * @returns {Date}                  the date clamped to be within the range
 	 */
 	clampDateToRange( date, { dateFrom, dateTo } ) {
 		// Ensure endDate is within bounds of firstSelectableDate
@@ -509,7 +509,7 @@ export class DateRange extends Component {
 	 * for display in a text input. Also converts
 	 * to locale appropriate format.
 	 *
-	 * @param  {Date|Moment} date the date for conversion
+	 * @param  {Date} date the date for conversion
 	 * @returns {string}      the date expressed as a locale appropriate string or if null
 	 *                       then returns the locale format (eg: MM/DD/YYYY)
 	 */
@@ -588,7 +588,7 @@ export class DateRange extends Component {
 	/**
 	 * Renders the Popover component
 	 *
-	 * @returns {ReactComponent} the Popover component
+	 * @returns {React.Component} the Popover component
 	 */
 	renderPopover() {
 		const headerProps = {
@@ -627,7 +627,7 @@ export class DateRange extends Component {
 	/**
 	 * Renders the DatePicker component
 	 *
-	 * @returns {ReactComponent} the DatePicker component
+	 * @returns {React.Component} the DatePicker component
 	 */
 	renderDatePicker() {
 		const fromDate = this.momentDateToJsDate( this.state.startDate );
@@ -679,7 +679,7 @@ export class DateRange extends Component {
 	/**
 	 * Renders the component
 	 *
-	 * @returns {ReactComponent} the DateRange component
+	 * @returns {React.Component} the DateRange component
 	 */
 	render() {
 		const rootClassNames = classNames( {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -679,7 +679,7 @@ export class DateRange extends Component {
 	/**
 	 * Renders the component
 	 *
-	 * @returns {React.Component} the DateRange component
+	 * @returns {JSX.Element} the DateRange component
 	 */
 	render() {
 		const rootClassNames = classNames( {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -444,7 +444,7 @@ export class DateRange extends Component {
 	/**
 	 * Converts a moment date to a native JS Date object
 	 *
-	 * @param  {Date} momentDate a momentjs date object to convert
+	 * @param  {import('moment').Moment} momentDate a momentjs date object to convert
 	 * @returns {Date}            the converted JS Date object
 	 */
 	momentDateToJsDate( momentDate ) {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -485,11 +485,11 @@ export class DateRange extends Component {
 	 * Enforces that given date is within the bounds of the
 	 * range specified
 	 *
-	 * @param  {Date}  date             momentJS instance
-	 * @param  {Array} options          date range
-	 * @param  {Date}  options.dateFrom the start of the date range
-	 * @param  {Date}  options.dateTo   the end of the date range
-	 * @returns {Date}                  the date clamped to be within the range
+	 * @param  {import('moment').Moment}  date             momentJS instance
+	 * @param  {object} options          date range
+	 * @param  {import('moment').Moment | Date}  options.dateFrom the start of the date range
+	 * @param  {import('moment').Moment | Date}  options.dateTo   the end of the date range
+	 * @returns {import('moment').Moment}                  the date clamped to be within the range
 	 */
 	clampDateToRange( date, { dateFrom, dateTo } ) {
 		// Ensure endDate is within bounds of firstSelectableDate

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -297,7 +297,7 @@ export class DateRange extends Component {
 	 *
 	 * Dates are only persisted via the commitDates method.
 	 *
-	 * @param  {Date} date the newly selected date object
+	 * @param  {import('moment').Moment} date the newly selected date object
 	 */
 	onSelectDate = ( date ) => {
 		if ( ! this.isValidDate( date ) ) {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -509,7 +509,7 @@ export class DateRange extends Component {
 	 * for display in a text input. Also converts
 	 * to locale appropriate format.
 	 *
-	 * @param  {Date} date the date for conversion
+	 * @param  {import('moment').Moment | Date} date the date for conversion
 	 * @returns {string}      the date expressed as a locale appropriate string or if null
 	 *                       then returns the locale format (eg: MM/DD/YYYY)
 	 */

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -627,7 +627,7 @@ export class DateRange extends Component {
 	/**
 	 * Renders the DatePicker component
 	 *
-	 * @returns {React.Component} the DatePicker component
+	 * @returns {JSX.Element} the DatePicker component
 	 */
 	renderDatePicker() {
 		const fromDate = this.momentDateToJsDate( this.state.startDate );

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -455,7 +455,7 @@ export class DateRange extends Component {
 	 * Converts a native JS Date object to a MomentJS Date object
 	 *
 	 * @param  {Date} nativeDate date to be converted
-	 * @returns {Date}            the converted Date
+	 * @returns {import('moment').Moment}            the converted Date
 	 */
 	nativeDateToMoment( nativeDate ) {
 		return this.props.moment( nativeDate );

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -588,7 +588,7 @@ export class DateRange extends Component {
 	/**
 	 * Renders the Popover component
 	 *
-	 * @returns {React.Component} the Popover component
+	 * @returns {JSX.Element} the Popover component
 	 */
 	renderPopover() {
 		const headerProps = {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -465,7 +465,7 @@ export class DateRange extends Component {
 	 * Formats a given date to the appropriate format for the
 	 * current locale
 	 *
-	 * @param  {Date} date the date to be converted
+	 * @param  {import('moment').Moment | Date} date the date to be converted
 	 * @returns {string}      the date as a formatted locale string
 	 */
 	formatDateToLocale( date ) {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -278,8 +278,8 @@ export class DateRange extends Component {
 	 * Converts moment dates to a DateRange
 	 * as required by Day Picker DateUtils
 	 *
-	 * @param  {Date} startDate the start date for the range
-	 * @param  {Date} endDate   the end date for the range
+	 * @param  {import('moment').Moment} startDate the start date for the range
+	 * @param  {import('moment').Moment} endDate   the end date for the range
 	 * @returns {object}           the date range object
 	 */
 	toDateRange( startDate, endDate ) {

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
-import { isNull } from 'lodash';
 
 /**
  * Internal dependencies
@@ -100,7 +99,7 @@ export class FacebookSharePreview extends PureComponent {
 							</a>
 						</div>
 
-						{ ! isNull( imageUrl ) && (
+						{ imageUrl !== null && (
 							<div className="facebook-share-preview__image-wrapper">
 								<img
 									alt="Facebook Preview Thumbnail"
@@ -110,7 +109,7 @@ export class FacebookSharePreview extends PureComponent {
 							</div>
 						) }
 
-						{ isNull( imageUrl ) && (
+						{ imageUrl === null && (
 							<div className="facebook-share-preview__card-wrapper">
 								<FacebookPreview
 									title={ seoTitle }

--- a/client/extensions/woocommerce/app/product-categories/create.js
+++ b/client/extensions/woocommerce/app/product-categories/create.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isEmpty, omit, isNumber, isNull } from 'lodash';
+import { isEmpty, omit, isNumber } from 'lodash';
 import page from 'page';
 
 /**
@@ -122,7 +122,7 @@ class ProductCategoryCreate extends React.Component {
 			category &&
 			category.name &&
 			category.name.length &&
-			! isNull( category.parent ) &&
+			category.parent !== null &&
 			! isUploading;
 
 		return (

--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-import { isNumber, head, isNull } from 'lodash';
+import { isNumber, head } from 'lodash';
 
 /**
  * Internal dependencies
@@ -65,7 +65,7 @@ class ProductCategoryForm extends Component {
 		}
 
 		if ( nextProps.category.parent !== this.props.category.parent ) {
-			if ( isNull( nextProps.category.parent ) ) {
+			if ( nextProps.category.parent === null ) {
 				this.setState( {
 					selectedParent: [],
 					isTopLevel: false,
@@ -274,7 +274,7 @@ class ProductCategoryForm extends Component {
 									</span>
 								</FormLabel>
 
-								{ ( ! isTopLevel || isNull( category.parent ) ) && (
+								{ ( ! isTopLevel || category.parent === null ) && (
 									<div>
 										<FormLabel>{ translate( 'Select a parent category' ) }</FormLabel>
 										<TermTreeSelectorTerms

--- a/client/extensions/woocommerce/app/product-categories/update.js
+++ b/client/extensions/woocommerce/app/product-categories/update.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { isEmpty, omit, debounce, isNull } from 'lodash';
+import { isEmpty, omit, debounce } from 'lodash';
 import page from 'page';
 
 /**
@@ -172,7 +172,7 @@ class ProductCategoryUpdate extends React.Component {
 			category &&
 			category.name &&
 			category.name.length &&
-			! isNull( category.parent ) &&
+			category.parent !== null &&
 			! isUploading;
 
 		return (

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { isNull, isUndefined } from 'lodash';
+import { isUndefined } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -102,7 +102,7 @@ const ProductFormSimpleCard = ( {
 	} );
 
 	const { stock_quantity } = product;
-	const quantity = isNull( stock_quantity ) || isUndefined( stock_quantity ) ? '' : stock_quantity;
+	const quantity = stock_quantity === null || isUndefined( stock_quantity ) ? '' : stock_quantity;
 
 	const stockDisabled = 'no' === storeIsManagingStock ? true : false;
 	const inventorySettingsUrl =

--- a/client/extensions/woocommerce/state/sites/settings/general/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/reducer.js
@@ -4,7 +4,6 @@
 
 import { withoutPersistence } from 'calypso/state/utils';
 import { ERROR, LOADING } from 'woocommerce/state/constants';
-import { isNull } from 'lodash';
 import { updateSettings } from '../helpers';
 import {
 	WOOCOMMERCE_CURRENCY_UPDATE_SUCCESS,
@@ -49,7 +48,7 @@ export default withoutPersistence( ( state = null, action ) => {
 
 			// Don't set the loading indicator if data has previously been loaded,
 			// or if the data layer is dispatching with meta attached.
-			if ( ! data && ! error && ( isNull( state ) || ERROR === state ) ) {
+			if ( ! data && ! error && ( state === null || ERROR === state ) ) {
 				return LOADING;
 			}
 			return state;

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -9,7 +9,6 @@ import {
 	get,
 	includes,
 	isEmpty,
-	isNull,
 	omitBy,
 	pick,
 	startsWith,
@@ -101,7 +100,10 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 
 		SignupCart.createCart(
 			siteId,
-			omitBy( pick( dependencies, 'domainItem', 'privacyItem', 'cartItem' ), isNull ),
+			omitBy(
+				pick( dependencies, 'domainItem', 'privacyItem', 'cartItem' ),
+				( dep ) => dep === null
+			),
 			( error ) => {
 				callback( error, providedDependencies );
 			}


### PR DESCRIPTION
There's hardly a more useless lodash method than `isNull`. This PR removes it in favor of the equally simple `=== null`.

#### Changes proposed in this Pull Request

* Framework: Get rid of lodash's `isNull`

#### Testing instructions

* Replacement is straightforward - verify changes make sense and tests pass.
