### PR TITLE
Force add the nav-unification css in reader and me sections

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -36,6 +36,7 @@ import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
  * Style dependencies
  */
 import './style.scss';
+import 'calypso/my-sites/sidebar-unified/style.scss'; // nav-unification overrides. Should be removed once launched.
 
 class MeSidebar extends React.Component {
 	onNavigate = () => {

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -48,6 +48,7 @@ import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions'
  * Style dependencies
  */
 import './style.scss';
+import 'calypso/my-sites/sidebar-unified/style.scss'; // nav-unification overrides. Should be removed once launched.
 
 const A8CConversationsIcon = () => (
 	<svg


### PR DESCRIPTION
#### Changes proposed in this Pull Request
As of now, by enabling nav-unification paYJgx-1af-p2 and going to `https://wordpress.com/read` or `https://wordpress.com/me` you will see that the sidebar doesn't used the nav-unification look. You would still get the nav-unification look if you first visit `https://wordpress.com/home/` though. 

This is a temporary hack, till we launch nav-unification to all users. It actually force loads the nav-unification styles of the my-sites sidebar for both reader and me sections. Since all the rules are nested in `.is-nav-unification` there will be no problem for users who don't have the feature enabled. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

By loading the calypso.live of this branch you should see the following

(Reader) Before | (Reader) After
-------|------
![](https://cln.sh/XqBoVR+) | ![](https://cln.sh/2jDcFD+)

(Me) Before | (Me) After
-------|------
![](https://cln.sh/GWI7sW+) | ![](https://cln.sh/TGyYPn+)

Fixes https://github.com/Automattic/wp-calypso/issues/48768
