### PR TITLE
Editor: Async load revisions

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -32,7 +32,6 @@ import getGutenbergEditorUrl from 'calypso/state/selectors/get-gutenberg-editor-
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import getEditorCloseConfig from 'calypso/state/selectors/get-editor-close-config';
 import wpcom from 'calypso/lib/wp';
-import EditorRevisionsDialog from 'calypso/post-editor/editor-revisions/dialog';
 import { openPostRevisionsDialog } from 'calypso/state/posts/revisions/actions';
 import { setEditorIframeLoaded, startEditingPost } from 'calypso/state/editor/actions';
 import {
@@ -759,7 +758,11 @@ class CalypsoifyIframe extends Component<
 				{ isFocusedLaunchCalypsoEnabled && (
 					<AsyncLoad require="calypso/blocks/editor-launch-modal" />
 				) }
-				<EditorRevisionsDialog loadRevision={ this.loadRevision } />
+				<AsyncLoad
+					require="calypso/post-editor/editor-revisions/dialog"
+					placeholder={ null }
+					loadRevision={ this.loadRevision }
+				/>
 				<WebPreview
 					externalUrl={ postUrl }
 					onClose={ this.closePreviewModal }


### PR DESCRIPTION
Currently, we're requiring the editor revisions as part of the main Gutenberg editor chunk. However, it isn't critical at all and is never displayed immediately. So we can async load it, to defer its loading and reduce the critical bytes. This actually reduces the `gutenberg-editor` chunk by over 30% in my quick tests. Seems like the zipped results are much smaller, so it's negotiable if this is worthy. 😉 

#### Changes proposed in this Pull Request

* Editor: Async load revisions

#### Testing instructions

* Load a post in your editor.
* Verify post revisions still work like they do in production.
