### PR TITLE
Marketing header card copy tweak.

### DIFF
--- a/client/my-sites/marketing/tools/header.tsx
+++ b/client/my-sites/marketing/tools/header.tsx
@@ -33,7 +33,7 @@ const MarketingToolsHeader: FunctionComponent< Props > = ( { handleButtonClick }
 
 				<h2 className="tools__header-description">
 					{ translate(
-						'From finance services to productivity apps and marketing tools, our Business Tool marketplace includes hand-picked services that we think can help you grow your business.'
+						'From finance services to productivity apps and marketing tools, our Business Tool hub includes hand-picked services that we think can help you grow your business.'
 					) }
 				</h2>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Changing the word "marketplace" to "hub" in the header card of the main Marketing page in Calypso (/marketing/tools/)

<img width="1006" alt="Screen Shot 2020-12-18 at 8 14 40 PM" src="https://user-images.githubusercontent.com/35781181/102676894-b3e06380-416d-11eb-8e45-c27436333be5.png">


#### Testing instructions
* Start Calypso in your local environment
* Navigate to /marketing/tools/siteslug
* Confirm that the copy on the header card says "hub" instead of "marketplace"

