### PR TITLE
Dismiss settings sidebar when welcome tour activated

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-welcome-tour/src/tour-launch.js
@@ -26,6 +26,7 @@ function LaunchWpcomWelcomeTour() {
 	const isWpcomNuxEnabled = useSelect( ( select ) =>
 		select( 'automattic/nux' ).isWpcomNuxEnabled()
 	);
+	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
 	const { setWpcomNuxStatus } = useDispatch( 'automattic/nux' );
 
 	// Preload first card image (others preloaded after NUX status confirmed)
@@ -43,6 +44,11 @@ function LaunchWpcomWelcomeTour() {
 		};
 		fetchWpcomNuxStatus();
 	}, [ isWpcomNuxEnabled, setWpcomNuxStatus ] );
+
+	// Hide editor sidebar first time user sees the editor
+	useEffect( () => {
+		isWpcomNuxEnabled && closeGeneralSidebar();
+	}, [ closeGeneralSidebar, isWpcomNuxEnabled ] );
 
 	useEffect( () => {
 		if ( ! isWpcomNuxEnabled ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide the general settings sidebar when the welcome tour is activated

This [matches the behaviour of the existing wpcom nux modal](https://github.com/Automattic/wp-calypso/blob/58b0f45740914d4fd9feffdc40d4f46ccbd4ed98/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js#L37) that the welcome tour replaces. Makes sense to me to keep the same behaviour.

One thing I notice is that it will dismiss the sidebar each time the tour is activated, even if it's been opened a 2nd or 3rd time. I think this behaviour is probably actually good since one of the steps in the tour is to open the sidebar yourself. Makes sense that at the start of the tour we'd reset the UI state to something where the user can go through the whole tour again.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* pre-choose a domain for your test site (e.g. `mytestsite123.wordpress.com`) and pre-emptively sandbox it.
* define `SHOW_WELCOME_TOUR` in your sandbox
* apply this PR to your sandbox (e.g. with `yarn dev --sync`)
* create a new site starting from `/new`
   * use your pre-chosen domain
   * use an incognito browser to create a new user
* after landing in the editor the welcome tour should be open and the general settings sidebar should be closed
* dismiss the tour and open the settings sidebar
* re-open the tour from the triple-dot menu, the settings sidebar should close