### PR TITLE
Domains: Update GSuiteUpgrade to use useShoppingCart

### DIFF
--- a/client/components/upgrades/gsuite/README.md
+++ b/client/components/upgrades/gsuite/README.md
@@ -1,12 +1,12 @@
 # GSuiteUpgrade
 
-GSuiteUpgrade is a React component used to add G Suite email addresses to domains. It expects to be wrapped in a `CartData` Component.
+GSuiteUpgrade is a React component used to add G Suite email addresses to domains. It expects to be wrapped in a `ShoppingCartProvider` Component.
 
 ## Usage
 
 ```jsx
 import React from 'react';
-import CartData from 'calypso/components/data/cart';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import GSuiteUpgrade from 'calypso/components/upgrades/gsuite';
 import productsListFactory from 'calypso/lib/products-list';
 
@@ -15,9 +15,9 @@ const productsList = productsListFactory();
 class MyComponent extends React.Component {
 	render() {
 		return (
-			<CartData>
+			<CalypsoShoppingCartProvider>
 				<GSuiteUpgrade domain={ domain } />;
-			</CartData>
+			</CalypsoShoppingCartProvider>
 		);
 	}
 }

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -210,9 +210,9 @@ const googleAppsWithRegistration = ( context, next ) => {
 						args: { domain: context.params.registerDomain },
 					} ) }
 				/>
-				<CartData>
+				<CalypsoShoppingCartProvider>
 					<GSuiteUpgrade domain={ context.params.registerDomain } />
-				</CartData>
+				</CalypsoShoppingCartProvider>
 			</Main>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates `GSuiteUpgrade` to use `useShoppingCart` from `@automattic/shopping-cart` in place of `CartData`. This will help us eventually remove `CartData` (see #24019). This is similar to the upgrade to `GSuiteNudge` from https://github.com/Automattic/wp-calypso/pull/48438.

Depends on https://github.com/Automattic/wp-calypso/pull/48202 because otherwise the domain that was added by the domain search page will not have finished updating the cart by the time we hit the G Suite page, causing the G Suite submission to overwrite it (which will probably fail since it will be in a cart without a domain).

#### Testing instructions

- Add a domain to your cart.
- Verify that you see the G Suite upsell before you reach checkout.
- Add a G Suite product to your cart from the upsell.
- Verify that you arrive at checkout and that the cart contains both your domain and the G Suite product.