### PR TITLE
Packages: Bump `calypso-build` version

### DIFF
--- a/packages/calypso-build/README.md
+++ b/packages/calypso-build/README.md
@@ -130,6 +130,8 @@ module.exports = {
 
 Another way to set the `modules` option is to set the `MODULES` environment variable to `'esm'` (maps to `false`) or any other valid value. That's convenient for running Babel from command line, where specifying options for presets (`--presets=...`) is not supported.
 
+The `default` preset also specifies `corejs`, `debug`, and `useBuiltIns` options that's passed through to [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env#options).
+
 ## Advanced Usage: Use own PostCSS Config
 
 You can also customize how PostCSS transforms your project's style files by adding a `postcss.config.js` to it.

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "6.4.0",
+	"version": "6.5.0",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bump `calypso-build` version in its `package.json`; I forgot to do so in #48534.
* Update readme to include descriptions for options introduced in #48534.

#### Testing instructions

* N/A