### PR TITLE
Payment Methods: add PayPal to change payment method form

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -953,6 +953,31 @@ Undocumented.prototype.assignPaymentMethod = function ( subscriptionId, stored_d
 };
 
 /**
+ * Returns a PayPal Express URL to redirect to for confirming the creation of a billing agreement.
+ *
+ * @param {string} subscription_id The subscription ID (a.k.a. purchase ID) to assign the billing agreement to after it is created
+ * @param {string} success_url The URL to return the user to for a successful billing agreement creation
+ * @param {string} cancel_url The URL to return the user to if they cancel the billing agreement creation
+ * @param {Function} [fn] The callback function
+ */
+Undocumented.prototype.createPayPalAgreement = function (
+	subscription_id,
+	success_url,
+	cancel_url,
+	fn
+) {
+	debug( '/payment-methods/create-paypal-agreement', { subscription_id, success_url, cancel_url } );
+	return this.wpcom.req.post(
+		{
+			path: '/payment-methods/create-paypal-agreement',
+			body: { subscription_id, success_url, cancel_url },
+			apiVersion: '1',
+		},
+		fn
+	);
+};
+
+/**
  * Return a list of third-party services that WordPress.com can integrate with for a specific site
  *
  * @param {number|string} siteId The site ID or domain

--- a/client/me/purchases/manage-purchase/change-payment-method/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/assignment-processor-functions.ts
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import { createStripeSetupIntent } from '@automattic/calypso-stripe';
+import type { Stripe, StripeConfiguration } from '@automattic/calypso-stripe';
+import { makeRedirectResponse, makeSuccessResponse } from '@automattic/composite-checkout';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import wp from 'calypso/lib/wp';
+import {
+	getTokenForSavingCard,
+	updateCreditCard,
+	getInitializedFields,
+} from 'calypso/me/purchases/components/payment-method-form/helpers';
+
+const wpcom = wp.undocumented();
+const wpcomAssignPaymentMethod = (
+	subscriptionId: string,
+	stored_details_id: string
+): Promise< unknown > => wpcom.assignPaymentMethod( subscriptionId, stored_details_id );
+const wpcomCreatePayPalAgreement = (
+	subscriptionId: string,
+	successUrl: string,
+	cancelUrl: string
+): Promise< string > => wpcom.createPayPalAgreement( subscriptionId, successUrl, cancelUrl );
+
+export async function assignNewCardProcessor(
+	{
+		purchase,
+		translate,
+		siteSlug,
+		apiParams,
+		stripe,
+		stripeConfiguration,
+	}: {
+		purchase: { id: string };
+		translate: ReturnType< typeof useTranslate >;
+		siteSlug: string;
+		apiParams: unknown;
+		stripe: Stripe;
+		stripeConfiguration: StripeConfiguration;
+	},
+	{ name, countryCode, postalCode }: { name: string; countryCode: string; postalCode: string }
+): Promise< PaymentProcessorResponse > {
+	const createStripeSetupIntentAsync = async ( paymentDetails: {
+		country: string;
+		'postal-code': string | number;
+	} ) => {
+		const { country, 'postal-code': zip } = paymentDetails;
+		const paymentDetailsForStripe = {
+			name,
+			address: {
+				country: country,
+				postal_code: zip,
+			},
+		};
+		return createStripeSetupIntent( stripe, stripeConfiguration, paymentDetailsForStripe );
+	};
+
+	const formFieldValues = getInitializedFields( {
+		country: countryCode,
+		postalCode,
+		name,
+	} );
+
+	return getTokenForSavingCard( {
+		formFieldValues,
+		createCardToken: createStripeSetupIntentAsync,
+		parseTokenFromResponse: ( response: { payment_method: string } ) => response.payment_method,
+		translate,
+	} )
+		.then( ( token ) =>
+			updateCreditCard( {
+				formFieldValues,
+				apiParams,
+				purchase,
+				siteSlug,
+				token,
+				translate,
+				stripeConfiguration,
+			} )
+		)
+		.then( ( data ) => {
+			return makeSuccessResponse( data );
+		} );
+}
+
+export async function assignExistingCardProcessor(
+	purchase: { id: string },
+	{ storedDetailsId }: { storedDetailsId: string }
+): Promise< PaymentProcessorResponse > {
+	return wpcomAssignPaymentMethod( purchase.id, storedDetailsId ).then( ( data ) => {
+		return makeSuccessResponse( data );
+	} );
+}
+
+export async function assignPayPalProcessor( purchase: {
+	id: string;
+} ): Promise< PaymentProcessorResponse > {
+	return wpcomCreatePayPalAgreement( purchase.id, window.location.href, window.location.href ).then(
+		( data ) => {
+			return makeRedirectResponse( data );
+		}
+	);
+}

--- a/client/me/purchases/manage-purchase/change-payment-method/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/assignment-processor-functions.ts
@@ -5,6 +5,7 @@ import { createStripeSetupIntent } from '@automattic/calypso-stripe';
 import type { Stripe, StripeConfiguration } from '@automattic/calypso-stripe';
 import { makeRedirectResponse, makeSuccessResponse } from '@automattic/composite-checkout';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -101,9 +102,11 @@ export async function assignExistingCardProcessor(
 export async function assignPayPalProcessor( purchase: {
 	id: string;
 } ): Promise< PaymentProcessorResponse > {
-	return wpcomCreatePayPalAgreement( purchase.id, window.location.href, window.location.href ).then(
-		( data ) => {
-			return makeRedirectResponse( data );
-		}
-	);
+	return wpcomCreatePayPalAgreement(
+		purchase.id,
+		addQueryArgs( window.location.href, { success: 'true' } ),
+		window.location.href
+	).then( ( data ) => {
+		return makeRedirectResponse( data );
+	} );
 }

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -232,7 +232,7 @@ function ChangePaymentMethodList( {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 	const { isStripeLoading, stripe, stripeConfiguration } = useStripe();
-	const paymentMethods = useAssignablePaymentMethods();
+	const paymentMethods = useAssignablePaymentMethods( currentlyAssignedPaymentMethodId );
 
 	const showErrorMessage = useCallback( ( error ) => {
 		const message = error?.toString ? error.toString() : error;
@@ -452,7 +452,7 @@ const mapStateToProps = ( state, { cardId, purchaseId } ) => ( {
 	locale: getCurrentUserLocale( state ),
 } );
 
-function useAssignablePaymentMethods() {
+function useAssignablePaymentMethods( currentPaymentMethodId ) {
 	const translate = useTranslate();
 	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
 
@@ -467,7 +467,8 @@ function useAssignablePaymentMethods() {
 	} );
 
 	const payPalMethod = useCreatePayPal( {
-		labelText: translate( 'Add a new PayPal account' ),
+		labelText:
+			currentPaymentMethodId === 'paypal-existing' ? translate( 'New PayPal account' ) : 'PayPal',
 	} );
 
 	// getStoredCards always returns a new array, but we need a memoized version

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -68,7 +68,7 @@ import {
 	getInitializedFields,
 } from 'calypso/me/purchases/components/payment-method-form/helpers';
 import {
-	useDisplayErrorMessageFromUrl,
+	useHandleRedirectChangeError,
 	useHandleRedirectChangeComplete,
 } from './url-event-handlers';
 import 'calypso/me/purchases/components/payment-method-form/style.scss';
@@ -250,9 +250,11 @@ function ChangePaymentMethodList( {
 		( paymentMethod ) => paymentMethod.id === currentlyAssignedPaymentMethodId
 	);
 
-	useDisplayErrorMessageFromUrl(
-		translate( 'There was a problem assigning that payment method. Please try again.' )
-	);
+	useHandleRedirectChangeError( () => {
+		showErrorMessage(
+			translate( 'There was a problem assigning that payment method. Please try again.' )
+		);
+	} );
 	useHandleRedirectChangeComplete( () => {
 		onChangeComplete( { successCallback, translate, showSuccessMessage, reduxDispatch } );
 	} );

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -236,7 +236,7 @@ function ChangePaymentMethodList( {
 
 	const showErrorMessage = useCallback( ( error ) => {
 		const message = error?.toString ? error.toString() : error;
-		notices.error( message );
+		notices.error( message, { persistent: true } );
 	}, [] );
 
 	const showInfoMessage = useCallback( ( message ) => {

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -245,13 +245,6 @@ function ChangePaymentMethodList( {
 
 	return (
 		<CheckoutProvider
-			items={ [] }
-			total={ {
-				amount: { value: 0, currency: 'USD', displayValue: '$0' },
-				id: 'xyzzy',
-				type: 'FAAAKE',
-				label: 'fake thing',
-			} }
 			onPaymentComplete={ () =>
 				onChangeComplete( { successCallback, translate, showSuccessMessage, reduxDispatch } )
 			}

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -107,7 +107,6 @@ function ChangePaymentMethod( props ) {
 		props.clearPurchases();
 		page( props.getManagePurchaseUrlFor( props.siteSlug, id ) );
 	};
-	const purchaseUrl = props.getManagePurchaseUrlFor( props.siteSlug, props.purchase.id );
 
 	return (
 		<Fragment>
@@ -136,7 +135,6 @@ function ChangePaymentMethod( props ) {
 							purchase={ props.purchase }
 							successCallback={ successCallback }
 							siteSlug={ props.siteSlug }
-							purchaseUrl={ purchaseUrl }
 							apiParams={ { purchaseId: props.purchase.id } }
 						/>
 					) : (
@@ -224,7 +222,6 @@ function ChangePaymentMethodList( {
 	purchase,
 	successCallback,
 	siteSlug,
-	purchaseUrl,
 	apiParams,
 } ) {
 	const translate = useTranslate();
@@ -259,7 +256,7 @@ function ChangePaymentMethodList( {
 			showSuccessMessage={ showSuccessMessage }
 			paymentMethods={ paymentMethods }
 			paymentProcessors={ {
-				paypal: () => assignPayPalProcessor( purchase, purchaseUrl ),
+				paypal: () => assignPayPalProcessor( purchase ),
 				'existing-card': ( data ) => assignExistingCardProcessor( purchase, data ),
 				card: ( data ) =>
 					assignNewCardProcessor(
@@ -304,8 +301,8 @@ async function assignExistingCardProcessor( purchase, { storedDetailsId } ) {
 	} );
 }
 
-async function assignPayPalProcessor( purchase, purchaseUrl ) {
-	return wpcomCreatePayPalAgreement( purchase.id, purchaseUrl, window.location.href ).then(
+async function assignPayPalProcessor( purchase ) {
+	return wpcomCreatePayPalAgreement( purchase.id, window.location.href, window.location.href ).then(
 		( data ) => {
 			return makeRedirectResponse( data );
 		}

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -51,8 +51,6 @@ import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-
 import { isEnabled } from 'calypso/config';
 import { concatTitle } from 'calypso/lib/react-helpers';
 import Gridicon from 'calypso/components/gridicon';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'calypso/lib/url/support';
 import {
 	useHandleRedirectChangeError,
 	useHandleRedirectChangeComplete,
@@ -63,6 +61,7 @@ import {
 	assignNewCardProcessor,
 	assignExistingCardProcessor,
 } from './assignment-processor-functions';
+import TosText from './tos-text';
 
 import 'calypso/me/purchases/components/payment-method-form/style.scss';
 
@@ -280,7 +279,7 @@ function ChangePaymentMethodList( {
 				<div className="change-payment-method__terms">
 					<Gridicon icon="info-outline" size={ 18 } />
 					<p>
-						<TosText translate={ translate } />
+						<TosText />
 					</p>
 				</div>
 
@@ -294,34 +293,6 @@ function onChangeComplete( { successCallback, translate, showSuccessMessage, red
 	reduxDispatch( recordTracksEvent( 'calypso_purchases_save_new_payment_method' ) );
 	showSuccessMessage( translate( 'Your payment method has been set.' ) );
 	successCallback();
-}
-
-function TosText( { translate } ) {
-	// TODO: Make sure we use the correct ToS text for paypal
-	return translate(
-		'By saving a credit card, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and if ' +
-			'you use it to pay for a subscription or plan, you authorize your credit card to be charged ' +
-			'on a recurring basis until you cancel, which you can do at any time. ' +
-			'You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} ' +
-			'and {{managePurchasesSupportPage}}how to cancel{{/managePurchasesSupportPage}}.',
-		{
-			components: {
-				tosLink: (
-					<a
-						href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-						target="_blank"
-						rel="noopener noreferrer"
-					/>
-				),
-				autoRenewalSupportPage: (
-					<a href={ AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
-				),
-				managePurchasesSupportPage: (
-					<a href={ MANAGE_PURCHASES } target="_blank" rel="noopener noreferrer" />
-				),
-			},
-		}
-	);
 }
 
 function CurrentPaymentMethodNotAvailableNotice( { purchase } ) {

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -183,7 +183,9 @@ function getCurrentPaymentMethodId( payment ) {
 		return 'credits';
 	}
 	if ( payment?.type === 'paypal' ) {
-		return 'paypal';
+		// This intentionally is not 'paypal' because we don't want to highlight
+		// the paypal checkbox in case they want to add a new paypal agreement.
+		return 'paypal-existing';
 	}
 	if ( payment?.type === 'credit_card' ) {
 		return 'existingCard-' + payment.creditCard.id;
@@ -415,7 +417,7 @@ function CurrentPaymentMethodNotAvailableNotice( { purchase } ) {
 		return <Notice { ...noticeProps } />;
 	}
 
-	if ( getCurrentPaymentMethodId( purchase.payment ) === 'paypal' ) {
+	if ( getCurrentPaymentMethodId( purchase.payment ) === 'paypal-existing' ) {
 		const storedPaymentAgreement = storedPaymentAgreements.find(
 			( agreement ) => agreement.stored_details_id === purchase.payment.storedDetailsId
 		);

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -56,6 +56,7 @@ import { concatTitle } from 'calypso/lib/react-helpers';
 import {
 	useCreateCreditCard,
 	useCreateExistingCards,
+	useCreatePayPal,
 } from 'calypso/my-sites/checkout/composite-checkout/use-create-payment-methods';
 import Gridicon from 'calypso/components/gridicon';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
@@ -446,6 +447,8 @@ function useAssignablePaymentMethods() {
 		activePayButtonText: translate( 'Save card' ),
 	} );
 
+	const payPalMethod = useCreatePayPal();
+
 	// getStoredCards always returns a new array, but we need a memoized version
 	// to pass to useCreateExistingCards, which has storedCards as a data dependency.
 	const rawStoredCards = useSelector( getStoredCards );
@@ -457,8 +460,8 @@ function useAssignablePaymentMethods() {
 	} );
 
 	const paymentMethods = useMemo(
-		() => [ ...existingCardMethods, stripeMethod ].filter( Boolean ),
-		[ stripeMethod, existingCardMethods ]
+		() => [ ...existingCardMethods, stripeMethod, payPalMethod ].filter( Boolean ),
+		[ stripeMethod, existingCardMethods, payPalMethod ]
 	);
 
 	return paymentMethods;

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -107,6 +107,7 @@ function ChangePaymentMethod( props ) {
 		props.clearPurchases();
 		page( props.getManagePurchaseUrlFor( props.siteSlug, id ) );
 	};
+	const purchaseUrl = props.getManagePurchaseUrlFor( props.siteSlug, props.purchase.id );
 
 	return (
 		<Fragment>
@@ -135,6 +136,7 @@ function ChangePaymentMethod( props ) {
 							purchase={ props.purchase }
 							successCallback={ successCallback }
 							siteSlug={ props.siteSlug }
+							purchaseUrl={ purchaseUrl }
 							apiParams={ { purchaseId: props.purchase.id } }
 						/>
 					) : (
@@ -222,6 +224,7 @@ function ChangePaymentMethodList( {
 	purchase,
 	successCallback,
 	siteSlug,
+	purchaseUrl,
 	apiParams,
 } ) {
 	const translate = useTranslate();
@@ -256,7 +259,7 @@ function ChangePaymentMethodList( {
 			showSuccessMessage={ showSuccessMessage }
 			paymentMethods={ paymentMethods }
 			paymentProcessors={ {
-				paypal: () => assignPayPalProcessor( purchase ),
+				paypal: () => assignPayPalProcessor( purchase, purchaseUrl ),
 				'existing-card': ( data ) => assignExistingCardProcessor( purchase, data ),
 				card: ( data ) =>
 					assignNewCardProcessor(
@@ -301,8 +304,8 @@ async function assignExistingCardProcessor( purchase, { storedDetailsId } ) {
 	} );
 }
 
-async function assignPayPalProcessor( purchase ) {
-	return wpcomCreatePayPalAgreement( purchase.id, window.location.href, window.location.href ).then(
+async function assignPayPalProcessor( purchase, purchaseUrl ) {
+	return wpcomCreatePayPalAgreement( purchase.id, purchaseUrl, window.location.href ).then(
 		( data ) => {
 			return makeRedirectResponse( data );
 		}

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -213,6 +213,8 @@ function getInitiallySelectedPaymentMethodId( currentlyAssignedPaymentMethodId, 
 const wpcom = wp.undocumented();
 const wpcomAssignPaymentMethod = ( subscriptionId, stored_details_id, fn ) =>
 	wpcom.assignPaymentMethod( subscriptionId, stored_details_id, fn );
+const wpcomCreatePayPalAgreement = ( subscriptionId, successUrl, cancelUrl, fn ) =>
+	wpcom.createPayPalAgreement( subscriptionId, successUrl, cancelUrl, fn );
 
 function ChangePaymentMethodList( {
 	currentlyAssignedPaymentMethodId,
@@ -253,7 +255,7 @@ function ChangePaymentMethodList( {
 			showSuccessMessage={ showSuccessMessage }
 			paymentMethods={ paymentMethods }
 			paymentProcessors={ {
-				paypal: assignPayPalProcessor,
+				paypal: () => assignPayPalProcessor( purchase ),
 				'existing-card': ( data ) => assignExistingCardProcessor( purchase, data ),
 				card: ( data ) =>
 					assignNewCardProcessor(
@@ -298,8 +300,13 @@ async function assignExistingCardProcessor( purchase, { storedDetailsId } ) {
 	} );
 }
 
-async function assignPayPalProcessor() {
-	// TODO: create a new paypal billing agreement
+async function assignPayPalProcessor( purchase ) {
+	return wpcomCreatePayPalAgreement( purchase.id, window.location.href, window.location.href ).then(
+		( data ) => {
+			// @todo Implement this better; right now it pops an error message on the screen before redirecting.
+			window.location.href = data;
+		}
+	);
 }
 
 async function assignNewCardProcessor(

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -10,6 +10,7 @@ import {
 	CheckoutProvider,
 	CheckoutPaymentMethods,
 	CheckoutSubmitButton,
+	makeRedirectResponse,
 	makeSuccessResponse,
 } from '@automattic/composite-checkout';
 import { Card } from '@automattic/components';
@@ -303,8 +304,7 @@ async function assignExistingCardProcessor( purchase, { storedDetailsId } ) {
 async function assignPayPalProcessor( purchase ) {
 	return wpcomCreatePayPalAgreement( purchase.id, window.location.href, window.location.href ).then(
 		( data ) => {
-			// @todo Implement this better; right now it pops an error message on the screen before redirecting.
-			window.location.href = data;
+			return makeRedirectResponse( data );
 		}
 	);
 }

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -260,6 +260,7 @@ function ChangePaymentMethodList( {
 			showSuccessMessage={ showSuccessMessage }
 			paymentMethods={ paymentMethods }
 			paymentProcessors={ {
+				paypal: assignPayPalProcessor,
 				'existing-card': ( data ) => assignExistingCardProcessor( purchase, data ),
 				card: ( data ) =>
 					assignNewCardProcessor(
@@ -302,6 +303,10 @@ async function assignExistingCardProcessor( purchase, { storedDetailsId } ) {
 	return wpcomAssignPaymentMethod( purchase.id, storedDetailsId ).then( ( data ) => {
 		return makeSuccessResponse( data );
 	} );
+}
+
+async function assignPayPalProcessor() {
+	// TODO: create a new paypal billing agreement
 }
 
 async function assignNewCardProcessor(

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -107,9 +107,8 @@ function ChangePaymentMethod( props ) {
 		} );
 
 	const successCallback = () => {
-		const { id } = props.purchase;
 		props.clearPurchases();
-		page( props.getManagePurchaseUrlFor( props.siteSlug, id ) );
+		page( props.getManagePurchaseUrlFor( props.siteSlug, props.purchase.id ) );
 	};
 
 	return (

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -445,7 +445,9 @@ function useAssignablePaymentMethods() {
 		activePayButtonText: translate( 'Save card' ),
 	} );
 
-	const payPalMethod = useCreatePayPal();
+	const payPalMethod = useCreatePayPal( {
+		labelText: translate( 'Add a new PayPal account' ),
+	} );
 
 	// getStoredCards always returns a new array, but we need a memoized version
 	// to pass to useCreateExistingCards, which has storedCards as a data dependency.

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -67,6 +67,10 @@ import {
 	updateCreditCard,
 	getInitializedFields,
 } from 'calypso/me/purchases/components/payment-method-form/helpers';
+import {
+	useDisplayErrorMessageFromUrl,
+	useHandleRedirectChangeComplete,
+} from './url-event-handlers';
 import 'calypso/me/purchases/components/payment-method-form/style.scss';
 
 function ChangePaymentMethod( props ) {
@@ -245,6 +249,13 @@ function ChangePaymentMethodList( {
 	const currentPaymentMethodNotAvailable = ! paymentMethods.some(
 		( paymentMethod ) => paymentMethod.id === currentlyAssignedPaymentMethodId
 	);
+
+	useDisplayErrorMessageFromUrl(
+		translate( 'There was a problem assigning that payment method. Please try again.' )
+	);
+	useHandleRedirectChangeComplete( () => {
+		onChangeComplete( { successCallback, translate, showSuccessMessage, reduxDispatch } );
+	} );
 
 	return (
 		<CheckoutProvider

--- a/client/me/purchases/manage-purchase/change-payment-method/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/tos-text.tsx
@@ -15,7 +15,7 @@ export default function TosText(): JSX.Element {
 	return (
 		<>
 			{ translate(
-				'You agree to our {{tosLink}}Terms of Service{{/tosLink}}, and if you use it to pay for a subscription or plan, you authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{faqCancellingSupportPage}}how to cancel{{/faqCancellingSupportPage}}.',
+				'By saving a payment method, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and if you use it to pay for a subscription or plan, you authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{faqCancellingSupportPage}}how to cancel{{/faqCancellingSupportPage}}.',
 				{
 					components: {
 						tosLink: (

--- a/client/me/purchases/manage-purchase/change-payment-method/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/tos-text.tsx
@@ -8,14 +8,17 @@ import { useTranslate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'calypso/lib/url/support';
+import {
+	MANAGE_PURCHASES_AUTOMATIC_RENEWAL,
+	MANAGE_PURCHASES_FAQ_CANCELLING,
+} from 'calypso/lib/url/support';
 
 export default function TosText(): JSX.Element {
 	const translate = useTranslate();
 	return (
 		<>
 			{ translate(
-				'By saving a payment method, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and if you use it to pay for a subscription or plan, you authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{faqCancellingSupportPage}}how to cancel{{/faqCancellingSupportPage}}.',
+				'You agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{faqCancellingSupportPage}}how to cancel{{/faqCancellingSupportPage}}.',
 				{
 					components: {
 						tosLink: (
@@ -26,10 +29,18 @@ export default function TosText(): JSX.Element {
 							/>
 						),
 						autoRenewalSupportPage: (
-							<a href={ AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
+							<a
+								href={ MANAGE_PURCHASES_AUTOMATIC_RENEWAL }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
 						),
 						faqCancellingSupportPage: (
-							<a href={ MANAGE_PURCHASES } target="_blank" rel="noopener noreferrer" />
+							<a
+								href={ MANAGE_PURCHASES_FAQ_CANCELLING }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
 						),
 					},
 				}

--- a/client/me/purchases/manage-purchase/change-payment-method/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/tos-text.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'calypso/lib/url/support';
+
+export default function TosText(): JSX.Element {
+	const translate = useTranslate();
+	// TODO: Make sure we use the correct ToS text for paypal
+	return (
+		<>
+			{ translate(
+				'By saving a credit card, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and if ' +
+					'you use it to pay for a subscription or plan, you authorize your credit card to be charged ' +
+					'on a recurring basis until you cancel, which you can do at any time. ' +
+					'You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} ' +
+					'and {{managePurchasesSupportPage}}how to cancel{{/managePurchasesSupportPage}}.',
+				{
+					components: {
+						tosLink: (
+							<a
+								href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+						autoRenewalSupportPage: (
+							<a href={ AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
+						),
+						managePurchasesSupportPage: (
+							<a href={ MANAGE_PURCHASES } target="_blank" rel="noopener noreferrer" />
+						),
+					},
+				}
+			) }
+		</>
+	);
+}

--- a/client/me/purchases/manage-purchase/change-payment-method/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/tos-text.tsx
@@ -12,15 +12,10 @@ import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'calypso/lib/url/support';
 
 export default function TosText(): JSX.Element {
 	const translate = useTranslate();
-	// TODO: Make sure we use the correct ToS text for paypal
 	return (
 		<>
 			{ translate(
-				'By saving a credit card, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and if ' +
-					'you use it to pay for a subscription or plan, you authorize your credit card to be charged ' +
-					'on a recurring basis until you cancel, which you can do at any time. ' +
-					'You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} ' +
-					'and {{managePurchasesSupportPage}}how to cancel{{/managePurchasesSupportPage}}.',
+				'You agree to our {{tosLink}}Terms of Service{{/tosLink}}, and if you use it to pay for a subscription or plan, you authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{faqCancellingSupportPage}}how to cancel{{/faqCancellingSupportPage}}.',
 				{
 					components: {
 						tosLink: (
@@ -33,7 +28,7 @@ export default function TosText(): JSX.Element {
 						autoRenewalSupportPage: (
 							<a href={ AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
 						),
-						managePurchasesSupportPage: (
+						faqCancellingSupportPage: (
 							<a href={ MANAGE_PURCHASES } target="_blank" rel="noopener noreferrer" />
 						),
 					},

--- a/client/me/purchases/manage-purchase/change-payment-method/url-event-handlers.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/url-event-handlers.ts
@@ -1,30 +1,28 @@
 /**
  * External dependencies
  */
-import { useEffect } from 'react';
-import { TranslateResult } from 'i18n-calypso';
+import { useEffect, useRef } from 'react';
 
-/**
- * Internal Dependencies
- */
-import notices from 'calypso/notices';
-
-export function useDisplayErrorMessageFromUrl( errorMessage: string | TranslateResult ): void {
-	useEffect( () => {
-		const urlParams = new URLSearchParams( window.location.search );
-		const errorParam = urlParams.get( 'error' );
-		if ( errorParam ) {
-			notices.error( errorMessage );
-		}
-	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+export function useHandleRedirectChangeError( errorCallback: () => void ): void {
+	useCallbackOnceForQueryParam( 'error', errorCallback );
 }
 
 export function useHandleRedirectChangeComplete( successCallback: () => void ): void {
+	useCallbackOnceForQueryParam( 'success', successCallback );
+}
+
+function useCallbackOnceForQueryParam( queryParamKey: string, callback: () => void ): void {
+	const didRunCallback = useRef< boolean >( false );
+
 	useEffect( () => {
-		const urlParams = new URLSearchParams( window.location.search );
-		const errorParam = urlParams.get( 'success' );
-		if ( errorParam ) {
-			successCallback();
+		if ( didRunCallback.current ) {
+			return;
 		}
-	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+		const urlParams = new URLSearchParams( window.location.search );
+		const param = urlParams.get( queryParamKey );
+		if ( param ) {
+			callback();
+			didRunCallback.current = true;
+		}
+	}, [ callback, queryParamKey ] );
 }

--- a/client/me/purchases/manage-purchase/change-payment-method/url-event-handlers.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/url-event-handlers.ts
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+import { TranslateResult } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import notices from 'calypso/notices';
+
+export function useDisplayErrorMessageFromUrl( errorMessage: string | TranslateResult ): void {
+	useEffect( () => {
+		const urlParams = new URLSearchParams( window.location.search );
+		const errorParam = urlParams.get( 'error' );
+		if ( errorParam ) {
+			notices.error( errorMessage );
+		}
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+}
+
+export function useHandleRedirectChangeComplete( successCallback: () => void ): void {
+	useEffect( () => {
+		const urlParams = new URLSearchParams( window.location.search );
+		const errorParam = urlParams.get( 'success' );
+		if ( errorParam ) {
+			successCallback();
+		}
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+}

--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
@@ -35,7 +35,9 @@ export default function useCreateAssignablePaymentMethods(
 
 	const payPalMethod = useCreatePayPal( {
 		labelText:
-			currentPaymentMethodId === 'paypal-existing' ? translate( 'New PayPal account' ) : 'PayPal',
+			currentPaymentMethodId === 'paypal-existing'
+				? translate( 'New PayPal account' )
+				: translate( 'PayPal' ),
 	} );
 
 	// getStoredCards always returns a new array, but we need a memoized version

--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { useStripe } from '@automattic/calypso-stripe';
+import { useTranslate } from 'i18n-calypso';
+import type { PaymentMethod } from '@automattic/composite-checkout';
+
+/**
+ * Internal Dependencies
+ */
+import { getStoredCards } from 'calypso/state/stored-cards/selectors';
+import {
+	useCreateCreditCard,
+	useCreateExistingCards,
+	useCreatePayPal,
+} from 'calypso/my-sites/checkout/composite-checkout/use-create-payment-methods';
+
+export default function useCreateAssignablePaymentMethods(
+	currentPaymentMethodId: string
+): PaymentMethod[] {
+	const translate = useTranslate();
+	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
+
+	const stripeMethod = useCreateCreditCard( {
+		isStripeLoading,
+		stripeLoadingError,
+		stripeConfiguration,
+		stripe,
+		shouldUseEbanx: false,
+		shouldShowTaxFields: true,
+		activePayButtonText: translate( 'Save card' ),
+	} );
+
+	const payPalMethod = useCreatePayPal( {
+		labelText:
+			currentPaymentMethodId === 'paypal-existing' ? translate( 'New PayPal account' ) : 'PayPal',
+	} );
+
+	// getStoredCards always returns a new array, but we need a memoized version
+	// to pass to useCreateExistingCards, which has storedCards as a data dependency.
+	const rawStoredCards = useSelector( getStoredCards );
+	const storedCards = useMemo( () => rawStoredCards, [] ); // eslint-disable-line
+	const existingCardMethods = useCreateExistingCards( {
+		storedCards,
+		activePayButtonText: translate( 'Use this card' ),
+	} );
+
+	const paymentMethods = useMemo(
+		() => [ ...existingCardMethods, stripeMethod, payPalMethod ].filter( Boolean ),
+		[ stripeMethod, existingCardMethods, payPalMethod ]
+	);
+
+	return paymentMethods;
+}

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -47,7 +47,7 @@ import { createFullCreditsMethod } from './payment-methods/full-credits';
 import { createFreePaymentMethod } from './payment-methods/free-purchase';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 
-export function useCreatePayPal( { labelText = null } ) {
+export function useCreatePayPal( { labelText = null } = {} ) {
 	const paypalMethod = useMemo( () => createPayPalMethod( { labelText } ), [ labelText ] );
 	return paypalMethod;
 }

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -47,8 +47,8 @@ import { createFullCreditsMethod } from './payment-methods/full-credits';
 import { createFreePaymentMethod } from './payment-methods/free-purchase';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 
-export function useCreatePayPal() {
-	const paypalMethod = useMemo( createPayPalMethod, [] );
+export function useCreatePayPal( { labelText = null } ) {
+	const paypalMethod = useMemo( () => createPayPalMethod( { labelText } ), [ labelText ] );
 	return paypalMethod;
 }
 
@@ -288,10 +288,7 @@ function useCreateApplePay( {
 	return applePayMethod;
 }
 
-export function useCreateExistingCards( {
-	storedCards,
-	activePayButtonText = undefined,
-} ) {
+export function useCreateExistingCards( { storedCards, activePayButtonText = undefined } ) {
 	const existingCardMethods = useMemo( () => {
 		return storedCards.map( ( storedDetails ) =>
 			createExistingCardMethod( {

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -24,7 +24,7 @@ declare global {
 
 type StripeFactory = ( key: string, options?: Record< string, string > ) => Stripe;
 
-type PaymentDetails = Record< string, string >;
+type PaymentDetails = Record< string, unknown >;
 
 type HandleCardSetupResponse = { setupIntent: StripeSetupIntent; error: StripeError };
 

--- a/packages/composite-checkout/src/components/use-process-payment.ts
+++ b/packages/composite-checkout/src/components/use-process-payment.ts
@@ -121,12 +121,5 @@ function validateProcessorResponse( response: unknown ): response is PaymentProc
 	if ( ! processorResponse || ! processorResponse.type ) {
 		return false;
 	}
-	if (
-		processorResponse.type === PaymentProcessorResponseType.SUCCESS &&
-		! processorResponse.payload
-	) {
-		return false;
-	}
-	// No need to validate missing redirect payloads; they are already handled by redirectErrorMessage
 	return true;
 }

--- a/packages/composite-checkout/src/components/use-process-payment.ts
+++ b/packages/composite-checkout/src/components/use-process-payment.ts
@@ -8,7 +8,11 @@ import { useI18n } from '@automattic/react-i18n';
 /**
  * Internal dependencies
  */
-import { usePaymentProcessors, useTransactionStatus } from '../public-api';
+import {
+	usePaymentProcessors,
+	useTransactionStatus,
+	InvalidPaymentProcessorResponseError,
+} from '../public-api';
 import {
 	PaymentProcessorResponse,
 	PaymentProcessorResponseType,
@@ -92,7 +96,7 @@ async function handlePaymentProcessorResponse(
 	debug( 'payment processor function response', rawResponse );
 	const isValid = validateProcessorResponse( rawResponse );
 	if ( ! isValid ) {
-		throw new Error( `Invalid payment processor response for processor "${ paymentProcessorId }"` );
+		throw new InvalidPaymentProcessorResponseError( paymentProcessorId );
 	}
 	const processorResponse = rawResponse as PaymentProcessorResponse;
 	if ( processorResponse.type === PaymentProcessorResponseType.REDIRECT ) {
@@ -109,7 +113,7 @@ async function handlePaymentProcessorResponse(
 	if ( processorResponse.type === PaymentProcessorResponseType.MANUAL ) {
 		return processorResponse;
 	}
-	throw new Error( `Unknown payment processor response for processor "${ paymentProcessorId }"` );
+	throw new InvalidPaymentProcessorResponseError( paymentProcessorId );
 }
 
 function validateProcessorResponse( response: unknown ): response is PaymentProcessorResponse {

--- a/packages/composite-checkout/src/lib/invalid-payment-processor-response-error.ts
+++ b/packages/composite-checkout/src/lib/invalid-payment-processor-response-error.ts
@@ -1,0 +1,7 @@
+export default class InvalidPaymentProcessorResponseError extends Error {
+	constructor( paymentProcessorId: string ) {
+		const message = `Unknown payment processor response for processor "${ paymentProcessorId }". Payment processor functions should return one of makeManualResponse, makeSuccessResponse, or makeRedirectResponse.`;
+		super( message );
+		this.name = 'InvalidPaymentProcessorResponseError';
+	}
+}

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -21,23 +21,23 @@ import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
 const debug = debugFactory( 'composite-checkout:paypal' );
 
-export function createPayPalMethod() {
+export function createPayPalMethod( { labelText = null } ) {
 	debug( 'creating new paypal payment method' );
 	return {
 		id: 'paypal',
-		label: <PaypalLabel />,
+		label: <PaypalLabel labelText={ labelText } />,
 		submitButton: <PaypalSubmitButton />,
 		inactiveContent: <PaypalSummary />,
 		getAriaLabel: ( __ ) => __( 'PayPal' ),
 	};
 }
 
-export function PaypalLabel() {
+export function PaypalLabel( { labelText = null } ) {
 	const { __ } = useI18n();
 
 	return (
 		<React.Fragment>
-			<span>{ __( 'PayPal' ) }</span>
+			<span>{ labelText || __( 'PayPal' ) }</span>
 			<PaymentMethodLogos className="paypal__logo payment-logos">
 				<PaypalLogo />
 			</PaymentMethodLogos>

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -84,6 +84,7 @@ import {
 import useProcessPayment from './components/use-process-payment';
 import RadioButton from './components/radio-button';
 import checkoutTheme from './lib/theme';
+import InvalidPaymentProcessorResponseError from './lib/invalid-payment-processor-response-error';
 export * from './types';
 
 // Re-export the public API
@@ -106,6 +107,7 @@ export {
 	CheckoutSubmitButton,
 	CheckoutSummaryArea,
 	CheckoutSummaryCard,
+	InvalidPaymentProcessorResponseError,
 	MainContentWrapper,
 	OrderReviewLineItems,
 	OrderReviewSection,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a PayPal button to the list of options displayed by `ChangePaymentMethod`. Selecting this option will create a new PayPal billing agreement for the subscription in question.

![Screen Shot 2021-01-07 at 3 12 05 PM](https://user-images.githubusercontent.com/9310939/103945492-e3deaf00-50fa-11eb-9ee2-6b882ca876e0.png)

Fixes https://github.com/Automattic/wp-calypso/issues/47518

#### Testing instructions

- Apply D54805-code 
- Visit `/purchases` for a site which has at least one subscription.
- Click on the subscription.
- Click "Add payment method" or "Change payment method"
- Verify that "PayPal" is one of the radio button options. Click to select PayPal.
- Click the submit button at the bottom of the form.
- Verify that you are redirected to PayPal to create a new billing agreement.
- Refuse the billing agreement and verify that you are redirected back to the form to select a payment method.
- Click to select PayPal again.
- Confirm the PayPal billing agreement this time and verify that you are redirected back to the subscription page.
- Verify that you see a notification that says your payment method has been assigned.
- Verify that the payment method assigned to the subscription is PayPal (you should see it in the subscription's card).