### PR TITLE
Focused Launch: Update step highlighting logic

### DIFF
--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -27,7 +27,6 @@ import {
 	useSite,
 	usePlans,
 	useCart,
-	usePlanFromCart,
 } from '../../hooks';
 import FocusedLaunchSummaryItem, {
 	LeadingContentSide,
@@ -491,7 +490,6 @@ const Summary: React.FunctionComponent = () => {
 	const { onDomainSelect, onExistingSubdomainSelect, currentDomain } = useDomainSelection();
 	const { domainSearch, isLoading } = useDomainSearch();
 	const { isPaidPlan: hasPaidPlan } = useSite();
-	const hasPlanInCart = usePlanFromCart();
 
 	const { siteId, redirectTo } = React.useContext( LaunchContext );
 
@@ -543,7 +541,7 @@ const Summary: React.FunctionComponent = () => {
 	);
 
 	const isDomainStepHighlighted =
-		!! hasPlanInCart || !! hasSelectedDomain || isValidSiteTitle( title );
+		!! selectedPlan || !! hasSelectedDomain || isValidSiteTitle( title );
 
 	const renderDomainStep: StepIndexRenderFunction = ( { stepIndex, forwardStepIndex } ) => (
 		<DomainStep

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -27,6 +27,7 @@ import {
 	useSite,
 	usePlans,
 	useCart,
+	usePlanFromCart,
 } from '../../hooks';
 import FocusedLaunchSummaryItem, {
 	LeadingContentSide,
@@ -490,6 +491,7 @@ const Summary: React.FunctionComponent = () => {
 	const { onDomainSelect, onExistingSubdomainSelect, currentDomain } = useDomainSelection();
 	const { domainSearch, isLoading } = useDomainSearch();
 	const { isPaidPlan: hasPaidPlan } = useSite();
+	const hasPlanInCart = usePlanFromCart();
 
 	const { siteId, redirectTo } = React.useContext( LaunchContext );
 
@@ -540,7 +542,8 @@ const Summary: React.FunctionComponent = () => {
 		/>
 	);
 
-	const isDomainStepHighlighted = !! hasSelectedDomain || isValidSiteTitle( title );
+	const isDomainStepHighlighted =
+		!! hasPlanInCart || !! hasSelectedDomain || isValidSiteTitle( title );
 
 	const renderDomainStep: StepIndexRenderFunction = ( { stepIndex, forwardStepIndex } ) => (
 		<DomainStep


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a user enters the Focused Launch with a pre-selected item (either a domain or plan from the abandoned shopping cart), not all steps are highlighted in the Summary View. In this PR, the highlighting logic is updated to satisfy the following scenario's:

1. No items in the cart when starting Focused Launch flow? Only the first step in the Focused Launch Summary View is highlighted. Depending on the validity of site title it can be `SiteTitleStep` or `DomainStep`.
2. The user enters a valid site title in the first step OR an available domain exists in the cart so it is displayed as pre-selected in `DomainStep` => `DomainStep` is highlighted.
3. A domain is selected OR a plan exists in the cart so it is pre-selected in the `PlanStep` => All steps in the Focused Launch Summary View are highlighted.

**Note 1**: removing items from cart after Focused Launch flow was started shouldn't change the highlighting status.
**Note 2**: no user action (except clearing local storage) should make a step non-highlighted.

#### Testing instructions

#### Focused Launch

1. Check out this branch and run `yarn dev --sync` from `/apps/editing-toolkit`, ensuring you're also logged into your sandbox environment.
2. Create a new site `UNLAUNCHED_SITE_ID_CREATED_WITH_START.wordpress.com`
3. Go to `/plans` and add a paid plan to the cart.
4. Go to `/page/UNLAUNCHED_SITE_ID_CREATED_WITH_START.wordpress.com/home?fresh&flags=create/focused-launch-flow-calypso`.
5. Clear `local storage`.
6. Click "Launch" to open the Focused Launch flow.
7. Confirm that:
    * [x] All steps are highlighted (i.e. the step has had its opacity removed and it's "enabled")
8. Remove all items from the shopping cart.
9. Repeat steps 2 - 4.
10. Confirm that:
    * [x] Only the first step is highlighted (i.e. the step has had its opacity removed and it's "enabled").

#### Editing Toolkit Step-by-Step Launch - Regression testing

1. Check out this branch and run `yarn dev --sync` from `/apps/editing-toolkit` ensuring you're also logged into your sandbox environment.
2. Go to `/new` and go through the process to create a new site, you will land in the editing experience.
3. Sandbox your newly created site in your host file.
4. Flush your cache & DNS and then refresh your site made in step 1 and ensure that you're using the dev version of the ETK.
5. Go to `/plans` and add a paid plan to the cart.
6. Go to `/page/UNLAUNCHED_SITE_ID_CREATED_WITH_START.wordpress.com/home`
7. Clear `local storage`.
8. Click "Launch". This should open the launch modal.
9. Confirm that:
    * [x] No unexpected changes have appeared.
10. Remove all items from the shopping cart.
11. Repeat steps 6 - 8.
12. Confirm that:
    * [x] Only the first step is highlighted (i.e. the step has had its opacity removed and it's "enabled").

Fixes #48047
