### PR TITLE
Site Settings: Localize date and time format suggestions like in wp-admin

### DIFF
--- a/client/my-sites/site-settings/date-time-format/date-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/date-format-option.jsx
@@ -13,7 +13,7 @@ import FormInput from 'calypso/components/forms/form-text-input';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import { defaultDateFormats } from './default-formats';
+import { getDefaultDateFormats } from './default-formats';
 import { phpToMomentDatetimeFormat } from './utils';
 
 export const DateFormatOption = ( {
@@ -27,7 +27,7 @@ export const DateFormatOption = ( {
 } ) => (
 	<FormFieldset>
 		<FormLabel>{ translate( 'Date Format' ) }</FormLabel>
-		{ defaultDateFormats.map( ( format ) => (
+		{ getDefaultDateFormats().map( ( format ) => (
 			<FormLabel key={ format }>
 				<FormRadio
 					checked={ ! isCustom && format === dateFormat }

--- a/client/my-sites/site-settings/date-time-format/default-formats.js
+++ b/client/my-sites/site-settings/date-time-format/default-formats.js
@@ -1,17 +1,22 @@
 /**
+ * External dependencies
+ */
+import { uniq } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { translate } from 'i18n-calypso';
 
 export function getDefaultDateFormats() {
-	return [
+	return uniq( [
 		translate( 'F j, Y' ),
 		translate( 'Y-m-d' ),
 		translate( 'm/d/Y' ),
 		translate( 'd/m/Y' ),
-	];
+	] );
 }
 
 export function getDefaultTimeFormats() {
-	return [ translate( 'g:i a' ), translate( 'g:i A' ), translate( 'H:i' ) ];
+	return uniq( [ translate( 'g:i a' ), translate( 'g:i A' ), translate( 'H:i' ) ] );
 }

--- a/client/my-sites/site-settings/date-time-format/default-formats.js
+++ b/client/my-sites/site-settings/date-time-format/default-formats.js
@@ -1,3 +1,17 @@
-export const defaultDateFormats = [ 'F j, Y', 'Y-m-d', 'm/d/Y', 'd/m/Y' ];
+/**
+ * Internal dependencies
+ */
+import { translate } from 'i18n-calypso';
 
-export const defaultTimeFormats = [ 'g:i a', 'g:i A', 'H:i' ];
+export function getDefaultDateFormats() {
+	return [
+		translate( 'F j, Y' ),
+		translate( 'Y-m-d' ),
+		translate( 'm/d/Y' ),
+		translate( 'd/m/Y' ),
+	];
+}
+
+export function getDefaultTimeFormats() {
+	return [ translate( 'g:i a' ), translate( 'g:i A' ), translate( 'H:i' ) ];
+}

--- a/client/my-sites/site-settings/date-time-format/index.jsx
+++ b/client/my-sites/site-settings/date-time-format/index.jsx
@@ -14,7 +14,7 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import DateFormatOption from './date-format-option';
 import StartOfWeekOption from './start-of-week-option';
 import TimeFormatOption from './time-format-option';
-import { defaultDateFormats, defaultTimeFormats } from './default-formats';
+import { getDefaultDateFormats, getDefaultTimeFormats } from './default-formats';
 import { getLocalizedDate, phpToMomentDatetimeFormat } from './utils';
 
 /**
@@ -58,8 +58,8 @@ export class DateTimeFormat extends Component {
 		}
 
 		this.setState( {
-			customDateFormat: ! includes( defaultDateFormats, dateFormat ),
-			customTimeFormat: ! includes( defaultTimeFormats, timeFormat ),
+			customDateFormat: ! includes( getDefaultDateFormats(), dateFormat ),
+			customTimeFormat: ! includes( getDefaultTimeFormats(), timeFormat ),
 			isLoadingSettings: false,
 		} );
 	}
@@ -72,9 +72,9 @@ export class DateTimeFormat extends Component {
 		} );
 	};
 
-	setDateFormat = this.setFormat( 'date', defaultDateFormats );
+	setDateFormat = this.setFormat( 'date', getDefaultDateFormats() );
 
-	setTimeFormat = this.setFormat( 'time', defaultTimeFormats );
+	setTimeFormat = this.setFormat( 'time', getDefaultTimeFormats() );
 
 	setCustomFormat = ( name ) => ( event ) => {
 		const { value: format } = event.currentTarget;

--- a/client/my-sites/site-settings/date-time-format/time-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/time-format-option.jsx
@@ -14,7 +14,7 @@ import FormInput from 'calypso/components/forms/form-text-input';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import { defaultTimeFormats } from './default-formats';
+import { getDefaultTimeFormats } from './default-formats';
 import { phpToMomentDatetimeFormat } from './utils';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 
@@ -29,7 +29,7 @@ export const TimeFormatOption = ( {
 } ) => (
 	<FormFieldset>
 		<FormLabel>{ translate( 'Time Format' ) }</FormLabel>
-		{ defaultTimeFormats.map( ( format ) => (
+		{ getDefaultTimeFormats().map( ( format ) => (
 			<FormLabel key={ format }>
 				<FormRadio
 					checked={ ! isCustom && format === timeFormat }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Before: date format suggestions are not localized:
<img width="393" alt="Screen Shot 2020-12-28 at 3 32 44 PM" src="https://user-images.githubusercontent.com/36699353/103246846-21388500-4922-11eb-90e9-96728b367f12.png">

wp-admin: should be localized like this:

<img width="562" alt="Screen Shot 2020-12-28 at 3 32 52 PM" src="https://user-images.githubusercontent.com/36699353/103246853-272e6600-4922-11eb-920d-37e1e783cee9.png">

#### Testing instructions

* Go to https://wordpress.com/settings/writing/site.wordpress.com while not in English
* Expand the time and date settings.
* Right now the translations don't appear because they are not in the translated JSONs yet.
