### PR TITLE
Deduplicate debug

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11035,14 +11035,7 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
-cssstyle@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.2.0.tgz#e4c44debccd6b7911ed617a4395e5754bba59992"
-  integrity sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==
-  dependencies:
-    cssom "~0.3.6"
-
-cssstyle@^2.2.0:
+cssstyle@^2.0.0, cssstyle@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
@@ -11243,17 +11236,24 @@ debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.1.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
   dependencies:
-    ms "^2.1.1"
+    ms "2.1.2"
 
 debug@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
   integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  dependencies:
+    ms "^2.1.1"
+
+debug@4.1.1, debug@~4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -11263,13 +11263,6 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
-  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
-  dependencies:
-    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `debug` (done automatically with `npx yarn-deduplicate --packages debug`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 ->  -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> @automattic/data-stores@1.0.0-alpha.1 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> @automattic/wp-babel-makepot@1.0.2 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> @babel/core@7.12.3 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> @typescript-eslint/eslint-plugin@4.12.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> @typescript-eslint/parser@4.12.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.2.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> babel-eslint@10.1.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> capture-website@1.0.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> eslint-plugin-jest@23.20.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> eslint@7.12.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> i18n-calypso-cli@1.0.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> i18n-calypso@5.0.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> nock@12.0.3 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> photon@3.0.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> debug@4.1.1
< wp-calypso@0.17.0 -> wpcom@6.0.0 -> ... -> debug@4.1.1
> wp-calypso@0.17.0 ->  -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> @automattic/data-stores@1.0.0-alpha.1 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> @automattic/wp-babel-makepot@1.0.2 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> @babel/core@7.12.3 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> @storybook/react@6.1.10 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> @typescript-eslint/eslint-plugin@4.12.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> @typescript-eslint/parser@4.12.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> @wordpress/jest-preset-default@6.2.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> babel-eslint@10.1.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> babel-jest@26.3.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> calypso-codemods@0.1.6 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> capture-website@1.0.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> eslint-plugin-jest@23.20.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> eslint@7.12.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> i18n-calypso-cli@1.0.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> i18n-calypso@5.0.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> jest@26.4.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> nock@12.0.3 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> photon@3.0.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> stylelint@13.7.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> webpack-dev-server@3.11.0 -> ... -> debug@4.2.0
> wp-calypso@0.17.0 -> wpcom@6.0.0 -> ... -> debug@4.2.0
```

[Changelog](https://github.com/visionmedia/debug/compare/4.2.0...4.1.1)