### PR TITLE
Gutenboarding: Lengthen title width in some browser widths

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/style.scss
@@ -17,6 +17,8 @@ $placeholder-color: #ccd0d4; // former light-gray-700
 	padding: 0;
 	color: var( --mainColor );
 	caret-color: var( --mainColor );
+	overflow: hidden;
+	text-overflow: ellipsis;
 
 	&:focus {
 		box-shadow: none;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -57,10 +57,11 @@
 
 	@include break-small {
 		min-width: 300px;
+		max-width: 400px;
 	}
 
 	@include break-medium {
-		min-width: 600px;
+		max-width: 750px;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -57,11 +57,10 @@
 
 	@include break-small {
 		min-width: 300px;
-		max-width: 400px;
 	}
 
 	@include break-medium {
-		max-width: 750px;
+		min-width: 600px;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Tweak CSS to Lengthen title width in some browser widths

![2021-01-11_16-09](https://user-images.githubusercontent.com/937354/104244149-777bec80-5427-11eb-8c73-086ea4917b45.png)


#### Testing instructions

* Visit http://calypso.localhost:3000/new?anchor_podcast=3e51070
* Paste/Type in "Word1 Word2 Word3 Word4 Word5 Word6" as the podcast title.
* Compare before and after the fix, across a range of browser widths in both cases.

#### Notes (Before Fix)

"Word1 Word2 Word3 Word4 Word5 Word6"


(438px is the thinnest I can make my browser)
* 438px: "Word1 Word2 Word3 Wo" 
Between 438 and 588, the text field expands (you can see more as you widen the browser.)

* 588px: "Word1 Word2 Word3 "
Between 588, and 773, the text field **does not** expand.

* 773px: "Word1 Word2 W"
Between 773 and 1080, the text field **does** expand.

* 1080px: "Word1 Word2 Word3 Word"
Between 1080 and 1197, the text field **does not** expand.

* 1197px: "Word1 Wor"
Between 1197 and 1638, the text field **does** expand.

* 1638px: "Word1 Word2 Word3 Word"
Between 1638 and infinity, the text field **does not** expand.


#### Notes (After Fix)

* 438px: "Word1 Word2 Word3 Wo" 
Between 438 and 588, the text field expands (you can see more as you widen the browser.)

* 588px: "Word1 Word2 Word3 "
Between 588, and 773, the text field does expand.  _(Used to be: Does not)_

* 773px: "Word1 Word2 Word3" _(Used to be: "Word1 Word2 W")_
Between 773 and 1496, the text field does expand.

* 1496px: "Word1 Word2 Word3 "
Between 1496 and 1638, the text field does expand.

* 1638px: "Word1 Word2 Word3 Word"
Between 1638 and infinity, the text field does not expand.

#### Commentary

Overall it seems better, in that you can always see at least 3 words, but not perfect.  However, I'm not a CSS or design wizard, and I'm open to other suggestions or even entirely different approaches!

Also, I didn't have time to investigate, and I'm not 100% sure, but it seemed like the longer I had this page open, the slower it got.  Possible resource leak with the autotyper.  If y'all notice anything similar please let me know.


Fixes 397-gh-Automattic/dotcom-manage