### PR TITLE
Nav Unification: expand current section after collapsing all

### DIFF
--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -19,7 +19,10 @@ import PropTypes from 'prop-types';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import MySitesSidebarUnifiedStatsSparkline from './sparkline';
-import { collapseAllMySitesSidebarSections } from 'calypso/state/my-sites/sidebar/actions';
+import {
+	collapseAllMySitesSidebarSections,
+	expandMySitesSidebarSection,
+} from 'calypso/state/my-sites/sidebar/actions';
 
 export const MySitesSidebarUnifiedItem = ( {
 	title,
@@ -28,6 +31,7 @@ export const MySitesSidebarUnifiedItem = ( {
 	slug,
 	selected = false,
 	isSubItem = false,
+	sectionId,
 } ) => {
 	const reduxDispatch = useDispatch();
 
@@ -35,7 +39,10 @@ export const MySitesSidebarUnifiedItem = ( {
 		<SidebarItem
 			label={ title }
 			link={ url }
-			onNavigate={ () => reduxDispatch( collapseAllMySitesSidebarSections() ) }
+			onNavigate={ () => {
+				reduxDispatch( collapseAllMySitesSidebarSections() );
+				reduxDispatch( expandMySitesSidebarSection( sectionId ) );
+			} }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
 			forceInternalLink
@@ -47,8 +54,10 @@ export const MySitesSidebarUnifiedItem = ( {
 };
 
 MySitesSidebarUnifiedItem.propTypes = {
-	title: PropTypes.string,
 	icon: PropTypes.string,
+	sectionId: PropTypes.string,
+	slug: PropTypes.string,
+	title: PropTypes.string,
 	url: PropTypes.string,
 };
 

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -88,6 +88,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 							key={ item.slug }
 							{ ...item }
 							selected={ isSelected }
+							sectionId={ sectionId }
 							isSubItem={ true }
 						/>
 					);


### PR DESCRIPTION
The `onNavigate` prop for unified menu sub-items closes all sections, including the current one. This is a quick fix to keep the current section open.

Fixes: #48240

**To test:**
- on an account with the unified navigation test variant applied
- visit a menu item with sub-menu (i.e. Upgrades)
- verify that the section is correctly expanded
- click one of the non-default sub-menu items (i.e. Domains)
- verify that the section remains open
- visit a different section
- verify that the old section collapses and the new one is expanded