### PR TITLE
Signup: Allow only public-api for social signup redirect URL

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -63,11 +63,15 @@ function getSiteDestination( dependencies ) {
 }
 
 function getRedirectDestination( dependencies ) {
-	if (
-		dependencies.oauth2_redirect &&
-		new URL( dependencies.oauth2_redirect ).host === 'public-api.wordpress.com'
-	) {
-		return dependencies.oauth2_redirect;
+	try {
+		if (
+			dependencies.oauth2_redirect &&
+			new URL( dependencies.oauth2_redirect ).host === 'public-api.wordpress.com'
+		) {
+			return dependencies.oauth2_redirect;
+		}
+	} catch {
+		return '/';
 	}
 
 	return '/';

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -65,7 +65,7 @@ function getSiteDestination( dependencies ) {
 function getRedirectDestination( dependencies ) {
 	if (
 		dependencies.oauth2_redirect &&
-		dependencies.oauth2_redirect.startsWith( 'https://public-api.wordpress.com' )
+		new URL( dependencies.oauth2_redirect ).host === 'public-api.wordpress.com'
 	) {
 		return dependencies.oauth2_redirect;
 	}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -205,8 +205,12 @@ export class UserStep extends Component {
 	};
 
 	isOauth2RedirectValid( oauth2Redirect ) {
-		const url = new URL( oauth2Redirect );
-		return url.host === 'public-api.wordpress.com';
+		try {
+			const url = new URL( oauth2Redirect );
+			return url.host === 'public-api.wordpress.com';
+		} catch {
+			return false;
+		}
 	}
 
 	submit = ( data ) => {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -25,6 +25,7 @@ import {
 	getPreviousStepName,
 	getStepUrl,
 } from 'calypso/signup/utils';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -203,6 +204,11 @@ export class UserStep extends Component {
 		} );
 	};
 
+	isOauth2RedirectValid( oauth2Redirect ) {
+		const url = new URL( oauth2Redirect );
+		return url.host === 'public-api.wordpress.com';
+	}
+
 	submit = ( data ) => {
 		const { flowName, stepName, oauth2Signup } = this.props;
 		const dependencies = {};
@@ -276,6 +282,15 @@ export class UserStep extends Component {
 	 * @param {object} userData     (Optional) extra user information that can be used to create a new account
 	 */
 	handleSocialResponse = ( service, access_token, id_token = null, userData = null ) => {
+		const { translate } = this.props;
+
+		if ( ! this.isOauth2RedirectValid( this.props.initialContext.query.oauth2_redirect ) ) {
+			this.props.errorNotice(
+				translate( 'An unexpected error occurred. Please try again later.' )
+			);
+			return;
+		}
+
 		this.submit( {
 			service,
 			access_token,
@@ -464,6 +479,7 @@ export default connect(
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 	} ),
 	{
+		errorNotice,
 		recordTracksEvent,
 		fetchOAuth2ClientData,
 		saveSignupStep,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -368,7 +368,8 @@ export class UserStep extends Component {
 		if (
 			this.props.oauth2Signup &&
 			this.props.initialContext &&
-			this.props.initialContext.query.oauth2_redirect
+			this.props.initialContext.query.oauth2_redirect &&
+			this.isOauth2RedirectValid( this.props.initialContext.query.oauth2_redirect )
 		) {
 			return this.props.initialContext.query.oauth2_redirect;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Signup: Allow only `public-api.wordpress.com` for social signup redirect URL.

#### Testing instructions

* Go to https://app.crowdsignal.com/login and replace any `wordpress.com` with `calypso.localhost:3000` or the `calypso.live` URL (depending on where you run this branch).
* Try signing up with a Google account and verify it still works well.
* Try logging in with a Google account and verify it still works well.
* Try altering the `oauth2_redirect` param before logging in / signing up with the google account. Verify you get an error notice.
