### PR TITLE
Domain Picker: use ref to focus on SuggestionItem

### DIFF
--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -199,14 +199,10 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		}
 	}, [ initialDomainSearch, showSearchField ] );
 
+	const suggestionRefs = React.useRef< ( HTMLButtonElement | null )[] >( [] );
 	useEffect( () => {
-		// when people unfold for more results, focus on the first item after the fold
-		// this is not the cleanest solution, but still cleaner than useRef spaghetti
 		if ( isExpanded ) {
-			const focusableElements = document.querySelectorAll(
-				'.domain-picker__suggestion-select-button, button.domain-picker__suggestion-item'
-			);
-			( focusableElements[ quantity ] as HTMLButtonElement )?.focus?.();
+			suggestionRefs.current[ quantity ]?.focus?.();
 		}
 	}, [ isExpanded, quantity ] );
 
@@ -356,6 +352,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 													: true;
 												return (
 													<SuggestionItem
+														ref={ ( ref ) => {
+															suggestionRefs.current[ index ] = ref;
+														} }
 														key={ suggestion.domain_name }
 														isUnavailable={ ! isAvailable }
 														domain={ suggestion.domain_name }

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -69,202 +69,201 @@ interface Props {
 	onSelect: ( domain: string ) => void;
 	selected?: boolean;
 	type?: SUGGESTION_ITEM_TYPE;
+	buttonRef?: React.Ref< HTMLButtonElement >;
 }
 
-const DomainPickerSuggestionItem = React.forwardRef< HTMLButtonElement, Props >(
-	(
-		{
-			isUnavailable,
-			domain,
-			isLoading,
-			cost,
-			railcarId,
-			hstsRequired = false,
-			isFree = false,
-			isExistingSubdomain = false,
-			isRecommended = false,
-			onSelect,
-			onRender,
-			selected,
-			type = ITEM_TYPE_RADIO,
-		},
-		ref
-	) => {
-		const { __ } = useI18n();
-		const localizeUrl = useLocalizeUrl();
+const DomainPickerSuggestionItem: React.FC< Props > = ( {
+	isUnavailable,
+	domain,
+	isLoading,
+	cost,
+	railcarId,
+	hstsRequired = false,
+	isFree = false,
+	isExistingSubdomain = false,
+	isRecommended = false,
+	onSelect,
+	onRender,
+	selected,
+	type = ITEM_TYPE_RADIO,
+	buttonRef,
+} ) => {
+	const { __ } = useI18n();
+	const localizeUrl = useLocalizeUrl();
 
-		const isMobile = useViewportMatch( 'small', '<' );
+	const isMobile = useViewportMatch( 'small', '<' );
 
-		const dotPos = domain.indexOf( '.' );
-		const domainName = domain.slice( 0, dotPos );
-		const domainTld = domain.slice( dotPos );
+	const dotPos = domain.indexOf( '.' );
+	const domainName = domain.slice( 0, dotPos );
+	const domainTld = domain.slice( dotPos );
 
-		const [ previousDomain, setPreviousDomain ] = React.useState< string | undefined >();
-		const [ previousRailcarId, setPreviousRailcarId ] = React.useState< string | undefined >();
+	const [ previousDomain, setPreviousDomain ] = React.useState< string | undefined >();
+	const [ previousRailcarId, setPreviousRailcarId ] = React.useState< string | undefined >();
 
-		const freeDomainLabel =
-			type === ITEM_TYPE_INDIVIDUAL_ITEM
-				? __( 'Default', __i18n_text_domain__ )
-				: __( 'Free', __i18n_text_domain__ );
+	const freeDomainLabel =
+		type === ITEM_TYPE_INDIVIDUAL_ITEM
+			? __( 'Default', __i18n_text_domain__ )
+			: __( 'Free', __i18n_text_domain__ );
 
-		const firstYearIncludedInPaid = isMobile
-			? __( 'Included in paid plans', __i18n_text_domain__ )
-			: createInterpolateElement(
-					__( '<strong>First year included</strong> in paid plans', __i18n_text_domain__ ),
-					{
-						strong: <strong />,
-					}
-			  );
+	const firstYearIncludedInPaid = isMobile
+		? __( 'Included in paid plans', __i18n_text_domain__ )
+		: createInterpolateElement(
+				__( '<strong>First year included</strong> in paid plans', __i18n_text_domain__ ),
+				{
+					strong: <strong />,
+				}
+		  );
 
-		const paidIncludedDomainLabel =
-			type === ITEM_TYPE_INDIVIDUAL_ITEM
-				? firstYearIncludedInPaid
-				: __( 'Included in plans', __i18n_text_domain__ );
+	const paidIncludedDomainLabel =
+		type === ITEM_TYPE_INDIVIDUAL_ITEM
+			? firstYearIncludedInPaid
+			: __( 'Included in plans', __i18n_text_domain__ );
 
-		React.useEffect( () => {
-			// Only record TrainTracks render event when the domain name and railcarId change.
-			// This effectively records the render event only once for each set of search results.
-			if ( domain !== previousDomain && previousRailcarId !== railcarId && railcarId ) {
-				onRender();
-				setPreviousDomain( domain );
-				setPreviousRailcarId( railcarId );
-			}
-		}, [ domain, previousDomain, previousRailcarId, railcarId, onRender ] );
+	React.useEffect( () => {
+		// Only record TrainTracks render event when the domain name and railcarId change.
+		// This effectively records the render event only once for each set of search results.
+		if ( domain !== previousDomain && previousRailcarId !== railcarId && railcarId ) {
+			onRender();
+			setPreviousDomain( domain );
+			setPreviousRailcarId( railcarId );
+		}
+	}, [ domain, previousDomain, previousRailcarId, railcarId, onRender ] );
 
-		const onDomainSelect = () => {
-			// Use previousRailcarId to make sure the select action matches the last rendered railcarId.
-			if ( previousRailcarId ) {
-				recordTrainTracksInteract( {
-					action: 'domain_selected',
-					railcarId: previousRailcarId,
-				} );
-			}
-			onSelect( domain );
-		};
+	const onDomainSelect = () => {
+		// Use previousRailcarId to make sure the select action matches the last rendered railcarId.
+		if ( previousRailcarId ) {
+			recordTrainTracksInteract( {
+				action: 'domain_selected',
+				railcarId: previousRailcarId,
+			} );
+		}
+		onSelect( domain );
+	};
 
-		return (
-			<WrappingComponent
-				ref={ ref }
-				type={ type }
-				key={ domainName }
-				className={ classnames(
-					'domain-picker__suggestion-item',
-					{
-						'is-free': isFree,
-						'is-selected': selected,
-						'is-unavailable': isUnavailable,
-					},
-					`type-${ type }`
-				) }
-				// if the wrapping element is a div, don't assign a click listener
-				onClick={ type !== 'button' ? onDomainSelect : undefined }
-				disabled={ isUnavailable }
-			>
-				{ type === ITEM_TYPE_RADIO &&
-					( isLoading ? (
-						<Spinner />
-					) : (
-						<span
-							className={ classnames( 'domain-picker__suggestion-radio-circle', {
-								'is-checked': selected,
-								'is-unavailable': isUnavailable,
-							} ) }
-						/>
-					) ) }
-				<div className="domain-picker__suggestion-item-name">
-					<div className="domain-picker__suggestion-item-name-inner">
-						<span
-							className={ classnames( 'domain-picker__domain-wrapper', {
-								'with-margin': ! hstsRequired,
-							} ) }
+	return (
+		<WrappingComponent
+			ref={ buttonRef }
+			type={ type }
+			key={ domainName }
+			className={ classnames(
+				'domain-picker__suggestion-item',
+				{
+					'is-free': isFree,
+					'is-selected': selected,
+					'is-unavailable': isUnavailable,
+				},
+				`type-${ type }`
+			) }
+			// if the wrapping element is a div, don't assign a click listener
+			onClick={ type !== 'button' ? onDomainSelect : undefined }
+			disabled={ isUnavailable }
+		>
+			{ type === ITEM_TYPE_RADIO &&
+				( isLoading ? (
+					<Spinner />
+				) : (
+					<span
+						className={ classnames( 'domain-picker__suggestion-radio-circle', {
+							'is-checked': selected,
+							'is-unavailable': isUnavailable,
+						} ) }
+					/>
+				) ) }
+			<div className="domain-picker__suggestion-item-name">
+				<div className="domain-picker__suggestion-item-name-inner">
+					<span
+						className={ classnames( 'domain-picker__domain-wrapper', {
+							'with-margin': ! hstsRequired,
+						} ) }
+					>
+						<span className="domain-picker__domain-sub-domain">{ domainName }</span>
+						<span className="domain-picker__domain-tld">{ domainTld }</span>
+					</span>
+					{ hstsRequired && (
+						<InfoTooltip
+							position={ isMobile ? 'bottom center' : 'middle right' }
+							noArrow={ false }
+							className="domain-picker__info-tooltip"
 						>
-							<span className="domain-picker__domain-sub-domain">{ domainName }</span>
-							<span className="domain-picker__domain-tld">{ domainTld }</span>
-						</span>
-						{ hstsRequired && (
-							<InfoTooltip
-								position={ isMobile ? 'bottom center' : 'middle right' }
-								noArrow={ false }
-								className="domain-picker__info-tooltip"
-							>
-								{ createInterpolateElement(
-									__(
-										'All domains ending with <tld /> require an SSL certificate to host a website. When you host this domain at WordPress.com an SSL certificate is included. <learn_more_link>Learn more</learn_more_link>',
-										__i18n_text_domain__
+							{ createInterpolateElement(
+								__(
+									'All domains ending with <tld /> require an SSL certificate to host a website. When you host this domain at WordPress.com an SSL certificate is included. <learn_more_link>Learn more</learn_more_link>',
+									__i18n_text_domain__
+								),
+								{
+									tld: <b>{ domainTld }</b>,
+									learn_more_link: (
+										<a
+											target="_blank"
+											rel="noreferrer"
+											href={ localizeUrl( 'https://wordpress.com/support/https-ssl' ) }
+										/>
 									),
-									{
-										tld: <b>{ domainTld }</b>,
-										learn_more_link: (
-											<a
-												target="_blank"
-												rel="noreferrer"
-												href={ localizeUrl( 'https://wordpress.com/support/https-ssl' ) }
-											/>
-										),
-									}
-								) }
-							</InfoTooltip>
-						) }
-						{ isRecommended && ! isUnavailable && (
-							<div className="domain-picker__badge is-recommended">
-								{ __( 'Recommended', __i18n_text_domain__ ) }
-							</div>
+								}
+							) }
+						</InfoTooltip>
+					) }
+					{ isRecommended && ! isUnavailable && (
+						<div className="domain-picker__badge is-recommended">
+							{ __( 'Recommended', __i18n_text_domain__ ) }
+						</div>
+					) }
+				</div>
+				{ isExistingSubdomain && type !== ITEM_TYPE_INDIVIDUAL_ITEM && (
+					<div className="domain-picker__change-subdomain-tip">
+						{ __(
+							'You can change your free subdomain later under Domain Settings.',
+							__i18n_text_domain__
 						) }
 					</div>
-					{ isExistingSubdomain && type !== ITEM_TYPE_INDIVIDUAL_ITEM && (
-						<div className="domain-picker__change-subdomain-tip">
-							{ __(
-								'You can change your free subdomain later under Domain Settings.',
-								__i18n_text_domain__
-							) }
-						</div>
-					) }
-				</div>
-				<div
-					className={ classnames( 'domain-picker__price', {
-						'is-paid': ! isFree,
-					} ) }
-				>
-					{ isUnavailable && __( 'Unavailable', __i18n_text_domain__ ) }
-					{ isFree && ! isUnavailable && freeDomainLabel }
-					{ ! isFree && ! isUnavailable && (
-						<>
-							<span className="domain-picker__price-inclusive">
-								{ /* Intentional whitespace to get the spacing around the text right */ }{ ' ' }
-								{ paidIncludedDomainLabel }{ ' ' }
-							</span>
-							<span className="domain-picker__price-cost">
-								{
-									/* translators: %s is the price with currency. Eg: $15/year. */
-									sprintf( __( '%s/year', __i18n_text_domain__ ), cost )
-								}
-							</span>
-						</>
-					) }
-				</div>
-				{ type === ITEM_TYPE_BUTTON &&
-					( isLoading ? (
-						<Spinner />
-					) : (
-						<div className="domain-picker__action">
-							<Button
-								ref={ ref }
-								isSecondary
-								className={ classnames( 'domain-picker__suggestion-select-button', {
-									'is-selected': selected && ! isUnavailable,
-								} ) }
-								disabled={ isUnavailable }
-								onClick={ onDomainSelect }
-							>
-								{ selected && ! isUnavailable
-									? __( 'Selected', __i18n_text_domain__ )
-									: __( 'Select', __i18n_text_domain__ ) }
-							</Button>
-						</div>
-					) ) }
-			</WrappingComponent>
-		);
-	}
-);
+				) }
+			</div>
+			<div
+				className={ classnames( 'domain-picker__price', {
+					'is-paid': ! isFree,
+				} ) }
+			>
+				{ isUnavailable && __( 'Unavailable', __i18n_text_domain__ ) }
+				{ isFree && ! isUnavailable && freeDomainLabel }
+				{ ! isFree && ! isUnavailable && (
+					<>
+						<span className="domain-picker__price-inclusive">
+							{ /* Intentional whitespace to get the spacing around the text right */ }{ ' ' }
+							{ paidIncludedDomainLabel }{ ' ' }
+						</span>
+						<span className="domain-picker__price-cost">
+							{
+								/* translators: %s is the price with currency. Eg: $15/year. */
+								sprintf( __( '%s/year', __i18n_text_domain__ ), cost )
+							}
+						</span>
+					</>
+				) }
+			</div>
+			{ type === ITEM_TYPE_BUTTON &&
+				( isLoading ? (
+					<Spinner />
+				) : (
+					<div className="domain-picker__action">
+						<Button
+							ref={ buttonRef }
+							isSecondary
+							className={ classnames( 'domain-picker__suggestion-select-button', {
+								'is-selected': selected && ! isUnavailable,
+							} ) }
+							disabled={ isUnavailable }
+							onClick={ onDomainSelect }
+						>
+							{ selected && ! isUnavailable
+								? __( 'Selected', __i18n_text_domain__ )
+								: __( 'Select', __i18n_text_domain__ ) }
+						</Button>
+					</div>
+				) ) }
+		</WrappingComponent>
+	);
+};
 
-export default DomainPickerSuggestionItem;
+export default React.forwardRef< HTMLButtonElement, Props >( ( props, ref ) => {
+	return <DomainPickerSuggestionItem { ...props } buttonRef={ ref } />;
+} );

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -1,16 +1,20 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent, useEffect, useState } from 'react';
+import * as React from 'react';
+import classnames from 'classnames';
 import { useI18n } from '@automattic/react-i18n';
+import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
+
+/**
+ * Wordpress dependencies
+ */
 import { createInterpolateElement } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import classnames from 'classnames';
-import { sprintf } from '@wordpress/i18n';
-import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
-import { useLocalizeUrl } from '@automattic/i18n-utils';
+import { sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -29,22 +33,27 @@ export type SUGGESTION_ITEM_TYPE =
 
 // to avoid nesting buttons, wrap the item with a div instead of button in button mode
 // (button mode means there is a Select button, not the whole item being a button)
-const WrappingComponent: React.FC<
-	{ type: SUGGESTION_ITEM_TYPE; disabled?: boolean } & (
-		| React.HTMLAttributes< HTMLDivElement >
-		| React.ButtonHTMLAttributes< HTMLButtonElement >
-	 )
-> = ( { type, disabled, ...props } ) => {
+
+interface WrappingComponentProps {
+	type: SUGGESTION_ITEM_TYPE;
+	disabled?: boolean;
+}
+const WrappingComponent = React.forwardRef<
+	HTMLButtonElement,
+	WrappingComponentProps &
+		( React.HTMLAttributes< HTMLDivElement > | React.ButtonHTMLAttributes< HTMLButtonElement > )
+>( ( { type, disabled, ...props }, ref ) => {
 	if ( type === 'button' ) {
 		return <div { ...( props as React.HTMLAttributes< HTMLDivElement > ) } />;
 	}
 	return (
 		<button
+			ref={ ref }
 			disabled={ disabled }
 			{ ...( props as React.ButtonHTMLAttributes< HTMLButtonElement > ) }
 		/>
 	);
-};
+} );
 
 interface Props {
 	isUnavailable?: boolean;
@@ -62,193 +71,200 @@ interface Props {
 	type?: SUGGESTION_ITEM_TYPE;
 }
 
-const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
-	isUnavailable,
-	domain,
-	isLoading,
-	cost,
-	railcarId,
-	hstsRequired = false,
-	isFree = false,
-	isExistingSubdomain = false,
-	isRecommended = false,
-	onSelect,
-	onRender,
-	selected,
-	type = ITEM_TYPE_RADIO,
-} ) => {
-	const { __ } = useI18n();
-	const localizeUrl = useLocalizeUrl();
+const DomainPickerSuggestionItem = React.forwardRef< HTMLButtonElement, Props >(
+	(
+		{
+			isUnavailable,
+			domain,
+			isLoading,
+			cost,
+			railcarId,
+			hstsRequired = false,
+			isFree = false,
+			isExistingSubdomain = false,
+			isRecommended = false,
+			onSelect,
+			onRender,
+			selected,
+			type = ITEM_TYPE_RADIO,
+		},
+		ref
+	) => {
+		const { __ } = useI18n();
+		const localizeUrl = useLocalizeUrl();
 
-	const isMobile = useViewportMatch( 'small', '<' );
+		const isMobile = useViewportMatch( 'small', '<' );
 
-	const dotPos = domain.indexOf( '.' );
-	const domainName = domain.slice( 0, dotPos );
-	const domainTld = domain.slice( dotPos );
+		const dotPos = domain.indexOf( '.' );
+		const domainName = domain.slice( 0, dotPos );
+		const domainTld = domain.slice( dotPos );
 
-	const [ previousDomain, setPreviousDomain ] = useState< string | undefined >();
-	const [ previousRailcarId, setPreviousRailcarId ] = useState< string | undefined >();
+		const [ previousDomain, setPreviousDomain ] = React.useState< string | undefined >();
+		const [ previousRailcarId, setPreviousRailcarId ] = React.useState< string | undefined >();
 
-	const freeDomainLabel =
-		type === ITEM_TYPE_INDIVIDUAL_ITEM
-			? __( 'Default', __i18n_text_domain__ )
-			: __( 'Free', __i18n_text_domain__ );
+		const freeDomainLabel =
+			type === ITEM_TYPE_INDIVIDUAL_ITEM
+				? __( 'Default', __i18n_text_domain__ )
+				: __( 'Free', __i18n_text_domain__ );
 
-	const firstYearIncludedInPaid = isMobile
-		? __( 'Included in paid plans', __i18n_text_domain__ )
-		: createInterpolateElement(
-				__( '<strong>First year included</strong> in paid plans', __i18n_text_domain__ ),
-				{
-					strong: <strong />,
-				}
-		  );
+		const firstYearIncludedInPaid = isMobile
+			? __( 'Included in paid plans', __i18n_text_domain__ )
+			: createInterpolateElement(
+					__( '<strong>First year included</strong> in paid plans', __i18n_text_domain__ ),
+					{
+						strong: <strong />,
+					}
+			  );
 
-	const paidIncludedDomainLabel =
-		type === ITEM_TYPE_INDIVIDUAL_ITEM
-			? firstYearIncludedInPaid
-			: __( 'Included in plans', __i18n_text_domain__ );
+		const paidIncludedDomainLabel =
+			type === ITEM_TYPE_INDIVIDUAL_ITEM
+				? firstYearIncludedInPaid
+				: __( 'Included in plans', __i18n_text_domain__ );
 
-	useEffect( () => {
-		// Only record TrainTracks render event when the domain name and railcarId change.
-		// This effectively records the render event only once for each set of search results.
-		if ( domain !== previousDomain && previousRailcarId !== railcarId && railcarId ) {
-			onRender();
-			setPreviousDomain( domain );
-			setPreviousRailcarId( railcarId );
-		}
-	}, [ domain, previousDomain, previousRailcarId, railcarId, onRender ] );
+		React.useEffect( () => {
+			// Only record TrainTracks render event when the domain name and railcarId change.
+			// This effectively records the render event only once for each set of search results.
+			if ( domain !== previousDomain && previousRailcarId !== railcarId && railcarId ) {
+				onRender();
+				setPreviousDomain( domain );
+				setPreviousRailcarId( railcarId );
+			}
+		}, [ domain, previousDomain, previousRailcarId, railcarId, onRender ] );
 
-	const onDomainSelect = () => {
-		// Use previousRailcarId to make sure the select action matches the last rendered railcarId.
-		if ( previousRailcarId ) {
-			recordTrainTracksInteract( {
-				action: 'domain_selected',
-				railcarId: previousRailcarId,
-			} );
-		}
-		onSelect( domain );
-	};
+		const onDomainSelect = () => {
+			// Use previousRailcarId to make sure the select action matches the last rendered railcarId.
+			if ( previousRailcarId ) {
+				recordTrainTracksInteract( {
+					action: 'domain_selected',
+					railcarId: previousRailcarId,
+				} );
+			}
+			onSelect( domain );
+		};
 
-	return (
-		<WrappingComponent
-			type={ type }
-			key={ domainName }
-			className={ classnames(
-				'domain-picker__suggestion-item',
-				{
-					'is-free': isFree,
-					'is-selected': selected,
-					'is-unavailable': isUnavailable,
-				},
-				`type-${ type }`
-			) }
-			// if the wrapping element is a div, don't assign a click listener
-			onClick={ type !== 'button' ? onDomainSelect : undefined }
-			disabled={ isUnavailable }
-		>
-			{ type === ITEM_TYPE_RADIO &&
-				( isLoading ? (
-					<Spinner />
-				) : (
-					<span
-						className={ classnames( 'domain-picker__suggestion-radio-circle', {
-							'is-checked': selected,
-							'is-unavailable': isUnavailable,
-						} ) }
-					/>
-				) ) }
-			<div className="domain-picker__suggestion-item-name">
-				<div className="domain-picker__suggestion-item-name-inner">
-					<span
-						className={ classnames( 'domain-picker__domain-wrapper', {
-							'with-margin': ! hstsRequired,
-						} ) }
-					>
-						<span className="domain-picker__domain-sub-domain">{ domainName }</span>
-						<span className="domain-picker__domain-tld">{ domainTld }</span>
-					</span>
-					{ hstsRequired && (
-						<InfoTooltip
-							position={ isMobile ? 'bottom center' : 'middle right' }
-							noArrow={ false }
-							className="domain-picker__info-tooltip"
+		return (
+			<WrappingComponent
+				ref={ ref }
+				type={ type }
+				key={ domainName }
+				className={ classnames(
+					'domain-picker__suggestion-item',
+					{
+						'is-free': isFree,
+						'is-selected': selected,
+						'is-unavailable': isUnavailable,
+					},
+					`type-${ type }`
+				) }
+				// if the wrapping element is a div, don't assign a click listener
+				onClick={ type !== 'button' ? onDomainSelect : undefined }
+				disabled={ isUnavailable }
+			>
+				{ type === ITEM_TYPE_RADIO &&
+					( isLoading ? (
+						<Spinner />
+					) : (
+						<span
+							className={ classnames( 'domain-picker__suggestion-radio-circle', {
+								'is-checked': selected,
+								'is-unavailable': isUnavailable,
+							} ) }
+						/>
+					) ) }
+				<div className="domain-picker__suggestion-item-name">
+					<div className="domain-picker__suggestion-item-name-inner">
+						<span
+							className={ classnames( 'domain-picker__domain-wrapper', {
+								'with-margin': ! hstsRequired,
+							} ) }
 						>
-							{ createInterpolateElement(
-								__(
-									'All domains ending with <tld /> require an SSL certificate to host a website. When you host this domain at WordPress.com an SSL certificate is included. <learn_more_link>Learn more</learn_more_link>',
-									__i18n_text_domain__
-								),
-								{
-									tld: <b>{ domainTld }</b>,
-									learn_more_link: (
-										<a
-											target="_blank"
-											rel="noreferrer"
-											href={ localizeUrl( 'https://wordpress.com/support/https-ssl' ) }
-										/>
+							<span className="domain-picker__domain-sub-domain">{ domainName }</span>
+							<span className="domain-picker__domain-tld">{ domainTld }</span>
+						</span>
+						{ hstsRequired && (
+							<InfoTooltip
+								position={ isMobile ? 'bottom center' : 'middle right' }
+								noArrow={ false }
+								className="domain-picker__info-tooltip"
+							>
+								{ createInterpolateElement(
+									__(
+										'All domains ending with <tld /> require an SSL certificate to host a website. When you host this domain at WordPress.com an SSL certificate is included. <learn_more_link>Learn more</learn_more_link>',
+										__i18n_text_domain__
 									),
-								}
+									{
+										tld: <b>{ domainTld }</b>,
+										learn_more_link: (
+											<a
+												target="_blank"
+												rel="noreferrer"
+												href={ localizeUrl( 'https://wordpress.com/support/https-ssl' ) }
+											/>
+										),
+									}
+								) }
+							</InfoTooltip>
+						) }
+						{ isRecommended && ! isUnavailable && (
+							<div className="domain-picker__badge is-recommended">
+								{ __( 'Recommended', __i18n_text_domain__ ) }
+							</div>
+						) }
+					</div>
+					{ isExistingSubdomain && type !== ITEM_TYPE_INDIVIDUAL_ITEM && (
+						<div className="domain-picker__change-subdomain-tip">
+							{ __(
+								'You can change your free subdomain later under Domain Settings.',
+								__i18n_text_domain__
 							) }
-						</InfoTooltip>
-					) }
-					{ isRecommended && ! isUnavailable && (
-						<div className="domain-picker__badge is-recommended">
-							{ __( 'Recommended', __i18n_text_domain__ ) }
 						</div>
 					) }
 				</div>
-				{ isExistingSubdomain && type !== ITEM_TYPE_INDIVIDUAL_ITEM && (
-					<div className="domain-picker__change-subdomain-tip">
-						{ __(
-							'You can change your free subdomain later under Domain Settings.',
-							__i18n_text_domain__
-						) }
-					</div>
-				) }
-			</div>
-			<div
-				className={ classnames( 'domain-picker__price', {
-					'is-paid': ! isFree,
-				} ) }
-			>
-				{ isUnavailable && __( 'Unavailable', __i18n_text_domain__ ) }
-				{ isFree && ! isUnavailable && freeDomainLabel }
-				{ ! isFree && ! isUnavailable && (
-					<>
-						<span className="domain-picker__price-inclusive">
-							{ /* Intentional whitespace to get the spacing around the text right */ }{ ' ' }
-							{ paidIncludedDomainLabel }{ ' ' }
-						</span>
-						<span className="domain-picker__price-cost">
-							{
-								/* translators: %s is the price with currency. Eg: $15/year. */
-								sprintf( __( '%s/year', __i18n_text_domain__ ), cost )
-							}
-						</span>
-					</>
-				) }
-			</div>
-			{ type === ITEM_TYPE_BUTTON &&
-				( isLoading ? (
-					<Spinner />
-				) : (
-					<div className="domain-picker__action">
-						<Button
-							isSecondary
-							className={ classnames( 'domain-picker__suggestion-select-button', {
-								'is-selected': selected && ! isUnavailable,
-							} ) }
-							disabled={ isUnavailable }
-							onClick={ onDomainSelect }
-						>
-							{ selected && ! isUnavailable
-								? __( 'Selected', __i18n_text_domain__ )
-								: __( 'Select', __i18n_text_domain__ ) }
-						</Button>
-					</div>
-				) ) }
-		</WrappingComponent>
-	);
-};
+				<div
+					className={ classnames( 'domain-picker__price', {
+						'is-paid': ! isFree,
+					} ) }
+				>
+					{ isUnavailable && __( 'Unavailable', __i18n_text_domain__ ) }
+					{ isFree && ! isUnavailable && freeDomainLabel }
+					{ ! isFree && ! isUnavailable && (
+						<>
+							<span className="domain-picker__price-inclusive">
+								{ /* Intentional whitespace to get the spacing around the text right */ }{ ' ' }
+								{ paidIncludedDomainLabel }{ ' ' }
+							</span>
+							<span className="domain-picker__price-cost">
+								{
+									/* translators: %s is the price with currency. Eg: $15/year. */
+									sprintf( __( '%s/year', __i18n_text_domain__ ), cost )
+								}
+							</span>
+						</>
+					) }
+				</div>
+				{ type === ITEM_TYPE_BUTTON &&
+					( isLoading ? (
+						<Spinner />
+					) : (
+						<div className="domain-picker__action">
+							<Button
+								ref={ ref }
+								isSecondary
+								className={ classnames( 'domain-picker__suggestion-select-button', {
+									'is-selected': selected && ! isUnavailable,
+								} ) }
+								disabled={ isUnavailable }
+								onClick={ onDomainSelect }
+							>
+								{ selected && ! isUnavailable
+									? __( 'Selected', __i18n_text_domain__ )
+									: __( 'Select', __i18n_text_domain__ ) }
+							</Button>
+						</div>
+					) ) }
+			</WrappingComponent>
+		);
+	}
+);
 
 export default DomainPickerSuggestionItem;

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -34,26 +34,27 @@ export type SUGGESTION_ITEM_TYPE =
 // to avoid nesting buttons, wrap the item with a div instead of button in button mode
 // (button mode means there is a Select button, not the whole item being a button)
 
-interface WrappingComponentProps {
+interface WrappingComponentAdditionalProps {
 	type: SUGGESTION_ITEM_TYPE;
 	disabled?: boolean;
 }
-const WrappingComponent = React.forwardRef<
-	HTMLButtonElement,
-	WrappingComponentProps &
-		( React.HTMLAttributes< HTMLDivElement > | React.ButtonHTMLAttributes< HTMLButtonElement > )
->( ( { type, disabled, ...props }, ref ) => {
-	if ( type === 'button' ) {
-		return <div { ...( props as React.HTMLAttributes< HTMLDivElement > ) } />;
+type WrappingComponentProps = WrappingComponentAdditionalProps &
+	( React.HTMLAttributes< HTMLDivElement > | React.ButtonHTMLAttributes< HTMLButtonElement > );
+
+const WrappingComponent = React.forwardRef< HTMLButtonElement, WrappingComponentProps >(
+	( { type, disabled, ...props }, ref ) => {
+		if ( type === 'button' ) {
+			return <div { ...( props as React.HTMLAttributes< HTMLDivElement > ) } />;
+		}
+		return (
+			<button
+				ref={ ref }
+				disabled={ disabled }
+				{ ...( props as React.ButtonHTMLAttributes< HTMLButtonElement > ) }
+			/>
+		);
 	}
-	return (
-		<button
-			ref={ ref }
-			disabled={ disabled }
-			{ ...( props as React.ButtonHTMLAttributes< HTMLButtonElement > ) }
-		/>
-	);
-} );
+);
 
 interface Props {
 	isUnavailable?: boolean;


### PR DESCRIPTION
This is a proposal mentioned in https://github.com/Automattic/wp-calypso/pull/48172#discussion_r550247065

#### Changes proposed in this Pull Request

* Enable ref forwarding for SuggestionItem component
* Use suggestionRefs to focus on next suggestion after expanding