### PR TITLE
Add from-calypso arg to WC URL used during and after sunsetting Store

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -722,7 +722,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const storeLink = site.options.admin_url + 'admin.php?page=wc-admin';
+		const storeLink = site.options.admin_url + 'admin.php?page=wc-admin&from-calypso';
 
 		return (
 			<SidebarItem

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -222,7 +222,9 @@ describe( 'MySitesSidebar', () => {
 
 			const wrapper = shallow( <WooCommerce /> );
 			expect( wrapper.html() ).not.toEqual( null );
-			expect( wrapper.props().link ).toEqual( 'http://test.com/wp-admin/admin.php?page=wc-admin' );
+			expect( wrapper.props().link ).toEqual(
+				'http://test.com/wp-admin/admin.php?page=wc-admin&from-calypso'
+			);
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #48420 

This PR adds a `from-calypso` argument to the WooCommerce URL used during and after sunsetting the Store.

## Test instructions:

Open Calypso with either `woocommerce/store-deprecated` or `woocommerce/store-removed` feature flags set (add `?flags=woocommerce/store-deprecated` to the URL).

The WooCommerce URL should now include `&from-calypso`. This will be used in this PR https://github.com/woocommerce/woocommerce-admin/pull/6004 which shows a different welcome modal.

![image](https://user-images.githubusercontent.com/224531/103501740-d9be7580-4e9a-11eb-9e82-e2a2c4a1b4cf.png)
