### PR TITLE
Remove the Traffic Guide from Jetpack sites for now

### DIFF
--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -11,7 +11,8 @@ import config from 'calypso/config';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
 import { hasTrafficGuidePurchase } from 'calypso/my-sites/marketing/ultimate-traffic-guide';
@@ -53,9 +54,12 @@ export const MarketingTools: FunctionComponent = () => {
 	const dispatch = useDispatch();
 	const recordTracksEvent = ( event: string ) => dispatch( recordTracksEventAction( event ) );
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) ) || 0;
+	const siteId = useSelector( getSelectedSiteId );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( ( state ) =>
 		getSelectedSiteSlug( state )
 	);
+
 	const purchases = useSelector( ( state ) => getUserPurchases( state, userId ) );
 
 	const handleBusinessToolsClick = () => {
@@ -231,7 +235,7 @@ export const MarketingTools: FunctionComponent = () => {
 					</Button>
 				</MarketingToolsFeature>
 
-				{ isEnglish && (
+				{ isEnglish && ! isJetpack && (
 					<MarketingToolsFeature
 						title={ translate( 'Introducing the WordPress.com Ultimate Traffic Guide' ) }
 						description={ translate(

--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -15,7 +15,7 @@ import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { getProductCost, isProductsListFetching } from 'calypso/state/products-list/selectors';
 import { isFetchingUserPurchases, getUserPurchases } from 'calypso/state/purchases/selectors';
 import { getCurrentUserCurrencyCode, getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import Experiment, {
@@ -83,6 +83,7 @@ const SalesPage = ( { translate } ) => {
 	const isLoading = useSelector( ( state ) => isProductsListFetching( state ) );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 
 	/**
 	 * The reference cost is calculated to the nearest 100
@@ -94,9 +95,17 @@ const SalesPage = ( { translate } ) => {
 
 	const cta = () => (
 		<p>
-			<Button href={ `/checkout/${ siteSlug }/${ WPCOM_TRAFFIC_GUIDE }` } primary>
-				{ translate( 'Click here to buy the guide now!' ) }
-			</Button>
+			{ isJetpack ? (
+				<em>
+					{ translate(
+						'The Ultimate Traffic Guide is currently only available on WordPress.com sites.'
+					) }
+				</em>
+			) : (
+				<Button href={ `/checkout/${ siteSlug }/${ WPCOM_TRAFFIC_GUIDE }` } primary>
+					{ translate( 'Click here to buy the guide now!' ) }
+				</Button>
+			) }
 		</p>
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Ultimate Traffic Guide is a WordPress.com product and currently does not work for Jetpack sites. It was proposed by @anneforbush to hide it from /marketing until v2 where we'll add support for Jetpack sites as well.

#### Testing instructions

0. If you don't have a Jetpack site, create one from the Jurassic ninja service (FG it), and then connect it to a test wpcom account from /jetpack/connect
1. With that site, go to /marketing and make sure there's no Traffic Guide offer at the bottom
<img width="1076" alt="Screenshot 2020-12-22 at 16 53 48" src="https://user-images.githubusercontent.com/82778/102906640-9406b380-447d-11eb-9190-5d1078778809.png">

2. Go to the landing page http://calypso.localhost:3000/marketing/ultimate-traffic-guide/relevant-grouse.jurassic.ninja and make sure there's no clickable button for buying the Traffic Guide
<img width="1083" alt="Screenshot 2020-12-22 at 17 38 23" src="https://user-images.githubusercontent.com/82778/102906536-70dc0400-447d-11eb-9695-e5da04eea312.png">

3. With another site, go to /marketing and make sure the Traffic Guide is at the bottom and works well
<img width="1101" alt="Screenshot 2020-12-22 at 16 54 15" src="https://user-images.githubusercontent.com/82778/102906597-86e9c480-447d-11eb-984d-93181d027ccf.png">

