### PR TITLE
Devdocs: Add the color scheme picker to the WP components library

### DIFF
--- a/client/devdocs/design/wordpress-components-gallery/index.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/index.tsx
@@ -49,6 +49,8 @@ import ToolbarExample from './toolbar';
 import TooltipExample from './tooltip';
 import TreeSelectExample from './tree-select';
 import VisuallyHiddenExample from './visually-hidden';
+import { isEnabled } from 'calypso/config';
+import ColorSchemePicker from 'calypso/blocks/color-scheme-picker/docs/example';
 
 import './style.scss';
 
@@ -68,6 +70,9 @@ const WordPressComponentsGallery = () => (
 		<h1 className="wordpress-components-gallery__heading">
 			The kitchen sink of WordPress components from the <code>@wordpress/components</code> package.
 		</h1>
+		{ isEnabled( 'devdocs/color-scheme-picker' ) && (
+			<ColorSchemePicker readmeFilePath="color-scheme-picker" />
+		) }
 		<Flex justify="flex-start" gap={ 4 } style={ { flexWrap: 'wrap' } }>
 			<ExampleComponent name="Angle Picker Control">
 				<AnglePickerControlExample />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Since we're adding component overrides for WordPress components (eg. #48717) the ability to quickly switch between color schemes to test them is nice! This adds the color scheme picker to the top of the screen like we do for Calypso blocks.

<img width="1678" alt="Screen Shot 2021-01-08 at 10 01 40 AM" src="https://user-images.githubusercontent.com/2124984/104029957-a3ce0980-5198-11eb-9bd2-34b3a3686040.png">

#### Testing instructions

* Switch to this PR and navigate to `/devdocs/wordpress-components-gallery`
* Make sure the color picker is working and doesn't introduce any errors.
