### PR TITLE
State: Reduxify immediate login notices

### DIFF
--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { once, defer } from 'lodash';
-import notices from 'calypso/notices';
 import page from 'page';
 
 /**
@@ -32,6 +31,7 @@ import {
 	createPathWithoutImmediateLoginInformation,
 } from 'calypso/state/immediate-login/utils';
 import { saveImmediateLoginInformation } from 'calypso/state/immediate-login/actions';
+import { successNotice } from 'calypso/state/notices/actions';
 
 /**
  * Module variables
@@ -83,7 +83,7 @@ const notifyAboutImmediateLoginLinkEffects = once( ( dispatch, action, getState 
 
 	// Let redux process all dispatches that are currently queued and show the message
 	defer( () => {
-		notices.success( createImmediateLoginMessage( action.query.login_reason, email ) );
+		dispatch( successNotice( createImmediateLoginMessage( action.query.login_reason, email ) ) );
 	} );
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reduxifies notices for immediate login in the state middleware.

Part of #48408.

#### Testing instructions

* As a logged-in user, go to `/me/purchases?immediate_login_attempt=1&immediate_login_success=1&login_reason=plan-expired`
* Verify you still see the success notice, saying "You're logged in as %YOUREMAIL%" where `%YOUREMAIL%` is your email address.
