### PR TITLE
Disable "Reynolds" design in new onboarding flow

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -117,6 +117,7 @@
 			},
 			"categories": [ "featured", "portfolio" ],
 			"is_premium": false,
+			"is_alpha": true,
 			"features": []
 		},
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hides Reynolds from `/new` flow until [issues](https://github.com/Automattic/themes/issues/2971) in it have been fixed. 

Note that design grid will have different order for you than in screenshot.

![image](https://user-images.githubusercontent.com/87168/104502167-fb310700-55e8-11eb-9b1e-da97f36c01e5.png)

![image](https://user-images.githubusercontent.com/87168/104502053-f1a79f00-55e8-11eb-870f-5b1913ae5d1c.png)

#### Testing instructions

- `/new`
- No more Reynolds