### PR TITLE
Grey style appears when launching a free site

### DIFF
--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -35,7 +35,8 @@
 	margin-top: 25px;
 }
 
-.signup__step.is-plans .formatted-header__subtitle .button.is-borderless {
+.signup__step.is-plans .formatted-header__subtitle .button.is-borderless,
+.signup__step.is-plans-launch .formatted-header__subtitle .button.is-borderless {
 	padding: 0;
 	color: inherit;
 	font-size: inherit;
@@ -43,3 +44,4 @@
 	line-height: inherit;
 	text-decoration: underline;
 }
+


### PR DESCRIPTION
The button is grey and strange, and it's supposed to be white and inline

#### Changes proposed in this Pull Request

Change this:
<img width="1320" alt="Screenshot 2021-01-12 at 17 14 38" src="https://user-images.githubusercontent.com/82778/104336493-23dbd280-54fd-11eb-9c07-cdc2e2c96454.png">

The grey link should not look like that, it should look like this:
<img width="495" alt="Screenshot 2021-01-12 at 17 39 52" src="https://user-images.githubusercontent.com/82778/104336604-40780a80-54fd-11eb-8908-c8d6f062556e.png">


#### Testing instructions

1. Create a new free site
2. Launch it as a free site. The plans step should have a white button for free site.

Fixes #
