### PR TITLE
Add an initial sync to remove need to make an edit for sync to happen

### DIFF
--- a/apps/editing-toolkit/bin/wpcom-watch-and-sync.sh
+++ b/apps/editing-toolkit/bin/wpcom-watch-and-sync.sh
@@ -4,5 +4,7 @@ LOCAL_PATH="./editing-toolkit-plugin/"
 REMOTE_PATH="/home/wpcom/public_html/wp-content/plugins/full-site-editing-plugin/dev"
 REMOTE_SSH="wpcom-sandbox"
 COMMAND="rsync -ahz $LOCAL_PATH $REMOTE_SSH:$REMOTE_PATH"
-
+echo "Running initial sync"
+$COMMAND
+echo "Starting watch"
 npx chokidar "$LOCAL_PATH**" --debounce 1000 --throttle 10000 -c "$COMMAND"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sync files first before adding the watch

#### Testing instructions

* Run `editing-toolkit/bin/wpcom-watch-and-sync.sh` and check that there is an initial sync to sandbox before the file watcher starts


