### PR TITLE
AnchorFM: Font Selection CTA

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -16,6 +16,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { useTrackStep } from '../../hooks/use-track-step';
 import useStepNavigation from '../../hooks/use-step-navigation';
 import type { Viewport } from './types';
+import { useIsAnchorFm } from '../../../gutenboarding/path';
 
 /**
  * Style dependencies
@@ -30,6 +31,8 @@ const StylePreview: React.FunctionComponent = () => {
 
 	const [ selectedViewport, setSelectedViewport ] = React.useState< Viewport >( 'desktop' );
 
+	const isAnchorFmSignup = useIsAnchorFm();
+
 	useTrackStep( 'Style', () => ( {
 		selected_heading_font: getSelectedFonts()?.headings,
 		selected_body_font: getSelectedFonts()?.base,
@@ -42,7 +45,13 @@ const StylePreview: React.FunctionComponent = () => {
 					<div className="style-preview__titles">
 						<Title>{ __( 'Pick a font pairing' ) }</Title>
 						<SubTitle>
-							{ __( 'Customize your design with typography. You can always fine-tune it later.' ) }
+							{ isAnchorFmSignup
+								? __(
+										'Customize your design with typography that best suits your podcast. You can always fine-tune it later.'
+								  )
+								: __(
+										'Customize your design with typography. You can always fine-tune it later.'
+								  ) }
 						</SubTitle>
 					</div>
 					<ViewportSelect selected={ selectedViewport } onSelect={ setSelectedViewport } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Dynamically show font selection CTA for Anchor FM podcast sites

#### Testing instructions
1. Checkout this branch
2. Go to http://calypso.localhost:3000/new?anchor_podcast={anchor_podcast_id}
3. Enter a podcast name
5. Click one of the available designs
6. The font selection CTA should be podcast-specific

#### Screenshots
<img width="594" alt="Screen Shot 2021-01-12 at 5 49 08 PM" src="https://user-images.githubusercontent.com/66652282/104396223-44fdec80-5518-11eb-9c25-eb88f8c5b757.png">


Fixes 382-gh-Automattic/dotcom-manage