### PR TITLE
Reader: fix /following route

### DIFF
--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -14,4 +14,7 @@ export default function () {
 	page( '/following/*', initAbTests );
 	page( '/following/manage', updateLastRoute, sidebar, followingManage, makeLayout, clientRender );
 	page( '/following/edit*', '/following/manage' );
+
+	// Send /following to Reader root
+	page( '/following', '/read' );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While working on some routing changes (D45105-code) I noticed that Calypso doesn't handle the `/following` route but it does handle `/following/manage` and `/following/edit`.

Working on the principle that [good URLs should be hackable](http://jeremy.zawodny.com/blog/archives/006323.html), and therefore that some users will end up at `/following` even though we're not linking to it anywhere, this PR adds a redirect to /read from that route.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit http://calypso.localhost:3000/following and ensure that you're redirected to /read.
* Visit http://calypso.localhost:3000/following/manage and ensure that you still reach Manage Following.

