### PR TITLE
Changes experiment name of Traffic Guide sales page copy test

### DIFF
--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -271,7 +271,7 @@ const SalesPage = ( { translate } ) => {
 
 	return (
 		<>
-			<Experiment name="traffic_guide_copy_test">
+			<Experiment name="traffic_guide_copy_test_v2">
 				<DefaultVariation>{ defaultVariation() }</DefaultVariation>
 				<Variation name="treatment">{ treatmentVariation() }</Variation>
 				<LoadingVariations>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the experiment name of the sales page copy test to `traffic_guide_copy_test_v2`.
* Additional context: pbxNRc-De-p2#comment-1331

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Ensure that you haven't purchased the traffic guide, or follow the refund flow if you have purchased it.
* Navigate to `/marketing/ultimate-traffic-guide`.
* Make sure the sales page renders correctly.
* Switch to the `treatment` variant for the test.
* The alternate copy should be shown.