### PR TITLE
Jetpack Plans: remove color overrides on WordPress.com

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-i5/style.scss
@@ -24,7 +24,7 @@
 	width: 100%;
 	padding: 8px;
 
-	background-color: var( --studio-purple-50 );
+	background-color: var( --color-primary );
 	border-top-left-radius: inherit;
 	border-top-right-radius: inherit;
 	color: var( --color-text-inverted );
@@ -47,7 +47,7 @@
 	padding: 24px 32px;
 
 	.is-featured & {
-		border: solid 2px var( --studio-purple-50 );
+		border: solid 2px var( --color-primary );
 		border-top: none;
 		border-bottom-left-radius: inherit;
 		border-bottom-right-radius: inherit;

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -124,4 +124,16 @@
 			}
 		}
 	}
+
+	// On cloud.jetpack.com, we want to override the primary color, used on
+	// the featured product card, with --studio-purple-50.
+	.jetpack-product-card-i5.is-featured {
+		.jetpack-product-card-i5__header {
+			background-color: var( --studio-purple-50 );
+		}
+
+		.jetpack-product-card-i5__body {
+			border: solid 2px var( --studio-purple-50 );
+		}
+	}
 }

--- a/client/my-sites/plans/jetpack-plans/more-info-box/style.scss
+++ b/client/my-sites/plans/jetpack-plans/more-info-box/style.scss
@@ -33,7 +33,6 @@
 
 	border: solid 2px currentColor;
 	border-radius: 4px;
-	color: var( --studio-jetpack-green-40 );
 
 	font-size: 1rem;
 	font-weight: 700;
@@ -49,5 +48,9 @@
 .is-section-jetpack-cloud-pricing {
 	.more-info-box__more-container {
 		background-color: rgba( var( --studio-jetpack-green-10-rgb ), 0.1 );
+	}
+
+	.more-info-box__more-button.button {
+		color: var( --studio-jetpack-green-40 );
 	}
 }

--- a/client/my-sites/plans/jetpack-plans/style.scss
+++ b/client/my-sites/plans/jetpack-plans/style.scss
@@ -2,22 +2,6 @@
 	position: relative;
 }
 
-// Override WordPress.com primary colors with Jetpack Cloud primary colors.
-// This only affects the Plans grid and the Filter bar.
-.selector__main {
-	.plans-filter-bar,
-	.plans-filter-bar-i5,
-	.products-grid-alt,
-	.products-grid-alt-2,
-	.products-grid-i5__section {
-		--color-accent: var( --studio-jetpack-green-40 );
-		--color-primary: var( --studio-jetpack-green-40 );
-		--color-accent-60: var( --studio-jetpack-green-60 );
-		--color-primary-light: var( --studio-jetpack-green-40 );
-		--color-primary-dark: var( --studio-jetpack-green-60 );
-	}
-}
-
 .jetpack-plans__heading {
 	padding: 1rem 0;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 1164141197617539-as-1199641948041429

* Remove color overrides on WordPress.com without affecting Jetpack cloud.

#### Testing instructions

Prerequisite: a Jetpack site.

* Run this PR locally and start both Calypsos. You can also test it from the live URL but you will only be able to test Calypso Blue.
* On Calypso Blue, visit the `/plans/:site` replacing `:site` with your Jetpack site URL.
* Verify that the primary and other colors of the selected color scheme are honored.
* Change your user's color scheme and repeat the verification. Do the same with multiple color schemes.
* On Calypso Green, visit the `/pricing`.
* Verify that colors haven't changed at all and that the page looks exactly the same as in production.

#### Demo – Calypso Green
![jetpack cloud localhost_3001_pricing](https://user-images.githubusercontent.com/3418513/103104865-b416ae00-4608-11eb-9014-ab6a0f257189.png)

#### Demo – Calypso Blue

#### Aquatic
![calypso localhost_3000_plans_inquisitive-ray jurassic ninja_site=rcdev sa ngrok io](https://user-images.githubusercontent.com/3418513/103226601-4241ab80-490b-11eb-912c-91612b1f1b9f.png)

#### Classic Blue
![calypso localhost_3000_plans_inquisitive-ray jurassic ninja_site=rcdev sa ngrok io](https://user-images.githubusercontent.com/3418513/103226630-58e80280-490b-11eb-9f7e-1adf6a0d7b1e.png)

#### Classic Bright
![calypso localhost_3000_plans_inquisitive-ray jurassic ninja_site=rcdev sa ngrok io](https://user-images.githubusercontent.com/3418513/103226669-6b623c00-490b-11eb-8d43-0021e671ca18.png)

#### Classic Dark
![calypso localhost_3000_plans_inquisitive-ray jurassic ninja_site=rcdev sa ngrok io](https://user-images.githubusercontent.com/3418513/103226695-7cab4880-490b-11eb-8ad2-e9eedea2a05a.png)

#### Coffee
![calypso localhost_3000_plans_inquisitive-ray jurassic ninja_site=rcdev sa ngrok io copy](https://user-images.githubusercontent.com/3418513/103226568-2dfdae80-490b-11eb-95d8-9b72af11b0af.png)

### Contrast
![calypso localhost_3000_plans_inquisitive-ray jurassic ninja_site=rcdev sa ngrok io](https://user-images.githubusercontent.com/3418513/103226519-158d9400-490b-11eb-9b56-9aa1f011dfcc.png)

#### Midnight
![calypso localhost_3000_plans_inquisitive-ray jurassic ninja_site=rcdev sa ngrok io](https://user-images.githubusercontent.com/3418513/103226764-93ea3600-490b-11eb-9671-9ed24b15839c.png)

#### Sakura
![calypso localhost_3000_plans_inquisitive-ray jurassic ninja_site=rcdev sa ngrok io](https://user-images.githubusercontent.com/3418513/103226792-a06e8e80-490b-11eb-8520-b9e427110f3a.png)

