### PR TITLE
Help: Fix domains link, update Contact Us icon color

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -67,7 +67,7 @@ class Help extends React.PureComponent {
 				),
 			},
 			{
-				link: 'https://wordpress.com/support/all-about-domains/',
+				link: 'https://wordpress.com/support/domains/',
 				title: this.props.translate( 'All About Domains' ),
 				description: this.props.translate(
 					'Set up your domain whether it’s registered with WordPress.com or elsewhere.'

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -184,7 +184,8 @@
 	justify-content: space-between;
 	margin-bottom: 48px;
 
-	&:hover .gridicon {
+	&:hover .gridicon,
+	.gridicon {
 		fill: var( --color-primary );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* @fashuvo pointed out that the All About Domains link on this screen was broken! I've re-pointed it to the Domains support page, as it looks like All About Domains page is a Draft.
* The Contact Us banner's icon color was using `currentColor`, but since that's wrapped in a link, it was using the link color rather than the primary color. I've updated it to use `--color-primary` for better parity with the color scheme.

**Before**

<img width="1668" alt="Screen Shot 2021-01-05 at 2 54 01 PM" src="https://user-images.githubusercontent.com/2124984/103692591-fa9fcd00-4f65-11eb-893a-dff7cc45f706.png">

**After**

<img width="1668" alt="Screen Shot 2021-01-05 at 2 54 16 PM" src="https://user-images.githubusercontent.com/2124984/103692542-e52aa300-4f65-11eb-8db8-35d42f1b957e.png">

#### Testing instructions

* Switch to this PR and navigate to `/help`
* Click all the links! Make sure they go where they're supposed to and there are no dead ends.
* Look for visual issues with different color schemes (you can change your color scheme under Me -> Account Settings)
