### PR TITLE
Nav-Unification: fix mobile submenus UX

### DIFF
--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -65,13 +65,13 @@ export const MySitesSidebarUnifiedMenu = ( {
 		<li>
 			<ExpandableSidebarMenu
 				onClick={ () => {
-					if ( isExternal( link ) ) {
-						// If the URL is external, page() will fail to replace state between different domains.
-						externalRedirect( link );
-						return;
-					}
-
 					if ( isWithinBreakpoint( '>660px' ) ) {
+						if ( isExternal( link ) ) {
+							// If the URL is external, page() will fail to replace state between different domains.
+							externalRedirect( link );
+							return;
+						}
+
 						// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
 						page( link );
 

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -28,6 +28,7 @@ import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import { isExternal } from 'calypso/lib/url';
 import { externalRedirect } from 'calypso/lib/route/path';
 import { itemLinkMatches } from '../sidebar/utils';
+import { isWithinBreakpoint } from '@automattic/viewport';
 
 export const MySitesSidebarUnifiedMenu = ( {
 	count,
@@ -64,18 +65,23 @@ export const MySitesSidebarUnifiedMenu = ( {
 		<li>
 			<ExpandableSidebarMenu
 				onClick={ () => {
-					if ( link ) {
-						if ( isExternal( link ) ) {
-							// If the URL is external, page() will fail to replace state between different domains.
-							externalRedirect( link );
-							return;
-						}
+					if ( isExternal( link ) ) {
+						// If the URL is external, page() will fail to replace state between different domains.
+						externalRedirect( link );
+						return;
+					}
+
+					if ( isWithinBreakpoint( '>660px' ) ) {
+						// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
 						page( link );
+
+						if ( ! sidebarCollapsed ) {
+							// Keep only current submenu open.
+							reduxDispatch( collapseAllMySitesSidebarSections() );
+						}
 					}
-					if ( ! sidebarCollapsed ) {
-						reduxDispatch( collapseAllMySitesSidebarSections() );
-						reduxDispatch( toggleSection( sectionId ) );
-					}
+
+					reduxDispatch( toggleSection( sectionId ) );
 				} }
 				expanded={ ! sidebarCollapsed && isExpanded }
 				title={ title }

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -28,7 +28,6 @@ import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import { isExternal } from 'calypso/lib/url';
 import { externalRedirect } from 'calypso/lib/route/path';
 import { itemLinkMatches } from '../sidebar/utils';
-import { isWithinBreakpoint } from '@automattic/viewport';
 
 export const MySitesSidebarUnifiedMenu = ( {
 	count,
@@ -65,7 +64,8 @@ export const MySitesSidebarUnifiedMenu = ( {
 		<li>
 			<ExpandableSidebarMenu
 				onClick={ () => {
-					if ( isWithinBreakpoint( '>660px' ) ) {
+					// @automattic/viewport doesn't have a breakpoint for medium (782px)
+					if ( window.innerWidth > 782 ) {
 						if ( isExternal( link ) ) {
 							// If the URL is external, page() will fail to replace state between different domains.
 							externalRedirect( link );

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -12,6 +12,7 @@ import React, { useEffect, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import page from 'page';
+import { isWithinBreakpoint } from '@automattic/viewport';
 
 /**
  * Internal dependencies
@@ -64,8 +65,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 		<li>
 			<ExpandableSidebarMenu
 				onClick={ () => {
-					// @automattic/viewport doesn't have a breakpoint for medium (782px)
-					if ( window.innerWidth > 782 ) {
+					if ( isWithinBreakpoint( '>782px' ) ) {
 						if ( isExternal( link ) ) {
 							// If the URL is external, page() will fail to replace state between different domains.
 							externalRedirect( link );

--- a/packages/viewport/README.md
+++ b/packages/viewport/README.md
@@ -67,6 +67,7 @@ Note: the above usage is more easily accomplished using the hooks and higher-ord
 
 - '<480px'
 - '<660px'
+- '<782px'
 - '<800px'
 - '<960px'
 - '<1040px'
@@ -74,6 +75,7 @@ Note: the above usage is more easily accomplished using the hooks and higher-ord
 - '<1400px'
 - '>480px'
 - '>660px'
+- '>782px'
 - '>800px'
 - '>960px'
 - '>1040px'

--- a/packages/viewport/src/index.js
+++ b/packages/viewport/src/index.js
@@ -72,6 +72,7 @@ function createMediaQueryList( { min, max } = {} ) {
 const mediaQueryLists = {
 	'<480px': createMediaQueryList( { max: 480 } ),
 	'<660px': createMediaQueryList( { max: 660 } ),
+	'<782px': createMediaQueryList( { max: 782 } ),
 	'<800px': createMediaQueryList( { max: 800 } ),
 	'<960px': createMediaQueryList( { max: 960 } ),
 	'<1040px': createMediaQueryList( { max: 1040 } ),
@@ -79,6 +80,7 @@ const mediaQueryLists = {
 	'<1400px': createMediaQueryList( { max: 1400 } ),
 	'>480px': createMediaQueryList( { min: 480 } ),
 	'>660px': createMediaQueryList( { min: 660 } ),
+	'>782px': createMediaQueryList( { min: 782 } ),
 	'>800px': createMediaQueryList( { min: 800 } ),
 	'>960px': createMediaQueryList( { min: 960 } ),
 	'>1040px': createMediaQueryList( { min: 1040 } ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* closes all sections only for > 782px
* leaves sections open in mobile < 782px

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* enable nav-unification (paYJgx-1af-p2)
* on calypso live, switch to a mobile breakpoint (<=660px), try navigating to a submenu. 
* clicking on a submenu header should not redirect to the respective section, it should only expand the submenu

Fixes #48709