### PR TITLE
Add Custom Description for Rollback Fixer

### DIFF
--- a/client/components/jetpack/threat-item/utils.ts
+++ b/client/components/jetpack/threat-item/utils.ts
@@ -80,6 +80,20 @@ export const getThreatFix = ( fixable: ThreatFix ): i18nCalypso.TranslateResult 
 			return translate( 'Jetpack Scan will update to a newer version.' );
 		case 'edit':
 			return translate( 'Jetpack Scan will edit the affected file or directory.' );
+		case 'rollback':
+			if ( fixable.target ) {
+				return translate(
+					'Jetpack Scan will rollback the affected file to the version from %(version)s.',
+					{
+						args: {
+							version: fixable.target,
+						},
+					}
+				);
+			}
+			return translate(
+				'Jetpack Scan will rollback the affected file to an older (clean) version.'
+			);
 		default:
 			return translate( 'Jetpack Scan will resolve the threat.' );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Jetpack Scan provides customized descriptions of how it will fix a threat. This PR adds a custom description for fixing threats with a "rollback".
Example: Jetpack Scan will rollback the affected file to the version from January 8, 2021, 3:40 am.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a test site with backup and scan plans
* Ensure the site has at least one successful, full backup
* Using the Threat Tester Plugin on your test site - add a "infect a file" threat. ([You can get the plugin here](https://github.com/Automattic/jetpack-threat-tester))
* Run calypso locally and initiate a scan of the test site
* Verify that the threat was discovered and that a Fix is available
* The description of the fix should read something like `Jetpack Scan will rollback the affected file to the version from <date-and-time>.`
