### PR TITLE
Add/info tooltip store removal

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -662,6 +662,13 @@ export class MySitesSidebar extends Component {
 
 	store() {
 		const { translate, site, siteSuffix, canUserUseStore } = this.props;
+		let tooltipTitle;
+
+		if ( isEnabled( 'woocommerce/store-deprecated' ) ) {
+			tooltipTitle = 'Store is moving to WooCommerce';
+		} else if ( isEnabled( 'woocommerce/store-removed' ) ) {
+			tooltipTitle = 'Store has moved to WooCommerce';
+		}
 		const isCalypsoStoreDeprecatedOrRemoved =
 			isEnabled( 'woocommerce/store-deprecated' ) || isEnabled( 'woocommerce/store-removed' );
 
@@ -692,7 +699,7 @@ export class MySitesSidebar extends Component {
 			>
 				{ isCalypsoStoreDeprecatedOrRemoved && isBusiness( site.plan ) && (
 					<InfoPopover className="sidebar__store-tooltip" position="bottom right">
-						<div>{ 'Store is moving to WooCommerce' }.</div>
+						<div>{ tooltipTitle }.</div>
 						<ExternalLink href="https://wordpress.com/support/store/">{ 'More' }</ExternalLink>
 					</InfoPopover>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a follow up to https://github.com/Automattic/wp-calypso/pull/48596. 

Previously the tooltip next to Store menu displays the same copy for both `woocommerce/store-deprecated` and `woocommerce/store-removed`. This PR adds the logic to properly handle different copies for both cases. Copy changes pending.

#### Testing instructions

* Run calypso, login as a user with a business site
* In calypso home, enable `woocommerce/store-deprecated` flag by appending the following to your URL: `?flags=woocommerce/store-deprecated`
* Next to Store menu item, verify that the tooltip displays `Store is moving to WooCommerce`
* Change the URL flags parameter to `?flags=woocommerce/store-removed` and hit enter
* Verify that the tooltip now displays `Store has moved to WooCommerce`