### PR TITLE
End the Free Plans Domain Upsell experiment

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -65,15 +65,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
-	freePlansDomainUpsell: {
-		datestamp: '20201210',
-		variations: {
-			test: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	newUsersWithFreePlan: {
 		datestamp: '20210107',
 		variations: {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -23,7 +23,7 @@ import {
 import wpcom from 'calypso/lib/wp';
 import guessTimezone from 'calypso/lib/i18n-utils/guess-timezone';
 import user from 'calypso/lib/user';
-import { abtest, getSavedVariations } from 'calypso/lib/abtest';
+import { getSavedVariations } from 'calypso/lib/abtest';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
 import {
@@ -806,7 +806,7 @@ export function isFreePlansDomainUpsellFulfilled( stepName, defaultDependencies,
 		return;
 	}
 
-	if ( isPaidPlan || domainItem || cartItem || 'test' !== abtest( 'freePlansDomainUpsell' ) ) {
+	if ( isPaidPlan || domainItem || cartItem ) {
 		const selectedDomainUpsellItem = null;
 		submitSignupStep(
 			{ stepName, selectedDomainUpsellItem, wasSkipped: true },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The test variation is winning

#### Testing instructions

1. Create a new free site
2. Launch the site from /home, selecting Free domain and Free plan
3. It should display a 4th step that looks like this:

<img width="999" alt="Screenshot 2021-01-12 at 17 45 13" src="https://user-images.githubusercontent.com/82778/104337286-fcd1d080-54fd-11eb-91fb-5928c95db251.png">

4. Create a new free site or use the Back button to get back to domains and plans steps
5. Launch it with a paid domain or a paid plan - the new 4th step should be skipped