### PR TITLE
ETK: Switch on block pattern modifications

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -282,7 +282,7 @@ add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
  * are loaded via load_block_patterns_from_api.
  */
 function load_wpcom_block_patterns_modifications() {
-	if ( apply_filters( 'a8c_enable_block_patterns_modifications', false ) ) {
+	if ( apply_filters( 'a8c_enable_block_patterns_modifications', true ) ) {
 		require_once __DIR__ . '/block-patterns/class-block-patterns-modifications.php';
 	}
 }


### PR DESCRIPTION
This PR switches on the Editing Toolkit's block pattern modifications containing the premium patterns highlighting.

Our A/B test on the new highlight is inconclusive but they do show that there's no detriment so we're conditionally enabling the feature for now.

We expect the change to be more impactful when we have more premium blocks so we'll retest again later after those are launched.

#### Testing instructions

- [ ] * Test the pink dot appears on Atomic and doesn't cause other errors. (Enabling the new functionality on Atomic is the most significant change in this patch).
- [ ] Check that the pink dot still appears on a sandboxed simple site with code-D55245 applied (the patch stops the server from enabling the pattern modifications so we can check that the the ETK will enable them instead).

See https://github.com/Automattic/wp-calypso/tree/trunk/apps/editing-toolkit for details on building/installing the ETK, but for simple sites I use the rather defensive:
`(cd ~/calypso; composer install; yarn install; yarn build; cd ~/calypso/apps/editing-toolkit; yarn install; yarn run dev --sync)` and for atomic sites I use:
`(TEST_USER=myusername; TEST_SITE=example.wordpress.com; cd ~/calypso/apps/editing-toolkit/editing-toolkit-plugin; yarn build &&  rsync -azP . $TEST_USER@$TEST_SITE:~/wp-content/plugins/full-site-editing )`


