### PR TITLE
Refunds: update copy to reflect 14-day refunds

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -115,7 +115,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 						{ createInterpolateElement(
 							/* translators: pressing <Link> will redirect user to plan selection step */
 							__(
-								'<Link>Upgrade to Premium</Link> to get access to 13GB storage space, payment collection options, 24/7 Live Chat support, and more. Not sure? Give it a spin—we offer 30-day full-refunds, guaranteed.',
+								'<Link>Upgrade to Premium</Link> to get access to 13GB storage space, payment collection options, 24/7 Live Chat support, and more. Not sure? Give it a spin—we offer 14-day full-refunds, guaranteed.',
 								'full-site-editing'
 							),
 							{

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import classnames from 'classnames';
 import { ThemeProvider } from 'emotion-theming';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Button, Tip } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
@@ -113,10 +113,13 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 					<p>{ __( 'Plan subscription: Free forever', 'full-site-editing' ) }</p>
 					<Tip>
 						{ createInterpolateElement(
-							/* translators: pressing <Link> will redirect user to plan selection step */
-							__(
-								'<Link>Upgrade to Premium</Link> to get access to 13GB storage space, payment collection options, 24/7 Live Chat support, and more. Not sure? Give it a spin—we offer 14-day full-refunds, guaranteed.',
-								'full-site-editing'
+							sprintf(
+								/* translators: pressing <Link> will redirect user to plan selection step; %1$d is the number of days */
+								__(
+									'<Link>Upgrade to Premium</Link> to get access to 13GB storage space, payment collection options, 24/7 Live Chat support, and more. Not sure? Give it a spin—we offer %1$d-day full-refunds, guaranteed.',
+									'full-site-editing'
+								),
+								14
 							),
 							{
 								Link: <Button isLink onClick={ () => setStep( LaunchStep.Plan ) } />,

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -46,7 +46,7 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 					<Title>{ __( 'Select a plan', 'full-site-editing' ) }</Title>
 					<SubTitle>
 						{ __(
-							'Pick a plan that’s right for you. Switch plans as your needs change. There’s no risk, you can cancel for a full refund within 30 days.',
+							'Pick a plan that’s right for you. Switch plans as your needs change. There’s no risk, you can cancel for a full refund within 14 days.',
 							'full-site-editing'
 						) }
 					</SubTitle>

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -3,7 +3,7 @@
  */
 import * as React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Plans } from '@automattic/data-stores';
 import PlansGrid from '@automattic/plans-grid';
 import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
@@ -45,9 +45,13 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 				<div>
 					<Title>{ __( 'Select a plan', 'full-site-editing' ) }</Title>
 					<SubTitle>
-						{ __(
-							'Pick a plan that’s right for you. Switch plans as your needs change. There’s no risk, you can cancel for a full refund within 14 days.',
-							'full-site-editing'
+						{ sprintf(
+							/* translators: number of days */
+							__(
+								'Pick a plan that’s right for you. Switch plans as your needs change. There’s no risk, you can cancel for a full refund within %1$d days.',
+								'full-site-editing'
+							),
+							14
 						) }
 					</SubTitle>
 				</div>

--- a/client/components/faq/docs/example.jsx
+++ b/client/components/faq/docs/example.jsx
@@ -23,8 +23,8 @@ export default class extends React.Component {
 				<FAQItem
 					question="Can I cancel my subscription?"
 					answer={ [
-						'Yes. We want you to love everything you do at WordPress.com, so we provide a 30-day refund on all of our plans. ',
-						<a href="#" key="manage-purchases">
+						'Yes. We want you to love everything you do at WordPress.com, so we provide a 14-day refund on all of our plans. ',
+						<a href="/devdocs/design/f-a-q" key="manage-purchases">
 							Manage purchases
 						</a>,
 					] }
@@ -48,8 +48,8 @@ export default class extends React.Component {
 				<FAQItem
 					question="Can I cancel my subscription?"
 					answer={ [
-						'Yes. We want you to love everything you do at WordPress.com, so we provide a 30-day refund on all of our plans. ',
-						<a href="#" key="manage-purchases-two">
+						'Yes. We want you to love everything you do at WordPress.com, so we provide a 14-day refund on all of our plans. ',
+						<a href="/devdocs/design/f-a-q" key="manage-purchases-two">
 							Manage purchases
 						</a>,
 					] }

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -92,7 +92,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				<Title>{ __( 'Select a plan' ) }</Title>
 				<SubTitle>
 					{ __(
-						'Pick a plan that’s right for you. There’s no risk, you can cancel for a full refund within 30 days.'
+						'Pick a plan that’s right for you. There’s no risk, you can cancel for a full refund within 14 days.'
 					) }
 				</SubTitle>
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import PlansGrid from '@automattic/plans-grid';
 import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
@@ -91,8 +92,12 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			<div>
 				<Title>{ __( 'Select a plan' ) }</Title>
 				<SubTitle>
-					{ __(
-						'Pick a plan that’s right for you. There’s no risk, you can cancel for a full refund within 14 days.'
+					{ sprintf(
+						/* translators: number of days */
+						__(
+							'Pick a plan that’s right for you. There’s no risk, you can cancel for a full refund within %1$d days.'
+						),
+						14
 					) }
 				</SubTitle>
 			</div>

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -460,7 +460,7 @@ function isRechargeable( purchase ) {
 
 /**
  * Checks if a purchase can be canceled and refunded via the WordPress.com API.
- * Purchases usually can be refunded up to 30 days after purchase.
+ * Purchases usually can be refunded up to 14 days after purchase.
  * Domains and domain mappings can be refunded up to 96 hours.
  * Purchases included with plan can't be refunded.
  *

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -115,7 +115,7 @@ class AppointmentInfo extends Component {
 							<br />
 							<FormSettingExplanation>
 								{ translate(
-									'Note: You have 30 days from the date of purchase to cancel an unused Quick Start ' +
+									'Note: You have 14 days from the date of purchase to cancel an unused Quick Start ' +
 										'session and receive a refund. Please note, if you miss a scheduled session twice, ' +
 										'the purchase will be cancelled without a refund.'
 								) }

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -115,9 +115,10 @@ class AppointmentInfo extends Component {
 							<br />
 							<FormSettingExplanation>
 								{ translate(
-									'Note: You have 14 days from the date of purchase to cancel an unused Quick Start ' +
+									'Note: You have %(days)d days from the date of purchase to cancel an unused Quick Start ' +
 										'session and receive a refund. Please note, if you miss a scheduled session twice, ' +
-										'the purchase will be cancelled without a refund.'
+										'the purchase will be cancelled without a refund.',
+									{ args: { days: 14 } }
 								) }
 							</FormSettingExplanation>
 						</>

--- a/client/my-sites/checkout/composite-checkout/components/concierge-refund-policy.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/concierge-refund-policy.jsx
@@ -23,8 +23,9 @@ class ConciergeRefundPolicy extends React.Component {
 
 	renderPolicy = () => {
 		const message = this.props.translate(
-			'You understand that {{refundsSupportPage}}Quick Start Session refunds{{/refundsSupportPage}} are limited to 14 days from the date of purchase.',
+			'You understand that {{refundsSupportPage}}Quick Start Session refunds{{/refundsSupportPage}} are limited to %(days)d days from the date of purchase.',
 			{
+				args: { days: 14 },
 				components: {
 					refundsSupportPage: (
 						<a

--- a/client/my-sites/checkout/composite-checkout/components/concierge-refund-policy.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/concierge-refund-policy.jsx
@@ -23,7 +23,7 @@ class ConciergeRefundPolicy extends React.Component {
 
 	renderPolicy = () => {
 		const message = this.props.translate(
-			'You understand that {{refundsSupportPage}}Quick Start Session refunds{{/refundsSupportPage}} are limited to 30 days from the date of purchase.',
+			'You understand that {{refundsSupportPage}}Quick Start Session refunds{{/refundsSupportPage}} are limited to 14 days from the date of purchase.',
 			{
 				components: {
 					refundsSupportPage: (

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -155,11 +155,11 @@ function CheckoutSummaryFeaturesList( props ) {
 
 	let refundText = translate( 'Money back guarantee' );
 	if ( hasDomainsInCart && ! hasPlanInCart ) {
-		refundText = translate( '4 day money back guarantee' );
+		refundText = translate( '4-day money back guarantee' );
 	} else if ( hasPlanInCart && ! hasDomainsInCart ) {
 		refundText = hasMonthlyPlan
-			? translate( '7 day money back guarantee' )
-			: translate( '30 day money back guarantee' );
+			? translate( '7-day money back guarantee' )
+			: translate( '14-day money back guarantee' );
 	}
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -154,12 +154,24 @@ function CheckoutSummaryFeaturesList( props ) {
 	const { hasMonthlyPlan = false } = props;
 
 	let refundText = translate( 'Money back guarantee' );
+
+	let refundDays = 0;
 	if ( hasDomainsInCart && ! hasPlanInCart ) {
-		refundText = translate( '4-day money back guarantee' );
+		refundDays = 4;
 	} else if ( hasPlanInCart && ! hasDomainsInCart ) {
-		refundText = hasMonthlyPlan
-			? translate( '7-day money back guarantee' )
-			: translate( '14-day money back guarantee' );
+		refundDays = hasMonthlyPlan ? 7 : 14;
+	}
+
+	if ( refundDays !== 0 ) {
+		// Using plural translation because some languages have multiple plural forms and no plural-agnostic.
+		refundText = translate(
+			'%(days)d-day money back guarantee',
+			'%(days)d-day money back guarantee',
+			{
+				count: refundDays,
+				args: { days: refundDays },
+			}
+		);
 	}
 
 	return (

--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -223,7 +223,7 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 								) }
 							{ ! hasSevenDayRefundPeriod &&
 								translate(
-									'The good news is that you can upgrade your plan today and try the Business plan risk-free thanks to our {{b}}30-day money-back guarantee{{/b}}.',
+									'The good news is that you can upgrade your plan today and try the Business plan risk-free thanks to our {{b}}14-day money-back guarantee{{/b}}.',
 									{
 										components: { b: <b /> },
 									}
@@ -249,7 +249,7 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 								) }
 							{ ! hasSevenDayRefundPeriod &&
 								translate(
-									'Simply click the link below and select the Business plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have 30 days to evaluate the plan and decide if it’s right for you.',
+									'Simply click the link below and select the Business plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have 14 days to evaluate the plan and decide if it’s right for you.',
 									{
 										components: {
 											del: <del />,

--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -213,56 +213,41 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 							) }
 						</p>
 						<p>
-							{ hasSevenDayRefundPeriod && // @todo - Remove the duplicate translations once the new string is translated
+							{
+								// Using plural translation because some languages have multiple plural forms and no plural-agnostic.
 								translate(
 									'The good news is that you can upgrade your plan today and try the Business plan risk-free thanks to our {{b}}%(days)d-day money-back guarantee{{/b}}.',
+									'The good news is that you can upgrade your plan today and try the Business plan risk-free thanks to our {{b}}%(days)d-day money-back guarantee{{/b}}.',
 									{
-										args: { days: 7 },
+										count: hasSevenDayRefundPeriod ? 7 : 14,
 										components: { b: <b /> },
+										args: { days: hasSevenDayRefundPeriod ? 7 : 14 },
 									}
-								) }
-							{ ! hasSevenDayRefundPeriod &&
-								translate(
-									'The good news is that you can upgrade your plan today and try the Business plan risk-free thanks to our {{b}}14-day money-back guarantee{{/b}}.',
-									{
-										components: { b: <b /> },
-									}
-								) }
+								)
+							}
 						</p>
 						<p>
-							{ hasSevenDayRefundPeriod &&
+							{
+								// Using plural translation because some languages have multiple plural forms and no plural-agnostic.
 								translate(
+									'Simply click the link below and select the Business plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have %(days)d day to evaluate the plan and decide if it’s right for you.',
 									'Simply click the link below and select the Business plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have %(days)d days to evaluate the plan and decide if it’s right for you.',
 									{
+										count: hasSevenDayRefundPeriod ? 7 : 14,
 										components: {
 											del: <del />,
 											b: <b />,
 										},
 										args: {
-											days: 7,
+											days: hasSevenDayRefundPeriod ? 7 : 14,
 											fullPrice: formatCurrency( planRawPrice, currencyCode, { stripZeros: true } ),
 											discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
 												stripZeros: true,
 											} ),
 										},
 									}
-								) }
-							{ ! hasSevenDayRefundPeriod &&
-								translate(
-									'Simply click the link below and select the Business plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have 14 days to evaluate the plan and decide if it’s right for you.',
-									{
-										components: {
-											del: <del />,
-											b: <b />,
-										},
-										args: {
-											fullPrice: formatCurrency( planRawPrice, currencyCode, { stripZeros: true } ),
-											discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
-												stripZeros: true,
-											} ),
-										},
-									}
-								) }
+								)
+							}
 						</p>
 						<p>{ translate( 'So are you ready to explore our most powerful plan ever?' ) }</p>
 					</div>

--- a/client/my-sites/checkout/upsell-nudge/premium-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/premium-plan-upgrade-upsell/index.jsx
@@ -188,7 +188,7 @@ export class PremiumPlanUpgradeUpsell extends PureComponent {
 						</ul>
 						<p>
 							{ translate(
-								'Try Premium risk-free with our {{strong}}30-day money-back guarantee{{/strong}}. If you don’t love it, you can return to the Personal Plan.',
+								'Try Premium risk-free with our {{strong}}14-day money-back guarantee{{/strong}}. If you don’t love it, you can return to the Personal Plan.',
 								{
 									components: { strong: <strong /> },
 								}

--- a/client/my-sites/checkout/upsell-nudge/premium-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/premium-plan-upgrade-upsell/index.jsx
@@ -188,8 +188,9 @@ export class PremiumPlanUpgradeUpsell extends PureComponent {
 						</ul>
 						<p>
 							{ translate(
-								'Try Premium risk-free with our {{strong}}14-day money-back guarantee{{/strong}}. If you don’t love it, you can return to the Personal Plan.',
+								'Try Premium risk-free with our {{strong}}%(days)d-day money-back guarantee{{/strong}}. If you don’t love it, you can return to the Personal Plan.',
 								{
+									args: { days: 14 },
 									components: { strong: <strong /> },
 								}
 							) }

--- a/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
+++ b/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
@@ -53,7 +53,7 @@ const JetpackFAQi5: React.FC = () => {
 				>
 					{ translate(
 						'We want to make sure Jetpack is exactly what you need, so you can request a cancellation' +
-							' within 30 days of purchase and receive a full refund. If there’s something you’d like' +
+							' within 14 days of purchase and receive a full refund. If there’s something you’d like' +
 							' to see changed in Jetpack to better suit your needs, {{helpLink}}please let us know{{/helpLink}}!',
 						{
 							components: { helpLink: getHelpLink( 'cancellation' ) },

--- a/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
+++ b/client/my-sites/plans-features-main/jetpack-faq-i5/index.tsx
@@ -53,9 +53,10 @@ const JetpackFAQi5: React.FC = () => {
 				>
 					{ translate(
 						'We want to make sure Jetpack is exactly what you need, so you can request a cancellation' +
-							' within 14 days of purchase and receive a full refund. If there’s something you’d like' +
+							' within %(days)d days of purchase and receive a full refund. If there’s something you’d like' +
 							' to see changed in Jetpack to better suit your needs, {{helpLink}}please let us know{{/helpLink}}!',
 						{
+							args: { days: 14 },
 							components: { helpLink: getHelpLink( 'cancellation' ) },
 						}
 					) }

--- a/client/my-sites/plans-features-main/jetpack-faq.jsx
+++ b/client/my-sites/plans-features-main/jetpack-faq.jsx
@@ -38,7 +38,7 @@ const JetpackFAQ = () => {
 				question={ translate( 'What is the cancellation policy?' ) }
 				answer={ translate(
 					'We want to make sure Jetpack is exactly what you need, so you can request a cancellation' +
-						' within 30 days of purchase and receive a full refund. If there’s something you’d like' +
+						' within 14 days of purchase and receive a full refund. If there’s something you’d like' +
 						' to see changed in Jetpack to better suit your needs, {{helpLink}}please let us know{{/helpLink}}!',
 					{
 						components: { helpLink: getHelpLink( 'cancellation' ) },

--- a/client/my-sites/plans-features-main/jetpack-faq.jsx
+++ b/client/my-sites/plans-features-main/jetpack-faq.jsx
@@ -38,9 +38,10 @@ const JetpackFAQ = () => {
 				question={ translate( 'What is the cancellation policy?' ) }
 				answer={ translate(
 					'We want to make sure Jetpack is exactly what you need, so you can request a cancellation' +
-						' within 14 days of purchase and receive a full refund. If there’s something you’d like' +
+						' within %(days)d days of purchase and receive a full refund. If there’s something you’d like' +
 						' to see changed in Jetpack to better suit your needs, {{helpLink}}please let us know{{/helpLink}}!',
 					{
+						args: { days: 14 },
 						components: { helpLink: getHelpLink( 'cancellation' ) },
 					}
 				) }

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -142,8 +142,9 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 			<FAQItem
 				question={ translate( 'Can I cancel my subscription?' ) }
 				answer={ translate(
-					'Yes. We want you to love everything you do at WordPress.com, so we provide a 14-day refund on all of our annual plans and a 7-day refund on all of our monthly plans. {{a}}Manage purchases{{/a}}.',
+					'Yes. We want you to love everything you do at WordPress.com, so we provide a %(annualDays)d-day refund on all of our annual plans and a %(monthlyDays)d-day refund on all of our monthly plans. {{a}}Manage purchases{{/a}}.',
 					{
+						args: { annualDays: 14, monthlyDays: 7 },
 						components: { a: <a href={ purchasesRoot } /> },
 					}
 				) }

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -142,8 +142,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 			<FAQItem
 				question={ translate( 'Can I cancel my subscription?' ) }
 				answer={ translate(
-					'Yes. We want you to love everything you do at WordPress.com, so we provide a 14-day' +
-						' refund on all of our plans. {{a}}Manage purchases{{/a}}.',
+					'Yes. We want you to love everything you do at WordPress.com, so we provide a 14-day refund on all of our annual plans and a 7-day refund on all of our monthly plans. {{a}}Manage purchases{{/a}}.',
 					{
 						components: { a: <a href={ purchasesRoot } /> },
 					}

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -142,7 +142,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 			<FAQItem
 				question={ translate( 'Can I cancel my subscription?' ) }
 				answer={ translate(
-					'Yes. We want you to love everything you do at WordPress.com, so we provide a 30-day' +
+					'Yes. We want you to love everything you do at WordPress.com, so we provide a 14-day' +
 						' refund on all of our plans. {{a}}Manage purchases{{/a}}.',
 					{
 						components: { a: <a href={ purchasesRoot } /> },

--- a/packages/launch/src/focused-launch/plan-details/index.tsx
+++ b/packages/launch/src/focused-launch/plan-details/index.tsx
@@ -5,7 +5,7 @@
  */
 import * as React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import PlansGrid from '@automattic/plans-grid';
 import { Title, SubTitle } from '@automattic/onboarding';
 import { useHistory } from 'react-router-dom';
@@ -48,9 +48,13 @@ const PlanDetails: React.FunctionComponent = () => {
 			<div className="focused-launch-details__header">
 				<Title tagName="h2">{ __( 'Select a plan', __i18n_text_domain__ ) }</Title>
 				<SubTitle tagName="h3">
-					{ __(
-						"There's no risk, you can cancel for a full refund within 14 days.",
-						__i18n_text_domain__
+					{ sprintf(
+						/* translators: number of days */
+						__(
+							"There's no risk, you can cancel for a full refund within %1$d days.",
+							__i18n_text_domain__
+						),
+						14
 					) }
 				</SubTitle>
 			</div>

--- a/packages/launch/src/focused-launch/plan-details/index.tsx
+++ b/packages/launch/src/focused-launch/plan-details/index.tsx
@@ -49,7 +49,7 @@ const PlanDetails: React.FunctionComponent = () => {
 				<Title tagName="h2">{ __( 'Select a plan', __i18n_text_domain__ ) }</Title>
 				<SubTitle tagName="h3">
 					{ __(
-						"There's no risk, you can cancel for a full refund within 30 days.",
+						"There's no risk, you can cancel for a full refund within 14 days.",
 						__i18n_text_domain__
 					) }
 				</SubTitle>


### PR DESCRIPTION
This updates mentions of the 30-day refund policy to the new 14-day refund policy. This change is limited to copy - business logic changes will be made at a future point.

ref: pbOQVh-Lt-p2

**To Test:**
- visual check of changes should suffice
- search codebase for additional mentions of the refund policy

**Screenshots for translation:**
<img width="765" alt="Screen Shot 2021-01-17 at 10 40 59 PM" src="https://user-images.githubusercontent.com/942359/104869910-3139f800-5915-11eb-84a8-6e71faf0216a.png">
<img width="748" alt="Screen Shot 2021-01-17 at 10 34 54 PM" src="https://user-images.githubusercontent.com/942359/104869911-326b2500-5915-11eb-82bd-58818b56c393.png">
<img width="746" alt="Screen Shot 2021-01-17 at 10 33 28 PM" src="https://user-images.githubusercontent.com/942359/104869913-3303bb80-5915-11eb-82e6-a4fb93f7c279.png">
<img width="435" alt="Screen Shot 2021-01-17 at 10 30 59 PM" src="https://user-images.githubusercontent.com/942359/104869918-36974280-5915-11eb-8a38-a6b8e69eb804.png">
<img width="346" alt="Screen Shot 2021-01-17 at 10 27 46 PM" src="https://user-images.githubusercontent.com/942359/104869919-372fd900-5915-11eb-90d9-65ae052486f7.png">
<img width="359" alt="Screen Shot 2021-01-17 at 10 21 43 PM" src="https://user-images.githubusercontent.com/942359/104869923-37c86f80-5915-11eb-915a-8d0860a5fce4.png">
