### PR TITLE
Adjust padding for the button in the store move notice

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -156,7 +156,7 @@
     text-align: center;
 
     a {
-        margin-top: 40px;
+        margin-top: 20px;
     }
 
     h1 {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This just adjusts the top padding for the button in the store move notice from 40px to 20px

#### Testing instructions

* visit http://calypso.localhost:3000/store/YOUR_SITE.wpcomstaging.com?flags=woocommerce/store-deprecated
* The notice should show as below

![image](https://user-images.githubusercontent.com/224531/103970840-e7367100-51b4-11eb-9c4b-c1999741a191.png)
