### PR TITLE
AnchorFM: Augment Signup Events with AnchorFM Flow

### DIFF
--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -8,6 +8,7 @@ import type { ValuesType } from 'utility-types';
  *
  */
 export const FLOW_ID = 'gutenboarding';
+export const ANCHOR_FM_FLOW_ID = 'anchor-fm';
 
 const fontTitles: Partial< Record< Font, string > > = {
 	'Playfair Display': 'Playfair',

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import wp from '../../../lib/wp';
-import { FLOW_ID } from '../../gutenboarding/constants';
+import { FLOW_ID, ANCHOR_FM_FLOW_ID } from '../../gutenboarding/constants';
 
 /**
  * Internal dependencies
@@ -121,14 +121,14 @@ export default function useOnSiteCreation(): void {
 				recordOnboardingComplete( {
 					...flowCompleteTrackingParams,
 					hasCartItems: true,
-					flow: isAnchorFmSignup ? 'anchor-fm' : FLOW_ID,
+					flow: isAnchorFmSignup ? ANCHOR_FM_FLOW_ID : FLOW_ID,
 				} );
 				go();
 				return;
 			}
 			recordOnboardingComplete( {
 				...flowCompleteTrackingParams,
-				flow: isAnchorFmSignup ? 'anchor-fm' : FLOW_ID,
+				flow: isAnchorFmSignup ? ANCHOR_FM_FLOW_ID : FLOW_ID,
 			} );
 			resetOnboardStore();
 			clearLastNonEditorRoute();

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -4,7 +4,6 @@
 import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import wp from '../../../lib/wp';
-import { FLOW_ID, ANCHOR_FM_FLOW_ID } from '../../gutenboarding/constants';
 
 /**
  * Internal dependencies
@@ -15,7 +14,7 @@ import { SITE_STORE } from '../stores/site';
 import { recordOnboardingComplete } from '../lib/analytics';
 import { useSelectedPlan, useShouldRedirectToEditorAfterCheckout } from './use-selected-plan';
 import { clearLastNonEditorRoute } from '../lib/clear-last-non-editor-route';
-import { useIsAnchorFm, useAnchorFmParams } from '../path';
+import { useIsAnchorFm, useAnchorFmParams, useOnboardingFlow } from '../path';
 
 const wpcom = wp.undocumented();
 
@@ -67,6 +66,7 @@ export default function useOnSiteCreation(): void {
 	const design = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 
 	const isAnchorFmSignup = useIsAnchorFm();
+	const flow = useOnboardingFlow();
 	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyShowUrl } = useAnchorFmParams();
 
 	const { resetOnboardStore, setIsRedirecting, setSelectedSite } = useDispatch( ONBOARD_STORE );
@@ -121,14 +121,14 @@ export default function useOnSiteCreation(): void {
 				recordOnboardingComplete( {
 					...flowCompleteTrackingParams,
 					hasCartItems: true,
-					flow: isAnchorFmSignup ? ANCHOR_FM_FLOW_ID : FLOW_ID,
+					flow,
 				} );
 				go();
 				return;
 			}
 			recordOnboardingComplete( {
 				...flowCompleteTrackingParams,
-				flow: isAnchorFmSignup ? ANCHOR_FM_FLOW_ID : FLOW_ID,
+				flow,
 			} );
 			resetOnboardStore();
 			clearLastNonEditorRoute();

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import wp from '../../../lib/wp';
+import { FLOW_ID } from '../../gutenboarding/constants';
 
 /**
  * Internal dependencies
@@ -120,12 +121,15 @@ export default function useOnSiteCreation(): void {
 				recordOnboardingComplete( {
 					...flowCompleteTrackingParams,
 					hasCartItems: true,
+					flow: isAnchorFmSignup ? 'anchor-fm' : FLOW_ID,
 				} );
 				go();
 				return;
 			}
-
-			recordOnboardingComplete( flowCompleteTrackingParams );
+			recordOnboardingComplete( {
+				...flowCompleteTrackingParams,
+				flow: isAnchorFmSignup ? 'anchor-fm' : FLOW_ID,
+			} );
 			resetOnboardStore();
 			clearLastNonEditorRoute();
 			setSelectedSite( newSite.blogid );

--- a/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
+++ b/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
@@ -10,7 +10,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { recordOnboardingStart } from '../lib/analytics';
 import { USER_STORE } from '../stores/user';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
-import { useIsAnchorFm } from '../path';
+import { useOnboardingFlow } from '../path';
 
 /**
  * Records an event in tracks on starting the onboarding flow, after trying to get the current user
@@ -20,13 +20,13 @@ export default function useTrackOnboardingStart() {
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const { hasOnboardingStarted } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const { startOnboarding } = useDispatch( ONBOARD_STORE );
-	const isAnchorFmSignup = useIsAnchorFm();
+	const flow = useOnboardingFlow();
 
 	React.useEffect( () => {
 		if ( ! hasOnboardingStarted && currentUser !== undefined ) {
 			const ref = new URLSearchParams( window.location.search ).get( 'ref' ) || '';
 			const siteCount = currentUser?.site_count ?? 0;
-			recordOnboardingStart( ref, siteCount, isAnchorFmSignup );
+			recordOnboardingStart( ref, siteCount, flow );
 			startOnboarding();
 		}
 	}, [ currentUser, hasOnboardingStarted, startOnboarding ] );

--- a/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
+++ b/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
@@ -10,6 +10,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { recordOnboardingStart } from '../lib/analytics';
 import { USER_STORE } from '../stores/user';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
+import { useIsAnchorFm } from '../path';
 
 /**
  * Records an event in tracks on starting the onboarding flow, after trying to get the current user
@@ -19,12 +20,13 @@ export default function useTrackOnboardingStart() {
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const { hasOnboardingStarted } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const { startOnboarding } = useDispatch( ONBOARD_STORE );
+	const isAnchorFmSignup = useIsAnchorFm();
 
 	React.useEffect( () => {
 		if ( ! hasOnboardingStarted && currentUser !== undefined ) {
 			const ref = new URLSearchParams( window.location.search ).get( 'ref' ) || '';
 			const siteCount = currentUser?.site_count ?? 0;
-			recordOnboardingStart( ref, siteCount );
+			recordOnboardingStart( ref, siteCount, isAnchorFmSignup );
 			startOnboarding();
 		}
 	}, [ currentUser, hasOnboardingStarted, startOnboarding ] );

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -41,10 +41,12 @@ export function recordOnboardingStart(
 	if ( ! ref ) {
 		ref = new URLSearchParams( window.location.search ).get( 'ref' ) || ref;
 	}
-
-	trackEventWithFlow( 'calypso_newsite_start', { ref, site_count, is_podcasting_site } );
+	const eventProps = is_podcasting_site
+		? { ref, site_count, flow: 'anchor-fm' }
+		: { ref, site_count };
+	trackEventWithFlow( 'calypso_newsite_start', eventProps );
 	// Also fire the signup start|complete events. See: pbmFJ6-95-p2
-	trackEventWithFlow( 'calypso_signup_start', { ref, site_count, is_podcasting_site } );
+	trackEventWithFlow( 'calypso_signup_start', eventProps );
 }
 
 /**

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -6,7 +6,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 /**
  * Internal dependencies
  */
-import { FLOW_ID } from '../../constants';
+import { FLOW_ID, ANCHOR_FM_FLOW_ID } from '../../constants';
 import type { StepNameType } from '../../path';
 import type { ErrorParameters, OnboardingCompleteParameters, TracksEventProperties } from './types';
 
@@ -41,7 +41,7 @@ export function recordOnboardingStart(
 	if ( ! ref ) {
 		ref = new URLSearchParams( window.location.search ).get( 'ref' ) || ref;
 	}
-	const flow = is_podcasting_site ? 'anchor-fm' : '';
+	const flow = is_podcasting_site ? ANCHOR_FM_FLOW_ID : '';
 	const eventProps = { ref, site_count };
 	trackEventWithFlow( 'calypso_newsite_start', eventProps, flow );
 	// Also fire the signup start|complete events. See: pbmFJ6-95-p2

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -6,7 +6,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 /**
  * Internal dependencies
  */
-import { FLOW_ID, ANCHOR_FM_FLOW_ID } from '../../constants';
+import { FLOW_ID } from '../../constants';
 import type { StepNameType } from '../../path';
 import type { ErrorParameters, OnboardingCompleteParameters, TracksEventProperties } from './types';
 
@@ -31,17 +31,12 @@ export function trackEventWithFlow( eventId: string, params = {}, flow = FLOW_ID
  *
  * @param {string} ref  The value of a `ref` query parameter, usually set by marketing landing pages
  * @param {number} site_count The number of sites owned by the current user or 0 if there is no logged in user
- * @param {boolean} is_podcasting_site If the current onboarding flow is a Podcast-flavored onboarding flow
+ * @param {string} flow the current onboarding flow
  */
-export function recordOnboardingStart(
-	ref = '',
-	site_count: number,
-	is_podcasting_site: boolean
-): void {
+export function recordOnboardingStart( ref = '', site_count: number, flow: string ): void {
 	if ( ! ref ) {
 		ref = new URLSearchParams( window.location.search ).get( 'ref' ) || ref;
 	}
-	const flow = is_podcasting_site ? ANCHOR_FM_FLOW_ID : '';
 	const eventProps = { ref, site_count };
 	trackEventWithFlow( 'calypso_newsite_start', eventProps, flow );
 	// Also fire the signup start|complete events. See: pbmFJ6-95-p2

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -59,6 +59,7 @@ export function recordOnboardingComplete( params: OnboardingCompleteParameters )
 		is_new_site: params.isNewSite,
 		blog_id: params.blogId,
 		has_cart_items: params.hasCartItems,
+		flow: params.flow,
 	};
 	trackEventWithFlow( 'calypso_newsite_complete', trackingParams );
 	// Also fire the signup start|complete events. See: pbmFJ6-95-p2

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -31,15 +31,20 @@ export function trackEventWithFlow( eventId: string, params = {}, flow = FLOW_ID
  *
  * @param {string} ref  The value of a `ref` query parameter, usually set by marketing landing pages
  * @param {number} site_count The number of sites owned by the current user or 0 if there is no logged in user
+ * @param {boolean} is_podcasting_site If the current onboarding flow is a Podcast-flavored onboarding flow
  */
-export function recordOnboardingStart( ref = '', site_count: number ): void {
+export function recordOnboardingStart(
+	ref = '',
+	site_count: number,
+	is_podcasting_site: boolean
+): void {
 	if ( ! ref ) {
 		ref = new URLSearchParams( window.location.search ).get( 'ref' ) || ref;
 	}
 
-	trackEventWithFlow( 'calypso_newsite_start', { ref, site_count } );
+	trackEventWithFlow( 'calypso_newsite_start', { ref, site_count, is_podcasting_site } );
 	// Also fire the signup start|complete events. See: pbmFJ6-95-p2
-	trackEventWithFlow( 'calypso_signup_start', { ref, site_count } );
+	trackEventWithFlow( 'calypso_signup_start', { ref, site_count, is_podcasting_site } );
 }
 
 /**

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -41,12 +41,11 @@ export function recordOnboardingStart(
 	if ( ! ref ) {
 		ref = new URLSearchParams( window.location.search ).get( 'ref' ) || ref;
 	}
-	const eventProps = is_podcasting_site
-		? { ref, site_count, flow: 'anchor-fm' }
-		: { ref, site_count };
-	trackEventWithFlow( 'calypso_newsite_start', eventProps );
+	const flow = is_podcasting_site ? 'anchor-fm' : '';
+	const eventProps = { ref, site_count };
+	trackEventWithFlow( 'calypso_newsite_start', eventProps, flow );
 	// Also fire the signup start|complete events. See: pbmFJ6-95-p2
-	trackEventWithFlow( 'calypso_signup_start', eventProps );
+	trackEventWithFlow( 'calypso_signup_start', eventProps, flow );
 }
 
 /**

--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -36,6 +36,11 @@ export interface OnboardingCompleteParameters {
 	 * Whether the user has a paid plan or other checkout item
 	 */
 	hasCartItems?: boolean;
+
+	/**
+	 * Type of onboarding flow
+	 */
+	flow?: string;
 }
 
 export type TracksAcquireIntentEventProperties = {

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -5,13 +5,13 @@ import { findKey } from 'lodash';
 import { generatePath, useLocation, useRouteMatch } from 'react-router-dom';
 import { Plans } from '@automattic/data-stores';
 import languages from '@automattic/languages';
-
 import type { ValuesType } from 'utility-types';
 
 /**
  * Internal dependencies
  */
 import config from 'calypso/config';
+import { FLOW_ID, ANCHOR_FM_FLOW_ID } from '../gutenboarding/constants';
 
 type PlanPath = Plans.PlanPath;
 
@@ -114,6 +114,13 @@ export function useNewQueryParam() {
 export function useIsAnchorFm(): boolean {
 	const { anchorFmPodcastId } = useAnchorFmParams();
 	return Boolean( anchorFmPodcastId && anchorFmPodcastId.match( /^[0-9a-f]{7,8}$/i ) );
+}
+
+export function useOnboardingFlow(): string {
+	if ( useIsAnchorFm() ) {
+		return ANCHOR_FM_FLOW_ID;
+	}
+	return FLOW_ID;
 }
 
 export interface AnchorFmParams {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Adds a `anchor-fm` flow prop to the `calypso_newsite_start`, `calypso_signup_start`, and `calypso_signup_complete` event to answer the question "How many podcast sites were launched?". Context for this approach to support funneling: p1608037471216200-slack-C0Q664T29

#### Screenshots
Calypso Signup Start
<img width="752" alt="Screen Shot 2021-01-07 at 1 58 37 AM" src="https://user-images.githubusercontent.com/66652282/103861749-eb1aa400-508b-11eb-9bd8-582c71492d6d.png">

Calypso Signup Complete
<img width="695" alt="Screen Shot 2021-01-07 at 1 58 46 AM" src="https://user-images.githubusercontent.com/66652282/103861755-ed7cfe00-508b-11eb-89a8-705a4db2b3bc.png">

#### Testing instructions

1. Go to http://calypso.localhost:3000/new?anchor_podcast={podcast_id}
2. Complete the onboarding flow.
3. After 5 minutes go to MC -- `/tracks/live/?eventname=calypso_signup_start` and ` `/tracks/live/?eventname=calypso_signup_complete` look for your specific signup (if the username isn't captured it could be difficult to find) and ensure there is a the flow prop of `anchor-fm`.
4. Create a funnel with the create time frame and segmentation as the MC link in the issue
5. The funnel should show the two events

Fixes 396-gh-Automattic/dotcom-manage