### PR TITLE
Add notice about the current payment method when it's not available to select on the Update Payment Method page

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -50,6 +50,7 @@ function createPurchaseObject( purchase ) {
 			type: purchase.payment_type,
 			countryCode: purchase.payment_country_code,
 			countryName: purchase.payment_country_name,
+			storedDetailsId: purchase.stored_details_id,
 		},
 		pendingTransfer: Boolean( purchase.pending_transfer ),
 		productId: Number( purchase.product_id ),

--- a/client/lib/purchases/test/assembler.js
+++ b/client/lib/purchases/test/assembler.js
@@ -27,6 +27,7 @@ describe( 'assembler', () => {
 	test( 'should convert the payment credit card data to the right data structure', () => {
 		const purchase = createPurchasesArray( [
 			{
+				stored_details_id: 1234,
 				payment_card_id: 1234,
 				payment_card_type: 'visa',
 				payment_details: 7890,
@@ -49,5 +50,6 @@ describe( 'assembler', () => {
 		expect( payment.countryCode ).to.equal( 'US' );
 		expect( payment.countryName ).to.equal( 'United States' );
 		expect( payment.name ).to.equal( 'My VISA' );
+		expect( payment.storedDetailsId ).to.equal( 1234 );
 	} );
 } );

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -379,23 +379,30 @@ function CurrentPaymentMethodNotAvailableNotice( { purchase } ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const storedPaymentAgreements = useSelector( getStoredPaymentAgreements );
-
-	let noticeText = '';
+	const noticeProps = { showDismiss: false };
 
 	if ( creditCardHasAlreadyExpired( purchase ) ) {
-		noticeText = translate( 'Your %(cardType)s ending in %(cardNumber)d expired %(cardExpiry)s.', {
-			args: {
-				cardType: purchase.payment.creditCard.type.toUpperCase(),
-				cardNumber: parseInt( purchase.payment.creditCard.number, 10 ),
-				cardExpiry: moment( purchase.payment.creditCard.expiryDate, 'MM/YY' ).format( 'MMMM YYYY' ),
-			},
-		} );
-	} else if ( getCurrentPaymentMethodId( purchase.payment ) === 'paypal' ) {
+		noticeProps.text = translate(
+			'Your %(cardType)s ending in %(cardNumber)d expired %(cardExpiry)s.',
+			{
+				args: {
+					cardType: purchase.payment.creditCard.type.toUpperCase(),
+					cardNumber: parseInt( purchase.payment.creditCard.number, 10 ),
+					cardExpiry: moment( purchase.payment.creditCard.expiryDate, 'MM/YY' ).format(
+						'MMMM YYYY'
+					),
+				},
+			}
+		);
+		return <Notice { ...noticeProps } />;
+	}
+
+	if ( getCurrentPaymentMethodId( purchase.payment ) === 'paypal' ) {
 		const storedPaymentAgreement = storedPaymentAgreements.find(
 			( agreement ) => agreement.stored_details_id === purchase.payment.storedDetailsId
 		);
 		if ( storedPaymentAgreement?.email ) {
-			noticeText = translate(
+			noticeProps.text = translate(
 				'This purchase is currently billed to your PayPal account (%(emailAddress)s).',
 				{
 					args: {
@@ -403,12 +410,14 @@ function CurrentPaymentMethodNotAvailableNotice( { purchase } ) {
 					},
 				}
 			);
-		} else {
-			noticeText = translate( 'This purchase is currently billed to your PayPal account.' );
+			return <Notice { ...noticeProps } />;
 		}
+
+		noticeProps.text = translate( 'This purchase is currently billed to your PayPal account.' );
+		return <Notice { ...noticeProps } />;
 	}
 
-	return noticeText && <Notice text={ noticeText } showDismiss={ false } />;
+	return null;
 }
 
 const mapStateToProps = ( state, { cardId, purchaseId } ) => ( {

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -5,7 +5,6 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Fragment, useMemo, useCallback } from 'react';
 import { connect, useSelector, useDispatch } from 'react-redux';
-import { find, some } from 'lodash';
 import { createStripeSetupIntent, StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import {
 	CheckoutProvider,
@@ -199,7 +198,11 @@ function getChangePaymentMethodTitleCopy( currentPaymentMethodId ) {
 
 // We want to preselect the current method if it is in the list, but if not, preselect the first method.
 function getInitiallySelectedPaymentMethodId( currentlyAssignedPaymentMethodId, paymentMethods ) {
-	if ( ! some( paymentMethods, [ 'id', currentlyAssignedPaymentMethodId ] ) ) {
+	if (
+		! paymentMethods.some(
+			( paymentMethod ) => paymentMethod.id === currentlyAssignedPaymentMethodId
+		)
+	) {
 		return paymentMethods?.[ 0 ]?.id;
 	}
 
@@ -235,10 +238,9 @@ function ChangePaymentMethodList( {
 		notices.success( message, { persistent: true, duration: 5000 } );
 	}, [] );
 
-	const currentPaymentMethodNotAvailable = ! some( paymentMethods, [
-		'id',
-		currentlyAssignedPaymentMethodId,
-	] );
+	const currentPaymentMethodNotAvailable = ! paymentMethods.some(
+		( paymentMethod ) => paymentMethod.id === currentlyAssignedPaymentMethodId
+	);
 
 	return (
 		<CheckoutProvider
@@ -389,10 +391,9 @@ function CurrentPaymentMethodNotAvailableNotice( { purchase } ) {
 			},
 		} );
 	} else if ( getCurrentPaymentMethodId( purchase.payment ) === 'paypal' ) {
-		const storedPaymentAgreement = find( storedPaymentAgreements, [
-			'stored_details_id',
-			purchase.payment.storedDetailsId,
-		] );
+		const storedPaymentAgreement = storedPaymentAgreements.find(
+			( agreement ) => agreement.stored_details_id === purchase.payment.storedDetailsId
+		);
 		if ( storedPaymentAgreement?.email ) {
 			noticeText = translate(
 				'This purchase is currently billed to your PayPal account (%(emailAddress)s).',

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -103,6 +103,7 @@ describe( 'selectors', () => {
 					countryName: undefined,
 					name: undefined,
 					type: undefined,
+					storedDetailsId: undefined,
 				},
 				priceText: undefined,
 				productId: NaN,


### PR DESCRIPTION
### Changes proposed in this Pull Request

When a purchase is currently being billed to an expired card or PayPal, that existing payment method is unavailable to select on the page for changing the purchase's payment method.  This pull request adds a message on the screen in each of those cases which should help make the user aware of their current payment method and the fact that if they make a selection on this page they'll be switching to something else.

It also standardizes the behavior of pre-selecting the first payment method in the list when the current payment method is unavailable.  That was already done for PayPal in https://github.com/Automattic/wp-calypso/pull/48466, but I'm extending it to expired cards here for consistency.

**Before (expired card):**

![expired-card-before](https://user-images.githubusercontent.com/235183/103041392-430dc280-4544-11eb-9812-f76879c03557.png)

**After (expired card):**

![expired-card-after](https://user-images.githubusercontent.com/235183/103041397-46a14980-4544-11eb-97c9-56e5fa479989.png)

**Before (PayPal):**

![paypal-before](https://user-images.githubusercontent.com/235183/103041404-4acd6700-4544-11eb-8cce-4d2a5f8f3c96.png)

**After (PayPal):**

![paypal-after](https://user-images.githubusercontent.com/235183/103041691-20c87480-4545-11eb-9990-7e0bbb99b48f.png)

### Testing instructions

Pay for a subscription with PayPal, visit it on the Manage Purchases page, and select the "Change Payment Method" option.  Look for the new message on the resulting page.

You can do the same thing for a subscription paid for with an expired card, but that is harder to test (since you can't add an already-expired card in the first place).  The best way to test may be to edit the WordPress.com sandbox database on the server to force an existing card to have an expiration date in the past.

In any other scenario (subscription paid with a non-expired card, subscription with a deleted payment method, etc.) there should be no changes.

Fixes https://github.com/Automattic/wp-calypso/issues/48433