### PR TITLE
Add store deprecated notice when woocommerce/store-deprecated flag is set to true

### DIFF
--- a/client/extensions/woocommerce/components/store-deprecated-notice/index.js
+++ b/client/extensions/woocommerce/components/store-deprecated-notice/index.js
@@ -11,23 +11,19 @@ import React, { Component } from 'react';
 
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import './style.scss';
 
 class StoreDeprecatedNotice extends Component {
 	render() {
 		return (
-			<div className="store-deprecated-notice">
-				<Notice
-					status="is-success"
-					icon="notice"
-					text={ translate( 'Store is moving to WooCommerce' ) }
-					showDismiss={ false }
-				>
-					<NoticeAction href="https://wordpress.com/support/store/">
-						{ translate( 'More' ) }
-					</NoticeAction>
-				</Notice>
-			</div>
+			<Notice
+				status="is-warning"
+				text={ translate( 'Store is moving to WooCommerce' ) }
+				showDismiss={ false }
+			>
+				<NoticeAction href="https://wordpress.com/support/store/">
+					{ translate( 'More' ) }
+				</NoticeAction>
+			</Notice>
 		);
 	}
 }

--- a/client/extensions/woocommerce/components/store-deprecated-notice/style.scss
+++ b/client/extensions/woocommerce/components/store-deprecated-notice/style.scss
@@ -1,6 +1,0 @@
-.layout__content .notice.is-success .notice__icon-wrapper {
-    background: #d3af3f;
-    .notice__icon-wrapper-drop {
-        background: #9a752e;
-    }
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is a follow-up ticket for [PR](https://github.com/Automattic/wp-calypso/pull/48436) to improve code quality. Thank you @mattsherman for the suggestions 👍 
* Removed unnecessary CSS override, div wrap, and icon prop.

#### Testing instructions

Please refer to the original [PR](https://github.com/Automattic/wp-calypso/pull/48436)