### PR TITLE
Domain picker: fix domain picker suggestion item layout for long domains

### DIFF
--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -248,6 +248,7 @@ $accent-blue: #117ac9;
 	color: var( --studio-blue-40 );
 	// keep TLDs intact as they're had to read if they were across-lines
 	word-break: keep-all;
+	margin-right: 5px;
 
 	.domain-picker__suggestion-item.is-unavailable & {
 		color: var( --studio-gray-40 );

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -214,6 +214,7 @@ $accent-blue: #117ac9;
 	letter-spacing: 0.4px;
 	// smaller gap between domain name and price on mobile
 	margin-right: 10px;
+	word-break: break-all;
 
 	@include break-medium {
 		margin-right: 24px;
@@ -245,6 +246,8 @@ $accent-blue: #117ac9;
 
 .domain-picker__domain-tld {
 	color: var( --studio-blue-40 );
+	// keep TLDs intact as they're had to read if they were across-lines
+	word-break: keep-all;
 
 	.domain-picker__suggestion-item.is-unavailable & {
 		color: var( --studio-gray-40 );

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -246,7 +246,7 @@ $accent-blue: #117ac9;
 
 .domain-picker__domain-tld {
 	color: var( --studio-blue-40 );
-	// keep TLDs intact as they're had to read if they were across-lines
+	// keep TLDs intact as they're hard to read if they were across-lines
 	word-break: keep-all;
 	margin-right: 5px;
 

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -149,6 +149,11 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 						<span className="domain-picker__domain-sub-domain">{ domainName }</span>
 						<span className="domain-picker__domain-tld">{ domainTld }</span>
 					</span>
+					{ isRecommended && ! isUnavailable && (
+						<div className="domain-picker__badge is-recommended">
+							{ __( 'Recommended', __i18n_text_domain__ ) }
+						</div>
+					) }
 					{ hstsRequired && (
 						<InfoTooltip
 							position={ isMobile ? 'bottom center' : 'middle right' }
@@ -172,11 +177,6 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 								}
 							) }
 						</InfoTooltip>
-					) }
-					{ isRecommended && ! isUnavailable && (
-						<div className="domain-picker__badge is-recommended">
-							{ __( 'Recommended', __i18n_text_domain__ ) }
-						</div>
 					) }
 				</div>
 				{ isExistingSubdomain && type !== ITEM_TYPE_INDIVIDUAL_ITEM && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Breaks domain names in a newline when they're too long. This preserves the sanity of the UI.

#### Before
<kbd><img width
="300" src="https://user-images.githubusercontent.com/17054134/103291487-1ea26200-49ec-11eb-9038-d52f6a623067.png"></kbd>

#### After
<kbd><img width="300" src="https://user-images.githubusercontent.com/17054134/103291451-0b8f9200-49ec-11eb-8b77-d2369afc1bee.png"></kbd>

#### Testing instructions

* Go to [`/new/domains`](https://hash-b9a3e4f48eeef8c607a80b53aa7e275ab46c8d31.calypso.live/new/domains) and type a long query. 
* Domain names shouldn't cross the box boundaries of the suggestion item.

Fixes #48261

