### PR TITLE
Update default Titan feature flags

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -185,6 +185,7 @@
 		"memberships": true,
 		"support-user": true,
 		"titan/iframe-control-panel": true,
+		"titan/phase-2": true,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -154,7 +154,7 @@
 		"signup/wpforteams": true,
 		"site-indicator": true,
 		"support-user": true,
-		"titan/iframe-control-panel": true,
+		"titan/phase-2": true,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR enables the `titan/phase-2` feature flag in development and wpcalypso by default
* This PR also **disables** the `titan/iframe-control-panel` feature in the `wpcalypso` environment, as we want to test the existing flow before we enable the embedded control panel

#### Testing instructions

Navigate to the calypso.live branch for this PR. Verify that starting a Titan purchase flow for a domain requests the number of mailboxes you want.
If you have an existing Titan subscription, verify that trying to manage the domain doesn't iframe the Titan control panel.