### PR TITLE
Revert "Remove the Traffic Guide from Jetpack sites for now"

### DIFF
--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -11,8 +11,7 @@ import config from 'calypso/config';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
 import { hasTrafficGuidePurchase } from 'calypso/my-sites/marketing/ultimate-traffic-guide';
@@ -54,12 +53,9 @@ export const MarketingTools: FunctionComponent = () => {
 	const dispatch = useDispatch();
 	const recordTracksEvent = ( event: string ) => dispatch( recordTracksEventAction( event ) );
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) ) || 0;
-	const siteId = useSelector( getSelectedSiteId );
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( ( state ) =>
 		getSelectedSiteSlug( state )
 	);
-
 	const purchases = useSelector( ( state ) => getUserPurchases( state, userId ) );
 
 	const handleBusinessToolsClick = () => {
@@ -235,7 +231,7 @@ export const MarketingTools: FunctionComponent = () => {
 					</Button>
 				</MarketingToolsFeature>
 
-				{ isEnglish && ! isJetpack && (
+				{ isEnglish && (
 					<MarketingToolsFeature
 						title={ translate( 'Introducing the WordPress.com Ultimate Traffic Guide' ) }
 						description={ translate(

--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -15,7 +15,7 @@ import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { getProductCost, isProductsListFetching } from 'calypso/state/products-list/selectors';
 import { isFetchingUserPurchases, getUserPurchases } from 'calypso/state/purchases/selectors';
 import { getCurrentUserCurrencyCode, getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import Experiment, {
@@ -83,7 +83,6 @@ const SalesPage = ( { translate } ) => {
 	const isLoading = useSelector( ( state ) => isProductsListFetching( state ) );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 
 	/**
 	 * The reference cost is calculated to the nearest 100
@@ -95,17 +94,9 @@ const SalesPage = ( { translate } ) => {
 
 	const cta = () => (
 		<p>
-			{ isJetpack ? (
-				<em>
-					{ translate(
-						'The Ultimate Traffic Guide is currently only available on WordPress.com sites.'
-					) }
-				</em>
-			) : (
-				<Button href={ `/checkout/${ siteSlug }/${ WPCOM_TRAFFIC_GUIDE }` } primary>
-					{ translate( 'Click here to buy the guide now!' ) }
-				</Button>
-			) }
+			<Button href={ `/checkout/${ siteSlug }/${ WPCOM_TRAFFIC_GUIDE }` } primary>
+				{ translate( 'Click here to buy the guide now!' ) }
+			</Button>
 		</p>
 	);
 


### PR DESCRIPTION
After we introduced Traffic Guides for Jetpack, this restriction is no longer necessary. See D54725-code and  #48599

Reverts Automattic/wp-calypso#48540