### PR TITLE
G Suite: Fix error preventing new G Suite users from being added

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -16,7 +16,12 @@ import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopp
 
 export default {
 	emailManagementAddGSuiteUsers( pageContext, next ) {
-		pageContext.primary = <GSuiteAddUsers selectedDomainName={ pageContext.params.domain } />;
+		pageContext.primary = (
+			<CalypsoShoppingCartProvider>
+				<GSuiteAddUsers selectedDomainName={ pageContext.params.domain } />
+			</CalypsoShoppingCartProvider>
+		);
+
 		next();
 	},
 
@@ -35,6 +40,7 @@ export default {
 				/>
 			</CalypsoShoppingCartProvider>
 		);
+
 		next();
 	},
 
@@ -44,16 +50,19 @@ export default {
 				<TitanMailQuantitySelection selectedDomainName={ pageContext.params.domain } />
 			</CalypsoShoppingCartProvider>
 		);
+
 		next();
 	},
 
 	emailManagementForwarding( pageContext, next ) {
 		pageContext.primary = <EmailForwarding selectedDomainName={ pageContext.params.domain } />;
+
 		next();
 	},
 
 	emailManagement( pageContext, next ) {
 		pageContext.primary = <EmailManagement selectedDomainName={ pageContext.params.domain } />;
+
 		next();
 	},
 };


### PR DESCRIPTION
This pull request fixes a bug introduced in https://github.com/Automattic/wp-calypso/pull/48687 which would trigger a `useShoppingCart must be used inside a ShoppingCartProvider` error when clicking on the `Add New Users` button on the `Email` page:

![ERROR](https://user-images.githubusercontent.com/594356/103881258-7de22f80-50da-11eb-9fb9-739bd88d4d13.png)

This would result in displaying an error page to the user:

![SCREEN](https://user-images.githubusercontent.com/594356/103881281-86d30100-50da-11eb-95ba-11a629672e9e.png)

#### Testing instructions

1. Run `git checkout fix/gsuite-extra-licenses` and start your server, or open a [live branch](https://calypso.live/?branch=fix/gsuite-extra-licenses)
2. Log into a WordPress.com account which has a G Suite
3. Open the [`Email` page](http://calypso.localhost:3000/email)
4. Click the `Add New Users` button
5. Assert that you are presented with the `Add New Users` form
6. Assert you can proceed to the payment page