### PR TITLE
Gutenboarding: Remove Doyle design temporarily due to issue with Alves theme and that design

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -68,19 +68,6 @@
 			"features": []
 		},
 		{
-			"title": "Doyle",
-			"slug": "doyle",
-			"template": "doyle",
-			"theme": "alves",
-			"fonts": {
-				"headings": "Playfair Display",
-				"base": "Fira Sans"
-			},
-			"categories": [ "featured", "business" ],
-			"is_premium": true,
-			"features": []
-		},
-		{
 			"title": "Bowen",
 			"slug": "bowen",
 			"template": "bowen",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove Doyle design from Gutenboarding due to the following issue: https://github.com/Automattic/themes/issues/2976

Once the issue is resolved in Alves, we can add Doyle back to the list of designs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new` and on the design selection step ensure that the Doyle design does not appear for selection. E.g. you should not see the following in the list:

![image](https://user-images.githubusercontent.com/14988353/103954683-de37a680-5198-11eb-92db-20ec45bcc0ad.png)

* Make sure that selecting any other design works and you can still create a site

Fixes #
