### PR TITLE
Editing Toolkit: Update to 2.8.18

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.8.17
+ * Version: 2.8.18
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.8.17' );
+define( 'PLUGIN_VERSION', '2.8.18' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -45,6 +45,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Domain Picker: Added "Use a domain I own" item (https://github.com/Automattic/wp-calypso/pull/48119)
 * Welcome Tour: update copy and add i18n wrappers (https://github.com/Automattic/wp-calypso/pull/48783)
 * Editor welcome tour: Remove editor welcome tour images and replace with images urls from the CDN (https://github.com/Automattic/wp-calypso/pull/48784)
+* Add "Renews at {renewal_price} / year" label to domain picker suggestion items (https://github.com/Automattic/wp-calypso/pull/48669)
+* Payment Methods: add PayPal to change payment method form (https://github.com/Automattic/wp-calypso/pull/48553)
+* eact-i18n: Upgrade @wordpress/hooks dependency version (https://github.com/Automattic/wp-calypso/pull/48664)
 
 = 2.8.17 =
 * Domain Picker: make items keyboard accessible (https://github.com/Automattic/wp-calypso/pull/48172)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.8.17
+Stable tag: 2.8.18
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,12 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.8.18 =
+* Focused Launch: Debounce domain search for focused launch on key press (https://github.com/Automattic/wp-calypso/pull/48535)
+* Domain Picker: Added "Use a domain I own" item (https://github.com/Automattic/wp-calypso/pull/48119)
+* Welcome Tour: update copy and add i18n wrappers (https://github.com/Automattic/wp-calypso/pull/48783)
+* Editor welcome tour: Remove editor welcome tour images and replace with images urls from the CDN (https://github.com/Automattic/wp-calypso/pull/48784)
 
 = 2.8.17 =
 * Domain Picker: make items keyboard accessible (https://github.com/Automattic/wp-calypso/pull/48172)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.8.17",
+	"version": "2.8.18",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Bumps version of Editing Toolkit to 2.8.18

### [Editing Toolkit changes included in this release](https://github.com/Automattic/wp-calypso/commits/trunk/apps/editing-toolkit)

- [x] Focused Launch: Debounce domain search for focused launch on key press (https://github.com/Automattic/wp-calypso/pull/48535) - @tjcafferkey 
- [x] Domain Picker: Added "Use a domain I own" item (https://github.com/Automattic/wp-calypso/pull/48119) - @tjcafferkey 
- [ ] Welcome Tour: update copy and add i18n wrappers (https://github.com/Automattic/wp-calypso/pull/48783) - @ramonjd
- [ ] Editor welcome tour: Remove editor welcome tour images and replace with images urls from the CDN (https://github.com/Automattic/wp-calypso/pull/48784) - @andrewserong 

### Other [changes](https://github.com/Automattic/wp-calypso/commits/trunk/packages) included from the [imported @automattic packages](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/tsconfig.json#L37-L46) and their imports

- [x] Add "Renews at {renewal_price} / year" label to domain picker suggestion items (https://github.com/Automattic/wp-calypso/pull/48669) - @StefanNieuwenhuis 
- [x] Payment Methods: add PayPal to change payment method form (https://github.com/Automattic/wp-calypso/pull/48553) - @sirbrillig 
- [ ] react-i18n: Upgrade @wordpress/hooks dependency version (https://github.com/Automattic/wp-calypso/pull/48664) - @yuliyan 

### Testing instructions

1. Load the diff on your sandbox (D55214-code) and confirm that the above changes work correctly
2. When a change has been tested to work correctly, please mark it as checked in the list above
3. Test that the new version of the plugin doesn't break Atomic sites by following the instructions in the "Atomic Testing" section at PCYsg-ly5-p2.
    - [ ] Tested on atomic 