### PR TITLE
Remove Calypsoify parameter from WooCommerce links.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -111,7 +111,7 @@ class AtomicStoreThankYouCard extends Component {
 			<div className="checkout-thank-you__atomic-store-action-buttons">
 				<a
 					className={ classNames( 'button', 'thank-you-card__button' ) }
-					href={ site.URL + '/wp-admin/admin.php?page=wc-setup&calypsoify=1' }
+					href={ site.URL + '/wp-admin/admin.php?page=wc-setup' }
 				>
 					{ translate( 'Create your store!' ) }
 				</a>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-checklist-ecommerce/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-checklist-ecommerce/index.jsx
@@ -24,7 +24,7 @@ export const SiteSetupListEcommerce = ( { siteUrl } ) => {
 				"You're not ready to receive orders until you complete store setup."
 			) }
 			actionText={ translate( 'Finish store setup' ) }
-			actionUrl={ `${ siteUrl }/wp-admin/admin.php?page=wc-admin&calypsoify=1` }
+			actionUrl={ `${ siteUrl }/wp-admin/admin.php?page=wc-admin` }
 			completeOnStart={ true }
 			illustration={ earnSectionImage }
 			taskId={ TASK_SITE_SETUP_CHECKLIST_ECOMMERCE }

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -680,7 +680,7 @@ export class MySitesSidebar extends Component {
 
 		let storeLink = '/store' + siteSuffix;
 		if ( isEcommerce( site.plan ) ) {
-			storeLink = site.options.admin_url + 'admin.php?page=wc-admin&calypsoify=1';
+			storeLink = site.options.admin_url + 'admin.php?page=wc-admin';
 		}
 
 		const infoCopy = translate(

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -96,9 +96,7 @@ describe( 'MySitesSidebar', () => {
 			const Store = () => Sidebar.store();
 
 			const wrapper = shallow( <Store /> );
-			expect( wrapper.props().link ).toEqual(
-				'http://test.com/wp-admin/admin.php?page=wc-admin&calypsoify=1'
-			);
+			expect( wrapper.props().link ).toEqual( 'http://test.com/wp-admin/admin.php?page=wc-admin' );
 		} );
 
 		test( 'Should return null item if user who can upgrade can not use store on this site (control a/b group)', () => {


### PR DESCRIPTION
Calypsoify is being abandoned in WooCommerce in favor of the new Navigation. More details in pbIJXs-67-p2.

Calypsoify is turned on by adding the extra query parameter `&calypsoify=1` to WooCommerce links. Since Jetpack still has Calypsoify CSS and logic to turn it on via inclusion of the query parameter, it needs to be removed from links pointing to WooCommerce and WooCommerce Admin.

#### Changes proposed in this Pull Request

Remove `&calypsoify=1` query parameter added to all WooCommerce links.

#### Testing instructions

1. View changes in the diff to make surer resulting URLs will still be valid and correct.
2. Visit an eComm store plan and make sure the sidebar link remains valid. 
3. Perform a quick search for any wc-admin or woocommerce links
