### PR TITLE
Plans Page: Display tiered pricing for products that have it

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card-i5/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card-i5/index.tsx
@@ -14,6 +14,7 @@ import JetpackProductCardTimeFrame from './time-frame';
 import { preventWidows } from 'calypso/lib/formatting';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import JetpackProductCardFeatures, { Props as FeaturesProps } from './features';
+import InfoPopover from 'calypso/components/info-popover';
 
 /**
  * Type dependencies
@@ -45,6 +46,8 @@ type OwnProps = {
 	isOwned?: boolean;
 	isDeprecated?: boolean;
 	isAligned?: boolean;
+	displayFrom?: boolean;
+	tooltipText?: TranslateResult | ReactNode;
 };
 
 export type Props = OwnProps & Partial< FeaturesProps >;
@@ -68,6 +71,8 @@ const JetpackProductCardAlt2: React.FC< Props > = ( {
 	isDeprecated,
 	isAligned,
 	features,
+	displayFrom,
+	tooltipText,
 }: Props ) => {
 	const translate = useTranslate();
 	const isDiscounted = isFinite( discountedPrice );
@@ -103,6 +108,7 @@ const JetpackProductCardAlt2: React.FC< Props > = ( {
 				<div className="jetpack-product-card-i5__price">
 					{ currencyCode && originalPrice ? (
 						<>
+							{ displayFrom && <span className="jetpack-product-card-i5__price-from">from</span> }
 							<span className="jetpack-product-card-i5__raw-price">
 								<PlanPrice
 									rawPrice={ ( isDiscounted ? discountedPrice : originalPrice ) as number }
@@ -110,6 +116,11 @@ const JetpackProductCardAlt2: React.FC< Props > = ( {
 								/>
 							</span>
 							<JetpackProductCardTimeFrame expiryDate={ expiryDate } billingTerm={ billingTerm } />
+							{ tooltipText && (
+								<InfoPopover position="top" className="jetpack-product-card-i5__price-tooltip">
+									{ tooltipText }
+								</InfoPopover>
+							) }
 						</>
 					) : (
 						<>

--- a/client/components/jetpack/card/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-i5/style.scss
@@ -102,6 +102,13 @@
 	}
 }
 
+.jetpack-product-card-i5__price-from {
+	margin-right: 12px;
+	color: var( --studio-gray-40 );
+	font-size: 0.875rem;
+	line-height: 1.2;
+}
+
 .jetpack-product-card-i5 .plan-price {
 	display: flex;
 
@@ -127,12 +134,23 @@
 
 .jetpack-product-card-i5__billing-time-frame,
 .jetpack-product-card-i5__expiration-date {
-	margin-left: 12px;
+	margin: 0 12px;
 
 	color: var( --studio-gray-40 );
 
 	font-size: 0.875rem;
 	line-height: 1.2;
+}
+
+.jetpack-product-card-i5__price-tooltip {
+	color: var( --studio-gray-40 );
+}
+
+.jetpack-product-card-i5__price-tooltip.popover .popover__inner {
+	text-align: center;
+}
+.jetpack-product-card-i5__price-tooltip p {
+	margin-bottom: 1rem;
 }
 
 .jetpack-product-card-i5__expiration-date {

--- a/client/components/jetpack/card/jetpack-product-card-i5/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card-i5/style.scss
@@ -6,8 +6,8 @@
 
 	background: var( --color-surface );
 	border: 1px solid var( --color-border-subtle );
-	border-radius: 8px;
-	box-shadow: 0px 4px 24px rgba( 0, 0, 0, 0.05 );
+	border-radius: ( 2px * 4 );
+	box-shadow: 0 4px 24px rgba( 0, 0, 0, 0.05 );
 
 	&.is-featured.is-aligned {
 		position: relative;
@@ -70,7 +70,7 @@
 
 	color: var( --studio-gray-100 );
 
-	font-size: 1.875rem;
+	font-size: 2rem;
 	font-weight: 700;
 	line-height: 1.2;
 
@@ -143,7 +143,7 @@
 	width: 100%;
 	height: 45px;
 
-	border-radius: 4px;
+	border-radius: ( 2px * 2 );
 
 	font-size: 1rem;
 	font-weight: 700;

--- a/client/my-sites/plans/jetpack-plans/product-card-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card-i5/index.tsx
@@ -9,7 +9,7 @@ import { useSelector } from 'react-redux';
  */
 import PlanRenewalMessage from '../plan-renewal-message';
 import useItemPrice from '../use-item-price';
-import { productButtonLabel } from '../utils';
+import { productButtonLabel, productTooltip } from '../utils';
 import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card-i5';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { planHasFeature } from 'calypso/lib/plans';
@@ -64,7 +64,7 @@ const ProductCardI5: React.FC< ProductCardProps > = ( {
 	}, [ item.productSlug, sitePlan, siteProducts ] );
 
 	// Calculate the product price.
-	const { originalPrice, discountedPrice } = useItemPrice(
+	const { originalPrice, discountedPrice, priceTiers } = useItemPrice(
 		siteId,
 		item,
 		item?.monthlyProductSlug || ''
@@ -104,6 +104,8 @@ const ProductCardI5: React.FC< ProductCardProps > = ( {
 			isDeprecated={ item.legacy }
 			isAligned={ isAligned }
 			features={ item.features }
+			displayFrom={ priceTiers !== null }
+			tooltipText={ priceTiers && productTooltip( item, priceTiers ) }
 		/>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-card-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card-i5/index.tsx
@@ -104,8 +104,8 @@ const ProductCardI5: React.FC< ProductCardProps > = ( {
 			isDeprecated={ item.legacy }
 			isAligned={ isAligned }
 			features={ item.features }
-			displayFrom={ priceTiers !== null }
-			tooltipText={ priceTiers && productTooltip( item, priceTiers ) }
+			displayFrom={ ! siteId && priceTiers !== null }
+			tooltipText={ ! siteId && priceTiers && productTooltip( item, priceTiers ) }
 		/>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -47,6 +47,12 @@ export interface ProductsGridProps {
 	onDurationChange?: DurationChangeCallback;
 }
 
+export type PlanGridProducts = {
+	availableProducts: SelectorProduct[];
+	purchasedProducts: SelectorProduct[];
+	includedInPlanProducts: SelectorProduct[];
+};
+
 export interface JetpackFreeProps {
 	urlQueryArgs: QueryArgs;
 	siteId: number | null;
@@ -104,10 +110,12 @@ export interface SelectorProduct extends SelectorProductCost {
 	buttonLabel?: TranslateResult;
 	features: SelectorProductFeatures;
 	subtypes: string[];
+	infoText?: TranslateResult | ReactNode;
 	legacy?: boolean;
 	hidePrice?: boolean;
 	externalUrl?: string;
 	displayTerm?: Duration;
 	displayPrice?: number;
 	displayCurrency?: string;
+	displayFrom?: boolean;
 }

--- a/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
@@ -24,7 +24,12 @@ import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
 import { slugToSelectorProduct } from './utils';
 
-const useSelectorPageProducts = ( siteId: number | null ) => {
+/**
+ * Type dependencies
+ */
+import type { PlanGridProducts, SelectorProduct } from './types';
+
+const useSelectorPageProducts = ( siteId: number | null ): PlanGridProducts => {
 	let availableProducts: string[] = [];
 
 	// Products/features included in the current plan
@@ -117,9 +122,11 @@ const useSelectorPageProducts = ( siteId: number | null ) => {
 	}
 
 	return {
-		availableProducts: availableProducts.map( slugToSelectorProduct ),
-		purchasedProducts: purchasedProducts.map( slugToSelectorProduct ),
-		includedInPlanProducts: includedInPlanProducts.map( slugToSelectorProduct ),
+		availableProducts: availableProducts.map( slugToSelectorProduct ) as SelectorProduct[],
+		purchasedProducts: purchasedProducts.map( slugToSelectorProduct ) as SelectorProduct[],
+		includedInPlanProducts: includedInPlanProducts.map(
+			slugToSelectorProduct
+		) as SelectorProduct[],
 	};
 };
 

--- a/client/state/products-list/selectors/get-product-price-tiers.ts
+++ b/client/state/products-list/selectors/get-product-price-tiers.ts
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { getProductBySlug } from './get-product-by-slug';
+
+import 'calypso/state/products-list/init';
+import type { AppState } from 'calypso/types';
+
+type Product = {
+	price_tiers: PriceTiers;
+};
+
+export type PriceTiers = Record< string, PriceTier >;
+
+export type PriceTier =
+	| {
+			flat_price: number;
+	  }
+	| {
+			variable_price_per_unit: number;
+			unit: number;
+	  };
+
+/**
+ * Returns the price tiers of the specified product.
+ *
+ * @param {object} state - global state tree
+ * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
+ * @returns {PriceTiers|null} The price tiers or null. See PriceTiers for format.
+ */
+export function getProductPriceTiers( state: AppState, productSlug?: string ): PriceTiers | null {
+	if ( ! productSlug ) {
+		return null;
+	}
+	const product = getProductBySlug( state, productSlug ) as Product;
+
+	if ( ! product || ! product.price_tiers || ! Object.keys( product.price_tiers ).length ) {
+		return null;
+	}
+
+	return product.price_tiers;
+}
+
+export default getProductPriceTiers;

--- a/client/state/products-list/selectors/index.js
+++ b/client/state/products-list/selectors/index.js
@@ -5,6 +5,7 @@ export { getPlanPrice } from './get-plan-price';
 export { getProductBySlug } from './get-product-by-slug';
 export { getProductCost } from './get-product-cost';
 export { getProductDisplayCost } from './get-product-display-cost';
+export { getProductPriceTiers } from './get-product-price-tiers';
 export { getProductsList } from './get-products-list';
 export { isProductsListFetching } from './is-products-list-fetching';
 export { planSlugToPlanProduct } from './plan-slug-to-plan-product';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Creates a new selector that leverages the newly exposed pricing tiers in D54957-code.
* Updates product card component to allow "from" and tooltip to be added.
* Links two to show tiers in products that have them.

#### Screenshots
<img width="355" alt="Screen Shot 2021-01-06 at 3 09 25 PM" src="https://user-images.github
usercontent.com/1760168/103815742-d01b4600-5031-11eb-8109-8b780d88126f.png">

☝🏻  Monthly price

<img width="385" alt="Screen Shot 2021-01-06 at 3 04 02 PM" src="https://user-images.githubusercontent.com/1760168/103815743-d0b3dc80-5031-11eb-9ddd-b6965d5e4d58.png">

☝🏻 Annual price with popover

<img width="363" alt="Screen Shot 2021-01-06 at 3 24 05 PM" src="https://user-images.githubusercontent.com/1760168/103816643-4d938600-5033-11eb-8c06-3e6b61c42cf8.png">

☝🏻 Specific price for site

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit either a site's plan page or the standalone version.
* View a product with tiers such as Jetpack Search.
* For a site:
  * Verify that the price is accurate for the site's number of records. 
* For no site:
  * Verify that pricing matches designs and works on smaller screen sizes.
  * Verify link and prices are accurate.

Fixes 1164141197617539-as-1199720441821497.