### PR TITLE
New Onboarding: Add option to use your own domain

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -25,6 +25,7 @@ import useStepNavigation from '../../hooks/use-step-navigation';
 import { trackEventWithFlow } from '../../lib/analytics';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { DOMAIN_SUGGESTIONS_STORE } from '../../stores/domain-suggestions';
+import { USER_STORE } from '../../stores/user';
 import { FLOW_ID, domainIsAvailableStatus } from '../../constants';
 import waitForDomainAvailability from './wait-for-domain-availability';
 
@@ -50,6 +51,8 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 
 	// using the selector will get the explicit domain search query with site title and vertical as fallbacks
 	const domainSearch = useSelect( ( select ) => select( ONBOARD_STORE ).getDomainSearch() );
+
+	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 
 	const isCheckingDomainAvailability = useSelect( ( select ): boolean =>
 		select( 'core/data' ).isResolving( DOMAIN_SUGGESTIONS_STORE, 'isAvailable', [
@@ -157,7 +160,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				onDomainSelect={ onDomainSelect }
 				analyticsUiAlgo={ isModal ? 'domain_modal' : 'domain_page' }
 				locale={ locale }
-				onUseYourDomainClick={ handleUseYourDomain }
+				onUseYourDomainClick={ currentUser ? handleUseYourDomain : undefined }
 			/>
 		</div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -137,6 +137,13 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 		} );
 	};
 
+	const handleUseYourDomain = () => {
+		trackEventWithFlow( 'calypso_newsite_use_your_domain_click', {
+			where: isModal ? 'domain_modal' : 'domain_page',
+		} );
+		window.location.href = `/start/domains/use-your-domain?source=${ window.location.href }`;
+	};
+
 	return (
 		<div className="gutenboarding-page domains">
 			<DomainPicker
@@ -150,6 +157,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				onDomainSelect={ onDomainSelect }
 				analyticsUiAlgo={ isModal ? 'domain_modal' : 'domain_page' }
 				locale={ locale }
+				onUseYourDomainClick={ handleUseYourDomain }
 			/>
 		</div>
 	);

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -246,6 +246,10 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	if ( persistentSelectedDomain ) {
 		placeholdersCount += 1;
 	}
+	// If onUseYourDomainClick is defined, UseYourDomainItem will appended to the list of options
+	if ( onUseYourDomainClick ) {
+		placeholdersCount += 1;
+	}
 	// If existingSubdomain is defined, it will be rendered separately with its own placeholder
 	if ( existingSubdomain ) {
 		placeholdersCount -= 1;
@@ -394,7 +398,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 												times( placeholdersCount, ( i ) => (
 													<SuggestionItemPlaceholder type={ itemType } key={ i } />
 												) ) }
-											{ onUseYourDomainClick && (
+											{ onUseYourDomainClick && !! domainSuggestions && (
 												<UseYourDomainItem onClick={ onUseYourDomainClick } />
 											) }
 										</ItemGrouper>

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -124,7 +124,7 @@ $accent-blue: #117ac9;
 			border-top-left-radius: 5px; /* stylelint-disable-line scales/radii */
 			border-top-right-radius: 5px; /* stylelint-disable-line scales/radii */
 		}
-	
+
 		&.type-individual-item,
 		&:last-child {
 			border-bottom-left-radius: 5px; /* stylelint-disable-line scales/radii */
@@ -145,7 +145,7 @@ $accent-blue: #117ac9;
 	}
 
 	// animate the added domains after you click expand
-	@for $i from 7 through 14 {
+	@for $i from 8 through 14 {
 		&:nth-child( #{$i} ) {
 			transform: translateY( 20px );
 			opacity: 0;

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -97,10 +97,6 @@ $accent-blue: #117ac9;
 		outline: none;
 	}
 
-	&.contains-link {
-		cursor: default;
-	}
-
 	&.type-individual-item {
 		min-height: 64px;
 		border-width: 2px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the option to use a domain I own to Gutenboarding, for logged-in users as discussed in p1609939662195100-slack-C0KDTA48Y

#### Testing instructions

* Go to `/new` as a logged in user.
* Advance to [domains](http://calypso.localhost:3000/new/domains) step.
* Type a search query if there isn't one
* Click _Use a domain I own_ button at the bottom
* You should land on `http://calypso.localhost:3000/start/domains/use-your-domain?source=http://calypso.localhost:3000/new/domains`
* At this point you can continue the `/start` flow until site creation or press top-left _Back_ button to return to Gutenboarding

#### Screenshot
<img width="1133" alt="Screenshot 2021-01-06 at 15 54 43" src="https://user-images.githubusercontent.com/14192054/103788880-05cb2980-5048-11eb-9b71-9faf8822c5be.png">

Fixes part of https://github.com/Automattic/wp-calypso/issues/44645