### PR TITLE
Enable seen counts in production for automatticians

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -24,11 +24,14 @@ import FollowButton from 'calypso/reader/follow-button';
 import { getPostsByKeys } from 'calypso/state/reader/posts/selectors';
 import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
 import PostBlocked from 'calypso/blocks/reader-post-card/blocked';
+import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 
 /**
  * Style dependencies
  */
 import './style.scss';
+import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
 
 class ReaderCombinedCardComponent extends React.Component {
 	static propTypes = {
@@ -203,6 +206,10 @@ function mapStateToProps( st, ownProps ) {
 		const postKeys = combinedCardPostKeyToKeys( ownProps.postKey, memoized );
 
 		return {
+			isWPForTeams:
+				isFeedWPForTeams( state, ownProps.postKey.feedId ) ||
+				isSiteWPForTeams( state, ownProps.postKey.blogId ),
+			teams: getReaderTeams( state ),
 			posts: getPostsByKeys( state, postKeys ),
 			postKeys,
 		};

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -26,12 +26,12 @@ import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
 import PostBlocked from 'calypso/blocks/reader-post-card/blocked';
 import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
 
 class ReaderCombinedCardComponent extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -8,7 +8,6 @@ import ReactDom from 'react-dom';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
-import config from 'calypso/config';
 
 /**
  * Internal dependencies
@@ -25,9 +24,12 @@ import ReaderFeaturedVideo from 'calypso/blocks/reader-featured-video';
 import ReaderCombinedCardPostPlaceholder from 'calypso/blocks/reader-combined-card/placeholders/post';
 import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
 import QueryReaderPost from 'calypso/components/data/query-reader-post';
+import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 
 class ReaderCombinedCardPost extends React.Component {
 	static propTypes = {
+		isWPForTeams: PropTypes.bool,
+		teams: PropTypes.array,
 		post: PropTypes.object,
 		streamUrl: PropTypes.string,
 		onClick: PropTypes.func,
@@ -35,6 +37,7 @@ class ReaderCombinedCardPost extends React.Component {
 	};
 
 	static defaultProps = {
+		teams: [],
 		showFeaturedAsset: true,
 	};
 
@@ -77,7 +80,7 @@ class ReaderCombinedCardPost extends React.Component {
 	};
 
 	render() {
-		const { post, streamUrl, isDiscover, isSelected, postKey } = this.props;
+		const { post, streamUrl, isDiscover, isSelected, postKey, teams, isWPForTeams } = this.props;
 		const isLoading = ! post || post._state === 'pending' || post._state === 'minimal';
 
 		if ( isLoading ) {
@@ -113,7 +116,7 @@ class ReaderCombinedCardPost extends React.Component {
 			recordPermalinkClick( 'timestamp_combined_card', post );
 		};
 
-		const isSeen = config.isEnabled( 'reader/seen-posts' ) && !! post.is_seen;
+		const isSeen = isEligibleForUnseen( teams, isWPForTeams ) && !! post.is_seen;
 		const classes = classnames( {
 			'reader-combined-card__post': true,
 			'is-selected': isSelected,

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -8,7 +8,6 @@ import { noop, truncate, get } from 'lodash';
 import classnames from 'classnames';
 import ReactDom from 'react-dom';
 import closest from 'component-closest';
-import config from 'calypso/config';
 
 /**
  * Internal Dependencies
@@ -37,6 +36,10 @@ import isReaderCardExpanded from 'calypso/state/selectors/is-reader-card-expande
  * Style dependencies
  */
 import './style.scss';
+import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
+import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
 
 class ReaderPostCard extends React.Component {
 	static propTypes = {
@@ -130,9 +133,11 @@ class ReaderPostCard extends React.Component {
 			isExpanded,
 			expandCard,
 			compact,
+			teams,
+			isWPForTeams,
 		} = this.props;
 
-		const isSeen = config.isEnabled( 'reader/seen-posts' ) && !! post.is_seen;
+		const isSeen = isEligibleForUnseen( teams, isWPForTeams ) && !! post.is_seen;
 		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY ) && ! compact;
 		const isGalleryPost = !! ( post.display_type & DisplayTypes.GALLERY ) && ! compact;
 		const isVideo = !! ( post.display_type & DisplayTypes.FEATURED_VIDEO ) && ! compact;
@@ -279,6 +284,10 @@ class ReaderPostCard extends React.Component {
 
 export default connect(
 	( state, ownProps ) => ( {
+		isWPForTeams:
+			isSiteWPForTeams( state, ownProps.site && ownProps.postKey.blogId ) ||
+			isFeedWPForTeams( state, ownProps.feed && ownProps.postKey.feedId ),
+		teams: getReaderTeams( state ),
 		isExpanded: isReaderCardExpanded( state, ownProps.postKey ),
 	} ),
 	{ expandCard: expandCardAction }

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -8,7 +8,6 @@ import page from 'page';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import config from 'calypso/config';
 
 /**
  * Internal dependencies
@@ -37,6 +36,9 @@ import {
 	requestMarkAsSeenBlog,
 	requestMarkAsUnseenBlog,
 } from 'calypso/state/reader/seen-posts/actions';
+import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
 
 /**
  * Style dependencies
@@ -240,7 +242,7 @@ class ReaderPostOptionsMenu extends React.Component {
 	};
 
 	render() {
-		const { post, site, feed, teams, translate, position, posts } = this.props;
+		const { post, site, feed, teams, translate, position, posts, isWPForTeams } = this.props;
 
 		if ( ! post ) {
 			return null;
@@ -302,14 +304,14 @@ class ReaderPostOptionsMenu extends React.Component {
 						/>
 					) }
 
-					{ config.isEnabled( 'reader/seen-posts' ) && post.is_seen && (
+					{ isEligibleForUnseen( teams, isWPForTeams ) && post.is_seen && (
 						<PopoverMenuItem onClick={ this.markAsUnSeen } icon="not-visible" itemComponent={ 'a' }>
 							{ size( posts ) > 0 && translate( 'Mark all as unseen' ) }
 							{ size( posts ) === 0 && translate( 'Mark as unseen' ) }
 						</PopoverMenuItem>
 					) }
 
-					{ config.isEnabled( 'reader/seen-posts' ) && ! post.is_seen && (
+					{ isEligibleForUnseen( teams, isWPForTeams ) && ! post.is_seen && (
 						<PopoverMenuItem onClick={ this.markAsSeen } icon="visible">
 							{ size( posts ) > 0 && translate( 'Mark all as seen' ) }
 							{ size( posts ) === 0 && translate( 'Mark as seen' ) }
@@ -361,6 +363,7 @@ export default connect(
 		const siteId = is_external ? null : site_ID;
 
 		return Object.assign(
+			{ isWPForTeams: isSiteWPForTeams( state, siteId ) || isFeedWPForTeams( state, feedId ) },
 			{ teams: getReaderTeams( state ) },
 			feedId > 0 && { feed: getFeed( state, feedId ) },
 			siteId > 0 && { site: getSite( state, siteId ) }

--- a/client/reader/a8c/main.jsx
+++ b/client/reader/a8c/main.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect, useDispatch } from 'react-redux';
-import config from 'calypso/config';
 
 /**
  * Internal dependencies
@@ -16,9 +15,11 @@ import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
 import { SECTION_A8C_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
 import { AUTOMATTIC_ORG_ID } from 'calypso/state/reader/organizations/constants';
 import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizations/selectors';
+import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
+import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 
 const A8CFollowing = ( props ) => {
-	const { translate } = props;
+	const { translate, teams } = props;
 	const dispatch = useDispatch();
 
 	const markAllAsSeen = ( feedsInfo ) => {
@@ -29,7 +30,7 @@ const A8CFollowing = ( props ) => {
 	return (
 		<Stream { ...props } shouldCombineCards={ false }>
 			<SectionHeader label={ translate( 'Followed A8C Sites' ) }>
-				{ config.isEnabled( 'reader/seen-posts' ) && (
+				{ isEligibleForUnseen( teams ) && (
 					<Button
 						compact
 						onClick={ () => markAllAsSeen( props.feedsInfo ) }
@@ -44,5 +45,6 @@ const A8CFollowing = ( props ) => {
 };
 
 export default connect( ( state ) => ( {
+	teams: getReaderTeams( state ),
 	feedsInfo: getReaderOrganizationFeedsInfo( state, AUTOMATTIC_ORG_ID ),
 } ) )( localize( A8CFollowing ) );

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -6,7 +6,6 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import { initial, flatMap, trim } from 'lodash';
 import { connect, useDispatch } from 'react-redux';
-import config from 'calypso/config';
 
 /**
  * Internal dependencies
@@ -26,6 +25,8 @@ import { SECTION_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
 import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizations/selectors';
 import { NO_ORG_ID } from 'calypso/state/reader/organizations/constants';
 import FollowingVoteBanner from './vote-banner';
+import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
+import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 
 /**
  * Style dependencies
@@ -52,7 +53,7 @@ const FollowingStream = ( props ) => {
 			] )
 		);
 	const placeholderText = getSearchPlaceholderText();
-	const { translate } = props;
+	const { translate, teams } = props;
 	const dispatch = useDispatch();
 	const voteBanner = <FollowingVoteBanner />;
 	const markAllAsSeen = ( feedsInfo ) => {
@@ -74,7 +75,7 @@ const FollowingStream = ( props ) => {
 			</CompactCard>
 			<BlankSuggestions suggestions={ suggestionList } />
 			<SectionHeader label={ translate( 'Followed Sites' ) }>
-				{ config.isEnabled( 'reader/seen-posts' ) && (
+				{ isEligibleForUnseen( teams ) && (
 					<Button
 						compact
 						onClick={ () => markAllAsSeen( props.feedsInfo ) }
@@ -93,5 +94,6 @@ const FollowingStream = ( props ) => {
 };
 
 export default connect( ( state ) => ( {
+	teams: getReaderTeams( state ),
 	feedsInfo: getReaderOrganizationFeedsInfo( state, NO_ORG_ID ),
 } ) )( SuggestionProvider( localize( FollowingStream ) ) );

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -10,6 +10,8 @@ import { trim } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { isSiteDescriptionBlocked } from 'calypso/reader/lib/site-description-blocklist';
 import { getUrlParts } from 'calypso/lib/url';
+import config from 'calypso/config';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 
 /**
  * Given a feed, site, or post: return the site url. return false if one could not be found.
@@ -91,4 +93,28 @@ export const getSiteAuthorName = ( site ) => {
 			trim( `${ siteAuthor.first_name || '' } ${ siteAuthor.last_name || '' }` ) );
 
 	return decodeEntities( authorFullName );
+};
+
+/**
+ * Check if user is eligible to use seen posts feature (unseen counts and mark as seen)
+ *
+ * @param {Array} teams list of reader teams
+ * @param {boolean} isWPForTeams id if exists
+ *
+ * @returns {boolean} whether or not the user can use the feature for the given site
+ */
+export const isEligibleForUnseen = ( teams, isWPForTeams = false ) => {
+	if ( ! config.isEnabled( 'reader/seen-posts' ) ) {
+		return false;
+	}
+
+	if ( isAutomatticTeamMember( teams ) ) {
+		return true;
+	} else if ( isWPForTeams ) {
+		// For now disable it even for p2 sites if the user is not an automattician
+		// return true;
+		return false;
+	}
+
+	return false;
 };

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -21,7 +21,10 @@ import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
 import Emojify from 'calypso/components/emojify';
 import { getUrlParts } from 'calypso/lib/url';
-import config from 'calypso/config';
+import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
+import { getReaderTeams } from 'calypso/state/reader/teams/selectors';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 class CrossPost extends PureComponent {
@@ -162,12 +165,12 @@ class CrossPost extends PureComponent {
 	};
 
 	render() {
-		const { post, postKey, site, feed, translate } = this.props;
+		const { post, postKey, site, feed, translate, teams, isWPForTeams } = this.props;
 		const { blogId: siteId, feedId } = postKey;
 		const siteIcon = get( site, 'icon.img' );
 		const feedIcon = get( feed, 'image' );
 
-		const isSeen = config.isEnabled( 'reader/seen-posts' ) && !! post.is_seen;
+		const isSeen = isEligibleForUnseen( teams, isWPForTeams ) && !! post.is_seen;
 		const articleClasses = classnames( {
 			reader__card: true,
 			'is-x-post': true,
@@ -229,6 +232,8 @@ export default connect( ( state, ownProps ) => {
 		feed = site && site.feed_ID ? getFeed( state, site.feed_ID ) : undefined;
 	}
 	return {
+		isWPForTeams: isSiteWPForTeams( state, blogId ) || isFeedWPForTeams( state, feedId ),
+		teams: getReaderTeams( state ),
 		feed,
 		site,
 	};

--- a/client/state/reader-ui/seen-posts/selectors.js
+++ b/client/state/reader-ui/seen-posts/selectors.js
@@ -9,6 +9,9 @@ import 'calypso/state/reader-ui/init';
  * @param state redux state
  * @returns {boolean} whether or not we have unseen posts
  */
+// eslint-disable-next-line no-unused-vars
 export const hasUnseen = ( state ) => {
-	return state.readerUi.hasUnseenPosts;
+	// force hide the unseen dot until we release the feature to all users, no easy way to show it just to a12s in prod
+	// return state.readerUi.hasUnseenPosts;
+	return false;
 };

--- a/client/state/selectors/is-feed-wpforteams.js
+++ b/client/state/selectors/is-feed-wpforteams.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+
+/**
+ * Check whether a feed is a wpforteams site (new p2)
+ *
+ * @param {object} state redux state
+ * @param {number} feedId feed identifier
+ *
+ * @returns {boolean} whether or not the feed is for a wpforteams site
+ */
+export default function isFeedWPForTeams( state, feedId ) {
+	const feed = getFeed( state, feedId );
+
+	if ( ! feed || ! feed.blog_ID ) {
+		return false;
+	}
+
+	return isSiteWPForTeams( state, feed.blog_ID );
+}

--- a/config/production.json
+++ b/config/production.json
@@ -115,7 +115,7 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/seen-posts": false,
+		"reader/seen-posts": true,
 		"reader/user-mention-suggestions": false,
 		"republicize": true,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Temporarily hide the Reader new posts bubble (since it is hard to just hide for a12s)
* Enable unseen counts and Mark as seen/unseen capability in production for a12s (it was available just in staging before)

#### Testing instructions
- For a12s accounts nothing should change, unseen counts and mark as seen/unseen buttons should be visible in dev env
- For non a8c accounts there should be no unseen count or mark as seen/buttons in the Reader in dev env