### PR TITLE
Deduplicate cross-spawn

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10570,7 +10570,7 @@ cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@7.0.1, cross-spawn@^7.0.0:
+cross-spawn@7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
   integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
@@ -10596,7 +10596,7 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `cross-spawn` (done automatically with `npx yarn-deduplicate --packages cross-spawn`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> cross-spawn@7.0.1
< wp-calypso@0.17.0 -> chroma-js@2.1.0 -> ... -> cross-spawn@7.0.1
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> cross-spawn@7.0.1
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> cross-spawn@7.0.3
> wp-calypso@0.17.0 -> chroma-js@2.1.0 -> ... -> cross-spawn@7.0.3
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> cross-spawn@7.0.3
```

[Changelog](https://github.com/moxystudio/node-cross-spawn/blob/master/CHANGELOG.md)