### PR TITLE
Plugins: Reduxify plugin sites

### DIFF
--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -60,12 +60,6 @@ Note: pluginFilter can be any of the following string: 'none' , 'all', 'active',
 
 Returns an array of plugin objects for a particular site.
 
----
-
-#### PluginsStore.getSites( sites, pluginSlug );
-
-Returns an array of sites that have a particular plugin.
-
 ### Example Component Code
 
 ```js

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { assign, clone, isArray, sortBy, values, find } from 'lodash';
+import { assign, isArray, sortBy, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,7 +14,6 @@ import versionCompare from 'calypso/lib/version-compare';
 import { normalizePluginData } from 'calypso/lib/plugins/utils';
 import { reduxDispatch, reduxGetState } from 'calypso/lib/redux-bridge';
 import getNetworkSites from 'calypso/state/selectors/get-network-sites';
-import { getSite } from 'calypso/state/sites/selectors';
 import { sitePluginUpdated } from 'calypso/state/sites/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 
@@ -163,32 +162,6 @@ const PluginsStore = {
 			return _pluginsBySite[ site.ID ];
 		}
 		return values( _pluginsBySite[ site.ID ] );
-	},
-
-	// Array of sites with a particular plugin.
-	getSites: function ( sites, pluginSlug ) {
-		const plugins = this.getPlugins( sites );
-		if ( ! plugins ) {
-			return;
-		}
-
-		const plugin = find( plugins, _filters.isEqual.bind( this, pluginSlug ) );
-		if ( ! plugin ) {
-			return null;
-		}
-
-		const pluginSites = plugin.sites
-			.filter( ( site ) => site.visible )
-			.map( ( site ) => {
-				// clone the site object before adding a new property. Don't modify the return value of getSite
-				const pluginSite = clone( getSite( reduxGetState(), site.ID ) );
-				pluginSite.plugin = site.plugin;
-				return pluginSite;
-			} );
-
-		return pluginSites.sort( function ( first, second ) {
-			return first.title.toLowerCase() > second.title.toLowerCase() ? 1 : -1;
-		} );
 	},
 
 	emitChange: function () {

--- a/client/lib/plugins/test/store.js
+++ b/client/lib/plugins/test/store.js
@@ -108,25 +108,6 @@ describe( 'Plugins Store', () => {
 			} );
 		} );
 
-		describe( 'getSites method', () => {
-			test( 'Store should have method getSites', () => {
-				assert.isFunction( PluginsStore.getSites );
-			} );
-
-			test( 'Should return Array of Objects', () => {
-				const Sites = PluginsStore.getSites( site, 'akismet' );
-				assert.isArray( Sites );
-				assert.isObject( Sites[ 0 ] );
-			} );
-
-			test( 'Should return Array of Objects that has the pluginSlug as a attribute', () => {
-				const Sites = PluginsStore.getSites( site, 'akismet' );
-				assert.isArray( Sites );
-				assert.isObject( Sites[ 0 ] );
-				assert.equal( Sites[ 0 ].plugin.slug, 'akismet' );
-			} );
-		} );
-
 		test( 'Should return an empty array if RECEIVE_PLUGINS errors', () => {
 			Dispatcher.handleServerAction( actions.fetchedError );
 			const UpdatedStore = PluginsStore.getPlugins( {

--- a/client/my-sites/plugins/notices.jsx
+++ b/client/my-sites/plugins/notices.jsx
@@ -66,8 +66,9 @@ class PluginNotices extends React.Component {
 
 	getPluginById( pluginId ) {
 		return this.props.plugins.find(
-			( plugin ) =>
-				isSamePluginIdSlug( plugin.id, pluginId ) || isSamePluginIdSlug( plugin.slug, pluginId )
+			( { id, slug } ) =>
+				( id && isSamePluginIdSlug( id, pluginId ) ) ||
+				( slug && isSamePluginIdSlug( slug, pluginId ) )
 		);
 	}
 

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -423,9 +423,17 @@ export class PluginMeta extends Component {
 			.filter( ( newVersions ) => newVersions );
 	}
 
+	getPluginForSite = ( siteId ) => {
+		return {
+			...this.props.plugin,
+			...this.props.pluginsOnSites.sites[ siteId ],
+		};
+	};
+
 	handlePluginUpdatesSingleSite = ( event ) => {
 		event.preventDefault();
-		this.props.updatePlugin( this.props.sites[ 0 ].ID, this.props.sites[ 0 ].plugin );
+		const plugin = this.getPluginForSite( this.props.sites[ 0 ].ID );
+		this.props.updatePlugin( this.props.sites[ 0 ].ID, plugin );
 
 		gaRecordEvent(
 			'Plugins',
@@ -435,7 +443,7 @@ export class PluginMeta extends Component {
 		);
 		recordTracksEvent( 'calypso_plugins_actions_update_plugin', {
 			site: this.props.sites[ 0 ].ID,
-			plugin: this.props.sites[ 0 ].plugin.slug,
+			plugin: plugin.slug,
 			selected_site: this.props.sites[ 0 ].ID,
 		} );
 	};
@@ -443,7 +451,7 @@ export class PluginMeta extends Component {
 	handlePluginUpdatesMultiSite = ( event ) => {
 		event.preventDefault();
 		this.props.sites.forEach( ( site ) => {
-			const { plugin } = site;
+			const plugin = this.getPluginForSite( site.ID );
 			if (
 				site.canUpdateFiles &&
 				plugin.update &&
@@ -503,10 +511,11 @@ export class PluginMeta extends Component {
 			'is-placeholder': !! this.props.isPlaceholder,
 		} );
 
-		const plugin =
-			this.props.selectedSite && this.props.sites[ 0 ] && this.props.sites[ 0 ].plugin
-				? this.props.sites[ 0 ].plugin
-				: this.props.plugin;
+		let { plugin } = this.props;
+		if ( this.props.selectedSite ) {
+			plugin = this.getPluginForSite( this.props.selectedSite.ID );
+		}
+
 		const path =
 			( ! this.props.selectedSite || plugin.active ) && getExtensionSettingsPath( plugin );
 

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -426,7 +426,7 @@ export class PluginMeta extends Component {
 	getPluginForSite = ( siteId ) => {
 		return {
 			...this.props.plugin,
-			...this.props.pluginsOnSites.sites[ siteId ],
+			...this.props.pluginsOnSites?.sites[ siteId ],
 		};
 	};
 

--- a/client/my-sites/plugins/plugin-meta/test/index.js
+++ b/client/my-sites/plugins/plugin-meta/test/index.js
@@ -65,6 +65,9 @@ const selectedSite = {
 const props = {
 	selectedSite,
 	sites: [ [ {} ] ],
+	pluginsOnSites: {
+		sites: {},
+	},
 	plugin: { active: false },
 	selectedSiteId: 123,
 	translate: ( x ) => x,

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -13,9 +13,11 @@ import PropTypes from 'prop-types';
 import getNetworkSites from 'calypso/state/selectors/get-network-sites';
 import isConnectedSecondaryNetworkSite from 'calypso/state/selectors/is-connected-secondary-network-site';
 import PluginSite from 'calypso/my-sites/plugins/plugin-site/plugin-site';
-import PluginsStore from 'calypso/lib/plugins/store';
 import SectionHeader from 'calypso/components/section-header';
-import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
+import {
+	getPluginOnSites,
+	getSiteObjectsWithPlugin,
+} from 'calypso/state/plugins/installed/selectors';
 
 /**
  * Style dependencies
@@ -31,10 +33,12 @@ export class PluginSiteList extends Component {
 	};
 
 	getSecondaryPluginSites( site, secondarySites ) {
-		const sitePlugin = this.props.pluginsOnSites?.sites[ site.ID ];
-		const secondaryPluginSites = sitePlugin
-			? PluginsStore.getSites( secondarySites, this.props.plugin.slug )
-			: secondarySites;
+		const pluginsOnSites = this.props.pluginsOnSites?.sites[ site.ID ];
+		const secondarySitesWithPlugin = this.props.sitesWithPlugin.filter(
+			( siteWithPlugin ) =>
+				secondarySites && secondarySites.some( ( secSite ) => secSite.ID === siteWithPlugin.ID )
+		);
+		const secondaryPluginSites = pluginsOnSites ? secondarySitesWithPlugin : secondarySites;
 		return compact( secondaryPluginSites );
 	}
 
@@ -81,6 +85,7 @@ export default connect( ( state, { plugin, sites } ) => {
 	const siteIds = sites.map( ( site ) => site.ID );
 
 	return {
+		sitesWithPlugin: getSiteObjectsWithPlugin( state, siteIds, plugin.slug ),
 		sitesWithSecondarySites: getSitesWithSecondarySites( state, sites ),
 		pluginsOnSites: getPluginOnSites( state, siteIds, plugin.slug ),
 	};

--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -57,6 +57,10 @@ class PluginSiteUpdateIndicator extends React.Component {
 	};
 
 	getOngoingUpdates = () => {
+		if ( ! this.props.pluginOnSite?.update?.new_version ) {
+			return [];
+		}
+
 		return this.props.inProgressStatuses.filter(
 			( status ) =>
 				parseInt( status.siteId ) === this.props.site.ID && status.action === UPDATE_PLUGIN

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -153,13 +153,11 @@ class SinglePlugin extends React.Component {
 	}
 
 	getPlugin() {
-		const { pluginSlug, wporgPlugin } = this.props;
+		const { plugin, wporgPlugin } = this.props;
 
 		// assign it .org details
 		return {
-			name: pluginSlug,
-			id: pluginSlug,
-			slug: pluginSlug,
+			...plugin,
 			...wporgPlugin,
 		};
 	}

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -451,7 +451,7 @@ function installPluginHelper( siteId, plugin, isMainNetworkSite = false ) {
 	return ( dispatch, getState ) => {
 		const state = getState();
 		const site = getSite( state, siteId );
-		const pluginId = plugin.id;
+		const pluginId = plugin.id || plugin.slug;
 		const defaultAction = {
 			action: INSTALL_PLUGIN,
 			siteId,
@@ -552,7 +552,7 @@ export function removePlugin( siteId, plugin ) {
 	return ( dispatch, getState ) => {
 		const state = getState();
 		const site = getSite( state, siteId );
-		const pluginId = plugin.id;
+		const pluginId = plugin.id || plugin.slug;
 		const defaultAction = {
 			action: REMOVE_PLUGIN,
 			siteId,

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -120,6 +120,11 @@ export function getSitesWithPlugin( state, siteIds, pluginSlug ) {
 	return sortBy( pluginSites, ( siteId ) => getSiteTitle( state, siteId ).toLowerCase() );
 }
 
+export function getSiteObjectsWithPlugin( state, siteIds, pluginSlug ) {
+	const siteIdsWithPlugin = getSitesWithPlugin( state, siteIds, pluginSlug );
+	return siteIdsWithPlugin.map( ( siteId ) => getSite( state, siteId ) );
+}
+
 export function getSitesWithoutPlugin( state, siteIds, pluginSlug ) {
 	const installedOnSiteIds = getSitesWithPlugin( state, siteIds, pluginSlug ) || [];
 	return filter( siteIds, function ( siteId ) {

--- a/client/state/plugins/installed/test/selectors.js
+++ b/client/state/plugins/installed/test/selectors.js
@@ -16,6 +16,7 @@ import {
 import * as selectors from '../selectors';
 import { akismet, helloDolly, jetpack } from './fixtures/plugins';
 import { userState } from 'calypso/state/selectors/test/fixtures/user-state';
+import { getSite } from 'calypso/state/sites/selectors';
 
 const createError = function ( error, message, name = false ) {
 	const errorObj = new Error( message );
@@ -99,6 +100,10 @@ describe( 'Installed plugin selectors', () => {
 
 	test( 'should contain getSitesWithPlugin method', () => {
 		expect( selectors.getSitesWithPlugin ).to.be.a( 'function' );
+	} );
+
+	test( 'should contain getSiteObjectsWithPlugin method', () => {
+		expect( selectors.getSiteObjectsWithPlugin ).to.be.a( 'function' );
 	} );
 
 	test( 'should contain getSitesWithoutPlugin method', () => {
@@ -264,6 +269,29 @@ describe( 'Installed plugin selectors', () => {
 		test( 'Should get an array of sites with the requested plugin', () => {
 			const siteIds = selectors.getSitesWithPlugin( state, [ 'site.one', 'site.two' ], 'jetpack' );
 			expect( siteIds ).to.eql( [ 'site.two' ] );
+		} );
+	} );
+
+	describe( 'getSiteObjectsWithPlugin', () => {
+		test( 'Should get an empty array if the requested site is not in the current state', () => {
+			expect(
+				selectors.getSiteObjectsWithPlugin( state, [ 'no.site' ], 'akismet' )
+			).to.have.lengthOf( 0 );
+		} );
+
+		test( "Should get an empty array if the requested plugin doesn't exist on any sites' state", () => {
+			expect(
+				selectors.getSiteObjectsWithPlugin( state, [ 'site.one', 'site.two' ], 'vaultpress' )
+			).to.have.lengthOf( 0 );
+		} );
+
+		test( 'Should get an array of sites with the requested plugin', () => {
+			const siteIds = selectors.getSiteObjectsWithPlugin(
+				state,
+				[ 'site.one', 'site.two' ],
+				'jetpack'
+			);
+			expect( siteIds ).to.eql( [ getSite( state, 'site.two' ) ] );
 		} );
 	} );
 


### PR DESCRIPTION
After all the PRs for decoupling sites from plugins, we can now finally reduxify how we work with plugin sites. This PR achieves that by introducing a new selector, and using that where applicable. It also removes an unnecessary indirection with component state in favor of directly using props, and removes the now unnecessary `getSites` flux method.

Part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Reduxify plugin sites

#### Testing instructions

* Get some Jetpack sites (including multisite with subsites) for testing.
* Compare against production and verify that all actions with a certain plugin works the same way when updating, installing or removing plugins, as well as toggling auto-updates and enabling/disabling plugins:
  * `/plugins/:plugin/:site`
  * `/plugins/:plugin` - make sure to try multisite and its subsites, too.
* Verify all tests pass.
