### PR TITLE
Fix link for updating payment method on multiple subscriptions with expiring credit cards

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -40,7 +40,11 @@ import {
 	purchaseType,
 	getName,
 } from 'calypso/lib/purchases';
-import { canEditPaymentDetails, getChangePaymentMethodPath } from '../utils';
+import {
+	canEditPaymentDetails,
+	getAddNewPaymentMethodPath,
+	getChangePaymentMethodPath,
+} from '../utils';
 import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
@@ -110,7 +114,7 @@ import './style.scss';
 class ManagePurchase extends Component {
 	static propTypes = {
 		cardTitle: PropTypes.string,
-		getAddPaymentMethodUrlFor: PropTypes.func,
+		getAddNewPaymentMethodUrlFor: PropTypes.func,
 		getCancelPurchaseUrlFor: PropTypes.func,
 		getChangePaymentMethodUrlFor: PropTypes.func,
 		getManagePurchaseUrlFor: PropTypes.func,
@@ -134,7 +138,7 @@ class ManagePurchase extends Component {
 	static defaultProps = {
 		showHeader: true,
 		purchaseListUrl: purchasesRoot,
-		getAddPaymentMethodUrlFor: getChangePaymentMethodPath,
+		getAddNewPaymentMethodUrlFor: getAddNewPaymentMethodPath,
 		getChangePaymentMethodUrlFor: getChangePaymentMethodPath,
 		cardTitle: titles.managePurchase,
 		getCancelPurchaseUrlFor: cancelPurchase,
@@ -669,7 +673,7 @@ class ManagePurchase extends Component {
 			isPurchaseTheme,
 			translate,
 			getManagePurchaseUrlFor,
-			getAddPaymentMethodUrlFor,
+			getAddNewPaymentMethodUrlFor,
 			getChangePaymentMethodUrlFor,
 			isProductOwner,
 		} = this.props;
@@ -720,7 +724,7 @@ class ManagePurchase extends Component {
 						changePaymentMethodPath={ changePaymentMethodPath }
 						getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 						isProductOwner={ isProductOwner }
-						getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
+						getAddNewPaymentMethodUrlFor={ getAddNewPaymentMethodUrlFor }
 					/>
 				) }
 				<AsyncLoad

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -12,7 +12,7 @@ import { isEmpty, merge, minBy } from 'lodash';
  */
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import config from 'calypso/config';
-import { getChangePaymentMethodPath } from '../utils';
+import { getAddNewPaymentMethodPath } from '../utils';
 import {
 	canExplicitRenew,
 	creditCardExpiresBeforeSubscription,
@@ -65,13 +65,13 @@ class PurchaseNotice extends Component {
 		selectedSite: PropTypes.object,
 		changePaymentMethodPath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		getManagePurchaseUrlFor: PropTypes.func,
-		getAddPaymentMethodUrlFor: PropTypes.func,
+		getAddNewPaymentMethodUrlFor: PropTypes.func,
 		isProductOwner: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		getManagePurchaseUrlFor: managePurchase,
-		getAddPaymentMethodUrlFor: getChangePaymentMethodPath,
+		getAddNewPaymentMethodUrlFor: getAddNewPaymentMethodPath,
 	};
 
 	state = {
@@ -345,7 +345,7 @@ class PurchaseNotice extends Component {
 			selectedSite,
 			renewableSitePurchases,
 			getManagePurchaseUrlFor,
-			getAddPaymentMethodUrlFor,
+			getAddNewPaymentMethodUrlFor,
 		} = this.props;
 
 		if ( ! config.isEnabled( 'upgrades/upcoming-renewals-notices' ) ) {
@@ -651,7 +651,7 @@ class PurchaseNotice extends Component {
 				);
 			} else {
 				noticeStatus = showCreditCardExpiringWarning( currentPurchase ) ? 'is-error' : 'is-info';
-				noticeActionHref = getAddPaymentMethodUrlFor( selectedSite.slug, currentPurchase );
+				noticeActionHref = getAddNewPaymentMethodUrlFor( selectedSite.slug );
 				noticeActionOnClick = this.handleExpiringCardNoticeUpdateAll;
 				noticeActionText = translate( 'Update all' );
 				noticeImpressionName = 'current-renews-soon-others-renew-soon-cc-expiring';
@@ -745,7 +745,7 @@ class PurchaseNotice extends Component {
 				);
 			} else {
 				noticeStatus = 'is-info';
-				noticeActionHref = getAddPaymentMethodUrlFor( selectedSite.slug, currentPurchase );
+				noticeActionHref = getAddNewPaymentMethodUrlFor( selectedSite.slug );
 				noticeActionOnClick = this.handleExpiringCardNoticeUpdateAll;
 				noticeActionText = translate( 'Update all' );
 				noticeImpressionName = 'current-renews-later-others-renew-soon-cc-expiring';

--- a/client/me/purchases/payment-methods/main.tsx
+++ b/client/me/purchases/payment-methods/main.tsx
@@ -7,7 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { addCreditCard, addNewPaymentMethod } from 'calypso/me/purchases/paths';
+import { getAddNewPaymentMethodPath } from 'calypso/me/purchases/utils';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import PaymentMethodList from 'calypso/me/purchases/payment-methods/payment-method-list';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
@@ -16,7 +16,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import titles from 'calypso/me/purchases/titles';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { isEnabled } from 'calypso/config';
 
 /**
  * Style dependencies
@@ -33,11 +32,7 @@ export default function PaymentMethods(): JSX.Element {
 			<MeSidebarNavigation />
 			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 			<PurchasesNavigation section={ 'payment-methods' } />
-			<PaymentMethodList
-				addPaymentMethodUrl={
-					isEnabled( 'purchases/new-payment-methods' ) ? addNewPaymentMethod : addCreditCard
-				}
-			/>
+			<PaymentMethodList addPaymentMethodUrl={ getAddNewPaymentMethodPath() } />
 		</Main>
 	);
 }

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -1,7 +1,14 @@
 /**
  * Internal dependencies
  */
-import { addCardDetails, editCardDetails, addPaymentMethod, changePaymentMethod } from './paths';
+import {
+	addCardDetails,
+	editCardDetails,
+	addCreditCard,
+	addPaymentMethod,
+	changePaymentMethod,
+	addNewPaymentMethod,
+} from './paths';
 import {
 	isExpired,
 	isIncludedWithPlan,
@@ -44,4 +51,13 @@ function getChangePaymentMethodPath( siteSlug, purchase ) {
 	return addCardDetails( siteSlug, purchase.id );
 }
 
-export { canEditPaymentDetails, getChangePaymentMethodPath, isDataLoading };
+function getAddNewPaymentMethodPath() {
+	return isEnabled( 'purchases/new-payment-methods' ) ? addNewPaymentMethod : addCreditCard;
+}
+
+export {
+	canEditPaymentDetails,
+	getChangePaymentMethodPath,
+	getAddNewPaymentMethodPath,
+	isDataLoading,
+};

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -22,7 +22,7 @@ import {
 	getCancelPurchaseUrlFor,
 	getConfirmCancelDomainUrlFor,
 	getManagePurchaseUrlFor,
-	getAddPaymentMethodUrlFor,
+	getAddNewPaymentMethodUrlFor,
 } from './paths';
 import { getChangeOrAddPaymentMethodUrlFor } from './utils';
 import ChangePaymentMethod from 'calypso/me/purchases/manage-purchase/change-payment-method';
@@ -117,7 +117,7 @@ export function PurchaseDetails( {
 					purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 					redirectTo={ getManagePurchaseUrlFor( siteSlug, purchaseId ) }
 					getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
-					getAddPaymentMethodUrlFor={ getAddPaymentMethodUrlFor }
+					getAddNewPaymentMethodUrlFor={ getAddNewPaymentMethodUrlFor }
 					getChangePaymentMethodUrlFor={ getChangeOrAddPaymentMethodUrlFor }
 					getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 				/>

--- a/client/my-sites/purchases/paths.ts
+++ b/client/my-sites/purchases/paths.ts
@@ -23,13 +23,13 @@ export const getPurchaseListUrlFor = ( targetSiteSlug: string ) =>
 
 export const getAddPaymentMethodUrlFor = (
 	targetSiteSlug: string,
-	targetPurchase: { id: string | number }
+	targetPurchaseId: string | number
 ) =>
 	isEnabled( 'purchases/new-payment-methods' )
-		? `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchase }/payment-method/add`
-		: `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchase }/payment/add`;
+		? `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/payment-method/add`
+		: `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/payment/add`;
 
-export const getAddNewPaymentMethod = ( targetSiteSlug: string ) =>
+export const getAddNewPaymentMethodUrlFor = ( targetSiteSlug: string ) =>
 	isEnabled( 'purchases/new-payment-methods' )
 		? `/purchases/add-payment-method/${ targetSiteSlug }`
 		: `/purchases/add-credit-card/${ targetSiteSlug }`;
@@ -39,12 +39,12 @@ export const getPaymentMethodsUrlFor = ( targetSiteSlug: string ) =>
 
 export const getChangePaymentMethodUrlFor = (
 	targetSiteSlug: string,
-	targetPurchase: { id: string | number },
-	targetCardId: { id: string | number }
+	targetPurchaseId: string | number,
+	targetCardId: string | number
 ) =>
 	isEnabled( 'purchases/new-payment-methods' )
-		? `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchase }/payment-method/change/${ targetCardId }`
-		: `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchase }/payment/edit/${ targetCardId }`;
+		? `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/payment-method/change/${ targetCardId }`
+		: `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }/payment/edit/${ targetCardId }`;
 
 export const getReceiptUrlFor = ( targetSiteSlug: string, targetReceiptId: string | number ) =>
 	`/purchases/billing-history/${ targetSiteSlug }/${ targetReceiptId }`;

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -19,7 +19,7 @@ import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
 import PaymentMethodList from 'calypso/me/purchases/payment-methods/payment-method-list';
 import HeaderCake from 'calypso/components/header-cake';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { getAddNewPaymentMethod, getPaymentMethodsUrlFor } from '../paths';
+import { getAddNewPaymentMethodUrlFor, getPaymentMethodsUrlFor } from '../paths';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import PaymentMethodForm from 'calypso/me/purchases/components/payment-method-form';
 import titles from 'calypso/me/purchases/titles';
@@ -78,7 +78,7 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ): JSX.Elemen
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logPaymentMethodsError }
 			>
-				<PaymentMethodList addPaymentMethodUrl={ getAddNewPaymentMethod( siteSlug ) } />
+				<PaymentMethodList addPaymentMethodUrl={ getAddNewPaymentMethodUrlFor( siteSlug ) } />
 			</SiteLevelPurchasesErrorBoundary>
 		</Main>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request

The recent work to reorganize the billing screens and change the way adding payment methods work seems to have introduced a bug (via https://github.com/Automattic/wp-calypso/pull/46069) in the case where a subscription has an expiring card that potentially affects multiple subscriptions.

In this case, the user sees a message on the Manage Purchase page similar to the following:

>Your VISA ending in 4242 expires December 2020 – before the next renewal. You have other upgrades on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.

And there is an "Update all" link next to it.

The idea is that the link should take them to the page for adding a new payment method on all of their subscriptions at once.  But following the above change, this now takes you to the page for changing the payment method for the current subscription only.  Also, if you do it from the site-specific billing page, the link doesn't work at all.

This pull request:
- Fixes the link to once again go to the page for adding a new payment method (which automatically applies that payment method to all the user's subscriptions).
- Fixes the broken documentation and variable names in some API methods for generating the links; these implied that objects rather than IDs should be passed in (and is almost certainly the reason the broken link on the site-specific billing page was introduced).  As far as I can tell, all other callers were already passing in IDs.

As a result of this change, users in this particular scenario will no longer get an easy opportunity to reuse an _existing_ credit card when updating their payment method for the affected subscriptions (because the page for adding a new payment method doesn't allow it).  But it's still the better choice, because it optimizes for the most likely scenario (expiring credit card and the user wants to update it everywhere, not just on a single subscription).  And that's also the way it worked before.

### Testing instructions

1. Buy an annual WordPress.com plan in store sandbox with a credit card that expires soon (you can make the expiration date the current month and year).
2. Then buy another annual subscription with the same credit card on the same site (easiest might be Jetpack Search, https://jetpack.com/upgrade/search/).
3. Edit the expiration dates for both subscriptions to be soon (e.g. ~1 month after the credit card expiration).  This can only be done with WordPress.com server access.
4. Go to http://calypso.localhost:3000/me/purchases, click on one of the subscriptions, and look for the message about the expiring credit card.
5. Click the "Update All" link and make sure it takes you to http://calypso.localhost:3000/me/purchases/add-payment-method.
6. Navigate to the per-site billing page (under Plan > Billing) and click on the subscription from there also.  The "Update All" link should work similarly, but this time it will take you to the page for adding a new payment method in a site-specific navigation context.

You can also test other places where there is a link to add a new payment method (for example http://calypso.localhost:3000/me/purchases/payment-methods or the equivalent site-specific page) and make sure the links there continue to work as expected.
