### PR TITLE
Customizer: Change Customize to use checkout url for adding a theme

### DIFF
--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -27,9 +27,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { getCustomizerUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
 import wpcom from 'calypso/lib/wp';
-import { addItem } from 'calypso/lib/cart/actions';
 import { trackClick } from 'calypso/my-sites/themes/helpers';
-import { themeItem } from 'calypso/lib/cart-values/cart-items';
 import { getUrlParts } from 'calypso/lib/url';
 
 /**
@@ -317,9 +315,8 @@ class Customize extends React.Component {
 					break;
 				case 'purchased': {
 					const themeSlug = message.theme.stylesheet.split( '/' )[ 1 ];
-					addItem( themeItem( themeSlug, 'customizer' ) );
 					trackClick( 'customizer', 'purchase' );
-					page( '/checkout/' + site.slug );
+					page( '/checkout/' + site.slug + '/theme:' + themeSlug );
 					break;
 				}
 				case 'navigateTo': {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the project to remove `CartStore` (see https://github.com/Automattic/wp-calypso/issues/24019), this PR replaces the `CartStore` action creator in the `Customize` component with a straightforward checkout URL.

<img width="513" alt="Screen Shot 2021-01-08 at 6 37 24 PM" src="https://user-images.githubusercontent.com/2036909/104075368-92105480-51e0-11eb-8640-1ba2f8efd97c.png">


#### Testing instructions

- Use a site with a free plan to make sure you don't get premium themes for free.
- Visit the theme page for a non-free theme, eg: `http://calypso.localhost:3000/theme/thefour/example.com`.
- Click "Open Live Demo".
- In the modal preview, click "Try & Customize".
- Verify that you're redirected to the customizer.
- Click "Purchase" in the customizer (where the "Save" button would normally be).
- Verify that you are taken to checkout and that the theme is in your cart.
