### PR TITLE
Bugfix: Catch non-array API responses in useStoredCards hook

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-stored-cards.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-stored-cards.ts
@@ -66,7 +66,11 @@ export default function useStoredCards(
 function storedCardsReducer( state: StoredCardState, action: StoredCardAction ) {
 	switch ( action.type ) {
 		case 'FETCH_END':
-			return { ...state, storedCards: action.payload, isLoading: false };
+			// The endpoint may have returned a non-array without actually failing,
+			// so we need to ensure that storedCards is actually an array here.
+			// eslint-disable-next-line no-case-declarations
+			const storedCards = Array.isArray( action.payload ) ? action.payload : [];
+			return { ...state, storedCards, isLoading: false };
 		case 'FETCH_ERROR':
 			return { ...state, storedCards: [], error: action.payload, isLoading: false };
 		default:

--- a/client/my-sites/checkout/composite-checkout/hooks/use-stored-cards.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-stored-cards.ts
@@ -3,6 +3,7 @@
  */
 import { useReducer, useEffect } from 'react';
 import debugFactory from 'debug';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,12 +15,12 @@ const debug = debugFactory( 'calypso:composite-checkout:use-stored-cards' );
 export interface StoredCardState {
 	storedCards: StoredCard[];
 	isLoading: boolean;
-	error: string | null;
+	error: string | TranslateResult | null;
 }
 
 type StoredCardAction =
 	| { type: 'FETCH_END'; payload: StoredCard[] }
-	| { type: 'FETCH_ERROR'; payload: string };
+	| { type: 'FETCH_ERROR'; payload: string | TranslateResult };
 
 export default function useStoredCards(
 	getStoredCards: () => StoredCard[],
@@ -30,6 +31,7 @@ export default function useStoredCards(
 		isLoading: true,
 		error: null,
 	} );
+	const translate = useTranslate();
 
 	useEffect( () => {
 		if ( isLoggedOutCart ) {
@@ -43,6 +45,12 @@ export default function useStoredCards(
 
 		fetchStoredCards()
 			.then( ( cards ) => {
+				if ( ! Array.isArray( cards ) ) {
+					const payload = translate( 'There was a problem loading your stored cards.' );
+					debug( 'stored cards response is not an array', cards );
+					isSubscribed && dispatch( { type: 'FETCH_ERROR', payload } );
+					return;
+				}
 				debug( 'stored cards fetched', cards );
 				isSubscribed && dispatch( { type: 'FETCH_END', payload: cards } );
 			} )
@@ -66,11 +74,7 @@ export default function useStoredCards(
 function storedCardsReducer( state: StoredCardState, action: StoredCardAction ) {
 	switch ( action.type ) {
 		case 'FETCH_END':
-			// The endpoint may have returned a non-array without actually failing,
-			// so we need to ensure that storedCards is actually an array here.
-			// eslint-disable-next-line no-case-declarations
-			const storedCards = Array.isArray( action.payload ) ? action.payload : [];
-			return { ...state, storedCards, isLoading: false };
+			return { ...state, storedCards: action.payload, isLoading: false };
 		case 'FETCH_ERROR':
 			return { ...state, storedCards: [], error: action.payload, isLoading: false };
 		default:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I'm not sure how it happens, but apparently the API endpoint used by the `useStoredCards` hook can (rarely) return something other than an array without actually failing, and in this situation `storedCardsReducer` will happily set the `storedCards` state to this value. However all the consumers of this hook expect its state to be an array, which has led to errors in production of the form `storedCards.map is not a function`. The result is that checkout triggers an error boundary, which prevents people from giving us money. :)

Figuring out what caused this on the backend is a different issue; it appears to have happened 3 times in production since Nov 18, which is as far back as logs for this error boundary go. We can at least handle this gracefully on the frontend by making sure the `useStoredCards` state is always an array.

#### Testing instructions

Because it's still not clear exactly why this is happening, triggering the error this fixes requires some backend changes. See D54817-code and its description to apply these changes.

To reproduce the bug on trunk, force the endpoint to return a string response and try to load checkout. You should see an error like `storedCards.map is not a function`.

On this branch, with the `/me/stored-cards` endpoint short circuited (there are 3 ways to do this), verify that checkout loads and does not trigger an error boundary or raise a console error.