### PR TITLE
Coming Soon: add php unit tests

### DIFF
--- a/apps/editing-toolkit/README.md
+++ b/apps/editing-toolkit/README.md
@@ -27,6 +27,7 @@ The following items did not change:
 - `editing-toolkit-plugin/`: The root of the editing toolkit plugin.
   - `full-site-editing-plugin.php`: All initialization code should go here.
   - `block-patterns/`: Additional block patterns for Gutenberg.
+  - `coming-soon/`: Coming Soon page and associated functionality.
   - `common/`: General functionality which doesn't fit a specific feature and is always executed.
   - `dotcom-fse/`: (_deprecated_) An early experiment for a consistent site editing experience in Gutenberg. (Superceeded by the site-editor work in Gutenberg.)
   - `e2e-test-helpers/`: Functions to assist with e2e tests in Puppeteer.
@@ -136,6 +137,14 @@ If you wish to "watch" and run tests on file change then run:
 // Note the additional `:watch` below
 yarn test:js:watch
 ```
+
+To run PHP units tests:
+
+```shell
+yarn run test:php
+```
+
+Making sure you add your test suite to `editing-toolkit-plugin/phpunit.xml.dist`
 
 ### Troubleshooting wp-env
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -67,7 +67,8 @@ function render_fallback_coming_soon_page() {
  * @return array current value of `wpcom_public_coming_soon`
  */
 function add_public_coming_soon_to_settings_endpoint_get( $options ) {
-	$options['wpcom_public_coming_soon'] = (int) get_option( 'wpcom_public_coming_soon' );
+	$wpcom_public_coming_soon            = (int) get_option( 'wpcom_public_coming_soon' );
+	$options['wpcom_public_coming_soon'] = $wpcom_public_coming_soon;
 
 	return $options;
 }
@@ -94,15 +95,17 @@ add_filter( 'rest_api_update_site_settings', __NAMESPACE__ . '\add_public_coming
  * This can happen due to clicking the launch button from the banner
  * Or due to manually updating the setting in wp-admin or calypso settings page.
  *
- * @param string $old_value the old value of blog_public.
- * @param string $value     the new value of blog_public.
+ * @param  string $old_value the old value of blog_public.
+ * @param  string $value     the new value of blog_public.
+ * @return bool              whether an update occurred.
  */
 function disable_coming_soon_on_privacy_change( $old_value, $value ) {
 	if ( 0 !== (int) $old_value || 0 === (int) $value ) {
 		// Do nothing if not moving from public-not-indexed.
-		return;
+		return false;
 	}
 	update_option( 'wpcom_public_coming_soon', 0 );
+	return true;
 }
 add_action( 'update_option_blog_public', __NAMESPACE__ . '\disable_coming_soon_on_privacy_change', 10, 2 );
 
@@ -116,11 +119,14 @@ add_action( 'update_option_blog_public', __NAMESPACE__ . '\disable_coming_soon_o
  * @param string $path       Site path.
  * @param int    $network_id Network ID. Only relevant on multi-network installations.
  * @param array  $meta       Meta data. Used to set initial site options.
+ * @return bool              whether an update occurred.
  */
 function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $network_id, $meta ) {
 	if ( 0 === $meta['public'] && 1 === (int) $meta['options']['wpcom_public_coming_soon'] ) {
 		add_blog_option( $blog_id, 'wpcom_public_coming_soon', 1 );
+		return true;
 	}
+	return false;
 }
 // phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed
 add_action( 'wpmu_new_blog', __NAMESPACE__ . '\add_option_to_new_site', 10, 6 );

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -123,7 +123,9 @@ add_action( 'update_option_blog_public', __NAMESPACE__ . '\disable_coming_soon_o
  */
 function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $network_id, $meta ) {
 	if ( 0 === $meta['public'] && 1 === (int) $meta['options']['wpcom_public_coming_soon'] ) {
-		update_option( 'wpcom_public_coming_soon', 1 );
+		if ( function_exists( 'add_blog_option' ) ) {
+			add_blog_option( $blog_id, 'wpcom_public_coming_soon', 1 );
+		}
 		return true;
 	}
 	return false;

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -123,7 +123,7 @@ add_action( 'update_option_blog_public', __NAMESPACE__ . '\disable_coming_soon_o
  */
 function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $network_id, $meta ) {
 	if ( 0 === $meta['public'] && 1 === (int) $meta['options']['wpcom_public_coming_soon'] ) {
-		add_blog_option( $blog_id, 'wpcom_public_coming_soon', 1 );
+		update_option( 'wpcom_public_coming_soon', 1 );
 		return true;
 	}
 	return false;

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/test/class-coming-soon-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/test/class-coming-soon-test.php
@@ -12,19 +12,11 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../coming-soon.php';
 
 /**
- * Class Is_FSE_Active_Test
+ * Class Coming_Soon_Test
  */
 class Coming_Soon_Test extends TestCase {
 	/**
-	 * Pre-test suite set up.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-		apply_filters( 'a8c_enable_public_coming_soon', '__return_true' );
-	}
-
-	/**
-	 * Post-test uite actions.
+	 * Post-test suite actions.
 	 */
 	public static function tearDownAfterClass() {
 		self::delete_coming_soon_site_options();

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/test/class-coming-soon-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/test/class-coming-soon-test.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Coming Soon Tests File
+ *
+ * @package full-site-editing-plugin
+ */
+
+namespace A8C\FSE\Coming_soon;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../coming-soon.php';
+
+/**
+ * Class Is_FSE_Active_Test
+ */
+class Coming_Soon_Test extends TestCase {
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		apply_filters( 'a8c_enable_public_coming_soon', '__return_true' );
+	}
+
+	public static function tearDownAfterClass() {
+		self::delete_coming_soon_site_options();
+		parent::tearDownAfterClass();
+	}
+
+	private static function set_site_as_coming_soon() {
+		self::delete_coming_soon_site_options();
+		add_option( 'blog_public', 0 );
+		add_option( 'wpcom_public_coming_soon', 1 );
+	}
+
+	private static function delete_coming_soon_site_options() {
+		delete_option( 'blog_public' );
+		delete_option( 'wpcom_public_coming_soon' );
+	}
+
+	public function test_disable_coming_soon_on_privacy_change() {
+		self::set_site_as_coming_soon();
+
+		// Should deactivate Coming Soon when moving from public not indexed to public indexed (launch)
+		$result = disable_coming_soon_on_privacy_change( 0, 1 );
+		$this->assertTrue( $result );
+		$this->assertEquals( 0, get_option( 'wpcom_public_coming_soon' ) );
+
+		self::set_site_as_coming_soon();
+
+		// Should not deactivate when moving from public indexed to public not indexed
+		$result = disable_coming_soon_on_privacy_change( 1, 0 );
+		$this->assertFalse( $result );
+		$this->assertEquals( 1, get_option( 'wpcom_public_coming_soon' ) );
+
+		self::set_site_as_coming_soon();
+
+		// Should not deactivate when moving from private to public
+		$result = disable_coming_soon_on_privacy_change( -1, 1 );
+		$this->assertFalse( $result );
+		$this->assertEquals( 1, get_option( 'wpcom_public_coming_soon' ) );
+	}
+
+	public function test_add_public_coming_soon_to_settings_endpoint_post() {
+		$input            = array();
+		$unfiltered_input = array( 'wpcom_public_coming_soon' => '111111' );
+		$result           = add_public_coming_soon_to_settings_endpoint_post( $input, $unfiltered_input );
+
+		$this->assertEquals( 111111, $result['wpcom_public_coming_soon'] );
+	}
+
+	public function test_add_public_coming_soon_to_settings_endpoint_get() {
+		self::delete_coming_soon_site_options();
+		$options = array();
+		self::set_site_as_coming_soon();
+		$result = add_public_coming_soon_to_settings_endpoint_get( $options );
+
+		$this->assertEquals( 1, $result['wpcom_public_coming_soon'] );
+	}
+
+
+	public function test_add_option_to_new_site() {
+		self::delete_coming_soon_site_options();
+		$this->assertEquals( 0, get_option( 'wpcom_public_coming_soon' ) );
+		$meta   = array(
+			'public'  => 0,
+			'options' => array( 'wpcom_public_coming_soon' => 1 ),
+		);
+		$result = add_option_to_new_site( get_current_blog_id(), null, null, null, null, $meta );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( 1, get_option( 'wpcom_public_coming_soon' ) );
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/test/class-coming-soon-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/test/class-coming-soon-test.php
@@ -15,79 +15,151 @@ require_once __DIR__ . '/../coming-soon.php';
  * Class Is_FSE_Active_Test
  */
 class Coming_Soon_Test extends TestCase {
-
+	/**
+	 * Pre-test suite set up.
+	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 		apply_filters( 'a8c_enable_public_coming_soon', '__return_true' );
 	}
 
+	/**
+	 * Post-test uite actions.
+	 */
 	public static function tearDownAfterClass() {
 		self::delete_coming_soon_site_options();
 		parent::tearDownAfterClass();
 	}
 
+	/**
+	 * Add coming soon options.
+	 */
 	private static function set_site_as_coming_soon() {
 		self::delete_coming_soon_site_options();
 		add_option( 'blog_public', 0 );
 		add_option( 'wpcom_public_coming_soon', 1 );
 	}
 
+	/**
+	 * Remove coming soon options.
+	 */
 	private static function delete_coming_soon_site_options() {
 		delete_option( 'blog_public' );
 		delete_option( 'wpcom_public_coming_soon' );
 	}
 
+	/**
+	 * Tests that we update the coming soon option when the public option moves
+	 * from public not indexed to anything.
+	 */
 	public function test_disable_coming_soon_on_privacy_change() {
 		self::set_site_as_coming_soon();
 
-		// Should deactivate Coming Soon when moving from public not indexed to public indexed (launch)
+		// Should deactivate Coming Soon when moving from public not indexed to public indexed (launch).
 		$result = disable_coming_soon_on_privacy_change( 0, 1 );
 		$this->assertTrue( $result );
 		$this->assertEquals( 0, get_option( 'wpcom_public_coming_soon' ) );
 
 		self::set_site_as_coming_soon();
 
-		// Should not deactivate when moving from public indexed to public not indexed
+		// Should deactivate Coming Soon when moving from public not indexed to private.
+		$result = disable_coming_soon_on_privacy_change( 0, -1 );
+		$this->assertTrue( $result );
+		$this->assertEquals( 0, get_option( 'wpcom_public_coming_soon' ) );
+
+		self::set_site_as_coming_soon();
+
+		// Should not deactivate when moving from public indexed to public not indexed.
 		$result = disable_coming_soon_on_privacy_change( 1, 0 );
 		$this->assertFalse( $result );
 		$this->assertEquals( 1, get_option( 'wpcom_public_coming_soon' ) );
 
 		self::set_site_as_coming_soon();
 
-		// Should not deactivate when moving from private to public
+		// Should not deactivate when moving from private to public.
 		$result = disable_coming_soon_on_privacy_change( -1, 1 );
 		$this->assertFalse( $result );
 		$this->assertEquals( 1, get_option( 'wpcom_public_coming_soon' ) );
 	}
 
+	/**
+	 * Tests that we add the unfiltered option to the return value.
+	 */
 	public function test_add_public_coming_soon_to_settings_endpoint_post() {
-		$input            = array();
+		$input  = array();
+		$result = add_public_coming_soon_to_settings_endpoint_post( $input, array() );
+
+		$this->assertEquals( $input, $result );
+
 		$unfiltered_input = array( 'wpcom_public_coming_soon' => '111111' );
 		$result           = add_public_coming_soon_to_settings_endpoint_post( $input, $unfiltered_input );
 
 		$this->assertEquals( 111111, $result['wpcom_public_coming_soon'] );
 	}
 
+	/**
+	 * Tests that we add the coming soon option to the return value.
+	 */
 	public function test_add_public_coming_soon_to_settings_endpoint_get() {
 		self::delete_coming_soon_site_options();
 		$options = array();
+		$result  = add_public_coming_soon_to_settings_endpoint_get( $options );
+		$this->assertEquals( 0, $result['wpcom_public_coming_soon'] );
+
+		// Now set the coming soon option to `1`.
 		self::set_site_as_coming_soon();
 		$result = add_public_coming_soon_to_settings_endpoint_get( $options );
 
 		$this->assertEquals( 1, $result['wpcom_public_coming_soon'] );
 	}
 
-
-	public function test_add_option_to_new_site() {
+	/**
+	 * Tests that we're adding the right option value on site creation
+	 * when the coming soon option is added to the meta.
+	 */
+	public function test_add_option_to_new_site_with_coming_soon_meta() {
 		self::delete_coming_soon_site_options();
-		$this->assertEquals( 0, get_option( 'wpcom_public_coming_soon' ) );
-		$meta   = array(
+
+		$meta = array(
 			'public'  => 0,
 			'options' => array( 'wpcom_public_coming_soon' => 1 ),
 		);
+
+		// Check that the function updates the option and returns `true`.
 		$result = add_option_to_new_site( get_current_blog_id(), null, null, null, null, $meta );
 
 		$this->assertTrue( $result );
 		$this->assertEquals( 1, get_option( 'wpcom_public_coming_soon' ) );
+
+		// Check that we've added the action correctly.
+		self::delete_coming_soon_site_options();
+		$this->assertEquals( 0, get_option( 'wpcom_public_coming_soon' ) );
+		do_action( 'wpmu_new_blog', get_current_blog_id(), null, null, null, null, $meta );
+		$this->assertEquals( 1, get_option( 'wpcom_public_coming_soon' ) );
+	}
+
+	/**
+	 * Tests that we're adding the right option value on site creation
+	 * when the coming soon option is not available in the meta.
+	 */
+	public function test_add_option_to_new_site_without_coming_soon_meta() {
+		self::delete_coming_soon_site_options();
+
+		$meta = array(
+			'public'  => 0,
+			'options' => array(),
+		);
+
+		// Check that the function updates the option and returns `true`.
+		$result = add_option_to_new_site( get_current_blog_id(), null, null, null, null, $meta );
+
+		$this->assertFalse( $result );
+		$this->assertEquals( 0, get_option( 'wpcom_public_coming_soon' ) );
+
+		// Check that we've added the action correctly.
+		self::delete_coming_soon_site_options();
+
+		do_action( 'wpmu_new_blog', get_current_blog_id(), null, null, null, null, $meta );
+		$this->assertEquals( 0, get_option( 'wpcom_public_coming_soon' ) );
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit.xml.dist
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit.xml.dist
@@ -6,6 +6,9 @@
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
 	>
+    <php>
+        <const name="WP_TESTS_MULTISITE" value="1" />
+    </php>
 	<testsuites>
 		<testsuite name="default">
 			<directory suffix="-test.php">./phpunit/</directory>

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit.xml.dist
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit.xml.dist
@@ -13,5 +13,8 @@
 		<testsuite name="block-patterns">
 			<directory suffix="-test.php">./block-patterns/test/</directory>
 		</testsuite>
+		<testsuite name="coming-soon">
+			<directory suffix="-test.php">./coming-soon/test/</directory>
+		</testsuite>
 	</testsuites>
 </phpunit>


### PR DESCRIPTION
##  Changes proposed in this Pull Request

Adding PHP units for coming soon. 

Also updating comments on the Readme to add coming soon and a references to the php unit tests command.

## Testing instructions

### Manual tests

Run `yarn dev --sync` create a new site. Sandbox that site, and check that it's in Coming Soon mode. 

### Unit tests

From `apps/editing-toolkit` run:

```
yarn run test:php
```
