### PR TITLE
Partner Portal: Add masterbar navigation to switch between managing sites and the portal

### DIFF
--- a/client/components/jetpack/masterbar/index.jsx
+++ b/client/components/jetpack/masterbar/index.jsx
@@ -17,6 +17,7 @@ import Masterbar from 'calypso/layout/masterbar/masterbar';
 import ProfileDropdown from 'calypso/components/jetpack/profile-dropdown';
 import { useBreakpoint } from '@automattic/viewport-react';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import PortalNav from 'calypso/components/jetpack/portal-nav';
 
 /**
  * Style dependencies
@@ -57,6 +58,7 @@ const JetpackCloudMasterBar = () => {
 			>
 				<JetpackLogo size={ 28 } full={ ! isNarrow || isExteriorPage } />
 			</Item>
+			<PortalNav />
 			<Item className="masterbar__item-title">{ headerTitle }</Item>
 			<Item
 				tipTarget="me"

--- a/client/components/jetpack/portal-nav/index.tsx
+++ b/client/components/jetpack/portal-nav/index.tsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+import classnames from 'classnames';
+import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { isSectionNameEnabled } from 'calypso/sections-filter';
+import {
+	getCurrentPartner,
+	hasFetchedPartner,
+	isPartnerPortal,
+} from 'calypso/state/partner-portal/selectors';
+import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
+import SectionNav from 'calypso/components/section-nav';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import NavItem from 'calypso/components/section-nav/item';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	className: string;
+}
+
+export default function PortalNav( { className = '' }: Props ): ReactElement | null {
+	const translate = useTranslate();
+	const partnerFetched = useSelector( hasFetchedPartner );
+	const partner = useSelector( getCurrentPartner );
+	const isManagingSites = ! useSelector( isPartnerPortal );
+	const selectedText = isManagingSites
+		? translate( 'Manage Sites' )
+		: translate( 'Partner Portal' );
+	const show = partnerFetched && partner;
+
+	if ( ! isSectionNameEnabled( 'jetpack-cloud-partner-portal' ) ) {
+		return null;
+	}
+
+	return (
+		<>
+			<QueryJetpackPartnerPortalPartner />
+
+			{ show && (
+				<SectionNav
+					selectedText={ selectedText }
+					className={ classnames( 'portal-nav', className ) }
+				>
+					<NavTabs label={ translate( 'Portal' ) }>
+						<NavItem path="/" selected={ isManagingSites }>
+							{ translate( 'Manage Sites' ) }
+						</NavItem>
+						<NavItem path="/partner-portal" selected={ ! isManagingSites }>
+							{ translate( 'Partner Portal' ) }
+						</NavItem>
+					</NavTabs>
+				</SectionNav>
+			) }
+		</>
+	);
+}

--- a/client/components/jetpack/portal-nav/style.scss
+++ b/client/components/jetpack/portal-nav/style.scss
@@ -1,0 +1,20 @@
+.portal-nav {
+	flex: 1 1 180px;
+	max-width: 280px;
+	margin: 0;
+	background: none;
+	box-shadow: none;
+
+	.section-nav-tabs {
+		// Using a deprecated breakpoint in order to match the usage in the section component we are overriding.
+		@include breakpoint-deprecated( '>480px' ) {
+			&.is-dropdown {
+				margin: 0;
+			}
+		}
+	}
+
+	.section-nav-tab__link {
+		padding: 14px 16px 11px;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/select-partner-key/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/select-partner-key/index.tsx
@@ -57,7 +57,7 @@ export default function SelectPartnerKey(): ReactElement | null {
 					<Card>{ translate( 'You are not registered as a partner.' ) }</Card>
 				) }
 
-				{ keys.map( ( key ) => (
+				{ ! isFetching && keys.map( ( key ) => (
 					<Card key={ key.id } className="select-partner-key__card">
 						<div className="select-partner-key__key-name">{ key.name }</div>
 						<Button primary onClick={ () => dispatch( setActivePartnerKey( key.id ) ) }>

--- a/client/state/partner-portal/index.d.ts
+++ b/client/state/partner-portal/index.d.ts
@@ -19,6 +19,7 @@ export interface Partner {
 }
 
 export interface PartnerState {
+	hasFetched: boolean;
 	isFetching: boolean;
 	activePartnerKey: number;
 	current: Partner | null;

--- a/client/state/partner-portal/reducer/partner.ts
+++ b/client/state/partner-portal/reducer/partner.ts
@@ -13,27 +13,41 @@ import {
 	JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { combineReducers, withoutPersistence, withSchemaValidation } from 'calypso/state/utils';
-import filter from 'lodash/filter';
 
 export const initialState = {
+	hasFetched: false,
 	isFetching: false,
 	activePartnerKey: 0,
 	current: null,
 	error: '',
 };
 
-export const isFetching = withoutPersistence( ( state = initialState.isFetching, action: AnyAction ) => {
-	switch ( action.type ) {
-		case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST:
-			return true;
+export const hasFetched = withoutPersistence(
+	( state = initialState.isFetching, action: AnyAction ) => {
+		switch ( action.type ) {
+			case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_SUCCESS:
+			case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_FAILURE:
+				return true;
+		}
 
-		case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_SUCCESS:
-		case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_FAILURE:
-			return false;
+		return state;
 	}
+);
 
-	return state;
-} );
+export const isFetching = withoutPersistence(
+	( state = initialState.isFetching, action: AnyAction ) => {
+		switch ( action.type ) {
+			case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST:
+				return true;
+
+			case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_SUCCESS:
+			case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_FAILURE:
+				return false;
+		}
+
+		return state;
+	}
+);
 
 export const activePartnerKey = withSchemaValidation(
 	{
@@ -73,6 +87,7 @@ export const error = withoutPersistence( ( state = initialState.error, action: A
 } );
 
 export default combineReducers( {
+	hasFetched,
 	isFetching,
 	activePartnerKey,
 	current,

--- a/client/state/partner-portal/reducer/partner.ts
+++ b/client/state/partner-portal/reducer/partner.ts
@@ -13,6 +13,7 @@ import {
 	JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { combineReducers, withoutPersistence, withSchemaValidation } from 'calypso/state/utils';
+import filter from 'lodash/filter';
 
 export const initialState = {
 	isFetching: false,
@@ -21,20 +22,18 @@ export const initialState = {
 	error: '',
 };
 
-export const isFetching = withoutPersistence(
-	( state = initialState.isFetching, action: AnyAction ) => {
-		switch ( action.type ) {
-			case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST:
-				return true;
+export const isFetching = withoutPersistence( ( state = initialState.isFetching, action: AnyAction ) => {
+	switch ( action.type ) {
+		case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST:
+			return true;
 
-			case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_SUCCESS:
-			case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_FAILURE:
-				return false;
-		}
-
-		return state;
+		case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_SUCCESS:
+		case JETPACK_PARTNER_PORTAL_PARTNER_REQUEST_FAILURE:
+			return false;
 	}
-);
+
+	return state;
+} );
 
 export const activePartnerKey = withSchemaValidation(
 	{

--- a/client/state/partner-portal/selectors/index.js
+++ b/client/state/partner-portal/selectors/index.js
@@ -1,4 +1,8 @@
 /**
  * Internal dependencies
  */
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+
 export * from 'calypso/state/partner-portal/selectors/partner';
+
+export const isPartnerPortal = ( state ) => /^\/partner-portal(?:\/[^/]*)?/.test( getCurrentRoute( state ) );

--- a/client/state/partner-portal/selectors/index.js
+++ b/client/state/partner-portal/selectors/index.js
@@ -1,8 +1,14 @@
 /**
+ * External dependencies
+ */
+import startsWith from 'lodash/startsWith';
+
+/**
  * Internal dependencies
  */
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 export * from 'calypso/state/partner-portal/selectors/partner';
 
-export const isPartnerPortal = ( state ) => /^\/partner-portal(?:\/[^/]*)?/.test( getCurrentRoute( state ) );
+export const isPartnerPortal = ( state ) =>
+	startsWith( getCurrentRoute( state ), '/partner-portal' );

--- a/client/state/partner-portal/selectors/partner.ts
+++ b/client/state/partner-portal/selectors/partner.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import find from 'lodash/find';
-import flatMap from 'lodash/flatMap';
 
 /**
  * Internal dependencies

--- a/client/state/partner-portal/selectors/partner.ts
+++ b/client/state/partner-portal/selectors/partner.ts
@@ -2,19 +2,20 @@
  * External dependencies
  */
 import find from 'lodash/find';
+import flatMap from 'lodash/flatMap';
 
 /**
  * Internal dependencies
  */
-import { Partner, PartnerKey, PartnerPortalStore } from 'calypso/state/partner-portal';
+import { PartnerPortalStore } from 'calypso/state/partner-portal';
 // Required for modular state.
 import 'calypso/state/partner-portal/init';
 
-export function getActivePartnerKeyId( state: PartnerPortalStore ): number {
+export function getActivePartnerKeyId( state: PartnerPortalStore ) {
 	return state.partnerPortal.partner.activePartnerKey;
 }
 
-export function getActivePartnerKey( state: PartnerPortalStore ): PartnerKey | null {
+export function getActivePartnerKey( state: PartnerPortalStore ) {
 	const partner = getCurrentPartner( state );
 
 	if ( ! partner ) {
@@ -22,23 +23,23 @@ export function getActivePartnerKey( state: PartnerPortalStore ): PartnerKey | n
 	}
 
 	const keyId = getActivePartnerKeyId( state );
-	const partnerKey = find( partner.keys, ( key ) => key.id === keyId ) || null;
+	const partnerKey = find( partner.keys, ( key ) => key.id === keyId );
 
 	return partnerKey;
 }
 
-export function hasActivePartnerKey( state: PartnerPortalStore ): boolean {
+export function hasActivePartnerKey( state: PartnerPortalStore ) {
 	return !! getActivePartnerKey( state );
 }
 
-export function isFetchingPartner( state: PartnerPortalStore ): boolean {
+export function isFetchingPartner( state: PartnerPortalStore ) {
 	return state.partnerPortal.partner.isFetching;
 }
 
-export function getCurrentPartner( state: PartnerPortalStore ): Partner | null {
+export function getCurrentPartner( state: PartnerPortalStore ) {
 	return state.partnerPortal.partner.current;
 }
 
-export function getPartnerRequestError( state: PartnerPortalStore ): string {
+export function getPartnerRequestError( state: PartnerPortalStore ) {
 	return state.partnerPortal.partner.error;
 }

--- a/client/state/partner-portal/selectors/partner.ts
+++ b/client/state/partner-portal/selectors/partner.ts
@@ -6,15 +6,15 @@ import find from 'lodash/find';
 /**
  * Internal dependencies
  */
-import { PartnerPortalStore } from 'calypso/state/partner-portal';
+import { Partner, PartnerKey, PartnerPortalStore } from 'calypso/state/partner-portal';
 // Required for modular state.
 import 'calypso/state/partner-portal/init';
 
-export function getActivePartnerKeyId( state: PartnerPortalStore ) {
+export function getActivePartnerKeyId( state: PartnerPortalStore ): number {
 	return state.partnerPortal.partner.activePartnerKey;
 }
 
-export function getActivePartnerKey( state: PartnerPortalStore ) {
+export function getActivePartnerKey( state: PartnerPortalStore ): PartnerKey | null {
 	const partner = getCurrentPartner( state );
 
 	if ( ! partner ) {
@@ -22,23 +22,27 @@ export function getActivePartnerKey( state: PartnerPortalStore ) {
 	}
 
 	const keyId = getActivePartnerKeyId( state );
-	const partnerKey = find( partner.keys, ( key ) => key.id === keyId );
+	const partnerKey = find( partner.keys, ( key ) => key.id === keyId ) || null;
 
 	return partnerKey;
 }
 
-export function hasActivePartnerKey( state: PartnerPortalStore ) {
+export function hasActivePartnerKey( state: PartnerPortalStore ): boolean {
 	return !! getActivePartnerKey( state );
 }
 
-export function isFetchingPartner( state: PartnerPortalStore ) {
+export function hasFetchedPartner( state: PartnerPortalStore ): boolean {
+	return state.partnerPortal.partner.hasFetched;
+}
+
+export function isFetchingPartner( state: PartnerPortalStore ): boolean {
 	return state.partnerPortal.partner.isFetching;
 }
 
-export function getCurrentPartner( state: PartnerPortalStore ) {
+export function getCurrentPartner( state: PartnerPortalStore ): Partner | null {
 	return state.partnerPortal.partner.current;
 }
 
-export function getPartnerRequestError( state: PartnerPortalStore ) {
+export function getPartnerRequestError( state: PartnerPortalStore ): string {
 	return state.partnerPortal.partner.error;
 }


### PR DESCRIPTION
Context:
- Project thread: pbtFPC-Um-p2
- i4 designs: pbtFPC-103-p2

#### Changes proposed in this Pull Request

* Add a navigation to the masterbar in Calypso Green to switch between managing sites and the portal.

#### Testing instructions

* Checkout PR locally and run `yarn && yarn start-jetpack-cloud`.
* Open up the local env in your browser (the url should be listed in the yarn output when it's ready).
* If you have a partner key (please contact Infinity if you wish to test this) makes sure the navigation DOES appear:
 ![Screenshot 2021-01-12 at 21 44 21](https://user-images.githubusercontent.com/22746396/104366096-8777f700-5521-11eb-9aaf-4ca8fc377a07.png)
* If you don't have any partner keys, make sure the navigation DOES NOT appear.
  * If you already have keys you can fake the response by editing `getJetpackPartnerPortalPartners` in `client/lib/wpcom-undocumented/lib/undocumented.js` to return early: `return Promise.resolve([]);`
* Make sure toggling between "Manage Sites" and "Partner Portal" toggles the current page accordingly.
* Make sure the correct page is highlighted as active when navigating, refreshing etc.