### PR TITLE
Add Titan incoming urls handling

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -775,7 +775,7 @@ Undocumented.prototype.getTitanOrderProvisioningURL = function ( domain, fn ) {
 	);
 };
 
-Undocumented.prototype.getTitanIncomingURL = function ( mode, jwt, fn ) {
+Undocumented.prototype.getTitanDetailsForIncomingRedirect = function ( mode, jwt, fn ) {
 	return this.wpcom.req.get(
 		{
 			path: `/titan/${ encodeURIComponent( mode ) }`,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -778,7 +778,7 @@ Undocumented.prototype.getTitanOrderProvisioningURL = function ( domain, fn ) {
 Undocumented.prototype.getTitanDetailsForIncomingRedirect = function ( mode, jwt, fn ) {
 	return this.wpcom.req.get(
 		{
-			path: `/titan/${ encodeURIComponent( mode ) }`,
+			path: `/titan/redirect-info/${ encodeURIComponent( mode ) }`,
 			apiNamespace: 'wpcom/v2',
 		},
 		{ jwt },

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -775,6 +775,17 @@ Undocumented.prototype.getTitanOrderProvisioningURL = function ( domain, fn ) {
 	);
 };
 
+Undocumented.prototype.getTitanIncomingURL = function ( mode, jwt, fn ) {
+	return this.wpcom.req.get(
+		{
+			path: `/titan/${ encodeURIComponent( mode ) }`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ jwt },
+		fn
+	);
+};
+
 /**
  * Retrieves the auto login link to Titan's control panel.
  *

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -88,3 +88,7 @@ export function emailManagementEdit( siteName, domainName, slug, relativeTo = nu
 export function isUnderEmailManagementAll( path ) {
 	return path?.startsWith( emailManagementAllSitesPrefix + '/' );
 }
+
+export function emailManagementTitanExternal( environment, orderId, action ) {
+	return '/titan/' + environment + '/' + orderId + '/' + action;
+}

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -89,6 +89,6 @@ export function isUnderEmailManagementAll( path ) {
 	return path?.startsWith( emailManagementAllSitesPrefix + '/' );
 }
 
-export function emailManagementTitanExternal( environment, orderId, action ) {
-	return '/titan/' + environment + '/' + orderId + '/' + action;
+export function emailManagementTitanExternal( mode ) {
+	return '/titan/' + mode;
 }

--- a/client/my-sites/email/titan-redirector/controller.js
+++ b/client/my-sites/email/titan-redirector/controller.js
@@ -12,9 +12,9 @@ export default {
 	emailTitanAddMailboxes( pageContext, next ) {
 		pageContext.primary = (
 			<TitanRedirector
-				environment={ pageContext.params.environment }
-				linkType={ pageContext.params.linkType }
-				orderId={ pageContext.params.orderId }
+				mode={ pageContext.params.mode }
+				jwt={ pageContext.query.jwt }
+				redirectUrl={ pageContext.query.redirect_url }
 			/>
 		);
 

--- a/client/my-sites/email/titan-redirector/controller.js
+++ b/client/my-sites/email/titan-redirector/controller.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import TitanRedirector from 'calypso/my-sites/email/titan-redirector/titan-redirector';
+
+export default {
+	emailTitanAddMailboxes( pageContext, next ) {
+		pageContext.primary = (
+			<TitanRedirector
+				environment={ pageContext.params.environment }
+				linkType={ pageContext.params.linkType }
+				orderId={ pageContext.params.orderId }
+			/>
+		);
+
+		next();
+	},
+};

--- a/client/my-sites/email/titan-redirector/index.js
+++ b/client/my-sites/email/titan-redirector/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import controller from './controller';
+import * as paths from 'calypso/my-sites/email/paths';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+
+export default function () {
+	page(
+		paths.emailManagementTitanExternal( ':environment', ':orderId', ':linkType' ),
+		controller.emailTitanAddMailboxes,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/my-sites/email/titan-redirector/index.js
+++ b/client/my-sites/email/titan-redirector/index.js
@@ -12,7 +12,7 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	page(
-		paths.emailManagementTitanExternal( ':environment', ':orderId', ':linkType' ),
+		paths.emailManagementTitanExternal( ':mode' ),
 		controller.emailTitanAddMailboxes,
 		makeLayout,
 		clientRender

--- a/client/my-sites/email/titan-redirector/titan-redirector.jsx
+++ b/client/my-sites/email/titan-redirector/titan-redirector.jsx
@@ -16,12 +16,13 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { emailManagementNewTitanAccount } from 'calypso/my-sites/email/paths';
 import getSitesItems from 'calypso/state/selectors/get-sites-items';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, hasAllSitesList } from 'calypso/state/sites/selectors';
 import { SUPPORT_ROOT } from 'calypso/lib/url/support';
 import { addQueryArgs } from 'calypso/lib/route';
 import { login } from 'calypso/lib/paths';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import QuerySites from 'calypso/components/data/query-sites';
 
 class TitanRedirector extends Component {
 	state = {
@@ -43,7 +44,7 @@ class TitanRedirector extends Component {
 		}
 
 		wp.undocumented()
-			.getTitanIncomingURL( mode, jwt )
+			.getTitanDetailsForIncomingRedirect( mode, jwt )
 			.then(
 				( data ) => {
 					this.setState( {
@@ -67,8 +68,15 @@ class TitanRedirector extends Component {
 	}
 
 	render() {
-		const { translate, isLoggedIn, siteSlugs, currentQuery, currentRoute } = this.props;
-		const { loaded, hasError, error, action, domain, blogId, subscriptionId } = this.state;
+		const {
+			translate,
+			isLoggedIn,
+			siteSlugs,
+			currentQuery,
+			currentRoute,
+			hasAllSitesLoaded,
+		} = this.props;
+		const { loaded, hasError, action, domain, blogId, subscriptionId } = this.state;
 
 		if ( ! isLoggedIn ) {
 			const redirectTo = currentQuery ? addQueryArgs( currentQuery, currentRoute ) : currentRoute;
@@ -81,15 +89,22 @@ class TitanRedirector extends Component {
 			);
 		}
 
-		if ( ! loaded ) {
-			return <EmptyContent title={ translate( 'Redirecting…' ) } />;
+		if ( ! loaded || ! hasAllSitesLoaded ) {
+			return (
+				<React.Fragment>
+					{ ! hasAllSitesLoaded && <QuerySites allSites={ true } /> }
+					<EmptyContent title={ translate( 'Redirecting…' ) } />
+				</React.Fragment>
+			);
 		}
 
 		if ( loaded && hasError ) {
 			return (
 				<EmptyContent
-					title={ translate( 'An error occurred when decoding your request' ) }
-					line={ error }
+					title={ translate( "We couldn't process your link" ) }
+					line={ translate(
+						"We can't work out where this link is supposed to go. Can you check the website that sent you?"
+					) }
 					action={ translate( 'Contact support' ) }
 					actionURL={ SUPPORT_ROOT }
 				/>
@@ -99,8 +114,10 @@ class TitanRedirector extends Component {
 		if ( ! subscriptionId || ! blogId ) {
 			return (
 				<EmptyContent
-					title={ translate( 'No subscription found' ) }
-					line={ translate( 'Are you logged in with the appropriate user?' ) }
+					title={ translate( "We couldn't locate your account details" ) }
+					line={ translate(
+						'Please check that you purchased the Email subscription, as only the original purchaser can manage billing and add more accounts'
+					) }
 					action={ translate( 'Contact support' ) }
 					actionURL={ SUPPORT_ROOT }
 				/>
@@ -123,7 +140,7 @@ class TitanRedirector extends Component {
 		if ( ! redirectURL ) {
 			return (
 				<EmptyContent
-					title={ translate( 'Unknown request' ) }
+					title={ translate( 'Unexpected request' ) }
 					line={ translate(
 						"We received a request for %(action)s but we don't know how to handle that",
 						{ args: { action } }
@@ -151,5 +168,6 @@ export default connect( ( state ) => {
 		siteSlugs: fromPairs( siteSlugPairs ),
 		currentQuery: getCurrentQueryArguments( state ),
 		currentRoute: getCurrentRoute( state ),
+		hasAllSitesLoaded: hasAllSitesList( state ),
 	};
 } )( localize( TitanRedirector ) );

--- a/client/my-sites/email/titan-redirector/titan-redirector.jsx
+++ b/client/my-sites/email/titan-redirector/titan-redirector.jsx
@@ -4,27 +4,83 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-// import wp from 'calypso/lib/wp';
+import wp from 'calypso/lib/wp';
 import EmptyContent from 'calypso/components/empty-content';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 
 class TitanRedirector extends Component {
+	state = {
+		loaded: false,
+		hasError: false,
+		action: null,
+		orderId: null,
+		subscriptionId: null,
+		error: null,
+	};
+
 	componentDidMount() {
-		// call wp.undocumented().
+		const { mode, jwt } = this.props;
+
+		wp.undocumented()
+			.getTitanIncomingURL( mode, jwt )
+			.then(
+				( data ) => {
+					this.setState( {
+						hasError: false,
+						loaded: true,
+						action: data?.action,
+						orderId: data?.order_id,
+						subscriptionId: data?.subscription_id,
+					} );
+				},
+				( error ) => {
+					this.setState( {
+						hasError: true,
+						loaded: true,
+						error: error?.message,
+					} );
+				}
+			);
 	}
 
 	render() {
 		const { translate, isLoggedIn } = this.props;
+		const { loaded, hasError, error, action, subscriptionId } = this.state;
 
 		if ( ! isLoggedIn ) {
-			return <EmptyContent title={ translate( 'You need to be logged in to open this page' ) } />;
+			return (
+				<EmptyContent
+					title={ translate( 'You need to be logged in WordPress.com to open this page' ) }
+					action={ 'whaat' }
+				/>
+			);
 		}
 
-		return <EmptyContent title={ translate( 'Loading…' ) } />;
+		if ( ! loaded ) {
+			return <EmptyContent title={ translate( 'Loading…' ) } />;
+		}
+
+		if ( loaded && hasError ) {
+			return <EmptyContent title={ translate( 'Oops - an error occurred' ) } line={ error } />;
+		}
+
+		if ( ! subscriptionId ) {
+			return <EmptyContent title={ translate( 'No subscription found' ) } />;
+		}
+
+		if ( 'billing' === action ) {
+			return <div>You'll be redirected to: { getManagePurchaseUrlFor( '', subscriptionId ) }</div>;
+			// eslint-disable-next-line no-constant-condition,no-unreachable
+			if ( false ) {
+				page( getManagePurchaseUrlFor( '', subscriptionId ) );
+			}
+		}
 	}
 }
 

--- a/client/my-sites/email/titan-redirector/titan-redirector.jsx
+++ b/client/my-sites/email/titan-redirector/titan-redirector.jsx
@@ -129,6 +129,7 @@ class TitanRedirector extends Component {
 		let redirectURL;
 
 		switch ( action ) {
+			case 'renewOrder':
 			case 'billing':
 				redirectURL = getManagePurchaseUrlFor( siteSlug, subscriptionId );
 				break;

--- a/client/my-sites/email/titan-redirector/titan-redirector.jsx
+++ b/client/my-sites/email/titan-redirector/titan-redirector.jsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+// import wp from 'calypso/lib/wp';
+import EmptyContent from 'calypso/components/empty-content';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+
+class TitanRedirector extends Component {
+	componentDidMount() {
+		// call wp.undocumented().
+	}
+
+	render() {
+		const { translate, isLoggedIn } = this.props;
+
+		if ( ! isLoggedIn ) {
+			return <EmptyContent title={ translate( 'You need to be logged in to open this page' ) } />;
+		}
+
+		return <EmptyContent title={ translate( 'Loading…' ) } />;
+	}
+}
+
+export default connect( ( state ) => {
+	return {
+		isLoggedIn: isUserLoggedIn( state ),
+	};
+} )( localize( TitanRedirector ) );

--- a/client/my-sites/email/titan-redirector/titan-redirector.jsx
+++ b/client/my-sites/email/titan-redirector/titan-redirector.jsx
@@ -152,6 +152,8 @@ class TitanRedirector extends Component {
 		}
 
 		page.redirect( redirectURL );
+
+		return null;
 	}
 }
 

--- a/client/my-sites/email/titan-redirector/titan-redirector.jsx
+++ b/client/my-sites/email/titan-redirector/titan-redirector.jsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';
+import { map, fromPairs } from 'lodash-es';
 
 /**
  * Internal dependencies
@@ -13,6 +14,9 @@ import wp from 'calypso/lib/wp';
 import EmptyContent from 'calypso/components/empty-content';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
+import { emailManagementNewTitanAccount } from 'calypso/my-sites/email/paths';
+import getSitesItems from 'calypso/state/selectors/get-sites-items';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 class TitanRedirector extends Component {
 	state = {
@@ -21,11 +25,17 @@ class TitanRedirector extends Component {
 		action: null,
 		orderId: null,
 		subscriptionId: null,
+		blogId: null,
+		domain: null,
 		error: null,
 	};
 
 	componentDidMount() {
-		const { mode, jwt } = this.props;
+		const { mode, jwt, isLoggedIn } = this.props;
+
+		if ( ! isLoggedIn ) {
+			return;
+		}
 
 		wp.undocumented()
 			.getTitanIncomingURL( mode, jwt )
@@ -37,6 +47,8 @@ class TitanRedirector extends Component {
 						action: data?.action,
 						orderId: data?.order_id,
 						subscriptionId: data?.subscription_id,
+						blogId: data?.blog_id,
+						domain: data?.domain,
 					} );
 				},
 				( error ) => {
@@ -50,8 +62,8 @@ class TitanRedirector extends Component {
 	}
 
 	render() {
-		const { translate, isLoggedIn } = this.props;
-		const { loaded, hasError, error, action, subscriptionId } = this.state;
+		const { translate, isLoggedIn, siteSlugs } = this.props;
+		const { loaded, hasError, error, action, domain, blogId, subscriptionId } = this.state;
 
 		if ( ! isLoggedIn ) {
 			return (
@@ -67,25 +79,63 @@ class TitanRedirector extends Component {
 		}
 
 		if ( loaded && hasError ) {
-			return <EmptyContent title={ translate( 'Oops - an error occurred' ) } line={ error } />;
+			return (
+				<EmptyContent
+					title={ translate( 'An error occurred when decoding your request' ) }
+					line={ error }
+				/>
+			);
 		}
 
-		if ( ! subscriptionId ) {
+		if ( ! subscriptionId || ! blogId ) {
 			return <EmptyContent title={ translate( 'No subscription found' ) } />;
 		}
 
-		if ( 'billing' === action ) {
-			return <div>You'll be redirected to: { getManagePurchaseUrlFor( '', subscriptionId ) }</div>;
-			// eslint-disable-next-line no-constant-condition,no-unreachable
-			if ( false ) {
-				page( getManagePurchaseUrlFor( '', subscriptionId ) );
-			}
+		const siteSlug = siteSlugs[ blogId ];
+
+		let redirectURL;
+
+		switch ( action ) {
+			case 'billing':
+				redirectURL = getManagePurchaseUrlFor( siteSlug, subscriptionId );
+				break;
+			case 'buyMoreAccounts':
+				redirectURL = emailManagementNewTitanAccount( siteSlug, domain );
+				break;
+		}
+
+		if ( ! redirectURL ) {
+			return (
+				<EmptyContent
+					title={ translate( 'There is a problem with this page' ) }
+					line={ translate( 'Please contact our support team' ) }
+				/>
+			);
+		}
+
+		return (
+			<div>
+				You'll be redirected to: <a href={ redirectURL }>{ redirectURL }</a>
+			</div>
+		);
+
+		// eslint-disable-next-line no-constant-condition,no-unreachable
+		if ( false ) {
+			page.redirect( redirectURL );
 		}
 	}
 }
 
 export default connect( ( state ) => {
+	const sitesItems = getSitesItems( state );
+
+	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+	const siteSlugPairs = map( sitesItems, ( site ) => {
+		return [ site.ID, getSiteSlug( state, site.ID ) ];
+	} );
+
 	return {
 		isLoggedIn: isUserLoggedIn( state ),
+		siteSlugs: fromPairs( siteSlugPairs ),
 	};
 } )( localize( TitanRedirector ) );

--- a/client/sections.js
+++ b/client/sections.js
@@ -222,6 +222,12 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'titan-links',
+		paths: [ '/titan' ],
+		module: 'calypso/my-sites/email/titan-redirector',
+		enableLoggedOut: true,
+	},
+	{
 		name: 'email',
 		paths: [ '/email' ],
 		module: 'calypso/my-sites/email',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're going to get incoming URLs from Titan with JWT encoded payload. We'll need to decode the payload and redirect the clients to the specified action. The actions we'd like to support should be "billing" and "buyMoreAccounts"

It'll briefly show a screen like this while we decode the JWT via a REST API endpoint

<img width="647" alt="Screenshot 2021-01-13 at 15 37 25" src="https://user-images.githubusercontent.com/1355045/104459415-5ea14180-55b5-11eb-86b6-29652fe85ec3.png">

and then if you visit the page not logged in you'll see this:

<img width="998" alt="Screenshot 2021-01-13 at 15 36 58" src="https://user-images.githubusercontent.com/1355045/104459458-6cef5d80-55b5-11eb-8842-8ecc6c9e1142.png">

depends on D55232-code

#### Testing instructions

* Follow the instructions in D55232-code - the URL we'd like to test with are `/titan/staging` or `/titan/live` once we launch
