### PR TITLE
Plugins: Fix post-upload installed state of plugins

### DIFF
--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -8,8 +8,11 @@ import { find, includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import { PLUGIN_UPLOAD } from 'calypso/state/action-types';
-import { PLUGIN_UPLOAD as PLUGIN_UPLOAD_ACTION } from 'calypso/lib/plugins/constants';
+import { PLUGIN_INSTALL_REQUEST_SUCCESS, PLUGIN_UPLOAD } from 'calypso/state/action-types';
+import {
+	INSTALL_PLUGIN,
+	PLUGIN_UPLOAD as PLUGIN_UPLOAD_ACTION,
+} from 'calypso/lib/plugins/constants';
 import {
 	completePluginUpload,
 	pluginUploadError,
@@ -78,6 +81,15 @@ export const uploadComplete = ( { siteId }, data ) => ( dispatch, getState ) => 
 	);
 
 	dispatch( completePluginUpload( siteId, pluginId ) );
+
+	// Notifying installed plugins that this plugin was successfully installed
+	dispatch( {
+		type: PLUGIN_INSTALL_REQUEST_SUCCESS,
+		action: INSTALL_PLUGIN,
+		siteId,
+		pluginId: data.id,
+		data,
+	} );
 
 	/*
 	 * Adding plugin to legacy flux store provides data for plugin page


### PR DESCRIPTION
A couple of days ago, @flootr reported this:

> I noticed a bug when installing a plugin by upload. when I hit Install plugin I’m redirected to the plugin detail page but it doesn’t show as installed (the Install button is still there). Installing from the detail page itself works as expected though.

This PR fixes that by updating how the upload plugin Redux implementation works. Previously, we were only notifying the flux store about the successfully uploaded plugin, and now we're also notifying Redux.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Fix post-upload installed state of plugins

#### Testing instructions
* Go to `/plugins/:plugin/:site` where `:site` is one of your Jetpack sites, and `:plugin` is a plugin that's not installed there.
* Validate the button there says "Install".
* Go to `/plugins/upload/:site` and upload that same plugin that you previously downloaded from https://wordpress.org/plugins/
* Verify that after installation, you are redirected to the plugin page and you see the plugin activation and autoupdate toggle, as well as the removal button, instead of the Install button.

#### Note

ESLint warnings are expected in one of the files - they're coming from #48526 and will be fixed when this PR is rebased.