### PR TITLE
Jetpack Cloud: Fix Pricing page shown twice in a row

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card-button/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card-button/index.tsx
@@ -36,6 +36,7 @@ const JetpackFreeCardButton: FC< JetpackFreeCardButtonProps > = ( {
 	urlQueryArgs,
 } ) => {
 	const translate = useTranslate();
+	const isSiteinContext = !! siteId;
 	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
 	const onClickTrack = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
 		site_id: siteId || undefined,
@@ -43,9 +44,10 @@ const JetpackFreeCardButton: FC< JetpackFreeCardButtonProps > = ( {
 
 	// Jetpack Connect flow uses `url` instead of `site` as the query parameter for a site URL
 	const { site: url, ...restQueryArgs } = urlQueryArgs;
-	const startHref = isJetpackCloud()
-		? addQueryArgs( { url, ...restQueryArgs }, `https://wordpress.com${ JPC_PATH_BASE }` )
-		: wpAdminUrl || JPC_PATH_BASE;
+	const startHref =
+		isJetpackCloud() && ! isSiteinContext
+			? addQueryArgs( { url, ...restQueryArgs }, `https://wordpress.com${ JPC_PATH_BASE }` )
+			: wpAdminUrl || JPC_PATH_BASE;
 	return (
 		<Button primary={ primary } className={ className } href={ startHref } onClick={ onClickTrack }>
 			{ label || translate( 'Start for free' ) }

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -24,8 +24,8 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 		page.redirect( addQueryArgs( urlQueryArgs, `/pricing` ) );
 	}
 
-	if ( pathname === '/pricing' && siteFromUrl ) {
-		page.redirect( addQueryArgs( urlQueryArgs, `/plans/${ siteFromUrl }` ) );
+	if ( /\/(pricing|plans)$/.test( pathname ) && siteFromUrl ) {
+		page.redirect( addQueryArgs( urlQueryArgs, `${ pathname }/${ siteFromUrl }` ) );
 	}
 
 	context.store.dispatch( hideMasterbar() );

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -15,11 +15,16 @@ import { addQueryArgs } from 'calypso/lib/route';
 
 export function jetpackPricingContext( context: PageJS.Context, next: () => void ): void {
 	const urlQueryArgs = context.query;
+	const { site: siteFromUrl, ...restQueryArgs } = urlQueryArgs;
 	const { locale } = context.params;
 
 	if ( locale ) {
 		context.store.dispatch( setLocale( locale ) );
 		page.redirect( addQueryArgs( urlQueryArgs, `/pricing` ) );
+	}
+
+	if ( siteFromUrl ) {
+		page.redirect( addQueryArgs( restQueryArgs, `/plans/${ siteFromUrl }` ) );
 	}
 
 	context.store.dispatch( hideMasterbar() );

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -14,8 +14,9 @@ import { setLocale } from 'calypso/state/ui/language/actions';
 import { addQueryArgs } from 'calypso/lib/route';
 
 export function jetpackPricingContext( context: PageJS.Context, next: () => void ): void {
+	const { pathname } = context;
 	const urlQueryArgs = context.query;
-	const { site: siteFromUrl, ...restQueryArgs } = urlQueryArgs;
+	const { site: siteFromUrl } = urlQueryArgs;
 	const { locale } = context.params;
 
 	if ( locale ) {
@@ -23,8 +24,8 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 		page.redirect( addQueryArgs( urlQueryArgs, `/pricing` ) );
 	}
 
-	if ( siteFromUrl ) {
-		page.redirect( addQueryArgs( restQueryArgs, `/plans/${ siteFromUrl }` ) );
+	if ( pathname === '/pricing' && siteFromUrl ) {
+		page.redirect( addQueryArgs( urlQueryArgs, `/plans/${ siteFromUrl }` ) );
 	}
 
 	context.store.dispatch( hideMasterbar() );

--- a/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/products-grid-i5/index.tsx
@@ -29,7 +29,6 @@ import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import MoreInfoBox from '../more-info-box';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
-import getSiteId from 'calypso/state/selectors/get-site-id';
 
 /**
  * Type dependencies
@@ -58,7 +57,7 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 	const siteId = useSelector( getSelectedSiteId );
 	// If a site is passed by URL and the site is found in the app's state, we will assume the site
 	// is connected, and thus, we don't need to show the Jetpack Free card.
-	const isUrlSiteConnected = useSelector( ( state ) => getSiteId( state, urlQueryArgs?.site ) );
+	const isSiteInContext = !! siteId;
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const currentPlanSlug =
 		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
@@ -195,7 +194,7 @@ const ProductsGridI5: React.FC< ProductsGridProps > = ( {
 					) ) }
 				</ul>
 				<div className="products-grid-i5__free">
-					{ ( isInConnectFlow || ( isInJetpackCloud && ! isUrlSiteConnected ) ) && (
+					{ ( isInConnectFlow || ( isInJetpackCloud && ! isSiteInContext ) ) && (
 						<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
 					) }
 				</div>


### PR DESCRIPTION
This PR is a fix for the issue referenced here: p8oabR-B4-p2#comment-4837

Copied directly from the report:
> "With Jp already connected (free plan, in that case), if the user chooses to explore the “Plans” link in the Jp Dashboard toolbar, they will be sent to a plans page on cloud.jetpack.com/pricing.
> If the user selects a free plan again, instead of being returned to their site, they are then sent to what looks like the same plans page,

### Changes proposed in this Pull Request

On Jetpack Cloud Pricing page (`cloud.jetpack.com/pricing`):
* If `?site=:site` url query param is found in the `/pricing` route, redirect to `/pricing/:site` which loads the selected site into context (in redux state).
* Show Jetpack Free card if inConnectFlow or if there is no site in context.
* Make Jetpack Free button point to connect flow (`/jetpack/connect/`) if site is not in context, otherwise we assume jetpack is connected and point it back to the site wp-admin jetpack dashboard.

### Testing instructions

1. Checkout this PR and run Calypso (`yarn start`) and Jetpack Cloud (`yarn start-jetpack-cloud-p`) concurrently.
2. You can create a jurassic.ninja site and click "Setup Jetpack" button and "Approve" to connect.  Once connected you will be routed to: `https://cloud.jetpack.com/pricing?site=:SITE&source=jetpack-connect-plans`
2. In the URL, change `https://cloud.jetpack.com` to `http://jetpack.cloud.localhost:3001` - So the full URL is  `http://jetpack.cloud.localhost:3001/pricing?site=:SITE&source=jetpack-connect-plans`
3. Verify you are redirected to `/pricing/:site` route.
4. Select Jetpack Free plan
5. Verify you are taken to the site wp-admin jetpack dashboard.
6. Now in wp-admin, select Jetpack --> Dashboard --> Plans link.
7. Verify to are taken to the Jetpack Cloud pricing page and then in the url change `https://cloud.jetpack.com` to `http://jetpack.cloud.localhost:3001`
8. Verify that the Jetpack Free card is NOT showing.

Fixes 1164141197617539-as-1199363227138777