### PR TITLE
P2+: fix the renewal button & add the plan to isPlan check

### DIFF
--- a/client/lib/products-values/is-p2-plus.js
+++ b/client/lib/products-values/is-p2-plus.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { isP2PlusPlan } from 'calypso/lib/plans';
+import { assertValidProduct } from 'calypso/lib/products-values/utils/assert-valid-product';
+import { formatProduct } from 'calypso/lib/products-values/format-product';
+
+export function isP2Plus( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return isP2PlusPlan( product.product_slug );
+}

--- a/client/lib/products-values/is-plan.js
+++ b/client/lib/products-values/is-plan.js
@@ -11,6 +11,7 @@ import { isJetpackPlan } from 'calypso/lib/products-values/is-jetpack-plan';
 import { isJpphpBundle } from 'calypso/lib/products-values/is-jpphp-bundle';
 import { isPersonal } from 'calypso/lib/products-values/is-personal';
 import { isPremium } from 'calypso/lib/products-values/is-premium';
+import { isP2Plus } from 'calypso/lib/products-values/is-p2-plus';
 
 export function isPlan( product ) {
 	product = formatProduct( product );
@@ -24,6 +25,7 @@ export function isPlan( product ) {
 		isEcommerce( product ) ||
 		isEnterprise( product ) ||
 		isJetpackPlan( product ) ||
-		isJpphpBundle( product )
+		isJpphpBundle( product ) ||
+		isP2Plus( product )
 	);
 }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -110,6 +110,7 @@ import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dial
  * Style dependencies
  */
 import './style.scss';
+import { isP2Plus } from 'calypso/lib/products-values/is-p2-plus';
 
 class ManagePurchase extends Component {
 	static propTypes = {
@@ -270,7 +271,12 @@ class ManagePurchase extends Component {
 			? translate( 'Pick Another Plan' )
 			: translate( 'Upgrade Plan' );
 
-		if ( ! isPlan( purchase ) || isEcommerce( purchase ) || isComplete( purchase ) ) {
+		if (
+			! isPlan( purchase ) ||
+			isEcommerce( purchase ) ||
+			isComplete( purchase ) ||
+			isP2Plus( purchase )
+		) {
 			return null;
 		}
 


### PR DESCRIPTION
In this PR, we fix the Renewal button on the P2+ Manage plan page. We do it by adding the P2+ plan to the `isPlan` check. We forgot to do this initially when we introduced the P2+ plan to Calypso.

## Testing instructions

Get a P2 site through wp.com/p2 and upgrade it to P2+ on the Plans page. Now, click on the "Manage plan" button and then on the "Renew Now" button. You should be navigated to the checkout page with the P2+ renewal in the cart.

Now, it's very important to check various plans and checkout flows since we've added P2+ to the `isPlan` check as there could be other places where we want a different behavior than what's there currently. For example, after adding the plan there, the button to "Upgrade" was shown on the Manage plan screen. But since there's nowhere to upgrade from P2+, I had to manually remove the button in this PR. There could be other places like this in the app now.