### PR TITLE
Add missing dependency on react-dom

### DIFF
--- a/packages/calypso-stripe/package.json
+++ b/packages/calypso-stripe/package.json
@@ -40,6 +40,7 @@
 		"@automattic/load-script": "^1.0.0",
 		"debug": "^4.1.1",
 		"react": "^16.12.0",
+		"react-dom": "^16.12.0",
 		"react-stripe-elements": "^4.0.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds missing dependency on `react-dom`. 

Fixes

```
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/calypso-stripe/package.json:43:28: Unmet transitive peer dependency on react-dom@^15.5.4 || ^16.0.0-0, via react-stripe-elements@^4.0.2
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/calypso-stripe/package.json:48:29: Unmet transitive peer dependency on react-dom@*, via @testing-library/react@^10.0.5
```
