### PR TITLE
P2 Free: remove "Manage plan" btn

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -15,7 +15,7 @@ import classNames from 'classnames';
 import { Button } from '@automattic/components';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { isMonthly } from 'calypso/lib/plans/constants';
+import { isMonthly, PLAN_P2_FREE } from 'calypso/lib/plans/constants';
 import { getPlanClass, planLevelsMatch } from 'calypso/lib/plans';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -76,7 +76,7 @@ const PlanFeaturesActionsButton = ( {
 		onUpgradeClick();
 	};
 
-	if ( current && ! isInSignup ) {
+	if ( current && ! isInSignup && planType !== PLAN_P2_FREE ) {
 		return (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				{ canPurchase ? translate( 'Manage plan' ) : translate( 'View plan' ) }


### PR DESCRIPTION
In this PR, we hide the "Manage plan" button for the P2 Free plan.

## Testing instructions

Get a new P2 site through wp.com/p2. Navigate to the Plans page. Verify there's no "Manage plan" button on the P2 Free plan.