### PR TITLE
Plugins: Reduxify getPlugins

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -157,7 +157,7 @@ class PluginItem extends Component {
 			);
 		}
 
-		const updated_versions = this.props.plugin.sites
+		const updated_versions = sites
 			.map( ( site ) => {
 				const sitePlugin = pluginsOnSites?.sites[ site.ID ];
 				return sitePlugin?.update?.new_version;
@@ -176,10 +176,10 @@ class PluginItem extends Component {
 		);
 	}
 
-	hasUpdate( pluginData ) {
-		const { pluginsOnSites } = this.props;
+	hasUpdate() {
+		const { pluginsOnSites, sites } = this.props;
 
-		return pluginData.sites.some( ( site ) => {
+		return sites.some( ( site ) => {
 			const sitePlugin = pluginsOnSites?.sites[ site.ID ];
 			return sitePlugin?.update && site.canUpdateFiles;
 		} );
@@ -201,7 +201,7 @@ class PluginItem extends Component {
 			);
 		}
 
-		if ( this.hasUpdate( pluginData ) ) {
+		if ( this.hasUpdate() ) {
 			return this.renderUpdateFlag();
 		}
 
@@ -329,9 +329,9 @@ class PluginItem extends Component {
 
 export default connect( ( state, { plugin, sites } ) => {
 	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-	const siteIds = sites.map( ( site ) => site.ID );
+	const siteIds = sites?.map( ( site ) => site.ID );
 
 	return {
-		pluginsOnSites: getPluginOnSites( state, siteIds, plugin.slug ),
+		pluginsOnSites: getPluginOnSites( state, siteIds, plugin?.slug ),
 	};
 } )( localize( withLocalizedMoment( PluginItem ) ) );

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { debounce } from 'lodash';
 import { findDOMNode } from 'react-dom';
@@ -13,6 +13,7 @@ import Gridicon from 'calypso/components/gridicon';
 /**
  * Internal dependencies
  */
+import getSites from 'calypso/state/selectors/get-sites';
 import SectionHeader from 'calypso/components/section-header';
 import ButtonGroup from 'calypso/components/button-group';
 import { Button } from '@automattic/components';
@@ -109,8 +110,11 @@ export class PluginsListHeader extends PureComponent {
 	}
 
 	canUpdatePlugins() {
-		return this.props.selected.some( ( plugin ) =>
-			Object.values( plugin.sites ).some( ( site ) => site.canUpdateFiles )
+		const { selected, allSites } = this.props;
+		return selected.some( ( plugin ) =>
+			Object.values( allSites )
+				.filter( ( { ID } ) => plugin.sites.hasOwnProperty( ID ) )
+				.some( ( site ) => site.canUpdateFiles )
 		);
 	}
 
@@ -376,4 +380,6 @@ export class PluginsListHeader extends PureComponent {
 	}
 }
 
-export default localize( PluginsListHeader );
+export default connect( ( state ) => ( {
+	allSites: getSites( state ),
+} ) )( localize( PluginsListHeader ) );

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -110,7 +110,7 @@ export class PluginsListHeader extends PureComponent {
 
 	canUpdatePlugins() {
 		return this.props.selected.some( ( plugin ) =>
-			plugin.sites.some( ( site ) => site.canUpdateFiles )
+			Object.values( plugin.sites ).some( ( site ) => site.canUpdateFiles )
 		);
 	}
 

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -241,12 +241,14 @@ export class PluginsList extends React.Component {
 			.map( ( p ) => {
 				return Object.keys( p.sites ).map( ( siteId ) => {
 					const site = this.props.allSites.find( ( s ) => s.ID === parseInt( siteId ) );
-					site.plugin = p;
-					return site;
+					return {
+						site,
+						plugin: p,
+					};
 				} );
-			} ) // list of plugins -> list of list of sites
-			.reduce( flattenArrays, [] ) // flatten the list into one big list of sites
-			.forEach( ( site ) => action( site.ID, site.plugin ) );
+			} ) // list of plugins -> list of plugin+site objects
+			.reduce( flattenArrays, [] ) // flatten the list into one big list of plugin+site objects
+			.forEach( ( { plugin, site } ) => action( site.ID, plugin ) );
 	}
 
 	getSitePlugin = ( plugin, siteId ) => {

--- a/client/my-sites/plugins/plugins-list/test/fixtures/index.js
+++ b/client/my-sites/plugins/plugins-list/test/fixtures/index.js
@@ -51,3 +51,8 @@ export const sites = [
 		user_can_manage: true,
 	},
 ];
+
+export const sitesObject = sites.reduce( ( acc, site ) => {
+	acc[ site.ID ] = site;
+	return acc;
+}, {} );

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -12,7 +12,7 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import { PluginsList } from '..';
-import { sites } from './fixtures';
+import { sites, sitesObject } from './fixtures';
 
 describe( 'PluginsList', () => {
 	describe( 'rendering bulk actions', () => {
@@ -22,8 +22,8 @@ describe( 'PluginsList', () => {
 
 		beforeAll( () => {
 			plugins = [
-				{ sites, slug: 'hello', name: 'Hello Dolly' },
-				{ sites, slug: 'jetpack', name: 'Jetpack' },
+				{ sites: sitesObject, slug: 'hello', name: 'Hello Dolly' },
+				{ sites: sitesObject, slug: 'jetpack', name: 'Jetpack' },
 			];
 
 			props = {
@@ -38,6 +38,7 @@ describe( 'PluginsList', () => {
 					hello: plugins[ 0 ],
 					jetpack: plugins[ 1 ],
 				},
+				allSites: sites,
 			};
 		} );
 

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -63,6 +63,10 @@ export function getPlugins( state, siteIds, pluginFilter ) {
 	let pluginList = reduce(
 		siteIds,
 		( memo, siteId ) => {
+			if ( isRequesting( state, siteId ) ) {
+				return memo;
+			}
+
 			const list = state.plugins.installed.plugins[ siteId ] || [];
 			list.forEach( ( item ) => {
 				const sitePluginInfo = pick( item, [ 'active', 'autoupdate', 'update' ] );

--- a/client/state/plugins/installed/test/selectors.js
+++ b/client/state/plugins/installed/test/selectors.js
@@ -170,6 +170,11 @@ describe( 'Installed plugin selectors', () => {
 			expect( plugins ).to.have.lengthOf( 0 );
 		} );
 
+		test( 'Should get an empty array if the plugins for this site are still being requested', () => {
+			const plugins = selectors.getPlugins( state, [ 'site.three' ] );
+			expect( plugins ).to.have.lengthOf( 0 );
+		} );
+
 		test( 'Should get a plugin list of length 3 if both sites are requested', () => {
 			const plugins = selectors.getPlugins( state, [ 'site.one', 'site.two' ] );
 			expect( plugins ).to.have.lengthOf( 3 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After #48570 that reduxifies plugin sites, we can now finally reduxify how we work with the actual plugins. This PR achieves that by adding a `QueryJetpackPlugins` query component and updating the relevant components to pull Redux plugins data instead of doing it from the flux store. This also requires us to change all the locations where we're working with site objects to site IDs, as that's how we're now handling site plugin data in Redux (to avoid duplications with the `sites` state tree). We're also using the chance to remove the unnecessary component state indirection and update the component to use props directly.

Furthermore, this PR improves the `getPlugins` selector performance by making it ignore calculating plugin data for sites for which we're still retrieving that data. Potentially, we could improve this by splitting it into two selectors and memorizing that data per site, but that's something we could do later.

Finally, this PR takes care of updating and fixing some tests.

The exciting thing about this PR is that it removes the last direct usage of the plugins store 🎉 ! However, removing the actual store requires a couple more tweaks, so I'll follow up with that in another PR.

Part of #24180.

#### Testing instructions

* Get several Jetpack sites (including multisite with subsites) with some plugins for testing. 
* Test the following scenarios with and without an empty Redux store.
* Thoroughly test lists of plugins in all plugin scenarios; compare against production and verify that they still work the same way when updating, installing, or removing plugins, as well as toggling auto-updates and activating/deactivating plugins:
  * `/plugins`
  * `/plugins/manage`
  * `/plugins/manage` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
  * `/plugins/manage/:site` - for a single plugin
  * `/plugins/manage/:site` - for multiple selected plugins (bulk actions are enabled by clicking the "Edit All" button)
* Specifically try uploading an old version of a plugin and verify everything behaves the same way before, during, and after the upload.
* Specifically test updating an old plugin and verify everything behaves the same way before, during, and after the update.
* Test filtering of plugins specifically.
* While on one of the above pages, try switching between sites, between all sites and a single site, and the other way around and verify plugins are always loaded accordingly.
* Verify all tests pass.

