### PR TITLE
Help: Remove unused feature flag

### DIFF
--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -42,7 +42,7 @@ export function help( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Help', { textOnly: true } ) ) );
 
-	context.primary = <HelpComponent isCoursesEnabled={ config.isEnabled( 'help/courses' ) } />;
+	context.primary = <HelpComponent />;
 	next();
 }
 

--- a/client/me/help/index.js
+++ b/client/me/help/index.js
@@ -27,14 +27,12 @@ export default function () {
 		);
 	}
 
-	if ( config.isEnabled( 'help/courses' ) ) {
-		page(
-			'/help/courses',
-			helpController.loggedOut,
-			sidebar,
-			helpController.courses,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		'/help/courses',
+		helpController.loggedOut,
+		sidebar,
+		helpController.courses,
+		makeLayout,
+		clientRender
+	);
 }

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -43,7 +43,6 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": false,
 		"help": true,
-		"help/courses": true,
 		"inline-help": true,
 		"ive/use-external-assignment": false,
 		"jetpack/api-cache": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -37,7 +37,6 @@
 		"gdpr-banner": true,
 		"google-my-business": false,
 		"help": true,
-		"help/courses": true,
 		"inline-help": true,
 		"ive/use-external-assignment": false,
 		"jetpack/concierge-sessions": false,

--- a/config/development.json
+++ b/config/development.json
@@ -77,7 +77,6 @@
 		"gutenboarding/new-launch-mobile": true,
 		"gutenboarding/show-vertical-input": false,
 		"help": true,
-		"help/courses": true,
 		"home/layout-dev": true,
 		"inline-help": true,
 		"i18n/community-translator": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -49,7 +49,6 @@
 		"gutenboarding/new-launch-mobile": true,
 		"happychat": false,
 		"help": true,
-		"help/courses": true,
 		"inline-help": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,

--- a/config/production.json
+++ b/config/production.json
@@ -46,7 +46,6 @@
 		"gutenboarding/new-launch-mobile": true,
 		"happychat": true,
 		"help": true,
-		"help/courses": true,
 		"inline-help": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,7 +51,6 @@
 		"gutenboarding/new-launch-mobile": true,
 		"happychat": true,
 		"help": true,
-		"help/courses": true,
 		"inline-help": true,
 		"i18n/empathy-mode": true,
 		"ive/use-external-assignment": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -59,7 +59,6 @@
 		"gutenboarding/new-launch-mobile": true,
 		"happychat": true,
 		"help": true,
-		"help/courses": true,
 		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"ive/use-external-assignment": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Following up on #48222 this removes the `help/courses` feature flag which was set to `true` in all environments.

#### Testing instructions

* Switch to this PR.
* Make sure nothing breaks in `/help`, `/help/courses`, or elsewhere in Calypso as a result of removing the feature flag