### PR TITLE
Help Form: Align Form Button

### DIFF
--- a/client/me/help/help-contact-form/style.scss
+++ b/client/me/help/help-contact-form/style.scss
@@ -6,6 +6,7 @@
 
 	.form-button {
 		margin-top: 11px;
+		float: right;
 	}
 }
 

--- a/client/me/help/help-contact-form/style.scss
+++ b/client/me/help/help-contact-form/style.scss
@@ -5,8 +5,8 @@
 	}
 
 	.form-button {
+		display: block;
 		margin-top: 11px;
-		float: right;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This appears to be a new bug since it always was right-aligned until recently, but this change ensures the Help Form's button is right-aligned again

#### Testing instructions

1. View `/help/contact`
2. Compare the button at the bottom

**Before:**

<img width="872" alt="Screenshot 2020-12-19 at 09 38 26" src="https://user-images.githubusercontent.com/43215253/102686261-52a4a880-41de-11eb-8a71-63e6a604d95f.png">


**After:**

<img width="781" alt="Screenshot 2020-12-19 at 09 41 17" src="https://user-images.githubusercontent.com/43215253/102686272-5d5f3d80-41de-11eb-96f4-229e118b3fe1.png">


cc @sixhours
