### PR TITLE
Add/richer titan navigation

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -13,6 +13,7 @@ import { emailManagementAddGSuiteUsers } from 'calypso/my-sites/email/paths';
 import GSuiteAddUsers from 'calypso/my-sites/email/gsuite-add-users';
 import TitanMailQuantitySelection from 'calypso/my-sites/email/titan-mail-quantity-selection';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import TitanManagementIframe from 'calypso/my-sites/email/email-management/titan-management-iframe';
 
 export default {
 	emailManagementAddGSuiteUsers( pageContext, next ) {
@@ -40,6 +41,12 @@ export default {
 				/>
 			</CalypsoShoppingCartProvider>
 		);
+
+		next();
+	},
+
+	emailManagementManageTitanAccount( pageContext, next ) {
+		pageContext.primary = <TitanManagementIframe domainName={ pageContext.params.domain } />;
 
 		next();
 	},

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -26,9 +26,9 @@ import GSuiteUserItem from 'calypso/my-sites/email/email-management/gsuite-user-
 import Notice from 'calypso/components/notice';
 import PendingGSuiteTosNotice from 'calypso/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
 import SectionHeader from 'calypso/components/section-header';
+import TitanManagementNav from 'calypso/my-sites/email/email-management/titan-management-nav';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
-import TitanControlPanelLoginCard from 'calypso/my-sites/email/email-management/titan-control-panel-login-card';
 
 /**
  * Style dependencies
@@ -93,7 +93,7 @@ class GSuiteUsersCard extends React.Component {
 
 	renderDomain( domain, users ) {
 		if ( hasTitanMailWithUs( domain ) ) {
-			return <TitanControlPanelLoginCard domain={ domain } key={ `titan-${ domain.name }` } />;
+			return <TitanManagementNav domain={ domain } key={ `titan-${ domain.name }` } />;
 		}
 
 		return this.renderDomainWithGSuite( domain.name, users );

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -23,9 +23,11 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import GSuiteUserItem from 'calypso/my-sites/email/email-management/gsuite-user-item';
+import { isEnabled } from 'calypso/config';
 import Notice from 'calypso/components/notice';
 import PendingGSuiteTosNotice from 'calypso/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
 import SectionHeader from 'calypso/components/section-header';
+import TitanControlPanelLoginCard from 'calypso/my-sites/email/email-management/titan-control-panel-login-card';
 import TitanManagementNav from 'calypso/my-sites/email/email-management/titan-management-nav';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
@@ -93,7 +95,11 @@ class GSuiteUsersCard extends React.Component {
 
 	renderDomain( domain, users ) {
 		if ( hasTitanMailWithUs( domain ) ) {
-			return <TitanManagementNav domain={ domain } key={ `titan-${ domain.name }` } />;
+			const domainKey = `titan-${ domain.name }`;
+			if ( isEnabled( 'titan/phase-2' ) ) {
+				return <TitanManagementNav domain={ domain } key={ domainKey } />;
+			}
+			return <TitanControlPanelLoginCard domain={ domain } key={ domainKey } />;
 		}
 
 		return this.renderDomainWithGSuite( domain.name, users );

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -34,7 +34,11 @@ import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import EmptyContent from 'calypso/components/empty-content';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
-import { emailManagementForwarding } from 'calypso/my-sites/email/paths';
+import {
+	emailManagement,
+	emailManagementForwarding,
+	isUnderEmailManagementAll,
+} from 'calypso/my-sites/email/paths';
 import {
 	getSelectedDomain,
 	isMappedDomain,
@@ -272,8 +276,14 @@ class EmailManagement extends React.Component {
 	goToEditOrList = () => {
 		const { selectedDomainName, selectedSiteSlug, currentRoute, previousRoute } = this.props;
 		const domainPath = domainManagementEdit( selectedSiteSlug, selectedDomainName, currentRoute );
+		const emailPath = emailManagement( selectedSiteSlug );
 
-		if ( selectedDomainName && previousRoute.startsWith( domainPath ) ) {
+		if (
+			selectedDomainName &&
+			( previousRoute.startsWith( domainPath ) ||
+				currentRoute.startsWith( emailPath ) ||
+				isUnderEmailManagementAll( currentRoute ) )
+		) {
 			page( domainPath );
 		} else {
 			page( domainManagementList( selectedSiteSlug, currentRoute ) );

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -10,10 +10,13 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { isEnabled } from 'calypso/config';
-import wpcom from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { Button, CompactCard } from '@automattic/components';
 import SectionHeader from 'calypso/components/section-header';
+import {
+	fetchTitanAutoLoginURL,
+	fetchTitanIframeURL,
+} from 'calypso/my-sites/email/email-management/titan-functions';
 import { getTitanMailOrderId } from 'calypso/lib/titan/get-titan-mail-order-id';
 
 /**
@@ -30,7 +33,7 @@ class TitanControlPanelLoginCard extends React.Component {
 	componentDidMount() {
 		this._mounted = true;
 
-		this.fetchTitanIframeURL( getTitanMailOrderId( this.props.domain ) ).then(
+		fetchTitanIframeURL( getTitanMailOrderId( this.props.domain ) ).then(
 			( { error, iframeURL } ) => {
 				if ( error ) {
 					this.props.errorNotice(
@@ -47,28 +50,6 @@ class TitanControlPanelLoginCard extends React.Component {
 		this._mounted = false;
 	}
 
-	fetchTitanAutoLoginURL = ( orderId ) => {
-		return new Promise( ( resolve ) => {
-			wpcom.undocumented().getTitanControlPanelAutoLoginURL( orderId, ( serverError, result ) => {
-				resolve( {
-					error: serverError?.message,
-					loginURL: serverError ? null : result.auto_login_url,
-				} );
-			} );
-		} );
-	};
-
-	fetchTitanIframeURL = ( orderId ) => {
-		return new Promise( ( resolve ) => {
-			wpcom.undocumented().getTitanControlPanelIframeURL( orderId, ( serverError, result ) => {
-				resolve( {
-					error: serverError?.message,
-					iframeURL: serverError ? null : result.iframe_url,
-				} );
-			} );
-		} );
-	};
-
 	onLogInClick = () => {
 		if ( this.state.isFetchingAutoLoginLink ) {
 			return;
@@ -77,7 +58,7 @@ class TitanControlPanelLoginCard extends React.Component {
 		const { domain, translate } = this.props;
 		this.setState( { isFetchingAutoLoginLink: true } );
 
-		this.fetchTitanAutoLoginURL( getTitanMailOrderId( domain ) ).then( ( { error, loginURL } ) => {
+		fetchTitanAutoLoginURL( getTitanMailOrderId( domain ) ).then( ( { error, loginURL } ) => {
 			this.setState( { isFetchingAutoLoginLink: false } );
 			if ( error ) {
 				this.props.errorNotice(

--- a/client/my-sites/email/email-management/titan-functions.js
+++ b/client/my-sites/email/email-management/titan-functions.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'calypso/lib/wp';
+
+export const fetchTitanAutoLoginURL = ( orderId ) => {
+	return new Promise( ( resolve ) => {
+		wpcom.undocumented().getTitanControlPanelAutoLoginURL( orderId, ( serverError, result ) => {
+			resolve( {
+				error: serverError?.message,
+				loginURL: serverError ? null : result.auto_login_url,
+			} );
+		} );
+	} );
+};
+
+export const fetchTitanIframeURL = ( orderId ) => {
+	return new Promise( ( resolve ) => {
+		wpcom.undocumented().getTitanControlPanelIframeURL( orderId, ( serverError, result ) => {
+			resolve( {
+				error: serverError?.message,
+				iframeURL: serverError ? null : result.iframe_url,
+			} );
+		} );
+	} );
+};

--- a/client/my-sites/email/email-management/titan-management-iframe/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-iframe/index.jsx
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import DocumentHead from 'calypso/components/data/document-head';
+import { emailManagement } from 'calypso/my-sites/email/paths';
+import EmptyContent from 'calypso/components/empty-content';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import Header from 'calypso/my-sites/domains/domain-management/components/header';
+import { isEnabled } from 'calypso/config';
+import Main from 'calypso/components/main';
+import QueryEmailAccounts from 'calypso/components/data/query-email-accounts';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import TitanControlPanelLoginCard from 'calypso/my-sites/email/email-management/titan-control-panel-login-card';
+
+class TitanManagementIframe extends React.Component {
+	static propTypes = {
+		canManageSite: PropTypes.bool.isRequired,
+		currentRoute: PropTypes.string,
+		domainName: PropTypes.string.isRequired,
+		hasSiteDomainsLoaded: PropTypes.bool.isRequired,
+		selectedSiteId: PropTypes.number.isRequired,
+		selectedSiteSlug: PropTypes.string.isRequired,
+	};
+
+	renderManagementSection() {
+		const { domainName } = this.props;
+		const selectedDomain = this.props.domains
+			.filter( function ( domain ) {
+				return domain?.name === domainName;
+			} )
+			.pop();
+		if ( ! selectedDomain ) {
+			return null;
+		}
+		return <TitanControlPanelLoginCard domain={ selectedDomain } />;
+	}
+
+	render() {
+		const {
+			canManageSite,
+			currentRoute,
+			domainName,
+			selectedSiteId,
+			selectedSiteSlug,
+			translate,
+		} = this.props;
+
+		if ( ! canManageSite ) {
+			return (
+				<Main>
+					<SidebarNavigation />
+					<EmptyContent
+						title={ translate( 'You are not authorized to view this page' ) }
+						illustration={ '/calypso/images/illustrations/illustration-404.svg' }
+					/>
+				</Main>
+			);
+		}
+		const emailManagementPath = emailManagement( selectedSiteSlug, domainName, currentRoute );
+
+		return (
+			<Main className="titan-management-iframe" wideLayout>
+				{ isEnabled( 'email-accounts/enabled' ) && (
+					<QueryEmailAccounts siteId={ selectedSiteId } />
+				) }
+				<QuerySiteDomains siteId={ selectedSiteId } />
+				<DocumentHead title={ translate( 'Email Management' ) } />
+				<SidebarNavigation />
+
+				<Header backHref={ emailManagementPath } selectedDomainName={ domainName }>
+					{ translate( 'Email Settings' ) }
+				</Header>
+				{ this.renderManagementSection() }
+			</Main>
+		);
+	}
+}
+
+export default connect( ( state ) => {
+	const selectedSiteId = getSelectedSiteId( state );
+	return {
+		currentRoute: getCurrentRoute( state ),
+		canManageSite: canCurrentUser( state, selectedSiteId, 'manage_options' ),
+		domains: getDomainsBySiteId( state, selectedSiteId ),
+		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, selectedSiteId ),
+		selectedSiteId,
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+	};
+} )( localize( TitanManagementIframe ) );

--- a/client/my-sites/email/email-management/titan-management-nav/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-nav/index.jsx
@@ -1,0 +1,158 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { CompactCard } from '@automattic/components';
+import {
+	emailManagementManageTitanAccount,
+	emailManagementNewTitanAccount,
+} from 'calypso/my-sites/email/paths';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { fetchTitanAutoLoginURL } from 'calypso/my-sites/email/email-management/titan-functions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getTitanMailOrderId } from 'calypso/lib/titan/get-titan-mail-order-id';
+import { isEnabled } from 'calypso/config';
+import SectionHeader from 'calypso/components/section-header';
+import VerticalNav from 'calypso/components/vertical-nav';
+import VerticalNavItem from 'calypso/components/vertical-nav/item';
+
+class TitanManagementNav extends React.Component {
+	static propTypes = {
+		domain: PropTypes.object.isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isFetchingExternalManagementUrl: this.shouldFetchControlPanelLink(),
+			externalManagementUrl: '',
+		};
+	}
+
+	shouldFetchControlPanelLink() {
+		return ! isEnabled( 'titan/iframe-control-panel' );
+	}
+
+	componentDidMount() {
+		this._mounted = true;
+
+		if ( this.shouldFetchControlPanelLink() ) {
+			const { domain, translate } = this.props;
+
+			fetchTitanAutoLoginURL( getTitanMailOrderId( domain ) ).then( ( { error, loginURL } ) => {
+				if ( this._mounted ) {
+					this.setState( { isFetchingExternalManagementUrl: false } );
+				}
+				if ( error ) {
+					this.props.errorNotice(
+						error ?? translate( 'An unknown error occurred. Please try again later.' )
+					);
+				} else if ( this._mounted ) {
+					this.setState( { externalManagementUrl: loginURL } );
+				}
+			} );
+		}
+	}
+
+	componentWillUnmount() {
+		this._mounted = false;
+	}
+
+	renderTitanManagementLink = () => {
+		const { currentRoute, domain, selectedSiteSlug, translate } = this.props;
+		const linkTitle = translate( 'Manage your email settings and accounts' );
+		if ( isEnabled( 'titan/iframe-control-panel' ) ) {
+			return (
+				<VerticalNavItem
+					path={ emailManagementManageTitanAccount( selectedSiteSlug, domain.name, currentRoute ) }
+				>
+					{ linkTitle }
+				</VerticalNavItem>
+			);
+		}
+		const { externalManagementUrl, isFetchingExternalManagementUrl } = this.state;
+		if ( ! externalManagementUrl || isFetchingExternalManagementUrl ) {
+			return <VerticalNavItem isPlaceholder={ true } />;
+		}
+		return <VerticalNavItem path={ externalManagementUrl }>{ linkTitle }</VerticalNavItem>;
+	};
+
+	renderPurchaseManagementLink = () => {
+		const { domain, selectedSiteSlug, translate } = this.props;
+		if ( ! domain?.titanMailSubscription?.subscriptionId ) {
+			return null;
+		}
+
+		return (
+			<VerticalNavItem
+				path={ getManagePurchaseUrlFor(
+					selectedSiteSlug,
+					domain.titanMailSubscription.subscriptionId
+				) }
+			>
+				{ translate( 'Update your billing and payment settings' ) }
+			</VerticalNavItem>
+		);
+	};
+
+	renderAddMailboxesLink = () => {
+		const { currentRoute, domain, selectedSiteSlug, translate } = this.props;
+		// If we don't have a subscription, we can't add mailboxes.
+		if ( ! domain?.titanMailSubscription?.subscriptionId ) {
+			return null;
+		}
+
+		return (
+			<VerticalNavItem
+				path={ emailManagementNewTitanAccount( selectedSiteSlug, domain.name, currentRoute ) }
+			>
+				{ translate( 'Add more mailboxes' ) }
+			</VerticalNavItem>
+		);
+	};
+
+	render() {
+		const { domain, translate } = this.props;
+		const translateArgs = {
+			args: {
+				domainName: domain.name,
+			},
+			comment: '%(domainName)s is a domain name, e.g. example.com',
+		};
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Titan Mail: %(domainName)s', translateArgs ) } />
+				<CompactCard>
+					<VerticalNav>
+						{ this.renderTitanManagementLink() }
+						{ this.renderPurchaseManagementLink() }
+						{ this.renderAddMailboxesLink() }
+					</VerticalNav>
+				</CompactCard>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		return {
+			currentRoute: getCurrentRoute( state ),
+			selectedSiteSlug: getSelectedSiteSlug( state ),
+		};
+	},
+	( dispatch ) => {
+		return {
+			errorNotice: ( text, options ) => dispatch( errorNotice( text, options ) ),
+		};
+	}
+)( localize( TitanManagementNav ) );

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -75,6 +75,23 @@ export default function () {
 
 	registerMultiPage( {
 		paths: [
+			paths.emailManagementManageTitanAccount(
+				':site',
+				':domain',
+				paths.emailManagementAllSitesPrefix
+			),
+			paths.emailManagementManageTitanAccount( ':site', ':domain' ),
+		],
+		handlers: [
+			...commonHandlers,
+			controller.emailManagementManageTitanAccount,
+			makeLayout,
+			clientRender,
+		],
+	} );
+
+	registerMultiPage( {
+		paths: [
 			paths.emailManagementNewTitanAccount(
 				':site',
 				':domain',

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -50,6 +50,10 @@ export function emailManagementNewGSuiteAccount(
 	return emailManagementEdit( siteName, domainName, 'gsuite/new/' + planType, relativeTo );
 }
 
+export function emailManagementManageTitanAccount( siteName, domainName, relativeTo = null ) {
+	return emailManagementEdit( siteName, domainName, 'titan/manage', relativeTo );
+}
+
 export function emailManagementNewTitanAccount( siteName, domainName, relativeTo = null ) {
 	return emailManagementEdit( siteName, domainName, 'titan/new', relativeTo );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR introduces a vertical nav to show three links for managing a Titan account:
  - A link to the embedded console (if that feature is enabled with the `titan/iframe-control-panel` flag) OR the external Titan console (when the feature is not enabled)
  - A link to manage the subscription (if we have the subscription ID)
  - A link to pay for more mailboxes 
<img width="1599" alt="WIP titles for nav" src="https://user-images.githubusercontent.com/3376401/104245317-b4b69d80-546c-11eb-948e-dd851e799e5c.png">

* This PR also introduces a standalone component at `titan/manage` to wrap the embedded control panel, as we need a way to signal when we are loading the dedicated management path.
* As a final change, this PR tweaks the way the "Back" button in the Email Management screen determines where it should go back to, as the changes result in additional paths being possible

**Note:** For now, I haven't added any styles, as I want some feedback on the core approach first.

#### Testing instructions

Note 1: The nav section of this feature is currently behind the `titan/phase-2` feature flag, but the new `titan/manage` path is not protected by that feature flag, as it's highly unlikely anyone gets to that URL, and it doesn't expose any new functionality anyway.
Note 2: The PR takes into account the `titan/iframe-control-panel` feature flag as well:
 -  If both this flag and the `titan/phase-2` flags are enabled, the clicking on the Titan nav option for "Manage your email settings and accounts" should load the new `titan/manage` page and show the embedded management console. 
 - If the `titan/iframe-control-panel` flag is disabled, but the `titan/phase-2` flag is enabled, clicking on "Manage your email settings and accounts" should immediately launch the external control panel.

1. Ensure that you're working against a sandboxed back end that has Store Sandbox enabled and has the update from D55163-code.
2. If you don't have a domain where you have purchased Titan:
  a. Enable the `titan/phase-2` feature flag in the UI by adding `?flags=titan/phase-2` to the URL you're using (either locally or on calypso.live).
  b. Purchase Titan for a domain you own.
3. Ensure the `titan/phase-2` and `titan/iframe-control-panel` flags are enabled.
4. For the domain above, navigate to the domain management screen and click on the "Manage your email accounts" option.
5. Verify that you see a list containing three links, one for management/configuration, one for billing, and one for adding accounts.
6. Confirm that clicking on all three links works and takes you to the correct page. Ensure that clicking the Back button works correctly in all three cases. (Note that you should see the iframed control panel.)
7. Disable the `titan/iframe-control-panel` flag and keep the `titan/phase-2` flag enabled. (You can do this by adding `?flags=titan/phase-2,-titan/iframe-control-panel` to the URL.)
8. Repeat steps 4-6, and verify that you're launched into the full management console for that link.
9. Disable both flags. (You can add `?flags=-titan/phase-2,-titan/iframe-control-panel` to the URL to make this happen.)
10. Repeat step 4.
11. You should be taken to a page showing a basic description and a button to log into the control panel.
12. Enable `titan/iframe-control-panel` and disable `titan/phase-2`.
13. Repeat step 4.
14. You should be taken to a page that loads the embedded management console.

And then repeat these steps (especially those involving navigation) starting from the all domains view.