### PR TITLE
Nav Unification: Fixes flyout arrow

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -86,6 +86,7 @@ $font-size: rem( 14px );
 			&::after {
 				content: ' ';
 				display: none;
+				z-index: 1;
 				position: absolute;
 				top: 50%;
 				right: 0;


### PR DESCRIPTION
This is a regression of https://github.com/Automattic/wp-calypso/pull/48642. After adding the box-shadow the arrow was under the shadow.

#### Changes proposed in this Pull Request

* adds z-index to the arrow

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before | After
-------|------
![](https://cln.sh/mxZOvh+) | ![](https://cln.sh/vY0sxc+)

Please follow the same testing instructions https://github.com/Automattic/wp-calypso/pull/48642