### PR TITLE
Plugins: Fix property access in PluginMeta

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -152,7 +152,7 @@ class PluginItem extends Component {
 		const updated_versions = this.props.plugin.sites
 			.map( ( site ) => {
 				const sitePlugin = pluginsOnSites?.sites[ site.ID ];
-				return sitePlugin.update.new_version;
+				return sitePlugin?.update?.new_version;
 			} )
 			.filter( ( version ) => version );
 

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -413,7 +413,7 @@ export class PluginMeta extends Component {
 				}
 
 				const sitePlugin = pluginsOnSites?.sites[ site.ID ];
-				if ( 'error' !== sitePlugin?.update?.new_version ) {
+				if ( sitePlugin?.update?.new_version && 'error' !== sitePlugin.update.new_version ) {
 					return {
 						title: site.title,
 						newVersion: sitePlugin.update.new_version,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Plugins: Fix property access in PluginMeta

#### Testing instructions

* Go to `/plugins/akismet/:site` where it's installed at the latest version.
* Verify it works well and doesn't error out.
* Go to `/plugins/akismet` where it's installed at an older version.
* Verify it works well and doesn't error out.
* Go to `/plugins/manage` and verify it throws no errors and looks the same way as in production
