### PR TITLE
Anchor Gutenboarding: Hide locale button

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -41,6 +41,9 @@ const Header: React.FunctionComponent = () => {
 	const showPlansButton =
 		[ 'DesignSelection', 'Style', 'Features' ].includes( currentStep ) && ! isAnchorFmSignup;
 
+	// locale button is hidden on AnchorFM flavored gutenboarding
+	const showLocaleButton = ! isAnchorFmSignup;
+
 	// CreateSite step clears state before redirecting, don't show the default text in this case
 	const siteTitleDefault = 'CreateSite' === currentStep ? '' : __( 'Start your website' );
 
@@ -85,7 +88,7 @@ const Header: React.FunctionComponent = () => {
 				<div className="gutenboarding__header-section-item gutenboarding__header-domain-section">
 					{ showDomainsButton && <DomainPickerButton /> }
 				</div>
-				{ changeLocaleButton() }
+				{ showLocaleButton && changeLocaleButton() }
 				<div className="gutenboarding__header-section-item gutenboarding__header-plan-section gutenboarding__header-section-item--right">
 					{ showPlansButton && <PlansButton /> }
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When going through Anchor-FM Flavored gutenboarding, the header button for changing language/locale is hidden
  * If it is visible and pressed while inside anchor gutenboarding, all gutenboarding steps are skipped and you're brought to a non-anchor site with all anchor-related information no longer available
* We've done similar work in the past by hiding the domains and plans buttons from the header for anchor gutenboarding (see: #48375), keeping the anchor gutenboarding flow lean and focused on as few features as possible

#### Testing instructions

* Run calypso locally
* Create a new incognito browser window 
* Visit http://calypso.localhost:3000/new?&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q
* Create a new account (using an @example.com email is fine)
* The header show no longer display a "Site Language [EN]" button

Fixes 398-gh-Automattic/dotcom-manage

