### PR TITLE
Activity Log Tasklist: Fix Colour Contrast

### DIFF
--- a/client/my-sites/activity/activity-log-tasklist/style.scss
+++ b/client/my-sites/activity/activity-log-tasklist/style.scss
@@ -52,7 +52,7 @@
 
 .activity-log-tasklist__update-bullet,
 .activity-log-tasklist__update-type {
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 }
 
 .activity-log-tasklist__update-bullet {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some of the text on the Activity Log tasklist doesn't pass colour contrast requirements - it was probably accidentally missed when all the others were updated in 2019.

#### Testing instructions

You can find this on `/activity-log/site` if there's a theme/plugin update available. 

**Before:**

<img width="1112" alt="Screenshot 2021-01-03 at 14 20 52" src="https://user-images.githubusercontent.com/43215253/103480930-71ef2880-4dcf-11eb-8cb7-446eea1a8fcf.png">

**After:**

<img width="1085" alt="Screenshot 2021-01-03 at 14 20 47" src="https://user-images.githubusercontent.com/43215253/103480929-70bdfb80-4dcf-11eb-8020-94a1ea211279.png">

cc @sixhours

