### PR TITLE
Styles: Use correct theme colors for WordPress/components Button

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -2,3 +2,77 @@
 .components-form-toggle.is-checked .components-form-toggle__track {
 	background-color: var( --color-primary );
 }
+
+/* @wordpress/components Button overrides */
+.components-button {
+	color: var( --color-neutral-70 );
+
+	&:hover:not( :disabled ) {
+		color: var( --color-neutral-70 );
+	}
+}
+
+.components-button.is-primary {
+	background-color: var( --color-accent );
+	border-color: var( --color-accent );
+	color: var( --color-text-inverted );
+
+	&:hover:not( :disabled ),
+	&:focus:not( :disabled ) {
+		background-color: var( --color-accent-60 );
+		border-color: var( --color-accent-60 );
+		color: var( --color-text-inverted );
+	}
+
+	&[disabled],
+	&:disabled,
+	&.disabled {
+		color: var( --color-neutral-20 );
+		background-color: var( --color-surface );
+		border-color: var( --color-neutral-5 );
+	}
+}
+
+.components-button.is-secondary {
+	background-color: var( --color-surface );
+	color: var( --color-neutral-70 );
+	box-shadow: inset 0 0 0 1px var( --color-neutral-10 );
+
+	&:active:not( :disabled ),
+	&:hover:not( :disabled ) {
+		box-shadow: inset 0 0 0 1px var( --color-neutral-20 );
+		color: var( --color-neutral-70 );
+	}
+
+	&:visited {
+		color: var( --color-neutral-70 );
+	}
+
+	&[disabled],
+	&:disabled,
+	&.disabled {
+		color: var( --color-neutral-20 );
+		background-color: var( --color-surface );
+		box-shadow: inset 0 0 0 1px var( --color-neutral-5 );
+	}
+}
+
+.components-button.is-tertiary {
+	color: var( --color-accent );
+
+	&:active:not( :disabled ),
+	&:hover:not( :disabled ) {
+		box-shadow: inset 0 0 0 1px var( --color-neutral-20 );
+		color: var( --color-accent-60 );
+	}
+
+	&:visited {
+		color: var( --color-accent-60 );
+	}
+
+	&[disabled],
+	&:disabled,
+	&.disabled {
+		color: var( --color-accent-60 );
+	}
+}

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -5,8 +5,7 @@
 
 /* @wordpress/components Button overrides */
 .components-button {
-	color: var( --color-neutral-70 );
-
+	&,
 	&:hover:not( :disabled ) {
 		color: var( --color-neutral-70 );
 	}
@@ -66,10 +65,7 @@
 		color: var( --color-accent-60 );
 	}
 
-	&:visited {
-		color: var( --color-accent-60 );
-	}
-
+	&:visited,
 	&[disabled],
 	&:disabled,
 	&.disabled {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Building off of https://github.com/Automattic/wp-calypso/pull/48515, this PR uses the correct theme values for Button colors

This is just a starting point, I took a best guess for what colors to use but this could use a designer's eye (as well as an a11y audit, especially for the tertiary button).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the WordPress/components gallery (`/devdocs/wordpress-components-gallery`) and verify that the buttons look correct with various themes.
