### PR TITLE
Updating event names and display criteria for nav bar.

### DIFF
--- a/client/my-sites/marketing/business-tools/index.tsx
+++ b/client/my-sites/marketing/business-tools/index.tsx
@@ -61,7 +61,7 @@ export const MarketingBusinessTools: FunctionComponent< Props > = ( { recordTrac
 	};
 
 	const handleTodoistClick = () => {
-		recordTracksEvent( 'calypso_marketing_business_todois_button_click' );
+		recordTracksEvent( 'calypso_marketing_business_todoist_button_click' );
 	};
 
 	const handleBenchClick = () => {
@@ -69,11 +69,11 @@ export const MarketingBusinessTools: FunctionComponent< Props > = ( { recordTrac
 	};
 
 	const handleStreakClick = () => {
-		recordTracksEvent( 'calypso_marketing_tools_streak_button_click' );
+		recordTracksEvent( 'calypso_marketing_business_streak_button_click' );
 	};
 
 	const handleBillcomClick = () => {
-		recordTracksEvent( 'calypso_marketing_tools_billcom_button_click' );
+		recordTracksEvent( 'calypso_marketing_business_billcom_button_click' );
 	};
 
 	return (

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -84,8 +84,8 @@ export const Sharing = ( {
 	}
 
 	// Include Business Tools link if a site is selected and the
-	// required Jetpack module is active
-	if ( showBusinessTools ) {
+	// site is not VIP
+	if ( ! isVip && showBusinessTools ) {
 		filters.push( {
 			id: 'business-buttons',
 			route: '/marketing/business-tools' + pathSuffix,
@@ -156,7 +156,7 @@ export default connect( ( state ) => {
 		showButtons: siteId && canManageOptions && ( ! isJetpack || hasSharedaddy ),
 		showConnections: !! siteId,
 		showTraffic: canManageOptions && !! siteId,
-		showBusinessTools: !! siteId && canManageOptions && ! isJetpack,
+		showBusinessTools: !! siteId && canManageOptions,
 		isVip: isVipSite( state, siteId ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import DocumentHead from 'calypso/components/data/document-head';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -149,6 +150,7 @@ Sharing.propTypes = {
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const isJetpack = isJetpackSite( state, siteId );
+	const isAtomic = isSiteWpcomAtomic( state, siteId );
 	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 	const hasSharedaddy = isJetpackModuleActive( state, siteId, 'sharedaddy' );
 
@@ -156,7 +158,7 @@ export default connect( ( state ) => {
 		showButtons: siteId && canManageOptions && ( ! isJetpack || hasSharedaddy ),
 		showConnections: !! siteId,
 		showTraffic: canManageOptions && !! siteId,
-		showBusinessTools: !! siteId && canManageOptions,
+		showBusinessTools: ( !! siteId && canManageOptions && ! isJetpack ) || isAtomic,
 		isVip: isVipSite( state, siteId ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -90,6 +90,10 @@ export const MarketingTools: FunctionComponent = () => {
 		recordTracksEvent( 'calypso_marketing_tools_verblio_button_click' );
 	};
 
+	const handleSimpleTextingClick = () => {
+		recordTracksEvent( 'calypso_marketing_tools_simpletexting_button_click' );
+	};
+
 	const handleStartSharingClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_start_sharing_button_click' );
 
@@ -191,7 +195,7 @@ export const MarketingTools: FunctionComponent = () => {
 					imagePath={ simpletextLogo }
 				>
 					<Button
-						onClick={ handleCreateALogoClick }
+						onClick={ handleSimpleTextingClick }
 						href="https://simpletexting.grsm.io/wordpresscom"
 						target="_blank"
 					>


### PR DESCRIPTION
This PR corrects typos in the event names for a few of the marketing tool cards, and updates the display logic for the "Business Tools" link  in the Marketing nav bar so that it displays to Atomic site users.

#### Testing instructions
* Checkout this PR and start Calypso
* Navigate to /marketing/tools/SITESLUG with an atomic site
* Confirm that the "Business Tools" link is showing.
* Click the cards and confirm that you are taken to the correct partner site.

Here's a screenshot from an atomic site now displaying the Business Tools link in the Marketing nav bar:
<img width="1025" alt="Screen Shot 2021-01-05 at 10 36 05 AM" src="https://user-images.githubusercontent.com/35781181/103665863-e944c980-4f41-11eb-8afe-c911b8abd10d.png">
