### PR TITLE
Restore the original "per month" display for non-monthly plans in signup

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -225,7 +225,7 @@ export class PlanFeaturesHeader extends Component {
 		}
 
 		if ( isInSignup && ! isMonthlyPlan ) {
-			return translate( 'per month, billed annually' );
+			return translate( 'billed annually' );
 		}
 
 		if ( typeof discountPrice !== 'number' || typeof rawPrice !== 'number' ) {
@@ -359,13 +359,15 @@ export class PlanFeaturesHeader extends Component {
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ fullPrice }
-							isInSignup={ displayFlatPrice }
+							displayFlatPrice={ displayFlatPrice }
+							isInSignup={ isInSignup }
 							original
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ discountedPrice }
-							isInSignup={ displayFlatPrice }
+							displayFlatPrice={ displayFlatPrice }
+							isInSignup={ isInSignup }
 							discounted
 						/>
 					</div>
@@ -378,7 +380,8 @@ export class PlanFeaturesHeader extends Component {
 			<PlanPrice
 				currencyCode={ currencyCode }
 				rawPrice={ fullPrice }
-				isInSignup={ displayFlatPrice }
+				displayFlatPrice={ displayFlatPrice }
+				isInSignup={ isInSignup }
 			/>
 		);
 	}

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -26,6 +26,7 @@ export class PlanPrice extends Component {
 			original,
 			discounted,
 			className,
+			displayFlatPrice,
 			isInSignup,
 			isOnSale,
 			taxText,
@@ -62,7 +63,7 @@ export class PlanPrice extends Component {
 			return priceObj.price.integer;
 		};
 
-		if ( isInSignup ) {
+		if ( displayFlatPrice ) {
 			const smallerPrice = renderPrice( priceRange[ 0 ] );
 			const higherPrice = priceRange[ 1 ] && renderPrice( priceRange[ 1 ] );
 


### PR DESCRIPTION
As an alternative to https://github.com/Automattic/wp-calypso/pull/48890, this tries to fix https://github.com/Automattic/wp-calypso/issues/48885 to display the way it did before https://github.com/Automattic/wp-calypso/pull/48345 (and match the designs).

### When paying annually

Before:

![before](https://user-images.githubusercontent.com/235183/104517522-28b78980-55c4-11eb-8b8d-0ba10907c43c.png)

After:

![after](https://user-images.githubusercontent.com/235183/104517527-2a814d00-55c4-11eb-86dc-5fba57a0fabe.png)

### When paying monthly

Before:

![before-monthly](https://user-images.githubusercontent.com/235183/104545919-19066800-55f9-11eb-9259-aeefe12e9ad8.png)

After:

![after-monthly](https://user-images.githubusercontent.com/235183/104545927-1c99ef00-55f9-11eb-9fe8-1724e18cd08e.png)

Can be tested at http://calypso.localhost:3000/start/plans