### PR TITLE
Anchor Gutenboarding: "Log in" link preserves all three anchor params

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -50,7 +50,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	const makePath = usePath();
 	const currentStep = useCurrentStep();
 	const isMobile = useViewportMatch( 'small', '<' );
-	const { anchorFmPodcastId } = useAnchorFmParams();
+	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyShowUrl } = useAnchorFmParams();
 	const isAnchorFmSignup = useIsAnchorFm();
 
 	const closeModal = () => {
@@ -167,13 +167,25 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	}
 
 	const langFragment = lang ? `/${ lang }` : '';
-	const loginRedirectUrl = encodeURIComponent(
-		isAnchorFmSignup
-			? `${ window.location.origin }/new${ makePath(
-					Step.IntentGathering
-			  ) }?new&anchor_podcast=${ anchorFmPodcastId }` // Fix in #48389
-			: `${ window.location.origin }/new${ makePath( Step.CreateSite ) }?new`
-	);
+
+	let loginRedirectUrl = window.location.origin + '/new';
+	if ( isAnchorFmSignup ) {
+		loginRedirectUrl += `${ makePath( Step.IntentGathering ) }?new`;
+		const queryParts = {
+			anchor_podcast: anchorFmPodcastId,
+			anchor_episode: anchorFmEpisodeId,
+			spotify_show_url: anchorFmSpotifyShowUrl,
+		};
+		for ( const [ k, v ] of Object.entries( queryParts ) ) {
+			if ( v ) {
+				loginRedirectUrl += `&${ k }=${ encodeURIComponent( v ) }`;
+			}
+		}
+	} else {
+		loginRedirectUrl += `${ makePath( Step.CreateSite ) }?new`;
+	}
+	loginRedirectUrl = encodeURIComponent( loginRedirectUrl );
+
 	const signupUrl = encodeURIComponent( `/new${ makePath( Step[ currentStep ] ) }?signup` );
 	const loginUrl = `/log-in/new${ langFragment }?redirect_to=${ loginRedirectUrl }&signup_url=${ signupUrl }`;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When starting the anchor gutenboarding process, the "Log In" link will now preserve the anchor_podcast, anchor_episode and spotify_show_url parameters.  Previously, it only preserved the anchor_podcast parameter.

#### Testing instructions

First - Create an account and site using the anchor gutenboarding process.

* In an incognito window, Visit http://calypso.localhost:3000/new?&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q
* Create a new account (note its email and password - you don't have to use a real email, one ending in @example.com is fine).
* Go through the gutenboarding process, end in the editor, 
* Close all incognito windows to remove cookies+state from those windows.

Second - Go through the anchor gutenboarding process, but this time, log in to your existing account.

* Open a new incognito window and visit http://calypso.localhost:3000/new?&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https%3A%2F
* This time, click the "Log In" link.  Note that the "Log In" link now contains a redirect destination that keeps the anchor_podcast, anchor_episode, and spotify_show_url params (before this change, it was only anchor_podcast).
![2021-01-05_14-17](https://user-images.githubusercontent.com/937354/103694629-e3aaac00-4f60-11eb-9528-94c1891dad41.png)
* Log in with your account.  
![2021-01-05_14-10](https://user-images.githubusercontent.com/937354/103694710-089f1f00-4f61-11eb-95a2-7a6be3aa12d5.png)
* After logging in, you should be sent to the anchor gutenboarding process.  Here, you should be able to check the url and see that the anchor_podcast, anchor_episode, and spotify_show_url params are all preserved.
![2021-01-05_14-11](https://user-images.githubusercontent.com/937354/103694750-18b6fe80-4f61-11eb-97e7-19d01520bc68.png)
* Continue the onboarding process and end up at the editor.  You should still see the three parameters in the ending url.
![2021-01-05_14-15](https://user-images.githubusercontent.com/937354/103694798-2c626500-4f61-11eb-9d14-ee722a944d62.png)

#### Notes

* There is a bigger question of if someone who already has an anchor podcast site should be creating a second one.  I'll make a separate issue for this one.
* The spotify show url is double url encoded at one point, I am aware, but I believe it's the right thing to do.
* The code here is a bit complex and hard to understand, I did my best to clean it up, but I am open to any suggestions.

