### PR TITLE
Checkout: Remove siteId check from stored card prepurchase validation

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -76,9 +76,6 @@ function isValidTransactionData(
 	// Validate data required for this payment method type. Some other data may
 	// be required by the server but not required here since the server will give
 	// a better localized error message than we can provide.
-	if ( ! data.siteId ) {
-		throw new Error( 'Transaction requires siteId and none was provided' );
-	}
 	if ( ! data.country ) {
 		throw new Error( 'Transaction requires country code and none was provided' );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A siteId is indeed required by the transaction endpoint; however for siteless checkout the corresponding `no-site` id value and related properties like `create_new_site` are added in `createTransactionEndpointRequestPayloadFromLineItems`, _after_ this validation check happens.

With this check in place, when the siteId is not set we throw an error before getting to the code that cleans up the transaction payload. Removing this check has no effect on purchases with a site ID, and allows siteless purchases to proceed.

I think this regression was added in #48069 (which I reviewed 😬), and I missed it at the time because I didn't test it with the siteless flow. It is hard to keep track of which flows can be affected by what changes!

#### Testing instructions

We need to check two things: (1) that siteless purchases with a stored card succeed or fail as expected, and (2) that non-siteless (siteful?) purchases with a stored card are not affected.

- To test the siteless flow, navigate to `/domains`, choose a domain, and when prompted to select a plan opt for "Just a domain". Once in checkout, verify that you can complete the purchase with a stored card.
- To test the siteful flow, enter checkout with some product on either an existing site or a new site and make sure you can check out with a stored card.
