### PR TITLE
Focused Launch: go back to summary after free domain selection

### DIFF
--- a/packages/launch/src/focused-launch/domain-details/index.tsx
+++ b/packages/launch/src/focused-launch/domain-details/index.tsx
@@ -41,6 +41,11 @@ const DomainDetails: React.FunctionComponent = () => {
 		goBack();
 	};
 
+	const handleSubdomainSelect = () => {
+		onExistingSubdomainSelect();
+		goBack();
+	};
+
 	const trackDomainSearchInteraction = ( query: string ) => {
 		recordTracksEvent( 'calypso_newsite_domain_search_blur', {
 			flow: FOCUSED_LAUNCH_FLOW_ID,
@@ -68,7 +73,7 @@ const DomainDetails: React.FunctionComponent = () => {
 					currentDomain={ currentDomain }
 					existingSubdomain={ mockDomainSuggestion( siteSubdomain?.domain ) }
 					onDomainSelect={ handleSelect }
-					onExistingSubdomainSelect={ onExistingSubdomainSelect }
+					onExistingSubdomainSelect={ handleSubdomainSelect }
 					analyticsFlowId={ FOCUSED_LAUNCH_FLOW_ID }
 					analyticsUiAlgo={ ANALYTICS_UI_LOCATION }
 					segregateFreeAndPaid


### PR DESCRIPTION
3-5 minutes review

#### Changes proposed in this Pull Request

* Fixes https://github.com/Automattic/wp-calypso/issues/48268

#### Testing instructions

In Focused Launch:

- Go to the detailed domains step
- Pick a free domain
- You should be taken back to summary.

Fixes #48268
