### PR TITLE
Titan: Show control panel in an iframe

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -792,6 +792,22 @@ Undocumented.prototype.getTitanControlPanelAutoLoginURL = function ( orderId, fn
 };
 
 /**
+ * Retrieves the URL to embed Titan's control panel in an iframe.
+ *
+ * @param orderId the Titan order ID
+ * @param fn The callback function
+ */
+Undocumented.prototype.getTitanControlPanelIframeURL = function ( orderId, fn ) {
+	return this.wpcom.req.get(
+		{
+			path: `/emails/titan/${ encodeURIComponent( orderId ) }/control-panel-iframe-url`,
+			apiNamespace: 'wpcom/v2',
+		},
+		fn
+	);
+};
+
+/**
  * Get a list of WordPress.com products
  *
  * @param {Function} fn The callback function

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -36,7 +36,7 @@ class TitanControlPanelLoginCard extends React.Component {
 					this.props.errorNotice(
 						error ?? this.props.translate( 'An unknown error occurred. Please try again later.' )
 					);
-				} else {
+				} else if ( this._mounted ) {
 					this.setState( { iframeURL } );
 				}
 			}

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'calypso/config';
 import wpcom from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { Button, CompactCard } from '@automattic/components';
@@ -23,7 +24,28 @@ import './style.scss';
 class TitanControlPanelLoginCard extends React.Component {
 	state = {
 		isFetchingAutoLoginLink: false,
+		iframeURL: '',
 	};
+
+	componentDidMount() {
+		this._mounted = true;
+
+		this.fetchTitanIframeURL( getTitanMailOrderId( this.props.domain ) ).then(
+			( { error, iframeURL } ) => {
+				if ( error ) {
+					this.props.errorNotice(
+						error ?? this.props.translate( 'An unknown error occurred. Please try again later.' )
+					);
+				} else {
+					this.setState( { iframeURL } );
+				}
+			}
+		);
+	}
+
+	componentWillUnmount() {
+		this._mounted = false;
+	}
 
 	fetchTitanAutoLoginURL = ( orderId ) => {
 		return new Promise( ( resolve ) => {
@@ -31,6 +53,17 @@ class TitanControlPanelLoginCard extends React.Component {
 				resolve( {
 					error: serverError?.message,
 					loginURL: serverError ? null : result.auto_login_url,
+				} );
+			} );
+		} );
+	};
+
+	fetchTitanIframeURL = ( orderId ) => {
+		return new Promise( ( resolve ) => {
+			wpcom.undocumented().getTitanControlPanelIframeURL( orderId, ( serverError, result ) => {
+				resolve( {
+					error: serverError?.message,
+					iframeURL: serverError ? null : result.iframe_url,
 				} );
 			} );
 		} );
@@ -56,7 +89,7 @@ class TitanControlPanelLoginCard extends React.Component {
 		} );
 	};
 
-	render() {
+	renderAutoLogin() {
 		const { domain, translate } = this.props;
 		const translateArgs = {
 			args: {
@@ -85,6 +118,42 @@ class TitanControlPanelLoginCard extends React.Component {
 				</CompactCard>
 			</div>
 		);
+	}
+
+	renderIframe() {
+		const { domain, translate } = this.props;
+		const translateArgs = {
+			args: {
+				domainName: domain.name,
+			},
+			comment: '%(domainName)s is a domain name, e.g. example.com',
+		};
+
+		return (
+			<div className="titan-control-panel-login-card">
+				<SectionHeader label={ translate( 'Titan Mail: %(domainName)s', translateArgs ) } />
+				<CompactCard>
+					{ this.state.iframeURL ? (
+						<iframe
+							title="Titan Control Panel"
+							src={ this.state.iframeURL }
+							width="100%"
+							height="650px"
+						/>
+					) : (
+						<div>Loading the control panel...</div>
+					) }
+				</CompactCard>
+			</div>
+		);
+	}
+
+	render() {
+		if ( isEnabled( 'titan/iframe-control-panel' ) ) {
+			return this.renderIframe();
+		}
+
+		return this.renderAutoLogin();
 	}
 }
 

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -135,13 +135,13 @@ class TitanControlPanelLoginCard extends React.Component {
 				<CompactCard>
 					{ this.state.iframeURL ? (
 						<iframe
-							title="Titan Control Panel"
+							title={ translate( 'Email Control Panel' ) }
 							src={ this.state.iframeURL }
 							width="100%"
 							height="650px"
 						/>
 					) : (
-						<div>Loading the control panel...</div>
+						<div>{ translate( 'Loading the control panel…' ) }</div>
 					) }
 				</CompactCard>
 			</div>

--- a/config/development.json
+++ b/config/development.json
@@ -183,6 +183,7 @@
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,
+		"titan/iframe-control-panel": true,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -151,6 +151,7 @@
 		"signup/wpforteams": true,
 		"site-indicator": true,
 		"support-user": true,
+		"titan/iframe-control-panel": true,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Instead of showing an auto-login link, let's embed Titan's control panel in an iframe using their special API.

#### Testing instructions

Make sure you've applied D54806-code on your sandbox.
You need to enable Store Sandbox as well - the production control panel iframe has additional security checks which will prevent it from being displayed (CSP et al.)

On a domain with an Titan email, go to example.com -> Email. With the feature flag disabled, it should look like this:

<img width="1083" alt="Screenshot 2020-12-31 at 15 38 39" src="https://user-images.githubusercontent.com/3392497/103416541-234b4f80-4b7f-11eb-9c24-55ffecfb900b.png">

With the feature flag enabled (it's enabled by default on `development` and `wpcalypso`):
<img width="1082" alt="Screenshot 2020-12-31 at 15 42 56" src="https://user-images.githubusercontent.com/3392497/103416561-34945c00-4b7f-11eb-94ab-5a8010427585.png">


#### Known issues

There seems to be a small visual issue with the back button within the control panel:

<img width="177" alt="Screenshot 2020-12-31 at 15 45 58" src="https://user-images.githubusercontent.com/3392497/103416586-51c92a80-4b7f-11eb-9793-78b07b59a1f0.png">

That should be easily fixed by the Titan team.