### PR TITLE
Disable signup test failing due to purchase thank you page

### DIFF
--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -515,7 +515,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 	} );
 
-	describe( 'Sign up for a site on a premium paid plan coming in via /create as premium flow in JPY currency @signup', function () {
+	describe.skip( 'Sign up for a site on a premium paid plan coming in via /create as premium flow in JPY currency @signup', function () {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable the `Sign up for a site on a premium paid plan coming in via /create as premium flow in JPY currency @signup` test

Discussion: p1608581047206100-slack-C1A1EKDGQ

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests should pass on `trunk` now 🤞 

