### PR TITLE
Fix Store info icon alignment

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -689,6 +689,7 @@ export class MySitesSidebar extends Component {
 				onNavigate={ this.trackStoreClick }
 				materialIcon="shopping_cart"
 				forceInternalLink
+				className="sidebar__store"
 			>
 				{ isCalypsoStoreDeprecatedOrRemoved && isBusiness( site.plan ) && (
 					<InfoPopover className="sidebar__store-tooltip" position="bottom right">

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -39,3 +39,9 @@
 		}
 	}
 }
+
+.sidebar__store {
+	button {
+		margin-right: 5px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the alignment of the Store info icon.

Before:
![image](https://user-images.githubusercontent.com/224531/103499509-0ae77780-4e94-11eb-9bf9-3c2da673fcd4.png)
After:
![image](https://user-images.githubusercontent.com/224531/103607352-684af980-4f64-11eb-8f0d-8cd4e51e6ae0.png)


Fixes #48639