### PR TITLE
Add tooltip next to "Store" link in my sites sidebar for store deprecation

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -662,6 +662,8 @@ export class MySitesSidebar extends Component {
 
 	store() {
 		const { translate, site, siteSuffix, canUserUseStore } = this.props;
+		const isCalypsoStoreDeprecatedOrRemoved =
+			isEnabled( 'woocommerce/store-deprecated' ) || isEnabled( 'woocommerce/store-removed' );
 
 		if ( ! isEnabled( 'woocommerce/extension-dashboard' ) || ! site ) {
 			return null;
@@ -688,7 +690,7 @@ export class MySitesSidebar extends Component {
 				materialIcon="shopping_cart"
 				forceInternalLink
 			>
-				{ isEnabled( 'woocommerce/store-deprecated' ) && isBusiness( site.plan ) && (
+				{ isCalypsoStoreDeprecatedOrRemoved && isBusiness( site.plan ) && (
 					<InfoPopover className="sidebar__store-tooltip" position="bottom right">
 						<div>{ translate( 'Store is moving to WooCommerce' ) }.</div>
 						<ExternalLink href="https://wordpress.com/support/store/">

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -688,7 +688,7 @@ export class MySitesSidebar extends Component {
 				materialIcon="shopping_cart"
 				forceInternalLink
 			>
-				{ isEnabled( 'woocommerce/store-deprecated' ) && (
+				{ isEnabled( 'woocommerce/store-deprecated' ) && isBusiness( site.plan ) && (
 					<InfoPopover className="sidebar__store-tooltip" position="bottom right">
 						<div>{ translate( 'Store is moving to WooCommerce' ) }.</div>
 						<ExternalLink href="https://wordpress.com/support/store/">

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -692,10 +692,8 @@ export class MySitesSidebar extends Component {
 			>
 				{ isCalypsoStoreDeprecatedOrRemoved && isBusiness( site.plan ) && (
 					<InfoPopover className="sidebar__store-tooltip" position="bottom right">
-						<div>{ translate( 'Store is moving to WooCommerce' ) }.</div>
-						<ExternalLink href="https://wordpress.com/support/store/">
-							{ translate( 'More' ) }
-						</ExternalLink>
+						<div>{ 'Store is moving to WooCommerce' }.</div>
+						<ExternalLink href="https://wordpress.com/support/store/">{ 'More' }</ExternalLink>
 					</InfoPopover>
 				) }
 			</SidebarItem>

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -85,6 +85,7 @@ import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import { isUnderDomainManagementAll } from 'calypso/my-sites/domains/paths';
 import { isUnderEmailManagementAll } from 'calypso/my-sites/email/paths';
 import JetpackSidebarMenuItems from 'calypso/components/jetpack/sidebar/menu-items/calypso';
+import InfoPopover from 'calypso/components/info-popover';
 import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
 import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
 import { isP2PlusPlan } from 'calypso/lib/plans';
@@ -686,7 +687,16 @@ export class MySitesSidebar extends Component {
 				onNavigate={ this.trackStoreClick }
 				materialIcon="shopping_cart"
 				forceInternalLink
-			/>
+			>
+				{ isEnabled( 'woocommerce/store-deprecated' ) && (
+					<InfoPopover className="sidebar__store-tooltip" position="bottom right">
+						<div>{ translate( 'Store is moving to WooCommerce' ) }.</div>
+						<ExternalLink href="https://wordpress.com/support/store/">
+							{ translate( 'More' ) }
+						</ExternalLink>
+					</InfoPopover>
+				) }
+			</SidebarItem>
 		);
 	}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -15,3 +15,27 @@
 	filter: brightness( 100 );
 	-webkit-filter: brightness( 100 );
 }
+
+.sidebar__store-tooltip {
+	&.popover.info-popover__tooltip {
+		&.is-bottom .popover__arrow::before,
+		&.is-bottom-left .popover__arrow::before,
+		&.is-bottom-right .popover__arrow::before {
+			border-bottom-color: var( --color-neutral-100 );
+		}
+
+		.popover__inner {
+			display: flex;
+			align-items: center;
+			max-width: 300px;
+			color: var( --color-text-inverted );
+			background-color: var( --color-neutral-100 );
+		}
+
+		.external-link {
+			margin-left: 8px;
+			color: var( --color-text-inverted );
+			text-decoration: underline;
+		}
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a clickable tooltip button next to Store sidebar menu item for business plan sites. 

- The tooltip is built using the `InfoPopover` component, which allows it to contain links.
- Tooltip should appear only for sites with a Business plan that have the WooCommerce plugin installed.
- It is behind the feature flags `woocommerce/store-deprecated` and `woocommerce/store-removed`.

Fixes #48200.

![image](https://user-images.githubusercontent.com/3747241/103073756-24bacc00-4603-11eb-82f6-64af58f74c85.png)

#### Testing instructions

_Instructions copied and modified from https://github.com/Automattic/wp-calypso/pull/48288_

##### Verify that with the feature flags disabled, the experience is not modified

* Run branch with the feature flags disabled (the default)
* Verify that the existing experience is not modified at all

##### Verify that with the feature flag enabled, the experience is modified

* Run branch with the `woocommerce/store-deprecated` enabled

```
ENABLE_FEATURES=woocommerce/store-deprecated yarn start
```

or, by appending the following to your URL: 

```
/?flags=woocommerce/store-deprecated
```

* Verify that the tooltip button does not appear for a site with the Personal plan
* Verify that the tooltip button does not appear for a site with the eCommerce plan
* Verify that the tooltip button appears for a site with the Business plan with the WooCommerce plugin activated
* Clicking on the info button will pop up a tooltip with a link to Store documentation
