### PR TITLE
Nav Unification: fix sidebar sub-menu overlap

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -115,7 +115,6 @@ $z-layers: (
 		'.editor-featured-image .editor-drawer-well__remove': 20,
 		'.main': 20, //TODO: this doesn't always have a stacking context
 		'.main.calypsoify.is-iframe': 20,
-		'.is-nav-unification .layout__secondary': 21,
 		'.search': 22,
 		'.reader-update-notice': 22,
 		'.editor-ground-control': 22,
@@ -132,6 +131,7 @@ $z-layers: (
 		'.inline-help__mobile-overlay': 175,
 		'.floating-help': 176,
 		'.directly-rtm.is-minimized': 176,
+		'.is-nav-unification .layout__secondary': 176,
 		'.editor-confirmation-sidebar__overlay': 176,
 		'.editor-confirmation-sidebar__sidebar': 177,
 		'.happychat__container.is-open': 177,

--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -115,6 +115,7 @@ $z-layers: (
 		'.editor-featured-image .editor-drawer-well__remove': 20,
 		'.main': 20, //TODO: this doesn't always have a stacking context
 		'.main.calypsoify.is-iframe': 20,
+		'.is-nav-unification .layout__secondary': 21,
 		'.search': 22,
 		'.reader-update-notice': 22,
 		'.editor-ground-control': 22,

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -474,7 +474,6 @@ $font-size: rem( 14px );
 		&.focus-sidebar {
 			.sidebar,
 			.layout__secondary {
-				z-index: 1;
 				z-index: z-index( 'root', '.is-nav-unification .layout__secondary' );
 				overflow: initial;
 			}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -475,6 +475,7 @@ $font-size: rem( 14px );
 			.sidebar,
 			.layout__secondary {
 				z-index: 1;
+				z-index: z-index( 'root', '.is-nav-unification .layout__secondary' );
 				overflow: initial;
 			}
 		}


### PR DESCRIPTION
The unified sidebar introduces hovered sub-menus that overlay the main content area. This uses Calypso's z-index map to make sure the z-index for the sidebar is higher than the main content items.

Fixes: #48490, Fixes: #48143

<img width="1424" alt="Screen Shot 2020-12-28 at 12 04 45 PM" src="https://user-images.githubusercontent.com/942359/103231102-01469880-4905-11eb-9fa0-28bc3daaa7a7.png">

**To test:**
- on an account with the unified navigation test variant applied
- navigate to Settings > Hosting Configuration
- hover over sidebar items with sub-menus
- verify that the sub-menus are on top of the content
- on a Jetpack/Atomic site
- navigate to Upgrades > Plans
- hover over sidebar items with sub-menus
- verify that the sub-menus are on top of the content
- repeat on other screens to see if any content items overlap sub-menus