### PR TITLE
Marketing: Ultimate Traffic Guide - Fix Typo

### DIFF
--- a/client/my-sites/marketing/ultimate-traffic-guide/index.js
+++ b/client/my-sites/marketing/ultimate-traffic-guide/index.js
@@ -210,7 +210,7 @@ const SalesPage = ( { translate } ) => {
 				{ translate(
 					'Do you want more traffic to your website?' +
 						' Of course you do, who builds a website and doesn’t want traffic?' +
-						' You’ve time building your website and you’ve just realized that “if you build it, they will come” does not always apply.'
+						' You’ve spent time building your website and you’ve just realized that “if you build it, they will come” does not always apply.'
 				) }
 			</p>
 			<p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I was reading the Ultimate Traffic Guide page, and it's probably not my place so I won't propose anything beyond fixing this typo (unless requested), but I would just gently say that this whole page could probably be substantially improved. 

This is just a typo fix though!

#### Testing instructions

It should just be enough to check the change in this PR, but the link is: `/marketing/ultimate-traffic-guide/site`

cc @dzver, @aneeshd16 
