### PR TITLE
Domain Picker: Show fallback suggestions when domain suggestions fail.

### DIFF
--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -64,6 +64,11 @@ export interface DomainSuggestionQuery {
 	 * Domain category slug
 	 */
 	category_slug?: string;
+
+	/**
+	 * Fallback domain search term
+	 */
+	fallback_query?: string;
 }
 
 export type DomainName = string;

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -151,14 +151,25 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestionVendor()
 	);
 
+	const searchTerm = domainSearch.trim();
+	const fallbackSearchTerm = existingSubdomain?.domain_name;
+
 	const {
 		allDomainSuggestions,
+		fallbackDomainSuggestions,
 		errorMessage: domainSuggestionErrorMessage,
 		state: domainSuggestionState,
 		retryRequest: retryDomainSuggestionRequest,
-	} = useDomainSuggestions( domainSearch.trim(), quantityExpanded, domainCategory, locale ) || {};
+	} =
+		useDomainSuggestions(
+			searchTerm,
+			fallbackSearchTerm,
+			quantityExpanded,
+			domainCategory,
+			locale
+		) || {};
 
-	const domainSuggestions = allDomainSuggestions?.slice(
+	const domainSuggestions = ( allDomainSuggestions || fallbackDomainSuggestions )?.slice(
 		existingSubdomain ? 1 : 0,
 		isExpanded ? quantityExpanded : quantity
 	);

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -156,7 +156,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 
 	const {
 		allDomainSuggestions,
-		fallbackDomainSuggestions,
 		errorMessage: domainSuggestionErrorMessage,
 		state: domainSuggestionState,
 		retryRequest: retryDomainSuggestionRequest,
@@ -169,7 +168,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 			locale
 		) || {};
 
-	const domainSuggestions = ( allDomainSuggestions || fallbackDomainSuggestions )?.slice(
+	const domainSuggestions = allDomainSuggestions?.slice(
 		existingSubdomain ? 1 : 0,
 		isExpanded ? quantityExpanded : quantity
 	);

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { DataStatus } from '@automattic/data-stores/src/domain-suggestions/constants';
+import type { DataStatus } from '@automattic/data-stores/src/domain-suggestions/constants';
 import type { DomainSuggestion } from '@automattic/data-stores/src/domain-suggestions/types';
 import { useDebounce } from 'use-debounce';
 
@@ -13,7 +13,6 @@ import { DOMAIN_SUGGESTIONS_STORE, DOMAIN_SEARCH_DEBOUNCE_INTERVAL } from '../co
 
 type DomainSuggestionsResult = {
 	allDomainSuggestions: DomainSuggestion[] | undefined;
-	fallbackDomainSuggestions: DomainSuggestion[] | undefined;
 	errorMessage: string | null;
 	state: DataStatus;
 	retryRequest: () => void;
@@ -54,6 +53,7 @@ export function useDomainSuggestions(
 				quantity: quantity + 1, // increment the count to add the free domain
 				locale,
 				category_slug: domainCategory,
+				fallback_query: fallbackSearchTerm,
 			};
 
 			const allDomainSuggestions = getDomainSuggestions( domainSearch, domainSearchOptions );
@@ -62,14 +62,7 @@ export function useDomainSuggestions(
 
 			const errorMessage = getDomainErrorMessage();
 
-			const hasFallbackSearchTerm = !! fallbackSearchTerm && fallbackSearchTerm.length > 2;
-
-			const fallbackDomainSuggestions =
-				errorMessage === DataStatus.Failure && hasFallbackSearchTerm
-					? getDomainSuggestions( fallbackSearchTerm, domainSearchOptions )
-					: [];
-
-			return { allDomainSuggestions, fallbackDomainSuggestions, state, errorMessage, retryRequest };
+			return { allDomainSuggestions, state, errorMessage, retryRequest };
 		},
 		[ domainSearch, domainCategory, quantity ]
 	);

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -27,7 +27,7 @@ export function useDomainSuggestions(
 ): DomainSuggestionsResult | undefined {
 	const [ domainSearch ] = useDebounce( searchTerm, DOMAIN_SEARCH_DEBOUNCE_INTERVAL );
 
-	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
 	// Missing types for invalidateResolutionForStoreSelector
 	// (see packages/data/src/namespace-store/metadata/actions.js#L57)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Show fallback suggestions based on site's subdomain when site title or the search term that user entered contains invalid character or keyword.

The `fallback_query` param is introduced on the domain suggestions API endpoint (see D55999-code) and the domain picker is updated to make use of that param by passing in the site's subdomain.

This only applies to domain picker in Launch flow. The domain picker in `/new` will still display an error message educating the user what went wrong with the entered domain search term.

#### Testing instructions

* Apply patch D55999-code.
* Test on Step-By-Step / Focused Launch's Domain Picker by entering an invalid keyword like "wordpress" or non-latin characters like "你好“ or emojis like 🤔 .

Fixes #47813