### PR TITLE
Adds nav-unifcation class to dialog__backdrop so that masterbar-height used is the correct.

### DIFF
--- a/packages/components/src/dialog/index.jsx
+++ b/packages/components/src/dialog/index.jsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'react-modal';
 import classnames from 'classnames';
+import config from 'calypso/config';
 
 /**
  * Style dependencies
@@ -108,6 +109,7 @@ class Dialog extends Component {
 		const backdropClassName = classnames( baseClassName + '__backdrop', {
 			'is-full-screen': isFullScreen,
 			'is-hidden': ! isBackdropVisible,
+			'is-nav-unification': config.isEnabled( 'nav-unification' ),
 		} );
 
 		const contentClassName = classnames( baseClassName + '__content', className );

--- a/packages/components/src/dialog/index.jsx
+++ b/packages/components/src/dialog/index.jsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'react-modal';
 import classnames from 'classnames';
+// eslint-disable-next-line import/no-extraneous-dependencies, no-restricted-imports
 import config from 'calypso/config';
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Temporarily add nav-unification class to dialog component so that css rules declared here https://github.com/Automattic/wp-calypso/blob/6f34d4329437d597deff0e59c4c47137974e306f/client/assets/stylesheets/_nav-unification.scss#L17 kick in

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* with nav-unifcation enabled (paYJgx-1af-p2)
* on localhost go to `http://calypso.localhost:3000/me` 
* you should be prompted `Please enter the verification code generated by your authenticator app.` on a dialog
* make sure that the backdrop that blurs the background starts right after the masterbar

Before | After
-------|------
![image](https://user-images.githubusercontent.com/12430020/104467186-b2645880-55be-11eb-8329-166928883d38.png) | ![](https://cln.sh/pcuO8e+)