### PR TITLE
Deduplicate ajv-keywords

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7103,12 +7103,7 @@ ajv-errors@^1.0.0, ajv-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
-ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
-  integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
-
-ajv-keywords@^3.5.2:
+ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `ajv-keywords` (done automatically with `npx yarn-deduplicate --packages ajv-keywords`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> ajv-keywords@3.4.1
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> ajv-keywords@3.4.1
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> ajv-keywords@3.4.1
< wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> ajv-keywords@3.4.1
< wp-calypso@0.17.0 -> webpack@4.44.2 -> ... -> ajv-keywords@3.4.1
> wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> ajv-keywords@3.5.2
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> ajv-keywords@3.5.2
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> ajv-keywords@3.5.2
> wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> ajv-keywords@3.5.2
> wp-calypso@0.17.0 -> webpack@4.44.2 -> ... -> ajv-keywords@3.5.2
```