### PR TITLE
Update Upwork Banner to Point to DFIM

### DIFF
--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -73,7 +73,7 @@ class UpworkBanner extends PureComponent {
 	}
 
 	render() {
-		const { isBannerVisible, location, translate } = this.props;
+		const { isBannerVisible, translate } = this.props;
 		if ( ! isBannerVisible ) {
 			return null;
 		}
@@ -83,18 +83,14 @@ class UpworkBanner extends PureComponent {
 				role="button"
 				style={ { backgroundColor: '#DAF5FC' } }
 				onClick={ this.onStartNowClick }
-				href={ `/experts/upwork?source=${ location }` }
-				target="_blank"
-				rel="noopener noreferrer"
+				href={ 'https://wordpress.com/built-by-wordpress-com/' }
 			>
 				<QueryPreferences />
 				<h1 className="upwork-banner__title">
 					{ translate( 'Need an expert to help realize your vision? Hire one!' ) }
 				</h1>
 				<p className="upwork-banner__description">
-					{ translate(
-						"We've partnered with Upwork, a network of freelancers with a huge pool of WordPress experts. They know their stuff and they're waiting to help you build your dream site."
-					) }
+					{ translate( 'You want the website of your dreams. Our experts can create it for you.' ) }
 				</p>
 				<Button className="upwork-banner__cta" compact primary={ this.props.primaryButton }>
 					{ translate( 'Find your expert' ) }
@@ -103,7 +99,7 @@ class UpworkBanner extends PureComponent {
 					<Gridicon icon="cross-small" size={ 18 } />
 				</Button>
 				<img
-					alt={ translate( 'Upwork' ) }
+					alt={ translate( 'Find your expert' ) }
 					width={ 390 }
 					className="upwork-banner__image"
 					src={ builderIllustration }

--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -87,7 +87,7 @@ class UpworkBanner extends PureComponent {
 			>
 				<QueryPreferences />
 				<h1 className="upwork-banner__title">
-					{ translate( 'Need an expert to help realize your vision? Hire one!' ) }
+					{ translate( 'Hire a WordPress.com Expert to Build Your Site' ) }
 				</h1>
 				<p className="upwork-banner__description">
 					{ translate( 'You want the website of your dreams. Our experts can create it for you.' ) }

--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -87,7 +87,7 @@ class UpworkBanner extends PureComponent {
 			>
 				<QueryPreferences />
 				<h1 className="upwork-banner__title">
-					{ translate( 'Hire a WordPress.com Expert to Build Your Site' ) }
+					{ translate( 'Let Our WordPress.com Experts Build Your Site!' ) }
 				</h1>
 				<p className="upwork-banner__description">
 					{ translate( 'You want the website of your dreams. Our experts can create it for you.' ) }

--- a/client/blocks/upwork-banner/test/__snapshots__/index.js.snap
+++ b/client/blocks/upwork-banner/test/__snapshots__/index.js.snap
@@ -3,16 +3,14 @@
 exports[`UpworkBanner renders correctly 1`] = `
 <a
   className="upwork-banner"
-  href="/experts/upwork?source=foo"
+  href="https://wordpress.com/built-by-wordpress-com/"
   onClick={[Function]}
-  rel="noopener noreferrer"
   role="button"
   style={
     Object {
       "backgroundColor": "#DAF5FC",
     }
   }
-  target="_blank"
 >
   <h1
     className="upwork-banner__title"
@@ -22,7 +20,7 @@ exports[`UpworkBanner renders correctly 1`] = `
   <p
     className="upwork-banner__description"
   >
-    We've partnered with Upwork, a network of freelancers with a huge pool of WordPress experts. They know their stuff and they're waiting to help you build your dream site.
+    You want the website of your dreams. Our experts can create it for you.
   </p>
   <button
     className="button upwork-banner__cta is-compact"
@@ -48,7 +46,7 @@ exports[`UpworkBanner renders correctly 1`] = `
     </svg>
   </button>
   <img
-    alt="Upwork"
+    alt="Find your expert"
     className="upwork-banner__image"
     src="builder-referral.svg"
     width={390}

--- a/client/blocks/upwork-banner/test/__snapshots__/index.js.snap
+++ b/client/blocks/upwork-banner/test/__snapshots__/index.js.snap
@@ -15,7 +15,7 @@ exports[`UpworkBanner renders correctly 1`] = `
   <h1
     className="upwork-banner__title"
   >
-    Need an expert to help realize your vision? Hire one!
+    Hire a WordPress.com Expert to Build Your Site
   </h1>
   <p
     className="upwork-banner__description"

--- a/client/blocks/upwork-banner/test/__snapshots__/index.js.snap
+++ b/client/blocks/upwork-banner/test/__snapshots__/index.js.snap
@@ -15,7 +15,7 @@ exports[`UpworkBanner renders correctly 1`] = `
   <h1
     className="upwork-banner__title"
   >
-    Hire a WordPress.com Expert to Build Your Site
+    Let Our WordPress.com Experts Build Your Site!
   </h1>
   <p
     className="upwork-banner__description"

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -19,14 +19,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	builderReferralThemesBanner: {
-		datestamp: '20181218',
-		variations: {
-			builderReferralBanner: 25,
-			original: 75,
-		},
-		defaultVariation: 'original',
-	},
 	pageBuilderMVP: {
 		datestamp: '20190419',
 		variations: {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -12,7 +12,6 @@ import Gridicon from 'calypso/components/gridicon';
 /**
  * Internal dependencies
  */
-import { abtest } from 'calypso/lib/abtest';
 import { Button } from '@automattic/components';
 import ThemesSelection from './themes-selection';
 import SubMasterbarNav from 'calypso/components/sub-masterbar-nav';
@@ -372,11 +371,7 @@ class ThemeShowcase extends React.Component {
 										'These themes offer more power and flexibility, but can be harder to setup and customize.'
 									) }
 								</p>
-								{ showBanners &&
-									abtest &&
-									abtest( 'builderReferralThemesBanner' ) === 'builderReferralBanner' && (
-										<UpworkBanner location={ 'theme-banner' } />
-									) }
+								{ showBanners && <UpworkBanner location={ 'theme-banner' } /> }
 							</>
 						) }
 						<QueryThemeFilters />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We are currently not sending users to Upwork because the landing page is 404. Update it banner and the copy to point to DFIM instead.

The banner currently shows on /themes, when the button "Show all themes" is clicked. It was suggested that it's either there or on top of the /themes page. The problem is that showing it on top of the page would be an issue for the Install Theme upsell.

Here's the button:
<img width="1022" alt="Screenshot 2021-01-06 at 14 47 09" src="https://user-images.githubusercontent.com/82778/103770108-225a6800-502e-11eb-8990-ba5634167fe3.png">

And this is how it looks after clicking:
<img width="1000" alt="Screenshot 2021-01-06 at 15 21 28" src="https://user-images.githubusercontent.com/82778/103772883-e2e24a80-5032-11eb-923c-9f44b0083242.png">

Check pau2Xa-2wz-p2 for more information

#### Testing instructions
1. Go to themes
2. Click the Show all themes button
3. Make sure the DFIM banner appears
4. Click the button. It should lead to the DFIM landing page