### PR TITLE
Onboarding: create ecommerce sites in coming soon mode

### DIFF
--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -74,15 +74,6 @@ export function useSelectedPlan(): Plan | undefined {
 }
 
 export function useNewSiteVisibility(): Site.Visibility {
-	const currentSlug = useSelectedPlan()?.periodAgnosticSlug;
-	const isEcommerce = useSelect( ( select ) =>
-		select( PLANS_STORE ).isPlanEcommerce( currentSlug )
-	);
-
-	if ( isEcommerce ) {
-		return Site.Visibility.PublicIndexed;
-	}
-
 	return Site.Visibility.PublicNotIndexed;
 }
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Let's make all new sites in Coming Soon mode via Gutenboarding. 

This commit removes the ecommerce plan check and, with it, the public indexed return value for new sites.

## Testing instructions

Create a new Ecommerce site via `/new`

The site should be in Coming Soon mode

Launch the site and check that it flips to public.

Fixes https://github.com/Automattic/wp-calypso/issues/47655
