### PR TITLE
Redirect to checkout thank you page for traffic guide purchases

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -182,8 +182,18 @@ export default function getThankYouPageUrl( {
 	}
 
 	// Display mode is used to show purchase specific messaging, for e.g. the Schedule Session button
-	// when purchasing a concierge session.
+	// when purchasing a concierge session or when purchasing the Ultimate Traffic Guide
 	const displayModeParam = getDisplayModeParamFromCart( cart );
+
+	const thankYouPageUrlForTrafficGuide = getThankYouPageUrlForTrafficGuide( {
+		cart,
+		siteSlug,
+		pendingOrReceiptId,
+	} );
+	if ( thankYouPageUrlForTrafficGuide ) {
+		return getUrlWithQueryParam( thankYouPageUrlForTrafficGuide, displayModeParam );
+	}
+
 	if ( isEligibleForSignupDestinationResult && urlFromCookie ) {
 		debug( 'is eligible for signup destination', urlFromCookie );
 		return getUrlWithQueryParam( urlFromCookie, displayModeParam );
@@ -442,5 +452,20 @@ function modifyCookieUrlIfAtomic(
 
 	if ( updatedUrl !== urlFromCookie ) {
 		saveUrlToCookie( updatedUrl );
+	}
+}
+
+function getThankYouPageUrlForTrafficGuide( {
+	cart,
+	siteSlug,
+	pendingOrReceiptId,
+}: {
+	cart: ResponseCart | undefined;
+	siteSlug: string | undefined;
+	pendingOrReceiptId: string;
+} ) {
+	if ( ! cart ) return;
+	if ( hasTrafficGuide( cart ) ) {
+		return `/checkout/thank-you/${ siteSlug }/${ pendingOrReceiptId }`;
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -758,4 +758,22 @@ describe( 'getThankYouPageUrl', () => {
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd?d=traffic-guide' );
 	} );
+
+	it( 'redirects to thank you page (with traffic guide display mode) if traffic guide is in cart and site has a non-atomic jetpack plan', () => {
+		const cart = {
+			products: [
+				{
+					product_slug: 'traffic-guide',
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+			receiptId: '1234abcd',
+			isJetpackNotAtomic: true,
+		} );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd?d=traffic-guide' );
+	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This patch forces the redirect URL to be the thank you page with `traffic-guide` set as the `displayParam` if the user has purchased the Traffic Guide product. This was necessary since the default behaviour for Jetpack enabled sites was to redirect to a Jetpack specific page.
* Adds a test for the above condition.

This PR can be merged independently but it depends on #48595 and D54725-code for manual testing.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D54725-code and ensure #48595 has been merged.
* Connect a Jetpack site to your WPCOM account.
* Go to Tools -> Marketing -> Introducing the WordPress.com Ultimate Traffic Guide
* Purchase the product.
* After checkout, a thank you page should be seen with a link to download the guide
![screenshot](https://d.pr/i/g54TE5+) **Image Link:** https://d.pr/i/g54TE5
* Test the same scenario for simple as well as atomic sites.