### PR TITLE
Deduplicate eslint-scope

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12748,15 +12748,7 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
-  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
-  dependencies:
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
-eslint-scope@^5.1.1:
+eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `eslint-scope` (done automatically with `npx yarn-deduplicate --packages eslint-scope`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @typescript-eslint/eslint-plugin@4.12.0 -> ... -> eslint-scope@5.0.0
< wp-calypso@0.17.0 -> eslint-plugin-jest@23.20.0 -> ... -> eslint-scope@5.0.0
< wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> eslint-scope@5.0.0
> wp-calypso@0.17.0 -> @typescript-eslint/eslint-plugin@4.12.0 -> ... -> eslint-scope@5.1.1
> wp-calypso@0.17.0 -> eslint-plugin-jest@23.20.0 -> ... -> eslint-scope@5.1.1
> wp-calypso@0.17.0 -> eslint-plugin-md@1.0.19 -> ... -> eslint-scope@5.1.1
```