### PR TITLE
Nav Unification: set hover state to false when expandable menu is clicked

### DIFF
--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -116,7 +116,10 @@ export const ExpandableSidebarMenu = ( {
 				<ExpandableSidebarHeading
 					title={ title }
 					count={ count }
-					onClick={ onClick }
+					onClick={ () => {
+						setSubmenuHovered( false );
+						onClick();
+					} }
 					customIcon={ customIcon }
 					icon={ icon }
 					materialIcon={ materialIcon }


### PR DESCRIPTION
When different menu items with sub-menus are clicked before `HoverIntent` resets the component's `submenuHovered` state, zombie hovered sub-menus can persist. This kills the zombies by manually setting the `submenuHovered` state to false when a menu item is clicked.

Fixes: #48019, Fixes: #48006

**To Test:**
- on an account with the unified navigation test variant applied
- click back and forth between "Upgrades" and "Posts" multiple times
- verify that the sub-menu is shown as a hovered fly-out when appropriate and as an expanded sub-menu when appropriate