### PR TITLE
Plugins: Add missing state init in status actions

### DIFF
--- a/client/state/plugins/installed/status/actions.js
+++ b/client/state/plugins/installed/status/actions.js
@@ -3,6 +3,8 @@
  */
 import { PLUGIN_NOTICES_REMOVE } from 'calypso/state/action-types';
 
+import 'calypso/state/plugins/init';
+
 export function removePluginStatuses( ...statuses ) {
 	return {
 		type: PLUGIN_NOTICES_REMOVE,


### PR DESCRIPTION
When we added an action for clearning plugin statuses, we forgot to require the plugins state initialization. In the rare (impossible to reproduce right now actually) case where the plugins state hasn't been initialized, and we attempt to remove all notices, this would error out because that piece of state isn't initialized. This PR adds that initialization just in case.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Add missing state init in status actions

#### Testing instructions

* Testing shouldn't be necessary, but feel free to smoke test plugin notifications.