### PR TITLE
Plugins: Remove unnecessary shortLists from wporg store

### DIFF
--- a/client/lib/plugins/wporg-data/list-store.js
+++ b/client/lib/plugins/wporg-data/list-store.js
@@ -11,7 +11,6 @@ import Dispatcher from 'calypso/dispatcher';
 import emitter from 'calypso/lib/mixins/emitter';
 import PluginsDataActions from './actions';
 
-let _shortLists = {};
 let _fullLists = {};
 let _fetching = {};
 let _currentSearchTerm = null;
@@ -24,7 +23,6 @@ function appendPage( category, page, list ) {
 
 function update( category, page, list ) {
 	if ( ! page || page === _DEFAULT_FIRST_PAGE ) {
-		_shortLists[ category ] = clone( list.slice( 0, 6 ) );
 		_fullLists[ category ] = clone( list );
 	} else {
 		appendPage( category, page, list );
@@ -32,16 +30,6 @@ function update( category, page, list ) {
 }
 
 const PluginsListsStore = {
-	getShortList: function ( category ) {
-		if ( ! _shortLists[ category ] && ! _fetching[ category ] ) {
-			PluginsDataActions.fetchPluginsList( category, _DEFAULT_FIRST_PAGE );
-		}
-		return {
-			fetching: !! _fetching[ category ],
-			list: _shortLists[ category ] || [],
-		};
-	},
-
 	getFullList: function ( category ) {
 		if ( ! _fullLists[ category ] ) {
 			PluginsDataActions.fetchPluginsList( category, _DEFAULT_FIRST_PAGE );
@@ -100,7 +88,6 @@ PluginsListsStore.dispatchToken = Dispatcher.register( function ( payload ) {
 			}
 			break;
 		case 'RESET_WPORG_PLUGINS_LIST':
-			_shortLists = {};
 			_fullLists = {};
 			_fetching = {};
 			_currentSearchTerm = null;

--- a/client/lib/plugins/wporg-data/test/list-store.js
+++ b/client/lib/plugins/wporg-data/test/list-store.js
@@ -36,10 +36,6 @@ describe( 'WPORG Plugins Lists Store', () => {
 		assert.isFunction( PluginsListsStore.emitChange );
 	} );
 
-	test( 'Store should have method getShortList', () => {
-		assert.isFunction( PluginsListsStore.getShortList );
-	} );
-
 	test( 'Store should have method getFullList', () => {
 		assert.isFunction( PluginsListsStore.getFullList );
 	} );
@@ -56,31 +52,6 @@ describe( 'WPORG Plugins Lists Store', () => {
 	test( 'should return the content of a list when requested', () => {
 		pluginsList = PluginsListsStore.getFullList( 'popular' );
 		assert.isDefined( pluginsList.list );
-	} );
-
-	describe( 'short lists', () => {
-		test( 'should be empty if the list has not been fetched yet', () => {
-			const newPlugins = PluginsListsStore.getShortList( 'new' );
-			assert.lengthOf( newPlugins.list, 0 );
-		} );
-
-		test( 'should return a list of plugins if the list has been fetched already', () => {
-			Dispatcher.handleServerAction( actionsData.fetchedNewPluginsList );
-			const newPlugins = PluginsListsStore.getShortList( 'new' );
-			assert.isArray( newPlugins.list );
-			assert.lengthOf( newPlugins.list, 1 );
-		} );
-
-		test( 'should not fetch from wporg if the category list is already in store', () => {
-			Dispatcher.handleServerAction( actionsData.fetchedPopularPluginsList );
-			PluginsListsStore.getShortList( 'popular' );
-			assert.isFalse( actionsSpies.fetchPluginsList.called );
-		} );
-
-		test( 'should fetch from wporg if the category list is not already in store', () => {
-			PluginsListsStore.getShortList( 'popular' );
-			assert.isTrue( actionsSpies.fetchPluginsList.called );
-		} );
 	} );
 
 	describe( 'Full lists', () => {

--- a/client/my-sites/plugins/plugin-meta/test/index.js
+++ b/client/my-sites/plugins/plugin-meta/test/index.js
@@ -36,7 +36,6 @@ jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 jest.mock( 'calypso/lib/translator-jumpstart', () => ( {} ) );
 jest.mock( 'calypso/lib/plugins/wporg-data/actions', () => ( {} ) );
 jest.mock( 'calypso/lib/plugins/wporg-data/list-store', () => ( {
-	getShortList: () => {},
 	getFullList: () => {},
 	getSearchList: () => {},
 	on: () => {},

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -145,20 +145,14 @@ export class PluginsBrowser extends Component {
 	};
 
 	getPluginsLists( search ) {
-		const shortLists = {};
 		const fullLists = {};
 
 		this.getVisibleCategories().forEach( ( category ) => {
-			shortLists[ category ] = PluginsListStore.getShortList( category );
 			fullLists[ category ] = PluginsListStore.getFullList( category );
 		} );
 
 		fullLists.search = PluginsListStore.getSearchList( search );
-		return { shortLists, fullLists };
-	}
-
-	getPluginsShortList( listName ) {
-		return get( this.state.shortLists, [ listName, 'list' ], [] );
+		return { fullLists };
 	}
 
 	getPluginsFullList( listName ) {
@@ -255,15 +249,14 @@ export class PluginsBrowser extends Component {
 
 	getPluginSingleListView( category ) {
 		const listLink = '/plugins/' + category + '/';
+		const pluginsFullList = this.getPluginsFullList( category );
 		return (
 			<PluginsBrowserList
-				plugins={ this.getPluginsShortList( category ) }
+				plugins={ pluginsFullList.slice( 0, SHORT_LIST_LENGTH ) }
 				listName={ category }
 				title={ this.translateCategory( category ) }
 				site={ this.props.siteSlug }
-				expandedListLink={
-					this.getPluginsFullList( category ).length > SHORT_LIST_LENGTH ? listLink : false
-				}
+				expandedListLink={ pluginsFullList.length > SHORT_LIST_LENGTH ? listLink : false }
 				size={ SHORT_LIST_LENGTH }
 				showPlaceholders={ get( this.state.fullLists, [ category, 'fetching' ] ) !== false }
 				currentSites={ this.props.sites }

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -8,7 +8,6 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 jest.mock( 'calypso/lib/plugins/wporg-data/list-store', () => ( {
-	getShortList: () => {},
 	getFullList: () => {},
 	getSearchList: () => {},
 	on: () => {},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After #48666 removed the last bits of the primary plugins store, it's time to reduxify the WP.org one.

In my initial research, I noticed that we have 2 concepts of holding non-categorized WP.org plugins: `shortLists` and `fullLists`. 
Shortlists are used only for displaying a condensed version of the full lists, with 6 instead of 24 items. And that is the only difference. That means that shortlists can completely be removed, and sliced full lists can be used instead. This is what this PR takes care of.

Removing the shortlists concept will make reduxification of the wporg plugins store easier.

Part of #24180.

#### Testing instructions

* Verify the plugin lists work the same way as in production/staging:
  * `/plugins/`
  * `/plugins/:site`
  * `/plugins/manage`
  * `/plugins/manage/:site`
  * When you click on a category (Engagement, Security) or plugins view type (All, Popular, New)
  * When you search for a keyword.
* Verify all tests pass.
