### PR TITLE
Use "Email" instead of "Titan Mail"

### DIFF
--- a/client/lib/titan/get-titan-product-name.js
+++ b/client/lib/titan/get-titan-product-name.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { isEnabled } from 'calypso/config';
+import i18n from 'i18n-calypso';
+
+export function getTitanProductName() {
+	if ( isEnabled( 'titan/phase-2' ) ) {
+		return i18n.translate( 'Email' );
+	}
+	return i18n.translate( 'Titan Mail' );
+}

--- a/client/lib/titan/get-titan-product-name.js
+++ b/client/lib/titan/get-titan-product-name.js
@@ -10,7 +10,9 @@ import { isEnabled } from 'calypso/config';
 
 export function getTitanProductName() {
 	if ( isEnabled( 'titan/phase-2' ) ) {
-		return i18n.translate( 'Email' );
+		return i18n.translate( 'Email', {
+			comment: 'Email is the name of a WordPress.com product, not just a capitalization of "email"',
+		} );
 	}
 	return i18n.translate( 'Titan Mail' );
 }

--- a/client/lib/titan/get-titan-product-name.js
+++ b/client/lib/titan/get-titan-product-name.js
@@ -1,8 +1,12 @@
 /**
+ * External dependencies
+ */
+import i18n from 'i18n-calypso';
+
+/**
  * Internal dependencies
  */
 import { isEnabled } from 'calypso/config';
-import i18n from 'i18n-calypso';
 
 export function getTitanProductName() {
 	if ( isEnabled( 'titan/phase-2' ) ) {

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -21,6 +21,7 @@ import { getName } from 'calypso/lib/purchases';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
+import { isEnabled } from 'calypso/config';
 
 class RemoveDomainDialog extends Component {
 	static propTypes = {
@@ -52,12 +53,15 @@ class RemoveDomainDialog extends Component {
 						components: { strong: <strong /> },
 					}
 				) }
-				{ hasTitanWithUs &&
-					' ' +
-						translate(
+				{ hasTitanWithUs && ' ' + isEnabled( 'titan/phase-2' )
+					? translate(
 							'You also have an active Titan Mail subscription for this domain, and your emails will stop ' +
 								'working if you delete your domain.'
-						) }
+					  )
+					: translate(
+							'You also have an active Email subscription for this domain, and your emails will stop ' +
+								'working if you delete your domain.'
+					  ) }
 			</p>
 		);
 	}

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -20,8 +20,8 @@ import { MOVE_DOMAIN } from 'calypso/lib/url/support';
 import { getName } from 'calypso/lib/purchases';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedDomain } from 'calypso/lib/domains';
+import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
 import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
-import { isEnabled } from 'calypso/config';
 
 class RemoveDomainDialog extends Component {
 	static propTypes = {
@@ -53,15 +53,19 @@ class RemoveDomainDialog extends Component {
 						components: { strong: <strong /> },
 					}
 				) }
-				{ hasTitanWithUs && ' ' + isEnabled( 'titan/phase-2' )
-					? translate(
-							'You also have an active Titan Mail subscription for this domain, and your emails will stop ' +
-								'working if you delete your domain.'
-					  )
-					: translate(
-							'You also have an active Email subscription for this domain, and your emails will stop ' +
-								'working if you delete your domain.'
-					  ) }
+				{ hasTitanWithUs &&
+					' ' +
+						translate(
+							'You also have an active %(productName)s subscription for this domain, and your emails will stop ' +
+								'working if you delete your domain.',
+							{
+								args: {
+									productName: getTitanProductName(),
+								},
+								comment:
+									'%(productName) is the name of the product, which is either Email or Titan Mail',
+							}
+						) }
 			</p>
 		);
 	}

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -37,13 +37,13 @@ import { emailManagement } from 'calypso/my-sites/email/paths';
 import { type as domainTypes, transferStatus, sslStatuses } from 'calypso/lib/domains/constants';
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { isCancelable } from 'calypso/lib/purchases';
-import { isEnabled } from 'calypso/config';
 import { cancelPurchase } from 'calypso/me/purchases/paths';
 import { getUnmappedUrl } from 'calypso/lib/site/utils';
 import { withoutHttp } from 'calypso/lib/url';
 import RemovePurchase from 'calypso/me/purchases/remove-purchase';
 import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
 import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -113,9 +113,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 				}
 			);
 		} else if ( hasTitanMailWithUs( domain ) ) {
-			navigationDescription = isEnabled( 'titan/phase-2' )
-				? translate( 'Email' )
-				: translate( 'Titan Mail' );
+			navigationDescription = getTitanProductName();
 		} else if ( emailForwardsCount > 0 ) {
 			navigationDescription = translate(
 				'%(emailForwardsCount)d forward',

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -37,6 +37,7 @@ import { emailManagement } from 'calypso/my-sites/email/paths';
 import { type as domainTypes, transferStatus, sslStatuses } from 'calypso/lib/domains/constants';
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { isCancelable } from 'calypso/lib/purchases';
+import { isEnabled } from 'calypso/config';
 import { cancelPurchase } from 'calypso/me/purchases/paths';
 import { getUnmappedUrl } from 'calypso/lib/site/utils';
 import { withoutHttp } from 'calypso/lib/url';
@@ -112,7 +113,9 @@ class DomainManagementNavigationEnhanced extends React.Component {
 				}
 			);
 		} else if ( hasTitanMailWithUs( domain ) ) {
-			navigationDescription = translate( 'Titan Mail' );
+			navigationDescription = isEnabled( 'titan/phase-2' )
+				? translate( 'Email' )
+				: translate( 'Titan Mail' );
 		} else if ( emailForwardsCount > 0 ) {
 			navigationDescription = translate(
 				'%(emailForwardsCount)d forward',

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -19,7 +19,6 @@ import DomainNotice from 'calypso/my-sites/domains/domain-management/components/
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
-import { isEnabled } from 'calypso/config';
 import { withoutHttp } from 'calypso/lib/url';
 import { type as domainTypes } from 'calypso/lib/domains/constants';
 import { handleRenewNowClick } from 'calypso/lib/purchases';
@@ -42,6 +41,7 @@ import {
 import Spinner from 'calypso/components/spinner';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
 import { hasTitanMailWithUs } from 'calypso/lib/titan/has-titan-mail-with-us';
 
 class DomainItem extends PureComponent {
@@ -302,7 +302,7 @@ class DomainItem extends PureComponent {
 		}
 
 		if ( hasTitanMailWithUs( domainDetails ) ) {
-			return isEnabled( 'titan/phase-2' ) ? translate( 'Email' ) : translate( 'Titan Mail' );
+			return getTitanProductName();
 		}
 
 		if ( domainDetails?.emailForwardsCount > 0 ) {

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -19,6 +19,7 @@ import DomainNotice from 'calypso/my-sites/domains/domain-management/components/
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
+import { isEnabled } from 'calypso/config';
 import { withoutHttp } from 'calypso/lib/url';
 import { type as domainTypes } from 'calypso/lib/domains/constants';
 import { handleRenewNowClick } from 'calypso/lib/purchases';
@@ -301,7 +302,7 @@ class DomainItem extends PureComponent {
 		}
 
 		if ( hasTitanMailWithUs( domainDetails ) ) {
-			return translate( 'Titan Mail' );
+			return isEnabled( 'titan/phase-2' ) ? translate( 'Email' ) : translate( 'Titan Mail' );
 		}
 
 		if ( domainDetails?.emailForwardsCount > 0 ) {

--- a/client/my-sites/domains/domain-management/list/list-header.jsx
+++ b/client/my-sites/domains/domain-management/list/list-header.jsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import { CompactCard } from '@automattic/components';
 import InfoPopover from 'calypso/components/info-popover';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
-import { isEnabled } from 'calypso/config';
+import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
 
 /**
  * Style dependencies
@@ -28,24 +28,6 @@ class ListHeader extends React.PureComponent {
 		const { headerClasses, translate } = this.props;
 
 		const listHeaderClasses = classNames( 'list-header', headerClasses );
-		const emailPopoverText = isEnabled( 'titan/phase-2' )
-			? translate(
-					'You can receive email using your custom domain by purchasing Email or %(googleMailService)s, or by ' +
-						'setting up email forwarding. Note that email forwarding requires a plan subscription.',
-					{
-						args: { googleMailService: getGoogleMailServiceFamily() },
-						comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-					}
-			  )
-			: translate(
-					'You can receive email using your custom domain by using email forwarding or by ' +
-						'purchasing Titan Mail or %(googleMailService)s. Note that ' +
-						'email forwarding requires a plan subscription.',
-					{
-						args: { googleMailService: getGoogleMailServiceFamily() },
-						comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-					}
-			  );
 
 		return (
 			<CompactCard className={ listHeaderClasses }>
@@ -81,7 +63,20 @@ class ListHeader extends React.PureComponent {
 				</div>
 				<div className="list__domain-email">
 					<span>{ translate( 'Email' ) }</span>
-					<InfoPopover iconSize={ 18 }>{ emailPopoverText }</InfoPopover>
+					<InfoPopover iconSize={ 18 }>
+						{ translate(
+							'You can receive email using your custom domain by purchasing %(titanMailService)s or %(googleMailService)s, or by ' +
+								'setting up email forwarding. Note that email forwarding requires a plan subscription.',
+							{
+								args: {
+									googleMailService: getGoogleMailServiceFamily(),
+									titanMailService: getTitanProductName(),
+								},
+								comment:
+									'%(googleMailService)s can be either "G Suite" or "Google Workspace"; %(titanMailService)s can be either "Email" or "Titan Mail"',
+							}
+						) }
+					</InfoPopover>
 				</div>
 				<div className="list__domain-options"></div>
 			</CompactCard>

--- a/client/my-sites/domains/domain-management/list/list-header.jsx
+++ b/client/my-sites/domains/domain-management/list/list-header.jsx
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 import { CompactCard } from '@automattic/components';
 import InfoPopover from 'calypso/components/info-popover';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import { isEnabled } from 'calypso/config';
 
 /**
  * Style dependencies
@@ -27,6 +28,24 @@ class ListHeader extends React.PureComponent {
 		const { headerClasses, translate } = this.props;
 
 		const listHeaderClasses = classNames( 'list-header', headerClasses );
+		const emailPopoverText = isEnabled( 'titan/phase-2' )
+			? translate(
+					'You can receive email using your custom domain by purchasing Email or %(googleMailService)s, or by ' +
+						'setting up email forwarding. Note that email forwarding requires a plan subscription.',
+					{
+						args: { googleMailService: getGoogleMailServiceFamily() },
+						comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+					}
+			  )
+			: translate(
+					'You can receive email using your custom domain by using email forwarding or by ' +
+						'purchasing Titan Mail or %(googleMailService)s. Note that ' +
+						'email forwarding requires a plan subscription.',
+					{
+						args: { googleMailService: getGoogleMailServiceFamily() },
+						comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+					}
+			  );
 
 		return (
 			<CompactCard className={ listHeaderClasses }>
@@ -62,17 +81,7 @@ class ListHeader extends React.PureComponent {
 				</div>
 				<div className="list__domain-email">
 					<span>{ translate( 'Email' ) }</span>
-					<InfoPopover iconSize={ 18 }>
-						{ translate(
-							'You can receive email using your custom domain by using email forwarding or by ' +
-								'purchasing Titan Mail or %(googleMailService)s. Note that ' +
-								'email forwarding requires a plan subscription.',
-							{
-								args: { googleMailService: getGoogleMailServiceFamily() },
-								comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-							}
-						) }
-					</InfoPopover>
+					<InfoPopover iconSize={ 18 }>{ emailPopoverText }</InfoPopover>
 				</div>
 				<div className="list__domain-options"></div>
 			</CompactCard>

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -78,25 +78,35 @@ class TitanControlPanelLoginCard extends React.Component {
 			},
 			comment: '%(domainName)s is a domain name, e.g. example.com',
 		};
+		const sectionHeaderLabel = isEnabled( 'titan/phase-2' )
+			? translate( 'Email: %(domainName)s', translateArgs )
+			: translate( 'Titan Mail: %(domainName)s', translateArgs );
+		const buttonCtaText = isEnabled( 'titan/phase-2' )
+			? translate( 'Log in to the Email control panel' )
+			: translate( "Log in to Titan's control panel" );
+		const cardText = isEnabled( 'titan/phase-2' )
+			? translate(
+					'Go to the Email control panel to manage email for %(domainName)s.',
+					translateArgs
+			  )
+			: translate(
+					"Go to Titan's control panel to manage email for %(domainName)s.",
+					translateArgs
+			  );
 
 		return (
 			<div className="titan-control-panel-login-card">
-				<SectionHeader label={ translate( 'Titan Mail: %(domainName)s', translateArgs ) }>
+				<SectionHeader label={ sectionHeaderLabel }>
 					<Button
 						primary
 						compact
 						busy={ this.state.isFetchingAutoLoginLink }
 						onClick={ this.onLogInClick }
 					>
-						{ translate( "Log in to Titan's control panel" ) }
+						{ buttonCtaText }
 					</Button>
 				</SectionHeader>
-				<CompactCard>
-					{ translate(
-						"Go to Titan's control panel to manage email for %(domainName)s.",
-						translateArgs
-					) }
-				</CompactCard>
+				<CompactCard>{ cardText }</CompactCard>
 			</div>
 		);
 	}
@@ -109,10 +119,13 @@ class TitanControlPanelLoginCard extends React.Component {
 			},
 			comment: '%(domainName)s is a domain name, e.g. example.com',
 		};
+		const sectionHeaderLabel = isEnabled( 'titan/phase-2' )
+			? translate( 'Email: %(domainName)s', translateArgs )
+			: translate( 'Titan Mail: %(domainName)s', translateArgs );
 
 		return (
 			<div className="titan-control-panel-login-card">
-				<SectionHeader label={ translate( 'Titan Mail: %(domainName)s', translateArgs ) } />
+				<SectionHeader label={ sectionHeaderLabel } />
 				<CompactCard>
 					{ this.state.iframeURL ? (
 						<iframe

--- a/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
+++ b/client/my-sites/email/email-management/titan-control-panel-login-card/index.jsx
@@ -18,6 +18,7 @@ import {
 	fetchTitanIframeURL,
 } from 'calypso/my-sites/email/email-management/titan-functions';
 import { getTitanMailOrderId } from 'calypso/lib/titan/get-titan-mail-order-id';
+import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
 
 /**
  * Style dependencies
@@ -75,24 +76,19 @@ class TitanControlPanelLoginCard extends React.Component {
 		const translateArgs = {
 			args: {
 				domainName: domain.name,
+				productName: getTitanProductName(),
 			},
-			comment: '%(domainName)s is a domain name, e.g. example.com',
+			comment:
+				'%(domainName)s is a domain name, e.g. example.com; %(productName)s is the product name, either Email or Titan Mail',
 		};
-		const sectionHeaderLabel = isEnabled( 'titan/phase-2' )
-			? translate( 'Email: %(domainName)s', translateArgs )
-			: translate( 'Titan Mail: %(domainName)s', translateArgs );
+		const sectionHeaderLabel = translate( '%(productName)s: %(domainName)s', translateArgs );
 		const buttonCtaText = isEnabled( 'titan/phase-2' )
 			? translate( 'Log in to the Email control panel' )
 			: translate( "Log in to Titan's control panel" );
-		const cardText = isEnabled( 'titan/phase-2' )
-			? translate(
-					'Go to the Email control panel to manage email for %(domainName)s.',
-					translateArgs
-			  )
-			: translate(
-					"Go to Titan's control panel to manage email for %(domainName)s.",
-					translateArgs
-			  );
+		const cardText = translate(
+			'Go to the %(productName)s control panel to manage email for %(domainName)s.',
+			translateArgs
+		);
 
 		return (
 			<div className="titan-control-panel-login-card">
@@ -116,12 +112,12 @@ class TitanControlPanelLoginCard extends React.Component {
 		const translateArgs = {
 			args: {
 				domainName: domain.name,
+				productName: getTitanProductName(),
 			},
-			comment: '%(domainName)s is a domain name, e.g. example.com',
+			comment:
+				'%(domainName)s is a domain name, e.g. example.com; %(productName)s is the product name, either Email or Titan Mail',
 		};
-		const sectionHeaderLabel = isEnabled( 'titan/phase-2' )
-			? translate( 'Email: %(domainName)s', translateArgs )
-			: translate( 'Titan Mail: %(domainName)s', translateArgs );
+		const sectionHeaderLabel = translate( '%(productName)s: %(domainName)s', translateArgs );
 
 		return (
 			<div className="titan-control-panel-login-card">

--- a/client/my-sites/email/email-management/titan-management-nav/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-nav/index.jsx
@@ -23,6 +23,7 @@ import { isEnabled } from 'calypso/config';
 import SectionHeader from 'calypso/components/section-header';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
+import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
 
 /**
  * Style
@@ -126,16 +127,14 @@ class TitanManagementNav extends React.Component {
 
 	render() {
 		const { domain, translate } = this.props;
-		const translateArgs = {
+		const headerLabel = translate( '%(productName)s: %(domainName)s', {
 			args: {
 				domainName: domain.name,
+				productName: getTitanProductName(),
 			},
-			comment: '%(domainName)s is a domain name, e.g. example.com',
-		};
-		const headerLabel = isEnabled( 'titan/phase-2' )
-			? translate( 'Email: %(domainName)s', translateArgs )
-			: translate( 'Titan Mail: %(domainName)s', translateArgs );
-
+			comment:
+				'%(domainName)s is a domain name, e.g. example.com; %(productName)s is the product name, either "Email" or "Titan Mail"',
+		} );
 		return (
 			<div className="titan-management-nav">
 				<SectionHeader label={ headerLabel } />

--- a/client/my-sites/email/email-management/titan-management-nav/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-nav/index.jsx
@@ -132,10 +132,13 @@ class TitanManagementNav extends React.Component {
 			},
 			comment: '%(domainName)s is a domain name, e.g. example.com',
 		};
+		const headerLabel = isEnabled( 'titan/phase-2' )
+			? translate( 'Email: %(domainName)s', translateArgs )
+			: translate( 'Titan Mail: %(domainName)s', translateArgs );
 
 		return (
 			<div className="titan-management-nav">
-				<SectionHeader label={ translate( 'Titan Mail: %(domainName)s', translateArgs ) } />
+				<SectionHeader label={ headerLabel } />
 				<VerticalNav>
 					{ this.renderTitanManagementLink() }
 					{ this.renderPurchaseManagementLink() }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -44,6 +44,7 @@ import titanLogo from 'calypso/assets/images/email-providers/titan.svg';
 import googleWorkspaceLogo from 'calypso/assets/images/email-providers/google-workspace.svg';
 import gSuiteLogo from 'calypso/assets/images/email-providers/gsuite.svg';
 import forwardingIcon from 'calypso/assets/images/email-providers/forwarding.svg';
+import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
 
 /**
  * Style dependencies
@@ -195,12 +196,13 @@ class EmailProvidersComparison extends React.Component {
 					},
 					comment: '{{price/}} is the formatted price, e.g. $20',
 			  } );
-		const providerTitle = config.isEnabled( 'titan/phase-2' )
-			? translate( 'Email' )
-			: translate( 'Titan Mail' );
-		const providerCtaText = config.isEnabled( 'titan/phase-2' )
-			? translate( 'Add Email' )
-			: translate( 'Add Titan Mail' );
+		const providerName = getTitanProductName();
+		const providerCtaText = translate( 'Add %(emailProductName)s', {
+			args: {
+				emailProductName: providerName,
+			},
+			comment: '%(emailProductName)s is the product name, either "Email" or "Titan Mail"',
+		} );
 		const providerEmailLogo = config.isEnabled( 'titan/phase-2' ) ? (
 			<Gridicon
 				className="email-providers-comparison__providers-wordpress-com-email"
@@ -212,7 +214,7 @@ class EmailProvidersComparison extends React.Component {
 
 		return (
 			<EmailProviderDetails
-				title={ providerTitle }
+				title={ providerName }
 				description={ translate(
 					'Easy-to-use email with incredibly powerful features. Manage your email and more on any device.'
 				) }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -37,6 +37,7 @@ import wpcom from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import Gridicon from 'calypso/components/gridicon';
 import formatCurrency from '@automattic/format-currency';
 import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
 import titanLogo from 'calypso/assets/images/email-providers/titan.svg';
@@ -176,7 +177,8 @@ class EmailProvidersComparison extends React.Component {
 		const { currencyCode, currentUserLocale, titanMailProduct, translate } = this.props;
 		const isEnglish = includes( config( 'english_locales' ), currentUserLocale );
 		const billingFrequency =
-			isEnglish || i18n.hasTranslation( 'Annual or monthly billing' )
+			! config.isEnabled( 'titan/phase-2' ) &&
+			( isEnglish || i18n.hasTranslation( 'Annual or monthly billing' ) )
 				? translate( 'Annual or monthly billing' )
 				: translate( 'Monthly billing' );
 
@@ -193,14 +195,28 @@ class EmailProvidersComparison extends React.Component {
 					},
 					comment: '{{price/}} is the formatted price, e.g. $20',
 			  } );
+		const providerTitle = config.isEnabled( 'titan/phase-2' )
+			? translate( 'Email' )
+			: translate( 'Titan Mail' );
+		const providerCtaText = config.isEnabled( 'titan/phase-2' )
+			? translate( 'Add Email' )
+			: translate( 'Add Titan Mail' );
+		const providerEmailLogo = config.isEnabled( 'titan/phase-2' ) ? (
+			<Gridicon
+				className="email-providers-comparison__providers-wordpress-com-email"
+				icon="my-sites"
+			/>
+		) : (
+			{ path: titanLogo }
+		);
 
 		return (
 			<EmailProviderDetails
-				title={ translate( 'Titan Mail' ) }
+				title={ providerTitle }
 				description={ translate(
 					'Easy-to-use email with incredibly powerful features. Manage your email and more on any device.'
 				) }
-				image={ { path: titanLogo } }
+				image={ providerEmailLogo }
 				features={ [
 					billingFrequency,
 					translate( 'Send and receive from your custom domain' ),
@@ -210,7 +226,7 @@ class EmailProvidersComparison extends React.Component {
 					translate( 'Read receipts to track email opens' ),
 				] }
 				formattedPrice={ formattedPrice }
-				buttonLabel={ translate( 'Add Titan Mail' ) }
+				buttonLabel={ providerCtaText }
 				hasPrimaryButton={ true }
 				isButtonBusy={ this.state.isFetchingProvisioningURL }
 				onButtonClick={ this.onAddTitanClick }

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -8,6 +8,10 @@
 		width: calc( 33% - 0.5em );
 		margin: 8px 0;
 
+		.email-providers-comparison__providers-wordpress-com-email {
+			color: var( --color-wordpress-com );
+		}
+
 		&.no-gsuite {
 			width: calc( 50% - 0.5em );
 		}

--- a/client/my-sites/email/titan-mail-quantity-selection/index.jsx
+++ b/client/my-sites/email/titan-mail-quantity-selection/index.jsx
@@ -34,7 +34,7 @@ import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasTitanMailWithUs, getMaxTitanMailboxCount } from 'calypso/lib/titan';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductsList } from 'calypso/state/products-list/selectors';
-import { isEnabled } from 'calypso/config';
+import { getTitanProductName } from 'calypso/lib/titan/get-titan-product-name';
 
 /**
  * Style dependencies
@@ -123,9 +123,7 @@ class TitanMailQuantitySelection extends React.Component {
 						'domains have forwards:',
 					{
 						args: {
-							productName: isEnabled( 'titan/phase-2' )
-								? translate( 'Email' )
-								: translate( 'Titan Mail' ),
+							productName: getTitanProductName(),
 						},
 						comment: '%(productName)s is the name of the product, e.g. Titan Mail or Email',
 					}
@@ -182,7 +180,6 @@ class TitanMailQuantitySelection extends React.Component {
 			selectedSite,
 			isSelectedDomainNameValid,
 			isLoadingDomains,
-			translate,
 		} = this.props;
 
 		if ( ! isLoadingDomains && ! isSelectedDomainNameValid ) {
@@ -198,7 +195,7 @@ class TitanMailQuantitySelection extends React.Component {
 						onClick={ this.goToEmail }
 						selectedDomainName={ selectedDomainName }
 					>
-						{ isEnabled( 'titan/phase-2' ) ? translate( 'Email' ) : translate( 'Titan Mail' ) }
+						{ getTitanProductName() }
 					</DomainManagementHeader>
 
 					{ this.renderForwardsNotice() }

--- a/client/my-sites/email/titan-mail-quantity-selection/index.jsx
+++ b/client/my-sites/email/titan-mail-quantity-selection/index.jsx
@@ -34,6 +34,7 @@ import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasTitanMailWithUs, getMaxTitanMailboxCount } from 'calypso/lib/titan';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import { isEnabled } from 'calypso/config';
 
 /**
  * Style dependencies
@@ -122,9 +123,11 @@ class TitanMailQuantitySelection extends React.Component {
 						'domains have forwards:',
 					{
 						args: {
-							productName: translate( 'Titan Mail' ),
+							productName: isEnabled( 'titan/phase-2' )
+								? translate( 'Email' )
+								: translate( 'Titan Mail' ),
 						},
-						comment: '%(productName)s is the name of the product, e.g. Titan Mail',
+						comment: '%(productName)s is the name of the product, e.g. Titan Mail or Email',
 					}
 				) }
 				<ul>
@@ -195,7 +198,7 @@ class TitanMailQuantitySelection extends React.Component {
 						onClick={ this.goToEmail }
 						selectedDomainName={ selectedDomainName }
 					>
-						{ translate( 'Titan Mail' ) }
+						{ isEnabled( 'titan/phase-2' ) ? translate( 'Email' ) : translate( 'Titan Mail' ) }
 					</DomainManagementHeader>
 
 					{ this.renderForwardsNotice() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR replaces uses of "Titan Mail" and "Titan" with "Email"
* I also added the correct logo and colour for the Email icon on the email comparison page

This PR does _not_ include a "Powered by Titan" logo/sticker for the email comparison page, which was something we should probably add.

#### Screenshots
<img width="1060" alt="Screenshot 2021-01-14 at 14 53 23" src="https://user-images.githubusercontent.com/3376401/104594107-590d2f80-5679-11eb-873f-d3033925c691.png">
<img width="527" alt="Screenshot 2021-01-14 at 14 59 35" src="https://user-images.githubusercontent.com/3376401/104594113-5b6f8980-5679-11eb-9de6-6a55f0708ea8.png">
<img width="1052" alt="Screenshot 2021-01-14 at 14 58 47" src="https://user-images.githubusercontent.com/3376401/104594116-5ca0b680-5679-11eb-8dda-6e44dbc3557f.png">
<img width="1052" alt="Screenshot 2021-01-14 at 14 56 53" src="https://user-images.githubusercontent.com/3376401/104594117-5d394d00-5679-11eb-9547-48f1ab0aa782.png">
<img width="1057" alt="Screenshot 2021-01-14 at 14 54 27" src="https://user-images.githubusercontent.com/3376401/104594119-5dd1e380-5679-11eb-9a78-a456cc67332d.png">
<img width="535" alt="Screenshot 2021-01-14 at 14 53 43" src="https://user-images.githubusercontent.com/3376401/104594122-5e6a7a00-5679-11eb-840a-6597aed93d03.png">





#### Testing instructions

Check all the things... ;)

More seriously, check that when the `titan/phase-2` feature flag is enabled (which it should be in wpcalypso and calypso.live), the following places in the UI reference "Email" and not "Titan":
* The email comparison page for a domain that doesn't have email configured yet
* The error message/warning when trying to cancel a domain that has Titan mail configured
* The domain listing page should use "Email" in the Email column for domains that have Titan email, and the popover for the Email column should use "Email" (I also tweaked the language here slightly)
* The domain management page should use "Email" if the domain has Titan email configured
* The new navigation menu should use a title of "Email"
* The mailbox quantity selection page should use "Email"
* The card for showing the embedded control panel (which can be enabled via the `titan/iframe-control-panel` flag) should use Email
* The card for showing a link to the Titan control panel (outside of the nav) should use "Email". (This will likely need the `titan/phase-2` feature flag to be disabled.)