### PR TITLE
Billing: Add physical address to self-serve receipts

### DIFF
--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -102,29 +102,25 @@ export function ReceiptBody( { transaction, handlePrintLinkClick } ) {
 				<div className="billing-history__app-overview">
 					<img src={ transaction.icon } title={ transaction.service } alt={ transaction.service } />
 					<h2>
-						{ ' ' }
-						{ translate(
-							'{{link}}%(service)s{{/link}} {{small}}by %(organization)s{{/small}} {{small}}%(address)s{{/small}}',
-							{
-								components: {
-									link: serviceLink,
-									small: <small />,
-								},
-								args: {
-									service: transaction.service,
-									organization: transaction.org,
-									address: transaction.address,
-								},
-								comment:
-									'This string is "Service by Organization". ' +
-									'The {{link}} and {{small}} add html styling and attributes. ' +
-									'Screenshot: https://cloudup.com/isX-WEFYlOs',
-							}
-						) }
-						<div className="billing-history__transaction-date">
-							{ moment( transaction.date ).format( 'll' ) }
-						</div>
+						{ translate( '{{link}}%(service)s{{/link}} {{small}}by %(organization)s{{/small}}', {
+							components: {
+								link: serviceLink,
+								small: <small />,
+							},
+							args: {
+								service: transaction.service,
+								organization: transaction.org,
+							},
+							comment:
+								'This string is "Service by Organization". ' +
+								'The {{link}} and {{small}} add html styling and attributes. ' +
+								'Screenshot: https://cloudup.com/isX-WEFYlOs',
+						} ) }
+						<small className="billing-history__organization-address">{ transaction.address }</small>
 					</h2>
+					<span className="billing-history__transaction-date">
+						{ moment( transaction.date ).format( 'll' ) }
+					</span>
 				</div>
 				<ul className="billing-history__receipt-details group">
 					<li>

--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -103,20 +103,24 @@ export function ReceiptBody( { transaction, handlePrintLinkClick } ) {
 					<img src={ transaction.icon } title={ transaction.service } alt={ transaction.service } />
 					<h2>
 						{ ' ' }
-						{ translate( '{{link}}%(service)s{{/link}} {{small}}by %(organization)s{{/small}}', {
-							components: {
-								link: serviceLink,
-								small: <small />,
-							},
-							args: {
-								service: transaction.service,
-								organization: transaction.org,
-							},
-							comment:
-								'This string is "Service by Organization". ' +
-								'The {{link}} and {{small}} add html styling and attributes. ' +
-								'Screenshot: https://cloudup.com/isX-WEFYlOs',
-						} ) }
+						{ translate(
+							'{{link}}%(service)s{{/link}} {{small}}by %(organization)s{{/small}} {{small}}%(address)s{{/small}}',
+							{
+								components: {
+									link: serviceLink,
+									small: <small />,
+								},
+								args: {
+									service: transaction.service,
+									organization: transaction.org,
+									address: transaction.address,
+								},
+								comment:
+									'This string is "Service by Organization". ' +
+									'The {{link}} and {{small}} add html styling and attributes. ' +
+									'Screenshot: https://cloudup.com/isX-WEFYlOs',
+							}
+						) }
 						<div className="billing-history__transaction-date">
 							{ moment( transaction.date ).format( 'll' ) }
 						</div>

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -158,32 +158,28 @@
 
 // View Receipt
 .billing-history__app-overview {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
 	min-height: 65px;
-	padding: 10px 40px;
+	padding: 10px 20px;
 	position: relative;
-	overflow: auto;
 
-	@include breakpoint-deprecated( '<480px' ) {
-		padding: 10px 20px;
+	@include breakpoint-deprecated( '>480px' ) {
+		flex-wrap: nowrap;
+		padding: 10px 40px;
 	}
 
 	img {
-		max-width: 65px;
-		min-height: 65px;
-		float: left;
-
-		@include breakpoint-deprecated( '<480px' ) {
-			left: 20px;
-		}
+		width: 65px;
+		height: 65px;
 	}
 
 	h2 {
-		clear: none;
-		float: left;
-		padding: 10px 20px;
+		padding: 0 10px;
 
-		@include breakpoint-deprecated( '<480px' ) {
-			padding-top: 0;
+		@include breakpoint-deprecated( '>480px' ) {
+			padding: 0 20px;
 		}
 
 		small {
@@ -194,10 +190,10 @@
 	.billing-history__transaction-date {
 		color: var( --color-neutral );
 		font-size: $font-body-small;
-		font-style: italic;
-		padding: 5px 0 0;
+		padding: 20px 0 0;
 
 		@include breakpoint-deprecated( '>480px' ) {
+			padding: 5px 0 0;
 			position: absolute;
 			top: 10px;
 			right: 40px;
@@ -227,7 +223,7 @@ textarea.billing-history__billing-details-editable {
 	background: var( --color-neutral-0 );
 	list-style: none;
 	padding: 20px 40px;
-	margin: 20px 0 0;
+	margin: 10px 0 0;
 	overflow: auto;
 
 	@include breakpoint-deprecated( '<480px' ) {
@@ -379,6 +375,7 @@ textarea.billing-history__billing-details-editable {
 .billing-history__receipt-card.is-placeholder {
 	.billing-history__app-overview {
 		display: flex;
+		flex-wrap: nowrap;
 		margin-bottom: 16px;
 
 		.billing-history__placeholder-image,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This feature was requested in pNPgK-5it-p2.

#### Testing instructions

- Apply D55023-code to your sandbox to make the data available from the backend.
- View a wpcom or jetpack receipt from `/me/purchases/billing` and verify that a8c's physical address is displayed on the receipt. This probably needs some design help to decide where to put the address and how to format it.

![Screen Shot 2021-01-07 at 2 03 10 PM](https://user-images.githubusercontent.com/9310939/103939263-1edbe500-50f1-11eb-9724-ccfd90ab9886.png)
