### PR TITLE
Form toggles: Use admin color schemes' primary color as background

### DIFF
--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -312,8 +312,3 @@ object {
 html.no-scroll {
 	overflow: hidden;
 }
-
-/* @wordpress/components Form toggles use the color scheme's background color */
-.components-form-toggle.is-checked .components-form-toggle__track {
-	background-color: var( --color-primary );
-}

--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -206,6 +206,7 @@ code,
 kbd,
 tt,
 var {
+	/* stylelint-disable-next-line scales/font-size */
 	font: 15px $code;
 }
 abbr,
@@ -310,4 +311,9 @@ object {
 // added to the html element when we don't want the background content to scroll
 html.no-scroll {
 	overflow: hidden;
+}
+
+/* @wordpress/components Form toggles use the color scheme's background color */
+.components-form-toggle.is-checked .components-form-toggle__track {
+	background-color: var( --color-primary );
 }

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -1,0 +1,4 @@
+/* @wordpress/components Form toggles use the color scheme's background color */
+.components-form-toggle.is-checked .components-form-toggle__track {
+	background-color: var( --color-primary );
+}

--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -20,3 +20,6 @@
 
 // @wordpress/components stylesheet
 @import '~@wordpress/components/build-style/style.css';
+
+// Overrides for @wordpress/components
+@import './_wp-components-overrides.scss';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `var( --color-primary )` as the background color for `@wordpress/components` form toggles so they better match with our color schemes.
* I'm not sure if this is where the override should live, so I'm open to suggestions!

**Before**

<img width="785" alt="Screen Shot 2020-12-18 at 4 38 51 PM" src="https://user-images.githubusercontent.com/2124984/102663818-93091580-414f-11eb-9766-2589002f4949.png">

**After**

<img width="787" alt="Screen Shot 2020-12-18 at 4 37 02 PM" src="https://user-images.githubusercontent.com/2124984/102663676-52110100-414f-11eb-8cc7-2250d4ece851.png">

#### Testing instructions

* Switch to this PR
* Check out toggles across WP.com on simple, Atomic, and Jetpack sites. The Settings area has many of these, but check the Reader or Account contexts, too.
* Change color schemes. The toggles should match the primary color for each color scheme.
* Make sure there are no visual regressions

Fixes #48509
