### PR TITLE
Update gutenboarding e2e test to include more of the happy-path

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/features/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/features/index.tsx
@@ -91,6 +91,7 @@ const FeaturesStep: React.FunctionComponent = () => {
 							key={ id }
 							onClick={ () => toggleFeature( feature.id ) }
 							isTertiary
+							data-e2e-button={ `feature-${ id }` }
 						>
 							<div className="features__item-image">
 								<FeatureIcon featureId={ feature.id } />

--- a/test/e2e/lib/components/gutenboarding-language-picker.js
+++ b/test/e2e/lib/components/gutenboarding-language-picker.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverHelper from '../driver-helper';
+import AsyncBaseContainer from '../async-base-container';
+
+export default class GutenboardingLanguagePickerComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( 'a[href*="language-modal"]' ) );
+	}
+
+	async switchLanguage( languageSlug ) {
+		await driverHelper.clickWhenClickable( this.driver, this.expectedElementSelector );
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( `.language-picker-component__language-button [lang="${ languageSlug }"]` )
+		);
+	}
+}

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -592,3 +592,22 @@ function getInnerTextMatcherFunction( match ) {
 		throw new Error( 'Unknown matcher type; must be a string or a regular expression' );
 	};
 }
+
+export async function waitTillTextPresent( driver, selector, text, waitOverride ) {
+	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
+
+	return driver.wait(
+		function () {
+			return driver.findElements( selector ).then(
+				async function ( allElements ) {
+					return await webdriver.promise.filter( allElements, getInnerTextMatcherFunction( text ) );
+				},
+				function () {
+					return false;
+				}
+			);
+		},
+		timeoutWait,
+		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be present and displayed with text '${ text }'`
+	);
+}

--- a/test/e2e/lib/flows/delete-site-flow.js
+++ b/test/e2e/lib/flows/delete-site-flow.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import SettingsPage from '../pages/settings-page';
+import * as SlackNotifier from '../slack-notifier';
+import * as dataHelper from '../data-helper';
+
+export default class DeleteSiteFlow {
+	constructor( driver ) {
+		this.driver = driver;
+	}
+
+	async deleteSite( siteDomain ) {
+		await this.driver.sleep( 2000 ); // wait before open site settings page
+
+		return ( async () => {
+			await this.driver.get( dataHelper.getCalypsoURL( `settings/general/${ siteDomain }` ) );
+			const settingsPage = await SettingsPage.Expect( this.driver );
+			return await settingsPage.deleteSite( siteDomain );
+		} )().catch( ( err ) => {
+			SlackNotifier.warn(
+				`There was an error in the hooks that delete test sites, but since it is cleaning up we really don't care: '${ err }'`,
+				{ suppressDuplicateMessages: true }
+			);
+		} );
+	}
+}

--- a/test/e2e/lib/flows/gutenboarding-flow.js
+++ b/test/e2e/lib/flows/gutenboarding-flow.js
@@ -32,8 +32,8 @@ export default class CreateSiteFlow {
 		const domainsPage = await DomainsPage.Expect( this.driver );
 		await domainsPage.skipStep();
 
-		const featureswPage = await FeaturesPage.Expect( this.driver );
-		await featureswPage.skipStep();
+		const featuresPage = await FeaturesPage.Expect( this.driver );
+		await featuresPage.skipStep();
 
 		const plansPage = await PlansPage.Expect( this.driver );
 		await plansPage.expandAllPlans();

--- a/test/e2e/lib/flows/gutenboarding-flow.js
+++ b/test/e2e/lib/flows/gutenboarding-flow.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
  * Internal dependencies
  */
 import AcquireIntentPage from '../pages/gutenboarding/acquire-intent-page.js';
@@ -7,14 +12,16 @@ import StylePreviewPage from '../pages/gutenboarding/style-preview-page.js';
 import PlansPage from '../pages/gutenboarding/plans-page.js';
 import DomainsPage from '../pages/gutenboarding/domains-page.js';
 import FeaturesPage from '../pages/gutenboarding/features-page.js';
+import SignupPage from '../pages/gutenboarding/signup-page.js';
 import GutenbergEditorComponent from '../gutenberg/gutenberg-editor-component';
+import * as dataHelper from '../../lib/data-helper';
 
 export default class CreateSiteFlow {
 	constructor( driver ) {
 		this.driver = driver;
 	}
 
-	async createFreeSite( name ) {
+	async skipAllSteps( name ) {
 		const acquireIntentPage = await AcquireIntentPage.Expect( this.driver );
 		if ( name ) {
 			await acquireIntentPage.enterSiteTitle( name );
@@ -38,6 +45,26 @@ export default class CreateSiteFlow {
 		const plansPage = await PlansPage.Expect( this.driver );
 		await plansPage.expandAllPlans();
 		await plansPage.selectFreePlan();
+	}
+
+	async createFreeSite( name ) {
+		await this.skipAllSteps( name );
+
+		const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+		await gEditorComponent.initEditor();
+	}
+
+	async signupAndCreateFreeSite( { siteName, emailAddress, password } = {} ) {
+		emailAddress =
+			emailAddress || dataHelper.getEmailAddress( this.accountName, config.get( 'signupInboxId' ) );
+		password = password || config.get( 'passwordForNewTestSignUps' );
+
+		await this.skipAllSteps( siteName );
+
+		const signupPage = await SignupPage.Expect( this.driver );
+		await signupPage.enterEmail( emailAddress );
+		await signupPage.enterPassword( password );
+		await signupPage.createAccount();
 
 		const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
 		await gEditorComponent.initEditor();

--- a/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
+++ b/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
@@ -8,10 +8,11 @@ import { By } from 'selenium-webdriver';
  */
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
+import * as dataHelper from '../../data-helper';
 
 export default class AcquireIntentPage extends AsyncBaseContainer {
-	constructor( driver ) {
-		super( driver, By.css( '.acquire-intent' ) );
+	constructor( driver, url = dataHelper.getCalypsoURL( 'new' ) ) {
+		super( driver, By.css( '.acquire-intent' ), url );
 	}
 
 	async enterSiteTitle( siteTitle ) {

--- a/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
+++ b/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
@@ -8,11 +8,10 @@ import { By } from 'selenium-webdriver';
  */
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
-import * as dataHelper from '../../data-helper';
 
 export default class AcquireIntentPage extends AsyncBaseContainer {
-	constructor( driver, url = dataHelper.getCalypsoURL( 'new' ) ) {
-		super( driver, By.css( '.acquire-intent' ), url );
+	constructor( driver ) {
+		super( driver, By.css( '.acquire-intent' ) );
 	}
 
 	async enterSiteTitle( siteTitle ) {

--- a/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
+++ b/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
@@ -12,6 +12,7 @@ import * as driverHelper from '../../driver-helper';
 export default class AcquireIntentPage extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.acquire-intent' ) );
+		this.nextButtonSelector = By.css( '.action-buttons__next' );
 	}
 
 	async enterSiteTitle( siteTitle ) {
@@ -20,8 +21,7 @@ export default class AcquireIntentPage extends AsyncBaseContainer {
 	}
 
 	async goToNextStep() {
-		const nextButtonSelector = By.css( '.action-buttons__next' );
-		return await driverHelper.clickWhenClickable( this.driver, nextButtonSelector );
+		return await driverHelper.clickWhenClickable( this.driver, this.nextButtonSelector );
 	}
 
 	async skipStep() {

--- a/test/e2e/lib/pages/gutenboarding/domains-page.js
+++ b/test/e2e/lib/pages/gutenboarding/domains-page.js
@@ -35,4 +35,9 @@ export default class DomainsPage extends AsyncBaseContainer {
 		const skipButtonSelector = By.css( '.action-buttons__skip' );
 		return await driverHelper.clickWhenClickable( this.driver, skipButtonSelector );
 	}
+
+	async enterDomainQuery( query ) {
+		const searchFieldSelector = By.css( '.domain-picker__search input[type="text"]' );
+		return await driverHelper.setWhenSettable( this.driver, searchFieldSelector, query );
+	}
 }

--- a/test/e2e/lib/pages/gutenboarding/domains-page.js
+++ b/test/e2e/lib/pages/gutenboarding/domains-page.js
@@ -21,6 +21,11 @@ export default class DomainsPage extends AsyncBaseContainer {
 		);
 	}
 
+	/**
+	 * Selects the free domain from the list of search results
+	 *
+	 * @returns {Promise<string>} The selected domain
+	 */
 	async selectFreeDomain() {
 		const freeDomainButtonSelector = By.css( '.domain-picker__suggestion-item.is-free' );
 		const freeDomainNameSelector = By.css(

--- a/test/e2e/lib/pages/gutenboarding/domains-page.js
+++ b/test/e2e/lib/pages/gutenboarding/domains-page.js
@@ -22,8 +22,15 @@ export default class DomainsPage extends AsyncBaseContainer {
 	}
 
 	async selectFreeDomain() {
-		const firstDomainSelector = By.css( '.domain-picker__suggestion-item.is-free' );
-		return await driverHelper.clickWhenClickable( this.driver, firstDomainSelector );
+		const freeDomainButtonSelector = By.css( '.domain-picker__suggestion-item.is-free' );
+		const freeDomainNameSelector = By.css(
+			'.domain-picker__suggestion-item.is-free .domain-picker__suggestion-item-name'
+		);
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, freeDomainNameSelector );
+		const domainNameElement = await this.driver.findElement( freeDomainNameSelector );
+		const domainName = await domainNameElement.getText();
+		await driverHelper.clickWhenClickable( this.driver, freeDomainButtonSelector );
+		return domainName;
 	}
 
 	async continueToNextStep() {

--- a/test/e2e/lib/pages/gutenboarding/features-page.js
+++ b/test/e2e/lib/pages/gutenboarding/features-page.js
@@ -18,4 +18,14 @@ export default class PlansPage extends AsyncBaseContainer {
 		const skipButtonSelector = By.css( '.action-buttons__skip' );
 		return await driverHelper.clickWhenClickable( this.driver, skipButtonSelector );
 	}
+
+	async goToNextStep() {
+		const nextButtonSelector = By.css( '.action-buttons__next' );
+		return await driverHelper.clickWhenClickable( this.driver, nextButtonSelector );
+	}
+
+	async selectPluginsFeature() {
+		const pluginsFeatureButon = By.css( 'button[data-e2e-button="feature-plugins"]' );
+		return await driverHelper.clickIfPresent( this.driver, pluginsFeatureButon );
+	}
 }

--- a/test/e2e/lib/pages/gutenboarding/new-page.js
+++ b/test/e2e/lib/pages/gutenboarding/new-page.js
@@ -19,8 +19,19 @@ export default class NewPage extends AsyncBaseContainer {
 		super( driver, by.css( '.is-section-gutenboarding' ), url );
 	}
 
-	static getGutenboardingURL() {
-		return dataHelper.getCalypsoURL( 'new' );
+	static getGutenboardingURL( { locale = 'en', query = '' } = {} ) {
+		let route = 'new';
+		const queryStrings = [];
+
+		if ( locale !== 'en' ) {
+			route += '/' + locale;
+		}
+
+		if ( query !== '' ) {
+			queryStrings.push( query );
+		}
+
+		return dataHelper.getCalypsoURL( route, queryStrings );
 	}
 
 	async waitForBlock() {

--- a/test/e2e/lib/pages/gutenboarding/plans-page.js
+++ b/test/e2e/lib/pages/gutenboarding/plans-page.js
@@ -30,4 +30,13 @@ export default class PlansPage extends AsyncBaseContainer {
 		await driverHelper.scrollIntoView( this.driver, freePlanSelector );
 		return await driverHelper.clickWhenClickable( this.driver, freePlanSelector );
 	}
+
+	async getRecommendedPlan() {
+		// Using the .has-badge selector to find the recommended plan
+		const planNameSelector = By.css(
+			'.plans-accordion-item.has-badge .plans-accordion-item__name'
+		);
+		const planName = await this.driver.findElement( planNameSelector );
+		return await planName.getText();
+	}
 }

--- a/test/e2e/lib/pages/gutenboarding/plans-page.js
+++ b/test/e2e/lib/pages/gutenboarding/plans-page.js
@@ -31,6 +31,9 @@ export default class PlansPage extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable( this.driver, freePlanSelector );
 	}
 
+	/**
+	 * @returns {Promise<string>} the name of the plan that's being recommended
+	 */
 	async getRecommendedPlan() {
 		// Using the .has-badge selector to find the recommended plan
 		const planNameSelector = By.css(

--- a/test/e2e/lib/pages/gutenboarding/signup-page.js
+++ b/test/e2e/lib/pages/gutenboarding/signup-page.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import AsyncBaseContainer from '../../async-base-container';
+import * as driverHelper from '../../driver-helper';
+
+export default class SignupPage extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.signup-form__body' ) );
+	}
+
+	async enterEmail( email ) {
+		const emailSelector = By.css( '.signup-form__body input[type="email"]' );
+		return await driverHelper.setWhenSettable( this.driver, emailSelector, email );
+	}
+
+	async enterPassword( password ) {
+		const passwordSelector = By.css( '.signup-form__body input[type="password"]' );
+		return await driverHelper.setWhenSettable( this.driver, passwordSelector, password );
+	}
+
+	async createAccount() {
+		const submitButtonSelector = By.css( '.signup-form__body button[type="submit"]' );
+		return await driverHelper.clickWhenClickable( this.driver, submitButtonSelector );
+	}
+}

--- a/test/e2e/lib/pages/gutenboarding/style-preview-page.js
+++ b/test/e2e/lib/pages/gutenboarding/style-preview-page.js
@@ -8,6 +8,7 @@ import { By } from 'selenium-webdriver';
  */
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
+import * as dataHelper from '../../data-helper';
 
 export default class StylePreviewPage extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -17,5 +18,17 @@ export default class StylePreviewPage extends AsyncBaseContainer {
 	async continue() {
 		const continueButton = By.css( '.action-buttons__next' );
 		await driverHelper.clickWhenClickable( this.driver, continueButton );
+	}
+
+	async selectFontPairing( fontIndex ) {
+		const fontOptions = await this.driver.findElements(
+			By.css( 'button.style-preview__font-option' )
+		);
+
+		if ( fontIndex === undefined ) {
+			fontIndex = dataHelper.getRandomInt( 0, fontOptions.length - 1 );
+		}
+
+		fontOptions[ fontIndex ].click();
 	}
 }

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -17,9 +17,11 @@ import PlansPage from '../lib/pages/gutenboarding/plans-page.js';
 import DomainsPage from '../lib/pages/gutenboarding/domains-page.js';
 import FeaturesPage from '../lib/pages/gutenboarding/features-page.js';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
+import LanguagePickerComponent from '../lib/components/gutenboarding-language-picker';
 
 import * as driverManager from '../lib/driver-manager.js';
 import * as dataHelper from '../lib/data-helper.js';
+import * as driverHelper from '../lib/driver-helper.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -44,7 +46,12 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 		} );
 
 		step( 'Can visit Gutenboarding page and see Onboarding block', async function () {
-			const page = await NewPage.Visit( driver );
+			const page = await NewPage.Visit(
+				driver,
+				NewPage.getGutenboardingURL( {
+					query: 'flags=gutenboarding/language-picker',
+				} )
+			);
 			const blockExists = await page.waitForBlock();
 			assert( blockExists, 'Onboarding block is not rendered' );
 		} );
@@ -52,6 +59,28 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 		step( 'Can see Acquire Intent and set site title', async function () {
 			const acquireIntentPage = await AcquireIntentPage.Expect( driver );
 			await acquireIntentPage.enterSiteTitle( siteTitle );
+		} );
+
+		step( 'Can change language to Spanish and back to English', async function () {
+			const acquireIntentPage = await AcquireIntentPage.Expect( driver );
+			const languagePicker = await LanguagePickerComponent.Expect( driver );
+
+			await languagePicker.switchLanguage( 'es' );
+
+			await driverHelper.waitTillTextPresent(
+				driver,
+				acquireIntentPage.nextButtonSelector,
+				'Continuar'
+			);
+
+			await languagePicker.switchLanguage( 'en' );
+
+			await driverHelper.waitTillTextPresent(
+				driver,
+				acquireIntentPage.nextButtonSelector,
+				'Continue'
+			);
+
 			await acquireIntentPage.goToNextStep();
 		} );
 

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -34,13 +34,7 @@ import DomainDetailsPage from '../lib/pages/domain-details-page';
 import CancelPurchasePage from '../lib/pages/cancel-purchase-page';
 import CancelDomainPage from '../lib/pages/cancel-domain-page';
 import SettingsPage from '../lib/pages/settings-page';
-import GutenboardingAcquireIntentPage from '../lib/pages/gutenboarding/acquire-intent-page';
-import GutenboardingDomainsPage from '../lib/pages/gutenboarding/domains-page';
-import GutenboardingDesignSelectorPage from '../lib/pages/gutenboarding/design-selector-page';
-import GutenboardingStylePreviewPage from '../lib/pages/gutenboarding/style-preview-page';
-import GutenboardingFeaturesPage from '../lib/pages/gutenboarding/features-page';
-import GutenboardingPlansPage from '../lib/pages/gutenboarding/plans-page';
-import GutenboardingSignupPage from '../lib/pages/gutenboarding/signup-page';
+import NewPage from '../lib/pages/gutenboarding/new-page';
 import AccountSettingsPage from '../lib/pages/account/account-settings-page';
 
 import FindADomainComponent from '../lib/components/find-a-domain-component.js';
@@ -1345,79 +1339,23 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 	} );
 
-	describe( 'Signup and create new site using gutenboarding flow @signup', function () {
-		const blogName = dataHelper.getNewBlogName();
-		const domainQuery = dataHelper.getNewBlogName();
+	describe( 'Signup and create new site using the New Onboarding (Gutenboarding) @signup', function () {
 		const emailAddress = dataHelper.getEmailAddress( dataHelper.getNewBlogName(), signupInboxId );
 
 		before( async function () {
 			await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can enter the gutenboarding flow and enter site title', async function () {
-			const acquireIntentPage = await GutenboardingAcquireIntentPage.Visit( driver );
-			await acquireIntentPage.enterSiteTitle( blogName );
-			await acquireIntentPage.goToNextStep();
-		} );
+		step( 'Signup and create site using default options', async function () {
+			await NewPage.Visit( driver );
 
-		step( 'Can see the domain picker and choose a free sub domain', async function () {
-			const domainsPage = await GutenboardingDomainsPage.Expect( driver );
-			await domainsPage.enterDomainQuery( domainQuery );
-			await domainsPage.selectFreeDomain();
-			await domainsPage.continueToNextStep();
-		} );
-
-		step( 'Can see the design selector and choose a free design', async function () {
-			const designSelectorPage = await GutenboardingDesignSelectorPage.Expect( driver );
-			await designSelectorPage.selectFreeDesign();
-		} );
-
-		step( 'Can see the style preview step and choose a random font pairing', async function () {
-			const stylePreviewPage = await GutenboardingStylePreviewPage.Expect( driver );
-			await stylePreviewPage.selectFontPairing();
-			await stylePreviewPage.continue();
-		} );
-
-		step(
-			'Can see the feature picker and choose a feature that requires a business plan',
-			async function () {
-				const featuresPage = await GutenboardingFeaturesPage.Expect( driver );
-				await featuresPage.selectPluginsFeature();
-				await featuresPage.goToNextStep();
-			}
-		);
-
-		step(
-			'Can see the plan picker with business plan recommended and can choose free plan',
-			async function () {
-				const plansPage = await GutenboardingPlansPage.Expect( driver );
-				const recommendedPlan = await plansPage.getRecommendedPlan( driver );
-				assert.strictEqual(
-					recommendedPlan,
-					'Business',
-					'The Business plan should be recommended because the plugins feature was selected in the previous step'
-				);
-				await plansPage.expandAllPlans();
-				await plansPage.selectFreePlan();
-			}
-		);
-
-		step( 'Can see signup page and create a new account', async function () {
-			const signupPage = await GutenboardingSignupPage.Expect( driver );
-			await signupPage.enterEmail( emailAddress );
-			await signupPage.enterPassword( passwordForTestAccounts );
-			await signupPage.createAccount();
-		} );
-
-		step( 'Can see the gutenberg page editor', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
-			await gEditorComponent.initEditor();
+			await new GutenboardingFlow( driver ).signupAndCreateFreeSite( { emailAddress } );
 		} );
 
 		after( 'Can delete our newly created account', async function () {
 			// Gutenboarding creates users with auto-generated usernames so we need
 			// to find the username before we can delete it.
-			const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
+			const accountSettingsPage = await AccountSettingsPage.Visit( driver );
 			const username = await accountSettingsPage.getUsername();
 
 			return await new DeleteAccountFlow( driver ).deleteAccount( username );

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -34,6 +34,14 @@ import DomainDetailsPage from '../lib/pages/domain-details-page';
 import CancelPurchasePage from '../lib/pages/cancel-purchase-page';
 import CancelDomainPage from '../lib/pages/cancel-domain-page';
 import SettingsPage from '../lib/pages/settings-page';
+import GutenboardingAcquireIntentPage from '../lib/pages/gutenboarding/acquire-intent-page';
+import GutenboardingDomainsPage from '../lib/pages/gutenboarding/domains-page';
+import GutenboardingDesignSelectorPage from '../lib/pages/gutenboarding/design-selector-page';
+import GutenboardingStylePreviewPage from '../lib/pages/gutenboarding/style-preview-page';
+import GutenboardingFeaturesPage from '../lib/pages/gutenboarding/features-page';
+import GutenboardingPlansPage from '../lib/pages/gutenboarding/plans-page';
+import GutenboardingSignupPage from '../lib/pages/gutenboarding/signup-page';
+import AccountSettingsPage from '../lib/pages/account/account-settings-page';
 
 import FindADomainComponent from '../lib/components/find-a-domain-component.js';
 import SecurePaymentComponent from '../lib/components/secure-payment-component.js';
@@ -1334,6 +1342,85 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		after( 'Can delete our newly created account', async function () {
 			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+		} );
+	} );
+
+	describe( 'Signup and create new site using gutenboarding flow @signup', function () {
+		const blogName = dataHelper.getNewBlogName();
+		const domainQuery = dataHelper.getNewBlogName();
+		const emailAddress = dataHelper.getEmailAddress( dataHelper.getNewBlogName(), signupInboxId );
+
+		before( async function () {
+			await driverManager.ensureNotLoggedIn( driver );
+		} );
+
+		step( 'Can enter the gutenboarding flow and enter site title', async function () {
+			const acquireIntentPage = await GutenboardingAcquireIntentPage.Visit( driver );
+			await acquireIntentPage.enterSiteTitle( blogName );
+			await acquireIntentPage.goToNextStep();
+		} );
+
+		step( 'Can see the domain picker and choose a free sub domain', async function () {
+			const domainsPage = await GutenboardingDomainsPage.Expect( driver );
+			await domainsPage.enterDomainQuery( domainQuery );
+			await domainsPage.selectFreeDomain();
+			await domainsPage.continueToNextStep();
+		} );
+
+		step( 'Can see the design selector and choose a free design', async function () {
+			const designSelectorPage = await GutenboardingDesignSelectorPage.Expect( driver );
+			await designSelectorPage.selectFreeDesign();
+		} );
+
+		step( 'Can see the style preview step and choose a random font pairing', async function () {
+			const stylePreviewPage = await GutenboardingStylePreviewPage.Expect( driver );
+			await stylePreviewPage.selectFontPairing();
+			await stylePreviewPage.continue();
+		} );
+
+		step(
+			'Can see the feature picker and choose a feature that requires a business plan',
+			async function () {
+				const featuresPage = await GutenboardingFeaturesPage.Expect( driver );
+				await featuresPage.selectPluginsFeature();
+				await featuresPage.goToNextStep();
+			}
+		);
+
+		step(
+			'Can see the plan picker with business plan recommended and can choose free plan',
+			async function () {
+				const plansPage = await GutenboardingPlansPage.Expect( driver );
+				const recommendedPlan = await plansPage.getRecommendedPlan( driver );
+				assert.strictEqual(
+					recommendedPlan,
+					'Business',
+					'The Business plan should be recommended because the plugins feature was selected in the previous step'
+				);
+				await plansPage.expandAllPlans();
+				await plansPage.selectFreePlan();
+			}
+		);
+
+		step( 'Can see signup page and create a new account', async function () {
+			const signupPage = await GutenboardingSignupPage.Expect( driver );
+			await signupPage.enterEmail( emailAddress );
+			await signupPage.enterPassword( passwordForTestAccounts );
+			await signupPage.createAccount();
+		} );
+
+		step( 'Can see the gutenberg page editor', async function () {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+			await gEditorComponent.initEditor();
+		} );
+
+		after( 'Can delete our newly created account', async function () {
+			// Gutenboarding creates users with auto-generated usernames so we need
+			// to find the username before we can delete it.
+			const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
+			const username = await accountSettingsPage.getUsername();
+
+			return await new DeleteAccountFlow( driver ).deleteAccount( username );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `Signup and create new site using the New Onboarding (Gutenboarding)` test which is a `@signup` test that runs through the simplest gutenboarding flow and ends by creating a user
* Update the existing gutenboarding test to create a site as an existing user and check more of the features are working. Feel happy about this running in `@canary` because it's not relying a signup, which can fail sometimes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the `Create new site as existing user` test runs in circleci
* Check the `Signup and create new site using the New Onboarding (Gutenboarding)` test runs in circleci

Part of #41082