### PR TITLE
Focused Launch: add defaultAllPlansExpanded bool to plans table's API

### DIFF
--- a/packages/launch/src/focused-launch/plan-details/index.tsx
+++ b/packages/launch/src/focused-launch/plan-details/index.tsx
@@ -78,6 +78,7 @@ const PlanDetails: React.FunctionComponent = () => {
 					CTAVariation="FULL_WIDTH"
 					locale={ locale }
 					hidePlansComparison
+					defaultAllPlansExpanded
 				/>
 			</div>
 		</div>

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -40,6 +40,7 @@ export interface Props {
 	popularBadgeVariation?: PopularBadgeVariation;
 	customTagLines?: CustomTagLinesMap;
 	hidePlansComparison?: boolean;
+	defaultAllPlansExpanded?: boolean;
 }
 
 const PlansGrid: React.FunctionComponent< Props > = ( {
@@ -57,6 +58,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 	popularBadgeVariation = 'ON_TOP',
 	customTagLines,
 	hidePlansComparison = false,
+	defaultAllPlansExpanded = false,
 } ) => {
 	const { __ } = useI18n();
 
@@ -90,6 +92,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 							disabledPlans={ disabledPlans }
 							locale={ locale }
 							showTaglines={ showPlanTaglines }
+							defaultAllPlansExpanded={ defaultAllPlansExpanded }
 						></PlansTable>
 					) }
 				</div>

--- a/packages/plans-grid/src/plans-table/index.tsx
+++ b/packages/plans-grid/src/plans-table/index.tsx
@@ -28,6 +28,7 @@ export interface Props {
 	CTAVariation?: CTAVariation;
 	popularBadgeVariation: PopularBadgeVariation;
 	customTagLines?: CustomTagLinesMap;
+	defaultAllPlansExpanded?: boolean;
 }
 
 const PlansTable: React.FunctionComponent< Props > = ( {
@@ -41,10 +42,11 @@ const PlansTable: React.FunctionComponent< Props > = ( {
 	CTAVariation = 'NORMAL',
 	popularBadgeVariation = 'ON_TOP',
 	customTagLines,
+	defaultAllPlansExpanded = false,
 } ) => {
 	const supportedPlans = useSelect( ( select ) => select( PLANS_STORE ).getSupportedPlans() );
 	const prices = useSelect( ( select ) => select( PLANS_STORE ).getPrices( locale ) );
-	const [ allPlansExpanded, setAllPlansExpanded ] = useState( false );
+	const [ allPlansExpanded, setAllPlansExpanded ] = useState( defaultAllPlansExpanded );
 
 	return (
 		<div className="plans-table">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This boolean allows the PlansTable users to decide the default state of accordion plan items.
* I then use that boolean in Focused Launch.

#### Testing instructions

In Focused Launch

- Visit the plan details page on a mobile viewport
- All plans should be expanded

Fixes #47859
