### PR TITLE
Fixes cloud.jetpack.com with nav-unification enabled:

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -10,7 +10,7 @@
  * IMPORTANT: When adding to this file please also add the source file in a comment.
  */
 
-.is-nav-unification {
+.theme-default .is-nav-unification { // excludes theme-jetpack-cloud.
 	// breakpoint used in wp-admin
 	@media only screen and ( min-width: 782px ) {
 		// client/assets/stylesheets/shared/_variables.scss

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -159,7 +159,7 @@ class Site extends React.Component {
 						<div className="site__title">{ site.title }</div>
 						<div className="site__domain">
 							{ /* eslint-disable-next-line no-nested-ternary */ }
-							{ isEnabled( 'nav-unification' )
+							{ isEnabled( 'nav-unification' ) && ! isEnabled( 'jetpack-cloud' )
 								? site.domain
 								: this.props.homeLink
 								? translate( 'View %(domain)s', {

--- a/client/components/jetpack/sidebar/style.scss
+++ b/client/components/jetpack/sidebar/style.scss
@@ -1,5 +1,11 @@
+@import url( '//s1.wp.com/wp-includes/css/dashicons.css?v=20150727' ); // Used for switch-sites icon.
+
 // Menu links
 .sidebar__jetpack-cloud {
+
+	.current-site__switch-sites .button.is-borderless .gridicon {
+		top: 15px;
+	}
 
 	.sidebar__menu-link {
 		padding-top: 14px;

--- a/client/components/jetpack/sidebar/style.scss
+++ b/client/components/jetpack/sidebar/style.scss
@@ -3,7 +3,7 @@
 // Menu links
 .sidebar__jetpack-cloud {
 
-	.current-site__switch-sites .button.is-borderless .gridicon {
+	.current-site__switch-sites .button.is-borderless .dashicons-before {
 		top: 15px;
 	}
 

--- a/client/components/sidebar-navigation/index.jsx
+++ b/client/components/sidebar-navigation/index.jsx
@@ -20,7 +20,7 @@ import config from 'calypso/config';
 import './style.scss';
 
 function SidebarNavigation( { sectionTitle, children, toggleSidebar } ) {
-	if ( config.isEnabled( 'nav-unification' ) ) {
+	if ( config.isEnabled( 'nav-unification' ) && ! config.isEnabled( 'jetpack-cloud' ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes cloud.jetpack.com with nav-unification enabled:
- applies `nav-unification` styles only for `.theme-default`
- imports icon dependency and positions it for site-switcher
- reinstates SidebarNavigation only for jetpack-cloud while in mobile breakpoints

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* enable nav-unification (paYJgx-1af-p2)
* add `127.0.0.1 jetpack.cloud.localhost`to your “hosts” file
* `CALYPSO_ENV=jetpack-cloud-development yarn start`
* load `http://jetpack.cloud.localhost:3000/`
* inspect that the environment is usable, check also the mobile breakpoints
* now stop the process and run `yarn start` and go to `http://calypso.localhost:3000` everything should be normal

Before | After
-------|------
![](https://cln.sh/FjthD2+) | ![](https://cln.sh/PJOVF4+)

Fixes #48315