### PR TITLE
Use the new language picker modal API in the quick language selector

### DIFF
--- a/client/layout/masterbar/quick-language-switcher.jsx
+++ b/client/layout/masterbar/quick-language-switcher.jsx
@@ -20,9 +20,9 @@ import {
 
 function QuickLanguageSwitcher( props ) {
 	const [ isShowingModal, toggleLanguagesModal ] = useReducer( ( toggled ) => ! toggled, false );
-	const onSelected = ( languageSlug, { empathyMode, useFallbackForIncompleteLanguages } ) => {
+	const onSelected = ( language, { empathyMode, useFallbackForIncompleteLanguages } ) => {
 		props.setLocale(
-			useFallbackForIncompleteLanguages ? config( 'i18n_default_locale_slug' ) : languageSlug
+			useFallbackForIncompleteLanguages ? config( 'i18n_default_locale_slug' ) : language.langSlug
 		);
 		toggleLanguageEmpathyMode( empathyMode );
 	};
@@ -38,11 +38,11 @@ function QuickLanguageSwitcher( props ) {
 			</MasterbarItem>
 			{ isShowingModal && (
 				<LanguagePickerModal
-					isVisible
 					languages={ languages }
-					selected={ props.selectedLanguageSlug }
+					selectedLanguageSlug={ props.selectedLanguageSlug }
 					empathyMode={ getLanguageEmpathyModeActive() }
-					onSelected={ onSelected }
+					showEmpathyModeControl
+					onSelectLanguage={ onSelected }
 					onClose={ toggleLanguagesModal }
 				/>
 			) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the `QuickLanguageSwitcher` to use the new modal API

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch and update `layout/masterbar/logged-in.jsx` to always display the quick language switcher. Then try to change the language, enable empathy mode, and the fallback mode. Verify these all work.
