### PR TITLE
Send user to the Editor instead of Customizer when activating a new theme

### DIFF
--- a/client/state/selectors/get-customize-or-edit-front-page-url.js
+++ b/client/state/selectors/get-customize-or-edit-front-page-url.js
@@ -5,7 +5,6 @@ import { getThemeCustomizeUrl, isThemeActive } from 'calypso/state/themes/select
 import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
 import getFrontPageEditorUrl from 'calypso/state/selectors/get-front-page-editor-url';
 import shouldCustomizeHomepageWithGutenberg from 'calypso/state/selectors/should-customize-homepage-with-gutenberg';
-import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 
 /**
  * Returns the URL for opening customizing the given site in either the block editor with
@@ -24,11 +23,11 @@ export default function getCustomizeOrEditFrontPageUrl( state, themeId, siteId )
 	const shouldUseGutenberg =
 		shouldCustomizeHomepageWithGutenberg( state, siteId ) ||
 		isSiteUsingFullSiteEditing( state, siteId );
-	const isAtomic = isSiteAtomic( state, siteId );
+	const frontPageEditorUrl = getFrontPageEditorUrl( state, siteId );
 
-	// If the theme is not active, use the other function to preview customization with the theme.
-	if ( ! isAtomic && shouldUseGutenberg && isThemeActive( state, themeId, siteId ) ) {
-		return getFrontPageEditorUrl( state, siteId );
+	// If the theme is not active or getFrontPageEditorUrl has returned 'false', use the other function to preview customization with the theme.
+	if ( frontPageEditorUrl && shouldUseGutenberg && isThemeActive( state, themeId, siteId ) ) {
+		return frontPageEditorUrl;
 	}
 
 	return getThemeCustomizeUrl( state, themeId, siteId );


### PR DESCRIPTION
**Context**

An initial fix for put in place to send the user to the Customizer after activating a theme on Atomic sites, and clicking "Edit homepage" to prevent Calypso erroring and showing a blank white screen (context: p9F6qB-63w-p2).

This was due to, in some cases the `getFrontPageEditorUrl` returning `false` which can be seen [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/selectors/get-front-page-editor-url.js#L17) as this resulting value (`false`) was used in `addQueryArgs` [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/themes/thanks-modal.jsx#L306) which expects a string, the cause of the error.

This change checks that the value is not `false` before returning it, in the event that it is `false` it will return the Customizer url.

#### Changes proposed in this Pull Request

* Check `getFrontPageEditorUrl` is not a `false` value before returning it.

#### Testing instructions

**Simple sites**

* Create a Simple Site, head over to `/themes/SITE_ID.wordpress.com`
* Select a new theme, and activate it
* Click "Edit homepage" which should redirect you to the Editor
* Now, go into WP Admin and head over to Settings > Reading
* Like the below screenshot, unset your homepage (but make sure your Posts page has a value still)
* Go back to `/themes/SITE_ID.wordpress.com`
* Activate a theme and click "Edit homepage" should take you to the Cutomzier

**Atomic sites**
* Create an Atomic Site, head over to `/themes/SITE_ID.wordpress.com`
* Select a new theme, and activate it
* Click "Edit homepage" which should redirect you to the editor
* Go into WP Admin and head over to Settings > Reading
* Like the below screenshot, unset your homepage (but make sure your Posts page has a value still)
* Go back to `/themes/SITE_ID.wordpress.com` (In this scenario you would have seen the original white screen error)
* Activate a theme and click "Edit homepage" should take you to the Editor

![Screenshot 2021-01-13 at 14 11 07](https://user-images.githubusercontent.com/8639742/104464018-5d1e4c00-55aa-11eb-9c59-35bc106ba33f.png)

Fixes https://github.com/Automattic/wp-calypso/issues/46831