### PR TITLE
Billing: Update PlanBillingPeriod to remove CartStore action

### DIFF
--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -7,19 +7,17 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
+import { Button } from '@automattic/components';
 
 /**
  * Internal Dependencies
  */
-import { Button } from '@automattic/components';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { isMonthly } from 'calypso/lib/plans/constants';
 import { getYearlyPlanByMonthly } from 'calypso/lib/plans';
-import { planItem } from 'calypso/lib/cart-values/cart-items';
-import { addItem } from 'calypso/lib/cart/actions';
 import {
 	isExpired,
 	isExpiring,
@@ -44,8 +42,7 @@ export class PlanBillingPeriod extends Component {
 			current_plan: purchase.productSlug,
 			upgrading_to: yearlyPlanSlug,
 		} );
-		addItem( planItem( yearlyPlanSlug ) );
-		page( '/checkout/' + purchase.domain );
+		page( '/checkout/' + purchase.domain + '/' + yearlyPlanSlug );
 	};
 
 	renderYearlyBillingInformation() {

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -11,8 +11,6 @@ import { translate } from 'i18n-calypso';
  */
 import { PlanBillingPeriod } from '../billing-period';
 import page from 'page';
-import { planItem } from 'calypso/lib/cart-values/cart-items';
-import { addItem } from 'calypso/lib/cart/actions';
 
 const props = {
 	purchase: {
@@ -59,9 +57,7 @@ describe( 'PlanBillingPeriod', () => {
 		it( 'should upgrade to a yearly plan when the button is clicked', () => {
 			const wrapper = shallow( <PlanBillingPeriod { ...props } /> );
 			wrapper.find( 'Button' ).simulate( 'click' );
-			expect( planItem ).toHaveBeenCalledWith( 'jetpack_premium' );
-			expect( addItem ).toHaveBeenCalled();
-			expect( page ).toHaveBeenCalledWith( '/checkout/site.com' );
+			expect( page ).toHaveBeenCalledWith( '/checkout/site.com/jetpack_premium' );
 		} );
 
 		describe( 'a disconnected site', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of removing `CartStore` (see https://github.com/Automattic/wp-calypso/issues/24019), this PR converts `PlanBillingPeriod`, part of `ManagePurchase`, to use a checkout URL with a slug to modify the cart rather than the `CartStore` action creators.

<img width="329" alt="Screen Shot 2021-01-08 at 5 53 37 PM" src="https://user-images.githubusercontent.com/2036909/104073146-eb758500-51da-11eb-9cde-a506b80d04f8.png">

This component is only rendered for Jetpack sites with a monthly subscription that isn't expired.

#### Testing instructions

- You'll need a jetpack site.
- Purchase a _monthly_ paid plan for the jetpack site like `Jetpack Security Daily` (the "Backup" product won't work for this test; it has to be a monthly plan).
- Click Plan > Billing in the sidebar and then click your plan item in the subscription list.
- In the second card on the page you should see a button labeled "Upgrade to yearly billing". Click this button.
- Verify that you are taken to checkout and that the yearly plan matching your monthly plan is in the cart.