### PR TITLE
Plans: Remove the 'popularProductsOffering' test, accepting the 'dailyProducts' variant

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -74,13 +74,4 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	popularProductsOffering: {
-		datestamp: '20201217',
-		variations: {
-			dailyProducts: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 };

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -12,7 +12,6 @@ import * as constants from './constants';
 import MaterialIcon from 'calypso/components/material-icon';
 import ExternalLink from 'calypso/components/external-link';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
-import { POPULAR_PRODUCTS_OFFERING_VARIANT } from 'calypso/my-sites/plans/jetpack-plans/experiments';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'calypso/lib/url/support';
 import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 
@@ -1022,15 +1021,7 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_PLAN_SECURITY_DAILY ]: {
 		getSlug: () => constants.FEATURE_PLAN_SECURITY_DAILY,
 		getIcon: () => 'lock',
-		getTitle: ( variation ) =>
-			POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-				? i18n.translate( 'All Security Daily features' )
-				: i18n.translate( '{{strong}}All Security {{em}}Daily{{/em}}{{/strong}} features', {
-						components: {
-							em: <em />,
-							strong: <strong />,
-						},
-				  } ),
+		getTitle: () => i18n.translate( 'All Security Daily features' ),
 		isPlan: true,
 	},
 
@@ -1076,20 +1067,14 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_BACKUP_DAILY_V2 ]: {
 		getSlug: () => constants.FEATURE_BACKUP_DAILY_V2,
-		getTitle: ( variation ) =>
-			POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-				? i18n.translate( 'Automated daily backups (off-site)' )
-				: i18n.translate( 'Automated daily site backups' ),
+		getTitle: () => i18n.translate( 'Automated daily backups (off-site)' ),
 	},
 
 	[ constants.FEATURE_BACKUP_REALTIME_V2 ]: {
 		getSlug: () => constants.FEATURE_BACKUP_REALTIME_V2,
-		getTitle: ( variation ) =>
+		getTitle: () =>
 			( {
-				i5:
-					POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-						? i18n.translate( 'Backup (real-time, off-site)' )
-						: i18n.translate( 'Automated real-time backups' ),
+				i5: i18n.translate( 'Backup (real-time, off-site)' ),
 			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'Automated real-time site backups' ) ),
 	},
 
@@ -1112,7 +1097,7 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_PRODUCT_BACKUP_DAILY_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
 		getIcon: () => 'cloud-upload',
-		getTitle: ( variation ) =>
+		getTitle: () =>
 			( {
 				v2: i18n.translate( 'Backup {{strong}}{{em}}Daily{{/em}}{{/strong}}', {
 					components: {
@@ -1120,10 +1105,7 @@ export const FEATURES_LIST = {
 						strong: <strong />,
 					},
 				} ),
-				i5:
-					POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-						? i18n.translate( 'All Backup Daily features' )
-						: i18n.translate( 'Backup Daily (off-site)' ),
+				i5: i18n.translate( 'All Backup Daily features' ),
 			}[ getJetpackCROActiveVersion() ] ||
 			i18n.translate( 'Backup {{em}}Daily{{/em}}', {
 				components: {
@@ -1222,12 +1204,9 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_PRODUCT_SCAN_DAILY_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_SCAN_DAILY_V2,
 		getIcon: () => ( { icon: 'security', component: MaterialIcon } ),
-		getTitle: ( variation ) =>
+		getTitle: () =>
 			( {
-				i5:
-					POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-						? i18n.translate( 'Scan (daily, automated)' )
-						: i18n.translate( 'Scan Daily (automated)' ),
+				i5: i18n.translate( 'Scan (daily, automated)' ),
 			}[ getJetpackCROActiveVersion() ] ||
 			i18n.translate( 'Scan {{em}}Daily{{/em}}', {
 				components: {
@@ -1253,12 +1232,9 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_PRODUCT_SCAN_REALTIME_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
 		getIcon: () => ( { icon: 'security', component: MaterialIcon } ),
-		getTitle: ( variation ) =>
+		getTitle: () =>
 			( {
-				i5:
-					POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-						? i18n.translate( 'Scan (real-time, automated)' )
-						: i18n.translate( 'Real-time Scan (automated)' ),
+				i5: i18n.translate( 'Scan (real-time, automated)' ),
 			}[ getJetpackCROActiveVersion() ] ||
 			i18n.translate( 'Scan {{em}}Real-time{{/em}}', {
 				components: {
@@ -1279,12 +1255,9 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_ANTISPAM_V2 ]: {
 		getSlug: () => constants.FEATURE_ANTISPAM_V2,
-		getTitle: ( variation ) =>
+		getTitle: () =>
 			( {
-				i5:
-					POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-						? i18n.translate( 'Anti-spam ' )
-						: i18n.translate( 'Always-on spam protection' ),
+				i5: i18n.translate( 'Anti-spam ' ),
 			}[ getJetpackCROActiveVersion() ] || i18n.translate( 'Automated spam protection' ) ),
 	},
 
@@ -1530,10 +1503,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_SECURE_STORAGE_V2 ]: {
 		getSlug: () => constants.FEATURE_SECURE_STORAGE_V2,
-		getTitle: ( variation ) =>
-			POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-				? i18n.translate( 'Unlimited site storage' )
-				: i18n.translate( 'Unlimited secure storage' ),
+		getTitle: () => i18n.translate( 'Unlimited site storage' ),
 	},
 
 	[ constants.FEATURE_ONE_CLICK_RESTORE_V2 ]: {

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -9,7 +9,6 @@ import i18n, { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { isEnabled } from 'calypso/config';
-import { POPULAR_PRODUCTS_OFFERING_VARIANT } from 'calypso/my-sites/plans/jetpack-plans/experiments';
 import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 import * as constants from './constants';
 
@@ -432,7 +431,7 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 		return translate( 'Best for sites with occasional updates' );
 	},
 	getPlanCompareFeatures: () => [],
-	getPlanCardFeatures: ( variation ) =>
+	getPlanCardFeatures: () =>
 		( {
 			v2: [
 				constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
@@ -443,20 +442,12 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 				constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
 				constants.FEATURE_SITE_MONETIZATION_V2,
 			],
-			i5:
-				POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-					? [
-							constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
-							constants.FEATURE_PRODUCT_SCAN_DAILY_V2,
-							constants.FEATURE_ANTISPAM_V2,
-							constants.FEATURE_VIDEO_HOSTING_V2,
-					  ]
-					: [
-							constants.FEATURE_ALL_FREE_FEATURES,
-							constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
-							constants.FEATURE_PRODUCT_SCAN_DAILY_V2,
-							constants.FEATURE_ANTISPAM_V2,
-					  ],
+			i5: [
+				constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
+				constants.FEATURE_PRODUCT_SCAN_DAILY_V2,
+				constants.FEATURE_ANTISPAM_V2,
+				constants.FEATURE_VIDEO_HOSTING_V2,
+			],
 		}[ getJetpackCROActiveVersion() ] || {
 			[ constants.FEATURE_CATEGORY_SECURITY ]: [
 				constants.FEATURE_PRODUCT_BACKUP_DAILY_V2,
@@ -606,27 +597,20 @@ const getPlanJetpackCompleteDetails = () => ( {
 		),
 	getTagline: () => translate( 'For best-in-class WordPress sites' ),
 	getPlanCompareFeatures: () => [],
-	getPlanCardFeatures: ( variation ) =>
+	getPlanCardFeatures: () =>
 		( {
 			v2: [
 				constants.FEATURE_PLAN_SECURITY_REALTIME,
 				constants.FEATURE_CRM_V2,
 				constants.FEATURE_PRODUCT_SEARCH_V2,
 			],
-			i5:
-				POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-					? [
-							constants.FEATURE_PLAN_SECURITY_DAILY,
-							constants.FEATURE_BACKUP_REALTIME_V2,
-							constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
-							constants.FEATURE_CRM_V2,
-							constants.FEATURE_PRODUCT_SEARCH_V2,
-					  ]
-					: [
-							constants.FEATURE_PLAN_SECURITY_REALTIME,
-							constants.FEATURE_CRM_V2,
-							constants.FEATURE_PRODUCT_SEARCH_V2,
-					  ],
+			i5: [
+				constants.FEATURE_PLAN_SECURITY_DAILY,
+				constants.FEATURE_BACKUP_REALTIME_V2,
+				constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
+				constants.FEATURE_CRM_V2,
+				constants.FEATURE_PRODUCT_SEARCH_V2,
+			],
 		}[ getJetpackCROActiveVersion() ] || {
 			[ constants.FEATURE_CATEGORY_SECURITY ]: [
 				[

--- a/client/lib/products-values/products-list.ts
+++ b/client/lib/products-values/products-list.ts
@@ -8,7 +8,6 @@ import { isObject } from 'lodash';
  */
 import * as constants from './constants';
 import { getJetpackProductsShortNames } from './translations';
-import { POPULAR_PRODUCTS_OFFERING_VARIANT } from 'calypso/my-sites/plans/jetpack-plans/experiments';
 import {
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
@@ -18,7 +17,6 @@ import {
 	FEATURE_BACKUP_REALTIME_V2,
 	FEATURE_ONE_CLICK_RESTORE_V2,
 	FEATURE_SECURE_STORAGE_V2,
-	FEATURE_ACTIVITY_LOG_30_DAYS_V2,
 	FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 	FEATURE_PRIORITY_SUPPORT_V2,
 	FEATURE_SCAN_V2,
@@ -58,16 +56,11 @@ export const JETPACK_PRODUCTS_LIST: Record< JetpackProductSlug, Product > = {
 		type: constants.PRODUCT_JETPACK_BACKUP_DAILY,
 		term: TERM_ANNUALLY,
 		bill_period: PLAN_ANNUAL_PERIOD,
-		getFeatures: ( variation: string ): string[] =>
-			POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-				? [ FEATURE_BACKUP_DAILY_V2, FEATURE_ONE_CLICK_RESTORE_V2, FEATURE_SECURE_STORAGE_V2 ]
-				: [
-						FEATURE_BACKUP_DAILY_V2,
-						FEATURE_ONE_CLICK_RESTORE_V2,
-						FEATURE_SECURE_STORAGE_V2,
-						FEATURE_ACTIVITY_LOG_30_DAYS_V2,
-						FEATURE_PRIORITY_SUPPORT_V2,
-				  ],
+		getFeatures: (): string[] => [
+			FEATURE_BACKUP_DAILY_V2,
+			FEATURE_ONE_CLICK_RESTORE_V2,
+			FEATURE_SECURE_STORAGE_V2,
+		],
 	},
 	[ constants.PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: {
 		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ],
@@ -75,16 +68,11 @@ export const JETPACK_PRODUCTS_LIST: Record< JetpackProductSlug, Product > = {
 		type: constants.PRODUCT_JETPACK_BACKUP_DAILY,
 		term: TERM_MONTHLY,
 		bill_period: PLAN_MONTHLY_PERIOD,
-		getFeatures: ( variation: string ): string[] =>
-			POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-				? [ FEATURE_BACKUP_DAILY_V2, FEATURE_ONE_CLICK_RESTORE_V2, FEATURE_SECURE_STORAGE_V2 ]
-				: [
-						FEATURE_BACKUP_DAILY_V2,
-						FEATURE_ONE_CLICK_RESTORE_V2,
-						FEATURE_SECURE_STORAGE_V2,
-						FEATURE_ACTIVITY_LOG_30_DAYS_V2,
-						FEATURE_PRIORITY_SUPPORT_V2,
-				  ],
+		getFeatures: (): string[] => [
+			FEATURE_BACKUP_DAILY_V2,
+			FEATURE_ONE_CLICK_RESTORE_V2,
+			FEATURE_SECURE_STORAGE_V2,
+		],
 	},
 	[ constants.PRODUCT_JETPACK_BACKUP_REALTIME ]: {
 		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_BACKUP_REALTIME ],

--- a/client/my-sites/plans/jetpack-plans/abtest.ts
+++ b/client/my-sites/plans/jetpack-plans/abtest.ts
@@ -1,8 +1,6 @@
 /**
  * Internal dependencies
  */
-import { POPULAR_PRODUCTS_OFFERING_AB_TEST } from './experiments';
-import { abtest } from 'calypso/lib/abtest';
 import { getUrlParts } from 'calypso/lib/url/url-parts';
 
 const VERSIONS = [ 'v1', 'v2', 'i5' ];
@@ -27,8 +25,4 @@ export const getJetpackCROActiveVersion = (): string => {
 	}
 
 	return version || DEFAULT_VERSION;
-};
-
-export const getPopularProductsOfferingVariation = (): string => {
-	return abtest( POPULAR_PRODUCTS_OFFERING_AB_TEST );
 };

--- a/client/my-sites/plans/jetpack-plans/experiments.ts
+++ b/client/my-sites/plans/jetpack-plans/experiments.ts
@@ -1,11 +1,4 @@
 /**
- * Tracks A/B test: new popular products offering
- */
-export const POPULAR_PRODUCTS_OFFERING_AB_TEST = 'popularProductsOffering';
-export const POPULAR_PRODUCTS_OFFERING_CONTROL = 'control';
-export const POPULAR_PRODUCTS_OFFERING_VARIANT = 'dailyProducts';
-
-/**
  * ExPlat experiment: jetpack_pricing_switch_plan_sides
  */
 export const SWITCH_PLAN_SIDES_EXPERIMENT = 'jetpack_pricing_switch_plan_sides2';

--- a/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { POPULAR_PRODUCTS_OFFERING_VARIANT } from '../experiments';
 import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 import {
 	PLAN_JETPACK_SECURITY_DAILY,
@@ -54,25 +53,7 @@ const PRODUCT_POSITION_IN_GRID_V2: Record< string, number > = {
 	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 60 ),
 };
 
-const PRODUCT_POSITION_IN_GRID_I5_CONTROL: Record< string, number > = {
-	// Plans
-	[ PLAN_JETPACK_SECURITY_DAILY ]: 1,
-	[ PLAN_JETPACK_SECURITY_DAILY_MONTHLY ]: 1,
-	[ PLAN_JETPACK_SECURITY_REALTIME ]: 10,
-	[ PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ]: 10,
-	...setProductsInPosition( JETPACK_COMPLETE_PLANS, 20 ),
-	// Products
-	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: 30,
-	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: 30,
-	[ PRODUCT_JETPACK_BACKUP_DAILY ]: 40,
-	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: 40,
-	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 50 ),
-	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 60 ),
-	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 70 ),
-	...setProductsInPosition( JETPACK_CRM_PRODUCTS, 80 ),
-};
-
-const PRODUCT_POSITION_IN_GRID_I5_TREATMENT: Record< string, number > = {
+const PRODUCT_POSITION_IN_GRID_I5: Record< string, number > = {
 	[ PRODUCT_JETPACK_BACKUP_DAILY ]: 1,
 	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: 1,
 	[ PLAN_JETPACK_SECURITY_DAILY ]: 10,
@@ -88,19 +69,14 @@ const PRODUCT_POSITION_IN_GRID_I5_TREATMENT: Record< string, number > = {
 	...setProductsInPosition( JETPACK_CRM_PRODUCTS, 80 ),
 };
 
-export function getProductPosition(
-	slug: JetpackPlanSlugs | JetpackProductSlug,
-	variation?: string
-): number {
+export function getProductPosition( slug: JetpackPlanSlugs | JetpackProductSlug ): number {
 	switch ( getJetpackCROActiveVersion() ) {
 		case 'v1':
 			return PRODUCT_POSITION_IN_GRID_V1[ slug ];
 		case 'v2':
 			return PRODUCT_POSITION_IN_GRID_V2[ slug ];
 		case 'i5':
-			return POPULAR_PRODUCTS_OFFERING_VARIANT === variation
-				? PRODUCT_POSITION_IN_GRID_I5_TREATMENT[ slug ]
-				: PRODUCT_POSITION_IN_GRID_I5_CONTROL[ slug ];
+			return PRODUCT_POSITION_IN_GRID_I5[ slug ];
 		default:
 			return 100;
 	}

--- a/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
@@ -10,12 +10,7 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import {
-	POPULAR_PRODUCTS_OFFERING_AB_TEST,
-	POPULAR_PRODUCTS_OFFERING_VARIANT,
-	SWITCH_PLAN_SIDES_EXPERIMENT,
-	SWITCH_PLAN_SIDES_TREATMENT,
-} from '../experiments';
+import { SWITCH_PLAN_SIDES_EXPERIMENT, SWITCH_PLAN_SIDES_TREATMENT } from '../experiments';
 import PlansFilterBarI5 from '../plans-filter-bar-i5';
 import ProductCardI5 from '../product-card-i5';
 import { getProductPosition } from '../product-grid/products-order';
@@ -23,13 +18,10 @@ import { getPlansToDisplay, getProductsToDisplay, isConnectionFlow } from '../pr
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
 import Experiment from 'calypso/components/experiment';
 import JetpackFreeCard from 'calypso/components/jetpack/card/jetpack-free-card-i5';
-import { abtest } from 'calypso/lib/abtest';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	PLAN_JETPACK_SECURITY_DAILY,
 	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
-	PLAN_JETPACK_SECURITY_REALTIME,
-	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
 } from 'calypso/lib/plans/constants';
 import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 import { getVariationForUser } from 'calypso/state/experiments/selectors';
@@ -70,7 +62,6 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const currentPlanSlug =
 		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
-	const tracksVariation = abtest( POPULAR_PRODUCTS_OFFERING_AB_TEST );
 	const exPlatVariation =
 		useSelector( ( state ) => getVariationForUser( state, SWITCH_PLAN_SIDES_EXPERIMENT ) ) || '';
 
@@ -83,9 +74,9 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 	const sortedPlans = useMemo(
 		() =>
 			sortBy( getPlansToDisplay( { duration, currentPlanSlug } ), ( item ) =>
-				getProductPosition( item.productSlug as JetpackPlanSlugs, tracksVariation )
+				getProductPosition( item.productSlug as JetpackPlanSlugs )
 			),
-		[ duration, currentPlanSlug, tracksVariation ]
+		[ duration, currentPlanSlug ]
 	);
 	const sortedProducts = useMemo(
 		() =>
@@ -96,25 +87,19 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 					purchasedProducts,
 					includedInPlanProducts,
 				} ),
-				( item ) => getProductPosition( item.productSlug as JetpackProductSlug, tracksVariation )
+				( item ) => getProductPosition( item.productSlug as JetpackProductSlug )
 			),
-		[ duration, availableProducts, includedInPlanProducts, purchasedProducts, tracksVariation ]
+		[ duration, availableProducts, includedInPlanProducts, purchasedProducts ]
 	);
 
 	let popularProducts = [] as SelectorProduct[];
 	let otherProducts = [] as SelectorProduct[];
 
-	if ( POPULAR_PRODUCTS_OFFERING_VARIANT === tracksVariation ) {
-		const allProducts = sortBy( [ ...sortedPlans, ...sortedProducts ], ( item ) =>
-			getProductPosition(
-				item.productSlug as JetpackPlanSlugs | JetpackProductSlug,
-				tracksVariation
-			)
-		);
-
-		popularProducts = allProducts.slice( 0, 3 );
-		otherProducts = allProducts.slice( 3 );
-	}
+	const allProducts = sortBy( [ ...sortedPlans, ...sortedProducts ], ( item ) =>
+		getProductPosition( item.productSlug as JetpackPlanSlugs | JetpackProductSlug )
+	);
+	popularProducts = allProducts.slice( 0, 3 );
+	otherProducts = allProducts.slice( 3 );
 
 	const scrollToComparison = () => {
 		if ( bundleComparisonRef.current ) {
@@ -150,11 +135,7 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 	return (
 		<Experiment name={ SWITCH_PLAN_SIDES_EXPERIMENT }>
 			<section className="products-grid-i5__section">
-				<h2 className="products-grid-i5__section-title">
-					{ POPULAR_PRODUCTS_OFFERING_VARIANT === tracksVariation
-						? translate( 'Most Popular' )
-						: translate( 'Product Bundles' ) }
-				</h2>
+				<h2 className="products-grid-i5__section-title">{ translate( 'Most Popular' ) }</h2>
 				<div className="products-grid-i5__filter-bar">
 					<PlansFilterBarI5
 						showDiscountMessage
@@ -169,10 +150,7 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 					} ) }
 					ref={ planGridRef }
 				>
-					{ ( POPULAR_PRODUCTS_OFFERING_VARIANT === tracksVariation
-						? popularProducts
-						: sortedPlans
-					).map( ( product ) => (
+					{ popularProducts.map( ( product ) => (
 						<li key={ product.iconSlug }>
 							<ProductCardI5
 								item={ product }
@@ -181,11 +159,10 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 								currencyCode={ currencyCode }
 								selectedTerm={ duration }
 								isAligned={ ! isPlanRowWrapping }
-								featuredPlans={
-									POPULAR_PRODUCTS_OFFERING_VARIANT === tracksVariation
-										? [ PLAN_JETPACK_SECURITY_DAILY, PLAN_JETPACK_SECURITY_DAILY_MONTHLY ]
-										: [ PLAN_JETPACK_SECURITY_REALTIME, PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ]
-								}
+								featuredPlans={ [
+									PLAN_JETPACK_SECURITY_DAILY,
+									PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+								] }
 							/>
 						</li>
 					) ) }
@@ -203,16 +180,9 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 				</div>
 			</section>
 			<section className="products-grid-i5__section">
-				<h2 className="products-grid-i5__section-title">
-					{ POPULAR_PRODUCTS_OFFERING_VARIANT === tracksVariation
-						? translate( 'More Products' )
-						: translate( 'Individual Products' ) }
-				</h2>
+				<h2 className="products-grid-i5__section-title">{ translate( 'More Products' ) }</h2>
 				<ul className="products-grid-i5__product-grid">
-					{ ( POPULAR_PRODUCTS_OFFERING_VARIANT === tracksVariation
-						? otherProducts
-						: sortedProducts
-					).map( ( product ) => (
+					{ otherProducts.map( ( product ) => (
 						<li key={ product.iconSlug }>
 							<ProductCardI5
 								item={ product }

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -58,10 +58,7 @@ import { getJetpackProductCallToAction } from 'calypso/lib/products-values/get-j
 import { getJetpackProductDescription } from 'calypso/lib/products-values/get-jetpack-product-description';
 import { getJetpackProductShortName } from 'calypso/lib/products-values/get-jetpack-product-short-name';
 import config from 'calypso/config';
-import {
-	getJetpackCROActiveVersion,
-	getPopularProductsOfferingVariation,
-} from 'calypso/my-sites/plans/jetpack-plans/abtest';
+import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 import { MORE_FEATURES_LINK } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { addQueryArgs } from 'calypso/lib/route';
 import { getProductCost } from 'calypso/state/products-list/selectors/get-product-cost';
@@ -557,24 +554,16 @@ export function buildCardFeaturesFromItem(
 	options?: Record< string, unknown >
 ): SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[] {
 	if ( objectIsPlan( item ) ) {
-		const features = item.getPlanCardFeatures?.( getPopularProductsOfferingVariation() );
+		const features = item.getPlanCardFeatures?.();
 
 		if ( features ) {
-			return buildCardFeaturesFromFeatureKeys(
-				features,
-				options,
-				getPopularProductsOfferingVariation()
-			);
+			return buildCardFeaturesFromFeatureKeys( features, options );
 		}
 	} else if ( isFunction( item.getFeatures ) ) {
-		const features = item.getFeatures( getPopularProductsOfferingVariation() );
+		const features = item.getFeatures();
 
 		if ( features ) {
-			return buildCardFeaturesFromFeatureKeys(
-				features,
-				options,
-				getPopularProductsOfferingVariation()
-			);
+			return buildCardFeaturesFromFeatureKeys( features, options );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addresses `p1HpG7-aIo-p2#comment-43811`.

* Remove all references to the `popularProductsOffering` experiment.
* Anywhere conditional logic exists for this experiment, remove the conditional and use behavior from the `dailyProducts` variant.

#### Testing instructions

*For additional context on the original experiment and its testing instructions, see #48360.*

1. Check out this pull request in your testing environment.
2. Run Calypso (either blue or green).
3. Visit the pricing page.
4. Verify that the `popularProductsOffering` test is no longer visible in the AB testing menu (see screenshot).
5. Check that the order of the plan cards, the 2 section headings, and (in the top row) features match the copy and mock-ups shown below. (Feature text may be *slightly* different, to maintain consistency with the rest of the page.)

#### Reference creenshots

<img width="1075" alt="Screen Shot 2020-12-15 at 10 15 13 AM" src="https://user-images.githubusercontent.com/1620183/102236133-1d881580-3ec1-11eb-9747-833c5ce7db23.png">

<img width="1133" alt="Screen Shot 2020-12-15 at 10 15 23 AM" src="https://user-images.githubusercontent.com/1620183/102236142-22e56000-3ec1-11eb-8073-23143f8a171f.png">

<img width="256" alt="image" src="https://user-images.githubusercontent.com/670067/103239459-293cf880-4913-11eb-94a2-3119bd49f7a5.png">