### PR TITLE
Domains: Update GSuiteAddUsers to use withShoppingCart

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -28,10 +28,12 @@ export default {
 
 	emailManagementNewGSuiteAccount( pageContext, next ) {
 		pageContext.primary = (
-			<GSuiteAddUsers
-				planType={ pageContext.params.planType }
-				selectedDomainName={ pageContext.params.domain }
-			/>
+			<CalypsoShoppingCartProvider>
+				<GSuiteAddUsers
+					planType={ pageContext.params.planType }
+					selectedDomainName={ pageContext.params.domain }
+				/>
+			</CalypsoShoppingCartProvider>
 		);
 		next();
 	},

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -7,11 +7,11 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
+import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
  */
-import { addItems } from 'calypso/lib/cart/actions';
 import AddEmailAddressesCardPlaceholder from './add-users-placeholder';
 import { Button, Card } from '@automattic/components';
 import DomainManagementHeader from 'calypso/my-sites/domains/domain-management/components/header';
@@ -46,6 +46,8 @@ import QueryGSuiteUsers from 'calypso/components/data/query-gsuite-users';
 import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
+import { getProductsList } from 'calypso/state/products-list/selectors/get-products-list';
 
 /**
  * Style dependencies
@@ -56,6 +58,8 @@ class GSuiteAddUsers extends React.Component {
 	state = {
 		users: [],
 	};
+
+	isMounted = false;
 
 	static getDerivedStateFromProps(
 		{ domains, isRequestingDomains, selectedDomainName },
@@ -80,14 +84,17 @@ class GSuiteAddUsers extends React.Component {
 		this.recordClickEvent( 'calypso_email_management_gsuite_add_users_continue_button_click' );
 
 		if ( canContinue ) {
-			addItems(
-				getItemsForCart(
-					domains,
-					'basic' === planType ? GSUITE_BASIC_SLUG : GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
-					users
+			this.props.shoppingCartManager
+				.addProductsToCart(
+					getItemsForCart(
+						domains,
+						'basic' === planType ? GSUITE_BASIC_SLUG : GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+						users
+					).map( ( item ) => fillInSingleCartItemAttributes( item, this.props.productsList ) )
 				)
-			);
-			page( '/checkout/' + selectedSite.slug );
+				.then( () => {
+					this.isMounted && page( '/checkout/' + selectedSite.slug );
+				} );
 		}
 	};
 
@@ -137,6 +144,11 @@ class GSuiteAddUsers extends React.Component {
 	componentDidMount() {
 		const { domains, isRequestingDomains, selectedDomainName } = this.props;
 		this.redirectIfCannotAddEmail( domains, isRequestingDomains, selectedDomainName );
+		this.isMounted = true;
+	}
+
+	componentWillUnmount() {
+		this.isMounted = false;
 	}
 
 	shouldComponentUpdate( nextProps ) {
@@ -287,8 +299,9 @@ export default connect(
 			domainsWithForwards: getDomainsWithForwards( state, domains ),
 			gsuiteUsers: getGSuiteUsers( state, siteId ),
 			isRequestingDomains: isRequestingSiteDomains( state, siteId ),
+			productsList: getProductsList( state ),
 			selectedSite,
 		};
 	},
 	{ recordTracksEvent: recordTracksEventAction }
-)( localize( GSuiteAddUsers ) );
+)( withShoppingCart( localize( GSuiteAddUsers ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of removing `CartStore` (see https://github.com/Automattic/wp-calypso/issues/24019), this PR updates `GSuiteAddUsers` to use `withShoppingCart` to add products to the cart.

#### Testing instructions

- Use a site that has a domain or domain mapping.
- Visit domain settings for that site.
- Click the domain product to view the details.
- Click "set up your email".
- Click "Add G Suite".
- Fill in the form and submit it.
- Verify that you end up in checkout and that the G Suite product is in your cart.