### PR TITLE
Plugins: Remove last arg of doActionOverSelected

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -221,7 +221,7 @@ export class PluginsList extends React.Component {
 		this.props.removePluginStatuses( 'completed', 'error' );
 	}
 
-	doActionOverSelected( actionName, action, siteIdOnly = false ) {
+	doActionOverSelected( actionName, action ) {
 		const isDeactivatingAndJetpackSelected = ( { slug } ) =>
 			( 'deactivating' === actionName || 'activating' === actionName ) && 'jetpack' === slug;
 
@@ -232,11 +232,7 @@ export class PluginsList extends React.Component {
 			.filter( negate( isDeactivatingAndJetpackSelected ) ) // ignore sites that are deactiving or activating jetpack
 			.map( ( p ) => p.sites ) // list of plugins -> list of list of sites
 			.reduce( flattenArrays, [] ) // flatten the list into one big list of sites
-			.forEach( ( site ) => {
-				// Our Redux actions only need a site ID instead of an entire site object
-				const siteArg = siteIdOnly ? site.ID : site;
-				return action( siteArg, site.plugin );
-			} );
+			.forEach( ( site ) => action( site.ID, site.plugin ) );
 	}
 
 	pluginHasUpdate( plugin ) {
@@ -254,31 +250,27 @@ export class PluginsList extends React.Component {
 	};
 
 	updateSelected = () => {
-		this.doActionOverSelected( 'updating', this.props.updatePlugin, true );
+		this.doActionOverSelected( 'updating', this.props.updatePlugin );
 		this.recordEvent( 'Clicked Update Plugin(s)', true );
 	};
 
 	activateSelected = () => {
-		this.doActionOverSelected( 'activating', this.props.activatePlugin, true );
+		this.doActionOverSelected( 'activating', this.props.activatePlugin );
 		this.recordEvent( 'Clicked Activate Plugin(s)', true );
 	};
 
 	deactivateSelected = () => {
-		this.doActionOverSelected( 'deactivating', this.props.deactivatePlugin, true );
+		this.doActionOverSelected( 'deactivating', this.props.deactivatePlugin );
 		this.recordEvent( 'Clicked Deactivate Plugin(s)', true );
 	};
 
 	deactiveAndDisconnectSelected = () => {
 		let waitForDeactivate = false;
 
-		this.doActionOverSelected(
-			'deactivating',
-			( site, plugin ) => {
-				waitForDeactivate = true;
-				this.props.deactivatePlugin( site, plugin, true );
-			},
-			true
-		);
+		this.doActionOverSelected( 'deactivating', ( site, plugin ) => {
+			waitForDeactivate = true;
+			this.props.deactivatePlugin( site, plugin );
+		} );
 
 		if ( waitForDeactivate && this.props.selectedSite ) {
 			this.setState( { disconnectJetpackNotice: true } );
@@ -288,12 +280,12 @@ export class PluginsList extends React.Component {
 	};
 
 	setAutoupdateSelected = () => {
-		this.doActionOverSelected( 'enablingAutoupdates', this.props.enableAutoupdatePlugin, true );
+		this.doActionOverSelected( 'enablingAutoupdates', this.props.enableAutoupdatePlugin );
 		this.recordEvent( 'Clicked Enable Autoupdate Plugin(s)', true );
 	};
 
 	unsetAutoupdateSelected = () => {
-		this.doActionOverSelected( 'disablingAutoupdates', this.props.disableAutoupdatePlugin, true );
+		this.doActionOverSelected( 'disablingAutoupdates', this.props.disableAutoupdatePlugin );
 		this.recordEvent( 'Clicked Disable Autoupdate Plugin(s)', true );
 	};
 
@@ -409,7 +401,7 @@ export class PluginsList extends React.Component {
 
 	removeSelected = ( accepted ) => {
 		if ( accepted ) {
-			this.doActionOverSelected( 'removing', this.props.removePlugin, true );
+			this.doActionOverSelected( 'removing', this.props.removePlugin );
 			this.recordEvent( 'Clicked Remove Plugin(s)', true );
 		}
 	};


### PR DESCRIPTION
In the process of reduxifying `PluginsList`, we introduced a third argument to `doActionOverSelected()` that supported passing a site ID to the action instead of the entire site object. This was necessary because the flux actions worked with site objects, but Redux ones - with site IDs. 

Nowadays, because we've migrated all actions to Redux, and we're always using the site ID, that third argument can be removed. This is what this PR does.

This PR is part of #24180.

#### Changes proposed in this Pull Request

* Plugins: Remove last arg of `doActionOverSelected`

#### Testing instructions

* Get several Jetpack sites with some plugins for testing. Ideally, you would also have a connected multisite with 1-2 subsites that are also connected too. 
* Thoroughly test plugin lists in scenarios; compare against production and verify that single and bulk actions still work the same way when updating, installing, or removing plugins, as well as toggling auto-updates and activating/deactivating plugins:
  * `/plugins/manage`
  * `/plugins/manage` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
  * `/plugins/manage/:site` - for a single plugin
  * `/plugins/manage/:site` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
* Verify all tests pass.
