### PR TITLE
Deduplicate core-js

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9295,12 +9295,7 @@ core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3, core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-js@^3.0.1, core-js@^3.0.4, core-js@^3.6.3, core-js@^3.6.4:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
-  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
-
-core-js@^3.6.5:
+core-js@^3.0.1, core-js@^3.0.4, core-js@^3.6.3, core-js@^3.6.4, core-js@^3.6.5:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.7.0.tgz#b0a761a02488577afbf97179e4681bf49568520f"
   integrity sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `core-js` (done automatically with `npx yarn-deduplicate --packages core-js`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/calypso-polyfills@1.0.0 -> ... -> core-js@3.6.5
< wp-calypso@0.17.0 -> @storybook/addon-actions@6.1.10 -> ... -> core-js@3.6.5
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> core-js@3.6.5
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> core-js@3.6.5
> wp-calypso@0.17.0 -> @automattic/calypso-polyfills@1.0.0 -> ... -> core-js@3.7.0
> wp-calypso@0.17.0 -> @storybook/addon-actions@6.1.10 -> ... -> core-js@3.7.0
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> core-js@3.7.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> core-js@3.7.0
```


[Changelog](https://github.com/zloirock/core-js/blob/master/CHANGELOG.md#370---20201106)