### PR TITLE
Deduplicate moment

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20184,12 +20184,7 @@ moment-timezone@^0.5.16, moment-timezone@^0.5.31:
   dependencies:
     moment ">= 2.9.0"
 
-moment@*, "moment@>= 2.9.0", moment@>=1.6.0, moment@^2.10.3, moment@^2.22.1, moment@^2.24.0, moment@^2.26.0:
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"
-  integrity sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==
-
-moment@^2.19.3:
+moment@*, "moment@>= 2.9.0", moment@>=1.6.0, moment@^2.10.3, moment@^2.19.3, moment@^2.22.1, moment@^2.24.0, moment@^2.26.0:
   version "2.27.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
   integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `moment` (done automatically with `npx yarn-deduplicate --packages moment`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @wordpress/components@10.0.5 -> ... -> moment@2.26.0
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> moment@2.26.0
> wp-calypso@0.17.0 -> @wordpress/components@10.0.5 -> ... -> moment@2.27.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> moment@2.27.0
```