### PR TITLE
Jetpack Connection Manager UI: Skip the plans page

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -227,7 +227,8 @@ export class JetpackAuthorize extends Component {
 			this.isFromBlockEditor() ||
 			this.shouldRedirectJetpackStart() ||
 			getRoleFromScope( scope ) === 'subscriber' ||
-			this.isJetpackUpgradeFlow()
+			this.isJetpackUpgradeFlow() ||
+			this.isFromJetpackConnectionManager()
 		) {
 			debug(
 				'Going back to WP Admin.',
@@ -301,6 +302,11 @@ export class JetpackAuthorize extends Component {
 	isJetpackUpgradeFlow( props = this.props ) {
 		const { redirectAfterAuth } = props.authQuery;
 		return redirectAfterAuth.includes( 'page=jetpack&action=authorize_redirect' );
+	}
+
+	isFromJetpackConnectionManager( props = this.props ) {
+		const { from } = props.authQuery;
+		return startsWith( from, 'connection-ui' );
 	}
 
 	isWooRedirect = ( props = this.props ) => {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -227,6 +227,30 @@ describe( 'JetpackAuthorize', () => {
 		} );
 	} );
 
+	describe( 'isFromJetpackConnectionManager', () => {
+		const isFromJetpackConnectionManager = new JetpackAuthorize().isFromJetpackConnectionManager;
+
+		test( 'is from connection manager', () => {
+			const props = {
+				authQuery: {
+					from: 'connection-ui',
+				},
+			};
+
+			expect( isFromJetpackConnectionManager( props ) ).toBe( true );
+		} );
+
+		test( 'is not from connection manager', () => {
+			const props = {
+				authQuery: {
+					from: 'not-connection-ui',
+				},
+			};
+
+			expect( isFromJetpackConnectionManager( props ) ).toBe( false );
+		} );
+	} );
+
 	describe( 'isFromJetpackBoost', () => {
 		const isFromJetpackBoost = new JetpackAuthorize().isFromJetpackBoost;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
When the connection is being refreshed via Connection Manager UI, the plans page should not show up, and the user needs to be redirected back to the Connection Manager.

This PR checks the `from` parameter to make sure we send the user back to the redirect URL directly.

Related to https://github.com/Automattic/jetpack/pull/18182

#### Testing instructions
Testing the new functionality is not possible at the moment, so we only need to ensure the existing behavior is not modified.

1. Disconnect a Jetpack site.
2. Add the following constant into your `wp-config.php` to use the Calypso connection flow:
```php
define( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME', true );
```
3. Switch Jetpack to the local Calypso. You could do that by defining the constant in your `wp-config.php`:
```php
define( 'CALYPSO_ENV', 'development' );
```
4. Confirm that you get redirected to the Plans page in the end of the connection flow.