### PR TITLE
Domains: Update MapDomain and MapDomainStep to use withShoppingCart

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { includes, noop, get } from 'lodash';
+import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -176,7 +177,7 @@ class MapDomainStep extends React.Component {
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					key={ suggestion.domain_name }
 					cart={ this.props.cart }
-					isCartPendingUpdate={ this.props.cart.hasPendingServerUpdates }
+					isCartPendingUpdate={ this.props.shoppingCartManager.isPendingUpdate }
 					onButtonClick={ this.registerSuggestedDomain }
 				/>
 			</div>
@@ -273,4 +274,4 @@ export default connect(
 		recordInputFocusInMapDomain,
 		recordGoButtonClickInMapDomain,
 	}
-)( localize( MapDomainStep ) );
+)( withShoppingCart( localize( MapDomainStep ) ) );

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -110,9 +110,9 @@ const mapDomain = ( context, next ) => {
 		<Main wideLayout>
 			<PageViewTracker path={ domainMapping( ':site' ) } title="Domain Search > Domain Mapping" />
 			<DocumentHead title={ translate( 'Map a Domain' ) } />
-			<CartData>
+			<CalypsoShoppingCartProvider>
 				<MapDomain initialQuery={ context.query.initialQuery } />
-			</CartData>
+			</CalypsoShoppingCartProvider>
 		</Main>
 	);
 	next();

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -14,7 +14,7 @@ import { get, isEmpty } from 'lodash';
 import HeaderCake from 'calypso/components/header-cake';
 import MapDomainStep from 'calypso/components/domains/map-domain-step';
 import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
-import { domainRegistration, domainMapping } from 'calypso/lib/cart-values/cart-items';
+import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { addItem } from 'calypso/lib/cart/actions';
 import wp from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
@@ -110,9 +110,7 @@ export class MapDomain extends Component {
 			return;
 		}
 
-		addItem( domainMapping( { domain } ) );
-
-		page( '/checkout/' + selectedSiteSlug );
+		page( '/checkout/' + selectedSiteSlug + '/domain-mapping:' + domain );
 	};
 
 	UNSAFE_componentWillMount() {

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -73,7 +73,7 @@ export class MapDomain extends Component {
 	addDomainToCart = ( suggestion ) => {
 		const { selectedSiteSlug } = this.props;
 
-		this.props
+		this.props.shoppingCartManager
 			.addProductsToCart( [
 				fillInSingleCartItemAttributes(
 					domainRegistration( {

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -37,7 +37,6 @@ export class MapDomain extends Component {
 	static propTypes = {
 		initialQuery: PropTypes.string,
 		query: PropTypes.string,
-		cart: PropTypes.object.isRequired,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
 		isSiteUpgradeable: PropTypes.bool,
 		productsList: PropTypes.object.isRequired,
@@ -175,7 +174,6 @@ export class MapDomain extends Component {
 		}
 
 		const {
-			cart,
 			domainsWithPlansOnly,
 			initialQuery,
 			productsList,
@@ -194,7 +192,6 @@ export class MapDomain extends Component {
 				{ errorMessage && <Notice status="is-error" text={ errorMessage } /> }
 
 				<MapDomainStep
-					cart={ cart }
 					domainsWithPlansOnly={ domainsWithPlansOnly }
 					initialQuery={ initialQuery }
 					products={ productsList }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -537,17 +537,19 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="mappingForm">
-				<MapDomainStep
-					analyticsSection={ this.getAnalyticsSection() }
-					initialState={ initialState }
-					path={ this.props.path }
-					onRegisterDomain={ this.handleAddDomain }
-					onMapDomain={ this.handleAddMapping.bind( this, 'mappingForm' ) }
-					onSave={ this.handleSave.bind( this, 'mappingForm' ) }
-					products={ this.props.productsList }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					initialQuery={ initialQuery }
-				/>
+				<CalypsoShoppingCartProvider>
+					<MapDomainStep
+						analyticsSection={ this.getAnalyticsSection() }
+						initialState={ initialState }
+						path={ this.props.path }
+						onRegisterDomain={ this.handleAddDomain }
+						onMapDomain={ this.handleAddMapping.bind( this, 'mappingForm' ) }
+						onSave={ this.handleSave.bind( this, 'mappingForm' ) }
+						products={ this.props.productsList }
+						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+						initialQuery={ initialQuery }
+					/>
+				</CalypsoShoppingCartProvider>
 			</div>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the effort to remove CartStore (see https://github.com/Automattic/wp-calypso/issues/24019), this PR updates `MapDomain` and `MapDomainStep` so that they use `withShoppingCart` instead of `CartData` and `addItem`.

<img width="1023" alt="map-a-domain" src="https://user-images.githubusercontent.com/2036909/104382075-8338e300-54fb-11eb-83ab-8adc5e9b116c.png">

Note that the "Add" button does not have its own busy state. See https://github.com/Automattic/wp-calypso/pull/48843 which handles that.

#### Testing instructions

To test `handleRegisterDomain`:

- Visit the page to add a mapped domain, eg: http://calypso.localhost:3000/domains/add/mapping/example.com
- Enter a domain name that you cannot map (it doesn't have to be yours), eg: `cape.com`
- Click "Add" and wait for the results to load. If you get an error message, try a different domain name.
- You should see a domain box with a "Select" button appear below the search field.
- Click the "Select" button next to the domain.
- Verify that the "Select" button becomes busy while it's loading.
- Verify that you are redirected to checkout with the domain registration in the cart.

To test `handleMapDomain`:

- Visit the page to add a mapped domain, eg: http://calypso.localhost:3000/domains/add/mapping/example.com
- Enter a domain name that you can map (it doesn't have to be yours), eg: `foolord.com`
- Click "Add".
- Verify that you are redirected to checkout with the domain mapping in the cart.

To test signup:

- Visit the page to add a mapped domain in signup, http://calypso.localhost:3000/start/domains/mapping
- Repeat the steps above for both registering a domain and mapping a domain and verify that the cart contains the correct product.
