### PR TITLE
Plugins: Add support content to single plugin page view

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -39,7 +39,7 @@ import { findFirstSimilarPlanKey } from 'calypso/lib/plans';
 import { isBusiness, isEcommerce, isEnterprise } from 'calypso/lib/products-values';
 import { addSiteFragment } from 'calypso/lib/route';
 import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { isAutomatedTransferActive } from 'calypso/state/automated-transfer/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -149,6 +149,22 @@ export class PluginMeta extends Component {
 			! this.props.selectedSite.jetpack && includes( installedPlugins, this.props.plugin.name )
 		);
 	};
+
+	renderSupportedFlag() {
+		const supportedAuthors = [ 'Automattic', 'WooCommerce' ];
+		if (
+			this.props.isJetpackSite ||
+			supportedAuthors.indexOf( this.props.plugin.author_name ) < 0
+		) {
+			return;
+		}
+
+		return (
+			<div className="plugin-meta__supported-flag">
+				{ this.props.translate( 'Supported by WordPress.com' ) }
+			</div>
+		);
+	}
 
 	renderActions() {
 		if ( ! this.props.selectedSite ) {
@@ -559,7 +575,9 @@ export class PluginMeta extends Component {
 								isPlaceholder={ this.props.isPlaceholder }
 							/>
 							{ this.renderName() }
-							<div className="plugin-meta__meta">{ this.renderAuthorUrl() }</div>
+							<div className="plugin-meta__meta">
+								{ this.renderAuthorUrl() } { this.renderSupportedFlag() }
+							</div>
 						</div>
 						{ ! this.props.calypsoify && this.renderActions() }
 					</div>
@@ -639,6 +657,7 @@ const mapStateToProps = ( state, { plugin, sites } ) => {
 		isVipSite: isVipSite( state, siteId ),
 		slug: getSiteSlug( state, siteId ),
 		pluginsOnSites: getPluginOnSites( state, siteIds, plugin.slug ),
+		isJetpackSite: isJetpackSite( state, siteId ),
 	};
 };
 

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -152,16 +152,17 @@ export class PluginMeta extends Component {
 
 	renderSupportedFlag() {
 		const supportedAuthors = [ 'Automattic', 'WooCommerce' ];
+		const { plugin, translate } = this.props;
 		if (
 			this.props.isJetpackSite ||
-			supportedAuthors.indexOf( this.props.plugin.author_name ) < 0
+			! supportedAuthors.find( ( author ) => author === plugin.author_name )
 		) {
 			return;
 		}
 
 		return (
 			<div className="plugin-meta__supported-flag">
-				{ this.props.translate( 'Supported by WordPress.com' ) }
+				{ translate( 'Supported by WordPress.com' ) }
 			</div>
 		);
 	}

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -86,6 +86,11 @@
 	color: transparent !important;
 }
 
+.plugin-meta__supported-flag {
+	display: inline;
+	margin-left: 12px;
+}
+
 .plugin-meta__actions {
 	border-top: 1px solid var( --color-neutral-0 );
 	flex-grow: 1;

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -25,6 +25,11 @@ import './style.scss';
 class PluginSections extends React.Component {
 	static displayName = 'PluginSections';
 
+	constructor( props ) {
+		super( props );
+		this.descriptionContent = React.createRef();
+	}
+
 	state = {
 		selectedSection: false,
 		readMore: false,
@@ -46,8 +51,8 @@ class PluginSections extends React.Component {
 	}
 
 	calculateDescriptionHeight() {
-		if ( this.refs.content ) {
-			const node = this.refs.content;
+		if ( this.descriptionContent ) {
+			const node = this.descriptionContent.current;
 			if ( node && node.offsetHeight && node.offsetHeight !== this.state.descriptionHeight ) {
 				this.setState( { descriptionHeight: node.offsetHeight } );
 			}
@@ -109,7 +114,7 @@ class PluginSections extends React.Component {
 			},
 			{
 				key: 'faq',
-				title: this.props.translate( 'Support', {
+				title: this.props.translate( 'FAQs', {
 					context: 'Navigation item',
 					textOnly: true,
 				} ),
@@ -212,7 +217,7 @@ class PluginSections extends React.Component {
 				</div>
 				<Card>
 					<div
-						ref="content"
+						ref={ this.descriptionContent }
 						className={ contentClasses }
 						// Sanitized in client/lib/plugins/utils.js with sanitizeHtml
 						dangerouslySetInnerHTML={ {

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -107,6 +107,13 @@ class PluginSections extends React.Component {
 					textOnly: true,
 				} ),
 			},
+			{
+				key: 'faq',
+				title: this.props.translate( 'Support', {
+					context: 'Navigation item',
+					textOnly: true,
+				} ),
+			},
 		];
 	};
 

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -16,6 +16,8 @@ import { Card } from '@automattic/components';
 import SectionNav from 'calypso/components/section-nav';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import NavItem from 'calypso/components/section-nav/item';
+import ExternalLink from 'calypso/components/external-link';
+import safeProtocolUrl from 'calypso/lib/safe-protocol-url';
 
 /**
  * Style dependencies
@@ -122,6 +124,49 @@ class PluginSections extends React.Component {
 		];
 	};
 
+	getWpcomSupportContent = () => {
+		const supportedAuthors = [ 'Automattic', 'WooCommerce' ];
+		const { translate, plugin } = this.props;
+
+		if ( supportedAuthors.indexOf( plugin.author_name ) > -1 ) {
+			return;
+		}
+
+		const linkToAuthor = (
+			<ExternalLink href={ safeProtocolUrl( plugin.author_url ) } target="_blank">
+				{ plugin.author_url }
+			</ExternalLink>
+		);
+
+		const linkToSupportForum = (
+			<ExternalLink
+				href={ safeProtocolUrl( 'https://wordpress.org/support/plugin/' + plugin.slug ) }
+				target="_blank"
+			>
+				{ 'https://wordpress.org/support/plugin/' + plugin.slug }
+			</ExternalLink>
+		);
+
+		return (
+			<div className="plugin-sections__support">
+				<h3>{ translate( 'Support' ) }</h3>
+				<p>
+					{ translate(
+						'Support for this plugin is provided by the plugin author. You may find additional documentation at the following websites:'
+					) }
+				</p>
+				<ul>
+					<li>
+						<span>{ translate( 'Author website:' ) }</span> { linkToAuthor }
+					</li>
+					<li>
+						<span>{ translate( 'Support forum:' ) }</span> { linkToSupportForum }
+					</li>
+				</ul>
+			</div>
+		);
+	};
+
 	getSelected = () => {
 		return this.state.selectedSection || this.getDefaultSection();
 	};
@@ -216,6 +261,7 @@ class PluginSections extends React.Component {
 					</SectionNav>
 				</div>
 				<Card>
+					{ 'faq' === this.getSelected() && this.props.isWpcom && this.getWpcomSupportContent() }
 					<div
 						ref={ this.descriptionContent }
 						className={ contentClasses }

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -134,7 +134,7 @@ class PluginSections extends React.Component {
 
 		const linkToAuthor = (
 			<ExternalLink href={ safeProtocolUrl( plugin.author_url ) } target="_blank">
-				{ plugin.author_url }
+				{ translate( 'Author website' ) }
 			</ExternalLink>
 		);
 
@@ -143,7 +143,7 @@ class PluginSections extends React.Component {
 				href={ safeProtocolUrl( 'https://wordpress.org/support/plugin/' + plugin.slug ) }
 				target="_blank"
 			>
-				{ 'https://wordpress.org/support/plugin/' + plugin.slug }
+				{ translate( 'Support forum' ) }
 			</ExternalLink>
 		);
 
@@ -152,15 +152,15 @@ class PluginSections extends React.Component {
 				<h3>{ translate( 'Support' ) }</h3>
 				<p>
 					{ translate(
-						'Support for this plugin is provided by the plugin author. You may find additional documentation at the following websites:'
+						'Support for this plugin is provided by the plugin author. You may find additional documentation here:'
 					) }
 				</p>
 				<ul>
 					<li>
-						<span>{ translate( 'Author website:' ) }</span> { linkToAuthor }
+						<span>{ linkToAuthor }</span>
 					</li>
 					<li>
-						<span>{ translate( 'Support forum:' ) }</span> { linkToSupportForum }
+						<span>{ linkToSupportForum }</span>
 					</li>
 				</ul>
 			</div>

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -64,6 +64,22 @@
 	}
 }
 
+.plugin-sections__support {
+	margin-bottom: 16px;
+	padding-bottom: 16px;
+	border-bottom: 1px solid var( --color-border-subtle );
+	font-size: $font-body-small;
+
+	h3 {
+		font-weight: bold;
+		margin-bottom: 16px;
+	}
+
+	span {
+		font-weight: bold;
+	}
+}
+
 .plugin-sections__read-more {
 	text-align: center;
 }

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -74,10 +74,6 @@
 		font-weight: bold;
 		margin-bottom: 16px;
 	}
-
-	span {
-		font-weight: bold;
-	}
 }
 
 .plugin-sections__read-more {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a supported flag to plugin meta for WP.com sites
* Add the FAQs as some preliminary support as a tab for WP.com users
* Add a support section to the top of the FAQs to note that users can find support at the author website for third-party plugins.

**Before**

<img width="755" alt="Screen Shot 2021-01-13 at 11 33 28 AM" src="https://user-images.githubusercontent.com/2124984/104481451-ce063980-5593-11eb-93aa-acc8bacaedfd.png">

<img width="741" alt="Screen Shot 2021-01-20 at 3 51 28 PM" src="https://user-images.githubusercontent.com/2124984/105233105-62920e00-5b37-11eb-9ea1-66da447c1036.png">

**After**

<img width="747" alt="Screen Shot 2021-01-13 at 11 33 12 AM" src="https://user-images.githubusercontent.com/2124984/104481466-d3fc1a80-5593-11eb-8125-2af316c93b38.png">

<img width="740" alt="Screen Shot 2021-01-20 at 3 52 45 PM" src="https://user-images.githubusercontent.com/2124984/105233228-8c4b3500-5b37-11eb-82f8-07612236c438.png">

#### Testing instructions

* Switch to this PR and navigate to `/plugins`
* Look at individual plugin pages for both Automattic-supported and third-party plugins
* Check out the changes on an Atomic site (should be redirected to wp-admin), Simple site with multiple plan types, and Jetpack site.