### PR TITLE
Email: Update post checkout page for Titan Mail

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/features-header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/features-header.jsx
@@ -16,6 +16,7 @@ import {
 	isDomainTransfer,
 	isGoogleApps,
 	isGuidedTransfer,
+	isTitanMail,
 } from 'calypso/lib/products-values';
 
 const FeaturesHeader = ( { isDataLoaded, isGenericReceipt, purchases, hasFailedPurchases } ) => {
@@ -37,7 +38,8 @@ const FeaturesHeader = ( { isDataLoaded, isGenericReceipt, purchases, hasFailedP
 		purchases.some( isDomainRegistration ) ||
 		purchases.some( isDomainMapping ) ||
 		purchases.some( isGuidedTransfer ) ||
-		purchases.some( isDomainTransfer );
+		purchases.some( isDomainTransfer ) ||
+		purchases.some( isTitanMail );
 
 	if ( shouldHideFeaturesHeading ) {
 		return <div />;

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -20,6 +20,7 @@ import {
 	isGuidedTransfer,
 	isPlan,
 	isSiteRedirect,
+	isTitanMail,
 } from 'calypso/lib/products-values';
 import {
 	isGSuiteExtraLicenseProductSlug,
@@ -39,6 +40,7 @@ import getCheckoutUpgradeIntent from '../../../state/selectors/get-checkout-upgr
 import { Button } from '@automattic/components';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { downloadTrafficGuide } from 'calypso/my-sites/marketing/ultimate-traffic-guide';
+import { emailManagementEdit } from 'calypso/my-sites/email/paths';
 
 export class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
@@ -218,6 +220,12 @@ export class CheckoutThankYouHeader extends PureComponent {
 			);
 		}
 
+		if ( isTitanMail( primaryPurchase ) ) {
+			return preventWidows(
+				translate( 'You will receive an email confirmation shortly for your purchase.' )
+			);
+		}
+
 		if ( isGuidedTransfer( primaryPurchase ) ) {
 			if ( typeof primaryPurchase.meta === 'string' ) {
 				return translate(
@@ -326,6 +334,12 @@ export class CheckoutThankYouHeader extends PureComponent {
 		window.location.href = selectedSite.URL;
 	};
 
+	visitEmailManagement = ( event ) => {
+		event.preventDefault();
+		const { primaryPurchase, selectedSite } = this.props;
+		page( emailManagementEdit( selectedSite.slug, primaryPurchase.meta ) );
+	};
+
 	visitSiteHostingSettings = ( event ) => {
 		event.preventDefault();
 
@@ -425,7 +439,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 				: translate( 'Manage domains' );
 		}
 
-		if ( isGoogleApps( primaryPurchase ) ) {
+		if ( isGoogleApps( primaryPurchase ) || isTitanMail( primaryPurchase ) ) {
 			return translate( 'Manage email' );
 		}
 
@@ -510,6 +524,8 @@ export class CheckoutThankYouHeader extends PureComponent {
 			clickHandler = this.visitDomain;
 		} else if ( isTrafficGuidePurchase ) {
 			clickHandler = this.downloadTrafficGuideHandler;
+		} else if ( isTitanMail( primaryPurchase ) || isGoogleApps( primaryPurchase ) ) {
+			clickHandler = this.visitEmailManagement;
 		}
 
 		return (

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -524,7 +524,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			clickHandler = this.visitDomain;
 		} else if ( isTrafficGuidePurchase ) {
 			clickHandler = this.downloadTrafficGuideHandler;
-		} else if ( isTitanMail( primaryPurchase ) || isGoogleApps( primaryPurchase ) ) {
+		} else if ( isTitanMail( primaryPurchase ) ) {
 			clickHandler = this.visitEmailManagement;
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -53,6 +53,7 @@ import {
 	isBusiness,
 	isSiteRedirect,
 	isTheme,
+	isTitanMail,
 } from 'calypso/lib/products-values';
 import { isExternal } from 'calypso/lib/url';
 import JetpackPlanDetails from './jetpack-plan-details';
@@ -537,6 +538,8 @@ export class CheckoutThankYou extends React.Component {
 				return [ SiteRedirectDetails, ...findPurchaseAndDomain( purchases, isSiteRedirect ) ];
 			} else if ( purchases.some( isDomainTransfer ) ) {
 				return [ false, ...findPurchaseAndDomain( purchases, isDomainTransfer ) ];
+			} else if ( purchases.some( isTitanMail ) ) {
+				return [ false, ...findPurchaseAndDomain( purchases, isTitanMail ) ];
 			} else if ( purchases.some( isChargeback ) ) {
 				return [ ChargebackDetails, find( purchases, isChargeback ) ];
 			} else if ( purchases.some( isGuidedTransfer ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes some minor updates to the post checkout page, to display a button to manage email when Titan mail is purchased.

<img width="695" alt="Screenshot 2021-01-13 at 3 29 52 PM" src="https://user-images.githubusercontent.com/13062352/104465299-3107c880-55b4-11eb-893d-56f464a3d202.png">

#### Testing instructions

- Purchase a Titan mail subscription
- The post checkout page should look like the screenshot above
- Clicking the manage email button should take you to the proper view to manage email
