### PR TITLE
Reduce usage of package-imports

### DIFF
--- a/client/components/empty-component/README.md
+++ b/client/components/empty-component/README.md
@@ -10,8 +10,8 @@ In the webpack server [config file](/webpack.config.node.js):
 const config = {
 	plugins: [
 		new webpack.NormalModuleReplacementPlugin(
-			/^my-sites\/themes\/thanks-modal$/,
-			'components/empty-component'
+			/^calypso\/my-sites\/themes\/thanks-modal$/,
+			'calypso/components/empty-component'
 		), // Depends on BOM
 	],
 };

--- a/client/server/pages/test/analytics.js
+++ b/client/server/pages/test/analytics.js
@@ -10,7 +10,7 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import analytics from '../../lib/analytics';
-import { logSectionResponse } from 'pages/analytics';
+import { logSectionResponse } from 'calypso/server/pages/analytics';
 import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
 
 const TWO_SECONDS = 2000;

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -165,7 +165,7 @@ const buildApp = ( environment ) => {
 			serverRender,
 		} = require( 'calypso/server/render' );
 		mocks = { ...mocks, attachBuildTimestamp, attachI18n, attachHead, renderJsx, serverRender };
-		mocks.sanitize = require( 'sanitize' );
+		mocks.sanitize = require( 'calypso/server/sanitize' );
 		mocks.createReduxStore = require( 'calypso/state' ).createReduxStore;
 		mocks.execSync = require( 'child_process' ).execSync;
 		mocks.login = require( 'calypso/lib/paths' ).login;

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -56,7 +56,7 @@ function bumpStat( group, name ) {
  * @returns {string} Rendered markup
  */
 export function renderJsx( view, props ) {
-	const requireComponent = require.context( 'document', true, /\.jsx$/ );
+	const requireComponent = require.context( 'calypso/document', true, /\.jsx$/ );
 	const component = requireComponent( './' + view + '.jsx' ).default;
 	const doctype = `<!DOCTYPE html><!--
 	<3

--- a/client/webpack.config.desktop.js
+++ b/client/webpack.config.desktop.js
@@ -86,8 +86,8 @@ module.exports = {
 		mainFields: [ 'calypso:src', 'module', 'main' ],
 		modules: [ __dirname, 'node_modules' ],
 		alias: {
-			config: 'server/config',
-			'calypso/config': 'server/config',
+			config: 'calypso/server/config',
+			'calypso/config': 'calypso/server/config',
 			// Alias calypso to ./client. This allows for smaller bundles, as it ensures that
 			// importing `./client/file.js` is the same thing than importing `calypso/file.js`
 			calypso: __dirname,
@@ -103,7 +103,7 @@ module.exports = {
 		), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin(
 			/^calypso[/\\]my-sites[/\\]themes[/\\]theme-upload$/,
-			'components/empty-component'
+			'calypso/components/empty-component'
 		), // Depends on BOM
 		new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ), // server doesn't use moment locales
 	],

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -366,7 +366,7 @@ const webpackConfig = {
 		 */
 		new webpack.NormalModuleReplacementPlugin( /dashicon/, ( res ) => {
 			if ( res.context.includes( '@wordpress/components/' ) ) {
-				res.request = 'components/empty-component';
+				res.request = 'calypso/components/empty-component';
 			}
 		} ),
 		/*

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -137,8 +137,8 @@ const webpackConfig = {
 		mainFields: [ 'calypso:src', 'module', 'main' ],
 		modules: [ __dirname, path.join( __dirname, 'extensions' ), 'node_modules' ],
 		alias: {
-			'calypso/config': 'server/config',
-			config: 'server/config',
+			'calypso/config': 'calypso/server/config',
+			config: 'calypso/server/config',
 		},
 	},
 	node: {
@@ -173,7 +173,7 @@ const webpackConfig = {
 		), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin(
 			/^calypso[/\\]my-sites[/\\]themes[/\\]theme-upload$/,
-			'components/empty-component'
+			'calypso/components/empty-component'
 		), // Depends on BOM
 		new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ), // server doesn't use moment locales
 		! isDevelopment && new ExternalModulesWriter(),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor some parts that were still using package-relative imports. Those parts were found in https://github.com/Automattic/wp-calypso/pull/48302 by droppping support for pakage-relative imports and see what breaks.

#### Testing

* Verifying builds are green and doing a smoke test in the live branch should be enough.