### PR TITLE
Focused Launch: convert cart domains into domain picker suggestion items

### DIFF
--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -15,6 +15,7 @@ import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
 
 export * from './types';
+export { getFormattedPrice } from './utils';
 export type { State };
 
 let isRegistered = false;

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -88,14 +88,14 @@ export interface DomainSuggestion {
 	 *
 	 * @example 40
 	 */
-	raw_price?: number;
+	raw_price: number;
 
 	/**
 	 * Currency code
 	 *
 	 * @example USD
 	 */
-	currency_code?: string;
+	currency_code: string;
 
 	/**
 	 * Relevance as a percent: 0 <= relevance <= 1
@@ -137,7 +137,7 @@ export interface DomainSuggestion {
 	is_free?: boolean;
 
 	/**
-	 * Whether the domain requies HSTS
+	 * Whether the domain requires HSTS
 	 */
 	hsts_required?: boolean;
 }
@@ -201,6 +201,11 @@ export interface DomainAvailability {
 	 * Vendor
 	 */
 	vendor?: string;
+
+	/**
+	 * Whether the domain requires HSTS
+	 */
+	hsts_required?: boolean;
 }
 
 export type TimestampMS = ReturnType< typeof Date.now >;

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -22,15 +22,17 @@ export function useDomainSuggestions(
 	searchTerm = '',
 	quantity: number,
 	domainCategory?: string,
-	locale = 'en'
+	locale = 'en',
+	extraOptions = {}
 ): DomainSuggestionsResult | undefined {
 	const [ domainSearch ] = useDebounce( searchTerm, DOMAIN_SEARCH_DEBOUNCE_INTERVAL );
-
-	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-	// @ts-ignore
 	// Missing types for invalidateResolutionForStoreSelector
 	// (see packages/data/src/namespace-store/metadata/actions.js#L57)
-	const { invalidateResolutionForStoreSelector } = useDispatch( DOMAIN_SUGGESTIONS_STORE );
+	const { invalidateResolutionForStoreSelector } = ( useDispatch(
+		DOMAIN_SUGGESTIONS_STORE
+	) as unknown ) as {
+		invalidateResolutionForStoreSelector: ( arg0: string ) => void;
+	};
 
 	return useSelect(
 		( select ) => {
@@ -52,6 +54,7 @@ export function useDomainSuggestions(
 				quantity: quantity + 1, // increment the count to add the free domain
 				locale,
 				category_slug: domainCategory,
+				...extraOptions,
 			} );
 
 			const state = getDomainState();

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -26,12 +26,10 @@ export function useDomainSuggestions(
 	extraOptions = {}
 ): DomainSuggestionsResult | undefined {
 	const [ domainSearch ] = useDebounce( searchTerm, DOMAIN_SEARCH_DEBOUNCE_INTERVAL );
-	// Missing types for invalidateResolutionForStoreSelector
-	// (see packages/data/src/namespace-store/metadata/actions.js#L57)
 	const { invalidateResolutionForStoreSelector } = ( useDispatch(
 		DOMAIN_SUGGESTIONS_STORE
 	) as unknown ) as {
-		invalidateResolutionForStoreSelector: ( arg0: string ) => void;
+		invalidateResolutionForStoreSelector: ( selectorName: string ) => void;
 	};
 
 	return useSelect(

--- a/packages/domain-picker/src/index.tsx
+++ b/packages/domain-picker/src/index.tsx
@@ -8,3 +8,4 @@ export { ITEM_TYPE_RADIO, ITEM_TYPE_BUTTON } from './domain-picker/suggestion-it
 export type { SUGGESTION_ITEM_TYPE } from './domain-picker/suggestion-item';
 
 export { mockDomainSuggestion, isGoodDefaultDomainQuery } from './utils';
+export { useDomainSuggestions } from './hooks';

--- a/packages/domain-picker/src/utils.ts
+++ b/packages/domain-picker/src/utils.ts
@@ -16,6 +16,8 @@ export function mockDomainSuggestion(
 		cost: '',
 		product_id: 0,
 		product_slug: '',
+		raw_price: 0,
+		currency_code: '',
 	};
 }
 

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -44,7 +44,9 @@ export function useDomainSuggestionFromCart(): DomainSuggestions.DomainSuggestio
 
 	const domainSuggestion = useDomainSuggestions( domainName, 1, undefined, undefined, {
 		include_wordpressdotcom: false,
-		include_dotblogsubdomain: true,
+		include_dotblogsubdomain: domainName?.includes( '.blog' ),
+		exact_sld_matches_only: true,
+		include_registered: true,
 	} )?.allDomainSuggestions?.[ 0 ];
 
 	return domainSuggestion;

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -42,14 +42,17 @@ export function useDomainSuggestionFromCart(): DomainSuggestions.DomainSuggestio
 
 	const domainName = domainProductFromCart?.meta;
 
-	const domainSuggestion = useDomainSuggestions( domainName, 1, undefined, undefined, {
+	// const TLD = domainName?.split( '.' )[ 1 ];
+
+	const domainSuggestions = useDomainSuggestions( domainName, 5, undefined, undefined, {
 		include_wordpressdotcom: false,
-		include_dotblogsubdomain: domainName?.includes( '.blog' ),
 		exact_sld_matches_only: true,
 		include_registered: true,
-	} )?.allDomainSuggestions?.[ 0 ];
+		// tlds: [ TLD ], // an attempt for more precise results, didn't help
+	} )?.allDomainSuggestions;
 
-	return domainSuggestion;
+	// search for a matching suggestion and return `undefined` if nothing matches
+	return domainSuggestions?.find( ( domain ) => domain.domain_name === domainName );
 }
 
 type DomainSelection = {

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -4,13 +4,13 @@
 import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import type { DomainSuggestions } from '@automattic/data-stores';
-import { mockDomainSuggestion } from '@automattic/domain-picker';
+import { mockDomainSuggestion, useDomainSuggestions } from '@automattic/domain-picker';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
-import { LAUNCH_STORE, SITE_STORE, DOMAIN_SUGGESTIONS_STORE, PLANS_STORE } from '../stores';
+import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
 import LaunchContext from '../context';
 import { isDomainProduct } from '../utils';
 import type { DomainProduct } from '../utils';
@@ -42,15 +42,10 @@ export function useDomainSuggestionFromCart(): DomainSuggestions.DomainSuggestio
 
 	const domainName = domainProductFromCart?.meta;
 
-	const domainSuggestion = useSelect( ( select ) =>
-		domainName
-			? select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( domainName, {
-					quantity: 1,
-					include_wordpressdotcom: false,
-					include_dotblogsubdomain: false,
-			  } )?.[ 0 ]
-			: undefined
-	);
+	const domainSuggestion = useDomainSuggestions( domainName, 1, undefined, undefined, {
+		include_wordpressdotcom: false,
+		include_dotblogsubdomain: true,
+	} )?.allDomainSuggestions?.[ 0 ];
 
 	return domainSuggestion;
 }

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -52,7 +52,9 @@ export function useDomainSuggestionFromCart(): DomainSuggestions.DomainSuggestio
 		domainProductFromCart &&
 		domainName &&
 		domainDetails &&
-		[ 'available', 'available_premium' ].indexOf( domainDetails.status ) > -1
+		// for now, we consider premium domains unavailable and don't convert them into suggestions
+		// [ 'available', 'available_premium' ].indexOf( domainDetails.status ) > -1
+		domainDetails.status === 'available'
 	) {
 		return {
 			hsts_required: domainDetails.hsts_required,

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -6,12 +6,11 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { DomainSuggestions } from '@automattic/data-stores';
 import { mockDomainSuggestion } from '@automattic/domain-picker';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
-import { DOMAIN_SUGGESTIONS_STORE } from '../stores';
 
 /**
  * Internal dependencies
  */
-import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
+import { LAUNCH_STORE, SITE_STORE, PLANS_STORE, DOMAIN_SUGGESTIONS_STORE } from '../stores';
 import LaunchContext from '../context';
 import { isDomainProduct } from '../utils';
 import type { DomainProduct } from '../utils';
@@ -52,8 +51,10 @@ export function useDomainSuggestionFromCart(): DomainSuggestions.DomainSuggestio
 		domainProductFromCart &&
 		domainName &&
 		domainDetails &&
+		// the availability endpoint returns "status: available|premium_available"
 		// for now, we consider premium domains unavailable and don't convert them into suggestions
-		// [ 'available', 'available_premium' ].indexOf( domainDetails.status ) > -1
+		// so instead of using [ 'available', 'available_premium' ].indexOf( domainDetails.status ) > -1
+		// we only accept domainDetails.status === 'available'
 		domainDetails.status === 'available'
 	) {
 		return {

--- a/packages/launch/src/utils.ts
+++ b/packages/launch/src/utils.ts
@@ -45,6 +45,11 @@ export type DomainProduct = {
 		privacy?: boolean;
 		source: string;
 	};
+	product_cost_display: string;
+	currency_code?: string;
+	product_slug?: string;
+	cost: number;
+	currency: string;
 };
 
 export const getDomainProduct = (
@@ -62,6 +67,11 @@ export const getDomainProduct = (
 			privacy: domain?.supports_privacy,
 			source: flow,
 		},
+		product_cost_display: domain.cost,
+		currency_code: domain.currency_code,
+		product_slug: domain.product_slug,
+		cost: domain.raw_price,
+		currency: domain.currency_code,
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- This uses the [is-available](https://public-api.wordpress.com/rest/v1.3/domains/waters.blog/is-available?is_cart_pre_check=true) endpoint to check the domain's availability and to get the missing info in the cart domain. Merging the cart domain and the availability response gives a complete domain suggestion that use usable in the domain picker.


#### Testing instructions
* Apply D56375-code and sandbox public-api.
* Run calypso and in `apps/editing-toolkit` run `yarn dev --sync`.
* Create a site using `/start` until you land in the editor.
* Clear your local storage while in the editor.
* Sandbox the created site.
* In another tab, in Calypso, add a domain item to your cart.
* Go back to your original tab that has the editor of the new site.
* Refresh the page to get a sandboxed site, then click launch.
* In the summary view of focused launch, you should see the domain in your cart listed in the correct price.

Fixes #48544