### PR TITLE
Deduplicate acorn

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6993,12 +6993,7 @@ acorn@^6.0.1, acorn@^6.1.1, acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^7.0.0, acorn@^7.1.0, acorn@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
-  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
-
-acorn@^7.4.0:
+acorn@^7.0.0, acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `acorn` (done automatically with `npx yarn-deduplicate --packages acorn`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> acorn@7.1.1
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> acorn@7.1.1
< wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> acorn@7.1.1
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> acorn@7.1.1
< wp-calypso@0.17.0 -> webpack-bundle-analyzer@3.7.0 -> ... -> acorn@7.1.1
> wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> acorn@7.4.1
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> acorn@7.4.1
> wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> acorn@7.4.1
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> acorn@7.4.1
> wp-calypso@0.17.0 -> webpack-bundle-analyzer@3.7.0 -> ... -> acorn@7.4.1
```