### PR TITLE
Admin Menu: Show update count in submenu items

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -149,7 +149,12 @@
 		line-height: 0;
 		padding: 8px 6px;
 		position: absolute;
-		top: 10px;
+		top: 9px;
+
+		// No positioning necessary for submenu items.
+		.sidebar__menu-item--child & {
+			top: 6px;
+		}
 	}
 
 	.badge {

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -25,18 +25,20 @@ import {
 } from 'calypso/state/my-sites/sidebar/actions';
 
 export const MySitesSidebarUnifiedItem = ( {
-	title,
+	count,
 	icon,
-	url,
-	slug,
-	selected = false,
 	isSubItem = false,
 	sectionId,
+	selected = false,
+	slug,
+	title,
+	url,
 } ) => {
 	const reduxDispatch = useDispatch();
 
 	return (
 		<SidebarItem
+			count={ count }
 			label={ title }
 			link={ url }
 			onNavigate={ () => {
@@ -54,6 +56,7 @@ export const MySitesSidebarUnifiedItem = ( {
 };
 
 MySitesSidebarUnifiedItem.propTypes = {
+	count: PropTypes.number,
 	icon: PropTypes.string,
 	sectionId: PropTypes.string,
 	slug: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Makes `count` value available to submenu items.
* Updates styles to have count value in line with menu item text for top level and submenu items.

#### Screenshots (after)
![Screen Shot 2021-01-05 at 3 18 39 PM](https://user-images.githubusercontent.com/1398304/103710756-b236de00-4f6a-11eb-82a0-93ac4f9b1313.png)

![Screen Shot 2021-01-05 at 3 18 50 PM](https://user-images.githubusercontent.com/1398304/103710758-b3680b00-4f6a-11eb-9609-3efc3ad0bcb8.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have an Atomic site with an unmoderated comment and a theme or plugin that needs updating
* Enable Jetpack Beta on that site and set it to Bleeding Edge
* Visit wordpress.com/home for your Atomic site and make sure the update count bubble look sharp.

Fixes #48607.
