### PR TITLE
Welcome Tour: update copy and add i18n wrappers

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-card.js
@@ -19,6 +19,7 @@ import { close } from '@wordpress/icons';
 import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { __ } from '@wordpress/i18n';
 
 // eslint-disable-next-line react-hooks/exhaustive-deps
 const useEffectOnlyOnce = ( func ) => useEffect( func, [] );
@@ -59,7 +60,7 @@ function WelcomeTourCard( {
 				slideNumber={ cardIndex + 1 }
 			/>
 			<CardMedia>
-				<img alt="Editor Welcome Tour" src={ imgSrc } />
+				<img alt={ __( 'Editor Welcome Tour', 'full-site-editing' ) } src={ imgSrc } />
 			</CardMedia>
 			<CardBody>
 				<h2 className="welcome-tour-card__heading">{ heading }</h2>
@@ -103,11 +104,11 @@ function CardNavigation( { cardIndex, lastCardIndex, onDismiss, setCurrentCardIn
 			<div>
 				{ cardIndex === 0 ? (
 					<Button isTertiary={ true } onClick={ () => onDismiss( 'no-thanks-btn' ) }>
-						No thanks
+						{ __( 'Skip', 'full-site-editing' ) }
 					</Button>
 				) : (
 					<Button isTertiary={ true } onClick={ () => setCurrentCardIndex( cardIndex - 1 ) }>
-						Back
+						{ __( 'Back', 'full-site-editing' ) }
 					</Button>
 				) }
 
@@ -116,7 +117,9 @@ function CardNavigation( { cardIndex, lastCardIndex, onDismiss, setCurrentCardIn
 					isPrimary={ true }
 					onClick={ () => setCurrentCardIndex( cardIndex + 1 ) }
 				>
-					{ cardIndex === 0 ? "Let's start" : 'Next' }
+					{ cardIndex === 0
+						? __( 'Start Tour', 'full-site-editing' )
+						: __( 'Next', 'full-site-editing' ) }
 				</Button>
 			</div>
 		</>
@@ -136,7 +139,7 @@ function CardOverlayControls( { onMinimize, onDismiss, slideNumber } ) {
 		<div className="welcome-tour-card__overlay-controls">
 			<Flex>
 				<Button
-					aria-label="Minimize Tour"
+					aria-label={ __( 'Minimize Tour', 'full-site-editing' ) }
 					isPrimary
 					className="welcome-tour-card__minimize-icon"
 					icon={ minimize }
@@ -144,7 +147,7 @@ function CardOverlayControls( { onMinimize, onDismiss, slideNumber } ) {
 					onClick={ handleOnMinimize }
 				></Button>
 				<Button
-					aria-label="Close Tour"
+					aria-label={ __( 'Close Tour', 'full-site-editing' ) }
 					isPrimary
 					icon={ close }
 					iconSize={ 24 }
@@ -180,7 +183,7 @@ function TourRating() {
 			<p className="welcome-tour__end-text">Did you find this guide helpful?</p>
 			<div>
 				<Button
-					aria-label="Rate thumbs up"
+					aria-label={ __( 'Rate thumbs up', 'full-site-editing' ) }
 					className={ classNames( 'welcome-tour__end-icon', {
 						active: tourRating === 'thumbs-up',
 					} ) }
@@ -190,7 +193,7 @@ function TourRating() {
 					iconSize={ 24 }
 				/>
 				<Button
-					aria-label="Rate thumbs down"
+					aria-label={ __( 'Rate thumbs down', 'full-site-editing' ) }
 					className={ classNames( 'welcome-tour__end-icon', {
 						active: tourRating === 'thumbs-down',
 					} ) }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-content.js
@@ -73,7 +73,7 @@ function getTourContent() {
 		{
 			heading: __( 'Drag & drop', 'full-site-editing' ),
 			description: __(
-				'To move blocks around click and drag the handle around.',
+				'To move blocks around click and drag the handle.',
 				'full-site-editing'
 			),
 			imgSrc: moveBlock,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-content.js
@@ -72,10 +72,7 @@ function getTourContent() {
 		},
 		{
 			heading: __( 'Drag & drop', 'full-site-editing' ),
-			description: __(
-				'To move blocks around click and drag the handle.',
-				'full-site-editing'
-			),
+			description: __( 'To move blocks around click and drag the handle.', 'full-site-editing' ),
 			imgSrc: moveBlock,
 			animation: 'undo-button',
 		},

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-content.js
@@ -66,17 +66,14 @@ function getTourContent() {
 		},
 		{
 			heading: __( 'Undo any mistake', 'full-site-editing' ),
-			description: __(
-				"Simply click the Undo button if you've made a mistake.",
-				'full-site-editing'
-			),
+			description: __( "Click the Undo button if you've made a mistake.", 'full-site-editing' ),
 			imgSrc: undo,
 			animation: 'undo-button',
 		},
 		{
 			heading: __( 'Drag & drop', 'full-site-editing' ),
 			description: __(
-				'To move blocks around simply click and drag the handle around.',
+				'To move blocks around click and drag the handle around.',
 				'full-site-editing'
 			),
 			imgSrc: moveBlock,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
@@ -19,6 +19,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createPortal, useEffect, useState, useRef } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { __ } from '@wordpress/i18n';
 
 function LaunchWpcomWelcomeTour() {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
@@ -123,7 +124,7 @@ function WelcomeTourMinimized( { onMaximize, setJustMaximized, slideNumber } ) {
 	return (
 		<Button onClick={ handleOnMaximize } className="wpcom-editor-welcome-tour__resume-btn">
 			<Flex gap={ 13 }>
-				<p>Click to resume tutorial</p>
+				<p>{ __( 'Click to resume tutorial', 'full-site-editing' ) }</p>
 				<Icon icon={ maximize } size={ 24 } />
 			</Flex>
 		</Button>


### PR DESCRIPTION
## Changes proposed in this Pull Request

Let's update the copy and add translation functions around remaining strings!

<img width="405" alt="Screen Shot 2021-01-12 at 12 07 19 pm" src="https://user-images.githubusercontent.com/6458278/104256409-5078f580-54cf-11eb-903e-f8bfad0fbfe7.png">


## Testing instructions

Checkout this branch and run `yarn dev --sync` under `apps/editing-toolkit`

Add `define( 'SHOW_WELCOME_TOUR', true );` to your 0-sandbox.php

Sandbox a test site 

Clear the local storage for the test site domain (if your test site has already shown/dismissed the Welcome Tour modal)

Check that the copy changes look good

Check the copy we've wrapped in `__()`

Part of https://github.com/Automattic/wp-calypso/issues/48751
