### PR TITLE
composite-checkout: Fix types on Checkout steps

### DIFF
--- a/packages/composite-checkout/src/components/checkout-next-step-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-next-step-button.tsx
@@ -8,18 +8,23 @@ import React from 'react';
  */
 import Button, { ButtonProps } from './button';
 
-const CheckoutNextStepButton: React.FC<
-	CheckoutNextStepButtonProps & ButtonProps & React.ButtonHTMLAttributes< HTMLButtonElement >
-> = ( { value, onClick, ariaLabel, ...props } ) => {
+function CheckoutNextStepButton( {
+	value,
+	onClick,
+	ariaLabel,
+	...props
+}: CheckoutNextStepButtonProps &
+	ButtonProps &
+	React.ButtonHTMLAttributes< HTMLButtonElement > ): JSX.Element {
 	return (
 		<Button onClick={ onClick } buttonType="primary" aria-label={ ariaLabel } { ...props }>
 			{ value }
 		</Button>
 	);
-};
+}
 
 interface CheckoutNextStepButtonProps {
-	value: React.ReactChildren;
+	value: React.ReactNode;
 	onClick: () => void;
 	ariaLabel: string;
 }

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -27,6 +27,10 @@ import { FormStatus } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout-payment-methods' );
 
+export const RadioButtons = styled.div`
+	margin-bottom: 16px;
+`;
+
 export default function CheckoutPaymentMethods( {
 	summary,
 	isComplete,
@@ -35,7 +39,7 @@ export default function CheckoutPaymentMethods( {
 	summary?: boolean;
 	isComplete: boolean;
 	className?: string;
-} ) {
+} ): JSX.Element | null {
 	const { __ } = useI18n();
 	const onEvent = useEvents();
 	const onError = useCallback(
@@ -119,11 +123,11 @@ CheckoutPaymentMethods.propTypes = {
 	className: PropTypes.string,
 };
 
-export function CheckoutPaymentMethodsTitle() {
+export function CheckoutPaymentMethodsTitle(): JSX.Element {
 	const { __ } = useI18n();
 	const isActive = useIsStepActive();
 	const isComplete = useIsStepComplete();
-	return ! isActive && isComplete ? __( 'Payment method' ) : __( 'Pick a payment method' );
+	return <>{ ! isActive && isComplete ? __( 'Payment method' ) : __( 'Pick a payment method' ) }</>;
 }
 
 function PaymentMethod( {
@@ -178,7 +182,3 @@ interface PaymentMethodProps {
 	inactiveContent?: React.ReactNode;
 	summary?: boolean;
 }
-
-export const RadioButtons = styled.div`
-	margin-bottom: 16px;
-`;

--- a/packages/composite-checkout/src/components/checkout-review-order.tsx
+++ b/packages/composite-checkout/src/components/checkout-review-order.tsx
@@ -31,9 +31,9 @@ export default function CheckoutReviewOrder( { className }: { className?: string
 	);
 }
 
-export function CheckoutReviewOrderTitle() {
+export function CheckoutReviewOrderTitle(): JSX.Element {
 	const { __ } = useI18n();
-	return __( 'Review your order' );
+	return <>{ __( 'Review your order' ) }</>;
 }
 
 CheckoutReviewOrder.propTypes = {

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -34,7 +34,7 @@ import {
 } from '../public-api';
 import styled from '../lib/styled';
 import { Theme } from '../lib/theme';
-import { FormStatus } from '../types';
+import { FormStatus, CheckoutStepProps } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout' );
 
@@ -275,20 +275,7 @@ export const CheckoutStep = ( {
 	nextStepButtonAriaLabel,
 	validatingButtonText,
 	validatingButtonAriaLabel,
-}: {
-	stepId: string;
-	titleContent: React.ReactNode;
-	isCompleteCallback: () => boolean | Promise< boolean >;
-	activeStepContent?: React.ReactNode;
-	completeStepContent?: React.ReactNode;
-	className?: string;
-	editButtonText?: string;
-	editButtonAriaLabel?: string;
-	nextStepButtonText?: string;
-	nextStepButtonAriaLabel?: string;
-	validatingButtonText?: string;
-	validatingButtonAriaLabel?: string;
-} ): JSX.Element => {
+}: CheckoutStepProps ): JSX.Element => {
 	const { __ } = useI18n();
 	const { setActiveStepNumber, setStepCompleteStatus, stepCompleteStatus } = useContext(
 		CheckoutStepDataContext

--- a/packages/composite-checkout/src/components/default-steps.tsx
+++ b/packages/composite-checkout/src/components/default-steps.tsx
@@ -12,53 +12,44 @@ import CheckoutOrderSummaryStep, {
 } from './checkout-order-summary';
 import CheckoutReviewOrder, { CheckoutReviewOrderTitle } from './checkout-review-order';
 import CheckoutPaymentMethods, { CheckoutPaymentMethodsTitle } from './checkout-payment-methods';
+import type { CheckoutStepProps, OrderSummaryData } from '../types';
 
-export function getDefaultOrderSummary() {
+export function getDefaultOrderSummary(): OrderSummaryData {
 	return {
-		id: 'order-summary',
 		className: 'checkout__order-summary',
 		summaryContent: <CheckoutOrderSummary />,
 	};
 }
 
-export function getDefaultOrderSummaryStep() {
+export function getDefaultOrderSummaryStep(): CheckoutStepProps {
 	return {
-		id: 'order-summary-step',
+		stepId: 'order-summary-step',
+		isCompleteCallback: () => true,
 		className: 'checkout__order-summary-step',
-		hasStepNumber: false,
 		titleContent: <CheckoutOrderSummaryStepTitle />,
 		activeStepContent: null,
-		incompleteStepContent: null,
 		completeStepContent: <CheckoutOrderSummaryStep />,
 	};
 }
 
-export function getDefaultPaymentMethodStep() {
+export function getDefaultPaymentMethodStep(): CheckoutStepProps {
 	return {
-		id: 'payment-method',
+		stepId: 'payment-method',
+		isCompleteCallback: () => true,
 		className: 'checkout__payment-methods-step',
-		hasStepNumber: true,
 		titleContent: <CheckoutPaymentMethodsTitle />,
 		activeStepContent: <CheckoutPaymentMethods isComplete={ false } />,
-		incompleteStepContent: null,
 		completeStepContent: <CheckoutPaymentMethods summary isComplete={ true } />,
-		isEditableCallback: () => true,
-		// These cannot be translated because they are not inside a component and
-		// we don't know if they are being created by the package or the host page.
-		// They can be replaced by the consumer to get translation.
-		getEditButtonAriaLabel: () => 'Edit the payment method',
-		getNextStepButtonAriaLabel: () => 'Continue with the selected payment method',
 	};
 }
 
-export function getDefaultOrderReviewStep() {
+export function getDefaultOrderReviewStep(): CheckoutStepProps {
 	return {
-		id: 'order-review',
+		stepId: 'order-review',
+		isCompleteCallback: () => true,
 		className: 'checkout__review-order-step',
-		hasStepNumber: true,
 		titleContent: <CheckoutReviewOrderTitle />,
 		activeStepContent: <CheckoutReviewOrder />,
-		incompleteStepContent: null,
 		completeStepContent: null,
 	};
 }

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -12,7 +12,7 @@ import { Theme } from './lib/theme';
 export interface CheckoutStepProps {
 	stepId: string;
 	titleContent: React.ReactNode;
-	isCompleteCallback: () => boolean | Promise< boolean >;
+	isCompleteCallback: IsCompleteCallback;
 	activeStepContent?: React.ReactNode;
 	completeStepContent?: React.ReactNode;
 	className?: string;
@@ -23,6 +23,8 @@ export interface CheckoutStepProps {
 	validatingButtonText?: string;
 	validatingButtonAriaLabel?: string;
 }
+
+export type IsCompleteCallback = () => boolean | Promise< boolean >;
 
 export interface OrderSummaryData {
 	className: string;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -9,6 +9,26 @@ import { ReactElement } from 'react';
  */
 import { Theme } from './lib/theme';
 
+export interface CheckoutStepProps {
+	stepId: string;
+	titleContent: React.ReactNode;
+	isCompleteCallback: () => boolean | Promise< boolean >;
+	activeStepContent?: React.ReactNode;
+	completeStepContent?: React.ReactNode;
+	className?: string;
+	editButtonText?: string;
+	editButtonAriaLabel?: string;
+	nextStepButtonText?: string;
+	nextStepButtonAriaLabel?: string;
+	validatingButtonText?: string;
+	validatingButtonAriaLabel?: string;
+}
+
+export interface OrderSummaryData {
+	className: string;
+	summaryContent: React.ReactNode;
+}
+
 export interface PaymentMethod {
 	id: string;
 	label: React.ReactNode;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This was extracted from https://github.com/Automattic/wp-calypso/pull/46223 where there were TypeScript errors coming from the `composite-checkout` package. This improves and cleans up the types for various checkout step components.

#### Testing instructions

- Visit checkout and verify that the steps work as expected (you can click to jump between them).