### PR TITLE
Editing Toolkit: Update to 2.8.17

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.16
+ * Version: 2.8.17
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.16' );
+define( 'PLUGIN_VERSION', '2.8.17' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -48,6 +48,8 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Editor welcome tour tracking and fixes. (https://github.com/Automattic/wp-calypso/pull/48390)
 * New Onboarding: pre-select subdomain in editor launch flow. (https://github.com/Automattic/wp-calypso/pull/48247)
 * New Onboarding: use site slug instead of siteId when redirecting after launch. (https://github.com/Automattic/wp-calypso/pull/48248)
+* Focused Launch: miscellaneous improvements and fixes
+* Checkout: miscellaneous fixes
 
 = 2.8.16 =
 * Page layout selector: Fixed an issue where the wrong close button would appear in certain circumstances. (https://github.com/Automattic/wp-calypso/pull/48469)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.16
+Stable tag: 2.8.17
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,15 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.17 =
+* Domain Picker: make items keyboard accessible (https://github.com/Automattic/wp-calypso/pull/48172)
+* Patterns: Guard the premium patterns indicator behind an Object.isExtensible check to prevent editor fatals in SCRIPT_DEBUG mode. (https://github.com/Automattic/wp-calypso/pull/48640)
+* Onboarding: Fix plan picker comparison table width on large displays. (https://github.com/Automattic/wp-calypso/pull/48112)
+* Add an initial sync to remove need to make an edit for sync to happen. (https://github.com/Automattic/wp-calypso/pull/48586)
+* Editor welcome tour tracking and fixes. (https://github.com/Automattic/wp-calypso/pull/48390)
+* New Onboarding: pre-select subdomain in editor launch flow. (https://github.com/Automattic/wp-calypso/pull/48247)
+* New Onboarding: use site slug instead of siteId when redirecting after launch. (https://github.com/Automattic/wp-calypso/pull/48248)
 
 = 2.8.16 =
 * Page layout selector: Fixed an issue where the wrong close button would appear in certain circumstances. (https://github.com/Automattic/wp-calypso/pull/48469)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -48,6 +48,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Editor welcome tour tracking and fixes. (https://github.com/Automattic/wp-calypso/pull/48390)
 * New Onboarding: pre-select subdomain in editor launch flow. (https://github.com/Automattic/wp-calypso/pull/48247)
 * New Onboarding: use site slug instead of siteId when redirecting after launch. (https://github.com/Automattic/wp-calypso/pull/48248)
+* Coming Soon: add php unit tests. (https://github.com/Automattic/wp-calypso/pull/48584)
 * Focused Launch: miscellaneous improvements and fixes
 * Checkout: miscellaneous fixes
 

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.16",
+	"version": "2.8.17",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Bumps version of Editing Toolkit to 2.8.17

### [Editing Toolkit changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)

- [x] Domain Picker: make items keyboard accessible (#48172) — @alshakero 
- [x] Patterns: Guard the premium patterns indicator behind an Object.isExtensible check to prevent editor fatals in SCRIPT_DEBUG mode. (#48640) — @andrewserong
- [x] Onboarding: Fix plan picker comparison table width on large displays. (#48112) — @ciampo 
- [x] Add an initial sync to remove need to make an edit for sync to happen. (#48586) — @glendaviesnz 
- [x] Editor welcome tour tracking and fixes. (#48390) — @autumnfjeld
- [x] New Onboarding: pre-select subdomain in editor launch flow. (#48247) — @razvanpapadopol 
- [x] New Onboarding: use site slug instead of siteId when redirecting after launch. (#48248) — @razvanpapadopol
- [x] Coming Soon: add php unit tests. (#48584) — @ramonjd

### Other [changes](https://github.com/Automattic/wp-calypso/commits/trunk/packages) included from the [imported @automattic packages](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/tsconfig.json#L37-L46) and their imports

- [x] Fully handle invalid URLs ([#48507](https://github.com/Automattic/wp-calypso/pull/48507) ) - @saramarcondes
- [x] Focused-Launch: Add error handling for LaunchSite ( [#48348](https://github.com/Automattic/wp-calypso/pull/48348) ) - @StefanNieuwenhuis 
- [x] Focused Launch: go back to summary after free domain selection ( [#48575](https://github.com/Automattic/wp-calypso/pull/48575) ) - @alshakero
- [x] Focused Launch: hide plan comparisons from detailed plans step ( [#48571](https://github.com/Automattic/wp-calypso/pull/48571) ) - @alshakero
- [x] Focused Launch: Handle paid plan coming from the cart ( [#48551](https://github.com/Automattic/wp-calypso/pull/48551) ) - @alshakero
- [x] Focused Launch: add defaultAllPlansExpanded bool to plans table’s API (48576) - @alshakero
- [x] Domain picker: fix domain picker suggestion item layout for long domains ( [#48624](https://github.com/Automattic/wp-calypso/pull/48624) ) - @alshakero
- [x] Focused Launch: handle already-purchased domains properly in summary ( [#48574](https://github.com/Automattic/wp-calypso/pull/48574) ) - @alshakero
- [x] Focused Launch: fix Summary View plan step placeholders ( [#48620](https://github.com/Automattic/wp-calypso/pull/48620) ) -  @alshakero
- [x] Focused Launch: display selected popular plan only once in Summary View ( [#48619](https://github.com/Automattic/wp-calypso/pull/48619) ) - @razvanpapadopol 
- [x] Checkout: Move analytics for redirect payment methods into payment processors (#48435) - @sirbrillig
- [x] composite-checkout: Fix types on Checkout steps (#48679) - @sirbrillig 
- [x] Include info about anchor flavoring when submitting gutenboarding signup (#48506) - @blackjackkent
- [x] Focused-Launch: Update mobile styling for select buttons (#48663) - @StefanNieuwenhuis 

### Testing instructions

1. Load the diff on your sandbox (D54935-code) and confirm that the above changes work correctly
2. When a change has been tested to work correctly, please mark it as checked in the list above
3. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.
    - [x] Tested on atomic 