### PR TITLE
Fix wording on the Payment Methods listing page

### DIFF
--- a/client/me/purchases/payment-methods/payment-method-list.jsx
+++ b/client/me/purchases/payment-methods/payment-method-list.jsx
@@ -42,7 +42,9 @@ class PaymentMethodList extends Component {
 		}
 
 		if ( ! cards.length ) {
-			return <CompactCard>{ this.props.translate( 'You have no saved cards.' ) }</CompactCard>;
+			return (
+				<CompactCard>{ this.props.translate( 'You have no saved payment methods.' ) }</CompactCard>
+			);
 		}
 
 		return cards.map( ( card ) => {
@@ -74,18 +76,19 @@ class PaymentMethodList extends Component {
 	}
 
 	render() {
+		let paymentMethods = this.props.cards;
+		if ( this.props.hasLoadedFromServer && this.props.paymentAgreements.length > 0 ) {
+			paymentMethods = paymentMethods.concat( this.props.paymentAgreements );
+		}
+
 		return (
 			<div className="payment-method-list">
 				<QueryStoredCards />
-				<SectionHeader label={ this.props.translate( 'Manage Your Payment Agreements' ) }>
+				<SectionHeader label={ this.props.translate( 'Manage Your Payment Methods' ) }>
 					{ this.renderAddPaymentMethodButton() }
 				</SectionHeader>
 
-				{ this.renderPaymentMethods( this.props.cards ) }
-
-				{ this.props.hasLoadedFromServer && this.props.paymentAgreements.length > 0 && (
-					<>{ this.renderPaymentMethods( this.props.paymentAgreements ) }</>
-				) }
+				{ this.renderPaymentMethods( paymentMethods ) }
 			</div>
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This fixes some wording bugs on the Payment Methods listing page (https://wordpress.com/me/purchases/payment-methods).  I believe they were all introduced in https://github.com/Automattic/wp-calypso/pull/47379.

1. The description at the top of the page should say "Manage Your Payment Methods" rather than "Manage Your Payment Agreements", since "agreements" are specific to PayPal but "methods" is how we refer to generic payment methods.  I think the current wording is left over from the original implementation in https://github.com/Automattic/wp-calypso/pull/41161, where the PayPal agreements and credit cards were listed separately, and where that heading was only used for the PayPal section.
2. When you don't have any payment methods it should say "You have no saved payment methods" rather than "You have no saved cards".
3. If you have PayPal agreements but no credit cards, the "You have no..." message shouldn't be shown at all.  Again, showing it made sense in the original implementation in https://github.com/Automattic/wp-calypso/pull/41161 because it was only shown in the separate credit card section, but with the two sections now merged together we should only show that message if the user has zero payment methods of any kind.

### Screenshots

#### Before (no payment methods)

![none-before](https://user-images.githubusercontent.com/235183/103243396-bdb15600-4927-11eb-9390-9239d480c823.png)

#### After (no payment methods)

![none-after](https://user-images.githubusercontent.com/235183/103243407-c4d86400-4927-11eb-9415-26ad070dbac7.png)

#### Before (PayPal only)

![paypal-only-before](https://user-images.githubusercontent.com/235183/103243400-c013b000-4927-11eb-9495-2db599d8d942.png)

#### After (PayPal only)

![paypal-only-after](https://user-images.githubusercontent.com/235183/103243410-c73abe00-4927-11eb-8614-86acd48bdb57.png)

#### Before (multiple payment methods)

![both-before](https://user-images.githubusercontent.com/235183/103243403-c1dd7380-4927-11eb-92a3-9fc0da7412f8.png)

#### After (multiple payment methods)

![both-after](https://user-images.githubusercontent.com/235183/103243416-cace4500-4927-11eb-942f-d19ff8843464.png)

### Testing instructions

Start with a new account that has no payment methods.  Check http://calypso.localhost:3000/me/purchases/payment-methods (or the equivalent page on the per-site billing screen) to see how it looks.  Then, by adding credit credit cards via the button on the above page, or by buying/renewing a subscription using PayPal, you can get different combinations of payment methods in the list and see how it looks with those.