### PR TITLE
Jetpack Plans Page: Remove Jetpack CRM Monthly product.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
@@ -18,7 +18,6 @@ import {
 	JETPACK_SEARCH_PRODUCTS,
 	JETPACK_PRODUCTS_LIST,
 	PRODUCT_JETPACK_CRM,
-	PRODUCT_JETPACK_CRM_MONTHLY,
 } from 'calypso/lib/products-values/constants';
 import { getJetpackCROActiveVersion } from 'calypso/my-sites/plans/jetpack-plans/abtest';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
@@ -50,13 +49,11 @@ const useSelectorPageProducts = ( siteId: number | null ) => {
 		availableProducts = [ ...availableProducts, ...JETPACK_SEARCH_PRODUCTS ];
 	}
 
-	// Include Jetpack CRM
+	// Include Jetpack CRM (currently we're only offering the yearly billing CRM product)
 	if (
-		! ownedProducts.some( ( ownedProduct ) =>
-			[ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes( ownedProduct )
-		)
+		! ownedProducts.some( ( ownedProduct ) => [ PRODUCT_JETPACK_CRM ].includes( ownedProduct ) )
 	) {
-		availableProducts = [ ...availableProducts, PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ];
+		availableProducts = [ ...availableProducts, PRODUCT_JETPACK_CRM ];
 	}
 
 	const backupProductsToShow = [];


### PR DESCRIPTION
### Changes proposed in this Pull Request
We only sell Jetpack CRM yearly plans so we shouldn't be offering a monthly one on our Jetpack Plans page.

This PR removes the Jetpack CRM monthly product from the Jetpack Plans page.

### Testing instructions
* Checkout and run calypso and jetpack cloud environments concurrently. (`yarn start` and `yarn start-jetpack-cloud-p`)
* Go to `calypso.localhost:3000/plans/:site`.
* Make sure the "Billing Yearly" toggle switch is activated and verify you see the `CRM Entrepreneur` product card in the product grid.
*  Now select the "Billing Monthly" toggle and verify that the `CRM Entrepreneur` product is no longer showing in the product grid. (See screen capture below)
* Go to `jetpack.cloud.localhost:3001/plans` and verify the same behavior above.

![chrome-capture (18)](https://user-images.githubusercontent.com/11078128/103675106-8a854d00-4f4d-11eb-91e1-ad20c2e0868e.gif)



Fixes 1164141197617539-as-1199720441821493