### PR TITLE
Build: Add `corejs`, `debug`, and `useBuiltIns` Babel configs

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## trunk
 
+## 6.5.0
+
+- Added `corejs`, `debug`, and `useBuiltIns` options to the `babel/default` preset.
+
 ## 6.4.0
 
 - Added `--esm` and `--cjs` options to `copy-assets` and `transpile` to do only one kind of

--- a/packages/calypso-build/babel/default.js
+++ b/packages/calypso-build/babel/default.js
@@ -16,10 +16,10 @@ module.exports = ( api, opts ) => ( {
 		[
 			require.resolve( '@babel/preset-env' ),
 			{
-				corejs: opts.corejs ?? 3.6,
-				debug: opts.debug ?? false,
+				corejs: opts.corejs ? opts.corejs : 3.6,
+				debug: opts.debug ? opts.debug : false,
 				modules: modulesOption( opts ),
-				useBuiltIns: opts.useBuiltIns ?? 'entry',
+				useBuiltIns: opts.useBuiltIns ? opts.useBuiltIns : 'entry',
 				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
 				exclude: [ 'transform-typeof-symbol' ],
 			},

--- a/packages/calypso-build/babel/default.js
+++ b/packages/calypso-build/babel/default.js
@@ -17,6 +17,7 @@ module.exports = ( api, opts ) => ( {
 			require.resolve( '@babel/preset-env' ),
 			{
 				corejs: opts.corejs ?? 3.6,
+				debug: opts.debug ?? false,
 				modules: modulesOption( opts ),
 				useBuiltIns: opts.useBuiltIns ?? 'entry',
 				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278

--- a/packages/calypso-build/babel/default.js
+++ b/packages/calypso-build/babel/default.js
@@ -16,9 +16,9 @@ module.exports = ( api, opts ) => ( {
 		[
 			require.resolve( '@babel/preset-env' ),
 			{
-				corejs: 3.6,
+				corejs: opts.corejs ?? 3.6,
 				modules: modulesOption( opts ),
-				useBuiltIns: 'entry',
+				useBuiltIns: opts.useBuiltIns ?? 'entry',
 				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
 				exclude: [ 'transform-typeof-symbol' ],
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables configuring `corejs`, `debug`, and `useBuiltIns` when using `@automattic/calypso-build/babel/default` as a preset.

#### Testing instructions

* Try configuring `corejs`, `debug`, and `useBuiltIns`. Ensure that they take effect.
