### PR TITLE
Jetpack Email Reports: Add new mailing list category and description

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -157,6 +157,8 @@ class MainComponent extends React.Component {
 			return this.props.translate( 'Sales and promotions for Jetpack products and services.' );
 		} else if ( 'jetpack_news' === category ) {
 			return this.props.translate( 'Jetpack news, announcements, and product spotlights.' );
+		} else if ( 'jetpack_reports' === category ) {
+			return this.props.translate( 'Jetpack security and performance reports.' );
 		}
 
 		return null;

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -118,6 +118,8 @@ class MainComponent extends React.Component {
 			return this.props.translate( 'Jetpack Promotions' );
 		} else if ( 'jetpack_news' === category ) {
 			return this.props.translate( 'Jetpack Newsletter' );
+		} else if ( 'jetpack_reports' === category ) {
+			return this.props.translate( 'Jetpack Reports' );
 		}
 
 		return category;

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -50,6 +50,7 @@ const options = {
 	jetpack_research: 'jetpack_research',
 	jetpack_promotion: 'jetpack_promotion',
 	jetpack_news: 'jetpack_news',
+	jetpack_reports: 'jetpack_reports',
 };
 
 class WPCOMNotifications extends React.Component {
@@ -170,6 +171,13 @@ class WPCOMNotifications extends React.Component {
 							isEnabled={ get( settings, options.jetpack_news ) }
 							title={ translate( 'Newsletter' ) }
 							description={ translate( 'Jetpack news, announcements, and product spotlights.' ) }
+						/>
+
+						<EmailCategory
+							name={ options.jetpack_reports }
+							isEnabled={ get( settings, options.jetpack_reports ) }
+							title={ translate( 'Reports' ) }
+							description={ translate( 'Reports on your own site and its performance.' ) }
 						/>
 					</>
 				) : (

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -177,7 +177,7 @@ class WPCOMNotifications extends React.Component {
 							name={ options.jetpack_reports }
 							isEnabled={ get( settings, options.jetpack_reports ) }
 							title={ translate( 'Reports' ) }
-							description={ translate( 'Reports on your own site and its performance.' ) }
+							description={ translate( 'Jetpack security and performance reports.' ) }
 						/>
 					</>
 				) : (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* There is a planned test rollout of the Jetpack Weekly Email Reports starting soon (`pbtFPC-Pq-p2#comment-2347`), and we are adding a new mailing list category `jetpack_reports` for these emails as reflected in this patch: `D55094-code`. This PR updates the corresponding Calypso changes, adding the new category and its descriptions to the the email notifications section of the client.
* For translators: 
   *  "Jetpack Reports"
   * "Jetpack security and performance reports."

**Before:**
<img width="1193" alt="Calypso-before" src="https://user-images.githubusercontent.com/19717814/104451070-e8b9bd80-5555-11eb-96d6-56edf65570d8.png">
**After:**
<img width="975" alt="Calypso-after" src="https://user-images.githubusercontent.com/19717814/104451189-0edf5d80-5556-11eb-80c7-91e6427d2864.png">

#### Testing instructions

1. Start local Calypso environment and point `calypso.localhost` to `127.0.0.1`
2. Go to http://calypso.localhost:3000/me/notifications/updates
3. Checkout this branch
4. Refresh browser and ensure changes match screenshots

* Note: functionality may not work fully before deploy of the corresponding Phabricator patch, but for the purposes of this PR, testing the UI appearance is sufficient.
