### PR TITLE
Domains: Add busy state to "Add" button

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -125,7 +125,7 @@ class MapDomainStep extends React.Component {
 							busy={ this.state.isPendingSubmit }
 							disabled={ ! getTld( searchQuery ) || this.state.isPendingSubmit }
 							className="map-domain-step__go button is-primary"
-							onClick={ this.recordGoButtonClick }
+							onClick={ this.handleAddButtonClick }
 						>
 							{ translate( 'Add', {
 								context: 'Upgrades: Label for mapping an existing domain',
@@ -209,6 +209,11 @@ class MapDomainStep extends React.Component {
 
 	setSearchQuery = ( event ) => {
 		this.setState( { searchQuery: event.target.value } );
+	};
+
+	handleAddButtonClick = ( event ) => {
+		this.recordGoButtonClick();
+		this.handleFormSubmit( event );
 	};
 
 	handleFormSubmit = ( event ) => {

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { includes, noop, get } from 'lodash';
 import { withShoppingCart } from '@automattic/shopping-cart';
+import { Button } from '@automattic/components';
 
 /**
  * Internal dependencies
@@ -120,7 +121,8 @@ class MapDomainStep extends React.Component {
 							onClick={ this.recordInputFocus }
 							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 						/>
-						<button
+						<Button
+							busy={ this.state.isPendingSubmit }
 							disabled={ ! getTld( searchQuery ) || this.state.isPendingSubmit }
 							className="map-domain-step__go button is-primary"
 							onClick={ this.recordGoButtonClick }
@@ -128,7 +130,7 @@ class MapDomainStep extends React.Component {
 							{ translate( 'Add', {
 								context: 'Upgrades: Label for mapping an existing domain',
 							} ) }
-						</button>
+						</Button>
 					</div>
 
 					{ this.domainRegistrationUpsell() }

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -58,6 +58,7 @@ class MapDomainStep extends React.Component {
 	state = {
 		...this.props.initialState,
 		searchQuery: this.props.initialQuery,
+		isPendingSubmit: false,
 	};
 
 	componentWillUnmount() {
@@ -120,7 +121,7 @@ class MapDomainStep extends React.Component {
 							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 						/>
 						<button
-							disabled={ ! getTld( searchQuery ) }
+							disabled={ ! getTld( searchQuery ) || this.state.isPendingSubmit }
 							className="map-domain-step__go button is-primary"
 							onClick={ this.recordGoButtonClick }
 						>
@@ -213,7 +214,7 @@ class MapDomainStep extends React.Component {
 
 		const domain = getFixedDomainSearch( this.state.searchQuery );
 		this.props.recordFormSubmitInMapDomain( this.state.searchQuery );
-		this.setState( { suggestion: null, notice: null } );
+		this.setState( { suggestion: null, notice: null, isPendingSubmit: true } );
 
 		checkDomainAvailability(
 			{ domainName: domain, blogId: get( this.props, 'selectedSite.ID', null ) },
@@ -230,7 +231,7 @@ class MapDomainStep extends React.Component {
 				} = domainAvailability;
 
 				if ( status === AVAILABLE ) {
-					this.setState( { suggestion: result } );
+					this.setState( { suggestion: result, isPendingSubmit: false } );
 					return;
 				}
 
@@ -238,6 +239,7 @@ class MapDomainStep extends React.Component {
 					! includes( [ AVAILABILITY_CHECK_ERROR, NOT_REGISTRABLE ], status ) &&
 					includes( [ MAPPABLE, UNKNOWN ], mappableStatus )
 				) {
+					// No need to disable isPendingSubmit because this handler should perform a redirect
 					this.props.onMapDomain( domain );
 					return;
 				}
@@ -254,7 +256,7 @@ class MapDomainStep extends React.Component {
 					site,
 					maintenanceEndTime,
 				} );
-				this.setState( { notice: message, noticeSeverity: severity } );
+				this.setState( { notice: message, noticeSeverity: severity, isPendingSubmit: false } );
 			}
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies the "Add" button on the `MapDomainStep` component to be disabled and busy when the form is submitting.

<img width="520" alt="busybutton" src="https://user-images.githubusercontent.com/2036909/104393582-c9e60780-5512-11eb-99b5-e9be62816e96.png">

#### Testing instructions

To test `handleRegisterDomain`:

- Visit the page to add a mapped domain, eg: http://calypso.localhost:3000/domains/add/mapping/example.com
- Enter a domain name that you cannot map (it doesn't have to be yours), eg: `cape.com`
- Click "Add" and wait for the results to load. If you get an error message, try a different domain name.
- Verify that the "Add" button is busy and disabled until the domain list loads below the input field.
- Verify that the button becomes available again after the domain registration suggestion loads.

To test `handleMapDomain`:

- Visit the page to add a mapped domain, eg: http://calypso.localhost:3000/domains/add/mapping/example.com
- Enter a domain name that you can map (it doesn't have to be yours), eg: `foolord.com`
- Click "Add".
- Verify that the "Add" button is busy and disabled until the page redirects.

To test signup:

- Visit the page to add a mapped domain in signup, http://calypso.localhost:3000/start/domains/mapping
- Repeat the steps above for both registering a domain and mapping a domain.
