### PR TITLE
Deduplicate chalk

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9133,16 +9133,7 @@ camelcase-keys@^4.0.0:
     map-obj "^2.0.0"
     quick-lru "^1.0.0"
 
-camelcase-keys@^6.1.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.1.tgz#cd3e2d2d7db767aa3f247e4c2df93b4661008945"
-  integrity sha512-BPCNVH56RVIxQQIXskp5tLQXUNGQ6sXr7iCv1FHDt81xBOQ/1r6H8SPxf19InVP6DexWar4s87q9thfuk8X9HA==
-  dependencies:
-    camelcase "^5.3.1"
-    map-obj "^4.0.0"
-    quick-lru "^4.0.1"
-
-camelcase-keys@^6.2.2:
+camelcase-keys@^6.1.1, camelcase-keys@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
   integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
@@ -9302,15 +9293,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
-  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -23762,7 +23745,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-"react-dom@^0.14.3 || ^15.1.0 || ^16.0.0", react-dom@^16.10.2, react-dom@^16.12.0, react-dom@^16.9.0, react-dom@^16.13.1:
+"react-dom@^0.14.3 || ^15.1.0 || ^16.0.0", react-dom@^16.10.2, react-dom@^16.12.0, react-dom@^16.13.1, react-dom@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
@@ -24099,7 +24082,7 @@ react-with-styles@^3.2.0:
     prop-types "^15.6.2"
     react-with-direction "^1.3.0"
 
-"react@^0.14.3 || ^15.1.0 || ^16.0.0", react@^16.10.2, react@^16.12.0, react@^16.9.0, react@^16.13.1:
+"react@^0.14.3 || ^15.1.0 || ^16.0.0", react@^16.10.2, react@^16.12.0, react@^16.13.1, react@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `chalk` (done automatically with `npx yarn-deduplicate --packages chalk`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 ->  -> ... -> chalk@4.0.0
< wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> chalk@4.0.0
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> chalk@4.0.0
< wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> chalk@4.0.0
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> chalk@4.0.0
< wp-calypso@0.17.0 -> eslint@7.12.0 -> ... -> chalk@4.0.0
< wp-calypso@0.17.0 -> husky@4.2.5 -> ... -> chalk@4.0.0
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> chalk@4.0.0
< wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> chalk@4.0.0
> wp-calypso@0.17.0 ->  -> ... -> chalk@4.1.0
> wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> chalk@4.1.0
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> chalk@4.1.0
> wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> chalk@4.1.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> chalk@4.1.0
> wp-calypso@0.17.0 -> eslint@7.12.0 -> ... -> chalk@4.1.0
> wp-calypso@0.17.0 -> husky@4.2.5 -> ... -> chalk@4.1.0
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> chalk@4.1.0
> wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> chalk@4.1.0
```

[Changelog](https://github.com/chalk/chalk/compare/v4.0.0...v4.1.0)