### PR TITLE
Imports: provide stable key for ImporterComponent to prevent re-mount

### DIFF
--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -221,7 +221,7 @@ class SectionImport extends Component {
 	renderActiveImporters( importsForSite ) {
 		const { fromSite, site, siteTitle } = this.props;
 
-		return importsForSite.map( ( importItem ) => {
+		return importsForSite.map( ( importItem, idx ) => {
 			const importer = getImporterByKey( importItem.type );
 			if ( ! importer ) {
 				return;
@@ -232,7 +232,7 @@ class SectionImport extends Component {
 			return (
 				ImporterComponent && (
 					<ImporterComponent
-						key={ importItem.importerId }
+						key={ idx }
 						site={ site }
 						fromSite={ fromSite }
 						siteTitle={ siteTitle }


### PR DESCRIPTION
Fixes #48660.

In #48455 I introduced a regression where I changed the key for the `ImporterComponent` from
```jsx
<ImporterComponent key={ importItem.type + idx } />
```
to
```jsx
<ImporterComponent key={ importItem.importId } />
```
But the `importId` changes after the upload is complete, from a temporary local-generated ID to one assigned by server. 

That causes the `<ImporterComponent />` to be unmounted and mounted again, causing it to lose local state, and, more importantly, the `componentDidUpdate` method is not called with prev and next props, the transition between the "uploading/processing" and "upload complete" states is not detected, and `startMappingAuthors` is not called. Then the importer is forever stuck on the "Success! File uploaded" screen.

Happens only for XML files, because uploading these returns the `uploadSuccess` status right away, in the same update that provides a new import ID.

When uploading a ZIP file, there is an intermediate `uploadProcessing` state which only later becomes `uploadSuccess`. At that time, the import ID is already stable and the `componentDidUpdate` transition proceeds correctly.

A much better future fix would be not to rely on React lifecycles methods, but implement the "upload success" -> "mapping authors" transitions in the Redux actions that manage the import workflow. Then React will merely observe the import state and react to user's UI actions, instead of providing code that glues parts of the workflow together.
