### PR TITLE
Anchor FM Theme Font Pairings

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -294,8 +294,8 @@
 			"template": "gilbert",
 			"theme": "gilbert",
 			"fonts": {
-				"headings": "Chivo",
-				"base": "Open Sans"
+				"headings": "Roboto",
+				"base": "Roboto"
 			},
 			"categories": [ "featured" ],
 			"is_premium": false,
@@ -307,8 +307,8 @@
 			"template": "riley",
 			"theme": "riley",
 			"fonts": {
-				"headings": "Fira Sans",
-				"base": "Fira Sans"
+				"headings": "Raleway",
+				"base": "Cabin"
 			},
 			"categories": [ "featured" ],
 			"is_premium": false,

--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -48,6 +48,22 @@ export const fontPairings = [
 	},
 ] as const;
 
+/**
+ * Pairings of fontFamilies for AnchorFM onboarding
+ *
+ * To get the name of the font for display, use `getFontTitle( fontName )`.
+ */
+export const anchorFmFontPairings = [
+	{
+		headings: 'Roboto',
+		base: 'Roboto',
+	},
+	{
+		headings: 'Raleway',
+		base: 'Cabin',
+	},
+] as const;
+
 export type Font = ValuesType< ValuesType< typeof fontPairings > >;
 export interface FontPair {
 	headings: Font;

--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -8,7 +8,6 @@ import type { ValuesType } from 'utility-types';
  *
  */
 export const FLOW_ID = 'gutenboarding';
-export const ANCHOR_FM_FLOW_ID = 'anchor-fm';
 
 const fontTitles: Partial< Record< Font, string > > = {
 	'Playfair Display': 'Playfair',

--- a/client/landing/gutenboarding/fonts.ts
+++ b/client/landing/gutenboarding/fonts.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { fontPairings, anchorFmFontPairings } from '../gutenboarding/constants';
+import { useIsAnchorFm } from '../gutenboarding/path';
+
+export function useFontPairings() {
+	const isAnchorFmSignup = useIsAnchorFm();
+	const effectiveFontPairings = isAnchorFmSignup
+		? [ ...fontPairings, ...anchorFmFontPairings ]
+		: fontPairings;
+	return effectiveFontPairings;
+}

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -18,7 +18,7 @@ import { useI18n } from '@automattic/react-i18n';
 import Header from './components/header';
 import SignupForm from './components/signup-form';
 import { name, settings } from './onboarding-block';
-import { getFontTitle } from './constants';
+import { FontPair, getFontTitle } from './constants';
 import useOnSiteCreation from './hooks/use-on-site-creation';
 import { usePageViewTracksEvents } from './hooks/use-page-view-tracks-events';
 import useSignup from './hooks/use-signup';
@@ -46,7 +46,7 @@ const Gutenboard: React.FunctionComponent = () => {
 	// TODO: Explore alternatives for loading fonts and optimizations
 	// TODO: Don't load like this
 	React.useEffect( () => {
-		effectiveFontPairings.forEach( ( { base, headings } ) => {
+		effectiveFontPairings.forEach( ( { base, headings }: FontPair ) => {
 			const linkBase = document.createElement( 'link' );
 			const linkHeadings = document.createElement( 'link' );
 

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -18,7 +18,7 @@ import { useI18n } from '@automattic/react-i18n';
 import Header from './components/header';
 import SignupForm from './components/signup-form';
 import { name, settings } from './onboarding-block';
-import { fontPairings, getFontTitle } from './constants';
+import { getFontTitle } from './constants';
 import useOnSiteCreation from './hooks/use-on-site-creation';
 import { usePageViewTracksEvents } from './hooks/use-page-view-tracks-events';
 import useSignup from './hooks/use-signup';
@@ -26,6 +26,7 @@ import useOnSignup from './hooks/use-on-signup';
 import useOnLogin from './hooks/use-on-login';
 import useSiteTitle from './hooks/use-site-title';
 import useTrackOnboardingStart from './hooks/use-track-onboarding-start';
+import { useFontPairings } from '../gutenboarding/fonts';
 
 import './style.scss';
 
@@ -40,11 +41,12 @@ const Gutenboard: React.FunctionComponent = () => {
 	useTrackOnboardingStart();
 	useSiteTitle();
 	const { showSignupDialog, onSignupDialogClose } = useSignup();
+	const effectiveFontPairings = useFontPairings();
 
 	// TODO: Explore alternatives for loading fonts and optimizations
 	// TODO: Don't load like this
 	React.useEffect( () => {
-		fontPairings.forEach( ( { base, headings } ) => {
+		effectiveFontPairings.forEach( ( { base, headings } ) => {
 			const linkBase = document.createElement( 'link' );
 			const linkHeadings = document.createElement( 'link' );
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -8,12 +8,12 @@ import classnames from 'classnames';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
-import { useIsAnchorFm } from '../../path';
+import { useFontPairings } from '../../fonts';
 
 /**
  * Internal dependencies
  */
-import { fontPairings, getFontTitle, FontPair, anchorFmFontPairings } from '../../constants';
+import { getFontTitle, FontPair } from '../../constants';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 
 const FontSelect: React.FunctionComponent = () => {
@@ -58,11 +58,7 @@ const FontSelect: React.FunctionComponent = () => {
 		__( 'Select fonts' )
 	);
 
-	const isAnchorFmSignup = useIsAnchorFm();
-
-	const effectiveFontPairings = isAnchorFmSignup
-		? [ ...fontPairings, ...anchorFmFontPairings ]
-		: fontPairings;
+	const effectiveFontPairings = useFontPairings();
 
 	const fontPairingsFilter = ( pair: FontPair ): boolean => {
 		if ( ! selectedDesignDefaultFonts ) {

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -86,30 +86,33 @@ const FontSelect: React.FunctionComponent = () => {
 					>
 						<span className="style-preview__font-option-contents">{ defaultFontOption }</span>
 					</Button>
-					{ effectiveFontPairings.filter( fontPairingsFilter ).map( ( fontPair ) => {
-						// Font pairs are objects, we need `isShallowEqual` as we can't guarantee referential equality
-						// (E.g. if `selectedFonts` is coming from persisted state)
-						const isSelected = !! selectedFonts && isShallowEqual( fontPair, selectedFonts );
-						const { headings, base } = fontPair;
+					{ /* https://github.com/microsoft/TypeScript/issues/36390 */ }
+					{ ( effectiveFontPairings as FontPair[] )
+						.filter( fontPairingsFilter )
+						.map( ( fontPair ) => {
+							// Font pairs are objects, we need `isShallowEqual` as we can't guarantee referential equality
+							// (E.g. if `selectedFonts` is coming from persisted state)
+							const isSelected = !! selectedFonts && isShallowEqual( fontPair, selectedFonts );
+							const { headings, base } = fontPair;
 
-						return (
-							<Button
-								className={ classnames( 'style-preview__font-option', {
-									'is-selected': isSelected,
-								} ) }
-								onClick={ () => setFonts( fontPair ) }
-								key={ headings + base }
-							>
-								<span className="style-preview__font-option-contents">
-									<span style={ { fontFamily: headings, fontWeight: 700 } }>
-										{ getFontTitle( headings ) }
+							return (
+								<Button
+									className={ classnames( 'style-preview__font-option', {
+										'is-selected': isSelected,
+									} ) }
+									onClick={ () => setFonts( fontPair ) }
+									key={ headings + base }
+								>
+									<span className="style-preview__font-option-contents">
+										<span style={ { fontFamily: headings, fontWeight: 700 } }>
+											{ getFontTitle( headings ) }
+										</span>
+										&nbsp;/&nbsp;
+										<span style={ { fontFamily: base } }>{ getFontTitle( base ) }</span>
 									</span>
-									&nbsp;/&nbsp;
-									<span style={ { fontFamily: base } }>{ getFontTitle( base ) }</span>
-								</span>
-							</Button>
-						);
-					} ) }
+								</Button>
+							);
+						} ) }
 				</div>
 				<div className="style-preview__font-options-mobile">
 					<Button
@@ -146,34 +149,36 @@ const FontSelect: React.FunctionComponent = () => {
 						>
 							<span className="style-preview__font-option-contents">{ defaultFontOption }</span>
 						</Button>
-						{ effectiveFontPairings.filter( fontPairingsFilter ).map( ( fontPair ) => {
-							// Font pairs are objects, we need `isShallowEqual` as we can't guarantee referential equality
-							// (E.g. if `selectedFonts` is coming from persisted state)
-							const isSelected = !! selectedFonts && isShallowEqual( fontPair, selectedFonts );
-							const { headings, base } = fontPair;
+						{ ( effectiveFontPairings as FontPair[] )
+							.filter( fontPairingsFilter )
+							.map( ( fontPair ) => {
+								// Font pairs are objects, we need `isShallowEqual` as we can't guarantee referential equality
+								// (E.g. if `selectedFonts` is coming from persisted state)
+								const isSelected = !! selectedFonts && isShallowEqual( fontPair, selectedFonts );
+								const { headings, base } = fontPair;
 
-							return (
-								<Button
-									className={ classnames(
-										'style-preview__font-option',
-										'style-preview__font-option-mobile',
-										{
-											'is-selected-dropdown-option': isSelected,
-										}
-									) }
-									onClick={ () => setFontsAndClose( fontPair ) }
-									key={ headings + base }
-								>
-									<span className="style-preview__font-option-contents">
-										<span style={ { fontFamily: headings, fontWeight: 700 } }>
-											{ getFontTitle( headings ) }
+								return (
+									<Button
+										className={ classnames(
+											'style-preview__font-option',
+											'style-preview__font-option-mobile',
+											{
+												'is-selected-dropdown-option': isSelected,
+											}
+										) }
+										onClick={ () => setFontsAndClose( fontPair ) }
+										key={ headings + base }
+									>
+										<span className="style-preview__font-option-contents">
+											<span style={ { fontFamily: headings, fontWeight: 700 } }>
+												{ getFontTitle( headings ) }
+											</span>
+											&nbsp;/&nbsp;
+											<span style={ { fontFamily: base } }>{ getFontTitle( base ) }</span>
 										</span>
-										&nbsp;/&nbsp;
-										<span style={ { fontFamily: base } }>{ getFontTitle( base ) }</span>
-									</span>
-								</Button>
-							);
-						} ) }
+									</Button>
+								);
+							} ) }
 					</div>
 				</div>
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -8,11 +8,12 @@ import classnames from 'classnames';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
+import { useIsAnchorFm } from '../../path';
 
 /**
  * Internal dependencies
  */
-import { fontPairings, getFontTitle, FontPair } from '../../constants';
+import { fontPairings, getFontTitle, FontPair, anchorFmFontPairings } from '../../constants';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 
 const FontSelect: React.FunctionComponent = () => {
@@ -57,6 +58,12 @@ const FontSelect: React.FunctionComponent = () => {
 		__( 'Select fonts' )
 	);
 
+	const isAnchorFmSignup = useIsAnchorFm();
+
+	const effectiveFontPairings = isAnchorFmSignup
+		? [ ...fontPairings, ...anchorFmFontPairings ]
+		: fontPairings;
+
 	const fontPairingsFilter = ( pair: FontPair ): boolean => {
 		if ( ! selectedDesignDefaultFonts ) {
 			return true;
@@ -83,7 +90,7 @@ const FontSelect: React.FunctionComponent = () => {
 					>
 						<span className="style-preview__font-option-contents">{ defaultFontOption }</span>
 					</Button>
-					{ fontPairings.filter( fontPairingsFilter ).map( ( fontPair ) => {
+					{ effectiveFontPairings.filter( fontPairingsFilter ).map( ( fontPair ) => {
 						// Font pairs are objects, we need `isShallowEqual` as we can't guarantee referential equality
 						// (E.g. if `selectedFonts` is coming from persisted state)
 						const isSelected = !! selectedFonts && isShallowEqual( fontPair, selectedFonts );
@@ -143,7 +150,7 @@ const FontSelect: React.FunctionComponent = () => {
 						>
 							<span className="style-preview__font-option-contents">{ defaultFontOption }</span>
 						</Button>
-						{ fontPairings.filter( fontPairingsFilter ).map( ( fontPair ) => {
+						{ effectiveFontPairings.filter( fontPairingsFilter ).map( ( fontPair ) => {
 							// Font pairs are objects, we need `isShallowEqual` as we can't guarantee referential equality
 							// (E.g. if `selectedFonts` is coming from persisted state)
 							const isSelected = !! selectedFonts && isShallowEqual( fontPair, selectedFonts );

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -14,7 +14,7 @@ import type { Viewport } from './types';
 import { useFontPairings } from '../../fonts';
 import type { FontPair } from '../../constants';
 
-function getFontsLoadingHTML( effectiveFontPairings: FontPair[] ) {
+function getFontsLoadingHTML( effectiveFontPairings: readonly FontPair[] ) {
 	const baseURL = 'https://fonts.googleapis.com/css2';
 
 	// matrix: regular,bold * regular,italic

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -14,7 +14,7 @@ import type { Viewport } from './types';
 import { useFontPairings } from '../../fonts';
 import type { FontPair } from '../../constants';
 
-function getFontsLoadingHTML( effectiveFontPairings ) {
+function getFontsLoadingHTML( effectiveFontPairings: FontPair[] ) {
 	const baseURL = 'https://fonts.googleapis.com/css2';
 
 	// matrix: regular,bold * regular,italic

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -10,17 +10,17 @@ import { useLocale } from '@automattic/i18n-utils';
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
-import { fontPairings } from '../../constants';
 import type { Viewport } from './types';
+import { useFontPairings } from '../../fonts';
 
-function getFontsLoadingHTML() {
+function getFontsLoadingHTML( effectiveFontPairings ) {
 	const baseURL = 'https://fonts.googleapis.com/css2';
 
 	// matrix: regular,bold * regular,italic
 	const axis = 'ital,wght@0,400;0,700;1,400;1,700';
 
 	// create a query for all fonts together
-	const query = fontPairings.reduce( ( acc, pairing ) => {
+	const query = effectiveFontPairings.reduce( ( acc, pairing ) => {
 		acc.push(
 			`family=${ encodeURI( pairing.headings ) }:${ axis }`,
 			`family=${ encodeURI( pairing.base ) }:${ axis }`
@@ -36,7 +36,7 @@ function getFontsLoadingHTML() {
 
 	// Chrome doesn't load the fonts in memory until they're actually used,
 	// this keeps the fonts used and ready in memory.
-	const fontsHolders = fontPairings.reduce( ( acc, pairing ) => {
+	const fontsHolders = effectiveFontPairings.reduce( ( acc, pairing ) => {
 		Object.values( pairing ).forEach( ( font ) => {
 			const fontHolder = document.createElement( 'div' );
 			fontHolder.style.fontFamily = font;
@@ -62,6 +62,7 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 	);
 
 	const iframe = React.useRef< HTMLIFrameElement >( null );
+	const effectiveFontPairings = useFontPairings();
 
 	React.useEffect(
 		() => {
@@ -98,7 +99,7 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 					return;
 				}
 				const html = await resp.text();
-				const { head, fontsHolders } = getFontsLoadingHTML();
+				const { head, fontsHolders } = getFontsLoadingHTML( effectiveFontPairings );
 				// the browser automatically moves the head code to the <head />
 				setPreviewHtml( head + html + fontsHolders );
 			};

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -12,6 +12,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { STORE_KEY } from '../../stores/onboard';
 import type { Viewport } from './types';
 import { useFontPairings } from '../../fonts';
+import type { FontPair } from '../../constants';
 
 function getFontsLoadingHTML( effectiveFontPairings ) {
 	const baseURL = 'https://fonts.googleapis.com/css2';
@@ -36,7 +37,7 @@ function getFontsLoadingHTML( effectiveFontPairings ) {
 
 	// Chrome doesn't load the fonts in memory until they're actually used,
 	// this keeps the fonts used and ready in memory.
-	const fontsHolders = effectiveFontPairings.reduce( ( acc, pairing ) => {
+	const fontsHolders = ( effectiveFontPairings as FontPair[] ).reduce( ( acc, pairing ) => {
 		Object.values( pairing ).forEach( ( font ) => {
 			const fontHolder = document.createElement( 'div' );
 			fontHolder.style.fontFamily = font;

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -122,7 +122,6 @@ export function useOnboardingFlow(): string {
 	}
 	return FLOW_ID;
 }
-
 export interface AnchorFmParams {
 	anchorFmPodcastId: string | null;
 	anchorFmEpisodeId: string | null;

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -11,7 +11,7 @@ import type { ValuesType } from 'utility-types';
  * Internal dependencies
  */
 import config from 'calypso/config';
-import { FLOW_ID, ANCHOR_FM_FLOW_ID } from '../gutenboarding/constants';
+import { FLOW_ID } from '../gutenboarding/constants';
 
 type PlanPath = Plans.PlanPath;
 
@@ -118,10 +118,11 @@ export function useIsAnchorFm(): boolean {
 
 export function useOnboardingFlow(): string {
 	if ( useIsAnchorFm() ) {
-		return ANCHOR_FM_FLOW_ID;
+		return 'anchor-fm';
 	}
 	return FLOW_ID;
 }
+
 export interface AnchorFmParams {
 	anchorFmPodcastId: string | null;
 	anchorFmEpisodeId: string | null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Dynamically add font pairings

#### Testing instructions
1. Checkout this branch
2. Go to http://calypso.localhost:3000/new?anchor_podcast={anchor_podcast_id}
3. Enter a podcast name
5. Click one of the available designs
6. The font pairings should include additional font pairings specific to the type of onboarding flow

#### Screenshots
<img width="414" alt="Screen Shot 2021-01-09 at 1 49 45 AM" src="https://user-images.githubusercontent.com/66652282/104085479-c3f3dc00-521d-11eb-8890-4f66d79a112e.png">
<img width="481" alt="Screen Shot 2021-01-09 at 1 49 49 AM" src="https://user-images.githubusercontent.com/66652282/104085480-c3f3dc00-521d-11eb-96e7-4616b2b7c3eb.png">


Fixes 382-gh-Automattic/dotcom-manage