### PR TITLE
Focused Launch: handle already-purchased domains properly in summary view

### DIFF
--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -67,7 +67,7 @@ export function useDomainSelection(): DomainSelection {
 	const { domain: selectedDomain, plan, confirmedDomainSelection } = useSelect( ( select ) =>
 		select( LAUNCH_STORE ).getState()
 	);
-	const { siteSubdomain } = useSiteDomains();
+	const { siteSubdomain, hasPaidDomain, sitePrimaryDomain } = useSiteDomains();
 
 	function onDomainSelect( suggestion: DomainSuggestions.DomainSuggestion ) {
 		confirmDomainSelection();
@@ -86,6 +86,8 @@ export function useDomainSelection(): DomainSelection {
 
 	if ( selectedDomain ) {
 		currentDomain = selectedDomain;
+	} else if ( hasPaidDomain ) {
+		currentDomain = mockDomainSuggestion( sitePrimaryDomain?.domain );
 	} else if ( confirmedDomainSelection ) {
 		// in the scenario where confirmedDomainSelection is true and selectedDomain is falsey we can assume they've selected the sub-domain
 		currentDomain = mockDomainSuggestion( siteSubdomain?.domain );


### PR DESCRIPTION
3-5 mins review.

#### Changes proposed in this Pull Request

In short, fixes https://github.com/Automattic/wp-calypso/issues/48410.

This is the easy quick way to test, but it might fail since you don't own my site:

1. visit https://testingdomainwithpurchaseddomain.wordpress.com/wp-admin/post-new.php
2. In console, run `wp.data.dispatch('automattic/launch' ).openFocusedLaunch()`.
3. The paid domain should have a visible name.

#### Testing instructions - Plan B

* Create a site with a paid domain and plan but don't launch it.
   * Let's say its called **https://mytestingsite3424234234234.com**.
* Go to `https://mytestingsite3424234234234.com/wp-admin/post-new.php`.
* In console, run `wp.data.dispatch('automattic/launch' ).openFocusedLaunch()`
* The paid domain should have a visible name. 

Fixes https://github.com/Automattic/wp-calypso/issues/48410
