### PR TITLE
Deduplicate react and react-dom in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -23762,20 +23762,10 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-"react-dom@^0.14.3 || ^15.1.0 || ^16.0.0", react-dom@^16.10.2, react-dom@^16.12.0, react-dom@^16.9.0:
+"react-dom@^0.14.3 || ^15.1.0 || ^16.0.0", react-dom@^16.10.2, react-dom@^16.12.0, react-dom@^16.9.0, react-dom@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
-
-react-dom@^16.13.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -24109,19 +24099,10 @@ react-with-styles@^3.2.0:
     prop-types "^15.6.2"
     react-with-direction "^1.3.0"
 
-"react@^0.14.3 || ^15.1.0 || ^16.0.0", react@^16.10.2, react@^16.12.0, react@^16.9.0:
+"react@^0.14.3 || ^15.1.0 || ^16.0.0", react@^16.10.2, react@^16.12.0, react@^16.9.0, react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
-react@^16.13.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Fixes a wrong `yarn.lock` that causes two duplicate versions of React (16.3.1 and 16.4.0) to be installed.

Before the patch, there are many copies of `react` and `react-dom` in the installed tree:
```
react
  16.13.1 in ./node_modules/@wordpress/edit-site/node_modules/@wordpress/components/node_modules
  16.13.1 in ./node_modules/@wordpress/edit-site/node_modules/downshift/node_modules
  16.14.0 in ./node_modules/@wordpress/edit-site/node_modules
  16.13.1 in ./node_modules/@wordpress/edit-site/node_modules/react-transition-group/node_modules
  16.14.0 in ./node_modules/@wordpress/keyboard-shortcuts/node_modules
  16.14.0 in ./node_modules/@wordpress/notices/node_modules
  16.13.1 in ./node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components/node_modules
  16.13.1 in ./node_modules/@wordpress/reusable-blocks/node_modules/downshift/node_modules
  16.14.0 in ./node_modules/@wordpress/reusable-blocks/node_modules
  16.13.1 in ./node_modules/@wordpress/reusable-blocks/node_modules/react-transition-group/node_modules
  16.13.1 in ./node_modules
  16.14.0 in ./apps/editing-toolkit/node_modules/@wordpress/primitives/node_modules
```
After this patch, there only one React again:
```
react
  16.13.1 in ./node_modules
```

The problematic lockfile part, the one that resolves `^16.13.1` to `16.14.0`, was introduced in #47779. @autumnfjeld was the `yarn.lock` update there intentional? Does the Editor Welcome Tour need the 16.4 version for some reason? The PR has a commit labeled "Update yarn lock" that introduces the undesired change.