### PR TITLE
localizeUrl: Don't modify contact URL when logged-in

### DIFF
--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -153,18 +153,16 @@ export function useLocalizeUrl(): (
 	locale?: Locale,
 	isLoggedIn?: boolean
 ) => string {
-	const loggedIn = typeof isLoggedIn === 'undefined' ? true : !! isLoggedIn;
 	const providerLocale = useLocale();
 
 	return useCallback(
 		( fullUrl: string, locale?: Locale, isLoggedIn?: boolean ) => {
-			const loggedIn = typeof isLoggedIn === 'undefined' ? true : !! isLoggedIn;
 			if ( locale ) {
-				return localizeUrl( fullUrl, locale, loggedIn );
+				return localizeUrl( fullUrl, locale, isLoggedIn );
 			}
-			return localizeUrl( fullUrl, providerLocale, loggedIn );
+			return localizeUrl( fullUrl, providerLocale, isLoggedIn );
 		},
-		[ providerLocale, loggedIn ]
+		[ providerLocale ]
 	);
 }
 

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -88,7 +88,7 @@ const urlLocalizationMapping: UrlLocalizationMapping = {
 	'en.forums.wordpress.com': setLocalizedUrlHost( 'forums.wordpress.com', forumLocales ),
 	'automattic.com/privacy/': prefixLocalizedUrlPath( localesWithPrivacyPolicy ),
 	'automattic.com/cookies/': prefixLocalizedUrlPath( localesWithCookiePolicy ),
-	'wordpress.com/help/contact/': ( url: URL, localeSlug: Locale, isLoggedIn?: boolean ) => {
+	'wordpress.com/help/contact/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		if ( isLoggedIn ) {
 			return url;
 		}
@@ -98,8 +98,7 @@ const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
 };
 
-export function localizeUrl( fullUrl: string, locale: Locale, isLoggedIn?: boolean ): string {
-	const loggedIn = typeof isLoggedIn === 'undefined' ? true : !! isLoggedIn;
+export function localizeUrl( fullUrl: string, locale: Locale, isLoggedIn = true ): string {
 	let url;
 	try {
 		url = new URL( String( fullUrl ), INVALID_URL );
@@ -140,7 +139,7 @@ export function localizeUrl( fullUrl: string, locale: Locale, isLoggedIn?: boole
 
 	for ( let i = lookup.length - 1; i >= 0; i-- ) {
 		if ( lookup[ i ] in urlLocalizationMapping ) {
-			return urlLocalizationMapping[ lookup[ i ] ]( url, locale, loggedIn ).href;
+			return urlLocalizationMapping[ lookup[ i ] ]( url, locale, isLoggedIn ).href;
 		}
 	}
 

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -72,7 +72,7 @@ const prefixLocalizedUrlPath = (
 	return url;
 };
 
-type LinkLocalizer = ( url: URL, localeSlug: string ) => URL;
+type LinkLocalizer = ( url: URL, localeSlug: string, isLoggedIn: boolean ) => URL;
 
 interface UrlLocalizationMapping {
 	[ key: string ]: LinkLocalizer;
@@ -88,7 +88,7 @@ const urlLocalizationMapping: UrlLocalizationMapping = {
 	'en.forums.wordpress.com': setLocalizedUrlHost( 'forums.wordpress.com', forumLocales ),
 	'automattic.com/privacy/': prefixLocalizedUrlPath( localesWithPrivacyPolicy ),
 	'automattic.com/cookies/': prefixLocalizedUrlPath( localesWithCookiePolicy ),
-	'wordpress.com/help/contact/': ( url: URL, localeSlug: Locale, isLoggedIn?: bool ) => {
+	'wordpress.com/help/contact/': ( url: URL, localeSlug: Locale, isLoggedIn?: boolean ) => {
 		if ( isLoggedIn ) {
 			return url;
 		}
@@ -98,7 +98,7 @@ const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
 };
 
-export function localizeUrl( fullUrl: string, locale: Locale, isLoggedIn?: bool ): string {
+export function localizeUrl( fullUrl: string, locale: Locale, isLoggedIn?: boolean ): string {
 	const loggedIn = typeof isLoggedIn === 'undefined' ? true : !! isLoggedIn;
 	let url;
 	try {
@@ -151,13 +151,13 @@ export function localizeUrl( fullUrl: string, locale: Locale, isLoggedIn?: bool 
 export function useLocalizeUrl(): (
 	fullUrl: string,
 	locale?: Locale,
-	isLoggedIn?: bool
+	isLoggedIn?: boolean
 ) => string {
 	const loggedIn = typeof isLoggedIn === 'undefined' ? true : !! isLoggedIn;
 	const providerLocale = useLocale();
 
 	return useCallback(
-		( fullUrl: string, locale?: Locale, isLoggedIn?: bool ) => {
+		( fullUrl: string, locale?: Locale, isLoggedIn?: boolean ) => {
 			const loggedIn = typeof isLoggedIn === 'undefined' ? true : !! isLoggedIn;
 			if ( locale ) {
 				return localizeUrl( fullUrl, locale, loggedIn );

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -147,11 +147,7 @@ export function localizeUrl( fullUrl: string, locale: Locale, isLoggedIn = true 
 	return fullUrl;
 }
 
-export function useLocalizeUrl(): (
-	fullUrl: string,
-	locale?: Locale,
-	isLoggedIn?: boolean
-) => string {
+export function useLocalizeUrl() {
 	const providerLocale = useLocale();
 
 	return useCallback(

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -279,7 +279,7 @@ describe( '#localizeUrl', () => {
 	} );
 
 	test( 'Contact Support', () => {
-		// Assumes logged-in, these URLs should not be modified
+		// Assumes logged-in, these URLs should not be modified.
 		expect( localizeUrl( 'https://wordpress.com/help/contact', 'en' ) ).toEqual(
 			'https://wordpress.com/help/contact/'
 		);
@@ -292,6 +292,10 @@ describe( '#localizeUrl', () => {
 		);
 		expect( localizeUrl( 'https://wordpress.com/help/contact', 'de', false ) ).toEqual(
 			'https://wordpress.com/de/support/contact/'
+		);
+		// pl is not a supportSiteLocale:
+		expect( localizeUrl( 'https://wordpress.com/help/contact', 'pl', false ) ).toEqual(
+			'https://wordpress.com/support/contact/'
 		);
 	} );
 } );

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -277,4 +277,21 @@ describe( '#localizeUrl', () => {
 			'https://wordpress.com/de/support/reader/#blocking-sites'
 		);
 	} );
+
+	test( 'Contact Support', () => {
+		// Assumes logged-in, these URLs should not be modified
+		expect( localizeUrl( 'https://wordpress.com/help/contact', 'en' ) ).toEqual(
+			'https://wordpress.com/help/contact/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/help/contact', 'de' ) ).toEqual(
+			'https://wordpress.com/help/contact/'
+		);
+		// When logged-out, use localized URLs.
+		expect( localizeUrl( 'https://wordpress.com/help/contact', 'en', false ) ).toEqual(
+			'https://wordpress.com/support/contact/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/help/contact', 'de', false ) ).toEqual(
+			'https://wordpress.com/de/support/contact/'
+		);
+	} );
 } );


### PR DESCRIPTION
To allow the use of the `localizeUrl` function in signup flows, we need to start differentiating between it being called logged-in or logged-out. Since we don't want to start to have the i18n-utils package start to depend on Calypso state, I added a parameter that allows to ask for a URL in the respective user state: `localizeUrl( url, locale?, isLoggedIn? )` with `isLoggedIn` defaulting to true. In Calypso, an easy way to pass in the logged-in/out state is via the `window.currentUser` variable.

With regards to the needs of #48033, this currently only changes the following behavior ([see the unit test](packages/i18n-utils/src/test/localize-url.js#L280)):

- When logged-in, `https://wordpress.com/help/contact` will remain `https://wordpress.com/help/contact` (the URL is displayed in the user's language, no need to pass in the locale)
- When logged-out, `https://wordpress.com/help/contact` will be rewritten to `https://wordpress.com/support/contact`, or, if the `locale` is in `supportSiteLocales` to `https://wordpress.com/<locale>/support/contact`.

#### Changes proposed in this Pull Request

* Enable support URL localization depending on the user logged-in or out.

#### Testing instructions

* Run the unit tests via `yarn test-packages i18n-utils`.

Fixes #48033
