### PR TITLE
Fix dependencies of eslint-plugin-wpcalypso

### DIFF
--- a/packages/eslint-plugin-wpcalypso/package.json
+++ b/packages/eslint-plugin-wpcalypso/package.json
@@ -28,6 +28,7 @@
 		"eslint-plugin-jsdoc": "^30.7.3"
 	},
 	"devDependencies": {
+		"eslint": ">=7.12.0",
 		"babel-eslint": "^10.1.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12851,7 +12851,7 @@ eslint@^6.8.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-eslint@^7.1.0, eslint@^7.12.0:
+eslint@^7.1.0, eslint@^7.12.0, eslint@>=7.12.0:
   version "7.12.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.12.0.tgz#7b6a85f87a9adc239e979bb721cde5ce0dc27da6"
   integrity sha512-n5pEU27DRxCSlOhJ2rO57GDLcNsxO0LPpAbpFdh7xmcDmjmlGUfoyrsB3I7yYdQXO5N3gkSTiDrPSPNFiiirXA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add missing peer dependency, required to run tests:

Fixes

```
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/eslint-plugin-wpcalypso/package.json:31:19: Unmet transitive peer dependency on eslint@>= 4.12.1, via babel-eslint@^10.1.0
```
