### PR TITLE
Focused Launch: Handle paid plan coming from the cart

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -289,25 +289,22 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 
 	const { defaultPaidPlan, defaultFreePlan, planPrices } = usePlans();
 
-	// persist selected plan if it's paid in order to keep displaying it in the
-	const onceSelectedPaidPlan = React.useRef( selectedPaidPlan );
+	// persist non-default selected paid plan if it's paid in order to keep displaying it in the plan picker
+	const [ nonDefaultPaidPlan, setNonDefaultPaidPlan ] = React.useState< Plan | undefined >();
+
+	React.useEffect( () => {
+		if ( selectedPaidPlan && selectedPaidPlan?.storeSlug !== defaultPaidPlan?.storeSlug ) {
+			setNonDefaultPaidPlan( selectedPaidPlan );
+		}
+	}, [ selectedPaidPlan, defaultPaidPlan, nonDefaultPaidPlan ] );
 
 	const isPlanSelected = ( plan: Plan ) => plan && plan.storeSlug === selectedPlan?.storeSlug;
 
 	const { sitePlan } = useSite();
 
-	const nonDefaultPaidPlan =
-		onceSelectedPaidPlan?.current &&
-		defaultPaidPlan &&
-		onceSelectedPaidPlan?.current?.storeSlug !== defaultPaidPlan?.storeSlug
-			? onceSelectedPaidPlan?.current
-			: undefined;
-
-	const allAvailablePlans: ( Plan | undefined )[] = [
-		defaultPaidPlan,
-		nonDefaultPaidPlan && onceSelectedPaidPlan.current,
-		defaultFreePlan,
-	];
+	const allAvailablePlans = [ defaultPaidPlan, nonDefaultPaidPlan, defaultFreePlan ].filter(
+		Boolean
+	) as Plan[];
 
 	return (
 		<SummaryStep
@@ -376,45 +373,42 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 							</span>
 						</p>
 						<div>
-							{ allAvailablePlans.map(
-								( plan ) =>
-									plan && (
-										<FocusedLaunchSummaryItem
-											key={ plan.storeSlug }
-											isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
-											onClick={ () => setPlan( plan ) }
-											isSelected={ isPlanSelected( plan ) }
-											readOnly={ plan.isFree && ( hasPaidDomain || selectedPaidDomain ) }
+							{ allAvailablePlans.map( ( plan ) => (
+								<FocusedLaunchSummaryItem
+									key={ plan.storeSlug }
+									isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
+									onClick={ () => setPlan( plan ) }
+									isSelected={ isPlanSelected( plan ) }
+									readOnly={ plan.isFree && ( hasPaidDomain || selectedPaidDomain ) }
+								>
+									<LeadingContentSide
+										label={
+											/* translators: %s is WordPress.com plan name (eg: Premium Plan) */
+											sprintf( __( '%s Plan', __i18n_text_domain__ ), plan.title ?? '' )
+										}
+										badgeText={ plan.isPopular ? __( 'Popular', __i18n_text_domain__ ) : '' }
+									/>
+									{ plan.isFree ? (
+										<TrailingContentSide
+											nodeType={ hasPaidDomain || selectedPaidDomain ? 'WARNING' : 'PRICE' }
 										>
-											<LeadingContentSide
-												label={
-													/* translators: %s is WordPress.com plan name (eg: Premium Plan) */
-													sprintf( __( '%s Plan', __i18n_text_domain__ ), plan.title ?? '' )
+											{ hasPaidDomain || selectedPaidDomain
+												? __( 'Not available with your domain selection', __i18n_text_domain__ )
+												: __( 'Free', __i18n_text_domain__ ) }
+										</TrailingContentSide>
+									) : (
+										<TrailingContentSide nodeType="PRICE">
+											<span>{ planPrices[ plan.storeSlug ] }</span>
+											<span>
+												{
+													// translators: /mo is short for "per-month"
+													__( '/mo', __i18n_text_domain__ )
 												}
-												badgeText={ plan.isPopular ? __( 'Popular', __i18n_text_domain__ ) : '' }
-											/>
-											{ plan.isFree ? (
-												<TrailingContentSide
-													nodeType={ hasPaidDomain || selectedPaidDomain ? 'WARNING' : 'PRICE' }
-												>
-													{ hasPaidDomain || selectedPaidDomain
-														? __( 'Not available with your domain selection', __i18n_text_domain__ )
-														: __( 'Free', __i18n_text_domain__ ) }
-												</TrailingContentSide>
-											) : (
-												<TrailingContentSide nodeType="PRICE">
-													<span>{ planPrices[ plan.storeSlug ] }</span>
-													<span>
-														{
-															// translators: /mo is short for "per-month"
-															__( '/mo', __i18n_text_domain__ )
-														}
-													</span>
-												</TrailingContentSide>
-											) }
-										</FocusedLaunchSummaryItem>
-									)
-							) }
+											</span>
+										</TrailingContentSide>
+									) }
+								</FocusedLaunchSummaryItem>
+							) ) }
 						</div>
 						<Link to={ Route.PlanDetails } className="focused-launch-summary__details-link">
 							{ __( 'View all plans', __i18n_text_domain__ ) }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* [In this line](https://github.com/Automattic/wp-calypso/blob/trunk/packages/launch/src/focused-launch/index.tsx#L61), we set the plan to the cart plan. But if it's a non-default paid plan, it is not set as ["onceSelectedPaidPlan"](https://github.com/Automattic/wp-calypso/blob/trunk/packages/launch/src/focused-launch/summary/index.tsx#L293). 

This PR fixes this issue. 

#### Testing instructions

* Create a free unlaunched site.
   * Let's say its called **http://test123_wordpress_dotcom**.
* Go to **http://calypso.localhost:3000/domains/add/test123_wordpress_dotcom**.
  * Add a paid plan to your cart. Make sure it's not Premium.
* Go to **http://calypso.localhost:3000/page/test123_wordpress_dotcom/home?fresh&flags=create/focused-launch-flow-calypso**.
  * You should see the plan that you added to your cart as the pre-selected choice.
* Click on **View All Plans**.
  * It should also be the pre-selected choice 

Fixes #48044
