### PR TITLE
Flag for tracking when Welcome Guid (NUX modal or Tour) is opened via the More Menu

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
@@ -19,7 +19,6 @@ subscribe( () => {
 	if ( select( 'core/nux' ).areTipsEnabled() ) {
 		dispatch( 'core/nux' ).disableTips();
 		dispatch( 'automattic/nux' ).setWpcomNuxStatus( { isNuxEnabled: true } );
-		dispatch( 'automattic/nux' ).setGuideOpenStatus( { isGuideManuallyOpened: true } );
 	}
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
@@ -14,13 +14,16 @@ const unsubscribe = subscribe( () => {
 } );
 
 // Listen for these features being triggered to call dotcom nux instead.
+// Note migration of areTipsEnabled: https://github.com/WordPress/gutenberg/blob/5c3a32dabe4393c45f7fe6ac5e4d78aebd5ee274/packages/data/src/plugins/persistence/index.js#L269
 subscribe( () => {
 	if ( select( 'core/nux' ).areTipsEnabled() ) {
 		dispatch( 'core/nux' ).disableTips();
 		dispatch( 'automattic/nux' ).setWpcomNuxStatus( { isNuxEnabled: true } );
+		dispatch( 'automattic/nux' ).setGuideOpenStatus( { isGuideManuallyOpened: true } );
 	}
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
 		dispatch( 'automattic/nux' ).setWpcomNuxStatus( { isNuxEnabled: true } );
+		dispatch( 'automattic/nux' ).setGuideOpenStatus( { isGuideManuallyOpened: true } );
 	}
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -4,8 +4,16 @@
 import apiFetch from '@wordpress/api-fetch';
 import { registerStore } from '@wordpress/data';
 
-const reducer = ( state = {}, { type, isNuxEnabled } ) =>
-	'WPCOM_BLOCK_EDITOR_NUX_SET_STATUS' === type ? { ...state, isNuxEnabled } : state;
+const reducer = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case 'WPCOM_BLOCK_EDITOR_NUX_SET_STATUS':
+			return { ...state, isNuxEnabled: action.isNuxEnabled };
+		case 'WPCOM_BLOCK_EDITOR_SET_GUIDE_OPEN':
+			return { ...state, isGuideManuallyOpened: action.isGuideManuallyOpened };
+		default:
+			return state;
+	}
+};
 
 const actions = {
 	setWpcomNuxStatus: ( { isNuxEnabled, bypassApi } ) => {
@@ -21,9 +29,16 @@ const actions = {
 			isNuxEnabled,
 		};
 	},
+	setGuideOpenStatus: ( { isGuideManuallyOpened } ) => {
+		return {
+			type: 'WPCOM_BLOCK_EDITOR_SET_GUIDE_OPEN',
+			isGuideManuallyOpened,
+		};
+	},
 };
 
 const selectors = {
+	isGuideManuallyOpened: ( state ) => state.isGuideManuallyOpened,
 	isWpcomNuxEnabled: ( state ) => state.isNuxEnabled,
 };
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -2,18 +2,29 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { registerStore } from '@wordpress/data';
+import { combineReducers, registerStore } from '@wordpress/data';
 
-const reducer = ( state = {}, action ) => {
+const isNuxEnabledReducer = ( state = undefined, action ) => {
 	switch ( action.type ) {
 		case 'WPCOM_BLOCK_EDITOR_NUX_SET_STATUS':
-			return { ...state, isNuxEnabled: action.isNuxEnabled };
-		case 'WPCOM_BLOCK_EDITOR_SET_GUIDE_OPEN':
-			return { ...state, isGuideManuallyOpened: action.isGuideManuallyOpened };
+			return action.isNuxEnabled;
 		default:
 			return state;
 	}
 };
+const isGuideManuallyOpenedReducer = ( state = false, action ) => {
+	switch ( action.type ) {
+		case 'WPCOM_BLOCK_EDITOR_SET_GUIDE_OPEN':
+			return action.isGuideManuallyOpened;
+		default:
+			return state;
+	}
+};
+
+const reducer = combineReducers( {
+	isNuxEnabled: isNuxEnabledReducer,
+	isGuideManuallyOpened: isGuideManuallyOpenedReducer,
+} );
 
 const actions = {
 	setWpcomNuxStatus: ( { isNuxEnabled, bypassApi } ) => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -33,9 +33,12 @@ function WpcomNux() {
 			select( 'automattic/starter-page-layouts' ).isOpen(),
 		site: select( 'automattic/site' ).getSite( window._currentSiteId ),
 	} ) );
+	const isGuideManuallyOpened = useSelect( ( select ) =>
+		select( 'automattic/nux' ).isGuideManuallyOpened()
+	);
 
 	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
-	const { setWpcomNuxStatus } = useDispatch( 'automattic/nux' );
+	const { setWpcomNuxStatus, setGuideOpenStatus } = useDispatch( 'automattic/nux' );
 
 	// On mount check if the WPCOM NUX status exists in state, otherwise fetch it from the API.
 	useEffect( () => {
@@ -59,6 +62,7 @@ function WpcomNux() {
 		if ( isWpcomNuxEnabled && ! isSPTOpen ) {
 			recordTracksEvent( 'calypso_editor_wpcom_nux_open', {
 				is_gutenboarding: window.calypsoifyGutenberg?.isGutenboarding,
+				is_manually_opened: isGuideManuallyOpened,
 			} );
 		}
 	}, [ isWpcomNuxEnabled, isSPTOpen ] );
@@ -72,6 +76,7 @@ function WpcomNux() {
 			is_gutenboarding: window.calypsoifyGutenberg?.isGutenboarding,
 		} );
 		setWpcomNuxStatus( { isNuxEnabled: false } );
+		setGuideOpenStatus( { isGuideManuallyOpened: false } );
 	};
 
 	const isPodcastingSite = !! site?.options?.anchor_podcast;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -65,7 +65,7 @@ function WpcomNux() {
 				is_manually_opened: isGuideManuallyOpened,
 			} );
 		}
-	}, [ isWpcomNuxEnabled, isSPTOpen ] );
+	}, [ isWpcomNuxEnabled, isSPTOpen, isGuideManuallyOpened ] );
 
 	if ( ! isWpcomNuxEnabled || isSPTOpen ) {
 		return null;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/disable-core-nux.js
@@ -22,5 +22,6 @@ subscribe( () => {
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
 		dispatch( 'automattic/nux' ).setWpcomNuxStatus( { isNuxEnabled: true } );
+		dispatch( 'automattic/nux' ).toggleWpcomTourManualOpenStatus( { isTourManuallyOpen: true } );
 	}
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/disable-core-nux.js
@@ -14,6 +14,7 @@ const unsubscribe = subscribe( () => {
 } );
 
 // Listen for these features being triggered to call dotcom nux instead.
+// Note migration of areTipsEnabled: https://github.com/WordPress/gutenberg/blob/5c3a32dabe4393c45f7fe6ac5e4d78aebd5ee274/packages/data/src/plugins/persistence/index.js#L269
 subscribe( () => {
 	if ( select( 'core/nux' ).areTipsEnabled() ) {
 		dispatch( 'core/nux' ).disableTips();

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/disable-core-nux.js
@@ -21,7 +21,9 @@ subscribe( () => {
 	}
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
-		dispatch( 'automattic/nux' ).setWpcomNuxStatus( { isNuxEnabled: true } );
-		dispatch( 'automattic/nux' ).toggleWpcomTourManualOpenStatus( { isTourManuallyOpen: true } );
+		dispatch( 'automattic/nux' ).setWpcomNuxStatus( {
+			isNuxEnabled: true,
+		} );
+		dispatch( 'automattic/nux' ).setTourOpenStatus( { isTourManuallyOpened: true } );
 	}
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/store.js
@@ -38,6 +38,8 @@ const reducer = combineReducers( {
 } );
 
 const actions = {
+	// TODO: Clarify variable naming of nux vs tour for consistency and to better reflect terminology in core
+	// isFeatureActive instead of isNuxEnabled would match core nad make this logic easier to understand.
 	setWpcomNuxStatus: ( { isNuxEnabled, bypassApi } ) => {
 		if ( ! bypassApi ) {
 			apiFetch( {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/store.js
@@ -12,6 +12,14 @@ const isNuxEnabledReducer = ( state = undefined, action ) => {
 			return state;
 	}
 };
+const isTourManuallyOpenedReducer = ( state = false, action ) => {
+	switch ( action.type ) {
+		case 'WPCOM_BLOCK_EDITOR_SET_TOUR_OPEN':
+			return action.isTourManuallyOpened;
+		default:
+			return state;
+	}
+};
 
 // TODO: next PR convert file to Typescript to ensure control of tourRating values: null, 'thumbs-up' 'thumbs-down'
 const tourRatingReducer = ( state = undefined, action ) => {
@@ -25,6 +33,7 @@ const tourRatingReducer = ( state = undefined, action ) => {
 
 const reducer = combineReducers( {
 	isNuxEnabled: isNuxEnabledReducer,
+	isTourManuallyOpened: isTourManuallyOpenedReducer,
 	tourRating: tourRatingReducer,
 } );
 
@@ -45,16 +54,16 @@ const actions = {
 	setTourRating: ( tourRating ) => {
 		return { type: 'WPCOM_BLOCK_EDITOR_SET_TOUR_RATING', tourRating };
 	},
-	toggleWpcomTourManualOpenStatus: ( isTourManuallyOpen ) => {
+	setTourOpenStatus: ( { isTourManuallyOpened } ) => {
 		return {
-			type: 'WPCOM_BLOCK_EDITOR_TOGGLE_TOUR_MANUALLY_OPEN',
-			isManuallyOpen,
+			type: 'WPCOM_BLOCK_EDITOR_SET_TOUR_OPEN',
+			isTourManuallyOpened,
 		};
 	},
 };
 
 const selectors = {
-	isWpcomTourManuallyOpen: ( state ) => state.isTourManuallyOpen,
+	isTourManuallyOpened: ( state ) => state.isTourManuallyOpened,
 	isWpcomNuxEnabled: ( state ) => state.isNuxEnabled,
 	tourRating: ( state ) => state.tourRating,
 };

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/store.js
@@ -45,9 +45,16 @@ const actions = {
 	setTourRating: ( tourRating ) => {
 		return { type: 'WPCOM_BLOCK_EDITOR_SET_TOUR_RATING', tourRating };
 	},
+	toggleWpcomTourManualOpenStatus: ( isTourManuallyOpen ) => {
+		return {
+			type: 'WPCOM_BLOCK_EDITOR_TOGGLE_TOUR_MANUALLY_OPEN',
+			isManuallyOpen,
+		};
+	},
 };
 
 const selectors = {
+	isWpcomTourManuallyOpen: ( state ) => state.isTourManuallyOpen,
 	isWpcomNuxEnabled: ( state ) => state.isNuxEnabled,
 	tourRating: ( state ) => state.tourRating,
 };

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-content.js
@@ -34,7 +34,7 @@ function getTourContent() {
 		{
 			heading: __( 'Everything is a block', 'full-site-editing' ),
 			description: __(
-				'In the WordPress Editor paragraphs, images, and videos are all blocks.',
+				'In the WordPress Editor, paragraphs, images, and videos are all blocks.',
 				'full-site-editing'
 			),
 			imgSrc: allBlocks,
@@ -72,7 +72,7 @@ function getTourContent() {
 		},
 		{
 			heading: __( 'Drag & drop', 'full-site-editing' ),
-			description: __( 'To move blocks around click and drag the handle.', 'full-site-editing' ),
+			description: __( 'To move blocks around, click and drag the handle.', 'full-site-editing' ),
 			imgSrc: moveBlock,
 			animation: 'undo-button',
 		},

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
@@ -27,6 +27,9 @@ function LaunchWpcomWelcomeTour() {
 		select( 'automattic/nux' ).isWpcomNuxEnabled()
 	);
 	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
+	const isTourManuallyOpened = useSelect( ( select ) =>
+		select( 'automattic/nux' ).isTourManuallyOpened()
+	);
 	const { setWpcomNuxStatus } = useDispatch( 'automattic/nux' );
 
 	// Preload first card image (others preloaded after NUX status confirmed)
@@ -59,6 +62,7 @@ function LaunchWpcomWelcomeTour() {
 
 		recordTracksEvent( 'calypso_editor_wpcom_tour_open', {
 			is_gutenboarding: window.calypsoifyGutenberg?.isGutenboarding,
+			is_manually_opened: isTourManuallyOpened,
 		} );
 		return () => {
 			document.body.removeChild( portalParent );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
@@ -67,7 +67,7 @@ function LaunchWpcomWelcomeTour() {
 		return () => {
 			document.body.removeChild( portalParent );
 		};
-	}, [ isWpcomNuxEnabled, portalParent ] );
+	}, [ isTourManuallyOpened, isWpcomNuxEnabled, portalParent ] );
 
 	if ( ! isWpcomNuxEnabled ) {
 		return null;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
@@ -81,7 +81,8 @@ function WelcomeTourFrame() {
 	const [ isMinimized, setIsMinimized ] = useState( false );
 	const [ currentCardIndex, setCurrentCardIndex ] = useState( 0 );
 	const [ justMaximized, setJustMaximized ] = useState( false );
-	const { setWpcomNuxStatus } = useDispatch( 'automattic/nux' );
+
+	const { setWpcomNuxStatus, setTourOpenStatus } = useDispatch( 'automattic/nux' );
 
 	const dismissWpcomNuxTour = ( source ) => {
 		recordTracksEvent( 'calypso_editor_wpcom_tour_dismiss', {
@@ -89,8 +90,8 @@ function WelcomeTourFrame() {
 			slide_number: currentCardIndex + 1,
 			action: source,
 		} );
-
 		setWpcomNuxStatus( { isNuxEnabled: false } );
+		setTourOpenStatus( { isTourManuallyOpened: false } );
 	};
 
 	// Preload card images


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Add `isTourManuallyOpened` and `isGuideManuallyOpened` flag to indicate in tracking events if user is seeing Welcome Guide (Tour or NUX) from More Menu OR if user is a new user, viewing the Welcome Guide automatically, when the open the editor for the first time.

Want to note that I've found the `isNuxEnabled` language confusing because it is toggled on and off when user accesses the Guide from the more menu.   Logic would be easier to follow using something like Gutenberg's  [toggleFeature( 'welcomeGuide' )](https://github.com/WordPress/gutenberg/blob/c88866cd91ea3eb7990a68978e03e2366ed7106c/packages/edit-post/src/components/welcome-guide/index.js#L38) and from the [MoreMenu](https://github.com/WordPress/gutenberg/blob/c88866cd91ea3eb7990a68978e03e2366ed7106c/packages/edit-post/src/plugins/welcome-guide-menu-item/index.js#L17)
Putting on my todo list for post MVP work.

## Testing instructions

If testing on local standalone WP:
* Pull down this branch
* Add define( 'SHOW_WELCOME_TOUR', true ); to wp-config.php

If testing on sandbox:
* Pull down this branch and sync to sandbox `yarn dev --sync`
* Add define( 'SHOW_WELCOME_TOUR', true ); to your /home/wpcom/public_html/wp-content/mu-plugins/0-sandbox.php file. This will force the Welcome Tour to show every time the editor loads.

❗ In dev tools Application tab you must clear the site's local storage to ensure the @automattic/nux store is reset. Must be done in order to show the Welcome Guide on first load.

### #1 Test Welcome Tour

* Open a test site 
* In dev tools Application tab: Clear local storage for the site
* In dev tools Network tab: and filter by `calypso` and keep tab open to watch network requests
* Open the editor , and view the network requests and look for  the tracking event
  * `calypso_editor_wpcom_tour_open`
    - data: {is_gutenboarding:}
    - data: {is_manually_opened: **false**}  🔫
![Screen Shot 2021-01-14 at 14 05 30](https://user-images.githubusercontent.com/5665959/104539420-9968af80-5671-11eb-99d1-ea13b11f373d.png)
* Close the Tour
* Got to more menu and open "Welcome Guide"
* Observe same open event in dev tools, but now {is_manually_opened: **true**} 🔫


### #2 Test NUX modal
* Do a little hack to get NUX modal to show instead of the tour:  make[ `load_wpcom_block_editor_nux() `](https://github.com/Automattic/wp-calypso/blob/12f778c15658ed71646145aab9f83586900d04e4/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php#L243) require the NUX modal and NOT the tour
* Repeat test steps given above but now for the NUX modal


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


Fixes #
