### PR TITLE
data-layer/settings: remove `onSuccess` callback

### DIFF
--- a/client/me/form-base/with-form-base.jsx
+++ b/client/me/form-base/with-form-base.jsx
@@ -57,7 +57,7 @@ const withFormBase = ( WrappedComponent ) => {
 		submitForm = ( event ) => {
 			event.preventDefault();
 
-			this.props.saveUserSettings( null, () => this.props.markSaved?.() );
+			this.props.saveUserSettings();
 		};
 
 		getFormBaseProps = () => ( {

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -95,9 +95,7 @@ export function userSettingsSaveFailure( { settingsOverride }, error ) {
  * After settings were successfully saved, update the settings stored in the Redux state,
  * clear the unsaved settings list, and re-fetch info about the user.
  */
-export const userSettingsSaveSuccess = ( { settingsOverride, onSuccess }, data ) => (
-	dispatch
-) => {
+export const userSettingsSaveSuccess = ( { settingsOverride }, data ) => ( dispatch ) => {
 	dispatch( saveUserSettingsSuccess( fromApi( data ) ) );
 	dispatch( clearUnsavedUserSettings( settingsOverride ? Object.keys( settingsOverride ) : null ) );
 
@@ -112,13 +110,6 @@ export const userSettingsSaveSuccess = ( { settingsOverride, onSuccess }, data )
 	const userLibModule = require( 'calypso/lib/user' );
 	const userLib = userLibModule.default ? userLibModule.default : userLibModule; // TODO: delete line after removing add-module-exports.
 	userLib().fetch();
-
-	/* @TODO this workaround was introduced as part of the reduxification efforts
-	   of the `lib/user-settings` flux store and should be removed after the flux
-	   store is gone eventually */
-	if ( onSuccess && typeof onSuccess === 'function' ) {
-		onSuccess( data );
-	}
 
 	dispatch(
 		successNotice( translate( 'Settings saved successfully!' ), {

--- a/client/state/user-settings/actions.js
+++ b/client/state/user-settings/actions.js
@@ -36,13 +36,11 @@ export const fetchUserSettings = () => ( {
  * Post settings to WordPress.com API at /me/settings endpoint
  *
  * @param {object} settingsOverride - default settings object
- * @param {Function} onSuccess A callback function to be called on success by the data layer handler
  * @returns {object} Action object
  */
-export const saveUserSettings = ( settingsOverride, onSuccess ) => ( {
+export const saveUserSettings = ( settingsOverride ) => ( {
 	type: USER_SETTINGS_SAVE,
 	settingsOverride,
-	onSuccess,
 } );
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `onSuccess` workaround in the `user-settings` data layer handler

Due to a change introduced in https://github.com/Automattic/wp-calypso/pull/48730/commits/c5f39417158e2c3e53cc5e76fbc785dd3e4393b2 that callback handler is not needed anymore.

#### Testing instructions

* Go to `/me`
* Change your profile details and try to navigate away, there should be a confirm dialog showing up asking if that's what you want.
* Change your profile details back to a pristine state without saving, there should no dialog showing up when trying to navigate away
* Change your profile details again and hit Save then try to navigate away, there shouldn't be a dialog showing up either.

part of #24162
