### PR TITLE
Components: Reduxify notices in UploadDropZone

### DIFF
--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -14,8 +14,8 @@ import classNames from 'classnames';
  */
 import FilePicker from 'calypso/components/file-picker';
 import DropZone from 'calypso/components/drop-zone';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import notices from 'calypso/notices';
 import debugFactory from 'debug';
 import { MAX_UPLOAD_ZIP_SIZE } from 'calypso/lib/automated-transfer/constants';
 
@@ -38,7 +38,7 @@ class UploadDropZone extends Component {
 		const { translate, siteId, doUpload } = this.props;
 
 		if ( files.length !== 1 ) {
-			notices.error( translate( 'Please drop a single zip file' ) );
+			this.props.errorNotice( translate( 'Please drop a single zip file' ) );
 			return;
 		}
 
@@ -47,7 +47,9 @@ class UploadDropZone extends Component {
 		debug( 'zip file:', file );
 
 		if ( file.size > MAX_UPLOAD_ZIP_SIZE ) {
-			notices.error( translate( 'Zip file is too large. Please upload a file under 50 MB.' ) );
+			this.props.errorNotice(
+				translate( 'Zip file is too large. Please upload a file under 50 MB.' )
+			);
 			return;
 		}
 
@@ -78,6 +80,11 @@ class UploadDropZone extends Component {
 	}
 }
 
-export default connect( ( state ) => ( {
-	siteId: getSelectedSiteId( state ),
-} ) )( localize( UploadDropZone ) );
+export default connect(
+	( state ) => ( {
+		siteId: getSelectedSiteId( state ),
+	} ),
+	{
+		errorNotice,
+	}
+)( localize( UploadDropZone ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reduxifies notices in the `UploadDropZone` block.

Part of #48408.

#### Testing instructions

* Go to `/plugins/upload/:site` where `:site` is a Jetpack site.
* Drag and drop a large zip archive (> 50MB).
* Verify you still get the right notice properly.
* Drag and drop multiple zip archives.
* Verify you still get the right notice properly.
