### PR TITLE
Jetpack Cloud: construct wp-admin URL from site in query parameters

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card-button/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card-button/index.tsx
@@ -9,11 +9,12 @@ import { Button } from '@automattic/components';
 /**
  * Internal dependencies
  */
+import { JPC_PATH_BASE } from 'calypso/jetpack-connect/constants';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { addQueryArgs } from 'calypso/lib/route';
+import { getUrlParts, getUrlFromParts } from 'calypso/lib/url';
 import getJetpackWpAdminUrl from 'calypso/state/selectors/get-jetpack-wp-admin-url';
-import { JPC_PATH_BASE } from 'calypso/jetpack-connect/constants';
 
 /**
  * Type dependencies
@@ -36,18 +37,32 @@ const JetpackFreeCardButton: FC< JetpackFreeCardButtonProps > = ( {
 	urlQueryArgs,
 } ) => {
 	const translate = useTranslate();
-	const isSiteinContext = !! siteId;
 	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
+
+	// If the user is not logged in and there is a site in the URL, we need to construct
+	// the URL to wp-admin from the `site` query parameter
+	const wpAdminUrlFromQuery = urlQueryArgs.site
+		? getUrlFromParts( {
+				...getUrlParts( `https://${ urlQueryArgs.site }/wp-admin/admin.php` ),
+				search: '?page=jetpack',
+				hash: '/my-plan',
+		  } ).href
+		: null;
+
 	const onClickTrack = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
 		site_id: siteId || undefined,
 	} );
+
+	// `siteId` is going to be null if the user is not logged in, so we need to check
+	// if there is a site in the URL also
+	const isSiteinContext = siteId || urlQueryArgs.site;
 
 	// Jetpack Connect flow uses `url` instead of `site` as the query parameter for a site URL
 	const { site: url, ...restQueryArgs } = urlQueryArgs;
 	const startHref =
 		isJetpackCloud() && ! isSiteinContext
 			? addQueryArgs( { url, ...restQueryArgs }, `https://wordpress.com${ JPC_PATH_BASE }` )
-			: wpAdminUrl || JPC_PATH_BASE;
+			: wpAdminUrl || wpAdminUrlFromQuery || JPC_PATH_BASE;
 	return (
 		<Button primary={ primary } className={ className } href={ startHref } onClick={ onClickTrack }>
 			{ label || translate( 'Start for free' ) }


### PR DESCRIPTION
#### Motivation

Continuation of #48836 to make it work with unauthenticated users. Fixes 1164141197617539-as-1199526095711090.

The Jetpack Free CTA takes users back to wp-admin if there is a site in context, otherwise, it takes users to the Jetpack Connect flow. This doesn't always work as expected. When users are not logged in cloud.jetpack.com we send them to the Jetpack Connect flow even when there is a site in context. This happens because we rely on a function, to construct the URL to the site's wp-admin dashboard, that only works for authenticated users.

#### Changes proposed in this Pull Request

* In the case of unauthenticated users, construct a URL back to the site's wp-admin dashboard from the site present in the URL. 

#### Testing instructions

* Download this PR and run Calypso Green.
* Visit the pricing page located at `/pricing`.
* Scroll down to the bottom of the page, and click the Jetpack Free CTA.
* Verify that you are redirected to the Jetpack Connect flow.
* From the wp-admin dashboard of a Jetpack site, click on the Plans tab of the Jetpack section.
* Verify that you are redirected to `https://cloud.jetpack.com/pricing/:site?site=:site&source=jetpack-connect-plans`.
* Replace `https://cloud.jetpack.com` with `jetpack.cloud.localhost:3000` and keep the rest of the URL intact.
* Scroll down to the bottom of the page, and click the Jetpack Free CTA.
* Verify that you are redirected back to your site wp-admin dashboard even if you are not authenticated.

#### Demo before
![DemoBug](https://user-images.githubusercontent.com/3418513/104462732-b3ca5c80-558f-11eb-9460-b38bb5b0ca9e.gif)

#### Demo after
![DemoFix](https://user-images.githubusercontent.com/3418513/104462447-56cea680-558f-11eb-9401-648f90a02ee8.gif)
