### PR TITLE
Focused Launch: fix Summary View plan step placeholders

### DIFF
--- a/packages/launch/src/focused-launch/summary/focused-launch-summary-item/index.tsx
+++ b/packages/launch/src/focused-launch/summary/focused-launch-summary-item/index.tsx
@@ -51,7 +51,10 @@ const FocusedLaunchSummaryItem: React.FunctionComponent<
 		isSelected?: boolean;
 		readOnly?: boolean;
 		isLoading?: boolean;
-		children: [ ReturnType< typeof LeadingContentSide >, ReturnType< typeof TrailingContentSide > ];
+		children?: [
+			ReturnType< typeof LeadingContentSide >,
+			ReturnType< typeof TrailingContentSide >
+		];
 	} & React.ButtonHTMLAttributes< HTMLButtonElement >
 > = ( { children, isSelected = false, readOnly = false, isLoading, ...rest } ) => {
 	return (
@@ -64,8 +67,8 @@ const FocusedLaunchSummaryItem: React.FunctionComponent<
 				'is-loading': isLoading,
 			} ) }
 		>
-			{ children[ 0 ] }
-			{ children[ 1 ] }
+			{ children?.[ 0 ] }
+			{ children?.[ 1 ] }
 		</button>
 	);
 };

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -302,11 +302,9 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 
 	const { sitePlan } = useSite();
 
-	const allAvailablePlans: ( Plan | undefined )[] = [
-		defaultPaidPlan,
-		...( nonDefaultPaidPlan ? [ nonDefaultPaidPlan ] : [] ),
-		defaultFreePlan,
-	];
+	const allAvailablePlans: ( Plan | undefined )[] = nonDefaultPaidPlan
+		? [ defaultPaidPlan, nonDefaultPaidPlan, defaultFreePlan ]
+		: [ defaultPaidPlan, defaultFreePlan ];
 
 	return (
 		<SummaryStep

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -302,9 +302,11 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 
 	const { sitePlan } = useSite();
 
-	const allAvailablePlans = [ defaultPaidPlan, nonDefaultPaidPlan, defaultFreePlan ].filter(
-		Boolean
-	) as Plan[];
+	const allAvailablePlans: ( Plan | undefined )[] = [
+		defaultPaidPlan,
+		...( nonDefaultPaidPlan ? [ nonDefaultPaidPlan ] : [] ),
+		defaultFreePlan,
+	];
 
 	return (
 		<SummaryStep
@@ -373,42 +375,46 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 							</span>
 						</p>
 						<div>
-							{ allAvailablePlans.map( ( plan ) => (
-								<FocusedLaunchSummaryItem
-									key={ plan.storeSlug }
-									isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
-									onClick={ () => setPlan( plan ) }
-									isSelected={ isPlanSelected( plan ) }
-									readOnly={ plan.isFree && ( hasPaidDomain || selectedPaidDomain ) }
-								>
-									<LeadingContentSide
-										label={
-											/* translators: %s is WordPress.com plan name (eg: Premium Plan) */
-											sprintf( __( '%s Plan', __i18n_text_domain__ ), plan.title ?? '' )
-										}
-										badgeText={ plan.isPopular ? __( 'Popular', __i18n_text_domain__ ) : '' }
-									/>
-									{ plan.isFree ? (
-										<TrailingContentSide
-											nodeType={ hasPaidDomain || selectedPaidDomain ? 'WARNING' : 'PRICE' }
-										>
-											{ hasPaidDomain || selectedPaidDomain
-												? __( 'Not available with your domain selection', __i18n_text_domain__ )
-												: __( 'Free', __i18n_text_domain__ ) }
-										</TrailingContentSide>
-									) : (
-										<TrailingContentSide nodeType="PRICE">
-											<span>{ planPrices[ plan.storeSlug ] }</span>
-											<span>
-												{
-													// translators: /mo is short for "per-month"
-													__( '/mo', __i18n_text_domain__ )
-												}
-											</span>
-										</TrailingContentSide>
-									) }
-								</FocusedLaunchSummaryItem>
-							) ) }
+							{ allAvailablePlans.map( ( plan, index ) =>
+								! plan ? (
+									<FocusedLaunchSummaryItem key={ index } isLoading />
+								) : (
+									<FocusedLaunchSummaryItem
+										key={ plan.storeSlug }
+										isLoading={ ! defaultFreePlan || ! defaultPaidPlan }
+										onClick={ () => setPlan( plan ) }
+										isSelected={ isPlanSelected( plan ) }
+										readOnly={ plan.isFree && ( hasPaidDomain || selectedPaidDomain ) }
+									>
+										<LeadingContentSide
+											label={
+												/* translators: %s is WordPress.com plan name (eg: Premium Plan) */
+												sprintf( __( '%s Plan', __i18n_text_domain__ ), plan.title ?? '' )
+											}
+											badgeText={ plan.isPopular ? __( 'Popular', __i18n_text_domain__ ) : '' }
+										/>
+										{ plan.isFree ? (
+											<TrailingContentSide
+												nodeType={ hasPaidDomain || selectedPaidDomain ? 'WARNING' : 'PRICE' }
+											>
+												{ hasPaidDomain || selectedPaidDomain
+													? __( 'Not available with your domain selection', __i18n_text_domain__ )
+													: __( 'Free', __i18n_text_domain__ ) }
+											</TrailingContentSide>
+										) : (
+											<TrailingContentSide nodeType="PRICE">
+												<span>{ planPrices[ plan.storeSlug ] }</span>
+												<span>
+													{
+														// translators: /mo is short for "per-month"
+														__( '/mo', __i18n_text_domain__ )
+													}
+												</span>
+											</TrailingContentSide>
+										) }
+									</FocusedLaunchSummaryItem>
+								)
+							) }
 						</div>
 						<Link to={ Route.PlanDetails } className="focused-launch-summary__details-link">
 							{ __( 'View all plans', __i18n_text_domain__ ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Render the correct number of loading placeholders for the plan step in Summary View. At the moment there are 2 placeholders expected (for popular paid plan and free plan). 

#### Testing instructions

* When opening focused launch on a poor connection (or even offline), the correct number of placeholders should be displayed for the plan step before data is loaded.

Fixes #48621