### PR TITLE
Focused Launch: hide plan comparisons from detailed plans step

### DIFF
--- a/packages/launch/src/focused-launch/plan-details/index.tsx
+++ b/packages/launch/src/focused-launch/plan-details/index.tsx
@@ -77,6 +77,7 @@ const PlanDetails: React.FunctionComponent = () => {
 					}
 					CTAVariation="FULL_WIDTH"
 					locale={ locale }
+					hidePlansComparison
 				/>
 			</div>
 		</div>

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -39,6 +39,7 @@ export interface Props {
 	CTAVariation?: CTAVariation;
 	popularBadgeVariation?: PopularBadgeVariation;
 	customTagLines?: CustomTagLinesMap;
+	hidePlansComparison?: boolean;
 }
 
 const PlansGrid: React.FunctionComponent< Props > = ( {
@@ -55,6 +56,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 	CTAVariation = 'NORMAL',
 	popularBadgeVariation = 'ON_TOP',
 	customTagLines,
+	hidePlansComparison = false,
 } ) => {
 	const { __ } = useI18n();
 
@@ -92,15 +94,16 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 					) }
 				</div>
 			</div>
-
-			<div className="plans-grid__details">
-				<div className="plans-grid__details-heading">
-					<Title tagName="h2">{ __( 'Detailed comparison', __i18n_text_domain__ ) }</Title>
+			{ ! hidePlansComparison && (
+				<div className="plans-grid__details">
+					<div className="plans-grid__details-heading">
+						<Title tagName="h2">{ __( 'Detailed comparison', __i18n_text_domain__ ) }</Title>
+					</div>
+					<div className="plans-grid__details-container">
+						<PlansDetails onSelect={ onPlanSelect } locale={ locale } />
+					</div>
 				</div>
-				<div className="plans-grid__details-container">
-					<PlansDetails onSelect={ onPlanSelect } locale={ locale } />
-				</div>
-			</div>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
5 minutes review. 

#### Changes proposed in this Pull Request

* as shown in the design (27a75-pb) the details plans step doesn't have the comparison table. This PR adds an optional flag to the Plans Grid API that hides the table, and uses said flag in focused launch.

#### Testing instructions

* Create a free unlaunched site.
   * Let's say its called **http://test123_wordpress_dotcom**.
* Go to **http://calypso.localhost:3000/page/test123_wordpress_dotcom/home?fresh&flags=create/focused-launch-flow-calypso**.
* View detailed plans step, you shouldn't see the comparison table.

Fixes https://github.com/Automattic/wp-calypso/issues/47792