### PR TITLE
reduxify: user-settings in `me/privacy`

### DIFF
--- a/client/me/privacy/controller.js
+++ b/client/me/privacy/controller.js
@@ -6,12 +6,9 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import userSettings from 'calypso/lib/user-settings';
 import PrivacyComponent from 'calypso/me/privacy/main';
 
 export function privacy( context, next ) {
-	context.primary = React.createElement( PrivacyComponent, {
-		userSettings: userSettings,
-	} );
+	context.primary = React.createElement( PrivacyComponent );
 	next();
 }

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -35,6 +35,23 @@ import QueryUserSettings from 'calypso/components/data/query-user-settings';
 
 const TRACKS_OPT_OUT_USER_SETTINGS_KEY = 'tracks_opt_out';
 
+const dpaRequestId = 'dpa-request';
+
+function requestDpa() {
+	requestHttpData(
+		dpaRequestId,
+		http( {
+			apiNamespace: 'wpcom/v2',
+			method: 'POST',
+			path: '/me/request-dpa',
+		} ),
+		{
+			freshness: -Infinity, // we want to allow the user to re-request
+			fromApi: () => () => [ [ dpaRequestId, true ] ],
+		}
+	);
+}
+
 class Privacy extends React.Component {
 	componentDidUpdate( oldProps ) {
 		const { dpaRequest, translate } = this.props;
@@ -186,7 +203,7 @@ class Privacy extends React.Component {
 							) }
 						</strong>
 					</p>
-					<Button className="privacy__dpa-request-button" onClick={ this.props.requestDpa }>
+					<Button className="privacy__dpa-request-button" onClick={ requestDpa }>
 						{ translate( 'Request a DPA', {
 							comment:
 								'A Data Processing Addendum (DPA) is a document to assure customers, vendors, and partners that their data handling complies with the law.',
@@ -196,23 +213,6 @@ class Privacy extends React.Component {
 			</Main>
 		);
 	}
-}
-
-const dpaRequestId = 'dpa-request';
-
-function requestDpa() {
-	requestHttpData(
-		dpaRequestId,
-		http( {
-			apiNamespace: 'wpcom/v2',
-			method: 'POST',
-			path: '/me/request-dpa',
-		} ),
-		{
-			freshness: -Infinity, // we want to allow the user to re-request
-			fromApi: () => () => [ [ dpaRequestId, true ] ],
-		}
-	);
 }
 
 const dpaRequestState = ( request ) => {
@@ -239,6 +239,6 @@ export default compose(
 			hasUnsavedUserSettings: hasUnsavedUserSettings( state ),
 			isUpdatingUserSettings: isUpdatingUserSettings( state ),
 		} ),
-		{ requestDpa, successNotice, errorNotice, setUserSetting, saveUserSettings }
+		{ successNotice, errorNotice, setUserSetting, saveUserSettings }
 	)
 )( Privacy );

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import React from 'react';
@@ -36,12 +35,7 @@ import QueryUserSettings from 'calypso/components/data/query-user-settings';
 
 const TRACKS_OPT_OUT_USER_SETTINGS_KEY = 'tracks_opt_out';
 
-/* eslint-disable react/prefer-es6-class */
-const Privacy = createReactClass( {
-	updateTracksOptOut( isSendingTracksEvents ) {
-		this.props.setUserSetting( TRACKS_OPT_OUT_USER_SETTINGS_KEY, ! isSendingTracksEvents );
-	},
-
+class Privacy extends React.Component {
 	componentDidUpdate( oldProps ) {
 		const { dpaRequest, translate } = this.props;
 		const { dpaRequest: oldDpaRequest } = oldProps;
@@ -63,13 +57,17 @@ const Privacy = createReactClass( {
 					  } )
 			);
 		}
-	},
+	}
 
-	submitForm( event ) {
+	updateTracksOptOut = ( isSendingTracksEvents ) => {
+		this.props.setUserSetting( TRACKS_OPT_OUT_USER_SETTINGS_KEY, ! isSendingTracksEvents );
+	};
+
+	submitForm = ( event ) => {
 		event.preventDefault();
 
 		this.props.saveUserSettings( null, () => this.props.markSaved() );
-	},
+	};
 
 	render() {
 		const {
@@ -197,8 +195,8 @@ const Privacy = createReactClass( {
 				</Card>
 			</Main>
 		);
-	},
-} );
+	}
+}
 
 const dpaRequestId = 'dpa-request';
 

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -23,8 +23,7 @@ import ReauthRequired from 'calypso/me/reauth-required';
 import SectionHeader from 'calypso/components/section-header';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { requestHttpData, getHttpData } from 'calypso/state/data-layer/http-data';
-import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { getHttpData } from 'calypso/state/data-layer/http-data';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import FormattedHeader from 'calypso/components/formatted-header';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
@@ -32,25 +31,11 @@ import { setUserSetting, saveUserSettings } from 'calypso/state/user-settings/ac
 import hasUnsavedUserSettings from 'calypso/state/selectors/has-unsaved-user-settings';
 import { isUpdatingUserSettings } from 'calypso/state/user-settings/selectors';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import { requestDpa } from 'calypso/state/data-getters';
 
 const TRACKS_OPT_OUT_USER_SETTINGS_KEY = 'tracks_opt_out';
 
 const dpaRequestId = 'dpa-request';
-
-function requestDpa() {
-	requestHttpData(
-		dpaRequestId,
-		http( {
-			apiNamespace: 'wpcom/v2',
-			method: 'POST',
-			path: '/me/request-dpa',
-		} ),
-		{
-			freshness: -Infinity, // we want to allow the user to re-request
-			fromApi: () => () => [ [ dpaRequestId, true ] ],
-		}
-	);
-}
 
 class Privacy extends React.Component {
 	componentDidUpdate( oldProps ) {
@@ -207,7 +192,10 @@ class Privacy extends React.Component {
 							) }
 						</strong>
 					</p>
-					<Button className="privacy__dpa-request-button" onClick={ requestDpa }>
+					<Button
+						className="privacy__dpa-request-button"
+						onClick={ () => requestDpa( dpaRequestId ) }
+					>
 						{ translate( 'Request a DPA', {
 							comment:
 								'A Data Processing Addendum (DPA) is a document to assure customers, vendors, and partners that their data handling complies with the law.',

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -74,6 +74,10 @@ class Privacy extends React.Component {
 					  } )
 			);
 		}
+
+		if ( oldProps.hasUnsavedUserSettings && ! this.props.hasUnsavedUserSettings ) {
+			this.props.markSaved();
+		}
 	}
 
 	updateTracksOptOut = ( isSendingTracksEvents ) => {
@@ -83,7 +87,7 @@ class Privacy extends React.Component {
 	submitForm = ( event ) => {
 		event.preventDefault();
 
-		this.props.saveUserSettings( null, () => this.props.markSaved() );
+		this.props.saveUserSettings();
 	};
 
 	render() {

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { omit, isArray, isUndefined, sortBy } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -281,3 +282,18 @@ export const requestSiteAlerts = ( siteId ) => {
 		}
 	);
 };
+
+export function requestDpa( requestId ) {
+	requestHttpData(
+		requestId,
+		http( {
+			apiNamespace: 'wpcom/v2',
+			method: 'POST',
+			path: '/me/request-dpa',
+		} ),
+		{
+			freshness: -Infinity, // we want to allow the user to re-request
+			fromApi: () => () => [ [ requestId, true ] ],
+		}
+	);
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use reduxified user settings in `me/privacy`
* Get rid of the `formBase` mixin and use user settings directly in the component (without adding the `withFormBase` hoc)

#### Testing instructions

* Go to `/me/privacy`
* Make sure the _Usage information_ opt-in/-out toggle works the same way as on prod
* Also make sure the _Request a DPA_ works still as expected


part of #24162 
