### PR TITLE
Reader Share: improve a11y

### DIFF
--- a/client/assets/stylesheets/shared/mixins/_mixins.scss
+++ b/client/assets/stylesheets/shared/mixins/_mixins.scss
@@ -11,6 +11,7 @@
 @import 'long-content-fade';
 @import 'no-select';
 @import 'placeholder';
+@import 'screen-reader-text';
 @import 'stats-fade-text';
 
 //======================================================

--- a/client/assets/stylesheets/shared/mixins/_screen-reader-text.scss
+++ b/client/assets/stylesheets/shared/mixins/_screen-reader-text.scss
@@ -1,0 +1,16 @@
+// ==========================================================================
+// Screen Reader Text mixin
+// To hide text visually without concealing from screen reader users
+// https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/
+// ==========================================================================
+@mixin screen-reader-text {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect( 0, 0, 0, 0 );
+	white-space: nowrap;
+	border-width: 0;
+}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -374,6 +374,7 @@
 	.site-icon {
 		width: 32px !important;
 		height: 32px !important;
+		/* stylelint-disable-next-line scales/font-size */
 		font-size: 32px !important;
 		line-height: 32px !important;
 	}
@@ -541,11 +542,11 @@
 	.comment-button__label-status,
 	.like-button__label-status {
 		@include breakpoint-deprecated( '>960px' ) {
-			display: none;
+			@include screen-reader-text();
 		}
 
 		@include breakpoint-deprecated( '<660px' ) {
-			display: none;
+			@include screen-reader-text();
 		}
 	}
 }

--- a/client/blocks/reader-share/README.md
+++ b/client/blocks/reader-share/README.md
@@ -4,6 +4,5 @@ A component that wraps up the Share button and Popover Menu that results from us
 
 ## Props
 
-- `tagName`: string or ReactComponent, the component to render as the root of this component.
 - `position`: string, the PopoverMenu position to use
 - `post`: object, the post to share

--- a/client/blocks/reader-share/docs/example.jsx
+++ b/client/blocks/reader-share/docs/example.jsx
@@ -8,12 +8,11 @@ import React from 'react';
  * Internal dependencies
  */
 import ReaderShare from 'calypso/blocks/reader-share';
-import { Card } from '@automattic/components';
 import { posts } from 'calypso/blocks/reader-post-card/docs/fixtures';
 
 const ReaderShareExample = () => (
-	<div className="design-assets__group" style={ { width: '100px' } }>
-		<ReaderShare post={ posts[ 0 ] } tagName="div" />
+	<div style={ { width: '100px' } }>
+		<ReaderShare post={ posts[ 0 ] } />
 	</div>
 );
 

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -83,7 +83,6 @@ class ReaderShare extends React.Component {
 
 	static defaultProps = {
 		position: 'bottom',
-		tagName: 'li',
 		iconSize: 24,
 	};
 
@@ -169,30 +168,25 @@ class ReaderShare extends React.Component {
 			'is-active': this.state.showingMenu,
 		} );
 
-		return React.createElement(
-			this.props.tagName,
-			{
-				className: 'reader-share',
-				onClick: ( event ) => event.preventDefault(),
-				onTouchStart: preloadEditor,
-				onMouseEnter: preloadEditor,
-			},
-			[
+		return (
+			<div className="reader-share">
 				<Button
 					aria-label={ translate( 'Share post' ) }
-					key="button"
-					ref={ this.shareButton }
-					className={ buttonClasses }
-					onClick={ this.toggle }
 					borderless
+					className={ buttonClasses }
 					compact={ this.props.iconSize === 18 }
+					key="button"
+					onClick={ this.toggle }
+					onMouseEnter={ preloadEditor }
+					onTouchStart={ preloadEditor }
+					ref={ this.shareButton }
 				>
-					<Gridicon icon="share" />
+					<Gridicon aria-hidden="true" icon="share" />
 					<span className="reader-share__button-label">
 						{ translate( 'Share', { comment: 'Share the post' } ) }
 					</span>
-				</Button>,
-				this.state.showingMenu && (
+				</Button>
+				{ this.state.showingMenu && (
 					<ReaderPopoverMenu
 						key="menu"
 						context={ this.shareButton.current }
@@ -228,8 +222,8 @@ class ReaderShare extends React.Component {
 							/>
 						) }
 					</ReaderPopoverMenu>
-				),
-			]
+				) }
+			</div>
 		);
 	}
 }

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -174,7 +174,6 @@ class ReaderShare extends React.Component {
 			// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
 			<div className="reader-share" onClick={ ( event ) => event.preventDefault() }>
 				<Button
-					aria-label={ translate( 'Share post' ) }
 					borderless
 					className={ buttonClasses }
 					compact={ this.props.iconSize === 18 }

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -179,6 +179,7 @@ class ReaderShare extends React.Component {
 			},
 			[
 				<Button
+					aria-label={ translate( 'Share post' ) }
 					key="button"
 					ref={ this.shareButton }
 					className={ buttonClasses }

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -168,8 +168,11 @@ class ReaderShare extends React.Component {
 			'is-active': this.state.showingMenu,
 		} );
 
+		// The event.preventDefault() on the wrapping div is needed to prevent the
+		// full post opening when a share method is selected in the popover
 		return (
-			<div className="reader-share">
+			// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+			<div className="reader-share" onClick={ ( event ) => event.preventDefault() }>
 				<Button
 					aria-label={ translate( 'Share post' ) }
 					borderless

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -42,7 +42,7 @@
 	font-weight: normal;
 
 	@include breakpoint-deprecated( '<480px' ) {
-		display: none;
+		@include screen-reader-text();
 	}
 }
 

--- a/client/components/seo-preview-pane/style.scss
+++ b/client/components/seo-preview-pane/style.scss
@@ -133,7 +133,7 @@
 		.like-button__label-status,
 		.reader-share__button-label {
 			@include breakpoint-deprecated( '<960px' ) {
-				display: none;
+				@include screen-reader-text();
 			}
 		}
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -350,7 +350,7 @@
 	.reader-share__button-label,
 	.comment-button__label-status,
 	.like-button__label-status {
-		display: none;
+		@include screen-reader-text();
 	}
 
 	.reader-share__button {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -23,7 +23,7 @@
 .reader__content {
 	sup, sub {
 		position: relative;
-		font-size: 0.83em;
+		font-size: 0.875rem;
 	}
 
 	sup {
@@ -218,11 +218,11 @@
 .is-group-reader .comment-button__label-status,
 .is-group-reader .like-button__label-status {
 	@media( max-width: 530px ) {
-		display: none;
+		@include screen-reader-text();
 	}
 
 	@media( min-width: 661px ) and ( max-width: 790px ) {
-		display: none;
+		@include screen-reader-text();
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/issues/46737, @jeryj notes that the Reader Share does not make an accessible name available to screenreaders.

This PR remedies that by adding an `aria-label` to the Share button. It also removes some event handlers from the non-interactive wrapping element and adds them to the button instead.

We also remove the redundant `tagName` prop - the block is only used in one place, and it uses a div wrapping element.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to Reader at http://calypso.localhost:3000 and find a post with a Reader share button:

<img width="835" alt="Screen Shot 2021-01-22 at 14 37 07" src="https://user-images.githubusercontent.com/17325/105433897-5fc22500-5cbf-11eb-9ccb-9def517b52bd.png">

Ensure that the Share button works as intended with Twitter, Facebook and share to WP post.

Check the document structure with your browser's accessibility inspector and make the title is shown:

<img width="877" alt="Screen Shot 2021-01-22 at 14 38 55" src="https://user-images.githubusercontent.com/17325/105434001-94ce7780-5cbf-11eb-9900-9c492beb83a4.png">

Part of https://github.com/Automattic/wp-calypso/issues/46737.