### PR TITLE
Security: Reduxify password page notices

### DIFF
--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -8,7 +8,6 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import notices from 'calypso/notices';
 import userSettings from 'calypso/lib/user-settings';
 import PasswordComponent from 'calypso/me/security/main';
 import accountPasswordData from 'calypso/lib/account-password-data';
@@ -17,12 +16,15 @@ import ConnectedAppsComponent from 'calypso/me/connected-applications';
 import AccountRecoveryComponent from 'calypso/me/security-account-recovery';
 import SecurityCheckupComponent from 'calypso/me/security-checkup';
 import { getSocialServiceFromClientId } from 'calypso/lib/login';
+import { successNotice } from 'calypso/state/notices/actions';
 
 export function password( context, next ) {
 	if ( context.query && context.query.updated === 'password' ) {
-		notices.success( i18n.translate( 'Your password was saved successfully.' ), {
-			persistent: true,
-		} );
+		context.store.dispatch(
+			successNotice( i18n.translate( 'Your password was saved successfully.' ), {
+				displayOnNextPage: true,
+			} )
+		);
 
 		page.replace( window.location.pathname );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reduxifies the notices in `SiteTools`. Most of the changes are whitespace changes, related to the fact that we're now introducing a `mapDispatchToProps`.

Part of #48408.

#### Testing instructions

* Go to `/me/security/password`
* Change your password and save it.
* Page will refresh - that is expected behavior.
* Verify you see a success notice after the refresh.