### PR TITLE
Adding feature flag for Cloudflare partnership dev work

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -22,6 +22,7 @@
 		"async-payments": false,
 		"automated-transfer": true,
 		"blogger-plan": false,
+		"cloudflare": false,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -18,6 +18,7 @@
 		"async-payments": false,
 		"blogger-plan": false,
 		"catch-js-errors": false,
+		"cloudflare": false,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,

--- a/config/development.json
+++ b/config/development.json
@@ -35,6 +35,7 @@
 		"automated-transfer": true,
 		"blogger-plan": true,
 		"calypsoify/plugins": true,
+		"cloudflare": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -22,6 +22,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
+		"cloudflare": false,
 		"composite-checkout-testing": true,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,

--- a/config/production.json
+++ b/config/production.json
@@ -22,6 +22,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
+		"cloudflare": false,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -23,6 +23,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
+		"cloudflare": false,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -32,6 +32,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
+		"cloudflare": false,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -25,6 +25,7 @@
 		"comments/management/threaded-view": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
+		"cloudflare": false,
 		"create/persistent-launch-button": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a `cloudflare` feature flag (enabled only in dev by default) which can be used to feature-gate development on the Cloudflare partnership.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

Fixes 400-gh-Automattic/dotcom-manage