### PR TITLE
react-i18n: Upgrade @wordpress/hooks dependency version

### DIFF
--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -33,7 +33,7 @@
 	},
 	"dependencies": {
 		"@wordpress/compose": "1.x.x - 3.x.x",
-		"@wordpress/hooks": "^2.9.0",
+		"@wordpress/hooks": "^2.11.0",
 		"@wordpress/i18n": "^3.14.0",
 		"tslib": "^1.10.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -6004,6 +6004,13 @@
   dependencies:
     "@babel/runtime" "^7.11.2"
 
+"@wordpress/hooks@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-2.11.0.tgz#a919fbaad710c34162eeef91a0ceaea99362f4bb"
+  integrity sha512-TbvCrHcMiSZoyiflegEqVS3DDytDTpkms+yLUaGN4sMvNdR/Mv5s0WnNKyM0T49lbmZYPWlbWhwJ1F6hr/FQDg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@wordpress/hooks@^2.9.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-2.9.0.tgz#181328fbb2899698e2c429da98af765b1294f627"


### PR DESCRIPTION
With the release of `@wordpress/hooks` version `2.11.0`, the bug with internal `hookAdded` and `hookRemoved` internal hooks has been fixed. Therefore, the workaround in `@automattic/react-i18n` package for the said hooks is no longer needed to maintain the reactivity when adding/removing filters.

#### Changes proposed in this Pull Request

* Upgrade `@wordpress/hooks` to `^2.11.0`.
* Remove `hookAdded` and `hookRemoved` internal hooks workaround for older versions.

#### Testing instructions

* Review code changes
* `yarn install` to make sure local environment is using the specified version of `@wordpress/hooks`
* Open `http://calypso.localhost:3000/home/somesite.wordpress.com` and look for `Test placeholder string` at the top of the page
* ~5 seconds after loading the page, a filter should be applied and the said string should re-render into `Filter applied::Test placeholder string`

#### Merge instructions
* Drop https://github.com/Automattic/wp-calypso/commit/3242967c6d64824ddf758719f347090d8ffb2676 before merge. It only serves the purpose of making the testing process easier, since there are translation filters currently used in Calypso.
