### PR TITLE
Fix Titan navigation styles

### DIFF
--- a/client/my-sites/email/email-management/titan-management-nav/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-nav/index.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { CompactCard } from '@automattic/components';
 import {
 	emailManagementManageTitanAccount,
 	emailManagementNewTitanAccount,
@@ -24,6 +23,11 @@ import { isEnabled } from 'calypso/config';
 import SectionHeader from 'calypso/components/section-header';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
+
+/**
+ * Style
+ */
+import './style.scss';
 
 class TitanManagementNav extends React.Component {
 	static propTypes = {
@@ -128,16 +132,15 @@ class TitanManagementNav extends React.Component {
 			},
 			comment: '%(domainName)s is a domain name, e.g. example.com',
 		};
+
 		return (
-			<div>
+			<div className="titan-management-nav">
 				<SectionHeader label={ translate( 'Titan Mail: %(domainName)s', translateArgs ) } />
-				<CompactCard>
-					<VerticalNav>
-						{ this.renderTitanManagementLink() }
-						{ this.renderPurchaseManagementLink() }
-						{ this.renderAddMailboxesLink() }
-					</VerticalNav>
-				</CompactCard>
+				<VerticalNav>
+					{ this.renderTitanManagementLink() }
+					{ this.renderPurchaseManagementLink() }
+					{ this.renderAddMailboxesLink() }
+				</VerticalNav>
 			</div>
 		);
 	}

--- a/client/my-sites/email/email-management/titan-management-nav/style.scss
+++ b/client/my-sites/email/email-management/titan-management-nav/style.scss
@@ -1,0 +1,3 @@
+.titan-management-nav .vertical-nav {
+	margin-top: 0;
+}

--- a/client/my-sites/email/email-management/titan-management-nav/style.scss
+++ b/client/my-sites/email/email-management/titan-management-nav/style.scss
@@ -1,4 +1,5 @@
 .titan-management-nav .vertical-nav {
+	margin-bottom: 1em;
 	margin-top: 0;
 
 	.vertical-nav-item span {

--- a/client/my-sites/email/email-management/titan-management-nav/style.scss
+++ b/client/my-sites/email/email-management/titan-management-nav/style.scss
@@ -1,3 +1,7 @@
 .titan-management-nav .vertical-nav {
 	margin-top: 0;
+
+	.vertical-nav-item span {
+		color: var( --color-neutral-90 );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR improves some of the styles that were added in PR #48781, notably by removing a wrapping `CompactCard` which was called out in [this comment](https://github.com/Automattic/wp-calypso/pull/48781#issuecomment-758513520), but I never pushed up the relevant commit 🤦 
* The PR also uses the same text colour as the main domain management menu and introduces some trailing space to improve the display when viewed via `/email/<site>` and multiple domains have email enabled.

#### Testing instructions

* Try to manage Titan Email for a domain where it is configured (you may need to purchase a subscription if you don't have one)
* The menu items should be flush with the "Titan Mail" header (as opposed to having the nav items within a card)
* The text of the menu items should be a dark grey (and not a blue-ish colour)