### PR TITLE
Admin Menu: Show update count in expendable sidebar menus

### DIFF
--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -42,8 +42,10 @@ const ExpandableSidebarHeading = ( {
 				/>
 			) }
 			{ undefined !== customIcon && customIcon }
-			<span className="sidebar__expandable-title">{ title }</span>
-			{ undefined !== count && <Count count={ count } /> }
+			<span className="sidebar__expandable-title">
+				{ title }
+				{ undefined !== count && <Count count={ count } /> }
+			</span>
 			<MaterialIcon icon="keyboard_arrow_down" className="sidebar__expandable-arrow" />
 		</SidebarHeading>
 	);

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -38,6 +38,13 @@
 	li {
 		list-style: none;
 	}
+
+	.count {
+		margin-left: 8px;
+		background-color: var( --color-sidebar-menu-hover-background );
+		border-color: var( --color-sidebar-menu-hover-background );
+		color: var( --color-sidebar-menu-hover-text );
+	}
 }
 
 // This button is hidden until focused. It allows screen-readers
@@ -141,22 +148,6 @@
 		}
 	}
 
-	.count {
-		margin-left: 8px;
-		color: var( --color-sidebar-menu-hover-text );
-		background-color: var( --color-sidebar-menu-hover-background );
-		border-color: var( --color-sidebar-menu-hover-background );
-		line-height: 0;
-		padding: 8px 6px;
-		position: absolute;
-		top: 9px;
-
-		// No positioning necessary for submenu items.
-		.sidebar__menu-item--child & {
-			top: 6px;
-		}
-	}
-
 	.badge {
 		margin: -7px 0 -8px;
 	}
@@ -244,17 +235,6 @@
 
 	.sidebar__expandable-title {
 		flex: 1 1 0;
-	}
-
-	.count {
-		margin-left: 8px;
-		color: var( --color-sidebar-menu-hover-text );
-		background-color: var( --color-sidebar-menu-hover-background );
-		border-color: var( --color-sidebar-menu-hover-background );
-		line-height: 0;
-		padding: 8px 6px;
-		position: absolute;
-		top: 9px;
 	}
 
 	.sidebar__expandable-arrow {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -233,11 +233,28 @@
 			.sidebar__expandable-arrow {
 				fill: var( --color-sidebar-menu-hover-text );
 			}
+
+			.count {
+				background-color: transparent;
+				border-color: var( --color-sidebar-menu-selected-text );
+				color: var( --color-sidebar-menu-selected-text );
+			}
 		}
 	}
 
 	.sidebar__expandable-title {
 		flex: 1 1 0;
+	}
+
+	.count {
+		margin-left: 8px;
+		color: var( --color-sidebar-menu-hover-text );
+		background-color: var( --color-sidebar-menu-hover-background );
+		border-color: var( --color-sidebar-menu-hover-background );
+		line-height: 0;
+		padding: 8px 6px;
+		position: absolute;
+		top: 9px;
 	}
 
 	.sidebar__expandable-arrow {
@@ -252,6 +269,11 @@
 	&.is-toggle-open {
 		.sidebar__expandable-arrow {
 			transform: rotate( 180deg );
+		}
+		.count {
+			background-color: transparent;
+			border-color: var( --color-sidebar-menu-selected-text );
+			color: var( --color-sidebar-menu-selected-text );
 		}
 	}
 }

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -30,6 +30,7 @@ import { externalRedirect } from 'calypso/lib/route/path';
 import { itemLinkMatches } from '../sidebar/utils';
 
 export const MySitesSidebarUnifiedMenu = ( {
+	count,
 	slug,
 	title,
 	icon,
@@ -80,6 +81,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 				title={ title }
 				customIcon={ <SidebarCustomIcon icon={ icon } /> }
 				className={ ( selected || childIsSelected ) && 'sidebar__menu--selected' }
+				count={ count }
 			>
 				{ children.map( ( item ) => {
 					const isSelected = selectedMenuItem?.url === item.url;
@@ -99,6 +101,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 };
 
 MySitesSidebarUnifiedMenu.propTypes = {
+	count: PropTypes.number,
 	path: PropTypes.string,
 	slug: PropTypes.string,
 	title: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds support for `count` prop to expandable sidebar menus

#### Testing instructions
* Install an outdated plugin on an Atomic site: https://downloads.wordpress.org/plugin/wp-search-suggest.4.zip
* WP's update check should display a count in the Plugins menu item. If it doesn't, visit `/wp-admin/update-core.php`.
* Load Calypso for that atomic site and check if that update count shows up there, too.

#### After
Nav-unification Disabled | Nav-unification Enabled
-------|------
![](https://cln.sh/IL75Vs+) | ![](https://cln.sh/nRN6VB+)


