### PR TITLE
Do not import calypso state

### DIFF
--- a/apps/notifications/src/panel/state/selectors/get-keyboard-shortcuts-enabled.js
+++ b/apps/notifications/src/panel/state/selectors/get-keyboard-shortcuts-enabled.js
@@ -1,6 +1,1 @@
-/**
- * Internal dependencies
- */
-import 'calypso/state/ui/init';
-
 export default ( state ) => state.ui?.keyboardShortcutsAreEnabled;

--- a/apps/notifications/src/panel/state/selectors/get-ui.js
+++ b/apps/notifications/src/panel/state/selectors/get-ui.js
@@ -1,8 +1,3 @@
-/**
- * Internal dependencies
- */
-import 'calypso/state/ui/init';
-
 export const getUI = ( state ) => state.ui;
 
 export default getUI;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Do not import Calypso state into Notifications

#### Testing instructions

* Follow the deployment process in PCYsg-elI-p2 to deploy this branch to your sandbox
* Go to your test site's wp-admin and open the notifications bar. Ensure it loads inside an iframe.
* Verify notifications work.

Fixes the bug introduced in #47754 (see https://github.com/Automattic/wp-calypso/pull/47754#issuecomment-749533670)