### PR TITLE
Desktop boot refactors

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -446,7 +446,7 @@ const boot = ( currentUser, registerRoutes ) => {
 	} );
 };
 
-function waitForCookieAuth( user ) {
+function waitForDesktopCookieAuth( user ) {
 	const timeoutMs = 1500;
 	const loggedIn = user.get() !== false;
 
@@ -496,7 +496,7 @@ export const bootApp = async ( appName, registerRoutes ) => {
 	const user = userFactory();
 	await user.initialize();
 	if ( config.isEnabled( 'desktop' ) ) {
-		await waitForCookieAuth( user );
+		await waitForDesktopCookieAuth( user );
 	}
 	debug( `Starting ${ appName }. Let's do this.` );
 	boot( user, registerRoutes );

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -461,35 +461,33 @@ function waitForDesktopCookieAuth( user ) {
 		return Promise.race( [ promise, timeout ] );
 	};
 
-	const renderPromise = () => {
-		return new Promise( function ( resolve ) {
-			const sendUserAuth = () => {
-				debug( 'Sending user info to desktop...' );
-				window.electron.send(
-					'user-auth',
-					{ id: user.data.ID, username: user.data.username },
-					getToken()
-				);
-			};
+	const renderPromise = new Promise( ( resolve ) => {
+		const sendUserAuth = () => {
+			debug( 'Sending user info to desktop...' );
+			window.electron.send(
+				'user-auth',
+				{ id: user.data.ID, username: user.data.username },
+				getToken()
+			);
+		};
 
-			if ( loggedIn ) {
-				debug( 'Desktop user logged in, waiting on cookie authentication...' );
-				window.electron.receive( 'cookie-auth-complete', function () {
-					debug( 'Desktop cookies set, rendering main layout...' );
-					resolve();
-				} );
-				// Send user auth and wait on cookie-auth-complete
-				sendUserAuth();
-			} else {
-				debug( 'Desktop user logged out, rendering main layout...' );
-				// Send user auth and resolve immediately
-				sendUserAuth();
+		if ( loggedIn ) {
+			debug( 'Desktop user logged in, waiting on cookie authentication...' );
+			window.electron.receive( 'cookie-auth-complete', function () {
+				debug( 'Desktop cookies set, rendering main layout...' );
 				resolve();
-			}
-		} );
-	};
+			} );
+			// Send user auth and wait on cookie-auth-complete
+			sendUserAuth();
+		} else {
+			debug( 'Desktop user logged out, rendering main layout...' );
+			// Send user auth and resolve immediately
+			sendUserAuth();
+			resolve();
+		}
+	} );
 
-	return promiseTimeout( timeoutMs, renderPromise() );
+	return promiseTimeout( timeoutMs, renderPromise );
 }
 
 export const bootApp = async ( appName, registerRoutes ) => {

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -451,10 +451,12 @@ function waitForDesktopCookieAuth( user ) {
 	const loggedIn = user.get() !== false;
 
 	const promiseTimeout = ( ms, promise ) => {
-		const timeout = new Promise( ( _, reject ) => {
+		const timeout = new Promise( ( resolve ) => {
 			const id = setTimeout( () => {
 				clearTimeout( id );
-				reject( `Request timed out in ${ ms } ms` );
+				debug( `Request timed out in ${ ms } ms` );
+				// Resolve anyway so the entire boot sequence isn't aborted
+				resolve();
 			}, ms );
 		} );
 

--- a/client/desktop/lib/cookie-auth/index.js
+++ b/client/desktop/lib/cookie-auth/index.js
@@ -70,6 +70,11 @@ function parseCookie( cookieStr ) {
 function setSessionCookies( window, authorizeResponse ) {
 	return new Promise( ( resolve ) => {
 		let cookieHeaders = authorizeResponse.headers[ 'set-cookie' ];
+		if ( ! cookieHeaders ) {
+			log.info( `'set-cookie' header not present in response.` );
+			return resolve( true );
+		}
+
 		let count = 0;
 		if ( ! Array.isArray( cookieHeaders ) ) {
 			cookieHeaders = [ cookieHeaders ];

--- a/client/desktop/lib/cookie-auth/index.js
+++ b/client/desktop/lib/cookie-auth/index.js
@@ -81,6 +81,7 @@ function setSessionCookies( window, authorizeResponse ) {
 			return resolve( true );
 		}
 
+		// Note: Do not use Promise.all as we do not want to abort setting subsequent cookies when an error is encountered.
 		cookieHeaders.forEach( async function ( cookieStr ) {
 			const cookie = parseCookie( cookieStr );
 			cookie.url = 'https://wordpress.com/';


### PR DESCRIPTION
### Description

This PR addresses some PR feedback received as part of #46621.

Note: one of the initial suggestions was to use `Promise.all` instead of forEach when setting cookies. However, it turns out that Promise.all is an all-or-nothing operation and will abort the entire sequence if an error is encountered. I added a comment to clarify.