### PR TITLE
Signup: Track if the user selected video storage in the new site features step

### DIFF
--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -95,9 +95,14 @@ type TracksPlanSelectEventProperties = {
 
 type TracksFeaturesSelectEventProperties = {
 	/**
-	 * The selected features
+	 * If the user selected features
 	 */
 	has_selected_features: boolean | undefined;
+
+	/**
+	 * If the user seleceted the "Video storage" feature
+	 */
+	has_selected_video_storage: boolean | undefined;
 };
 
 export type TracksEventProperties =

--- a/client/landing/gutenboarding/onboarding-block/features/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/features/index.tsx
@@ -42,6 +42,7 @@ const FeaturesStep: React.FunctionComponent = () => {
 	const { addFeature, removeFeature } = useDispatch( ONBOARD_STORE );
 
 	const hasSelectedFeatures = selectedFeatures.length > 0;
+	const hasSelectedVideoStorage = selectedFeatures.includes( 'video-storage' );
 
 	const toggleFeature = ( featureId: FeatureId ) => {
 		if ( selectedFeatures.includes( featureId ) ) {
@@ -53,12 +54,15 @@ const FeaturesStep: React.FunctionComponent = () => {
 
 	// Keep a copy of the selected domain locally so it's available when the component is unmounting
 	const hasSelectedFeaturesRef = React.useRef< boolean >();
+	const hasSelectedVideoStorageRef = React.useRef< boolean >();
 	React.useEffect( () => {
 		hasSelectedFeaturesRef.current = hasSelectedFeatures;
+		hasSelectedVideoStorageRef.current = hasSelectedVideoStorage;
 	}, [ hasSelectedFeatures ] );
 
 	useTrackStep( 'Features', () => ( {
 		has_selected_features: hasSelectedFeaturesRef.current,
+		has_selected_video_storage: hasSelectedVideoStorageRef.current
 	} ) );
 
 	return (

--- a/client/landing/gutenboarding/onboarding-block/features/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/features/index.tsx
@@ -58,11 +58,11 @@ const FeaturesStep: React.FunctionComponent = () => {
 	React.useEffect( () => {
 		hasSelectedFeaturesRef.current = hasSelectedFeatures;
 		hasSelectedVideoStorageRef.current = hasSelectedVideoStorage;
-	}, [ hasSelectedFeatures ] );
+	}, [ hasSelectedFeatures, hasSelectedVideoStorage ] );
 
 	useTrackStep( 'Features', () => ( {
 		has_selected_features: hasSelectedFeaturesRef.current,
-		has_selected_video_storage: hasSelectedVideoStorageRef.current
+		has_selected_video_storage: hasSelectedVideoStorageRef.current,
 	} ) );
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new boolean `has_selected_video_storage` to allow tracks to record if the "Video Storage" feature was selected during signup:

<img width="964" alt="Screen Shot 2020-12-22 at 8 47 33 AM" src="https://user-images.githubusercontent.com/789137/102906816-66e0e380-4432-11eb-946e-57f7253e5ea1.png">

I thought it would be nice to pass all of the selected features, but tracks doesn't support nested properties so I opted for just passing a specific boolean for the video feature.

#### Testing instructions

* Head to `/new` and start to create a new site.
* At the Features step, select the Video Storage option, then continue to the next step.
* Repeat the previous, but don't select Video Storage this time.
* Ping me on Slack for a link to Tracks where you can see if your event was recorded.
