### PR TITLE
Domains: Reduxify notices in EditContactInfoFormCard

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -14,13 +14,12 @@ import { localize } from 'i18n-calypso';
 import { Card, Dialog } from '@automattic/components';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
-import notices from 'calypso/notices';
 import {
 	domainManagementContactsPrivacy,
 	domainManagementEdit,
 } from 'calypso/my-sites/domains/paths';
 import wp from 'calypso/lib/wp';
-import { successNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES } from 'calypso/lib/url/support';
 import { registrar as registrarNames } from 'calypso/lib/domains/constants';
 import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/components/designated-agent-notice';
@@ -369,7 +368,7 @@ class EditContactInfoFormCard extends React.Component {
 					'Please try again later or contact support.'
 			);
 
-		notices.error( message );
+		this.props.errorNotice( message );
 	};
 
 	handleSubmitButtonClick = ( newContactDetails ) => {
@@ -456,6 +455,7 @@ export default connect(
 		};
 	},
 	{
+		errorNotice,
 		fetchSiteDomains,
 		requestWhois,
 		saveWhois,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reduxifies the notices in `EditContactInfoFormCard`. 

Part of #48408.

#### Testing instructions

* Go to `/domains/manage/:site/edit-contact-info/:domain` where `:site` is a site with a custom domain at WP.com and `:domain` is the domain.
* Save the form.
* While the form is saving, quickly type this in the browser console: `dispatch( { type: 'DOMAIN_MANAGEMENT_WHOIS_SAVE_FAILURE', error: { message: 'An error has occurred.' }, domain: 'DOMAIN.NAME' } )` where `DOMAIN.NAME` is your domain.
* Verify you see the error message notice.