### PR TITLE
Jetpack Guided Tour: automatically scroll down to the second step

### DIFF
--- a/client/layout/guided-tours/tours/jetpack-checklist-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-checklist-tour/index.js
@@ -50,6 +50,7 @@ export const JetpackChecklistTour = makeTour(
 				marginTop: '-25px',
 			} }
 			target="jetpack-checklist-wpadmin-link"
+			shouldScrollTo
 		>
 			{ ( { translate } ) => (
 				<>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 1164141197617539-as-1199702075754309 (reported in https://github.com/Automattic/wp-calypso/issues/37050).

* Enable the `shouldScrollTo` prop of the second step of the tour.

#### Testing instructions

* Run this PR (calypso.live is enough).
* Make sure your browser window is around 500px in height.
* Visit `/plans/my-plan/:site?thank-you=true&product=jetpack_security_daily`, replacing `:site` with a Jetpack site URL.
* Click on the `Continue` button.
* Verify that you see the first step of the tour.
* Click on the `Got it` button.
* Verify that the app scrolled down automatically to make the second step of the tour visible.

#### Demo – before
![Kapture 2020-12-30 at 11 24 12](https://user-images.githubusercontent.com/3418513/103357313-a1312d00-4a91-11eb-9c1d-06bd3d51841e.gif)

#### Demo – after
![Kapture 2020-12-30 at 11 23 37](https://user-images.githubusercontent.com/3418513/103357316-a2faf080-4a91-11eb-8ae4-c2f7d2150af9.gif)

