### PR TITLE
Deduplicate eslint-plugin-react-hooks

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12713,15 +12713,10 @@ eslint-plugin-prettier@^3.1.2, eslint-plugin-prettier@^3.1.4:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-hooks@^4.0.4:
+eslint-plugin-react-hooks@^4.0.4, eslint-plugin-react-hooks@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.8.tgz#a9b1e3d57475ccd18276882eff3d6cba00da7a56"
   integrity sha512-6SSb5AiMCPd8FDJrzah+Z4F44P2CdOaK026cXFV+o/xSRzfOiV1FNFeLl2z6xm3yqWOQEZ5OfVgiec90qV2xrQ==
-
-eslint-plugin-react-hooks@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.5.tgz#4879003aa38e5d05d0312175beb6e4a1f617bfcf"
-  integrity sha512-3YLSjoArsE2rUwL8li4Yxx1SUg3DQWp+78N3bcJQGWVZckcp+yeQGsap/MSq05+thJk57o+Ww4PtZukXGL02TQ==
 
 eslint-plugin-react@^7.20.0, eslint-plugin-react@^7.21.5:
   version "7.21.5"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `eslint-plugin-react-hooks` (done automatically with `npx yarn-deduplicate --packages eslint-plugin-react-hooks`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 ->  -> ... -> eslint-plugin-react-hooks@4.0.5
> wp-calypso@0.17.0 ->  -> ... -> eslint-plugin-react-hooks@4.0.8
```