### PR TITLE
Patterns: guard premium patterns indicator behind an Object.isExtensible check to prevent fatals in debug mode

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/src/premium-block-patterns.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/src/premium-block-patterns.tsx
@@ -53,16 +53,23 @@ export const PremiumBlockPatterns: React.FunctionComponent = () => {
 			if ( pattern.isPremium && typeof pattern.title === 'string' ) {
 				const originalTitle = pattern.title;
 
-				pattern.title = <PatternTitleContainer title={ originalTitle } />;
-				// Add simple premium badging for screen readers
-				pattern.title.toString = () =>
-					sprintf(
-						// translators: %s is the title of a block pattern e.g. "Two columns (Premium)". "Premium" is synonymous with "paid"
-						__( '%s (Premium)', 'full-site-editing' ),
-						originalTitle
-					);
+				const titleOverride = <PatternTitleContainer title={ originalTitle } />;
 
-				shouldUpdateBlockPatterns = true;
+				// When React is running in development mode, ReactElement calls Object.freeze() on the element.
+				// To prevent the editor from throwing a fatal, we should only attempt to run the override
+				// when the React element is extensible so we can use the custom toString method. This means that
+				// in React development mode (define SCRIPT_DEBUG as true in PHP) this feature is switched off.
+				// See: https://github.com/facebook/react/blob/702fad4b1b48ac8f626ed3f35e8f86f5ea728084/packages/react/src/jsx/ReactJSXElement.js#L194
+				if ( Object.isExtensible( titleOverride ) ) {
+					pattern.title = titleOverride;
+					pattern.title.toString = () =>
+						sprintf(
+							// translators: %s is the title of a block pattern e.g. "Two columns (Premium)". "Premium" is synonymous with "paid"
+							__( '%s (Premium)', 'full-site-editing' ),
+							originalTitle
+						);
+					shouldUpdateBlockPatterns = true;
+				}
 			}
 			updatedPatterns.push( pattern );
 		} );


### PR DESCRIPTION
To support the premium patterns indicator, we override the pattern title by setting it to a React element, and then override the React element's `toString` method to return the name of the pattern so that existing places that reference the pattern title behave in an expected way. However, in React development mode (invoked by setting `SCRIPT_DEBUG` to `true` in PHP), React element objects [are not extensible](https://github.com/facebook/react/blob/702fad4b1b48ac8f626ed3f35e8f86f5ea728084/packages/react/src/jsx/ReactJSXElement.js#L194). Attempting to override the `toString` method in development mode causes a fatal in the editor. This fix skips the premium patterns indicator when the element is not extensible, to ensure we don't accidentally break the editor.

#### Changes proposed in this Pull Request

* Guard the premium patterns indicator pattern title override behind an `Object.isExtensible` check to avoid editor fatals when running in `SCRIPT_DEBUG` mode.

#### The bug

Prior to this PR, if you run the Editing Toolkit plugin in your sandbox with `define( 'SCRIPT_DEBUG', true );` set in a `sandbox.php` file that gets loaded early enough (PCYsg-t5D-p2), then the editor will throw a fatal. Here's what it looks like:

![image](https://user-images.githubusercontent.com/14988353/103500714-02953980-4ea0-11eb-995b-17163eee0608.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Check that this does not cause a regression

* Check out this branch.
* In apps/editing-toolkit, run `yarn run dev --sync` to sync to your sandbox
* In your sandbox, open up the `0-sandbox.php` file under `wp-content/mu-plugins`, add the following to ensure that the premium pattern indicator is displayed for you:
```
add_filter( 'a8c_enable_block_patterns_modifications', '__return_true' );
```
* Sandbox a test site and open the editor. Go to add a pattern, and under the Media pattern category look for the Audio player pattern. It should render with a pink circle next to the pattern title:

![image](https://user-images.githubusercontent.com/14988353/103500300-06748c00-4e9f-11eb-93e3-3e51e7085034.png)

* Insert the pattern, and in the snackbar notification at the bottom left, you should see that the pattern title followed by (Premium) is rendered. For example:

![image](https://user-images.githubusercontent.com/14988353/103500588-9e727580-4e9f-11eb-8c0b-cd11aec8d873.png)

##### Check that the premium pattern indicator feature is gracefully switched off when running in SCRIPT_DEBUG mode

* In your sandbox, in `.config/sandbox.php` (create the file if it doesn't exist), add the following to switch on SCRIPT_DEBUG mode and run React in development mode:

```
define( 'SCRIPT_DEBUG', true );
```

* Reload the editor. It should not throw a fatal and cause the error to crash. And if you open up the pattern inserter, you should still be able to see and add the Audio player pattern, however it will not have the pink circle next to the title, and if you add it, in the snackbar notification it will not say `(Premium)` after the title of the pattern.

Fixes #