### PR TITLE
Guided transfer: Update checkout redirects to use product slug instead of cart modification

### DIFF
--- a/client/my-sites/exporter/guided-transfer-card/complete-purchase-notice.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/complete-purchase-notice.jsx
@@ -12,13 +12,10 @@ import { localize } from 'i18n-calypso';
  */
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import { guidedTransferItem } from 'calypso/lib/cart-values/cart-items';
-import { addItem } from 'calypso/lib/cart/actions';
 import page from 'page';
 
 const redirectToCart = ( siteSlug ) => () => {
-	addItem( guidedTransferItem() );
-	page( `/checkout/${ siteSlug }` );
+	page( `/checkout/${ siteSlug }/guided_transfer` );
 };
 
 const CompletePurchaseNotice = ( { translate, siteSlug } ) => (

--- a/client/my-sites/guided-transfer/host-credentials-page/index.jsx
+++ b/client/my-sites/guided-transfer/host-credentials-page/index.jsx
@@ -14,8 +14,6 @@ import ErrorNotice from './error-notice';
 import SiteGround from './siteground';
 import Pressable from './pressable';
 import SectionHeader from 'calypso/components/section-header';
-import { guidedTransferItem } from 'calypso/lib/cart-values/cart-items';
-import { addItem } from 'calypso/lib/cart/actions';
 import page from 'page';
 import { saveHostDetails } from 'calypso/state/sites/guided-transfer/actions';
 import {
@@ -45,8 +43,7 @@ class HostCredentialsPage extends Component {
 	};
 
 	redirectToCart = () => {
-		addItem( guidedTransferItem() );
-		page.redirect( `/checkout/${ this.props.siteSlug }` );
+		page.redirect( `/checkout/${ this.props.siteSlug }/guided_transfer` );
 	};
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {

--- a/client/my-sites/guided-transfer/host-credentials-page/index.jsx
+++ b/client/my-sites/guided-transfer/host-credentials-page/index.jsx
@@ -46,8 +46,8 @@ class HostCredentialsPage extends Component {
 		page.redirect( `/checkout/${ this.props.siteSlug }/guided_transfer` );
 	};
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.isAwaitingPurchase ) {
+	componentDidUpdate() {
+		if ( this.props.isAwaitingPurchase ) {
 			this.redirectToCart();
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates two guided transfer components, `HostCredentialsPage`, and `CompletePurchaseNotice`, to remove usage of `CartStore` (see https://github.com/Automattic/wp-calypso/issues/24019) functions to modify the shopping cart and instead redirect to checkout with the product slug in the URL.

#### Testing instructions

To test `HostCredentialsPage`:

- Start with an empty cart.
- Enable guided transfer by applying D55181-code to your sandbox and sandboxing the API.
- Visit http://calypso.localhost:3000/export/guided/pressable/example.com for your site.
- Because it's hard to fake the validation, it's probably easiest to use React devtools to convince the component that the form is complete. To do this, select `HostCredentialsPage` in the React devtools "Components" panel to view its props. Modify `isAwaitingPurchase` to `true`.
- Verify that you're redirected to checkout and that guided transfer is in your cart.

To test `CompletePurchaseNotice`:

- Start with an empty cart.
- Visit http://calypso.localhost:3000/export/example.com for your site.
- Because it's hard to fake the setup, it's probably easiest to use React devtools to convince the component that the form is complete. To do this, select `Notices` in the React devtools "Components" panel  under `ExporterContainer` to view its props. Modify `isGuidedTransferAwaitingPurchase` to `true`.
- You should see a notice on the screen that reads "It looks like you've started a Guided Transfer. We just need your payment to confirm the transfer and then we'll get started!" with a button. Click on the "Continue" button in the notice.
- Verify that you're redirected to checkout and that guided transfer is in your cart.
