### PR TITLE
Split ME Account settings form fields into two groups/cards

### DIFF
--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -318,8 +318,18 @@ UserSettings.prototype.removeUnsavedSetting = function ( settingName ) {
 	}
 };
 
-UserSettings.prototype.hasUnsavedSettings = function () {
-	return ! isEmpty( this.unsavedSettings );
+UserSettings.prototype.hasUnsavedSettings = function ( fields ) {
+	if ( isEmpty( this.unsavedSettings ) ) {
+		return false;
+	}
+
+	const unsavedSettingsKeys = Object.keys( this.unsavedSettings );
+
+	if ( fields ) {
+		return fields.some( ( field ) => unsavedSettingsKeys.includes( field ) );
+	}
+
+	return true;
 };
 
 /**

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -882,7 +882,7 @@ const Account = createReactClass( {
 				<PageViewTracker path="/me/account" title="Me > Account Settings" />
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
-				<FormattedHeader brandFont headerText={ translate( 'Account Settings' ) } align="left" />
+				<FormattedHeader brandFont headerText={ translate( 'Account settings' ) } align="left" />
 
 				<SectionHeader label={ translate( 'Account Information' ) } />
 				<Card className="account__settings">
@@ -921,7 +921,7 @@ const Account = createReactClass( {
 					</form>
 				</Card>
 
-				<SectionHeader label={ translate( 'Interface Settings' ) } />
+				<SectionHeader label={ translate( 'Interface settings' ) } />
 				<Card className="account__settings">
 					<form onChange={ markChanged } onSubmit={ this.saveInterfaceSettings }>
 						<FormFieldset>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -20,7 +20,7 @@ import SectionHeader from 'calypso/components/section-header';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import { protectForm } from 'calypso/lib/protect-form';
 import formBase from 'calypso/me/form-base';
-import config, { isEnabled } from '@automattic/calypso-config';
+import config from '@automattic/calypso-config';
 import languages from '@automattic/languages';
 import { supportsCssCustomProperties } from 'calypso/lib/feature-detection';
 import { Card, Button } from '@automattic/components';

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -9,13 +9,14 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
 import emailValidator from 'email-validator';
-import { debounce, flowRight as compose, get, has, map, size, update } from 'lodash';
+import { debounce, flowRight as compose, get, has, map, size, update, pick } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import LanguagePicker from 'calypso/components/language-picker';
+import SectionHeader from 'calypso/components/section-header';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import { protectForm } from 'calypso/lib/protect-form';
 import formBase from 'calypso/me/form-base';
@@ -77,7 +78,15 @@ const debug = debugFactory( 'calypso:me:account' );
 
 const ALLOWED_USERNAME_CHARACTERS_REGEX = /^[a-z0-9]+$/;
 const USERNAME_MIN_LENGTH = 4;
-
+const ACCOUNT_FORM_NAME = 'account';
+const INTERFACE_FORM_NAME = 'interface';
+const ACCOUNT_FIELDS = [ 'user_login', 'user_email', 'user_URL', 'primary_site_ID' ];
+const INTERFACE_FIELDS = [
+	'locale_variant',
+	'language',
+	'enable_translator',
+	'calypso_preferences',
+];
 /* eslint-disable react/prefer-es6-class */
 const Account = createReactClass( {
 	displayName: 'Account',
@@ -277,7 +286,7 @@ const Account = createReactClass( {
 					<FormCheckbox
 						checked={ this.getUserSetting( ENABLE_TRANSLATOR_KEY ) }
 						onChange={ this.updateCommunityTranslatorSetting }
-						disabled={ this.getDisabledState() }
+						disabled={ this.getDisabledState( INTERFACE_FORM_NAME ) }
 						id={ ENABLE_TRANSLATOR_KEY }
 						name={ ENABLE_TRANSLATOR_KEY }
 						onClick={ this.getCheckboxHandler( 'Community Translator' ) }
@@ -623,23 +632,37 @@ const Account = createReactClass( {
 		return <FormTextValidation isError={ true } text={ notice } />;
 	},
 
+	shouldDisableAccountSubmitButton() {
+		const { userSettings } = this.props;
+
+		return (
+			! userSettings.hasUnsavedSettings( ACCOUNT_FIELDS ) ||
+			this.getDisabledState( ACCOUNT_FORM_NAME ) ||
+			this.hasEmailValidationError()
+		);
+	},
+
+	shouldDisableInterfaceSubmitButton() {
+		const { userSettings } = this.props;
+
+		return (
+			! userSettings.hasUnsavedSettings( INTERFACE_FIELDS ) ||
+			this.getDisabledState( INTERFACE_FORM_NAME )
+		);
+	},
+
 	/*
 	 * These form fields are displayed when there is not a username change in progress.
 	 */
 	renderAccountFields() {
-		const { translate, userSettings } = this.props;
-
-		const isSubmitButtonDisabled =
-			! userSettings.hasUnsavedSettings() ||
-			this.getDisabledState() ||
-			this.hasEmailValidationError();
+		const { translate } = this.props;
 
 		return (
 			<div className="account__settings-form" key="settingsForm">
 				<FormFieldset>
 					<FormLabel htmlFor="user_email">{ translate( 'Email address' ) }</FormLabel>
 					<FormTextInput
-						disabled={ this.getDisabledState() || this.hasPendingEmailChange() }
+						disabled={ this.getDisabledState( ACCOUNT_FORM_NAME ) || this.hasPendingEmailChange() }
 						id="user_email"
 						name="user_email"
 						isError={ !! this.state.emailValidationError }
@@ -662,7 +685,7 @@ const Account = createReactClass( {
 				<FormFieldset>
 					<FormLabel htmlFor="user_URL">{ translate( 'Web address' ) }</FormLabel>
 					<FormTextInput
-						disabled={ this.getDisabledState() }
+						disabled={ this.getDisabledState( ACCOUNT_FORM_NAME ) }
 						id="user_URL"
 						name="user_URL"
 						type="url"
@@ -675,56 +698,12 @@ const Account = createReactClass( {
 					</FormSettingExplanation>
 				</FormFieldset>
 
-				<FormFieldset>
-					<FormLabel id="account__language" htmlFor="language">
-						{ translate( 'Interface language' ) }
-					</FormLabel>
-					<LanguagePicker
-						disabled={ this.getDisabledState() }
-						languages={ languages }
-						onClick={ this.getClickHandler( 'Interface Language Field' ) }
-						valueKey="langSlug"
-						value={
-							this.getUserSetting( 'locale_variant' ) || this.getUserSetting( 'language' ) || ''
-						}
-						empathyMode={ this.getUserSetting( 'i18n_empathy_mode' ) }
-						useFallbackForIncompleteLanguages={ this.getUserSetting(
-							'use_fallback_for_incomplete_languages'
-						) }
-						onChange={ this.updateLanguage }
-					/>
-					<FormSettingExplanation>
-						{ translate(
-							'This is the language of the interface you see across WordPress.com as a whole.'
-						) }
-					</FormSettingExplanation>
-					{ this.thankTranslationContributors() }
-				</FormFieldset>
-
-				{ canDisplayCommunityTranslator( this.getUserSetting( 'language' ) ) &&
-					this.communityTranslator() }
-
-				{ config.isEnabled( 'me/account/color-scheme-picker' ) && supportsCssCustomProperties() && (
-					<FormFieldset>
-						<FormLabel id="account__color_scheme" htmlFor="color_scheme">
-							{ translate( 'Dashboard color scheme' ) }
-						</FormLabel>
-						<ColorSchemePicker
-							temporarySelection
-							defaultSelection={
-								isEnabled( 'nav-unification' ) ? 'classic-dark' : 'classic-bright'
-							}
-							onSelection={ this.updateColorScheme }
-						/>
-					</FormFieldset>
-				) }
-
 				<FormButton
-					isSubmitting={ this.state.submittingForm }
-					disabled={ isSubmitButtonDisabled }
+					isSubmitting={ this.isSubmittingForm( ACCOUNT_FORM_NAME ) }
+					disabled={ this.shouldDisableAccountSubmitButton() }
 					onClick={ this.handleSubmitButtonClick }
 				>
-					{ this.state.submittingForm
+					{ this.isSubmittingForm( ACCOUNT_FORM_NAME )
 						? translate( 'Saving…' )
 						: translate( 'Save account settings' ) }
 				</FormButton>
@@ -877,6 +856,19 @@ const Account = createReactClass( {
 			</div>
 		);
 	},
+	saveAccountSettings( event ) {
+		const unSavedUserSettings = this.props.userSettings.unsavedSettings;
+		const fieldsForSave = pick( unSavedUserSettings, ACCOUNT_FIELDS );
+
+		this.submitForm( event, fieldsForSave, ACCOUNT_FORM_NAME );
+	},
+
+	saveInterfaceSettings( event ) {
+		const unSavedUserSettings = this.props.userSettings.unsavedSettings;
+		const fieldsForSave = pick( unSavedUserSettings, INTERFACE_FIELDS );
+
+		this.submitForm( event, fieldsForSave, INTERFACE_FORM_NAME );
+	},
 
 	render() {
 		const { markChanged, translate, userSettings } = this.props;
@@ -890,8 +882,9 @@ const Account = createReactClass( {
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<FormattedHeader brandFont headerText={ translate( 'Account Settings' ) } align="left" />
 
+				<SectionHeader label={ translate( 'Account Information' ) } />
 				<Card className="account__settings">
-					<form onChange={ markChanged } onSubmit={ this.submitForm }>
+					<form onChange={ markChanged } onSubmit={ this.saveAccountSettings }>
 						<FormFieldset>
 							<FormLabel htmlFor="user_login">{ translate( 'Username' ) }</FormLabel>
 							<FormTextInput
@@ -900,7 +893,8 @@ const Account = createReactClass( {
 								autoCorrect="off"
 								className="account__username"
 								disabled={
-									this.getDisabledState() || ! this.getUserSetting( 'user_login_can_be_changed' )
+									this.getDisabledState( ACCOUNT_FORM_NAME ) ||
+									! this.getUserSetting( 'user_login_can_be_changed' )
 								}
 								id="user_login"
 								name="user_login"
@@ -922,6 +916,60 @@ const Account = createReactClass( {
 								{ renderUsernameForm ? this.renderUsernameFields() : this.renderAccountFields() }
 							</CSSTransition>
 						</TransitionGroup>
+					</form>
+				</Card>
+
+				<SectionHeader label={ translate( 'Interface Settings' ) } />
+				<Card className="account__settings">
+					<form onChange={ markChanged } onSubmit={ this.saveInterfaceSettings }>
+						<FormFieldset>
+							<FormLabel id="account__language" htmlFor="language">
+								{ translate( 'Interface language' ) }
+							</FormLabel>
+							<LanguagePicker
+								disabled={ this.getDisabledState( INTERFACE_FORM_NAME ) }
+								languages={ languages }
+								onClick={ this.getClickHandler( 'Interface Language Field' ) }
+								valueKey="langSlug"
+								value={
+									this.getUserSetting( 'locale_variant' ) || this.getUserSetting( 'language' ) || ''
+								}
+								empathyMode={ this.getUserSetting( 'i18n_empathy_mode' ) }
+								useFallbackForIncompleteLanguages={ this.getUserSetting(
+									'use_fallback_for_incomplete_languages'
+								) }
+								onChange={ this.updateLanguage }
+							/>
+							<FormSettingExplanation>
+								{ translate(
+									'This is the language of the interface you see across WordPress.com as a whole.'
+								) }
+							</FormSettingExplanation>
+							{ this.thankTranslationContributors() }
+						</FormFieldset>
+
+						{ canDisplayCommunityTranslator( this.getUserSetting( 'language' ) ) &&
+							this.communityTranslator() }
+
+						{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
+							supportsCssCustomProperties() && (
+								<FormFieldset>
+									<FormLabel id="account__color_scheme" htmlFor="color_scheme">
+										{ translate( 'Dashboard color scheme' ) }
+									</FormLabel>
+									<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
+								</FormFieldset>
+							) }
+
+						<FormButton
+							isSubmitting={ this.isSubmittingForm( INTERFACE_FORM_NAME ) }
+							disabled={ this.shouldDisableInterfaceSubmitButton() }
+							onClick={ this.handleSubmitButtonClick }
+						>
+							{ this.isSubmittingForm( INTERFACE_FORM_NAME )
+								? translate( 'Saving…' )
+								: translate( 'Save interface settings' ) }
+						</FormButton>
 					</form>
 				</Card>
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -705,9 +705,7 @@ const Account = createReactClass( {
 				>
 					{ this.isSubmittingForm( ACCOUNT_FORM_NAME )
 						? translate( 'Saving…' )
-						: translate( 'Save %s settings', {
-								args: 'account',
-						  } ) }
+						: translate( 'Save account settings' ) }
 				</FormButton>
 			</div>
 		);

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -705,7 +705,9 @@ const Account = createReactClass( {
 				>
 					{ this.isSubmittingForm( ACCOUNT_FORM_NAME )
 						? translate( 'Saving…' )
-						: translate( 'Save account settings' ) }
+						: translate( 'Save %s settings', {
+								args: 'account',
+						  } ) }
 				</FormButton>
 			</div>
 		);
@@ -968,7 +970,9 @@ const Account = createReactClass( {
 						>
 							{ this.isSubmittingForm( INTERFACE_FORM_NAME )
 								? translate( 'Saving…' )
-								: translate( 'Save interface settings' ) }
+								: translate( 'Save %s settings', {
+										args: 'interface',
+								  } ) }
 						</FormButton>
 					</form>
 				</Card>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -970,9 +970,7 @@ const Account = createReactClass( {
 						>
 							{ this.isSubmittingForm( INTERFACE_FORM_NAME )
 								? translate( 'Saving…' )
-								: translate( 'Save %s settings', {
-										args: 'interface',
-								  } ) }
+								: translate( 'Save interface settings' ) }
 						</FormButton>
 					</form>
 				</Card>

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -48,13 +48,23 @@ export default {
 	},
 
 	showNotice: function ( formName ) {
+		let noticeMsg = '';
 		if ( this.props.userSettings.initialized && this.state.showNotice ) {
 			notices.clearNotices( 'notices' );
-			notices.success(
-				this.props.translate( '%s Settings saved successfully!', {
+
+			if ( formName ) {
+				const targetSetting = this.props.translate( '%s settings', {
 					args: upperFirst( formName ),
-				} )
-			);
+				} );
+
+				noticeMsg = this.props.translate( '%s saved successfully!', {
+					args: targetSetting,
+				} );
+			} else {
+				noticeMsg = this.props.translate( 'Settings saved successfully!' );
+			}
+
+			notices.success( noticeMsg );
 			this.state.showNotice = false;
 		}
 	},

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -55,13 +55,17 @@ export default {
 			if ( formName ) {
 				const targetSetting = this.props.translate( '%s settings', {
 					args: upperFirst( formName ),
+					comment: 'A name for the group of related settings.',
 				} );
 
 				noticeMsg = this.props.translate( '%s saved successfully!', {
 					args: targetSetting,
+					comment: 'Notice informing user of successfully saved group of related form fields.',
 				} );
 			} else {
-				noticeMsg = this.props.translate( 'Settings saved successfully!' );
+				noticeMsg = this.props.translate( 'Settings saved successfully!', {
+					comment: 'Notice informing user of successfully saved group of related form fields.',
+				} );
 			}
 
 			notices.success( noticeMsg );
@@ -93,6 +97,7 @@ export default {
 			notices.error(
 				this.props.translate( 'There was a problem saving your %s changes.', {
 					args: upperFirst( formName ),
+					comment: 'Notice informing user of an error saving a group of related form fields.',
 				} )
 			);
 		}

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
+import { upperFirst } from 'lodash';
 
 const debug = debugFactory( 'calypso:me:form-base' );
 
@@ -46,10 +47,14 @@ export default {
 		};
 	},
 
-	showNotice: function () {
+	showNotice: function ( formName ) {
 		if ( this.props.userSettings.initialized && this.state.showNotice ) {
 			notices.clearNotices( 'notices' );
-			notices.success( this.props.translate( 'Settings saved successfully!' ) );
+			notices.success(
+				this.props.translate( '%s Settings saved successfully!', {
+					args: upperFirst( formName ),
+				} )
+			);
 			this.state.showNotice = false;
 		}
 	},
@@ -75,7 +80,11 @@ export default {
 		if ( error.message ) {
 			notices.error( error.message );
 		} else {
-			notices.error( this.props.translate( 'There was a problem saving your changes.' ) );
+			notices.error(
+				this.props.translate( 'There was a problem saving your %s changes.', {
+					args: upperFirst( formName ),
+				} )
+			);
 		}
 
 		this.setState( {
@@ -113,7 +122,7 @@ export default {
 				...( formName && { [ formName ]: false } ),
 			},
 		} );
-		this.showNotice();
+		this.showNotice( formName );
 		debug( 'Settings saved successfully ' + JSON.stringify( response ) );
 	},
 

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { upperFirst } from 'lodash';
 
 const debug = debugFactory( 'calypso:me:form-base' );
 
@@ -47,28 +46,11 @@ export default {
 		};
 	},
 
-	showNotice: function ( formName ) {
-		let noticeMsg = '';
+	showNotice: function () {
 		if ( this.props.userSettings.initialized && this.state.showNotice ) {
 			notices.clearNotices( 'notices' );
 
-			if ( formName ) {
-				const targetSetting = this.props.translate( '%s settings', {
-					args: upperFirst( formName ),
-					comment: 'A name for the group of related settings.',
-				} );
-
-				noticeMsg = this.props.translate( '%s saved successfully!', {
-					args: targetSetting,
-					comment: 'Notice informing user of successfully saved group of related form fields.',
-				} );
-			} else {
-				noticeMsg = this.props.translate( 'Settings saved successfully!', {
-					comment: 'Notice informing user of successfully saved group of related form fields.',
-				} );
-			}
-
-			notices.success( noticeMsg );
+			notices.success( this.props.translate( 'Settings saved successfully!' ) );
 			this.state.showNotice = false;
 		}
 	},
@@ -94,12 +76,7 @@ export default {
 		if ( error.message ) {
 			notices.error( error.message );
 		} else {
-			notices.error(
-				this.props.translate( 'There was a problem saving your %s changes.', {
-					args: upperFirst( formName ),
-					comment: 'Notice informing user of an error saving a group of related form fields.',
-				} )
-			);
+			notices.error( this.props.translate( 'There was a problem saving your changes.' ) );
 		}
 
 		this.setState( {
@@ -137,7 +114,7 @@ export default {
 				...( formName && { [ formName ]: false } ),
 			},
 		} );
-		this.showNotice( formName );
+		this.showNotice();
 		debug( 'Settings saved successfully ' + JSON.stringify( response ) );
 	},
 

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -21,8 +21,8 @@ export default {
 		this.props.userSettings.unsavedSettings = {};
 	},
 
-	getDisabledState: function () {
-		return this.state.submittingForm;
+	getDisabledState: function ( formName ) {
+		return formName ? this.state.formsSubmitting[ formName ] : this.state.submittingForm;
 	},
 
 	UNSAFE_componentWillReceiveProps: function ( nextProp ) {
@@ -39,6 +39,7 @@ export default {
 		return {
 			redirect: false,
 			submittingForm: false,
+			formsSubmitting: {},
 			changingUsername: false,
 			usernameAction: 'new',
 			showNotice: false,
@@ -67,42 +68,76 @@ export default {
 		this.props.userSettings.updateSetting( name, value );
 	},
 
-	submitForm: function ( event ) {
+	handleSubmitError( error, formName = '' ) {
+		debug( 'Error saving settings: ' + JSON.stringify( error ) );
+
+		// handle error case here
+		if ( error.message ) {
+			notices.error( error.message );
+		} else {
+			notices.error( this.props.translate( 'There was a problem saving your changes.' ) );
+		}
+
+		this.setState( {
+			submittingForm: false,
+			formsSubmitting: {
+				...this.state.formsSubmitting,
+				...( formName && { [ formName ]: false } ),
+			},
+		} );
+	},
+
+	isSubmittingForm( formName ) {
+		return formName ? this.state.formsSubmitting[ formName ] : this.state.submittingForm;
+	},
+
+	handleSubmitSuccess( response, formName = '' ) {
+		this.props.markSaved && this.props.markSaved();
+
+		if ( this.state && this.state.redirect ) {
+			user()
+				.clear()
+				.then( () => {
+					// Sometimes changes in settings require a url refresh to update the UI.
+					// For example when the user changes the language.
+					window.location = this.state.redirect + '?updated=success';
+				} );
+			return;
+		}
+		// if we set submittingForm too soon the UI updates before the response is handled
+		this.setState( {
+			showNotice: true,
+			submittingForm: false,
+			formsSubmitting: {
+				...this.state.formsSubmitting,
+				...( formName && { [ formName ]: false } ),
+			},
+		} );
+		this.showNotice();
+		debug( 'Settings saved successfully ' + JSON.stringify( response ) );
+	},
+
+	submitForm: function ( event, settingsToSave, formName = '' ) {
 		event.preventDefault();
 		debug( 'Submitting form' );
 
-		this.setState( { submittingForm: true } );
+		this.setState( {
+			submittingForm: true,
+			formsSubmitting: {
+				...this.state.formsSubmitting,
+				...( formName && { [ formName ]: true } ),
+			},
+		} );
+
 		this.props.userSettings.saveSettings(
 			function ( error, response ) {
 				if ( error ) {
-					debug( 'Error saving settings: ' + JSON.stringify( error ) );
-
-					// handle error case here
-					if ( error.message ) {
-						notices.error( error.message );
-					} else {
-						notices.error( this.props.translate( 'There was a problem saving your changes.' ) );
-					}
-					this.setState( { submittingForm: false } );
+					this.handleSubmitError( error, formName );
 				} else {
-					this.props.markSaved && this.props.markSaved();
-
-					if ( this.state && this.state.redirect ) {
-						user()
-							.clear()
-							.then( () => {
-								// Sometimes changes in settings require a url refresh to update the UI.
-								// For example when the user changes the language.
-								window.location = this.state.redirect + '?updated=success';
-							} );
-						return;
-					}
-					// if we set submittingForm too soon the UI updates before the response is handled
-					this.setState( { showNotice: true, submittingForm: false } );
-					this.showNotice();
-					debug( 'Settings saved successfully ' + JSON.stringify( response ) );
+					this.handleSubmitSuccess( response, formName );
 				}
-			}.bind( this )
+			}.bind( this ),
+			settingsToSave
 		);
 	},
 };


### PR DESCRIPTION
#### Description

This address the visual portion of https://github.com/Automattic/wp-calypso/issues/47043 by splitting the `/me/account` settings UI into two separate cards.

Unfortunately this is more than a UI change as behind the scenes the data layer handles all these settings as `User Settings`. Therefore we have had to introduce a means to differentiate between updating a subset of the user settings in order to reflect that state within the UI.

#### Why are we doing this?

This work is in preparation for adding a new toggle for opting out of Calypso links for the upcoming Nav Unification (see https://github.com/Automattic/wp-calypso/issues/47043). This will be addressed in a followup.


#### Changes proposed in this Pull Request

* Split `/me/account` into two card sections for `Account Information` and `Interface Settings`.
* Move fields into appropriate card section.
* Update `FormBase` mixin to allow for tracking individual forms submitted _and_ disabled state `true/false`.
* Update `UserSettings` to enable checking for a subset of unsaved changes.

#### Testing instructions

I am nervous about 2 things:

1. `FormBase` mixin is used elsewhere in the UI and our changes might have unforeseen consequences.
2. The `<Account />` component is not covered by tests and so manual testing is required to verify the changes.

Testing instructions:

* Use Firefox because Chrome has a bug whereby if you have 2-factor auth enabled it will constantly ask for your auth details 🤦 .
* Run Calypso `yarn && yarn start`.
* Go to http://calypso.localhost:3000/me/account.
* You should see x2 groups of fields:
- Account
- Interface
* Verify the fields match up 1:1 with what is currently in Production (ie: none have gone missing!).

Next the key is verify that you can save each set of fields independently and that saving one does not overwrite the other:

* Change some fields in one group and hit save - only one group should show the "Updating" UI state.
* Change some fields in both groups but only hit "Save" on a _single_ group 
  - verify only _one_ group should show the "Updating" UI state.
  - reload the page entirely and verify that no data was persisted for the group where you _didn't_ hit save.
* Try saving both fields at the same time:
  - check both groups show the "Saving" UI state.
  - check both groups have had their data saved.
  - reload and check the data is persisted



