### PR TITLE
Adds box-shadow to sidebar flyouts

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -114,7 +114,6 @@ $font-size: rem( 14px );
 
 		.sidebar__expandable-content {
 			background: var( --color-sidebar-submenu-background );
-			box-shadow: 0 3px 5px rgba( 0, 0, 0, 0.2 );
 			padding: 7px 0 8px;
 
 			.sidebar__menu-link {
@@ -503,6 +502,7 @@ $font-size: rem( 14px );
 				position: absolute;
 				left: var( --sidebar-width-max );
 				width: 160px;
+				box-shadow: 0 3px 5px rgba( 0, 0, 0, 0.2 );
 
 				.sidebar__menu-link:hover {
 					font-weight: normal;

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -114,6 +114,7 @@ $font-size: rem( 14px );
 
 		.sidebar__expandable-content {
 			background: var( --color-sidebar-submenu-background );
+			box-shadow: 0 3px 5px rgba( 0, 0, 0, 0.2 );
 			padding: 7px 0 8px;
 
 			.sidebar__menu-link {


### PR DESCRIPTION
After using the Light theme with nav-unification enabled (paYJgx-1af-p2) for a while, I discovered that the flyouts were blending in with the main content
![](https://cln.sh/d85efU+)

It seems that we are missing a box-shadow property that already exists in wp-admin.

#### Changes proposed in this Pull Request

* Adds box-shadow to flyouts

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable nav-unification(paYJgx-1af-p2)
* Switch to Light theme
* Go to /home and hover Posts
* Check that box-shadow exists

![](https://cln.sh/2JPcz9+)