### PR TITLE
Fix e2e tests to work on newer chrome browsers

### DIFF
--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -278,7 +278,7 @@ export async function ensureNotLoggedIn( driver ) {
 	}
 
 	await driver.executeScript(
-		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";'
+		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";SameSite=None;Secure'
 	);
 	return driver.sleep( 500 );
 }

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -278,10 +278,7 @@ export async function ensureNotLoggedIn( driver ) {
 	}
 
 	await driver.executeScript(
-		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";SameSite=None;Secure'
-	);
-	await driver.executeScript(
-		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com"'
+		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com;SameSite=None;Secure"'
 	);
 	return driver.sleep( 500 );
 }

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -280,6 +280,9 @@ export async function ensureNotLoggedIn( driver ) {
 	await driver.executeScript(
 		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";SameSite=None;Secure'
 	);
+	await driver.executeScript(
+		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com"'
+	);
 	return driver.sleep( 500 );
 }
 

--- a/test/e2e/lib/pages/wp-home-page.js
+++ b/test/e2e/lib/pages/wp-home-page.js
@@ -21,6 +21,7 @@ export default class WPHomePage extends AsyncBaseContainer {
 		const setCookieCode = function ( sandboxValue ) {
 			window.document.cookie =
 				'store_sandbox=' + sandboxValue + ';domain=.wordpress.com;SameSite=None;Secure';
+			window.document.cookie = 'store_sandbox=' + sandboxValue + ';domain=.wordpress.com';
 		};
 		await this.driver.executeScript( setCookieCode, sandboxCookieValue );
 		return true;
@@ -30,6 +31,7 @@ export default class WPHomePage extends AsyncBaseContainer {
 		const setCookieCode = function ( currencyValue ) {
 			window.document.cookie =
 				'landingpage_currency=' + currencyValue + ';domain=.wordpress.com;SameSite=None;Secure';
+			window.document.cookie = 'landingpage_currency=' + currencyValue + ';domain=.wordpress.com';
 		};
 		return await this.driver.executeScript( setCookieCode, currency );
 	}

--- a/test/e2e/lib/pages/wp-home-page.js
+++ b/test/e2e/lib/pages/wp-home-page.js
@@ -19,7 +19,8 @@ export default class WPHomePage extends AsyncBaseContainer {
 
 	async setSandboxModeForPayments( sandboxCookieValue ) {
 		const setCookieCode = function ( sandboxValue ) {
-			window.document.cookie = 'store_sandbox=' + sandboxValue + ';domain=.wordpress.com';
+			window.document.cookie =
+				'store_sandbox=' + sandboxValue + ';domain=.wordpress.com;SameSite=None;Secure';
 		};
 		await this.driver.executeScript( setCookieCode, sandboxCookieValue );
 		return true;
@@ -27,7 +28,8 @@ export default class WPHomePage extends AsyncBaseContainer {
 
 	async setCurrencyForPayments( currency ) {
 		const setCookieCode = function ( currencyValue ) {
-			window.document.cookie = 'landingpage_currency=' + currencyValue + ';domain=.wordpress.com';
+			window.document.cookie =
+				'landingpage_currency=' + currencyValue + ';domain=.wordpress.com;SameSite=None;Secure';
 		};
 		return await this.driver.executeScript( setCookieCode, currency );
 	}

--- a/test/e2e/lib/pages/wp-home-page.js
+++ b/test/e2e/lib/pages/wp-home-page.js
@@ -21,7 +21,6 @@ export default class WPHomePage extends AsyncBaseContainer {
 		const setCookieCode = function ( sandboxValue ) {
 			window.document.cookie =
 				'store_sandbox=' + sandboxValue + ';domain=.wordpress.com;SameSite=None;Secure';
-			window.document.cookie = 'store_sandbox=' + sandboxValue + ';domain=.wordpress.com';
 		};
 		await this.driver.executeScript( setCookieCode, sandboxCookieValue );
 		return true;
@@ -31,7 +30,6 @@ export default class WPHomePage extends AsyncBaseContainer {
 		const setCookieCode = function ( currencyValue ) {
 			window.document.cookie =
 				'landingpage_currency=' + currencyValue + ';domain=.wordpress.com;SameSite=None;Secure';
-			window.document.cookie = 'landingpage_currency=' + currencyValue + ';domain=.wordpress.com';
 		};
 		return await this.driver.executeScript( setCookieCode, currency );
 	}


### PR DESCRIPTION
Newer Chrome browsers filter out cookies that don't have a proper `SameSite` attribute set. This got me into a bit of a hurdle because the only option to run the e2e tests locally was to enable store sandbox on my sandboxed API using a backend config constant. However that didn't surface another problem in the backend which we only noticed after it started generating a bunch of errors in the support email queue. Turned out that the `store_sandbox` cookie gets filtered out but the backend config constant is not 100% equal to the `store_sandbox` cookie so some things worked differently in production.

#### Changes proposed in this Pull Request

* Add `SameSite` cookie policy attribute and also the `Secure` attribute to make the e2e tests work on newer chrome browsers

#### Testing instructions

* Sandbox `public-api.wordpress.com` and make sure that store sandbox is disabled in your local config (`USE_STORE_SANDBOX` is not defined in there)
* Try and run one of the e2e tests using the following command `env BROWSERSIZE=desktop ./node_modules/.bin/mocha specs/wp-signup-spec.js --fgrep "Sign up for a site on a business paid plan w"`
* It will probably still fail but that's a different issue you should be able to fix if you change the following line - https://github.com/Automattic/wp-calypso/pull/46233/commits/bcc49ea398c9447623baf6f8dbd4c63fdd51fe19
* You can also manually debug this if you put a few `driver.sleep(20000)` within the spec and inspect individual public-api network requests and specifically the "Cookies" tab (there is a "show filtered out request cookies" checkbox that will show you all filtered out cookies and the reason they were filtered out). It's tedious but that's how I figured out what's happening.