### PR TITLE
Deduplicate enzyme-to-json

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12372,14 +12372,7 @@ enzyme-shallow-equal@^1.0.0, enzyme-shallow-equal@^1.0.1:
     has "^1.0.3"
     object-is "^1.0.2"
 
-enzyme-to-json@^3.3.0, enzyme-to-json@^3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.4.3.tgz#ed4386f48768ed29e2d1a2910893542c34e7e0af"
-  integrity sha512-jqNEZlHqLdz7OTpXSzzghArSS3vigj67IU/fWkPyl1c0TCj9P5s6Ze0kRkYZWNEoCqCR79xlQbigYlMx5erh8A==
-  dependencies:
-    lodash "^4.17.15"
-
-enzyme-to-json@^3.4.4:
+enzyme-to-json@^3.3.0, enzyme-to-json@^3.4.3, enzyme-to-json@^3.4.4:
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.4.4.tgz#b30726c59091d273521b6568c859e8831e94d00e"
   integrity sha512-50LELP/SCPJJGic5rAARvU7pgE3m1YaNj7JLM+Qkhl5t7PAs6fiyc8xzc50RnkKPFQCv0EeFVjEWdIFRGPWMsA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `enzyme-to-json` (done automatically with `npx yarn-deduplicate --packages enzyme-to-json`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 ->  -> ... -> enzyme-to-json@3.4.3
< wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> enzyme-to-json@3.4.3
< wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> enzyme-to-json@3.4.3
< wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> enzyme-to-json@3.4.3
> wp-calypso@0.17.0 ->  -> ... -> enzyme-to-json@3.4.4
> wp-calypso@0.17.0 -> @automattic/calypso-build@6.5.0 -> ... -> enzyme-to-json@3.4.4
> wp-calypso@0.17.0 -> calypso@0.17.0 -> ... -> enzyme-to-json@3.4.4
> wp-calypso@0.17.0 -> jest-enzyme@7.1.2 -> ... -> enzyme-to-json@3.4.4
```

[Changelog](https://github.com/adriantoine/enzyme-to-json/releases)