### PR TITLE
add "per month" to non-monthly plans in signup

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -225,7 +225,7 @@ export class PlanFeaturesHeader extends Component {
 		}
 
 		if ( isInSignup && ! isMonthlyPlan ) {
-			return translate( 'billed annually' );
+			return translate( 'per month, billed annually' );
 		}
 
 		if ( typeof discountPrice !== 'number' || typeof rawPrice !== 'number' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add missing "per month" copy to annual plans in signup.

#### Testing instructions

* Go through the signup flow as an existing, logged-in user.
* On the plans step, with the "Pay annually" tab selected, you should see "per month, billed annually" under the prices.
<img width="1644" alt="Screen Shot 2021-01-13 at 1 23 22 PM" src="https://user-images.githubusercontent.com/690843/104513444-86d47480-55a4-11eb-8b94-52a32a4a1b8f.png">

* Select the "Pay monthly" tab and make sure you don't see "per month, billed annually"
* Test again as a logged-out/new user.
* Check the /plans page in Calypso
