### PR TITLE
Deduplicate acorn-jsx

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6954,12 +6954,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.0.1, acorn-jsx@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
-  integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
-
-acorn-jsx@^5.2.0:
+acorn-jsx@^5.0.1, acorn-jsx@^5.1.0, acorn-jsx@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
   integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `acorn-jsx` (done automatically with `npx yarn-deduplicate --packages acorn-jsx`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> acorn-jsx@5.1.0
< wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> acorn-jsx@5.1.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> acorn-jsx@5.2.0
> wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> acorn-jsx@5.2.0
```