### PR TITLE
Shopping cart: Add CartMessages to CalypsoShoppingCartProvider

### DIFF
--- a/client/components/upgrades/gsuite/index.jsx
+++ b/client/components/upgrades/gsuite/index.jsx
@@ -3,7 +3,7 @@
  */
 import page from 'page';
 import React, { useEffect, useRef } from 'react';
-import { connect, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { useShoppingCart } from '@automattic/shopping-cart';
 
@@ -22,9 +22,10 @@ import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductsList } from 'calypso/state/products-list/selectors/get-products-list';
 
-const GSuiteUpgrade = ( { cart, domain, selectedSiteSlug } ) => {
+export default function GSuiteUpgrade( { domain } ) {
+	const { responseCart: cart, addProductsToCart, isLoading } = useShoppingCart();
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const productsList = useSelector( getProductsList );
-	const { addProductsToCart, isLoading } = useShoppingCart();
 
 	const isMounted = useRef( true );
 	useEffect( () => {
@@ -76,8 +77,4 @@ const GSuiteUpgrade = ( { cart, domain, selectedSiteSlug } ) => {
 			/>
 		</div>
 	);
-};
-
-export default connect( ( state ) => ( {
-	selectedSiteSlug: getSelectedSiteSlug( state ),
-} ) )( GSuiteUpgrade );
+}

--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { ShoppingCartProvider } from '@automattic/shopping-cart';
+import { ShoppingCartProvider, useShoppingCart } from '@automattic/shopping-cart';
 import type { RequestCart, ResponseCart } from '@automattic/shopping-cart';
 
 /**
@@ -12,6 +12,7 @@ import type { RequestCart, ResponseCart } from '@automattic/shopping-cart';
 import wp from 'calypso/lib/wp';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import getCartKey from './get-cart-key';
+import CartMessages from 'calypso/my-sites/checkout/cart/cart-messages';
 
 // Aliasing wpcom functions explicitly bound to wpcom is required here;
 // otherwise we get `this is not defined` errors.
@@ -41,7 +42,13 @@ export default function CalypsoShoppingCartProvider( {
 			getCart={ getCart || wpcomGetCart }
 			setCart={ wpcomSetCart }
 		>
+			<CalypsoShoppingCartMessages />
 			{ children }
 		</ShoppingCartProvider>
 	);
+}
+
+function CalypsoShoppingCartMessages() {
+	const { responseCart, isLoading } = useShoppingCart();
+	return <CartMessages cart={ responseCart } isLoadingCart={ isLoading } />;
 }

--- a/client/my-sites/checkout/cart/cart-messages.jsx
+++ b/client/my-sites/checkout/cart/cart-messages.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
+import React, { useRef, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,120 +12,108 @@ import notices from 'calypso/notices';
 import { getNewMessages } from 'calypso/lib/cart-values';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-class CartMessages extends PureComponent {
-	static propTypes = {
-		cart: PropTypes.object.isRequired,
-		isLoadingCart: PropTypes.bool,
+export default function CartMessages( { cart, isLoadingCart } ) {
+	const previousCart = useRef( null );
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const translate = useTranslate();
 
-		// from HOCs
-		translate: PropTypes.func.isRequired,
-		selectedSiteSlug: PropTypes.string,
-	};
-
-	previousCart = null;
-
-	componentDidMount() {
-		this.displayCartMessages();
-	}
-
-	componentDidUpdate() {
-		this.displayCartMessages();
-	}
-
-	getChargebackErrorMessage() {
-		return this.props.translate(
-			'{{strong}}Warning:{{/strong}} One or more transactions linked to this site were refunded due to a contested charge. ' +
-				'This may have happened because of a chargeback by the credit card holder or a PayPal investigation. Each contested ' +
-				'charge carries a fine. To resolve the issue and re-enable posting, please {{a}}pay for the chargeback fine{{/a}}.',
-			{
-				components: {
-					strong: <strong />,
-					a: <a href={ '/checkout/' + this.props.selectedSiteSlug ?? '' } />,
-				},
-			}
-		);
-	}
-
-	getBlockedPurchaseErrorMessage() {
-		return this.props.translate(
-			'Purchases are currently disabled. Please {{a}}contact us{{/a}} to re-enable purchases.',
-			{
-				components: {
-					a: (
-						<a
-							href={
-								'https://wordpress.com/error-report/' + this.props.selectedSiteSlug
-									? '?url=payment@' + this.props.selectedSiteSlug
-									: ''
-							}
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-				},
-			}
-		);
-	}
-
-	getPrettyErrorMessages( messages ) {
-		if ( ! messages ) {
-			return [];
-		}
-
-		return messages.map( ( error ) => {
-			switch ( error.code ) {
-				case 'chargeback':
-					return Object.assign( error, { message: this.getChargebackErrorMessage() } );
-
-				case 'blocked':
-					return Object.assign( error, { message: this.getBlockedPurchaseErrorMessage() } );
-
-				default:
-					return error;
-			}
+	useEffect( () => {
+		displayCartMessages( {
+			cart,
+			isLoadingCart,
+			translate,
+			selectedSiteSlug,
+			previousCart: previousCart.current,
 		} );
-	}
+		previousCart.current = cart;
+	}, [ cart, isLoadingCart, translate, selectedSiteSlug ] );
 
-	displayCartMessages() {
-		const newCart = this.props.cart;
-		if ( this.props.isLoadingCart ) {
-			return;
-		}
-		const messages = getNewMessages( this.previousCart, newCart );
-
-		messages.errors = this.getPrettyErrorMessages( messages.errors );
-
-		this.previousCart = newCart;
-
-		if ( messages.errors?.length > 0 ) {
-			notices.error(
-				messages.errors.map( ( error ) => (
-					<p key={ `${ error.code }-${ error.message }` }>{ error.message }</p>
-				) ),
-				{ persistent: true }
-			);
-			return;
-		}
-
-		if ( messages.success?.length > 0 ) {
-			notices.success(
-				messages.success.map( ( success ) => (
-					<p key={ `${ success.code }-${ success.message }` }>{ success.message }</p>
-				) )
-			);
-			return;
-		}
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-function mapStateToProps( state ) {
-	return {
-		selectedSiteSlug: getSelectedSiteSlug( state ),
-	};
+function getChargebackErrorMessage( { translate, selectedSiteSlug } ) {
+	return translate(
+		'{{strong}}Warning:{{/strong}} One or more transactions linked to this site were refunded due to a contested charge. ' +
+			'This may have happened because of a chargeback by the credit card holder or a PayPal investigation. Each contested ' +
+			'charge carries a fine. To resolve the issue and re-enable posting, please {{a}}pay for the chargeback fine{{/a}}.',
+		{
+			components: {
+				strong: <strong />,
+				a: <a href={ '/checkout/' + selectedSiteSlug ?? '' } />,
+			},
+		}
+	);
 }
 
-export default connect( mapStateToProps )( localize( CartMessages ) );
+function getBlockedPurchaseErrorMessage( { translate, selectedSiteSlug } ) {
+	return translate(
+		'Purchases are currently disabled. Please {{a}}contact us{{/a}} to re-enable purchases.',
+		{
+			components: {
+				a: (
+					<a
+						href={
+							'https://wordpress.com/error-report/' + selectedSiteSlug
+								? '?url=payment@' + selectedSiteSlug
+								: ''
+						}
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			},
+		}
+	);
+}
+
+function getPrettyErrorMessages( messages, { translate, selectedSiteSlug } ) {
+	if ( ! messages ) {
+		return [];
+	}
+
+	return messages.map( ( error ) => {
+		switch ( error.code ) {
+			case 'chargeback':
+				return Object.assign( error, {
+					message: getChargebackErrorMessage( { translate, selectedSiteSlug } ),
+				} );
+
+			case 'blocked':
+				return Object.assign( error, {
+					message: getBlockedPurchaseErrorMessage( { translate, selectedSiteSlug } ),
+				} );
+
+			default:
+				return error;
+		}
+	} );
+}
+
+function displayCartMessages( { cart, isLoadingCart, translate, selectedSiteSlug, previousCart } ) {
+	const newCart = cart;
+	if ( isLoadingCart ) {
+		return;
+	}
+	const messages = getNewMessages( previousCart, newCart );
+
+	messages.errors = getPrettyErrorMessages( messages.errors, { translate, selectedSiteSlug } );
+
+	if ( messages.errors?.length > 0 ) {
+		notices.error(
+			messages.errors.map( ( error ) => (
+				<p key={ `${ error.code }-${ error.message }` }>{ error.message }</p>
+			) ),
+			{ persistent: true }
+		);
+		return;
+	}
+
+	if ( messages.success?.length > 0 ) {
+		notices.success(
+			messages.success.map( ( success ) => (
+				<p key={ `${ success.code }-${ success.message }` }>{ success.message }</p>
+			) )
+		);
+		return;
+	}
+}

--- a/client/my-sites/checkout/cart/cart-messages.jsx
+++ b/client/my-sites/checkout/cart/cart-messages.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
@@ -10,17 +11,16 @@ import { localize } from 'i18n-calypso';
  */
 import notices from 'calypso/notices';
 import { getNewMessages } from 'calypso/lib/cart-values';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 class CartMessages extends PureComponent {
 	static propTypes = {
 		cart: PropTypes.object.isRequired,
 		isLoadingCart: PropTypes.bool,
-		selectedSite: PropTypes.shape( {
-			slug: PropTypes.string,
-		} ).isRequired,
 
-		// connected
+		// from HOCs
 		translate: PropTypes.func.isRequired,
+		selectedSiteSlug: PropTypes.string,
 	};
 
 	previousCart = null;
@@ -41,7 +41,7 @@ class CartMessages extends PureComponent {
 			{
 				components: {
 					strong: <strong />,
-					a: <a href={ '/checkout/' + this.props.selectedSite.slug } />,
+					a: <a href={ '/checkout/' + this.props.selectedSiteSlug ?? '' } />,
 				},
 			}
 		);
@@ -55,7 +55,9 @@ class CartMessages extends PureComponent {
 					a: (
 						<a
 							href={
-								'https://wordpress.com/error-report/?url=payment@' + this.props.selectedSite.slug
+								'https://wordpress.com/error-report/' + this.props.selectedSiteSlug
+									? '?url=payment@' + this.props.selectedSiteSlug
+									: ''
 							}
 							target="_blank"
 							rel="noopener noreferrer"
@@ -121,4 +123,10 @@ class CartMessages extends PureComponent {
 	}
 }
 
-export default localize( CartMessages );
+function mapStateToProps( state ) {
+	return {
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+	};
+}
+
+export default connect( mapStateToProps )( localize( CartMessages ) );

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -16,7 +16,6 @@ import { withShoppingCart } from '@automattic/shopping-cart';
  */
 import CartBody from './cart-body';
 import CartBodyLoadingPlaceholder from './cart-body/loading-placeholder';
-import CartMessages from './cart-messages';
 import HeaderButton from 'calypso/components/header-button';
 import CartButtons from './cart-buttons';
 import Count from 'calypso/components/count';
@@ -87,7 +86,6 @@ class PopoverCart extends React.Component {
 	};
 
 	render() {
-		const { cart, selectedSite, shoppingCartManager } = this.props;
 		let countBadge;
 		const classes = classNames( 'popover-cart', {
 			pinned: this.props.pinned,
@@ -104,11 +102,6 @@ class PopoverCart extends React.Component {
 
 		return (
 			<div>
-				<CartMessages
-					cart={ cart }
-					selectedSite={ selectedSite }
-					isLoadingCart={ ! shoppingCartManager.isLoading }
-				/>
 				<div className={ classes }>
 					<HeaderButton
 						icon="cart"

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -40,7 +40,6 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QueryPlans from 'calypso/components/data/query-plans';
 import QueryProducts from 'calypso/components/data/query-products-list';
 import QueryExperiments from 'calypso/components/data/query-experiments';
-import CartMessages from 'calypso/my-sites/checkout/cart/cart-messages';
 import useIsApplePayAvailable from './hooks/use-is-apple-pay-available';
 import filterAppropriatePaymentMethods from './lib/filter-appropriate-payment-methods';
 import useStoredCards from './hooks/use-stored-cards';
@@ -581,11 +580,6 @@ export default function CompositeCheckout( {
 		return (
 			<React.Fragment>
 				<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />
-				<CartMessages
-					cart={ responseCart }
-					selectedSite={ { slug: siteSlug } }
-					isLoadingCart={ isInitialCartLoading }
-				/>
 				<ThemeProvider theme={ theme }>
 					<MainContentWrapper>
 						<CheckoutStepAreaWrapper>
@@ -611,11 +605,6 @@ export default function CompositeCheckout( {
 			<QueryProducts />
 			<QueryContactDetailsCache />
 			<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />
-			<CartMessages
-				cart={ responseCart }
-				selectedSite={ { slug: siteSlug } }
-				isLoadingCart={ isInitialCartLoading }
-			/>
 			<CheckoutProvider
 				items={ itemsForCheckout }
 				total={ total }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This renders the `CartMessages` component everywhere that `CalypsoShoppingCartProvider` is rendered, which will make sure that any success or failure messages returned by the shopping cart endpoint will be displayed.

Fixes https://github.com/Automattic/wp-calypso/issues/48654

#### Testing instructions

1. Starting at URL: http://calypso.localhost:3000/domains/add/example.com
2. Apply D54847-code to your sandbox and sandbox the API. This will break adding G Suite products.
3. Add a domain to your cart.
4. At the upsell, add G Suite to your cart.
5. Verify that you end up in checkout, but that the G Suite product is not in the cart and that you see an appropriate error message.

<img width="1106" alt="Screen Shot 2021-01-04 at 6 23 39 PM" src="https://user-images.githubusercontent.com/2036909/103590057-e652c600-4eba-11eb-9b6e-e48169330ef3.png">
