### PR TITLE
Focused Launch: display selected popular plan only once in Summary View

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -293,7 +293,11 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 	const [ nonDefaultPaidPlan, setNonDefaultPaidPlan ] = React.useState< Plan | undefined >();
 
 	React.useEffect( () => {
-		if ( selectedPaidPlan && selectedPaidPlan?.storeSlug !== defaultPaidPlan?.storeSlug ) {
+		if (
+			selectedPaidPlan &&
+			defaultPaidPlan &&
+			selectedPaidPlan?.storeSlug !== defaultPaidPlan?.storeSlug
+		) {
 			setNonDefaultPaidPlan( selectedPaidPlan );
 		}
 	}, [ selectedPaidPlan, defaultPaidPlan, nonDefaultPaidPlan ] );

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -296,7 +296,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 		if (
 			selectedPaidPlan &&
 			defaultPaidPlan &&
-			selectedPaidPlan?.storeSlug !== defaultPaidPlan?.storeSlug
+			selectedPaidPlan.storeSlug !== defaultPaidPlan.storeSlug
 		) {
 			setNonDefaultPaidPlan( selectedPaidPlan );
 		}


### PR DESCRIPTION
Follow up of #48551 

#### Changes proposed in this Pull Request
* Before pre-selecting a plan, make sure popular plan is already loaded to prevent duplication

#### Testing instructions
* Same as #48551 but also check the case when popular plan is selected

Fixes #47789
