### PR TITLE
Settings: Reduxify notices in SEO settings

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -16,7 +16,6 @@ import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-secti
 import MetaTitleEditor from 'calypso/components/seo/meta-title-editor';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import notices from 'calypso/notices';
 import { protectForm } from 'calypso/lib/protect-form';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -38,6 +37,7 @@ import isHiddenSite from 'calypso/state/selectors/is-hidden-site';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
+import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { toApi as seoTitleToApi } from 'calypso/components/seo/meta-title-editor/mappings';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -116,7 +116,12 @@ export class SeoForm extends React.Component {
 		// save error
 		if ( this.state.isSubmittingForm && nextProps.saveError ) {
 			this.setState( { isSubmittingForm: false } );
-			notices.error( translate( 'There was a problem saving your changes. Please, try again.' ) );
+			this.props.errorNotice(
+				translate( 'There was a problem saving your changes. Please, try again.' ),
+				{
+					id: 'seo-settings-form-error',
+				}
+			);
 		}
 
 		// if we are changing sites, everything goes
@@ -190,7 +195,7 @@ export class SeoForm extends React.Component {
 			event.preventDefault();
 		}
 
-		notices.clearNotices( 'notices' );
+		this.props.removeNotice( 'seo-settings-form-error' );
 
 		this.setState( {
 			isSubmittingForm: true,
@@ -511,6 +516,8 @@ const mapStateToProps = ( state ) => {
 };
 
 const mapDispatchToProps = {
+	errorNotice,
+	removeNotice,
 	refreshSiteData: requestSite,
 	requestSiteSettings,
 	saveSiteSettings,

--- a/client/my-sites/site-settings/seo-settings/main.jsx
+++ b/client/my-sites/site-settings/seo-settings/main.jsx
@@ -10,9 +10,9 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import AsyncLoad from 'calypso/components/async-load';
-import notices from 'calypso/notices';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
+import { errorNotice } from 'calypso/state/notices/actions';
 import {
 	getSitePurchases,
 	hasLoadedSitePurchasesFromServer,
@@ -23,7 +23,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 export class SeoSettings extends Component {
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( nextProps.purchasesError ) {
-			notices.error( nextProps.purchasesError );
+			this.props.errorNotice( nextProps.purchasesError );
 		}
 	}
 
@@ -52,12 +52,17 @@ SeoSettings.propTypes = {
 	siteId: PropTypes.number,
 };
 
-export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-	return {
-		siteId,
-		hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
-		purchasesError: getPurchasesError( state ),
-		sitePurchases: getSitePurchases( state, siteId ),
-	};
-} )( SeoSettings );
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		return {
+			siteId,
+			hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
+			purchasesError: getPurchasesError( state ),
+			sitePurchases: getSitePurchases( state, siteId ),
+		};
+	},
+	{
+		errorNotice,
+	}
+)( SeoSettings );

--- a/client/my-sites/site-settings/seo-settings/main.jsx
+++ b/client/my-sites/site-settings/seo-settings/main.jsx
@@ -22,7 +22,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export class SeoSettings extends Component {
 	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.purchasesError ) {
+		if ( ! this.props.purchasesError && nextProps.purchasesError ) {
 			this.props.errorNotice( nextProps.purchasesError );
 		}
 	}
@@ -47,7 +47,7 @@ SeoSettings.propTypes = {
 	section: PropTypes.string,
 	//connected
 	hasLoadedSitePurchasesFromServer: PropTypes.bool,
-	purchasesError: PropTypes.object,
+	purchasesError: PropTypes.string,
 	sitePurchases: PropTypes.array,
 	siteId: PropTypes.number,
 };

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
-import notices from 'calypso/notices';
 import { connect } from 'react-redux';
 import { get, includes, isString, omit, partial, pickBy } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -22,6 +20,7 @@ import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
+import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -78,7 +77,12 @@ class SiteVerification extends Component {
 		// save error
 		if ( this.state.isSubmittingForm && nextProps.saveError ) {
 			this.setState( { isSubmittingForm: false } );
-			notices.error( translate( 'There was a problem saving your changes. Please, try again.' ) );
+			this.props.errorNotice(
+				translate( 'There was a problem saving your changes. Please, try again.' ),
+				{
+					id: 'site-verification-settings-error',
+				}
+			);
 		}
 
 		// if we are changing sites, everything goes
@@ -211,7 +215,7 @@ class SiteVerification extends Component {
 			event.preventDefault();
 		}
 
-		notices.clearNotices( 'notices' );
+		this.props.removeNotice( 'site-verification-settings-error' );
 
 		const verificationCodes = {
 			google: this.state.googleCode,
@@ -227,7 +231,9 @@ class SiteVerification extends Component {
 
 		this.setState( { invalidCodes } );
 		if ( invalidCodes.length > 0 ) {
-			notices.error( translate( 'Invalid site verification tag entered.' ) );
+			this.props.errorNotice( translate( 'Invalid site verification tag entered.' ), {
+				id: 'site-verification-settings-error',
+			} );
 			return;
 		}
 
@@ -440,6 +446,8 @@ export default connect(
 		};
 	},
 	{
+		errorNotice,
+		removeNotice,
 		requestSite,
 		requestSiteSettings,
 		saveSiteSettings,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reduxifies notices in SEO settings components.

Part of #48408.

#### Testing instructions

* Go to `/marketing/traffic/:site` where `:site` is a WP.com simple site on a business plan.
* Test Site Verification Services:
  * Scroll down to "Site verification services".
  * Paste `<meta />` in the first field and click the save button.
  * Verify you see an error notice.
  * Change and resubmit, verify notice instantly disappears.
  * Paste a valid verification code in the first field (you can copy it from the placeholder of the field).
  * Disable network connection and submit the form.
  * Verify you can see an error notice.
  * Re-enable network connection.
  * Resubmit and verify notice instantly disappears.
* Test Page Title Structure:
  * Scroll to "Page Title Structure".
  * Input something in the page title field.
  * Disable network connection and submit the form.
  * Verify you can see an error notice.
  * Re-enable network connection.
  * Resubmit and verify notice instantly disappears.
* Test the `SeoSettings` component:
  * In the console, input `dispatch( { type: 'PURCHASES_SITE_FETCH_FAILED', error: 'An error has occurred.' } )`
  * Verify you can see a notice.
  * Input that again and verify notice still remains and not a new one is created.